### PR TITLE
Functional mode polymorphism

### DIFF
--- a/external/merlin/src/analysis/mode_enclosing.ml
+++ b/external/merlin/src/analysis/mode_enclosing.ml
@@ -6,7 +6,7 @@ module Mode_info = struct
   let to_string ~verbosity mode =
     (* Zap mode variables to floor. *)
     let snap = Btype.snapshot () in
-    let const = Mode.Value.zap_to_floor mode in
+    let const = Mode.Value.zap_to_floor_force mode in
     Btype.backtrack snap;
     (* Convert modes into a list of modes. *)
     let verbose =

--- a/external/merlin/src/analysis/ptyp_of_type.ml
+++ b/external/merlin/src/analysis/ptyp_of_type.ml
@@ -181,9 +181,9 @@ and extension_constructor id { ext_args; ext_ret_type; ext_attributes; _ } =
 
 and modes ~arg mode =
   let snapshot = Btype.snapshot () in
-  let mode = Mode.Alloc.zap_to_legacy ~arg mode in
+  let mode = Mode.Alloc.zap_to_legacy_force ~arg mode in
   Btype.backtrack snapshot;
-  Out_type.tree_of_modes mode
+  Out_type.tree_of_modes_const mode
   |> List.map ~f:(fun mode -> Location.mknoloc (Parsetree.Mode mode))
 
 and const_modalities ~mut modality =

--- a/external/merlin/src/analysis/type_utils.ml
+++ b/external/merlin/src/analysis/type_utils.ml
@@ -86,7 +86,8 @@ module Printtyp = struct
         if mark ty0 then
           let open Types in
           let ty' = Ctype.full_expand ~may_forget_scope:true env ty0 in
-          if get_desc ty' == get_desc ty0 then Btype.iter_type_expr (iter d) ty0
+          if get_desc ty' == get_desc ty0 then
+            Btype.iter_type_expr (iter d) (Fun.const ()) ty0
           else begin
             let desc =
               match get_desc ty' with
@@ -95,7 +96,8 @@ module Printtyp = struct
               | desc -> desc
             in
             Types.Transient_expr.(set_desc (repr ty0) desc);
-            if d > 0 then Btype.iter_type_expr (iter (pred d)) ty0
+            if d > 0 then
+              Btype.iter_type_expr (iter (pred d)) (Fun.const ()) ty0
           end
       in
       iter

--- a/external/merlin/src/ocaml/merlin_specific/tast_helper.ml
+++ b/external/merlin/src/ocaml/merlin_specific/tast_helper.ml
@@ -24,7 +24,7 @@ module Pat = struct
     (* The level we use here isn't important - the constructed type is just used for
        printing and is never unified. *)
     let sort = Jkind.Sort.new_var ~level:(Ctype.get_current_level ()) in
-    let mode = Mode.Value.newvar () in
+    let mode = Mode.Value.newvar (Ctype.get_current_level ()) in
     let pat_desc =
       Tpat_var
         { id = Ident.create_local str.Asttypes.txt;

--- a/external/merlin/src/ocaml/parsing/language_extension.ml
+++ b/external/merlin/src/ocaml/parsing/language_extension.ml
@@ -64,6 +64,8 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Mode -> (module Maturity)
   | Unique -> (module Maturity)
   | Overwriting -> (module Unit)
+  | Mode_polymorphism -> (module Maturity)
+  | Mode_polymorphism_printing -> (module Unit)
   | Include_functor -> (module Unit)
   | Polymorphic_parameters -> (module Unit)
   | Immutable_arrays -> (module Unit)
@@ -85,7 +87,9 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
    But we've decided to punt on this issue in the short term.
 *)
 let is_erasable : type a. a t -> bool = function
-  | Mode | Unique | Overwriting | Layouts | Layout_poly -> true
+  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism
+  | Mode_polymorphism_printing ->
+    true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
   | Runtime_metaprogramming ->
@@ -98,22 +102,24 @@ let maturity_of_unique_for_destruction = Alpha
 module Exist_pair = struct
   type t = Pair : 'a language_extension * 'a -> t
 
-  let maturity : t -> Maturity.t = function
-    | Pair (Comprehensions, ()) -> Beta
-    | Pair (Mode, m) -> m
-    | Pair (Unique, m) -> m
-    | Pair (Overwriting, ()) -> Alpha
-    | Pair (Include_functor, ()) -> Stable
-    | Pair (Polymorphic_parameters, ()) -> Stable
-    | Pair (Immutable_arrays, ()) -> Stable
-    | Pair (Module_strengthening, ()) -> Stable
-    | Pair (Layouts, m) -> m
-    | Pair (SIMD, m) -> m
-    | Pair (Small_numbers, m) -> m
-    | Pair (Instances, ()) -> Stable
-    | Pair (Let_mutable, ()) -> Stable
-    | Pair (Layout_poly, m) -> m
-    | Pair (Runtime_metaprogramming, ()) -> Beta
+  let maturity : t -> Maturity.t option = function
+    | Pair (Comprehensions, ()) -> Some Beta
+    | Pair (Mode, m) -> Some m
+    | Pair (Unique, m) -> Some m
+    | Pair (Overwriting, ()) -> Some Alpha
+    | Pair (Mode_polymorphism, m) -> Some m
+    | Pair (Mode_polymorphism_printing, ()) -> None
+    | Pair (Include_functor, ()) -> Some Stable
+    | Pair (Polymorphic_parameters, ()) -> Some Stable
+    | Pair (Immutable_arrays, ()) -> Some Stable
+    | Pair (Module_strengthening, ()) -> Some Stable
+    | Pair (Layouts, m) -> Some m
+    | Pair (SIMD, m) -> Some m
+    | Pair (Small_numbers, m) -> Some m
+    | Pair (Instances, ()) -> Some Stable
+    | Pair (Let_mutable, ()) -> Some Stable
+    | Pair (Layout_poly, m) -> Some m
+    | Pair (Runtime_metaprogramming, ()) -> Some Beta
 
   let is_erasable : t -> bool = function Pair (ext, _) -> is_erasable ext
 
@@ -126,10 +132,13 @@ module Exist_pair = struct
     | Pair (SIMD, m) -> to_string SIMD ^ "_" ^ maturity_to_string m
     | Pair (Layout_poly, m) ->
       to_string Layout_poly ^ "_" ^ maturity_to_string m
+    | Pair (Mode_polymorphism, m) ->
+      to_string Mode_polymorphism ^ "_" ^ maturity_to_string m
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
-           | Let_mutable | Runtime_metaprogramming ) as ext),
+           | Let_mutable | Runtime_metaprogramming | Mode_polymorphism_printing
+             ) as ext),
           _ ) ->
       to_string ext
 
@@ -143,6 +152,11 @@ module Exist_pair = struct
     | "mode" -> Some (Pair (Mode, Stable))
     | "mode_beta" -> Some (Pair (Mode, Beta))
     | "mode_alpha" -> Some (Pair (Mode, Alpha))
+    | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
+    | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
+    | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
+    | "mode_polymorphism_printing" ->
+      Some (Pair (Mode_polymorphism_printing, ()))
     | "unique" -> Some (Pair (Unique, Stable))
     | "unique_beta" -> Some (Pair (Unique, Beta))
     | "unique_alpha" -> Some (Pair (Unique, Alpha))
@@ -176,6 +190,8 @@ let all_extensions =
   [ Pack Comprehensions;
     Pack Mode;
     Pack Unique;
+    Pack Mode_polymorphism;
+    Pack Mode_polymorphism_printing;
     Pack Overwriting;
     Pack Include_functor;
     Pack Polymorphic_parameters;
@@ -217,6 +233,8 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Mode, Mode -> Some Refl
   | Unique, Unique -> Some Refl
   | Overwriting, Overwriting -> Some Refl
+  | Mode_polymorphism, Mode_polymorphism -> Some Refl
+  | Mode_polymorphism_printing, Mode_polymorphism_printing -> Some Refl
   | Include_functor, Include_functor -> Some Refl
   | Polymorphic_parameters, Polymorphic_parameters -> Some Refl
   | Immutable_arrays, Immutable_arrays -> Some Refl
@@ -231,7 +249,8 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming ),
+      | Runtime_metaprogramming | Mode_polymorphism | Mode_polymorphism_printing
+        ),
       _ ) ->
     None
 
@@ -324,14 +343,14 @@ end = struct
     | Alpha -> "flag -extension-universe alpha (default CLI option)"
 
   let is_allowed_in t extn_pair =
-    match t with
-    | No_extensions -> false
-    | Upstream_compatible ->
-      Exist_pair.is_erasable extn_pair
-      && Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Stable -> Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Beta -> Maturity.compare (Exist_pair.maturity extn_pair) Beta <= 0
-    | Alpha -> true
+    match t, Exist_pair.maturity extn_pair with
+    | No_extensions, _ -> false
+    | _, None -> true
+    | Upstream_compatible, Some maturity ->
+      Exist_pair.is_erasable extn_pair && Maturity.compare maturity Stable <= 0
+    | Stable, Some maturity -> Maturity.compare maturity Stable <= 0
+    | Beta, Some maturity -> Maturity.compare maturity Beta <= 0
+    | Alpha, Some _ -> true
 
   let is_allowed extn_pair = is_allowed_in !universe extn_pair
 
@@ -351,7 +370,11 @@ end = struct
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
       let allowed_levels =
-        Ops.all |> List.filter (fun lvl -> is_allowed_in t (Pair (extn, lvl)))
+        Ops.all
+        |> List.filter (fun lvl ->
+            match Exist_pair.maturity (Pair (extn, lvl)) with
+            | None -> false
+            | Some _ -> is_allowed_in t (Pair (extn, lvl)))
       in
       match allowed_levels with
       | [] -> None

--- a/external/merlin/src/ocaml/parsing/language_extension.ml
+++ b/external/merlin/src/ocaml/parsing/language_extension.ml
@@ -606,6 +606,7 @@ let _ =
   let lower_mode_extension = function
   | Pair (Mode, Alpha) -> Pair (Mode, Beta)
   | Pair (Layouts, Alpha) -> Pair (Layouts, Beta)
+  | Pair (Mode_polymorphism, Alpha) -> Pair (Mode_polymorphism, Beta)
   | _ as pair -> pair
 in
   extensions := List.map lower_mode_extension !extensions

--- a/external/merlin/src/ocaml/parsing/language_extension.mli
+++ b/external/merlin/src/ocaml/parsing/language_extension.mli
@@ -21,6 +21,8 @@ type 'a t = 'a Language_extension_kernel.t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/external/merlin/src/ocaml/typing/btype.ml
+++ b/external/merlin/src/ocaml/typing/btype.ml
@@ -108,7 +108,7 @@ end
 
 (**** Type level management ****)
 
-let generic_level = Ident.highest_scope
+let generic_level = Mode.Alloc.generic_level
 let lowest_level = Ident.lowest_scope
 
 (**** leveled type pool ****)
@@ -335,11 +335,13 @@ let iter_row f row =
   fold_row (fun () v -> f v) () row
 
 
-let fold_type_expr f init ty =
+let fold_type_expr f fm init ty =
   match get_desc ty with
     Tvar _              -> init
-  | Tarrow (_, ty1, ty2, _) ->
-      let result = f init ty1 in
+  | Tarrow ((_, m1, m2), ty1, ty2, _) ->
+      let result = fm init m1 in
+      let result = fm result m2 in
+      let result = f result ty1 in
       f result ty2
   | Ttuple l            -> List.fold_left (fun acc (_, t) -> f acc t) init l
   | Tunboxed_tuple l    -> List.fold_left (fun acc (_, t) -> f acc t) init l
@@ -372,8 +374,8 @@ let fold_type_expr f init ty =
   | Tof_kind _ -> init
   | Tbox ty -> f init ty
 
-let iter_type_expr f ty =
-  fold_type_expr (fun () v -> f v) () ty
+let iter_type_expr f fm ty =
+  fold_type_expr (fun () v -> f v) (fun () v -> fm v) () ty
 
 let rec iter_abbrev f = function
     Mnil                   -> ()
@@ -410,10 +412,11 @@ let iter_type_expr_kind f = function
                   (**********************************)
 
 let rec mark_type mark ty =
-  if try_mark_node mark ty then iter_type_expr (mark_type mark) ty
+  if try_mark_node mark ty then
+    iter_type_expr (mark_type mark) (Fun.const ()) ty
 
 let mark_type_params mark ty =
-  iter_type_expr (mark_type mark) ty
+  iter_type_expr (mark_type mark) (Fun.const ()) ty
 
                   (**********************************)
                   (*  (Object-oriented) iterator    *)
@@ -438,6 +441,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -456,7 +461,8 @@ let type_iterators_without_type_expr =
     | Sig_class_type (_, ctd, _, _) -> it.it_class_type_declaration it ctd
     | Sig_jkind (_ , jkd, _)        -> it.it_jkind_declaration it jkd
   and it_value_description it vd =
-    it.it_type_expr it vd.val_type
+    it.it_type_expr it vd.val_type;
+    it.it_modality vd.val_modalities
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
@@ -468,7 +474,8 @@ let type_iterators_without_type_expr =
     iter_type_expr_cstr_args (it.it_type_expr it) td.ext_args;
     Option.iter (it.it_type_expr it) td.ext_ret_type
   and it_module_declaration it md =
-    it.it_module_type it md.md_type
+    it.it_module_type it md.md_type;
+    it.it_modality md.md_modalities
   and it_modtype_declaration it mtd =
     Option.iter (it.it_module_type it) mtd.mtd_type
   and it_class_declaration it cd =
@@ -490,15 +497,18 @@ let type_iterators_without_type_expr =
       ()
   and it_functor_param it = function
     | Unit -> ()
-    | Named (_, mt, _) -> it.it_module_type it mt
+    | Named (_, mt, mm) ->
+        it.it_module_type it mt;
+        it.it_mode_expr mm
   and it_module_type it = function
       Mty_ident p
     | Mty_alias p -> it.it_path p
     | Mty_for_hole -> ()
     | Mty_signature sg -> it.it_signature it sg
-    | Mty_functor (p, mt, _) ->
+    | Mty_functor (p, mt, mm) ->
         it.it_functor_param it p;
-        it.it_module_type it mt
+        it.it_module_type it mt;
+        it.it_mode_expr mm
     | Mty_strengthen (mty, p, _) ->
         it.it_module_type it mty;
         it.it_path p
@@ -518,19 +528,22 @@ let type_iterators_without_type_expr =
   and it_type_kind it kind =
     iter_type_expr_kind (it.it_type_expr it) kind
   and it_path _p = ()
+  and it_mode_expr _m = ()
+  and it_modality _m = ()
   in
   { it_path; it_type_expr = (fun _ _ -> ()); it_do_type_expr = (fun _ _ -> ());
     it_type_kind; it_class_type; it_functor_param; it_module_type;
     it_signature; it_class_type_declaration; it_class_declaration;
     it_jkind_declaration;
     it_modtype_declaration; it_module_declaration; it_extension_constructor;
-    it_type_declaration; it_value_description; it_signature_item; }
+    it_type_declaration; it_value_description;
+    it_signature_item; it_mode_expr; it_modality }
 
 let type_iterators mark =
   let it_type_expr it ty =
     if try_mark_node mark ty then it.it_do_type_expr it ty
   and it_do_type_expr it ty =
-    iter_type_expr (it.it_type_expr it) ty;
+    iter_type_expr (it.it_type_expr it) (it.it_mode_expr) ty;
     match get_desc ty with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
@@ -583,11 +596,12 @@ let instance_jkind (t : jkind_lr) : jkind_lr =
   | Layout l ->
     { t with jkind = { t.jkind with base = Layout (instance_layout l) } }
 
-let rec copy_type_desc ?(keep_names=false) f = function
+let rec copy_type_desc ?(keep_names=false) f fm = function
     Tvar { name; jkind } ->
      let jkind = instance_jkind jkind in
      if keep_names then Tvar { name; jkind } else Tvar { name=None; jkind }
-  | Tarrow (p, ty1, ty2, c)-> Tarrow (p, f ty1, f ty2, copy_commu c)
+  | Tarrow ((p, m1, m2), ty1, ty2, c)->
+    Tarrow ((p, fm m1, fm m2), f ty1, f ty2, copy_commu c)
   | Ttuple l            -> Ttuple (List.map (fun (label, t) -> label, f t) l)
   | Tunboxed_tuple l    ->
     Tunboxed_tuple (List.map (fun (label, t) -> label, f t) l)
@@ -604,7 +618,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tfield (p, field_kind_internal_repr k, f ty1, f ty2)
       (* the kind is kept shared, with indirections removed for performance *)
   | Tnil                -> Tnil
-  | Tlink ty            -> copy_type_desc f (get_desc ty)
+  | Tlink ty            -> copy_type_desc f fm (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
@@ -624,11 +638,23 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_for_saving : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_for_restoring : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
     mutable saved_desc : (transient_expr * type_desc) list;
     (* Save association of generic nodes with their description. *)
+    saved_mode_changes : Mode.copy_scope;
   }
 
   let redirect_desc copy_scope ty desc =
@@ -636,13 +662,30 @@ end = struct
     copy_scope.saved_desc <- (ty, ty.desc) :: copy_scope.saved_desc;
     Transient_expr.set_desc ty desc
 
+  let mode_instantiate copy_scope ~current_level m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.instantiate ~copy_scope ~current_level m
+
+  let mode_copy_generic copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_generic ~copy_scope m
+
+  let mode_copy_for_saving copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_for_saving ~copy_scope m
+
+  let mode_copy_for_restoring copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_for_restoring ~copy_scope m
+
   (* Restore type descriptions. *)
   let cleanup { saved_desc; _ } =
     List.iter (fun (ty, desc) -> Transient_expr.set_desc ty desc) saved_desc
 
   let with_scope f =
-    let scope = { saved_desc = [] } in
-    Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope)
+    Mode.with_copy_scope (fun ms ->
+      let scope = { saved_desc = []; saved_mode_changes = ms } in
+      Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope))
 
 end
 

--- a/external/merlin/src/ocaml/typing/btype.mli
+++ b/external/merlin/src/ocaml/typing/btype.mli
@@ -157,15 +157,20 @@ val set_static_row_name: type_declaration -> Path.t -> unit
 
 (**** Utilities for type traversal ****)
 
-val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
+val iter_type_expr:
+  (type_expr -> unit) -> (Mode.Alloc.lr -> unit) ->
+  type_expr -> unit
         (* Iteration on types *)
-val fold_type_expr: ('a -> type_expr -> 'a) -> 'a -> type_expr -> 'a
+val fold_type_expr:
+  ('a -> type_expr -> 'a) -> ('a -> Mode.Alloc.lr -> 'a) ->
+  'a -> type_expr -> 'a
 val iter_row: (type_expr -> unit) -> row_desc -> unit
         (* Iteration on types in a row *)
 val fold_row: ('a -> type_expr -> 'a) -> 'a -> row_desc -> 'a
 val iter_abbrev: (type_expr -> unit) -> abbrev_memo -> unit
         (* Iteration on types in an abbreviation list *)
-val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
+val iter_type_expr_kind: (type_expr -> unit) ->
+  (type_decl_kind -> unit)
 
 val iter_type_expr_cstr_args: (type_expr -> unit) ->
   (constructor_arguments -> unit)
@@ -200,6 +205,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -216,7 +223,8 @@ val type_iterators_without_type_expr: type_iterators_without_type_expr
 (**** Utilities for copying ****)
 
 val copy_type_desc:
-    ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc
+    ?keep_names:bool -> (type_expr -> type_expr) ->
+    (Mode.Alloc.lr -> Mode.Alloc.lr) -> type_desc -> type_desc
         (* Copy on types *)
 val copy_row:
     (type_expr -> type_expr) ->
@@ -235,6 +243,26 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
         (* Temporarily change a type description *)
+
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Instantiates a generic mode variable to level [current_level] *)
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Copies the generic parts of a mode variable
+           without changing its level *)
+
+  val mode_copy_for_saving :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Deeply copies a mode variable without changing its level, giving
+           the copies negative (persistent) ids, for storing in a cmi file. *)
+
+  val mode_copy_for_restoring :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Deeply copies a mode variable without changing its level.
+           Asserts that the original has negative ids. *)
 
   val with_scope: (copy_scope -> 'a) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -267,26 +267,33 @@ let with_local_level_gen ~begin_def ~structure ?before_generalize f =
         else begin
           (* Generalize all remaining nodes *)
           Transient_expr.set_level ty generic_level;
-          if structure then match ty.desc with
-            Tconstr (_, _, abbrev) ->
+          match ty.desc with
+          | Tconstr (_, _, abbrev) when structure ->
               (* In structure mode, we drop abbreviations, as the goal of
                  this mode is to reduce sharing *)
               abbrev := Mnil
+          | Tarrow ((_, marg, mret), _, _, _) when not structure ->
+              Alloc.generalize_topology ~current_level:!current_level marg;
+              Alloc.generalize_topology ~current_level:!current_level mret
           | _ -> ()
         end
   end pool;
   result
 
-let with_local_level_generalize_structure f =
-  with_local_level_gen ~begin_def ~structure:true f
 let with_local_level_generalize ~before_generalize f =
   with_local_level_gen ~begin_def ~structure:false ~before_generalize f
 let with_local_level_generalize_if cond ~before_generalize f =
   if cond then with_local_level_generalize ~before_generalize f else f ()
-let with_local_level_generalize_structure_if cond f =
-  if cond then with_local_level_generalize_structure f else f ()
-let with_local_level_generalize_structure_if_principal f =
-  if !Clflags.principal then with_local_level_generalize_structure f else f ()
+let with_local_level_generalize_structure ~before_generalize f =
+  with_local_level_gen ~begin_def ~structure:true ~before_generalize f
+let with_local_level_generalize_structure_if cond ~before_generalize f =
+  if cond then
+    with_local_level_generalize_structure ~before_generalize f
+  else f ()
+let with_local_level_generalize_structure_if_principal ~before_generalize f =
+  if !Clflags.principal then
+    with_local_level_generalize_structure ~before_generalize f
+  else f ()
 let with_local_level_generalize_for_class ~before_generalize f =
   with_local_level_gen
     ~begin_def:begin_class_def ~structure:false ~before_generalize f
@@ -516,7 +523,7 @@ let decr_stage env =
 let incr_stage env =
   Env.enter_quote env
 
-let iter_type_expr_with_stages f env ty =
+let iter_type_expr_with_stages f env fm ty =
   match get_desc ty with
   | Tquote ty ->
     f (incr_stage env) ty
@@ -525,7 +532,7 @@ let iter_type_expr_with_stages f env ty =
   | Tquote_eval ty ->
     f (incr_stage env) ty
   | _ ->
-    iter_type_expr (f env) ty
+    iter_type_expr (f env) fm ty
 
 (* CR metaprogramming jbachurski: We use this to adjust the environment while
    printing error messages. The original type may have been well-staged,
@@ -550,6 +557,7 @@ let contains_initial_stage_splice stage ty =
       in
       fold_type_expr
         (fun x y -> x || loop (acc + offset) y)
+        (fun a _ -> a)
         (acc < 0) ty
     end
   in
@@ -751,7 +759,7 @@ let rec filter_row_fields erase = function
       | _ -> p :: fi
 
 (* Ensure all mode variables are fully determined *)
-let remove_mode_and_jkind_variables ty =
+let remove_mode_and_jkind_variables ~zap_scope ty =
   let visited = ref TypeSet.empty in
   let rec go ty =
     if TypeSet.mem ty !visited then () else begin
@@ -760,10 +768,20 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
+<<<<<<< HEAD
          let _ = Alloc.zap_to_legacy ~arg:true marg in
          let _ = Alloc.zap_to_legacy ~arg:false mret in
+=======
+         if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope marg zap_scope;
+          Alloc.add_mode_to_zap_scope mret zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force marg |> ignore;
+          Alloc.zap_to_legacy_force mret |> ignore
+         end;
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
          go targ; go tret
-      | _ -> iter_type_expr go ty
+      | _ -> iter_type_expr go (Fun.const ()) ty
     end
   in go ty
 
@@ -819,7 +837,7 @@ let[@inline] free_vars ~init ~add_one ?env mark tys =
           if static_row row then acc
           else fv ~kind:Row_variable acc (row_more row)
       | _    ->
-          fold_type_expr (fv ~kind) acc ty
+          fold_type_expr (fv ~kind) (fun acc _ -> acc) acc ty
   in
   List.fold_left (fv ~kind:Type_variable) init tys
 
@@ -869,20 +887,21 @@ let closed_type_expr ?env ty =
     try closed_type ?env mark ty; true
     with Non_closed _ -> false)
 
-let close_type mark ty =
-  remove_mode_and_jkind_variables ty;
+let close_type ~zap_scope mark ty =
+  remove_mode_and_jkind_variables ~zap_scope ty;
   closed_type mark ty
 
 let closed_parameterized_type params ty =
   with_type_mark begin fun mark ->
     List.iter (mark_type mark) params;
-    try close_type mark ty; true with Non_closed _ -> false
+    try Alloc.with_zap_scope (fun ~zap_scope -> close_type ~zap_scope mark ty);
+    true with Non_closed _ -> false
   end
 
-let closed_type_decl decl =
+let closed_type_decl ~zap_scope decl =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) decl.type_params;
-    List.iter remove_mode_and_jkind_variables decl.type_params;
+    List.iter (remove_mode_and_jkind_variables ~zap_scope) decl.type_params;
     begin match decl.type_kind with
       Type_abstract _ ->
         ()
@@ -896,30 +915,32 @@ let closed_type_decl decl =
                    them. Test case: typing-layouts-gadt-sort-var/test.ml *)
                 begin match cd_args with
                 | Cstr_tuple l -> List.iter (fun ca ->
-                    remove_mode_and_jkind_variables ca.ca_type) l
+                    remove_mode_and_jkind_variables ~zap_scope ca.ca_type) l
                 | Cstr_record l -> List.iter (fun l ->
-                    remove_mode_and_jkind_variables l.ld_type) l
+                    remove_mode_and_jkind_variables ~zap_scope l.ld_type) l
                 end;
-                remove_mode_and_jkind_variables res_ty
-            | None -> List.iter (close_type mark) (tys_of_constr_args cd_args)
+                remove_mode_and_jkind_variables ~zap_scope res_ty
+            | None ->
+              List.iter (close_type mark ~zap_scope)
+                (tys_of_constr_args cd_args)
           )
           v
     | Type_record(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_record_unboxed_product(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_open -> ()
     end;
     begin match decl.type_manifest with
       None    -> ()
-    | Some ty -> close_type mark ty
+    | Some ty -> close_type mark ~zap_scope ty
     end;
     None
   with Non_closed (ty, _) ->
     Some ty
   end
 
-let closed_extension_constructor ext =
+let closed_extension_constructor ~zap_scope ext =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) ext.ext_type_params;
     begin match ext.ext_ret_type with
@@ -927,10 +948,12 @@ let closed_extension_constructor ext =
         (* gadts cannot have free type variables, but they might
            have undefaulted sort variables; these lines default
            them. Test case: typing-layouts-gadt-sort-var/test_extensible.ml *)
-        iter_type_expr_cstr_args remove_mode_and_jkind_variables ext.ext_args;
-        remove_mode_and_jkind_variables res_ty
+        iter_type_expr_cstr_args
+          (remove_mode_and_jkind_variables ~zap_scope)
+          ext.ext_args;
+        remove_mode_and_jkind_variables ~zap_scope res_ty
     | None ->
-        iter_type_expr_cstr_args (close_type mark) ext.ext_args
+        iter_type_expr_cstr_args (close_type mark ~zap_scope) ext.ext_args
     end;
     None
   with Non_closed (ty, _) ->
@@ -944,7 +967,7 @@ type closed_class_failure = {
 }
 exception CCFailure of closed_class_failure
 
-let closed_class params sign =
+let closed_class ~zap_scope params sign =
   with_type_mark begin fun mark ->
   List.iter (mark_type mark) params;
   ignore (try_mark_node mark sign.csig_self_row);
@@ -952,7 +975,8 @@ let closed_class params sign =
     Meths.iter
       (fun lab (priv, _, ty) ->
         if priv = Mpublic then begin
-          try close_type mark ty with Non_closed (ty0, variable_kind) ->
+          try close_type ~zap_scope mark ty
+          with Non_closed (ty0, variable_kind) ->
             raise (CCFailure {
               free_variable = (ty0, variable_kind);
               meth = lab;
@@ -986,7 +1010,7 @@ let duplicate_class_type ty =
 let rec lower_all ty =
   if get_level ty > !current_level then begin
     set_level ty !current_level;
-    iter_type_expr lower_all ty
+    iter_type_expr lower_all (Fun.const ()) ty
   end
 
 (*
@@ -998,7 +1022,8 @@ let rec lower_all ty =
 *)
 let rec generalize stage_offset ty =
   let level = get_level ty in
-  if (level > !current_level) && (level <> generic_level) then begin
+  let current_level = !current_level in
+  if (level > current_level) && (level <> generic_level) then begin
     set_level ty generic_level;
     begin match get_desc ty with
     (* Keep track of [stage_offset] *)
@@ -1011,7 +1036,7 @@ let rec generalize stage_offset ty =
     (* Normalize the variable to be at [stage_offset = 0] *)
     | Tvar name ->
         update_variable_stage stage_offset ty name.name name.jkind;
-        Jkind.generalize ~current_level:!current_level name.jkind
+        Jkind.generalize ~current_level name.jkind
     (* Do not generalize cross-stage row-polymorphic types, as we cannot
        quote or splice row variables.
        Weak type variables that arise here are considered cross-stage,
@@ -1025,16 +1050,43 @@ let rec generalize stage_offset ty =
         lower_all ty
     (* recur into abbrev for the speed *)
     | Tconstr (_, _, abbrev) ->
+        let mgen m = Mode.Alloc.generalize ~current_level m in
         iter_abbrev (generalize stage_offset) !abbrev;
-        iter_type_expr (generalize stage_offset) ty
+        iter_type_expr (generalize stage_offset) mgen ty
     | _ ->
-        iter_type_expr (generalize stage_offset) ty
+
+      let mgen m = Mode.Alloc.generalize ~current_level m in
+      iter_type_expr (generalize stage_offset) mgen ty
     end;
   end
 
 let generalize ty =
   simple_abbrevs := Mnil;
   generalize 0 ty
+
+(* Generalize the structure and lower the variables *)
+
+let rec generalize_structure ty =
+  let level = get_level ty in
+  let current_level = !current_level in
+  if level <> generic_level then begin
+    if is_Tvar ty && level > current_level then
+      set_level ty current_level
+    else if level > current_level then begin
+      begin match get_desc ty with
+        Tconstr (_, _, abbrev) ->
+          abbrev := Mnil
+      | _ -> ()
+      end;
+      set_level ty generic_level;
+      let mgen m = Mode.Alloc.generalize_structure ~current_level m in
+      iter_type_expr generalize_structure mgen ty
+    end
+  end
+
+let generalize_structure ty =
+  simple_abbrevs := Mnil;
+  generalize_structure ty
 
 (*
    Build a copy of a type in which nodes reachable through a path composed
@@ -1065,15 +1117,20 @@ let rec copy_spine copy_scope ty =
   | ( Tarrow _ | Tpoly _ | Trepr _ | Ttuple _ | Tunboxed_tuple _ | Tpackage _
     | Tconstr _ | Tmod _ ) as desc ->
       let level = get_level ty in
-      if level < !current_level || level = generic_level then ty else
+      let current_level = !current_level in
+      if level < current_level || level = generic_level then ty else
       let t =
         newgenstub ~scope:(get_scope ty) (Jkind.Builtin.any ~why:Dummy_jkind)
       in
       For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
       let copy_rec = copy_spine copy_scope in
       let desc' = match desc with
-      | Tarrow (lbl, ty1, ty2, _) ->
-          Tarrow (lbl, copy_rec ty1, copy_rec ty2, commu_ok)
+      | Tarrow ((lbl, marg, mret), ty1, ty2, _) ->
+          Tarrow
+            ((lbl, marg, mret),
+             copy_rec ty1,
+             copy_rec ty2,
+             commu_ok)
       | Tpoly (ty', tvl) ->
           Tpoly (copy_rec ty', tvl)
       | Trepr (ty', sl) ->
@@ -1142,7 +1199,7 @@ let rec check_scope_escape mark env level ty =
             (Tpackage {pack with pack_path = p'}))
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> check_scope_escape mark env level) env ty
+          (fun env -> check_scope_escape mark env level) env (Fun.const ()) ty
     end;
   end
 
@@ -1158,7 +1215,8 @@ let rec update_scope scope ty =
     if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
     (* Only recurse in principal mode as this is not necessary for soundness *)
-    if !Clflags.principal then iter_type_expr (update_scope scope) ty
+    if !Clflags.principal then
+      iter_type_expr (update_scope scope) (Fun.const ()) ty
   end
 
 let update_scope_for tr_exn scope ty =
@@ -1210,7 +1268,8 @@ let rec update_level env level expand ty =
           update_level env level expand ty'
         with Cannot_expand ->
           set_level ();
-          iter_type_expr (update_level env level expand) ty
+          iter_type_expr (update_level env level expand)
+            (Mode.Alloc.update_level level) ty
         end
     | Tpackage ({pack_path = p} as pack) when level < Path.scope p ->
         let p' = normalize_package_path env p in
@@ -1228,7 +1287,8 @@ let rec update_level env level expand ty =
         | _ -> ()
         end;
         set_level ();
-        iter_type_expr (update_level env level expand) ty
+        iter_type_expr (update_level env level expand)
+          (Mode.Alloc.update_level level) ty
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && level < get_scope ty1 ->
         raise_escape_exn Self
@@ -1236,7 +1296,8 @@ let rec update_level env level expand ty =
         set_level ();
         (* XXX what about abbreviations in Tconstr ? *)
         iter_type_expr_with_stages
-          (fun env -> update_level env level expand) env ty
+          (fun env -> update_level env level expand) env
+          (Mode.Alloc.update_level level) ty
   end
 
 (* First try without expanding, then expand everything,
@@ -1298,12 +1359,15 @@ let rec lower_contravariant env var_level visited contra ty =
           else not_expanded ()
     | Tpackage p ->
         List.iter (fun (_n, ty) -> lower_rec true ty) p.pack_cstrs
-    | Tarrow (_, t1, t2, _) ->
+    | Tarrow ((_, m1, m2), t1, t2, _) ->
+        Mode.Alloc.update_level var_level m1;
+        if contra then Mode.Alloc.update_level var_level m2;
         lower_rec true t1;
         lower_rec contra t2
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> lower_contravariant env var_level visited contra) env ty
+          (fun env -> lower_contravariant env var_level visited contra)
+          env (Fun.const ()) ty
   end
 
 let lower_variables_only env level ty =
@@ -1328,6 +1392,9 @@ let rec generalize_class_type gen =
       gen ty;
       generalize_class_type gen cty
 
+let generalize_class_type_structure cty =
+  generalize_class_type generalize_structure cty
+
 (* Only generalize the type ty0 in ty *)
 let limited_generalize ty0 ~inside:ty =
   let graph = TypeHash.create 17 in
@@ -1343,7 +1410,7 @@ let limited_generalize ty0 ~inside:ty =
           (* XXX: why generic_level needs to be a root *)
           if (level = generic_level) || eq_type ty ty0 then
             roots := ty :: !roots;
-          iter_type_expr (inverse [ty]) ty
+          iter_type_expr (inverse [ty]) (Fun.const ()) ty
         end
   in
 
@@ -1387,7 +1454,7 @@ let rec inv_type hash pty ty =
   with Not_found ->
     let inv = { inv_type = ty; inv_parents = pty } in
     TypeHash.add hash ty inv;
-    iter_type_expr (inv_type hash [inv]) ty
+    iter_type_expr (inv_type hash [inv]) (Fun.const ()) ty
 
 let compute_univars ty =
   let inverted = TypeHash.create 17 in
@@ -1417,7 +1484,8 @@ let fully_generic ty =
   with_type_mark begin fun mark ->
     let rec aux ty =
       if try_mark_node mark ty then
-        if get_level ty = generic_level then iter_type_expr aux ty
+        if get_level ty = generic_level then
+          iter_type_expr aux (Fun.const ()) ty
         else raise Exit
     in
     try aux ty; true with Exit -> false
@@ -1572,7 +1640,11 @@ let rec copy ?partial ?keep_names copy_scope ty =
           Tunivar { name; jkind = Jkind.instance jkind }
       | Tobject (ty1, _) when partial <> None ->
           Tobject (copy ty1, ref None)
-      | _ -> copy_type_desc ?keep_names copy desc
+      | _ ->
+        let copy_mode =
+          For_copy.mode_instantiate copy_scope ~current_level:!current_level
+        in
+        copy_type_desc ?keep_names copy copy_mode desc
     in
     Transient_expr.set_stub_desc t desc';
     t
@@ -1862,7 +1934,11 @@ let copy_sep ~copy_scope ~fixed ~partial ~bound_univars
             Tfield (p, field_kind_internal_repr k,
                     copy_rec ~may_share:true ty1,
                     copy_rec ~may_share:false ty2)
-        | desc -> copy_type_desc (copy_rec ~may_share:true) desc
+        | desc ->
+          let copy_mode =
+            For_copy.mode_instantiate copy_scope ~current_level:!current_level
+          in
+          copy_type_desc (copy_rec ~may_share:true) copy_mode desc
       in
       Transient_expr.set_stub_desc t desc';
       t
@@ -2007,9 +2083,9 @@ let prim_mode' mvars = function
     | None -> assert false
 
 (* Exported version. *)
-let prim_mode mvar prim =
+let prim_mode mvar prim ~level =
   let mvar = Option.map
-    (fun mvar_l -> mvar_l, (Forkable.newvar (), Yielding.newvar ())) mvar
+    (fun mvar_l -> mvar_l, (Forkable.newvar level, Yielding.newvar level)) mvar
   in
   fst (prim_mode' mvar prim)
 
@@ -2019,7 +2095,7 @@ let prim_mode mvar prim =
 let with_locality_and_forkable_yielding (locality, fy) m =
   let forkable = Option.map fst fy in
   let yielding = Option.map snd fy in
-  let m' = Alloc.newvar () in
+  let m' = Alloc.newvar 0 in
   Locality.equate_exn (Alloc.proj_comonadic Areality m') locality;
   let forkable =
     Option.value ~default:(Alloc.proj_comonadic Forkable m) forkable
@@ -2046,7 +2122,12 @@ comonadic axes of [B -> C] reflect that.
 On the other hand, the monadic axes of [fun b -> ...] won't be constrained by
 this (but maybe constrained by other things); therefore, we take it to be legacy
 for compatibility. *)
-let curry_mode alloc arg : Alloc.Const.t =
+let curry_mode (type r)
+    (alloc : (allowed * r) Alloc.Comonadic.t)
+    (arg : Alloc.lr) : Alloc.Comonadic.l =
+  Alloc.Comonadic.join
+    [(Alloc.close_over arg).comonadic; (Alloc.Comonadic.disallow_right alloc)]
+let curry_mode_const alloc arg : Alloc.Const.t =
   let acc =
     Alloc.Comonadic.Const.join
       (Alloc.Const.close_over arg)
@@ -2069,9 +2150,14 @@ let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
      in
      let mret =
        match locals with
-       | [] -> with_locality_and_forkable_yielding (loc, yld) mret
+       | [] ->
+         with_locality_and_forkable_yielding
+           (loc, yld) mret
        | _ :: _ ->
-          let mret', _ = Alloc.newvar_above macc in (* curried arrow *)
+          (* curried arrow *)
+          let mret', _ =
+            Alloc.newvar_above (get_current_level ()) macc
+          in
           mret'
      in
      let ret = instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ret in
@@ -2154,7 +2240,7 @@ let instance_prim_layout env (desc : Primitive.description) ty =
           | None -> ())
         | _ -> ()
         end;
-        iter_type_expr (inner mark) ty
+        iter_type_expr (inner mark) (Fun.const ()) ty
       end
     in
     with_type_mark (fun mark -> inner mark ty);
@@ -2171,8 +2257,8 @@ let instance_prim_mode (desc : Primitive.description) ty =
   let is_poly = function Primitive.Prim_poly, _ -> true | _ -> false in
   if is_poly desc.prim_native_repr_res ||
        List.exists is_poly desc.prim_native_repr_args then
-    let mode_l = Locality.newvar () in
-    let mode_fy = Forkable.newvar (), Yielding.newvar () in
+    let mode_l = Locality.newvar 0 in
+    let mode_fy = Forkable.newvar 0, Yielding.newvar 0 in
     let finalret =
       prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res
     in
@@ -2749,6 +2835,14 @@ let try_expand_safe_opt env ty =
 let expand_head_opt env ty =
   try try_expand_head try_expand_safe_opt env ty with Cannot_expand -> ty
 
+let create_yielding_mode_l yielding =
+  let yielding =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then fst (Yielding.newvar_above 0 yielding)
+    else yielding
+  in
+  Yielding.disallow_right yielding
+
 let prim_params_yielding env ty ~arity =
   let rec arg_yieldings acc ty n =
     if n <= 0 then Some acc
@@ -2763,7 +2857,8 @@ let prim_params_yielding env ty ~arity =
   in
   match arg_yieldings [] ty arity with
   | None | Some [] -> Yielding.disallow_right Yielding.max
-  | Some (_ :: _ as yieldings) -> Yielding.join yieldings
+  | Some (_ :: _ as yieldings) ->
+    create_yielding_mode_l (Yielding.join yieldings)
 
 let is_principal ty =
   not !Clflags.principal || get_level ty = generic_level
@@ -3750,7 +3845,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
         set_type_desc ty (Tunivar {r with jkind = new_jkind})
       | _ -> ()
       end;
-      iter_type_expr (inner mark) ty
+      iter_type_expr (inner mark) (Fun.const ()) ty
     end
   in
   with_type_mark (fun mark -> inner mark ty)
@@ -3828,7 +3923,9 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
         begin try
           if TypeSet.mem ty parents then raise Occur;
           let parents = TypeSet.add ty parents in
-          iter_type_expr (occur_rec env visited allow_recursive parents ty0) ty
+          iter_type_expr
+            (occur_rec env visited allow_recursive parents ty0)
+            (Fun.const ()) ty
         with Occur -> try
           let ty' = try_expand_head try_expand_safe env ty in
           (* This call used to be inlined, but there seems no reason for it.
@@ -3844,7 +3941,8 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
           let parents = TypeSet.add ty parents in
           iter_type_expr_with_stages
             (fun env -> occur_rec env visited allow_recursive parents ty0)
-            env ty
+            env
+            (Fun.const ()) ty
         end
     end;
     ignore (try_mark_node visited ty)
@@ -3914,8 +4012,10 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
           let visited = get_id ty :: visited in
           iter_type_expr_with_stages
             (fun env ->
-              local_non_recursive_abbrev ~allow_rec true visited env p)
-            env ty
+              local_non_recursive_abbrev
+               ~allow_rec true visited env p)
+            env
+            (Fun.const ()) ty
   end
 
 let local_non_recursive_abbrev uenv p ty =
@@ -4039,7 +4139,9 @@ let occur_univar ?(inj_only=false) env ty =
           with Not_found ->
             if not inj_only then List.iter (occur_rec env bound) tl
           end
-      | _ -> iter_type_expr_with_stages (fun env -> occur_rec env bound) env ty
+      | _ ->
+          iter_type_expr_with_stages
+            (fun env -> occur_rec env bound) env (Fun.const ()) ty
   in
   occur_rec env TypeSet.empty ty
   end
@@ -4093,7 +4195,7 @@ let univars_escape env univar_pairs vl ty =
             List.iter (occur env) tl
           end
       | _ ->
-          iter_type_expr_with_stages occur env t
+          iter_type_expr_with_stages occur env (Fun.const ()) t
     end
   in
   occur env ty
@@ -4226,7 +4328,7 @@ let unexpanded_diff ~got ~expected =
 let rec deep_occur_rec mark t0 ty =
   if get_level ty >= get_level t0 && try_mark_node mark ty then begin
     if eq_type ty t0 then raise Occur;
-    iter_type_expr (deep_occur_rec mark t0) ty
+    iter_type_expr (deep_occur_rec mark t0) (Fun.const ()) ty
   end
 
 let deep_occur t0 ty =
@@ -4294,7 +4396,7 @@ let reify uenv t =
           end;
           iter_row iterator r
       | _ ->
-          iter_type_expr iterator ty
+          iter_type_expr iterator (Fun.const ()) ty
     end
   in
   iterator t
@@ -4746,7 +4848,7 @@ let find_lowest_level ty =
       if try_mark_node mark ty then begin
         let level = get_level ty in
         if level < !lowest then lowest := level;
-        iter_type_expr find ty
+        iter_type_expr find (Fun.const ()) ty
       end
     in find ty
   end;
@@ -5823,8 +5925,8 @@ let filter_arrow env t l ~force_tpoly =
       end
     in
     let ty_ret = newvar2 level k_res in
-    let arg_mode = Alloc.newvar () in
-    let ret_mode = Alloc.newvar () in
+    let arg_mode = Alloc.newvar level in
+    let ret_mode = Alloc.newvar level in
     let t' =
       newty2 ~level (Tarrow ((l, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok))
     in
@@ -6261,7 +6363,7 @@ let moregen_occur env level ty =
       let lv = get_level ty in
       if lv <= level then () else
       if is_Tvar ty && lv >= subject_level then raise Occur else
-      if try_mark_node mark ty then iter_type_expr occur ty
+      if try_mark_node mark ty then iter_type_expr occur (Fun.const ()) ty
     in
     try
       occur ty
@@ -6871,7 +6973,7 @@ let rec rigidify_rec mark vars ty =
         if not (static_row row) then
           rigidify_rec mark vars (row_more row)
     | _ ->
-        iter_type_expr (rigidify_rec mark vars) ty
+        iter_type_expr (rigidify_rec mark vars) (Fun.const ()) ty
     end
 
 type var = { name : string option
@@ -7594,13 +7696,13 @@ let find_cltype_for_path env p =
 let has_constr_row' env t =
   has_constr_row (expand_abbrev env t)
 
-let build_submode_pos m =
-  let m', changed = Alloc.newvar_below m in
+let build_submode_pos level m =
+  let m', changed = Alloc.newvar_below level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
-let build_submode_neg m =
-  let m', changed = Alloc.newvar_above m in
+let build_submode_neg level m =
+  let m', changed = Alloc.newvar_above level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
@@ -7633,10 +7735,10 @@ let rec build_subtype env (visited : transient_expr list)
           let posi_arg = not posi in
           if posi_arg then begin
             let a = cross_right_alloc env t1 a in
-            build_submode_pos a
+            build_submode_pos level a
           end else begin
             let a = cross_left_alloc env t1 a in
-            build_submode_neg a
+            build_submode_neg level a
           end
         end else a, Unchanged
       in
@@ -7645,10 +7747,10 @@ let rec build_subtype env (visited : transient_expr list)
           (* As for the argument mode above, pick the smaller type. *)
           if posi then begin
             let r = cross_right_alloc_ret env t2' r in
-            build_submode_pos r
+            build_submode_pos level r
           end else begin
             let r = cross_left_alloc_ret env t2 r in
-            build_submode_neg r
+            build_submode_neg level r
           end
         end else r, Unchanged
       in
@@ -8228,6 +8330,7 @@ let add_nongen_vars_in_schema =
           let (_, unexpanded_candidate) as unexpanded_candidate' =
             fold_type_expr
               (loop env)
+              (fun a _ -> a)
               (visited, weak_set)
               ty
           in
@@ -8259,17 +8362,17 @@ let add_nongen_vars_in_schema =
           then loop env (visited, weak_set) (row_more row)
           else (visited, weak_set)
       | _ ->
-          fold_type_expr (loop env) (visited, weak_set) ty
+          fold_type_expr (loop env) (fun a _ -> a) (visited, weak_set) ty
     end
   in
-  fun env acc ty ->
-    remove_mode_and_jkind_variables ty;
+  fun zap_scope env acc ty ->
+    remove_mode_and_jkind_variables ~zap_scope ty;
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 
 (* Return all non-generic variables of [ty]. *)
-let nongen_vars_in_schema env ty =
-  let result = add_nongen_vars_in_schema env TypeSet.empty ty in
+let nongen_vars_in_schema ~zap_scope env ty =
+  let result = add_nongen_vars_in_schema zap_scope env TypeSet.empty ty in
   if TypeSet.is_empty result
   then None
   else Some result
@@ -8277,44 +8380,45 @@ let nongen_vars_in_schema env ty =
 (* Check that all type variables are generalizable *)
 (* Use Env.empty to prevent expansion of recursively defined object types;
    cf. typing-poly/poly.ml *)
-let nongen_class_type =
-  let add_nongen_vars_in_schema' ty weak_set =
-    add_nongen_vars_in_schema Env.empty weak_set ty
+let nongen_class_type zap_scope =
+  let add_nongen_vars_in_schema' zap_scope ty weak_set =
+    add_nongen_vars_in_schema zap_scope Env.empty weak_set ty
   in
-  let add_nongen_vars_in_schema_fold fold m weak_set =
+  let add_nongen_vars_in_schema_fold fold zap_scope m weak_set =
     let f _key (_,_,ty) weak_set =
-      add_nongen_vars_in_schema Env.empty weak_set ty
+      add_nongen_vars_in_schema zap_scope Env.empty weak_set ty
     in
     fold f m weak_set
   in
-  let rec nongen_class_type cty weak_set =
+  let rec nongen_class_type zap_scope cty weak_set =
     match cty with
     | Cty_constr (_, params, _) ->
         List.fold_left
-          (add_nongen_vars_in_schema Env.empty)
+          (add_nongen_vars_in_schema zap_scope Env.empty)
           weak_set
           params
     | Cty_signature sign ->
         weak_set
-        |> add_nongen_vars_in_schema' sign.csig_self
-        |> add_nongen_vars_in_schema' sign.csig_self_row
-        |> add_nongen_vars_in_schema_fold Meths.fold sign.csig_meths
-        |> add_nongen_vars_in_schema_fold Vars.fold sign.csig_vars
+        |> add_nongen_vars_in_schema' zap_scope sign.csig_self
+        |> add_nongen_vars_in_schema' zap_scope sign.csig_self_row
+        |> add_nongen_vars_in_schema_fold Meths.fold zap_scope sign.csig_meths
+        |> add_nongen_vars_in_schema_fold Vars.fold zap_scope sign.csig_vars
     | Cty_arrow (_, ty, cty) ->
-        add_nongen_vars_in_schema' ty weak_set
-        |> nongen_class_type cty
+        add_nongen_vars_in_schema' zap_scope ty weak_set
+        |> nongen_class_type zap_scope cty
   in
-  nongen_class_type
+  nongen_class_type zap_scope
 
-let nongen_class_declaration cty =
+let nongen_class_declaration zap_scope cty =
   List.fold_left
-    (add_nongen_vars_in_schema Env.empty)
+    (add_nongen_vars_in_schema zap_scope Env.empty)
     TypeSet.empty
     cty.cty_params
-  |> nongen_class_type cty.cty_type
+  |> nongen_class_type zap_scope cty.cty_type
 
 let nongen_vars_in_class_declaration cty =
-  let result = nongen_class_declaration cty in
+  let result = Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+    nongen_class_declaration zap_scope cty) in
   if TypeSet.is_empty result
   then None
   else Some result
@@ -8383,7 +8487,7 @@ let rec normalize_type_rec mark ty =
         set_type_desc fi (get_desc fi')
     | _ -> ()
     end;
-    iter_type_expr (normalize_type_rec mark) ty;
+    iter_type_expr (normalize_type_rec mark) (Fun.const ()) ty;
   end
 
 let normalize_type ty =
@@ -8530,7 +8634,7 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
           (* CR layouts v2.8: This should be done with a proper nondep_jkind.
              Internal ticket 5113. *)
           Tof_kind (Jkind.map_type_expr (nondep_type_rec env ids) jk)
-      | desc -> copy_type_desc (nondep_type_rec env ids) desc
+      | desc -> copy_type_desc (nondep_type_rec env ids) Fun.id desc
     with
     | desc ->
       Transient_expr.set_stub_desc ty' desc;
@@ -8737,7 +8841,8 @@ let rec collapse_conj env visited ty =
         (row_fields row);
       iter_row (collapse_conj env visited) row
   | _ ->
-      iter_type_expr_with_stages (fun env -> collapse_conj env visited) env ty
+      iter_type_expr_with_stages
+        (fun env -> collapse_conj env visited) env (Fun.const ()) ty
 
 let collapse_conj_params env params =
   List.iter (collapse_conj env []) params

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -768,18 +768,13 @@ let remove_mode_and_jkind_variables ~zap_scope ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-<<<<<<< HEAD
-         let _ = Alloc.zap_to_legacy ~arg:true marg in
-         let _ = Alloc.zap_to_legacy ~arg:false mret in
-=======
          if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
-          Alloc.add_mode_to_zap_scope marg zap_scope;
-          Alloc.add_mode_to_zap_scope mret zap_scope
+          Alloc.add_mode_to_zap_scope ~arg:true marg zap_scope;
+          Alloc.add_mode_to_zap_scope ~arg:false mret zap_scope
          end else begin
-          Alloc.zap_to_legacy_force marg |> ignore;
-          Alloc.zap_to_legacy_force mret |> ignore
+          Alloc.zap_to_legacy_force ~arg:true marg |> ignore;
+          Alloc.zap_to_legacy_force ~arg:false mret |> ignore
          end;
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
          go targ; go tret
       | _ -> iter_type_expr go (Fun.const ()) ty
     end

--- a/external/merlin/src/ocaml/typing/ctype.mli
+++ b/external/merlin/src/ocaml/typing/ctype.mli
@@ -613,17 +613,9 @@ val remove_mode_and_jkind_variables:
   zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
-val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
-        (* Return any non-generic variables in the type scheme. Also ensures
-||||||| Compiler:last-imported
-val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
-        (* Return any non-generic variables in the type scheme.  Also ensures
-=======
 val nongen_vars_in_schema:
   zap_scope:Alloc.zap_scope -> Env.t -> type_expr -> Btype.TypeSet.t option
         (* Return any non-generic variables in the type scheme.  Also ensures
->>>>>>> Compiler:HEAD
            mode variables are fully determined. *)
 
 val nongen_vars_in_class_declaration:class_declaration -> Btype.TypeSet.t option

--- a/external/merlin/src/ocaml/typing/ctype.mli
+++ b/external/merlin/src/ocaml/typing/ctype.mli
@@ -38,9 +38,12 @@ val with_local_level_generalize:
     before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 val with_local_level_generalize_if:
         bool -> before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
-val with_local_level_generalize_structure: (unit -> 'a) -> 'a
-val with_local_level_generalize_structure_if: bool -> (unit -> 'a) -> 'a
-val with_local_level_generalize_structure_if_principal: (unit -> 'a) -> 'a
+val with_local_level_generalize_structure:
+    before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
+val with_local_level_generalize_structure_if:
+        bool -> before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
+val with_local_level_generalize_structure_if_principal:
+    before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 val with_local_level_generalize_for_class:
     before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 
@@ -155,7 +158,8 @@ val filter_row_fields:
 
 val contains_initial_stage_splice: int -> type_expr -> bool
 val iter_type_expr_with_stages:
-        (Env.t -> type_expr -> unit) -> Env.t -> type_expr -> unit
+        (Env.t -> type_expr -> unit) -> Env.t -> (Mode.Alloc.lr -> unit)
+        -> type_expr -> unit
 
 val generalize: type_expr -> unit
 (* Generalize in-place the given type *)
@@ -166,8 +170,13 @@ val lower_variables_only: Env.t -> int -> type_expr -> unit
         (* Lower all variables to the given level *)
 val enforce_current_level: Env.t -> type_expr -> unit
         (* Lower whole type to !current_level *)
+val generalize_structure: type_expr -> unit
+        (* Generalize the structure of a type, lowering variables
+           to !current_level *)
 val generalize_class_signature_spine: class_signature -> unit
        (* Special function to generalize methods during inference *)
+val generalize_class_type_structure: class_type -> unit
+        (* Generalize the structure of a class type *)
 val limited_generalize: type_expr -> inside:type_expr -> unit
         (* Only generalize some part of the type
            Make the remaining of the type non-generalizable *)
@@ -271,7 +280,8 @@ val instance_label_declarations:
         (* Same, but for label declarations and the type parameters from the
            type declaration *)
 val prim_mode :
-        (Mode.allowed * 'r) Mode.Locality.t option -> (Primitive.mode * Primitive.native_repr)
+        (Mode.allowed * 'r) Mode.Locality.t option ->
+        (Primitive.mode * Primitive.native_repr) -> level:int
         -> (Mode.allowed * 'r) Mode.Locality.t
 val instance_prim:
         Env.t ->
@@ -279,6 +289,8 @@ val instance_prim:
         type_expr *
         Mode.Locality.lr option * (Mode.Forkable.lr * Mode.Yielding.lr) option *
         Jkind.Sort.t option
+
+val create_yielding_mode_l : Mode.Yielding.l -> Mode.Yielding.l
 
 (** The join of the yielding modes of the first [arity] parameters of a
     primitive of type [ty]; [Yielding.max] if [ty] has fewer arrows. *)
@@ -288,7 +300,13 @@ val prim_params_yielding:
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)
-val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+val curry_mode_const : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+
+(** Applies the same logic as [curry_mode_const] over
+    the comonadic mode for [m0] and the lr mode [m1] *)
+val curry_mode :
+  (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr ->
+  Alloc.Comonadic.l
 
 val apply:
         ?use_current_level:bool ->
@@ -591,11 +609,21 @@ val nondep_jkind_declaration:
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 
-val remove_mode_and_jkind_variables: type_expr -> unit
+val remove_mode_and_jkind_variables:
+  zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
 val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
         (* Return any non-generic variables in the type scheme. Also ensures
+||||||| Compiler:last-imported
+val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
+        (* Return any non-generic variables in the type scheme.  Also ensures
+=======
+val nongen_vars_in_schema:
+  zap_scope:Alloc.zap_scope -> Env.t -> type_expr -> Btype.TypeSet.t option
+        (* Return any non-generic variables in the type scheme.  Also ensures
+>>>>>>> Compiler:HEAD
            mode variables are fully determined. *)
 
 val nongen_vars_in_class_declaration:class_declaration -> Btype.TypeSet.t option
@@ -625,10 +653,14 @@ val closed_type_expr: ?env:Env.t -> type_expr -> bool
         (* If env present, expand abbreviations to see if expansion
            eliminates the variable *)
 
-val closed_type_decl: type_declaration -> type_expr option
-val closed_extension_constructor: extension_constructor -> type_expr option
+val closed_type_decl:
+  zap_scope:Alloc.zap_scope ->
+  type_declaration -> type_expr option
+val closed_extension_constructor:
+  zap_scope:Alloc.zap_scope ->
+  extension_constructor -> type_expr option
 val closed_class:
-        type_expr list -> class_signature ->
+        zap_scope:Alloc.zap_scope -> type_expr list -> class_signature ->
         closed_class_failure option
         (* Check whether all type variables are bound *)
 

--- a/external/merlin/src/ocaml/typing/datarepr.ml
+++ b/external/merlin/src/ocaml/typing/datarepr.ml
@@ -39,7 +39,7 @@ let free_vars ?(param=false) ty =
             end
                 (* XXX: What about Tobject ? *)
         | _ ->
-            iter_type_expr loop ty
+            iter_type_expr loop (Fun.const ()) ty
     in
     loop ty
   end;

--- a/external/merlin/src/ocaml/typing/env.ml
+++ b/external/merlin/src/ocaml/typing/env.ml
@@ -3437,7 +3437,7 @@ let enter_unbound_module name reason env =
 let read_signature modname cmi =
   let mty, mode = read_pers_mod modname cmi in
   (* [mode] read from the cmi is always a constant *)
-  Subst.Lazy.force_signature mty, (Mode.Value.zap_to_floor mode).staticity
+  Subst.Lazy.force_signature mty, (Mode.Value.zap_to_floor_exn mode).staticity
 
 let find_import ~chain modname =
   try Persistent_env.find_import !persistent_env modname

--- a/external/merlin/src/ocaml/typing/includemod.ml
+++ b/external/merlin/src/ocaml/typing/includemod.ml
@@ -793,7 +793,8 @@ and try_modtypes ~core ~direction ~loc env subst ~modes
               | Specific ((m, _locks), _) ->
                 Yielding.disallow_right (Value.proj_comonadic Yielding m)
             in
-            Yielding.join (funct_yielding :: param_yielding)
+            Ctype.create_yielding_mode_l
+              (Yielding.join (funct_yielding :: param_yielding))
           in
           Ok
             (Tcoerce_functor(cc_arg, cc_res, application_yielding),

--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -4406,6 +4406,8 @@ module S = Solver_mono (Hint_for_solver) (C)
 
 let erase_hints () = S.erase_hints ()
 
+let reset_persistent_id () = S.reset_persistent_id ()
+
 type monadic = C.monadic =
   { uniqueness : C.Uniqueness.t;
     contention : C.Contention.t;
@@ -5313,6 +5315,10 @@ let append_changes : (changes ref -> unit) ref = ref (fun _ -> assert false)
 
 let set_append_changes f = append_changes := f
 
+type copy_scope = S.copy_scope
+
+let with_copy_scope = S.with_copy_scope
+
 type ('a, 'd) mode = ('a, 'd) S.mode
 
 module Error = struct
@@ -5448,6 +5454,10 @@ let equate_from_submode' submode m1 m2 =
     | Ok () -> Ok ())
 [@@inline]
 
+exception Cannot_zap_generic
+
+exception Cannot_get_constant_from_generic
+
 module Comonadic_gen (Obj : Obj) = struct
   open Obj
 
@@ -5475,15 +5485,28 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_right m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then level
+    else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.min obj
 
   let max : lr = S.max obj
 
-  let newvar_above m = S.newvar_above obj 0 m
+  let generic_level = S.generic_level
 
-  let newvar_below m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
+
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj a b ~log
@@ -5499,6 +5522,41 @@ module Comonadic_gen (Obj : Obj) = struct
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
   let print_error pp err = Error.print_all pp obj err
+
+  let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize_topology ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_topology ~log:None ~current_level a
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a
+
+  let copy_for_saving ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Save obj a
+
+  let copy_for_restoring ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
   let join l = S.join obj l
 
@@ -5519,14 +5577,42 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let check_const_or_level_0 m = S.check_const_or_level_0 m
 
-  let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
+  let check_generic a = S.check_generic a
 
-  let zap_to_floor m = with_log (S.zap_to_floor obj m)
+  let iter_covariant a iter = S.iter_covariant obj a iter
+
+  let iter_contravariant a iter = S.iter_contravariant obj a iter
+
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
+
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
+
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
 
   let of_const : type l r. ?hint:(l * r) pos Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_generic m then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5544,6 +5630,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
     let get_floor m = S.get_floor obj m
 
@@ -5552,6 +5640,16 @@ module Comonadic_gen (Obj : Obj) = struct
     let get_loose_floor m = S.get_loose_floor obj m
 
     let get_loose_ceil m = S.get_loose_ceil obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj ceil floor then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj floor c && C.le obj c ceil
   end
 end
 [@@inline]
@@ -5584,15 +5682,26 @@ module Monadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_left m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then level
+    else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.allow_left (S.max obj)
 
   let max : lr = S.allow_right (S.min obj)
 
-  let newvar_above m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
-  let newvar_below m = S.newvar_above obj 0 m
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj b a ~log
@@ -5606,6 +5715,43 @@ module Monadic_gen (Obj : Obj) = struct
     match submode ~pp a b with
     | Ok () -> ()
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
+
+  let generic_level = S.generic_level
+
+  let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize_topology ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_topology ~log:None ~current_level a
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a
+
+  let copy_for_saving ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Save obj a
+
+  let copy_for_restoring ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
   let print_error pp err = Error.print_all pp obj err
 
@@ -5628,14 +5774,42 @@ module Monadic_gen (Obj : Obj) = struct
 
   let check_const_or_level_0 m = S.check_const_or_level_0 m
 
-  let zap_to_ceil m = with_log (S.zap_to_floor obj m)
+  let check_generic a = S.check_generic a
 
-  let zap_to_floor m = with_log (S.zap_to_ceil obj m)
+  let iter_covariant a iter = S.iter_contravariant obj a iter
+
+  let iter_contravariant a iter = S.iter_covariant obj a iter
+
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
+
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
+
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
 
   let of_const : type l r. ?hint:(l * r) neg Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_generic m then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5653,8 +5827,22 @@ module Monadic_gen (Obj : Obj) = struct
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
+    let get_floor m = S.get_ceil obj m
+
     let get_ceil m = S.get_floor obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj floor ceil then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj c floor && C.le obj ceil c
   end
 end
 [@@inline]
@@ -5676,7 +5864,7 @@ module Locality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 
   module Guts = struct
     let check_const m =
@@ -5710,7 +5898,7 @@ module Regionality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Linearity = struct
@@ -5730,7 +5918,7 @@ module Linearity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Statefulness = struct
@@ -5754,7 +5942,7 @@ module Statefulness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Visibility = struct
@@ -5778,7 +5966,7 @@ module Visibility = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Portability = struct
@@ -5794,6 +5982,7 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
+<<<<<<< HEAD
   let zap_to_ceil_clamped c m =
     (match submode m (of_const c) with Ok () | Error _ -> ());
     zap_to_ceil m
@@ -5804,6 +5993,15 @@ module Portability = struct
     | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
     | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
     | Statefulness.Const.Stateless -> zap_to_floor m
+=======
+  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
+  let zap_to_legacy_force ~statefulness =
+    match statefulness with
+    | Statefulness.Const.Stateful | Statefulness.Const.Reading
+    | Statefulness.Const.Writing ->
+      zap_to_ceil_force
+    | Statefulness.Const.Stateless -> zap_to_floor_force
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 end
 
 module Uniqueness = struct
@@ -5823,7 +6021,7 @@ module Uniqueness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Contention = struct
@@ -5839,18 +6037,28 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
+<<<<<<< HEAD
   let zap_to_floor_clamped c m =
     (match submode (of_const c) m with Ok () | Error _ -> ());
     zap_to_floor m
 
   let zap_to_legacy ~visibility ~arg m =
+=======
+  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
+  let zap_to_legacy_force ~visibility =
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     match visibility with
     | Visibility.Const.Read_write -> zap_to_floor m
     | Visibility.Const.Immutable -> zap_to_ceil m
     | Visibility.Const.Read ->
       if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
     | Visibility.Const.Write ->
+<<<<<<< HEAD
       if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
+=======
+      zap_to_floor_force
+    | Visibility.Const.Immutable -> zap_to_ceil_force
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 end
 
 module Forkable = struct
@@ -5871,9 +6079,9 @@ module Forkable = struct
   let legacy = of_const Const.legacy
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Yielding = struct
@@ -5894,9 +6102,9 @@ module Yielding = struct
   let legacy = of_const Const.legacy
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Staticity = struct
@@ -5916,7 +6124,7 @@ module Staticity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module type Areality = sig
@@ -5924,7 +6132,8 @@ module type Areality = sig
 
   module Obj : Obj with type const = Const.t
 
-  val zap_to_legacy : (Const.t, allowed * 'r) S.mode -> Const.t
+  val zap_to_legacy_force :
+    ?commit:bool -> (Const.t, allowed * 'r) S.mode -> Const.t
 end
 
 module Lattice_Product (L : Lattice) = struct
@@ -6039,16 +6248,23 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy m : Const.t =
-    let areality = proj Areality m |> Areality.zap_to_legacy in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy in
-    let statefulness = proj Statefulness m |> Statefulness.zap_to_legacy in
+  let zap_to_legacy_force ?commit m : Const.t =
+    let areality = proj Areality m |> Areality.zap_to_legacy_force ?commit in
+    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force ?commit in
+    let statefulness =
+      proj Statefulness m |> Statefulness.zap_to_legacy_force ?commit
+    in
     let portability =
-      proj Portability m |> Portability.zap_to_legacy ~statefulness
+      proj Portability m
+      |> Portability.zap_to_legacy_force ?commit ~statefulness
     in
     let global = Areality.Const.equal areality Areality.Const.legacy in
-    let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
+    let forkable =
+      proj Forkable m |> Forkable.zap_to_legacy_force ?commit ~global
+    in
+    let yielding =
+      proj Yielding m |> Yielding.zap_to_legacy_force ?commit ~global
+    in
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
@@ -6191,13 +6407,25 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
+<<<<<<< HEAD
   let zap_to_legacy ~arg m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let visibility = proj Visibility m |> Visibility.zap_to_legacy in
     let contention =
       proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
+=======
+  let zap_to_legacy_force ?commit m : Const.t =
+    let uniqueness =
+      proj Uniqueness m |> Uniqueness.zap_to_legacy_force ?commit
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     in
-    let staticity = proj Staticity m |> Staticity.zap_to_legacy in
+    let visibility =
+      proj Visibility m |> Visibility.zap_to_legacy_force ?commit
+    in
+    let contention =
+      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility
+    in
+    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }
 
   let legacy = of_const Const.legacy
@@ -6569,6 +6797,40 @@ module Value_with (Areality : Areality) = struct
           visibility
           (option_print Staticity.Const.print)
           staticity
+
+      let partial_print ppf
+          { areality;
+            uniqueness;
+            linearity;
+            portability;
+            contention;
+            forkable;
+            yielding;
+            statefulness;
+            visibility;
+            staticity
+          } =
+        let option_to_string print a =
+          Option.map (fun a -> Fmt.asprintf "%a" print a) a
+        in
+        let l =
+          [ option_to_string Areality.Const.print areality;
+            option_to_string Linearity.Const.print linearity;
+            option_to_string Uniqueness.Const.print uniqueness;
+            option_to_string Portability.Const.print portability;
+            option_to_string Contention.Const.print contention;
+            option_to_string Forkable.Const.print forkable;
+            option_to_string Yielding.Const.print yielding;
+            option_to_string Statefulness.Const.print statefulness;
+            option_to_string Visibility.Const.print visibility;
+            option_to_string Staticity.Const.print staticity ]
+        in
+        let l = List.filter_map Fun.id l in
+        Fmt.fprintf ppf "%a"
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf " ")
+             (fun ppf s -> Fmt.fprintf ppf "%s" s))
+          l
     end
 
     let diff m1 m2 =
@@ -6646,9 +6908,116 @@ module Value_with (Areality : Areality) = struct
     let merge = merge
   end
 
+  module C = C
+  module Desc = S.Desc
+
+  let obj_monadic = Monadic.Obj.obj
+
+  let obj_comonadic = Comonadic.Obj.obj
+
+  let get_monadic_desc m = Monadic.desc m
+
+  let get_comonadic_desc m = Comonadic.desc m
+
+  let meet_const_morph a = C.Simple (C.Simple_morph.Meet_const a)
+
+  (* only print the interesting parts of the monadic meet; omit max (min due to
+      flipping of Monadic axis) modes *)
+  let monadic_meet_atoms c =
+    let c = merge { monadic = c; comonadic = Comonadic.Const.min } in
+    Const.diff c Const.min
+
+  (* only print the interesting parts of the meet; omit max modes *)
+  let comonadic_meet_atoms c =
+    let c = merge { monadic = Monadic.Const.max; comonadic = c } in
+    Const.diff c Const.max
+
+  let pretty_print_mod : type a.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      Const.Option.t ->
+      unit =
+   fun printm m ppf atoms ->
+    if atoms = Const.Option.none
+    then Fmt.fprintf ppf "%a" printm m
+    else Fmt.fprintf ppf "%a mod %a" printm m Const.Option.partial_print atoms
+
+  let pretty_print_monadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c ->
+      pretty_print_mod printm m ppf (monadic_meet_atoms c)
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_monadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_monadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c ->
+      pretty_print_mod printm m ppf (comonadic_meet_atoms c)
+    | C.Simple_morph.Core C.Core_morph.Monadic_op_to_comonadic_min ->
+      Fmt.fprintf ppf "close(%a)" printm m
+    | C.Simple_morph.Meet_const_core
+        (c, C.Core_morph.Monadic_op_to_comonadic_min) ->
+      (* since the meet is applied to a monadic_to_comonadic_min, we filter out the
+      comonadic only axes *)
+      let c : Comonadic.Const.t =
+        { c with
+          areality = Areality.Const.max;
+          forkable = Forkable.Const.max;
+          yielding = Yielding.Const.max
+        }
+      in
+      pretty_print_mod
+        (fun ppf m -> Fmt.fprintf ppf "close(%a)" printm m)
+        m ppf (comonadic_meet_atoms c)
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_comonadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_comonadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_comonadic) f printm m
+  [@@warning "-4"]
+
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
+
+  let generic_level = Comonadic.generic_level
 
   include Magic_allow_disallow (struct
     type (_, _, 'd) sided = 'd t
@@ -6674,19 +7043,19 @@ module Value_with (Areality : Areality) = struct
       { monadic; comonadic }
   end)
 
-  let newvar () =
-    let comonadic = Comonadic.newvar () in
-    let monadic = Monadic.newvar () in
+  let newvar level =
+    let comonadic = Comonadic.newvar level in
+    let monadic = Monadic.newvar level in
     { comonadic; monadic }
 
-  let newvar_above { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_above comonadic in
-    let monadic, b2 = Monadic.newvar_above monadic in
+  let newvar_above level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_above level comonadic in
+    let monadic, b2 = Monadic.newvar_above level monadic in
     { monadic; comonadic }, b1 || b2
 
-  let newvar_below { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_below comonadic in
-    let monadic, b2 = Monadic.newvar_below monadic in
+  let newvar_below level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_below level comonadic in
+    let monadic, b2 = Monadic.newvar_below level monadic in
     { monadic; comonadic }, b1 || b2
 
   type atom = Atom : 'a Axis.t * 'a -> atom
@@ -6732,6 +7101,54 @@ module Value_with (Areality : Areality) = struct
   let submode_err pp a b =
     Comonadic.submode_err pp a.comonadic b.comonadic;
     Monadic.submode_err pp a.monadic b.monadic
+
+  let update_level i { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.update_level i monadic0;
+    Comonadic.update_level i comonadic0
+
+  let generalize_topology ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_topology ~current_level monadic0;
+    Comonadic.generalize_topology ~current_level comonadic0
+
+  let generalize ~current_level { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize ~current_level monadic0;
+    Comonadic.generalize ~current_level comonadic0
+
+  let generalize_structure ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_structure ~current_level monadic0;
+    Comonadic.generalize_structure ~current_level comonadic0
+
+  let instantiate ~copy_scope ~current_level
+      ({ monadic = monadic0; comonadic = comonadic0 } as m) =
+    let monadic1 = Monadic.instantiate ~copy_scope ~current_level monadic0 in
+    let comonadic1 =
+      Comonadic.instantiate ~copy_scope ~current_level comonadic0
+    in
+    if monadic1 == monadic0 && comonadic1 == comonadic0
+    then m
+    else { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_generic ~copy_scope { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_generic ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_generic ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_for_saving ~copy_scope { monadic = monadic0; comonadic = comonadic0 }
+      =
+    let monadic1 = Monadic.copy_for_saving ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_for_saving ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_for_restoring ~copy_scope
+      { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_for_restoring ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_for_restoring ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let check_generic { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_generic monadic0 || Comonadic.check_generic comonadic0
 
   let equate_err pp a b =
     Comonadic.equate_err pp a.comonadic b.comonadic;
@@ -6828,20 +7245,266 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
-  let zap_to_ceil { comonadic; monadic } =
-    let monadic = Monadic.zap_to_ceil monadic in
-    let comonadic = Comonadic.zap_to_ceil comonadic in
+  let zap_to_ceil_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_ceil_force monadic in
+    let comonadic = Comonadic.zap_to_ceil_force comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_floor { comonadic; monadic } =
-    let monadic = Monadic.zap_to_floor monadic in
-    let comonadic = Comonadic.zap_to_floor comonadic in
+  let zap_to_floor_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_floor_force monadic in
+    let comonadic = Comonadic.zap_to_floor_force comonadic in
     merge { monadic; comonadic }
 
+<<<<<<< HEAD
   let zap_to_legacy ~arg { comonadic; monadic } =
     let monadic = Monadic.zap_to_legacy ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy comonadic in
+=======
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
+
+  let zap_to_legacy_force ?commit { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ?commit monadic in
+    let comonadic = Comonadic.zap_to_legacy_force ?commit comonadic in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     merge { monadic; comonadic }
+
+  let zap_to_legacy_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_legacy_force m
+
+  let zap_to_legacy m =
+    if check_generic m then None else Some (zap_to_legacy_force m)
+
+  let zap_to_legacy_obj : type a.
+      a C.obj -> (a, allowed * allowed) S.mode -> unit =
+   fun obj mode ->
+    match (obj : a C.obj) with
+    | Locality -> Locality.zap_to_legacy_force mode |> ignore
+    | Regionality -> Regionality.zap_to_legacy_force mode |> ignore
+    | Uniqueness_op -> Uniqueness.zap_to_legacy_force mode |> ignore
+    | Visibility_op -> Visibility.zap_to_legacy_force mode |> ignore
+    | Linearity -> Linearity.zap_to_legacy_force mode |> ignore
+    | Statefulness -> Statefulness.zap_to_legacy_force mode |> ignore
+    | Staticity_op -> Staticity.zap_to_legacy_force mode |> ignore
+    | Monadic_op -> Monadic.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_regionality ->
+      let module M = Comonadic_with (Regionality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_locality ->
+      let module M = Comonadic_with (Locality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Portability ->
+      Portability.zap_to_legacy_force ~statefulness:Statefulness.Const.legacy
+        mode
+      |> ignore
+    | Contention_op ->
+      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy mode
+      |> ignore
+    | Forkable -> Forkable.zap_to_legacy_force ~global:true mode |> ignore
+    | Yielding -> Yielding.zap_to_legacy_force ~global:true mode |> ignore
+
+  let zap_to_legacy_src_var_monadic m =
+    S.mode_iter Monadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  let zap_to_legacy_src_var_comonadic m =
+    S.mode_iter Comonadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  module Zap_scope = struct
+    module ModeIdMap = Hashtbl.Make (Int)
+
+    type 'd packed_mode =
+      | Pco of 'd Comonadic.t
+      | Pmon of 'd Monadic.t
+
+    let disallow_left : type l r.
+        (l * r) packed_mode -> (disallowed * r) packed_mode = function
+      | Pco m -> Pco (Comonadic.disallow_left m)
+      | Pmon m -> Pmon (Monadic.disallow_left m)
+
+    let disallow_right : type l r.
+        (l * r) packed_mode -> (l * disallowed) packed_mode = function
+      | Pco m -> Pco (Comonadic.disallow_right m)
+      | Pmon m -> Pmon (Monadic.disallow_right m)
+
+    type packed_morph =
+      | Pmorph_mon : ('a, Monadic.Obj.const, 'd) C.morph -> packed_morph
+      | Pmorph_co : ('a, Comonadic.Obj.const, 'd) C.morph -> packed_morph
+
+    let morph_key_mon (S.Packed_morph f) = Pmorph_mon f
+
+    let morph_key_co (S.Packed_morph f) = Pmorph_co f
+
+    module MorphMap = Map.Make (struct
+      type t = packed_morph
+
+      let compare k1 k2 =
+        match k1, k2 with
+        | Pmorph_mon m1, Pmorph_mon m2 -> C.compare_morph Monadic.Obj.obj m1 m2
+        | Pmorph_co m1, Pmorph_co m2 -> C.compare_morph Comonadic.Obj.obj m1 m2
+        | Pmorph_mon _, Pmorph_co _ -> -1
+        | Pmorph_co _, Pmorph_mon _ -> 1
+    end)
+
+    type zap_scope =
+      { zap_to_floor_map :
+          (allowed * disallowed) packed_mode MorphMap.t ModeIdMap.t;
+        zap_to_ceil_map :
+          (disallowed * allowed) packed_mode MorphMap.t ModeIdMap.t;
+        zap_to_legacy_map : (disallowed * disallowed) packed_mode ModeIdMap.t
+      }
+
+    let create () =
+      { zap_to_floor_map = ModeIdMap.create 17;
+        zap_to_ceil_map = ModeIdMap.create 17;
+        zap_to_legacy_map = ModeIdMap.create 17
+      }
+
+    let add_to_morph_map map id morph mode =
+      let morphs =
+        match ModeIdMap.find_opt map id with
+        | Some morphs -> morphs
+        | None -> MorphMap.empty
+      in
+      ModeIdMap.replace map id (MorphMap.add morph mode morphs)
+
+    let add_zap_to_floor_to_zap_scope i k p zs =
+      if ModeIdMap.mem zs.zap_to_legacy_map i
+      then ()
+      else
+        begin if ModeIdMap.mem zs.zap_to_ceil_map i
+        then begin
+          ModeIdMap.remove zs.zap_to_ceil_map i;
+          ModeIdMap.add zs.zap_to_legacy_map i (disallow_left p)
+        end
+        else add_to_morph_map zs.zap_to_floor_map i k p
+        end
+
+    let add_zap_to_ceil_to_zap_scope i k p zs =
+      if ModeIdMap.mem zs.zap_to_legacy_map i
+      then ()
+      else
+        begin if ModeIdMap.mem zs.zap_to_floor_map i
+        then begin
+          ModeIdMap.remove zs.zap_to_floor_map i;
+          ModeIdMap.add zs.zap_to_legacy_map i (disallow_right p)
+        end
+        else add_to_morph_map zs.zap_to_ceil_map i k p
+        end
+
+    let resolve_zap_scope
+        { zap_to_floor_map; zap_to_ceil_map; zap_to_legacy_map } =
+      ModeIdMap.iter
+        (fun _ p ->
+          match p with
+          | Pmon m -> zap_to_legacy_src_var_monadic m
+          | Pco m -> zap_to_legacy_src_var_comonadic m)
+        zap_to_legacy_map;
+      ModeIdMap.iter
+        (fun _ mm ->
+          MorphMap.iter
+            (fun _ p ->
+              match p with
+              | Pmon m -> Monadic.zap_to_floor_force m |> ignore
+              | Pco m -> Comonadic.zap_to_floor_force m |> ignore)
+            mm)
+        zap_to_floor_map;
+      ModeIdMap.iter
+        (fun _ mm ->
+          MorphMap.iter
+            (fun _ p ->
+              match p with
+              | Pmon m -> Monadic.zap_to_ceil_force m |> ignore
+              | Pco m -> Comonadic.zap_to_ceil_force m |> ignore)
+            mm)
+        zap_to_ceil_map
+  end
+
+  module Z = Zap_scope
+
+  type zap_scope =
+    { variables : Z.zap_scope;
+      visible : (allowed * allowed) t list ref
+    }
+
+  let add_covariant_to_zap_scope { monadic; comonadic } scope =
+    let comonadic_upper =
+      Comonadic.Guts.get_floor comonadic |> Comonadic.of_const
+    in
+    let monadic_upper = Monadic.Guts.get_floor monadic |> Monadic.of_const in
+    Monadic.iter_covariant monadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_floor_to_zap_scope id (Z.morph_key_mon morph)
+            (Z.Pmon (Monadic.join [monadic_upper; m]))
+            scope);
+    Comonadic.iter_covariant comonadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_floor_to_zap_scope id (Z.morph_key_co morph)
+            (Z.Pco (Comonadic.join [comonadic_upper; m]))
+            scope)
+
+  let add_contravariant_to_zap_scope { monadic; comonadic } scope =
+    let comonadic_upper =
+      Comonadic.Guts.get_ceil comonadic |> Comonadic.of_const
+    in
+    let monadic_lower = Monadic.Guts.get_ceil monadic |> Monadic.of_const in
+    Monadic.iter_contravariant monadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_ceil_to_zap_scope id (Z.morph_key_mon morph)
+            (Z.Pmon (Monadic.meet [monadic_lower; m]))
+            scope);
+    Comonadic.iter_contravariant comonadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_ceil_to_zap_scope id (Z.morph_key_co morph)
+            (Z.Pco (Comonadic.meet [comonadic_upper; m]))
+            scope)
+
+  let add_mode_to_zap_scope m { visible } = visible := m :: !visible
+
+  let resolve_zap_scope { variables; visible } =
+    (* we first zap all visible non generic modes to legacy *)
+    List.iter (fun m -> zap_to_legacy m |> ignore) !visible;
+    (* we then iterate over the children of visible generic modes and zap level 0
+    according to the following rules:
+    1) if a mode appears only as an upper bound to generic modes, it is zapped to
+      ceiling
+    2) if a mode appears only as a lower bound to generic modes, it is zapped to
+      floor
+    3) if it appears as both, it is zapped to legacy *)
+    List.iter
+      (fun m ->
+        if check_generic m
+        then begin
+          add_covariant_to_zap_scope m variables;
+          add_contravariant_to_zap_scope m variables
+        end)
+      !visible;
+    Z.resolve_zap_scope variables
+
+  let create_zap_scope () = { variables = Z.create (); visible = ref [] }
+
+  let with_zap_scope f =
+    let zap_scope = create_zap_scope () in
+    let res = f ~zap_scope in
+    resolve_zap_scope zap_scope;
+    res
 
   (** This is about partially applying [A -> B -> C] to [A] and getting
       [B -> C]. [comonadic] and [monadic] constutute the mode of [A], and we
@@ -6881,6 +7544,25 @@ module Value_with (Areality : Areality) = struct
 
       let disallow_right l = List.map disallow_right l
     end)
+  end
+
+  module Guts = struct
+    let check_const { monadic; comonadic } =
+      let open Misc.Stdlib.Monad.Option.Syntax in
+      let* monadic = Monadic.Guts.check_const monadic in
+      let* comonadic = Comonadic.Guts.check_const comonadic in
+      Some (merge { comonadic; monadic })
+
+    let get_ceil { monadic; comonadic } =
+      let monadic = Monadic.Guts.get_ceil monadic in
+      let comonadic = Comonadic.Guts.get_ceil comonadic in
+      merge { monadic; comonadic }
+
+    let in_bounds c { monadic; comonadic } =
+      let c = split c in
+      let monadic = Monadic.Guts.in_bounds c.monadic monadic in
+      let comonadic = Comonadic.Guts.in_bounds c.comonadic comonadic in
+      monadic && comonadic
   end
 end
 [@@inline]
@@ -7182,7 +7864,7 @@ module Modality = struct
            [mm] to construct the floor of [c]. *)
         let cc = Mode.Guts.get_ceil mm in
         let c = Mode.subtract_const cc m in
-        let c = Mode.zap_to_floor c in
+        let c = Mode.zap_to_floor_exn c in
         (* Note that we did not mutate [mm] but simply took its ceil, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7370,7 +8052,7 @@ module Modality = struct
            construct the ceil of [c]. *)
         let cc = Mode.Guts.get_floor mm in
         let c = Mode.imply_const cc m in
-        let c = Mode.zap_to_ceil c in
+        let c = Mode.zap_to_ceil_exn c in
         (* Note that we did not mutate [mm] but simply took its floor, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7395,8 +8077,8 @@ module Modality = struct
            good workaround. *)
         (* CR zqian: Find a better solution *)
         Mode.submode mm Mode.legacy |> ignore;
-        let m = Mode.zap_to_floor m in
-        let mm = Mode.zap_to_ceil mm in
+        let m = Mode.zap_to_floor_exn m in
+        let mm = Mode.zap_to_ceil_exn mm in
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 

--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -5982,26 +5982,18 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-<<<<<<< HEAD
-  let zap_to_ceil_clamped c m =
+  let zap_to_ceil_clamped_force ?commit c m =
     (match submode m (of_const c) with Ok () | Error _ -> ());
-    zap_to_ceil m
+    zap_to_ceil_force ?commit m
 
-  let zap_to_legacy ~statefulness m =
+  let zap_to_legacy_force ?commit ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful -> zap_to_ceil m
-    | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
-    | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
-    | Statefulness.Const.Stateless -> zap_to_floor m
-=======
-  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
-  let zap_to_legacy_force ~statefulness =
-    match statefulness with
-    | Statefulness.Const.Stateful | Statefulness.Const.Reading
+    | Statefulness.Const.Stateful -> zap_to_ceil_force ?commit m
+    | Statefulness.Const.Reading ->
+      zap_to_ceil_clamped_force ?commit Const.Shareable m
     | Statefulness.Const.Writing ->
-      zap_to_ceil_force
-    | Statefulness.Const.Stateless -> zap_to_floor_force
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+      zap_to_ceil_clamped_force ?commit Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor_force ?commit m
 end
 
 module Uniqueness = struct
@@ -6037,28 +6029,22 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-<<<<<<< HEAD
-  let zap_to_floor_clamped c m =
+  let zap_to_floor_clamped_force ?commit c m =
     (match submode (of_const c) m with Ok () | Error _ -> ());
-    zap_to_floor m
+    zap_to_floor_force ?commit m
 
-  let zap_to_legacy ~visibility ~arg m =
-=======
-  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
-  let zap_to_legacy_force ~visibility =
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+  let zap_to_legacy_force ?commit ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write -> zap_to_floor m
-    | Visibility.Const.Immutable -> zap_to_ceil m
+    | Visibility.Const.Read_write -> zap_to_floor_force ?commit m
+    | Visibility.Const.Immutable -> zap_to_ceil_force ?commit m
     | Visibility.Const.Read ->
-      if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
+      if arg
+      then zap_to_floor_clamped_force ?commit Const.Shared m
+      else zap_to_floor_force ?commit m
     | Visibility.Const.Write ->
-<<<<<<< HEAD
-      if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
-=======
-      zap_to_floor_force
-    | Visibility.Const.Immutable -> zap_to_ceil_force
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+      if arg
+      then zap_to_floor_clamped_force ?commit Const.Corrupted m
+      else zap_to_floor_force ?commit m
 end
 
 module Forkable = struct
@@ -6080,8 +6066,10 @@ module Forkable = struct
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
      or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
-  let zap_to_legacy_force ~global =
-    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
+  let zap_to_legacy_force ?commit ~global =
+    match global with
+    | true -> zap_to_floor_force ?commit
+    | false -> zap_to_ceil_force ?commit
 end
 
 module Yielding = struct
@@ -6103,8 +6091,10 @@ module Yielding = struct
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
      or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
-  let zap_to_legacy_force ~global =
-    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
+  let zap_to_legacy_force ?commit ~global =
+    match global with
+    | true -> zap_to_floor_force ?commit
+    | false -> zap_to_ceil_force ?commit
 end
 
 module Staticity = struct
@@ -6407,23 +6397,16 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-<<<<<<< HEAD
-  let zap_to_legacy ~arg m : Const.t =
-    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
-    let visibility = proj Visibility m |> Visibility.zap_to_legacy in
-    let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
-=======
-  let zap_to_legacy_force ?commit m : Const.t =
+  let zap_to_legacy_force ?commit ~arg m : Const.t =
     let uniqueness =
       proj Uniqueness m |> Uniqueness.zap_to_legacy_force ?commit
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     in
     let visibility =
       proj Visibility m |> Visibility.zap_to_legacy_force ?commit
     in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility
+      proj Contention m
+      |> Contention.zap_to_legacy_force ?commit ~visibility ~arg
     in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }
@@ -7255,11 +7238,6 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.zap_to_floor_force comonadic in
     merge { monadic; comonadic }
 
-<<<<<<< HEAD
-  let zap_to_legacy ~arg { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy ~arg monadic in
-    let comonadic = Comonadic.zap_to_legacy comonadic in
-=======
   let zap_to_ceil_exn m =
     if check_generic m then raise Cannot_zap_generic;
     zap_to_ceil_force m
@@ -7274,18 +7252,17 @@ module Value_with (Areality : Areality) = struct
   let zap_to_ceil m =
     if check_generic m then None else Some (zap_to_ceil_force m)
 
-  let zap_to_legacy_force ?commit { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy_force ?commit monadic in
+  let zap_to_legacy_force ?commit ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ?commit ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy_force ?commit comonadic in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     merge { monadic; comonadic }
 
-  let zap_to_legacy_exn m =
+  let zap_to_legacy_exn ~arg m =
     if check_generic m then raise Cannot_zap_generic;
-    zap_to_legacy_force m
+    zap_to_legacy_force ~arg m
 
-  let zap_to_legacy m =
-    if check_generic m then None else Some (zap_to_legacy_force m)
+  let zap_to_legacy ~arg m =
+    if check_generic m then None else Some (zap_to_legacy_force ~arg m)
 
   let zap_to_legacy_obj : type a.
       a C.obj -> (a, allowed * allowed) S.mode -> unit =
@@ -7298,7 +7275,7 @@ module Value_with (Areality : Areality) = struct
     | Linearity -> Linearity.zap_to_legacy_force mode |> ignore
     | Statefulness -> Statefulness.zap_to_legacy_force mode |> ignore
     | Staticity_op -> Staticity.zap_to_legacy_force mode |> ignore
-    | Monadic_op -> Monadic.zap_to_legacy_force mode |> ignore
+    | Monadic_op -> Monadic.zap_to_legacy_force ~arg:false mode |> ignore
     | Comonadic_with_regionality ->
       let module M = Comonadic_with (Regionality) in
       M.zap_to_legacy_force mode |> ignore
@@ -7310,7 +7287,8 @@ module Value_with (Areality : Areality) = struct
         mode
       |> ignore
     | Contention_op ->
-      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy mode
+      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy
+        ~arg:false mode
       |> ignore
     | Forkable -> Forkable.zap_to_legacy_force ~global:true mode |> ignore
     | Yielding -> Yielding.zap_to_legacy_force ~global:true mode |> ignore
@@ -7437,7 +7415,7 @@ module Value_with (Areality : Areality) = struct
 
   type zap_scope =
     { variables : Z.zap_scope;
-      visible : (allowed * allowed) t list ref
+      visible : (bool * (allowed * allowed) t) list ref
     }
 
   let add_covariant_to_zap_scope { monadic; comonadic } scope =
@@ -7476,11 +7454,11 @@ module Value_with (Areality : Areality) = struct
             (Z.Pco (Comonadic.meet [comonadic_upper; m]))
             scope)
 
-  let add_mode_to_zap_scope m { visible } = visible := m :: !visible
+  let add_mode_to_zap_scope ~arg m { visible } = visible := (arg, m) :: !visible
 
   let resolve_zap_scope { variables; visible } =
     (* we first zap all visible non generic modes to legacy *)
-    List.iter (fun m -> zap_to_legacy m |> ignore) !visible;
+    List.iter (fun (arg, m) -> zap_to_legacy ~arg m |> ignore) !visible;
     (* we then iterate over the children of visible generic modes and zap level 0
     according to the following rules:
     1) if a mode appears only as an upper bound to generic modes, it is zapped to
@@ -7489,7 +7467,7 @@ module Value_with (Areality : Areality) = struct
       floor
     3) if it appears as both, it is zapped to legacy *)
     List.iter
-      (fun m ->
+      (fun (_, m) ->
         if check_generic m
         then begin
           add_covariant_to_zap_scope m variables;

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -998,6 +998,8 @@ module type S = sig
 
     val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
 
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
+
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -128,7 +128,9 @@ module type Common = sig
 
   val legacy : lr
 
-  val newvar : unit -> ('l * 'r) t
+  val generic_level : int
+
+  val newvar : int -> ('l * 'r) t
 
   (* How to submode
 
@@ -170,6 +172,14 @@ module type Common = sig
   val submode_err :
     Mode_hint.pinpoint -> (allowed * 'r) t -> ('l * allowed) t -> unit
 
+  val update_level : int -> ('l * 'r) t -> unit
+
+  val generalize_topology : current_level:int -> ('l * 'r) t -> unit
+
+  val generalize : current_level:int -> ('l * 'r) t -> unit
+
+  val generalize_structure : current_level:int -> ('l * 'r) t -> unit
+
   (** Similar to [submode_err], but checks the two modes are equal by submoding
       in both directions. *)
   val equate_err : Mode_hint.pinpoint -> lr -> lr -> unit
@@ -187,18 +197,33 @@ module type Common = sig
 
   val meet : ('l * allowed) t list -> right_only t
 
-  val newvar_above : (allowed * 'r) t -> ('l * 'r_) t * bool
+  val newvar_above : int -> (allowed * 'r) t -> ('l * 'r_) t * bool
 
-  val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
+  val newvar_below : int -> ('l * allowed) t -> ('l_ * 'r) t * bool
 
   (** Returns true if the mode is a constant or a mode variable at level 0 *)
   val check_const_or_level_0 : ('l * 'r) t -> bool
 
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
-  val zap_to_ceil : ('l * allowed) t -> Const.t
+  (** Returns true if the mode includes a mode variable at generic level *)
+  val check_generic : ('l * 'r) t -> bool
 
-  val zap_to_floor : (allowed * 'r) t -> Const.t
+  (** zaps non-generic variables to ceil, raises a [Cannot_zap_generic] excetion
+      if variable is generic *)
+  val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+  (** zaps non-generic variables to floor, raises a [Cannot_zap_generic]
+      excetion if variable is generic *)
+  val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+  (** zaps non-generic variables to ceil, returns [None] if variable is generic.
+  *)
+  val zap_to_ceil : ('l * allowed) t -> Const.t option
+
+  (** zaps non-generic variables to floor, returns [None] if variable is
+      generic. *)
+  val zap_to_floor : (allowed * 'r) t -> Const.t option
 end
 
 module type Common_axis = sig
@@ -328,6 +353,10 @@ module type S = sig
       on [erase_hint] in [Solver_intf] for details. *)
   val erase_hints : unit -> unit
 
+  (** Resets the counter allocating the (negative) ids of persistent copies of
+      mode variables. (see [Subst.reset_additional_action_id]). *)
+  val reset_persistent_id : unit -> unit
+
   module Hint = Mode_hint
 
   (** Prints a [pinpoint]. Say "a foo" if [definite] is [false], say "the foo"
@@ -349,6 +378,10 @@ module type S = sig
   val undo_changes : changes -> unit
 
   val set_append_changes : (changes ref -> unit) -> unit
+
+  type copy_scope
+
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
 
   type nonrec allowed = allowed
 
@@ -659,6 +692,12 @@ module type S = sig
         val zap_to_ceil : 'a Axis.t -> ('a, 'l * allowed) mode -> 'a
       end
 
+      module Guts : sig
+        (** Returns the precise floor of a mode. see notes on [get_floor] in
+            [solver_intf.mli] for cautions. *)
+        val get_floor : (allowed * 'r) t -> Const.t
+      end
+
       val max_with : 'a Axis.t -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
     end
 
@@ -726,6 +765,8 @@ module type S = sig
         val proj : 'a Axis.t -> t -> 'a option
 
         val set : 'a Axis.t -> 'a option -> t -> t
+
+        val partial_print : Fmt.formatter -> t -> unit
       end
 
       val is_max : 'a Axis.t -> 'a -> bool
@@ -768,6 +809,123 @@ module type S = sig
     type simple_error = Error : 'a Axis.t * 'a simple_axerror -> simple_error
 
     type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
+
+    (** Scope containing pending zap jobs *)
+    type zap_scope
+
+    val with_zap_scope : (zap_scope:zap_scope -> 'a) -> 'a
+
+    val create_zap_scope : unit -> zap_scope
+
+    val resolve_zap_scope : zap_scope -> unit
+
+    (** Exposed subset of the monotone Lattices interface *)
+    module C : sig
+      type ('a, 'b, 'd) morph
+
+      type 'a obj
+
+      val le : 'a obj -> 'a -> 'a -> bool
+
+      val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.is_eq
+
+      val src : 'b obj -> ('a, 'b, 'd) morph -> 'a obj
+
+      val id : ('a, 'a, 'd) morph
+
+      val compose :
+        'c obj -> ('b, 'c, 'd) morph -> ('a, 'b, 'd) morph -> ('a, 'c, 'd) morph
+
+      val equal_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        ('a0, 'a1) Misc.is_eq
+
+      val compare_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        int
+
+      val left_adjoint :
+        'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
+
+      val disallow_right :
+        ('a, 'b, 'l * 'r) morph -> ('a, 'b, 'l * disallowed) morph
+
+      val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
+
+      val print_morph : 'b obj -> Fmt.formatter -> ('a, 'b, 'd) morph -> unit
+    end
+
+    (** The exposed description of modes *)
+    module Desc : sig
+      module Var : sig
+        type 'a t
+
+        type ('b, 'd) t_with_morph =
+          | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+        module Head : sig
+          type 'a t =
+            { desc_id : int;
+              desc_upper : 'a;
+              desc_lower : 'a;
+              desc_vlower : ('a, left_only) t_with_morph list;
+              desc_level : int
+            }
+
+          val equal : 'a t -> 'b t -> bool
+
+          val hash : 'a t -> int
+        end
+
+        val force : 'a C.obj -> 'a t -> 'a Head.t
+      end
+
+      type ('b, 'd) morphvar =
+        | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+      type ('a, 'd) t =
+        | Amode : 'a -> ('a, 'l * 'r) t
+        | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+        | Amodejoin :
+            'a * ('a, 'l * disallowed) morphvar list
+            -> ('a, 'l * disallowed) t
+        | Amodemeet :
+            'a * ('a, disallowed * 'r) morphvar list
+            -> ('a, disallowed * 'r) t
+
+      val equal : 'a C.obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+      val print : 'a C.obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+    end
+
+    val obj_monadic : Monadic.Const.t C.obj
+
+    val obj_comonadic : Comonadic.Const.t C.obj
+
+    val get_comonadic_desc : 'd Comonadic.t -> (Comonadic.Const.t, 'd) Desc.t
+
+    val get_monadic_desc :
+      ('l * 'r) Monadic.t -> (Monadic.Const.t, 'r * 'l) Desc.t
+
+    val meet_const_morph : 'a -> ('a, 'a, allowed * disallowed) C.morph
+
+    val pretty_print_monadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Monadic.Const.t, 'f) C.morph ->
+      unit
+
+    val pretty_print_comonadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Comonadic.Const.t, 'f) C.morph ->
+      unit
 
     include
       Common
@@ -817,6 +975,7 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
+<<<<<<< HEAD
     (** [arg] determines co-/contravariance, and is used to infer the most
         general mode for implied middle values on monadic axes.\
 
@@ -830,6 +989,19 @@ module type S = sig
           let zap_ret_read x : _ @ read = ()
         ]} *)
     val zap_to_legacy : arg:bool -> lr -> Const.t
+=======
+    val add_mode_to_zap_scope : (allowed * allowed) t -> zap_scope -> unit
+
+    val zap_to_legacy_exn : lr -> Const.t
+
+    val zap_to_legacy : lr -> Const.t option
+
+    val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
+
+    val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->
@@ -851,6 +1023,38 @@ module type S = sig
     (** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C]
     *)
     val partial_apply : (allowed * 'r) t -> l
+
+    (** Copies a mode variable and its children from generic level to the
+        current level *)
+    val instantiate :
+      copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Copies a mode variable and its children at generic level, preserving
+        levels *)
+    val copy_generic : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Deeply copies a mode variable and all its children, preserving levels.
+        The copies receive negative ids (mirroring [Subst.newpersty] for types)
+        and are suitable for storing in a cmi file. *)
+    val copy_for_saving : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Deeply copies a mode variable and all its children, preserving levels.
+        The copies receive positive ids. *)
+    val copy_for_restoring : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    module Guts : sig
+      (** Returns [Some c] if the given mode has been constrained to constant
+          [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val check_const : (allowed * allowed) t -> Const.t option
+
+      (** Returns the precise ceiling of a mode. see notes on [get_ceil] in
+          [solver_intf.mli] for cautions. *)
+      val get_ceil : ('l * allowed) t -> Const.t
+
+      (** Checks that a constant is within the precise bounds of a mode. see
+          notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val in_bounds : Const.t -> (allowed * allowed) t -> bool
+    end
   end
 
   (** The most general mode. Used in most type checking, including in value

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -975,9 +975,21 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-<<<<<<< HEAD
-    (** [arg] determines co-/contravariance, and is used to infer the most
-        general mode for implied middle values on monadic axes.\
+    (** Registers a mode in the scope, to be zapped to legacy when the scope is
+        resolved. See [zap_to_legacy] for an explanation of [arg]. *)
+    val add_mode_to_zap_scope :
+      arg:bool -> (allowed * allowed) t -> zap_scope -> unit
+
+    (** Zaps non-generic variables to legacy, raises a [Cannot_zap_generic]
+        exception if a variable is generic. See [zap_to_legacy] for an
+        explanation of [arg]. *)
+    val zap_to_legacy_exn : arg:bool -> lr -> Const.t
+
+    (** Zaps non-generic variables to legacy, returns [None] if a variable is
+        generic.
+
+        [arg] determines co-/contravariance, and is used to infer the most
+        general mode for implied middle values on monadic axes.
 
         Consider:
 
@@ -988,22 +1000,17 @@ module type S = sig
           (* Implies [read uncontended]. *)
           let zap_ret_read x : _ @ read = ()
         ]} *)
-    val zap_to_legacy : arg:bool -> lr -> Const.t
-=======
-    val add_mode_to_zap_scope : (allowed * allowed) t -> zap_scope -> unit
+    val zap_to_legacy : arg:bool -> lr -> Const.t option
 
-    val zap_to_legacy_exn : lr -> Const.t
-
-    val zap_to_legacy : lr -> Const.t option
-
-    val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
+    (** Zaps all variables to legacy (including generic variables): use with
+        caution. See [zap_to_legacy] for an explanation of [arg]. *)
+    val zap_to_legacy_force : ?commit:bool -> arg:bool -> lr -> Const.t
 
     val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->

--- a/external/merlin/src/ocaml/typing/mtype.ml
+++ b/external/merlin/src/ocaml/typing/mtype.ml
@@ -934,6 +934,8 @@ let lower_nongen nglev mty =
       | _ ->
           super.it_do_type_expr it ty
     in
-    let it = {super with it_do_type_expr} in
-    it.it_module_type it mty
+  let it_mode_expr m =
+    if not (Mode.Alloc.check_generic m) then Mode.Alloc.update_level nglev m in
+  let it = {super with it_do_type_expr; it_mode_expr} in
+  it.it_module_type it mty
   end

--- a/external/merlin/src/ocaml/typing/out_type.ml
+++ b/external/merlin/src/ocaml/typing/out_type.ml
@@ -2533,17 +2533,11 @@ module Aliases = struct
           if List.memq px !visited_objects then add_proxy px else begin
             if not (static_row row) then
               visited_objects := px :: !visited_objects;
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
             match row_name row with
             | Some(_p, tyl) when nameable_row row ->
                 List.iter (mark_loops_rec visited) tyl
             | _ ->
                 iter_row (mark_loops_rec visited) row
-||||||| Compiler:last-imported
-            printer_iter_type_expr (mark_loops_rec visited) ty
-=======
-            printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
->>>>>>> Compiler:HEAD
           end
       | Tobject (fi, nm) ->
           if List.memq px !visited_objects then add_proxy px else begin
@@ -2577,15 +2571,7 @@ module Aliases = struct
       | Tpoly(ty, tyl) ->
           List.iter add tyl;
           mark_loops_rec visited ty
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
       | Tunivar _ -> Variable_names.reserve ty
-||||||| Compiler:last-imported
-      | _ ->
-          printer_iter_type_expr (mark_loops_rec visited) ty
-=======
-      | _ ->
-          printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
->>>>>>> Compiler:HEAD
 
   let mark_loops ty =
     mark_loops_rec [] ty

--- a/external/merlin/src/ocaml/typing/out_type.ml
+++ b/external/merlin/src/ocaml/typing/out_type.ml
@@ -1079,7 +1079,7 @@ let const_or_generic_upper : const_or_generic -> Alloc.Const.t = function
     arrow. *)
 let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
   fun acc marg ->
-    match acc, Alloc.zap_to_legacy marg with
+    match acc, Alloc.zap_to_legacy ~arg:true marg with
     | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
     | Generic (acc, bound), _ ->
       Generic
@@ -1095,13 +1095,14 @@ let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
            Ctype.curry_mode_const acc (Alloc.Guts.get_ceil marg))
       else
         Const
-          (Ctype.curry_mode_const acc (Alloc.zap_to_legacy_force marg))
+          (Ctype.curry_mode_const acc
+             (Alloc.zap_to_legacy_force ~arg:true marg))
 
 (** The view of a mode occurrence [m]; zaps [m] when it has to be a
     constant. *)
-let const_or_generic_of_mode : Alloc.lr -> const_or_generic =
-  fun m ->
-    match Alloc.zap_to_legacy m with
+let const_or_generic_of_mode : arg:bool -> Alloc.lr -> const_or_generic =
+  fun ~arg m ->
+    match Alloc.zap_to_legacy ~arg m with
     | Some c -> Const c
     | None ->
       if mode_polymorphism_printing_enabled ()
@@ -1109,7 +1110,7 @@ let const_or_generic_of_mode : Alloc.lr -> const_or_generic =
         Generic
           (Alloc.Comonadic.disallow_right m.comonadic,
            Alloc.Guts.get_ceil m)
-      else Const (Alloc.zap_to_legacy_force m)
+      else Const (Alloc.zap_to_legacy_force ~arg m)
 
 (** Whether the return mode [m] of an arrow agrees with the constant
     content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
@@ -1460,7 +1461,7 @@ end = struct
       let tty = Transient_expr.repr ty in
       match tty.desc with
       | Tarrow ((_l, marg, mret), ty1, ty2, _) ->
-        zap_non_generic_modes (const_or_generic_of_mode marg) ty1;
+        zap_non_generic_modes (const_or_generic_of_mode ~arg:true marg) ty1;
         let acc_mode = curry_acc acc_mode marg in
         equate_curry acc_mode mret ty2
       | Tpoly (ty, []) | Trepr (ty, []) ->
@@ -1477,7 +1478,7 @@ end = struct
       | Tarrow _ when equate_with_curry_bounds mret acc_mode ->
           zap_non_generic_modes acc_mode ty
       | _ ->
-        zap_non_generic_modes (const_or_generic_of_mode mret) ty
+        zap_non_generic_modes (const_or_generic_of_mode ~arg:false mret) ty
 
   let zap_non_generic_modes ty =
     zap_non_generic_modes (Const Alloc.Const.legacy) ty
@@ -2749,13 +2750,8 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-<<<<<<< HEAD
-        let mode = Alloc.zap_to_legacy ~arg:false mode in
-        Otyp_ret (Orm_any (tree_of_modes mode), tree)
-=======
-        let acc = const_or_generic_of_mode mode in
+        let acc = const_or_generic_of_mode ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode acc), tree)
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     | Other _ -> tree
   in
   let ty =
@@ -2784,11 +2780,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-<<<<<<< HEAD
-        let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
-=======
-        let arg_acc = const_or_generic_of_mode marg in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+        let arg_acc = const_or_generic_of_mode ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -3070,23 +3062,13 @@ and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
       end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-<<<<<<< HEAD
-        let m = Alloc.zap_to_legacy ~arg:false m in
-        (Orm_parens (tree_of_modes m), m)
-=======
-        let acc_mode = const_or_generic_of_mode m in
+        let acc_mode = const_or_generic_of_mode ~arg:false m in
         (Orm_parens (tree_of_modes m acc_mode), acc_mode)
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       end
     end
   | _ ->
-<<<<<<< HEAD
-    let m = Alloc.zap_to_legacy ~arg:false m in
-    (Orm_any (tree_of_modes m), m)
-=======
-    let acc_mode = const_or_generic_of_mode m in
+    let acc_mode = const_or_generic_of_mode ~arg:false m in
     (Orm_any (tree_of_modes m acc_mode), acc_mode)
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -4096,13 +4078,9 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-<<<<<<< HEAD
       let mres =
-        m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
+        m_res |> Alloc.zap_to_legacy_exn ~arg:false |> tree_of_modes_const
       in
-=======
-      let mres = m_res |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       let p = best_module_path p in
@@ -4133,13 +4111,9 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-<<<<<<< HEAD
       let marg =
-        m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
+        m_arg |> Alloc.zap_to_legacy_exn ~arg:true |> tree_of_modes_const
       in
-=======
-      let marg = m_arg |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/external/merlin/src/ocaml/typing/out_type.ml
+++ b/external/merlin/src/ocaml/typing/out_type.ml
@@ -15,6 +15,9 @@
 
 (* Compute a spanning tree representation of types *)
 
+module Std_map = Map
+module Std_set = Set
+
 open Misc
 open Ctype
 open Longident
@@ -942,7 +945,7 @@ let nameable_row row =
 (* This specialized version of [Btype.iter_type_expr] normalizes and
    short-circuits the traversal of the [type_expr], so that it covers only the
    subterms that would be printed by the type printer. *)
-let printer_iter_type_expr f ty =
+let printer_iter_type_expr f fm ty =
   match get_desc ty with
   | Tconstr(p, tyl, _) -> begin
       match best_type_path_resolution p with
@@ -979,10 +982,17 @@ let printer_iter_type_expr f ty =
   | Tmod (ty, _) ->
       f ty
   | _ ->
-      Btype.iter_type_expr f ty
+      Btype.iter_type_expr f fm ty
 
 let quoted_ident ppf x =
   Style.as_inline_code !Oprint.out_ident ppf x
+
+(* Mode variables for mode polymorphism should only be printed if
+  the following two flags are enabled *)
+let mode_polymorphism_printing_enabled () =
+  Language_extension.(
+    is_at_least Mode_polymorphism Alpha
+    && is_enabled Mode_polymorphism_printing)
 
 module Internal_names : sig
 
@@ -1048,6 +1058,126 @@ end = struct
 
 end
 
+(** A mode as seen by printing: either a determined constant, or a
+    generic comonadic mode. Along an arrow chain, the accumulated curry
+    mode is a constant until a generic mode variable is encountered.
+
+    A generic accumulator is the currying fold evaluated twice: the
+    argument modes themselves ([Ctype.curry_mode]), and their constant upper
+    bounds ([Ctype.curry_mode_const]). *)
+type const_or_generic =
+  | Const of Alloc.Const.t
+  | Generic of Alloc.Comonadic.l * Alloc.Const.t
+
+(** The upper bound of a const_or_generic: exact for [Const],
+    the constant upper bound for [Generic] *)
+let const_or_generic_upper : const_or_generic -> Alloc.Const.t = function
+  | Const c -> c
+  | Generic (_, bound) -> bound
+
+(** Extends the curry accumulator with the argument mode [marg] of an
+    arrow. *)
+let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
+  fun acc marg ->
+    match acc, Alloc.zap_to_legacy marg with
+    | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
+    | Generic (acc, bound), _ ->
+      Generic
+        (Ctype.curry_mode acc marg,
+         Ctype.curry_mode_const bound (Alloc.Guts.get_ceil marg))
+    | Const acc, None ->
+      if mode_polymorphism_printing_enabled ()
+      then
+        Generic
+          (Ctype.curry_mode
+             (Alloc.Comonadic.of_const (Alloc.Const.partial_apply acc))
+             marg,
+           Ctype.curry_mode_const acc (Alloc.Guts.get_ceil marg))
+      else
+        Const
+          (Ctype.curry_mode_const acc (Alloc.zap_to_legacy_force marg))
+
+(** The view of a mode occurrence [m]; zaps [m] when it has to be a
+    constant. *)
+let const_or_generic_of_mode : Alloc.lr -> const_or_generic =
+  fun m ->
+    match Alloc.zap_to_legacy m with
+    | Some c -> Const c
+    | None ->
+      if mode_polymorphism_printing_enabled ()
+      then
+        Generic
+          (Alloc.Comonadic.disallow_right m.comonadic,
+           Alloc.Guts.get_ceil m)
+      else Const (Alloc.zap_to_legacy_force m)
+
+(** Whether the return mode [m] of an arrow agrees with the constant
+    content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
+    with the constant (a [Generic] contains generic variables and cannot
+    be equated with directly); otherwise a pure bounds check.
+
+    [equate_with_const] additionally checks [m]'s edges;
+    [Variable_names.equate_curry] calls this function alone, so that the
+    mutations happen during preprocessing, before bounds and edges are
+    computed. *)
+let equate_with_curry_bounds : Alloc.lr -> const_or_generic -> bool =
+  fun m acc_mode ->
+    if not (Alloc.check_generic m)
+       || not (mode_polymorphism_printing_enabled ())
+    then
+      Result.is_ok
+        (Alloc.equate m (Alloc.of_const (const_or_generic_upper acc_mode)))
+    else
+      Alloc.Guts.in_bounds (const_or_generic_upper acc_mode) m
+
+let erase_implied_axes (modes : Mode.Alloc.Const.t) :
+    Mode.Alloc.Const.Option.t =
+  (* [forkable] has implied defaults depending on [areality]: *)
+  let forkable =
+    match modes.areality, modes.forkable with
+    | Local, Unforkable | Global, Forkable -> None
+    | _, _ -> Some modes.forkable
+  in
+
+  (* [yielding] has implied defaults depending on [areality]: *)
+  let yielding =
+    match modes.areality, modes.yielding with
+    | Local, Yielding | Global, Unyielding -> None
+    | _, _ -> Some modes.yielding
+  in
+
+  (* [contention] has implied defaults based on [visibility]: *)
+  let contention =
+    match modes.visibility, modes.contention with
+    | Immutable, Contended
+    | Read, Shared
+    | Write, Corrupted
+    | Read_write, Uncontended -> None
+    | _, _ -> Some modes.contention
+  in
+
+  (* [portability] has implied defaults based on [statefulness]: *)
+  let portability =
+    match modes.statefulness, modes.portability with
+    | Stateless, Portable
+    | Reading, Shareable
+    | Writing, Corruptible
+    | Stateful, Nonportable -> None
+    | _, _ -> Some modes.portability
+  in
+
+  { areality = Some modes.areality;
+    linearity = Some modes.linearity;
+    uniqueness = Some modes.uniqueness;
+    portability;
+    contention;
+    forkable;
+    yielding;
+    statefulness = Some modes.statefulness;
+    visibility = Some modes.visibility;
+    staticity = Some modes.staticity
+  }
+
 module Variable_names : sig
   val reset_names : unit -> unit
 
@@ -1057,6 +1187,16 @@ module Variable_names : sig
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
   val name_of_type : (unit -> string) -> transient_expr -> string
+  val name_of_mode : Alloc.lr -> string
+
+  (** Whether the edges on the curry mode [m] are exactly the
+      [past]/[close] edges from [acc], i.e. implied by the currying
+      interpretation. [bounds_implied] says whether the constant bounds of
+      [m] are implied as well ([equate_with_curry_bounds]); the edges into
+      [m] are suppressed (not printed by the other modes) only when both
+      hold, since [m] is then elided. Must be called after [reserve]. *)
+  val curry_edges_implied :
+    bounds_implied:bool -> acc:const_or_generic -> Alloc.lr -> bool
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1070,6 +1210,13 @@ module Variable_names : sig
      itself for the toplevel *)
   val refresh_weak : unit -> unit
 end = struct
+  type monadic_description =
+    (Alloc.Monadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type comonadic_description =
+    (Alloc.Comonadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type visible_pair =
+    (monadic_description, comonadic_description) monadic_comonadic
+
   (* We map from types to names, but not directly; we also store a substitution,
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
@@ -1079,17 +1226,205 @@ end = struct
   let name_counter = ref 0
   let named_vars = ref ([] : string list)
   let visited_for_named_vars = ref ([] : transient_expr list)
+  let visited_for_modes = ref ([] : transient_expr list)
+  let visited_for_named_modevars = ref ([] : transient_expr list)
+
+  module Desc = Alloc.Desc
+  module C = Alloc.C
+
+  (** Boxed var and morphisms (paths) to use in hashtables *)
+  type boxedvar =
+  | K : 'a C.obj * 'a Desc.Var.Head.t -> boxedvar
+  type boxedpath =
+  | P :
+      { dst : 'b C.obj;
+        var : 'a Desc.Var.Head.t;
+        path : ('a, 'b, (allowed * disallowed)) C.morph
+      }
+      -> boxedpath
+
+  (** The name of polymorphic mode variables will be
+  determined by two variables and morphism pair. The object
+  types are irrelevant, and are thus forgotten. See [edge]
+  for more explanation *)
+  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
+  type monadic_morph =
+    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
+  type comonadic_morph =
+    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
+      morphl
+  type closing_over_morph =
+    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
+
+  type boxedname =
+  | Simple_name :
+      { target : 'c Desc.Var.Head.t;
+        src : 'd Desc.Var.Head.t;
+        via : (monadic_morph, comonadic_morph) monadic_comonadic
+      }
+      -> boxedname
+  | Comonadic_name :
+      { target : 'c Desc.Var.Head.t;
+        src : 'd Desc.Var.Head.t;
+        morph : comonadic_morph
+      }
+      -> boxedname
+
+  module VarTbl = Hashtbl.Make (struct
+    type t = boxedvar
+    let equal (K (_, v1)) (K (_, v2)) = Desc.Var.Head.equal v1 v2
+    let hash (K (_, v)) = Desc.Var.Head.hash v
+  end)
+
+  module VarPairMap = Std_map.Make (struct
+    type t = boxedvar * boxedvar
+    let compare (K (_, v1), K (_, v1')) (K (_, v2), K (_, v2')) =
+      match Int.compare v1.desc_id v2.desc_id with
+      | 0 -> Int.compare v1'.desc_id v2'.desc_id
+      | c -> c
+  end)
+
+  module Paths = struct
+    module Store (X : sig
+      type s
+      type d
+      val dst : d C.obj
+    end) =
+    struct
+      module Morph_set = Std_set.Make (struct
+        type t = (X.s, X.d) morphl
+        let compare m1 m2 = C.compare_morph X.dst m1 m2
+      end)
+
+      type t = Morph_set.t VarPairMap.t
+
+      let empty : t = VarPairMap.empty
+
+      let add key path t =
+        let set =
+          match VarPairMap.find_opt key t with
+          | None -> Morph_set.singleton path
+          | Some set -> Morph_set.add path set
+        in
+        VarPairMap.add key set t
+
+      let find key t =
+        match VarPairMap.find_opt key t with
+        | None -> []
+        | Some set -> Morph_set.elements set
+    end
+
+    module Monadic_paths = Store (struct
+      type s = Alloc.Monadic.Const.t
+      type d = Alloc.Monadic.Const.t
+      let dst = Alloc.obj_monadic
+    end)
+
+    module Comonadic_paths = Store (struct
+      type s = Alloc.Comonadic.Const.t
+      type d = Alloc.Comonadic.Const.t
+      let dst = Alloc.obj_comonadic
+    end)
+
+    module Closing_over_paths = Store (struct
+      type s = Alloc.Monadic.Const.t
+      type d = Alloc.Comonadic.Const.t
+      let dst = Alloc.obj_comonadic
+    end)
+
+    type ('s, 'd) table =
+      | Monadic : (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) table
+          (** Tracks all paths from a visible monadic mode
+          variable to another. A path is defined as follows:
+            let [(v, f)] and [(u, h)] be two visible monadic
+            morphvars, such that [v] can reach [u] by following
+            vlowers. Let [g] be one such composition of vlower
+            functions. By
+            transitivity, we know the following to be true: [g u <= v].
+
+            A path from [(v, f)] to [(u, h)] is defined as: [f ∘ g ∘ h'],
+            where [h'] is the left adjoint of [h] *)
+      | Comonadic : (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t) table
+          (** Tracks all paths from a visible comonadic mode
+          variable to another. See description of
+          [Monadic] for a definition of a path *)
+      | Closing_over : (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) table
+          (** Tracks all paths from a visible comonadic mode
+          variable to visible monadic mode variable. Since
+          the path goes from a comonadic to a monadic mode,
+          it will have to go through a "monadic to comonadic"
+          morphism. These paths will correspond to a closing
+          over relation between two mode variables
+
+          See description of [Monadic] for a definition of
+          a path *)
+
+    type t =
+      { mutable monadic : Monadic_paths.t;
+        mutable comonadic : Comonadic_paths.t;
+        mutable closing_over : Closing_over_paths.t
+      }
+
+    let create () =
+      { monadic = Monadic_paths.empty;
+        comonadic = Comonadic_paths.empty;
+        closing_over = Closing_over_paths.empty
+      }
+
+    let reset t =
+      t.monadic <- Monadic_paths.empty;
+      t.comonadic <- Comonadic_paths.empty;
+      t.closing_over <- Closing_over_paths.empty
+
+    let src_obj : type s d. (s, d) table -> s C.obj =
+      function
+      | Monadic -> Alloc.obj_monadic
+      | Comonadic -> Alloc.obj_comonadic
+      | Closing_over -> Alloc.obj_monadic
+
+    let dst_obj : type s d. (s, d) table -> d C.obj =
+      function
+      | Monadic -> Alloc.obj_monadic
+      | Comonadic -> Alloc.obj_comonadic
+      | Closing_over -> Alloc.obj_comonadic
+
+    let add : type s d.
+        t -> (s, d) table -> boxedvar * boxedvar -> (s, d) morphl -> unit =
+      fun t table key path ->
+      match table with
+      | Monadic -> t.monadic <- Monadic_paths.add key path t.monadic
+      | Comonadic -> t.comonadic <- Comonadic_paths.add key path t.comonadic
+      | Closing_over ->
+        t.closing_over <- Closing_over_paths.add key path t.closing_over
+
+    let find : type s d.
+        t -> (s, d) table -> boxedvar * boxedvar -> ((s, d) morphl) list =
+      fun t table key ->
+      match table with
+      | Monadic -> Monadic_paths.find key t.monadic
+      | Comonadic -> Comonadic_paths.find key t.comonadic
+      | Closing_over -> Closing_over_paths.find key t.closing_over
+  end
+
+  (** Tracks the mapping of monadic and comonadic mode
+  descriptions visible in the type *)
+  let visible_pairs = ref ([] : visible_pair list)
+  let aliased_visible_pairs = ref ([] : visible_pair list)
+  let printed_aliased_visible_pairs = ref ([] : (visible_pair * string) list)
+
+  (** Tracks all mode variables that may occur in the above
+  list (for fast visibility checking) *)
+  let visible_vars = VarTbl.create 17
+
+  let visible_paths = Paths.create ()
+
+  (** counter used to generate names for polymorphic mode variables *)
+  let modename_counter = ref 0
+  let modenames = ref ([] : (boxedname * string) list)
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
   let named_weak_vars = ref String.Set.empty
-
-  let reset_names () =
-    names := [];
-    name_subst := [];
-    name_counter := 0;
-    named_vars := [];
-    visited_for_named_vars := []
 
   let add_named_var tty =
     match tty.desc with
@@ -1107,8 +1442,901 @@ end = struct
       | Tvar _ | Tunivar _ ->
           add_named_var tty
       | _ ->
-          printer_iter_type_expr add_named_vars ty
+          printer_iter_type_expr add_named_vars (Fun.const ()) ty
     end
+
+  (* The following preprocessing step zaps non-generic
+    modes to legacy, while equating a derived curry mode
+    with the inferred non-generic return modes. This step
+    should exactly mirror the mutations performed by
+    [tree_of_modal_typexp]. It is needed so we get the
+    correct precise bounds of mode descriptions
+  *)
+  let rec zap_non_generic_modes : const_or_generic -> type_expr -> unit =
+    fun acc_mode ty ->
+    let px = proxy ty in
+    if List.memq px !visited_for_modes then () else begin
+      visited_for_modes := px :: !visited_for_modes;
+      let tty = Transient_expr.repr ty in
+      match tty.desc with
+      | Tarrow ((_l, marg, mret), ty1, ty2, _) ->
+        zap_non_generic_modes (const_or_generic_of_mode marg) ty1;
+        let acc_mode = curry_acc acc_mode marg in
+        equate_curry acc_mode mret ty2
+      | Tpoly (ty, []) | Trepr (ty, []) ->
+        zap_non_generic_modes acc_mode ty
+      | _ ->
+        printer_iter_type_expr
+          (zap_non_generic_modes (Const Alloc.Const.legacy))
+          (Fun.const ()) ty
+    end
+
+  and equate_curry : const_or_generic -> Alloc.lr -> type_expr -> unit =
+    fun acc_mode mret ty ->
+      match get_desc ty with
+      | Tarrow _ when equate_with_curry_bounds mret acc_mode ->
+          zap_non_generic_modes acc_mode ty
+      | _ ->
+        zap_non_generic_modes (const_or_generic_of_mode mret) ty
+
+  let zap_non_generic_modes ty =
+    zap_non_generic_modes (Const Alloc.Const.legacy) ty
+
+  let eq_pair :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun { monadic = mon0; comonadic = com0 }
+        { monadic = mon1; comonadic = com1 } ->
+    Desc.equal Alloc.obj_monadic mon0 mon1
+    && Desc.equal Alloc.obj_comonadic com0 com1
+
+  (* The following preprocessing step registers all the
+    modes pointed to by a type. Recall that a [Alloc.lr]
+    has two parts: { monadic; comonadic }. We need to
+    register each individual mode variable, as well as
+    the association between the monadic and comonadic
+    parts.
+
+    The former are registered in a VarTbl, the latter
+    in a list of mode descriptions
+    We also use this step to register mode aliases
+  *)
+  let add_visible : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> unit =
+    fun dst desc ->
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let src = C.src dst f in
+        let v = K (src, v) in
+        VarTbl.add visible_vars v ()
+
+  let add_named_modevar : Alloc.lr -> unit =
+    fun ({ monadic; comonadic } as mode) ->
+      if Alloc.check_generic mode then begin
+        let monadic_desc = Alloc.get_monadic_desc monadic in
+        let comonadic_desc = Alloc.get_comonadic_desc comonadic in
+        let pair = { monadic = monadic_desc; comonadic = comonadic_desc } in
+        add_visible Alloc.obj_monadic monadic_desc;
+        add_visible Alloc.obj_comonadic comonadic_desc;
+        if List.exists (eq_pair pair) !visible_pairs then
+          aliased_visible_pairs := pair :: !aliased_visible_pairs
+        else
+          visible_pairs := pair :: !visible_pairs
+      end
+
+  let rec add_named_modevars ty =
+    let px = proxy ty in
+    if not (List.memq px !visited_for_named_modevars) then begin
+      visited_for_named_modevars := px :: !visited_for_named_modevars;
+      printer_iter_type_expr add_named_modevars add_named_modevar ty
+    end
+
+  (* The next preprocessing step registers all direct
+    paths from one visible mode variable to another.
+  *)
+
+  type stack = unit VarTbl.t
+
+  (* Find the [b -> Paths.src_obj table] morphism
+    associated with some visible variable [v] of object
+    type [b] *)
+  let find_visible_morph_opt : type b s d.
+      (s, d) Paths.table -> b C.obj -> b Desc.Var.Head.t
+      -> ((b, s, (allowed * allowed)) C.morph) option =
+    fun table obj v ->
+      let sobj = Paths.src_obj table in
+      let desc_of_pair (pair : visible_pair)
+          : (s, (allowed * allowed)) Desc.t =
+        match table with
+        | Paths.Monadic -> pair.monadic
+        | Paths.Comonadic -> pair.comonadic
+        | Paths.Closing_over -> pair.monadic
+      in
+      let find_match pair =
+        match desc_of_pair pair with
+        | Desc.Amodevar (Amorphvar (u, f)) ->
+            if not (Desc.Var.Head.equal v u) then None else begin
+              let obj' = C.src sobj f in
+                match C.equal_obj obj obj' with
+                | Is_eq ->
+                  let (f : ((b, s, (allowed * allowed)) C.morph)) = f in
+                  Some f
+                | Is_not_eq ->
+                  fatal_error "Out_type.find_visible_morph_opt"
+            end
+        | Desc.Amode _ -> None
+      in
+      List.find_map find_match !visible_pairs
+
+  let visible : type b. b C.obj -> b Desc.Var.Head.t -> bool =
+    fun obj v ->
+      VarTbl.mem visible_vars (K (obj, v))
+
+  (* Find all direct paths (via vlowers) from some
+    variable [v] to all other reachable visible variables
+    at generic level. *)
+  (* WARNING: cycles are *not* registered
+      as a separate morphism:
+      e.g.: let [w] be a visible generic variable with
+            the following (vlower) edges:
+            v -f> u1 -g> u2 -g'> u1 -h> w
+            [find_paths v] will return only the direct
+            path [(f ∘ h)]
+      In the future, we might want to register all
+      paths. This will require a lattice of morphisms,
+      so we can calculate the fixed point of cycle *)
+  let rec paths_to_visible :
+      type b. stack:stack
+      -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~stack dst v ->
+      if visible dst v then [P { dst; var = v; path = C.id }]
+      else paths_from_vlowers ~stack dst v
+
+  and paths_from_vlowers :
+      type b. stack:stack
+      -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~stack dst v ->
+      if VarTbl.mem stack (K (dst, v)) then [] else begin
+        VarTbl.add stack (K (dst, v)) ();
+        let paths =
+          List.concat_map (fun (Desc.Var.Amorphvar (w, f)) ->
+            let fsrc = C.src dst f in
+            let w = Desc.Var.force fsrc w in
+            if w.desc_level <> generic_level then []
+            else
+              List.map (fun (P { dst = gdst; var = u; path = g }) ->
+                match C.equal_obj fsrc gdst with
+                | Is_eq -> P { dst; var = u; path = C.compose dst f g }
+                | Is_not_eq -> fatal_error "Out_type.paths_from_vlowers")
+                (paths_to_visible ~stack fsrc w))
+            v.desc_vlower
+        in
+        VarTbl.remove stack (K (dst, v));
+        paths
+      end
+
+  let find_paths : boxedvar -> boxedpath list =
+    fun (K (dst, v)) ->
+      paths_from_vlowers ~stack:(VarTbl.create 17) dst v
+
+  (** [find_path_from_description] constructs all morphisms
+    from one visible mode variable to another, and records
+    them in the [table] of [visible_paths].
+    [find_visible_morph_opt table] takes a variable as
+    input, and returns its associated morphism. The final
+    morphism is constructed as follows:
+      - let the parameter [desc] be a morphvar
+        description [(v, f)]
+      - let g be vlower path from [v] to some [u].
+        (recall g : [u.obj] -> [v.obj])
+      - let [find_visible_morph_opt table u] = Some [h]
+    [find_path_from_description] records
+    ([v], [u]) and [fgh'] where [h'] is the left
+    adjoint of [h].
+
+    See [Paths.Monadic] for an explanation
+    why this is the morphism we want *)
+  let find_path_from_description :
+      type s d.
+      (d, (allowed * allowed)) Desc.t
+      -> (s, d) Paths.table
+      -> unit =
+    fun desc table ->
+      let dst = Paths.dst_obj table in
+      let bobj = Paths.src_obj table in
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let fsrc = C.src dst f in
+        let v = K (fsrc, v) in
+        let paths = find_paths v in
+        List.iter (fun (P { dst = gdst; var = u; path = g }) ->
+          match C.equal_obj fsrc gdst with
+            | Is_eq ->
+              let gsrc = C.src gdst g in
+              Option.iter (fun h ->
+                let h' = C.left_adjoint bobj h in
+                let fg = C.compose dst (C.disallow_right f) g in
+                let fgh' = C.compose dst fg h' in
+                Paths.add visible_paths table (v, (K (gsrc, u))) fgh'
+              ) (find_visible_morph_opt table gsrc u)
+            | Is_not_eq ->
+              fatal_error "Out_type.find_path_from_description"
+          ) paths
+
+
+  (* The following function is expensive and should be
+  called once during preprocessing. It constructs all
+  morphisms from a visible monadic/comonadic variable to
+  another visible monadic/comonadic variable, and records
+  them in their respective tables *)
+  let add_visible_paths () =
+    List.iter
+      (fun { monadic; comonadic } ->
+        find_path_from_description monadic Paths.Monadic;
+        find_path_from_description comonadic Paths.Comonadic;
+        find_path_from_description comonadic Paths.Closing_over
+      ) !visible_pairs
+
+  type simple_edge =
+    { via :
+        (monadic_morph, comonadic_morph)
+          monadic_comonadic;
+        (** The pair of morphisms between the two modes.
+        The monadic morphism gives a path from the
+        monadic part of [src] to the monadic part of
+        [target], the comonadic morphism gives a path
+        from the comonadic part of [target] to the
+        comonadic part of [src] *)
+      name : boxedname;
+        (** When printing, we name edges rather than
+        nodes, such that we can print monadic and
+        comonadic constraints in different bounds, thus
+        only printing left_only morphisms. By default,
+        the name is determined by the comonadic
+        morphism, but if this morphism is trivial (i.e.
+        the bounds can determine it), we use the
+        monadic morphism instead. *)
+    }
+
+  type comonadic_edge =
+    { c_via : comonadic_morph;
+        (** The comonadic morphism between two modes
+        when there is no path between their monadic
+        counterparts. This edge represents a partial
+        constraint between two modes. The morphism
+        gives a path from [target] to [src] *)
+      c_name : boxedname;
+        (** The boxed name of [c_via] *)
+    }
+
+  (** [closing_over_edge] describes a specific pattern
+  that may arise between an argument, a return and a
+  curry-mode.
+
+  Consider the following function (the K-combinator)
+  let k x y = x
+
+  The mode of the argument [x] describes a lower bound on
+  the inner return. But when [k] is partially applied, this
+  mode also describes an upper bound on the closure [k x].
+
+  We want to print such a pattern as follows:
+
+  [k : x @ [< 'm] -> (y @ 'n -> x @ [> 'm]) @ [> close('m)]]
+
+  Where [close('m)] denotes a relation to the comonadic
+  parts of the argument, and the monadic part of the return *)
+
+  (** A [closing_over_edge] describes a relationship between
+  three visible mode variables: [src], [target] and [curry]*)
+  type closing_over_edge =
+    { cls_target : closing_over_morph;
+        (** A path from [curry] to monadic
+        part of [target] *)
+      cls_src : comonadic_morph;
+        (** A path from [curry] to comonadic
+        part of [src] *)
+      cls_edge : simple_edge
+        (** the edge from [src] to [target].
+        The name of a [closing_over_edge]
+        corresponds to the name of [cls_edge]. *)
+    }
+
+  type edge =
+  | Simple of simple_edge
+      (** a constraint between two alloc modes *)
+  | Comonadic of comonadic_edge
+      (** a constraint between the comonadic parts
+      of two alloc modes *)
+  | ClosingOver of closing_over_edge
+      (** a constraint between the monadic part
+      of one mode and the comonadic part of another *)
+
+   let dupper_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_upper
+
+  let dlower_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_lower
+
+  let construct_morphs :
+      type a. (a, a) Paths.table
+        -> (a, (allowed * allowed)) Desc.t
+        -> (a, (allowed * allowed)) Desc.t
+        -> ((a, a) morphl) list =
+    fun table src_descr target_descr ->
+      let dst = Paths.dst_obj table in
+      match src_descr, target_descr with
+      | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+        let vobj = C.src dst f in
+        let uobj = C.src dst g in
+        let src_lower = C.apply dst f v.desc_lower in
+        let target_upper = C.apply dst g u.desc_upper in
+        if C.le dst target_upper src_lower
+        then [C.id] (* [target <= src] already holds by bounds *)
+        else Paths.find visible_paths table (K (vobj, v), K (uobj, u))
+      | _, _ ->
+        let src_lower = dlower_lr dst src_descr in
+        let target_upper = dupper_lr dst target_descr in
+        if C.le dst target_upper src_lower
+        then [C.id] (* [target <= src] already holds by bounds *)
+        else [Alloc.meet_const_morph src_lower]
+
+  let construct_closing_over_morphs :
+      (Alloc.Comonadic.Const.t, allowed * allowed) Desc.t
+      -> (Alloc.Monadic.Const.t, allowed * allowed) Desc.t
+      -> closing_over_morph list =
+    fun src_descr target_descr ->
+    match src_descr, target_descr with
+    | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+      let vobj = C.src Alloc.obj_comonadic f in
+      let uobj = C.src Alloc.obj_monadic g in
+        Paths.find visible_paths Paths.Closing_over (K (vobj, v), K (uobj, u))
+    | _, _ -> []
+
+  let construct_monadic_morphs src_descr target_descr =
+    construct_morphs Paths.Monadic src_descr target_descr
+
+  let construct_comonadic_morphs src_descr target_descr =
+    construct_morphs Paths.Comonadic src_descr target_descr
+
+  (* Tests whether the relation between two descriptions can be decided by
+  their bounds. If the following is true for two parts of a mode variable pair,
+  then no constraint needs to be printed *)
+  let descr_compare_dec :
+      type a. a C.obj
+      -> (a, (allowed * allowed)) Desc.t
+      -> (a, (allowed * allowed)) Desc.t
+      -> bool =
+    fun dst a0 a1 ->
+      let upper0 = dupper_lr dst a0 in
+      let lower0 = dlower_lr dst a0 in
+      let upper1 = dupper_lr dst a1 in
+      let lower1 = dlower_lr dst a1 in
+      C.le dst upper0 lower1 ||
+      C.le dst upper1 lower0
+
+  let descr_is_var : type a. (a, (allowed * allowed)) Desc.t -> bool =
+    fun v ->
+      match v with
+      | Amode _ -> false
+      | Amodevar _ -> true
+
+  (** We only want to print a constraint (and thus
+  construct an edge) between [(mon0, com0)] and
+  [(mon1, com1)] if the following is true:
+
+  1) Either [compare mon0 mon1], or
+     [compare com0 com1] can't be decided via bounds
+  2) Either [mon0] and [mon1] are both variables,
+     or [com0] and [com1] are both variables
+  3) [(mon0, com0)] and [(mon1, com1)] are not equal
+  *)
+  let construct_edge_condition :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun ({ monadic = mon0; comonadic = com0 } as pair0)
+        ({ monadic = mon1; comonadic = com1 } as pair1) ->
+      let compare_dec =
+        not (descr_compare_dec
+               Alloc.obj_monadic mon0 mon1)
+        || not (descr_compare_dec
+                  Alloc.obj_comonadic com0 com1)
+      in
+      let check_signature =
+        (descr_is_var mon0 && descr_is_var mon1)
+        || (descr_is_var com0 && descr_is_var com1)
+      in
+      let pairs_ne = not (eq_pair pair0 pair1) in
+      compare_dec && check_signature && pairs_ne
+
+  let construct_name :
+      visible_pair
+      -> (monadic_morph, comonadic_morph) monadic_comonadic
+      -> visible_pair
+      -> boxedname =
+    fun { monadic = mon0; comonadic = com0 }
+        via
+        { monadic = mon1; comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        Simple_name { target = u; src = v; via }
+      | _, _ ->
+        match mon0, mon1 with
+        | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+          Simple_name { target = u; src = v; via }
+        | _, _ ->
+          fatal_error
+            "Out_type.construct_name: edge without variable endpoints"
+
+  let construct_comonadic_name :
+      visible_pair
+      -> comonadic_morph
+      -> visible_pair
+      -> boxedname =
+    fun { comonadic = com0 }
+        com_morph
+        { comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        Comonadic_name { target = u; src = v; morph = com_morph }
+      | _, _ ->
+        fatal_error
+          "Out_type.construct_comonadic_name: edge without variable endpoints"
+
+  let construct_simple_between pair0 pair1 =
+    let mon_morphs =
+      construct_monadic_morphs pair0.monadic pair1.monadic
+    in
+    let com_morphs =
+      construct_comonadic_morphs pair1.comonadic pair0.comonadic
+    in
+    List.concat_map (fun com_morph ->
+      List.map (fun mon_morph ->
+        let via = { monadic = mon_morph; comonadic = com_morph } in
+        { via; name = construct_name pair0 via pair1 })
+        mon_morphs)
+      com_morphs
+
+  let check_closing_over_candidate pair0 pair1 =
+    List.exists
+      (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs pair1.comonadic pair2.monadic
+        in
+        let edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else []
+        in
+        not (List.is_empty edges)
+        && not (List.is_empty closing_over_morphs))
+      !visible_pairs
+
+  let construct_comonadic_between pair0 pair1 =
+    let mon_morphs =
+      construct_monadic_morphs pair0.monadic pair1.monadic
+    in
+    let com_morphs =
+      construct_comonadic_morphs pair1.comonadic pair0.comonadic
+    in
+    if List.is_empty mon_morphs
+       && not (check_closing_over_candidate pair0 pair1)
+    then
+      List.map (fun com_morph ->
+        let c_name = construct_comonadic_name pair0 com_morph pair1 in
+        Comonadic { c_via = com_morph; c_name })
+        com_morphs
+    else []
+
+  let eq_morph : type a0 a1 b l0 r0 l1 r1.
+      b C.obj
+      -> (a0, b, l0 * r0) C.morph
+      -> (a1, b, l1 * r1) C.morph
+      -> bool =
+    fun obj f g ->
+    match C.equal_morph obj f g with
+    | Is_eq -> true
+    | Is_not_eq -> false
+
+  let eq_boxedname n1 n2 =
+    match n1, n2 with
+    | Simple_name { target = v; src = v'; via = via1 },
+      Simple_name { target = u; src = u'; via = via2 } ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && eq_morph Alloc.obj_monadic via1.monadic via2.monadic
+      && eq_morph Alloc.obj_comonadic via1.comonadic via2.comonadic
+    | Comonadic_name { target = v; src = v'; morph = f },
+      Comonadic_name { target = u; src = u'; morph = g } ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && eq_morph Alloc.obj_comonadic f g
+    | Simple_name _, Comonadic_name _ | Comonadic_name _, Simple_name _ ->
+      false
+
+  let closing_over_composition { cls_target; cls_src; _ } =
+    C.compose Alloc.obj_comonadic cls_src cls_target
+
+  let eq_closing_over e1 e2 =
+    eq_boxedname e1.cls_edge.name e2.cls_edge.name
+    && C.compare_morph Alloc.obj_comonadic
+         (closing_over_composition e1)
+         (closing_over_composition e2)
+       = 0
+
+  let dedup_closing_over edges =
+    List.rev
+      (List.fold_left
+         (fun acc e ->
+           if List.exists (eq_closing_over e) acc then acc else e :: acc)
+         [] edges)
+
+  let construct_closing_over_to pair1 =
+    let edges =
+    List.concat_map (fun pair0 ->
+      let com_morphs =
+        construct_comonadic_morphs pair1.comonadic pair0.comonadic
+      in
+      List.concat_map (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs pair1.comonadic pair2.monadic
+        in
+        let simple_edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else []
+        in
+        List.concat_map (fun edge ->
+          List.concat_map (fun cls_morph ->
+            List.map (fun com_morph ->
+                { cls_target = cls_morph;
+                  cls_src = com_morph;
+                  cls_edge = edge
+                })
+              com_morphs)
+            closing_over_morphs)
+          simple_edges)
+        !visible_pairs)
+      !visible_pairs
+    in
+    List.map (fun e -> ClosingOver e) (dedup_closing_over edges)
+
+  let construct_edges_between pair0 pair1 =
+    if not (construct_edge_condition pair0 pair1) then []
+    else begin
+      let simple = construct_simple_between pair0 pair1 in
+      let comonadic = construct_comonadic_between pair0 pair1 in
+      List.map (fun edge -> Simple edge) simple @ comonadic
+    end
+
+  let construct_edges_to :
+      visible_pair -> edge list =
+    fun pair1 ->
+      let edges =
+        List.concat_map (fun pair0 -> construct_edges_between pair0 pair1)
+          !visible_pairs
+      in
+      construct_closing_over_to pair1 @ edges
+
+  let construct_edges_from :
+      visible_pair -> edge list =
+    fun pair0 ->
+      List.concat_map (fun pair1 -> construct_edges_between pair0 pair1)
+        !visible_pairs
+
+  let pick_name : int -> string = fun i ->
+    match i with
+    | 0 -> "'m"
+    | 1 -> "'n"
+    | 2 -> "'o"
+    | 3 -> "'p"
+    | 4 -> "'q"
+    | _ -> Fmt.asprintf "'mm%d" (i - 5)
+
+  let add_named_modevar name =
+    let mopt =
+      List.find_opt
+        (fun (name', _) -> eq_boxedname name name')
+        !modenames
+    in
+    match mopt with
+    | Some (_, m) -> m
+    | None ->
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      modenames := (name, m) :: !modenames;
+      m
+
+  type 'a interval = { lo: 'a; hi: 'a }
+  let construct_raw_bounds { monadic; comonadic } :
+      string interval =
+    let bound_diff bound trivial =
+      erase_implied_axes bound
+      |> Alloc.Const.Option.value ~default:trivial
+      |> fun bound -> Alloc.Const.diff bound trivial
+    in
+    let mupper = dupper_lr Alloc.obj_monadic monadic in
+    let mlower = dlower_lr Alloc.obj_monadic monadic in
+    let cupper = dupper_lr Alloc.obj_comonadic comonadic in
+    let clower = dlower_lr Alloc.obj_comonadic comonadic in
+    let lower =
+      Alloc.Const.merge
+        { monadic = mupper; comonadic = clower }
+    in
+    let upper =
+      Alloc.Const.merge
+        { monadic = mlower; comonadic = cupper }
+    in
+    let lower = bound_diff lower Alloc.Const.min in
+    let upper = bound_diff upper Alloc.Const.max in
+    { lo = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print lower;
+      hi = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print upper}
+
+  type edge_as_lower =
+  | Lower_simple : simple_edge -> edge_as_lower
+  | Lower_comonadic : comonadic_edge -> edge_as_lower
+  | Lower_closing_over_to : closing_over_edge -> edge_as_lower
+
+  type edge_as_upper =
+  | Upper_simple : simple_edge -> edge_as_upper
+  | Upper_comonadic : comonadic_edge -> edge_as_upper
+
+  let print_raw_upper_bound ppf edge =
+    match edge with
+    | Upper_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_monadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.monadic
+    | Upper_comonadic { c_name } ->
+      let m = add_named_modevar c_name in
+      Fmt.fprintf ppf "past(%s)" m
+
+  let print_raw_lower_bound ppf edge =
+    match edge with
+    | Lower_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.comonadic
+    | Lower_comonadic { c_via; c_name } ->
+      let m = add_named_modevar c_name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "past(%s)" s)
+        m ppf c_via
+    | Lower_closing_over_to { cls_target; cls_src; cls_edge } ->
+      let m = add_named_modevar cls_edge.name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf
+        (C.compose Alloc.obj_comonadic cls_src cls_target)
+
+  let partition_edges_into_bounds :
+      edges_from:edge list ->
+      edges_to:edge list ->
+      edge_as_lower list * edge_as_upper list =
+    fun ~edges_from ~edges_to ->
+    let into_lower_from = function
+      | ClosingOver _ -> assert false
+      | Simple e -> Upper_simple e
+      | Comonadic e -> Upper_comonadic e
+    in
+    let into_lower_to = function
+      | ClosingOver e -> Lower_closing_over_to e
+      | Simple e -> Lower_simple e
+      | Comonadic e -> Lower_comonadic e
+    in
+    let upper = List.map into_lower_from edges_from in
+    let lower = List.map into_lower_to edges_to in
+    lower, upper
+
+  type edges =
+    { lower : edge_as_lower list;
+      upper : edge_as_upper list
+    }
+
+  let edge_table = ref ([] : (visible_pair * edges) list)
+
+  type boxedhead = H : 'a Desc.Var.Head.t -> boxedhead
+
+  (* Comonadic heads of elided curry modes; edges into them must not be
+     printed. *)
+  let suppressed_curry_heads = ref ([] : boxedhead list)
+
+  let heads_of_mode (m : Alloc.lr) =
+    match Alloc.get_comonadic_desc m.comonadic with
+    | Amode _ -> []
+    | Amodevar (Amorphvar (v, _)) -> [H v]
+
+  let mem_head : boxedhead list -> 'a Desc.Var.Head.t -> bool =
+    fun heads v ->
+      List.exists (fun (H u) -> Desc.Var.Head.equal u v) heads
+
+  let reset_names () =
+    names := [];
+    name_subst := [];
+    name_counter := 0;
+    named_vars := [];
+    visited_for_named_vars := [];
+    visited_for_modes := [];
+    visited_for_named_modevars := [];
+    visible_pairs := [];
+    aliased_visible_pairs := [];
+    printed_aliased_visible_pairs := [];
+    modenames := [];
+    edge_table := [];
+    suppressed_curry_heads := [];
+    Paths.reset visible_paths;
+    VarTbl.reset visible_vars;
+    modename_counter := 0
+
+  let add_visible_edges () =
+    suppressed_curry_heads := [];
+    edge_table :=
+      List.map (fun pair ->
+        let lower, upper =
+          partition_edges_into_bounds
+            ~edges_from:(construct_edges_from pair)
+            ~edges_to:(construct_edges_to pair)
+        in
+        pair, { lower; upper })
+        !visible_pairs
+
+  let find_edges pair =
+    match
+      List.find_opt (fun (pair', _) -> eq_pair pair pair') !edge_table
+    with
+    | Some (_, edges) -> edges
+    | None -> { lower = []; upper = [] }
+
+  let pair_of_mode ({ monadic; comonadic } : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc monadic in
+    let comonadic = Alloc.get_comonadic_desc comonadic in
+    { monadic; comonadic }
+
+  (* The variable heads of the curry accumulator. *)
+  let acc_heads (acc : const_or_generic) : boxedhead list =
+    match acc with
+    | Const _ -> []
+    | Generic (acc, _) ->
+      let head (Desc.Amorphvar (v, _)) = H v in
+      (match Alloc.get_comonadic_desc acc with
+       | Amode _ -> []
+       | Amodevar mv -> [head mv]
+       | Amodejoin (_, mvs) -> List.map head mvs)
+
+  (* See the signature for the specification. *)
+  let curry_edges_implied ~bounds_implied ~(acc : const_or_generic)
+      (m : Alloc.lr) =
+    let pair = pair_of_mode m in
+    let implied =
+      bounds_implied
+      (* an aliased mode is printed at every occurrence *)
+      && (not (List.exists (eq_pair pair) !aliased_visible_pairs))
+      &&
+      let { lower; upper } = find_edges pair in
+      let acc_heads = acc_heads acc in
+      let from_acc = function
+        | Simple_name { src; _ } -> mem_head acc_heads src
+        | Comonadic_name { src; _ } -> mem_head acc_heads src
+      in
+      (* no edges from [m]... *)
+      List.is_empty upper
+      (* ...and every edge into [m] is a [past]/[close] edge from [acc] *)
+      && List.for_all
+           (function
+             | Lower_simple _ -> false
+             | Lower_comonadic { c_name; _ } -> from_acc c_name
+             | Lower_closing_over_to { cls_edge = { name; _ }; _ } ->
+               from_acc name)
+           lower
+    in
+    if implied then
+      suppressed_curry_heads := heads_of_mode m @ !suppressed_curry_heads;
+    implied
+
+  let print_raw_constraints { lo; hi } ppf pair =
+    let { lower = edges_lower; upper = edges_upper } = find_edges pair in
+    let edges_upper =
+      List.filter
+        (function
+          | Upper_comonadic { c_name = Comonadic_name { target; _ }; _ } ->
+            not (mem_head !suppressed_curry_heads target)
+          | Upper_comonadic { c_name = Simple_name _; _ }
+          | Upper_simple _ -> true)
+        edges_upper
+    in
+    if List.is_empty edges_lower && List.is_empty edges_upper
+       && lo = "" && hi = ""
+    then begin
+      let name =
+        construct_name pair
+          { monadic = C.id; comonadic = C.id }
+          pair
+      in
+      Fmt.fprintf ppf "%s" (add_named_modevar name)
+    end
+    else begin
+      let pp_sep sep ppf () =
+        Fmt.fprintf ppf "%s" sep
+      in
+      let pp_bounds pp sep extra ppf items =
+        match items, extra with
+        | [], "" -> ()
+        | [], s -> Fmt.fprintf ppf "%s" s
+        | l, "" ->
+          Fmt.pp_print_list
+            ~pp_sep:(pp_sep sep) pp ppf l
+        | l, s ->
+          Fmt.fprintf ppf "%a%s%s"
+            (Fmt.pp_print_list
+               ~pp_sep:(pp_sep sep) pp)
+            l sep s
+      in
+      let has_upper =
+        not (List.is_empty edges_upper) || hi <> ""
+      in
+      let has_lower =
+        not (List.is_empty edges_lower) || lo <> ""
+      in
+      Fmt.fprintf ppf "[%s%a%s%s%a]"
+        (if has_upper then "< " else "")
+        (pp_bounds print_raw_upper_bound
+           " & " hi)
+        edges_upper
+        (if has_upper && has_lower
+         then " " else "")
+        (if has_lower then "> " else "")
+        (pp_bounds print_raw_lower_bound
+           " | " lo)
+        edges_lower
+    end
+
+  let find_mode_already_printed pair =
+    let find (pair_alias, m) =
+      if eq_pair pair pair_alias then Some m else None
+    in
+    List.find_map find !printed_aliased_visible_pairs
+
+  let mode_print_alias ppf pair =
+    if List.exists (eq_pair pair)
+         !aliased_visible_pairs
+    then begin
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      printed_aliased_visible_pairs :=
+        (pair,m) :: !printed_aliased_visible_pairs;
+      Fmt.fprintf ppf "as %s" m
+    end
+
+  let name_of_mode (modes : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc modes.monadic in
+    let comonadic = Alloc.get_comonadic_desc modes.comonadic in
+    let pair = { monadic; comonadic } in
+    match find_mode_already_printed pair with
+    | Some m -> Fmt.asprintf "%s" m
+    | None ->
+        let bounds = construct_raw_bounds pair in
+        Fmt.asprintf "%a%a"
+          (print_raw_constraints bounds) pair
+          mode_print_alias pair
 
   let substitute ty =
     match List.assq ty !name_subst with
@@ -1209,8 +2437,29 @@ end = struct
 
   let reserve ty =
     normalize_type ty;
-    add_named_vars ty
+    add_named_vars ty;
+    if mode_polymorphism_printing_enabled () then begin
+      let snap = Btype.snapshot () in
+      zap_non_generic_modes ty;
+      add_named_modevars ty;
+      add_visible_paths ();
+      add_visible_edges ();
+      Btype.backtrack snap
+    end
 end
+
+(** Whether the return mode [m] of an arrow can be elided: the arrow is
+    then printed without parens and [m] is not printed. Mutates [m] when it
+    must be zapped (see [equate_with_curry_bounds]). *)
+let equate_with_const : Alloc.lr -> const_or_generic -> bool =
+  fun m acc_mode ->
+    if not (Alloc.check_generic m)
+       || not (mode_polymorphism_printing_enabled ())
+    then equate_with_curry_bounds m acc_mode
+    else
+      Variable_names.curry_edges_implied
+        ~bounds_implied:(equate_with_curry_bounds m acc_mode)
+        ~acc:acc_mode m
 
 module Aliases = struct
   let visited_objects = ref ([] : transient_expr list)
@@ -1284,11 +2533,17 @@ module Aliases = struct
           if List.memq px !visited_objects then add_proxy px else begin
             if not (static_row row) then
               visited_objects := px :: !visited_objects;
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
             match row_name row with
             | Some(_p, tyl) when nameable_row row ->
                 List.iter (mark_loops_rec visited) tyl
             | _ ->
                 iter_row (mark_loops_rec visited) row
+||||||| Compiler:last-imported
+            printer_iter_type_expr (mark_loops_rec visited) ty
+=======
+            printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
+>>>>>>> Compiler:HEAD
           end
       | Tobject (fi, nm) ->
           if List.memq px !visited_objects then add_proxy px else begin
@@ -1322,7 +2577,15 @@ module Aliases = struct
       | Tpoly(ty, tyl) ->
           List.iter add tyl;
           mark_loops_rec visited ty
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
       | Tunivar _ -> Variable_names.reserve ty
+||||||| Compiler:last-imported
+      | _ ->
+          printer_iter_type_expr (mark_loops_rec visited) ty
+=======
+      | _ ->
+          printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
+>>>>>>> Compiler:HEAD
 
   let mark_loops ty =
     mark_loops_rec [] ty
@@ -1432,46 +2695,16 @@ let out_modalities_of_mod_bounds mod_bounds =
   Typemode.untransl_mod_bounds mod_bounds
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let tree_of_modes (modes : Mode.Alloc.Const.t) =
+let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)
   let diff =
-
-    (* [forkable] has implied defaults depending on [areality]: *)
-    let forkable =
-      match modes.areality, modes.forkable with
-      | Local, Unforkable | Global, Forkable -> None
-      | _, _ -> Some modes.forkable
-    in
-
-    (* [yielding] has implied defaults depending on [areality]: *)
-    let yielding =
-      match modes.areality, modes.yielding with
-      | Local, Yielding | Global, Unyielding -> None
-      | _, _ -> Some modes.yielding
-    in
-
-    (* [contention] has implied defaults based on [visibility]: *)
-    let contention =
-      match modes.visibility, modes.contention with
-      | Immutable, Contended
-      | Read, Shared
-      | Write, Corrupted
-      | Read_write, Uncontended -> None
-      | _, _ -> Some modes.contention
-    in
-
-    (* [portability] has implied defaults based on [statefulness]: *)
-    let portability =
-      match modes.statefulness, modes.portability with
-      | Stateless, Portable
-      | Reading, Shareable
-      | Writing, Corruptible
-      | Stateful, Nonportable -> None
-      | _, _ -> Some modes.portability
-    in
-
+    let implied = erase_implied_axes modes in
     let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
-    { diff with forkable; yielding; contention; portability }
+    { diff with
+      forkable = implied.forkable;
+      yielding = implied.yielding;
+      contention = implied.contention;
+      portability = implied.portability }
   in
   (* Step 2: Print the modes *)
   List.filter_map
@@ -1481,11 +2714,19 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
       |> Option.map (Fmt.asprintf "%a" (Mode.Alloc.Const.print_axis ax)))
     Mode.Alloc.Axis.all
 
+let tree_of_modes : Alloc.lr -> const_or_generic -> string list =
+  fun modes acc ->
+    match acc with
+    | Generic _ ->
+      [ (Fmt.asprintf "%s"
+            (Variable_names.name_of_mode modes))]
+    | Const c -> tree_of_modes_const c
+
 (** The modal context on a type when printing it. This is to reproduce the mode
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
   | Arrow_return of
-    { acc : Mode.Alloc.Const.t;
+    { acc : const_or_generic;
       mode : Mode.Alloc.lr; }
     (** This is the RHS (say [r]) of an arrow type, where [mode] is the real
         mode of [r]. and:
@@ -1503,7 +2744,7 @@ type modal =
     If [r] is [Tpoly (Tarrow_, [])], it will be treated as NOT an arrow type.
     This gives tedious (but still correct) printing. *)
 
-  | Other of Mode.Alloc.Const.t
+  | Other of const_or_generic
     (** In other cases, the caller has already printed the modes (as the
         constructor argument) on the type. *)
 
@@ -1522,8 +2763,13 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
+<<<<<<< HEAD
         let mode = Alloc.zap_to_legacy ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
+=======
+        let acc = const_or_generic_of_mode mode in
+        Otyp_ret (Orm_any (tree_of_modes mode acc), tree)
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     | Other _ -> tree
   in
   let ty =
@@ -1536,7 +2782,7 @@ let rec tree_of_modal_typexp mode modal ty =
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
    not_arrow (Otyp_var (non_gen, name)) else
 
-  let pr_typ alloc_mode =
+  let pr_typ acc_mode =
     let tty = Transient_expr.repr ty in
     match tty.desc with
     | Tvar _ ->
@@ -1552,7 +2798,11 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
+<<<<<<< HEAD
         let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
+=======
+        let arg_acc = const_or_generic_of_mode marg in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
         let t1 =
           if is_optional l then
             match
@@ -1560,15 +2810,15 @@ let rec tree_of_modal_typexp mode modal ty =
             with
             | Tconstr(path, [ty], _)
               when Path.same path Predef.path_option ->
-                tree_of_typexp mode arg_mode ty
+                tree_of_acc_typexp mode arg_acc ty
             | _ -> Otyp_stuff "<hidden>"
           else
-            tree_of_typexp mode arg_mode ty1
+            tree_of_acc_typexp mode arg_acc ty1
         in
-        let acc_mode = curry_mode alloc_mode arg_mode in
+        let acc_mode = curry_acc acc_mode marg in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
-        Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
+        Otyp_arrow (lab, tree_of_modes marg arg_acc, t1, t2)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->
@@ -1613,16 +2863,16 @@ let rec tree_of_modal_typexp mode modal ty =
         tree_of_typobject mode fi !nm
     | Tmod (ty, mod_bounds) ->
         Otyp_mod
-          ( tree_of_typexp mode alloc_mode ty,
+          ( tree_of_acc_typexp mode acc_mode ty,
             out_modalities_of_mod_bounds mod_bounds )
     | Tquote ty ->
         wrap_printing_env_unguarded
           (Env.enter_quote !printing_env)
-          (fun () -> Otyp_quote (tree_of_typexp mode alloc_mode ty))
+          (fun () -> Otyp_quote (tree_of_acc_typexp mode acc_mode ty))
     | Tsplice ty ->
         wrap_printing_env_unguarded
           (Env.enter_splice ~loc:Location.none !printing_env)
-          (fun () -> Otyp_splice (tree_of_typexp mode alloc_mode ty))
+          (fun () -> Otyp_splice (tree_of_acc_typexp mode acc_mode ty))
     | Tquote_eval ty ->
         (* We use [Predef]'s [eval] as the syntax, so we need to quote [ty]. *)
         let ty = newgenty (Tquote ty) in
@@ -1647,7 +2897,7 @@ let rec tree_of_modal_typexp mode modal ty =
     | Tlink _ ->
         fatal_error "Out_type.tree_of_typexp"
     | Tpoly (ty, []) | Trepr (ty, []) ->
-        tree_of_typexp mode alloc_mode ty
+        tree_of_acc_typexp mode acc_mode ty
     | Tpoly (ty, tyl) ->
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
@@ -1658,7 +2908,7 @@ let rec tree_of_modal_typexp mode modal ty =
            printed once when used as proxy *)
         List.iter Aliases.add_delayed tyl;
         let tl = tree_of_univars tyl in
-        let tr = Otyp_poly (tl, tree_of_typexp mode alloc_mode ty) in
+        let tr = Otyp_poly (tl, tree_of_acc_typexp mode acc_mode ty) in
         (* Forget names when we leave scope *)
         Variable_names.remove_names tyl;
         Aliases.delayed := old_delayed; tr
@@ -1693,17 +2943,18 @@ let rec tree_of_modal_typexp mode modal ty =
                List.iter Aliases.add_delayed tyl;
                let sort_names = tree_of_qsvs tyl in
                let tr =
-                Otyp_repr (sort_names, tree_of_typexp mode alloc_mode inner_ty)
-              in
+                 Otyp_repr
+                   (sort_names, tree_of_acc_typexp mode acc_mode inner_ty)
+               in
                Variable_names.remove_names tyl;
                Aliases.delayed := old_delayed;
                tr
              end else
                (* Mismatch: print Trepr and Tpoly separately *)
-               tree_of_typexp mode alloc_mode ty
+               tree_of_acc_typexp mode acc_mode ty
          | _ ->
              (* No type variables, just print the body *)
-             tree_of_typexp mode alloc_mode ty)
+             tree_of_acc_typexp mode acc_mode ty)
     | Tunivar _ ->
         Otyp_var (false, Variable_names.(name_of_type new_name) tty)
     | Tpackage pack ->
@@ -1732,19 +2983,23 @@ let rec tree_of_modal_typexp mode modal ty =
        doesn't matter.*)
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
     let tree =
-      Otyp_alias {non_gen;  aliased = pr_typ Mode.Alloc.Const.legacy; alias }
+      Otyp_alias
+        {non_gen; aliased = pr_typ (Const Mode.Alloc.Const.legacy); alias}
     in
     not_arrow tree end
   else
     match modal with
     | Arrow_return {acc; mode} ->
-        let rm, alloc_mode = tree_of_ret_typ_mutating acc mode ty in
-        let ty = pr_typ alloc_mode in
+        let rm, acc_mode = tree_of_ret_typ_mutating acc mode ty in
+        let ty = pr_typ acc_mode in
         Otyp_ret (rm, ty)
-    | Other m -> pr_typ m
+    | Other acc_mode -> pr_typ acc_mode
+
+and tree_of_acc_typexp mode acc_mode ty =
+  tree_of_modal_typexp mode (Other acc_mode) ty
 
 and tree_of_typexp mode alloc_mode ty =
-  tree_of_modal_typexp mode (Other alloc_mode) ty
+  tree_of_acc_typexp mode (Const alloc_mode) ty
 
 and tree_of_qtv v jkind =
     (* CR layouts: We ignore nullability here to avoid needlessly printing
@@ -1819,23 +3074,33 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating acc_mode m ty=
+and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
-      match Alloc.equate (Alloc.of_const acc_mode) m with
-      | Ok () ->
+      if equate_with_const m acc_mode then begin
         (Orm_no_parens, acc_mode)
-      | Error _ ->
+      end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
+<<<<<<< HEAD
         let m = Alloc.zap_to_legacy ~arg:false m in
         (Orm_parens (tree_of_modes m), m)
+=======
+        let acc_mode = const_or_generic_of_mode m in
+        (Orm_parens (tree_of_modes m acc_mode), acc_mode)
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       end
+    end
   | _ ->
+<<<<<<< HEAD
     let m = Alloc.zap_to_legacy ~arg:false m in
     (Orm_any (tree_of_modes m), m)
+=======
+    let acc_mode = const_or_generic_of_mode m in
+    (Orm_any (tree_of_modes m acc_mode), acc_mode)
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -2845,9 +4110,13 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
+<<<<<<< HEAD
       let mres =
         m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
       in
+=======
+      let mres = m_res |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       let p = best_module_path p in
@@ -2878,9 +4147,13 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
+<<<<<<< HEAD
       let marg =
         m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
       in
+=======
+      let marg = m_arg |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/external/merlin/src/ocaml/typing/out_type.mli
+++ b/external/merlin/src/ocaml/typing/out_type.mli
@@ -108,7 +108,7 @@ val tree_of_type_scheme: type_expr -> out_type
 val tree_of_modalities:
   Types.mutability -> Mode.Modality.Const.t -> Outcometree.out_mode list
 
-val tree_of_modes:
+val tree_of_modes_const:
   Mode.Alloc.Const.t -> Outcometree.out_mode list
 
 (** [out_jkind_of_jkind env jkind] converts a jkind to an [out_jkind]

--- a/external/merlin/src/ocaml/typing/printtyped.ml
+++ b/external/merlin/src/ocaml/typing/printtyped.ml
@@ -671,7 +671,7 @@ and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
 
 and yielding_mode i ppf m =
   line i ppf "yielding_mode %s\n"
-    (match Mode.Yielding.zap_to_floor m with
+    (match Mode.Yielding.zap_to_floor_exn m with
      | Mode.Yielding.Const.Unyielding -> "unyielding"
      | Mode.Yielding.Const.Yielding -> "yielding")
 

--- a/external/merlin/src/ocaml/typing/solver.ml
+++ b/external/merlin/src/ocaml/typing/solver.ml
@@ -47,6 +47,15 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             -> ('a, 'c, 'l * 'r) t
         | Id : ('a, 'a, 'l * 'r) t
             (** Short-hand for [Base (H.id, C.id)] to save memory *)
+        | Adjoint_l :
+            ('a, 'b, 'l2 * allowed) t * ('b, 'a, allowed * disallowed) C.morph
+            -> ('b, 'a, 'l * disallowed) t
+            (** [Adjoint_l (h, m)] is the left adjoint of [h], deferred; [m] is
+                the (already computed) left adjoint of [h]'s morphism. *)
+        | Adjoint_r :
+            ('a, 'b, allowed * 'r2) t * ('b, 'a, disallowed * allowed) C.morph
+            -> ('b, 'a, disallowed * 'r) t
+            (** Right-adjoint analogue of [Adjoint_l]. *)
         constraint 'd = _ * _
       [@@ocaml.warning "-62"]
 
@@ -57,6 +66,56 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        fun m1 m2 ->
         match m1, m2 with Id, m -> m | m, Id -> m | _, _ -> Compose (m1, m2)
 
+      include Magic_allow_disallow (struct
+        type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
+
+        let rec allow_left : type l a b r.
+            (a, b, allowed * r) t -> (a, b, l * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.allow_left morph_hint, C.allow_left morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (allow_left a_morph_hint, allow_left b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+
+        let rec allow_right : type a b l r.
+            (a, b, l * allowed) t -> (a, b, l * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.allow_right morph_hint, C.allow_right morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (allow_right a_morph_hint, allow_right b_morph_hint)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+
+        let rec disallow_left : type a b l r.
+            (a, b, l * r) t -> (a, b, disallowed * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.disallow_left morph_hint, C.disallow_left morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (disallow_left a_morph_hint, disallow_left b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+
+        let rec disallow_right : type a b l r.
+            (a, b, l * r) t -> (a, b, l * disallowed) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.disallow_right morph_hint, C.disallow_right morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (disallow_right a_morph_hint, disallow_right b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+      end)
+
       let rec left_adjoint : type a b l.
           H.Pinpoint.t ->
           b C.obj ->
@@ -64,6 +123,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           H.Pinpoint.t * a C.obj * (b, a, allowed * disallowed) t =
        fun pp b_obj -> function
         | Id -> pp, b_obj, Id
+        | Adjoint_r (h, m) -> pp, C.src b_obj m, disallow_right h
         | Base (small_morph_hint, morph) ->
           let pp, small_morph_hint = H.Morph.left_adjoint pp small_morph_hint in
           ( pp,
@@ -85,6 +145,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           H.Pinpoint.t * a C.obj * (b, a, disallowed * allowed) t =
        fun pp b_obj -> function
         | Id -> pp, b_obj, Id
+        | Adjoint_l (h, m) -> pp, C.src b_obj m, disallow_left h
         | Base (small_morph_hint, morph) ->
           let pp, small_morph_hint =
             H.Morph.right_adjoint pp small_morph_hint
@@ -101,50 +162,6 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           in
           src_pp, src, Compose (g_morph_hint_adj, f_morph_hint_adj)
 
-      include Magic_allow_disallow (struct
-        type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
-
-        let rec allow_left : type l a b r.
-            (a, b, allowed * r) t -> (a, b, l * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.allow_left morph_hint, C.allow_left morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (allow_left a_morph_hint, allow_left b_morph_hint)
-
-        let rec allow_right : type a b l r.
-            (a, b, l * allowed) t -> (a, b, l * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.allow_right morph_hint, C.allow_right morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (allow_right a_morph_hint, allow_right b_morph_hint)
-
-        let rec disallow_left : type a b l r.
-            (a, b, l * r) t -> (a, b, disallowed * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.disallow_left morph_hint, C.disallow_left morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (disallow_left a_morph_hint, disallow_left b_morph_hint)
-
-        let rec disallow_right : type a b l r.
-            (a, b, l * r) t -> (a, b, l * disallowed) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.disallow_right morph_hint, C.disallow_right morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (disallow_right a_morph_hint, disallow_right b_morph_hint)
-      end)
-
       let rec populate : type b a l r.
           a C.obj ->
           (b, a, l * r) t ->
@@ -153,6 +170,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        fun obj_a hint cont ->
         match hint with
         | Id -> cont obj_a
+        | Adjoint_l (h, m) ->
+          let obj_b = C.src obj_a m in
+          let _, _, h' = left_adjoint H.Pinpoint.unknown obj_b h in
+          populate obj_a (allow_left h') cont
+        | Adjoint_r (h, m) ->
+          let obj_b = C.src obj_a m in
+          let _, _, h' = right_adjoint H.Pinpoint.unknown obj_b h in
+          populate obj_a (allow_right h') cont
         | Base (morph_hint, morph) ->
           let obj_b = C.src obj_a morph in
           let ahint = cont obj_b in
@@ -585,6 +610,133 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
     | Amodejoin (_, _, mvs) ->
       VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+
+  let check_generic : type a l r. (a, l * r) mode -> bool =
+   fun m ->
+    match m with
+    | Amode _ -> false
+    | Amodevar mv -> check_level_morphvar mv generic_level
+    | Amodemeet (_, _, mvs) ->
+      VarMap.exists (fun _ mv -> check_level_morphvar mv generic_level) mvs
+    | Amodejoin (_, _, mvs) ->
+      VarMap.exists (fun _ mv -> check_level_morphvar mv generic_level) mvs
+
+  type var_iterator =
+    { iter : 'a. 'a C.obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  let mode_iter : type a l r. a C.obj -> (a, l * r) mode -> var_iterator -> unit
+      =
+   fun dst m { iter } ->
+    let iter_morphvar : type l' r'. (a, l' * r') morphvar -> unit =
+     fun (Amorphvar (v, f, _f_hint)) ->
+      let src = C.src dst f in
+      iter src (Amodevar (Amorphvar (v, C.id, Id)))
+    in
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv -> iter_morphvar mv
+    | Amodejoin (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
+    | Amodemeet (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
+
+  type 'b packed_morph =
+    | Packed_morph : ('a, 'b, 'd) C.morph -> 'b packed_morph
+
+  let rec iter_covariant_morphvar : type a r.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, allowed * disallowed) mode ->
+      unit) ->
+      (a, allowed * r) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_right f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          iter ~id:u.id ~level:u.level ~morph:(Packed_morph fg) (Amodevar mu);
+          iter_covariant_morphvar ~visited dst iter mu)
+        v.vlower
+    end
+
+  let iter_covariant : type a r.
+      a C.obj ->
+      (a, allowed * r) mode ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, allowed * disallowed) mode ->
+      unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_covariant_morphvar ~visited dst iter mv
+    | Amodejoin (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter (fun _ mv -> iter_covariant_morphvar ~visited dst iter mv) mvs
+
+  let rec iter_contravariant_morphvar : type a l.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, disallowed * allowed) mode ->
+      unit) ->
+      (a, l * allowed) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_left f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          iter ~id:u.id ~level:u.level ~morph:(Packed_morph fg) (Amodevar mu);
+          iter_contravariant_morphvar ~visited dst iter mu)
+        v.vupper
+    end
+
+  let iter_contravariant : type a l.
+      a C.obj ->
+      (a, l * allowed) mode ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, disallowed * allowed) mode ->
+      unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_contravariant_morphvar ~visited dst iter mv
+    | Amodemeet (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter
+        (fun _ mv -> iter_contravariant_morphvar ~visited dst iter mv)
+        mvs
 
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
@@ -1148,7 +1300,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       unit =
    fun ~log pp dst v u f f_hint ->
     let f' = C.left_adjoint dst f in
-    let _, src, f'_hint = Comp_hint.Morph_hint.left_adjoint pp dst f_hint in
+    let src = C.src dst f in
+    let f'_hint = Comp_hint.Morph_hint.Adjoint_l (f_hint, f') in
     let x = Amorphvar (u, f', f'_hint) in
     let key = get_key src x in
     if VarMap.mem key v.vlower
@@ -1188,7 +1341,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       unit =
    fun ~log pp dst v u f f_hint ->
     let f' = C.right_adjoint dst f in
-    let _, src, f'_hint = Comp_hint.Morph_hint.right_adjoint pp dst f_hint in
+    let src = C.src dst f in
+    let f'_hint = Comp_hint.Morph_hint.Adjoint_r (f_hint, f') in
     let x = Amorphvar (u, f', f'_hint) in
     let key = get_key src x in
     if VarMap.mem key v.vupper
@@ -1266,9 +1420,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     decr persistent_id;
     id
 
-  let fresh ?(persistent = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower
-      ?vupper ~level obj =
-    let id = if persistent then next_persistent_id () else next_live_id () in
+  let fresh ?(neg = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper
+      ~level obj =
+    let id = if neg then next_persistent_id () else next_live_id () in
     let upper, upper_hint =
       match upper, upper_hint with
       | None, None -> C.max obj, Comp_hint.Max
@@ -1332,7 +1486,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     current_level < u.level < generic_level ==>
       Forall v in the reachable set of variables from u:
         v.level = generic_level + (v.level - current_level) *)
-  let rec generalize_topology : type a.
+  let rec generalize_topology_v : type a.
       log:_ -> current_level:int -> a var -> unit =
    fun ~log ~current_level u ->
     if u.level <= current_level || u.level >= generic_level
@@ -1341,7 +1495,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let new_level = generic_level + (u.level - current_level) in
       set_level ~log u new_level;
       let do_gen _ (Amorphvar (v, _f, _f_hint)) =
-        generalize_topology ~log ~current_level v
+        generalize_topology_v ~log ~current_level v
       in
       VarMap.iter do_gen u.vupper;
       VarMap.iter do_gen u.vlower
@@ -1375,7 +1529,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    generalize_topology ~log ~current_level u;
+    generalize_topology_v ~log ~current_level u;
     update_level_v ~log dst generic_level u
 
   (* generalize_structure first moves a variable to generic_level (like generalize does).
@@ -1408,8 +1562,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
    fun ~log dst ~current_level u ->
     (* if the following does not hold:
         current_level < u.level || u.level = generic_level
-      [generalize_topology] and [update_level] do nothing. We check it here to optimize
-      away the subsequent checks *)
+      [generalize_topology_v] and [update_level] do nothing. We check it here
+      to optimize away the subsequent checks *)
     if u.level <= current_level || u.level = generic_level
     then ()
     else begin
@@ -1419,7 +1573,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         set_vlower ~log u VarMap.empty;
         set_vupper ~log u VarMap.empty
       end;
-      generalize_topology ~log ~current_level u;
+      generalize_topology_v ~log ~current_level u;
       update_level_v ~log dst generic_level u;
       let vlower_above_current =
         VarMap.filter
@@ -1446,6 +1600,23 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         create_gencopy ~log dst ~current_level u
       end
     end
+
+  let generalize_topology (type a l r) ~current_level (a : (a, l * r) mode) ~log
+      =
+    match a with
+    | Amodevar (Amorphvar (v, _f, _f_hint)) ->
+      generalize_topology_v ~log ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, _f, _f_hint)) ->
+          generalize_topology_v ~log ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, _f, _f_hint)) ->
+          generalize_topology_v ~log ~current_level v)
+        mvs
 
   let generalize (type a l r) ~current_level (obj : a C.obj)
       (a : (a, l * r) mode) ~log =
@@ -1515,13 +1686,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       copy_from_level:int ->
       copy_below_level:int ->
       copy_to_level:int option ->
-      persistent:bool ->
+      cause:[`Save | `Restore | `Neither] ->
       a C.obj ->
       a var ->
       a var =
-   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~persistent
-       obj v ->
+   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~cause obj
+       v ->
     let in_window = v.level >= copy_from_level && v.level < copy_below_level in
+    if cause = `Restore then assert (v.id < 0);
     if not in_window
     then v
     else
@@ -1536,7 +1708,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         | Some v' -> v'
         | None ->
           let copy =
-            fresh ~persistent ~upper:v.upper ~lower:v.lower ~level:v.level obj
+            fresh ~neg:(cause = `Save) ~upper:v.upper ~lower:v.lower
+              ~level:v.level obj
           in
           set_optcopy ~changes:copy_scope obj ~target_level v (Some copy);
           let vupper =
@@ -1545,7 +1718,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                    ~copy_to_level ~persistent src u
+                    ~copy_to_level ~cause src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1557,7 +1730,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                    ~copy_to_level ~persistent src u
+                    ~copy_to_level ~cause src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1570,8 +1743,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       end
 
   let copy (type a l r) ~copy_scope ~copy_from_level ~copy_below_level
-      ?copy_to_level ?(persistent = false) (obj : a C.obj) (a : (a, l * r) mode)
-      : (a, l * r) mode =
+      ?copy_to_level ?(cause = `Neither) (obj : a C.obj) (a : (a, l * r) mode) :
+      (a, l * r) mode =
     (* We never want to copy variables above [generic_level]. *)
     assert (copy_below_level <= generic_level + 1);
     Option.iter
@@ -1587,7 +1760,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let obj = C.src obj f in
       let vcopy =
         copy_v ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level
-          ~persistent obj v
+          ~cause obj v
       in
       if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
     | Amode _ -> a
@@ -1598,7 +1771,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             let src = C.src obj f in
             let vcopy =
               copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                ~copy_to_level ~persistent src v
+                ~copy_to_level ~cause src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)
@@ -1612,7 +1785,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             let src = C.src obj f in
             let vcopy =
               copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                ~copy_to_level ~persistent src v
+                ~copy_to_level ~cause src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)
@@ -2104,5 +2277,127 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
           mvs;
         allow_left (Amodevar mu), true
+
+  (** Exposed description of mode variables, used for printing generic mode
+      variables *)
+  module Desc = struct
+    module Var = struct
+      type 'a t = 'a var
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+      module Head = struct
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        let equal v1 v2 = v1.desc_id = v2.desc_id
+
+        let hash v = Hashtbl.hash v.desc_id
+      end
+
+      let force : 'a C.obj -> 'a var -> 'a Head.t =
+       fun obj v ->
+        let desc_id = v.id in
+        let desc_lower =
+          get_floor obj
+            (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        let desc_upper =
+          get_ceil obj (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        (* let desc_lower = v.lower in
+          let desc_upper = v.upper in *)
+        let desc_vlower =
+          let f (Amorphvar (a, f, _) : _ morphvar) = Amorphvar (a, f) in
+          let vlower = VarMap.map f v.vlower in
+          var_map_to_list vlower
+        in
+        let desc_level = v.level in
+        { desc_id; desc_lower; desc_upper; desc_vlower; desc_level }
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    let equal_morphvar : type a l r.
+        a C.obj -> (a, l * r) morphvar -> (a, l * r) morphvar -> bool =
+     fun obj (Amorphvar (v1, m1)) (Amorphvar (v2, m2)) ->
+      let c = C.compare_morph obj m1 m2 in
+      c = 0 && Var.Head.equal v1 v2
+
+    let equal : type a l r. a C.obj -> (a, l * r) t -> (a, l * r) t -> bool =
+     fun obj m1 m2 ->
+      match m1, m2 with
+      | Amode a1, Amode a2 -> C.equal obj a1 a2
+      | Amodevar mv1, Amodevar mv2 -> equal_morphvar obj mv1 mv2
+      | Amodejoin (a1, mv1), Amodejoin (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | Amodemeet (a1, mv1), Amodemeet (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | _, _ -> false
+
+    let print_var : type a. a C.obj -> Fmt.formatter -> a Var.Head.t -> unit =
+     fun obj ppf { desc_id; desc_upper; desc_lower; desc_level } ->
+      Fmt.fprintf ppf "%x<%d>[%a--%a]" desc_id desc_level (C.print obj)
+        desc_lower (C.print obj) desc_upper
+
+    let print_morphvar : type a l r.
+        a C.obj -> Fmt.formatter -> (a, l * r) morphvar -> unit =
+     fun dst ppf mv ->
+      let (Amorphvar (v, f)) = mv in
+      let src = C.src dst f in
+      Fmt.fprintf ppf "%a(%a)" (C.print_morph dst) f (print_var src) v
+
+    let print : type a l r. a C.obj -> Fmt.formatter -> (a, l * r) t -> unit =
+     fun obj ppf m ->
+      match m with
+      | Amode a -> C.print obj ppf a
+      | Amodevar mv -> print_morphvar obj ppf mv
+      | Amodejoin (a, mvs) ->
+        Fmt.fprintf ppf "join(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+      | Amodemeet (a, mvs) ->
+        Fmt.fprintf ppf "meet(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+  end
+
+  let desc_morphvar : type a l r.
+      a C.obj -> (a, l * r) morphvar -> (a, l * r) Desc.morphvar =
+   fun dst (Amorphvar (v, f, _)) ->
+    let src = C.src dst f in
+    let v = Desc.Var.force src v in
+    Desc.Amorphvar (v, f)
+
+  let desc : type a l r. a C.obj -> (a, l * r) mode -> (a, l * r) Desc.t =
+   fun dst m ->
+    match m with
+    | Amode (a, _, _) -> Desc.Amode a
+    | Amodevar mv -> Desc.Amodevar (desc_morphvar dst mv)
+    | Amodejoin (a, _, mvs) ->
+      Desc.Amodejoin (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
+    | Amodemeet (a, _, mvs) ->
+      Desc.Amodemeet (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
 end
 [@@inline always]

--- a/external/merlin/src/ocaml/typing/solver_intf.mli
+++ b/external/merlin/src/ocaml/typing/solver_intf.mli
@@ -306,6 +306,13 @@ module type Solver_mono = sig
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
 
+  (** Moves a variable [u] whose level is above [current_level] and below
+      [generic_level] to [generic_level + i], where [i] is the difference
+      between [u.level] and [current_level] (the same is then done to all of
+      [u]'s children) *)
+  val generalize_topology :
+    current_level:int -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
   (** Generalizes a variable whose level is above [current_level], by putting
       its level to [generic_level], and all its children above [current_level]
       to [generic_level + i] for some nonzero [i]. *)
@@ -344,7 +351,7 @@ module type Solver_mono = sig
     copy_from_level:int ->
     copy_below_level:int ->
     ?copy_to_level:int ->
-    ?persistent:bool ->
+    ?cause:[`Save | `Restore | `Neither] ->
     'a obj ->
     ('a, 'l * 'r) mode ->
     ('a, 'l * 'r) mode
@@ -392,6 +399,47 @@ module type Solver_mono = sig
 
   (** Returns true if the mode is a constant or a mode variable at level 0 *)
   val check_const_or_level_0 : ('a, 'l * 'r) mode -> bool
+
+  (** Returns true if the mode includes a mode variable at generic level *)
+  val check_generic : ('a, 'l * 'r) mode -> bool
+
+  type var_iterator =
+    { iter : 'a. 'a obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  val mode_iter : 'a obj -> ('a, 'l * 'r) mode -> var_iterator -> unit
+
+  type 'b packed_morph = Packed_morph : ('a, 'b, 'd) morph -> 'b packed_morph
+
+  (** Applies an iterator over every reachable covariant (left-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_covariant :
+    'a obj ->
+    ('a, allowed * 'r) mode ->
+    (id:int ->
+    level:int ->
+    morph:'a packed_morph ->
+    ('a, allowed * disallowed) mode ->
+    unit) ->
+    unit
+
+  (** Applies an iterator over every reachable contravariant (right-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_contravariant :
+    'a obj ->
+    ('a, 'l * allowed) mode ->
+    (id:int ->
+    level:int ->
+    morph:'a packed_morph ->
+    ('a, disallowed * allowed) mode ->
+    unit) ->
+    unit
 
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
@@ -459,6 +507,52 @@ module type Solver_mono = sig
     val apply :
       'b obj -> ('a, 'b, 'l * 'r) morph -> ('a, 'l * 'r) t -> ('b, 'l * 'r) t
   end
+
+  (** The exposed description of modes *)
+  module Desc : sig
+    module Var : sig
+      type 'a t
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) morph -> ('b, 'd) t_with_morph
+
+      module Head : sig
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        val equal : 'a t -> 'b t -> bool
+
+        val hash : 'a t -> int
+      end
+
+      val force : 'a obj -> 'a t -> 'a Head.t
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    val equal : 'a obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+    val print : 'a obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+  end
+
+  (** Returns the description of a mode. *)
+  val desc : 'a obj -> ('a, 'd) mode -> ('a, 'd) Desc.t
 end
 
 (** Hint module to be provided by the user of the solver. *)

--- a/external/merlin/src/ocaml/typing/subst.ml
+++ b/external/merlin/src/ocaml/typing/subst.ml
@@ -40,7 +40,7 @@ type kind_replacement =
 type additional_action =
   | Prepare_for_saving of
       { prepare_jkind : 'l 'r. Location.t -> ('l * 'r) jkind -> ('l * 'r) jkind;
-        prepare_mode : Mode.Alloc.lr -> Mode.Alloc.lr;
+        prepare_mode : For_copy.copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr;
         prepare_modality : Mode.Modality.t -> Mode.Modality.t;
         prepare_ident : Ident.t -> Ident.t
       }
@@ -304,8 +304,11 @@ let with_additional_action =
         in
         (* CR-someday zqian: preserve the hints *)
         (* modes and modalities should have been zapped already *)
-        let prepare_mode mode =
-          Mode.Alloc.(mode |> to_const_exn |> of_const)
+        (* if a mode is generic we copy it persistently for saving *)
+        let prepare_mode copy_scope mode =
+          if Mode.Alloc.check_generic mode
+          then For_copy.mode_copy_for_saving copy_scope mode
+          else Mode.Alloc.(mode |> to_const_exn |> of_const)
         in
         let prepare_modality modality =
           Mode.Modality.(modality |> to_const_exn|> of_const)
@@ -446,6 +449,7 @@ let to_subst_by_type_function s p =
 let new_type_id = s_ref (-1)
 let reset_additional_action_id () =
   new_type_id := -1;
+  Mode.reset_persistent_id ();
   Jkind_types.Sort.reset_cmi_sort_id ()
 
 let newpersty desc =
@@ -521,7 +525,8 @@ let apply_type_function params args body =
           let t = newgenstub ~scope:(get_scope ty)
             (Jkind.Builtin.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
-          let desc' = copy_type_desc copy desc in
+          let copy_mode m = For_copy.mode_copy_generic copy_scope m in
+          let desc' = copy_type_desc copy copy_mode desc in
           Transient_expr.set_stub_desc t desc';
           t
     in
@@ -766,9 +771,17 @@ let rec typexp copy_scope s ty =
           Tlink (typexp copy_scope s t2)
       | Tarrow ((label, marg, mret), arg, ret, comm) ->
           let marg, mret =
+            if get_id ty < 0 then
+              For_copy.mode_copy_for_restoring copy_scope marg,
+              For_copy.mode_copy_for_restoring copy_scope mret
+            else
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              prepare_mode marg, prepare_mode mret
+              prepare_mode copy_scope marg,
+              prepare_mode copy_scope mret
+            | Duplicate_variables ->
+              For_copy.mode_copy_generic copy_scope marg,
+              For_copy.mode_copy_generic copy_scope mret
             | _ -> marg, mret
           in
           let arg = typexp copy_scope s arg in
@@ -778,7 +791,8 @@ let rec typexp copy_scope s ty =
       | Tof_kind jk -> Tof_kind (jkind copy_scope s jk)
       | Tmod (ty, mod_bounds) ->
           Tmod (typexp copy_scope s ty, mod_bounds)
-      | _ -> copy_type_desc (typexp copy_scope s) desc
+      | _ ->
+        copy_type_desc (typexp copy_scope s) (fun _ -> assert false) desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'
@@ -817,7 +831,8 @@ let jkind copy_scope s loc jk =
 *)
 let type_expr s ty =
   let loc = Option.value s.loc ~default:Location.none in
-  For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)
+  For_copy.with_scope (fun copy_scope ->
+    typexp copy_scope s loc ty)
 
 (* For idents that are guaranteed to be local/scoped, such as bound
    signature items and functor parameters. *)

--- a/external/merlin/src/ocaml/typing/typeclass.ml
+++ b/external/merlin/src/ocaml/typing/typeclass.ml
@@ -689,6 +689,8 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
         (fun () ->
            let cty =
              Ctype.with_local_level_generalize_structure_if_principal
+               ~before_generalize:(fun cty ->
+                 Ctype.generalize_structure cty.ctyp_type)
                (fun () -> Typetexp.transl_simple_type ~new_var_jkind:Any val_env
                             ~closed:false Alloc.Const.legacy styp)
            in
@@ -737,6 +739,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
            end;
            let definition =
              Ctype.with_local_level_generalize_structure_if_principal
+               ~before_generalize:Typecore.generalize_structure_exp
                (fun () -> Typecore.type_exp val_env sdefinition)
            in
            begin
@@ -1246,6 +1249,10 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
         raise(Error(spat.ppat_loc, val_env, Polymorphic_class_parameter));
       let (pat, pv, val_env', met_env) =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:begin fun (pat, _, _, _) ->
+            let gen {pat_type = ty} = Ctype.generalize_structure ty in
+            iter_pattern gen pat
+          end
           (fun () ->
             Typecore.type_class_arg_pattern cl_num val_env met_env l spat)
       in
@@ -1311,6 +1318,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       assert (sargs <> []);
       let cl =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun cl ->
+            Ctype.generalize_class_type_structure cl.cl_type)
           (fun () -> class_expr cl_num val_env met_env virt self_scope scl')
       in
       let rec nonopt_labels ls ty_fun =
@@ -1673,6 +1682,7 @@ let initial_env define_class approx
   (* Temporary type for the class constructor *)
   let constr_type =
     Ctype.with_local_level_generalize_structure_if_principal
+      ~before_generalize:Ctype.generalize_structure
       (fun () -> approx cl.pci_expr)
   in
   let dummy_cty = Cty_signature (Ctype.new_class_signature ()) in
@@ -1933,8 +1943,8 @@ let final_decl env define_class
                  , Non_generalizable_class { id; clty; nongen_vars }));
     );
   begin match
-    Ctype.closed_class clty.cty_params
-      (Btype.signature_of_class_type clty.cty_type)
+    Alloc.with_zap_scope (fun ~zap_scope -> Ctype.closed_class ~zap_scope
+      clty.cty_params (Btype.signature_of_class_type clty.cty_type))
   with
     None        -> ()
   | Some reason ->

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -309,6 +309,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -595,6 +596,12 @@ type expected_mode =
 
         Each location points to the corresponding sub-pattern of [Ppat_tuple].
     *)
+
+    return_from_exclave : bool ref option;
+    (** Indicates whether the expected mode is for an exclave expression in tail
+        position. The field is a bool ref so that it is preserved across all
+        copies.
+    *)
   }
 
 type position_and_mode = {
@@ -603,11 +610,13 @@ type position_and_mode = {
   region_mode : Regionality.r option;
   (** INVARIANT: [Some m] iff [apply_position] is [Tail], where [m] is the mode
      of the surrounding region *)
+  return_from_exclave : bool ref option;
 }
 
 let position_and_mode_default = {
   apply_position = Default;
   region_mode = None;
+  return_from_exclave = None;
 }
 
 (** Decides the runtime tail call behaviour based on lexical structures and user
@@ -626,14 +635,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   | RTail (m ,FTail) -> begin
       match requested with
       | Some `Tail | Some `Tail_if_possible | None ->
-          {apply_position = Tail; region_mode = Some m}
-      | Some `Nontail -> {apply_position = Nontail; region_mode = None}
+          { apply_position = Tail;
+            region_mode = Some m;
+            return_from_exclave = expected_mode.return_from_exclave }
+      | Some `Nontail ->
+          { apply_position = Nontail;
+            region_mode = None;
+            return_from_exclave = None }
     end
   | RNontail | RTail(_, FNontail) -> begin
       match requested with
       | None | Some `Tail_if_possible ->
-          {apply_position = Default; region_mode = None}
-      | Some `Nontail -> {apply_position = Nontail; region_mode = None}
+          { apply_position = Default;
+            region_mode = None;
+            return_from_exclave = None }
+      | Some `Nontail ->
+          { apply_position = Nontail;
+            region_mode = None;
+            return_from_exclave = None }
       | Some `Tail -> fail `Not_a_tailcall
   end
 
@@ -668,7 +687,8 @@ let mode_default mode =
   { position = RNontail;
     mode = Value.disallow_left mode;
     strictly_local = false;
-    tuple_modes = None }
+    tuple_modes = None;
+    return_from_exclave = None }
 
 let mode_legacy = mode_default Value.legacy
 
@@ -772,7 +792,7 @@ let mode_max_with_position position =
 
 (** Take the expected mode of [exclave_ exp], return the expected mode of [exp].
     [expected_mode] must be higher than [regional]. *)
-let mode_exclave expected_mode =
+let mode_exclave (expected_mode : expected_mode) =
   let mode =
      as_single_mode expected_mode
      (* if we expect an exclave to be [regional], then inside the exclave the
@@ -780,14 +800,23 @@ let mode_exclave expected_mode =
      |> value_to_alloc_r2l
      |> alloc_as_value
   in
+  Option.iter (fun excl -> excl := true) expected_mode.return_from_exclave;
   { (mode_default mode)
-    with strictly_local = true
+    with strictly_local = true;
+         return_from_exclave = expected_mode.return_from_exclave
   }
 
 let mode_strictly_local expected_mode =
   { expected_mode
     with strictly_local = true
   }
+
+let mode_return_from_exclave (expected_mode : expected_mode) =
+  match expected_mode.return_from_exclave with
+  | Some r -> r, expected_mode
+  | None ->
+    let r = ref false in
+    r, { expected_mode with return_from_exclave = Some r }
 
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
@@ -858,7 +887,10 @@ tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
 let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
-  let vmode , _ = Value.newvar_below (alloc_as_value marg) in
+  let vmode , _ =
+    Value.newvar_below
+      (Ctype.get_current_level ()) (alloc_as_value marg)
+  in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
   | Texp_ident { desc = {val_kind =
@@ -866,7 +898,9 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
                 kind = Id_prim _; _ }, 1, Tail ->
      (* RHS of (&&) and (||) is at the tail of function region if the
         application is. The argument mode is not constrained otherwise. *)
-     mode_with_position vmode (RTail (Option.get position_and_mode.region_mode, FTail)),
+     { (mode_with_position vmode
+          (RTail (Option.get position_and_mode.region_mode, FTail)))
+       with return_from_exclave = position_and_mode.return_from_exclave },
      vmode
   | Texp_ident { kind = Id_prim _; _ }, _, _ ->
      (* Other primitives cannot be tail-called *)
@@ -944,11 +978,40 @@ let reset_allocations () = allocations := []
 let register_allocation_mode alloc_mode =
   allocations := alloc_mode :: !allocations
 
+let newvar_below_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Alpha)
+  then fst (Locality.newvar_below level m)
+  else m
+
+let newvar_above_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Alpha)
+  then fst (Locality.newvar_above level m)
+  else m
+
+let create_allocation_mode_l mode =
+  Alloc.proj_comonadic Areality mode
+  |> newvar_above_if_modepoly 0
+  |> Locality.disallow_right
+
+let create_function_return_mode
+    ~return_from_exclave ret_mode : return_mode =
+  let ret_mode =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha) then
+      if return_from_exclave
+      then Locality.disallow_right Locality.local
+      else Locality.disallow_right Locality.global
+    else create_allocation_mode_l ret_mode
+  in
+  Typedtree.create_return_mode ret_mode
+
+let create_allocation_mode_r mode =
+  Alloc.proj_comonadic Areality mode
+  |> newvar_below_if_modepoly 0
+  |> Locality.disallow_left
+
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode =
-    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
-  in
+  let alloc_mode = create_allocation_mode_r (value_to_alloc_r2g mode) in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -968,9 +1031,11 @@ let register_closure_allocation (mode : Value.r) ~loc
   : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
   let (mode : Alloc.lr), _ =
-    Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
+    Alloc.newvar_below (Ctype.get_current_level ())
+      (value_to_alloc_r2g ~allocation mode)
   in
-  let alloc_mode = Alloc.proj_comonadic Areality mode in
+  let locality_mode = Alloc.proj_comonadic Areality mode in
+  let alloc_mode, _ = Locality.newvar_below 0 locality_mode in
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
@@ -995,7 +1060,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil mode
+      Locality.zap_to_ceil_exn mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -1375,8 +1440,8 @@ let check_dynamic pp hint expected_mode =
 (** Take [m0] which is the parameter to mutable, and the mode of the RHS (the
     content expression), returns the strongest mode the mutable variable can be.
 *)
-let mutvar_mode ~loc ~env m0 exp_mode =
-  let m = Value.newvar () in
+let mutvar_mode ~loc ~env level m0 exp_mode =
+  let m = Value.newvar level in
   let mode = mode_default m in
   let modalities = Typemode.let_mutable_modalities in
   submode ~loc ~env exp_mode (mode_modality modalities mode);
@@ -1980,7 +2045,9 @@ and build_as_type_and_mode_extra env p ~mode : _ -> _ * _ = function
          If we used [generic_instance] we would lose the sharing between
          [instance ty] and [ty].  *)
       let ty =
-        with_local_level_generalize_structure (fun () -> instance ty)
+        with_local_level_generalize_structure
+          ~before_generalize:generalize_structure
+          (fun () -> instance ty)
       in
       (* This call to unify may only fail due to missing GADT equations *)
       unify_pat_types p.pat_loc env (instance as_ty) (instance ty);
@@ -2032,7 +2099,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
       let priv = (cstr.cstr_private = Private) in
       let mode =
         if priv || pl <> [] then mode
-        else Value.newvar ()
+        else Value.newvar (get_current_level ())
       in
       let keep =
         priv ||
@@ -2053,7 +2120,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
   | Tpat_variant(l, p', _) ->
       let ty = Option.map (build_as_type env) p' in
       let mode =
-        if p' = None then Value.newvar ()
+        if p' = None then Value.newvar (get_current_level ())
         else mode
       in
       let ty =
@@ -2082,7 +2149,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
               fields
           in
           let mode =
-            if all_constant then Value.newvar ()
+            if all_constant then Value.newvar (get_current_level ())
             else mode
           in
           let ty =
@@ -2291,6 +2358,7 @@ let solve_constructor_annotation
   (* Translate the type annotation using these type names. *)
   let cty, ty, force =
     with_local_level_generalize_structure
+      ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
       (fun () ->
          Typetexp.transl_simple_type_delayed !!penv Alloc.Const.legacy sty)
   in
@@ -2415,16 +2483,22 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
       ~expected:expected_ty
   in
 
-  let ty_args, equated_types, existential_ctyp =
-    with_local_level_generalize_structure begin fun () ->
+  let (ty_args, equated_types, existential_ctyp), _ =
+    with_local_level_generalize_structure
+      ~before_generalize:(fun (_, tys) ->
+        List.iter generalize_structure tys)
+      begin fun () ->
       let expected_ty = instance expected_ty in
-      let ty_args, ty_res, equated_types, existential_ctyp =
+      let ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp =
         match existential_styp with
           None ->
             let ty_args, ty_res, _ =
               instance_constructor (Make_existentials_abstract penv) constr
             in
-            ty_args, ty_res, unify_res ty_res expected_ty, None
+            let ty_args_ty =
+              List.map (fun ca -> ca.Types.ca_type) ty_args
+            in
+            ty_args, ty_args_ty, ty_res, unify_res ty_res expected_ty, None
         | Some (name_list, sty) ->
             let existential_treatment =
               if name_list = [] then
@@ -2447,11 +2521,13 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
               List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args
                 ty_args_ty
             in
-            ty_args, ty_res, Lazy.force equated_types, existential_ctyp
+            ty_args, ty_args_ty, ty_res,
+            Lazy.force equated_types, existential_ctyp
       in
       if constr.cstr_existentials <> [] then
         lower_variables_only !!penv penv.Pattern_env.equations_scope ty_res;
-      (ty_args, equated_types, existential_ctyp)
+      (ty_args, equated_types, existential_ctyp),
+      expected_ty :: ty_res :: ty_args_ty
     end
   in
   if !Clflags.principal && not penv.in_counterexample then begin
@@ -2478,7 +2554,9 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
 
 let solve_Ppat_record_field loc penv label label_lid record_ty
       record_form =
-  with_local_level_generalize_structure begin fun () ->
+  with_local_level_generalize_structure
+    ~before_generalize:(fun (_, tys) -> List.iter generalize_structure tys)
+    begin fun () ->
     let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
     begin try
       unify_pat_types_penv loc penv ty_res (instance record_ty)
@@ -2486,8 +2564,9 @@ let solve_Ppat_record_field loc penv label label_lid record_ty
       raise(error(label_lid.loc, !!penv,
                   Label_mismatch(P record_form, label_lid.txt, err)))
     end;
-    ty_arg
+    ty_arg, [ty_res; ty_arg]
   end
+  |> fst
 
 let solve_Ppat_array loc env (mutability : mutable_flag) expected_ty
   : _ * _ * mutable_flag =
@@ -2524,6 +2603,7 @@ let solve_Ppat_lazy loc env expected_ty =
 let solve_Ppat_constraint tps loc env mode sty expected_ty =
   let cty, ty, force =
     with_local_level_generalize_structure
+      ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
       (fun () -> Typetexp.transl_simple_type_delayed env mode sty)
   in
   tps.tps_pattern_force <- force :: tps.tps_pattern_force;
@@ -3676,8 +3756,11 @@ and type_pat_aux
         match mutable_flag with
         | Immutable -> alloc_mode, Val_reg sort
         | Mutable ->
-            let m0 = Value.Comonadic.newvar () in
-            let mode = mutvar_mode ~loc ~env:!!penv m0 alloc_mode in
+            let m0 = Value.Comonadic.newvar (Ctype.get_current_level ()) in
+            let mode =
+              mutvar_mode ~loc ~env:!!penv
+                (Ctype.get_current_level ()) m0 alloc_mode
+            in
             let kind = Val_mut (m0, sort) in
             mode, kind
       in
@@ -4240,7 +4323,10 @@ let type_pattern_list
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   let pvs, pat =
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:(fun (pvs, _) ->
+        iter_pattern_variables_type generalize_structure pvs)
+      begin fun () ->
       let tps = create_type_pat_state Modules_rejected in
       let nv = newvar (Jkind.Builtin.value ~why:Class_term_argument) in
       let alloc_mode = simple_pat_mode Value.legacy in
@@ -5026,7 +5112,8 @@ let remaining_function_type_for_error ty_ret mode_ret rev_args =
                  (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
              in
              let mode_ret, _ =
-               Alloc.newvar_above (Alloc.join (mode_fun :: closed_args))
+               Alloc.newvar_above (Ctype.get_current_level ())
+               (Alloc.join (mode_fun :: closed_args))
              in
              (ty_ret, mode_ret, closed_args))
       (ty_ret, mode_ret, []) rev_args
@@ -5082,8 +5169,8 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
               then
                 Location.prerr_warning sarg.pexp_loc
                   Warnings.Ignored_extra_argument;
-              let mode_arg = Alloc.newvar () in
-              let mode_ret = Alloc.newvar () in
+              let mode_arg = Alloc.newvar (get_current_level ()) in
+              let mode_ret = Alloc.newvar (get_current_level ()) in
               let kind = (lbl, mode_arg, mode_ret) in
               begin try
                 unify env ty_fun
@@ -5286,7 +5373,18 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let args = (lbl, Arg (exp, sort), sch) :: args in
              (ty_ret, mode_ret, open_args, closed_args, args)
          | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg } ->
-             let arrow_desc = (lbl, mode_arg, mode_ret) in
+             (* Under mode polymorphism we define a new return mode above
+                mode_ret and a new level-0 allocation mode for mode_ret
+                (to know whether then function needs a region to allocate
+                the return value):
+                [mode_ret] < [mode_ret_alloc] < [mode_ret_eta] *)
+             let mode_ret_eta =
+               if Language_extension.(is_at_least Mode_polymorphism Alpha)
+               then
+                fst (Alloc.newvar_above (Ctype.get_current_level ()) mode_ret)
+               else mode_ret
+             in
+             let arrow_desc = (lbl, mode_arg, mode_ret_eta) in
              let sort_ret =
                match type_sort ~why:Function_result ~fixed:false env ty_ret with
                | Ok sort -> sort
@@ -5310,22 +5408,31 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
              let mode_cls, _ =
-               Alloc.newvar_above (Alloc.join
+               Alloc.newvar_above (Ctype.get_current_level ()) (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
-               Alloc.disallow_left mode_cls
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_r mode_cls
              in
              let mode_arg =
-               Alloc.disallow_right mode_arg
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_l mode_arg
                |> Typedtree.create_alloc_mode_l
              in
+             (* [mode_ret] < [mode_ret_alloc] < [mode_ret_eta]*)
+             let mode_ret_alloc =
+              if Language_extension.(is_at_least Mode_polymorphism Alpha)
+              then begin
+                let m = Locality.newvar 0 in
+                Locality.submode_exn
+                  (Alloc.proj_comonadic Areality mode_ret) m;
+                Locality.submode_exn
+                  m (Alloc.proj_comonadic Areality mode_ret_eta);
+                m
+              end else Alloc.proj_comonadic Areality mode_ret
+            in
              let mode_ret =
-               Alloc.disallow_right mode_ret
-               |> Alloc.proj_comonadic Areality
-               |> Typedtree.create_return_mode
+              Typedtree.create_return_mode
+                (Locality.disallow_right mode_ret_alloc)
              in
              register_allocation_mode mode_closure;
              let arg =
@@ -5736,7 +5843,7 @@ let rec approx_type env sty =
         in
         let ret = approx_type env sty in
         let marg = Alloc.of_const arg_mode.mode_modes in
-        let mret = Alloc.newvar () in
+        let mret = Alloc.newvar (get_current_level ()) in
         newty (Tarrow ((p,marg,mret), arg_ty.ctyp_type, ret, commu_ok))
       end
   | Ptyp_arrow (p, arg_sty, sty, arg_mode, _) ->
@@ -5749,7 +5856,7 @@ let rec approx_type env sty =
       in
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
-      let mret = Alloc.newvar () in
+      let mret = Alloc.newvar (get_current_level ()) in
       newty (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
@@ -6117,9 +6224,16 @@ let pattern_needs_partial_application_check p =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   with_type_mark begin fun mark ->
+    let check_const_mode m =
+      if Mode.Alloc.check_generic m then
+        Option.is_some (Mode.Alloc.Guts.check_const m)
+      else true
+    in
+    let checkmode m = if not (check_const_mode m) then raise Exit in
     let rec check ty =
       if try_mark_node mark ty then
-        if get_level ty <= level then raise Exit else iter_type_expr check ty
+        if get_level ty <= level then raise Exit
+        else iter_type_expr check checkmode ty
     in
     try check ty; true with Exit -> false
   end
@@ -6142,7 +6256,7 @@ let contains_variant_either ty =
               (row_fields row);
           iter_row loop row
       | _ ->
-          iter_type_expr loop ty
+          iter_type_expr loop (Fun.const ()) ty
       end
   in
   try loop ty; false with Exit -> true
@@ -6366,8 +6480,23 @@ let with_explanation explanation f =
         raise (error (loc', env', err))
 
 (* Generalize expressions *)
+let generalize_structure_exp exp = generalize_structure exp.exp_type
+
 let may_lower_contravariant env exp =
   if maybe_expansive exp then lower_contravariant env exp.exp_type
+
+let generalize_structure_type_block_access_result
+      { ba; base_ty; el_ty; modality = _ } =
+  generalize_structure base_ty;
+  generalize_structure el_ty;
+  match ba with
+  | Baccess_field _ -> ()
+  | Baccess_block (_, idx) ->
+    generalize_structure_exp idx
+
+let generalize_structure_type_unboxed_access_result
+      (el_ty, Uaccess_unboxed_field _) =
+  generalize_structure el_ty
 
 let unique_use ~loc ~env mode_l mode_r  =
   if not (Language_extension.is_at_least Unique
@@ -6484,7 +6613,11 @@ let split_function_ty
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
-    with_local_level_generalize_structure_if separate begin fun () ->
+    with_local_level_generalize_structure_if separate
+      ~before_generalize:(fun { ty_arg; ty_ret; _ } ->
+        generalize_structure ty_arg;
+        generalize_structure ty_ret)
+      begin fun () ->
       let force_tpoly =
         (* If [has_poly] is true then we rely on the later call to
            type_pat to enforce the invariant that the parameter type
@@ -6532,14 +6665,15 @@ let split_function_ty
   in
   let ret_value_mode = alloc_as_value ret_mode in
   let expected_inner_mode =
-    if not is_final_val_param then
+    if not is_final_val_param then begin
       (* no need to check mode crossing in this case because ty_res always a
       function *)
       mode_default ret_value_mode
-    else
+    end else begin
       let ret_value_mode = mode_return ret_value_mode in
       let ret_value_mode = expect_mode_cross env ty_ret ret_value_mode in
       ret_value_mode
+    end
   in
   let ty_arg_mono =
     if has_poly then ty_arg
@@ -6555,7 +6689,8 @@ let split_function_ty
   let env_monadic =
     if is_final_val_param
     then arg_mode.monadic
-    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+    else fst (Alloc.Monadic.newvar_above (get_current_level ())
+      arg_mode.monadic)
   in
   let arg_value_mode =
     alloc_to_value_l2r { arg_mode with monadic = env_monadic }
@@ -6583,7 +6718,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.Comonadic.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr
   }
 
 module Calling_convention_sort : sig
@@ -6695,7 +6830,7 @@ type type_function_result =
 
 and type_function_ret_info =
   { (* The mode the function returns at. *)
-    ret_mode: Mode.Alloc.l modes;
+    ret_mode: return_mode modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
     cases_arg_yielding: Mode.Yielding.l option;
@@ -6770,13 +6905,26 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     | None -> begin
         match pat_tuple_arity spat with
         | Not_local_tuple | Maybe_local_tuple ->
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
             (* TODO: mode can be more relaxed than this if fields are global *)
             let mode = Value.newvar () in
+||||||| Compiler:last-imported
+            let mode = Value.newvar () in
+=======
+            let mode = Value.newvar (get_current_level ()) in
+>>>>>>> Compiler:HEAD
             simple_pat_mode mode, mode_default mode
         | Local_tuple locs ->
-            let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+            let modes =
+              List.map
+                (fun loc ->
+                   Value.newvar (get_current_level ()), loc)
+                locs
+            in
             let modes_pat = List.map fst modes in
-            let mode = Value.newvar () in
+            let mode =
+              Value.newvar (get_current_level ())
+            in
             tuple_pat_mode mode modes_pat, mode_tuple mode modes
       end
     | Some mode ->
@@ -6923,8 +7071,11 @@ and type_expect_
         | None -> None
         | Some sexp ->
             let exp, mode =
-              with_local_level_generalize_structure_if_principal begin fun () ->
-                let mode = Value.newvar () in
+              with_local_level_generalize_structure_if_principal
+                ~before_generalize:(fun (exp, _) ->
+                  generalize_structure_exp exp)
+                begin fun () ->
+                let mode = Value.newvar (Ctype.get_current_level ()) in
                 let exp = type_exp ~recarg env (mode_default mode) sexp in
                 exp, mode
               end
@@ -6976,6 +7127,7 @@ and type_expect_
             let decl = Env.find_type p' env in
             let ty =
               with_local_level_generalize_structure
+                ~before_generalize:generalize_structure
                 (fun () -> newconstr p' (instance_list decl.type_params))
             in
             ty, opt_exp_opath
@@ -7572,12 +7724,12 @@ and type_expect_
         match pm.apply_position with
         | Tail ->
           let mode, _ =
-            Value.(newvar_below
+            Value.(newvar_below (get_current_level ())
               (of_const ~hint_comonadic:Tailcall_function
                 { Const.max with areality = Regional }))
           in
           mode
-        | Nontail | Default -> Value.newvar ()
+        | Nontail | Default -> Value.newvar (get_current_level ())
       in
       let funct_expected_mode = mode_default funct_mode in
       let outer_level = get_current_level () in
@@ -7606,6 +7758,7 @@ and type_expect_
       let type_sfunct sfunct =
         let funct =
           with_local_level_generalize_structure_if_principal
+            ~before_generalize:generalize_structure_exp
             (fun () -> type_exp env funct_expected_mode sfunct)
         in
         let ty = instance funct.exp_type in
@@ -7642,7 +7795,7 @@ and type_expect_
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
       let mode_ret = Alloc.disallow_right mode_ret in
-      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
+      let ap_mode = create_allocation_mode_l mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7662,8 +7815,8 @@ and type_expect_
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
         exp_desc = Texp_apply(funct, args, pm.apply_position,
-                              Typedtree.create_return_mode ap_mode,
-                              ap_yielding, zero_alloc);
+                    Typedtree.create_return_mode ap_mode,
+                    ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
         exp_attributes = sexp.pexp_attributes;
@@ -7716,12 +7869,19 @@ and type_expect_
           let arg_pat_mode, arg_expected_mode =
             match cases_tuple_arity caselist with
             | Not_local_tuple | Maybe_local_tuple ->
-              let mode = Value.newvar () in
+              let mode = Value.newvar (get_current_level ()) in
               simple_pat_mode mode, mode_default mode
             | Local_tuple locs ->
-              let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+              let modes =
+            List.map
+              (fun loc ->
+                 Value.newvar (get_current_level ()), loc)
+              locs
+          in
               let modes_pat = List.map fst modes in
-              let mode = Value.newvar () in
+              let mode =
+            Value.newvar (get_current_level ())
+          in
               tuple_pat_mode mode modes_pat, mode_tuple mode modes
           in
           env, arg_pat_mode, arg_expected_mode, expected_mode
@@ -8015,6 +8175,9 @@ and type_expect_
           (Texp_inspected_type (Label_disambiguation ambiguity), loc, [])
             :: record.exp_extra }
       in
+      let modality, _ =
+        Mode.Locality.newvar_above 0
+          (Mode.Alloc.proj_comonadic Areality (value_to_alloc_r2l rmode)) in
       unify_exp ~sexp env record ty_record;
       let record_repres =
         update_labels env Legacy ~representative_label:label ~loc
@@ -8025,10 +8188,7 @@ and type_expect_
         exp_desc = Texp_setfield {
           record;
           record_repres;
-          modality =
-            Locality.disallow_right
-              (Alloc.proj_comonadic Areality
-               (value_to_alloc_r2l rmode));
+          modality;
           lid = label_loc;
           label;
           newval;
@@ -8120,6 +8280,7 @@ and type_expect_
     let principal = is_principal ty_expected in
     let { ba; base_ty; el_ty; modality } =
       with_local_level_generalize_structure_if_principal
+        ~before_generalize:generalize_structure_type_block_access_result
         (fun () ->
            let res = type_block_access env expected_base_ty principal ba in
            (* This unification is to get a better [base_ty], and is not
@@ -8156,6 +8317,8 @@ and type_expect_
            (* Generalize after each step, otherwise we'll have more
               "non-principal" warnings than desired. *)
            with_local_level_generalize_structure_if_principal
+             ~before_generalize:(fun ((t, _), ua) ->
+               generalize_structure_type_unboxed_access_result (t, ua))
              (fun () ->
                 let (el_ty, ua_modality), ua =
                   type_unboxed_access env loc el_ty ua
@@ -8380,6 +8543,7 @@ and type_expect_
     begin try
       let (obj,meth,typ) =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (_, _, typ) -> generalize_structure typ)
           (fun () -> type_send env loc explanation e met.txt)
       in
       let typ, obj_extra =
@@ -8651,6 +8815,7 @@ and type_expect_
   | Pexp_poly(sbody, sty) ->
       let ty, cty =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (ty, _) -> generalize_structure ty)
           begin fun () ->
             match sty with None -> protect_expansion env ty_expected, None
             | Some sty ->
@@ -8676,6 +8841,8 @@ and type_expect_
               with_local_level_generalize begin fun () ->
                 let vars, ty'' =
                   with_local_level_generalize_structure_if_principal
+                    ~before_generalize:(fun (_, ty'') ->
+                      generalize_structure ty'')
                     (fun () -> instance_poly_fixed tl ty')
                 in
                 let exp = type_expect env expected_mode sbody (mk_expected ty'') in
@@ -8795,10 +8962,13 @@ and type_expect_
             let ty_acc = newty (Ttuple [None, ty_acc; None, ty]) in
             loop spat_acc ty_acc Jkind.Sort.scannable rest
       in
-      let op_path, op_desc, op_type, spat_params, ty_params, param_sort,
+      let (op_path, op_desc, op_type, spat_params, ty_params, param_sort,
           ty_func_result, body_sort, ty_result, op_result_sort,
-          ty_andops, sort_andops =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+          ty_andops, sort_andops), _ =
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:
+            (fun (_, tys) -> List.iter generalize_structure tys)
+          begin fun () ->
           let let_loc = slet.pbop_op.loc in
           let op_path, op_desc = type_binding_op_ident env slet.pbop_op in
           let op_type = op_desc.val_type in
@@ -8833,7 +9003,8 @@ and type_expect_
           end;
           (op_path, op_desc, op_type, spat_params, ty_params, param_sort,
            ty_func_result, body_sort, ty_result, op_result_sort,
-           ty_andops, sort_andops)
+           ty_andops, sort_andops),
+           [ty_andops; ty_params; ty_func_result; ty_result]
         end
       in
       let exp, exp_sort, ands =
@@ -9079,6 +9250,7 @@ and type_expect_
         (* The overwritten cell has to be unique
            and should have the areality expected here: *)
         Value.newvar_below
+          (get_current_level ())
           (Value.meet [
             Value.of_const {Value.Const.max with uniqueness = Unique};
             Value.max_with_comonadic Areality
@@ -9345,7 +9517,9 @@ and type_coerce
   match sty with
   | None ->
     let (cty', ty', force) =
-      with_local_level_generalize_structure begin fun () ->
+      with_local_level_generalize_structure
+        ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
+        begin fun () ->
         Typetexp.transl_simple_type_delayed env type_mode sty'
       end
     in
@@ -9395,14 +9569,17 @@ and type_coerce
       end;
       (arg, ty', Texp_coerce (None, cty'))
   | Some sty ->
-      let cty, ty, force, cty', ty', force' =
-        with_local_level_generalize_structure begin fun () ->
+      let (cty, ty, force, cty', ty', force'), _ =
+        with_local_level_generalize_structure
+          ~before_generalize:(fun (_, tys) ->
+            List.iter generalize_structure tys)
+          begin fun () ->
           let (cty, ty, force) =
             Typetexp.transl_simple_type_delayed env type_mode sty
           and (cty', ty', force') =
             Typetexp.transl_simple_type_delayed env type_mode sty'
           in
-          (cty, ty, force, cty', ty', force')
+          (cty, ty, force, cty', ty', force'), [ty; ty']
         end
       in
       begin try
@@ -9419,7 +9596,9 @@ and type_coerce
 and type_constraint env sty type_mode =
   (* Pretend separate = true, 1% slowdown for lablgtk *)
   let cty =
-    with_local_level_generalize_structure begin fun () ->
+    with_local_level_generalize_structure
+      ~before_generalize:(fun cty -> generalize_structure cty.ctyp_type)
+      begin fun () ->
       Typetexp.transl_simple_type ~new_var_jkind:Any env ~closed:false type_mode
         sty
     end
@@ -9495,7 +9674,7 @@ and type_newtype
         Hashtbl.add seen (get_id t) ();
         match get_desc t with
         | Tconstr (Path.Pident id', _, _) when id == id' -> link_type t ty
-        | _ -> Btype.iter_type_expr replace t
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t
       end
     in
     let ety = Subst.type_expr Subst.identity exp_type in
@@ -9876,6 +10055,9 @@ and type_function_
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
       in
+      let excl, expected_inner_mode =
+        mode_return_from_exclave expected_inner_mode
+      in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry,
            ext_env, inner_calling_convention_sorts), partial =
         (* Check everything else in the scope of the parameter. *)
@@ -9936,20 +10118,37 @@ and type_function_
                   begin match
                     Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
-                    | Ok () -> ()
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality arg_mode)
+                        alloc_mode
                     | Error e ->
                       raise (error(loc, env,
                         Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.Comonadic.submode
-                      (Alloc.Comonadic.disallow_right closure_mode)
-                      fun_closure_mode
-                  with
-                    | Ok () -> ()
+                      Alloc.Comonadic.submode closure_mode fun_closure_mode
+                    with
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality closure_mode)
+                        alloc_mode
                     | Error e ->
+<<<<<<< HEAD
                       raise (error(loc, env,
                         Uncurried_function_escapes_comonadic e))
+=======
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
+                      raise
+                        (error(loc, env, Uncurried_function_escapes_comonadic e))
+||||||| Compiler:last-imported
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
+=======
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e));
+>>>>>>> Compiler:HEAD
+>>>>>>> 468626124c (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
                   end;
                   More_args
                     { partial_mode =
@@ -10061,8 +10260,7 @@ and type_function_
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
       let arg_locality =
-        Alloc.disallow_right arg_mode
-        |> Alloc.proj_comonadic Areality
+        create_allocation_mode_l arg_mode
         |> Typedtree.create_alloc_mode_l
       in
       let param =
@@ -10109,12 +10307,16 @@ and type_function_
         in
         arg_ccs :: ret_ccs @ inner_calling_convention_sorts
       in
+      let return_from_exclave = !excl in
+      let ret_mode =
+        create_function_return_mode ~return_from_exclave ret_mode
+      in
       let ret_info =
         match ret_info with
         | Some _ as x -> x
         | None ->
           let ret_mode =
-            {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
+            {ret_mode_annots with mode_modes = ret_mode }
           in
           Some { ret_sort ; ret_mode; cases_arg_yielding = None }
       in
@@ -10249,13 +10451,14 @@ and type_label_access
   : 'rep . 'rep record_form -> _ -> _ -> _ -> _ ->
     _ * _ * _ * 'rep gen_label_description * _ * _
   = fun record_form env srecord usage lid ->
-  let mode = Value.newvar () in
+  let mode = Value.newvar (get_current_level ()) in
   let record_jkind, record_sort =
     Jkind.of_new_sort_var ~why:Record_projection
       ~level:(Ctype.get_current_level ())
   in
   let record =
     with_local_level_generalize_structure_if_principal
+      ~before_generalize:generalize_structure_exp
       (fun () ->
          type_expect ~recarg:Allowed env (mode_default mode) srecord
            (mk_expected (newvar record_jkind)))
@@ -10322,7 +10525,9 @@ and solve_Pexp_field
        [update_label], but doing it that way causes principality issues.
        Notably, this call to [update_label] happens inside a local level and the
        [Texp_setfield] call does not. *)
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:(fun (ty_arg, _) -> generalize_structure ty_arg)
+      begin fun () ->
       (* [ty_arg] is the type of field, [ty_res] is the type of record, they
        could share type variables, which are now instantiated *)
       let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
@@ -10627,9 +10832,15 @@ and type_label_exp
     (* raise level to check univars *)
     with_local_level_generalize_if is_poly begin fun () ->
       let unify_as_label ty_expected =
-        with_local_level_generalize_structure_if separate begin fun () ->
+        with_local_level_generalize_structure_if separate
+          ~before_generalize:(fun (_, ty_arg) ->
+            generalize_structure ty_arg)
+          begin fun () ->
           let (vars, ty_arg, ty_res) =
             with_local_level_generalize_structure_if separate
+              ~before_generalize:(fun (_, ty_arg, ty_res) ->
+                generalize_structure ty_arg;
+                generalize_structure ty_res)
               (fun () -> instance_label ~fixed:true label)
           in
           begin try
@@ -10682,15 +10893,19 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
     let lv = get_level expty in
     let lv' = get_level expty' in
     match get_desc expty', get_desc expty with
-    | Tarrow((l, marg, mret), ty_arg', ty_res', _),
+    | Tarrow((l, marg', mret'), ty_arg', ty_res', _),
       Tarrow(_, ty_arg,  ty_res,  _)
       when lv' = generic_level || not !Clflags.principal ->
       let ty_res', ty_res, changed = loosen_arrow_modes ty_res' ty_res in
-      let mret, changed' = Alloc.newvar_below mret in
-      let marg, changed'' = Alloc.newvar_above marg in
-      if changed || changed' || changed'' then
-        newty2 ~level:lv' (Tarrow((l, marg, mret), ty_arg', ty_res', commu_ok)),
-        newty2 ~level:lv  (Tarrow((l, marg, mret), ty_arg,  ty_res,  commu_ok)),
+      let mret', changed1 = Alloc.newvar_below (lv) mret' in
+      let marg', changed2 = Alloc.newvar_above (lv) marg' in
+      if changed || changed1 || changed2 then
+        newty2 ~level:lv'
+          (Tarrow((l, marg', mret'), ty_arg', ty_res',
+                  commu_ok)),
+        newty2 ~level:lv
+          (Tarrow((l, marg', mret'), ty_arg, ty_res,
+                  commu_ok)),
         true
       else
         ty', ty, false
@@ -10730,9 +10945,13 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
     Some (safe_expect, lv) ->
       (* apply omittable arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
-      let exp_mode, _ = Value.newvar_below (as_single_mode mode) in
+      let exp_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (as_single_mode mode)
+      in
       let texp =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:generalize_structure_exp
           (fun () ->
             let expected_mode =
               mode
@@ -10815,7 +11034,10 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
                       staticity = proj_staticity mode;
                       mode = Value.disallow_right mode }}
       in
-      let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in
+      let eta_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (alloc_as_value marg)
+      in
       Regionality.submode_exn
         (Value.proj_comonadic Areality eta_mode) Regionality.regional;
       let type_sort ~why ty =
@@ -10828,12 +11050,11 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       let fc_arg_mode =
-        Alloc.disallow_right marg
-        |> Alloc.proj_comonadic Areality
+        create_allocation_mode_l marg
         |> Typedtree.create_alloc_mode_l
       in
       let fc_ret_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        create_allocation_mode_l mret
         |> Typedtree.create_return_mode
       in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
@@ -10979,6 +11200,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
             with_local_level_generalize begin fun () ->
               let vars, ty_arg' =
                 with_local_level_generalize_structure_if separate
+                  ~before_generalize:(fun (_, ty_arg') ->
+                    generalize_structure ty_arg')
                   begin fun () ->
                   instance_poly_fixed vars ty_arg'
                 end
@@ -11030,8 +11253,10 @@ and type_application env app_loc expected_mode position_and_mode
   | (* Special case for ignore: avoid discarding warning *)
     [Parsetree.Nolabel, sarg] when is_ignore funct ->
       let {ty_arg; arg_mode; ty_ret; ret_mode} =
-        with_local_level_generalize_structure_if_principal (fun () ->
-          filter_arrow_mono env (instance funct.exp_type) Nolabel)
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun { ty_ret; _ } ->
+            generalize_structure ty_ret)
+          (fun () -> filter_arrow_mono env (instance funct.exp_type) Nolabel)
       in
       let type_sort ~why ty =
         match Ctype.type_sort ~why ~fixed:false env ty with
@@ -11069,7 +11294,10 @@ and type_application env app_loc expected_mode position_and_mode
         end
       in
       let ty_ret, mode_ret, args, position_and_mode, ap_yielding =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (ty_ret, _, _, _, _) ->
+            generalize_structure ty_ret)
+          begin fun () ->
           (* Consider for example the application
                [f n]
              with
@@ -11099,16 +11327,17 @@ and type_application env app_loc expected_mode position_and_mode
           (* The application can never perform a free effect if the function and
              all of its arguments are unyielding. *)
           let ap_yielding =
-            Mode.Value.proj_comonadic Yielding
-              (Mode.Value.join
-                 (funct_mode
-                  :: List.concat_map
-                       (fun (_, arg, _, ~mode_fun) ->
-                          mode_fun ::
-                          (match arg with
-                            | Arg (_, mode_arg, _) -> [mode_arg]
-                            | Omitted _ -> [] ))
-                       args))
+            create_yielding_mode_l
+              (Mode.Value.proj_comonadic Yielding
+                 (Mode.Value.join
+                    (funct_mode
+                     :: List.concat_map
+                          (fun (_, arg, _, ~mode_fun) ->
+                             mode_fun ::
+                             (match arg with
+                               | Arg (_, mode_arg, _) -> [mode_arg]
+                               | Omitted _ -> [] ))
+                          args)))
           in
           let args =
             List.map (fun (lbl, arg, sch, ~mode_fun:_) ->
@@ -11318,9 +11547,18 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
                   (lid.txt, constr.cstr_arity, List.length sargs)));
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let unify_as_construct ty_expected =
-    with_local_level_generalize_structure_if separate begin fun () ->
+    with_local_level_generalize_structure_if separate
+      ~before_generalize:(fun (ty_args, ty_res, _) ->
+        generalize_structure ty_res;
+        List.iter
+          (fun { Types.ca_type = ty; _ } -> generalize_structure ty)
+          ty_args)
+      begin fun () ->
       let ty_args, ty_res, texp =
-        with_local_level_generalize_structure_if separate begin fun () ->
+        with_local_level_generalize_structure_if separate
+          ~before_generalize:(fun (_, ty_res, _) ->
+            generalize_structure ty_res)
+          begin fun () ->
           let (ty_args, ty_res, _) =
             instance_constructor Keep_existentials_flexible constr
           in
@@ -11599,10 +11837,14 @@ and map_half_typed_cases
         map_conts
         (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) cont ->
           let htc =
-            with_local_level_generalize_structure_if_principal begin fun () ->
+            with_local_level_generalize_structure_if_principal
+              ~before_generalize:(fun htc ->
+                iter_pattern_variables_type generalize_structure htc.pat_vars)
+              begin fun () ->
               let ty_arg =
                 (* propagation of pattern *)
                 with_local_level_generalize_structure
+                  ~before_generalize:generalize_structure
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
               let (pat, ext_env, force, pvs, mvs) =
@@ -11872,6 +12114,9 @@ and type_function_cases_expect
         ~ret_mode_annots:Mode.Alloc.Const.Option.none
         ~is_first_val_param:first ~is_final_val_param:true
     in
+    let excl, expected_inner_mode =
+      mode_return_from_exclave expected_inner_mode
+    in
     let cases, partial =
       type_cases Value env
         expected_pat_mode expected_inner_mode ty_arg_mono arg_sort
@@ -11883,7 +12128,7 @@ and type_function_cases_expect
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     let fc_arg_mode =
-      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      create_allocation_mode_l arg_mode
       |> Typedtree.create_alloc_mode_l
     in
     let yielding_mode =
@@ -11945,10 +12190,13 @@ and type_function_cases_expect
         { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
+    let return_from_exclave = !excl in
     cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+          { mode_modes =
+              create_function_return_mode ~return_from_exclave ret_mode;
+            mode_desc = [] };
         cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts
   end
@@ -12015,7 +12263,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let entirely_functions = List.for_all vb_is_fun spat_sexp_list in
   let rec_mode_var =
     match rec_flag with
-    | Recursive when entirely_functions -> Some (Value.newvar ())
+    | Recursive when entirely_functions ->
+      Some (Value.newvar (get_current_level ()))
     | Recursive ->
         (* If the definitions are not purely functions, this involves multiple
            allocations pointing to each other. For this to be safe, they are all
@@ -12024,7 +12273,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let m, _ =
           {Value.Const.max with areality = Global}
           |> Value.of_const
-          |> Value.newvar_below
+          |> Value.newvar_below (get_current_level ())
         in
         Some m
     | Nonrecursive -> None
@@ -12040,7 +12289,13 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     with_local_level_generalize begin fun () ->
       if existential_context = At_toplevel then Typetexp.TyVarEnv.reset ();
       let (pat_list, new_env, force, pvs, mvs), sorts =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:
+            (fun ((pat_list, _, _, pvs, _), _) ->
+              iter_pattern_variables_type generalize_structure pvs;
+              List.iter
+                (fun (_, pat) -> generalize_structure pat.pat_type) pat_list)
+          begin fun () ->
           let nvs, sorts =
             List.split (List.map (fun _ -> new_rep_var ~why:Let_binding ())
                           spatl)
@@ -12143,6 +12398,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
             | Tpoly (ty, tl) ->
                 let vars, ty' =
                   with_local_level_generalize_structure_if_principal
+                    ~before_generalize:(fun (_, ty') ->
+                      generalize_structure ty')
                     (fun () -> instance_poly_fixed ~keep_names:true tl ty)
                 in
                 let exp =
@@ -12419,9 +12676,12 @@ and type_andops env sarg sands expected_sort expected_ty =
         expected_sort,
         []
     | { pbop_op = sop; pbop_exp = sexp; pbop_loc = loc; _ } :: rest ->
-        let op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
-            ty_result, op_result_sort =
-          with_local_level_generalize_structure_if_principal begin fun () ->
+        let (op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
+            ty_result, op_result_sort), _ =
+          with_local_level_generalize_structure_if_principal
+            ~before_generalize:
+              (fun (_, tys) -> List.iter generalize_structure tys)
+            begin fun () ->
             let op_path, op_desc = type_binding_op_ident env sop in
             let op_type = op_desc.val_type in
             let ty_arg, sort_arg = new_rep_var ~why:Function_argument () in
@@ -12440,7 +12700,7 @@ and type_andops env sarg sands expected_sort expected_ty =
               raise(error(sop.loc, env, Andop_type_clash(sop.txt, err)))
             end;
             (op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
-             ty_result, op_result_sort)
+             ty_result, op_result_sort), [ty_rest; ty_arg; ty_result]
           end
         in
         let let_arg, sort_let_arg, rest =
@@ -12533,7 +12793,9 @@ and type_n_ary_function
                           (Jkind.of_new_sort ~why
                              ~level:(Ctype.get_current_level ()))
                       in
-                      let new_mode_var () = Mode.Alloc.newvar () in
+                      let new_mode_var () =
+                        Mode.Alloc.newvar (get_current_level ())
+                      in
                       (newty
                          (Tarrow
                             ( (arg_label, new_mode_var (), new_mode_var ())
@@ -12591,14 +12853,6 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let ret_mode_modes =
-      Alloc.proj_comonadic Areality ret_mode.mode_modes
-      |> Typedtree.create_return_mode
-    in
-    let ret_mode =
-      { ret_mode with
-        mode_modes = ret_mode_modes }
-    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the
@@ -12617,10 +12871,11 @@ and type_n_ary_function
       | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Yielding.join
-        (Alloc.Comonadic.proj Yielding
-           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
-         :: param_yieldings)
+      create_yielding_mode_l
+        (Yielding.join
+           (Alloc.Comonadic.proj Yielding
+              (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
+            :: param_yieldings))
     in
     re
       { exp_desc =
@@ -12765,7 +13020,9 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
           ~why:Jkind.History.Array_comprehension_element
   in
   let element_ty =
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:generalize_structure
+      begin fun () ->
       let element_ty = newvar jkind in
       unify_exp_types
         loc
@@ -14139,6 +14396,11 @@ let report_error ~loc env =
               but expected to be %a."
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
+    end
+  | Uncurried_function_escapes_locality -> begin
+      Location.errorf ~loc
+        "This function or one of its parameters escape their region@ \
+        when it is partially applied."
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -10130,26 +10130,8 @@ and type_function_
                         (Alloc.Comonadic.proj Areality closure_mode)
                         alloc_mode
                     | Error e ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      raise (error(loc, env,
-                        Uncurried_function_escapes_comonadic e))
-=======
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
                       raise
                         (error(loc, env, Uncurried_function_escapes_comonadic e))
-||||||| Compiler:last-imported
-                      raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e))
-=======
-                      raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e));
->>>>>>> Compiler:HEAD
->>>>>>> 468626124c (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
-=======
-                      raise
-                        (error(loc, env, Uncurried_function_escapes_comonadic e))
->>>>>>> d8098fdfb0 (Fix merlin to build under mode polymorphism)
                   end;
                   More_args
                     { partial_mode =

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -5225,8 +5225,8 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
                     extra_arg_loc = sarg.pexp_loc; }))
     with Msupport.Resume ->
       let ty_arg, kind_arg = new_rep_var ~why:Function_argument () in
-      kind_arg, Mode.Alloc.newvar (), ty_arg,
-      Mode.Alloc.newvar (), ty_fun
+      kind_arg, Mode.Alloc.newvar (get_current_level ()), ty_arg,
+      Mode.Alloc.newvar (get_current_level ()), ty_fun
     in
     let arg = Unknown_arg { sarg; ty_arg_mono; mode_fun; mode_arg; sort_arg } in
     loop ty_res mode_ret ((lbl, Arg arg) :: rev_args) rest
@@ -6636,9 +6636,9 @@ let split_function_ty
         let arg_kind = Jkind.Builtin.any ~why:Inside_of_Tarrow in
         let ret_kind = Jkind.Builtin.any ~why:Inside_of_Tarrow in
         { ty_arg = newty (Tpoly (newvar2 level arg_kind, []))
-        ; arg_mode = Mode.Alloc.newvar ()
+        ; arg_mode = Mode.Alloc.newvar level
         ; ty_ret = newvar2 level ret_kind
-        ; ret_mode = Mode.Alloc.newvar ()
+        ; ret_mode = Mode.Alloc.newvar level
         }
     end
   in
@@ -6905,14 +6905,8 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     | None -> begin
         match pat_tuple_arity spat with
         | Not_local_tuple | Maybe_local_tuple ->
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
             (* TODO: mode can be more relaxed than this if fields are global *)
-            let mode = Value.newvar () in
-||||||| Compiler:last-imported
-            let mode = Value.newvar () in
-=======
             let mode = Value.newvar (get_current_level ()) in
->>>>>>> Compiler:HEAD
             simple_pat_mode mode, mode_default mode
         | Local_tuple locs ->
             let modes =
@@ -6966,9 +6960,10 @@ let create_merlin_type_error_node loc env ty_expected ~attributes =
                 val_modalities = Modality.of_const Modality.Const.id
               };
             kind = Id_value;
-            unique_use = (Uniqueness.newvar (), Linearity.newvar ());
-            mode = Mode.Value.newvar ();
-            staticity = Staticity.newvar ()
+            unique_use = (Uniqueness.newvar (get_current_level ()),
+                          Linearity.newvar (get_current_level ()));
+            mode = Mode.Value.newvar (get_current_level ());
+            staticity = Staticity.newvar (get_current_level ())
           };
       exp_loc = loc;
       exp_extra = [];
@@ -7832,7 +7827,7 @@ and type_expect_
                   args,
                   pm.apply_position,
                   Typedtree.create_return_mode ap_mode,
-                  Mode.Yielding.newvar (),
+                  Mode.Yielding.newvar 0,
                   None
                 );
               exp_loc = loc;
@@ -9852,7 +9847,11 @@ and type_function
              ~attributes:(Msupport.recovery_attributes []))
       in
       let ret_info =
-        { ret_mode = { mode_modes = Alloc.newvar (); mode_desc = [] };
+        { ret_mode =
+            { mode_modes =
+                Typedtree.create_return_mode
+                  (Locality.newvar 0);
+              mode_desc = [] };
           ret_sort = Var (Jkind.Sort.new_var ~level:(Ctype.get_current_level ()));
           cases_arg_yielding = None;
         }
@@ -9861,8 +9860,9 @@ and type_function
         newtypes = [];
         params_contain_gadt = No_gadt;
         fun_alloc_mode =
-          Some { alloc_mode = Locality.newvar ();
-                 fun_closure_mode = Alloc.Comonadic.newvar () };
+          Some { alloc_mode = Locality.newvar 0;
+                 fun_closure_mode =
+                   Alloc.Comonadic.newvar (get_current_level ()) };
         ret_info = Some ret_info;
         calling_convention_sorts = []
       })
@@ -9923,15 +9923,11 @@ and type_function_
                (let params = List.map (fun { param; _ } -> param) params in
                 let ret_mode, ret_sort =
                   match ret_info with
-                  | Some { ret_mode; ret_sort; _ } ->
-                    { ret_mode with
-                      mode_modes =
-                        Alloc.proj_comonadic Areality ret_mode.mode_modes
-                        |> Typedtree.create_return_mode },
-                    ret_sort
+                  | Some { ret_mode; ret_sort; _ } -> ret_mode, ret_sort
                   | None ->
                     ({ mode_modes =
-                         Typedtree.create_return_mode (Locality.newvar ());
+                         Typedtree.create_return_mode
+                           (Locality.newvar 0);
                        mode_desc = [] },
                      Var (Jkind.Sort.new_var ~level:(Ctype.get_current_level ())))
                 in
@@ -9939,7 +9935,7 @@ and type_function_
                   Typedtree.create_alloc_mode_r @@ Locality.disallow_left @@
                   match fun_alloc_mode with
                   | Some { alloc_mode; _ } -> alloc_mode
-                  | None -> Locality.newvar ()
+                  | None -> Locality.newvar 0
                 in
                 Texp_function
                   { params;
@@ -9948,7 +9944,7 @@ and type_function_
                     ret_sort;
                     alloc_mode;
                     zero_alloc=Zero_alloc.default;
-                    yielding = Yielding.newvar ()
+                    yielding = Yielding.newvar 0
                   });
               exp_loc = loc;
               exp_extra = [];
@@ -10135,6 +10131,7 @@ and type_function_
                         alloc_mode
                     | Error e ->
 <<<<<<< HEAD
+<<<<<<< HEAD
                       raise (error(loc, env,
                         Uncurried_function_escapes_comonadic e))
 =======
@@ -10149,6 +10146,10 @@ and type_function_
                         Uncurried_function_escapes_comonadic e));
 >>>>>>> Compiler:HEAD
 >>>>>>> 468626124c (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+=======
+                      raise
+                        (error(loc, env, Uncurried_function_escapes_comonadic e))
+>>>>>>> d8098fdfb0 (Fix merlin to build under mode polymorphism)
                   end;
                   More_args
                     { partial_mode =
@@ -10187,16 +10188,10 @@ and type_function_
                (let params = List.map (fun { param; _ } -> param) params in
                 let ret_mode, ret_sort =
                   match ret_info with
-                  | Some { ret_mode; ret_sort; _ } ->
-                    { ret_mode with
-                      mode_modes =
-                        Alloc.proj_comonadic Areality ret_mode.mode_modes
-                        |> Typedtree.create_return_mode },
-                    ret_sort
+                  | Some { ret_mode; ret_sort; _ } -> ret_mode, ret_sort
                   | None ->
                     ( { mode_modes =
-                          Alloc.proj_comonadic Areality
-                            (Alloc.disallow_right ret_mode)
+                          create_allocation_mode_l ret_mode
                           |> Typedtree.create_return_mode;
                         mode_desc = [] }
                     , ret_sort )
@@ -10207,7 +10202,7 @@ and type_function_
                       Typedtree.create_alloc_mode_r
                         (Locality.disallow_left alloc_mode);
                     zero_alloc = Zero_alloc.default;
-                    yielding = Yielding.newvar () });
+                    yielding = Yielding.newvar 0 });
               exp_loc = loc;
               exp_extra = [];
               exp_type;
@@ -12162,8 +12157,7 @@ and type_function_cases_expect
                   body = Tfunction_cases cases;
                   ret_mode =
                     { mode_modes =
-                        Alloc.proj_comonadic Areality
-                          (Alloc.disallow_right ret_mode)
+                        create_allocation_mode_l ret_mode
                         |> Typedtree.create_return_mode;
                       mode_desc = []};
                   ret_sort;
@@ -12171,7 +12165,7 @@ and type_function_cases_expect
                     Typedtree.create_alloc_mode_r
                       (Locality.disallow_left alloc_mode);
                   zero_alloc = Zero_alloc.default;
-                  yielding = Yielding.newvar ()
+                  yielding = Yielding.newvar 0
                 };
             exp_loc = loc;
             exp_extra = [];

--- a/external/merlin/src/ocaml/typing/typecore.mli
+++ b/external/merlin/src/ocaml/typing/typecore.mli
@@ -174,13 +174,9 @@ val type_option_some:
 val type_option_none:
         Env.t -> type_expr -> Location.t -> Typedtree.expression
 val generalizable: int -> type_expr -> bool
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
+val generalize_structure_exp: Typedtree.expression -> unit
 type delayed_check
 val delayed_checks: delayed_check list ref
-||||||| Compiler:last-imported
-=======
-val generalize_structure_exp: Typedtree.expression -> unit
->>>>>>> Compiler:HEAD
 val reset_delayed_checks: unit -> unit
 val force_delayed_checks: unit -> unit
 

--- a/external/merlin/src/ocaml/typing/typecore.mli
+++ b/external/merlin/src/ocaml/typing/typecore.mli
@@ -174,8 +174,13 @@ val type_option_some:
 val type_option_none:
         Env.t -> type_expr -> Location.t -> Typedtree.expression
 val generalizable: int -> type_expr -> bool
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
 type delayed_check
 val delayed_checks: delayed_check list ref
+||||||| Compiler:last-imported
+=======
+val generalize_structure_exp: Typedtree.expression -> unit
+>>>>>>> Compiler:HEAD
 val reset_delayed_checks: unit -> unit
 val force_delayed_checks: unit -> unit
 
@@ -382,6 +387,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -1016,7 +1016,10 @@ let transl_declaration env sdecl (id, uid) =
          traverses inside of any type constructors in the [with]-bound. It's
          also necessary because the variables here are at generic level, and so
          any containers of them should be, too! *)
-      Ctype.with_local_level_generalize_structure begin fun () ->
+      Ctype.with_local_level_generalize_structure
+        ~before_generalize:(fun cty ->
+          Ctype.generalize_structure cty.ctyp_type)
+        begin fun () ->
         Typetexp.transl_simple_type env ~new_var_jkind:Any
           ~closed:true Mode.Alloc.Const.legacy sty
       end
@@ -1567,7 +1570,8 @@ let rec check_constraints_rec env loc visited ty =
       check_constraints_rec env loc visited ty
   | _ ->
       Ctype.iter_type_expr_with_stages
-        (fun env -> check_constraints_rec env loc visited) env ty
+        (fun env -> check_constraints_rec env loc visited) env
+        (Fun.const ()) ty
   end
 
 let check_constraints_labels env visited l pl =
@@ -3220,7 +3224,8 @@ let check_well_founded ~abs_env env loc path to_check visited ty0 =
               List.iter (check_subtype parents trace ty env) tyl
         end
     | _ ->
-        Ctype.iter_type_expr_with_stages (check_subtype parents trace ty) env ty
+        Ctype.iter_type_expr_with_stages
+          (check_subtype parents trace ty) env (Fun.const ()) ty
   and check_subtype parents trace outer_ty env inner_ty =
       check parents (Contains (outer_ty, inner_ty) :: trace) env inner_ty
   in
@@ -3567,7 +3572,7 @@ let check_regularity ~abs_env env loc path decl to_check =
           check_regular cpath args prev_exp trace env ty
       | _ ->
           Ctype.iter_type_expr_with_stages
-            (check_subtype cpath args prev_exp trace ty) env ty
+            (check_subtype cpath args prev_exp trace ty) env (Fun.const ()) ty
     end
     and check_subtype cpath args prev_exp trace outer_ty env inner_ty =
       let trace = Contains (outer_ty, inner_ty) :: trace in
@@ -3995,10 +4000,19 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
+<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
        match Ctype.closed_type_decl decl with
          Some ty ->
           if not (Msupport.erroneous_type_check ty) then
             raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
+||||||| Compiler:last-imported
+       match Ctype.closed_type_decl decl with
+         Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
+=======
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+          Ctype.closed_type_decl ~zap_scope decl) with
+         Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
+>>>>>>> Compiler:HEAD
        | None   -> ())
     sdecl_list tdecls;
   (* Check that constraints are enforced *)
@@ -4283,7 +4297,10 @@ let transl_type_extension extend env loc styext =
   (* Check that all type variables are closed *)
   List.iter
     (fun (ext, _shape) ->
-       match Ctype.closed_extension_constructor ext.ext_type with
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+               Ctype.closed_extension_constructor ~zap_scope
+               ext.ext_type)
+       with
          Some ty ->
            raise(Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
        | None -> ())
@@ -4339,7 +4356,10 @@ let transl_exception env sext =
       end
   in
   (* Check that all type variables are closed *)
-  begin match Ctype.closed_extension_constructor ext.ext_type with
+  begin match
+    Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+        Ctype.closed_extension_constructor ~zap_scope ext.ext_type)
+  with
     Some ty ->
       raise (Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
   | None -> ()
@@ -4698,7 +4718,10 @@ let check_unboxable env loc ty =
       | _ -> acc
     with Not_found -> acc
   in
-  let all_unboxable_types = Btype.fold_type_expr check_type Path.Set.empty ty in
+  let all_unboxable_types =
+    Btype.fold_type_expr check_type
+      (fun a _ -> a) Path.Set.empty ty
+  in
   Path.Set.fold
     (fun p () ->
        let p = Out_type.shorten_type_path env p in
@@ -5146,7 +5169,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   in
   Option.iter (fun p -> set_private_row env sdecl.ptype_loc p new_sig_decl)
     fixed_row_path;
-  begin match Ctype.closed_type_decl new_sig_decl with None -> ()
+  begin match
+    Mode.Alloc.with_zap_scope
+      (fun ~zap_scope -> Ctype.closed_type_decl ~zap_scope new_sig_decl)
+  with None -> ()
   | Some ty -> raise(Error(loc, Unbound_type_var(ty, new_sig_decl)))
   end;
   let new_sig_decl = name_recursion sdecl id new_sig_decl in

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -4000,19 +4000,11 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
-<<<<<<< Merlin:ageorges/mode-polymorphism-integrate
-       match Ctype.closed_type_decl decl with
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+          Ctype.closed_type_decl ~zap_scope decl) with
          Some ty ->
           if not (Msupport.erroneous_type_check ty) then
             raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
-||||||| Compiler:last-imported
-       match Ctype.closed_type_decl decl with
-         Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
-=======
-       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
-          Ctype.closed_type_decl ~zap_scope decl) with
-         Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
->>>>>>> Compiler:HEAD
        | None   -> ())
     sdecl_list tdecls;
   (* Check that constraints are enforced *)

--- a/external/merlin/src/ocaml/typing/typedecl_variance.ml
+++ b/external/merlin/src/ocaml/typing/typedecl_variance.ml
@@ -169,13 +169,13 @@ let compute_variance_type env ~check (required, loc) decl tyl =
             | Tconstr _ ->
                 let old = !visited in
                 begin try
-                  Ctype.iter_type_expr_with_stages check env ty
+                  Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
                 with Exit ->
                   visited := old;
                   let ty' = Ctype.expand_head_opt env ty in
                   if eq_type ty ty' then raise Exit else check env ty'
                 end
-            | _ -> Ctype.iter_type_expr_with_stages check env ty
+            | _ -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
           end
         in
         try check env ty; compute_variance env tvl injective ty
@@ -247,7 +247,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                      , Bad_variance ( variance_error
                                     , (c1,n1,false)
                                     , (c2,n2,false))))
-        | None -> Ctype.iter_type_expr_with_stages check env ty
+        | None -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
       end
     in
     List.iter (fun (_,ty) -> check env ty) tyl;

--- a/external/merlin/src/ocaml/typing/typedtree.ml
+++ b/external/merlin/src/ocaml/typing/typedtree.ml
@@ -84,7 +84,7 @@ module Unique_barrier = struct
 
   let enable barrier = match !barrier with
     | Not_computed ->
-      barrier := Enabled (Uniqueness.newvar ())
+      barrier := Enabled (Uniqueness.newvar 0)
     | _ -> Misc.fatal_error "Unique barrier was enabled twice"
 
   (* Due to or-patterns a barrier may have several upper bounds. *)
@@ -96,7 +96,7 @@ module Unique_barrier = struct
   let resolve barrier =
     match !barrier with
     | Enabled uniq ->
-      let zapped = Uniqueness.zap_to_ceil uniq in
+      let zapped = Uniqueness.zap_to_ceil_exn uniq in
       barrier := Resolved zapped;
       zapped
     | Resolved barrier -> barrier
@@ -137,7 +137,7 @@ type alloc_mode_r = Mode.Locality.r
 let create_alloc_mode_r m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
+let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil_exn m
 
 let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
 
@@ -151,7 +151,7 @@ type alloc_mode_l = Mode.Locality.l
 let create_alloc_mode_l m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor_exn m
 
 let alloc_mode_l_map f m = f m
 
@@ -163,7 +163,7 @@ type return_mode = Mode.Locality.l
 let create_return_mode m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+let return_mode_zap_to_floor_exn m = Mode.Locality.zap_to_floor_exn m
 
 let print_return_mode ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m

--- a/external/merlin/src/ocaml/typing/typedtree.mli
+++ b/external/merlin/src/ocaml/typing/typedtree.mli
@@ -140,7 +140,7 @@ type return_mode
 
 val create_return_mode : Mode.Locality.l -> return_mode
 
-val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+val return_mode_zap_to_floor_exn : return_mode -> Mode.Locality.Const.t
 
 val print_return_mode : Format.formatter -> return_mode -> unit
 

--- a/external/merlin/src/ocaml/typing/typemod.ml
+++ b/external/merlin/src/ocaml/typing/typemod.ml
@@ -108,7 +108,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
-  let mode = Mode.Value.newvar () in
+  let mode = Mode.Value.newvar 0 in
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
   Value.submode_exn (min |> Alloc.of_const |> alloc_as_value) mode;
@@ -121,7 +121,7 @@ let register_allocation loc : Alloc.lr * Value.lr =
       ~hint_comonadic:Module_allocated_on_heap
       { Alloc.Const.max with areality = Global }
   in
-  let alloc_mode, _ = Alloc.newvar_below upper_bound in
+  let alloc_mode, _ = Alloc.newvar_below 0 upper_bound in
   let closed_over_mode =
     alloc_as_value ~allocation:({loc; txt = Unknown}) alloc_mode
   in
@@ -173,7 +173,7 @@ let infer_modalities pp ~loc_md item ~md_mode ~mode =
       To achieve that, the mode of [foo] to be exposed as [M.foo] should be a
       flexible mode variable weaker than its actual mode.
     *)
-    let mode, _ = Mode.Value.newvar_above mode in
+    let mode, _ = Mode.Value.newvar_above (Ctype.get_current_level ()) mode in
     (* Upon construction, for comonadic (prescriptive) axes, module
     must be weaker than the values therein, for otherwise operations
     would be allowed to performed on the module (and extended to the
@@ -256,7 +256,8 @@ let extract_sig_functor_open funct_body env loc mty sig_acc md_mode
     let yielding m =
       Yielding.disallow_right (Value.proj_comonadic Yielding m)
     in
-    Yielding.join [yielding funct_mode; yielding md_mode]
+    Ctype.create_yielding_mode_l
+      (Yielding.join [yielding funct_mode; yielding md_mode])
   in
   match Mtype.scrape_alias env mty with
   | Mty_functor (Named (param, mty_param, mm_param),mty_result,mm_result)
@@ -2834,8 +2835,9 @@ and nongen_signature_item env f g = function
       nongen_modtype env f g md.md_type
   | _ -> None
 
-let check_nongen_modtype env loc mty =
-  nongen_modtype env Ctype.nongen_vars_in_schema (fun _ _ -> ()) mty
+let check_nongen_modtype ~zap_scope env loc mty =
+  nongen_modtype env (Ctype.nongen_vars_in_schema ~zap_scope) (fun _ _ -> ())
+    mty
   |> Option.iter (fun (vars, item) ->
       let vars = Btype.TypeSet.elements vars in
       let error =
@@ -2844,10 +2846,10 @@ let check_nongen_modtype env loc mty =
       raise(Error(loc, env, error))
     )
 
-let check_nongen_signature_item env sig_item =
+let check_nongen_signature_item ~zap_scope env sig_item =
   match sig_item with
     Sig_value(_id, vd, _) ->
-      Ctype.nongen_vars_in_schema env vd.val_type
+      Ctype.nongen_vars_in_schema ~zap_scope env vd.val_type
       |> Option.iter (fun vars ->
           let vars = Btype.TypeSet.elements vars in
           let error =
@@ -2856,25 +2858,45 @@ let check_nongen_signature_item env sig_item =
           raise (Error (vd.val_loc, env, error))
         )
   | Sig_module (_id, _, md, _, _) ->
-      check_nongen_modtype env md.md_loc md.md_type
+      check_nongen_modtype ~zap_scope env md.md_loc md.md_type
   | _ -> ()
 
 let check_nongen_signature env sg =
-  List.iter (check_nongen_signature_item env) sg
+  Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+      List.iter (check_nongen_signature_item ~zap_scope env) sg)
 
-let remove_functor_mode_variables = function
+let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
+<<<<<<< HEAD
       Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
       begin match arg_opt with
       | Unit -> ()
       | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
+=======
+      let zap_mode mode =
+        if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope mode zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force mode |> ignore
+         end
+      in
+      zap_mode mres;
+      begin match arg_opt with
+      | Unit -> ()
+      | Named (_, _, marg) -> zap_mode marg
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       end
   | _ -> ()
 
 let remove_mode_and_jkind_variables env sg =
-  let rm_ty _env ty = Ctype.remove_mode_and_jkind_variables ty; None in
-  let rm_mty _env mty = remove_functor_mode_variables mty in
-  List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore
+  Mode.Alloc.with_zap_scope(fun ~zap_scope ->
+    let rm_ty _env ty =
+      Ctype.remove_mode_and_jkind_variables
+        ty ~zap_scope;
+      None
+    in
+    let rm_mty _env mty = remove_functor_mode_variables ~zap_scope mty in
+    List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore)
 
 (* Helpers for typing recursive modules *)
 
@@ -3330,7 +3352,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
         type_module ~strengthen:true ~funct_body None newenv sbody
       in
       let body_mode = mode_without_locks_exn body.mod_mode in
-      let ret_mode = Alloc.newvar () in
+      let ret_mode = Alloc.newvar 0 in
       Value.submode_exn body_mode (ret_mode |> alloc_as_value);
       (* Apply currying constraints if the body is a functor,
          similar to constraints for functions. *)
@@ -3400,9 +3422,10 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
         | _ -> raise exn
       end
   | Pmod_unpack sexp ->
-      let mode = Value.newvar () in
+      let mode = Value.newvar 0 in
       let exp =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:Typecore.generalize_structure_exp
           (fun () -> Typecore.type_exp env sexp
             ~mode:(Value.disallow_left mode))
       in
@@ -3553,8 +3576,9 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
      argument (the argument's mode). *)
   let functor_application_yielding ~funct ~arg_mode =
     let yielding m = Value.proj_comonadic Yielding m in
-    Yielding.join
-      [yielding (mode_without_locks_exn funct.mod_mode); yielding arg_mode]
+    Ctype.create_yielding_mode_l
+      (Yielding.join
+         [yielding (mode_without_locks_exn funct.mod_mode); yielding arg_mode])
   in
   (* CR modes: Apply currying constraints if the application is partial
      and returns a functor, similar to constraints for functions.
@@ -4328,7 +4352,9 @@ let remove_mode_and_jkind_variables_for_toplevel str =
                          vb_expr = exp}])) }] ->
      (* These types are printed by the toplevel,
         even though they do not appear in sg *)
-     Ctype.remove_mode_and_jkind_variables exp.exp_type
+     Mode.Alloc.with_zap_scope
+       (fun ~zap_scope ->
+          Ctype.remove_mode_and_jkind_variables ~zap_scope exp.exp_type)
   | _ -> ()
 
 let type_toplevel_phrase env sig_acc s =
@@ -4408,7 +4434,9 @@ let type_module_type_of env smod =
   in
   let mty = Mtype.scrape_for_type_of ~remove_aliases env tmty.mod_type in
   (* PR#5036: must not contain non-generalized type variables *)
-  if not skip_nongen_check then check_nongen_modtype env smod.pmod_loc mty;
+  if not skip_nongen_check then
+    Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+       check_nongen_modtype ~zap_scope env smod.pmod_loc mty);
   let zap_modality = Ctype.zap_modalities_to_floor_if_modes_enabled_at Stable in
   let mty =
     remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty

--- a/external/merlin/src/ocaml/typing/typemod.ml
+++ b/external/merlin/src/ocaml/typing/typemod.ml
@@ -3648,7 +3648,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       begin match app_view with
       | { arg = None; loc = app_loc; attributes = app_attributes; _ } ->
           Msupport.raise_error (apply_error ());
-          { mod_desc = Tmod_apply_unit(funct, Mode.Yielding.newvar ());
+          { mod_desc = Tmod_apply_unit(funct, Mode.Yielding.newvar 0);
             mod_type = mty_res;
             mod_mode = Value.(disallow_right min), None;
             mod_env = env;

--- a/external/merlin/src/ocaml/typing/typemod.ml
+++ b/external/merlin/src/ocaml/typing/typemod.ml
@@ -2867,24 +2867,17 @@ let check_nongen_signature env sg =
 
 let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
-<<<<<<< HEAD
-      Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
-      begin match arg_opt with
-      | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
-=======
-      let zap_mode mode =
+      let zap_mode ~arg mode =
         if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
-          Alloc.add_mode_to_zap_scope mode zap_scope
+          Alloc.add_mode_to_zap_scope ~arg mode zap_scope
          end else begin
-          Alloc.zap_to_legacy_force mode |> ignore
+          Alloc.zap_to_legacy_force ~arg mode |> ignore
          end
       in
-      zap_mode mres;
+      zap_mode ~arg:false mres;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> zap_mode marg
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+      | Named (_, _, marg) -> zap_mode ~arg:true marg
       end
   | _ -> ()
 

--- a/external/merlin/src/ocaml/typing/typetexp.ml
+++ b/external/merlin/src/ocaml/typing/typetexp.ml
@@ -1012,7 +1012,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode.mode_modes arg
           in
-          let acc_mode = curry_mode acc_mode arg_mode.mode_modes in
+          let acc_mode = curry_mode_const acc_mode arg_mode.mode_modes in
           let ret_mode =
             match rest with
             | [] -> ret_mode
@@ -1488,7 +1488,9 @@ and transl_type_alias env ~row_context ~policy mode attrs styp_loc styp name_opt
         cty, jkind_annot
       with Not_found ->
         let t, ty, jkind_annot =
-          with_local_level_generalize_structure_if_principal begin fun () ->
+          with_local_level_generalize_structure_if_principal
+            ~before_generalize:(fun (t, _, _) -> generalize_structure t)
+            begin fun () ->
             let jkind, rigid =
               jkind_for_fresh_var env alias alias_loc attrs jkind_annot_opt
             in
@@ -1699,7 +1701,7 @@ let rec make_fixed_univars mark ty =
                   ~fixed:(Some (Univar more))));
         Btype.iter_row (make_fixed_univars mark) row
     | _ ->
-        Btype.iter_type_expr (make_fixed_univars mark) ty
+        Btype.iter_type_expr (make_fixed_univars mark) (Fun.const ()) ty
     end
 
 let make_fixed_univars ty =
@@ -1766,7 +1768,8 @@ let transl_type_scheme_mono env styp =
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (fun ~zap_scope ->
+    remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =
@@ -1790,7 +1793,8 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ~before_generalize:(fun (_,_,typ) -> generalize_ctyp typ)
   in
   let _ : _ list = TyVarEnv.instance_poly_univars env loc univars in
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (fun ~zap_scope ->
+    remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
     ctyp_env = env;
@@ -1864,7 +1868,7 @@ let transl_type_scheme_newlayout env attrs loc vars inner_type =
               Types.set_var_jkind t jkind
             | None -> ())
           | _ -> ())
-        | _ -> Btype.iter_type_expr replace t)
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t)
       end
     in
     let ety = Subst.type_expr Subst.identity ty in

--- a/external/merlin/src/ocaml/utils/language_extension_kernel.ml
+++ b/external/merlin/src/ocaml/utils/language_extension_kernel.ml
@@ -9,6 +9,8 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -27,6 +29,8 @@ let to_string : type a. a t -> string = function
   | Mode -> "mode"
   | Unique -> "unique"
   | Overwriting -> "overwriting"
+  | Mode_polymorphism -> "mode_polymorphism"
+  | Mode_polymorphism_printing -> "mode_polymorphism_printing"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"

--- a/external/merlin/src/ocaml/utils/language_extension_kernel.mli
+++ b/external/merlin/src/ocaml/utils/language_extension_kernel.mli
@@ -20,6 +20,8 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/external/merlin/tests/test-dirs/function-recovery.t
+++ b/external/merlin/tests/test-dirs/function-recovery.t
@@ -42,7 +42,7 @@
                     Texp_function
                     alloc_mode id(modevar#1a<0>[global .. local])
                     yielding_mode unyielding
-                    return_mode proj_Locality(modevar#17<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
+                    return_mode id(modevar#18<0>[global .. local])
                     []
                     []
                     Tfunction_body
@@ -87,7 +87,7 @@
             Texp_function
             alloc_mode global
             yielding_mode unyielding
-            return_mode proj_Locality(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
+            return_mode proj_Locality(modevar#9<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -107,8 +107,8 @@
                     []
                   Tpat_var \"foo\"
                   sort value
-                  value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#7<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
-                proj_Locality(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
+                  value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#7<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#8<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+                proj_Locality(modevar#7<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body
@@ -256,7 +256,7 @@
                         "kind": "pattern (test.ml[1,0+6]..test.ml[1,0+9])
     Tpat_var \"x\"
     sort '_representable_layout_1
-    value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#a<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+    value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#7<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#b<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
   ",
                         "children": []
                       },

--- a/external/merlin/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/external/merlin/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -461,7 +461,7 @@ We try several places in the identifier to check the result stability
             Texp_function
             alloc_mode global
             yielding_mode unyielding
-            return_mode proj_Locality(modevar#1e<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
+            return_mode id(modevar#20<0>[global .. local])
             []
             [
               Nolabel
@@ -469,8 +469,8 @@ We try several places in the identifier to check the result stability
                 pattern (under.ml[2,13+6]..under.ml[2,13+9])
                   Tpat_var \"x\"
                   sort '_representable_layout_1
-                  value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#11<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
-                proj_Locality(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
+                  value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#e<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#12<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+                proj_Locality(modevar#e<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body

--- a/external/merlin/tests/test-dirs/typing-recovery.t
+++ b/external/merlin/tests/test-dirs/typing-recovery.t
@@ -100,7 +100,7 @@
             Texp_function
             alloc_mode global
             yielding_mode unyielding
-            return_mode proj_Locality(modevar#a<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
+            return_mode proj_Locality(modevar#b<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -116,8 +116,8 @@
                     []
                   Tpat_var \"x\"
                   sort value
-                  value_mode global,many,portable,forkable,unyielding,stateless;meet(unique,uncontended,read_write,static,imply(aliased,contended,immutable,static)(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
-                proj_Locality(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
+                  value_mode global,many,portable,forkable,unyielding,stateless;meet(unique,uncontended,read_write,static,imply(aliased,contended,immutable,static)(modevar#a<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+                proj_Locality(modevar#9<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body
@@ -287,7 +287,7 @@
             Texp_function
             alloc_mode global
             yielding_mode unyielding
-            return_mode proj_Locality(modevar#a<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
+            return_mode proj_Locality(modevar#b<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -304,7 +304,7 @@
                     global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
                     []
                   Tpat_any
-                proj_Locality(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
+                proj_Locality(modevar#9<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body

--- a/external/merlin/upstream/ocaml_flambda/parsing/language_extension.ml
+++ b/external/merlin/upstream/ocaml_flambda/parsing/language_extension.ml
@@ -64,6 +64,8 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Mode -> (module Maturity)
   | Unique -> (module Maturity)
   | Overwriting -> (module Unit)
+  | Mode_polymorphism -> (module Maturity)
+  | Mode_polymorphism_printing -> (module Unit)
   | Include_functor -> (module Unit)
   | Polymorphic_parameters -> (module Unit)
   | Immutable_arrays -> (module Unit)
@@ -85,7 +87,9 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
    But we've decided to punt on this issue in the short term.
 *)
 let is_erasable : type a. a t -> bool = function
-  | Mode | Unique | Overwriting | Layouts | Layout_poly -> true
+  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism
+  | Mode_polymorphism_printing ->
+    true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
   | Runtime_metaprogramming ->
@@ -98,22 +102,24 @@ let maturity_of_unique_for_destruction = Alpha
 module Exist_pair = struct
   type t = Pair : 'a language_extension * 'a -> t
 
-  let maturity : t -> Maturity.t = function
-    | Pair (Comprehensions, ()) -> Beta
-    | Pair (Mode, m) -> m
-    | Pair (Unique, m) -> m
-    | Pair (Overwriting, ()) -> Alpha
-    | Pair (Include_functor, ()) -> Stable
-    | Pair (Polymorphic_parameters, ()) -> Stable
-    | Pair (Immutable_arrays, ()) -> Stable
-    | Pair (Module_strengthening, ()) -> Stable
-    | Pair (Layouts, m) -> m
-    | Pair (SIMD, m) -> m
-    | Pair (Small_numbers, m) -> m
-    | Pair (Instances, ()) -> Stable
-    | Pair (Let_mutable, ()) -> Stable
-    | Pair (Layout_poly, m) -> m
-    | Pair (Runtime_metaprogramming, ()) -> Beta
+  let maturity : t -> Maturity.t option = function
+    | Pair (Comprehensions, ()) -> Some Beta
+    | Pair (Mode, m) -> Some m
+    | Pair (Unique, m) -> Some m
+    | Pair (Overwriting, ()) -> Some Alpha
+    | Pair (Mode_polymorphism, m) -> Some m
+    | Pair (Mode_polymorphism_printing, ()) -> None
+    | Pair (Include_functor, ()) -> Some Stable
+    | Pair (Polymorphic_parameters, ()) -> Some Stable
+    | Pair (Immutable_arrays, ()) -> Some Stable
+    | Pair (Module_strengthening, ()) -> Some Stable
+    | Pair (Layouts, m) -> Some m
+    | Pair (SIMD, m) -> Some m
+    | Pair (Small_numbers, m) -> Some m
+    | Pair (Instances, ()) -> Some Stable
+    | Pair (Let_mutable, ()) -> Some Stable
+    | Pair (Layout_poly, m) -> Some m
+    | Pair (Runtime_metaprogramming, ()) -> Some Beta
 
   let is_erasable : t -> bool = function Pair (ext, _) -> is_erasable ext
 
@@ -126,10 +132,13 @@ module Exist_pair = struct
     | Pair (SIMD, m) -> to_string SIMD ^ "_" ^ maturity_to_string m
     | Pair (Layout_poly, m) ->
       to_string Layout_poly ^ "_" ^ maturity_to_string m
+    | Pair (Mode_polymorphism, m) ->
+      to_string Mode_polymorphism ^ "_" ^ maturity_to_string m
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
-           | Let_mutable | Runtime_metaprogramming ) as ext),
+           | Let_mutable | Runtime_metaprogramming | Mode_polymorphism_printing
+             ) as ext),
           _ ) ->
       to_string ext
 
@@ -143,6 +152,11 @@ module Exist_pair = struct
     | "mode" -> Some (Pair (Mode, Stable))
     | "mode_beta" -> Some (Pair (Mode, Beta))
     | "mode_alpha" -> Some (Pair (Mode, Alpha))
+    | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
+    | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
+    | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
+    | "mode_polymorphism_printing" ->
+      Some (Pair (Mode_polymorphism_printing, ()))
     | "unique" -> Some (Pair (Unique, Stable))
     | "unique_beta" -> Some (Pair (Unique, Beta))
     | "unique_alpha" -> Some (Pair (Unique, Alpha))
@@ -176,6 +190,8 @@ let all_extensions =
   [ Pack Comprehensions;
     Pack Mode;
     Pack Unique;
+    Pack Mode_polymorphism;
+    Pack Mode_polymorphism_printing;
     Pack Overwriting;
     Pack Include_functor;
     Pack Polymorphic_parameters;
@@ -217,6 +233,8 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Mode, Mode -> Some Refl
   | Unique, Unique -> Some Refl
   | Overwriting, Overwriting -> Some Refl
+  | Mode_polymorphism, Mode_polymorphism -> Some Refl
+  | Mode_polymorphism_printing, Mode_polymorphism_printing -> Some Refl
   | Include_functor, Include_functor -> Some Refl
   | Polymorphic_parameters, Polymorphic_parameters -> Some Refl
   | Immutable_arrays, Immutable_arrays -> Some Refl
@@ -231,7 +249,8 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming ),
+      | Runtime_metaprogramming | Mode_polymorphism | Mode_polymorphism_printing
+        ),
       _ ) ->
     None
 
@@ -324,14 +343,14 @@ end = struct
     | Alpha -> "flag -extension-universe alpha (default CLI option)"
 
   let is_allowed_in t extn_pair =
-    match t with
-    | No_extensions -> false
-    | Upstream_compatible ->
-      Exist_pair.is_erasable extn_pair
-      && Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Stable -> Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Beta -> Maturity.compare (Exist_pair.maturity extn_pair) Beta <= 0
-    | Alpha -> true
+    match t, Exist_pair.maturity extn_pair with
+    | No_extensions, _ -> false
+    | _, None -> true
+    | Upstream_compatible, Some maturity ->
+      Exist_pair.is_erasable extn_pair && Maturity.compare maturity Stable <= 0
+    | Stable, Some maturity -> Maturity.compare maturity Stable <= 0
+    | Beta, Some maturity -> Maturity.compare maturity Beta <= 0
+    | Alpha, Some _ -> true
 
   let is_allowed extn_pair = is_allowed_in !universe extn_pair
 
@@ -351,7 +370,11 @@ end = struct
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
       let allowed_levels =
-        Ops.all |> List.filter (fun lvl -> is_allowed_in t (Pair (extn, lvl)))
+        Ops.all
+        |> List.filter (fun lvl ->
+            match Exist_pair.maturity (Pair (extn, lvl)) with
+            | None -> false
+            | Some _ -> is_allowed_in t (Pair (extn, lvl)))
       in
       match allowed_levels with
       | [] -> None

--- a/external/merlin/upstream/ocaml_flambda/parsing/language_extension.mli
+++ b/external/merlin/upstream/ocaml_flambda/parsing/language_extension.mli
@@ -21,6 +21,8 @@ type 'a t = 'a Language_extension_kernel.t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.ml
@@ -108,7 +108,7 @@ end
 
 (**** Type level management ****)
 
-let generic_level = Ident.highest_scope
+let generic_level = Mode.Alloc.generic_level
 let lowest_level = Ident.lowest_scope
 
 (**** leveled type pool ****)
@@ -335,11 +335,13 @@ let iter_row f row =
   fold_row (fun () v -> f v) () row
 
 
-let fold_type_expr f init ty =
+let fold_type_expr f fm init ty =
   match get_desc ty with
     Tvar _              -> init
-  | Tarrow (_, ty1, ty2, _) ->
-      let result = f init ty1 in
+  | Tarrow ((_, m1, m2), ty1, ty2, _) ->
+      let result = fm init m1 in
+      let result = fm result m2 in
+      let result = f result ty1 in
       f result ty2
   | Ttuple l            -> List.fold_left (fun acc (_, t) -> f acc t) init l
   | Tunboxed_tuple l    -> List.fold_left (fun acc (_, t) -> f acc t) init l
@@ -372,8 +374,8 @@ let fold_type_expr f init ty =
   | Tof_kind _ -> init
   | Tbox ty -> f init ty
 
-let iter_type_expr f ty =
-  fold_type_expr (fun () v -> f v) () ty
+let iter_type_expr f fm ty =
+  fold_type_expr (fun () v -> f v) (fun () v -> fm v) () ty
 
 let rec iter_abbrev f = function
     Mnil                   -> ()
@@ -410,10 +412,11 @@ let iter_type_expr_kind f = function
                   (**********************************)
 
 let rec mark_type mark ty =
-  if try_mark_node mark ty then iter_type_expr (mark_type mark) ty
+  if try_mark_node mark ty then
+    iter_type_expr (mark_type mark) (Fun.const ()) ty
 
 let mark_type_params mark ty =
-  iter_type_expr (mark_type mark) ty
+  iter_type_expr (mark_type mark) (Fun.const ()) ty
 
                   (**********************************)
                   (*  (Object-oriented) iterator    *)
@@ -438,6 +441,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -456,7 +461,8 @@ let type_iterators_without_type_expr =
     | Sig_class_type (_, ctd, _, _) -> it.it_class_type_declaration it ctd
     | Sig_jkind (_ , jkd, _)        -> it.it_jkind_declaration it jkd
   and it_value_description it vd =
-    it.it_type_expr it vd.val_type
+    it.it_type_expr it vd.val_type;
+    it.it_modality vd.val_modalities
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
@@ -468,7 +474,8 @@ let type_iterators_without_type_expr =
     iter_type_expr_cstr_args (it.it_type_expr it) td.ext_args;
     Option.iter (it.it_type_expr it) td.ext_ret_type
   and it_module_declaration it md =
-    it.it_module_type it md.md_type
+    it.it_module_type it md.md_type;
+    it.it_modality md.md_modalities
   and it_modtype_declaration it mtd =
     Option.iter (it.it_module_type it) mtd.mtd_type
   and it_class_declaration it cd =
@@ -490,14 +497,17 @@ let type_iterators_without_type_expr =
       ()
   and it_functor_param it = function
     | Unit -> ()
-    | Named (_, mt, _) -> it.it_module_type it mt
+    | Named (_, mt, mm) ->
+        it.it_module_type it mt;
+        it.it_mode_expr mm
   and it_module_type it = function
       Mty_ident p
     | Mty_alias p -> it.it_path p
     | Mty_signature sg -> it.it_signature it sg
-    | Mty_functor (p, mt, _) ->
+    | Mty_functor (p, mt, mm) ->
         it.it_functor_param it p;
-        it.it_module_type it mt
+        it.it_module_type it mt;
+        it.it_mode_expr mm
     | Mty_strengthen (mty, p, _) ->
         it.it_module_type it mty;
         it.it_path p
@@ -517,19 +527,22 @@ let type_iterators_without_type_expr =
   and it_type_kind it kind =
     iter_type_expr_kind (it.it_type_expr it) kind
   and it_path _p = ()
+  and it_mode_expr _m = ()
+  and it_modality _m = ()
   in
   { it_path; it_type_expr = (fun _ _ -> ()); it_do_type_expr = (fun _ _ -> ());
     it_type_kind; it_class_type; it_functor_param; it_module_type;
     it_signature; it_class_type_declaration; it_class_declaration;
     it_jkind_declaration;
     it_modtype_declaration; it_module_declaration; it_extension_constructor;
-    it_type_declaration; it_value_description; it_signature_item; }
+    it_type_declaration; it_value_description;
+    it_signature_item; it_mode_expr; it_modality }
 
 let type_iterators mark =
   let it_type_expr it ty =
     if try_mark_node mark ty then it.it_do_type_expr it ty
   and it_do_type_expr it ty =
-    iter_type_expr (it.it_type_expr it) ty;
+    iter_type_expr (it.it_type_expr it) (it.it_mode_expr) ty;
     match get_desc ty with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
@@ -582,11 +595,12 @@ let instance_jkind (t : jkind_lr) : jkind_lr =
   | Layout l ->
     { t with jkind = { t.jkind with base = Layout (instance_layout l) } }
 
-let rec copy_type_desc ?(keep_names=false) f = function
+let rec copy_type_desc ?(keep_names=false) f fm = function
     Tvar { name; jkind } ->
      let jkind = instance_jkind jkind in
      if keep_names then Tvar { name; jkind } else Tvar { name=None; jkind }
-  | Tarrow (p, ty1, ty2, c)-> Tarrow (p, f ty1, f ty2, copy_commu c)
+  | Tarrow ((p, m1, m2), ty1, ty2, c)->
+    Tarrow ((p, fm m1, fm m2), f ty1, f ty2, copy_commu c)
   | Ttuple l            -> Ttuple (List.map (fun (label, t) -> label, f t) l)
   | Tunboxed_tuple l    ->
     Tunboxed_tuple (List.map (fun (label, t) -> label, f t) l)
@@ -603,7 +617,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tfield (p, field_kind_internal_repr k, f ty1, f ty2)
       (* the kind is kept shared, with indirections removed for performance *)
   | Tnil                -> Tnil
-  | Tlink ty            -> copy_type_desc f (get_desc ty)
+  | Tlink ty            -> copy_type_desc f fm (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
@@ -623,11 +637,23 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_for_saving : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_for_restoring : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
     mutable saved_desc : (transient_expr * type_desc) list;
     (* Save association of generic nodes with their description. *)
+    saved_mode_changes : Mode.copy_scope;
   }
 
   let redirect_desc copy_scope ty desc =
@@ -635,13 +661,30 @@ end = struct
     copy_scope.saved_desc <- (ty, ty.desc) :: copy_scope.saved_desc;
     Transient_expr.set_desc ty desc
 
+  let mode_instantiate copy_scope ~current_level m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.instantiate ~copy_scope ~current_level m
+
+  let mode_copy_generic copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_generic ~copy_scope m
+
+  let mode_copy_for_saving copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_for_saving ~copy_scope m
+
+  let mode_copy_for_restoring copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_for_restoring ~copy_scope m
+
   (* Restore type descriptions. *)
   let cleanup { saved_desc; _ } =
     List.iter (fun (ty, desc) -> Transient_expr.set_desc ty desc) saved_desc
 
   let with_scope f =
-    let scope = { saved_desc = [] } in
-    Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope)
+    Mode.with_copy_scope (fun ms ->
+      let scope = { saved_desc = []; saved_mode_changes = ms } in
+      Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope))
 
 end
 

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.mli
@@ -157,15 +157,20 @@ val set_static_row_name: type_declaration -> Path.t -> unit
 
 (**** Utilities for type traversal ****)
 
-val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
+val iter_type_expr:
+  (type_expr -> unit) -> (Mode.Alloc.lr -> unit) ->
+  type_expr -> unit
         (* Iteration on types *)
-val fold_type_expr: ('a -> type_expr -> 'a) -> 'a -> type_expr -> 'a
+val fold_type_expr:
+  ('a -> type_expr -> 'a) -> ('a -> Mode.Alloc.lr -> 'a) ->
+  'a -> type_expr -> 'a
 val iter_row: (type_expr -> unit) -> row_desc -> unit
         (* Iteration on types in a row *)
 val fold_row: ('a -> type_expr -> 'a) -> 'a -> row_desc -> 'a
 val iter_abbrev: (type_expr -> unit) -> abbrev_memo -> unit
         (* Iteration on types in an abbreviation list *)
-val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
+val iter_type_expr_kind: (type_expr -> unit) ->
+  (type_decl_kind -> unit)
 
 val iter_type_expr_cstr_args: (type_expr -> unit) ->
   (constructor_arguments -> unit)
@@ -200,6 +205,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -216,7 +223,8 @@ val type_iterators_without_type_expr: type_iterators_without_type_expr
 (**** Utilities for copying ****)
 
 val copy_type_desc:
-    ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc
+    ?keep_names:bool -> (type_expr -> type_expr) ->
+    (Mode.Alloc.lr -> Mode.Alloc.lr) -> type_desc -> type_desc
         (* Copy on types *)
 val copy_row:
     (type_expr -> type_expr) ->
@@ -235,6 +243,26 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
         (* Temporarily change a type description *)
+
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Instantiates a generic mode variable to level [current_level] *)
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Copies the generic parts of a mode variable
+           without changing its level *)
+
+  val mode_copy_for_saving :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Deeply copies a mode variable without changing its level, giving
+           the copies negative (persistent) ids, for storing in a cmi file. *)
+
+  val mode_copy_for_restoring :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Deeply copies a mode variable without changing its level.
+           Asserts that the original has negative ids. *)
 
   val with_scope: (copy_scope -> 'a) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -749,18 +749,13 @@ let remove_mode_and_jkind_variables ~zap_scope ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-<<<<<<< HEAD
-         let _ = Alloc.zap_to_legacy ~arg:true marg in
-         let _ = Alloc.zap_to_legacy ~arg:false mret in
-=======
          if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
-          Alloc.add_mode_to_zap_scope marg zap_scope;
-          Alloc.add_mode_to_zap_scope mret zap_scope
+          Alloc.add_mode_to_zap_scope ~arg:true marg zap_scope;
+          Alloc.add_mode_to_zap_scope ~arg:false mret zap_scope
          end else begin
-          Alloc.zap_to_legacy_force marg |> ignore;
-          Alloc.zap_to_legacy_force mret |> ignore
+          Alloc.zap_to_legacy_force ~arg:true marg |> ignore;
+          Alloc.zap_to_legacy_force ~arg:false mret |> ignore
          end;
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
          go targ; go tret
       | _ -> iter_type_expr go (Fun.const ()) ty
     end

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -248,26 +248,33 @@ let with_local_level_gen ~begin_def ~structure ?before_generalize f =
         else begin
           (* Generalize all remaining nodes *)
           Transient_expr.set_level ty generic_level;
-          if structure then match ty.desc with
-            Tconstr (_, _, abbrev) ->
+          match ty.desc with
+          | Tconstr (_, _, abbrev) when structure ->
               (* In structure mode, we drop abbreviations, as the goal of
                  this mode is to reduce sharing *)
               abbrev := Mnil
+          | Tarrow ((_, marg, mret), _, _, _) when not structure ->
+              Alloc.generalize_topology ~current_level:!current_level marg;
+              Alloc.generalize_topology ~current_level:!current_level mret
           | _ -> ()
         end
   end pool;
   result
 
-let with_local_level_generalize_structure f =
-  with_local_level_gen ~begin_def ~structure:true f
 let with_local_level_generalize ~before_generalize f =
   with_local_level_gen ~begin_def ~structure:false ~before_generalize f
 let with_local_level_generalize_if cond ~before_generalize f =
   if cond then with_local_level_generalize ~before_generalize f else f ()
-let with_local_level_generalize_structure_if cond f =
-  if cond then with_local_level_generalize_structure f else f ()
-let with_local_level_generalize_structure_if_principal f =
-  if !Clflags.principal then with_local_level_generalize_structure f else f ()
+let with_local_level_generalize_structure ~before_generalize f =
+  with_local_level_gen ~begin_def ~structure:true ~before_generalize f
+let with_local_level_generalize_structure_if cond ~before_generalize f =
+  if cond then
+    with_local_level_generalize_structure ~before_generalize f
+  else f ()
+let with_local_level_generalize_structure_if_principal ~before_generalize f =
+  if !Clflags.principal then
+    with_local_level_generalize_structure ~before_generalize f
+  else f ()
 let with_local_level_generalize_for_class ~before_generalize f =
   with_local_level_gen
     ~begin_def:begin_class_def ~structure:false ~before_generalize f
@@ -497,7 +504,7 @@ let decr_stage env =
 let incr_stage env =
   Env.enter_quote env
 
-let iter_type_expr_with_stages f env ty =
+let iter_type_expr_with_stages f env fm ty =
   match get_desc ty with
   | Tquote ty ->
     f (incr_stage env) ty
@@ -506,7 +513,7 @@ let iter_type_expr_with_stages f env ty =
   | Tquote_eval ty ->
     f (incr_stage env) ty
   | _ ->
-    iter_type_expr (f env) ty
+    iter_type_expr (f env) fm ty
 
 (* CR metaprogramming jbachurski: We use this to adjust the environment while
    printing error messages. The original type may have been well-staged,
@@ -531,6 +538,7 @@ let contains_initial_stage_splice stage ty =
       in
       fold_type_expr
         (fun x y -> x || loop (acc + offset) y)
+        (fun a _ -> a)
         (acc < 0) ty
     end
   in
@@ -732,7 +740,7 @@ let rec filter_row_fields erase = function
       | _ -> p :: fi
 
 (* Ensure all mode variables are fully determined *)
-let remove_mode_and_jkind_variables ty =
+let remove_mode_and_jkind_variables ~zap_scope ty =
   let visited = ref TypeSet.empty in
   let rec go ty =
     if TypeSet.mem ty !visited then () else begin
@@ -741,10 +749,20 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
+<<<<<<< HEAD
          let _ = Alloc.zap_to_legacy ~arg:true marg in
          let _ = Alloc.zap_to_legacy ~arg:false mret in
+=======
+         if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope marg zap_scope;
+          Alloc.add_mode_to_zap_scope mret zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force marg |> ignore;
+          Alloc.zap_to_legacy_force mret |> ignore
+         end;
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
          go targ; go tret
-      | _ -> iter_type_expr go ty
+      | _ -> iter_type_expr go (Fun.const ()) ty
     end
   in go ty
 
@@ -800,7 +818,7 @@ let[@inline] free_vars ~init ~add_one ?env mark tys =
           if static_row row then acc
           else fv ~kind:Row_variable acc (row_more row)
       | _    ->
-          fold_type_expr (fv ~kind) acc ty
+          fold_type_expr (fv ~kind) (fun acc _ -> acc) acc ty
   in
   List.fold_left (fv ~kind:Type_variable) init tys
 
@@ -850,20 +868,21 @@ let closed_type_expr ?env ty =
     try closed_type ?env mark ty; true
     with Non_closed _ -> false)
 
-let close_type mark ty =
-  remove_mode_and_jkind_variables ty;
+let close_type ~zap_scope mark ty =
+  remove_mode_and_jkind_variables ~zap_scope ty;
   closed_type mark ty
 
 let closed_parameterized_type params ty =
   with_type_mark begin fun mark ->
     List.iter (mark_type mark) params;
-    try close_type mark ty; true with Non_closed _ -> false
+    try Alloc.with_zap_scope (fun ~zap_scope -> close_type ~zap_scope mark ty);
+    true with Non_closed _ -> false
   end
 
-let closed_type_decl decl =
+let closed_type_decl ~zap_scope decl =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) decl.type_params;
-    List.iter remove_mode_and_jkind_variables decl.type_params;
+    List.iter (remove_mode_and_jkind_variables ~zap_scope) decl.type_params;
     begin match decl.type_kind with
       Type_abstract _ ->
         ()
@@ -877,30 +896,32 @@ let closed_type_decl decl =
                    them. Test case: typing-layouts-gadt-sort-var/test.ml *)
                 begin match cd_args with
                 | Cstr_tuple l -> List.iter (fun ca ->
-                    remove_mode_and_jkind_variables ca.ca_type) l
+                    remove_mode_and_jkind_variables ~zap_scope ca.ca_type) l
                 | Cstr_record l -> List.iter (fun l ->
-                    remove_mode_and_jkind_variables l.ld_type) l
+                    remove_mode_and_jkind_variables ~zap_scope l.ld_type) l
                 end;
-                remove_mode_and_jkind_variables res_ty
-            | None -> List.iter (close_type mark) (tys_of_constr_args cd_args)
+                remove_mode_and_jkind_variables ~zap_scope res_ty
+            | None ->
+              List.iter (close_type mark ~zap_scope)
+                (tys_of_constr_args cd_args)
           )
           v
     | Type_record(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_record_unboxed_product(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_open -> ()
     end;
     begin match decl.type_manifest with
       None    -> ()
-    | Some ty -> close_type mark ty
+    | Some ty -> close_type mark ~zap_scope ty
     end;
     None
   with Non_closed (ty, _) ->
     Some ty
   end
 
-let closed_extension_constructor ext =
+let closed_extension_constructor ~zap_scope ext =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) ext.ext_type_params;
     begin match ext.ext_ret_type with
@@ -908,10 +929,12 @@ let closed_extension_constructor ext =
         (* gadts cannot have free type variables, but they might
            have undefaulted sort variables; these lines default
            them. Test case: typing-layouts-gadt-sort-var/test_extensible.ml *)
-        iter_type_expr_cstr_args remove_mode_and_jkind_variables ext.ext_args;
-        remove_mode_and_jkind_variables res_ty
+        iter_type_expr_cstr_args
+          (remove_mode_and_jkind_variables ~zap_scope)
+          ext.ext_args;
+        remove_mode_and_jkind_variables ~zap_scope res_ty
     | None ->
-        iter_type_expr_cstr_args (close_type mark) ext.ext_args
+        iter_type_expr_cstr_args (close_type mark ~zap_scope) ext.ext_args
     end;
     None
   with Non_closed (ty, _) ->
@@ -925,7 +948,7 @@ type closed_class_failure = {
 }
 exception CCFailure of closed_class_failure
 
-let closed_class params sign =
+let closed_class ~zap_scope params sign =
   with_type_mark begin fun mark ->
   List.iter (mark_type mark) params;
   ignore (try_mark_node mark sign.csig_self_row);
@@ -933,7 +956,8 @@ let closed_class params sign =
     Meths.iter
       (fun lab (priv, _, ty) ->
         if priv = Mpublic then begin
-          try close_type mark ty with Non_closed (ty0, variable_kind) ->
+          try close_type ~zap_scope mark ty
+          with Non_closed (ty0, variable_kind) ->
             raise (CCFailure {
               free_variable = (ty0, variable_kind);
               meth = lab;
@@ -967,7 +991,7 @@ let duplicate_class_type ty =
 let rec lower_all ty =
   if get_level ty > !current_level then begin
     set_level ty !current_level;
-    iter_type_expr lower_all ty
+    iter_type_expr lower_all (Fun.const ()) ty
   end
 
 (*
@@ -979,7 +1003,8 @@ let rec lower_all ty =
 *)
 let rec generalize stage_offset ty =
   let level = get_level ty in
-  if (level > !current_level) && (level <> generic_level) then begin
+  let current_level = !current_level in
+  if (level > current_level) && (level <> generic_level) then begin
     set_level ty generic_level;
     begin match get_desc ty with
     (* Keep track of [stage_offset] *)
@@ -992,7 +1017,7 @@ let rec generalize stage_offset ty =
     (* Normalize the variable to be at [stage_offset = 0] *)
     | Tvar name ->
         update_variable_stage stage_offset ty name.name name.jkind;
-        Jkind.generalize ~current_level:!current_level name.jkind
+        Jkind.generalize ~current_level name.jkind
     (* Do not generalize cross-stage row-polymorphic types, as we cannot
        quote or splice row variables.
        Weak type variables that arise here are considered cross-stage,
@@ -1006,16 +1031,43 @@ let rec generalize stage_offset ty =
         lower_all ty
     (* recur into abbrev for the speed *)
     | Tconstr (_, _, abbrev) ->
+        let mgen m = Mode.Alloc.generalize ~current_level m in
         iter_abbrev (generalize stage_offset) !abbrev;
-        iter_type_expr (generalize stage_offset) ty
+        iter_type_expr (generalize stage_offset) mgen ty
     | _ ->
-        iter_type_expr (generalize stage_offset) ty
+
+      let mgen m = Mode.Alloc.generalize ~current_level m in
+      iter_type_expr (generalize stage_offset) mgen ty
     end;
   end
 
 let generalize ty =
   simple_abbrevs := Mnil;
   generalize 0 ty
+
+(* Generalize the structure and lower the variables *)
+
+let rec generalize_structure ty =
+  let level = get_level ty in
+  let current_level = !current_level in
+  if level <> generic_level then begin
+    if is_Tvar ty && level > current_level then
+      set_level ty current_level
+    else if level > current_level then begin
+      begin match get_desc ty with
+        Tconstr (_, _, abbrev) ->
+          abbrev := Mnil
+      | _ -> ()
+      end;
+      set_level ty generic_level;
+      let mgen m = Mode.Alloc.generalize_structure ~current_level m in
+      iter_type_expr generalize_structure mgen ty
+    end
+  end
+
+let generalize_structure ty =
+  simple_abbrevs := Mnil;
+  generalize_structure ty
 
 (*
    Build a copy of a type in which nodes reachable through a path composed
@@ -1046,15 +1098,20 @@ let rec copy_spine copy_scope ty =
   | ( Tarrow _ | Tpoly _ | Trepr _ | Ttuple _ | Tunboxed_tuple _ | Tpackage _
     | Tconstr _ | Tmod _ ) as desc ->
       let level = get_level ty in
-      if level < !current_level || level = generic_level then ty else
+      let current_level = !current_level in
+      if level < current_level || level = generic_level then ty else
       let t =
         newgenstub ~scope:(get_scope ty) (Jkind.Builtin.any ~why:Dummy_jkind)
       in
       For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
       let copy_rec = copy_spine copy_scope in
       let desc' = match desc with
-      | Tarrow (lbl, ty1, ty2, _) ->
-          Tarrow (lbl, copy_rec ty1, copy_rec ty2, commu_ok)
+      | Tarrow ((lbl, marg, mret), ty1, ty2, _) ->
+          Tarrow
+            ((lbl, marg, mret),
+             copy_rec ty1,
+             copy_rec ty2,
+             commu_ok)
       | Tpoly (ty', tvl) ->
           Tpoly (copy_rec ty', tvl)
       | Trepr (ty', sl) ->
@@ -1123,7 +1180,7 @@ let rec check_scope_escape mark env level ty =
             (Tpackage {pack with pack_path = p'}))
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> check_scope_escape mark env level) env ty
+          (fun env -> check_scope_escape mark env level) env (Fun.const ()) ty
     end;
   end
 
@@ -1139,7 +1196,8 @@ let rec update_scope scope ty =
     if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
     (* Only recurse in principal mode as this is not necessary for soundness *)
-    if !Clflags.principal then iter_type_expr (update_scope scope) ty
+    if !Clflags.principal then
+      iter_type_expr (update_scope scope) (Fun.const ()) ty
   end
 
 let update_scope_for tr_exn scope ty =
@@ -1191,7 +1249,8 @@ let rec update_level env level expand ty =
           update_level env level expand ty'
         with Cannot_expand ->
           set_level ();
-          iter_type_expr (update_level env level expand) ty
+          iter_type_expr (update_level env level expand)
+            (Mode.Alloc.update_level level) ty
         end
     | Tpackage ({pack_path = p} as pack) when level < Path.scope p ->
         let p' = normalize_package_path env p in
@@ -1209,7 +1268,8 @@ let rec update_level env level expand ty =
         | _ -> ()
         end;
         set_level ();
-        iter_type_expr (update_level env level expand) ty
+        iter_type_expr (update_level env level expand)
+          (Mode.Alloc.update_level level) ty
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && level < get_scope ty1 ->
         raise_escape_exn Self
@@ -1217,7 +1277,8 @@ let rec update_level env level expand ty =
         set_level ();
         (* XXX what about abbreviations in Tconstr ? *)
         iter_type_expr_with_stages
-          (fun env -> update_level env level expand) env ty
+          (fun env -> update_level env level expand) env
+          (Mode.Alloc.update_level level) ty
   end
 
 (* First try without expanding, then expand everything,
@@ -1279,12 +1340,15 @@ let rec lower_contravariant env var_level visited contra ty =
           else not_expanded ()
     | Tpackage p ->
         List.iter (fun (_n, ty) -> lower_rec true ty) p.pack_cstrs
-    | Tarrow (_, t1, t2, _) ->
+    | Tarrow ((_, m1, m2), t1, t2, _) ->
+        Mode.Alloc.update_level var_level m1;
+        if contra then Mode.Alloc.update_level var_level m2;
         lower_rec true t1;
         lower_rec contra t2
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> lower_contravariant env var_level visited contra) env ty
+          (fun env -> lower_contravariant env var_level visited contra)
+          env (Fun.const ()) ty
   end
 
 let lower_variables_only env level ty =
@@ -1309,6 +1373,9 @@ let rec generalize_class_type gen =
       gen ty;
       generalize_class_type gen cty
 
+let generalize_class_type_structure cty =
+  generalize_class_type generalize_structure cty
+
 (* Only generalize the type ty0 in ty *)
 let limited_generalize ty0 ~inside:ty =
   let graph = TypeHash.create 17 in
@@ -1324,7 +1391,7 @@ let limited_generalize ty0 ~inside:ty =
           (* XXX: why generic_level needs to be a root *)
           if (level = generic_level) || eq_type ty ty0 then
             roots := ty :: !roots;
-          iter_type_expr (inverse [ty]) ty
+          iter_type_expr (inverse [ty]) (Fun.const ()) ty
         end
   in
 
@@ -1368,7 +1435,7 @@ let rec inv_type hash pty ty =
   with Not_found ->
     let inv = { inv_type = ty; inv_parents = pty } in
     TypeHash.add hash ty inv;
-    iter_type_expr (inv_type hash [inv]) ty
+    iter_type_expr (inv_type hash [inv]) (Fun.const ()) ty
 
 let compute_univars ty =
   let inverted = TypeHash.create 17 in
@@ -1398,7 +1465,8 @@ let fully_generic ty =
   with_type_mark begin fun mark ->
     let rec aux ty =
       if try_mark_node mark ty then
-        if get_level ty = generic_level then iter_type_expr aux ty
+        if get_level ty = generic_level then
+          iter_type_expr aux (Fun.const ()) ty
         else raise Exit
     in
     try aux ty; true with Exit -> false
@@ -1553,7 +1621,11 @@ let rec copy ?partial ?keep_names copy_scope ty =
           Tunivar { name; jkind = Jkind.instance jkind }
       | Tobject (ty1, _) when partial <> None ->
           Tobject (copy ty1, ref None)
-      | _ -> copy_type_desc ?keep_names copy desc
+      | _ ->
+        let copy_mode =
+          For_copy.mode_instantiate copy_scope ~current_level:!current_level
+        in
+        copy_type_desc ?keep_names copy copy_mode desc
     in
     Transient_expr.set_stub_desc t desc';
     t
@@ -1843,7 +1915,11 @@ let copy_sep ~copy_scope ~fixed ~partial ~bound_univars
             Tfield (p, field_kind_internal_repr k,
                     copy_rec ~may_share:true ty1,
                     copy_rec ~may_share:false ty2)
-        | desc -> copy_type_desc (copy_rec ~may_share:true) desc
+        | desc ->
+          let copy_mode =
+            For_copy.mode_instantiate copy_scope ~current_level:!current_level
+          in
+          copy_type_desc (copy_rec ~may_share:true) copy_mode desc
       in
       Transient_expr.set_stub_desc t desc';
       t
@@ -1984,9 +2060,9 @@ let prim_mode' mvars = function
     | None -> assert false
 
 (* Exported version. *)
-let prim_mode mvar prim =
+let prim_mode mvar prim ~level =
   let mvar = Option.map
-    (fun mvar_l -> mvar_l, (Forkable.newvar (), Yielding.newvar ())) mvar
+    (fun mvar_l -> mvar_l, (Forkable.newvar level, Yielding.newvar level)) mvar
   in
   fst (prim_mode' mvar prim)
 
@@ -1996,7 +2072,7 @@ let prim_mode mvar prim =
 let with_locality_and_forkable_yielding (locality, fy) m =
   let forkable = Option.map fst fy in
   let yielding = Option.map snd fy in
-  let m' = Alloc.newvar () in
+  let m' = Alloc.newvar 0 in
   Locality.equate_exn (Alloc.proj_comonadic Areality m') locality;
   let forkable =
     Option.value ~default:(Alloc.proj_comonadic Forkable m) forkable
@@ -2023,7 +2099,12 @@ comonadic axes of [B -> C] reflect that.
 On the other hand, the monadic axes of [fun b -> ...] won't be constrained by
 this (but maybe constrained by other things); therefore, we take it to be legacy
 for compatibility. *)
-let curry_mode alloc arg : Alloc.Const.t =
+let curry_mode (type r)
+    (alloc : (allowed * r) Alloc.Comonadic.t)
+    (arg : Alloc.lr) : Alloc.Comonadic.l =
+  Alloc.Comonadic.join
+    [(Alloc.close_over arg).comonadic; (Alloc.Comonadic.disallow_right alloc)]
+let curry_mode_const alloc arg : Alloc.Const.t =
   let acc =
     Alloc.Comonadic.Const.join
       (Alloc.Const.close_over arg)
@@ -2046,9 +2127,14 @@ let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
      in
      let mret =
        match locals with
-       | [] -> with_locality_and_forkable_yielding (loc, yld) mret
+       | [] ->
+         with_locality_and_forkable_yielding
+           (loc, yld) mret
        | _ :: _ ->
-          let mret', _ = Alloc.newvar_above macc in (* curried arrow *)
+          (* curried arrow *)
+          let mret', _ =
+            Alloc.newvar_above (get_current_level ()) macc
+          in
           mret'
      in
      let ret = instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ret in
@@ -2131,7 +2217,7 @@ let instance_prim_layout env (desc : Primitive.description) ty =
           | None -> ())
         | _ -> ()
         end;
-        iter_type_expr (inner mark) ty
+        iter_type_expr (inner mark) (Fun.const ()) ty
       end
     in
     with_type_mark (fun mark -> inner mark ty);
@@ -2148,8 +2234,8 @@ let instance_prim_mode (desc : Primitive.description) ty =
   let is_poly = function Primitive.Prim_poly, _ -> true | _ -> false in
   if is_poly desc.prim_native_repr_res ||
        List.exists is_poly desc.prim_native_repr_args then
-    let mode_l = Locality.newvar () in
-    let mode_fy = Forkable.newvar (), Yielding.newvar () in
+    let mode_l = Locality.newvar 0 in
+    let mode_fy = Forkable.newvar 0, Yielding.newvar 0 in
     let finalret =
       prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res
     in
@@ -2717,6 +2803,14 @@ let try_expand_safe_opt env ty =
 let expand_head_opt env ty =
   try try_expand_head try_expand_safe_opt env ty with Cannot_expand -> ty
 
+let create_yielding_mode_l yielding =
+  let yielding =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then fst (Yielding.newvar_above 0 yielding)
+    else yielding
+  in
+  Yielding.disallow_right yielding
+
 let prim_params_yielding env ty ~arity =
   let rec arg_yieldings acc ty n =
     if n <= 0 then Some acc
@@ -2731,7 +2825,8 @@ let prim_params_yielding env ty ~arity =
   in
   match arg_yieldings [] ty arity with
   | None | Some [] -> Yielding.disallow_right Yielding.max
-  | Some (_ :: _ as yieldings) -> Yielding.join yieldings
+  | Some (_ :: _ as yieldings) ->
+    create_yielding_mode_l (Yielding.join yieldings)
 
 let is_principal ty =
   not !Clflags.principal || get_level ty = generic_level
@@ -3718,7 +3813,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
         set_type_desc ty (Tunivar {r with jkind = new_jkind})
       | _ -> ()
       end;
-      iter_type_expr (inner mark) ty
+      iter_type_expr (inner mark) (Fun.const ()) ty
     end
   in
   with_type_mark (fun mark -> inner mark ty)
@@ -3796,7 +3891,9 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
         begin try
           if TypeSet.mem ty parents then raise Occur;
           let parents = TypeSet.add ty parents in
-          iter_type_expr (occur_rec env visited allow_recursive parents ty0) ty
+          iter_type_expr
+            (occur_rec env visited allow_recursive parents ty0)
+            (Fun.const ()) ty
         with Occur -> try
           let ty' = try_expand_head try_expand_safe env ty in
           (* This call used to be inlined, but there seems no reason for it.
@@ -3812,7 +3909,8 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
           let parents = TypeSet.add ty parents in
           iter_type_expr_with_stages
             (fun env -> occur_rec env visited allow_recursive parents ty0)
-            env ty
+            env
+            (Fun.const ()) ty
         end
     end;
     ignore (try_mark_node visited ty)
@@ -3882,8 +3980,10 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
           let visited = get_id ty :: visited in
           iter_type_expr_with_stages
             (fun env ->
-              local_non_recursive_abbrev ~allow_rec true visited env p)
-            env ty
+              local_non_recursive_abbrev
+               ~allow_rec true visited env p)
+            env
+            (Fun.const ()) ty
   end
 
 let local_non_recursive_abbrev uenv p ty =
@@ -4007,7 +4107,9 @@ let occur_univar ?(inj_only=false) env ty =
           with Not_found ->
             if not inj_only then List.iter (occur_rec env bound) tl
           end
-      | _ -> iter_type_expr_with_stages (fun env -> occur_rec env bound) env ty
+      | _ ->
+          iter_type_expr_with_stages
+            (fun env -> occur_rec env bound) env (Fun.const ()) ty
   in
   occur_rec env TypeSet.empty ty
   end
@@ -4061,7 +4163,7 @@ let univars_escape env univar_pairs vl ty =
             List.iter (occur env) tl
           end
       | _ ->
-          iter_type_expr_with_stages occur env t
+          iter_type_expr_with_stages occur env (Fun.const ()) t
     end
   in
   occur env ty
@@ -4194,7 +4296,7 @@ let unexpanded_diff ~got ~expected =
 let rec deep_occur_rec mark t0 ty =
   if get_level ty >= get_level t0 && try_mark_node mark ty then begin
     if eq_type ty t0 then raise Occur;
-    iter_type_expr (deep_occur_rec mark t0) ty
+    iter_type_expr (deep_occur_rec mark t0) (Fun.const ()) ty
   end
 
 let deep_occur t0 ty =
@@ -4262,7 +4364,7 @@ let reify uenv t =
           end;
           iter_row iterator r
       | _ ->
-          iter_type_expr iterator ty
+          iter_type_expr iterator (Fun.const ()) ty
     end
   in
   iterator t
@@ -4714,7 +4816,7 @@ let find_lowest_level ty =
       if try_mark_node mark ty then begin
         let level = get_level ty in
         if level < !lowest then lowest := level;
-        iter_type_expr find ty
+        iter_type_expr find (Fun.const ()) ty
       end
     in find ty
   end;
@@ -5791,8 +5893,8 @@ let filter_arrow env t l ~force_tpoly =
       end
     in
     let ty_ret = newvar2 level k_res in
-    let arg_mode = Alloc.newvar () in
-    let ret_mode = Alloc.newvar () in
+    let arg_mode = Alloc.newvar level in
+    let ret_mode = Alloc.newvar level in
     let t' =
       newty2 ~level (Tarrow ((l, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok))
     in
@@ -6229,7 +6331,7 @@ let moregen_occur env level ty =
       let lv = get_level ty in
       if lv <= level then () else
       if is_Tvar ty && lv >= subject_level then raise Occur else
-      if try_mark_node mark ty then iter_type_expr occur ty
+      if try_mark_node mark ty then iter_type_expr occur (Fun.const ()) ty
     in
     try
       occur ty
@@ -6839,7 +6941,7 @@ let rec rigidify_rec mark vars ty =
         if not (static_row row) then
           rigidify_rec mark vars (row_more row)
     | _ ->
-        iter_type_expr (rigidify_rec mark vars) ty
+        iter_type_expr (rigidify_rec mark vars) (Fun.const ()) ty
     end
 
 type var = { name : string option
@@ -7562,13 +7664,13 @@ let find_cltype_for_path env p =
 let has_constr_row' env t =
   has_constr_row (expand_abbrev env t)
 
-let build_submode_pos m =
-  let m', changed = Alloc.newvar_below m in
+let build_submode_pos level m =
+  let m', changed = Alloc.newvar_below level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
-let build_submode_neg m =
-  let m', changed = Alloc.newvar_above m in
+let build_submode_neg level m =
+  let m', changed = Alloc.newvar_above level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
@@ -7601,10 +7703,10 @@ let rec build_subtype env (visited : transient_expr list)
           let posi_arg = not posi in
           if posi_arg then begin
             let a = cross_right_alloc env t1 a in
-            build_submode_pos a
+            build_submode_pos level a
           end else begin
             let a = cross_left_alloc env t1 a in
-            build_submode_neg a
+            build_submode_neg level a
           end
         end else a, Unchanged
       in
@@ -7613,10 +7715,10 @@ let rec build_subtype env (visited : transient_expr list)
           (* As for the argument mode above, pick the smaller type. *)
           if posi then begin
             let r = cross_right_alloc_ret env t2' r in
-            build_submode_pos r
+            build_submode_pos level r
           end else begin
             let r = cross_left_alloc_ret env t2 r in
-            build_submode_neg r
+            build_submode_neg level r
           end
         end else r, Unchanged
       in
@@ -8196,6 +8298,7 @@ let add_nongen_vars_in_schema =
           let (_, unexpanded_candidate) as unexpanded_candidate' =
             fold_type_expr
               (loop env)
+              (fun a _ -> a)
               (visited, weak_set)
               ty
           in
@@ -8227,17 +8330,17 @@ let add_nongen_vars_in_schema =
           then loop env (visited, weak_set) (row_more row)
           else (visited, weak_set)
       | _ ->
-          fold_type_expr (loop env) (visited, weak_set) ty
+          fold_type_expr (loop env) (fun a _ -> a) (visited, weak_set) ty
     end
   in
-  fun env acc ty ->
-    remove_mode_and_jkind_variables ty;
+  fun zap_scope env acc ty ->
+    remove_mode_and_jkind_variables ~zap_scope ty;
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 
 (* Return all non-generic variables of [ty]. *)
-let nongen_vars_in_schema env ty =
-  let result = add_nongen_vars_in_schema env TypeSet.empty ty in
+let nongen_vars_in_schema ~zap_scope env ty =
+  let result = add_nongen_vars_in_schema zap_scope env TypeSet.empty ty in
   if TypeSet.is_empty result
   then None
   else Some result
@@ -8245,44 +8348,45 @@ let nongen_vars_in_schema env ty =
 (* Check that all type variables are generalizable *)
 (* Use Env.empty to prevent expansion of recursively defined object types;
    cf. typing-poly/poly.ml *)
-let nongen_class_type =
-  let add_nongen_vars_in_schema' ty weak_set =
-    add_nongen_vars_in_schema Env.empty weak_set ty
+let nongen_class_type zap_scope =
+  let add_nongen_vars_in_schema' zap_scope ty weak_set =
+    add_nongen_vars_in_schema zap_scope Env.empty weak_set ty
   in
-  let add_nongen_vars_in_schema_fold fold m weak_set =
+  let add_nongen_vars_in_schema_fold fold zap_scope m weak_set =
     let f _key (_,_,ty) weak_set =
-      add_nongen_vars_in_schema Env.empty weak_set ty
+      add_nongen_vars_in_schema zap_scope Env.empty weak_set ty
     in
     fold f m weak_set
   in
-  let rec nongen_class_type cty weak_set =
+  let rec nongen_class_type zap_scope cty weak_set =
     match cty with
     | Cty_constr (_, params, _) ->
         List.fold_left
-          (add_nongen_vars_in_schema Env.empty)
+          (add_nongen_vars_in_schema zap_scope Env.empty)
           weak_set
           params
     | Cty_signature sign ->
         weak_set
-        |> add_nongen_vars_in_schema' sign.csig_self
-        |> add_nongen_vars_in_schema' sign.csig_self_row
-        |> add_nongen_vars_in_schema_fold Meths.fold sign.csig_meths
-        |> add_nongen_vars_in_schema_fold Vars.fold sign.csig_vars
+        |> add_nongen_vars_in_schema' zap_scope sign.csig_self
+        |> add_nongen_vars_in_schema' zap_scope sign.csig_self_row
+        |> add_nongen_vars_in_schema_fold Meths.fold zap_scope sign.csig_meths
+        |> add_nongen_vars_in_schema_fold Vars.fold zap_scope sign.csig_vars
     | Cty_arrow (_, ty, cty) ->
-        add_nongen_vars_in_schema' ty weak_set
-        |> nongen_class_type cty
+        add_nongen_vars_in_schema' zap_scope ty weak_set
+        |> nongen_class_type zap_scope cty
   in
-  nongen_class_type
+  nongen_class_type zap_scope
 
-let nongen_class_declaration cty =
+let nongen_class_declaration zap_scope cty =
   List.fold_left
-    (add_nongen_vars_in_schema Env.empty)
+    (add_nongen_vars_in_schema zap_scope Env.empty)
     TypeSet.empty
     cty.cty_params
-  |> nongen_class_type cty.cty_type
+  |> nongen_class_type zap_scope cty.cty_type
 
 let nongen_vars_in_class_declaration cty =
-  let result = nongen_class_declaration cty in
+  let result = Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+    nongen_class_declaration zap_scope cty) in
   if TypeSet.is_empty result
   then None
   else Some result
@@ -8351,7 +8455,7 @@ let rec normalize_type_rec mark ty =
         set_type_desc fi (get_desc fi')
     | _ -> ()
     end;
-    iter_type_expr (normalize_type_rec mark) ty;
+    iter_type_expr (normalize_type_rec mark) (Fun.const ()) ty;
   end
 
 let normalize_type ty =
@@ -8498,7 +8602,7 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
           (* CR layouts v2.8: This should be done with a proper nondep_jkind.
              Internal ticket 5113. *)
           Tof_kind (Jkind.map_type_expr (nondep_type_rec env ids) jk)
-      | desc -> copy_type_desc (nondep_type_rec env ids) desc
+      | desc -> copy_type_desc (nondep_type_rec env ids) Fun.id desc
     with
     | desc ->
       Transient_expr.set_stub_desc ty' desc;
@@ -8705,7 +8809,8 @@ let rec collapse_conj env visited ty =
         (row_fields row);
       iter_row (collapse_conj env visited) row
   | _ ->
-      iter_type_expr_with_stages (fun env -> collapse_conj env visited) env ty
+      iter_type_expr_with_stages
+        (fun env -> collapse_conj env visited) env (Fun.const ()) ty
 
 let collapse_conj_params env params =
   List.iter (collapse_conj env []) params

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.mli
@@ -38,9 +38,12 @@ val with_local_level_generalize:
     before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 val with_local_level_generalize_if:
         bool -> before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
-val with_local_level_generalize_structure: (unit -> 'a) -> 'a
-val with_local_level_generalize_structure_if: bool -> (unit -> 'a) -> 'a
-val with_local_level_generalize_structure_if_principal: (unit -> 'a) -> 'a
+val with_local_level_generalize_structure:
+    before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
+val with_local_level_generalize_structure_if:
+        bool -> before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
+val with_local_level_generalize_structure_if_principal:
+    before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 val with_local_level_generalize_for_class:
     before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 
@@ -150,7 +153,8 @@ val filter_row_fields:
 
 val contains_initial_stage_splice: int -> type_expr -> bool
 val iter_type_expr_with_stages:
-        (Env.t -> type_expr -> unit) -> Env.t -> type_expr -> unit
+        (Env.t -> type_expr -> unit) -> Env.t -> (Mode.Alloc.lr -> unit)
+        -> type_expr -> unit
 
 val generalize: type_expr -> unit
 (* Generalize in-place the given type *)
@@ -161,8 +165,13 @@ val lower_variables_only: Env.t -> int -> type_expr -> unit
         (* Lower all variables to the given level *)
 val enforce_current_level: Env.t -> type_expr -> unit
         (* Lower whole type to !current_level *)
+val generalize_structure: type_expr -> unit
+        (* Generalize the structure of a type, lowering variables
+           to !current_level *)
 val generalize_class_signature_spine: class_signature -> unit
        (* Special function to generalize methods during inference *)
+val generalize_class_type_structure: class_type -> unit
+        (* Generalize the structure of a class type *)
 val limited_generalize: type_expr -> inside:type_expr -> unit
         (* Only generalize some part of the type
            Make the remaining of the type non-generalizable *)
@@ -266,7 +275,8 @@ val instance_label_declarations:
 (* Same, but for label declarations and the type parameters from the
    type declaration *)
 val prim_mode :
-        (Mode.allowed * 'r) Mode.Locality.t option -> (Primitive.mode * Primitive.native_repr)
+        (Mode.allowed * 'r) Mode.Locality.t option ->
+        (Primitive.mode * Primitive.native_repr) -> level:int
         -> (Mode.allowed * 'r) Mode.Locality.t
 val instance_prim:
         Env.t ->
@@ -274,6 +284,8 @@ val instance_prim:
         type_expr *
         Mode.Locality.lr option * (Mode.Forkable.lr * Mode.Yielding.lr) option *
         Jkind.Sort.t option
+
+val create_yielding_mode_l : Mode.Yielding.l -> Mode.Yielding.l
 
 (** The join of the yielding modes of the first [arity] parameters of a
     primitive of type [ty]; [Yielding.max] if [ty] has fewer arrows. *)
@@ -283,7 +295,13 @@ val prim_params_yielding:
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)
-val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+val curry_mode_const : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+
+(** Applies the same logic as [curry_mode_const] over
+    the comonadic mode for [m0] and the lr mode [m1] *)
+val curry_mode :
+  (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr ->
+  Alloc.Comonadic.l
 
 val apply:
         ?use_current_level:bool ->
@@ -586,10 +604,12 @@ val nondep_jkind_declaration:
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 
-val remove_mode_and_jkind_variables: type_expr -> unit
+val remove_mode_and_jkind_variables:
+  zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
-val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
+val nongen_vars_in_schema:
+  zap_scope:Alloc.zap_scope -> Env.t -> type_expr -> Btype.TypeSet.t option
         (* Return any non-generic variables in the type scheme.  Also ensures
            mode variables are fully determined. *)
 
@@ -620,10 +640,14 @@ val closed_type_expr: ?env:Env.t -> type_expr -> bool
         (* If env present, expand abbreviations to see if expansion
            eliminates the variable *)
 
-val closed_type_decl: type_declaration -> type_expr option
-val closed_extension_constructor: extension_constructor -> type_expr option
+val closed_type_decl:
+  zap_scope:Alloc.zap_scope ->
+  type_declaration -> type_expr option
+val closed_extension_constructor:
+  zap_scope:Alloc.zap_scope ->
+  extension_constructor -> type_expr option
 val closed_class:
-        type_expr list -> class_signature ->
+        zap_scope:Alloc.zap_scope -> type_expr list -> class_signature ->
         closed_class_failure option
         (* Check whether all type variables are bound *)
 

--- a/external/merlin/upstream/ocaml_flambda/typing/datarepr.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/datarepr.ml
@@ -39,7 +39,7 @@ let free_vars ?(param=false) ty =
             end
                 (* XXX: What about Tobject ? *)
         | _ ->
-            iter_type_expr loop ty
+            iter_type_expr loop (Fun.const ()) ty
     in
     loop ty
   end;

--- a/external/merlin/upstream/ocaml_flambda/typing/env.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/env.ml
@@ -3304,7 +3304,7 @@ let enter_unbound_module name reason env =
 let read_signature modname cmi =
   let mty, mode = read_pers_mod modname cmi in
   (* [mode] read from the cmi is always a constant *)
-  Subst.Lazy.force_signature mty, (Mode.Value.zap_to_floor mode).staticity
+  Subst.Lazy.force_signature mty, (Mode.Value.zap_to_floor_exn mode).staticity
 
 let find_import ~chain modname =
   try Persistent_env.find_import !persistent_env modname

--- a/external/merlin/upstream/ocaml_flambda/typing/includemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/includemod.ml
@@ -792,7 +792,8 @@ and try_modtypes ~core ~direction ~loc env subst ~modes
               | Specific ((m, _locks), _) ->
                 Yielding.disallow_right (Value.proj_comonadic Yielding m)
             in
-            Yielding.join (funct_yielding :: param_yielding)
+            Ctype.create_yielding_mode_l
+              (Yielding.join (funct_yielding :: param_yielding))
           in
           Ok
             (Tcoerce_functor(cc_arg, cc_res, application_yielding),

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -4406,6 +4406,8 @@ module S = Solver_mono (Hint_for_solver) (C)
 
 let erase_hints () = S.erase_hints ()
 
+let reset_persistent_id () = S.reset_persistent_id ()
+
 type monadic = C.monadic =
   { uniqueness : C.Uniqueness.t;
     contention : C.Contention.t;
@@ -5313,6 +5315,10 @@ let append_changes : (changes ref -> unit) ref = ref (fun _ -> assert false)
 
 let set_append_changes f = append_changes := f
 
+type copy_scope = S.copy_scope
+
+let with_copy_scope = S.with_copy_scope
+
 type ('a, 'd) mode = ('a, 'd) S.mode
 
 module Error = struct
@@ -5448,6 +5454,10 @@ let equate_from_submode' submode m1 m2 =
     | Ok () -> Ok ())
 [@@inline]
 
+exception Cannot_zap_generic
+
+exception Cannot_get_constant_from_generic
+
 module Comonadic_gen (Obj : Obj) = struct
   open Obj
 
@@ -5475,15 +5485,28 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_right m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then level
+    else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.min obj
 
   let max : lr = S.max obj
 
-  let newvar_above m = S.newvar_above obj 0 m
+  let generic_level = S.generic_level
 
-  let newvar_below m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
+
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj a b ~log
@@ -5499,6 +5522,41 @@ module Comonadic_gen (Obj : Obj) = struct
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
   let print_error pp err = Error.print_all pp obj err
+
+  let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize_topology ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_topology ~log:None ~current_level a
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a
+
+  let copy_for_saving ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Save obj a
+
+  let copy_for_restoring ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
   let join l = S.join obj l
 
@@ -5519,14 +5577,42 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let check_const_or_level_0 m = S.check_const_or_level_0 m
 
-  let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
+  let check_generic a = S.check_generic a
 
-  let zap_to_floor m = with_log (S.zap_to_floor obj m)
+  let iter_covariant a iter = S.iter_covariant obj a iter
+
+  let iter_contravariant a iter = S.iter_contravariant obj a iter
+
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
+
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
+
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
 
   let of_const : type l r. ?hint:(l * r) pos Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_generic m then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5544,6 +5630,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
     let get_floor m = S.get_floor obj m
 
@@ -5552,6 +5640,16 @@ module Comonadic_gen (Obj : Obj) = struct
     let get_loose_floor m = S.get_loose_floor obj m
 
     let get_loose_ceil m = S.get_loose_ceil obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj ceil floor then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj floor c && C.le obj c ceil
   end
 end
 [@@inline]
@@ -5584,15 +5682,26 @@ module Monadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_left m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then level
+    else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.allow_left (S.max obj)
 
   let max : lr = S.allow_right (S.min obj)
 
-  let newvar_above m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
-  let newvar_below m = S.newvar_above obj 0 m
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj b a ~log
@@ -5606,6 +5715,43 @@ module Monadic_gen (Obj : Obj) = struct
     match submode ~pp a b with
     | Ok () -> ()
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
+
+  let generic_level = S.generic_level
+
+  let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize_topology ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_topology ~log:None ~current_level a
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a
+
+  let copy_for_saving ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Save obj a
+
+  let copy_for_restoring ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
   let print_error pp err = Error.print_all pp obj err
 
@@ -5628,14 +5774,42 @@ module Monadic_gen (Obj : Obj) = struct
 
   let check_const_or_level_0 m = S.check_const_or_level_0 m
 
-  let zap_to_ceil m = with_log (S.zap_to_floor obj m)
+  let check_generic a = S.check_generic a
 
-  let zap_to_floor m = with_log (S.zap_to_ceil obj m)
+  let iter_covariant a iter = S.iter_contravariant obj a iter
+
+  let iter_contravariant a iter = S.iter_covariant obj a iter
+
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
+
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
+
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
 
   let of_const : type l r. ?hint:(l * r) neg Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_generic m then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5653,8 +5827,22 @@ module Monadic_gen (Obj : Obj) = struct
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
+    let get_floor m = S.get_ceil obj m
+
     let get_ceil m = S.get_floor obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj floor ceil then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj c floor && C.le obj ceil c
   end
 end
 [@@inline]
@@ -5676,7 +5864,7 @@ module Locality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 
   module Guts = struct
     let check_const m =
@@ -5710,7 +5898,7 @@ module Regionality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Linearity = struct
@@ -5730,7 +5918,7 @@ module Linearity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Statefulness = struct
@@ -5754,7 +5942,7 @@ module Statefulness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Visibility = struct
@@ -5778,7 +5966,7 @@ module Visibility = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Portability = struct
@@ -5794,6 +5982,7 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
+<<<<<<< HEAD
   let zap_to_ceil_clamped c m =
     (match submode m (of_const c) with Ok () | Error _ -> ());
     zap_to_ceil m
@@ -5804,6 +5993,15 @@ module Portability = struct
     | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
     | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
     | Statefulness.Const.Stateless -> zap_to_floor m
+=======
+  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
+  let zap_to_legacy_force ~statefulness =
+    match statefulness with
+    | Statefulness.Const.Stateful | Statefulness.Const.Reading
+    | Statefulness.Const.Writing ->
+      zap_to_ceil_force
+    | Statefulness.Const.Stateless -> zap_to_floor_force
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 end
 
 module Uniqueness = struct
@@ -5823,7 +6021,7 @@ module Uniqueness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Contention = struct
@@ -5839,18 +6037,28 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
+<<<<<<< HEAD
   let zap_to_floor_clamped c m =
     (match submode (of_const c) m with Ok () | Error _ -> ());
     zap_to_floor m
 
   let zap_to_legacy ~visibility ~arg m =
+=======
+  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
+  let zap_to_legacy_force ~visibility =
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     match visibility with
     | Visibility.Const.Read_write -> zap_to_floor m
     | Visibility.Const.Immutable -> zap_to_ceil m
     | Visibility.Const.Read ->
       if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
     | Visibility.Const.Write ->
+<<<<<<< HEAD
       if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
+=======
+      zap_to_floor_force
+    | Visibility.Const.Immutable -> zap_to_ceil_force
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 end
 
 module Forkable = struct
@@ -5871,9 +6079,9 @@ module Forkable = struct
   let legacy = of_const Const.legacy
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Yielding = struct
@@ -5894,9 +6102,9 @@ module Yielding = struct
   let legacy = of_const Const.legacy
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Staticity = struct
@@ -5916,7 +6124,7 @@ module Staticity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module type Areality = sig
@@ -5924,7 +6132,8 @@ module type Areality = sig
 
   module Obj : Obj with type const = Const.t
 
-  val zap_to_legacy : (Const.t, allowed * 'r) S.mode -> Const.t
+  val zap_to_legacy_force :
+    ?commit:bool -> (Const.t, allowed * 'r) S.mode -> Const.t
 end
 
 module Lattice_Product (L : Lattice) = struct
@@ -6039,16 +6248,23 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy m : Const.t =
-    let areality = proj Areality m |> Areality.zap_to_legacy in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy in
-    let statefulness = proj Statefulness m |> Statefulness.zap_to_legacy in
+  let zap_to_legacy_force ?commit m : Const.t =
+    let areality = proj Areality m |> Areality.zap_to_legacy_force ?commit in
+    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force ?commit in
+    let statefulness =
+      proj Statefulness m |> Statefulness.zap_to_legacy_force ?commit
+    in
     let portability =
-      proj Portability m |> Portability.zap_to_legacy ~statefulness
+      proj Portability m
+      |> Portability.zap_to_legacy_force ?commit ~statefulness
     in
     let global = Areality.Const.equal areality Areality.Const.legacy in
-    let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
+    let forkable =
+      proj Forkable m |> Forkable.zap_to_legacy_force ?commit ~global
+    in
+    let yielding =
+      proj Yielding m |> Yielding.zap_to_legacy_force ?commit ~global
+    in
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
@@ -6191,13 +6407,25 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
+<<<<<<< HEAD
   let zap_to_legacy ~arg m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let visibility = proj Visibility m |> Visibility.zap_to_legacy in
     let contention =
       proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
+=======
+  let zap_to_legacy_force ?commit m : Const.t =
+    let uniqueness =
+      proj Uniqueness m |> Uniqueness.zap_to_legacy_force ?commit
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     in
-    let staticity = proj Staticity m |> Staticity.zap_to_legacy in
+    let visibility =
+      proj Visibility m |> Visibility.zap_to_legacy_force ?commit
+    in
+    let contention =
+      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility
+    in
+    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }
 
   let legacy = of_const Const.legacy
@@ -6569,6 +6797,40 @@ module Value_with (Areality : Areality) = struct
           visibility
           (option_print Staticity.Const.print)
           staticity
+
+      let partial_print ppf
+          { areality;
+            uniqueness;
+            linearity;
+            portability;
+            contention;
+            forkable;
+            yielding;
+            statefulness;
+            visibility;
+            staticity
+          } =
+        let option_to_string print a =
+          Option.map (fun a -> Fmt.asprintf "%a" print a) a
+        in
+        let l =
+          [ option_to_string Areality.Const.print areality;
+            option_to_string Linearity.Const.print linearity;
+            option_to_string Uniqueness.Const.print uniqueness;
+            option_to_string Portability.Const.print portability;
+            option_to_string Contention.Const.print contention;
+            option_to_string Forkable.Const.print forkable;
+            option_to_string Yielding.Const.print yielding;
+            option_to_string Statefulness.Const.print statefulness;
+            option_to_string Visibility.Const.print visibility;
+            option_to_string Staticity.Const.print staticity ]
+        in
+        let l = List.filter_map Fun.id l in
+        Fmt.fprintf ppf "%a"
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf " ")
+             (fun ppf s -> Fmt.fprintf ppf "%s" s))
+          l
     end
 
     let diff m1 m2 =
@@ -6646,9 +6908,116 @@ module Value_with (Areality : Areality) = struct
     let merge = merge
   end
 
+  module C = C
+  module Desc = S.Desc
+
+  let obj_monadic = Monadic.Obj.obj
+
+  let obj_comonadic = Comonadic.Obj.obj
+
+  let get_monadic_desc m = Monadic.desc m
+
+  let get_comonadic_desc m = Comonadic.desc m
+
+  let meet_const_morph a = C.Simple (C.Simple_morph.Meet_const a)
+
+  (* only print the interesting parts of the monadic meet; omit max (min due to
+      flipping of Monadic axis) modes *)
+  let monadic_meet_atoms c =
+    let c = merge { monadic = c; comonadic = Comonadic.Const.min } in
+    Const.diff c Const.min
+
+  (* only print the interesting parts of the meet; omit max modes *)
+  let comonadic_meet_atoms c =
+    let c = merge { monadic = Monadic.Const.max; comonadic = c } in
+    Const.diff c Const.max
+
+  let pretty_print_mod : type a.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      Const.Option.t ->
+      unit =
+   fun printm m ppf atoms ->
+    if atoms = Const.Option.none
+    then Fmt.fprintf ppf "%a" printm m
+    else Fmt.fprintf ppf "%a mod %a" printm m Const.Option.partial_print atoms
+
+  let pretty_print_monadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c ->
+      pretty_print_mod printm m ppf (monadic_meet_atoms c)
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_monadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_monadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c ->
+      pretty_print_mod printm m ppf (comonadic_meet_atoms c)
+    | C.Simple_morph.Core C.Core_morph.Monadic_op_to_comonadic_min ->
+      Fmt.fprintf ppf "close(%a)" printm m
+    | C.Simple_morph.Meet_const_core
+        (c, C.Core_morph.Monadic_op_to_comonadic_min) ->
+      (* since the meet is applied to a monadic_to_comonadic_min, we filter out the
+      comonadic only axes *)
+      let c : Comonadic.Const.t =
+        { c with
+          areality = Areality.Const.max;
+          forkable = Forkable.Const.max;
+          yielding = Yielding.Const.max
+        }
+      in
+      pretty_print_mod
+        (fun ppf m -> Fmt.fprintf ppf "close(%a)" printm m)
+        m ppf (comonadic_meet_atoms c)
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_comonadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_comonadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_comonadic) f printm m
+  [@@warning "-4"]
+
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
+
+  let generic_level = Comonadic.generic_level
 
   include Magic_allow_disallow (struct
     type (_, _, 'd) sided = 'd t
@@ -6674,19 +7043,19 @@ module Value_with (Areality : Areality) = struct
       { monadic; comonadic }
   end)
 
-  let newvar () =
-    let comonadic = Comonadic.newvar () in
-    let monadic = Monadic.newvar () in
+  let newvar level =
+    let comonadic = Comonadic.newvar level in
+    let monadic = Monadic.newvar level in
     { comonadic; monadic }
 
-  let newvar_above { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_above comonadic in
-    let monadic, b2 = Monadic.newvar_above monadic in
+  let newvar_above level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_above level comonadic in
+    let monadic, b2 = Monadic.newvar_above level monadic in
     { monadic; comonadic }, b1 || b2
 
-  let newvar_below { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_below comonadic in
-    let monadic, b2 = Monadic.newvar_below monadic in
+  let newvar_below level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_below level comonadic in
+    let monadic, b2 = Monadic.newvar_below level monadic in
     { monadic; comonadic }, b1 || b2
 
   type atom = Atom : 'a Axis.t * 'a -> atom
@@ -6732,6 +7101,54 @@ module Value_with (Areality : Areality) = struct
   let submode_err pp a b =
     Comonadic.submode_err pp a.comonadic b.comonadic;
     Monadic.submode_err pp a.monadic b.monadic
+
+  let update_level i { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.update_level i monadic0;
+    Comonadic.update_level i comonadic0
+
+  let generalize_topology ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_topology ~current_level monadic0;
+    Comonadic.generalize_topology ~current_level comonadic0
+
+  let generalize ~current_level { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize ~current_level monadic0;
+    Comonadic.generalize ~current_level comonadic0
+
+  let generalize_structure ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_structure ~current_level monadic0;
+    Comonadic.generalize_structure ~current_level comonadic0
+
+  let instantiate ~copy_scope ~current_level
+      ({ monadic = monadic0; comonadic = comonadic0 } as m) =
+    let monadic1 = Monadic.instantiate ~copy_scope ~current_level monadic0 in
+    let comonadic1 =
+      Comonadic.instantiate ~copy_scope ~current_level comonadic0
+    in
+    if monadic1 == monadic0 && comonadic1 == comonadic0
+    then m
+    else { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_generic ~copy_scope { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_generic ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_generic ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_for_saving ~copy_scope { monadic = monadic0; comonadic = comonadic0 }
+      =
+    let monadic1 = Monadic.copy_for_saving ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_for_saving ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_for_restoring ~copy_scope
+      { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_for_restoring ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_for_restoring ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let check_generic { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_generic monadic0 || Comonadic.check_generic comonadic0
 
   let equate_err pp a b =
     Comonadic.equate_err pp a.comonadic b.comonadic;
@@ -6828,20 +7245,266 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
-  let zap_to_ceil { comonadic; monadic } =
-    let monadic = Monadic.zap_to_ceil monadic in
-    let comonadic = Comonadic.zap_to_ceil comonadic in
+  let zap_to_ceil_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_ceil_force monadic in
+    let comonadic = Comonadic.zap_to_ceil_force comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_floor { comonadic; monadic } =
-    let monadic = Monadic.zap_to_floor monadic in
-    let comonadic = Comonadic.zap_to_floor comonadic in
+  let zap_to_floor_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_floor_force monadic in
+    let comonadic = Comonadic.zap_to_floor_force comonadic in
     merge { monadic; comonadic }
 
+<<<<<<< HEAD
   let zap_to_legacy ~arg { comonadic; monadic } =
     let monadic = Monadic.zap_to_legacy ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy comonadic in
+=======
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
+
+  let zap_to_legacy_force ?commit { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ?commit monadic in
+    let comonadic = Comonadic.zap_to_legacy_force ?commit comonadic in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     merge { monadic; comonadic }
+
+  let zap_to_legacy_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_legacy_force m
+
+  let zap_to_legacy m =
+    if check_generic m then None else Some (zap_to_legacy_force m)
+
+  let zap_to_legacy_obj : type a.
+      a C.obj -> (a, allowed * allowed) S.mode -> unit =
+   fun obj mode ->
+    match (obj : a C.obj) with
+    | Locality -> Locality.zap_to_legacy_force mode |> ignore
+    | Regionality -> Regionality.zap_to_legacy_force mode |> ignore
+    | Uniqueness_op -> Uniqueness.zap_to_legacy_force mode |> ignore
+    | Visibility_op -> Visibility.zap_to_legacy_force mode |> ignore
+    | Linearity -> Linearity.zap_to_legacy_force mode |> ignore
+    | Statefulness -> Statefulness.zap_to_legacy_force mode |> ignore
+    | Staticity_op -> Staticity.zap_to_legacy_force mode |> ignore
+    | Monadic_op -> Monadic.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_regionality ->
+      let module M = Comonadic_with (Regionality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_locality ->
+      let module M = Comonadic_with (Locality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Portability ->
+      Portability.zap_to_legacy_force ~statefulness:Statefulness.Const.legacy
+        mode
+      |> ignore
+    | Contention_op ->
+      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy mode
+      |> ignore
+    | Forkable -> Forkable.zap_to_legacy_force ~global:true mode |> ignore
+    | Yielding -> Yielding.zap_to_legacy_force ~global:true mode |> ignore
+
+  let zap_to_legacy_src_var_monadic m =
+    S.mode_iter Monadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  let zap_to_legacy_src_var_comonadic m =
+    S.mode_iter Comonadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  module Zap_scope = struct
+    module ModeIdMap = Hashtbl.Make (Int)
+
+    type 'd packed_mode =
+      | Pco of 'd Comonadic.t
+      | Pmon of 'd Monadic.t
+
+    let disallow_left : type l r.
+        (l * r) packed_mode -> (disallowed * r) packed_mode = function
+      | Pco m -> Pco (Comonadic.disallow_left m)
+      | Pmon m -> Pmon (Monadic.disallow_left m)
+
+    let disallow_right : type l r.
+        (l * r) packed_mode -> (l * disallowed) packed_mode = function
+      | Pco m -> Pco (Comonadic.disallow_right m)
+      | Pmon m -> Pmon (Monadic.disallow_right m)
+
+    type packed_morph =
+      | Pmorph_mon : ('a, Monadic.Obj.const, 'd) C.morph -> packed_morph
+      | Pmorph_co : ('a, Comonadic.Obj.const, 'd) C.morph -> packed_morph
+
+    let morph_key_mon (S.Packed_morph f) = Pmorph_mon f
+
+    let morph_key_co (S.Packed_morph f) = Pmorph_co f
+
+    module MorphMap = Map.Make (struct
+      type t = packed_morph
+
+      let compare k1 k2 =
+        match k1, k2 with
+        | Pmorph_mon m1, Pmorph_mon m2 -> C.compare_morph Monadic.Obj.obj m1 m2
+        | Pmorph_co m1, Pmorph_co m2 -> C.compare_morph Comonadic.Obj.obj m1 m2
+        | Pmorph_mon _, Pmorph_co _ -> -1
+        | Pmorph_co _, Pmorph_mon _ -> 1
+    end)
+
+    type zap_scope =
+      { zap_to_floor_map :
+          (allowed * disallowed) packed_mode MorphMap.t ModeIdMap.t;
+        zap_to_ceil_map :
+          (disallowed * allowed) packed_mode MorphMap.t ModeIdMap.t;
+        zap_to_legacy_map : (disallowed * disallowed) packed_mode ModeIdMap.t
+      }
+
+    let create () =
+      { zap_to_floor_map = ModeIdMap.create 17;
+        zap_to_ceil_map = ModeIdMap.create 17;
+        zap_to_legacy_map = ModeIdMap.create 17
+      }
+
+    let add_to_morph_map map id morph mode =
+      let morphs =
+        match ModeIdMap.find_opt map id with
+        | Some morphs -> morphs
+        | None -> MorphMap.empty
+      in
+      ModeIdMap.replace map id (MorphMap.add morph mode morphs)
+
+    let add_zap_to_floor_to_zap_scope i k p zs =
+      if ModeIdMap.mem zs.zap_to_legacy_map i
+      then ()
+      else
+        begin if ModeIdMap.mem zs.zap_to_ceil_map i
+        then begin
+          ModeIdMap.remove zs.zap_to_ceil_map i;
+          ModeIdMap.add zs.zap_to_legacy_map i (disallow_left p)
+        end
+        else add_to_morph_map zs.zap_to_floor_map i k p
+        end
+
+    let add_zap_to_ceil_to_zap_scope i k p zs =
+      if ModeIdMap.mem zs.zap_to_legacy_map i
+      then ()
+      else
+        begin if ModeIdMap.mem zs.zap_to_floor_map i
+        then begin
+          ModeIdMap.remove zs.zap_to_floor_map i;
+          ModeIdMap.add zs.zap_to_legacy_map i (disallow_right p)
+        end
+        else add_to_morph_map zs.zap_to_ceil_map i k p
+        end
+
+    let resolve_zap_scope
+        { zap_to_floor_map; zap_to_ceil_map; zap_to_legacy_map } =
+      ModeIdMap.iter
+        (fun _ p ->
+          match p with
+          | Pmon m -> zap_to_legacy_src_var_monadic m
+          | Pco m -> zap_to_legacy_src_var_comonadic m)
+        zap_to_legacy_map;
+      ModeIdMap.iter
+        (fun _ mm ->
+          MorphMap.iter
+            (fun _ p ->
+              match p with
+              | Pmon m -> Monadic.zap_to_floor_force m |> ignore
+              | Pco m -> Comonadic.zap_to_floor_force m |> ignore)
+            mm)
+        zap_to_floor_map;
+      ModeIdMap.iter
+        (fun _ mm ->
+          MorphMap.iter
+            (fun _ p ->
+              match p with
+              | Pmon m -> Monadic.zap_to_ceil_force m |> ignore
+              | Pco m -> Comonadic.zap_to_ceil_force m |> ignore)
+            mm)
+        zap_to_ceil_map
+  end
+
+  module Z = Zap_scope
+
+  type zap_scope =
+    { variables : Z.zap_scope;
+      visible : (allowed * allowed) t list ref
+    }
+
+  let add_covariant_to_zap_scope { monadic; comonadic } scope =
+    let comonadic_upper =
+      Comonadic.Guts.get_floor comonadic |> Comonadic.of_const
+    in
+    let monadic_upper = Monadic.Guts.get_floor monadic |> Monadic.of_const in
+    Monadic.iter_covariant monadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_floor_to_zap_scope id (Z.morph_key_mon morph)
+            (Z.Pmon (Monadic.join [monadic_upper; m]))
+            scope);
+    Comonadic.iter_covariant comonadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_floor_to_zap_scope id (Z.morph_key_co morph)
+            (Z.Pco (Comonadic.join [comonadic_upper; m]))
+            scope)
+
+  let add_contravariant_to_zap_scope { monadic; comonadic } scope =
+    let comonadic_upper =
+      Comonadic.Guts.get_ceil comonadic |> Comonadic.of_const
+    in
+    let monadic_lower = Monadic.Guts.get_ceil monadic |> Monadic.of_const in
+    Monadic.iter_contravariant monadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_ceil_to_zap_scope id (Z.morph_key_mon morph)
+            (Z.Pmon (Monadic.meet [monadic_lower; m]))
+            scope);
+    Comonadic.iter_contravariant comonadic (fun ~id ~level ~morph m ->
+        if level <> generic_level
+        then
+          Z.add_zap_to_ceil_to_zap_scope id (Z.morph_key_co morph)
+            (Z.Pco (Comonadic.meet [comonadic_upper; m]))
+            scope)
+
+  let add_mode_to_zap_scope m { visible } = visible := m :: !visible
+
+  let resolve_zap_scope { variables; visible } =
+    (* we first zap all visible non generic modes to legacy *)
+    List.iter (fun m -> zap_to_legacy m |> ignore) !visible;
+    (* we then iterate over the children of visible generic modes and zap level 0
+    according to the following rules:
+    1) if a mode appears only as an upper bound to generic modes, it is zapped to
+      ceiling
+    2) if a mode appears only as a lower bound to generic modes, it is zapped to
+      floor
+    3) if it appears as both, it is zapped to legacy *)
+    List.iter
+      (fun m ->
+        if check_generic m
+        then begin
+          add_covariant_to_zap_scope m variables;
+          add_contravariant_to_zap_scope m variables
+        end)
+      !visible;
+    Z.resolve_zap_scope variables
+
+  let create_zap_scope () = { variables = Z.create (); visible = ref [] }
+
+  let with_zap_scope f =
+    let zap_scope = create_zap_scope () in
+    let res = f ~zap_scope in
+    resolve_zap_scope zap_scope;
+    res
 
   (** This is about partially applying [A -> B -> C] to [A] and getting
       [B -> C]. [comonadic] and [monadic] constutute the mode of [A], and we
@@ -6881,6 +7544,25 @@ module Value_with (Areality : Areality) = struct
 
       let disallow_right l = List.map disallow_right l
     end)
+  end
+
+  module Guts = struct
+    let check_const { monadic; comonadic } =
+      let open Misc.Stdlib.Monad.Option.Syntax in
+      let* monadic = Monadic.Guts.check_const monadic in
+      let* comonadic = Comonadic.Guts.check_const comonadic in
+      Some (merge { comonadic; monadic })
+
+    let get_ceil { monadic; comonadic } =
+      let monadic = Monadic.Guts.get_ceil monadic in
+      let comonadic = Comonadic.Guts.get_ceil comonadic in
+      merge { monadic; comonadic }
+
+    let in_bounds c { monadic; comonadic } =
+      let c = split c in
+      let monadic = Monadic.Guts.in_bounds c.monadic monadic in
+      let comonadic = Comonadic.Guts.in_bounds c.comonadic comonadic in
+      monadic && comonadic
   end
 end
 [@@inline]
@@ -7182,7 +7864,7 @@ module Modality = struct
            [mm] to construct the floor of [c]. *)
         let cc = Mode.Guts.get_ceil mm in
         let c = Mode.subtract_const cc m in
-        let c = Mode.zap_to_floor c in
+        let c = Mode.zap_to_floor_exn c in
         (* Note that we did not mutate [mm] but simply took its ceil, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7370,7 +8052,7 @@ module Modality = struct
            construct the ceil of [c]. *)
         let cc = Mode.Guts.get_floor mm in
         let c = Mode.imply_const cc m in
-        let c = Mode.zap_to_ceil c in
+        let c = Mode.zap_to_ceil_exn c in
         (* Note that we did not mutate [mm] but simply took its floor, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7395,8 +8077,8 @@ module Modality = struct
            good workaround. *)
         (* CR zqian: Find a better solution *)
         Mode.submode mm Mode.legacy |> ignore;
-        let m = Mode.zap_to_floor m in
-        let mm = Mode.zap_to_ceil mm in
+        let m = Mode.zap_to_floor_exn m in
+        let mm = Mode.zap_to_ceil_exn mm in
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -5982,26 +5982,18 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-<<<<<<< HEAD
-  let zap_to_ceil_clamped c m =
+  let zap_to_ceil_clamped_force ?commit c m =
     (match submode m (of_const c) with Ok () | Error _ -> ());
-    zap_to_ceil m
+    zap_to_ceil_force ?commit m
 
-  let zap_to_legacy ~statefulness m =
+  let zap_to_legacy_force ?commit ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful -> zap_to_ceil m
-    | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
-    | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
-    | Statefulness.Const.Stateless -> zap_to_floor m
-=======
-  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
-  let zap_to_legacy_force ~statefulness =
-    match statefulness with
-    | Statefulness.Const.Stateful | Statefulness.Const.Reading
+    | Statefulness.Const.Stateful -> zap_to_ceil_force ?commit m
+    | Statefulness.Const.Reading ->
+      zap_to_ceil_clamped_force ?commit Const.Shareable m
     | Statefulness.Const.Writing ->
-      zap_to_ceil_force
-    | Statefulness.Const.Stateless -> zap_to_floor_force
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+      zap_to_ceil_clamped_force ?commit Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor_force ?commit m
 end
 
 module Uniqueness = struct
@@ -6037,28 +6029,22 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-<<<<<<< HEAD
-  let zap_to_floor_clamped c m =
+  let zap_to_floor_clamped_force ?commit c m =
     (match submode (of_const c) m with Ok () | Error _ -> ());
-    zap_to_floor m
+    zap_to_floor_force ?commit m
 
-  let zap_to_legacy ~visibility ~arg m =
-=======
-  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
-  let zap_to_legacy_force ~visibility =
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+  let zap_to_legacy_force ?commit ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write -> zap_to_floor m
-    | Visibility.Const.Immutable -> zap_to_ceil m
+    | Visibility.Const.Read_write -> zap_to_floor_force ?commit m
+    | Visibility.Const.Immutable -> zap_to_ceil_force ?commit m
     | Visibility.Const.Read ->
-      if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
+      if arg
+      then zap_to_floor_clamped_force ?commit Const.Shared m
+      else zap_to_floor_force ?commit m
     | Visibility.Const.Write ->
-<<<<<<< HEAD
-      if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
-=======
-      zap_to_floor_force
-    | Visibility.Const.Immutable -> zap_to_ceil_force
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+      if arg
+      then zap_to_floor_clamped_force ?commit Const.Corrupted m
+      else zap_to_floor_force ?commit m
 end
 
 module Forkable = struct
@@ -6080,8 +6066,10 @@ module Forkable = struct
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
      or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
-  let zap_to_legacy_force ~global =
-    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
+  let zap_to_legacy_force ?commit ~global =
+    match global with
+    | true -> zap_to_floor_force ?commit
+    | false -> zap_to_ceil_force ?commit
 end
 
 module Yielding = struct
@@ -6103,8 +6091,10 @@ module Yielding = struct
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
      or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
-  let zap_to_legacy_force ~global =
-    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
+  let zap_to_legacy_force ?commit ~global =
+    match global with
+    | true -> zap_to_floor_force ?commit
+    | false -> zap_to_ceil_force ?commit
 end
 
 module Staticity = struct
@@ -6407,23 +6397,16 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-<<<<<<< HEAD
-  let zap_to_legacy ~arg m : Const.t =
-    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
-    let visibility = proj Visibility m |> Visibility.zap_to_legacy in
-    let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
-=======
-  let zap_to_legacy_force ?commit m : Const.t =
+  let zap_to_legacy_force ?commit ~arg m : Const.t =
     let uniqueness =
       proj Uniqueness m |> Uniqueness.zap_to_legacy_force ?commit
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     in
     let visibility =
       proj Visibility m |> Visibility.zap_to_legacy_force ?commit
     in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility
+      proj Contention m
+      |> Contention.zap_to_legacy_force ?commit ~visibility ~arg
     in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }
@@ -7255,11 +7238,6 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.zap_to_floor_force comonadic in
     merge { monadic; comonadic }
 
-<<<<<<< HEAD
-  let zap_to_legacy ~arg { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy ~arg monadic in
-    let comonadic = Comonadic.zap_to_legacy comonadic in
-=======
   let zap_to_ceil_exn m =
     if check_generic m then raise Cannot_zap_generic;
     zap_to_ceil_force m
@@ -7274,18 +7252,17 @@ module Value_with (Areality : Areality) = struct
   let zap_to_ceil m =
     if check_generic m then None else Some (zap_to_ceil_force m)
 
-  let zap_to_legacy_force ?commit { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy_force ?commit monadic in
+  let zap_to_legacy_force ?commit ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ?commit ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy_force ?commit comonadic in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     merge { monadic; comonadic }
 
-  let zap_to_legacy_exn m =
+  let zap_to_legacy_exn ~arg m =
     if check_generic m then raise Cannot_zap_generic;
-    zap_to_legacy_force m
+    zap_to_legacy_force ~arg m
 
-  let zap_to_legacy m =
-    if check_generic m then None else Some (zap_to_legacy_force m)
+  let zap_to_legacy ~arg m =
+    if check_generic m then None else Some (zap_to_legacy_force ~arg m)
 
   let zap_to_legacy_obj : type a.
       a C.obj -> (a, allowed * allowed) S.mode -> unit =
@@ -7298,7 +7275,7 @@ module Value_with (Areality : Areality) = struct
     | Linearity -> Linearity.zap_to_legacy_force mode |> ignore
     | Statefulness -> Statefulness.zap_to_legacy_force mode |> ignore
     | Staticity_op -> Staticity.zap_to_legacy_force mode |> ignore
-    | Monadic_op -> Monadic.zap_to_legacy_force mode |> ignore
+    | Monadic_op -> Monadic.zap_to_legacy_force ~arg:false mode |> ignore
     | Comonadic_with_regionality ->
       let module M = Comonadic_with (Regionality) in
       M.zap_to_legacy_force mode |> ignore
@@ -7310,7 +7287,8 @@ module Value_with (Areality : Areality) = struct
         mode
       |> ignore
     | Contention_op ->
-      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy mode
+      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy
+        ~arg:false mode
       |> ignore
     | Forkable -> Forkable.zap_to_legacy_force ~global:true mode |> ignore
     | Yielding -> Yielding.zap_to_legacy_force ~global:true mode |> ignore
@@ -7437,7 +7415,7 @@ module Value_with (Areality : Areality) = struct
 
   type zap_scope =
     { variables : Z.zap_scope;
-      visible : (allowed * allowed) t list ref
+      visible : (bool * (allowed * allowed) t) list ref
     }
 
   let add_covariant_to_zap_scope { monadic; comonadic } scope =
@@ -7476,11 +7454,11 @@ module Value_with (Areality : Areality) = struct
             (Z.Pco (Comonadic.meet [comonadic_upper; m]))
             scope)
 
-  let add_mode_to_zap_scope m { visible } = visible := m :: !visible
+  let add_mode_to_zap_scope ~arg m { visible } = visible := (arg, m) :: !visible
 
   let resolve_zap_scope { variables; visible } =
     (* we first zap all visible non generic modes to legacy *)
-    List.iter (fun m -> zap_to_legacy m |> ignore) !visible;
+    List.iter (fun (arg, m) -> zap_to_legacy ~arg m |> ignore) !visible;
     (* we then iterate over the children of visible generic modes and zap level 0
     according to the following rules:
     1) if a mode appears only as an upper bound to generic modes, it is zapped to
@@ -7489,7 +7467,7 @@ module Value_with (Areality : Areality) = struct
       floor
     3) if it appears as both, it is zapped to legacy *)
     List.iter
-      (fun m ->
+      (fun (_, m) ->
         if check_generic m
         then begin
           add_covariant_to_zap_scope m variables;

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -998,6 +998,8 @@ module type S = sig
 
     val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
 
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
+
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -128,7 +128,9 @@ module type Common = sig
 
   val legacy : lr
 
-  val newvar : unit -> ('l * 'r) t
+  val generic_level : int
+
+  val newvar : int -> ('l * 'r) t
 
   (* How to submode
 
@@ -170,6 +172,14 @@ module type Common = sig
   val submode_err :
     Mode_hint.pinpoint -> (allowed * 'r) t -> ('l * allowed) t -> unit
 
+  val update_level : int -> ('l * 'r) t -> unit
+
+  val generalize_topology : current_level:int -> ('l * 'r) t -> unit
+
+  val generalize : current_level:int -> ('l * 'r) t -> unit
+
+  val generalize_structure : current_level:int -> ('l * 'r) t -> unit
+
   (** Similar to [submode_err], but checks the two modes are equal by submoding
       in both directions. *)
   val equate_err : Mode_hint.pinpoint -> lr -> lr -> unit
@@ -187,18 +197,33 @@ module type Common = sig
 
   val meet : ('l * allowed) t list -> right_only t
 
-  val newvar_above : (allowed * 'r) t -> ('l * 'r_) t * bool
+  val newvar_above : int -> (allowed * 'r) t -> ('l * 'r_) t * bool
 
-  val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
+  val newvar_below : int -> ('l * allowed) t -> ('l_ * 'r) t * bool
 
   (** Returns true if the mode is a constant or a mode variable at level 0 *)
   val check_const_or_level_0 : ('l * 'r) t -> bool
 
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
-  val zap_to_ceil : ('l * allowed) t -> Const.t
+  (** Returns true if the mode includes a mode variable at generic level *)
+  val check_generic : ('l * 'r) t -> bool
 
-  val zap_to_floor : (allowed * 'r) t -> Const.t
+  (** zaps non-generic variables to ceil, raises a [Cannot_zap_generic] excetion
+      if variable is generic *)
+  val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+  (** zaps non-generic variables to floor, raises a [Cannot_zap_generic]
+      excetion if variable is generic *)
+  val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+  (** zaps non-generic variables to ceil, returns [None] if variable is generic.
+  *)
+  val zap_to_ceil : ('l * allowed) t -> Const.t option
+
+  (** zaps non-generic variables to floor, returns [None] if variable is
+      generic. *)
+  val zap_to_floor : (allowed * 'r) t -> Const.t option
 end
 
 module type Common_axis = sig
@@ -328,6 +353,10 @@ module type S = sig
       on [erase_hint] in [Solver_intf] for details. *)
   val erase_hints : unit -> unit
 
+  (** Resets the counter allocating the (negative) ids of persistent copies of
+      mode variables. (see [Subst.reset_additional_action_id]). *)
+  val reset_persistent_id : unit -> unit
+
   module Hint = Mode_hint
 
   (** Prints a [pinpoint]. Say "a foo" if [definite] is [false], say "the foo"
@@ -349,6 +378,10 @@ module type S = sig
   val undo_changes : changes -> unit
 
   val set_append_changes : (changes ref -> unit) -> unit
+
+  type copy_scope
+
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
 
   type nonrec allowed = allowed
 
@@ -659,6 +692,12 @@ module type S = sig
         val zap_to_ceil : 'a Axis.t -> ('a, 'l * allowed) mode -> 'a
       end
 
+      module Guts : sig
+        (** Returns the precise floor of a mode. see notes on [get_floor] in
+            [solver_intf.mli] for cautions. *)
+        val get_floor : (allowed * 'r) t -> Const.t
+      end
+
       val max_with : 'a Axis.t -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
     end
 
@@ -726,6 +765,8 @@ module type S = sig
         val proj : 'a Axis.t -> t -> 'a option
 
         val set : 'a Axis.t -> 'a option -> t -> t
+
+        val partial_print : Fmt.formatter -> t -> unit
       end
 
       val is_max : 'a Axis.t -> 'a -> bool
@@ -768,6 +809,123 @@ module type S = sig
     type simple_error = Error : 'a Axis.t * 'a simple_axerror -> simple_error
 
     type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
+
+    (** Scope containing pending zap jobs *)
+    type zap_scope
+
+    val with_zap_scope : (zap_scope:zap_scope -> 'a) -> 'a
+
+    val create_zap_scope : unit -> zap_scope
+
+    val resolve_zap_scope : zap_scope -> unit
+
+    (** Exposed subset of the monotone Lattices interface *)
+    module C : sig
+      type ('a, 'b, 'd) morph
+
+      type 'a obj
+
+      val le : 'a obj -> 'a -> 'a -> bool
+
+      val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.is_eq
+
+      val src : 'b obj -> ('a, 'b, 'd) morph -> 'a obj
+
+      val id : ('a, 'a, 'd) morph
+
+      val compose :
+        'c obj -> ('b, 'c, 'd) morph -> ('a, 'b, 'd) morph -> ('a, 'c, 'd) morph
+
+      val equal_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        ('a0, 'a1) Misc.is_eq
+
+      val compare_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        int
+
+      val left_adjoint :
+        'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
+
+      val disallow_right :
+        ('a, 'b, 'l * 'r) morph -> ('a, 'b, 'l * disallowed) morph
+
+      val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
+
+      val print_morph : 'b obj -> Fmt.formatter -> ('a, 'b, 'd) morph -> unit
+    end
+
+    (** The exposed description of modes *)
+    module Desc : sig
+      module Var : sig
+        type 'a t
+
+        type ('b, 'd) t_with_morph =
+          | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+        module Head : sig
+          type 'a t =
+            { desc_id : int;
+              desc_upper : 'a;
+              desc_lower : 'a;
+              desc_vlower : ('a, left_only) t_with_morph list;
+              desc_level : int
+            }
+
+          val equal : 'a t -> 'b t -> bool
+
+          val hash : 'a t -> int
+        end
+
+        val force : 'a C.obj -> 'a t -> 'a Head.t
+      end
+
+      type ('b, 'd) morphvar =
+        | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+      type ('a, 'd) t =
+        | Amode : 'a -> ('a, 'l * 'r) t
+        | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+        | Amodejoin :
+            'a * ('a, 'l * disallowed) morphvar list
+            -> ('a, 'l * disallowed) t
+        | Amodemeet :
+            'a * ('a, disallowed * 'r) morphvar list
+            -> ('a, disallowed * 'r) t
+
+      val equal : 'a C.obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+      val print : 'a C.obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+    end
+
+    val obj_monadic : Monadic.Const.t C.obj
+
+    val obj_comonadic : Comonadic.Const.t C.obj
+
+    val get_comonadic_desc : 'd Comonadic.t -> (Comonadic.Const.t, 'd) Desc.t
+
+    val get_monadic_desc :
+      ('l * 'r) Monadic.t -> (Monadic.Const.t, 'r * 'l) Desc.t
+
+    val meet_const_morph : 'a -> ('a, 'a, allowed * disallowed) C.morph
+
+    val pretty_print_monadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Monadic.Const.t, 'f) C.morph ->
+      unit
+
+    val pretty_print_comonadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Comonadic.Const.t, 'f) C.morph ->
+      unit
 
     include
       Common
@@ -817,6 +975,7 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
+<<<<<<< HEAD
     (** [arg] determines co-/contravariance, and is used to infer the most
         general mode for implied middle values on monadic axes.\
 
@@ -830,6 +989,19 @@ module type S = sig
           let zap_ret_read x : _ @ read = ()
         ]} *)
     val zap_to_legacy : arg:bool -> lr -> Const.t
+=======
+    val add_mode_to_zap_scope : (allowed * allowed) t -> zap_scope -> unit
+
+    val zap_to_legacy_exn : lr -> Const.t
+
+    val zap_to_legacy : lr -> Const.t option
+
+    val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
+
+    val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->
@@ -851,6 +1023,38 @@ module type S = sig
     (** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C]
     *)
     val partial_apply : (allowed * 'r) t -> l
+
+    (** Copies a mode variable and its children from generic level to the
+        current level *)
+    val instantiate :
+      copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Copies a mode variable and its children at generic level, preserving
+        levels *)
+    val copy_generic : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Deeply copies a mode variable and all its children, preserving levels.
+        The copies receive negative ids (mirroring [Subst.newpersty] for types)
+        and are suitable for storing in a cmi file. *)
+    val copy_for_saving : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Deeply copies a mode variable and all its children, preserving levels.
+        The copies receive positive ids. *)
+    val copy_for_restoring : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    module Guts : sig
+      (** Returns [Some c] if the given mode has been constrained to constant
+          [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val check_const : (allowed * allowed) t -> Const.t option
+
+      (** Returns the precise ceiling of a mode. see notes on [get_ceil] in
+          [solver_intf.mli] for cautions. *)
+      val get_ceil : ('l * allowed) t -> Const.t
+
+      (** Checks that a constant is within the precise bounds of a mode. see
+          notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val in_bounds : Const.t -> (allowed * allowed) t -> bool
+    end
   end
 
   (** The most general mode. Used in most type checking, including in value

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -975,9 +975,21 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-<<<<<<< HEAD
-    (** [arg] determines co-/contravariance, and is used to infer the most
-        general mode for implied middle values on monadic axes.\
+    (** Registers a mode in the scope, to be zapped to legacy when the scope is
+        resolved. See [zap_to_legacy] for an explanation of [arg]. *)
+    val add_mode_to_zap_scope :
+      arg:bool -> (allowed * allowed) t -> zap_scope -> unit
+
+    (** Zaps non-generic variables to legacy, raises a [Cannot_zap_generic]
+        exception if a variable is generic. See [zap_to_legacy] for an
+        explanation of [arg]. *)
+    val zap_to_legacy_exn : arg:bool -> lr -> Const.t
+
+    (** Zaps non-generic variables to legacy, returns [None] if a variable is
+        generic.
+
+        [arg] determines co-/contravariance, and is used to infer the most
+        general mode for implied middle values on monadic axes.
 
         Consider:
 
@@ -988,22 +1000,17 @@ module type S = sig
           (* Implies [read uncontended]. *)
           let zap_ret_read x : _ @ read = ()
         ]} *)
-    val zap_to_legacy : arg:bool -> lr -> Const.t
-=======
-    val add_mode_to_zap_scope : (allowed * allowed) t -> zap_scope -> unit
+    val zap_to_legacy : arg:bool -> lr -> Const.t option
 
-    val zap_to_legacy_exn : lr -> Const.t
-
-    val zap_to_legacy : lr -> Const.t option
-
-    val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
+    (** Zaps all variables to legacy (including generic variables): use with
+        caution. See [zap_to_legacy] for an explanation of [arg]. *)
+    val zap_to_legacy_force : ?commit:bool -> arg:bool -> lr -> Const.t
 
     val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->

--- a/external/merlin/upstream/ocaml_flambda/typing/mtype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mtype.ml
@@ -922,6 +922,8 @@ let lower_nongen nglev mty =
       | _ ->
           super.it_do_type_expr it ty
     in
-    let it = {super with it_do_type_expr} in
-    it.it_module_type it mty
+  let it_mode_expr m =
+    if not (Mode.Alloc.check_generic m) then Mode.Alloc.update_level nglev m in
+  let it = {super with it_do_type_expr; it_mode_expr} in
+  it.it_module_type it mty
   end

--- a/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
@@ -15,6 +15,9 @@
 
 (* Compute a spanning tree representation of types *)
 
+module Std_map = Map
+module Std_set = Set
+
 open Misc
 open Ctype
 open Longident
@@ -882,7 +885,7 @@ let nameable_row row =
 (* This specialized version of [Btype.iter_type_expr] normalizes and
    short-circuits the traversal of the [type_expr], so that it covers only the
    subterms that would be printed by the type printer. *)
-let printer_iter_type_expr f ty =
+let printer_iter_type_expr f fm ty =
   match get_desc ty with
   | Tconstr(p, tyl, _) ->
       let (_p', s) = best_type_path p in
@@ -913,10 +916,17 @@ let printer_iter_type_expr f ty =
   | Tmod (ty, _) ->
       f ty
   | _ ->
-      Btype.iter_type_expr f ty
+      Btype.iter_type_expr f fm ty
 
 let quoted_ident ppf x =
   Style.as_inline_code !Oprint.out_ident ppf x
+
+(* Mode variables for mode polymorphism should only be printed if
+  the following two flags are enabled *)
+let mode_polymorphism_printing_enabled () =
+  Language_extension.(
+    is_at_least Mode_polymorphism Alpha
+    && is_enabled Mode_polymorphism_printing)
 
 module Internal_names : sig
 
@@ -982,6 +992,126 @@ end = struct
 
 end
 
+(** A mode as seen by printing: either a determined constant, or a
+    generic comonadic mode. Along an arrow chain, the accumulated curry
+    mode is a constant until a generic mode variable is encountered.
+
+    A generic accumulator is the currying fold evaluated twice: the
+    argument modes themselves ([Ctype.curry_mode]), and their constant upper
+    bounds ([Ctype.curry_mode_const]). *)
+type const_or_generic =
+  | Const of Alloc.Const.t
+  | Generic of Alloc.Comonadic.l * Alloc.Const.t
+
+(** The upper bound of a const_or_generic: exact for [Const],
+    the constant upper bound for [Generic] *)
+let const_or_generic_upper : const_or_generic -> Alloc.Const.t = function
+  | Const c -> c
+  | Generic (_, bound) -> bound
+
+(** Extends the curry accumulator with the argument mode [marg] of an
+    arrow. *)
+let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
+  fun acc marg ->
+    match acc, Alloc.zap_to_legacy marg with
+    | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
+    | Generic (acc, bound), _ ->
+      Generic
+        (Ctype.curry_mode acc marg,
+         Ctype.curry_mode_const bound (Alloc.Guts.get_ceil marg))
+    | Const acc, None ->
+      if mode_polymorphism_printing_enabled ()
+      then
+        Generic
+          (Ctype.curry_mode
+             (Alloc.Comonadic.of_const (Alloc.Const.partial_apply acc))
+             marg,
+           Ctype.curry_mode_const acc (Alloc.Guts.get_ceil marg))
+      else
+        Const
+          (Ctype.curry_mode_const acc (Alloc.zap_to_legacy_force marg))
+
+(** The view of a mode occurrence [m]; zaps [m] when it has to be a
+    constant. *)
+let const_or_generic_of_mode : Alloc.lr -> const_or_generic =
+  fun m ->
+    match Alloc.zap_to_legacy m with
+    | Some c -> Const c
+    | None ->
+      if mode_polymorphism_printing_enabled ()
+      then
+        Generic
+          (Alloc.Comonadic.disallow_right m.comonadic,
+           Alloc.Guts.get_ceil m)
+      else Const (Alloc.zap_to_legacy_force m)
+
+(** Whether the return mode [m] of an arrow agrees with the constant
+    content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
+    with the constant (a [Generic] contains generic variables and cannot
+    be equated with directly); otherwise a pure bounds check.
+
+    [equate_with_const] additionally checks [m]'s edges;
+    [Variable_names.equate_curry] calls this function alone, so that the
+    mutations happen during preprocessing, before bounds and edges are
+    computed. *)
+let equate_with_curry_bounds : Alloc.lr -> const_or_generic -> bool =
+  fun m acc_mode ->
+    if not (Alloc.check_generic m)
+       || not (mode_polymorphism_printing_enabled ())
+    then
+      Result.is_ok
+        (Alloc.equate m (Alloc.of_const (const_or_generic_upper acc_mode)))
+    else
+      Alloc.Guts.in_bounds (const_or_generic_upper acc_mode) m
+
+let erase_implied_axes (modes : Mode.Alloc.Const.t) :
+    Mode.Alloc.Const.Option.t =
+  (* [forkable] has implied defaults depending on [areality]: *)
+  let forkable =
+    match modes.areality, modes.forkable with
+    | Local, Unforkable | Global, Forkable -> None
+    | _, _ -> Some modes.forkable
+  in
+
+  (* [yielding] has implied defaults depending on [areality]: *)
+  let yielding =
+    match modes.areality, modes.yielding with
+    | Local, Yielding | Global, Unyielding -> None
+    | _, _ -> Some modes.yielding
+  in
+
+  (* [contention] has implied defaults based on [visibility]: *)
+  let contention =
+    match modes.visibility, modes.contention with
+    | Immutable, Contended
+    | Read, Shared
+    | Write, Corrupted
+    | Read_write, Uncontended -> None
+    | _, _ -> Some modes.contention
+  in
+
+  (* [portability] has implied defaults based on [statefulness]: *)
+  let portability =
+    match modes.statefulness, modes.portability with
+    | Stateless, Portable
+    | Reading, Shareable
+    | Writing, Corruptible
+    | Stateful, Nonportable -> None
+    | _, _ -> Some modes.portability
+  in
+
+  { areality = Some modes.areality;
+    linearity = Some modes.linearity;
+    uniqueness = Some modes.uniqueness;
+    portability;
+    contention;
+    forkable;
+    yielding;
+    statefulness = Some modes.statefulness;
+    visibility = Some modes.visibility;
+    staticity = Some modes.staticity
+  }
+
 module Variable_names : sig
   val reset_names : unit -> unit
 
@@ -991,6 +1121,16 @@ module Variable_names : sig
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
   val name_of_type : (unit -> string) -> transient_expr -> string
+  val name_of_mode : Alloc.lr -> string
+
+  (** Whether the edges on the curry mode [m] are exactly the
+      [past]/[close] edges from [acc], i.e. implied by the currying
+      interpretation. [bounds_implied] says whether the constant bounds of
+      [m] are implied as well ([equate_with_curry_bounds]); the edges into
+      [m] are suppressed (not printed by the other modes) only when both
+      hold, since [m] is then elided. Must be called after [reserve]. *)
+  val curry_edges_implied :
+    bounds_implied:bool -> acc:const_or_generic -> Alloc.lr -> bool
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1004,6 +1144,13 @@ module Variable_names : sig
      itself for the toplevel *)
   val refresh_weak : unit -> unit
 end = struct
+  type monadic_description =
+    (Alloc.Monadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type comonadic_description =
+    (Alloc.Comonadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type visible_pair =
+    (monadic_description, comonadic_description) monadic_comonadic
+
   (* We map from types to names, but not directly; we also store a substitution,
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
@@ -1013,17 +1160,205 @@ end = struct
   let name_counter = ref 0
   let named_vars = ref ([] : string list)
   let visited_for_named_vars = ref ([] : transient_expr list)
+  let visited_for_modes = ref ([] : transient_expr list)
+  let visited_for_named_modevars = ref ([] : transient_expr list)
+
+  module Desc = Alloc.Desc
+  module C = Alloc.C
+
+  (** Boxed var and morphisms (paths) to use in hashtables *)
+  type boxedvar =
+  | K : 'a C.obj * 'a Desc.Var.Head.t -> boxedvar
+  type boxedpath =
+  | P :
+      { dst : 'b C.obj;
+        var : 'a Desc.Var.Head.t;
+        path : ('a, 'b, (allowed * disallowed)) C.morph
+      }
+      -> boxedpath
+
+  (** The name of polymorphic mode variables will be
+  determined by two variables and morphism pair. The object
+  types are irrelevant, and are thus forgotten. See [edge]
+  for more explanation *)
+  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
+  type monadic_morph =
+    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
+  type comonadic_morph =
+    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
+      morphl
+  type closing_over_morph =
+    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
+
+  type boxedname =
+  | Simple_name :
+      { target : 'c Desc.Var.Head.t;
+        src : 'd Desc.Var.Head.t;
+        via : (monadic_morph, comonadic_morph) monadic_comonadic
+      }
+      -> boxedname
+  | Comonadic_name :
+      { target : 'c Desc.Var.Head.t;
+        src : 'd Desc.Var.Head.t;
+        morph : comonadic_morph
+      }
+      -> boxedname
+
+  module VarTbl = Hashtbl.Make (struct
+    type t = boxedvar
+    let equal (K (_, v1)) (K (_, v2)) = Desc.Var.Head.equal v1 v2
+    let hash (K (_, v)) = Desc.Var.Head.hash v
+  end)
+
+  module VarPairMap = Std_map.Make (struct
+    type t = boxedvar * boxedvar
+    let compare (K (_, v1), K (_, v1')) (K (_, v2), K (_, v2')) =
+      match Int.compare v1.desc_id v2.desc_id with
+      | 0 -> Int.compare v1'.desc_id v2'.desc_id
+      | c -> c
+  end)
+
+  module Paths = struct
+    module Store (X : sig
+      type s
+      type d
+      val dst : d C.obj
+    end) =
+    struct
+      module Morph_set = Std_set.Make (struct
+        type t = (X.s, X.d) morphl
+        let compare m1 m2 = C.compare_morph X.dst m1 m2
+      end)
+
+      type t = Morph_set.t VarPairMap.t
+
+      let empty : t = VarPairMap.empty
+
+      let add key path t =
+        let set =
+          match VarPairMap.find_opt key t with
+          | None -> Morph_set.singleton path
+          | Some set -> Morph_set.add path set
+        in
+        VarPairMap.add key set t
+
+      let find key t =
+        match VarPairMap.find_opt key t with
+        | None -> []
+        | Some set -> Morph_set.elements set
+    end
+
+    module Monadic_paths = Store (struct
+      type s = Alloc.Monadic.Const.t
+      type d = Alloc.Monadic.Const.t
+      let dst = Alloc.obj_monadic
+    end)
+
+    module Comonadic_paths = Store (struct
+      type s = Alloc.Comonadic.Const.t
+      type d = Alloc.Comonadic.Const.t
+      let dst = Alloc.obj_comonadic
+    end)
+
+    module Closing_over_paths = Store (struct
+      type s = Alloc.Monadic.Const.t
+      type d = Alloc.Comonadic.Const.t
+      let dst = Alloc.obj_comonadic
+    end)
+
+    type ('s, 'd) table =
+      | Monadic : (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) table
+          (** Tracks all paths from a visible monadic mode
+          variable to another. A path is defined as follows:
+            let [(v, f)] and [(u, h)] be two visible monadic
+            morphvars, such that [v] can reach [u] by following
+            vlowers. Let [g] be one such composition of vlower
+            functions. By
+            transitivity, we know the following to be true: [g u <= v].
+
+            A path from [(v, f)] to [(u, h)] is defined as: [f ∘ g ∘ h'],
+            where [h'] is the left adjoint of [h] *)
+      | Comonadic : (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t) table
+          (** Tracks all paths from a visible comonadic mode
+          variable to another. See description of
+          [Monadic] for a definition of a path *)
+      | Closing_over : (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) table
+          (** Tracks all paths from a visible comonadic mode
+          variable to visible monadic mode variable. Since
+          the path goes from a comonadic to a monadic mode,
+          it will have to go through a "monadic to comonadic"
+          morphism. These paths will correspond to a closing
+          over relation between two mode variables
+
+          See description of [Monadic] for a definition of
+          a path *)
+
+    type t =
+      { mutable monadic : Monadic_paths.t;
+        mutable comonadic : Comonadic_paths.t;
+        mutable closing_over : Closing_over_paths.t
+      }
+
+    let create () =
+      { monadic = Monadic_paths.empty;
+        comonadic = Comonadic_paths.empty;
+        closing_over = Closing_over_paths.empty
+      }
+
+    let reset t =
+      t.monadic <- Monadic_paths.empty;
+      t.comonadic <- Comonadic_paths.empty;
+      t.closing_over <- Closing_over_paths.empty
+
+    let src_obj : type s d. (s, d) table -> s C.obj =
+      function
+      | Monadic -> Alloc.obj_monadic
+      | Comonadic -> Alloc.obj_comonadic
+      | Closing_over -> Alloc.obj_monadic
+
+    let dst_obj : type s d. (s, d) table -> d C.obj =
+      function
+      | Monadic -> Alloc.obj_monadic
+      | Comonadic -> Alloc.obj_comonadic
+      | Closing_over -> Alloc.obj_comonadic
+
+    let add : type s d.
+        t -> (s, d) table -> boxedvar * boxedvar -> (s, d) morphl -> unit =
+      fun t table key path ->
+      match table with
+      | Monadic -> t.monadic <- Monadic_paths.add key path t.monadic
+      | Comonadic -> t.comonadic <- Comonadic_paths.add key path t.comonadic
+      | Closing_over ->
+        t.closing_over <- Closing_over_paths.add key path t.closing_over
+
+    let find : type s d.
+        t -> (s, d) table -> boxedvar * boxedvar -> ((s, d) morphl) list =
+      fun t table key ->
+      match table with
+      | Monadic -> Monadic_paths.find key t.monadic
+      | Comonadic -> Comonadic_paths.find key t.comonadic
+      | Closing_over -> Closing_over_paths.find key t.closing_over
+  end
+
+  (** Tracks the mapping of monadic and comonadic mode
+  descriptions visible in the type *)
+  let visible_pairs = ref ([] : visible_pair list)
+  let aliased_visible_pairs = ref ([] : visible_pair list)
+  let printed_aliased_visible_pairs = ref ([] : (visible_pair * string) list)
+
+  (** Tracks all mode variables that may occur in the above
+  list (for fast visibility checking) *)
+  let visible_vars = VarTbl.create 17
+
+  let visible_paths = Paths.create ()
+
+  (** counter used to generate names for polymorphic mode variables *)
+  let modename_counter = ref 0
+  let modenames = ref ([] : (boxedname * string) list)
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
   let named_weak_vars = ref String.Set.empty
-
-  let reset_names () =
-    names := [];
-    name_subst := [];
-    name_counter := 0;
-    named_vars := [];
-    visited_for_named_vars := []
 
   let add_named_var tty =
     match tty.desc with
@@ -1041,8 +1376,901 @@ end = struct
       | Tvar _ | Tunivar _ ->
           add_named_var tty
       | _ ->
-          printer_iter_type_expr add_named_vars ty
+          printer_iter_type_expr add_named_vars (Fun.const ()) ty
     end
+
+  (* The following preprocessing step zaps non-generic
+    modes to legacy, while equating a derived curry mode
+    with the inferred non-generic return modes. This step
+    should exactly mirror the mutations performed by
+    [tree_of_modal_typexp]. It is needed so we get the
+    correct precise bounds of mode descriptions
+  *)
+  let rec zap_non_generic_modes : const_or_generic -> type_expr -> unit =
+    fun acc_mode ty ->
+    let px = proxy ty in
+    if List.memq px !visited_for_modes then () else begin
+      visited_for_modes := px :: !visited_for_modes;
+      let tty = Transient_expr.repr ty in
+      match tty.desc with
+      | Tarrow ((_l, marg, mret), ty1, ty2, _) ->
+        zap_non_generic_modes (const_or_generic_of_mode marg) ty1;
+        let acc_mode = curry_acc acc_mode marg in
+        equate_curry acc_mode mret ty2
+      | Tpoly (ty, []) | Trepr (ty, []) ->
+        zap_non_generic_modes acc_mode ty
+      | _ ->
+        printer_iter_type_expr
+          (zap_non_generic_modes (Const Alloc.Const.legacy))
+          (Fun.const ()) ty
+    end
+
+  and equate_curry : const_or_generic -> Alloc.lr -> type_expr -> unit =
+    fun acc_mode mret ty ->
+      match get_desc ty with
+      | Tarrow _ when equate_with_curry_bounds mret acc_mode ->
+          zap_non_generic_modes acc_mode ty
+      | _ ->
+        zap_non_generic_modes (const_or_generic_of_mode mret) ty
+
+  let zap_non_generic_modes ty =
+    zap_non_generic_modes (Const Alloc.Const.legacy) ty
+
+  let eq_pair :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun { monadic = mon0; comonadic = com0 }
+        { monadic = mon1; comonadic = com1 } ->
+    Desc.equal Alloc.obj_monadic mon0 mon1
+    && Desc.equal Alloc.obj_comonadic com0 com1
+
+  (* The following preprocessing step registers all the
+    modes pointed to by a type. Recall that a [Alloc.lr]
+    has two parts: { monadic; comonadic }. We need to
+    register each individual mode variable, as well as
+    the association between the monadic and comonadic
+    parts.
+
+    The former are registered in a VarTbl, the latter
+    in a list of mode descriptions
+    We also use this step to register mode aliases
+  *)
+  let add_visible : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> unit =
+    fun dst desc ->
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let src = C.src dst f in
+        let v = K (src, v) in
+        VarTbl.add visible_vars v ()
+
+  let add_named_modevar : Alloc.lr -> unit =
+    fun ({ monadic; comonadic } as mode) ->
+      if Alloc.check_generic mode then begin
+        let monadic_desc = Alloc.get_monadic_desc monadic in
+        let comonadic_desc = Alloc.get_comonadic_desc comonadic in
+        let pair = { monadic = monadic_desc; comonadic = comonadic_desc } in
+        add_visible Alloc.obj_monadic monadic_desc;
+        add_visible Alloc.obj_comonadic comonadic_desc;
+        if List.exists (eq_pair pair) !visible_pairs then
+          aliased_visible_pairs := pair :: !aliased_visible_pairs
+        else
+          visible_pairs := pair :: !visible_pairs
+      end
+
+  let rec add_named_modevars ty =
+    let px = proxy ty in
+    if not (List.memq px !visited_for_named_modevars) then begin
+      visited_for_named_modevars := px :: !visited_for_named_modevars;
+      printer_iter_type_expr add_named_modevars add_named_modevar ty
+    end
+
+  (* The next preprocessing step registers all direct
+    paths from one visible mode variable to another.
+  *)
+
+  type stack = unit VarTbl.t
+
+  (* Find the [b -> Paths.src_obj table] morphism
+    associated with some visible variable [v] of object
+    type [b] *)
+  let find_visible_morph_opt : type b s d.
+      (s, d) Paths.table -> b C.obj -> b Desc.Var.Head.t
+      -> ((b, s, (allowed * allowed)) C.morph) option =
+    fun table obj v ->
+      let sobj = Paths.src_obj table in
+      let desc_of_pair (pair : visible_pair)
+          : (s, (allowed * allowed)) Desc.t =
+        match table with
+        | Paths.Monadic -> pair.monadic
+        | Paths.Comonadic -> pair.comonadic
+        | Paths.Closing_over -> pair.monadic
+      in
+      let find_match pair =
+        match desc_of_pair pair with
+        | Desc.Amodevar (Amorphvar (u, f)) ->
+            if not (Desc.Var.Head.equal v u) then None else begin
+              let obj' = C.src sobj f in
+                match C.equal_obj obj obj' with
+                | Is_eq ->
+                  let (f : ((b, s, (allowed * allowed)) C.morph)) = f in
+                  Some f
+                | Is_not_eq ->
+                  fatal_error "Out_type.find_visible_morph_opt"
+            end
+        | Desc.Amode _ -> None
+      in
+      List.find_map find_match !visible_pairs
+
+  let visible : type b. b C.obj -> b Desc.Var.Head.t -> bool =
+    fun obj v ->
+      VarTbl.mem visible_vars (K (obj, v))
+
+  (* Find all direct paths (via vlowers) from some
+    variable [v] to all other reachable visible variables
+    at generic level. *)
+  (* WARNING: cycles are *not* registered
+      as a separate morphism:
+      e.g.: let [w] be a visible generic variable with
+            the following (vlower) edges:
+            v -f> u1 -g> u2 -g'> u1 -h> w
+            [find_paths v] will return only the direct
+            path [(f ∘ h)]
+      In the future, we might want to register all
+      paths. This will require a lattice of morphisms,
+      so we can calculate the fixed point of cycle *)
+  let rec paths_to_visible :
+      type b. stack:stack
+      -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~stack dst v ->
+      if visible dst v then [P { dst; var = v; path = C.id }]
+      else paths_from_vlowers ~stack dst v
+
+  and paths_from_vlowers :
+      type b. stack:stack
+      -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~stack dst v ->
+      if VarTbl.mem stack (K (dst, v)) then [] else begin
+        VarTbl.add stack (K (dst, v)) ();
+        let paths =
+          List.concat_map (fun (Desc.Var.Amorphvar (w, f)) ->
+            let fsrc = C.src dst f in
+            let w = Desc.Var.force fsrc w in
+            if w.desc_level <> generic_level then []
+            else
+              List.map (fun (P { dst = gdst; var = u; path = g }) ->
+                match C.equal_obj fsrc gdst with
+                | Is_eq -> P { dst; var = u; path = C.compose dst f g }
+                | Is_not_eq -> fatal_error "Out_type.paths_from_vlowers")
+                (paths_to_visible ~stack fsrc w))
+            v.desc_vlower
+        in
+        VarTbl.remove stack (K (dst, v));
+        paths
+      end
+
+  let find_paths : boxedvar -> boxedpath list =
+    fun (K (dst, v)) ->
+      paths_from_vlowers ~stack:(VarTbl.create 17) dst v
+
+  (** [find_path_from_description] constructs all morphisms
+    from one visible mode variable to another, and records
+    them in the [table] of [visible_paths].
+    [find_visible_morph_opt table] takes a variable as
+    input, and returns its associated morphism. The final
+    morphism is constructed as follows:
+      - let the parameter [desc] be a morphvar
+        description [(v, f)]
+      - let g be vlower path from [v] to some [u].
+        (recall g : [u.obj] -> [v.obj])
+      - let [find_visible_morph_opt table u] = Some [h]
+    [find_path_from_description] records
+    ([v], [u]) and [fgh'] where [h'] is the left
+    adjoint of [h].
+
+    See [Paths.Monadic] for an explanation
+    why this is the morphism we want *)
+  let find_path_from_description :
+      type s d.
+      (d, (allowed * allowed)) Desc.t
+      -> (s, d) Paths.table
+      -> unit =
+    fun desc table ->
+      let dst = Paths.dst_obj table in
+      let bobj = Paths.src_obj table in
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let fsrc = C.src dst f in
+        let v = K (fsrc, v) in
+        let paths = find_paths v in
+        List.iter (fun (P { dst = gdst; var = u; path = g }) ->
+          match C.equal_obj fsrc gdst with
+            | Is_eq ->
+              let gsrc = C.src gdst g in
+              Option.iter (fun h ->
+                let h' = C.left_adjoint bobj h in
+                let fg = C.compose dst (C.disallow_right f) g in
+                let fgh' = C.compose dst fg h' in
+                Paths.add visible_paths table (v, (K (gsrc, u))) fgh'
+              ) (find_visible_morph_opt table gsrc u)
+            | Is_not_eq ->
+              fatal_error "Out_type.find_path_from_description"
+          ) paths
+
+
+  (* The following function is expensive and should be
+  called once during preprocessing. It constructs all
+  morphisms from a visible monadic/comonadic variable to
+  another visible monadic/comonadic variable, and records
+  them in their respective tables *)
+  let add_visible_paths () =
+    List.iter
+      (fun { monadic; comonadic } ->
+        find_path_from_description monadic Paths.Monadic;
+        find_path_from_description comonadic Paths.Comonadic;
+        find_path_from_description comonadic Paths.Closing_over
+      ) !visible_pairs
+
+  type simple_edge =
+    { via :
+        (monadic_morph, comonadic_morph)
+          monadic_comonadic;
+        (** The pair of morphisms between the two modes.
+        The monadic morphism gives a path from the
+        monadic part of [src] to the monadic part of
+        [target], the comonadic morphism gives a path
+        from the comonadic part of [target] to the
+        comonadic part of [src] *)
+      name : boxedname;
+        (** When printing, we name edges rather than
+        nodes, such that we can print monadic and
+        comonadic constraints in different bounds, thus
+        only printing left_only morphisms. By default,
+        the name is determined by the comonadic
+        morphism, but if this morphism is trivial (i.e.
+        the bounds can determine it), we use the
+        monadic morphism instead. *)
+    }
+
+  type comonadic_edge =
+    { c_via : comonadic_morph;
+        (** The comonadic morphism between two modes
+        when there is no path between their monadic
+        counterparts. This edge represents a partial
+        constraint between two modes. The morphism
+        gives a path from [target] to [src] *)
+      c_name : boxedname;
+        (** The boxed name of [c_via] *)
+    }
+
+  (** [closing_over_edge] describes a specific pattern
+  that may arise between an argument, a return and a
+  curry-mode.
+
+  Consider the following function (the K-combinator)
+  let k x y = x
+
+  The mode of the argument [x] describes a lower bound on
+  the inner return. But when [k] is partially applied, this
+  mode also describes an upper bound on the closure [k x].
+
+  We want to print such a pattern as follows:
+
+  [k : x @ [< 'm] -> (y @ 'n -> x @ [> 'm]) @ [> close('m)]]
+
+  Where [close('m)] denotes a relation to the comonadic
+  parts of the argument, and the monadic part of the return *)
+
+  (** A [closing_over_edge] describes a relationship between
+  three visible mode variables: [src], [target] and [curry]*)
+  type closing_over_edge =
+    { cls_target : closing_over_morph;
+        (** A path from [curry] to monadic
+        part of [target] *)
+      cls_src : comonadic_morph;
+        (** A path from [curry] to comonadic
+        part of [src] *)
+      cls_edge : simple_edge
+        (** the edge from [src] to [target].
+        The name of a [closing_over_edge]
+        corresponds to the name of [cls_edge]. *)
+    }
+
+  type edge =
+  | Simple of simple_edge
+      (** a constraint between two alloc modes *)
+  | Comonadic of comonadic_edge
+      (** a constraint between the comonadic parts
+      of two alloc modes *)
+  | ClosingOver of closing_over_edge
+      (** a constraint between the monadic part
+      of one mode and the comonadic part of another *)
+
+   let dupper_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_upper
+
+  let dlower_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_lower
+
+  let construct_morphs :
+      type a. (a, a) Paths.table
+        -> (a, (allowed * allowed)) Desc.t
+        -> (a, (allowed * allowed)) Desc.t
+        -> ((a, a) morphl) list =
+    fun table src_descr target_descr ->
+      let dst = Paths.dst_obj table in
+      match src_descr, target_descr with
+      | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+        let vobj = C.src dst f in
+        let uobj = C.src dst g in
+        let src_lower = C.apply dst f v.desc_lower in
+        let target_upper = C.apply dst g u.desc_upper in
+        if C.le dst target_upper src_lower
+        then [C.id] (* [target <= src] already holds by bounds *)
+        else Paths.find visible_paths table (K (vobj, v), K (uobj, u))
+      | _, _ ->
+        let src_lower = dlower_lr dst src_descr in
+        let target_upper = dupper_lr dst target_descr in
+        if C.le dst target_upper src_lower
+        then [C.id] (* [target <= src] already holds by bounds *)
+        else [Alloc.meet_const_morph src_lower]
+
+  let construct_closing_over_morphs :
+      (Alloc.Comonadic.Const.t, allowed * allowed) Desc.t
+      -> (Alloc.Monadic.Const.t, allowed * allowed) Desc.t
+      -> closing_over_morph list =
+    fun src_descr target_descr ->
+    match src_descr, target_descr with
+    | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+      let vobj = C.src Alloc.obj_comonadic f in
+      let uobj = C.src Alloc.obj_monadic g in
+        Paths.find visible_paths Paths.Closing_over (K (vobj, v), K (uobj, u))
+    | _, _ -> []
+
+  let construct_monadic_morphs src_descr target_descr =
+    construct_morphs Paths.Monadic src_descr target_descr
+
+  let construct_comonadic_morphs src_descr target_descr =
+    construct_morphs Paths.Comonadic src_descr target_descr
+
+  (* Tests whether the relation between two descriptions can be decided by
+  their bounds. If the following is true for two parts of a mode variable pair,
+  then no constraint needs to be printed *)
+  let descr_compare_dec :
+      type a. a C.obj
+      -> (a, (allowed * allowed)) Desc.t
+      -> (a, (allowed * allowed)) Desc.t
+      -> bool =
+    fun dst a0 a1 ->
+      let upper0 = dupper_lr dst a0 in
+      let lower0 = dlower_lr dst a0 in
+      let upper1 = dupper_lr dst a1 in
+      let lower1 = dlower_lr dst a1 in
+      C.le dst upper0 lower1 ||
+      C.le dst upper1 lower0
+
+  let descr_is_var : type a. (a, (allowed * allowed)) Desc.t -> bool =
+    fun v ->
+      match v with
+      | Amode _ -> false
+      | Amodevar _ -> true
+
+  (** We only want to print a constraint (and thus
+  construct an edge) between [(mon0, com0)] and
+  [(mon1, com1)] if the following is true:
+
+  1) Either [compare mon0 mon1], or
+     [compare com0 com1] can't be decided via bounds
+  2) Either [mon0] and [mon1] are both variables,
+     or [com0] and [com1] are both variables
+  3) [(mon0, com0)] and [(mon1, com1)] are not equal
+  *)
+  let construct_edge_condition :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun ({ monadic = mon0; comonadic = com0 } as pair0)
+        ({ monadic = mon1; comonadic = com1 } as pair1) ->
+      let compare_dec =
+        not (descr_compare_dec
+               Alloc.obj_monadic mon0 mon1)
+        || not (descr_compare_dec
+                  Alloc.obj_comonadic com0 com1)
+      in
+      let check_signature =
+        (descr_is_var mon0 && descr_is_var mon1)
+        || (descr_is_var com0 && descr_is_var com1)
+      in
+      let pairs_ne = not (eq_pair pair0 pair1) in
+      compare_dec && check_signature && pairs_ne
+
+  let construct_name :
+      visible_pair
+      -> (monadic_morph, comonadic_morph) monadic_comonadic
+      -> visible_pair
+      -> boxedname =
+    fun { monadic = mon0; comonadic = com0 }
+        via
+        { monadic = mon1; comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        Simple_name { target = u; src = v; via }
+      | _, _ ->
+        match mon0, mon1 with
+        | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+          Simple_name { target = u; src = v; via }
+        | _, _ ->
+          fatal_error
+            "Out_type.construct_name: edge without variable endpoints"
+
+  let construct_comonadic_name :
+      visible_pair
+      -> comonadic_morph
+      -> visible_pair
+      -> boxedname =
+    fun { comonadic = com0 }
+        com_morph
+        { comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        Comonadic_name { target = u; src = v; morph = com_morph }
+      | _, _ ->
+        fatal_error
+          "Out_type.construct_comonadic_name: edge without variable endpoints"
+
+  let construct_simple_between pair0 pair1 =
+    let mon_morphs =
+      construct_monadic_morphs pair0.monadic pair1.monadic
+    in
+    let com_morphs =
+      construct_comonadic_morphs pair1.comonadic pair0.comonadic
+    in
+    List.concat_map (fun com_morph ->
+      List.map (fun mon_morph ->
+        let via = { monadic = mon_morph; comonadic = com_morph } in
+        { via; name = construct_name pair0 via pair1 })
+        mon_morphs)
+      com_morphs
+
+  let check_closing_over_candidate pair0 pair1 =
+    List.exists
+      (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs pair1.comonadic pair2.monadic
+        in
+        let edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else []
+        in
+        not (List.is_empty edges)
+        && not (List.is_empty closing_over_morphs))
+      !visible_pairs
+
+  let construct_comonadic_between pair0 pair1 =
+    let mon_morphs =
+      construct_monadic_morphs pair0.monadic pair1.monadic
+    in
+    let com_morphs =
+      construct_comonadic_morphs pair1.comonadic pair0.comonadic
+    in
+    if List.is_empty mon_morphs
+       && not (check_closing_over_candidate pair0 pair1)
+    then
+      List.map (fun com_morph ->
+        let c_name = construct_comonadic_name pair0 com_morph pair1 in
+        Comonadic { c_via = com_morph; c_name })
+        com_morphs
+    else []
+
+  let eq_morph : type a0 a1 b l0 r0 l1 r1.
+      b C.obj
+      -> (a0, b, l0 * r0) C.morph
+      -> (a1, b, l1 * r1) C.morph
+      -> bool =
+    fun obj f g ->
+    match C.equal_morph obj f g with
+    | Is_eq -> true
+    | Is_not_eq -> false
+
+  let eq_boxedname n1 n2 =
+    match n1, n2 with
+    | Simple_name { target = v; src = v'; via = via1 },
+      Simple_name { target = u; src = u'; via = via2 } ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && eq_morph Alloc.obj_monadic via1.monadic via2.monadic
+      && eq_morph Alloc.obj_comonadic via1.comonadic via2.comonadic
+    | Comonadic_name { target = v; src = v'; morph = f },
+      Comonadic_name { target = u; src = u'; morph = g } ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && eq_morph Alloc.obj_comonadic f g
+    | Simple_name _, Comonadic_name _ | Comonadic_name _, Simple_name _ ->
+      false
+
+  let closing_over_composition { cls_target; cls_src; _ } =
+    C.compose Alloc.obj_comonadic cls_src cls_target
+
+  let eq_closing_over e1 e2 =
+    eq_boxedname e1.cls_edge.name e2.cls_edge.name
+    && C.compare_morph Alloc.obj_comonadic
+         (closing_over_composition e1)
+         (closing_over_composition e2)
+       = 0
+
+  let dedup_closing_over edges =
+    List.rev
+      (List.fold_left
+         (fun acc e ->
+           if List.exists (eq_closing_over e) acc then acc else e :: acc)
+         [] edges)
+
+  let construct_closing_over_to pair1 =
+    let edges =
+    List.concat_map (fun pair0 ->
+      let com_morphs =
+        construct_comonadic_morphs pair1.comonadic pair0.comonadic
+      in
+      List.concat_map (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs pair1.comonadic pair2.monadic
+        in
+        let simple_edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else []
+        in
+        List.concat_map (fun edge ->
+          List.concat_map (fun cls_morph ->
+            List.map (fun com_morph ->
+                { cls_target = cls_morph;
+                  cls_src = com_morph;
+                  cls_edge = edge
+                })
+              com_morphs)
+            closing_over_morphs)
+          simple_edges)
+        !visible_pairs)
+      !visible_pairs
+    in
+    List.map (fun e -> ClosingOver e) (dedup_closing_over edges)
+
+  let construct_edges_between pair0 pair1 =
+    if not (construct_edge_condition pair0 pair1) then []
+    else begin
+      let simple = construct_simple_between pair0 pair1 in
+      let comonadic = construct_comonadic_between pair0 pair1 in
+      List.map (fun edge -> Simple edge) simple @ comonadic
+    end
+
+  let construct_edges_to :
+      visible_pair -> edge list =
+    fun pair1 ->
+      let edges =
+        List.concat_map (fun pair0 -> construct_edges_between pair0 pair1)
+          !visible_pairs
+      in
+      construct_closing_over_to pair1 @ edges
+
+  let construct_edges_from :
+      visible_pair -> edge list =
+    fun pair0 ->
+      List.concat_map (fun pair1 -> construct_edges_between pair0 pair1)
+        !visible_pairs
+
+  let pick_name : int -> string = fun i ->
+    match i with
+    | 0 -> "'m"
+    | 1 -> "'n"
+    | 2 -> "'o"
+    | 3 -> "'p"
+    | 4 -> "'q"
+    | _ -> Fmt.asprintf "'mm%d" (i - 5)
+
+  let add_named_modevar name =
+    let mopt =
+      List.find_opt
+        (fun (name', _) -> eq_boxedname name name')
+        !modenames
+    in
+    match mopt with
+    | Some (_, m) -> m
+    | None ->
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      modenames := (name, m) :: !modenames;
+      m
+
+  type 'a interval = { lo: 'a; hi: 'a }
+  let construct_raw_bounds { monadic; comonadic } :
+      string interval =
+    let bound_diff bound trivial =
+      erase_implied_axes bound
+      |> Alloc.Const.Option.value ~default:trivial
+      |> fun bound -> Alloc.Const.diff bound trivial
+    in
+    let mupper = dupper_lr Alloc.obj_monadic monadic in
+    let mlower = dlower_lr Alloc.obj_monadic monadic in
+    let cupper = dupper_lr Alloc.obj_comonadic comonadic in
+    let clower = dlower_lr Alloc.obj_comonadic comonadic in
+    let lower =
+      Alloc.Const.merge
+        { monadic = mupper; comonadic = clower }
+    in
+    let upper =
+      Alloc.Const.merge
+        { monadic = mlower; comonadic = cupper }
+    in
+    let lower = bound_diff lower Alloc.Const.min in
+    let upper = bound_diff upper Alloc.Const.max in
+    { lo = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print lower;
+      hi = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print upper}
+
+  type edge_as_lower =
+  | Lower_simple : simple_edge -> edge_as_lower
+  | Lower_comonadic : comonadic_edge -> edge_as_lower
+  | Lower_closing_over_to : closing_over_edge -> edge_as_lower
+
+  type edge_as_upper =
+  | Upper_simple : simple_edge -> edge_as_upper
+  | Upper_comonadic : comonadic_edge -> edge_as_upper
+
+  let print_raw_upper_bound ppf edge =
+    match edge with
+    | Upper_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_monadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.monadic
+    | Upper_comonadic { c_name } ->
+      let m = add_named_modevar c_name in
+      Fmt.fprintf ppf "past(%s)" m
+
+  let print_raw_lower_bound ppf edge =
+    match edge with
+    | Lower_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.comonadic
+    | Lower_comonadic { c_via; c_name } ->
+      let m = add_named_modevar c_name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "past(%s)" s)
+        m ppf c_via
+    | Lower_closing_over_to { cls_target; cls_src; cls_edge } ->
+      let m = add_named_modevar cls_edge.name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf
+        (C.compose Alloc.obj_comonadic cls_src cls_target)
+
+  let partition_edges_into_bounds :
+      edges_from:edge list ->
+      edges_to:edge list ->
+      edge_as_lower list * edge_as_upper list =
+    fun ~edges_from ~edges_to ->
+    let into_lower_from = function
+      | ClosingOver _ -> assert false
+      | Simple e -> Upper_simple e
+      | Comonadic e -> Upper_comonadic e
+    in
+    let into_lower_to = function
+      | ClosingOver e -> Lower_closing_over_to e
+      | Simple e -> Lower_simple e
+      | Comonadic e -> Lower_comonadic e
+    in
+    let upper = List.map into_lower_from edges_from in
+    let lower = List.map into_lower_to edges_to in
+    lower, upper
+
+  type edges =
+    { lower : edge_as_lower list;
+      upper : edge_as_upper list
+    }
+
+  let edge_table = ref ([] : (visible_pair * edges) list)
+
+  type boxedhead = H : 'a Desc.Var.Head.t -> boxedhead
+
+  (* Comonadic heads of elided curry modes; edges into them must not be
+     printed. *)
+  let suppressed_curry_heads = ref ([] : boxedhead list)
+
+  let heads_of_mode (m : Alloc.lr) =
+    match Alloc.get_comonadic_desc m.comonadic with
+    | Amode _ -> []
+    | Amodevar (Amorphvar (v, _)) -> [H v]
+
+  let mem_head : boxedhead list -> 'a Desc.Var.Head.t -> bool =
+    fun heads v ->
+      List.exists (fun (H u) -> Desc.Var.Head.equal u v) heads
+
+  let reset_names () =
+    names := [];
+    name_subst := [];
+    name_counter := 0;
+    named_vars := [];
+    visited_for_named_vars := [];
+    visited_for_modes := [];
+    visited_for_named_modevars := [];
+    visible_pairs := [];
+    aliased_visible_pairs := [];
+    printed_aliased_visible_pairs := [];
+    modenames := [];
+    edge_table := [];
+    suppressed_curry_heads := [];
+    Paths.reset visible_paths;
+    VarTbl.reset visible_vars;
+    modename_counter := 0
+
+  let add_visible_edges () =
+    suppressed_curry_heads := [];
+    edge_table :=
+      List.map (fun pair ->
+        let lower, upper =
+          partition_edges_into_bounds
+            ~edges_from:(construct_edges_from pair)
+            ~edges_to:(construct_edges_to pair)
+        in
+        pair, { lower; upper })
+        !visible_pairs
+
+  let find_edges pair =
+    match
+      List.find_opt (fun (pair', _) -> eq_pair pair pair') !edge_table
+    with
+    | Some (_, edges) -> edges
+    | None -> { lower = []; upper = [] }
+
+  let pair_of_mode ({ monadic; comonadic } : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc monadic in
+    let comonadic = Alloc.get_comonadic_desc comonadic in
+    { monadic; comonadic }
+
+  (* The variable heads of the curry accumulator. *)
+  let acc_heads (acc : const_or_generic) : boxedhead list =
+    match acc with
+    | Const _ -> []
+    | Generic (acc, _) ->
+      let head (Desc.Amorphvar (v, _)) = H v in
+      (match Alloc.get_comonadic_desc acc with
+       | Amode _ -> []
+       | Amodevar mv -> [head mv]
+       | Amodejoin (_, mvs) -> List.map head mvs)
+
+  (* See the signature for the specification. *)
+  let curry_edges_implied ~bounds_implied ~(acc : const_or_generic)
+      (m : Alloc.lr) =
+    let pair = pair_of_mode m in
+    let implied =
+      bounds_implied
+      (* an aliased mode is printed at every occurrence *)
+      && (not (List.exists (eq_pair pair) !aliased_visible_pairs))
+      &&
+      let { lower; upper } = find_edges pair in
+      let acc_heads = acc_heads acc in
+      let from_acc = function
+        | Simple_name { src; _ } -> mem_head acc_heads src
+        | Comonadic_name { src; _ } -> mem_head acc_heads src
+      in
+      (* no edges from [m]... *)
+      List.is_empty upper
+      (* ...and every edge into [m] is a [past]/[close] edge from [acc] *)
+      && List.for_all
+           (function
+             | Lower_simple _ -> false
+             | Lower_comonadic { c_name; _ } -> from_acc c_name
+             | Lower_closing_over_to { cls_edge = { name; _ }; _ } ->
+               from_acc name)
+           lower
+    in
+    if implied then
+      suppressed_curry_heads := heads_of_mode m @ !suppressed_curry_heads;
+    implied
+
+  let print_raw_constraints { lo; hi } ppf pair =
+    let { lower = edges_lower; upper = edges_upper } = find_edges pair in
+    let edges_upper =
+      List.filter
+        (function
+          | Upper_comonadic { c_name = Comonadic_name { target; _ }; _ } ->
+            not (mem_head !suppressed_curry_heads target)
+          | Upper_comonadic { c_name = Simple_name _; _ }
+          | Upper_simple _ -> true)
+        edges_upper
+    in
+    if List.is_empty edges_lower && List.is_empty edges_upper
+       && lo = "" && hi = ""
+    then begin
+      let name =
+        construct_name pair
+          { monadic = C.id; comonadic = C.id }
+          pair
+      in
+      Fmt.fprintf ppf "%s" (add_named_modevar name)
+    end
+    else begin
+      let pp_sep sep ppf () =
+        Fmt.fprintf ppf "%s" sep
+      in
+      let pp_bounds pp sep extra ppf items =
+        match items, extra with
+        | [], "" -> ()
+        | [], s -> Fmt.fprintf ppf "%s" s
+        | l, "" ->
+          Fmt.pp_print_list
+            ~pp_sep:(pp_sep sep) pp ppf l
+        | l, s ->
+          Fmt.fprintf ppf "%a%s%s"
+            (Fmt.pp_print_list
+               ~pp_sep:(pp_sep sep) pp)
+            l sep s
+      in
+      let has_upper =
+        not (List.is_empty edges_upper) || hi <> ""
+      in
+      let has_lower =
+        not (List.is_empty edges_lower) || lo <> ""
+      in
+      Fmt.fprintf ppf "[%s%a%s%s%a]"
+        (if has_upper then "< " else "")
+        (pp_bounds print_raw_upper_bound
+           " & " hi)
+        edges_upper
+        (if has_upper && has_lower
+         then " " else "")
+        (if has_lower then "> " else "")
+        (pp_bounds print_raw_lower_bound
+           " | " lo)
+        edges_lower
+    end
+
+  let find_mode_already_printed pair =
+    let find (pair_alias, m) =
+      if eq_pair pair pair_alias then Some m else None
+    in
+    List.find_map find !printed_aliased_visible_pairs
+
+  let mode_print_alias ppf pair =
+    if List.exists (eq_pair pair)
+         !aliased_visible_pairs
+    then begin
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      printed_aliased_visible_pairs :=
+        (pair,m) :: !printed_aliased_visible_pairs;
+      Fmt.fprintf ppf "as %s" m
+    end
+
+  let name_of_mode (modes : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc modes.monadic in
+    let comonadic = Alloc.get_comonadic_desc modes.comonadic in
+    let pair = { monadic; comonadic } in
+    match find_mode_already_printed pair with
+    | Some m -> Fmt.asprintf "%s" m
+    | None ->
+        let bounds = construct_raw_bounds pair in
+        Fmt.asprintf "%a%a"
+          (print_raw_constraints bounds) pair
+          mode_print_alias pair
 
   let substitute ty =
     match List.assq ty !name_subst with
@@ -1143,8 +2371,29 @@ end = struct
 
   let reserve ty =
     normalize_type ty;
-    add_named_vars ty
+    add_named_vars ty;
+    if mode_polymorphism_printing_enabled () then begin
+      let snap = Btype.snapshot () in
+      zap_non_generic_modes ty;
+      add_named_modevars ty;
+      add_visible_paths ();
+      add_visible_edges ();
+      Btype.backtrack snap
+    end
 end
+
+(** Whether the return mode [m] of an arrow can be elided: the arrow is
+    then printed without parens and [m] is not printed. Mutates [m] when it
+    must be zapped (see [equate_with_curry_bounds]). *)
+let equate_with_const : Alloc.lr -> const_or_generic -> bool =
+  fun m acc_mode ->
+    if not (Alloc.check_generic m)
+       || not (mode_polymorphism_printing_enabled ())
+    then equate_with_curry_bounds m acc_mode
+    else
+      Variable_names.curry_edges_implied
+        ~bounds_implied:(equate_with_curry_bounds m acc_mode)
+        ~acc:acc_mode m
 
 module Aliases = struct
   let visited_objects = ref ([] : transient_expr list)
@@ -1206,13 +2455,13 @@ module Aliases = struct
           if List.memq px !visited_objects then add_proxy px else begin
             if should_visit_object ty then
               visited_objects := px :: !visited_objects;
-            printer_iter_type_expr (mark_loops_rec visited) ty
+            printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
           end
       | Tpoly(ty, tyl) ->
           List.iter add tyl;
           mark_loops_rec visited ty
       | _ ->
-          printer_iter_type_expr (mark_loops_rec visited) ty
+          printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
 
   let mark_loops ty =
     mark_loops_rec [] ty
@@ -1322,46 +2571,16 @@ let out_modalities_of_mod_bounds mod_bounds =
   Typemode.untransl_mod_bounds mod_bounds
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let tree_of_modes (modes : Mode.Alloc.Const.t) =
+let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)
   let diff =
-
-    (* [forkable] has implied defaults depending on [areality]: *)
-    let forkable =
-      match modes.areality, modes.forkable with
-      | Local, Unforkable | Global, Forkable -> None
-      | _, _ -> Some modes.forkable
-    in
-
-    (* [yielding] has implied defaults depending on [areality]: *)
-    let yielding =
-      match modes.areality, modes.yielding with
-      | Local, Yielding | Global, Unyielding -> None
-      | _, _ -> Some modes.yielding
-    in
-
-    (* [contention] has implied defaults based on [visibility]: *)
-    let contention =
-      match modes.visibility, modes.contention with
-      | Immutable, Contended
-      | Read, Shared
-      | Write, Corrupted
-      | Read_write, Uncontended -> None
-      | _, _ -> Some modes.contention
-    in
-
-    (* [portability] has implied defaults based on [statefulness]: *)
-    let portability =
-      match modes.statefulness, modes.portability with
-      | Stateless, Portable
-      | Reading, Shareable
-      | Writing, Corruptible
-      | Stateful, Nonportable -> None
-      | _, _ -> Some modes.portability
-    in
-
+    let implied = erase_implied_axes modes in
     let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
-    { diff with forkable; yielding; contention; portability }
+    { diff with
+      forkable = implied.forkable;
+      yielding = implied.yielding;
+      contention = implied.contention;
+      portability = implied.portability }
   in
   (* Step 2: Print the modes *)
   List.filter_map
@@ -1371,11 +2590,19 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
       |> Option.map (Fmt.asprintf "%a" (Mode.Alloc.Const.print_axis ax)))
     Mode.Alloc.Axis.all
 
+let tree_of_modes : Alloc.lr -> const_or_generic -> string list =
+  fun modes acc ->
+    match acc with
+    | Generic _ ->
+      [ (Fmt.asprintf "%s"
+            (Variable_names.name_of_mode modes))]
+    | Const c -> tree_of_modes_const c
+
 (** The modal context on a type when printing it. This is to reproduce the mode
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
   | Arrow_return of
-    { acc : Mode.Alloc.Const.t;
+    { acc : const_or_generic;
       mode : Mode.Alloc.lr; }
     (** This is the RHS (say [r]) of an arrow type, where [mode] is the real
         mode of [r]. and:
@@ -1393,7 +2620,7 @@ type modal =
     If [r] is [Tpoly (Tarrow_, [])], it will be treated as NOT an arrow type.
     This gives tedious (but still correct) printing. *)
 
-  | Other of Mode.Alloc.Const.t
+  | Other of const_or_generic
     (** In other cases, the caller has already printed the modes (as the
         constructor argument) on the type. *)
 
@@ -1412,8 +2639,13 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
+<<<<<<< HEAD
         let mode = Alloc.zap_to_legacy ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
+=======
+        let acc = const_or_generic_of_mode mode in
+        Otyp_ret (Orm_any (tree_of_modes mode acc), tree)
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     | Other _ -> tree
   in
   let ty =
@@ -1426,7 +2658,7 @@ let rec tree_of_modal_typexp mode modal ty =
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
    not_arrow (Otyp_var (non_gen, name)) else
 
-  let pr_typ alloc_mode =
+  let pr_typ acc_mode =
     let tty = Transient_expr.repr ty in
     match tty.desc with
     | Tvar _ ->
@@ -1442,7 +2674,11 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
+<<<<<<< HEAD
         let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
+=======
+        let arg_acc = const_or_generic_of_mode marg in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
         let t1 =
           if is_optional l then
             match
@@ -1450,15 +2686,15 @@ let rec tree_of_modal_typexp mode modal ty =
             with
             | Tconstr(path, [ty], _)
               when Path.same path Predef.path_option ->
-                tree_of_typexp mode arg_mode ty
+                tree_of_acc_typexp mode arg_acc ty
             | _ -> Otyp_stuff "<hidden>"
           else
-            tree_of_typexp mode arg_mode ty1
+            tree_of_acc_typexp mode arg_acc ty1
         in
-        let acc_mode = curry_mode alloc_mode arg_mode in
+        let acc_mode = curry_acc acc_mode marg in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
-        Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
+        Otyp_arrow (lab, tree_of_modes marg arg_acc, t1, t2)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->
@@ -1500,16 +2736,16 @@ let rec tree_of_modal_typexp mode modal ty =
         tree_of_typobject mode fi !nm
     | Tmod (ty, mod_bounds) ->
         Otyp_mod
-          ( tree_of_typexp mode alloc_mode ty,
+          ( tree_of_acc_typexp mode acc_mode ty,
             out_modalities_of_mod_bounds mod_bounds )
     | Tquote ty ->
         wrap_printing_env_unguarded
           (Env.enter_quote !printing_env)
-          (fun () -> Otyp_quote (tree_of_typexp mode alloc_mode ty))
+          (fun () -> Otyp_quote (tree_of_acc_typexp mode acc_mode ty))
     | Tsplice ty ->
         wrap_printing_env_unguarded
           (Env.enter_splice ~loc:Location.none !printing_env)
-          (fun () -> Otyp_splice (tree_of_typexp mode alloc_mode ty))
+          (fun () -> Otyp_splice (tree_of_acc_typexp mode acc_mode ty))
     | Tquote_eval ty ->
         (* We use [Predef]'s [eval] as the syntax, so we need to quote [ty]. *)
         let ty = newgenty (Tquote ty) in
@@ -1530,7 +2766,7 @@ let rec tree_of_modal_typexp mode modal ty =
     | Tlink _ ->
         fatal_error "Out_type.tree_of_typexp"
     | Tpoly (ty, []) | Trepr (ty, []) ->
-        tree_of_typexp mode alloc_mode ty
+        tree_of_acc_typexp mode acc_mode ty
     | Tpoly (ty, tyl) ->
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
@@ -1541,7 +2777,7 @@ let rec tree_of_modal_typexp mode modal ty =
            printed once when used as proxy *)
         List.iter Aliases.add_delayed tyl;
         let tl = tree_of_univars tyl in
-        let tr = Otyp_poly (tl, tree_of_typexp mode alloc_mode ty) in
+        let tr = Otyp_poly (tl, tree_of_acc_typexp mode acc_mode ty) in
         (* Forget names when we leave scope *)
         Variable_names.remove_names tyl;
         Aliases.delayed := old_delayed; tr
@@ -1576,17 +2812,18 @@ let rec tree_of_modal_typexp mode modal ty =
                List.iter Aliases.add_delayed tyl;
                let sort_names = tree_of_qsvs tyl in
                let tr =
-                Otyp_repr (sort_names, tree_of_typexp mode alloc_mode inner_ty)
-              in
+                 Otyp_repr
+                   (sort_names, tree_of_acc_typexp mode acc_mode inner_ty)
+               in
                Variable_names.remove_names tyl;
                Aliases.delayed := old_delayed;
                tr
              end else
                (* Mismatch: print Trepr and Tpoly separately *)
-               tree_of_typexp mode alloc_mode ty
+               tree_of_acc_typexp mode acc_mode ty
          | _ ->
              (* No type variables, just print the body *)
-             tree_of_typexp mode alloc_mode ty)
+             tree_of_acc_typexp mode acc_mode ty)
     | Tunivar _ ->
         Otyp_var (false, Variable_names.(name_of_type new_name) tty)
     | Tpackage pack ->
@@ -1611,19 +2848,23 @@ let rec tree_of_modal_typexp mode modal ty =
        doesn't matter.*)
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
     let tree =
-      Otyp_alias {non_gen;  aliased = pr_typ Mode.Alloc.Const.legacy; alias }
+      Otyp_alias
+        {non_gen; aliased = pr_typ (Const Mode.Alloc.Const.legacy); alias}
     in
     not_arrow tree end
   else
     match modal with
     | Arrow_return {acc; mode} ->
-        let rm, alloc_mode = tree_of_ret_typ_mutating acc mode ty in
-        let ty = pr_typ alloc_mode in
+        let rm, acc_mode = tree_of_ret_typ_mutating acc mode ty in
+        let ty = pr_typ acc_mode in
         Otyp_ret (rm, ty)
-    | Other m -> pr_typ m
+    | Other acc_mode -> pr_typ acc_mode
+
+and tree_of_acc_typexp mode acc_mode ty =
+  tree_of_modal_typexp mode (Other acc_mode) ty
 
 and tree_of_typexp mode alloc_mode ty =
-  tree_of_modal_typexp mode (Other alloc_mode) ty
+  tree_of_acc_typexp mode (Const alloc_mode) ty
 
 and tree_of_qtv v jkind =
     (* CR layouts: We ignore nullability here to avoid needlessly printing
@@ -1698,23 +2939,33 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating acc_mode m ty=
+and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
-      match Alloc.equate (Alloc.of_const acc_mode) m with
-      | Ok () ->
+      if equate_with_const m acc_mode then begin
         (Orm_no_parens, acc_mode)
-      | Error _ ->
+      end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
+<<<<<<< HEAD
         let m = Alloc.zap_to_legacy ~arg:false m in
         (Orm_parens (tree_of_modes m), m)
+=======
+        let acc_mode = const_or_generic_of_mode m in
+        (Orm_parens (tree_of_modes m acc_mode), acc_mode)
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       end
+    end
   | _ ->
+<<<<<<< HEAD
     let m = Alloc.zap_to_legacy ~arg:false m in
     (Orm_any (tree_of_modes m), m)
+=======
+    let acc_mode = const_or_generic_of_mode m in
+    (Orm_any (tree_of_modes m acc_mode), acc_mode)
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -2705,9 +3956,13 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
+<<<<<<< HEAD
       let mres =
         m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
       in
+=======
+      let mres = m_res |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       Omty_alias (tree_of_path (Some Module) p)
@@ -2736,9 +3991,13 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
+<<<<<<< HEAD
       let marg =
         m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
       in
+=======
+      let marg = m_arg |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
@@ -1013,7 +1013,7 @@ let const_or_generic_upper : const_or_generic -> Alloc.Const.t = function
     arrow. *)
 let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
   fun acc marg ->
-    match acc, Alloc.zap_to_legacy marg with
+    match acc, Alloc.zap_to_legacy ~arg:true marg with
     | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
     | Generic (acc, bound), _ ->
       Generic
@@ -1029,13 +1029,14 @@ let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
            Ctype.curry_mode_const acc (Alloc.Guts.get_ceil marg))
       else
         Const
-          (Ctype.curry_mode_const acc (Alloc.zap_to_legacy_force marg))
+          (Ctype.curry_mode_const acc
+             (Alloc.zap_to_legacy_force ~arg:true marg))
 
 (** The view of a mode occurrence [m]; zaps [m] when it has to be a
     constant. *)
-let const_or_generic_of_mode : Alloc.lr -> const_or_generic =
-  fun m ->
-    match Alloc.zap_to_legacy m with
+let const_or_generic_of_mode : arg:bool -> Alloc.lr -> const_or_generic =
+  fun ~arg m ->
+    match Alloc.zap_to_legacy ~arg m with
     | Some c -> Const c
     | None ->
       if mode_polymorphism_printing_enabled ()
@@ -1043,7 +1044,7 @@ let const_or_generic_of_mode : Alloc.lr -> const_or_generic =
         Generic
           (Alloc.Comonadic.disallow_right m.comonadic,
            Alloc.Guts.get_ceil m)
-      else Const (Alloc.zap_to_legacy_force m)
+      else Const (Alloc.zap_to_legacy_force ~arg m)
 
 (** Whether the return mode [m] of an arrow agrees with the constant
     content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
@@ -1394,7 +1395,7 @@ end = struct
       let tty = Transient_expr.repr ty in
       match tty.desc with
       | Tarrow ((_l, marg, mret), ty1, ty2, _) ->
-        zap_non_generic_modes (const_or_generic_of_mode marg) ty1;
+        zap_non_generic_modes (const_or_generic_of_mode ~arg:true marg) ty1;
         let acc_mode = curry_acc acc_mode marg in
         equate_curry acc_mode mret ty2
       | Tpoly (ty, []) | Trepr (ty, []) ->
@@ -1411,7 +1412,7 @@ end = struct
       | Tarrow _ when equate_with_curry_bounds mret acc_mode ->
           zap_non_generic_modes acc_mode ty
       | _ ->
-        zap_non_generic_modes (const_or_generic_of_mode mret) ty
+        zap_non_generic_modes (const_or_generic_of_mode ~arg:false mret) ty
 
   let zap_non_generic_modes ty =
     zap_non_generic_modes (Const Alloc.Const.legacy) ty
@@ -2639,13 +2640,8 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-<<<<<<< HEAD
-        let mode = Alloc.zap_to_legacy ~arg:false mode in
-        Otyp_ret (Orm_any (tree_of_modes mode), tree)
-=======
-        let acc = const_or_generic_of_mode mode in
+        let acc = const_or_generic_of_mode ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode acc), tree)
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
     | Other _ -> tree
   in
   let ty =
@@ -2674,11 +2670,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-<<<<<<< HEAD
-        let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
-=======
-        let arg_acc = const_or_generic_of_mode marg in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+        let arg_acc = const_or_generic_of_mode ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -2949,23 +2941,13 @@ and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
       end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-<<<<<<< HEAD
-        let m = Alloc.zap_to_legacy ~arg:false m in
-        (Orm_parens (tree_of_modes m), m)
-=======
-        let acc_mode = const_or_generic_of_mode m in
+        let acc_mode = const_or_generic_of_mode ~arg:false m in
         (Orm_parens (tree_of_modes m acc_mode), acc_mode)
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       end
     end
   | _ ->
-<<<<<<< HEAD
-    let m = Alloc.zap_to_legacy ~arg:false m in
-    (Orm_any (tree_of_modes m), m)
-=======
-    let acc_mode = const_or_generic_of_mode m in
+    let acc_mode = const_or_generic_of_mode ~arg:false m in
     (Orm_any (tree_of_modes m acc_mode), acc_mode)
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -3956,13 +3938,9 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-<<<<<<< HEAD
       let mres =
-        m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
+        m_res |> Alloc.zap_to_legacy_exn ~arg:false |> tree_of_modes_const
       in
-=======
-      let mres = m_res |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       Omty_alias (tree_of_path (Some Module) p)
@@ -3991,13 +3969,9 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-<<<<<<< HEAD
       let marg =
-        m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
+        m_arg |> Alloc.zap_to_legacy_exn ~arg:true |> tree_of_modes_const
       in
-=======
-      let marg = m_arg |> Alloc.zap_to_legacy_exn |> tree_of_modes_const in
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/external/merlin/upstream/ocaml_flambda/typing/printtyped.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/printtyped.ml
@@ -668,7 +668,7 @@ and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
 
 and yielding_mode i ppf m =
   line i ppf "yielding_mode %s\n"
-    (match Mode.Yielding.zap_to_floor m with
+    (match Mode.Yielding.zap_to_floor_exn m with
      | Mode.Yielding.Const.Unyielding -> "unyielding"
      | Mode.Yielding.Const.Yielding -> "yielding")
 

--- a/external/merlin/upstream/ocaml_flambda/typing/solver.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver.ml
@@ -47,6 +47,15 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             -> ('a, 'c, 'l * 'r) t
         | Id : ('a, 'a, 'l * 'r) t
             (** Short-hand for [Base (H.id, C.id)] to save memory *)
+        | Adjoint_l :
+            ('a, 'b, 'l2 * allowed) t * ('b, 'a, allowed * disallowed) C.morph
+            -> ('b, 'a, 'l * disallowed) t
+            (** [Adjoint_l (h, m)] is the left adjoint of [h], deferred; [m] is
+                the (already computed) left adjoint of [h]'s morphism. *)
+        | Adjoint_r :
+            ('a, 'b, allowed * 'r2) t * ('b, 'a, disallowed * allowed) C.morph
+            -> ('b, 'a, disallowed * 'r) t
+            (** Right-adjoint analogue of [Adjoint_l]. *)
         constraint 'd = _ * _
       [@@ocaml.warning "-62"]
 
@@ -57,6 +66,56 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        fun m1 m2 ->
         match m1, m2 with Id, m -> m | m, Id -> m | _, _ -> Compose (m1, m2)
 
+      include Magic_allow_disallow (struct
+        type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
+
+        let rec allow_left : type l a b r.
+            (a, b, allowed * r) t -> (a, b, l * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.allow_left morph_hint, C.allow_left morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (allow_left a_morph_hint, allow_left b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+
+        let rec allow_right : type a b l r.
+            (a, b, l * allowed) t -> (a, b, l * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.allow_right morph_hint, C.allow_right morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (allow_right a_morph_hint, allow_right b_morph_hint)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+
+        let rec disallow_left : type a b l r.
+            (a, b, l * r) t -> (a, b, disallowed * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.disallow_left morph_hint, C.disallow_left morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (disallow_left a_morph_hint, disallow_left b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+
+        let rec disallow_right : type a b l r.
+            (a, b, l * r) t -> (a, b, l * disallowed) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.disallow_right morph_hint, C.disallow_right morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (disallow_right a_morph_hint, disallow_right b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+      end)
+
       let rec left_adjoint : type a b l.
           H.Pinpoint.t ->
           b C.obj ->
@@ -64,6 +123,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           H.Pinpoint.t * a C.obj * (b, a, allowed * disallowed) t =
        fun pp b_obj -> function
         | Id -> pp, b_obj, Id
+        | Adjoint_r (h, m) -> pp, C.src b_obj m, disallow_right h
         | Base (small_morph_hint, morph) ->
           let pp, small_morph_hint = H.Morph.left_adjoint pp small_morph_hint in
           ( pp,
@@ -85,6 +145,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           H.Pinpoint.t * a C.obj * (b, a, disallowed * allowed) t =
        fun pp b_obj -> function
         | Id -> pp, b_obj, Id
+        | Adjoint_l (h, m) -> pp, C.src b_obj m, disallow_left h
         | Base (small_morph_hint, morph) ->
           let pp, small_morph_hint =
             H.Morph.right_adjoint pp small_morph_hint
@@ -101,50 +162,6 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           in
           src_pp, src, Compose (g_morph_hint_adj, f_morph_hint_adj)
 
-      include Magic_allow_disallow (struct
-        type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
-
-        let rec allow_left : type l a b r.
-            (a, b, allowed * r) t -> (a, b, l * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.allow_left morph_hint, C.allow_left morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (allow_left a_morph_hint, allow_left b_morph_hint)
-
-        let rec allow_right : type a b l r.
-            (a, b, l * allowed) t -> (a, b, l * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.allow_right morph_hint, C.allow_right morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (allow_right a_morph_hint, allow_right b_morph_hint)
-
-        let rec disallow_left : type a b l r.
-            (a, b, l * r) t -> (a, b, disallowed * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.disallow_left morph_hint, C.disallow_left morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (disallow_left a_morph_hint, disallow_left b_morph_hint)
-
-        let rec disallow_right : type a b l r.
-            (a, b, l * r) t -> (a, b, l * disallowed) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.disallow_right morph_hint, C.disallow_right morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (disallow_right a_morph_hint, disallow_right b_morph_hint)
-      end)
-
       let rec populate : type b a l r.
           a C.obj ->
           (b, a, l * r) t ->
@@ -153,6 +170,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        fun obj_a hint cont ->
         match hint with
         | Id -> cont obj_a
+        | Adjoint_l (h, m) ->
+          let obj_b = C.src obj_a m in
+          let _, _, h' = left_adjoint H.Pinpoint.unknown obj_b h in
+          populate obj_a (allow_left h') cont
+        | Adjoint_r (h, m) ->
+          let obj_b = C.src obj_a m in
+          let _, _, h' = right_adjoint H.Pinpoint.unknown obj_b h in
+          populate obj_a (allow_right h') cont
         | Base (morph_hint, morph) ->
           let obj_b = C.src obj_a morph in
           let ahint = cont obj_b in
@@ -585,6 +610,133 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
     | Amodejoin (_, _, mvs) ->
       VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+
+  let check_generic : type a l r. (a, l * r) mode -> bool =
+   fun m ->
+    match m with
+    | Amode _ -> false
+    | Amodevar mv -> check_level_morphvar mv generic_level
+    | Amodemeet (_, _, mvs) ->
+      VarMap.exists (fun _ mv -> check_level_morphvar mv generic_level) mvs
+    | Amodejoin (_, _, mvs) ->
+      VarMap.exists (fun _ mv -> check_level_morphvar mv generic_level) mvs
+
+  type var_iterator =
+    { iter : 'a. 'a C.obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  let mode_iter : type a l r. a C.obj -> (a, l * r) mode -> var_iterator -> unit
+      =
+   fun dst m { iter } ->
+    let iter_morphvar : type l' r'. (a, l' * r') morphvar -> unit =
+     fun (Amorphvar (v, f, _f_hint)) ->
+      let src = C.src dst f in
+      iter src (Amodevar (Amorphvar (v, C.id, Id)))
+    in
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv -> iter_morphvar mv
+    | Amodejoin (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
+    | Amodemeet (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
+
+  type 'b packed_morph =
+    | Packed_morph : ('a, 'b, 'd) C.morph -> 'b packed_morph
+
+  let rec iter_covariant_morphvar : type a r.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, allowed * disallowed) mode ->
+      unit) ->
+      (a, allowed * r) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_right f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          iter ~id:u.id ~level:u.level ~morph:(Packed_morph fg) (Amodevar mu);
+          iter_covariant_morphvar ~visited dst iter mu)
+        v.vlower
+    end
+
+  let iter_covariant : type a r.
+      a C.obj ->
+      (a, allowed * r) mode ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, allowed * disallowed) mode ->
+      unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_covariant_morphvar ~visited dst iter mv
+    | Amodejoin (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter (fun _ mv -> iter_covariant_morphvar ~visited dst iter mv) mvs
+
+  let rec iter_contravariant_morphvar : type a l.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, disallowed * allowed) mode ->
+      unit) ->
+      (a, l * allowed) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_left f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          iter ~id:u.id ~level:u.level ~morph:(Packed_morph fg) (Amodevar mu);
+          iter_contravariant_morphvar ~visited dst iter mu)
+        v.vupper
+    end
+
+  let iter_contravariant : type a l.
+      a C.obj ->
+      (a, l * allowed) mode ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, disallowed * allowed) mode ->
+      unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_contravariant_morphvar ~visited dst iter mv
+    | Amodemeet (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter
+        (fun _ mv -> iter_contravariant_morphvar ~visited dst iter mv)
+        mvs
 
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
@@ -1148,7 +1300,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       unit =
    fun ~log pp dst v u f f_hint ->
     let f' = C.left_adjoint dst f in
-    let _, src, f'_hint = Comp_hint.Morph_hint.left_adjoint pp dst f_hint in
+    let src = C.src dst f in
+    let f'_hint = Comp_hint.Morph_hint.Adjoint_l (f_hint, f') in
     let x = Amorphvar (u, f', f'_hint) in
     let key = get_key src x in
     if VarMap.mem key v.vlower
@@ -1188,7 +1341,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       unit =
    fun ~log pp dst v u f f_hint ->
     let f' = C.right_adjoint dst f in
-    let _, src, f'_hint = Comp_hint.Morph_hint.right_adjoint pp dst f_hint in
+    let src = C.src dst f in
+    let f'_hint = Comp_hint.Morph_hint.Adjoint_r (f_hint, f') in
     let x = Amorphvar (u, f', f'_hint) in
     let key = get_key src x in
     if VarMap.mem key v.vupper
@@ -1266,9 +1420,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     decr persistent_id;
     id
 
-  let fresh ?(persistent = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower
-      ?vupper ~level obj =
-    let id = if persistent then next_persistent_id () else next_live_id () in
+  let fresh ?(neg = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper
+      ~level obj =
+    let id = if neg then next_persistent_id () else next_live_id () in
     let upper, upper_hint =
       match upper, upper_hint with
       | None, None -> C.max obj, Comp_hint.Max
@@ -1332,7 +1486,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     current_level < u.level < generic_level ==>
       Forall v in the reachable set of variables from u:
         v.level = generic_level + (v.level - current_level) *)
-  let rec generalize_topology : type a.
+  let rec generalize_topology_v : type a.
       log:_ -> current_level:int -> a var -> unit =
    fun ~log ~current_level u ->
     if u.level <= current_level || u.level >= generic_level
@@ -1341,7 +1495,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let new_level = generic_level + (u.level - current_level) in
       set_level ~log u new_level;
       let do_gen _ (Amorphvar (v, _f, _f_hint)) =
-        generalize_topology ~log ~current_level v
+        generalize_topology_v ~log ~current_level v
       in
       VarMap.iter do_gen u.vupper;
       VarMap.iter do_gen u.vlower
@@ -1375,7 +1529,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    generalize_topology ~log ~current_level u;
+    generalize_topology_v ~log ~current_level u;
     update_level_v ~log dst generic_level u
 
   (* generalize_structure first moves a variable to generic_level (like generalize does).
@@ -1408,8 +1562,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
    fun ~log dst ~current_level u ->
     (* if the following does not hold:
         current_level < u.level || u.level = generic_level
-      [generalize_topology] and [update_level] do nothing. We check it here to optimize
-      away the subsequent checks *)
+      [generalize_topology_v] and [update_level] do nothing. We check it here
+      to optimize away the subsequent checks *)
     if u.level <= current_level || u.level = generic_level
     then ()
     else begin
@@ -1419,7 +1573,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         set_vlower ~log u VarMap.empty;
         set_vupper ~log u VarMap.empty
       end;
-      generalize_topology ~log ~current_level u;
+      generalize_topology_v ~log ~current_level u;
       update_level_v ~log dst generic_level u;
       let vlower_above_current =
         VarMap.filter
@@ -1446,6 +1600,23 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         create_gencopy ~log dst ~current_level u
       end
     end
+
+  let generalize_topology (type a l r) ~current_level (a : (a, l * r) mode) ~log
+      =
+    match a with
+    | Amodevar (Amorphvar (v, _f, _f_hint)) ->
+      generalize_topology_v ~log ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, _f, _f_hint)) ->
+          generalize_topology_v ~log ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, _f, _f_hint)) ->
+          generalize_topology_v ~log ~current_level v)
+        mvs
 
   let generalize (type a l r) ~current_level (obj : a C.obj)
       (a : (a, l * r) mode) ~log =
@@ -1515,13 +1686,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       copy_from_level:int ->
       copy_below_level:int ->
       copy_to_level:int option ->
-      persistent:bool ->
+      cause:[`Save | `Restore | `Neither] ->
       a C.obj ->
       a var ->
       a var =
-   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~persistent
-       obj v ->
+   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~cause obj
+       v ->
     let in_window = v.level >= copy_from_level && v.level < copy_below_level in
+    if cause = `Restore then assert (v.id < 0);
     if not in_window
     then v
     else
@@ -1536,7 +1708,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         | Some v' -> v'
         | None ->
           let copy =
-            fresh ~persistent ~upper:v.upper ~lower:v.lower ~level:v.level obj
+            fresh ~neg:(cause = `Save) ~upper:v.upper ~lower:v.lower
+              ~level:v.level obj
           in
           set_optcopy ~changes:copy_scope obj ~target_level v (Some copy);
           let vupper =
@@ -1545,7 +1718,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                    ~copy_to_level ~persistent src u
+                    ~copy_to_level ~cause src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1557,7 +1730,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                    ~copy_to_level ~persistent src u
+                    ~copy_to_level ~cause src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1570,8 +1743,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       end
 
   let copy (type a l r) ~copy_scope ~copy_from_level ~copy_below_level
-      ?copy_to_level ?(persistent = false) (obj : a C.obj) (a : (a, l * r) mode)
-      : (a, l * r) mode =
+      ?copy_to_level ?(cause = `Neither) (obj : a C.obj) (a : (a, l * r) mode) :
+      (a, l * r) mode =
     (* We never want to copy variables above [generic_level]. *)
     assert (copy_below_level <= generic_level + 1);
     Option.iter
@@ -1587,7 +1760,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let obj = C.src obj f in
       let vcopy =
         copy_v ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level
-          ~persistent obj v
+          ~cause obj v
       in
       if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
     | Amode _ -> a
@@ -1598,7 +1771,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             let src = C.src obj f in
             let vcopy =
               copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                ~copy_to_level ~persistent src v
+                ~copy_to_level ~cause src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)
@@ -1612,7 +1785,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             let src = C.src obj f in
             let vcopy =
               copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                ~copy_to_level ~persistent src v
+                ~copy_to_level ~cause src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)
@@ -2104,5 +2277,127 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
           mvs;
         allow_left (Amodevar mu), true
+
+  (** Exposed description of mode variables, used for printing generic mode
+      variables *)
+  module Desc = struct
+    module Var = struct
+      type 'a t = 'a var
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+      module Head = struct
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        let equal v1 v2 = v1.desc_id = v2.desc_id
+
+        let hash v = Hashtbl.hash v.desc_id
+      end
+
+      let force : 'a C.obj -> 'a var -> 'a Head.t =
+       fun obj v ->
+        let desc_id = v.id in
+        let desc_lower =
+          get_floor obj
+            (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        let desc_upper =
+          get_ceil obj (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        (* let desc_lower = v.lower in
+          let desc_upper = v.upper in *)
+        let desc_vlower =
+          let f (Amorphvar (a, f, _) : _ morphvar) = Amorphvar (a, f) in
+          let vlower = VarMap.map f v.vlower in
+          var_map_to_list vlower
+        in
+        let desc_level = v.level in
+        { desc_id; desc_lower; desc_upper; desc_vlower; desc_level }
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    let equal_morphvar : type a l r.
+        a C.obj -> (a, l * r) morphvar -> (a, l * r) morphvar -> bool =
+     fun obj (Amorphvar (v1, m1)) (Amorphvar (v2, m2)) ->
+      let c = C.compare_morph obj m1 m2 in
+      c = 0 && Var.Head.equal v1 v2
+
+    let equal : type a l r. a C.obj -> (a, l * r) t -> (a, l * r) t -> bool =
+     fun obj m1 m2 ->
+      match m1, m2 with
+      | Amode a1, Amode a2 -> C.equal obj a1 a2
+      | Amodevar mv1, Amodevar mv2 -> equal_morphvar obj mv1 mv2
+      | Amodejoin (a1, mv1), Amodejoin (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | Amodemeet (a1, mv1), Amodemeet (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | _, _ -> false
+
+    let print_var : type a. a C.obj -> Fmt.formatter -> a Var.Head.t -> unit =
+     fun obj ppf { desc_id; desc_upper; desc_lower; desc_level } ->
+      Fmt.fprintf ppf "%x<%d>[%a--%a]" desc_id desc_level (C.print obj)
+        desc_lower (C.print obj) desc_upper
+
+    let print_morphvar : type a l r.
+        a C.obj -> Fmt.formatter -> (a, l * r) morphvar -> unit =
+     fun dst ppf mv ->
+      let (Amorphvar (v, f)) = mv in
+      let src = C.src dst f in
+      Fmt.fprintf ppf "%a(%a)" (C.print_morph dst) f (print_var src) v
+
+    let print : type a l r. a C.obj -> Fmt.formatter -> (a, l * r) t -> unit =
+     fun obj ppf m ->
+      match m with
+      | Amode a -> C.print obj ppf a
+      | Amodevar mv -> print_morphvar obj ppf mv
+      | Amodejoin (a, mvs) ->
+        Fmt.fprintf ppf "join(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+      | Amodemeet (a, mvs) ->
+        Fmt.fprintf ppf "meet(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+  end
+
+  let desc_morphvar : type a l r.
+      a C.obj -> (a, l * r) morphvar -> (a, l * r) Desc.morphvar =
+   fun dst (Amorphvar (v, f, _)) ->
+    let src = C.src dst f in
+    let v = Desc.Var.force src v in
+    Desc.Amorphvar (v, f)
+
+  let desc : type a l r. a C.obj -> (a, l * r) mode -> (a, l * r) Desc.t =
+   fun dst m ->
+    match m with
+    | Amode (a, _, _) -> Desc.Amode a
+    | Amodevar mv -> Desc.Amodevar (desc_morphvar dst mv)
+    | Amodejoin (a, _, mvs) ->
+      Desc.Amodejoin (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
+    | Amodemeet (a, _, mvs) ->
+      Desc.Amodemeet (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
 end
 [@@inline always]

--- a/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
@@ -306,6 +306,13 @@ module type Solver_mono = sig
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
 
+  (** Moves a variable [u] whose level is above [current_level] and below
+      [generic_level] to [generic_level + i], where [i] is the difference
+      between [u.level] and [current_level] (the same is then done to all of
+      [u]'s children) *)
+  val generalize_topology :
+    current_level:int -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
   (** Generalizes a variable whose level is above [current_level], by putting
       its level to [generic_level], and all its children above [current_level]
       to [generic_level + i] for some nonzero [i]. *)
@@ -344,7 +351,7 @@ module type Solver_mono = sig
     copy_from_level:int ->
     copy_below_level:int ->
     ?copy_to_level:int ->
-    ?persistent:bool ->
+    ?cause:[`Save | `Restore | `Neither] ->
     'a obj ->
     ('a, 'l * 'r) mode ->
     ('a, 'l * 'r) mode
@@ -392,6 +399,47 @@ module type Solver_mono = sig
 
   (** Returns true if the mode is a constant or a mode variable at level 0 *)
   val check_const_or_level_0 : ('a, 'l * 'r) mode -> bool
+
+  (** Returns true if the mode includes a mode variable at generic level *)
+  val check_generic : ('a, 'l * 'r) mode -> bool
+
+  type var_iterator =
+    { iter : 'a. 'a obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  val mode_iter : 'a obj -> ('a, 'l * 'r) mode -> var_iterator -> unit
+
+  type 'b packed_morph = Packed_morph : ('a, 'b, 'd) morph -> 'b packed_morph
+
+  (** Applies an iterator over every reachable covariant (left-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_covariant :
+    'a obj ->
+    ('a, allowed * 'r) mode ->
+    (id:int ->
+    level:int ->
+    morph:'a packed_morph ->
+    ('a, allowed * disallowed) mode ->
+    unit) ->
+    unit
+
+  (** Applies an iterator over every reachable contravariant (right-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_contravariant :
+    'a obj ->
+    ('a, 'l * allowed) mode ->
+    (id:int ->
+    level:int ->
+    morph:'a packed_morph ->
+    ('a, disallowed * allowed) mode ->
+    unit) ->
+    unit
 
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
@@ -459,6 +507,52 @@ module type Solver_mono = sig
     val apply :
       'b obj -> ('a, 'b, 'l * 'r) morph -> ('a, 'l * 'r) t -> ('b, 'l * 'r) t
   end
+
+  (** The exposed description of modes *)
+  module Desc : sig
+    module Var : sig
+      type 'a t
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) morph -> ('b, 'd) t_with_morph
+
+      module Head : sig
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        val equal : 'a t -> 'b t -> bool
+
+        val hash : 'a t -> int
+      end
+
+      val force : 'a obj -> 'a t -> 'a Head.t
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    val equal : 'a obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+    val print : 'a obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+  end
+
+  (** Returns the description of a mode. *)
+  val desc : 'a obj -> ('a, 'd) mode -> ('a, 'd) Desc.t
 end
 
 (** Hint module to be provided by the user of the solver. *)

--- a/external/merlin/upstream/ocaml_flambda/typing/subst.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/subst.ml
@@ -40,7 +40,7 @@ type kind_replacement =
 type additional_action =
   | Prepare_for_saving of
       { prepare_jkind : 'l 'r. Location.t -> ('l * 'r) jkind -> ('l * 'r) jkind;
-        prepare_mode : Mode.Alloc.lr -> Mode.Alloc.lr;
+        prepare_mode : For_copy.copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr;
         prepare_modality : Mode.Modality.t -> Mode.Modality.t;
         prepare_ident : Ident.t -> Ident.t
       }
@@ -302,8 +302,11 @@ let with_additional_action =
         in
         (* CR-someday zqian: preserve the hints *)
         (* modes and modalities should have been zapped already *)
-        let prepare_mode mode =
-          Mode.Alloc.(mode |> to_const_exn |> of_const)
+        (* if a mode is generic we copy it persistently for saving *)
+        let prepare_mode copy_scope mode =
+          if Mode.Alloc.check_generic mode
+          then For_copy.mode_copy_for_saving copy_scope mode
+          else Mode.Alloc.(mode |> to_const_exn |> of_const)
         in
         let prepare_modality modality =
           Mode.Modality.(modality |> to_const_exn|> of_const)
@@ -440,6 +443,7 @@ let to_subst_by_type_function s p =
 let new_type_id = s_ref (-1)
 let reset_additional_action_id () =
   new_type_id := -1;
+  Mode.reset_persistent_id ();
   Jkind_types.Sort.reset_cmi_sort_id ()
 
 let newpersty desc =
@@ -515,7 +519,8 @@ let apply_type_function params args body =
           let t = newgenstub ~scope:(get_scope ty)
             (Jkind.Builtin.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
-          let desc' = copy_type_desc copy desc in
+          let copy_mode m = For_copy.mode_copy_generic copy_scope m in
+          let desc' = copy_type_desc copy copy_mode desc in
           Transient_expr.set_stub_desc t desc';
           t
     in
@@ -760,9 +765,17 @@ let rec typexp copy_scope s ty =
           Tlink (typexp copy_scope s t2)
       | Tarrow ((label, marg, mret), arg, ret, comm) ->
           let marg, mret =
+            if get_id ty < 0 then
+              For_copy.mode_copy_for_restoring copy_scope marg,
+              For_copy.mode_copy_for_restoring copy_scope mret
+            else
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              prepare_mode marg, prepare_mode mret
+              prepare_mode copy_scope marg,
+              prepare_mode copy_scope mret
+            | Duplicate_variables ->
+              For_copy.mode_copy_generic copy_scope marg,
+              For_copy.mode_copy_generic copy_scope mret
             | _ -> marg, mret
           in
           let arg = typexp copy_scope s arg in
@@ -772,7 +785,8 @@ let rec typexp copy_scope s ty =
       | Tof_kind jk -> Tof_kind (jkind copy_scope s jk)
       | Tmod (ty, mod_bounds) ->
           Tmod (typexp copy_scope s ty, mod_bounds)
-      | _ -> copy_type_desc (typexp copy_scope s) desc
+      | _ ->
+        copy_type_desc (typexp copy_scope s) (fun _ -> assert false) desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'
@@ -811,7 +825,8 @@ let jkind copy_scope s loc jk =
 *)
 let type_expr s ty =
   let loc = Option.value s.loc ~default:Location.none in
-  For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)
+  For_copy.with_scope (fun copy_scope ->
+    typexp copy_scope s loc ty)
 
 (* For idents that are guaranteed to be local/scoped, such as bound
    signature items and functor parameters. *)

--- a/external/merlin/upstream/ocaml_flambda/typing/typeclass.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typeclass.ml
@@ -688,6 +688,8 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
         (fun () ->
            let cty =
              Ctype.with_local_level_generalize_structure_if_principal
+               ~before_generalize:(fun cty ->
+                 Ctype.generalize_structure cty.ctyp_type)
                (fun () -> Typetexp.transl_simple_type ~new_var_jkind:Any val_env
                             ~closed:false Alloc.Const.legacy styp)
            in
@@ -736,6 +738,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
            end;
            let definition =
              Ctype.with_local_level_generalize_structure_if_principal
+               ~before_generalize:Typecore.generalize_structure_exp
                (fun () -> Typecore.type_exp val_env sdefinition)
            in
            begin
@@ -1245,6 +1248,10 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
         raise(Error(spat.ppat_loc, val_env, Polymorphic_class_parameter));
       let (pat, pv, val_env', met_env) =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:begin fun (pat, _, _, _) ->
+            let gen {pat_type = ty} = Ctype.generalize_structure ty in
+            iter_pattern gen pat
+          end
           (fun () ->
             Typecore.type_class_arg_pattern cl_num val_env met_env l spat)
       in
@@ -1310,6 +1317,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       assert (sargs <> []);
       let cl =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun cl ->
+            Ctype.generalize_class_type_structure cl.cl_type)
           (fun () -> class_expr cl_num val_env met_env virt self_scope scl')
       in
       let rec nonopt_labels ls ty_fun =
@@ -1672,6 +1681,7 @@ let initial_env define_class approx
   (* Temporary type for the class constructor *)
   let constr_type =
     Ctype.with_local_level_generalize_structure_if_principal
+      ~before_generalize:Ctype.generalize_structure
       (fun () -> approx cl.pci_expr)
   in
   let dummy_cty = Cty_signature (Ctype.new_class_signature ()) in
@@ -1932,8 +1942,8 @@ let final_decl env define_class
                  , Non_generalizable_class { id; clty; nongen_vars }));
     );
   begin match
-    Ctype.closed_class clty.cty_params
-      (Btype.signature_of_class_type clty.cty_type)
+    Alloc.with_zap_scope (fun ~zap_scope -> Ctype.closed_class ~zap_scope
+      clty.cty_params (Btype.signature_of_class_type clty.cty_type))
   with
     None        -> ()
   | Some reason ->

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -307,6 +307,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -479,6 +480,12 @@ type expected_mode =
 
         Each location points to the corresponding sub-pattern of [Ppat_tuple].
     *)
+
+    return_from_exclave : bool ref option;
+    (** Indicates whether the expected mode is for an exclave expression in tail
+        position. The field is a bool ref so that it is preserved across all
+        copies.
+    *)
   }
 
 type position_and_mode = {
@@ -487,11 +494,13 @@ type position_and_mode = {
   region_mode : Regionality.r option;
   (** INVARIANT: [Some m] iff [apply_position] is [Tail], where [m] is the mode
      of the surrounding region *)
+  return_from_exclave : bool ref option;
 }
 
 let position_and_mode_default = {
   apply_position = Default;
   region_mode = None;
+  return_from_exclave = None;
 }
 
 (** Decides the runtime tail call behaviour based on lexical structures and user
@@ -510,14 +519,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   | RTail (m ,FTail) -> begin
       match requested with
       | Some `Tail | Some `Tail_if_possible | None ->
-          {apply_position = Tail; region_mode = Some m}
-      | Some `Nontail -> {apply_position = Nontail; region_mode = None}
+          { apply_position = Tail;
+            region_mode = Some m;
+            return_from_exclave = expected_mode.return_from_exclave }
+      | Some `Nontail ->
+          { apply_position = Nontail;
+            region_mode = None;
+            return_from_exclave = None }
     end
   | RNontail | RTail(_, FNontail) -> begin
       match requested with
       | None | Some `Tail_if_possible ->
-          {apply_position = Default; region_mode = None}
-      | Some `Nontail -> {apply_position = Nontail; region_mode = None}
+          { apply_position = Default;
+            region_mode = None;
+            return_from_exclave = None }
+      | Some `Nontail ->
+          { apply_position = Nontail;
+            region_mode = None;
+            return_from_exclave = None }
       | Some `Tail -> fail `Not_a_tailcall
   end
 
@@ -552,7 +571,8 @@ let mode_default mode =
   { position = RNontail;
     mode = Value.disallow_left mode;
     strictly_local = false;
-    tuple_modes = None }
+    tuple_modes = None;
+    return_from_exclave = None }
 
 let mode_legacy = mode_default Value.legacy
 
@@ -656,7 +676,7 @@ let mode_max_with_position position =
 
 (** Take the expected mode of [exclave_ exp], return the expected mode of [exp].
     [expected_mode] must be higher than [regional]. *)
-let mode_exclave expected_mode =
+let mode_exclave (expected_mode : expected_mode) =
   let mode =
      as_single_mode expected_mode
      (* if we expect an exclave to be [regional], then inside the exclave the
@@ -664,14 +684,23 @@ let mode_exclave expected_mode =
      |> value_to_alloc_r2l
      |> alloc_as_value
   in
+  Option.iter (fun excl -> excl := true) expected_mode.return_from_exclave;
   { (mode_default mode)
-    with strictly_local = true
+    with strictly_local = true;
+         return_from_exclave = expected_mode.return_from_exclave
   }
 
 let mode_strictly_local expected_mode =
   { expected_mode
     with strictly_local = true
   }
+
+let mode_return_from_exclave (expected_mode : expected_mode) =
+  match expected_mode.return_from_exclave with
+  | Some r -> r, expected_mode
+  | None ->
+    let r = ref false in
+    r, { expected_mode with return_from_exclave = Some r }
 
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
@@ -742,7 +771,10 @@ tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
 let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
-  let vmode , _ = Value.newvar_below (alloc_as_value marg) in
+  let vmode , _ =
+    Value.newvar_below
+      (Ctype.get_current_level ()) (alloc_as_value marg)
+  in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
   | Texp_ident { desc = {val_kind =
@@ -750,7 +782,9 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
                 kind = Id_prim _; _ }, 1, Tail ->
      (* RHS of (&&) and (||) is at the tail of function region if the
         application is. The argument mode is not constrained otherwise. *)
-     mode_with_position vmode (RTail (Option.get position_and_mode.region_mode, FTail)),
+     { (mode_with_position vmode
+          (RTail (Option.get position_and_mode.region_mode, FTail)))
+       with return_from_exclave = position_and_mode.return_from_exclave },
      vmode
   | Texp_ident { kind = Id_prim _; _ }, _, _ ->
      (* Other primitives cannot be tail-called *)
@@ -828,11 +862,40 @@ let reset_allocations () = allocations := []
 let register_allocation_mode alloc_mode =
   allocations := alloc_mode :: !allocations
 
+let newvar_below_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Alpha)
+  then fst (Locality.newvar_below level m)
+  else m
+
+let newvar_above_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Alpha)
+  then fst (Locality.newvar_above level m)
+  else m
+
+let create_allocation_mode_l mode =
+  Alloc.proj_comonadic Areality mode
+  |> newvar_above_if_modepoly 0
+  |> Locality.disallow_right
+
+let create_function_return_mode
+    ~return_from_exclave ret_mode : return_mode =
+  let ret_mode =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha) then
+      if return_from_exclave
+      then Locality.disallow_right Locality.local
+      else Locality.disallow_right Locality.global
+    else create_allocation_mode_l ret_mode
+  in
+  Typedtree.create_return_mode ret_mode
+
+let create_allocation_mode_r mode =
+  Alloc.proj_comonadic Areality mode
+  |> newvar_below_if_modepoly 0
+  |> Locality.disallow_left
+
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode =
-    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
-  in
+  let alloc_mode = create_allocation_mode_r (value_to_alloc_r2g mode) in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -852,9 +915,11 @@ let register_closure_allocation (mode : Value.r) ~loc
   : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
   let (mode : Alloc.lr), _ =
-    Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
+    Alloc.newvar_below (Ctype.get_current_level ())
+      (value_to_alloc_r2g ~allocation mode)
   in
-  let alloc_mode = Alloc.proj_comonadic Areality mode in
+  let locality_mode = Alloc.proj_comonadic Areality mode in
+  let alloc_mode, _ = Locality.newvar_below 0 locality_mode in
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
@@ -879,7 +944,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil mode
+      Locality.zap_to_ceil_exn mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -1259,8 +1324,8 @@ let check_dynamic pp hint expected_mode =
 (** Take [m0] which is the parameter to mutable, and the mode of the RHS (the
     content expression), returns the strongest mode the mutable variable can be.
 *)
-let mutvar_mode ~loc ~env m0 exp_mode =
-  let m = Value.newvar () in
+let mutvar_mode ~loc ~env level m0 exp_mode =
+  let m = Value.newvar level in
   let mode = mode_default m in
   let modalities = Typemode.let_mutable_modalities in
   submode ~loc ~env exp_mode (mode_modality modalities mode);
@@ -1863,7 +1928,9 @@ and build_as_type_and_mode_extra env p ~mode : _ -> _ * _ = function
          If we used [generic_instance] we would lose the sharing between
          [instance ty] and [ty].  *)
       let ty =
-        with_local_level_generalize_structure (fun () -> instance ty)
+        with_local_level_generalize_structure
+          ~before_generalize:generalize_structure
+          (fun () -> instance ty)
       in
       (* This call to unify may only fail due to missing GADT equations *)
       unify_pat_types p.pat_loc env (instance as_ty) (instance ty);
@@ -1915,7 +1982,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
       let priv = (cstr.cstr_private = Private) in
       let mode =
         if priv || pl <> [] then mode
-        else Value.newvar ()
+        else Value.newvar (get_current_level ())
       in
       let keep =
         priv ||
@@ -1936,7 +2003,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
   | Tpat_variant(l, p', _) ->
       let ty = Option.map (build_as_type env) p' in
       let mode =
-        if p' = None then Value.newvar ()
+        if p' = None then Value.newvar (get_current_level ())
         else mode
       in
       let ty =
@@ -1965,7 +2032,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
               fields
           in
           let mode =
-            if all_constant then Value.newvar ()
+            if all_constant then Value.newvar (get_current_level ())
             else mode
           in
           let ty =
@@ -2172,6 +2239,7 @@ let solve_constructor_annotation
   (* Translate the type annotation using these type names. *)
   let cty, ty, force =
     with_local_level_generalize_structure
+      ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
       (fun () ->
          Typetexp.transl_simple_type_delayed !!penv Alloc.Const.legacy sty)
   in
@@ -2296,16 +2364,22 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
       ~expected:expected_ty
   in
 
-  let ty_args, equated_types, existential_ctyp =
-    with_local_level_generalize_structure begin fun () ->
+  let (ty_args, equated_types, existential_ctyp), _ =
+    with_local_level_generalize_structure
+      ~before_generalize:(fun (_, tys) ->
+        List.iter generalize_structure tys)
+      begin fun () ->
       let expected_ty = instance expected_ty in
-      let ty_args, ty_res, equated_types, existential_ctyp =
+      let ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp =
         match existential_styp with
           None ->
             let ty_args, ty_res, _ =
               instance_constructor (Make_existentials_abstract penv) constr
             in
-            ty_args, ty_res, unify_res ty_res expected_ty, None
+            let ty_args_ty =
+              List.map (fun ca -> ca.Types.ca_type) ty_args
+            in
+            ty_args, ty_args_ty, ty_res, unify_res ty_res expected_ty, None
         | Some (name_list, sty) ->
             let existential_treatment =
               if name_list = [] then
@@ -2328,11 +2402,13 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
               List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args
                 ty_args_ty
             in
-            ty_args, ty_res, Lazy.force equated_types, existential_ctyp
+            ty_args, ty_args_ty, ty_res,
+            Lazy.force equated_types, existential_ctyp
       in
       if constr.cstr_existentials <> [] then
         lower_variables_only !!penv penv.Pattern_env.equations_scope ty_res;
-      (ty_args, equated_types, existential_ctyp)
+      (ty_args, equated_types, existential_ctyp),
+      expected_ty :: ty_res :: ty_args_ty
     end
   in
   if !Clflags.principal && not penv.in_counterexample then begin
@@ -2359,7 +2435,9 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
 
 let solve_Ppat_record_field loc penv label label_lid record_ty
       record_form =
-  with_local_level_generalize_structure begin fun () ->
+  with_local_level_generalize_structure
+    ~before_generalize:(fun (_, tys) -> List.iter generalize_structure tys)
+    begin fun () ->
     let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
     begin try
       unify_pat_types_penv loc penv ty_res (instance record_ty)
@@ -2367,8 +2445,9 @@ let solve_Ppat_record_field loc penv label label_lid record_ty
       raise(Error(label_lid.loc, !!penv,
                   Label_mismatch(P record_form, label_lid.txt, err)))
     end;
-    ty_arg
+    ty_arg, [ty_res; ty_arg]
   end
+  |> fst
 
 let solve_Ppat_array loc env (mutability : mutable_flag) expected_ty
   : _ * _ * mutable_flag =
@@ -2405,6 +2484,7 @@ let solve_Ppat_lazy loc env expected_ty =
 let solve_Ppat_constraint tps loc env mode sty expected_ty =
   let cty, ty, force =
     with_local_level_generalize_structure
+      ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
       (fun () -> Typetexp.transl_simple_type_delayed env mode sty)
   in
   tps.tps_pattern_force <- force :: tps.tps_pattern_force;
@@ -3533,8 +3613,11 @@ and type_pat_aux
         match mutable_flag with
         | Immutable -> alloc_mode, Val_reg sort
         | Mutable ->
-            let m0 = Value.Comonadic.newvar () in
-            let mode = mutvar_mode ~loc ~env:!!penv m0 alloc_mode in
+            let m0 = Value.Comonadic.newvar (Ctype.get_current_level ()) in
+            let mode =
+              mutvar_mode ~loc ~env:!!penv
+                (Ctype.get_current_level ()) m0 alloc_mode
+            in
             let kind = Val_mut (m0, sort) in
             mode, kind
       in
@@ -4097,7 +4180,10 @@ let type_pattern_list
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   let pvs, pat =
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:(fun (pvs, _) ->
+        iter_pattern_variables_type generalize_structure pvs)
+      begin fun () ->
       let tps = create_type_pat_state Modules_rejected in
       let nv = newvar (Jkind.Builtin.value ~why:Class_term_argument) in
       let alloc_mode = simple_pat_mode Value.legacy in
@@ -4879,7 +4965,8 @@ let remaining_function_type_for_error ty_ret mode_ret rev_args =
                  (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
              in
              let mode_ret, _ =
-               Alloc.newvar_above (Alloc.join (mode_fun :: closed_args))
+               Alloc.newvar_above (Ctype.get_current_level ())
+               (Alloc.join (mode_fun :: closed_args))
              in
              (ty_ret, mode_ret, closed_args))
       (ty_ret, mode_ret, []) rev_args
@@ -4933,8 +5020,8 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
               then
                 Location.prerr_warning sarg.pexp_loc
                   Warnings.Ignored_extra_argument;
-              let mode_arg = Alloc.newvar () in
-              let mode_ret = Alloc.newvar () in
+              let mode_arg = Alloc.newvar (get_current_level ()) in
+              let mode_ret = Alloc.newvar (get_current_level ()) in
               let kind = (lbl, mode_arg, mode_ret) in
               begin try
                 unify env ty_fun
@@ -5132,7 +5219,18 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let args = (lbl, Arg (exp, sort), sch) :: args in
              (ty_ret, mode_ret, open_args, closed_args, args)
          | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg } ->
-             let arrow_desc = (lbl, mode_arg, mode_ret) in
+             (* Under mode polymorphism we define a new return mode above
+                mode_ret and a new level-0 allocation mode for mode_ret
+                (to know whether then function needs a region to allocate
+                the return value):
+                [mode_ret] < [mode_ret_alloc] < [mode_ret_eta] *)
+             let mode_ret_eta =
+               if Language_extension.(is_at_least Mode_polymorphism Alpha)
+               then
+                fst (Alloc.newvar_above (Ctype.get_current_level ()) mode_ret)
+               else mode_ret
+             in
+             let arrow_desc = (lbl, mode_arg, mode_ret_eta) in
              let sort_ret =
                match type_sort ~why:Function_result ~fixed:false env ty_ret with
                | Ok sort -> sort
@@ -5156,22 +5254,31 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
              let mode_cls, _ =
-               Alloc.newvar_above (Alloc.join
+               Alloc.newvar_above (Ctype.get_current_level ()) (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
-               Alloc.disallow_left mode_cls
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_r mode_cls
              in
              let mode_arg =
-               Alloc.disallow_right mode_arg
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_l mode_arg
                |> Typedtree.create_alloc_mode_l
              in
+             (* [mode_ret] < [mode_ret_alloc] < [mode_ret_eta]*)
+             let mode_ret_alloc =
+              if Language_extension.(is_at_least Mode_polymorphism Alpha)
+              then begin
+                let m = Locality.newvar 0 in
+                Locality.submode_exn
+                  (Alloc.proj_comonadic Areality mode_ret) m;
+                Locality.submode_exn
+                  m (Alloc.proj_comonadic Areality mode_ret_eta);
+                m
+              end else Alloc.proj_comonadic Areality mode_ret
+            in
              let mode_ret =
-               Alloc.disallow_right mode_ret
-               |> Alloc.proj_comonadic Areality
-               |> Typedtree.create_return_mode
+              Typedtree.create_return_mode
+                (Locality.disallow_right mode_ret_alloc)
              in
              register_allocation_mode mode_closure;
              let arg =
@@ -5577,7 +5684,7 @@ let rec approx_type env sty =
         in
         let ret = approx_type env sty in
         let marg = Alloc.of_const arg_mode.mode_modes in
-        let mret = Alloc.newvar () in
+        let mret = Alloc.newvar (get_current_level ()) in
         newty (Tarrow ((p,marg,mret), arg_ty.ctyp_type, ret, commu_ok))
       end
   | Ptyp_arrow (p, arg_sty, sty, arg_mode, _) ->
@@ -5590,7 +5697,7 @@ let rec approx_type env sty =
       in
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
-      let mret = Alloc.newvar () in
+      let mret = Alloc.newvar (get_current_level ()) in
       newty (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
@@ -5957,9 +6064,16 @@ let pattern_needs_partial_application_check p =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   with_type_mark begin fun mark ->
+    let check_const_mode m =
+      if Mode.Alloc.check_generic m then
+        Option.is_some (Mode.Alloc.Guts.check_const m)
+      else true
+    in
+    let checkmode m = if not (check_const_mode m) then raise Exit in
     let rec check ty =
       if try_mark_node mark ty then
-        if get_level ty <= level then raise Exit else iter_type_expr check ty
+        if get_level ty <= level then raise Exit
+        else iter_type_expr check checkmode ty
     in
     try check ty; true with Exit -> false
   end
@@ -5982,7 +6096,7 @@ let contains_variant_either ty =
               (row_fields row);
           iter_row loop row
       | _ ->
-          iter_type_expr loop ty
+          iter_type_expr loop (Fun.const ()) ty
       end
   in
   try loop ty; false with Exit -> true
@@ -6206,8 +6320,23 @@ let with_explanation explanation f =
         raise (Error (loc', env', err))
 
 (* Generalize expressions *)
+let generalize_structure_exp exp = generalize_structure exp.exp_type
+
 let may_lower_contravariant env exp =
   if maybe_expansive exp then lower_contravariant env exp.exp_type
+
+let generalize_structure_type_block_access_result
+      { ba; base_ty; el_ty; modality = _ } =
+  generalize_structure base_ty;
+  generalize_structure el_ty;
+  match ba with
+  | Baccess_field _ -> ()
+  | Baccess_block (_, idx) ->
+    generalize_structure_exp idx
+
+let generalize_structure_type_unboxed_access_result
+      (el_ty, Uaccess_unboxed_field _) =
+  generalize_structure el_ty
 
 let unique_use ~loc ~env mode_l mode_r  =
   if not (Language_extension.is_at_least Unique
@@ -6324,7 +6453,11 @@ let split_function_ty
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
-    with_local_level_generalize_structure_if separate begin fun () ->
+    with_local_level_generalize_structure_if separate
+      ~before_generalize:(fun { ty_arg; ty_ret; _ } ->
+        generalize_structure ty_arg;
+        generalize_structure ty_ret)
+      begin fun () ->
       let force_tpoly =
         (* If [has_poly] is true then we rely on the later call to
            type_pat to enforce the invariant that the parameter type
@@ -6363,14 +6496,15 @@ let split_function_ty
   in
   let ret_value_mode = alloc_as_value ret_mode in
   let expected_inner_mode =
-    if not is_final_val_param then
+    if not is_final_val_param then begin
       (* no need to check mode crossing in this case because ty_res always a
       function *)
       mode_default ret_value_mode
-    else
+    end else begin
       let ret_value_mode = mode_return ret_value_mode in
       let ret_value_mode = expect_mode_cross env ty_ret ret_value_mode in
       ret_value_mode
+    end
   in
   let ty_arg_mono =
     if has_poly then ty_arg
@@ -6386,7 +6520,8 @@ let split_function_ty
   let env_monadic =
     if is_final_val_param
     then arg_mode.monadic
-    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+    else fst (Alloc.Monadic.newvar_above (get_current_level ())
+      arg_mode.monadic)
   in
   let arg_value_mode =
     alloc_to_value_l2r { arg_mode with monadic = env_monadic }
@@ -6414,7 +6549,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.Comonadic.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr
   }
 
 module Calling_convention_sort : sig
@@ -6526,7 +6661,7 @@ type type_function_result =
 
 and type_function_ret_info =
   { (* The mode the function returns at. *)
-    ret_mode: Mode.Alloc.l modes;
+    ret_mode: return_mode modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
     cases_arg_yielding: Mode.Yielding.l option;
@@ -6601,12 +6736,19 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     | None -> begin
         match pat_tuple_arity spat with
         | Not_local_tuple | Maybe_local_tuple ->
-            let mode = Value.newvar () in
+            let mode = Value.newvar (get_current_level ()) in
             simple_pat_mode mode, mode_default mode
         | Local_tuple locs ->
-            let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+            let modes =
+              List.map
+                (fun loc ->
+                   Value.newvar (get_current_level ()), loc)
+                locs
+            in
             let modes_pat = List.map fst modes in
-            let mode = Value.newvar () in
+            let mode =
+              Value.newvar (get_current_level ())
+            in
             tuple_pat_mode mode modes_pat, mode_tuple mode modes
       end
     | Some mode ->
@@ -6719,8 +6861,11 @@ and type_expect_
         | None -> None
         | Some sexp ->
             let exp, mode =
-              with_local_level_generalize_structure_if_principal begin fun () ->
-                let mode = Value.newvar () in
+              with_local_level_generalize_structure_if_principal
+                ~before_generalize:(fun (exp, _) ->
+                  generalize_structure_exp exp)
+                begin fun () ->
+                let mode = Value.newvar (Ctype.get_current_level ()) in
                 let exp = type_exp ~recarg env (mode_default mode) sexp in
                 exp, mode
               end
@@ -6772,6 +6917,7 @@ and type_expect_
             let decl = Env.find_type p' env in
             let ty =
               with_local_level_generalize_structure
+                ~before_generalize:generalize_structure
                 (fun () -> newconstr p' (instance_list decl.type_params))
             in
             ty, opt_exp_opath
@@ -7354,12 +7500,12 @@ and type_expect_
         match pm.apply_position with
         | Tail ->
           let mode, _ =
-            Value.(newvar_below
+            Value.(newvar_below (get_current_level ())
               (of_const ~hint_comonadic:Tailcall_function
                 { Const.max with areality = Regional }))
           in
           mode
-        | Nontail | Default -> Value.newvar ()
+        | Nontail | Default -> Value.newvar (get_current_level ())
       in
       let funct_expected_mode = mode_default funct_mode in
       let outer_level = get_current_level () in
@@ -7388,6 +7534,7 @@ and type_expect_
       let type_sfunct sfunct =
         let funct =
           with_local_level_generalize_structure_if_principal
+            ~before_generalize:generalize_structure_exp
             (fun () -> type_exp env funct_expected_mode sfunct)
         in
         let ty = instance funct.exp_type in
@@ -7424,7 +7571,7 @@ and type_expect_
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
       let mode_ret = Alloc.disallow_right mode_ret in
-      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
+      let ap_mode = create_allocation_mode_l mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7444,8 +7591,8 @@ and type_expect_
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
         exp_desc = Texp_apply(funct, args, pm.apply_position,
-                              Typedtree.create_return_mode ap_mode,
-                              ap_yielding, zero_alloc);
+                    Typedtree.create_return_mode ap_mode,
+                    ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
         exp_attributes = sexp.pexp_attributes;
@@ -7479,12 +7626,19 @@ and type_expect_
           let arg_pat_mode, arg_expected_mode =
             match cases_tuple_arity caselist with
             | Not_local_tuple | Maybe_local_tuple ->
-              let mode = Value.newvar () in
+              let mode = Value.newvar (get_current_level ()) in
               simple_pat_mode mode, mode_default mode
             | Local_tuple locs ->
-              let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+              let modes =
+            List.map
+              (fun loc ->
+                 Value.newvar (get_current_level ()), loc)
+              locs
+          in
               let modes_pat = List.map fst modes in
-              let mode = Value.newvar () in
+              let mode =
+            Value.newvar (get_current_level ())
+          in
               tuple_pat_mode mode modes_pat, mode_tuple mode modes
           in
           env, arg_pat_mode, arg_expected_mode, expected_mode
@@ -7778,6 +7932,9 @@ and type_expect_
           (Texp_inspected_type (Label_disambiguation ambiguity), loc, [])
             :: record.exp_extra }
       in
+      let modality, _ =
+        Mode.Locality.newvar_above 0
+          (Mode.Alloc.proj_comonadic Areality (value_to_alloc_r2l rmode)) in
       unify_exp ~sexp env record ty_record;
       let record_repres =
         update_labels env Legacy ~representative_label:label ~loc
@@ -7788,10 +7945,7 @@ and type_expect_
         exp_desc = Texp_setfield {
           record;
           record_repres;
-          modality =
-            Locality.disallow_right
-              (Alloc.proj_comonadic Areality
-               (value_to_alloc_r2l rmode));
+          modality;
           lid = label_loc;
           label;
           newval;
@@ -7883,6 +8037,7 @@ and type_expect_
     let principal = is_principal ty_expected in
     let { ba; base_ty; el_ty; modality } =
       with_local_level_generalize_structure_if_principal
+        ~before_generalize:generalize_structure_type_block_access_result
         (fun () ->
            let res = type_block_access env expected_base_ty principal ba in
            (* This unification is to get a better [base_ty], and is not
@@ -7919,6 +8074,8 @@ and type_expect_
            (* Generalize after each step, otherwise we'll have more
               "non-principal" warnings than desired. *)
            with_local_level_generalize_structure_if_principal
+             ~before_generalize:(fun ((t, _), ua) ->
+               generalize_structure_type_unboxed_access_result (t, ua))
              (fun () ->
                 let (el_ty, ua_modality), ua =
                   type_unboxed_access env loc el_ty ua
@@ -8141,6 +8298,7 @@ and type_expect_
       let pm = position_and_mode env expected_mode sexp in
       let (obj,meth,typ) =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (_, _, typ) -> generalize_structure typ)
           (fun () -> type_send env loc explanation e met.txt)
       in
       let typ, obj_extra =
@@ -8388,6 +8546,7 @@ and type_expect_
   | Pexp_poly(sbody, sty) ->
       let ty, cty =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (ty, _) -> generalize_structure ty)
           begin fun () ->
             match sty with None -> protect_expansion env ty_expected, None
             | Some sty ->
@@ -8413,6 +8572,8 @@ and type_expect_
               with_local_level_generalize begin fun () ->
                 let vars, ty'' =
                   with_local_level_generalize_structure_if_principal
+                    ~before_generalize:(fun (_, ty'') ->
+                      generalize_structure ty'')
                     (fun () -> instance_poly_fixed tl ty')
                 in
                 let exp = type_expect env expected_mode sbody (mk_expected ty'') in
@@ -8533,10 +8694,13 @@ and type_expect_
             let ty_acc = newty (Ttuple [None, ty_acc; None, ty]) in
             loop spat_acc ty_acc Jkind.Sort.scannable rest
       in
-      let op_path, op_desc, op_type, spat_params, ty_params, param_sort,
+      let (op_path, op_desc, op_type, spat_params, ty_params, param_sort,
           ty_func_result, body_sort, ty_result, op_result_sort,
-          ty_andops, sort_andops =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+          ty_andops, sort_andops), _ =
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:
+            (fun (_, tys) -> List.iter generalize_structure tys)
+          begin fun () ->
           let let_loc = slet.pbop_op.loc in
           let op_path, op_desc = type_binding_op_ident env slet.pbop_op in
           let op_type = op_desc.val_type in
@@ -8571,7 +8735,8 @@ and type_expect_
           end;
           (op_path, op_desc, op_type, spat_params, ty_params, param_sort,
            ty_func_result, body_sort, ty_result, op_result_sort,
-           ty_andops, sort_andops)
+           ty_andops, sort_andops),
+           [ty_andops; ty_params; ty_func_result; ty_result]
         end
       in
       let exp, exp_sort, ands =
@@ -8811,6 +8976,7 @@ and type_expect_
         (* The overwritten cell has to be unique
            and should have the areality expected here: *)
         Value.newvar_below
+          (get_current_level ())
           (Value.meet [
             Value.of_const {Value.Const.max with uniqueness = Unique};
             Value.max_with_comonadic Areality
@@ -9072,7 +9238,9 @@ and type_coerce
   match sty with
   | None ->
     let (cty', ty', force) =
-      with_local_level_generalize_structure begin fun () ->
+      with_local_level_generalize_structure
+        ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
+        begin fun () ->
         Typetexp.transl_simple_type_delayed env type_mode sty'
       end
     in
@@ -9122,14 +9290,17 @@ and type_coerce
       end;
       (arg, ty', Texp_coerce (None, cty'))
   | Some sty ->
-      let cty, ty, force, cty', ty', force' =
-        with_local_level_generalize_structure begin fun () ->
+      let (cty, ty, force, cty', ty', force'), _ =
+        with_local_level_generalize_structure
+          ~before_generalize:(fun (_, tys) ->
+            List.iter generalize_structure tys)
+          begin fun () ->
           let (cty, ty, force) =
             Typetexp.transl_simple_type_delayed env type_mode sty
           and (cty', ty', force') =
             Typetexp.transl_simple_type_delayed env type_mode sty'
           in
-          (cty, ty, force, cty', ty', force')
+          (cty, ty, force, cty', ty', force'), [ty; ty']
         end
       in
       begin try
@@ -9146,7 +9317,9 @@ and type_coerce
 and type_constraint env sty type_mode =
   (* Pretend separate = true, 1% slowdown for lablgtk *)
   let cty =
-    with_local_level_generalize_structure begin fun () ->
+    with_local_level_generalize_structure
+      ~before_generalize:(fun cty -> generalize_structure cty.ctyp_type)
+      begin fun () ->
       Typetexp.transl_simple_type ~new_var_jkind:Any env ~closed:false type_mode
         sty
     end
@@ -9222,7 +9395,7 @@ and type_newtype
         Hashtbl.add seen (get_id t) ();
         match get_desc t with
         | Tconstr (Path.Pident id', _, _) when id == id' -> link_type t ty
-        | _ -> Btype.iter_type_expr replace t
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t
       end
     in
     let ety = Subst.type_expr Subst.identity exp_type in
@@ -9505,6 +9678,9 @@ and type_function
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
       in
+      let excl, expected_inner_mode =
+        mode_return_from_exclave expected_inner_mode
+      in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry,
            ext_env, inner_calling_convention_sorts), partial =
         (* Check everything else in the scope of the parameter. *)
@@ -9565,20 +9741,24 @@ and type_function
                   begin match
                     Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
-                    | Ok () -> ()
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality arg_mode)
+                        alloc_mode
                     | Error e ->
                       raise (Error(loc_fun, env,
                         Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.Comonadic.submode
-                      (Alloc.Comonadic.disallow_right closure_mode)
-                      fun_closure_mode
-                  with
-                    | Ok () -> ()
+                      Alloc.Comonadic.submode closure_mode fun_closure_mode
+                    with
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality closure_mode)
+                        alloc_mode
                     | Error e ->
                       raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e))
+                        Uncurried_function_escapes_comonadic e));
                   end;
                   More_args
                     { partial_mode =
@@ -9654,8 +9834,7 @@ and type_function
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
       let arg_locality =
-        Alloc.disallow_right arg_mode
-        |> Alloc.proj_comonadic Areality
+        create_allocation_mode_l arg_mode
         |> Typedtree.create_alloc_mode_l
       in
       let param =
@@ -9701,12 +9880,16 @@ and type_function
         in
         arg_ccs :: ret_ccs @ inner_calling_convention_sorts
       in
+      let return_from_exclave = !excl in
+      let ret_mode =
+        create_function_return_mode ~return_from_exclave ret_mode
+      in
       let ret_info =
         match ret_info with
         | Some _ as x -> x
         | None ->
           let ret_mode =
-            {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
+            {ret_mode_annots with mode_modes = ret_mode }
           in
           Some { ret_sort ; ret_mode; cases_arg_yielding = None }
       in
@@ -9841,13 +10024,14 @@ and type_label_access
   : 'rep . 'rep record_form -> _ -> _ -> _ -> _ ->
     _ * _ * _ * 'rep gen_label_description * _ * _
   = fun record_form env srecord usage lid ->
-  let mode = Value.newvar () in
+  let mode = Value.newvar (get_current_level ()) in
   let record_jkind, record_sort =
     Jkind.of_new_sort_var ~why:Record_projection
       ~level:(Ctype.get_current_level ())
   in
   let record =
     with_local_level_generalize_structure_if_principal
+      ~before_generalize:generalize_structure_exp
       (fun () ->
          type_expect ~recarg:Allowed env (mode_default mode) srecord
            (mk_expected (newvar record_jkind)))
@@ -9886,7 +10070,9 @@ and solve_Pexp_field
        [update_label], but doing it that way causes principality issues.
        Notably, this call to [update_label] happens inside a local level and the
        [Texp_setfield] call does not. *)
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:(fun (ty_arg, _) -> generalize_structure ty_arg)
+      begin fun () ->
       (* [ty_arg] is the type of field, [ty_res] is the type of record, they
        could share type variables, which are now instantiated *)
       let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
@@ -10191,9 +10377,15 @@ and type_label_exp
     (* raise level to check univars *)
     with_local_level_generalize_if is_poly begin fun () ->
       let unify_as_label ty_expected =
-        with_local_level_generalize_structure_if separate begin fun () ->
+        with_local_level_generalize_structure_if separate
+          ~before_generalize:(fun (_, ty_arg) ->
+            generalize_structure ty_arg)
+          begin fun () ->
           let (vars, ty_arg, ty_res) =
             with_local_level_generalize_structure_if separate
+              ~before_generalize:(fun (_, ty_arg, ty_res) ->
+                generalize_structure ty_arg;
+                generalize_structure ty_res)
               (fun () -> instance_label ~fixed:true label)
           in
           begin try
@@ -10246,15 +10438,19 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     let lv = get_level expty in
     let lv' = get_level expty' in
     match get_desc expty', get_desc expty with
-    | Tarrow((l, marg, mret), ty_arg', ty_res', _),
+    | Tarrow((l, marg', mret'), ty_arg', ty_res', _),
       Tarrow(_, ty_arg,  ty_res,  _)
       when lv' = generic_level || not !Clflags.principal ->
       let ty_res', ty_res, changed = loosen_arrow_modes ty_res' ty_res in
-      let mret, changed' = Alloc.newvar_below mret in
-      let marg, changed'' = Alloc.newvar_above marg in
-      if changed || changed' || changed'' then
-        newty2 ~level:lv' (Tarrow((l, marg, mret), ty_arg', ty_res', commu_ok)),
-        newty2 ~level:lv  (Tarrow((l, marg, mret), ty_arg,  ty_res,  commu_ok)),
+      let mret', changed1 = Alloc.newvar_below (lv) mret' in
+      let marg', changed2 = Alloc.newvar_above (lv) marg' in
+      if changed || changed1 || changed2 then
+        newty2 ~level:lv'
+          (Tarrow((l, marg', mret'), ty_arg', ty_res',
+                  commu_ok)),
+        newty2 ~level:lv
+          (Tarrow((l, marg', mret'), ty_arg, ty_res,
+                  commu_ok)),
         true
       else
         ty', ty, false
@@ -10294,9 +10490,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     Some (safe_expect, lv) ->
       (* apply omittable arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
-      let exp_mode, _ = Value.newvar_below (as_single_mode mode) in
+      let exp_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (as_single_mode mode)
+      in
       let texp =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:generalize_structure_exp
           (fun () ->
             let expected_mode =
               mode
@@ -10379,7 +10579,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                       staticity = proj_staticity mode;
                       mode = Value.disallow_right mode }}
       in
-      let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in
+      let eta_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (alloc_as_value marg)
+      in
       Regionality.submode_exn
         (Value.proj_comonadic Areality eta_mode) Regionality.regional;
       let type_sort ~why ty =
@@ -10392,12 +10595,11 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       let fc_arg_mode =
-        Alloc.disallow_right marg
-        |> Alloc.proj_comonadic Areality
+        create_allocation_mode_l marg
         |> Typedtree.create_alloc_mode_l
       in
       let fc_ret_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        create_allocation_mode_l mret
         |> Typedtree.create_return_mode
       in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
@@ -10527,6 +10729,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
             with_local_level_generalize begin fun () ->
               let vars, ty_arg' =
                 with_local_level_generalize_structure_if separate
+                  ~before_generalize:(fun (_, ty_arg') ->
+                    generalize_structure ty_arg')
                   begin fun () ->
                   instance_poly_fixed vars ty_arg'
                 end
@@ -10578,8 +10782,10 @@ and type_application env app_loc expected_mode position_and_mode
   | (* Special case for ignore: avoid discarding warning *)
     [Parsetree.Nolabel, sarg] when is_ignore funct ->
       let {ty_arg; arg_mode; ty_ret; ret_mode} =
-        with_local_level_generalize_structure_if_principal (fun () ->
-          filter_arrow_mono env (instance funct.exp_type) Nolabel)
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun { ty_ret; _ } ->
+            generalize_structure ty_ret)
+          (fun () -> filter_arrow_mono env (instance funct.exp_type) Nolabel)
       in
       let type_sort ~why ty =
         match Ctype.type_sort ~why ~fixed:false env ty with
@@ -10618,7 +10824,10 @@ and type_application env app_loc expected_mode position_and_mode
         end
       in
       let ty_ret, mode_ret, args, position_and_mode, ap_yielding =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (ty_ret, _, _, _, _) ->
+            generalize_structure ty_ret)
+          begin fun () ->
           (* Consider for example the application
                [f n]
              with
@@ -10648,16 +10857,17 @@ and type_application env app_loc expected_mode position_and_mode
           (* The application can never perform a free effect if the function and
              all of its arguments are unyielding. *)
           let ap_yielding =
-            Mode.Value.proj_comonadic Yielding
-              (Mode.Value.join
-                 (funct_mode
-                  :: List.concat_map
-                       (fun (_, arg, _, ~mode_fun) ->
-                          mode_fun ::
-                          (match arg with
-                            | Arg (_, mode_arg, _) -> [mode_arg]
-                            | Omitted _ -> [] ))
-                       args))
+            create_yielding_mode_l
+              (Mode.Value.proj_comonadic Yielding
+                 (Mode.Value.join
+                    (funct_mode
+                     :: List.concat_map
+                          (fun (_, arg, _, ~mode_fun) ->
+                             mode_fun ::
+                             (match arg with
+                               | Arg (_, mode_arg, _) -> [mode_arg]
+                               | Omitted _ -> [] ))
+                          args)))
           in
           let args =
             List.map (fun (lbl, arg, sch, ~mode_fun:_) ->
@@ -10866,9 +11076,18 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
                   (lid.txt, constr.cstr_arity, List.length sargs)));
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let unify_as_construct ty_expected =
-    with_local_level_generalize_structure_if separate begin fun () ->
+    with_local_level_generalize_structure_if separate
+      ~before_generalize:(fun (ty_args, ty_res, _) ->
+        generalize_structure ty_res;
+        List.iter
+          (fun { Types.ca_type = ty; _ } -> generalize_structure ty)
+          ty_args)
+      begin fun () ->
       let ty_args, ty_res, texp =
-        with_local_level_generalize_structure_if separate begin fun () ->
+        with_local_level_generalize_structure_if separate
+          ~before_generalize:(fun (_, ty_res, _) ->
+            generalize_structure ty_res)
+          begin fun () ->
           let (ty_args, ty_res, _) =
             instance_constructor Keep_existentials_flexible constr
           in
@@ -11143,10 +11362,14 @@ and map_half_typed_cases
         map_conts
         (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) cont ->
           let htc =
-            with_local_level_generalize_structure_if_principal begin fun () ->
+            with_local_level_generalize_structure_if_principal
+              ~before_generalize:(fun htc ->
+                iter_pattern_variables_type generalize_structure htc.pat_vars)
+              begin fun () ->
               let ty_arg =
                 (* propagation of pattern *)
                 with_local_level_generalize_structure
+                  ~before_generalize:generalize_structure
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
               let (pat, ext_env, force, pvs, mvs) =
@@ -11415,6 +11638,9 @@ and type_function_cases_expect
         ~ret_mode_annots:Mode.Alloc.Const.Option.none
         ~is_first_val_param:first ~is_final_val_param:true
     in
+    let excl, expected_inner_mode =
+      mode_return_from_exclave expected_inner_mode
+    in
     let cases, partial =
       type_cases Value env
         expected_pat_mode expected_inner_mode ty_arg_mono arg_sort
@@ -11427,7 +11653,7 @@ and type_function_cases_expect
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
     let fc_arg_mode =
-      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      create_allocation_mode_l arg_mode
       |> Typedtree.create_alloc_mode_l
     in
     let yielding_mode =
@@ -11460,10 +11686,13 @@ and type_function_cases_expect
         { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
+    let return_from_exclave = !excl in
     cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+          { mode_modes =
+              create_function_return_mode ~return_from_exclave ret_mode;
+            mode_desc = [] };
         cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts
   end
@@ -11530,7 +11759,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let entirely_functions = List.for_all vb_is_fun spat_sexp_list in
   let rec_mode_var =
     match rec_flag with
-    | Recursive when entirely_functions -> Some (Value.newvar ())
+    | Recursive when entirely_functions ->
+      Some (Value.newvar (get_current_level ()))
     | Recursive ->
         (* If the definitions are not purely functions, this involves multiple
            allocations pointing to each other. For this to be safe, they are all
@@ -11539,7 +11769,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let m, _ =
           {Value.Const.max with areality = Global}
           |> Value.of_const
-          |> Value.newvar_below
+          |> Value.newvar_below (get_current_level ())
         in
         Some m
     | Nonrecursive -> None
@@ -11555,7 +11785,13 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     with_local_level_generalize begin fun () ->
       if existential_context = At_toplevel then Typetexp.TyVarEnv.reset ();
       let (pat_list, new_env, force, pvs, mvs), sorts =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:
+            (fun ((pat_list, _, _, pvs, _), _) ->
+              iter_pattern_variables_type generalize_structure pvs;
+              List.iter
+                (fun (_, pat) -> generalize_structure pat.pat_type) pat_list)
+          begin fun () ->
           let nvs, sorts =
             List.split (List.map (fun _ -> new_rep_var ~why:Let_binding ())
                           spatl)
@@ -11658,6 +11894,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
             | Tpoly (ty, tl) ->
                 let vars, ty' =
                   with_local_level_generalize_structure_if_principal
+                    ~before_generalize:(fun (_, ty') ->
+                      generalize_structure ty')
                     (fun () -> instance_poly_fixed ~keep_names:true tl ty)
                 in
                 let exp =
@@ -11934,9 +12172,12 @@ and type_andops env sarg sands expected_sort expected_ty =
         expected_sort,
         []
     | { pbop_op = sop; pbop_exp = sexp; pbop_loc = loc; _ } :: rest ->
-        let op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
-            ty_result, op_result_sort =
-          with_local_level_generalize_structure_if_principal begin fun () ->
+        let (op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
+            ty_result, op_result_sort), _ =
+          with_local_level_generalize_structure_if_principal
+            ~before_generalize:
+              (fun (_, tys) -> List.iter generalize_structure tys)
+            begin fun () ->
             let op_path, op_desc = type_binding_op_ident env sop in
             let op_type = op_desc.val_type in
             let ty_arg, sort_arg = new_rep_var ~why:Function_argument () in
@@ -11955,7 +12196,7 @@ and type_andops env sarg sands expected_sort expected_ty =
               raise(Error(sop.loc, env, Andop_type_clash(sop.txt, err)))
             end;
             (op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
-             ty_result, op_result_sort)
+             ty_result, op_result_sort), [ty_rest; ty_arg; ty_result]
           end
         in
         let let_arg, sort_let_arg, rest =
@@ -12048,7 +12289,9 @@ and type_n_ary_function
                           (Jkind.of_new_sort ~why
                              ~level:(Ctype.get_current_level ()))
                       in
-                      let new_mode_var () = Mode.Alloc.newvar () in
+                      let new_mode_var () =
+                        Mode.Alloc.newvar (get_current_level ())
+                      in
                       (newty
                          (Tarrow
                             ( (arg_label, new_mode_var (), new_mode_var ())
@@ -12106,14 +12349,6 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let ret_mode_modes =
-      Alloc.proj_comonadic Areality ret_mode.mode_modes
-      |> Typedtree.create_return_mode
-    in
-    let ret_mode =
-      { ret_mode with
-        mode_modes = ret_mode_modes }
-    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the
@@ -12132,10 +12367,11 @@ and type_n_ary_function
       | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Yielding.join
-        (Alloc.Comonadic.proj Yielding
-           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
-         :: param_yieldings)
+      create_yielding_mode_l
+        (Yielding.join
+           (Alloc.Comonadic.proj Yielding
+              (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
+            :: param_yieldings))
     in
     re
       { exp_desc =
@@ -12280,7 +12516,9 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
           ~why:Jkind.History.Array_comprehension_element
   in
   let element_ty =
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:generalize_structure
+      begin fun () ->
       let element_ty = newvar jkind in
       unify_exp_types
         loc
@@ -13654,6 +13892,11 @@ let report_error ~loc env =
               but expected to be %a."
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
+    end
+  | Uncurried_function_escapes_locality -> begin
+      Location.errorf ~loc
+        "This function or one of its parameters escape their region@ \
+        when it is partially applied."
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.mli
@@ -174,6 +174,7 @@ val type_option_some:
 val type_option_none:
         Env.t -> type_expr -> Location.t -> Typedtree.expression
 val generalizable: int -> type_expr -> bool
+val generalize_structure_exp: Typedtree.expression -> unit
 val reset_delayed_checks: unit -> unit
 val force_delayed_checks: unit -> unit
 
@@ -380,6 +381,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
@@ -1013,7 +1013,10 @@ let transl_declaration env sdecl (id, uid) =
          traverses inside of any type constructors in the [with]-bound. It's
          also necessary because the variables here are at generic level, and so
          any containers of them should be, too! *)
-      Ctype.with_local_level_generalize_structure begin fun () ->
+      Ctype.with_local_level_generalize_structure
+        ~before_generalize:(fun cty ->
+          Ctype.generalize_structure cty.ctyp_type)
+        begin fun () ->
         Typetexp.transl_simple_type env ~new_var_jkind:Any
           ~closed:true Mode.Alloc.Const.legacy sty
       end
@@ -1564,7 +1567,8 @@ let rec check_constraints_rec env loc visited ty =
       check_constraints_rec env loc visited ty
   | _ ->
       Ctype.iter_type_expr_with_stages
-        (fun env -> check_constraints_rec env loc visited) env ty
+        (fun env -> check_constraints_rec env loc visited) env
+        (Fun.const ()) ty
   end
 
 let check_constraints_labels env visited l pl =
@@ -3217,7 +3221,8 @@ let check_well_founded ~abs_env env loc path to_check visited ty0 =
               List.iter (check_subtype parents trace ty env) tyl
         end
     | _ ->
-        Ctype.iter_type_expr_with_stages (check_subtype parents trace ty) env ty
+        Ctype.iter_type_expr_with_stages
+          (check_subtype parents trace ty) env (Fun.const ()) ty
   and check_subtype parents trace outer_ty env inner_ty =
       check parents (Contains (outer_ty, inner_ty) :: trace) env inner_ty
   in
@@ -3564,7 +3569,7 @@ let check_regularity ~abs_env env loc path decl to_check =
           check_regular cpath args prev_exp trace env ty
       | _ ->
           Ctype.iter_type_expr_with_stages
-            (check_subtype cpath args prev_exp trace ty) env ty
+            (check_subtype cpath args prev_exp trace ty) env (Fun.const ()) ty
     end
     and check_subtype cpath args prev_exp trace outer_ty env inner_ty =
       let trace = Contains (outer_ty, inner_ty) :: trace in
@@ -3992,7 +3997,8 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
-       match Ctype.closed_type_decl decl with
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+          Ctype.closed_type_decl ~zap_scope decl) with
          Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
@@ -4278,7 +4284,10 @@ let transl_type_extension extend env loc styext =
   (* Check that all type variables are closed *)
   List.iter
     (fun (ext, _shape) ->
-       match Ctype.closed_extension_constructor ext.ext_type with
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+               Ctype.closed_extension_constructor ~zap_scope
+               ext.ext_type)
+       with
          Some ty ->
            raise(Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
        | None -> ())
@@ -4334,7 +4343,10 @@ let transl_exception env sext =
       end
   in
   (* Check that all type variables are closed *)
-  begin match Ctype.closed_extension_constructor ext.ext_type with
+  begin match
+    Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+        Ctype.closed_extension_constructor ~zap_scope ext.ext_type)
+  with
     Some ty ->
       raise (Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
   | None -> ()
@@ -4693,7 +4705,10 @@ let check_unboxable env loc ty =
       | _ -> acc
     with Not_found -> acc
   in
-  let all_unboxable_types = Btype.fold_type_expr check_type Path.Set.empty ty in
+  let all_unboxable_types =
+    Btype.fold_type_expr check_type
+      (fun a _ -> a) Path.Set.empty ty
+  in
   Path.Set.fold
     (fun p () ->
        Location.prerr_warning loc
@@ -5138,7 +5153,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   in
   Option.iter (fun p -> set_private_row env sdecl.ptype_loc p new_sig_decl)
     fixed_row_path;
-  begin match Ctype.closed_type_decl new_sig_decl with None -> ()
+  begin match
+    Mode.Alloc.with_zap_scope
+      (fun ~zap_scope -> Ctype.closed_type_decl ~zap_scope new_sig_decl)
+  with None -> ()
   | Some ty -> raise(Error(loc, Unbound_type_var(ty, new_sig_decl)))
   end;
   let new_sig_decl = name_recursion sdecl id new_sig_decl in

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl_variance.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl_variance.ml
@@ -169,13 +169,13 @@ let compute_variance_type env ~check (required, loc) decl tyl =
             | Tconstr _ ->
                 let old = !visited in
                 begin try
-                  Ctype.iter_type_expr_with_stages check env ty
+                  Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
                 with Exit ->
                   visited := old;
                   let ty' = Ctype.expand_head_opt env ty in
                   if eq_type ty ty' then raise Exit else check env ty'
                 end
-            | _ -> Ctype.iter_type_expr_with_stages check env ty
+            | _ -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
           end
         in
         try check env ty; compute_variance env tvl injective ty
@@ -247,7 +247,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                      , Bad_variance ( variance_error
                                     , (c1,n1,false)
                                     , (c2,n2,false))))
-        | None -> Ctype.iter_type_expr_with_stages check env ty
+        | None -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
       end
     in
     List.iter (fun (_,ty) -> check env ty) tyl;

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
@@ -84,7 +84,7 @@ module Unique_barrier = struct
 
   let enable barrier = match !barrier with
     | Not_computed ->
-      barrier := Enabled (Uniqueness.newvar ())
+      barrier := Enabled (Uniqueness.newvar 0)
     | _ -> Misc.fatal_error "Unique barrier was enabled twice"
 
   (* Due to or-patterns a barrier may have several upper bounds. *)
@@ -96,7 +96,7 @@ module Unique_barrier = struct
   let resolve barrier =
     match !barrier with
     | Enabled uniq ->
-      let zapped = Uniqueness.zap_to_ceil uniq in
+      let zapped = Uniqueness.zap_to_ceil_exn uniq in
       barrier := Resolved zapped;
       zapped
     | Resolved barrier -> barrier
@@ -137,7 +137,7 @@ type alloc_mode_r = Mode.Locality.r
 let create_alloc_mode_r m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
+let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil_exn m
 
 let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
 
@@ -151,7 +151,7 @@ type alloc_mode_l = Mode.Locality.l
 let create_alloc_mode_l m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor_exn m
 
 let alloc_mode_l_map f m = f m
 
@@ -163,7 +163,7 @@ type return_mode = Mode.Locality.l
 let create_return_mode m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+let return_mode_zap_to_floor_exn m = Mode.Locality.zap_to_floor_exn m
 
 let print_return_mode ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
@@ -140,7 +140,7 @@ type return_mode
 
 val create_return_mode : Mode.Locality.l -> return_mode
 
-val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+val return_mode_zap_to_floor_exn : return_mode -> Mode.Locality.Const.t
 
 val print_return_mode : Format.formatter -> return_mode -> unit
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
@@ -2844,24 +2844,17 @@ let check_nongen_signature env sg =
 
 let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
-<<<<<<< HEAD
-      Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
-      begin match arg_opt with
-      | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
-=======
-      let zap_mode mode =
+      let zap_mode ~arg mode =
         if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
-          Alloc.add_mode_to_zap_scope mode zap_scope
+          Alloc.add_mode_to_zap_scope ~arg mode zap_scope
          end else begin
-          Alloc.zap_to_legacy_force mode |> ignore
+          Alloc.zap_to_legacy_force ~arg mode |> ignore
          end
       in
-      zap_mode mres;
+      zap_mode ~arg:false mres;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> zap_mode marg
->>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
+      | Named (_, _, marg) -> zap_mode ~arg:true marg
       end
   | _ -> ()
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
@@ -108,7 +108,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
-  let mode = Mode.Value.newvar () in
+  let mode = Mode.Value.newvar 0 in
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
   Value.submode_exn (min |> Alloc.of_const |> alloc_as_value) mode;
@@ -121,7 +121,7 @@ let register_allocation loc : Alloc.lr * Value.lr =
       ~hint_comonadic:Module_allocated_on_heap
       { Alloc.Const.max with areality = Global }
   in
-  let alloc_mode, _ = Alloc.newvar_below upper_bound in
+  let alloc_mode, _ = Alloc.newvar_below 0 upper_bound in
   let closed_over_mode =
     alloc_as_value ~allocation:({loc; txt = Unknown}) alloc_mode
   in
@@ -173,7 +173,7 @@ let infer_modalities pp ~loc_md item ~md_mode ~mode =
       To achieve that, the mode of [foo] to be exposed as [M.foo] should be a
       flexible mode variable weaker than its actual mode.
     *)
-    let mode, _ = Mode.Value.newvar_above mode in
+    let mode, _ = Mode.Value.newvar_above (Ctype.get_current_level ()) mode in
     (* Upon construction, for comonadic (prescriptive) axes, module
     must be weaker than the values therein, for otherwise operations
     would be allowed to performed on the module (and extended to the
@@ -254,7 +254,8 @@ let extract_sig_functor_open funct_body env loc mty sig_acc md_mode
     let yielding m =
       Yielding.disallow_right (Value.proj_comonadic Yielding m)
     in
-    Yielding.join [yielding funct_mode; yielding md_mode]
+    Ctype.create_yielding_mode_l
+      (Yielding.join [yielding funct_mode; yielding md_mode])
   in
   match Mtype.scrape_alias env mty with
   | Mty_functor (Named (param, mty_param, mm_param),mty_result,mm_result)
@@ -2811,8 +2812,9 @@ and nongen_signature_item env f g = function
       nongen_modtype env f g md.md_type
   | _ -> None
 
-let check_nongen_modtype env loc mty =
-  nongen_modtype env Ctype.nongen_vars_in_schema (fun _ _ -> ()) mty
+let check_nongen_modtype ~zap_scope env loc mty =
+  nongen_modtype env (Ctype.nongen_vars_in_schema ~zap_scope) (fun _ _ -> ())
+    mty
   |> Option.iter (fun (vars, item) ->
       let vars = Btype.TypeSet.elements vars in
       let error =
@@ -2821,10 +2823,10 @@ let check_nongen_modtype env loc mty =
       raise(Error(loc, env, error))
     )
 
-let check_nongen_signature_item env sig_item =
+let check_nongen_signature_item ~zap_scope env sig_item =
   match sig_item with
     Sig_value(_id, vd, _) ->
-      Ctype.nongen_vars_in_schema env vd.val_type
+      Ctype.nongen_vars_in_schema ~zap_scope env vd.val_type
       |> Option.iter (fun vars ->
           let vars = Btype.TypeSet.elements vars in
           let error =
@@ -2833,25 +2835,45 @@ let check_nongen_signature_item env sig_item =
           raise (Error (vd.val_loc, env, error))
         )
   | Sig_module (_id, _, md, _, _) ->
-      check_nongen_modtype env md.md_loc md.md_type
+      check_nongen_modtype ~zap_scope env md.md_loc md.md_type
   | _ -> ()
 
 let check_nongen_signature env sg =
-  List.iter (check_nongen_signature_item env) sg
+  Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+      List.iter (check_nongen_signature_item ~zap_scope env) sg)
 
-let remove_functor_mode_variables = function
+let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
+<<<<<<< HEAD
       Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
       begin match arg_opt with
       | Unit -> ()
       | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
+=======
+      let zap_mode mode =
+        if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope mode zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force mode |> ignore
+         end
+      in
+      zap_mode mres;
+      begin match arg_opt with
+      | Unit -> ()
+      | Named (_, _, marg) -> zap_mode marg
+>>>>>>> 40e321c276 (Automated commit: Import compiler changes from e43e14fad80a80d291f5f27d80f32aa708ce98b4)
       end
   | _ -> ()
 
 let remove_mode_and_jkind_variables env sg =
-  let rm_ty _env ty = Ctype.remove_mode_and_jkind_variables ty; None in
-  let rm_mty _env mty = remove_functor_mode_variables mty in
-  List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore
+  Mode.Alloc.with_zap_scope(fun ~zap_scope ->
+    let rm_ty _env ty =
+      Ctype.remove_mode_and_jkind_variables
+        ty ~zap_scope;
+      None
+    in
+    let rm_mty _env mty = remove_functor_mode_variables ~zap_scope mty in
+    List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore)
 
 (* Helpers for typing recursive modules *)
 
@@ -3285,7 +3307,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
         type_module ~strengthen:true ~funct_body None newenv sbody
       in
       let body_mode = mode_without_locks_exn body.mod_mode in
-      let ret_mode = Alloc.newvar () in
+      let ret_mode = Alloc.newvar 0 in
       Value.submode_exn body_mode (ret_mode |> alloc_as_value);
       (* Apply currying constraints if the body is a functor,
          similar to constraints for functions. *)
@@ -3337,9 +3359,10 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
       },
       final_shape
   | Pmod_unpack sexp ->
-      let mode = Value.newvar () in
+      let mode = Value.newvar 0 in
       let exp =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:Typecore.generalize_structure_exp
           (fun () -> Typecore.type_exp env sexp
             ~mode:(Value.disallow_left mode))
       in
@@ -3482,8 +3505,9 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
      argument (the argument's mode). *)
   let functor_application_yielding ~funct ~arg_mode =
     let yielding m = Value.proj_comonadic Yielding m in
-    Yielding.join
-      [yielding (mode_without_locks_exn funct.mod_mode); yielding arg_mode]
+    Ctype.create_yielding_mode_l
+      (Yielding.join
+         [yielding (mode_without_locks_exn funct.mod_mode); yielding arg_mode])
   in
   (* CR modes: Apply currying constraints if the application is partial
      and returns a functor, similar to constraints for functions.
@@ -4223,7 +4247,9 @@ let remove_mode_and_jkind_variables_for_toplevel str =
                          vb_expr = exp}])) }] ->
      (* These types are printed by the toplevel,
         even though they do not appear in sg *)
-     Ctype.remove_mode_and_jkind_variables exp.exp_type
+     Mode.Alloc.with_zap_scope
+       (fun ~zap_scope ->
+          Ctype.remove_mode_and_jkind_variables ~zap_scope exp.exp_type)
   | _ -> ()
 
 let type_toplevel_phrase env sig_acc s =
@@ -4291,7 +4317,9 @@ let type_module_type_of env smod =
   in
   let mty = Mtype.scrape_for_type_of ~remove_aliases env tmty.mod_type in
   (* PR#5036: must not contain non-generalized type variables *)
-  if not skip_nongen_check then check_nongen_modtype env smod.pmod_loc mty;
+  if not skip_nongen_check then
+    Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+       check_nongen_modtype ~zap_scope env smod.pmod_loc mty);
   let zap_modality = Ctype.zap_modalities_to_floor_if_modes_enabled_at Stable in
   let mty =
     remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty

--- a/external/merlin/upstream/ocaml_flambda/typing/typetexp.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typetexp.ml
@@ -999,7 +999,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode.mode_modes arg
           in
-          let acc_mode = curry_mode acc_mode arg_mode.mode_modes in
+          let acc_mode = curry_mode_const acc_mode arg_mode.mode_modes in
           let ret_mode =
             match rest with
             | [] -> ret_mode
@@ -1475,7 +1475,9 @@ and transl_type_alias env ~row_context ~policy mode attrs styp_loc styp name_opt
         cty, jkind_annot
       with Not_found ->
         let t, ty, jkind_annot =
-          with_local_level_generalize_structure_if_principal begin fun () ->
+          with_local_level_generalize_structure_if_principal
+            ~before_generalize:(fun (t, _, _) -> generalize_structure t)
+            begin fun () ->
             let jkind, rigid =
               jkind_for_fresh_var env alias alias_loc attrs jkind_annot_opt
             in
@@ -1685,7 +1687,7 @@ let rec make_fixed_univars mark ty =
                   ~fixed:(Some (Univar more))));
         Btype.iter_row (make_fixed_univars mark) row
     | _ ->
-        Btype.iter_type_expr (make_fixed_univars mark) ty
+        Btype.iter_type_expr (make_fixed_univars mark) (Fun.const ()) ty
     end
 
 let make_fixed_univars ty =
@@ -1752,7 +1754,8 @@ let transl_type_scheme_mono env styp =
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (fun ~zap_scope ->
+    remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =
@@ -1776,7 +1779,8 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ~before_generalize:(fun (_,_,typ) -> generalize_ctyp typ)
   in
   let _ : _ list = TyVarEnv.instance_poly_univars env loc univars in
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (fun ~zap_scope ->
+    remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
     ctyp_env = env;
@@ -1850,7 +1854,7 @@ let transl_type_scheme_newlayout env attrs loc vars inner_type =
               Types.set_var_jkind t jkind
             | None -> ())
           | _ -> ())
-        | _ -> Btype.iter_type_expr replace t)
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t)
       end
     in
     let ety = Subst.type_expr Subst.identity ty in

--- a/external/merlin/upstream/ocaml_flambda/utils/language_extension_kernel.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/language_extension_kernel.ml
@@ -9,6 +9,8 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -27,6 +29,8 @@ let to_string : type a. a t -> string = function
   | Mode -> "mode"
   | Unique -> "unique"
   | Overwriting -> "overwriting"
+  | Mode_polymorphism -> "mode_polymorphism"
+  | Mode_polymorphism_printing -> "mode_polymorphism_printing"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"

--- a/external/merlin/upstream/ocaml_flambda/utils/language_extension_kernel.mli
+++ b/external/merlin/upstream/ocaml_flambda/utils/language_extension_kernel.mli
@@ -20,6 +20,8 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2158,7 +2158,7 @@ let rec transl_address loc = function
   | Env.Aunit (cu, mode) ->
     let staticity = Mode.Value.proj_monadic Staticity mode in
     let staticity =
-      match Mode.Staticity.zap_to_floor staticity with
+      match Mode.Staticity.zap_to_floor_exn staticity with
       | Static -> Static
       | Dynamic -> Dynamic
     in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -399,7 +399,10 @@ let can_apply_primitive p pmode pos args =
     else if nargs < p.prim_arity then false
     else if pos <> Typedtree.Tail then true
     else begin
-      let return_mode = Ctype.prim_mode pmode p.prim_native_repr_res in
+      (* CR ageorges: what level to choose here *)
+      let return_mode =
+        Ctype.prim_mode pmode p.prim_native_repr_res ~level:0
+      in
       is_heap_mode (transl_locality_mode_l return_mode)
     end
   end

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -399,7 +399,6 @@ let can_apply_primitive p pmode pos args =
     else if nargs < p.prim_arity then false
     else if pos <> Typedtree.Tail then true
     else begin
-      (* CR ageorges: what level to choose here *)
       let return_mode =
         Ctype.prim_mode pmode p.prim_native_repr_res ~level:0
       in

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -24,10 +24,10 @@ let transl_ret_mode = function
   | Locality.Const.Local -> maybe_alloc_stack
 
 let transl_locality_mode_l locality =
-  Locality.zap_to_floor locality |> transl_locality_mode
+  Locality.zap_to_floor_exn locality |> transl_locality_mode
 
 let transl_return_mode_l locality =
-  Locality.zap_to_floor locality |> transl_ret_mode
+  Locality.zap_to_floor_exn locality |> transl_ret_mode
 
 let transl_alloc_mode_l mode =
   Typedtree.alloc_mode_l_zap_to_floor mode |> transl_locality_mode
@@ -38,15 +38,15 @@ let transl_alloc_mode_r mode =
   Typedtree.alloc_mode_r_zap_to_ceil mode |> transl_locality_mode
 
 let transl_yielding_mode_l yielding =
-  match Yielding.zap_to_floor yielding with
+  match Yielding.zap_to_floor_exn yielding with
   | Yielding.Const.Unyielding -> Unyielding
   | Yielding.Const.Yielding -> May_yield
 
 let transl_ret_mode mode =
-  Typedtree.return_mode_zap_to_floor mode |> transl_ret_mode
+  Typedtree.return_mode_zap_to_floor_exn mode |> transl_ret_mode
 
 let transl_modify_mode locality =
-  match Locality.zap_to_floor locality with
+  match Locality.zap_to_floor_exn locality with
   | Global -> modify_heap
   | Local -> modify_maybe_stack
 

--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -168,7 +168,7 @@ let subst_type env t =
   let rec iter t =
     if List.memq t !deja_vu then () else begin
       deja_vu := t :: !deja_vu;
-      Btype.iter_type_expr iter t;
+      Btype.iter_type_expr iter (Fun.const ()) t;
       let open Types in
       match get_desc t with
       | Tconstr (p, [_], _) when Path.same p Predef.path_option ->

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -65,6 +65,7 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Unique -> (module Maturity)
   | Overwriting -> (module Unit)
   | Mode_polymorphism -> (module Maturity)
+  | Mode_polymorphism_printing -> (module Unit)
   | Include_functor -> (module Unit)
   | Polymorphic_parameters -> (module Unit)
   | Immutable_arrays -> (module Unit)
@@ -87,7 +88,8 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
 *)
 (* CR ageorges: is mode polymorphism erasable? *)
 let is_erasable : type a. a t -> bool = function
-  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism ->
+  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism
+  | Mode_polymorphism_printing ->
     true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
@@ -101,23 +103,24 @@ let maturity_of_unique_for_destruction = Alpha
 module Exist_pair = struct
   type t = Pair : 'a language_extension * 'a -> t
 
-  let maturity : t -> Maturity.t = function
-    | Pair (Comprehensions, ()) -> Beta
-    | Pair (Mode, m) -> m
-    | Pair (Unique, m) -> m
-    | Pair (Overwriting, ()) -> Alpha
-    | Pair (Mode_polymorphism, m) -> m
-    | Pair (Include_functor, ()) -> Stable
-    | Pair (Polymorphic_parameters, ()) -> Stable
-    | Pair (Immutable_arrays, ()) -> Stable
-    | Pair (Module_strengthening, ()) -> Stable
-    | Pair (Layouts, m) -> m
-    | Pair (SIMD, m) -> m
-    | Pair (Small_numbers, m) -> m
-    | Pair (Instances, ()) -> Stable
-    | Pair (Let_mutable, ()) -> Stable
-    | Pair (Layout_poly, m) -> m
-    | Pair (Runtime_metaprogramming, ()) -> Beta
+  let maturity : t -> Maturity.t option = function
+    | Pair (Comprehensions, ()) -> Some Beta
+    | Pair (Mode, m) -> Some m
+    | Pair (Unique, m) -> Some m
+    | Pair (Overwriting, ()) -> Some Alpha
+    | Pair (Mode_polymorphism, m) -> Some m
+    | Pair (Mode_polymorphism_printing, ()) -> None
+    | Pair (Include_functor, ()) -> Some Stable
+    | Pair (Polymorphic_parameters, ()) -> Some Stable
+    | Pair (Immutable_arrays, ()) -> Some Stable
+    | Pair (Module_strengthening, ()) -> Some Stable
+    | Pair (Layouts, m) -> Some m
+    | Pair (SIMD, m) -> Some m
+    | Pair (Small_numbers, m) -> Some m
+    | Pair (Instances, ()) -> Some Stable
+    | Pair (Let_mutable, ()) -> Some Stable
+    | Pair (Layout_poly, m) -> Some m
+    | Pair (Runtime_metaprogramming, ()) -> Some Beta
 
   let is_erasable : t -> bool = function Pair (ext, _) -> is_erasable ext
 
@@ -135,7 +138,8 @@ module Exist_pair = struct
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
-           | Let_mutable | Runtime_metaprogramming ) as ext),
+           | Let_mutable | Runtime_metaprogramming | Mode_polymorphism_printing
+             ) as ext),
           _ ) ->
       to_string ext
 
@@ -152,6 +156,8 @@ module Exist_pair = struct
     | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
     | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
     | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
+    | "mode_polymorphism_printing" ->
+      Some (Pair (Mode_polymorphism_printing, ()))
     | "unique" -> Some (Pair (Unique, Stable))
     | "unique_beta" -> Some (Pair (Unique, Beta))
     | "unique_alpha" -> Some (Pair (Unique, Alpha))
@@ -186,6 +192,7 @@ let all_extensions =
     Pack Mode;
     Pack Unique;
     Pack Mode_polymorphism;
+    Pack Mode_polymorphism_printing;
     Pack Overwriting;
     Pack Include_functor;
     Pack Polymorphic_parameters;
@@ -228,6 +235,7 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Unique, Unique -> Some Refl
   | Overwriting, Overwriting -> Some Refl
   | Mode_polymorphism, Mode_polymorphism -> Some Refl
+  | Mode_polymorphism_printing, Mode_polymorphism_printing -> Some Refl
   | Include_functor, Include_functor -> Some Refl
   | Polymorphic_parameters, Polymorphic_parameters -> Some Refl
   | Immutable_arrays, Immutable_arrays -> Some Refl
@@ -242,7 +250,8 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming | Mode_polymorphism ),
+      | Runtime_metaprogramming | Mode_polymorphism | Mode_polymorphism_printing
+        ),
       _ ) ->
     None
 
@@ -335,14 +344,14 @@ end = struct
     | Alpha -> "flag -extension-universe alpha (default CLI option)"
 
   let is_allowed_in t extn_pair =
-    match t with
-    | No_extensions -> false
-    | Upstream_compatible ->
-      Exist_pair.is_erasable extn_pair
-      && Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Stable -> Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Beta -> Maturity.compare (Exist_pair.maturity extn_pair) Beta <= 0
-    | Alpha -> true
+    match t, Exist_pair.maturity extn_pair with
+    | No_extensions, _ -> false
+    | _, None -> true
+    | Upstream_compatible, Some maturity ->
+      Exist_pair.is_erasable extn_pair && Maturity.compare maturity Stable <= 0
+    | Stable, Some maturity -> Maturity.compare maturity Stable <= 0
+    | Beta, Some maturity -> Maturity.compare maturity Beta <= 0
+    | Alpha, Some _ -> true
 
   let is_allowed extn_pair = is_allowed_in !universe extn_pair
 
@@ -362,7 +371,11 @@ end = struct
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
       let allowed_levels =
-        Ops.all |> List.filter (fun lvl -> is_allowed_in t (Pair (extn, lvl)))
+        Ops.all
+        |> List.filter (fun lvl ->
+            match Exist_pair.maturity (Pair (extn, lvl)) with
+            | None -> false
+            | Some _ -> is_allowed_in t (Pair (extn, lvl)))
       in
       match allowed_levels with
       | [] -> None

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -64,6 +64,7 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Mode -> (module Maturity)
   | Unique -> (module Maturity)
   | Overwriting -> (module Unit)
+  | Mode_polymorphism -> (module Maturity)
   | Include_functor -> (module Unit)
   | Polymorphic_parameters -> (module Unit)
   | Immutable_arrays -> (module Unit)
@@ -84,8 +85,10 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
 
    But we've decided to punt on this issue in the short term.
 *)
+(* CR ageorges: is mode polymorphism erasable? *)
 let is_erasable : type a. a t -> bool = function
-  | Mode | Unique | Overwriting | Layouts | Layout_poly -> true
+  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism ->
+    true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
   | Runtime_metaprogramming ->
@@ -103,6 +106,7 @@ module Exist_pair = struct
     | Pair (Mode, m) -> m
     | Pair (Unique, m) -> m
     | Pair (Overwriting, ()) -> Alpha
+    | Pair (Mode_polymorphism, m) -> m
     | Pair (Include_functor, ()) -> Stable
     | Pair (Polymorphic_parameters, ()) -> Stable
     | Pair (Immutable_arrays, ()) -> Stable
@@ -126,6 +130,8 @@ module Exist_pair = struct
     | Pair (SIMD, m) -> to_string SIMD ^ "_" ^ maturity_to_string m
     | Pair (Layout_poly, m) ->
       to_string Layout_poly ^ "_" ^ maturity_to_string m
+    | Pair (Mode_polymorphism, m) ->
+      to_string Mode_polymorphism ^ "_" ^ maturity_to_string m
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
@@ -143,6 +149,9 @@ module Exist_pair = struct
     | "mode" -> Some (Pair (Mode, Stable))
     | "mode_beta" -> Some (Pair (Mode, Beta))
     | "mode_alpha" -> Some (Pair (Mode, Alpha))
+    | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
+    | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
+    | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
     | "unique" -> Some (Pair (Unique, Stable))
     | "unique_beta" -> Some (Pair (Unique, Beta))
     | "unique_alpha" -> Some (Pair (Unique, Alpha))
@@ -176,6 +185,7 @@ let all_extensions =
   [ Pack Comprehensions;
     Pack Mode;
     Pack Unique;
+    Pack Mode_polymorphism;
     Pack Overwriting;
     Pack Include_functor;
     Pack Polymorphic_parameters;
@@ -217,6 +227,7 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Mode, Mode -> Some Refl
   | Unique, Unique -> Some Refl
   | Overwriting, Overwriting -> Some Refl
+  | Mode_polymorphism, Mode_polymorphism -> Some Refl
   | Include_functor, Include_functor -> Some Refl
   | Polymorphic_parameters, Polymorphic_parameters -> Some Refl
   | Immutable_arrays, Immutable_arrays -> Some Refl
@@ -231,7 +242,7 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming ),
+      | Runtime_metaprogramming | Mode_polymorphism ),
       _ ) ->
     None
 
@@ -347,6 +358,8 @@ end = struct
         (compiler_options !universe)
         ()
 
+  (* CR ageorges: Mode_polymorphism is omitted from universe to ensure
+  it is not enabled by -extension-universe alpha/beta. TODO: add when ready *)
   let allowed_extensions_in t =
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
@@ -359,7 +372,12 @@ end = struct
         let max_allowed_lvl = List.fold_left Ops.max lvl lvls in
         Some (Pair (extn, max_allowed_lvl))
     in
-    List.filter_map maximal_in_universe all_extensions
+    let all =
+      List.filter
+        (fun (Pack extn) -> not (equal extn Mode_polymorphism))
+        all_extensions
+    in
+    List.filter_map maximal_in_universe all
 end
 
 (*****************************************)

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -358,8 +358,6 @@ end = struct
         (compiler_options !universe)
         ()
 
-  (* CR ageorges: Mode_polymorphism is omitted from universe to ensure
-  it is not enabled by -extension-universe alpha/beta. TODO: add when ready *)
   let allowed_extensions_in t =
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
@@ -372,12 +370,7 @@ end = struct
         let max_allowed_lvl = List.fold_left Ops.max lvl lvls in
         Some (Pair (extn, max_allowed_lvl))
     in
-    let all =
-      List.filter
-        (fun (Pack extn) -> not (equal extn Mode_polymorphism))
-        all_extensions
-    in
-    List.filter_map maximal_in_universe all
+    List.filter_map maximal_in_universe all_extensions
 end
 
 (*****************************************)

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -86,7 +86,6 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
 
    But we've decided to punt on this issue in the short term.
 *)
-(* CR ageorges: is mode polymorphism erasable? *)
 let is_erasable : type a. a t -> bool = function
   | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism
   | Mode_polymorphism_printing ->

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -21,6 +21,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -22,6 +22,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Unique : maturity t
   | Overwriting : unit t
   | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -558,8 +558,8 @@ val f :
   string ->
   'd @ local ->
   'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
-  int array * string * (int -> (int -> int) @ local) *
-  (int -> (int -> int) @ local) @ local contended = <fun>
+  int array * string * (int -> int -> int) * (int -> int -> int) @ local
+  contended = <fun>
 |}]
 
 let f1 (_ @ local) = ()

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -558,8 +558,8 @@ val f :
   string ->
   'd @ local ->
   'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
-  int array * string * (int -> int -> int) * (int -> int -> int) @ local
-  contended = <fun>
+  int array * string * (int -> (int -> int) @ local) *
+  (int -> (int -> int) @ local) @ local contended = <fun>
 |}]
 
 let f1 (_ @ local) = ()

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -133,7 +133,7 @@ type succeeds = t_immediate_or_null accepts_nonfloat
 let f (x : int or_null @ local) (g : int or_null -> unit) = g x [@nontail]
 
 [%%expect{|
-val f : int or_null @ local -> ((int or_null -> unit) -> unit) = <fun>
+val f : int or_null @ local -> (int or_null -> unit) -> unit = <fun>
 |}, Principal{|
 val f : int or_null @ local -> (int or_null -> unit) -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -1,5 +1,6 @@
 (* TEST
- flags = "-extension-universe alpha";
+ flags += "-extension-universe alpha ";
+ flags += "-no-extension mode_polymorphism_alpha";
  expect;
 *)
 
@@ -133,7 +134,7 @@ type succeeds = t_immediate_or_null accepts_nonfloat
 let f (x : int or_null @ local) (g : int or_null -> unit) = g x [@nontail]
 
 [%%expect{|
-val f : int or_null @ local -> (int or_null -> unit) -> unit = <fun>
+val f : int or_null @ local -> ((int or_null -> unit) -> unit) = <fun>
 |}, Principal{|
 val f : int or_null @ local -> (int or_null -> unit) -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -15,14 +15,13 @@ type 'a myref = { mutable i : 'a }
 type 'a myref = { mutable i : 'a; }
 |}]
 
-(* CR ageorges: the following can accept stack locations but
-  uses setfield_ptr(maybe-stack). This is a soundness bug *)
-
 (* Must be [setfield_ptr(maybe-stack)] *)
 let foo r x = r.i <- x
 [%%expect{|
 (let
-  (foo/0 = (function {nlocal = 1} r/0[L] x/0 : int (setfield_ptr 0 r/0 x/0)))
+  (foo/0 =
+     (function {nlocal = 1} r/0[L] x/0 : int
+       (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo : 'a myref -> 'a -> unit = <fun>
 |}]
@@ -31,7 +30,7 @@ let foo (r @ local) x = r.i <- x
 [%%expect{|
 (let
   (foo/1 =
-     (function {nlocal = 1} r/1[L] x/1 : int
+     (function {nlocal = 2} r/1[L] x/1 : int
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
 val foo : 'a myref @ local -> 'a -> unit = <fun>
@@ -77,7 +76,8 @@ Warning 26 [unused-var]: unused variable "r".
      (function {nlocal = 1} param/2[L][value<int>] : stack
        (region
          (let (r/5 =mut "bar")
-           (function {nlocal = 1} r/6[L] : int (setfield_ptr 0 r/6 "foobar"))))))
+           (function {nlocal = 1} r/6[L] : int
+             (setfield_ptr(maybe-stack) 0 r/6 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/4))
 
 val foo : unit -> string myref -> unit = <fun>
@@ -227,7 +227,7 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
 (let
   (app/0 =? (apply (field_imm 0 (global Toploop!)) "app")
    app_yielding/0 =
-     (function {nlocal = 1} f/1[L] x/9[L]? : stack
+     (function {nlocal = 1} f/1 x/9[L]? : stack
        (apply[yielding] app/0 f/1 x/9)))
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
 val app_yielding : ('a @ yielding -> 'b) @ yielding -> 'a @ yielding -> 'b =

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -24,9 +24,8 @@ let foo r x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo :
-  'a myref @ [< past('m) & global corrupted write] ->
-  ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> past('m) | corruptible writing] =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -38,9 +37,8 @@ let foo (r @ local) x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
 val foo :
-  'a myref @ [< past('m) & corrupted write > local unforkable yielding] ->
-  ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> past('m) | local corruptible unforkable yielding writing] =
+  'a myref @ [< past('m) & write > local] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | local writing] =
   <fun>
 |}]
 
@@ -50,9 +48,8 @@ let foo (r @ global) x = r.i <- x
 (let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
 val foo :
-  'a myref @ [< past('m) & global corrupted forkable unyielding write] ->
-  ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> past('m) | corruptible writing] =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -71,8 +68,7 @@ let foo () =
          (function {nlocal = 1} param/1[L][value<int>] : int
            (apply store/0 r/3)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/3))
-val foo :
-  unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> corruptible writing] =
+val foo : unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> writing] =
   <fun>
 |}]
 
@@ -94,8 +90,7 @@ Warning 26 [unused-var]: unused variable "r".
              (setfield_ptr(maybe-stack) 0 r/6 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/4))
 
-val foo : unit @ 'o -> (string myref @ [< corrupted write] -> unit @ 'n) @ 'm =
-  <fun>
+val foo : unit @ 'o -> (string myref @ [< write] -> unit @ 'n) @ 'm = <fun>
 |}]
 
 let foo () =
@@ -113,8 +108,7 @@ let foo () =
          (function {nlocal = 1} param/4[L][value<int>] : int
            (apply store/1 r/7)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/5))
-val foo :
-  unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> corruptible writing] =
+val foo : unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> writing] =
   <fun>
 |}]
 
@@ -154,9 +148,8 @@ let fst_local (x @ local) = exclave_ fun y -> x
        (function[L] {nlocal = 1} y/2[L]? x/5)))
   (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/0))
 val fst_local :
-  'a @ [< 'm > local unforkable yielding] ->
-  ('b @ 'n -> 'a @ [> 'm | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
-  <fun>
+  'a @ [< 'm > local] ->
+  ('b @ 'n -> 'a @ [> 'm | local]) @ [> close('m) | local] = <fun>
 |}]
 
 let foo = fst 42
@@ -177,9 +170,7 @@ let foo () =
      (function {nlocal = 1} param/5[L][value<int>] : stack
        (apply[L] fst_local/0 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
-val foo :
-  unit @ 'n ->
-  ('a @ 'm -> int @ [> local unforkable yielding]) @ [> local unforkable yielding dynamic] =
+val foo : unit @ 'n -> ('a @ 'm -> int @ [> local]) @ [> local dynamic] =
   <fun>
 |}]
 
@@ -251,7 +242,7 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
 val app_yielding :
   ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< past('o) & global > yielding] ->
-  ('a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic]) @ [> past('o) | nonportable yielding stateful] =
+  ('a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic]) @ [> past('o) | yielding stateful] =
   <fun>
 |}]
 
@@ -277,8 +268,7 @@ let rec forward =
           (makeblock 0 g/0)))
       (apply (field_imm 1 (global Toploop!)) "forward" forward/0))))
 val forward :
-  int @ [< many uncontended read_write > dynamic] ->
-  int @ [< global > dynamic] = <fun>
+  int @ [< many read_write > dynamic] -> int @ [< global > dynamic] = <fun>
 |}]
 
 (* Same wrapper, but closing over the yielding [y]: all calls must be
@@ -314,8 +304,7 @@ let forward_yielding (y @ yielding) =
     forward_yielding/0))
 val forward_yielding :
   'a @ [< past('m) & global many > yielding] ->
-  (int @ [< many uncontended read_write > dynamic] ->
-   int @ [< global > dynamic]) @ [> past('m) | nonportable yielding stateful] =
+  (int @ [< many read_write > dynamic] -> int @ [< global > dynamic]) @ [> past('m) | yielding stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -161,8 +161,7 @@ let foo () =
      (function {nlocal = 1} param/5[L][value<int>] : stack
        (apply[L] fst_local/0 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
-val foo : unit @ 'n -> ('a @ 'm -> int @ [> local]) @ [> local dynamic] =
-  <fun>
+val foo : unit @ 'n -> 'a @ 'm -> int @ [> local] = <fun>
 |}]
 
 

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -24,8 +24,8 @@ let foo r x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo :
-  'a myref @ [< past('n) & global write] ->
-  'a @ [< global many read_write] -> unit @ 'm = <fun>
+  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  <fun>
 |}]
 
 let foo (r @ local) x = r.i <- x
@@ -36,7 +36,7 @@ let foo (r @ local) x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
 val foo :
-  'a myref @ [< past('n) & write > local] ->
+  'a myref @ [< write > local] ->
   'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
@@ -46,8 +46,8 @@ let foo (r @ global) x = r.i <- x
 (let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
 val foo :
-  'a myref @ [< past('n) & global write] ->
-  'a @ [< global many read_write] -> unit @ 'm = <fun>
+  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  <fun>
 |}]
 
 let foo () =
@@ -161,7 +161,8 @@ let foo () =
      (function {nlocal = 1} param/5[L][value<int>] : stack
        (apply[L] fst_local/0 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
-val foo : unit @ 'n -> 'a @ 'm -> int @ [> local] = <fun>
+val foo : unit @ 'n -> ('a @ 'm -> int @ [> local]) @ [> local dynamic] =
+  <fun>
 |}]
 
 
@@ -218,7 +219,7 @@ let app f x = f x
   (app/0 = (function {nlocal = 1} f/0[L] x/8[L]? (apply[yielding] f/0 x/8)))
   (apply (field_imm 1 (global Toploop!)) "app" app/0))
 val app :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
   'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
@@ -231,7 +232,7 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
      (function {nlocal = 1} f/1 x/9[L]? (apply[yielding] app/0 f/1 x/9)))
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
 val app_yielding :
-  ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< past('o) & global > yielding] ->
+  ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< global > yielding] ->
   'a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
@@ -292,7 +293,7 @@ let forward_yielding (y @ yielding) =
   (apply (field_imm 1 (global Toploop!)) "forward_yielding"
     forward_yielding/0))
 val forward_yielding :
-  'a @ [< past('m) & global many > yielding] ->
+  'a @ [< global many > yielding] ->
   int @ [< many read_write > dynamic] -> int @ [< global > dynamic] = <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -24,9 +24,9 @@ let foo r x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo :
-  'a myref @ [< 'm @@ past & global corrupted write] ->
+  'a myref @ [< past('m) & global corrupted write] ->
   ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> 'm | corruptible writing] =
+   unit @ 'n) @ [> past('m) | corruptible writing] =
   <fun>
 |}]
 
@@ -38,9 +38,9 @@ let foo (r @ local) x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
 val foo :
-  'a myref @ [< 'm @@ past & corrupted write > local unforkable yielding] ->
+  'a myref @ [< past('m) & corrupted write > local unforkable yielding] ->
   ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> 'm | local corruptible unforkable yielding writing] =
+   unit @ 'n) @ [> past('m) | local corruptible unforkable yielding writing] =
   <fun>
 |}]
 
@@ -50,9 +50,9 @@ let foo (r @ global) x = r.i <- x
 (let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
 val foo :
-  'a myref @ [< 'm @@ past & global corrupted forkable unyielding write] ->
+  'a myref @ [< past('m) & global corrupted forkable unyielding write] ->
   ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> 'm | corruptible writing] =
+   unit @ 'n) @ [> past('m) | corruptible writing] =
   <fun>
 |}]
 
@@ -237,8 +237,8 @@ let app f x = f x
   (app/0 = (function {nlocal = 1} f/0[L] x/8[L]? (apply[yielding] f/0 x/8)))
   (apply (field_imm 1 (global Toploop!)) "app" app/0))
 val app :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 (* Both arguments are yielding: must be [apply[yielding]]. *)
@@ -250,8 +250,8 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
      (function {nlocal = 1} f/1 x/9[L]? (apply[yielding] app/0 f/1 x/9)))
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
 val app_yielding :
-  ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global > yielding] ->
-  ('a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic]) @ [> 'o | nonportable yielding stateful] =
+  ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< past('o) & global > yielding] ->
+  ('a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic]) @ [> past('o) | nonportable yielding stateful] =
   <fun>
 |}]
 
@@ -313,9 +313,9 @@ let forward_yielding (y @ yielding) =
   (apply (field_imm 1 (global Toploop!)) "forward_yielding"
     forward_yielding/0))
 val forward_yielding :
-  'a @ [< 'm @@ past & global many > yielding] ->
+  'a @ [< past('m) & global many > yielding] ->
   (int @ [< many uncontended read_write > dynamic] ->
-   int @ [< global > dynamic]) @ [> 'm | nonportable yielding stateful] =
+   int @ [< global > dynamic]) @ [> past('m) | nonportable yielding stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -20,7 +20,7 @@ let foo r x = r.i <- x
 [%%expect{|
 (let
   (foo/0 =
-     (function {nlocal = 1} r/0[L] x/0 : int
+     (function {nlocal = 0} r/0[L] x/0 : int
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo :
@@ -47,7 +47,7 @@ val foo :
 (* Can be [setfield_ptr] *)
 let foo (r @ global) x = r.i <- x
 [%%expect{|
-(let (foo/2 = (function {nlocal = 1} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
+(let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
 val foo :
   'a myref @ [< 'm @@ past & global corrupted forkable unyielding write] ->
@@ -63,7 +63,7 @@ let foo () =
 [%%expect{|
 (let
   (foo/3 =
-     (function {nlocal = 1} param/0[L][value<int>] : stack
+     (function {nlocal = 1} param/0[L][value<int>]
        (let
          (r/3 = (makemutable 0 (*) "bar")
           store/0 =
@@ -87,7 +87,7 @@ Line 2, characters 6-7:
 Warning 26 [unused-var]: unused variable "r".
 (let
   (foo/4 =
-     (function {nlocal = 1} param/2[L][value<int>] : stack
+     (function {nlocal = 1} param/2[L][value<int>]
        (region
          (let (r/5 =mut "bar")
            (function {nlocal = 1} r/6[L] : int
@@ -105,7 +105,7 @@ let foo () =
 [%%expect{|
 (let
   (foo/5 =
-     (function {nlocal = 1} param/3[L][value<int>] : stack
+     (function {nlocal = 1} param/3[L][value<int>]
        (let
          (r/7 = (makemutable 0 (*) "bar")
           store/1 =
@@ -134,9 +134,7 @@ val foo :
 let fst x = fun y -> x
 [%%expect{|
 (let
-  (fst/0 =
-     (function {nlocal = 1} x/3? : stack
-       (function {nlocal = 1} y/0[L]? : stack x/3)))
+  (fst/0 = (function {nlocal = 0} x/3? (function {nlocal = 1} y/0[L]? x/3)))
   (apply (field_imm 1 (global Toploop!)) "fst" fst/0))
 val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
   <fun>
@@ -144,7 +142,7 @@ val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
 
 let fst' x y = x
 [%%expect{|
-(let (fst'/0 = (function {nlocal = 1} x/4[L]? y/1[L]? : stack x/4))
+(let (fst'/0 = (function {nlocal = 1} x/4[L]? y/1[L]? x/4))
   (apply (field_imm 1 (global Toploop!)) "fst'" fst'/0))
 val fst' : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
   <fun>
@@ -157,7 +155,7 @@ let fst_local (x @ local) = exclave_ fun y -> x
 (let
   (fst_local/0 =
      (function {nlocal = 1} x/5[L]? : stack
-       (function[L] {nlocal = 1} y/2[L]? : stack x/5)))
+       (function[L] {nlocal = 1} y/2[L]? x/5)))
   (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/0))
 val fst_local :
   'a @ [< 'm > local unforkable yielding] ->
@@ -206,7 +204,7 @@ val use_yield : 'a @ [> yielding] -> unit @ 'm = <fun>
 (let (use_unyielding/0 = (function {nlocal = 1} param/7[L]? : int 0))
   (apply (field_imm 1 (global Toploop!)) "use_unyielding" use_unyielding/0))
 val use_unyielding : 'a @ [< unyielding] -> unit @ 'm = <fun>
-(let (id/0 = (function {nlocal = 1} x/6[L]? : stack x/6))
+(let (id/0 = (function {nlocal = 1} x/6[L]? x/6))
   (apply (field_imm 1 (global Toploop!)) "id" id/0))
 val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
@@ -229,8 +227,7 @@ let apply_yielding (x @ yielding) = id x
 [%%expect{|
 (let
   (id/0 =? (apply (field_imm 0 (global Toploop!)) "id")
-   apply_yielding/0 =
-     (function {nlocal = 1} x/7? : stack (apply[yielding] id/0 x/7)))
+   apply_yielding/0 = (function {nlocal = 0} x/7? (apply[yielding] id/0 x/7)))
   (apply (field_imm 1 (global Toploop!)) "apply_yielding" apply_yielding/0))
 val apply_yielding :
   'a @ [< 'm & global > yielding] -> 'a @ [> 'm | yielding dynamic] = <fun>
@@ -241,8 +238,7 @@ val apply_yielding :
 let app f x = f x
 [%%expect{|
 (let
-  (app/0 =
-     (function {nlocal = 1} f/0[L] x/8[L]? : stack (apply[yielding] f/0 x/8)))
+  (app/0 = (function {nlocal = 1} f/0[L] x/8[L]? (apply[yielding] f/0 x/8)))
   (apply (field_imm 1 (global Toploop!)) "app" app/0))
 val app :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
@@ -255,8 +251,7 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
 (let
   (app/0 =? (apply (field_imm 0 (global Toploop!)) "app")
    app_yielding/0 =
-     (function {nlocal = 1} f/1 x/9[L]? : stack
-       (apply[yielding] app/0 f/1 x/9)))
+     (function {nlocal = 1} f/1 x/9[L]? (apply[yielding] app/0 f/1 x/9)))
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
 val app_yielding :
   ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global > yielding] ->
@@ -302,7 +297,7 @@ let forward_yielding (y @ yielding) =
 (let
   (use_yield/0 =? (apply (field_imm 0 (global Toploop!)) "use_yield")
    forward_yielding/0 =
-     (function {nlocal = 1} y/3? : stack
+     (function {nlocal = 0} y/3?
        (let (letrec_function_context/1 =? (caml_alloc_dummy 1))
          (letrec
            (f/2

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += "-dlambda -extension mode_polymorphism_alpha";
+ flags += "-dlambda -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
 *)
 
@@ -23,7 +23,11 @@ let foo r x = r.i <- x
      (function {nlocal = 1} r/0[L] x/0 : int
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
-val foo : 'a myref -> 'a -> unit = <fun>
+val foo :
+  'a myref @ [< 'm @@ past & global corrupted write] ->
+  ('a @ [< global many uncontended forkable unyielding read_write] ->
+   unit @ 'n) @ [> 'm | corruptible writing] =
+  <fun>
 |}]
 
 let foo (r @ local) x = r.i <- x
@@ -33,7 +37,11 @@ let foo (r @ local) x = r.i <- x
      (function {nlocal = 2} r/1[L] x/1 : int
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
-val foo : 'a myref @ local -> 'a -> unit = <fun>
+val foo :
+  'a myref @ [< 'm @@ past & corrupted write > local unforkable yielding] ->
+  ('a @ [< global many uncontended forkable unyielding read_write] ->
+   unit @ 'n) @ [> 'm | local corruptible unforkable yielding writing] =
+  <fun>
 |}]
 
 (* Can be [setfield_ptr] *)
@@ -41,7 +49,11 @@ let foo (r @ global) x = r.i <- x
 [%%expect{|
 (let (foo/2 = (function {nlocal = 1} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
-val foo : 'a myref -> 'a -> unit = <fun>
+val foo :
+  'a myref @ [< 'm @@ past & global corrupted forkable unyielding write] ->
+  ('a @ [< global many uncontended forkable unyielding read_write] ->
+   unit @ 'n) @ [> 'm | corruptible writing] =
+  <fun>
 |}]
 
 let foo () =
@@ -59,7 +71,9 @@ let foo () =
          (function {nlocal = 1} param/1[L][value<int>] : int
            (apply store/0 r/3)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/3))
-val foo : unit -> unit -> unit = <fun>
+val foo :
+  unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> corruptible writing] =
+  <fun>
 |}]
 
 let foo () =
@@ -80,7 +94,8 @@ Warning 26 [unused-var]: unused variable "r".
              (setfield_ptr(maybe-stack) 0 r/6 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/4))
 
-val foo : unit -> string myref -> unit = <fun>
+val foo : unit @ 'o -> (string myref @ [< corrupted write] -> unit @ 'n) @ 'm =
+  <fun>
 |}]
 
 let foo () =
@@ -98,7 +113,9 @@ let foo () =
          (function {nlocal = 1} param/4[L][value<int>] : int
            (apply store/1 r/7)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/5))
-val foo : unit -> unit -> unit = <fun>
+val foo :
+  unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> corruptible writing] =
+  <fun>
 |}]
 
 
@@ -121,14 +138,16 @@ let fst x = fun y -> x
      (function {nlocal = 1} x/3? : stack
        (function {nlocal = 1} y/0[L]? : stack x/3)))
   (apply (field_imm 1 (global Toploop!)) "fst" fst/0))
-val fst : 'a -> 'b -> 'a = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let fst' x y = x
 [%%expect{|
 (let (fst'/0 = (function {nlocal = 1} x/4[L]? y/1[L]? : stack x/4))
   (apply (field_imm 1 (global Toploop!)) "fst'" fst'/0))
-val fst' : 'a -> 'b -> 'a = <fun>
+val fst' : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* if explicitly annotated, the returned function is local [function[L]],
@@ -140,7 +159,10 @@ let fst_local (x @ local) = exclave_ fun y -> x
      (function {nlocal = 1} x/5[L]? : stack
        (function[L] {nlocal = 1} y/2[L]? : stack x/5)))
   (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/0))
-val fst_local : 'a @ local -> 'b -> 'a @ local = <fun>
+val fst_local :
+  'a @ [< 'm > local unforkable yielding] ->
+  ('b @ 'n -> 'a @ [> 'm | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
+  <fun>
 |}]
 
 let foo = fst 42
@@ -149,7 +171,7 @@ let foo = fst 42
   (fst/0 =? (apply (field_imm 0 (global Toploop!)) "fst")
    foo/6 = (apply fst/0 42))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/6))
-val foo : '_weak1 -> int = <fun>
+val foo : '_weak1 -> int @ [> aliased] = <fun>
 |}]
 
 let foo () =
@@ -161,7 +183,10 @@ let foo () =
      (function {nlocal = 1} param/5[L][value<int>] : stack
        (apply[L] fst_local/0 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
-val foo : unit -> ('a -> int @ local) @ local = <fun>
+val foo :
+  unit @ 'n ->
+  ('a @ 'm -> int @ [> local unforkable yielding]) @ [> local unforkable yielding dynamic] =
+  <fun>
 |}]
 
 
@@ -177,13 +202,13 @@ let id x = x
 [%%expect{|
 (let (use_yield/0 = (function {nlocal = 1} param/6[L]? : int 0))
   (apply (field_imm 1 (global Toploop!)) "use_yield" use_yield/0))
-val use_yield : 'a @ yielding -> unit = <fun>
+val use_yield : 'a @ [> yielding] -> unit @ 'm = <fun>
 (let (use_unyielding/0 = (function {nlocal = 1} param/7[L]? : int 0))
   (apply (field_imm 1 (global Toploop!)) "use_unyielding" use_unyielding/0))
-val use_unyielding : 'a -> unit = <fun>
+val use_unyielding : 'a @ [< unyielding] -> unit @ 'm = <fun>
 (let (id/0 = (function {nlocal = 1} x/6[L]? : stack x/6))
   (apply (field_imm 1 (global Toploop!)) "id" id/0))
-val id : 'a -> 'a = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 (* Toplevel [id] and constant [42] are unyielding: can be plain [apply]. *)
@@ -195,7 +220,7 @@ let apply_unyielding () = id 42
      (function {nlocal = 1} param/8[L][value<int>] : int (apply id/0 42)))
   (apply (field_imm 1 (global Toploop!)) "apply_unyielding"
     apply_unyielding/0))
-val apply_unyielding : unit -> int = <fun>
+val apply_unyielding : unit @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 (* [x] is yielding, despite [id] being mode-polymorphic: must be
@@ -207,7 +232,8 @@ let apply_yielding (x @ yielding) = id x
    apply_yielding/0 =
      (function {nlocal = 1} x/7? : stack (apply[yielding] id/0 x/7)))
   (apply (field_imm 1 (global Toploop!)) "apply_yielding" apply_yielding/0))
-val apply_yielding : 'a @ yielding -> 'a @ yielding = <fun>
+val apply_yielding :
+  'a @ [< 'm & global > yielding] -> 'a @ [> 'm | yielding dynamic] = <fun>
 |}]
 
 (* [f] and [x] have polymorphic modes, so either may be yielding: must be
@@ -218,7 +244,9 @@ let app f x = f x
   (app/0 =
      (function {nlocal = 1} f/0[L] x/8[L]? : stack (apply[yielding] f/0 x/8)))
   (apply (field_imm 1 (global Toploop!)) "app" app/0))
-val app : ('a -> 'b) -> 'a -> 'b = <fun>
+val app :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
 |}]
 
 (* Both arguments are yielding: must be [apply[yielding]]. *)
@@ -230,7 +258,9 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
      (function {nlocal = 1} f/1 x/9[L]? : stack
        (apply[yielding] app/0 f/1 x/9)))
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
-val app_yielding : ('a @ yielding -> 'b) @ yielding -> 'a @ yielding -> 'b =
+val app_yielding :
+  ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global > yielding] ->
+  ('a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic]) @ [> 'o | nonportable yielding stateful] =
   <fun>
 |}]
 
@@ -255,7 +285,9 @@ let rec forward =
                  (apply forward/0 (%int_sub x/11 1)))))
           (makeblock 0 g/0)))
       (apply (field_imm 1 (global Toploop!)) "forward" forward/0))))
-val forward : int -> int = <fun>
+val forward :
+  int @ [< many uncontended read_write > dynamic] ->
+  int @ [< global > dynamic] = <fun>
 |}]
 
 (* Same wrapper, but closing over the yielding [y]: all calls must be
@@ -289,7 +321,11 @@ let forward_yielding (y @ yielding) =
              f/2)))))
   (apply (field_imm 1 (global Toploop!)) "forward_yielding"
     forward_yielding/0))
-val forward_yielding : 'a @ yielding -> int -> int = <fun>
+val forward_yielding :
+  'a @ [< 'm @@ past & global many > yielding] ->
+  (int @ [< many uncontended read_write > dynamic] ->
+   int @ [< global > dynamic]) @ [> 'm | nonportable yielding stateful] =
+  <fun>
 |}]
 
 (* A first-class primitive's synthesized application ([Id_prim]) uses its

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -127,10 +127,6 @@ val foo :
 
   The following tests assert the locality of returned functions *)
 
-(* CR ageorges: the following two functions return local functions.
-  This will cause a crash if applied as global, (see [foo] below),
-  and is unsound *)
-
 let fst x = fun y -> x
 [%%expect{|
 (let

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -24,9 +24,8 @@ let foo r x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo :
-  'a myref @ [< past('m) & global write] ->
-  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
-  <fun>
+  'a myref @ [< past('n) & global write] ->
+  'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 let foo (r @ local) x = r.i <- x
@@ -37,9 +36,8 @@ let foo (r @ local) x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
 val foo :
-  'a myref @ [< past('m) & write > local] ->
-  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | local writing] =
-  <fun>
+  'a myref @ [< past('n) & write > local] ->
+  'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 (* Can be [setfield_ptr] *)
@@ -48,9 +46,8 @@ let foo (r @ global) x = r.i <- x
 (let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
 val foo :
-  'a myref @ [< past('m) & global write] ->
-  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
-  <fun>
+  'a myref @ [< past('n) & global write] ->
+  'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 let foo () =
@@ -68,8 +65,7 @@ let foo () =
          (function {nlocal = 1} param/1[L][value<int>] : int
            (apply store/0 r/3)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/3))
-val foo : unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> writing] =
-  <fun>
+val foo : unit @ 'n -> unit @ 'm -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo () =
@@ -90,7 +86,7 @@ Warning 26 [unused-var]: unused variable "r".
              (setfield_ptr(maybe-stack) 0 r/6 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/4))
 
-val foo : unit @ 'o -> (string myref @ [< write] -> unit @ 'n) @ 'm = <fun>
+val foo : unit @ 'n -> string myref @ [< write] -> unit @ 'm = <fun>
 |}]
 
 let foo () =
@@ -108,8 +104,7 @@ let foo () =
          (function {nlocal = 1} param/4[L][value<int>] : int
            (apply store/1 r/7)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/5))
-val foo : unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> writing] =
-  <fun>
+val foo : unit @ 'n -> unit @ 'm -> unit @ [> dynamic] = <fun>
 |}]
 
 
@@ -126,16 +121,14 @@ let fst x = fun y -> x
 (let
   (fst/0 = (function {nlocal = 0} x/3? (function {nlocal = 1} y/0[L]? x/3)))
   (apply (field_imm 1 (global Toploop!)) "fst" fst/0))
-val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let fst' x y = x
 [%%expect{|
 (let (fst'/0 = (function {nlocal = 1} x/4[L]? y/1[L]? x/4))
   (apply (field_imm 1 (global Toploop!)) "fst'" fst'/0))
-val fst' : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val fst' : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 (* if explicitly annotated, the returned function is local [function[L]],
@@ -147,9 +140,7 @@ let fst_local (x @ local) = exclave_ fun y -> x
      (function {nlocal = 1} x/5[L]? : stack
        (function[L] {nlocal = 1} y/2[L]? x/5)))
   (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/0))
-val fst_local :
-  'a @ [< 'm > local] ->
-  ('b @ 'n -> 'a @ [> 'm | local]) @ [> close('m) | local] = <fun>
+val fst_local : 'a @ [< 'm > local] -> 'b @ 'n -> 'a @ [> 'm | local] = <fun>
 |}]
 
 let foo = fst 42
@@ -170,8 +161,7 @@ let foo () =
      (function {nlocal = 1} param/5[L][value<int>] : stack
        (apply[L] fst_local/0 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
-val foo : unit @ 'n -> ('a @ 'm -> int @ [> local]) @ [> local dynamic] =
-  <fun>
+val foo : unit @ 'n -> 'a @ 'm -> int @ [> local] = <fun>
 |}]
 
 
@@ -229,7 +219,7 @@ let app f x = f x
   (apply (field_imm 1 (global Toploop!)) "app" app/0))
 val app :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 (* Both arguments are yielding: must be [apply[yielding]]. *)
@@ -242,8 +232,7 @@ let app_yielding (f @ yielding) (x @ yielding) = app f x
   (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
 val app_yielding :
   ('a @ [> 'n | yielding] -> 'b @ [< 'm & global]) @ [< past('o) & global > yielding] ->
-  ('a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic]) @ [> past('o) | yielding stateful] =
-  <fun>
+  'a @ [< 'n > yielding] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 (* The value-rec wrapper forwards at the closure's yielding mode, polymorphic
@@ -304,8 +293,7 @@ let forward_yielding (y @ yielding) =
     forward_yielding/0))
 val forward_yielding :
   'a @ [< past('m) & global many > yielding] ->
-  (int @ [< many read_write > dynamic] -> int @ [< global > dynamic]) @ [> past('m) | yielding stateful] =
-  <fun>
+  int @ [< many read_write > dynamic] -> int @ [< global > dynamic] = <fun>
 |}]
 
 (* A first-class primitive's synthesized application ([Id_prim]) uses its

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -1,0 +1,306 @@
+(* TEST
+ flags += "-dlambda -extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(* MUTABLE RECORD FIELDS *)
+
+(* If mutating a record field can be done on both local and global
+  records, it must be compiled to caml_modify_local.
+  Only when the record is always global can be compiled as caml_modify *)
+
+type 'a myref = { mutable i : 'a }
+[%%expect{|
+0
+type 'a myref = { mutable i : 'a; }
+|}]
+
+(* CR ageorges: the following can accept stack locations but
+  uses setfield_ptr(maybe-stack). This is a soundness bug *)
+
+(* Must be [setfield_ptr(maybe-stack)] *)
+let foo r x = r.i <- x
+[%%expect{|
+(let
+  (foo/0 = (function {nlocal = 1} r/0[L] x/0 : int (setfield_ptr 0 r/0 x/0)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
+val foo : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let foo (r @ local) x = r.i <- x
+[%%expect{|
+(let
+  (foo/1 =
+     (function {nlocal = 1} r/1[L] x/1 : int
+       (setfield_ptr(maybe-stack) 0 r/1 x/1)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
+val foo : 'a myref @ local -> 'a -> unit = <fun>
+|}]
+
+(* Can be [setfield_ptr] *)
+let foo (r @ global) x = r.i <- x
+[%%expect{|
+(let (foo/2 = (function {nlocal = 1} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
+val foo : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let foo () =
+  let r = { i = "bar" } in
+  let store r = r.i <- "foobar" in
+  fun () -> store r
+[%%expect{|
+(let
+  (foo/3 =
+     (function {nlocal = 1} param/0[L][value<int>] : stack
+       (let
+         (r/3 = (makemutable 0 (*) "bar")
+          store/0 =
+            (function {nlocal = 0} r/4 : int (setfield_ptr 0 r/4 "foobar")))
+         (function {nlocal = 1} param/1[L][value<int>] : int
+           (apply store/0 r/3)))))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/3))
+val foo : unit -> unit -> unit = <fun>
+|}]
+
+let foo () =
+  let r @ local = { i = "bar" } in
+  let store r = r.i <- "foobar" in
+  store
+[%%expect{|
+Line 2, characters 6-7:
+2 |   let r @ local = { i = "bar" } in
+          ^
+Warning 26 [unused-var]: unused variable "r".
+(let
+  (foo/4 =
+     (function {nlocal = 1} param/2[L][value<int>] : stack
+       (region
+         (let (r/5 =mut "bar")
+           (function {nlocal = 1} r/6[L] : int (setfield_ptr 0 r/6 "foobar"))))))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/4))
+
+val foo : unit -> string myref -> unit = <fun>
+|}]
+
+let foo () =
+  let r @ global = { i = "bar" } in
+  let store r = r.i <- "foobar" in
+  fun () -> store r
+[%%expect{|
+(let
+  (foo/5 =
+     (function {nlocal = 1} param/3[L][value<int>] : stack
+       (let
+         (r/7 = (makemutable 0 (*) "bar")
+          store/1 =
+            (function {nlocal = 0} r/8 : int (setfield_ptr 0 r/8 "foobar")))
+         (function {nlocal = 1} param/4[L][value<int>] : int
+           (apply store/1 r/7)))))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/5))
+val foo : unit -> unit -> unit = <fun>
+|}]
+
+
+(* FUNCTIONS *)
+
+(* In order to soundly choose the allocation of a return value, functions default
+  to global returns, unless a return is explicitly set to local, in which case it must
+  be always local.
+
+  The following tests assert the locality of returned functions *)
+
+(* CR ageorges: the following two functions return local functions.
+  This will cause a crash if applied as global, (see [foo] below),
+  and is unsound *)
+
+let fst x = fun y -> x
+[%%expect{|
+(let
+  (fst/0 =
+     (function {nlocal = 1} x/3? : stack
+       (function {nlocal = 1} y/0[L]? : stack x/3)))
+  (apply (field_imm 1 (global Toploop!)) "fst" fst/0))
+val fst : 'a -> 'b -> 'a = <fun>
+|}]
+
+let fst' x y = x
+[%%expect{|
+(let (fst'/0 = (function {nlocal = 1} x/4[L]? y/1[L]? : stack x/4))
+  (apply (field_imm 1 (global Toploop!)) "fst'" fst'/0))
+val fst' : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* if explicitly annotated, the returned function is local [function[L]],
+  the inner [x] is returned locally *)
+let fst_local (x @ local) = exclave_ fun y -> x
+[%%expect{|
+(let
+  (fst_local/0 =
+     (function {nlocal = 1} x/5[L]? : stack
+       (function[L] {nlocal = 1} y/2[L]? : stack x/5)))
+  (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/0))
+val fst_local : 'a @ local -> 'b -> 'a @ local = <fun>
+|}]
+
+let foo = fst 42
+[%%expect{|
+(let
+  (fst/0 =? (apply (field_imm 0 (global Toploop!)) "fst")
+   foo/6 = (apply fst/0 42))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/6))
+val foo : '_weak1 -> int = <fun>
+|}]
+
+let foo () =
+  exclave_ (fst_local 42)
+[%%expect{|
+(let
+  (fst_local/0 =? (apply (field_imm 0 (global Toploop!)) "fst_local")
+   foo/7 =
+     (function {nlocal = 1} param/5[L][value<int>] : stack
+       (apply[L] fst_local/0 42)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
+val foo : unit -> ('a -> int @ local) @ local = <fun>
+|}]
+
+
+(* YIELDING *)
+
+(* An application is compiled to [apply[yielding]] when the function or any of
+  its arguments may be yielding, and to a plain [apply] only when all of them
+  are known to be unyielding. *)
+
+let use_yield (_ @ yielding) = ()
+let use_unyielding (_ @ unyielding) = ()
+let id x = x
+[%%expect{|
+(let (use_yield/0 = (function {nlocal = 1} param/6[L]? : int 0))
+  (apply (field_imm 1 (global Toploop!)) "use_yield" use_yield/0))
+val use_yield : 'a @ yielding -> unit = <fun>
+(let (use_unyielding/0 = (function {nlocal = 1} param/7[L]? : int 0))
+  (apply (field_imm 1 (global Toploop!)) "use_unyielding" use_unyielding/0))
+val use_unyielding : 'a -> unit = <fun>
+(let (id/0 = (function {nlocal = 1} x/6[L]? : stack x/6))
+  (apply (field_imm 1 (global Toploop!)) "id" id/0))
+val id : 'a -> 'a = <fun>
+|}]
+
+(* Toplevel [id] and constant [42] are unyielding: can be plain [apply]. *)
+let apply_unyielding () = id 42
+[%%expect{|
+(let
+  (id/0 =? (apply (field_imm 0 (global Toploop!)) "id")
+   apply_unyielding/0 =
+     (function {nlocal = 1} param/8[L][value<int>] : int (apply id/0 42)))
+  (apply (field_imm 1 (global Toploop!)) "apply_unyielding"
+    apply_unyielding/0))
+val apply_unyielding : unit -> int = <fun>
+|}]
+
+(* [x] is yielding, despite [id] being mode-polymorphic: must be
+  [apply[yielding]]. *)
+let apply_yielding (x @ yielding) = id x
+[%%expect{|
+(let
+  (id/0 =? (apply (field_imm 0 (global Toploop!)) "id")
+   apply_yielding/0 =
+     (function {nlocal = 1} x/7? : stack (apply[yielding] id/0 x/7)))
+  (apply (field_imm 1 (global Toploop!)) "apply_yielding" apply_yielding/0))
+val apply_yielding : 'a @ yielding -> 'a @ yielding = <fun>
+|}]
+
+(* [f] and [x] have polymorphic modes, so either may be yielding: must be
+  [apply[yielding]]. *)
+let app f x = f x
+[%%expect{|
+(let
+  (app/0 =
+     (function {nlocal = 1} f/0[L] x/8[L]? : stack (apply[yielding] f/0 x/8)))
+  (apply (field_imm 1 (global Toploop!)) "app" app/0))
+val app : ('a -> 'b) -> 'a -> 'b = <fun>
+|}]
+
+(* Both arguments are yielding: must be [apply[yielding]]. *)
+let app_yielding (f @ yielding) (x @ yielding) = app f x
+[%%expect{|
+(let
+  (app/0 =? (apply (field_imm 0 (global Toploop!)) "app")
+   app_yielding/0 =
+     (function {nlocal = 1} f/1[L] x/9[L]? : stack
+       (apply[yielding] app/0 f/1 x/9)))
+  (apply (field_imm 1 (global Toploop!)) "app_yielding" app_yielding/0))
+val app_yielding : ('a @ yielding -> 'b) @ yielding -> 'a @ yielding -> 'b =
+  <fun>
+|}]
+
+(* The value-rec wrapper forwards at the closure's yielding mode, polymorphic
+  here: must be [apply[yielding]] (plain in typing-modes/yielding_lambda.ml).
+  The direct call [forward (x - 1)] is unyielding: can be plain [apply]. *)
+let rec forward =
+  let g = fun x -> if x <= 0 then 0 else forward (x - 1) in
+  g
+[%%expect{|
+(let (letrec_function_context/0 =? (caml_alloc_dummy 1))
+  (letrec
+    (forward/0
+       (function {nlocal = 1} x/10[L][value<int>] stub : int
+         (apply[yielding] (field_imm 0 letrec_function_context/0) x/10)))
+    (seq
+      (caml_update_dummy letrec_function_context/0
+        (let
+          (g/0 =
+             (function {nlocal = 1} x/11[L][value<int>] : int
+               (if (%int_lessequal x/11 0) 0
+                 (apply forward/0 (%int_sub x/11 1)))))
+          (makeblock 0 g/0)))
+      (apply (field_imm 1 (global Toploop!)) "forward" forward/0))))
+val forward : int -> int = <fun>
+|}]
+
+(* Same wrapper, but closing over the yielding [y]: all calls must be
+  [apply[yielding]]. *)
+let forward_yielding (y @ yielding) =
+  let rec f =
+    let g = fun x -> use_yield y; if x <= 0 then 0 else f (x - 1) in
+    g
+  in
+  f
+[%%expect{|
+(let
+  (use_yield/0 =? (apply (field_imm 0 (global Toploop!)) "use_yield")
+   forward_yielding/0 =
+     (function {nlocal = 1} y/3? : stack
+       (let (letrec_function_context/1 =? (caml_alloc_dummy 1))
+         (letrec
+           (f/2
+              (function {nlocal = 1} x/12[L][value<int>] stub : int
+                (apply[yielding] (field_imm 0 letrec_function_context/1)
+                  x/12)))
+           (seq
+             (caml_update_dummy letrec_function_context/1
+               (let
+                 (g/1 =
+                    (function {nlocal = 1} x/13[L][value<int>] : int
+                      (seq (apply[yielding] use_yield/0 y/3)
+                        (if (%int_lessequal x/13 0) 0
+                          (apply[yielding] f/2 (%int_sub x/13 1))))))
+                 (makeblock 0 g/1)))
+             f/2)))))
+  (apply (field_imm 1 (global Toploop!)) "forward_yielding"
+    forward_yielding/0))
+val forward_yielding : 'a @ yielding -> int -> int = <fun>
+|}]
+
+(* A first-class primitive's synthesized application ([Id_prim]) uses its
+  declared parameter modes, unyielding by default: can be plain [apply]. *)
+external revapply : 'a -> ('a -> 'b) -> 'b = "%revapply"
+let pipe = revapply
+[%%expect{|
+0
+external revapply : 'a -> ('a -> 'b) -> 'b = "%revapply"
+(let
+  (pipe/0 = (function {nlocal = 0} prim/0 prim/1 stub (apply prim/1 prim/0)))
+  (apply (field_imm 1 (global Toploop!)) "pipe" pipe/0))
+val pipe : 'a -> ('a -> 'b) -> 'b = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -1,0 +1,320 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a @ static -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* BASIC POLYMORPHISM *)
+
+let foo =
+  let foo x = x in
+  let x = ref 42 in
+  let x = foo x in
+  let (y @ contended) = ref !x in
+  let _ = foo y in
+  foo
+[%%expect{|
+val foo : '_weak1 -> '_weak1 = <fun>
+|}]
+
+let id x = x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+|}]
+
+let () =
+  let x = ref 42 in
+  let x = id x in
+  let (y @ contended) = ref !x in
+  let _ = id y in
+  ()
+[%%expect{|
+|}]
+
+(* instantiation [id] does not make it less polymorphic *)
+let foo (x @ portable) = id x
+let id' = id
+[%%expect{|
+val foo : 'a @ portable -> 'a = <fun>
+val id' : 'a -> 'a = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  let x = id' x in
+  use_portable x
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable x
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let bar (c @ unique) =
+  use_unique (id c)
+[%%expect{|
+val bar : 'a @ unique -> unit = <fun>
+|}]
+
+let bar (c @ local) =
+  let _ = use_unique (id c) in
+  ()
+[%%expect{|
+val bar : 'a @ local unique -> unit = <fun>
+|}]
+
+let bar (x @ aliased) =
+  let x = id x in
+  let _ = use_unique x in
+  ()
+[%%expect{|
+Line 3, characters 21-22:
+3 |   let _ = use_unique x in
+                         ^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+let bar (x @ many) =
+  let y @ once = x in
+  let y = id y in
+  (y, y)
+[%%expect{|
+Line 4, characters 6-7:
+4 |   (y, y)
+          ^
+Error: This value is used here,
+       but it is defined as once and is also being used at:
+Line 4, characters 3-4:
+4 |   (y, y)
+       ^
+
+|}]
+
+(* the result of a mode polymorphic function can't be static *)
+let foo (x @ static) =
+  let x = id x in
+  use_static x
+[%%expect{|
+Line 3, characters 13-14:
+3 |   use_static x
+                 ^
+Error: This value is "dynamic"
+         because function applications are always dynamic.
+       However, the highlighted expression is expected to be "static".
+|}]
+
+(* mode polymorphism allows us to combine take combine the bounds of two
+functions via joins *)
+let f (x : string) = x
+let g (x : string @ portable) = x
+let which = function
+  | false -> f
+  | true -> g
+[%%expect{|
+val f : string -> string = <fun>
+val g : string @ portable -> string = <fun>
+val which : bool -> string @ portable -> string = <fun>
+|}]
+
+(* The least upper bound between portable and nonportable is nonportable *)
+let foo (x @ portable) =
+  let f = which true in
+  use_portable (f x) (* x is weakened to nonportable before it's applied to f *)
+[%%expect{|
+val foo : string @ portable -> unit = <fun>
+|}]
+
+let foo (x @ portable) =
+  let f = which false in
+  use_global (f x) (* x is weakened to nonportable before it's applied to f *)
+[%%expect{|
+val foo : string @ portable -> unit = <fun>
+|}]
+
+(* mode variables used at some mode imposes a bound on them *)
+let id x = use_portable x; x
+[%%expect{|
+val id : 'a @ portable -> 'a = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  id x
+[%%expect{|
+Line 2, characters 5-6:
+2 |   id x
+         ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* but they remain polymorphic on the other axes *)
+
+let foo (x @ contended) (y @ uncontended) =
+  let x = id x in
+  let y = id y in
+  use_uncontended y; (* this use succeeds *)
+  use_uncontended x (* this use fails *)
+[%%expect{|
+Line 5, characters 18-19:
+5 |   use_uncontended x (* this use fails *)
+                      ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]
+
+(* CLOSING OVER MODE VARIABLES *)
+(* Basic closing-over behavior. See [currying.ml] for more intricate patterns *)
+
+let close_over x = fun () -> x
+[%%expect{|
+val close_over : 'a -> unit -> 'a = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let const_x = close_over x in
+  let const_y = close_over y in
+  use_portable (const_x ());
+  use_portable (const_y ())
+[%%expect{|
+Line 5, characters 15-27:
+5 |   use_portable (const_y ())
+                   ^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let close_over x = fun () -> fun () -> x
+[%%expect{|
+val close_over : 'a -> unit -> unit -> 'a = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let const_x = close_over x in
+  let const_y = close_over y in
+  use_portable (const_x () ());
+  use_portable (const_y () ())
+[%%expect{|
+Line 5, characters 15-30:
+5 |   use_portable (const_y () ())
+                   ^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* partially applying a nested closure similarly depends on input mode *)
+let foo (x @ portable) =
+  let const_x = close_over x in
+  use_portable (const_x ())
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (x @ portable) =
+  use_portable (close_over x)
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+(* MODE CROSSING *)
+
+(* mode crossing is stronger than mode polymorphism *)
+let foo (x : int @ portable) (y : int @ nonportable) =
+  let x = id x in
+  let y = id y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+val foo : int @ portable -> int -> unit = <fun>
+|}]
+
+(* LOCAL AND MODE POLYMORPHISM *)
+
+(* a function whose return does not allocate can be polymorphic over locality *)
+let id x = x
+
+let foo (x @ local) =
+  let x = id x in
+  use_global x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+Line 5, characters 13-14:
+5 |   use_global x
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* if the return value is allocated, its locality is restricted to global *)
+let some x = Some x
+
+let foo (x @ local) =
+  let x = some x in
+  ()
+[%%expect{|
+val some : 'a -> 'a option = <fun>
+Line 4, characters 15-16:
+4 |   let x = some x in
+                   ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+(* unless there is an exclave_ *)
+let some x = exclave_ (Some x)
+
+let foo (x @ local) =
+  let x = some x in
+  use_global x
+[%%expect{|
+val some : 'a -> 'a option @ local = <fun>
+Line 5, characters 13-14:
+5 |   use_global x
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* local values stay local through id_local - can't return without exclave_ *)
+let id_local (x @ local) = x
+
+let foo (x @ local) =
+  let y = id_local x in
+  y
+[%%expect{|
+val id_local : 'a @ local -> 'a @ local = <fun>
+Line 5, characters 2-3:
+5 |   y
+      ^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}]
+
+(* with exclave_ it works *)
+let foo (local_ x) = exclave_
+  let y = id_local x in
+  y
+[%%expect{|
+val foo : 'a @ local -> 'a @ local = <fun>
+|}]
+
+(* MULTIPLE MODE AXES *)
+
+(* Bounds can be imposed on multiple axes *)
+let foo (x @ uncontended portable) =
+  use_uncontended (id x);
+  use_portable (id x)
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,11 +9,11 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a @ static -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
 |}]
 
 (* BASIC POLYMORPHISM *)
@@ -32,12 +26,13 @@ let foo =
   let _ = foo y in
   foo
 [%%expect{|
-val foo : '_weak1 -> '_weak1 = <fun>
+val foo : '_weak1 -> '_weak1 @ [> aliased nonportable stateful dynamic] =
+  <fun>
 |}]
 
 let id x = x
 [%%expect{|
-val id : 'a -> 'a = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -53,8 +48,8 @@ let () =
 let foo (x @ portable) = id x
 let id' = id
 [%%expect{|
-val foo : 'a @ portable -> 'a = <fun>
-val id' : 'a -> 'a = <fun>
+val foo : 'a @ [< 'm & global portable] -> 'a @ [> 'm | dynamic] = <fun>
+val id' : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo (x @ nonportable) =
@@ -70,14 +65,14 @@ Error: This value is "nonportable" but is expected to be "portable".
 let bar (c @ unique) =
   use_unique (id c)
 [%%expect{|
-val bar : 'a @ unique -> unit = <fun>
+val bar : 'a @ [< global unique] -> unit @ [> dynamic] = <fun>
 |}]
 
 let bar (c @ local) =
   let _ = use_unique (id c) in
   ()
 [%%expect{|
-val bar : 'a @ local unique -> unit = <fun>
+val bar : 'a @ [< unique > local unforkable yielding] -> unit @ 'm = <fun>
 |}]
 
 let bar (x @ aliased) =
@@ -128,9 +123,17 @@ let which = function
   | false -> f
   | true -> g
 [%%expect{|
-val f : string -> string = <fun>
-val g : string @ portable -> string = <fun>
-val which : bool -> string @ portable -> string = <fun>
+val f :
+  string @ [< 'm . contended immutable] ->
+  string @ [> 'm @@ many portable forkable unyielding stateless] = <fun>
+val g :
+  string @ [< 'm . contended immutable & portable] ->
+  string @ [> 'm @@ many portable forkable unyielding stateless] = <fun>
+val which :
+  bool @ 'n ->
+  (string @ [< 'm . contended immutable & portable] ->
+   string @ [> 'm @@ many portable forkable unyielding stateless]) @ [> aliased nonportable stateful dynamic] =
+  <fun>
 |}]
 
 (* The least upper bound between portable and nonportable is nonportable *)
@@ -138,20 +141,20 @@ let foo (x @ portable) =
   let f = which true in
   use_portable (f x) (* x is weakened to nonportable before it's applied to f *)
 [%%expect{|
-val foo : string @ portable -> unit = <fun>
+val foo : string @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ portable) =
   let f = which false in
   use_global (f x) (* x is weakened to nonportable before it's applied to f *)
 [%%expect{|
-val foo : string @ portable -> unit = <fun>
+val foo : string @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 (* mode variables used at some mode imposes a bound on them *)
 let id x = use_portable x; x
 [%%expect{|
-val id : 'a @ portable -> 'a = <fun>
+val id : 'a @ [< 'm & many portable] -> 'a @ [> 'm | aliased] = <fun>
 |}]
 
 let foo (x @ nonportable) =
@@ -182,7 +185,8 @@ Error: This value is "contended" but is expected to be "uncontended".
 
 let close_over x = fun () -> x
 [%%expect{|
-val close_over : 'a -> unit -> 'a = <fun>
+val close_over :
+  'a @ [< 'm & global] -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -199,7 +203,10 @@ Error: This value is "nonportable" but is expected to be "portable".
 
 let close_over x = fun () -> fun () -> x
 [%%expect{|
-val close_over : 'a -> unit -> unit -> 'a = <fun>
+val close_over :
+  'a @ [< 'm & global] ->
+  (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -219,13 +226,13 @@ let foo (x @ portable) =
   let const_x = close_over x in
   use_portable (const_x ())
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ portable) =
   use_portable (close_over x)
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 (* MODE CROSSING *)
@@ -237,7 +244,10 @@ let foo (x : int @ portable) (y : int @ nonportable) =
   use_portable x;
   use_portable y
 [%%expect{|
-val foo : int @ portable -> int -> unit = <fun>
+val foo :
+  int @ [< 'm @@ past & global portable] ->
+  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  <fun>
 |}]
 
 (* LOCAL AND MODE POLYMORPHISM *)
@@ -249,7 +259,7 @@ let foo (x @ local) =
   let x = id x in
   use_global x
 [%%expect{|
-val id : 'a -> 'a = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 Line 5, characters 13-14:
 5 |   use_global x
                  ^
@@ -263,7 +273,7 @@ let foo (x @ local) =
   let x = some x in
   ()
 [%%expect{|
-val some : 'a -> 'a option = <fun>
+val some : 'a @ [< 'm & global] -> 'a option @ [> 'm] = <fun>
 Line 4, characters 15-16:
 4 |   let x = some x in
                    ^
@@ -277,7 +287,7 @@ let foo (x @ local) =
   let x = some x in
   use_global x
 [%%expect{|
-val some : 'a -> 'a option @ local = <fun>
+val some : 'a @ [< 'm] -> 'a option @ [> 'm | local] = <fun>
 Line 5, characters 13-14:
 5 |   use_global x
                  ^
@@ -291,7 +301,9 @@ let foo (x @ local) =
   let y = id_local x in
   y
 [%%expect{|
-val id_local : 'a @ local -> 'a @ local = <fun>
+val id_local :
+  'a @ [< 'm > local unforkable yielding] ->
+  'a @ [> 'm | local unforkable yielding] = <fun>
 Line 5, characters 2-3:
 5 |   y
       ^
@@ -306,7 +318,9 @@ let foo (local_ x) = exclave_
   let y = id_local x in
   y
 [%%expect{|
-val foo : 'a @ local -> 'a @ local = <fun>
+val foo :
+  'a @ [< 'm > local unforkable yielding] ->
+  'a @ [> 'm | local unforkable yielding dynamic] = <fun>
 |}]
 
 (* MULTIPLE MODE AXES *)
@@ -316,5 +330,6 @@ let foo (x @ uncontended portable) =
   use_uncontended (id x);
   use_portable (id x)
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global many portable uncontended] -> unit @ [> dynamic] =
+  <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -245,8 +245,8 @@ let foo (x : int @ portable) (y : int @ nonportable) =
   use_portable y
 [%%expect{|
 val foo :
-  int @ [< 'm @@ past & global portable] ->
-  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  int @ [< past('m) & global portable] ->
+  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -123,15 +123,15 @@ let which = function
   | true -> g
 [%%expect{|
 val f :
-  string @ [< 'm . contended immutable] ->
-  string @ [> 'm @@ many portable forkable unyielding stateless] = <fun>
+  string @ [< 'm mod contended immutable] ->
+  string @ [> 'm mod many portable forkable unyielding stateless] = <fun>
 val g :
-  string @ [< 'm . contended immutable & portable] ->
-  string @ [> 'm @@ many portable forkable unyielding stateless] = <fun>
+  string @ [< 'm mod contended immutable & portable] ->
+  string @ [> 'm mod many portable forkable unyielding stateless] = <fun>
 val which :
   bool @ 'n ->
-  (string @ [< 'm . contended immutable & portable] ->
-   string @ [> 'm @@ many portable forkable unyielding stateless]) @ [> aliased stateful dynamic] =
+  (string @ [< 'm mod contended immutable & portable] ->
+   string @ [> 'm mod many portable forkable unyielding stateless]) @ [> aliased stateful dynamic] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -239,6 +239,9 @@ let foo (x : int @ portable) (y : int @ nonportable) =
   use_portable x;
   use_portable y
 [%%expect{|
+val foo : int @ [< portable] -> int @ [> nonportable] -> unit @ [> dynamic] =
+  <fun>
+|}, Principal{|
 val foo :
   int @ [< global portable] -> int @ [> nonportable] -> unit @ [> dynamic] =
   <fun>

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -130,9 +130,8 @@ val g :
   string @ [> 'm mod many portable forkable unyielding stateless] = <fun>
 val which :
   bool @ 'n ->
-  (string @ [< 'm mod contended immutable & portable] ->
-   string @ [> 'm mod many portable forkable unyielding stateless]) @ [> aliased stateful dynamic] =
-  <fun>
+  string @ [< 'm mod contended immutable & portable] ->
+  string @ [> 'm mod many portable forkable unyielding stateless] = <fun>
 |}]
 
 (* The least upper bound between portable and nonportable is nonportable *)
@@ -184,8 +183,7 @@ Error: This value is "contended" but is expected to be "uncontended".
 
 let close_over x = fun () -> x
 [%%expect{|
-val close_over :
-  'a @ [< 'm & global] -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
+val close_over : 'a @ [< 'm & global] -> unit @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -203,9 +201,7 @@ Error: This value is "nonportable" but is expected to be "portable".
 let close_over x = fun () -> fun () -> x
 [%%expect{|
 val close_over :
-  'a @ [< 'm & global] ->
-  (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)] =
-  <fun>
+  'a @ [< 'm & global] -> unit @ 'o -> unit @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -245,8 +241,7 @@ let foo (x : int @ portable) (y : int @ nonportable) =
 [%%expect{|
 val foo :
   int @ [< past('m) & global portable] ->
-  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  int @ [> nonportable] -> unit @ [> dynamic] = <fun>
 |}]
 
 (* LOCAL AND MODE POLYMORPHISM *)

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -240,8 +240,8 @@ let foo (x : int @ portable) (y : int @ nonportable) =
   use_portable y
 [%%expect{|
 val foo :
-  int @ [< past('m) & global portable] ->
-  int @ [> nonportable] -> unit @ [> dynamic] = <fun>
+  int @ [< global portable] -> int @ [> nonportable] -> unit @ [> dynamic] =
+  <fun>
 |}]
 
 (* LOCAL AND MODE POLYMORPHISM *)

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -13,7 +13,7 @@ val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
 val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
 val use_static : 'a @ [< static] -> unit @ 'm = <fun>
-val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* BASIC POLYMORPHISM *)
@@ -26,8 +26,7 @@ let foo =
   let _ = foo y in
   foo
 [%%expect{|
-val foo : '_weak1 -> '_weak1 @ [> aliased nonportable stateful dynamic] =
-  <fun>
+val foo : '_weak1 -> '_weak1 @ [> aliased stateful dynamic] = <fun>
 |}]
 
 let id x = x
@@ -72,7 +71,7 @@ let bar (c @ local) =
   let _ = use_unique (id c) in
   ()
 [%%expect{|
-val bar : 'a @ [< unique > local unforkable yielding] -> unit @ 'm = <fun>
+val bar : 'a @ [< unique > local] -> unit @ 'm = <fun>
 |}]
 
 let bar (x @ aliased) =
@@ -132,7 +131,7 @@ val g :
 val which :
   bool @ 'n ->
   (string @ [< 'm . contended immutable & portable] ->
-   string @ [> 'm @@ many portable forkable unyielding stateless]) @ [> aliased nonportable stateful dynamic] =
+   string @ [> 'm @@ many portable forkable unyielding stateless]) @ [> aliased stateful dynamic] =
   <fun>
 |}]
 
@@ -246,7 +245,7 @@ let foo (x : int @ portable) (y : int @ nonportable) =
 [%%expect{|
 val foo :
   int @ [< past('m) & global portable] ->
-  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
+  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 
@@ -301,9 +300,7 @@ let foo (x @ local) =
   let y = id_local x in
   y
 [%%expect{|
-val id_local :
-  'a @ [< 'm > local unforkable yielding] ->
-  'a @ [> 'm | local unforkable yielding] = <fun>
+val id_local : 'a @ [< 'm > local] -> 'a @ [> 'm | local] = <fun>
 Line 5, characters 2-3:
 5 |   y
       ^
@@ -318,9 +315,7 @@ let foo (local_ x) = exclave_
   let y = id_local x in
   y
 [%%expect{|
-val foo :
-  'a @ [< 'm > local unforkable yielding] ->
-  'a @ [> 'm | local unforkable yielding dynamic] = <fun>
+val foo : 'a @ [< 'm > local] -> 'a @ [> 'm | local dynamic] = <fun>
 |}]
 
 (* MULTIPLE MODE AXES *)

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -60,13 +60,10 @@ Line 4, characters 10-21:
 Warning 5 [ignored-partial-application]: this function application is partial,
   maybe some arguments are missing.
 
-Line 5, characters 10-20:
+Line 5, characters 14-20:
 5 |   let _ = fst clocal in
-              ^^^^^^^^^^
-Warning 5 [ignored-partial-application]: this function application is partial,
-  maybe some arguments are missing.
-
-val foo : unit = ()
+                  ^^^^^^
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let bar (x @ once) =

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,11 +9,11 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a @ static -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
 |}]
 
 (* [fst] is the K-combinator and displays an interesting bi-directional dependency
@@ -39,7 +33,8 @@ val use_global : 'a -> unit = <fun>
 
 let fst x y = x
 [%%expect{|
-val fst : 'a -> 'b -> 'a = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* n-ary functions will impose locality bounds on arguments, since the middle end
@@ -69,14 +64,16 @@ Error: This value is "local" but is expected to be "global".
 let bar (x @ once) =
   fst x
 [%%expect{|
-val bar : 'a @ once -> 'b -> 'a @ once = <fun>
+val bar :
+  'a @ [< 'm & global > once] ->
+  ('b @ 'n -> 'a @ [> 'm | once]) @ [> close('m) | once dynamic] = <fun>
 |}]
 
 let bar (x @ unique) =
   let x = fst x () in
   use_unique x
 [%%expect{|
-val bar : 'a @ unique -> unit = <fun>
+val bar : 'a @ [< global unique] -> unit @ [> dynamic] = <fun>
 |}]
 
 (* Uniqueness is not broken in an n-ary function if it is used uniquely in the body *)
@@ -87,7 +84,11 @@ let check_tuple x y z =
   m, y, y
 [%%expect{|
 type box = { mutable x : int; }
-val check_tuple : 'a @ unique -> 'b -> 'c -> unit * 'b * 'b = <fun>
+val check_tuple :
+  'a @ [< 'o @@ past & 'm @@ past & global unique] ->
+  ('b @ [< 'n & global many] ->
+   ('c @ 'p -> unit * 'b * 'b @ [> 'n | aliased dynamic]) @ [> close('n) | 'o | once nonportable stateful]) @ [> 'm | once nonportable stateful] =
+  <fun>
 |}]
 
 let foo () =
@@ -126,21 +127,33 @@ Error: The value "bar1" is "nonportable"
 
 let many_arguments x y z s t = y
 [%%expect{|
-val many_arguments : 'a -> 'b -> 'c -> 'd -> 'e -> 'b = <fun>
+val many_arguments :
+  'a @ [< 'mm2 @@ past & 'q @@ past & 'o @@ past & 'm @@ past & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'mm1 @@ past & 'p @@ past & global] ->
+    ('d @ [< 'mm0 @@ past & global] ->
+     ('e @ 'mm3 -> 'b @ [> 'n]) @ [> close('n) | 'mm0 | 'mm1 | 'mm2]) @ [> close('n) | 'p | 'q]) @ [> close('n) | 'o]) @ [> 'm] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
   let y = many_arguments x y () () () in
   use_uncontended y
 [%%expect{|
-val foo : 'a @ portable -> 'b -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global uncontended] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
   let f = many_arguments x y in
   use_portable f
 [%%expect{|
-val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global portable uncontended] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -178,7 +191,8 @@ val foo : unit = ()
 
 let fst x = fun y -> x
 [%%expect{|
-val fst : 'a -> 'b -> 'a = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* x is < global as before *)
@@ -213,7 +227,7 @@ let bar (x @ unique) =
   let x = fst x in
   use_unique x
 [%%expect{|
-val bar : 'a @ unique -> unit = <fun>
+val bar : 'a @ [< global unique] -> unit @ [> dynamic] = <fun>
 |}]
 
 let bar (x @ unique) =
@@ -238,7 +252,7 @@ let var (x @ portable) =
   let x = fst x () in
   use_portable x
 [%%expect{|
-val var : 'a @ portable -> unit = <fun>
+val var : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 let var (x @ nonportable) =
   let x = fst x () in
@@ -255,7 +269,7 @@ let var (x @ uncontended) =
   let x = fst x () in
   use_uncontended x
 [%%expect{|
-val var : 'a -> unit = <fun>
+val var : 'a @ [< global uncontended] -> unit @ [> dynamic] = <fun>
 |}]
 let var (x @ contended) =
   let x = fst x () in
@@ -287,13 +301,17 @@ Error: The value "bar1" is "nonportable"
 (* deeply nested closures should still propagate modes *)
 let nest x = fun () -> fun () -> fun () -> x
 [%%expect{|
-val nest : 'a -> unit -> unit -> unit -> 'a = <fun>
+val nest :
+  'a @ [< 'm & global] ->
+  (unit @ 'p ->
+   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo (x @ portable) =
   use_portable (nest x () () ())
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ nonportable) =

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -1,0 +1,309 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a @ static -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* [fst] is the K-combinator and displays an interesting bi-directional dependency
+  between the curry mode, the argument, and the inner return
+
+  Its signature should look like the following:
+
+    val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+
+  Where close('m) refers to the meet between the comonadic parts of 'm and the
+  monadic part 'm, taken to its dual comonadic counterpart. Note that 'm describes
+  an upper bound in the argument, and a lower bound on the inner return.
+
+  Because of partial application, the inner closure needs to be allocated somewhere. The
+  default is to heap-allocate it, hence the global restriction on the first parameter.
+*)
+
+let fst x y = x
+[%%expect{|
+val fst : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* n-ary functions will impose locality bounds on arguments, since the middle end
+  must know where to allocate closures of partially applied functions *)
+
+(* CR ageorges: partially applying fst can't yield a polymorphic locality, and the
+   following ought to fail *)
+let foo =
+  let cglobal = "global" in
+  let clocal @ local = "local" in
+  let _ = fst cglobal in
+  let _ = fst clocal in
+  ()
+[%%expect{|
+Line 4, characters 10-21:
+4 |   let _ = fst cglobal in
+              ^^^^^^^^^^^
+Warning 5 [ignored-partial-application]: this function application is partial,
+  maybe some arguments are missing.
+
+Line 5, characters 10-20:
+5 |   let _ = fst clocal in
+              ^^^^^^^^^^
+Warning 5 [ignored-partial-application]: this function application is partial,
+  maybe some arguments are missing.
+
+val foo : unit = ()
+|}]
+
+let bar (x @ once) =
+  fst x
+[%%expect{|
+val bar : 'a @ once -> 'b -> 'a @ once = <fun>
+|}]
+
+let bar (x @ unique) =
+  let x = fst x () in
+  use_unique x
+[%%expect{|
+val bar : 'a @ unique -> unit = <fun>
+|}]
+
+(* Uniqueness is not broken in an n-ary function if it is used uniquely in the body *)
+type box = { mutable x : int }
+
+let check_tuple x y z =
+  let m = match x, y, z with | p, q, r -> use_unique p in
+  m, y, y
+[%%expect{|
+type box = { mutable x : int; }
+val check_tuple : 'a @ unique -> 'b -> 'c -> unit * 'b * 'b = <fun>
+|}]
+
+let foo () =
+  let (x @ unique) = { x = 0 } in
+  let f = check_tuple x () in
+  (f (), f ())
+[%%expect{|
+Line 4, characters 9-10:
+4 |   (f (), f ())
+             ^
+Error: This value is used here,
+       but it is defined as once and is also being used at:
+Line 4, characters 3-4:
+4 |   (f (), f ())
+       ^
+
+|}]
+
+(* The returned closure is nonportable *)
+
+let () =
+  let c = ref 42 in
+  let f = fun () -> !c in
+  let bar1 = fst f in
+  let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+  ()
+[%%expect{|
+Line 5, characters 56-60:
+5 |   let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+                                                            ^^^^
+Error: The value "bar1" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at line 5, characters 38-69
+         which is expected to be "portable".
+|}]
+
+let many_arguments x y z s t = y
+[%%expect{|
+val many_arguments : 'a -> 'b -> 'c -> 'd -> 'e -> 'b = <fun>
+|}]
+
+let foo (x @ portable) (y @ uncontended) =
+  let y = many_arguments x y () () () in
+  use_uncontended y
+[%%expect{|
+val foo : 'a @ portable -> 'b -> unit = <fun>
+|}]
+
+let foo (x @ portable) (y @ uncontended) =
+  let f = many_arguments x y in
+  use_portable f
+[%%expect{|
+val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let f = many_arguments x y in
+  use_portable f
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable f
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let foo (x @ global) (y @ nonportable) =
+  let f = many_arguments x y in
+  let g = f () in
+  use_portable g
+[%%expect{|
+Line 4, characters 15-16:
+4 |   use_portable g
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let foo =
+  let x @ global = "local" in
+  let y @ global = "global" in
+  let f = many_arguments x y in
+  use_global f
+[%%expect{|
+val foo : unit = ()
+|}]
+
+
+(* Let's eta-expand [fst] *)
+
+let fst x = fun y -> x
+[%%expect{|
+val fst : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* x is < global as before *)
+let () =
+  let c @ local = ref 42 in
+  fst c
+[%%expect{|
+Line 3, characters 6-7:
+3 |   fst c
+          ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* once argument yields a once closure *)
+let bar (x @ once) =
+  let x = (fst x) in
+  (x, x)
+[%%expect{|
+Line 3, characters 6-7:
+3 |   (x, x)
+          ^
+Error: This value is used here,
+       but it is defined as once and is also being used at:
+Line 3, characters 3-4:
+3 |   (x, x)
+       ^
+
+|}]
+
+(* unique argument yields unique and once result *)
+let bar (x @ unique) =
+  let x = fst x in
+  use_unique x
+[%%expect{|
+val bar : 'a @ unique -> unit = <fun>
+|}]
+
+let bar (x @ unique) =
+  let x = fst x in
+  let (f, g) = (x, x) in
+  use_unique (f ());
+  use_unique (g ())
+[%%expect{|
+Line 5, characters 14-15:
+5 |   use_unique (g ())
+                  ^
+Error: This value is used here,
+       but it is defined as once and has already been used at:
+Line 4, characters 14-15:
+4 |   use_unique (f ());
+                  ^
+
+|}]
+
+(* returned value matches input portability *)
+let var (x @ portable) =
+  let x = fst x () in
+  use_portable x
+[%%expect{|
+val var : 'a @ portable -> unit = <fun>
+|}]
+let var (x @ nonportable) =
+  let x = fst x () in
+  use_portable x
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable x
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* returned value matches input contention *)
+let var (x @ uncontended) =
+  let x = fst x () in
+  use_uncontended x
+[%%expect{|
+val var : 'a -> unit = <fun>
+|}]
+let var (x @ contended) =
+  let x = fst x () in
+  use_uncontended x
+[%%expect{|
+Line 3, characters 18-19:
+3 |   use_uncontended x
+                      ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]
+
+(* The returned closure is nonportable *)
+let () =
+  let c = ref 42 in
+  let f = fun () -> !c in
+  let bar1 = fst f in
+  let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+  ()
+[%%expect{|
+Line 5, characters 56-60:
+5 |   let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+                                                            ^^^^
+Error: The value "bar1" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at line 5, characters 38-69
+         which is expected to be "portable".
+|}]
+
+(* deeply nested closures should still propagate modes *)
+let nest x = fun () -> fun () -> fun () -> x
+[%%expect{|
+val nest : 'a -> unit -> unit -> unit -> 'a = <fun>
+|}]
+
+let foo (x @ portable) =
+  use_portable (nest x () () ())
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  use_portable (nest x () () ())
+[%%expect{|
+Line 2, characters 15-32:
+2 |   use_portable (nest x () () ())
+                   ^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -40,8 +40,6 @@ val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
 (* n-ary functions will impose locality bounds on arguments, since the middle end
   must know where to allocate closures of partially applied functions *)
 
-(* CR ageorges: partially applying fst can't yield a polymorphic locality, and the
-   following ought to fail *)
 let foo =
   let cglobal = "global" in
   let clocal @ local = "local" in

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -13,7 +13,7 @@ val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
 val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
 val use_static : 'a @ [< static] -> unit @ 'm = <fun>
-val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* [fst] is the K-combinator and displays an interesting bi-directional dependency
@@ -85,7 +85,7 @@ type box = { mutable x : int; }
 val check_tuple :
   'a @ [< past('o) & past('m) & global unique] ->
   ('b @ [< 'n & global many] ->
-   ('c @ 'p -> unit * 'b * 'b @ [> 'n | aliased dynamic]) @ [> close('n) | past('o) | once nonportable stateful]) @ [> past('m) | once nonportable stateful] =
+   ('c @ 'p -> unit * 'b * 'b @ [> 'n | aliased dynamic]) @ [> close('n) | past('o) | once stateful]) @ [> past('m) | once stateful] =
   <fun>
 |}]
 
@@ -140,7 +140,7 @@ let foo (x @ portable) (y @ uncontended) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global uncontended] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
+  ('b @ [< global uncontended] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 
@@ -150,7 +150,7 @@ let foo (x @ portable) (y @ uncontended) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global portable uncontended] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
+  ('b @ [< global portable uncontended] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -83,9 +83,9 @@ let check_tuple x y z =
 [%%expect{|
 type box = { mutable x : int; }
 val check_tuple :
-  'a @ [< 'o @@ past & 'm @@ past & global unique] ->
+  'a @ [< past('o) & past('m) & global unique] ->
   ('b @ [< 'n & global many] ->
-   ('c @ 'p -> unit * 'b * 'b @ [> 'n | aliased dynamic]) @ [> close('n) | 'o | once nonportable stateful]) @ [> 'm | once nonportable stateful] =
+   ('c @ 'p -> unit * 'b * 'b @ [> 'n | aliased dynamic]) @ [> close('n) | past('o) | once nonportable stateful]) @ [> past('m) | once nonportable stateful] =
   <fun>
 |}]
 
@@ -126,11 +126,11 @@ Error: The value "bar1" is "nonportable"
 let many_arguments x y z s t = y
 [%%expect{|
 val many_arguments :
-  'a @ [< 'mm2 @@ past & 'q @@ past & 'o @@ past & 'm @@ past & global] ->
+  'a @ [< past('mm2) & past('q) & past('o) & past('m) & global] ->
   ('b @ [< 'n & global] ->
-   ('c @ [< 'mm1 @@ past & 'p @@ past & global] ->
-    ('d @ [< 'mm0 @@ past & global] ->
-     ('e @ 'mm3 -> 'b @ [> 'n]) @ [> close('n) | 'mm0 | 'mm1 | 'mm2]) @ [> close('n) | 'p | 'q]) @ [> close('n) | 'o]) @ [> 'm] =
+   ('c @ [< past('mm1) & past('p) & global] ->
+    ('d @ [< past('mm0) & global] ->
+     ('e @ 'mm3 -> 'b @ [> 'n]) @ [> close('n) | past('mm0) | past('mm1) | past('mm2)]) @ [> close('n) | past('p) | past('q)]) @ [> close('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -139,8 +139,8 @@ let foo (x @ portable) (y @ uncontended) =
   use_uncontended y
 [%%expect{|
 val foo :
-  'a @ [< 'm @@ past & global portable] ->
-  ('b @ [< global uncontended] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  'a @ [< past('m) & global portable] ->
+  ('b @ [< global uncontended] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 
@@ -149,8 +149,8 @@ let foo (x @ portable) (y @ uncontended) =
   use_portable f
 [%%expect{|
 val foo :
-  'a @ [< 'm @@ past & global portable] ->
-  ('b @ [< global portable uncontended] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  'a @ [< past('m) & global portable] ->
+  ('b @ [< global portable uncontended] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -81,7 +81,7 @@ let check_tuple x y z =
 [%%expect{|
 type box = { mutable x : int; }
 val check_tuple :
-  'a @ [< past('o) & past('p) & global unique] ->
+  'a @ [< global unique] ->
   'b @ [< 'm & global many] ->
   'c @ 'n -> unit * 'b * 'b @ [> 'm | aliased dynamic] = <fun>
 |}]
@@ -123,10 +123,9 @@ Error: The value "bar1" is "nonportable"
 let many_arguments x y z s t = y
 [%%expect{|
 val many_arguments :
-  'a @ [< past('mm0) & past('mm1) & past('mm2) & past('mm3) & global] ->
+  'a @ [< global] ->
   'b @ [< 'm & global] ->
-  'c @ [< past('p) & past('q) & global] ->
-  'd @ [< past('o) & global] -> 'e @ 'n -> 'b @ [> 'm] = <fun>
+  'c @ [< global] -> 'd @ [< global] -> 'e @ 'n -> 'b @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
@@ -134,7 +133,7 @@ let foo (x @ portable) (y @ uncontended) =
   use_uncontended y
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global portable] ->
+  'a @ [< global portable] ->
   'b @ [< global uncontended] -> unit @ [> dynamic] = <fun>
 |}]
 
@@ -143,7 +142,7 @@ let foo (x @ portable) (y @ uncontended) =
   use_portable f
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global portable] ->
+  'a @ [< global portable] ->
   'b @ [< global portable uncontended] -> unit @ [> dynamic] = <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -33,8 +33,7 @@ val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 
 let fst x y = x
 [%%expect{|
-val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 (* n-ary functions will impose locality bounds on arguments, since the middle end
@@ -62,9 +61,8 @@ Error: This value is "local" but is expected to be "global".
 let bar (x @ once) =
   fst x
 [%%expect{|
-val bar :
-  'a @ [< 'm & global > once] ->
-  ('b @ 'n -> 'a @ [> 'm | once]) @ [> close('m) | once dynamic] = <fun>
+val bar : 'a @ [< 'm & global > once] -> 'b @ 'n -> 'a @ [> 'm | once] =
+  <fun>
 |}]
 
 let bar (x @ unique) =
@@ -83,10 +81,9 @@ let check_tuple x y z =
 [%%expect{|
 type box = { mutable x : int; }
 val check_tuple :
-  'a @ [< past('o) & past('m) & global unique] ->
-  ('b @ [< 'n & global many] ->
-   ('c @ 'p -> unit * 'b * 'b @ [> 'n | aliased dynamic]) @ [> close('n) | past('o) | once stateful]) @ [> past('m) | once stateful] =
-  <fun>
+  'a @ [< past('o) & past('p) & global unique] ->
+  'b @ [< 'm & global many] ->
+  'c @ 'n -> unit * 'b * 'b @ [> 'm | aliased dynamic] = <fun>
 |}]
 
 let foo () =
@@ -126,12 +123,10 @@ Error: The value "bar1" is "nonportable"
 let many_arguments x y z s t = y
 [%%expect{|
 val many_arguments :
-  'a @ [< past('mm2) & past('q) & past('o) & past('m) & global] ->
-  ('b @ [< 'n & global] ->
-   ('c @ [< past('mm1) & past('p) & global] ->
-    ('d @ [< past('mm0) & global] ->
-     ('e @ 'mm3 -> 'b @ [> 'n]) @ [> close('n) | past('mm0) | past('mm1) | past('mm2)]) @ [> close('n) | past('p) | past('q)]) @ [> close('n) | past('o)]) @ [> past('m)] =
-  <fun>
+  'a @ [< past('mm0) & past('mm1) & past('mm2) & past('mm3) & global] ->
+  'b @ [< 'm & global] ->
+  'c @ [< past('p) & past('q) & global] ->
+  'd @ [< past('o) & global] -> 'e @ 'n -> 'b @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
@@ -140,8 +135,7 @@ let foo (x @ portable) (y @ uncontended) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global uncontended] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  'b @ [< global uncontended] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
@@ -150,8 +144,7 @@ let foo (x @ portable) (y @ uncontended) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global portable uncontended] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  'b @ [< global portable uncontended] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -189,8 +182,7 @@ val foo : unit = ()
 
 let fst x = fun y -> x
 [%%expect{|
-val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 (* x is < global as before *)
@@ -300,9 +292,7 @@ Error: The value "bar1" is "nonportable"
 let nest x = fun () -> fun () -> fun () -> x
 [%%expect{|
 val nest :
-  'a @ [< 'm & global] ->
-  (unit @ 'p ->
-   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
+  'a @ [< 'm & global] -> unit @ 'p -> unit @ 'o -> unit @ 'n -> 'a @ [> 'm] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -51,6 +51,8 @@ val flip :
 
 let add a b = a + b
 [%%expect{|
+val add : int @ 'n -> int @ 'm -> int @ [> dynamic] = <fun>
+|}, Principal{|
 val add : int @ [< global] -> int @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
@@ -91,6 +93,11 @@ val local_closure :
 let use_and_return g x = ignore (g x); g
 [%%expect{|
 val use_and_return :
+  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n mod aliased contended immutable & global many] ->
+  'a @ [< 'm] ->
+  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased] = <fun>
+|}, Principal{|
+val use_and_return :
   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n & global many] ->
   'a @ [< 'm] ->
   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased] = <fun>
@@ -113,6 +120,12 @@ let store_and_call c g x = c.v <- g; c.v x
 val store_and_call :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
   (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
+   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) mod many forkable unyielding | stateful]) @ [> past('o) | past('p) mod many forkable unyielding | stateful] =
+  <fun>
+|}, Principal{|
+val store_and_call :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
+  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
    ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) | stateful]) @ [> past('o) | past('p) | stateful] =
   <fun>
 |}]
@@ -131,6 +144,11 @@ val unique_closure : 'a @ [< 'm & global unique] -> 'b @ 'n -> 'a @ [> 'm] =
 
 let unique_cell (c @ unique) x = c.v <- x; c
 [%%expect{|
+val unique_cell :
+  'a cell @ [< 'm & global unique write] ->
+  'a @ [< global many read_write] ->
+  'a cell @ [> 'm mod many forkable unyielding] = <fun>
+|}, Principal{|
 val unique_cell :
   'a cell @ [< 'm & global unique write] ->
   'a @ [< global many read_write] -> 'a cell @ [> 'm] = <fun>

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -1,0 +1,163 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+let const2 x y = 0
+[%%expect{|
+val const2 :
+  'a @ [< past('m) & global] -> ('b @ 'o -> int @ 'n) @ [> past('m)] = <fun>
+|}]
+
+let fst2 x y = x
+[%%expect{|
+val fst2 : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let three x y z = (x, z)
+[%%expect{|
+val three :
+  'a @ [< 'm & global] ->
+  ('b @ [< past('n) & global] ->
+   ('c @ [< 'o & global] -> 'a * 'c @ [> 'o | 'm]) @ [> close('m) | past('n)]) @ [> close('m)] =
+  <fun>
+|}]
+
+let pair x y = (x, y)
+[%%expect{|
+val pair :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let apply f x = f x
+[%%expect{|
+val apply :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+|}]
+
+let compose f g x = f (g x)
+[%%expect{|
+val compose :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
+  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
+   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)] =
+  <fun>
+|}]
+
+let flip f x y = f y x
+[%%expect{|
+val flip :
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
+  <fun>
+|}]
+
+let add a b = a + b
+[%%expect{|
+val add :
+  int @ [< past('m) & global] ->
+  (int @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] = <fun>
+|}]
+
+let once_closure (x @ once) = fun y -> (x, y)
+[%%expect{|
+val once_closure :
+  'a @ [< 'm & global > once] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm | once]) @ [> close('m) | once] =
+  <fun>
+|}]
+
+let portable_closure (x @ portable contended) y = (x, y)
+[%%expect{|
+val portable_closure :
+  'a @ [< 'm & global portable > contended] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm | contended]) @ [> close('m)] =
+  <fun>
+|}]
+
+type ('a, 'b) pair_record = { a : 'a; b : 'b }
+[%%expect{|
+type ('a, 'b) pair_record = { a : 'a; b : 'b; }
+|}]
+
+let mk_record a b = { a; b }
+[%%expect{|
+val mk_record :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) pair_record @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let local_closure x = exclave_ (fun y -> (x, y))
+[%%expect{|
+val local_closure :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m) | local] =
+  <fun>
+|}]
+
+let use_and_return g x = ignore (g x); g
+[%%expect{|
+val use_and_return :
+  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n & global many] ->
+  ('a @ [< 'm] ->
+   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased]) @ [> close('n) | stateful] =
+  <fun>
+|}]
+
+let both_branches g x = if x then g else (fun y -> y)
+[%%expect{|
+val both_branches :
+  ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'n & global] ->
+  (bool @ 'o -> ('a @ [< 'm] -> 'a @ [> 'm]) @ [> 'n | dynamic]) @ [> close('n)] =
+  <fun>
+|}]
+
+type 'a cell = { mutable v : 'a }
+[%%expect{|
+type 'a cell = { mutable v : 'a; }
+|}]
+
+let store_and_call c g x = c.v <- g; c.v x
+[%%expect{|
+val store_and_call :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
+  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
+   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) | stateful]) @ [> past('o) | past('p) | stateful] =
+  <fun>
+|}]
+
+let unique_fst (x @ unique) y = x
+[%%expect{|
+val unique_fst :
+  'a @ [< 'm & global unique] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let unique_closure (x @ unique) = fun y -> x
+[%%expect{|
+val unique_closure :
+  'a @ [< 'm & global unique] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let unique_cell (c @ unique) x = c.v <- x; c
+[%%expect{|
+val unique_cell :
+  'a cell @ [< 'm & global unique write] ->
+  ('a @ [< global many read_write] -> 'a cell @ [> 'm]) @ [> close('m) | writing] =
+  <fun>
+|}]
+
+let stack_args g = g (stack_ (1, 2)) (stack_ (3, 4)); ()
+[%%expect{|
+val stack_args :
+  (int * int @ [< past('m) > local] ->
+   (int * int @ [> local] -> 'a @ 'o) @ [> past('m) | past('n) | local]) @ [< past('n)] ->
+  unit @ 'p = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -5,79 +5,69 @@
 
 let const2 x y = 0
 [%%expect{|
-val const2 :
-  'a @ [< past('m) & global] -> ('b @ 'o -> int @ 'n) @ [> past('m)] = <fun>
+val const2 : 'a @ [< past('o) & global] -> 'b @ 'n -> int @ 'm = <fun>
 |}]
 
 let fst2 x y = x
 [%%expect{|
-val fst2 : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val fst2 : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let three x y z = (x, z)
 [%%expect{|
 val three :
-  'a @ [< 'm & global] ->
-  ('b @ [< past('n) & global] ->
-   ('c @ [< 'o & global] -> 'a * 'c @ [> 'o | 'm]) @ [> close('m) | past('n)]) @ [> close('m)] =
+  'a @ [< 'n & global] ->
+  'b @ [< past('o) & global] -> 'c @ [< 'm & global] -> 'a * 'c @ [> 'm | 'n] =
   <fun>
 |}]
 
 let pair x y = (x, y)
 [%%expect{|
 val pair :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
+  <fun>
 |}]
 
 let apply f x = f x
 [%%expect{|
 val apply :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
-  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
-   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)] =
-  <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('q) & past('mm0) & global] ->
+  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< past('p) & global] ->
+  'c @ [< 'o] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
-  ('b @ [< 'p & global] ->
-   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
-  <fun>
+  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
+  'b @ [< 'n & global] -> 'a @ [< 'p] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 let add a b = a + b
 [%%expect{|
-val add :
-  int @ [< past('m) & global] ->
-  (int @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] = <fun>
+val add : int @ [< past('n) & global] -> int @ 'm -> int @ [> dynamic] =
+  <fun>
 |}]
 
 let once_closure (x @ once) = fun y -> (x, y)
 [%%expect{|
 val once_closure :
-  'a @ [< 'm & global > once] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm | once]) @ [> close('m) | once] =
-  <fun>
+  'a @ [< 'n & global > once] ->
+  'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n | once] = <fun>
 |}]
 
 let portable_closure (x @ portable contended) y = (x, y)
 [%%expect{|
 val portable_closure :
-  'a @ [< 'm & global portable > contended] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm | contended]) @ [> close('m)] =
-  <fun>
+  'a @ [< 'n & global portable > contended] ->
+  'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n | contended] = <fun>
 |}]
 
 type ('a, 'b) pair_record = { a : 'a; b : 'b }
@@ -88,9 +78,8 @@ type ('a, 'b) pair_record = { a : 'a; b : 'b; }
 let mk_record a b = { a; b }
 [%%expect{|
 val mk_record :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> ('a, 'b) pair_record @ [> 'n | 'm]) @ [> close('m)] =
-  <fun>
+  'a @ [< 'n & global] ->
+  'b @ [< 'm & global] -> ('a, 'b) pair_record @ [> 'm | 'n] = <fun>
 |}]
 
 let local_closure x = exclave_ (fun y -> (x, y))
@@ -105,17 +94,14 @@ let use_and_return g x = ignore (g x); g
 [%%expect{|
 val use_and_return :
   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n & global many] ->
-  ('a @ [< 'm] ->
-   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased]) @ [> close('n) | stateful] =
-  <fun>
+  'a @ [< 'm] -> 'a @ [> 'm] -> 'b @ [< global many read_write] = <fun>
 |}]
 
 let both_branches g x = if x then g else (fun y -> y)
 [%%expect{|
 val both_branches :
-  ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'n & global] ->
-  (bool @ 'o -> ('a @ [< 'm] -> 'a @ [> 'm]) @ [> 'n | dynamic]) @ [> close('n)] =
-  <fun>
+  ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'o & global] ->
+  bool @ 'n -> 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 type 'a cell = { mutable v : 'a }
@@ -126,23 +112,20 @@ type 'a cell = { mutable v : 'a; }
 let store_and_call c g x = c.v <- g; c.v x
 [%%expect{|
 val store_and_call :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
-  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
-   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) | stateful]) @ [> past('o) | past('p) | stateful] =
-  <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('q) & past('mm0) & global read_write] ->
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many read_write] ->
+  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let unique_fst (x @ unique) y = x
 [%%expect{|
-val unique_fst :
-  'a @ [< 'm & global unique] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+val unique_fst : 'a @ [< 'm & global unique] -> 'b @ 'n -> 'a @ [> 'm] =
   <fun>
 |}]
 
 let unique_closure (x @ unique) = fun y -> x
 [%%expect{|
-val unique_closure :
-  'a @ [< 'm & global unique] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+val unique_closure : 'a @ [< 'm & global unique] -> 'b @ 'n -> 'a @ [> 'm] =
   <fun>
 |}]
 
@@ -150,14 +133,12 @@ let unique_cell (c @ unique) x = c.v <- x; c
 [%%expect{|
 val unique_cell :
   'a cell @ [< 'm & global unique write] ->
-  ('a @ [< global many read_write] -> 'a cell @ [> 'm]) @ [> close('m) | writing] =
-  <fun>
+  'a @ [< global many read_write] -> 'a cell @ [> 'm] = <fun>
 |}]
 
 let stack_args g = g (stack_ (1, 2)) (stack_ (3, 4)); ()
 [%%expect{|
 val stack_args :
-  (int * int @ [< past('m) > local] ->
-   (int * int @ [> local] -> 'a @ 'o) @ [> past('m) | past('n) | local]) @ [< past('n)] ->
-  unit @ 'p = <fun>
+  (int * int @ [< past('n) > local] -> int * int @ [> local] -> 'a @ 'm) @ [< past('p)] ->
+  unit @ 'o = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -5,7 +5,7 @@
 
 let const2 x y = 0
 [%%expect{|
-val const2 : 'a @ [< past('o) & global] -> 'b @ 'n -> int @ 'm = <fun>
+val const2 : 'a @ [< global] -> 'b @ 'n -> int @ 'm = <fun>
 |}]
 
 let fst2 x y = x
@@ -17,8 +17,7 @@ let three x y z = (x, z)
 [%%expect{|
 val three :
   'a @ [< 'n & global] ->
-  'b @ [< past('o) & global] -> 'c @ [< 'm & global] -> 'a * 'c @ [> 'm | 'n] =
-  <fun>
+  'b @ [< global] -> 'c @ [< 'm & global] -> 'a * 'c @ [> 'm | 'n] = <fun>
 |}]
 
 let pair x y = (x, y)
@@ -31,29 +30,29 @@ val pair :
 let apply f x = f x
 [%%expect{|
 val apply :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
   'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('q) & past('mm0) & global] ->
-  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< past('p) & global] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
+  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< global] ->
   'c @ [< 'o] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
-  'b @ [< 'n & global] -> 'a @ [< 'p] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
+  'b @ [< 'p & global] -> 'a @ [< 'q] -> 'c @ [> 'o | dynamic] = <fun>
 |}]
 
 let add a b = a + b
 [%%expect{|
-val add : int @ [< past('n) & global] -> int @ 'm -> int @ [> dynamic] =
-  <fun>
+val add : int @ [< global] -> int @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 let once_closure (x @ once) = fun y -> (x, y)
@@ -94,14 +93,15 @@ let use_and_return g x = ignore (g x); g
 [%%expect{|
 val use_and_return :
   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n & global many] ->
-  'a @ [< 'm] -> 'a @ [> 'm] -> 'b @ [< global many read_write] = <fun>
+  'a @ [< 'm] ->
+  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased] = <fun>
 |}]
 
 let both_branches g x = if x then g else (fun y -> y)
 [%%expect{|
 val both_branches :
-  ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'o & global] ->
-  bool @ 'n -> 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+  ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'n & global] ->
+  bool @ 'o -> ('a @ [< 'm] -> 'a @ [> 'm]) @ [> 'n | dynamic] = <fun>
 |}]
 
 type 'a cell = { mutable v : 'a }
@@ -112,9 +112,10 @@ type 'a cell = { mutable v : 'a; }
 let store_and_call c g x = c.v <- g; c.v x
 [%%expect{|
 val store_and_call :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('q) & past('mm0) & global read_write] ->
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many read_write] ->
-  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
+  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
+   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) | stateful]) @ [> past('o) | past('p) | stateful] =
+  <fun>
 |}]
 
 let unique_fst (x @ unique) y = x
@@ -139,6 +140,7 @@ val unique_cell :
 let stack_args g = g (stack_ (1, 2)) (stack_ (3, 4)); ()
 [%%expect{|
 val stack_args :
-  (int * int @ [< past('n) > local] -> int * int @ [> local] -> 'a @ 'm) @ [< past('p)] ->
-  unit @ 'o = <fun>
+  (int * int @ [< past('m) > local] ->
+   (int * int @ [> local] -> 'a @ 'o) @ [> past('m) | past('n) | local]) @ [< past('n)] ->
+  unit @ 'p = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -45,9 +45,8 @@ val compose :
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
-  'b @ [< 'p & global] -> 'a @ [< 'q] -> 'c @ [> 'o | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
+  'b @ [< 'n & global] -> 'a @ [< 'o] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 let add a b = a + b
@@ -140,7 +139,6 @@ val unique_cell :
 let stack_args g = g (stack_ (1, 2)) (stack_ (3, 4)); ()
 [%%expect{|
 val stack_args :
-  (int * int @ [< past('m) > local] ->
-   (int * int @ [> local] -> 'a @ 'o) @ [> past('m) | past('n) | local]) @ [< past('n)] ->
-  unit @ 'p = <fun>
+  (int * int @ [> local] -> int * int @ [> local] -> 'a @ 'm) @ 'o ->
+  unit @ 'n = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/fatal_application_modes.ml
+++ b/testsuite/tests/typing-mode-polymorphism/fatal_application_modes.ml
@@ -1,0 +1,102 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ native;
+*)
+
+(* Regression test: under mode polymorphism, a return mode may be inferred as
+  [local -- global]. However, if a return value does not cause an allocation
+    (meaning that a region can safely be removed), it's important that we do not
+  infer the application mode to be [local]. Under mode polymorphism, we infer the
+  return_mode to be local only when it returns via [exclave_]. The following tests
+  cause fatal errors if this is not implemented correctly. *)
+
+(* --- Local returning functions without [exclave_] that allocate --- *)
+
+let takes_local (_ @ local) =
+  ()
+
+let local_argument_application () =
+  takes_local 42
+
+let rec direct_tail_call x =
+  if x then x else direct_tail_call true
+
+(* Tail-call position with && and || *)
+let rec sequand_tail_call x =
+  x && sequand_tail_call false
+
+let rec sequor_tail_call x =
+  x || sequor_tail_call true
+
+let labelled_arguments ~a ~b ~c =
+  ()
+
+let omitted_labelled_argument =
+  labelled_arguments ~a:() ~c:()
+
+let omitted_labelled_argument_application () =
+  omitted_labelled_argument ~b:()
+
+let () =
+  local_argument_application ();
+  ignore (direct_tail_call false);
+  ignore (sequand_tail_call true);
+  ignore (sequor_tail_call false);
+  omitted_labelled_argument_application ()
+
+
+(* --- Local returning functions with [exclave_] that do not allocate --- *)
+
+let returns_local_unit () =
+  exclave_ ()
+
+(* does not type check without [exclave_] *)
+let tail_call_returns_local_unit x =
+  exclave_
+  returns_local_unit x
+
+
+(* --- Local returning functions with [exclave_] that allocate *)
+
+let takes_local_alloc (_ @ local) =
+  exclave_ ((), ())
+
+let local_argument_application_alloc () =
+  exclave_ (takes_local_alloc 42)
+
+let rec direct_tail_call_alloc x =
+  if x then exclave_ ((), ()) else exclave_ (direct_tail_call_alloc true)
+
+let rec sequand_tail_call_exclave x =
+  x && (sequand_tail_call_exclave false)
+
+let rec sequor_tail_call_exclave x =
+  x || (sequor_tail_call_exclave true)
+
+let labelled_arguments_alloc ~a ~b ~c =
+  exclave_ ((), ())
+
+let omitted_labelled_argument_alloc =
+  labelled_arguments_alloc ~a:() ~c:()
+
+let omitted_labelled_argument_alloc_application () =
+  exclave_ (omitted_labelled_argument_alloc ~b:())
+
+let call_local_argument_application_alloc () =
+  let local_ pair = local_argument_application_alloc () in
+  match pair with _x, _y -> ()
+
+let call_direct_tail_call_alloc () =
+  let local_ pair = direct_tail_call_alloc false in
+  match pair with _x, _y -> ()
+
+let call_omitted_labelled_argument_alloc_application () =
+  let local_ pair = omitted_labelled_argument_alloc_application () in
+  match pair with _x, _y -> ()
+
+let () =
+  call_local_argument_application_alloc ();
+  call_direct_tail_call_alloc ();
+  ignore (sequand_tail_call_exclave true);
+  ignore (sequor_tail_call_exclave false);
+  call_omitted_labelled_argument_alloc_application ()

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,11 +9,11 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a @ static -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
 |}]
 
 (* FUNCTION APPLICATION *)
@@ -28,8 +22,8 @@ val use_global : 'a -> unit = <fun>
 let id x = x
 let id' x = id x
 [%%expect{|
-val id : 'a -> 'a = <fun>
-val id' : 'a -> 'a = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+val id' : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -71,7 +65,9 @@ Error: This value is "nonportable" but is expected to be "portable".
 (* higher-order application should propagate mode constraints *)
 let apply f = fun x -> f x
 [%%expect{|
-val apply : ('a -> 'b) -> 'a -> 'b = <fun>
+val apply :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
 |}]
 
 let foo (x @ unique) (y @ aliased) =
@@ -103,7 +99,11 @@ Error: This value is "nonportable" but is expected to be "portable".
 
 let compose f g x = f (g x)
 [%%expect{|
-val compose : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b = <fun>
+val compose :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'mm0 @@ past & 'o @@ past & global] ->
+  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< 'q @@ past & global] ->
+   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> 'q | 'mm0]) @ [> 'o] =
+  <fun>
 |}]
 
 (* mode polymorphism propagates through composition *)
@@ -128,17 +128,17 @@ let chain x =
   let z = id y in
   z
 [%%expect{|
-val chain : 'a -> 'a = <fun>
+val chain : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 |}]
 
 let foo (x @ unique) = use_unique (chain x)
 [%%expect{|
-val foo : 'a @ unique -> unit = <fun>
+val foo : 'a @ [< global unique] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ portable) = use_portable (chain x)
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 (* RECURSIVE FUNCTIONS *)
@@ -146,19 +146,27 @@ val foo : 'a @ portable -> unit = <fun>
 let rec recursive x n =
   if n <= 0 then x else recursive x (n - 1)
 [%%expect{|
-val recursive : 'a -> int -> 'a = <fun>
+val recursive :
+  'a @ [< 'm & global] ->
+  (int @ [< many uncontended read_write > dynamic] ->
+   'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | nonportable stateful] =
+  <fun>
 |}]
 
 let foo (x @ portable) =
   let x = recursive x 10 in
   use_portable x
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let recursive' = recursive
 [%%expect{|
-val recursive' : 'a -> int -> 'a = <fun>
+val recursive' :
+  'a @ [< 'm & global] ->
+  (int @ [< many uncontended read_write > dynamic] ->
+   'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | nonportable stateful] =
+  <fun>
 |}]
 
 let foo (x @ nonportable) =
@@ -175,7 +183,10 @@ let rec map f = function
   | [] -> []
   | x :: xs -> f x :: map f xs
 [%%expect{|
-val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
+val map :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & 'p @@ past & global many > aliased] ->
+  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> 'o | 'p | nonportable stateful] =
+  <fun>
 |}]
 
 let foo (y @ portable) =
@@ -184,7 +195,7 @@ let foo (y @ portable) =
   let lg = map g l in
   use_portable lg
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global many portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (y @ nonportable) =
@@ -205,7 +216,7 @@ let foo (y @ portable) =
   let lg = map g l in
   use_portable lg
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global many portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (y @ nonportable) =
@@ -225,7 +236,9 @@ Error: This value is "nonportable" but is expected to be "portable".
 (* using a value and returning it *)
 let use_and_return x = ignore x; x
 [%%expect{|
-val use_and_return : 'a -> 'a = <fun>
+val use_and_return :
+  'a @ [< 'm & global many uncontended forkable unyielding read_write] ->
+  'a @ [> 'm | aliased] = <fun>
 |}]
 
 (* contended values cannot be use_and_returned due to uncontended bound *)

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -1,0 +1,238 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a @ static -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* FUNCTION APPLICATION *)
+
+(* mode polymorphism is preserved across function applications *)
+let id x = x
+let id' x = id x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+val id' : 'a -> 'a = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let x = id' x in
+  let y = id' y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 5, characters 15-16:
+5 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* [id'] imposes a global bound on its argument *)
+let foo (x @ local) =
+  let y = id' x in ()
+[%%expect{|
+Line 2, characters 14-15:
+2 |   let y = id' x in ()
+                  ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+(* HIGHER-ORDER FUNCTIONS *)
+
+let foo (x @ portable) (y @ nonportable) =
+  let x = (fun x -> x) x in
+  let y = (fun y -> y) y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 5, characters 15-16:
+5 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* higher-order application should propagate mode constraints *)
+let apply f = fun x -> f x
+[%%expect{|
+val apply : ('a -> 'b) -> 'a -> 'b = <fun>
+|}]
+
+let foo (x @ unique) (y @ aliased) =
+  let x = apply id x in
+  let y = apply id y in
+  use_unique x;
+  use_unique y
+[%%expect{|
+Line 5, characters 13-14:
+5 |   use_unique y
+                 ^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let id x = x in
+  let x = apply id x in
+  let y = apply id y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 6, characters 15-16:
+6 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* COMPOSITION *)
+
+let compose f g x = f (g x)
+[%%expect{|
+val compose : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b = <fun>
+|}]
+
+(* mode polymorphism propagates through composition *)
+
+let foo (x @ portable) (y @ nonportable) =
+  let x = compose id id x in
+  let y = compose id id y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 5, characters 15-16:
+5 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* CHAINING APPLICATIONS *)
+
+(* mode constraints propagate through a chain of polymorphic applications *)
+let chain x =
+  let y = id x in
+  let z = id y in
+  z
+[%%expect{|
+val chain : 'a -> 'a = <fun>
+|}]
+
+let foo (x @ unique) = use_unique (chain x)
+[%%expect{|
+val foo : 'a @ unique -> unit = <fun>
+|}]
+
+let foo (x @ portable) = use_portable (chain x)
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+(* RECURSIVE FUNCTIONS *)
+
+let rec recursive x n =
+  if n <= 0 then x else recursive x (n - 1)
+[%%expect{|
+val recursive : 'a -> int -> 'a = <fun>
+|}]
+
+let foo (x @ portable) =
+  let x = recursive x 10 in
+  use_portable x
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let recursive' = recursive
+[%%expect{|
+val recursive' : 'a -> int -> 'a = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  let x = recursive x 10 in
+  use_portable x
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable x
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let rec map f = function
+  | [] -> []
+  | x :: xs -> f x :: map f xs
+[%%expect{|
+val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
+|}]
+
+let foo (y @ portable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (y @ nonportable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+Line 5, characters 15-17:
+5 |   use_portable lg
+                   ^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let foo (y @ portable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (y @ nonportable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+Line 5, characters 15-17:
+5 |   use_portable lg
+                   ^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* SEQUENCING *)
+
+(* using a value and returning it *)
+let use_and_return x = ignore x; x
+[%%expect{|
+val use_and_return : 'a -> 'a = <fun>
+|}]
+
+(* contended values cannot be use_and_returned due to uncontended bound *)
+let foo (x @ contended) = use_and_return x
+[%%expect{|
+Line 1, characters 41-42:
+1 | let foo (x @ contended) = use_and_return x
+                                             ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -66,8 +66,8 @@ Error: This value is "nonportable" but is expected to be "portable".
 let apply f = fun x -> f x
 [%%expect{|
 val apply :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let foo (x @ unique) (y @ aliased) =
@@ -100,9 +100,9 @@ Error: This value is "nonportable" but is expected to be "portable".
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'mm0 @@ past & 'o @@ past & global] ->
-  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< 'q @@ past & global] ->
-   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> 'q | 'mm0]) @ [> 'o] =
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
+  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
+   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)] =
   <fun>
 |}]
 
@@ -184,8 +184,8 @@ let rec map f = function
   | x :: xs -> f x :: map f xs
 [%%expect{|
 val map :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & 'p @@ past & global many > aliased] ->
-  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> 'o | 'p | nonportable stateful] =
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
+  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | nonportable stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -181,6 +181,10 @@ let rec map f = function
   | x :: xs -> f x :: map f xs
 [%%expect{|
 val map :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global many] ->
+  'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
+|}, Principal{|
+val map :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global many > aliased] ->
   'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -67,7 +67,7 @@ let apply f = fun x -> f x
 [%%expect{|
 val apply :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let foo (x @ unique) (y @ aliased) =
@@ -100,10 +100,9 @@ Error: This value is "nonportable" but is expected to be "portable".
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
-  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
-   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)] =
-  <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('q) & past('mm0) & global] ->
+  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< past('p) & global] ->
+  'c @ [< 'o] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 (* mode polymorphism propagates through composition *)
@@ -148,7 +147,7 @@ let rec recursive x n =
 [%%expect{|
 val recursive :
   'a @ [< 'm & global] ->
-  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | stateful] =
+  int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic] =
   <fun>
 |}]
 
@@ -163,7 +162,7 @@ let recursive' = recursive
 [%%expect{|
 val recursive' :
   'a @ [< 'm & global] ->
-  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | stateful] =
+  int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic] =
   <fun>
 |}]
 
@@ -183,8 +182,7 @@ let rec map f = function
 [%%expect{|
 val map :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
-  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | stateful] =
-  <fun>
+  'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
 |}]
 
 let foo (y @ portable) =

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -148,7 +148,7 @@ let rec recursive x n =
 [%%expect{|
 val recursive :
   'a @ [< 'm & global] ->
-  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | stateful] =
+  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | stateful] =
   <fun>
 |}]
 
@@ -163,7 +163,7 @@ let recursive' = recursive
 [%%expect{|
 val recursive' :
   'a @ [< 'm & global] ->
-  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | stateful] =
+  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -13,7 +13,7 @@ val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
 val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
 val use_static : 'a @ [< static] -> unit @ 'm = <fun>
-val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* FUNCTION APPLICATION *)
@@ -148,8 +148,7 @@ let rec recursive x n =
 [%%expect{|
 val recursive :
   'a @ [< 'm & global] ->
-  (int @ [< many uncontended read_write > dynamic] ->
-   'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | nonportable stateful] =
+  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | stateful] =
   <fun>
 |}]
 
@@ -164,8 +163,7 @@ let recursive' = recursive
 [%%expect{|
 val recursive' :
   'a @ [< 'm & global] ->
-  (int @ [< many uncontended read_write > dynamic] ->
-   'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | nonportable stateful] =
+  (int @ [< many read_write > dynamic] -> 'a @ [< global > 'm | dynamic]) @ [> close('m) | close('m) | stateful] =
   <fun>
 |}]
 
@@ -185,7 +183,7 @@ let rec map f = function
 [%%expect{|
 val map :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
-  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | nonportable stateful] =
+  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | stateful] =
   <fun>
 |}]
 
@@ -237,8 +235,7 @@ Error: This value is "nonportable" but is expected to be "portable".
 let use_and_return x = ignore x; x
 [%%expect{|
 val use_and_return :
-  'a @ [< 'm & global many uncontended forkable unyielding read_write] ->
-  'a @ [> 'm | aliased] = <fun>
+  'a @ [< 'm & global many read_write] -> 'a @ [> 'm | aliased] = <fun>
 |}]
 
 (* contended values cannot be use_and_returned due to uncontended bound *)

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -66,7 +66,7 @@ Error: This value is "nonportable" but is expected to be "portable".
 let apply f = fun x -> f x
 [%%expect{|
 val apply :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
   'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
@@ -100,8 +100,8 @@ Error: This value is "nonportable" but is expected to be "portable".
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('q) & past('mm0) & global] ->
-  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< past('p) & global] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
+  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< global] ->
   'c @ [< 'o] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
@@ -181,7 +181,7 @@ let rec map f = function
   | x :: xs -> f x :: map f xs
 [%%expect{|
 val map :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global many > aliased] ->
   'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -1,0 +1,132 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+type _ t = A : bool t
+
+let id x = x
+
+let refine (type output) (w : output t) =
+  match w with
+  | A -> (id : bool -> output)
+[%%expect{|
+type _ t = A : bool t
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+val refine :
+  'output t @ 'm -> (bool -> 'output) @ [> nonportable stateful dynamic] =
+  <fun>
+|}]
+
+type _ arr = F : (int -> int) arr
+
+let apply (type a) (w : a arr) (g : a) =
+  match w with
+  | F -> g 3
+[%%expect{|
+type _ arr = F : (int -> int) arr
+val apply : 'a arr @ 'o -> ('a @ 'n -> int @ [> dynamic]) @ 'm = <fun>
+|}, Principal{|
+type _ arr = F : (int -> int) arr
+Line 5, characters 9-12:
+5 |   | F -> g 3
+             ^^^
+Error: This expression has type "int" but an expression was expected of type "'a"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+let pin (w : 'x arr) (g : 'x) =
+  match w with
+  | F -> g
+[%%expect{|
+val pin :
+  (int -> int) arr @ 'o ->
+  ((int -> int) @ [< 'n . aliased contended immutable] ->
+   (int -> int) @ [> 'n]) @ 'm =
+  <fun>
+|}, Principal{|
+val pin :
+  (int -> int) arr @ [< 'm @@ past & global] ->
+  ((int -> int) @ [< 'n] -> (int -> int) @ [> 'n]) @ [> 'm] = <fun>
+|}]
+
+type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
+
+let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
+  match w with
+  | L -> g s
+  | G -> 0
+[%%expect{|
+type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
+val local_arg_ok :
+  'a dom @ 'o ->
+  ('a @ [< 'n @@ past & global] ->
+   (string @ [> local unforkable yielding] -> int @ [> dynamic]) @ [> 'n]) @ 'm =
+  <fun>
+|}, Principal{|
+type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
+Line 5, characters 9-12:
+5 |   | L -> g s
+             ^^^
+Error: This expression has type "int" but an expression was expected of type "'a"
+       This instance of "int" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+let local_arg_bad (type a) (w : a dom) (g : a) (s : string @ local) =
+  match w with
+  | L -> 0
+  | G -> g s
+[%%expect{|
+Line 4, characters 11-12:
+4 |   | G -> g s
+               ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+type _ cross = Int : int cross | Str : string cross
+
+let crosses (type a) (w : a cross) (x : a @ local) : a @ global =
+  match w with
+  | Int -> x
+  | Str -> assert false
+[%%expect{|
+type _ cross = Int : int cross | Str : string cross
+val crosses :
+  'a cross @ 'n ->
+  ('a @ [> local unforkable yielding] ->
+   'a @ [< global forkable unyielding > dynamic]) @ 'm =
+  <fun>
+|}, Principal{|
+type _ cross = Int : int cross | Str : string cross
+val crosses :
+  'a cross @ [< 'm @@ past & global] ->
+  ('a @ [> local unforkable yielding] ->
+   'a @ [< global forkable unyielding > dynamic]) @ [> 'm] =
+  <fun>
+|}]
+
+let escapes (type a) (w : a cross) (x : a @ local) : a @ global =
+  match w with
+  | Int -> assert false
+  | Str -> x
+[%%expect{|
+Line 4, characters 11-12:
+4 |   | Str -> x
+               ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+type packed = P : (int -> int) -> packed
+
+let pack = P id
+
+let unpack (P f) = f
+[%%expect{|
+type packed = P : (int -> int) -> packed
+val pack : packed = P <fun>
+val unpack :
+  packed @ [< 'm . aliased contended immutable] -> (int -> int) @ [> 'm] =
+  <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -47,8 +47,8 @@ val pin :
   <fun>
 |}, Principal{|
 val pin :
-  (int -> int) arr @ [< 'm @@ past & global] ->
-  ((int -> int) @ [< 'n] -> (int -> int) @ [> 'n]) @ [> 'm] = <fun>
+  (int -> int) arr @ [< past('m) & global] ->
+  ((int -> int) @ [< 'n] -> (int -> int) @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -61,8 +61,8 @@ let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 val local_arg_ok :
   'a dom @ 'o ->
-  ('a @ [< 'n @@ past & global] ->
-   (string @ [> local unforkable yielding] -> int @ [> dynamic]) @ [> 'n]) @ 'm =
+  ('a @ [< past('n) & global] ->
+   (string @ [> local unforkable yielding] -> int @ [> dynamic]) @ [> past('n)]) @ 'm =
   <fun>
 |}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -101,9 +101,9 @@ val crosses :
 |}, Principal{|
 type _ cross = Int : int cross | Str : string cross
 val crosses :
-  'a cross @ [< 'm @@ past & global] ->
+  'a cross @ [< past('m) & global] ->
   ('a @ [> local unforkable yielding] ->
-   'a @ [< global forkable unyielding > dynamic]) @ [> 'm] =
+   'a @ [< global forkable unyielding > dynamic]) @ [> past('m)] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -39,12 +39,8 @@ let pin (w : 'x arr) (g : 'x) =
   | F -> g
 [%%expect{|
 val pin :
-  (int -> int) arr @ 'n ->
-  (int -> int) @ [< 'm mod aliased contended immutable] -> int -> int = <fun>
-|}, Principal{|
-val pin :
-  (int -> int) arr @ [< past('n) & global] ->
-  (int -> int) @ [< 'm] -> int -> int = <fun>
+  (int -> int) arr @ [< global] ->
+  (int -> int) @ [< 'm] -> (int -> int) @ [> 'm] = <fun>
 |}]
 
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -54,12 +50,6 @@ let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
   | L -> g s
   | G -> 0
 [%%expect{|
-type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
-val local_arg_ok :
-  'a dom @ 'n ->
-  'a @ [< past('m) & global] -> string @ [> local] -> int @ [> dynamic] =
-  <fun>
-|}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 Line 5, characters 9-12:
 5 |   | L -> g s
@@ -88,13 +78,9 @@ let crosses (type a) (w : a cross) (x : a @ local) : a @ global =
   | Str -> assert false
 [%%expect{|
 type _ cross = Int : int cross | Str : string cross
-val crosses : 'a cross @ 'm -> 'a @ [> local] -> 'a @ [< global > dynamic] =
-  <fun>
-|}, Principal{|
-type _ cross = Int : int cross | Str : string cross
 val crosses :
-  'a cross @ [< past('m) & global] ->
-  'a @ [> local] -> 'a @ [< global > dynamic] = <fun>
+  'a cross @ [< global] -> 'a @ [> local] -> 'a @ [< global > dynamic] =
+  <fun>
 |}]
 
 let escapes (type a) (w : a cross) (x : a @ local) : a @ global =
@@ -116,6 +102,7 @@ let unpack (P f) = f
 [%%expect{|
 type packed = P : (int -> int) -> packed
 val pack : packed = P <fun>
-val unpack : packed @ [< 'm mod aliased contended immutable] -> int -> int =
+val unpack :
+  packed @ [< 'm mod aliased contended immutable] -> (int -> int) @ [> 'm] =
   <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -39,6 +39,11 @@ let pin (w : 'x arr) (g : 'x) =
   | F -> g
 [%%expect{|
 val pin :
+  (int -> int) arr @ 'n ->
+  (int -> int) @ [< 'm mod aliased contended immutable] ->
+  (int -> int) @ [> 'm] = <fun>
+|}, Principal{|
+val pin :
   (int -> int) arr @ [< global] ->
   (int -> int) @ [< 'm] -> (int -> int) @ [> 'm] = <fun>
 |}]
@@ -50,6 +55,11 @@ let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
   | L -> g s
   | G -> 0
 [%%expect{|
+type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
+val local_arg_ok :
+  'a dom @ 'm -> 'a @ [< global] -> string @ [> local] -> int @ [> dynamic] =
+  <fun>
+|}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 Line 5, characters 9-12:
 5 |   | L -> g s
@@ -77,6 +87,10 @@ let crosses (type a) (w : a cross) (x : a @ local) : a @ global =
   | Int -> x
   | Str -> assert false
 [%%expect{|
+type _ cross = Int : int cross | Str : string cross
+val crosses : 'a cross @ 'm -> 'a @ [> local] -> 'a @ [< global > dynamic] =
+  <fun>
+|}, Principal{|
 type _ cross = Int : int cross | Str : string cross
 val crosses :
   'a cross @ [< global] -> 'a @ [> local] -> 'a @ [< global > dynamic] =

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -13,8 +13,7 @@ let refine (type output) (w : output t) =
 [%%expect{|
 type _ t = A : bool t
 val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
-val refine : 'output t @ 'm -> (bool -> 'output) @ [> stateful dynamic] =
-  <fun>
+val refine : 'output t @ 'm -> bool -> 'output = <fun>
 |}]
 
 type _ arr = F : (int -> int) arr
@@ -24,7 +23,7 @@ let apply (type a) (w : a arr) (g : a) =
   | F -> g 3
 [%%expect{|
 type _ arr = F : (int -> int) arr
-val apply : 'a arr @ 'o -> ('a @ 'n -> int @ [> dynamic]) @ 'm = <fun>
+val apply : 'a arr @ 'n -> 'a @ 'm -> int @ [> dynamic] = <fun>
 |}, Principal{|
 type _ arr = F : (int -> int) arr
 Line 5, characters 9-12:
@@ -40,14 +39,12 @@ let pin (w : 'x arr) (g : 'x) =
   | F -> g
 [%%expect{|
 val pin :
-  (int -> int) arr @ 'o ->
-  ((int -> int) @ [< 'n mod aliased contended immutable] ->
-   (int -> int) @ [> 'n]) @ 'm =
-  <fun>
+  (int -> int) arr @ 'n ->
+  (int -> int) @ [< 'm mod aliased contended immutable] -> int -> int = <fun>
 |}, Principal{|
 val pin :
-  (int -> int) arr @ [< past('m) & global] ->
-  ((int -> int) @ [< 'n] -> (int -> int) @ [> 'n]) @ [> past('m)] = <fun>
+  (int -> int) arr @ [< past('n) & global] ->
+  (int -> int) @ [< 'm] -> int -> int = <fun>
 |}]
 
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -59,9 +56,8 @@ let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
 [%%expect{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 val local_arg_ok :
-  'a dom @ 'o ->
-  ('a @ [< past('n) & global] ->
-   (string @ [> local] -> int @ [> dynamic]) @ [> past('n)]) @ 'm =
+  'a dom @ 'n ->
+  'a @ [< past('m) & global] -> string @ [> local] -> int @ [> dynamic] =
   <fun>
 |}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -92,13 +88,13 @@ let crosses (type a) (w : a cross) (x : a @ local) : a @ global =
   | Str -> assert false
 [%%expect{|
 type _ cross = Int : int cross | Str : string cross
-val crosses :
-  'a cross @ 'n -> ('a @ [> local] -> 'a @ [< global > dynamic]) @ 'm = <fun>
+val crosses : 'a cross @ 'm -> 'a @ [> local] -> 'a @ [< global > dynamic] =
+  <fun>
 |}, Principal{|
 type _ cross = Int : int cross | Str : string cross
 val crosses :
   'a cross @ [< past('m) & global] ->
-  ('a @ [> local] -> 'a @ [< global > dynamic]) @ [> past('m)] = <fun>
+  'a @ [> local] -> 'a @ [< global > dynamic] = <fun>
 |}]
 
 let escapes (type a) (w : a cross) (x : a @ local) : a @ global =
@@ -120,7 +116,6 @@ let unpack (P f) = f
 [%%expect{|
 type packed = P : (int -> int) -> packed
 val pack : packed = P <fun>
-val unpack :
-  packed @ [< 'm mod aliased contended immutable] -> (int -> int) @ [> 'm] =
+val unpack : packed @ [< 'm mod aliased contended immutable] -> int -> int =
   <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -13,8 +13,7 @@ let refine (type output) (w : output t) =
 [%%expect{|
 type _ t = A : bool t
 val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
-val refine :
-  'output t @ 'm -> (bool -> 'output) @ [> nonportable stateful dynamic] =
+val refine : 'output t @ 'm -> (bool -> 'output) @ [> stateful dynamic] =
   <fun>
 |}]
 
@@ -62,7 +61,7 @@ type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 val local_arg_ok :
   'a dom @ 'o ->
   ('a @ [< past('n) & global] ->
-   (string @ [> local unforkable yielding] -> int @ [> dynamic]) @ [> past('n)]) @ 'm =
+   (string @ [> local] -> int @ [> dynamic]) @ [> past('n)]) @ 'm =
   <fun>
 |}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -94,17 +93,12 @@ let crosses (type a) (w : a cross) (x : a @ local) : a @ global =
 [%%expect{|
 type _ cross = Int : int cross | Str : string cross
 val crosses :
-  'a cross @ 'n ->
-  ('a @ [> local unforkable yielding] ->
-   'a @ [< global forkable unyielding > dynamic]) @ 'm =
-  <fun>
+  'a cross @ 'n -> ('a @ [> local] -> 'a @ [< global > dynamic]) @ 'm = <fun>
 |}, Principal{|
 type _ cross = Int : int cross | Str : string cross
 val crosses :
   'a cross @ [< past('m) & global] ->
-  ('a @ [> local unforkable yielding] ->
-   'a @ [< global forkable unyielding > dynamic]) @ [> past('m)] =
-  <fun>
+  ('a @ [> local] -> 'a @ [< global > dynamic]) @ [> past('m)] = <fun>
 |}]
 
 let escapes (type a) (w : a cross) (x : a @ local) : a @ global =

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -41,7 +41,7 @@ let pin (w : 'x arr) (g : 'x) =
 [%%expect{|
 val pin :
   (int -> int) arr @ 'o ->
-  ((int -> int) @ [< 'n . aliased contended immutable] ->
+  ((int -> int) @ [< 'n mod aliased contended immutable] ->
    (int -> int) @ [> 'n]) @ 'm =
   <fun>
 |}, Principal{|
@@ -121,6 +121,6 @@ let unpack (P f) = f
 type packed = P : (int -> int) -> packed
 val pack : packed = P <fun>
 val unpack :
-  packed @ [< 'm . aliased contended immutable] -> (int -> int) @ [> 'm] =
+  packed @ [< 'm mod aliased contended immutable] -> (int -> int) @ [> 'm] =
   <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -1,0 +1,202 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a @ static -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+let id ~label1 = label1
+[%%expect{|
+val id : label1:'a -> 'a = <fun>
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let y = id ~label1:x in
+  use_uncontended y
+[%%expect{|
+|}]
+
+let fst ~label1 ~label2 = label1
+[%%expect{|
+val fst : label1:'a -> label2:'b -> 'a = <fun>
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let f = fst ~label1:x in
+  use_uncontended (f ~label2:())
+[%%expect{|
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let f = fst ~label2:() in
+  use_uncontended (f ~label1:x)
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = fst ~label1:x ~label2:() in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = fst ~label1:x ~label2:() in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = fst ~label2:() ~label2:x in
+  use_global y
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = fst ~label2:() ~label2:x in
+  use_global y
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+let snd ~label1 ~label2 = label2
+[%%expect{|
+val snd : label1:'a -> label2:'b -> 'b = <fun>
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let f = snd ~label2:x in
+  use_uncontended (f ~label1:())
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+let foo = fst ~label2:()
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+(* partially applying a labelled function yield
+the correct close-over behavior *)
+(* [foo] closes over a local variable and should thus be local *)
+let () =
+  let (label2 @ local) = "local" in
+  let foo = fst ~label2 in
+  use_global foo
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+let () =
+  let label2 = "global" in
+  let foo = fst ~label2 in
+  use_global foo
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
+
+|}]
+
+let foo = fun x -> fst ~label1:x
+[%%expect{|
+val foo : 'a -> label2:'b -> 'a = <fun>
+|}]
+
+let foo ?label1 x = x
+[%%expect{|
+val foo : ?label1:'a -> 'b -> 'b = <fun>
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let foo x ?label1 = x
+[%%expect{|
+val foo : 'a -> ?label1:'b -> 'a = <fun>
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let bar (x @ nonportable) =
+  let f = foo x in
+  use_portable f
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable f
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let bar (x @ uncontended) =
+  let f = foo x in
+  let y = f ~label1:() in
+  use_portable y
+[%%expect{|
+val bar : 'a @ portable -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -47,8 +47,6 @@ let () =
   let f = fst ~label2:() in
   use_uncontended (f ~label1:x)
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
 |}]
 
 let () =
@@ -74,8 +72,6 @@ let () =
   let y = fst ~label2:() ~label2:x in
   use_global y
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
 |}]
 
 let () =
@@ -83,8 +79,10 @@ let () =
   let y = fst ~label2:() ~label2:x in
   use_global y
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let snd ~label1 ~label2 = label2
@@ -99,14 +97,11 @@ let () =
   let f = snd ~label2:x in
   use_uncontended (f ~label1:())
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
 |}]
 
 let foo = fst ~label2:()
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
+val foo : label1:'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
 |}]
 
 (* partially applying a labelled function yield
@@ -117,8 +112,10 @@ let () =
   let foo = fst ~label2 in
   use_global foo
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
+Line 4, characters 13-16:
+4 |   use_global foo
+                 ^^^
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let () =
@@ -126,8 +123,6 @@ let () =
   let foo = fst ~label2 in
   use_global foo
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assertion failed
-
 |}]
 
 let foo = fun x -> fst ~label1:x

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -67,9 +67,9 @@ let () =
   let y = fst ~label1:x ~label2:() in
   use_global y
 [%%expect{|
-Line 4, characters 13-14:
-4 |   use_global y
-                 ^
+Line 3, characters 22-23:
+3 |   let y = fst ~label1:x ~label2:() in
+                          ^
 Error: This value is "local" but is expected to be "global".
 |}]
 
@@ -177,9 +177,9 @@ let () =
   let y = foo x in
   use_global y
 [%%expect{|
-Line 4, characters 13-14:
-4 |   use_global y
-                 ^
+Line 3, characters 14-15:
+3 |   let y = foo x in
+                  ^
 Error: This value is "local" but is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,16 +9,16 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a @ static -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
 |}]
 
 let id ~label1 = label1
 [%%expect{|
-val id : label1:'a -> 'a = <fun>
+val id : label1:'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -36,7 +30,9 @@ let () =
 
 let fst ~label1 ~label2 = label1
 [%%expect{|
-val fst : label1:'a -> label2:'b -> 'a = <fun>
+val fst :
+  label1:'a @ [< 'm & global] ->
+  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
 |}]
 
 let () =
@@ -93,7 +89,9 @@ Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assert
 
 let snd ~label1 ~label2 = label2
 [%%expect{|
-val snd : label1:'a -> label2:'b -> 'b = <fun>
+val snd :
+  label1:'a @ [< 'm @@ past & global] ->
+  (label2:'b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -134,12 +132,16 @@ Uncaught exception: File "typing/typedtree.ml", line 138, characters 2-8: Assert
 
 let foo = fun x -> fst ~label1:x
 [%%expect{|
-val foo : 'a -> label2:'b -> 'a = <fun>
+val foo :
+  'a @ [< 'm & global] ->
+  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m) | dynamic] = <fun>
 |}]
 
 let foo ?label1 x = x
 [%%expect{|
-val foo : ?label1:'a -> 'b -> 'b = <fun>
+val foo :
+  ?label1:'a @ [< 'm @@ past & global] ->
+  ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -162,7 +164,9 @@ Error: This value is "local" but is expected to be "global".
 
 let foo x ?label1 = x
 [%%expect{|
-val foo : 'a -> ?label1:'b -> 'a = <fun>
+val foo :
+  'a @ [< 'm & global] -> (?label1:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let () =
@@ -198,5 +202,5 @@ let bar (x @ uncontended) =
   let y = f ~label1:() in
   use_portable y
 [%%expect{|
-val bar : 'a @ portable -> unit = <fun>
+val bar : 'a @ [< global portable uncontended] -> unit @ [> dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -13,7 +13,7 @@ val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
 val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
 val use_static : 'a @ [< static] -> unit @ 'm = <fun>
-val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 let id ~label1 = label1

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -88,8 +88,8 @@ Error: This value is "local" but is expected to be "global".
 let snd ~label1 ~label2 = label2
 [%%expect{|
 val snd :
-  label1:'a @ [< 'm @@ past & global] ->
-  (label2:'b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] = <fun>
+  label1:'a @ [< past('m) & global] ->
+  (label2:'b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 let () =
@@ -135,8 +135,8 @@ val foo :
 let foo ?label1 x = x
 [%%expect{|
 val foo :
-  ?label1:'a @ [< 'm @@ past & global] ->
-  ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] = <fun>
+  ?label1:'a @ [< past('m) & global] ->
+  ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -86,9 +86,7 @@ Error: This value is "local" but is expected to be "global".
 
 let snd ~label1 ~label2 = label2
 [%%expect{|
-val snd :
-  label1:'a @ [< past('n) & global] -> label2:'b @ [< 'm] -> 'b @ [> 'm] =
-  <fun>
+val snd : label1:'a @ [< global] -> label2:'b @ [< 'm] -> 'b @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -131,8 +129,7 @@ val foo : 'a @ [< 'm & global] -> label2:'b @ 'n -> 'a @ [> 'm] = <fun>
 
 let foo ?label1 x = x
 [%%expect{|
-val foo : ?label1:'a @ [< past('n) & global] -> 'b @ [< 'm] -> 'b @ [> 'm] =
-  <fun>
+val foo : ?label1:'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -30,9 +30,8 @@ let () =
 
 let fst ~label1 ~label2 = label1
 [%%expect{|
-val fst :
-  label1:'a @ [< 'm & global] ->
-  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
+val fst : label1:'a @ [< 'm & global] -> label2:'b @ 'n -> 'a @ [> 'm] =
+  <fun>
 |}]
 
 let () =
@@ -88,8 +87,8 @@ Error: This value is "local" but is expected to be "global".
 let snd ~label1 ~label2 = label2
 [%%expect{|
 val snd :
-  label1:'a @ [< past('m) & global] ->
-  (label2:'b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
+  label1:'a @ [< past('n) & global] -> label2:'b @ [< 'm] -> 'b @ [> 'm] =
+  <fun>
 |}]
 
 let () =
@@ -127,16 +126,13 @@ let () =
 
 let foo = fun x -> fst ~label1:x
 [%%expect{|
-val foo :
-  'a @ [< 'm & global] ->
-  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m) | dynamic] = <fun>
+val foo : 'a @ [< 'm & global] -> label2:'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo ?label1 x = x
 [%%expect{|
-val foo :
-  ?label1:'a @ [< past('m) & global] ->
-  ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
+val foo : ?label1:'a @ [< past('n) & global] -> 'b @ [< 'm] -> 'b @ [> 'm] =
+  <fun>
 |}]
 
 let () =
@@ -159,9 +155,7 @@ Error: This value is "local" but is expected to be "global".
 
 let foo x ?label1 = x
 [%%expect{|
-val foo :
-  'a @ [< 'm & global] -> (?label1:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val foo : 'a @ [< 'm & global] -> ?label1:'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -114,9 +114,8 @@ val foo : 'a @ [< 'm & global] -> ('a, int) mytype @ [> 'm] = <fun>
 
 let foo r = { r with y = 42 }
 [%%expect{|
-val foo :
-  ('a, 'b) mytype @ [< global many uncontended forkable unyielding read_write] ->
-  ('a, int) mytype @ [> aliased nonportable stateful dynamic] = <fun>
+val foo : ('a, 'b) mytype @ [< 'm & global] -> ('a, int) mytype @ [> 'm] =
+  <fun>
 |}]
 
 type 'a myref = { mutable x : 'a }

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -18,8 +18,6 @@ let foo x = 42
 val foo : 'a @ 'n -> int @ 'm = <fun>
 |}]
 
-(* CR ageorges: Is there a way to explain the following? id is instantiated, but foo is
-  generalized with more bounds that necessary? *)
 let foo x = id x
 [%%expect{|
 val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
@@ -43,7 +41,6 @@ let foo =
 val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 |}]
 
-(* CR ageorges: make the printer aware of mode crossing/jkinds *)
 let foo a b = a + b
 [%%expect{|
 val foo : int @ 'n -> (int @ 'm -> int @ [> dynamic]) @ [> stateful] = <fun>
@@ -279,15 +276,12 @@ val foo :
 
 (* annotations *)
 
-(* CR ageorges: if a mode variable is fully determined (its bounds are equal) consider
-  printing it as a constant rather than variable *)
-let legacy_id (x @ global many aliased nonportable uncontended forkable unyielding stateful read_write dynamic) = x
+let legacy_id : 'a -> 'a = fun x -> x
 [%%expect{|
-val legacy_id :
-  'a @ [< global many uncontended forkable unyielding read_write > aliased nonportable stateful dynamic] ->
-  'a @ [> aliased nonportable stateful dynamic] = <fun>
+val legacy_id : 'a -> 'a = <fun>
 |}]
 
+(* CR mode-poly-printing: apply "X mode implies Y mode" logic to bounds *)
 let foo (x @ local) = x
 [%%expect{|
 val foo :
@@ -340,7 +334,6 @@ val foo :
   <fun>
 |}]
 
-(* CR ageorges: ideally we want to apply mode crossing reguardless of principality *)
 let foo (f : int -> int) x y = f
 [%%expect{|
 val foo :
@@ -473,7 +466,6 @@ module Foo :
   end
 |}]
 
-(* CR ageorges: remove duplicates in [< 'm & 'm] and [> 'm | 'm] *)
 module Foo : sig
   type t
 

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -503,8 +503,8 @@ Error: Signature mismatch:
        is not included in
          val illegal : t -> t @ portable
        The type
-         "t @ [< 'm & 'm & 'm & 'm > nonportable stateful dynamic] ->
-         t @ [> 'm | 'm | 'm | 'm | nonportable stateful dynamic]"
+         "t @ [< 'm > nonportable stateful dynamic] ->
+         t @ [> 'm | nonportable stateful dynamic]"
        is not compatible with the type "t -> t @ portable"
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -1,0 +1,668 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests printing of poymorphic mode variables
+*)
+
+
+let id x = x
+[%%expect{|
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo x = 42
+[%%expect{|
+val foo : 'a @ 'n -> int @ 'm = <fun>
+|}]
+
+(* CR ageorges: Is there a way to explain the following? id is instantiated, but foo is
+  generalized with more bounds that necessary? *)
+let foo x = id x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
+|}]
+
+let foo f x = f x
+[%%expect{|
+val foo :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
+|}, Principal{|
+val foo :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
+|}]
+
+let foo =
+  let id x = x in
+  fun x -> id x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
+|}]
+
+(* CR ageorges: make the printer aware of mode crossing/jkinds *)
+let foo a b = a + b
+[%%expect{|
+val foo : int @ 'n -> (int @ 'm -> int @ [> dynamic]) @ [> stateful] = <fun>
+|}, Principal{|
+val foo :
+  int @ [< 'm @@ past & global] ->
+  (int @ 'n -> int @ [> dynamic]) @ [> 'm | stateful] = <fun>
+|}]
+
+
+(* records *)
+
+type ('a,'b) mytypemod = { x : 'a; y : 'b @@ portable }
+
+let foo t = t.x
+[%%expect{|
+type ('a, 'b) mytypemod = { x : 'a; y : 'b @@ portable; }
+val foo : ('a, 'b) mytypemod @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo t = t.y
+[%%expect{|
+val foo : ('a, 'b) mytypemod @ [< 'm] -> 'b @ [> 'm @@ portable] = <fun>
+|}]
+
+let foo x z = x.y
+[%%expect{|
+val foo :
+  ('a, 'b) mytypemod @ [< 'm & global] ->
+  ('c @ 'n -> 'b @ [> 'm @@ portable]) @ [> close('m)] = <fun>
+|}]
+
+
+let x =
+  let foo x = x in
+  let _ @ contended = foo (ref 42 : _ @ contended ) in
+  let _ @ uncontended = foo  (ref 41 : _ @ uncontended) in
+  foo
+[%%expect{|
+val x : '_weak1 -> '_weak1 @ [> aliased nonportable stateful dynamic] = <fun>
+|}]
+
+type ('a,'b) mytype = { x : 'a; y : 'b }
+[%%expect{|
+type ('a, 'b) mytype = { x : 'a; y : 'b; }
+|}]
+
+let foo x y = { x; y }
+[%%expect{|
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo x = fun y -> { x; y }
+[%%expect{|
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo x = { x; y = 42 }
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> ('a, int) mytype @ [> 'm] = <fun>
+|}]
+
+let foo r = { r with y = 42 }
+[%%expect{|
+val foo :
+  ('a, 'b) mytype @ [< global many uncontended forkable unyielding read_write] ->
+  ('a, int) mytype @ [> aliased nonportable stateful dynamic] = <fun>
+|}]
+
+type 'a myref = { mutable x : 'a }
+[%%expect{|
+type 'a myref = { mutable x : 'a; }
+|}]
+
+let create a = { x = a }
+[%%expect{|
+val create :
+  'a @ [< global many forkable unyielding > 'm] ->
+  'a myref @ [< 'm @@ past > nonportable stateful] = <fun>
+|}]
+
+let read r = r.x
+[%%expect{|
+val read :
+  'a myref @ [< 'm & shared read] ->
+  'a @ [> 'm @@ global many forkable unyielding | aliased dynamic] = <fun>
+|}]
+
+let store r = fun a -> r.x <- a
+[%%expect{|
+val store :
+  'a myref @ [< 'm @@ past & global corrupted write] ->
+  ('a @ [< global many uncontended forkable unyielding read_write] ->
+   unit @ 'n) @ [> 'm | corruptible writing] =
+  <fun>
+|}]
+
+(* products *)
+
+let dupl x = (x, x)
+[%%expect{|
+val dupl : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased] = <fun>
+|}]
+
+let prod x y = (x, y)
+[%%expect{|
+val prod :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let prod_eta x = fun y -> (x, y)
+[%%expect{|
+val prod_eta :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let fst (a, _) = a
+let snd (_, b) = b
+[%%expect{|
+val fst : 'a * 'b @ [< 'm] -> 'a @ [> 'm] = <fun>
+val snd : 'a * 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+|}]
+
+let foo x = fun y ->
+  let x' = fst (x,y) in
+  let y' = snd (x,y) in
+  (x', y')
+[%%expect{|
+val foo :
+  'a @ [< 'm & global many] ->
+  ('b @ [< 'n & global many] -> 'a * 'b @ [> 'n | 'm | aliased dynamic]) @ [> close('m) | nonportable stateful] =
+  <fun>
+|}]
+
+(* currying *)
+
+let foo x y = x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo x y = y
+[%%expect{|
+val foo :
+  'a @ [< 'm @@ past & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] =
+  <fun>
+|}]
+
+let id x = x
+let foo x y = id x
+[%%expect{|
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ 'n -> 'a @ [> 'm | dynamic]) @ [> close('m) | nonportable stateful] =
+  <fun>
+|}]
+
+let foo f = fun x -> fun y -> f x y
+[%%expect{|
+val foo :
+  ('a @ [< 'm @@ past > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('a @ [< 'q & global] ->
+   ('b @ [< 'p] -> 'c @ [> 'o | dynamic]) @ [> close('q) | 'mm1]) @ [> 'mm0] =
+  <fun>
+|}]
+
+let fst x = fun y -> x
+[%%expect{|
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+let snd x = fun y -> y
+[%%expect{|
+val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
+|}]
+
+let foo x y = ref x
+[%%expect{|
+val foo :
+  'a @ [< global many uncontended forkable unyielding read_write > 'm] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< 'm @@ past > nonportable stateful] =
+  <fun>
+|}]
+
+let foo (x @ aliased) y = ref x
+[%%expect{|
+val foo :
+  'a @ [< global many uncontended forkable unyielding read_write > 'm | aliased] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< 'm @@ past > nonportable stateful] =
+  <fun>
+|}]
+
+let foo (x @ contended) y = x
+[%%expect{|
+val foo :
+  'a @ [< 'm & global > contended] ->
+  ('b @ 'n -> 'a @ [> 'm | contended]) @ [> close('m)] = <fun>
+|}]
+
+let foo x y z = 42
+[%%expect{|
+val foo :
+  'a @ [< 'o @@ past & 'm @@ past & global] ->
+  ('b @ [< 'n @@ past & global] -> ('c @ 'q -> int @ 'p) @ [> 'n | 'o]) @ [> 'm] =
+  <fun>
+|}]
+
+let foo x y = (x, y)
+[%%expect{|
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let foo x y z = (y,z)
+[%%expect{|
+val foo :
+  'a @ [< 'o @@ past & 'm @@ past & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'p & global] -> 'b * 'c @ [> 'p | 'n]) @ [> close('n) | 'o]) @ [> 'm] =
+  <fun>
+|}]
+
+(* annotations *)
+
+(* CR ageorges: if a mode variable is fully determined (its bounds are equal) consider
+  printing it as a constant rather than variable *)
+let legacy_id (x @ global many aliased nonportable uncontended forkable unyielding stateful read_write dynamic) = x
+[%%expect{|
+val legacy_id :
+  'a @ [< global many uncontended forkable unyielding read_write > aliased nonportable stateful dynamic] ->
+  'a @ [> aliased nonportable stateful dynamic] = <fun>
+|}]
+
+let foo (x @ local) = x
+[%%expect{|
+val foo :
+  'a @ [< 'm > local unforkable yielding] ->
+  'a @ [> 'm | local unforkable yielding] = <fun>
+|}]
+
+let foo x = exclave_ x
+[%%expect{|
+val foo : 'a @ [< 'm] -> 'a @ [> 'm | local] = <fun>
+|}]
+
+let foo (x @ portable) = x
+[%%expect{|
+val foo : 'a @ [< 'm & portable] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo : (unit -> unit) @ portable = fun () -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let foo (y @ unique) (z @ portable) = z
+[%%expect{|
+val foo :
+  'a @ [< 'm @@ past & global unique] ->
+  ('b @ [< 'n & portable] -> 'b @ [> 'n]) @ [> 'm] = <fun>
+|}]
+
+let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
+[%%expect{|
+val foo :
+  'a @ [< 'm > local unforkable yielding] ->
+  ('b @ [< 'n & unique] ->
+   ('c @ [< 'o & portable] ->
+    'a * 'b * 'c @ [> 'o | 'n | 'm | local unforkable yielding]) @ [> close('m) | close('n) | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
+  <fun>
+|}]
+
+(* if a type is annotated, mode crossing has an effect on the bounds of mode variable *)
+
+type intref = { mutable v : int }
+
+let foo (x : intref) (f : intref @ local -> int) = f x
+[%%expect{|
+type intref = { mutable v : int; }
+val foo :
+  intref @ [< 'm @@ past & global uncontended read_write] ->
+  ((intref @ local -> int) @ 'n -> int @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  <fun>
+|}]
+
+(* CR ageorges: ideally we want to apply mode crossing reguardless of principality *)
+let foo (f : int -> int) x y = f
+[%%expect{|
+val foo :
+  (int -> int) @ [< 'p . aliased contended immutable & 'o @@ past & 'm @@ past & global] ->
+  ('a @ [< 'n @@ past & global] ->
+   ('b @ 'q -> (int -> int) @ [> 'p]) @ [> 'n | 'o]) @ [> 'm] =
+  <fun>
+|}, Principal{|
+val foo :
+  (int -> int) @ [< 'm . aliased contended immutable & global] ->
+  ('a @ [< 'n @@ past & global] ->
+   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) @@ many portable stateless | 'n]) @ [> close('m) @@ many portable stateless] =
+  <fun>
+|}]
+
+let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
+[%%expect{|
+val foo :
+  (intref @ local -> int) @ [< 'o @@ past & 'm @@ past & global] ->
+  (intref @ [< 'n @@ past & global uncontended read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> 'n @@ many portable forkable unyielding stateless | 'o | nonportable stateful]) @ [> 'm] =
+  <fun>
+|}, Principal{|
+val foo :
+  (intref @ local -> int) @ [< 'o @@ past & 'm @@ past & global] ->
+  (intref @ [< 'n @@ past & global uncontended read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> 'n | 'o | nonportable stateful]) @ [> 'm] =
+  <fun>
+|}]
+
+(* aliases of non-polymorphic functions *)
+
+let map = List.map
+[%%expect{|
+val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
+|}]
+
+let map f l = List.map f l
+[%%expect{|
+val map :
+  ('a @ [< 'm @@ past > aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< 'n @@ past & global many forkable unyielding > 'o | 'm] ->
+  ('a list @ [< global many uncontended forkable unyielding read_write] ->
+   'b list @ [< 'o @@ past > aliased nonportable stateful dynamic]) @ [> 'n | stateful] =
+  <fun>
+|}, Principal{|
+val map :
+  ('a @ [< 'm @@ past > aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< 'n @@ past & global many forkable unyielding > 'o | 'm] ->
+  ('a list @ [< global many uncontended forkable unyielding read_write] ->
+   'b list @ [< 'o @@ past > aliased nonportable stateful dynamic]) @ [> 'n | stateful] =
+  <fun>
+|}]
+
+let map_eta f = fun l -> List.map f l
+[%%expect{|
+val map_eta :
+  ('a @ [< 'm @@ past > aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< 'n @@ past & global many forkable unyielding > 'o | 'm] ->
+  ('a list @ [< global many uncontended forkable unyielding read_write] ->
+   'b list @ [< 'o @@ past > aliased nonportable stateful dynamic]) @ [> 'n | stateful] =
+  <fun>
+|}]
+
+(* modules *)
+
+ module Counter : sig
+  type t
+
+  val incr : t -> t
+
+  val to_int : t -> int
+end = struct
+  type t = int
+
+  let incr n = n + 1
+
+  let to_int = fun n -> n
+ end
+ [%%expect{|
+module Counter : sig type t val incr : t -> t val to_int : t -> int end
+|}]
+
+let incr n = Counter.incr n
+[%%expect{|
+val incr :
+  Counter.t @ [< global many uncontended forkable unyielding read_write] ->
+  Counter.t @ [> aliased nonportable stateful dynamic] = <fun>
+|}]
+
+let incr = Counter.incr
+[%%expect{|
+val incr : Counter.t -> Counter.t = <fun>
+|}]
+
+let incr n = n + 1
+[%%expect{|
+val incr : int @ 'm -> int @ [> dynamic] = <fun>
+|}]
+
+let id x = x
+[%%expect{|
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+module Foo : sig
+  type t
+
+  val id_portable : t @ portable -> t @ portable
+
+  val id_nonportable : t -> t
+
+  val bar : t @ portable -> t
+end = struct
+  type t = unit -> unit
+
+  let id_portable = id
+
+  let id_nonportable = id
+
+  let bar = id
+end
+[%%expect{|
+module Foo :
+  sig
+    type t
+    val id_portable : t @ portable -> t @ portable
+    val id_nonportable : t -> t
+    val bar : t @ portable -> t
+  end
+|}]
+
+(* CR ageorges: remove duplicates in [< 'm & 'm] and [> 'm | 'm] *)
+module Foo : sig
+  type t
+
+  val illegal : t -> t @ portable
+end = struct
+  type t = unit -> unit
+
+  let illegal = id
+end
+[%%expect{|
+Lines 5-9, characters 6-3:
+5 | ......struct
+6 |   type t = unit -> unit
+7 |
+8 |   let illegal = id
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = unit -> unit
+           val illegal : 'a @ [< 'm] -> 'a @ [> 'm]
+         end
+       is not included in
+         sig type t val illegal : t -> t @ portable end
+       Values do not match:
+         val illegal : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val illegal : t -> t @ portable
+       The type
+         "t @ [< 'm & 'm & 'm & 'm > nonportable stateful dynamic] ->
+         t @ [> 'm | 'm | 'm | 'm | nonportable stateful dynamic]"
+       is not compatible with the type "t -> t @ portable"
+|}]
+
+(* variant types *)
+
+type 'a option' = None' | Some' of 'a
+
+let wrap x = Some' x
+[%%expect{|
+type 'a option' = None' | Some' of 'a
+val wrap : 'a @ [< 'm & global] -> 'a option' @ [> 'm] = <fun>
+|}]
+
+let unwrap_or default = function
+  | None' -> default
+  | Some' x -> x
+[%%expect{|
+val unwrap_or :
+  'a @ [< 'm & global] ->
+  ('a option' @ [< 'n] -> 'a @ [> 'n | 'm | dynamic]) @ [> close('m)] = <fun>
+|}]
+
+type ('a, 'b) either = Left of 'a | Right of 'b
+
+let map_left f = function
+  | Left x -> Left (f x)
+  | Right y -> Right y
+[%%expect{|
+type ('a, 'b) either = Left of 'a | Right of 'b
+val map_left :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  (('a, 'c) either @ [< 'p & 'n & global] ->
+   ('b, 'c) either @ [> 'p | 'm | dynamic]) @ [> 'o] =
+  <fun>
+|}]
+
+(* recursive functions *)
+
+let rec length = function
+  | [] -> 0
+  | _ :: tl -> 1 + length tl
+[%%expect{|
+val length : 'a list @ [> dynamic] -> int @ [> dynamic] = <fun>
+|}]
+
+let rec map f = function
+  | [] -> []
+  | x :: xs -> f x :: map f xs
+[%%expect{|
+val map :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & 'p @@ past & global many > aliased] ->
+  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> 'o | 'p | nonportable stateful] =
+  <fun>
+|}]
+
+(* if/then/else *)
+
+let choose b x y = if b then x else y
+[%%expect{|
+val choose :
+  bool @ [< 'o @@ past & 'm @@ past & global] ->
+  ('a @ [< 'n & global] ->
+   ('a @ [< 'p] -> 'a @ [> 'p | 'n | dynamic]) @ [> close('n) | 'o]) @ [> 'm] =
+  <fun>
+|}]
+
+(* nested closures *)
+
+let nest x = fun () -> fun () -> fun () -> x
+[%%expect{|
+val nest :
+  'a @ [< 'm & global] ->
+  (unit @ 'p ->
+   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
+|}]
+
+(* sequencing: using x then returning it *)
+
+let use_and_return x = ignore x; x
+[%%expect{|
+val use_and_return :
+  'a @ [< 'm & global many uncontended forkable unyielding read_write] ->
+  'a @ [> 'm | aliased] = <fun>
+|}]
+
+(* multiple distinct mode variables *)
+
+let swap (a, b) = (b, a)
+[%%expect{|
+val swap : 'a * 'b @ [< 'm & global] -> 'b * 'a @ [> 'm] = <fun>
+|}]
+
+let both_id x y = (x, y)
+[%%expect{|
+val both_id :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+(* let bindings preserving modes *)
+
+let let_chain x =
+  let a = x in
+  let b = a in
+  let c = b in
+  c
+[%%expect{|
+val let_chain : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+(* mode polymorphism with option type *)
+
+let map_option f = function
+  | None -> None
+  | Some x -> Some (f x)
+[%%expect{|
+val map_option :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a option @ [< 'n] -> 'b option @ [> 'm | dynamic]) @ [> 'o] = <fun>
+|}]
+
+(* Currying over three arguments *)
+
+let triple x y z = (x, y, z)
+[%%expect{|
+val triple :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'o & global] -> 'a * 'b * 'c @ [> 'o | 'n | 'm]) @ [> close('m) | close('n)]) @ [> close('m)] =
+  <fun>
+|}]
+
+let flip f (x, y) = f (y, x)
+[%%expect{|
+val flip :
+  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic]) @ [> 'o] = <fun>
+|}]
+
+let flip f x y = f y x
+[%%expect{|
+val flip :
+  ('a @ [< 'm @@ past > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | 'mm1]) @ [> 'mm0] =
+  <fun>
+|}]
+
+
+let flip f = fun x -> fun y -> f y x
+[%%expect{|
+val flip :
+  ('a @ [< 'm @@ past > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | 'mm1]) @ [> 'mm0] =
+  <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -317,7 +317,7 @@ val foo :
   'a @ [< 'm > local unforkable yielding] ->
   ('b @ [< 'n & unique] ->
    ('c @ [< 'o & portable] ->
-    'a * 'b * 'c @ [> 'o | 'n | 'm | local unforkable yielding]) @ [> close('m) | close('n) | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
+    'a * 'b * 'c @ [> 'o | 'n | 'm | local unforkable yielding]) @ [> close('n) | close('m) | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
   <fun>
 |}]
 
@@ -626,7 +626,7 @@ let triple x y z = (x, y, z)
 val triple :
   'a @ [< 'm & global] ->
   ('b @ [< 'n & global] ->
-   ('c @ [< 'o & global] -> 'a * 'b * 'c @ [> 'o | 'n | 'm]) @ [> close('m) | close('n)]) @ [> close('m)] =
+   ('c @ [< 'o & global] -> 'a * 'b * 'c @ [> 'o | 'n | 'm]) @ [> close('n) | close('m)]) @ [> close('m)] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -63,14 +63,14 @@ val foo : ('a, 'b) mytypemod @ [< 'm] -> 'a @ [> 'm] = <fun>
 
 let foo t = t.y
 [%%expect{|
-val foo : ('a, 'b) mytypemod @ [< 'm] -> 'b @ [> 'm @@ portable] = <fun>
+val foo : ('a, 'b) mytypemod @ [< 'm] -> 'b @ [> 'm mod portable] = <fun>
 |}]
 
 let foo x z = x.y
 [%%expect{|
 val foo :
   ('a, 'b) mytypemod @ [< 'm & global] ->
-  ('c @ 'n -> 'b @ [> 'm @@ portable]) @ [> close('m)] = <fun>
+  ('c @ 'n -> 'b @ [> 'm mod portable]) @ [> close('m)] = <fun>
 |}]
 
 
@@ -123,15 +123,15 @@ type 'a myref = { mutable x : 'a; }
 let create a = { x = a }
 [%%expect{|
 val create :
-  'a @ [< 'm . aliased dynamic & global many] -> 'a myref @ [> 'm | stateful] =
-  <fun>
+  'a @ [< 'm mod aliased dynamic & global many] ->
+  'a myref @ [> 'm | stateful] = <fun>
 |}]
 
 let read r = r.x
 [%%expect{|
 val read :
   'a myref @ [< 'm & read] ->
-  'a @ [> 'm @@ global many forkable unyielding | aliased dynamic] = <fun>
+  'a @ [> 'm mod global many forkable unyielding | aliased dynamic] = <fun>
 |}]
 
 let store r = fun a -> r.x <- a
@@ -333,15 +333,15 @@ val foo :
 let foo (f : int -> int) x y = f
 [%%expect{|
 val foo :
-  (int -> int) @ [< 'p . aliased contended immutable & past('o) & past('m) & global] ->
+  (int -> int) @ [< 'p mod aliased contended immutable & past('o) & past('m) & global] ->
   ('a @ [< past('n) & global] ->
    ('b @ 'q -> (int -> int) @ [> 'p]) @ [> past('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}, Principal{|
 val foo :
-  (int -> int) @ [< 'm . aliased contended immutable & global] ->
+  (int -> int) @ [< 'm mod aliased contended immutable & global] ->
   ('a @ [< past('n) & global] ->
-   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) @@ many portable stateless | past('n)]) @ [> close('m) @@ many portable stateless] =
+   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) mod many portable stateless | past('n)]) @ [> close('m) mod many portable stateless] =
   <fun>
 |}]
 
@@ -350,7 +350,7 @@ let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 val foo :
   (intref @ local -> int) @ [< past('o) & past('m) & global] ->
   (intref @ [< past('n) & global read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> past('n @@ many portable forkable unyielding stateless) | past('o) | stateful]) @ [> past('m)] =
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) mod many portable forkable unyielding stateless | past('o) | stateful]) @ [> past('m)] =
   <fun>
 |}, Principal{|
 val foo :

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -26,12 +26,12 @@ val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 let foo f x = f x
 [%%expect{|
 val foo :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}, Principal{|
 val foo :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> 'o] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let foo =
@@ -46,8 +46,8 @@ let foo a b = a + b
 val foo : int @ 'n -> (int @ 'm -> int @ [> dynamic]) @ [> stateful] = <fun>
 |}, Principal{|
 val foo :
-  int @ [< 'm @@ past & global] ->
-  (int @ 'n -> int @ [> dynamic]) @ [> 'm | stateful] = <fun>
+  int @ [< past('m) & global] ->
+  (int @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] = <fun>
 |}]
 
 
@@ -123,8 +123,8 @@ type 'a myref = { mutable x : 'a; }
 let create a = { x = a }
 [%%expect{|
 val create :
-  'a @ [< global many forkable unyielding > 'm] ->
-  'a myref @ [< 'm @@ past > nonportable stateful] = <fun>
+  'a @ [< global many forkable unyielding > past('m)] ->
+  'a myref @ [< past('m) > nonportable stateful] = <fun>
 |}]
 
 let read r = r.x
@@ -137,9 +137,9 @@ val read :
 let store r = fun a -> r.x <- a
 [%%expect{|
 val store :
-  'a myref @ [< 'm @@ past & global corrupted write] ->
+  'a myref @ [< past('m) & global corrupted write] ->
   ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> 'm | corruptible writing] =
+   unit @ 'n) @ [> past('m) | corruptible writing] =
   <fun>
 |}]
 
@@ -193,7 +193,7 @@ val foo : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
 let foo x y = y
 [%%expect{|
 val foo :
-  'a @ [< 'm @@ past & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] =
+  'a @ [< past('m) & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -210,10 +210,10 @@ val foo :
 let foo f = fun x -> fun y -> f x y
 [%%expect{|
 val foo :
-  ('a @ [< 'm @@ past > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
   ('a @ [< 'q & global] ->
-   ('b @ [< 'p] -> 'c @ [> 'o | dynamic]) @ [> close('q) | 'mm1]) @ [> 'mm0] =
+   ('b @ [< 'p] -> 'c @ [> 'o | dynamic]) @ [> close('q) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]
 
@@ -230,16 +230,16 @@ val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
 let foo x y = ref x
 [%%expect{|
 val foo :
-  'a @ [< global many uncontended forkable unyielding read_write > 'm] ->
-  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< 'm @@ past > nonportable stateful] =
+  'a @ [< global many uncontended forkable unyielding read_write > past('m)] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< past('m) > nonportable stateful] =
   <fun>
 |}]
 
 let foo (x @ aliased) y = ref x
 [%%expect{|
 val foo :
-  'a @ [< global many uncontended forkable unyielding read_write > 'm | aliased] ->
-  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< 'm @@ past > nonportable stateful] =
+  'a @ [< global many uncontended forkable unyielding read_write > past('m) | aliased] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< past('m) > nonportable stateful] =
   <fun>
 |}]
 
@@ -253,8 +253,9 @@ val foo :
 let foo x y z = 42
 [%%expect{|
 val foo :
-  'a @ [< 'o @@ past & 'm @@ past & global] ->
-  ('b @ [< 'n @@ past & global] -> ('c @ 'q -> int @ 'p) @ [> 'n | 'o]) @ [> 'm] =
+  'a @ [< past('o) & past('m) & global] ->
+  ('b @ [< past('n) & global] ->
+   ('c @ 'q -> int @ 'p) @ [> past('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -268,9 +269,9 @@ val foo :
 let foo x y z = (y,z)
 [%%expect{|
 val foo :
-  'a @ [< 'o @@ past & 'm @@ past & global] ->
+  'a @ [< past('o) & past('m) & global] ->
   ('b @ [< 'n & global] ->
-   ('c @ [< 'p & global] -> 'b * 'c @ [> 'p | 'n]) @ [> close('n) | 'o]) @ [> 'm] =
+   ('c @ [< 'p & global] -> 'b * 'c @ [> 'p | 'n]) @ [> close('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -307,8 +308,8 @@ val foo : unit -> unit = <fun>
 let foo (y @ unique) (z @ portable) = z
 [%%expect{|
 val foo :
-  'a @ [< 'm @@ past & global unique] ->
-  ('b @ [< 'n & portable] -> 'b @ [> 'n]) @ [> 'm] = <fun>
+  'a @ [< past('m) & global unique] ->
+  ('b @ [< 'n & portable] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
@@ -329,38 +330,38 @@ let foo (x : intref) (f : intref @ local -> int) = f x
 [%%expect{|
 type intref = { mutable v : int; }
 val foo :
-  intref @ [< 'm @@ past & global uncontended read_write] ->
-  ((intref @ local -> int) @ 'n -> int @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  intref @ [< past('m) & global uncontended read_write] ->
+  ((intref @ local -> int) @ 'n -> int @ [> dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 
 let foo (f : int -> int) x y = f
 [%%expect{|
 val foo :
-  (int -> int) @ [< 'p . aliased contended immutable & 'o @@ past & 'm @@ past & global] ->
-  ('a @ [< 'n @@ past & global] ->
-   ('b @ 'q -> (int -> int) @ [> 'p]) @ [> 'n | 'o]) @ [> 'm] =
+  (int -> int) @ [< 'p . aliased contended immutable & past('o) & past('m) & global] ->
+  ('a @ [< past('n) & global] ->
+   ('b @ 'q -> (int -> int) @ [> 'p]) @ [> past('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}, Principal{|
 val foo :
   (int -> int) @ [< 'm . aliased contended immutable & global] ->
-  ('a @ [< 'n @@ past & global] ->
-   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) @@ many portable stateless | 'n]) @ [> close('m) @@ many portable stateless] =
+  ('a @ [< past('n) & global] ->
+   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) @@ many portable stateless | past('n)]) @ [> close('m) @@ many portable stateless] =
   <fun>
 |}]
 
 let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 [%%expect{|
 val foo :
-  (intref @ local -> int) @ [< 'o @@ past & 'm @@ past & global] ->
-  (intref @ [< 'n @@ past & global uncontended read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> 'n @@ many portable forkable unyielding stateless | 'o | nonportable stateful]) @ [> 'm] =
+  (intref @ local -> int) @ [< past('o) & past('m) & global] ->
+  (intref @ [< past('n) & global uncontended read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n @@ many portable forkable unyielding stateless) | past('o) | nonportable stateful]) @ [> past('m)] =
   <fun>
 |}, Principal{|
 val foo :
-  (intref @ local -> int) @ [< 'o @@ past & 'm @@ past & global] ->
-  (intref @ [< 'n @@ past & global uncontended read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> 'n | 'o | nonportable stateful]) @ [> 'm] =
+  (intref @ local -> int) @ [< past('o) & past('m) & global] ->
+  (intref @ [< past('n) & global uncontended read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) | past('o) | nonportable stateful]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -374,27 +375,27 @@ val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 let map f l = List.map f l
 [%%expect{|
 val map :
-  ('a @ [< 'm @@ past > aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< 'n @@ past & global many forkable unyielding > 'o | 'm] ->
+  ('a @ [< past('m) > aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('n) & global many forkable unyielding > past('o) | past('m)] ->
   ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [< 'o @@ past > aliased nonportable stateful dynamic]) @ [> 'n | stateful] =
+   'b list @ [< past('o) > aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}, Principal{|
 val map :
-  ('a @ [< 'm @@ past > aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< 'n @@ past & global many forkable unyielding > 'o | 'm] ->
+  ('a @ [< past('m) > aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('n) & global many forkable unyielding > past('o) | past('m)] ->
   ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [< 'o @@ past > aliased nonportable stateful dynamic]) @ [> 'n | stateful] =
+   'b list @ [< past('o) > aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}]
 
 let map_eta f = fun l -> List.map f l
 [%%expect{|
 val map_eta :
-  ('a @ [< 'm @@ past > aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< 'n @@ past & global many forkable unyielding > 'o | 'm] ->
+  ('a @ [< past('m) > aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('n) & global many forkable unyielding > past('o) | past('m)] ->
   ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [< 'o @@ past > aliased nonportable stateful dynamic]) @ [> 'n | stateful] =
+   'b list @ [< past('o) > aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}]
 
@@ -527,9 +528,9 @@ let map_left f = function
 [%%expect{|
 type ('a, 'b) either = Left of 'a | Right of 'b
 val map_left :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
   (('a, 'c) either @ [< 'p & 'n & global] ->
-   ('b, 'c) either @ [> 'p | 'm | dynamic]) @ [> 'o] =
+   ('b, 'c) either @ [> 'p | 'm | dynamic]) @ [> past('o)] =
   <fun>
 |}]
 
@@ -547,8 +548,8 @@ let rec map f = function
   | x :: xs -> f x :: map f xs
 [%%expect{|
 val map :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & 'p @@ past & global many > aliased] ->
-  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> 'o | 'p | nonportable stateful] =
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
+  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | nonportable stateful] =
   <fun>
 |}]
 
@@ -557,9 +558,9 @@ val map :
 let choose b x y = if b then x else y
 [%%expect{|
 val choose :
-  bool @ [< 'o @@ past & 'm @@ past & global] ->
+  bool @ [< past('o) & past('m) & global] ->
   ('a @ [< 'n & global] ->
-   ('a @ [< 'p] -> 'a @ [> 'p | 'n | dynamic]) @ [> close('n) | 'o]) @ [> 'm] =
+   ('a @ [< 'p] -> 'a @ [> 'p | 'n | dynamic]) @ [> close('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -615,8 +616,8 @@ let map_option f = function
   | Some x -> Some (f x)
 [%%expect{|
 val map_option :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
-  ('a option @ [< 'n] -> 'b option @ [> 'm | dynamic]) @ [> 'o] = <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a option @ [< 'n] -> 'b option @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 (* Currying over three arguments *)
@@ -633,17 +634,17 @@ val triple :
 let flip f (x, y) = f (y, x)
 [%%expect{|
 val flip :
-  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< 'o @@ past & global] ->
-  ('b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic]) @ [> 'o] = <fun>
+  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('o) & global] ->
+  ('b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< 'm @@ past > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
   ('b @ [< 'p & global] ->
-   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | 'mm1]) @ [> 'mm0] =
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]
 
@@ -651,9 +652,9 @@ val flip :
 let flip f = fun x -> fun y -> f y x
 [%%expect{|
 val flip :
-  ('a @ [< 'm @@ past > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
   ('b @ [< 'p & global] ->
-   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | 'mm1]) @ [> 'mm0] =
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -28,10 +28,6 @@ let foo f x = f x
 val foo :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
   'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
-|}, Principal{|
-val foo :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
-  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let foo =
@@ -289,10 +285,9 @@ val foo : 'a @ [< global unique] -> 'b @ [< 'm & portable] -> 'b @ [> 'm] =
 let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
 [%%expect{|
 val foo :
-  'a @ [< 'n > local] ->
-  'b @ [< 'm & unique] ->
-  ('c @ [< 'o & portable] -> 'a * 'b * 'c @ [> 'o | 'm | 'n | local]) @ [> close('m) | close('n) | local] =
-  <fun>
+  'a @ [< 'o > local] ->
+  'b @ [< 'n & unique] ->
+  'c @ [< 'm & portable] -> 'a * 'b * 'c @ [> 'm | 'n | 'o | local] = <fun>
 |}]
 
 (* if a type is annotated, mode crossing has an effect on the bounds of mode variable *)
@@ -312,18 +307,10 @@ let foo (f : int -> int) x y = f
 val foo :
   (int -> int) @ [< 'm mod aliased contended immutable & global] ->
   'a @ [< global] -> 'b @ 'n -> (int -> int) @ [> 'm] = <fun>
-|}, Principal{|
-val foo :
-  (int -> int) @ [< 'm mod aliased contended immutable & global] ->
-  'a @ [< global] -> 'b @ 'n -> (int -> int) @ [> 'm] = <fun>
 |}]
 
 let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 [%%expect{|
-val foo :
-  (intref @ local -> int) @ [< global] ->
-  intref @ [< global read_write] -> intref @ 'm -> int @ [> dynamic] = <fun>
-|}, Principal{|
 val foo :
   (intref @ local -> int) @ [< global] ->
   intref @ [< global read_write] -> intref @ 'm -> int @ [> dynamic] = <fun>
@@ -338,12 +325,6 @@ val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 
 let map f l = List.map f l
 [%%expect{|
-val map :
-  ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
-  'a list @ [< global many read_write] ->
-  'b list @ [> past('n) | aliased stateful dynamic] = <fun>
-|}, Principal{|
 val map :
   ('a @ [> past('m) | aliased stateful dynamic] ->
    'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
@@ -507,6 +488,10 @@ let rec map f = function
   | x :: xs -> f x :: map f xs
 [%%expect{|
 val map :
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global many] ->
+  'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
+|}, Principal{|
+val map :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global many > aliased] ->
   'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
 |}]
@@ -515,6 +500,10 @@ val map :
 
 let choose b x y = if b then x else y
 [%%expect{|
+val choose :
+  bool @ 'o ->
+  'a @ [< 'n & global] -> 'a @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] = <fun>
+|}, Principal{|
 val choose :
   bool @ [< global] ->
   'a @ [< 'n & global] -> 'a @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] = <fun>

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -80,7 +80,7 @@ let x =
   let _ @ uncontended = foo  (ref 41 : _ @ uncontended) in
   foo
 [%%expect{|
-val x : '_weak1 -> '_weak1 @ [> aliased nonportable stateful dynamic] = <fun>
+val x : '_weak1 -> '_weak1 @ [> aliased stateful dynamic] = <fun>
 |}]
 
 type ('a,'b) mytype = { x : 'a; y : 'b }
@@ -123,23 +123,22 @@ type 'a myref = { mutable x : 'a; }
 let create a = { x = a }
 [%%expect{|
 val create :
-  'a @ [< 'm . aliased dynamic & global many forkable unyielding] ->
-  'a myref @ [> 'm | nonportable stateful] = <fun>
+  'a @ [< 'm . aliased dynamic & global many] -> 'a myref @ [> 'm | stateful] =
+  <fun>
 |}]
 
 let read r = r.x
 [%%expect{|
 val read :
-  'a myref @ [< 'm & shared read] ->
+  'a myref @ [< 'm & read] ->
   'a @ [> 'm @@ global many forkable unyielding | aliased dynamic] = <fun>
 |}]
 
 let store r = fun a -> r.x <- a
 [%%expect{|
 val store :
-  'a myref @ [< past('m) & global corrupted write] ->
-  ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> past('m) | corruptible writing] =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -178,7 +177,7 @@ let foo x = fun y ->
 [%%expect{|
 val foo :
   'a @ [< 'm & global many] ->
-  ('b @ [< 'n & global many] -> 'a * 'b @ [> 'n | 'm | aliased dynamic]) @ [> close('m) | nonportable stateful] =
+  ('b @ [< 'n & global many] -> 'a * 'b @ [> 'n | 'm | aliased dynamic]) @ [> close('m) | stateful] =
   <fun>
 |}]
 
@@ -203,8 +202,7 @@ let foo x y = id x
 val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 val foo :
   'a @ [< 'm & global] ->
-  ('b @ 'n -> 'a @ [> 'm | dynamic]) @ [> close('m) | nonportable stateful] =
-  <fun>
+  ('b @ 'n -> 'a @ [> 'm | dynamic]) @ [> close('m) | stateful] = <fun>
 |}]
 
 let foo f = fun x -> fun y -> f x y
@@ -230,16 +228,16 @@ val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
 let foo x y = ref x
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global many uncontended forkable unyielding read_write] ->
-  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [> past('m) | nonportable stateful] =
+  'a @ [< past('m) & global many read_write] ->
+  ('b @ 'n -> 'a ref @ [> aliased stateful dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 
 let foo (x @ aliased) y = ref x
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global many uncontended forkable unyielding read_write > aliased] ->
-  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [> past('m) | nonportable stateful] =
+  'a @ [< past('m) & global many read_write > aliased] ->
+  ('b @ 'n -> 'a ref @ [> aliased stateful dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 
@@ -285,9 +283,7 @@ val legacy_id : 'a -> 'a = <fun>
 (* CR mode-poly-printing: apply "X mode implies Y mode" logic to bounds *)
 let foo (x @ local) = x
 [%%expect{|
-val foo :
-  'a @ [< 'm > local unforkable yielding] ->
-  'a @ [> 'm | local unforkable yielding] = <fun>
+val foo : 'a @ [< 'm > local] -> 'a @ [> 'm | local] = <fun>
 |}]
 
 let foo x = exclave_ x
@@ -315,10 +311,9 @@ val foo :
 let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
 [%%expect{|
 val foo :
-  'a @ [< 'm > local unforkable yielding] ->
+  'a @ [< 'm > local] ->
   ('b @ [< 'n & unique] ->
-   ('c @ [< 'o & portable] ->
-    'a * 'b * 'c @ [> 'o | 'n | 'm | local unforkable yielding]) @ [> close('n) | close('m) | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
+   ('c @ [< 'o & portable] -> 'a * 'b * 'c @ [> 'o | 'n | 'm | local]) @ [> close('n) | close('m) | local]) @ [> close('m) | local] =
   <fun>
 |}]
 
@@ -330,8 +325,8 @@ let foo (x : intref) (f : intref @ local -> int) = f x
 [%%expect{|
 type intref = { mutable v : int; }
 val foo :
-  intref @ [< past('m) & global uncontended read_write] ->
-  ((intref @ local -> int) @ 'n -> int @ [> dynamic]) @ [> past('m) | nonportable stateful] =
+  intref @ [< past('m) & global read_write] ->
+  ((intref @ local -> int) @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 
@@ -354,14 +349,14 @@ let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 [%%expect{|
 val foo :
   (intref @ local -> int) @ [< past('o) & past('m) & global] ->
-  (intref @ [< past('n) & global uncontended read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> past('n @@ many portable forkable unyielding stateless) | past('o) | nonportable stateful]) @ [> past('m)] =
+  (intref @ [< past('n) & global read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n @@ many portable forkable unyielding stateless) | past('o) | stateful]) @ [> past('m)] =
   <fun>
 |}, Principal{|
 val foo :
   (intref @ local -> int) @ [< past('o) & past('m) & global] ->
-  (intref @ [< past('n) & global uncontended read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) | past('o) | nonportable stateful]) @ [> past('m)] =
+  (intref @ [< past('n) & global read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) | past('o) | stateful]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -375,27 +370,27 @@ val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 let map f l = List.map f l
 [%%expect{|
 val map :
-  ('a @ [> past('m) | aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('o) & past('m) & past('n) & global many forkable unyielding] ->
-  ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [> past('o) | aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
+  ('a @ [> past('m) | aliased stateful dynamic] ->
+   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
+  ('a list @ [< global many read_write] ->
+   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}, Principal{|
 val map :
-  ('a @ [> past('m) | aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('o) & past('m) & past('n) & global many forkable unyielding] ->
-  ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [> past('o) | aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
+  ('a @ [> past('m) | aliased stateful dynamic] ->
+   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
+  ('a list @ [< global many read_write] ->
+   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}]
 
 let map_eta f = fun l -> List.map f l
 [%%expect{|
 val map_eta :
-  ('a @ [> past('m) | aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('o) & past('m) & past('n) & global many forkable unyielding] ->
-  ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [> past('o) | aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
+  ('a @ [> past('m) | aliased stateful dynamic] ->
+   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
+  ('a list @ [< global many read_write] ->
+   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}]
 
@@ -421,8 +416,8 @@ module Counter : sig type t val incr : t -> t val to_int : t -> int end
 let incr n = Counter.incr n
 [%%expect{|
 val incr :
-  Counter.t @ [< global many uncontended forkable unyielding read_write] ->
-  Counter.t @ [> aliased nonportable stateful dynamic] = <fun>
+  Counter.t @ [< global many read_write] ->
+  Counter.t @ [> aliased stateful dynamic] = <fun>
 |}]
 
 let incr = Counter.incr
@@ -496,8 +491,7 @@ Error: Signature mismatch:
        is not included in
          val illegal : t -> t @ portable
        The type
-         "t @ [< 'm > nonportable stateful dynamic] ->
-         t @ [> 'm | nonportable stateful dynamic]"
+         "t @ [< 'm > stateful dynamic] -> t @ [> 'm | stateful dynamic]"
        is not compatible with the type "t -> t @ portable"
 |}]
 
@@ -549,7 +543,7 @@ let rec map f = function
 [%%expect{|
 val map :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
-  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | nonportable stateful] =
+  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | stateful] =
   <fun>
 |}]
 
@@ -580,8 +574,7 @@ val nest :
 let use_and_return x = ignore x; x
 [%%expect{|
 val use_and_return :
-  'a @ [< 'm & global many uncontended forkable unyielding read_write] ->
-  'a @ [> 'm | aliased] = <fun>
+  'a @ [< 'm & global many read_write] -> 'a @ [> 'm | aliased] = <fun>
 |}]
 
 (* multiple distinct mode variables *)

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -198,9 +198,8 @@ val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm | dynamic] = <fun>
 let foo f = fun x -> fun y -> f x y
 [%%expect{|
 val foo :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
-  'a @ [< 'q & global] -> 'b @ [< 'p] -> 'c @ [> 'o | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
+  'a @ [< 'o & global] -> 'b @ [< 'n] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 let fst x = fun y -> x
@@ -594,16 +593,14 @@ val flip :
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
-  'b @ [< 'p & global] -> 'a @ [< 'q] -> 'c @ [> 'o | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
+  'b @ [< 'n & global] -> 'a @ [< 'o] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 
 let flip f = fun x -> fun y -> f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
-  'b @ [< 'p & global] -> 'a @ [< 'q] -> 'c @ [> 'o | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
+  'b @ [< 'n & global] -> 'a @ [< 'o] -> 'c @ [> 'm | dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -123,8 +123,8 @@ type 'a myref = { mutable x : 'a; }
 let create a = { x = a }
 [%%expect{|
 val create :
-  'a @ [< global many forkable unyielding > past('m)] ->
-  'a myref @ [< past('m) > nonportable stateful] = <fun>
+  'a @ [< 'm . aliased dynamic & global many forkable unyielding] ->
+  'a myref @ [> 'm | nonportable stateful] = <fun>
 |}]
 
 let read r = r.x
@@ -230,16 +230,16 @@ val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
 let foo x y = ref x
 [%%expect{|
 val foo :
-  'a @ [< global many uncontended forkable unyielding read_write > past('m)] ->
-  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< past('m) > nonportable stateful] =
+  'a @ [< past('m) & global many uncontended forkable unyielding read_write] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 
 let foo (x @ aliased) y = ref x
 [%%expect{|
 val foo :
-  'a @ [< global many uncontended forkable unyielding read_write > past('m) | aliased] ->
-  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [< past('m) > nonportable stateful] =
+  'a @ [< past('m) & global many uncontended forkable unyielding read_write > aliased] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable stateful dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 
@@ -375,27 +375,27 @@ val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 let map f l = List.map f l
 [%%expect{|
 val map :
-  ('a @ [< past('m) > aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('n) & global many forkable unyielding > past('o) | past('m)] ->
+  ('a @ [> past('m) | aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('o) & past('m) & past('n) & global many forkable unyielding] ->
   ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [< past('o) > aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
+   'b list @ [> past('o) | aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}, Principal{|
 val map :
-  ('a @ [< past('m) > aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('n) & global many forkable unyielding > past('o) | past('m)] ->
+  ('a @ [> past('m) | aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('o) & past('m) & past('n) & global many forkable unyielding] ->
   ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [< past('o) > aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
+   'b list @ [> past('o) | aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}]
 
 let map_eta f = fun l -> List.map f l
 [%%expect{|
 val map_eta :
-  ('a @ [< past('m) > aliased nonportable stateful dynamic] ->
-   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('n) & global many forkable unyielding > past('o) | past('m)] ->
+  ('a @ [> past('m) | aliased nonportable stateful dynamic] ->
+   'b @ [< global many uncontended forkable unyielding read_write]) @ [< past('o) & past('m) & past('n) & global many forkable unyielding] ->
   ('a list @ [< global many uncontended forkable unyielding read_write] ->
-   'b list @ [< past('o) > aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
+   'b list @ [> past('o) | aliased nonportable stateful dynamic]) @ [> past('n) | stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -26,11 +26,11 @@ val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 let foo f x = f x
 [%%expect{|
 val foo :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
   'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}, Principal{|
 val foo :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
   'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
@@ -45,8 +45,7 @@ let foo a b = a + b
 [%%expect{|
 val foo : int @ 'n -> int @ 'm -> int @ [> dynamic] = <fun>
 |}, Principal{|
-val foo : int @ [< past('n) & global] -> int @ 'm -> int @ [> dynamic] =
-  <fun>
+val foo : int @ [< global] -> int @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 
@@ -134,8 +133,8 @@ val read :
 let store r = fun a -> r.x <- a
 [%%expect{|
 val store :
-  'a myref @ [< past('n) & global write] ->
-  'a @ [< global many read_write] -> unit @ 'm = <fun>
+  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  <fun>
 |}]
 
 (* products *)
@@ -186,7 +185,7 @@ val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 
 let foo x y = y
 [%%expect{|
-val foo : 'a @ [< past('n) & global] -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+val foo : 'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
 |}]
 
 let id x = x
@@ -199,8 +198,9 @@ val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm | dynamic] = <fun>
 let foo f = fun x -> fun y -> f x y
 [%%expect{|
 val foo :
-  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
-  'a @ [< 'p & global] -> 'b @ [< 'n] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
+  'a @ [< 'q & global] -> 'b @ [< 'p] -> 'c @ [> 'o | dynamic] = <fun>
 |}]
 
 let fst x = fun y -> x
@@ -215,14 +215,14 @@ val snd : 'a @ 'n -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
 let foo x y = ref x
 [%%expect{|
 val foo :
-  'a @ [< past('n) & global many read_write] ->
+  'a @ [< global many read_write] ->
   'b @ 'm -> 'a ref @ [> aliased stateful dynamic] = <fun>
 |}]
 
 let foo (x @ aliased) y = ref x
 [%%expect{|
 val foo :
-  'a @ [< past('n) & global many read_write > aliased] ->
+  'a @ [< global many read_write > aliased] ->
   'b @ 'm -> 'a ref @ [> aliased stateful dynamic] = <fun>
 |}]
 
@@ -235,9 +235,7 @@ val foo :
 
 let foo x y z = 42
 [%%expect{|
-val foo :
-  'a @ [< past('p) & past('q) & global] ->
-  'b @ [< past('o) & global] -> 'c @ 'n -> int @ 'm = <fun>
+val foo : 'a @ [< global] -> 'b @ [< global] -> 'c @ 'n -> int @ 'm = <fun>
 |}]
 
 let foo x y = (x, y)
@@ -250,7 +248,7 @@ val foo :
 let foo x y z = (y,z)
 [%%expect{|
 val foo :
-  'a @ [< past('o) & past('p) & global] ->
+  'a @ [< global] ->
   'b @ [< 'n & global] -> 'c @ [< 'm & global] -> 'b * 'c @ [> 'm | 'n] =
   <fun>
 |}]
@@ -285,17 +283,17 @@ val foo : unit -> unit = <fun>
 
 let foo (y @ unique) (z @ portable) = z
 [%%expect{|
-val foo :
-  'a @ [< past('n) & global unique] -> 'b @ [< 'm & portable] -> 'b @ [> 'm] =
+val foo : 'a @ [< global unique] -> 'b @ [< 'm & portable] -> 'b @ [> 'm] =
   <fun>
 |}]
 
 let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
 [%%expect{|
 val foo :
-  'a @ [< 'o > local] ->
-  'b @ [< 'n & unique] ->
-  'c @ [< 'm & portable] -> 'a * 'b * 'c @ [> 'm | 'n | 'o | local] = <fun>
+  'a @ [< 'n > local] ->
+  'b @ [< 'm & unique] ->
+  ('c @ [< 'o & portable] -> 'a * 'b * 'c @ [> 'o | 'm | 'n | local]) @ [> close('m) | close('n) | local] =
+  <fun>
 |}]
 
 (* if a type is annotated, mode crossing has an effect on the bounds of mode variable *)
@@ -306,32 +304,30 @@ let foo (x : intref) (f : intref @ local -> int) = f x
 [%%expect{|
 type intref = { mutable v : int; }
 val foo :
-  intref @ [< past('n) & global read_write] ->
+  intref @ [< global read_write] ->
   (intref @ local -> int) @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 let foo (f : int -> int) x y = f
 [%%expect{|
 val foo :
-  (int -> int) @ [< 'o mod aliased contended immutable & past('p) & past('q) & global] ->
-  'a @ [< past('n) & global] -> 'b @ 'm -> int -> int = <fun>
+  (int -> int) @ [< 'm mod aliased contended immutable & global] ->
+  'a @ [< global] -> 'b @ 'n -> (int -> int) @ [> 'm] = <fun>
 |}, Principal{|
 val foo :
-  (int -> int) @ [< 'o mod aliased contended immutable & global] ->
-  'a @ [< past('n) & global] -> 'b @ 'm -> int -> int = <fun>
+  (int -> int) @ [< 'm mod aliased contended immutable & global] ->
+  'a @ [< global] -> 'b @ 'n -> (int -> int) @ [> 'm] = <fun>
 |}]
 
 let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 [%%expect{|
 val foo :
-  (intref @ local -> int) @ [< past('o) & past('p) & global] ->
-  intref @ [< past('n) & global read_write] ->
-  intref @ 'm -> int @ [> dynamic] = <fun>
+  (intref @ local -> int) @ [< global] ->
+  intref @ [< global read_write] -> intref @ 'm -> int @ [> dynamic] = <fun>
 |}, Principal{|
 val foo :
-  (intref @ local -> int) @ [< past('o) & past('p) & global] ->
-  intref @ [< past('n) & global read_write] ->
-  intref @ 'm -> int @ [> dynamic] = <fun>
+  (intref @ local -> int) @ [< global] ->
+  intref @ [< global read_write] -> intref @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 (* aliases of non-polymorphic functions *)
@@ -345,13 +341,13 @@ let map f l = List.map f l
 [%%expect{|
 val map :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('n) & past('m) & past('o) & global many] ->
+   'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
   'a list @ [< global many read_write] ->
   'b list @ [> past('n) | aliased stateful dynamic] = <fun>
 |}, Principal{|
 val map :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('n) & past('m) & past('o) & global many] ->
+   'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
   'a list @ [< global many read_write] ->
   'b list @ [> past('n) | aliased stateful dynamic] = <fun>
 |}]
@@ -360,7 +356,7 @@ let map_eta f = fun l -> List.map f l
 [%%expect{|
 val map_eta :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('n) & past('m) & past('o) & global many] ->
+   'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
   'a list @ [< global many read_write] ->
   'b list @ [> past('n) | aliased stateful dynamic] = <fun>
 |}]
@@ -493,7 +489,7 @@ let map_left f = function
 [%%expect{|
 type ('a, 'b) either = Left of 'a | Right of 'b
 val map_left :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('p) & global] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
   ('a, 'c) either @ [< 'o & 'n & global] ->
   ('b, 'c) either @ [> 'o | 'm | dynamic] = <fun>
 |}]
@@ -512,7 +508,7 @@ let rec map f = function
   | x :: xs -> f x :: map f xs
 [%%expect{|
 val map :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global many > aliased] ->
   'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
 |}]
 
@@ -521,7 +517,7 @@ val map :
 let choose b x y = if b then x else y
 [%%expect{|
 val choose :
-  bool @ [< past('o) & past('p) & global] ->
+  bool @ [< global] ->
   'a @ [< 'n & global] -> 'a @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] = <fun>
 |}]
 
@@ -574,7 +570,7 @@ let map_option f = function
   | Some x -> Some (f x)
 [%%expect{|
 val map_option :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
   'a option @ [< 'n] -> 'b option @ [> 'm | dynamic] = <fun>
 |}]
 
@@ -591,21 +587,23 @@ val triple :
 let flip f (x, y) = f (y, x)
 [%%expect{|
 val flip :
-  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
   'b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
-  'b @ [< 'n & global] -> 'a @ [< 'p] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
+  'b @ [< 'p & global] -> 'a @ [< 'q] -> 'c @ [> 'o | dynamic] = <fun>
 |}]
 
 
 let flip f = fun x -> fun y -> f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
-  'b @ [< 'n & global] -> 'a @ [< 'p] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('n) & global] ->
+  'b @ [< 'p & global] -> 'a @ [< 'q] -> 'c @ [> 'o | dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -27,11 +27,11 @@ let foo f x = f x
 [%%expect{|
 val foo :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}, Principal{|
 val foo :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
 |}]
 
 let foo =
@@ -43,11 +43,10 @@ val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 
 let foo a b = a + b
 [%%expect{|
-val foo : int @ 'n -> (int @ 'm -> int @ [> dynamic]) @ [> stateful] = <fun>
+val foo : int @ 'n -> int @ 'm -> int @ [> dynamic] = <fun>
 |}, Principal{|
-val foo :
-  int @ [< past('m) & global] ->
-  (int @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] = <fun>
+val foo : int @ [< past('n) & global] -> int @ 'm -> int @ [> dynamic] =
+  <fun>
 |}]
 
 
@@ -69,8 +68,8 @@ val foo : ('a, 'b) mytypemod @ [< 'm] -> 'b @ [> 'm mod portable] = <fun>
 let foo x z = x.y
 [%%expect{|
 val foo :
-  ('a, 'b) mytypemod @ [< 'm & global] ->
-  ('c @ 'n -> 'b @ [> 'm mod portable]) @ [> close('m)] = <fun>
+  ('a, 'b) mytypemod @ [< 'm & global] -> 'c @ 'n -> 'b @ [> 'm mod portable] =
+  <fun>
 |}]
 
 
@@ -91,17 +90,15 @@ type ('a, 'b) mytype = { x : 'a; y : 'b; }
 let foo x y = { x; y }
 [%%expect{|
 val foo :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
-  <fun>
+  'a @ [< 'n & global] ->
+  'b @ [< 'm & global] -> ('a, 'b) mytype @ [> 'm | 'n] = <fun>
 |}]
 
 let foo x = fun y -> { x; y }
 [%%expect{|
 val foo :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
-  <fun>
+  'a @ [< 'n & global] ->
+  'b @ [< 'm & global] -> ('a, 'b) mytype @ [> 'm | 'n] = <fun>
 |}]
 
 let foo x = { x; y = 42 }
@@ -137,9 +134,8 @@ val read :
 let store r = fun a -> r.x <- a
 [%%expect{|
 val store :
-  'a myref @ [< past('m) & global write] ->
-  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
-  <fun>
+  'a myref @ [< past('n) & global write] ->
+  'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 (* products *)
@@ -152,15 +148,15 @@ val dupl : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased] = <fun>
 let prod x y = (x, y)
 [%%expect{|
 val prod :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
+  <fun>
 |}]
 
 let prod_eta x = fun y -> (x, y)
 [%%expect{|
 val prod_eta :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
+  <fun>
 |}]
 
 let fst (a, _) = a
@@ -176,8 +172,8 @@ let foo x = fun y ->
   (x', y')
 [%%expect{|
 val foo :
-  'a @ [< 'm & global many] ->
-  ('b @ [< 'n & global many] -> 'a * 'b @ [> 'n | 'm | aliased dynamic]) @ [> close('m) | stateful] =
+  'a @ [< 'n & global many] ->
+  'b @ [< 'm & global many] -> 'a * 'b @ [> 'm | 'n | aliased dynamic] =
   <fun>
 |}]
 
@@ -185,91 +181,77 @@ val foo :
 
 let foo x y = x
 [%%expect{|
-val foo : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo x y = y
 [%%expect{|
-val foo :
-  'a @ [< past('m) & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] =
-  <fun>
+val foo : 'a @ [< past('n) & global] -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
 |}]
 
 let id x = x
 let foo x y = id x
 [%%expect{|
 val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
-val foo :
-  'a @ [< 'm & global] ->
-  ('b @ 'n -> 'a @ [> 'm | dynamic]) @ [> close('m) | stateful] = <fun>
+val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm | dynamic] = <fun>
 |}]
 
 let foo f = fun x -> fun y -> f x y
 [%%expect{|
 val foo :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
-  ('a @ [< 'q & global] ->
-   ('b @ [< 'p] -> 'c @ [> 'o | dynamic]) @ [> close('q) | past('mm1)]) @ [> past('mm0)] =
-  <fun>
+  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
+  'a @ [< 'p & global] -> 'b @ [< 'n] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 let fst x = fun y -> x
 [%%expect{|
-val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
-  <fun>
+val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
 |}]
 let snd x = fun y -> y
 [%%expect{|
-val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
+val snd : 'a @ 'n -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
 |}]
 
 let foo x y = ref x
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global many read_write] ->
-  ('b @ 'n -> 'a ref @ [> aliased stateful dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  'a @ [< past('n) & global many read_write] ->
+  'b @ 'm -> 'a ref @ [> aliased stateful dynamic] = <fun>
 |}]
 
 let foo (x @ aliased) y = ref x
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global many read_write > aliased] ->
-  ('b @ 'n -> 'a ref @ [> aliased stateful dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  'a @ [< past('n) & global many read_write > aliased] ->
+  'b @ 'm -> 'a ref @ [> aliased stateful dynamic] = <fun>
 |}]
 
 let foo (x @ contended) y = x
 [%%expect{|
 val foo :
-  'a @ [< 'm & global > contended] ->
-  ('b @ 'n -> 'a @ [> 'm | contended]) @ [> close('m)] = <fun>
+  'a @ [< 'm & global > contended] -> 'b @ 'n -> 'a @ [> 'm | contended] =
+  <fun>
 |}]
 
 let foo x y z = 42
 [%%expect{|
 val foo :
-  'a @ [< past('o) & past('m) & global] ->
-  ('b @ [< past('n) & global] ->
-   ('c @ 'q -> int @ 'p) @ [> past('n) | past('o)]) @ [> past('m)] =
-  <fun>
+  'a @ [< past('p) & past('q) & global] ->
+  'b @ [< past('o) & global] -> 'c @ 'n -> int @ 'm = <fun>
 |}]
 
 let foo x y = (x, y)
 [%%expect{|
 val foo :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
+  <fun>
 |}]
 
 let foo x y z = (y,z)
 [%%expect{|
 val foo :
-  'a @ [< past('o) & past('m) & global] ->
-  ('b @ [< 'n & global] ->
-   ('c @ [< 'p & global] -> 'b * 'c @ [> 'p | 'n]) @ [> close('n) | past('o)]) @ [> past('m)] =
+  'a @ [< past('o) & past('p) & global] ->
+  'b @ [< 'n & global] -> 'c @ [< 'm & global] -> 'b * 'c @ [> 'm | 'n] =
   <fun>
 |}]
 
@@ -304,17 +286,16 @@ val foo : unit -> unit = <fun>
 let foo (y @ unique) (z @ portable) = z
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global unique] ->
-  ('b @ [< 'n & portable] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
+  'a @ [< past('n) & global unique] -> 'b @ [< 'm & portable] -> 'b @ [> 'm] =
+  <fun>
 |}]
 
 let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
 [%%expect{|
 val foo :
-  'a @ [< 'm > local] ->
-  ('b @ [< 'n & unique] ->
-   ('c @ [< 'o & portable] -> 'a * 'b * 'c @ [> 'o | 'n | 'm | local]) @ [> close('n) | close('m) | local]) @ [> close('m) | local] =
-  <fun>
+  'a @ [< 'o > local] ->
+  'b @ [< 'n & unique] ->
+  'c @ [< 'm & portable] -> 'a * 'b * 'c @ [> 'm | 'n | 'o | local] = <fun>
 |}]
 
 (* if a type is annotated, mode crossing has an effect on the bounds of mode variable *)
@@ -325,39 +306,32 @@ let foo (x : intref) (f : intref @ local -> int) = f x
 [%%expect{|
 type intref = { mutable v : int; }
 val foo :
-  intref @ [< past('m) & global read_write] ->
-  ((intref @ local -> int) @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  intref @ [< past('n) & global read_write] ->
+  (intref @ local -> int) @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 let foo (f : int -> int) x y = f
 [%%expect{|
 val foo :
-  (int -> int) @ [< 'p mod aliased contended immutable & past('o) & past('m) & global] ->
-  ('a @ [< past('n) & global] ->
-   ('b @ 'q -> (int -> int) @ [> 'p]) @ [> past('n) | past('o)]) @ [> past('m)] =
-  <fun>
+  (int -> int) @ [< 'o mod aliased contended immutable & past('p) & past('q) & global] ->
+  'a @ [< past('n) & global] -> 'b @ 'm -> int -> int = <fun>
 |}, Principal{|
 val foo :
-  (int -> int) @ [< 'm mod aliased contended immutable & global] ->
-  ('a @ [< past('n) & global] ->
-   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) mod many portable stateless | past('n)]) @ [> close('m) mod many portable stateless] =
-  <fun>
+  (int -> int) @ [< 'o mod aliased contended immutable & global] ->
+  'a @ [< past('n) & global] -> 'b @ 'm -> int -> int = <fun>
 |}]
 
 let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 [%%expect{|
 val foo :
-  (intref @ local -> int) @ [< past('o) & past('m) & global] ->
-  (intref @ [< past('n) & global read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) mod many portable forkable unyielding stateless | past('o) | stateful]) @ [> past('m)] =
-  <fun>
+  (intref @ local -> int) @ [< past('o) & past('p) & global] ->
+  intref @ [< past('n) & global read_write] ->
+  intref @ 'm -> int @ [> dynamic] = <fun>
 |}, Principal{|
 val foo :
-  (intref @ local -> int) @ [< past('o) & past('m) & global] ->
-  (intref @ [< past('n) & global read_write] ->
-   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) | past('o) | stateful]) @ [> past('m)] =
-  <fun>
+  (intref @ local -> int) @ [< past('o) & past('p) & global] ->
+  intref @ [< past('n) & global read_write] ->
+  intref @ 'm -> int @ [> dynamic] = <fun>
 |}]
 
 (* aliases of non-polymorphic functions *)
@@ -371,27 +345,24 @@ let map f l = List.map f l
 [%%expect{|
 val map :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
-  ('a list @ [< global many read_write] ->
-   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
-  <fun>
+   'b @ [< global many read_write]) @ [< past('n) & past('m) & past('o) & global many] ->
+  'a list @ [< global many read_write] ->
+  'b list @ [> past('n) | aliased stateful dynamic] = <fun>
 |}, Principal{|
 val map :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
-  ('a list @ [< global many read_write] ->
-   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
-  <fun>
+   'b @ [< global many read_write]) @ [< past('n) & past('m) & past('o) & global many] ->
+  'a list @ [< global many read_write] ->
+  'b list @ [> past('n) | aliased stateful dynamic] = <fun>
 |}]
 
 let map_eta f = fun l -> List.map f l
 [%%expect{|
 val map_eta :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
-  ('a list @ [< global many read_write] ->
-   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
-  <fun>
+   'b @ [< global many read_write]) @ [< past('n) & past('m) & past('o) & global many] ->
+  'a list @ [< global many read_write] ->
+  'b list @ [> past('n) | aliased stateful dynamic] = <fun>
 |}]
 
 (* modules *)
@@ -510,8 +481,8 @@ let unwrap_or default = function
   | Some' x -> x
 [%%expect{|
 val unwrap_or :
-  'a @ [< 'm & global] ->
-  ('a option' @ [< 'n] -> 'a @ [> 'n | 'm | dynamic]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'a option' @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] =
+  <fun>
 |}]
 
 type ('a, 'b) either = Left of 'a | Right of 'b
@@ -522,10 +493,9 @@ let map_left f = function
 [%%expect{|
 type ('a, 'b) either = Left of 'a | Right of 'b
 val map_left :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  (('a, 'c) either @ [< 'p & 'n & global] ->
-   ('b, 'c) either @ [> 'p | 'm | dynamic]) @ [> past('o)] =
-  <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('p) & global] ->
+  ('a, 'c) either @ [< 'o & 'n & global] ->
+  ('b, 'c) either @ [> 'o | 'm | dynamic] = <fun>
 |}]
 
 (* recursive functions *)
@@ -543,8 +513,7 @@ let rec map f = function
 [%%expect{|
 val map :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & past('p) & global many > aliased] ->
-  ('a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic]) @ [> past('o) | past('p) | stateful] =
-  <fun>
+  'a list @ [< 'n > dynamic] -> 'b list @ [< global > 'm | dynamic] = <fun>
 |}]
 
 (* if/then/else *)
@@ -552,10 +521,8 @@ val map :
 let choose b x y = if b then x else y
 [%%expect{|
 val choose :
-  bool @ [< past('o) & past('m) & global] ->
-  ('a @ [< 'n & global] ->
-   ('a @ [< 'p] -> 'a @ [> 'p | 'n | dynamic]) @ [> close('n) | past('o)]) @ [> past('m)] =
-  <fun>
+  bool @ [< past('o) & past('p) & global] ->
+  'a @ [< 'n & global] -> 'a @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] = <fun>
 |}]
 
 (* nested closures *)
@@ -563,9 +530,7 @@ val choose :
 let nest x = fun () -> fun () -> fun () -> x
 [%%expect{|
 val nest :
-  'a @ [< 'm & global] ->
-  (unit @ 'p ->
-   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
+  'a @ [< 'm & global] -> unit @ 'p -> unit @ 'o -> unit @ 'n -> 'a @ [> 'm] =
   <fun>
 |}]
 
@@ -587,8 +552,8 @@ val swap : 'a * 'b @ [< 'm & global] -> 'b * 'a @ [> 'm] = <fun>
 let both_id x y = (x, y)
 [%%expect{|
 val both_id :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
+  <fun>
 |}]
 
 (* let bindings preserving modes *)
@@ -610,7 +575,7 @@ let map_option f = function
 [%%expect{|
 val map_option :
   ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
-  ('a option @ [< 'n] -> 'b option @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'a option @ [< 'n] -> 'b option @ [> 'm | dynamic] = <fun>
 |}]
 
 (* Currying over three arguments *)
@@ -618,36 +583,29 @@ val map_option :
 let triple x y z = (x, y, z)
 [%%expect{|
 val triple :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] ->
-   ('c @ [< 'o & global] -> 'a * 'b * 'c @ [> 'o | 'n | 'm]) @ [> close('n) | close('m)]) @ [> close('m)] =
-  <fun>
+  'a @ [< 'o & global] ->
+  'b @ [< 'n & global] ->
+  'c @ [< 'm & global] -> 'a * 'b * 'c @ [> 'm | 'n | 'o] = <fun>
 |}]
 
 let flip f (x, y) = f (y, x)
 [%%expect{|
 val flip :
   ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('o) & global] ->
-  ('b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic]) @ [> past('o)] = <fun>
+  'b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
-  ('b @ [< 'p & global] ->
-   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
-  <fun>
+  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
+  'b @ [< 'n & global] -> 'a @ [< 'p] -> 'c @ [> 'm | dynamic] = <fun>
 |}]
 
 
 let flip f = fun x -> fun y -> f y x
 [%%expect{|
 val flip :
-  ('a @ [< past('m) > 'q] ->
-   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
-  ('b @ [< 'p & global] ->
-   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
-  <fun>
+  ('a @ [< past('o) > 'p] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('mm0) & past('mm1) & global] ->
+  'b @ [< 'n & global] -> 'a @ [< 'p] -> 'c @ [> 'm | dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/modules.ml
+++ b/testsuite/tests/typing-mode-polymorphism/modules.ml
@@ -1,11 +1,11 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
 *)
 
 let use_portable (x @ portable) = x
 [%%expect{|
-val use_portable : 'a @ portable -> 'a = <fun>
+val use_portable : 'a @ [< 'm & portable] -> 'a @ [> 'm] = <fun>
 |}]
 
 module M = struct

--- a/testsuite/tests/typing-mode-polymorphism/modules.ml
+++ b/testsuite/tests/typing-mode-polymorphism/modules.ml
@@ -1,0 +1,25 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+let use_portable (x @ portable) = x
+[%%expect{|
+val use_portable : 'a @ portable -> 'a = <fun>
+|}]
+
+module M = struct
+  let id x = x
+end
+[%%expect{|
+module M : sig val id : 'a -> 'a end
+|}]
+
+let a (x @ portable) = use_portable    (M.id x)
+let b (x @ nonportable) = use_portable (M.id x)
+[%%expect{|
+Line 1, characters 39-47:
+1 | let a (x @ portable) = use_portable    (M.id x)
+                                           ^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/modules.ml
+++ b/testsuite/tests/typing-mode-polymorphism/modules.ml
@@ -12,14 +12,15 @@ module M = struct
   let id x = x
 end
 [%%expect{|
-module M : sig val id : 'a -> 'a end
+module M : sig val id : 'a @ [< 'm] -> 'a @ [> 'm] end
 |}]
 
 let a (x @ portable) = use_portable    (M.id x)
 let b (x @ nonportable) = use_portable (M.id x)
 [%%expect{|
-Line 1, characters 39-47:
-1 | let a (x @ portable) = use_portable    (M.id x)
+val a : 'a @ [< 'm & global portable] -> 'a @ [> 'm | dynamic] = <fun>
+Line 2, characters 39-47:
+2 | let b (x @ nonportable) = use_portable (M.id x)
                                            ^^^^^^^^
 Error: This value is "nonportable" but is expected to be "portable".
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/modules.ml
+++ b/testsuite/tests/typing-mode-polymorphism/modules.ml
@@ -24,3 +24,50 @@ Line 2, characters 39-47:
                                            ^^^^^^^^
 Error: This value is "nonportable" but is expected to be "portable".
 |}]
+
+module type S = sig
+  type t
+
+  val v : t
+end
+[%%expect{|
+module type S = sig type t val v : t end
+|}]
+
+let make (type a) (x : a) : (module S with type t = a) =
+  (module struct
+    type t = a
+
+    let v = x
+  end)
+[%%expect{|
+val make :
+  'a @ [< global many uncontended forkable unyielding read_write] ->
+  (module S with type t = 'a) @ [> aliased nonportable stateful dynamic] =
+  <fun>
+|}]
+
+let unpack_inferred_witness () =
+  let e = make (fun (y : int ref) -> y) in
+  let module M = (val e) in
+  let l = local_ (ref 0) in
+  let _ = M.v l in
+  ()
+[%%expect{|
+val unpack_inferred_witness : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+let unpack_annotated_witness () =
+  let e : (module S with type t = int ref -> int ref) =
+    make (fun y -> y)
+  in
+  let module M = (val e) in
+  let l = local_ (ref 0) in
+  let _ = M.v l in
+  ()
+[%%expect{|
+Line 7, characters 14-15:
+7 |   let _ = M.v l in
+                  ^
+Error: This value is "local" but is expected to be "global".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/modules.ml
+++ b/testsuite/tests/typing-mode-polymorphism/modules.ml
@@ -42,9 +42,8 @@ let make (type a) (x : a) : (module S with type t = a) =
   end)
 [%%expect{|
 val make :
-  'a @ [< global many uncontended forkable unyielding read_write] ->
-  (module S with type t = 'a) @ [> aliased nonportable stateful dynamic] =
-  <fun>
+  'a @ [< global many read_write] ->
+  (module S with type t = 'a) @ [> aliased stateful dynamic] = <fun>
 |}]
 
 let unpack_inferred_witness () =

--- a/testsuite/tests/typing-mode-polymorphism/performance.ml
+++ b/testsuite/tests/typing-mode-polymorphism/performance.ml
@@ -1,0 +1,43 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ native;
+*)
+
+(* The following tests are known performance regressions *)
+
+(*
+
+This pattern shows polynomial growth
+
+  let f0 x = x
+  let f1 x = f0 x
+  let f2 x = f1 x
+  let f3 x = f2 x
+  (* ... *)
+  let f399 x = f398 x
+  let _ = f399
+
+Another pathological polynomial growth
+
+  let top =
+    (let g399 =
+       (let g398 =
+          (* ... *)
+            (let g1 =
+               (let g0 = (fun x -> x) in
+                (fun x -> g0 x)) in
+             (fun x -> g1 x))
+          (* ... *)
+        in (fun x -> g398 x)) in
+     (fun x -> g399 x))
+  let _ = top
+
+*)
+
+(* This pattern is exponential time with mode poly on, but polynomial with mode poly off *)
+let id1 x1 =
+    (let id2 x2 =
+       (let id3 x3 = x3 in
+        id3 (id3 x2)) in
+     id2 (id2 x1))
+  let _ = id1

--- a/testsuite/tests/typing-mode-polymorphism/performance.ml
+++ b/testsuite/tests/typing-mode-polymorphism/performance.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  native;
 *)
 

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -1,0 +1,129 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a @ static -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+type 'a myref = { mutable i : 'a }
+let alloc x = { i = x }
+[%%expect{|
+type 'a myref = { mutable i : 'a; }
+val alloc : 'a -> 'a myref = <fun>
+|}]
+
+let store_local (x @ local) y = x.i <- y
+[%%expect{|
+val store_local : 'a myref @ local -> 'a -> unit = <fun>
+|}]
+
+let store_global (x @ global) y = x.i <- y
+[%%expect{|
+val store_global : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let () =
+  let (x @ local) = { i = "local" } in
+  let (x' @ global) = { i = "global" } in
+  store_local x "test";
+  store_local x' "test";
+  store_global x "should fail"
+[%%expect{|
+Line 6, characters 15-16:
+6 |   store_global x "should fail"
+                   ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* mutable fields are not polymorphic *)
+let foo () =
+  let x @ unique = alloc 42 in
+  let z @ aliased = alloc 42 in
+  let yunique = alloc x in
+  let yaliased = alloc z in
+  use_unique yunique.i;
+  use_unique yaliased.i
+[%%expect{|
+Line 6, characters 13-22:
+6 |   use_unique yunique.i;
+                 ^^^^^^^^^
+Error: This value is "aliased"
+         because it is the field "i" (with some modality) of the record at line 6, characters 13-20.
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+type 'a myrecord = { j : 'a }
+let create x = { j = x }
+[%%expect{|
+type 'a myrecord = { j : 'a; }
+val create : 'a -> 'a myrecord = <fun>
+|}]
+
+(* but immutable fields are *)
+let foo () =
+  let x @ unique = create 42 in
+  let z @ aliased = create 42 in
+  let yunique = create x in
+  let yaliased = create z in
+  use_unique yunique.j;
+  use_unique yaliased.j
+
+[%%expect{|
+Line 7, characters 13-23:
+7 |   use_unique yaliased.j
+                 ^^^^^^^^^^
+Error: This value is "aliased"
+         because it is the field "j" of the record at line 7, characters 13-21
+         which is "aliased".
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+(* CR ageorges: principality issue with portable refs *)
+let foo () =
+  use_portable (alloc 42)
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}, Principal{|
+Line 2, characters 15-25:
+2 |   use_portable (alloc 42)
+                   ^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let foo (x @ local) = alloc x
+[%%expect{|
+Line 1, characters 28-29:
+1 | let foo (x @ local) = alloc x
+                                ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+let foo (x @ once) = alloc x
+[%%expect{|
+Line 1, characters 27-28:
+1 | let foo (x @ once) = alloc x
+                               ^
+Error: This value is "once" but is expected to be "many".
+|}]
+
+let foo (x @ contended) = alloc x
+[%%expect{|
+val foo : 'a @ contended -> 'a myref @ contended = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,28 +9,38 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a @ static -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
 |}]
 
 type 'a myref = { mutable i : 'a }
 let alloc x = { i = x }
 [%%expect{|
 type 'a myref = { mutable i : 'a; }
-val alloc : 'a -> 'a myref = <fun>
+val alloc :
+  'a @ [< global many forkable unyielding > 'm] ->
+  'a myref @ [< 'm @@ past > nonportable stateful] = <fun>
 |}]
 
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
-val store_local : 'a myref @ local -> 'a -> unit = <fun>
+val store_local :
+  'a myref @ [< 'm @@ past & corrupted write > local unforkable yielding] ->
+  ('a @ [< global many uncontended forkable unyielding read_write] ->
+   unit @ 'n) @ [> 'm | local corruptible unforkable yielding writing] =
+  <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
-val store_global : 'a myref -> 'a -> unit = <fun>
+val store_global :
+  'a myref @ [< 'm @@ past & global corrupted forkable unyielding write] ->
+  ('a @ [< global many uncontended forkable unyielding read_write] ->
+   unit @ 'n) @ [> 'm | corruptible writing] =
+  <fun>
 |}]
 
 let () =
@@ -73,7 +77,7 @@ type 'a myrecord = { j : 'a }
 let create x = { j = x }
 [%%expect{|
 type 'a myrecord = { j : 'a; }
-val create : 'a -> 'a myrecord = <fun>
+val create : 'a @ [< 'm & global] -> 'a myrecord @ [> 'm] = <fun>
 |}]
 
 (* but immutable fields are *)
@@ -99,7 +103,7 @@ Error: This value is "aliased"
 let foo () =
   use_portable (alloc 42)
 [%%expect{|
-val foo : unit -> unit = <fun>
+val foo : unit @ 'm -> unit @ [> dynamic] = <fun>
 |}, Principal{|
 Line 2, characters 15-25:
 2 |   use_portable (alloc 42)
@@ -125,5 +129,7 @@ Error: This value is "once" but is expected to be "many".
 
 let foo (x @ contended) = alloc x
 [%%expect{|
-val foo : 'a @ contended -> 'a myref @ contended = <fun>
+val foo :
+  'a @ [< global many forkable unyielding > 'm | contended] ->
+  'a myref @ [< 'm @@ past > nonportable contended stateful dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -99,15 +99,12 @@ Error: This value is "aliased"
        However, the highlighted expression is expected to be "unique".
 |}]
 
-(* CR ageorges: principality issue with portable refs *)
 let foo () =
-  use_portable (alloc 42)
+  use_portable (alloc (fun () -> ()))
 [%%expect{|
-val foo : unit @ 'm -> unit @ [> dynamic] = <fun>
-|}, Principal{|
-Line 2, characters 15-25:
-2 |   use_portable (alloc 42)
-                   ^^^^^^^^^^
+Line 2, characters 15-37:
+2 |   use_portable (alloc (fun () -> ()))
+                   ^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "nonportable" but is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -21,25 +21,25 @@ let alloc x = { i = x }
 [%%expect{|
 type 'a myref = { mutable i : 'a; }
 val alloc :
-  'a @ [< global many forkable unyielding > 'm] ->
-  'a myref @ [< 'm @@ past > nonportable stateful] = <fun>
+  'a @ [< global many forkable unyielding > past('m)] ->
+  'a myref @ [< past('m) > nonportable stateful] = <fun>
 |}]
 
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
 val store_local :
-  'a myref @ [< 'm @@ past & corrupted write > local unforkable yielding] ->
+  'a myref @ [< past('m) & corrupted write > local unforkable yielding] ->
   ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> 'm | local corruptible unforkable yielding writing] =
+   unit @ 'n) @ [> past('m) | local corruptible unforkable yielding writing] =
   <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
 val store_global :
-  'a myref @ [< 'm @@ past & global corrupted forkable unyielding write] ->
+  'a myref @ [< past('m) & global corrupted forkable unyielding write] ->
   ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> 'm | corruptible writing] =
+   unit @ 'n) @ [> past('m) | corruptible writing] =
   <fun>
 |}]
 
@@ -127,6 +127,6 @@ Error: This value is "once" but is expected to be "many".
 let foo (x @ contended) = alloc x
 [%%expect{|
 val foo :
-  'a @ [< global many forkable unyielding > 'm | contended] ->
-  'a myref @ [< 'm @@ past > nonportable contended stateful dynamic] = <fun>
+  'a @ [< global many forkable unyielding > past('m) | contended] ->
+  'a myref @ [< past('m) > nonportable contended stateful dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -13,7 +13,7 @@ val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
 val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
 val use_static : 'a @ [< static] -> unit @ 'm = <fun>
-val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 type 'a myref = { mutable i : 'a }
@@ -21,25 +21,23 @@ let alloc x = { i = x }
 [%%expect{|
 type 'a myref = { mutable i : 'a; }
 val alloc :
-  'a @ [< 'm . aliased dynamic & global many forkable unyielding] ->
-  'a myref @ [> 'm | nonportable stateful] = <fun>
+  'a @ [< 'm . aliased dynamic & global many] -> 'a myref @ [> 'm | stateful] =
+  <fun>
 |}]
 
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
 val store_local :
-  'a myref @ [< past('m) & corrupted write > local unforkable yielding] ->
-  ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> past('m) | local corruptible unforkable yielding writing] =
+  'a myref @ [< past('m) & write > local] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | local writing] =
   <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
 val store_global :
-  'a myref @ [< past('m) & global corrupted forkable unyielding write] ->
-  ('a @ [< global many uncontended forkable unyielding read_write] ->
-   unit @ 'n) @ [> past('m) | corruptible writing] =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -127,6 +125,6 @@ Error: This value is "once" but is expected to be "many".
 let foo (x @ contended) = alloc x
 [%%expect{|
 val foo :
-  'a @ [< 'm . aliased dynamic & global many forkable unyielding > contended] ->
-  'a myref @ [> 'm | nonportable contended stateful dynamic] = <fun>
+  'a @ [< 'm . aliased dynamic & global many > contended] ->
+  'a myref @ [> 'm | contended stateful dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -28,15 +28,15 @@ val alloc :
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
 val store_local :
-  'a myref @ [< past('n) & write > local] ->
+  'a myref @ [< write > local] ->
   'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
 val store_global :
-  'a myref @ [< past('n) & global write] ->
-  'a @ [< global many read_write] -> unit @ 'm = <fun>
+  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -21,8 +21,8 @@ let alloc x = { i = x }
 [%%expect{|
 type 'a myref = { mutable i : 'a; }
 val alloc :
-  'a @ [< 'm . aliased dynamic & global many] -> 'a myref @ [> 'm | stateful] =
-  <fun>
+  'a @ [< 'm mod aliased dynamic & global many] ->
+  'a myref @ [> 'm | stateful] = <fun>
 |}]
 
 let store_local (x @ local) y = x.i <- y
@@ -125,6 +125,6 @@ Error: This value is "once" but is expected to be "many".
 let foo (x @ contended) = alloc x
 [%%expect{|
 val foo :
-  'a @ [< 'm . aliased dynamic & global many > contended] ->
+  'a @ [< 'm mod aliased dynamic & global many > contended] ->
   'a myref @ [> 'm | contended stateful dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -28,17 +28,15 @@ val alloc :
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
 val store_local :
-  'a myref @ [< past('m) & write > local] ->
-  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | local writing] =
-  <fun>
+  'a myref @ [< past('n) & write > local] ->
+  'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
 val store_global :
-  'a myref @ [< past('m) & global write] ->
-  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
-  <fun>
+  'a myref @ [< past('n) & global write] ->
+  'a @ [< global many read_write] -> unit @ 'm = <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -21,8 +21,8 @@ let alloc x = { i = x }
 [%%expect{|
 type 'a myref = { mutable i : 'a; }
 val alloc :
-  'a @ [< global many forkable unyielding > past('m)] ->
-  'a myref @ [< past('m) > nonportable stateful] = <fun>
+  'a @ [< 'm . aliased dynamic & global many forkable unyielding] ->
+  'a myref @ [> 'm | nonportable stateful] = <fun>
 |}]
 
 let store_local (x @ local) y = x.i <- y
@@ -127,6 +127,6 @@ Error: This value is "once" but is expected to be "many".
 let foo (x @ contended) = alloc x
 [%%expect{|
 val foo :
-  'a @ [< global many forkable unyielding > past('m) | contended] ->
-  'a myref @ [< past('m) > nonportable contended stateful dynamic] = <fun>
+  'a @ [< 'm . aliased dynamic & global many forkable unyielding > contended] ->
+  'a myref @ [> 'm | nonportable contended stateful dynamic] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/toplevel_zap_scope.ml
+++ b/testsuite/tests/typing-mode-polymorphism/toplevel_zap_scope.ml
@@ -1,0 +1,11 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(* Makes sure that top-level zapping is accurate *)
+
+fun x -> x;;
+[%%expect{|
+- : 'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/toplevel_zap_scope.ml
+++ b/testsuite/tests/typing-mode-polymorphism/toplevel_zap_scope.ml
@@ -7,5 +7,5 @@
 
 fun x -> x;;
 [%%expect{|
-- : 'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
+- : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -1,0 +1,164 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a @ static -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* Since a tuple is returned in tail-position, its allocation will be global *)
+let prod x y = (x, y)
+[%%expect{|
+val prod : 'a -> 'b -> 'a * 'b = <fun>
+|}]
+
+(* With exclave_ the tuple is local *)
+let prod_local (x @ local) (y @ local) = exclave_ (x, y)
+[%%expect{|
+val prod_local : 'a @ local -> 'b @ local -> 'a * 'b @ local = <fun>
+|}]
+
+(* [prod] is polymorphic on the other axes *)
+let foo (x @ portable) (y @ portable) =
+  let (b, a) = prod x y in
+  use_portable b;
+  use_portable a
+[%%expect{|
+val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+|}]
+
+(* But the returned tuple will be the meet of its arguments *)
+let foo (x @ portable) (y @ nonportable) =
+  let (b, a) = prod x y in
+  use_portable b
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable b
+                   ^
+Error: This value is "nonportable"
+         because it is an element of the tuple at line 2, characters 15-23
+         which is "nonportable".
+       However, the highlighted expression is expected to be "portable".
+|}]
+
+let dupl x = (x, x)
+[%%expect{|
+val dupl : 'a -> 'a * 'a = <fun>
+|}]
+
+(* The arguments must be global *)
+let foo (x @ local) (y @ global) =
+    let _ = prod x y in ()
+[%%expect{|
+Line 2, characters 17-18:
+2 |     let _ = prod x y in ()
+                     ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+let foo (y @ local) (x @ global) =
+    let _ = prod y x in ()
+[%%expect{|
+Line 2, characters 17-18:
+2 |     let _ = prod y x in ()
+                     ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+(* They can be local using exclave_ *)
+let foo (x @ local) (y @ local) =
+  let p = prod_local x y in
+  use_global (fst p) (* but the elements of the product are local *)
+[%%expect{|
+Line 3, characters 13-20:
+3 |   use_global (fst p) (* but the elements of the product are local *)
+                 ^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* [dupl] uses an argument twice and the polymorphic mode must be many *)
+let foo (x @ once) =
+  let p = dupl x in ()
+[%%expect{|
+Line 2, characters 15-16:
+2 |   let p = dupl x in ()
+                   ^
+Error: This value is "once" but is expected to be "many".
+|}]
+
+(* [dupl] makes unique arguments aliased *)
+let foo (x @ unique) =
+  let p = dupl x in
+  use_unique (fst p)
+[%%expect{|
+Line 3, characters 13-20:
+3 |   use_unique (fst p)
+                 ^^^^^^^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+(* mode polymorphism works over tuples *)
+let swap (a, b) = (b, a)
+[%%expect{|
+val swap : 'a * 'b -> 'b * 'a = <fun>
+|}]
+
+let swap_local (a, b) = exclave_ (b, a)
+[%%expect{|
+val swap_local : 'a * 'b -> 'b * 'a @ local = <fun>
+|}]
+
+let foo (x @ portable) (y @ portable) =
+  let p = swap (x, y) in
+  use_portable p
+[%%expect{|
+val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+|}]
+
+let foo (x @ local) (y @ local) =
+  let _ = swap (x, y) in ()
+[%%expect{|
+Line 2, characters 16-17:
+2 |   let _ = swap (x, y) in ()
+                    ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is an element of the tuple at line 2, characters 15-21
+         which is expected to be "global".
+|}]
+
+let foo (x @ global) (y @ local) =
+  let p = swap_local (x, y) in
+  use_global (snd p)
+[%%expect{|
+Line 3, characters 13-20:
+3 |   use_global (snd p)
+                 ^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let foo (x @ global) (y @ global) =
+  let p = swap_local (x, y) in
+  use_global p
+[%%expect{|
+Line 3, characters 13-14:
+3 |   use_global p
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,23 +9,29 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a @ static -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
 |}]
 
 (* Since a tuple is returned in tail-position, its allocation will be global *)
 let prod x y = (x, y)
 [%%expect{|
-val prod : 'a -> 'b -> 'a * 'b = <fun>
+val prod :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 (* With exclave_ the tuple is local *)
 let prod_local (x @ local) (y @ local) = exclave_ (x, y)
 [%%expect{|
-val prod_local : 'a @ local -> 'b @ local -> 'a * 'b @ local = <fun>
+val prod_local :
+  'a @ [< 'm > local unforkable yielding] ->
+  ('b @ [< 'n > local unforkable yielding] ->
+   'a * 'b @ [> 'n | 'm | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
+  <fun>
 |}]
 
 (* [prod] is polymorphic on the other axes *)
@@ -40,7 +40,10 @@ let foo (x @ portable) (y @ portable) =
   use_portable b;
   use_portable a
 [%%expect{|
-val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  <fun>
 |}]
 
 (* But the returned tuple will be the meet of its arguments *)
@@ -59,7 +62,7 @@ Error: This value is "nonportable"
 
 let dupl x = (x, x)
 [%%expect{|
-val dupl : 'a -> 'a * 'a = <fun>
+val dupl : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased] = <fun>
 |}]
 
 (* The arguments must be global *)
@@ -116,19 +119,22 @@ Error: This value is "aliased" but is expected to be "unique".
 (* mode polymorphism works over tuples *)
 let swap (a, b) = (b, a)
 [%%expect{|
-val swap : 'a * 'b -> 'b * 'a = <fun>
+val swap : 'a * 'b @ [< 'm & global] -> 'b * 'a @ [> 'm] = <fun>
 |}]
 
 let swap_local (a, b) = exclave_ (b, a)
 [%%expect{|
-val swap_local : 'a * 'b -> 'b * 'a @ local = <fun>
+val swap_local : 'a * 'b @ [< 'm] -> 'b * 'a @ [> 'm | local] = <fun>
 |}]
 
 let foo (x @ portable) (y @ portable) =
   let p = swap (x, y) in
   use_portable p
 [%%expect{|
-val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  <fun>
 |}]
 
 let foo (x @ local) (y @ local) =

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -41,8 +41,8 @@ let foo (x @ portable) (y @ portable) =
   use_portable a
 [%%expect{|
 val foo :
-  'a @ [< 'm @@ past & global portable] ->
-  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  'a @ [< past('m) & global portable] ->
+  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 
@@ -132,8 +132,8 @@ let foo (x @ portable) (y @ portable) =
   use_portable p
 [%%expect{|
 val foo :
-  'a @ [< 'm @@ past & global portable] ->
-  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> 'm | nonportable stateful] =
+  'a @ [< past('m) & global portable] ->
+  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -13,7 +13,7 @@ val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
 val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
 val use_static : 'a @ [< static] -> unit @ 'm = <fun>
-val use_global : 'a @ [< global forkable unyielding] -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* Since a tuple is returned in tail-position, its allocation will be global *)
@@ -28,9 +28,8 @@ val prod :
 let prod_local (x @ local) (y @ local) = exclave_ (x, y)
 [%%expect{|
 val prod_local :
-  'a @ [< 'm > local unforkable yielding] ->
-  ('b @ [< 'n > local unforkable yielding] ->
-   'a * 'b @ [> 'n | 'm | local unforkable yielding]) @ [> close('m) | local unforkable yielding] =
+  'a @ [< 'm > local] ->
+  ('b @ [< 'n > local] -> 'a * 'b @ [> 'n | 'm | local]) @ [> close('m) | local] =
   <fun>
 |}]
 
@@ -42,7 +41,7 @@ let foo (x @ portable) (y @ portable) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
+  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 
@@ -133,7 +132,7 @@ let foo (x @ portable) (y @ portable) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | nonportable stateful] =
+  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -20,16 +20,15 @@ val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 let prod x y = (x, y)
 [%%expect{|
 val prod :
-  'a @ [< 'm & global] ->
-  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
+  <fun>
 |}]
 
 (* With exclave_ the tuple is local *)
 let prod_local (x @ local) (y @ local) = exclave_ (x, y)
 [%%expect{|
 val prod_local :
-  'a @ [< 'm > local] ->
-  ('b @ [< 'n > local] -> 'a * 'b @ [> 'n | 'm | local]) @ [> close('m) | local] =
+  'a @ [< 'n > local] -> 'b @ [< 'm > local] -> 'a * 'b @ [> 'm | 'n | local] =
   <fun>
 |}]
 
@@ -41,8 +40,7 @@ let foo (x @ portable) (y @ portable) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  'b @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 (* But the returned tuple will be the meet of its arguments *)
@@ -132,8 +130,7 @@ let foo (x @ portable) (y @ portable) =
 [%%expect{|
 val foo :
   'a @ [< past('m) & global portable] ->
-  ('b @ [< global portable] -> unit @ [> dynamic]) @ [> past('m) | stateful] =
-  <fun>
+  'b @ [< global portable] -> unit @ [> dynamic] = <fun>
 |}]
 
 let foo (x @ local) (y @ local) =

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -39,8 +39,8 @@ let foo (x @ portable) (y @ portable) =
   use_portable a
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global portable] ->
-  'b @ [< global portable] -> unit @ [> dynamic] = <fun>
+  'a @ [< global portable] -> 'b @ [< global portable] -> unit @ [> dynamic] =
+  <fun>
 |}]
 
 (* But the returned tuple will be the meet of its arguments *)
@@ -129,8 +129,8 @@ let foo (x @ portable) (y @ portable) =
   use_portable p
 [%%expect{|
 val foo :
-  'a @ [< past('m) & global portable] ->
-  'b @ [< global portable] -> unit @ [> dynamic] = <fun>
+  'a @ [< global portable] -> 'b @ [< global portable] -> unit @ [> dynamic] =
+  <fun>
 |}]
 
 let foo (x @ local) (y @ local) =

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -37,14 +37,14 @@ Uncaught exception: Misc.Fatal_error
 (*************************************)
 (* Checking uniqueness of overwrites *)
 
-let id = function x -> x
+let use_aliased (x @ aliased) = x
 
 let overwrite_shared (r : record_update) =
-  let r = id r in
+  let r = use_aliased r in
   let x = overwrite_ r with { x = "foo" } in
   x.x
 [%%expect{|
-val id : 'a -> 'a = <fun>
+val use_aliased : 'a -> 'a = <fun>
 Line 5, characters 21-22:
 5 |   let x = overwrite_ r with { x = "foo" } in
                          ^

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -15,16 +15,16 @@ type record = { x : string; y : string @@ many aliased }
 type record = { x : string; y : string @@ many aliased; }
 |}]
 
-let aliased_use x = x
+let aliased_use (x @ aliased global) = x
 [%%expect{|
-(let (aliased_use/0 = (function {nlocal = 0} x/0? x/0))
+(let (aliased_use/0 = (function {nlocal = 1} x/0? : stack x/0))
   (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/0))
 val aliased_use : 'a -> 'a = <fun>
 |}]
 
-let unique_use (x @ unique) = x
+let unique_use (x @ unique global) = x
 [%%expect{|
-(let (unique_use/0 = (function {nlocal = 0} x/1? x/1))
+(let (unique_use/0 = (function {nlocal = 1} x/1? : stack x/1))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/0))
 val unique_use : 'a @ unique -> 'a = <fun>
 |}]
@@ -38,7 +38,7 @@ let proj_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    proj_aliased/0 =
-     (function {nlocal = 0} r/0[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/0[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -59,7 +59,7 @@ let proj_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    proj_unique/0 =
-     (function {nlocal = 0} r/2[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/2[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -83,7 +83,7 @@ let match_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_aliased/0 =
-     (function {nlocal = 0} r/4[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/4[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -105,7 +105,7 @@ let match_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_unique/0 =
-     (function {nlocal = 0} r/6[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/6[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -130,7 +130,7 @@ let match_mini_anf_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_mini_anf_aliased/0 =
-     (function {nlocal = 0} r/8[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/8[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -156,7 +156,7 @@ let match_mini_anf_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_mini_anf_unique/0 =
-     (function {nlocal = 0} r/10[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/10[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -183,7 +183,7 @@ let match_anf_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_anf_aliased/0 =
-     (function {nlocal = 0} r/12[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/12[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (catch
@@ -214,7 +214,7 @@ let match_anf_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_anf_unique/0 =
-     (function {nlocal = 0} r/14[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/14[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (catch
@@ -256,7 +256,7 @@ let swap_inner (t : tree) =
 [%%expect{|
 (let
   (swap_inner/0 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        t/0[value<
             (consts (0))
              (non_consts ([0:
@@ -274,38 +274,13 @@ let swap_inner (t : tree) =
                          (consts (0)) (non_consts ([0: *, value<int>, *]))>]))
        (catch
          (if t/0
-           (let (*match*/6 =a? (field_imm 0 t/0))
+           (let (*match*/6 =o? (field_mut 0 t/0))
              (if *match*/6
-               (let (*match*/7 =a? (field_imm 2 t/0))
+               (let
+                 (lr/0 =o? (field_mut 2 *match*/6)
+                  *match*/7 =o? (field_mut 2 t/0))
                  (if *match*/7
-                   (makeblock 0 (value<
-                                  (consts (0))
-                                   (non_consts ([0:
-                                                 value<
-                                                  (consts (0))
-                                                   (non_consts ([0: *,
-                                                                 value<int>,
-                                                                 *]))>,
-                                                 value<int>,
-                                                 value<
-                                                  (consts (0))
-                                                   (non_consts ([0: *,
-                                                                 value<int>,
-                                                                 *]))>]))>,
-                     value<int>,value<
-                                 (consts (0))
-                                  (non_consts ([0:
-                                                value<
-                                                 (consts (0))
-                                                  (non_consts ([0: *,
-                                                                value<int>,
-                                                                *]))>,
-                                                value<int>,
-                                                value<
-                                                 (consts (0))
-                                                  (non_consts ([0: *,
-                                                                value<int>,
-                                                                *]))>]))>)
+                   (let (rl/0 =o? (field_mut 0 *match*/7))
                      (makeblock 0 (value<
                                     (consts (0))
                                      (non_consts ([0:
@@ -334,39 +309,67 @@ let swap_inner (t : tree) =
                                                     (non_consts ([0: *,
                                                                   value<int>,
                                                                   *]))>]))>)
-                       (field_imm 0 *match*/6) (field_int 1 *match*/6)
-                       (field_imm 0 *match*/7))
-                     (field_int 1 t/0)
-                     (makeblock 0 (value<
-                                    (consts (0))
-                                     (non_consts ([0:
-                                                   value<
-                                                    (consts (0))
-                                                     (non_consts ([0: *,
-                                                                   value<int>,
-                                                                   *]))>,
-                                                   value<int>,
-                                                   value<
-                                                    (consts (0))
-                                                     (non_consts ([0: *,
-                                                                   value<int>,
-                                                                   *]))>]))>,
-                       value<int>,value<
-                                   (consts (0))
-                                    (non_consts ([0:
-                                                  value<
-                                                   (consts (0))
-                                                    (non_consts ([0: *,
-                                                                  value<int>,
-                                                                  *]))>,
-                                                  value<int>,
-                                                  value<
-                                                   (consts (0))
-                                                    (non_consts ([0: *,
-                                                                  value<int>,
-                                                                  *]))>]))>)
-                       (field_imm 2 *match*/6) (field_int 1 *match*/7)
-                       (field_imm 2 *match*/7)))
+                       (makeblock 0 (value<
+                                      (consts (0))
+                                       (non_consts ([0:
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                     value<int>,
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>,
+                         value<int>,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                    value<int>,
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>)
+                         (field_imm 0 *match*/6) (field_int 1 *match*/6)
+                         rl/0)
+                       (field_int 1 t/0)
+                       (makeblock 0 (value<
+                                      (consts (0))
+                                       (non_consts ([0:
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                     value<int>,
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>,
+                         value<int>,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                    value<int>,
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>)
+                         lr/0 (field_int 1 *match*/7)
+                         (field_imm 2 *match*/7))))
                    (exit 36)))
                (exit 36)))
            (exit 36))
@@ -404,7 +407,7 @@ let match_guard r =
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_guard/0 =
-     (function {nlocal = 0} r/16[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 1} r/16[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let (y/9 =o? (field_mut 1 r/16))

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -17,14 +17,14 @@ type record = { x : string; y : string @@ many aliased; }
 
 let aliased_use (x @ aliased global) = x
 [%%expect{|
-(let (aliased_use/0 = (function {nlocal = 1} x/0? : stack x/0))
+(let (aliased_use/0 = (function {nlocal = 0} x/0? x/0))
   (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/0))
 val aliased_use : 'a -> 'a = <fun>
 |}]
 
 let unique_use (x @ unique global) = x
 [%%expect{|
-(let (unique_use/0 = (function {nlocal = 1} x/1? : stack x/1))
+(let (unique_use/0 = (function {nlocal = 0} x/1? x/1))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/0))
 val unique_use : 'a @ unique -> 'a = <fun>
 |}]
@@ -38,7 +38,7 @@ let proj_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    proj_aliased/0 =
-     (function {nlocal = 1} r/0[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/0[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -59,7 +59,7 @@ let proj_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    proj_unique/0 =
-     (function {nlocal = 1} r/2[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/2[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -83,7 +83,7 @@ let match_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_aliased/0 =
-     (function {nlocal = 1} r/4[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/4[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -105,7 +105,7 @@ let match_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_unique/0 =
-     (function {nlocal = 1} r/6[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/6[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -130,7 +130,7 @@ let match_mini_anf_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_mini_anf_aliased/0 =
-     (function {nlocal = 1} r/8[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/8[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -156,7 +156,7 @@ let match_mini_anf_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_mini_anf_unique/0 =
-     (function {nlocal = 1} r/10[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/10[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
@@ -183,7 +183,7 @@ let match_anf_aliased r =
 (let
   (aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_anf_aliased/0 =
-     (function {nlocal = 1} r/12[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/12[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (catch
@@ -214,7 +214,7 @@ let match_anf_unique r =
 (let
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_anf_unique/0 =
-     (function {nlocal = 1} r/14[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/14[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (catch
@@ -256,7 +256,7 @@ let swap_inner (t : tree) =
 [%%expect{|
 (let
   (swap_inner/0 =
-     (function {nlocal = 1}
+     (function {nlocal = 0}
        t/0[value<
             (consts (0))
              (non_consts ([0:
@@ -407,7 +407,7 @@ let match_guard r =
   (unique_use/0 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    aliased_use/0 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_guard/0 =
-     (function {nlocal = 1} r/16[value<(consts ()) (non_consts ([0: *, *]))>]
+     (function {nlocal = 0} r/16[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let (y/9 =o? (field_mut 1 r/16))

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -1,6 +1,7 @@
 (* TEST
    flags += "-extension-universe alpha ";
-   flags += "-dlambda -dcanonical-ids";
+   flags += "-dlambda -dcanonical-ids ";
+   flags += "-no-extension mode_polymorphism_alpha";
    expect;
 *)
 
@@ -274,13 +275,38 @@ let swap_inner (t : tree) =
                          (consts (0)) (non_consts ([0: *, value<int>, *]))>]))
        (catch
          (if t/0
-           (let (*match*/6 =o? (field_mut 0 t/0))
+           (let (*match*/6 =a? (field_imm 0 t/0))
              (if *match*/6
-               (let
-                 (lr/0 =o? (field_mut 2 *match*/6)
-                  *match*/7 =o? (field_mut 2 t/0))
+               (let (*match*/7 =a? (field_imm 2 t/0))
                  (if *match*/7
-                   (let (rl/0 =o? (field_mut 0 *match*/7))
+                   (makeblock 0 (value<
+                                  (consts (0))
+                                   (non_consts ([0:
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: *,
+                                                                 value<int>,
+                                                                 *]))>,
+                                                 value<int>,
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: *,
+                                                                 value<int>,
+                                                                 *]))>]))>,
+                     value<int>,value<
+                                 (consts (0))
+                                  (non_consts ([0:
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: *,
+                                                                value<int>,
+                                                                *]))>,
+                                                value<int>,
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: *,
+                                                                value<int>,
+                                                                *]))>]))>)
                      (makeblock 0 (value<
                                     (consts (0))
                                      (non_consts ([0:
@@ -309,67 +335,39 @@ let swap_inner (t : tree) =
                                                     (non_consts ([0: *,
                                                                   value<int>,
                                                                   *]))>]))>)
-                       (makeblock 0 (value<
-                                      (consts (0))
-                                       (non_consts ([0:
-                                                     value<
-                                                      (consts (0))
-                                                       (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>,
-                                                     value<int>,
-                                                     value<
-                                                      (consts (0))
-                                                       (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>]))>,
-                         value<int>,value<
-                                     (consts (0))
-                                      (non_consts ([0:
-                                                    value<
-                                                     (consts (0))
-                                                      (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>,
-                                                    value<int>,
-                                                    value<
-                                                     (consts (0))
-                                                      (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>]))>)
-                         (field_imm 0 *match*/6) (field_int 1 *match*/6)
-                         rl/0)
-                       (field_int 1 t/0)
-                       (makeblock 0 (value<
-                                      (consts (0))
-                                       (non_consts ([0:
-                                                     value<
-                                                      (consts (0))
-                                                       (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>,
-                                                     value<int>,
-                                                     value<
-                                                      (consts (0))
-                                                       (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>]))>,
-                         value<int>,value<
-                                     (consts (0))
-                                      (non_consts ([0:
-                                                    value<
-                                                     (consts (0))
-                                                      (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>,
-                                                    value<int>,
-                                                    value<
-                                                     (consts (0))
-                                                      (non_consts ([0: *,
-                                                                    value<
-                                                                    int>, *]))>]))>)
-                         lr/0 (field_int 1 *match*/7)
-                         (field_imm 2 *match*/7))))
+                       (field_imm 0 *match*/6) (field_int 1 *match*/6)
+                       (field_imm 0 *match*/7))
+                     (field_int 1 t/0)
+                     (makeblock 0 (value<
+                                    (consts (0))
+                                     (non_consts ([0:
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: *,
+                                                                   value<int>,
+                                                                   *]))>,
+                                                   value<int>,
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: *,
+                                                                   value<int>,
+                                                                   *]))>]))>,
+                       value<int>,value<
+                                   (consts (0))
+                                    (non_consts ([0:
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: *,
+                                                                  value<int>,
+                                                                  *]))>,
+                                                  value<int>,
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: *,
+                                                                  value<int>,
+                                                                  *]))>]))>)
+                       (field_imm 2 *match*/6) (field_int 1 *match*/7)
+                       (field_imm 2 *match*/7)))
                    (exit 36)))
                (exit 36)))
            (exit 36))

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -462,6 +462,7 @@ let type_iterators_without_type_expr =
     | Sig_jkind (_ , jkd, _)        -> it.it_jkind_declaration it jkd
   and it_value_description it vd =
     it.it_type_expr it vd.val_type;
+    it.it_modality vd.val_modalities
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
@@ -473,7 +474,8 @@ let type_iterators_without_type_expr =
     iter_type_expr_cstr_args (it.it_type_expr it) td.ext_args;
     Option.iter (it.it_type_expr it) td.ext_ret_type
   and it_module_declaration it md =
-    it.it_module_type it md.md_type
+    it.it_module_type it md.md_type;
+    it.it_modality md.md_modalities
   and it_modtype_declaration it mtd =
     Option.iter (it.it_module_type it) mtd.mtd_type
   and it_class_declaration it cd =
@@ -495,14 +497,17 @@ let type_iterators_without_type_expr =
       ()
   and it_functor_param it = function
     | Unit -> ()
-    | Named (_, mt, _) -> it.it_module_type it mt
+    | Named (_, mt, mm) ->
+        it.it_module_type it mt;
+        it.it_mode_expr mm
   and it_module_type it = function
       Mty_ident p
     | Mty_alias p -> it.it_path p
     | Mty_signature sg -> it.it_signature it sg
-    | Mty_functor (p, mt, _) ->
+    | Mty_functor (p, mt, mm) ->
         it.it_functor_param it p;
-        it.it_module_type it mt
+        it.it_module_type it mt;
+        it.it_mode_expr mm
     | Mty_strengthen (mty, p, _) ->
         it.it_module_type it mty;
         it.it_path p

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -646,6 +646,8 @@ module For_copy : sig
 
   val mode_copy_for_saving : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
 
+  val mode_copy_for_restoring : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
   val mode_copy_then_generalize :
     copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
 
@@ -673,6 +675,10 @@ end = struct
   let mode_copy_for_saving copy_scope m =
     let copy_scope = copy_scope.saved_mode_changes in
     Mode.Alloc.copy_for_saving ~copy_scope m
+
+  let mode_copy_for_restoring copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_for_restoring ~copy_scope m
 
   let mode_copy_then_generalize copy_scope ~current_level m =
     let copy_scope = copy_scope.saved_mode_changes in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -648,9 +648,6 @@ module For_copy : sig
 
   val mode_copy_for_restoring : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
 
-  val mode_copy_then_generalize :
-    copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
-
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
@@ -679,10 +676,6 @@ end = struct
   let mode_copy_for_restoring copy_scope m =
     let copy_scope = copy_scope.saved_mode_changes in
     Mode.Alloc.copy_for_restoring ~copy_scope m
-
-  let mode_copy_then_generalize copy_scope ~current_level m =
-    let copy_scope = copy_scope.saved_mode_changes in
-    Mode.Alloc.copy_then_generalize ~copy_scope ~current_level m
 
   (* Restore type descriptions. *)
   let cleanup { saved_desc; _ } =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -108,7 +108,7 @@ end
 
 (**** Type level management ****)
 
-let generic_level = Ident.highest_scope
+let generic_level = Mode.Alloc.generic_level
 let lowest_level = Ident.lowest_scope
 
 (**** leveled type pool ****)
@@ -335,11 +335,13 @@ let iter_row f row =
   fold_row (fun () v -> f v) () row
 
 
-let fold_type_expr f init ty =
+let fold_type_expr f fm init ty =
   match get_desc ty with
     Tvar _              -> init
-  | Tarrow (_, ty1, ty2, _) ->
-      let result = f init ty1 in
+  | Tarrow ((_, m1, m2), ty1, ty2, _) ->
+      let result = fm init m1 in
+      let result = fm result m2 in
+      let result = f result ty1 in
       f result ty2
   | Ttuple l            -> List.fold_left (fun acc (_, t) -> f acc t) init l
   | Tunboxed_tuple l    -> List.fold_left (fun acc (_, t) -> f acc t) init l
@@ -372,8 +374,8 @@ let fold_type_expr f init ty =
   | Tof_kind _ -> init
   | Tbox ty -> f init ty
 
-let iter_type_expr f ty =
-  fold_type_expr (fun () v -> f v) () ty
+let iter_type_expr f fm ty =
+  fold_type_expr (fun () v -> f v) (fun () v -> fm v) () ty
 
 let rec iter_abbrev f = function
     Mnil                   -> ()
@@ -410,10 +412,11 @@ let iter_type_expr_kind f = function
                   (**********************************)
 
 let rec mark_type mark ty =
-  if try_mark_node mark ty then iter_type_expr (mark_type mark) ty
+  if try_mark_node mark ty then
+    iter_type_expr (mark_type mark) (Fun.const ()) ty
 
 let mark_type_params mark ty =
-  iter_type_expr (mark_type mark) ty
+  iter_type_expr (mark_type mark) (Fun.const ()) ty
 
                   (**********************************)
                   (*  (Object-oriented) iterator    *)
@@ -438,6 +441,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -456,7 +461,7 @@ let type_iterators_without_type_expr =
     | Sig_class_type (_, ctd, _, _) -> it.it_class_type_declaration it ctd
     | Sig_jkind (_ , jkd, _)        -> it.it_jkind_declaration it jkd
   and it_value_description it vd =
-    it.it_type_expr it vd.val_type
+    it.it_type_expr it vd.val_type;
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
@@ -517,19 +522,22 @@ let type_iterators_without_type_expr =
   and it_type_kind it kind =
     iter_type_expr_kind (it.it_type_expr it) kind
   and it_path _p = ()
+  and it_mode_expr _m = ()
+  and it_modality _m = ()
   in
   { it_path; it_type_expr = (fun _ _ -> ()); it_do_type_expr = (fun _ _ -> ());
     it_type_kind; it_class_type; it_functor_param; it_module_type;
     it_signature; it_class_type_declaration; it_class_declaration;
     it_jkind_declaration;
     it_modtype_declaration; it_module_declaration; it_extension_constructor;
-    it_type_declaration; it_value_description; it_signature_item; }
+    it_type_declaration; it_value_description;
+    it_signature_item; it_mode_expr; it_modality }
 
 let type_iterators mark =
   let it_type_expr it ty =
     if try_mark_node mark ty then it.it_do_type_expr it ty
   and it_do_type_expr it ty =
-    iter_type_expr (it.it_type_expr it) ty;
+    iter_type_expr (it.it_type_expr it) (it.it_mode_expr) ty;
     match get_desc ty with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
@@ -582,11 +590,12 @@ let instance_jkind (t : jkind_lr) : jkind_lr =
   | Layout l ->
     { t with jkind = { t.jkind with base = Layout (instance_layout l) } }
 
-let rec copy_type_desc ?(keep_names=false) f = function
+let rec copy_type_desc ?(keep_names=false) f fm = function
     Tvar { name; jkind } ->
      let jkind = instance_jkind jkind in
      if keep_names then Tvar { name; jkind } else Tvar { name=None; jkind }
-  | Tarrow (p, ty1, ty2, c)-> Tarrow (p, f ty1, f ty2, copy_commu c)
+  | Tarrow ((p, m1, m2), ty1, ty2, c)->
+    Tarrow ((p, fm m1, fm m2), f ty1, f ty2, copy_commu c)
   | Ttuple l            -> Ttuple (List.map (fun (label, t) -> label, f t) l)
   | Tunboxed_tuple l    ->
     Tunboxed_tuple (List.map (fun (label, t) -> label, f t) l)
@@ -603,7 +612,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tfield (p, field_kind_internal_repr k, f ty1, f ty2)
       (* the kind is kept shared, with indirections removed for performance *)
   | Tnil                -> Tnil
-  | Tlink ty            -> copy_type_desc f (get_desc ty)
+  | Tlink ty            -> copy_type_desc f fm (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
@@ -623,11 +632,24 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_for_saving : copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_then_generalize :
+    copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
+
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
     mutable saved_desc : (transient_expr * type_desc) list;
     (* Save association of generic nodes with their description. *)
+    saved_mode_changes : Mode.copy_scope;
   }
 
   let redirect_desc copy_scope ty desc =
@@ -635,13 +657,30 @@ end = struct
     copy_scope.saved_desc <- (ty, ty.desc) :: copy_scope.saved_desc;
     Transient_expr.set_desc ty desc
 
+  let mode_instantiate copy_scope ~current_level m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.instantiate ~copy_scope ~current_level m
+
+  let mode_copy_generic copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_generic ~copy_scope m
+
+  let mode_copy_for_saving copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_for_saving ~copy_scope m
+
+  let mode_copy_then_generalize copy_scope ~current_level m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_then_generalize ~copy_scope ~current_level m
+
   (* Restore type descriptions. *)
   let cleanup { saved_desc; _ } =
     List.iter (fun (ty, desc) -> Transient_expr.set_desc ty desc) saved_desc
 
   let with_scope f =
-    let scope = { saved_desc = [] } in
-    Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope)
+    Mode.with_copy_scope (fun ms ->
+      let scope = { saved_desc = []; saved_mode_changes = ms } in
+      Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope))
 
 end
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -264,12 +264,6 @@ module For_copy : sig
         (* Deeply copies a mode variable without changing its level.
            Asserts that the original has negative ids. *)
 
-  val mode_copy_then_generalize :
-    copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
-        (* Copies the parts of a mode variable whose levels lie within
-           [[current_level, generic_level)], preserving levels, then
-           generalizes the copy *)
-
   val with_scope: (copy_scope -> 'a) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions
            before returning its result. *)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -259,6 +259,11 @@ module For_copy : sig
         (* Deeply copies a mode variable without changing its level, giving
            the copies negative (persistent) ids, for storing in a cmi file. *)
 
+  val mode_copy_for_restoring :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Deeply copies a mode variable without changing its level.
+           Asserts that the original has negative ids. *)
+
   val mode_copy_then_generalize :
     copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
         (* Copies the parts of a mode variable whose levels lie within

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -157,15 +157,20 @@ val set_static_row_name: type_declaration -> Path.t -> unit
 
 (**** Utilities for type traversal ****)
 
-val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
+val iter_type_expr:
+  (type_expr -> unit) -> (Mode.Alloc.lr -> unit) ->
+  type_expr -> unit
         (* Iteration on types *)
-val fold_type_expr: ('a -> type_expr -> 'a) -> 'a -> type_expr -> 'a
+val fold_type_expr:
+  ('a -> type_expr -> 'a) -> ('a -> Mode.Alloc.lr -> 'a) ->
+  'a -> type_expr -> 'a
 val iter_row: (type_expr -> unit) -> row_desc -> unit
         (* Iteration on types in a row *)
 val fold_row: ('a -> type_expr -> 'a) -> 'a -> row_desc -> 'a
 val iter_abbrev: (type_expr -> unit) -> abbrev_memo -> unit
         (* Iteration on types in an abbreviation list *)
-val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
+val iter_type_expr_kind: (type_expr -> unit) ->
+  (type_decl_kind -> unit)
 
 val iter_type_expr_cstr_args: (type_expr -> unit) ->
   (constructor_arguments -> unit)
@@ -200,6 +205,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -216,7 +223,8 @@ val type_iterators_without_type_expr: type_iterators_without_type_expr
 (**** Utilities for copying ****)
 
 val copy_type_desc:
-    ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc
+    ?keep_names:bool -> (type_expr -> type_expr) ->
+    (Mode.Alloc.lr -> Mode.Alloc.lr) -> type_desc -> type_desc
         (* Copy on types *)
 val copy_row:
     (type_expr -> type_expr) ->
@@ -235,6 +243,27 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
         (* Temporarily change a type description *)
+
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Instantiates a generic mode variable to level [current_level] *)
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Copies the generic parts of a mode variable
+           without changing its level *)
+
+  val mode_copy_for_saving :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Deeply copies a mode variable without changing its level, giving
+           the copies negative (persistent) ids, for storing in a cmi file. *)
+
+  val mode_copy_then_generalize :
+    copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Copies the parts of a mode variable whose levels lie within
+           [[current_level, generic_level)], preserving levels, then
+           generalizes the copy *)
 
   val with_scope: (copy_scope -> 'a) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1100,11 +1100,8 @@ let rec copy_spine copy_scope ty =
       let copy_rec = copy_spine copy_scope in
       let desc' = match desc with
       | Tarrow ((lbl, marg, mret), ty1, ty2, _) ->
-          let copy_mode =
-            For_copy.mode_copy_then_generalize copy_scope ~current_level
-          in
           Tarrow
-            ((lbl, copy_mode marg, copy_mode mret),
+            ((lbl, marg, mret),
              copy_rec ty1,
              copy_rec ty2,
              commu_ok)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -980,7 +980,6 @@ let duplicate_class_type ty =
                          (*  Type level manipulation  *)
                          (*****************************)
 
-(* CR ageorges: lower the level of mode variables as well? *)
 let rec lower_all ty =
   if get_level ty > !current_level then begin
     set_level ty !current_level;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -248,11 +248,14 @@ let with_local_level_gen ~begin_def ~structure ?before_generalize f =
         else begin
           (* Generalize all remaining nodes *)
           Transient_expr.set_level ty generic_level;
-          if structure then match ty.desc with
-            Tconstr (_, _, abbrev) ->
+          match ty.desc with
+          | Tconstr (_, _, abbrev) when structure ->
               (* In structure mode, we drop abbreviations, as the goal of
                  this mode is to reduce sharing *)
               abbrev := Mnil
+          | Tarrow ((_, marg, mret), _, _, _) when not structure ->
+              Alloc.generalize_topology ~current_level:!current_level marg;
+              Alloc.generalize_topology ~current_level:!current_level mret
           | _ -> ()
         end
   end pool;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2798,7 +2798,7 @@ let expand_head_opt env ty =
 
 let create_yielding_mode_l yielding =
   let yielding =
-    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then fst (Yielding.newvar_above 0 yielding)
     else yielding
   in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8329,15 +8329,14 @@ let add_nongen_vars_in_schema =
           fold_type_expr (loop env) (fun a _ -> a) (visited, weak_set) ty
     end
   in
-  fun env acc ty ->
-    Alloc.with_zap_scope (fun ~zap_scope ->
-      remove_mode_and_jkind_variables ~zap_scope ty);
+  fun zap_scope env acc ty ->
+    remove_mode_and_jkind_variables ~zap_scope ty;
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 
 (* Return all non-generic variables of [ty]. *)
-let nongen_vars_in_schema env ty =
-  let result = add_nongen_vars_in_schema env TypeSet.empty ty in
+let nongen_vars_in_schema ~zap_scope env ty =
+  let result = add_nongen_vars_in_schema zap_scope env TypeSet.empty ty in
   if TypeSet.is_empty result
   then None
   else Some result
@@ -8345,44 +8344,45 @@ let nongen_vars_in_schema env ty =
 (* Check that all type variables are generalizable *)
 (* Use Env.empty to prevent expansion of recursively defined object types;
    cf. typing-poly/poly.ml *)
-let nongen_class_type =
-  let add_nongen_vars_in_schema' ty weak_set =
-    add_nongen_vars_in_schema Env.empty weak_set ty
+let nongen_class_type zap_scope =
+  let add_nongen_vars_in_schema' zap_scope ty weak_set =
+    add_nongen_vars_in_schema zap_scope Env.empty weak_set ty
   in
-  let add_nongen_vars_in_schema_fold fold m weak_set =
+  let add_nongen_vars_in_schema_fold fold zap_scope m weak_set =
     let f _key (_,_,ty) weak_set =
-      add_nongen_vars_in_schema Env.empty weak_set ty
+      add_nongen_vars_in_schema zap_scope Env.empty weak_set ty
     in
     fold f m weak_set
   in
-  let rec nongen_class_type cty weak_set =
+  let rec nongen_class_type zap_scope cty weak_set =
     match cty with
     | Cty_constr (_, params, _) ->
         List.fold_left
-          (add_nongen_vars_in_schema Env.empty)
+          (add_nongen_vars_in_schema zap_scope Env.empty)
           weak_set
           params
     | Cty_signature sign ->
         weak_set
-        |> add_nongen_vars_in_schema' sign.csig_self
-        |> add_nongen_vars_in_schema' sign.csig_self_row
-        |> add_nongen_vars_in_schema_fold Meths.fold sign.csig_meths
-        |> add_nongen_vars_in_schema_fold Vars.fold sign.csig_vars
+        |> add_nongen_vars_in_schema' zap_scope sign.csig_self
+        |> add_nongen_vars_in_schema' zap_scope sign.csig_self_row
+        |> add_nongen_vars_in_schema_fold Meths.fold zap_scope sign.csig_meths
+        |> add_nongen_vars_in_schema_fold Vars.fold zap_scope sign.csig_vars
     | Cty_arrow (_, ty, cty) ->
-        add_nongen_vars_in_schema' ty weak_set
-        |> nongen_class_type cty
+        add_nongen_vars_in_schema' zap_scope ty weak_set
+        |> nongen_class_type zap_scope cty
   in
-  nongen_class_type
+  nongen_class_type zap_scope
 
-let nongen_class_declaration cty =
+let nongen_class_declaration zap_scope cty =
   List.fold_left
-    (add_nongen_vars_in_schema Env.empty)
+    (add_nongen_vars_in_schema zap_scope Env.empty)
     TypeSet.empty
     cty.cty_params
-  |> nongen_class_type cty.cty_type
+  |> nongen_class_type zap_scope cty.cty_type
 
 let nongen_vars_in_class_declaration cty =
-  let result = nongen_class_declaration cty in
+  let result = Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+    nongen_class_declaration zap_scope cty) in
   if TypeSet.is_empty result
   then None
   else Some result

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -258,16 +258,20 @@ let with_local_level_gen ~begin_def ~structure ?before_generalize f =
   end pool;
   result
 
-let with_local_level_generalize_structure f =
-  with_local_level_gen ~begin_def ~structure:true f
 let with_local_level_generalize ~before_generalize f =
   with_local_level_gen ~begin_def ~structure:false ~before_generalize f
 let with_local_level_generalize_if cond ~before_generalize f =
   if cond then with_local_level_generalize ~before_generalize f else f ()
-let with_local_level_generalize_structure_if cond f =
-  if cond then with_local_level_generalize_structure f else f ()
-let with_local_level_generalize_structure_if_principal f =
-  if !Clflags.principal then with_local_level_generalize_structure f else f ()
+let with_local_level_generalize_structure ~before_generalize f =
+  with_local_level_gen ~begin_def ~structure:true ~before_generalize f
+let with_local_level_generalize_structure_if cond ~before_generalize f =
+  if cond then
+    with_local_level_generalize_structure ~before_generalize f
+  else f ()
+let with_local_level_generalize_structure_if_principal ~before_generalize f =
+  if !Clflags.principal then
+    with_local_level_generalize_structure ~before_generalize f
+  else f ()
 let with_local_level_generalize_for_class ~before_generalize f =
   with_local_level_gen
     ~begin_def:begin_class_def ~structure:false ~before_generalize f
@@ -497,7 +501,7 @@ let decr_stage env =
 let incr_stage env =
   Env.enter_quote env
 
-let iter_type_expr_with_stages f env ty =
+let iter_type_expr_with_stages f env fm ty =
   match get_desc ty with
   | Tquote ty ->
     f (incr_stage env) ty
@@ -506,7 +510,7 @@ let iter_type_expr_with_stages f env ty =
   | Tquote_eval ty ->
     f (incr_stage env) ty
   | _ ->
-    iter_type_expr (f env) ty
+    iter_type_expr (f env) fm ty
 
 (* CR metaprogramming jbachurski: We use this to adjust the environment while
    printing error messages. The original type may have been well-staged,
@@ -531,6 +535,7 @@ let contains_initial_stage_splice stage ty =
       in
       fold_type_expr
         (fun x y -> x || loop (acc + offset) y)
+        (fun a _ -> a)
         (acc < 0) ty
     end
   in
@@ -732,7 +737,7 @@ let rec filter_row_fields erase = function
       | _ -> p :: fi
 
 (* Ensure all mode variables are fully determined *)
-let remove_mode_and_jkind_variables ty =
+let remove_mode_and_jkind_variables ~zap_scope ty =
   let visited = ref TypeSet.empty in
   let rec go ty =
     if TypeSet.mem ty !visited then () else begin
@@ -741,10 +746,15 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-         let _ = Alloc.zap_to_legacy ~arg:true marg in
-         let _ = Alloc.zap_to_legacy ~arg:false mret in
+         if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope ~arg:true marg zap_scope;
+          Alloc.add_mode_to_zap_scope ~arg:false mret zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force ~arg:true marg |> ignore;
+          Alloc.zap_to_legacy_force ~arg:false mret |> ignore
+         end;
          go targ; go tret
-      | _ -> iter_type_expr go ty
+      | _ -> iter_type_expr go (Fun.const ()) ty
     end
   in go ty
 
@@ -800,7 +810,7 @@ let[@inline] free_vars ~init ~add_one ?env mark tys =
           if static_row row then acc
           else fv ~kind:Row_variable acc (row_more row)
       | _    ->
-          fold_type_expr (fv ~kind) acc ty
+          fold_type_expr (fv ~kind) (fun acc _ -> acc) acc ty
   in
   List.fold_left (fv ~kind:Type_variable) init tys
 
@@ -850,20 +860,20 @@ let closed_type_expr ?env ty =
     try closed_type ?env mark ty; true
     with Non_closed _ -> false)
 
-let close_type mark ty =
-  remove_mode_and_jkind_variables ty;
+let close_type ~zap_scope mark ty =
+  remove_mode_and_jkind_variables ~zap_scope ty;
   closed_type mark ty
 
 let closed_parameterized_type params ty =
   with_type_mark begin fun mark ->
     List.iter (mark_type mark) params;
-    try close_type mark ty; true with Non_closed _ -> false
+    try Alloc.with_zap_scope close_type mark ty; true with Non_closed _ -> false
   end
 
-let closed_type_decl decl =
+let closed_type_decl ~zap_scope decl =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) decl.type_params;
-    List.iter remove_mode_and_jkind_variables decl.type_params;
+    List.iter (remove_mode_and_jkind_variables ~zap_scope) decl.type_params;
     begin match decl.type_kind with
       Type_abstract _ ->
         ()
@@ -877,30 +887,32 @@ let closed_type_decl decl =
                    them. Test case: typing-layouts-gadt-sort-var/test.ml *)
                 begin match cd_args with
                 | Cstr_tuple l -> List.iter (fun ca ->
-                    remove_mode_and_jkind_variables ca.ca_type) l
+                    remove_mode_and_jkind_variables ~zap_scope ca.ca_type) l
                 | Cstr_record l -> List.iter (fun l ->
-                    remove_mode_and_jkind_variables l.ld_type) l
+                    remove_mode_and_jkind_variables ~zap_scope l.ld_type) l
                 end;
-                remove_mode_and_jkind_variables res_ty
-            | None -> List.iter (close_type mark) (tys_of_constr_args cd_args)
+                remove_mode_and_jkind_variables ~zap_scope res_ty
+            | None ->
+              List.iter (close_type mark ~zap_scope)
+                (tys_of_constr_args cd_args)
           )
           v
     | Type_record(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_record_unboxed_product(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_open -> ()
     end;
     begin match decl.type_manifest with
       None    -> ()
-    | Some ty -> close_type mark ty
+    | Some ty -> close_type mark ~zap_scope ty
     end;
     None
   with Non_closed (ty, _) ->
     Some ty
   end
 
-let closed_extension_constructor ext =
+let closed_extension_constructor ~zap_scope ext =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) ext.ext_type_params;
     begin match ext.ext_ret_type with
@@ -908,10 +920,12 @@ let closed_extension_constructor ext =
         (* gadts cannot have free type variables, but they might
            have undefaulted sort variables; these lines default
            them. Test case: typing-layouts-gadt-sort-var/test_extensible.ml *)
-        iter_type_expr_cstr_args remove_mode_and_jkind_variables ext.ext_args;
-        remove_mode_and_jkind_variables res_ty
+        iter_type_expr_cstr_args
+          (remove_mode_and_jkind_variables ~zap_scope)
+          ext.ext_args;
+        remove_mode_and_jkind_variables ~zap_scope res_ty
     | None ->
-        iter_type_expr_cstr_args (close_type mark) ext.ext_args
+        iter_type_expr_cstr_args (close_type mark ~zap_scope) ext.ext_args
     end;
     None
   with Non_closed (ty, _) ->
@@ -925,7 +939,7 @@ type closed_class_failure = {
 }
 exception CCFailure of closed_class_failure
 
-let closed_class params sign =
+let closed_class ~zap_scope params sign =
   with_type_mark begin fun mark ->
   List.iter (mark_type mark) params;
   ignore (try_mark_node mark sign.csig_self_row);
@@ -933,7 +947,8 @@ let closed_class params sign =
     Meths.iter
       (fun lab (priv, _, ty) ->
         if priv = Mpublic then begin
-          try close_type mark ty with Non_closed (ty0, variable_kind) ->
+          try close_type ~zap_scope mark ty
+          with Non_closed (ty0, variable_kind) ->
             raise (CCFailure {
               free_variable = (ty0, variable_kind);
               meth = lab;
@@ -964,10 +979,11 @@ let duplicate_class_type ty =
                          (*  Type level manipulation  *)
                          (*****************************)
 
+(* CR ageorges: lower the level of mode variables as well? *)
 let rec lower_all ty =
   if get_level ty > !current_level then begin
     set_level ty !current_level;
-    iter_type_expr lower_all ty
+    iter_type_expr lower_all (Fun.const ()) ty
   end
 
 (*
@@ -979,7 +995,8 @@ let rec lower_all ty =
 *)
 let rec generalize stage_offset ty =
   let level = get_level ty in
-  if (level > !current_level) && (level <> generic_level) then begin
+  let current_level = !current_level in
+  if (level > current_level) && (level <> generic_level) then begin
     set_level ty generic_level;
     begin match get_desc ty with
     (* Keep track of [stage_offset] *)
@@ -992,7 +1009,7 @@ let rec generalize stage_offset ty =
     (* Normalize the variable to be at [stage_offset = 0] *)
     | Tvar name ->
         update_variable_stage stage_offset ty name.name name.jkind;
-        Jkind.generalize ~current_level:!current_level name.jkind
+        Jkind.generalize ~current_level name.jkind
     (* Do not generalize cross-stage row-polymorphic types, as we cannot
        quote or splice row variables.
        Weak type variables that arise here are considered cross-stage,
@@ -1006,16 +1023,43 @@ let rec generalize stage_offset ty =
         lower_all ty
     (* recur into abbrev for the speed *)
     | Tconstr (_, _, abbrev) ->
+        let mgen m = Mode.Alloc.generalize ~current_level m in
         iter_abbrev (generalize stage_offset) !abbrev;
-        iter_type_expr (generalize stage_offset) ty
+        iter_type_expr (generalize stage_offset) mgen ty
     | _ ->
-        iter_type_expr (generalize stage_offset) ty
+
+      let mgen m = Mode.Alloc.generalize ~current_level m in
+      iter_type_expr (generalize stage_offset) mgen ty
     end;
   end
 
 let generalize ty =
   simple_abbrevs := Mnil;
   generalize 0 ty
+
+(* Generalize the structure and lower the variables *)
+
+let rec generalize_structure ty =
+  let level = get_level ty in
+  let current_level = !current_level in
+  if level <> generic_level then begin
+    if is_Tvar ty && level > current_level then
+      set_level ty current_level
+    else if level > current_level then begin
+      begin match get_desc ty with
+        Tconstr (_, _, abbrev) ->
+          abbrev := Mnil
+      | _ -> ()
+      end;
+      set_level ty generic_level;
+      let mgen m = Mode.Alloc.generalize_structure ~current_level m in
+      iter_type_expr generalize_structure mgen ty
+    end
+  end
+
+let generalize_structure ty =
+  simple_abbrevs := Mnil;
+  generalize_structure ty
 
 (*
    Build a copy of a type in which nodes reachable through a path composed
@@ -1046,15 +1090,23 @@ let rec copy_spine copy_scope ty =
   | ( Tarrow _ | Tpoly _ | Trepr _ | Ttuple _ | Tunboxed_tuple _ | Tpackage _
     | Tconstr _ | Tmod _ ) as desc ->
       let level = get_level ty in
-      if level < !current_level || level = generic_level then ty else
+      let current_level = !current_level in
+      if level < current_level || level = generic_level then ty else
       let t =
         newgenstub ~scope:(get_scope ty) (Jkind.Builtin.any ~why:Dummy_jkind)
       in
       For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
       let copy_rec = copy_spine copy_scope in
       let desc' = match desc with
-      | Tarrow (lbl, ty1, ty2, _) ->
-          Tarrow (lbl, copy_rec ty1, copy_rec ty2, commu_ok)
+      | Tarrow ((lbl, marg, mret), ty1, ty2, _) ->
+          let copy_mode =
+            For_copy.mode_copy_then_generalize copy_scope ~current_level
+          in
+          Tarrow
+            ((lbl, copy_mode marg, copy_mode mret),
+             copy_rec ty1,
+             copy_rec ty2,
+             commu_ok)
       | Tpoly (ty', tvl) ->
           Tpoly (copy_rec ty', tvl)
       | Trepr (ty', sl) ->
@@ -1123,7 +1175,7 @@ let rec check_scope_escape mark env level ty =
             (Tpackage {pack with pack_path = p'}))
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> check_scope_escape mark env level) env ty
+          (fun env -> check_scope_escape mark env level) env (Fun.const ()) ty
     end;
   end
 
@@ -1139,7 +1191,8 @@ let rec update_scope scope ty =
     if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
     (* Only recurse in principal mode as this is not necessary for soundness *)
-    if !Clflags.principal then iter_type_expr (update_scope scope) ty
+    if !Clflags.principal then
+      iter_type_expr (update_scope scope) (Fun.const ()) ty
   end
 
 let update_scope_for tr_exn scope ty =
@@ -1191,7 +1244,8 @@ let rec update_level env level expand ty =
           update_level env level expand ty'
         with Cannot_expand ->
           set_level ();
-          iter_type_expr (update_level env level expand) ty
+          iter_type_expr (update_level env level expand)
+            (Mode.Alloc.update_level level) ty
         end
     | Tpackage ({pack_path = p} as pack) when level < Path.scope p ->
         let p' = normalize_package_path env p in
@@ -1209,7 +1263,8 @@ let rec update_level env level expand ty =
         | _ -> ()
         end;
         set_level ();
-        iter_type_expr (update_level env level expand) ty
+        iter_type_expr (update_level env level expand)
+          (Mode.Alloc.update_level level) ty
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && level < get_scope ty1 ->
         raise_escape_exn Self
@@ -1217,7 +1272,8 @@ let rec update_level env level expand ty =
         set_level ();
         (* XXX what about abbreviations in Tconstr ? *)
         iter_type_expr_with_stages
-          (fun env -> update_level env level expand) env ty
+          (fun env -> update_level env level expand) env
+          (Mode.Alloc.update_level level) ty
   end
 
 (* First try without expanding, then expand everything,
@@ -1279,12 +1335,15 @@ let rec lower_contravariant env var_level visited contra ty =
           else not_expanded ()
     | Tpackage p ->
         List.iter (fun (_n, ty) -> lower_rec true ty) p.pack_cstrs
-    | Tarrow (_, t1, t2, _) ->
+    | Tarrow ((_, m1, m2), t1, t2, _) ->
+        Mode.Alloc.update_level var_level m1;
+        if contra then Mode.Alloc.update_level var_level m2;
         lower_rec true t1;
         lower_rec contra t2
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> lower_contravariant env var_level visited contra) env ty
+          (fun env -> lower_contravariant env var_level visited contra)
+          env (Fun.const ()) ty
   end
 
 let lower_variables_only env level ty =
@@ -1309,6 +1368,9 @@ let rec generalize_class_type gen =
       gen ty;
       generalize_class_type gen cty
 
+let generalize_class_type_structure cty =
+  generalize_class_type generalize_structure cty
+
 (* Only generalize the type ty0 in ty *)
 let limited_generalize ty0 ~inside:ty =
   let graph = TypeHash.create 17 in
@@ -1324,7 +1386,7 @@ let limited_generalize ty0 ~inside:ty =
           (* XXX: why generic_level needs to be a root *)
           if (level = generic_level) || eq_type ty ty0 then
             roots := ty :: !roots;
-          iter_type_expr (inverse [ty]) ty
+          iter_type_expr (inverse [ty]) (Fun.const ()) ty
         end
   in
 
@@ -1368,7 +1430,7 @@ let rec inv_type hash pty ty =
   with Not_found ->
     let inv = { inv_type = ty; inv_parents = pty } in
     TypeHash.add hash ty inv;
-    iter_type_expr (inv_type hash [inv]) ty
+    iter_type_expr (inv_type hash [inv]) (Fun.const ()) ty
 
 let compute_univars ty =
   let inverted = TypeHash.create 17 in
@@ -1398,7 +1460,8 @@ let fully_generic ty =
   with_type_mark begin fun mark ->
     let rec aux ty =
       if try_mark_node mark ty then
-        if get_level ty = generic_level then iter_type_expr aux ty
+        if get_level ty = generic_level then
+          iter_type_expr aux (Fun.const ()) ty
         else raise Exit
     in
     try aux ty; true with Exit -> false
@@ -1553,7 +1616,11 @@ let rec copy ?partial ?keep_names copy_scope ty =
           Tunivar { name; jkind = Jkind.instance jkind }
       | Tobject (ty1, _) when partial <> None ->
           Tobject (copy ty1, ref None)
-      | _ -> copy_type_desc ?keep_names copy desc
+      | _ ->
+        let copy_mode =
+          For_copy.mode_instantiate copy_scope ~current_level:!current_level
+        in
+        copy_type_desc ?keep_names copy copy_mode desc
     in
     Transient_expr.set_stub_desc t desc';
     t
@@ -1843,7 +1910,11 @@ let copy_sep ~copy_scope ~fixed ~partial ~bound_univars
             Tfield (p, field_kind_internal_repr k,
                     copy_rec ~may_share:true ty1,
                     copy_rec ~may_share:false ty2)
-        | desc -> copy_type_desc (copy_rec ~may_share:true) desc
+        | desc ->
+          let copy_mode =
+            For_copy.mode_instantiate copy_scope ~current_level:!current_level
+          in
+          copy_type_desc (copy_rec ~may_share:true) copy_mode desc
       in
       Transient_expr.set_stub_desc t desc';
       t
@@ -1984,9 +2055,9 @@ let prim_mode' mvars = function
     | None -> assert false
 
 (* Exported version. *)
-let prim_mode mvar prim =
+let prim_mode mvar prim ~level =
   let mvar = Option.map
-    (fun mvar_l -> mvar_l, (Forkable.newvar (), Yielding.newvar ())) mvar
+    (fun mvar_l -> mvar_l, (Forkable.newvar level, Yielding.newvar level)) mvar
   in
   fst (prim_mode' mvar prim)
 
@@ -1996,7 +2067,7 @@ let prim_mode mvar prim =
 let with_locality_and_forkable_yielding (locality, fy) m =
   let forkable = Option.map fst fy in
   let yielding = Option.map snd fy in
-  let m' = Alloc.newvar () in
+  let m' = Alloc.newvar 0 in
   Locality.equate_exn (Alloc.proj_comonadic Areality m') locality;
   let forkable =
     Option.value ~default:(Alloc.proj_comonadic Forkable m) forkable
@@ -2023,7 +2094,12 @@ comonadic axes of [B -> C] reflect that.
 On the other hand, the monadic axes of [fun b -> ...] won't be constrained by
 this (but maybe constrained by other things); therefore, we take it to be legacy
 for compatibility. *)
-let curry_mode alloc arg : Alloc.Const.t =
+let curry_mode (type r)
+    (alloc : (allowed * r) Alloc.Comonadic.t)
+    (arg : Alloc.lr) : Alloc.Comonadic.l =
+  Alloc.Comonadic.join
+    [(Alloc.close_over arg).comonadic; (Alloc.Comonadic.disallow_right alloc)]
+let curry_mode_const alloc arg : Alloc.Const.t =
   let acc =
     Alloc.Comonadic.Const.join
       (Alloc.Const.close_over arg)
@@ -2046,9 +2122,14 @@ let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
      in
      let mret =
        match locals with
-       | [] -> with_locality_and_forkable_yielding (loc, yld) mret
+       | [] ->
+         with_locality_and_forkable_yielding
+           (loc, yld) mret
        | _ :: _ ->
-          let mret', _ = Alloc.newvar_above macc in (* curried arrow *)
+          (* curried arrow *)
+          let mret', _ =
+            Alloc.newvar_above (get_current_level ()) macc
+          in
           mret'
      in
      let ret = instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ret in
@@ -2131,7 +2212,7 @@ let instance_prim_layout env (desc : Primitive.description) ty =
           | None -> ())
         | _ -> ()
         end;
-        iter_type_expr (inner mark) ty
+        iter_type_expr (inner mark) (Fun.const ()) ty
       end
     in
     with_type_mark (fun mark -> inner mark ty);
@@ -2148,8 +2229,8 @@ let instance_prim_mode (desc : Primitive.description) ty =
   let is_poly = function Primitive.Prim_poly, _ -> true | _ -> false in
   if is_poly desc.prim_native_repr_res ||
        List.exists is_poly desc.prim_native_repr_args then
-    let mode_l = Locality.newvar () in
-    let mode_fy = Forkable.newvar (), Yielding.newvar () in
+    let mode_l = Locality.newvar 0 in
+    let mode_fy = Forkable.newvar 0, Yielding.newvar 0 in
     let finalret =
       prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res
     in
@@ -2717,6 +2798,14 @@ let try_expand_safe_opt env ty =
 let expand_head_opt env ty =
   try try_expand_head try_expand_safe_opt env ty with Cannot_expand -> ty
 
+let create_yielding_mode_l yielding =
+  let yielding =
+    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then fst (Yielding.newvar_above 0 yielding)
+    else yielding
+  in
+  Yielding.disallow_right yielding
+
 let prim_params_yielding env ty ~arity =
   let rec arg_yieldings acc ty n =
     if n <= 0 then Some acc
@@ -2731,7 +2820,8 @@ let prim_params_yielding env ty ~arity =
   in
   match arg_yieldings [] ty arity with
   | None | Some [] -> Yielding.disallow_right Yielding.max
-  | Some (_ :: _ as yieldings) -> Yielding.join yieldings
+  | Some (_ :: _ as yieldings) ->
+    create_yielding_mode_l (Yielding.join yieldings)
 
 let is_principal ty =
   not !Clflags.principal || get_level ty = generic_level
@@ -3718,7 +3808,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
         set_type_desc ty (Tunivar {r with jkind = new_jkind})
       | _ -> ()
       end;
-      iter_type_expr (inner mark) ty
+      iter_type_expr (inner mark) (Fun.const ()) ty
     end
   in
   with_type_mark (fun mark -> inner mark ty)
@@ -3796,7 +3886,9 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
         begin try
           if TypeSet.mem ty parents then raise Occur;
           let parents = TypeSet.add ty parents in
-          iter_type_expr (occur_rec env visited allow_recursive parents ty0) ty
+          iter_type_expr
+            (occur_rec env visited allow_recursive parents ty0)
+            (Fun.const ()) ty
         with Occur -> try
           let ty' = try_expand_head try_expand_safe env ty in
           (* This call used to be inlined, but there seems no reason for it.
@@ -3812,7 +3904,8 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
           let parents = TypeSet.add ty parents in
           iter_type_expr_with_stages
             (fun env -> occur_rec env visited allow_recursive parents ty0)
-            env ty
+            env
+            (Fun.const ()) ty
         end
     end;
     ignore (try_mark_node visited ty)
@@ -3882,8 +3975,10 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
           let visited = get_id ty :: visited in
           iter_type_expr_with_stages
             (fun env ->
-              local_non_recursive_abbrev ~allow_rec true visited env p)
-            env ty
+              local_non_recursive_abbrev
+               ~allow_rec true visited env p)
+            env
+            (Fun.const ()) ty
   end
 
 let local_non_recursive_abbrev uenv p ty =
@@ -4007,7 +4102,9 @@ let occur_univar ?(inj_only=false) env ty =
           with Not_found ->
             if not inj_only then List.iter (occur_rec env bound) tl
           end
-      | _ -> iter_type_expr_with_stages (fun env -> occur_rec env bound) env ty
+      | _ ->
+          iter_type_expr_with_stages
+            (fun env -> occur_rec env bound) env (Fun.const ()) ty
   in
   occur_rec env TypeSet.empty ty
   end
@@ -4061,7 +4158,7 @@ let univars_escape env univar_pairs vl ty =
             List.iter (occur env) tl
           end
       | _ ->
-          iter_type_expr_with_stages occur env t
+          iter_type_expr_with_stages occur env (Fun.const ()) t
     end
   in
   occur env ty
@@ -4194,7 +4291,7 @@ let unexpanded_diff ~got ~expected =
 let rec deep_occur_rec mark t0 ty =
   if get_level ty >= get_level t0 && try_mark_node mark ty then begin
     if eq_type ty t0 then raise Occur;
-    iter_type_expr (deep_occur_rec mark t0) ty
+    iter_type_expr (deep_occur_rec mark t0) (Fun.const ()) ty
   end
 
 let deep_occur t0 ty =
@@ -4262,7 +4359,7 @@ let reify uenv t =
           end;
           iter_row iterator r
       | _ ->
-          iter_type_expr iterator ty
+          iter_type_expr iterator (Fun.const ()) ty
     end
   in
   iterator t
@@ -4714,7 +4811,7 @@ let find_lowest_level ty =
       if try_mark_node mark ty then begin
         let level = get_level ty in
         if level < !lowest then lowest := level;
-        iter_type_expr find ty
+        iter_type_expr find (Fun.const ()) ty
       end
     in find ty
   end;
@@ -5791,8 +5888,8 @@ let filter_arrow env t l ~force_tpoly =
       end
     in
     let ty_ret = newvar2 level k_res in
-    let arg_mode = Alloc.newvar () in
-    let ret_mode = Alloc.newvar () in
+    let arg_mode = Alloc.newvar level in
+    let ret_mode = Alloc.newvar level in
     let t' =
       newty2 ~level (Tarrow ((l, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok))
     in
@@ -6229,7 +6326,7 @@ let moregen_occur env level ty =
       let lv = get_level ty in
       if lv <= level then () else
       if is_Tvar ty && lv >= subject_level then raise Occur else
-      if try_mark_node mark ty then iter_type_expr occur ty
+      if try_mark_node mark ty then iter_type_expr occur (Fun.const ()) ty
     in
     try
       occur ty
@@ -6839,7 +6936,7 @@ let rec rigidify_rec mark vars ty =
         if not (static_row row) then
           rigidify_rec mark vars (row_more row)
     | _ ->
-        iter_type_expr (rigidify_rec mark vars) ty
+        iter_type_expr (rigidify_rec mark vars) (Fun.const ()) ty
     end
 
 type var = { name : string option
@@ -7562,13 +7659,13 @@ let find_cltype_for_path env p =
 let has_constr_row' env t =
   has_constr_row (expand_abbrev env t)
 
-let build_submode_pos m =
-  let m', changed = Alloc.newvar_below m in
+let build_submode_pos level m =
+  let m', changed = Alloc.newvar_below level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
-let build_submode_neg m =
-  let m', changed = Alloc.newvar_above m in
+let build_submode_neg level m =
+  let m', changed = Alloc.newvar_above level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
@@ -7601,10 +7698,10 @@ let rec build_subtype env (visited : transient_expr list)
           let posi_arg = not posi in
           if posi_arg then begin
             let a = cross_right_alloc env t1 a in
-            build_submode_pos a
+            build_submode_pos level a
           end else begin
             let a = cross_left_alloc env t1 a in
-            build_submode_neg a
+            build_submode_neg level a
           end
         end else a, Unchanged
       in
@@ -7613,10 +7710,10 @@ let rec build_subtype env (visited : transient_expr list)
           (* As for the argument mode above, pick the smaller type. *)
           if posi then begin
             let r = cross_right_alloc_ret env t2' r in
-            build_submode_pos r
+            build_submode_pos level r
           end else begin
             let r = cross_left_alloc_ret env t2 r in
-            build_submode_neg r
+            build_submode_neg level r
           end
         end else r, Unchanged
       in
@@ -8196,6 +8293,7 @@ let add_nongen_vars_in_schema =
           let (_, unexpanded_candidate) as unexpanded_candidate' =
             fold_type_expr
               (loop env)
+              (fun a _ -> a)
               (visited, weak_set)
               ty
           in
@@ -8227,11 +8325,11 @@ let add_nongen_vars_in_schema =
           then loop env (visited, weak_set) (row_more row)
           else (visited, weak_set)
       | _ ->
-          fold_type_expr (loop env) (visited, weak_set) ty
+          fold_type_expr (loop env) (fun a _ -> a) (visited, weak_set) ty
     end
   in
   fun env acc ty ->
-    remove_mode_and_jkind_variables ty;
+    Alloc.with_zap_scope (remove_mode_and_jkind_variables ty);
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 
@@ -8351,7 +8449,7 @@ let rec normalize_type_rec mark ty =
         set_type_desc fi (get_desc fi')
     | _ -> ()
     end;
-    iter_type_expr (normalize_type_rec mark) ty;
+    iter_type_expr (normalize_type_rec mark) (Fun.const ()) ty;
   end
 
 let normalize_type ty =
@@ -8498,7 +8596,7 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
           (* CR layouts v2.8: This should be done with a proper nondep_jkind.
              Internal ticket 5113. *)
           Tof_kind (Jkind.map_type_expr (nondep_type_rec env ids) jk)
-      | desc -> copy_type_desc (nondep_type_rec env ids) desc
+      | desc -> copy_type_desc (nondep_type_rec env ids) Fun.id desc
     with
     | desc ->
       Transient_expr.set_stub_desc ty' desc;
@@ -8705,7 +8803,8 @@ let rec collapse_conj env visited ty =
         (row_fields row);
       iter_row (collapse_conj env visited) row
   | _ ->
-      iter_type_expr_with_stages (fun env -> collapse_conj env visited) env ty
+      iter_type_expr_with_stages
+        (fun env -> collapse_conj env visited) env (Fun.const ()) ty
 
 let collapse_conj_params env params =
   List.iter (collapse_conj env []) params

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -867,7 +867,8 @@ let close_type ~zap_scope mark ty =
 let closed_parameterized_type params ty =
   with_type_mark begin fun mark ->
     List.iter (mark_type mark) params;
-    try Alloc.with_zap_scope close_type mark ty; true with Non_closed _ -> false
+    try Alloc.with_zap_scope (fun ~zap_scope -> close_type ~zap_scope mark ty);
+    true with Non_closed _ -> false
   end
 
 let closed_type_decl ~zap_scope decl =
@@ -8329,7 +8330,8 @@ let add_nongen_vars_in_schema =
     end
   in
   fun env acc ty ->
-    Alloc.with_zap_scope (remove_mode_and_jkind_variables ty);
+    Alloc.with_zap_scope (fun ~zap_scope ->
+      remove_mode_and_jkind_variables ~zap_scope ty);
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -608,7 +608,8 @@ val remove_mode_and_jkind_variables:
   zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
-val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
+val nongen_vars_in_schema:
+  zap_scope:Alloc.zap_scope -> Env.t -> type_expr -> Btype.TypeSet.t option
         (* Return any non-generic variables in the type scheme.  Also ensures
            mode variables are fully determined. *)
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -38,9 +38,12 @@ val with_local_level_generalize:
     before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 val with_local_level_generalize_if:
         bool -> before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
-val with_local_level_generalize_structure: (unit -> 'a) -> 'a
-val with_local_level_generalize_structure_if: bool -> (unit -> 'a) -> 'a
-val with_local_level_generalize_structure_if_principal: (unit -> 'a) -> 'a
+val with_local_level_generalize_structure:
+    before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
+val with_local_level_generalize_structure_if:
+        bool -> before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
+val with_local_level_generalize_structure_if_principal:
+    before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 val with_local_level_generalize_for_class:
     before_generalize:('a -> unit) -> (unit -> 'a) -> 'a
 
@@ -150,7 +153,8 @@ val filter_row_fields:
 
 val contains_initial_stage_splice: int -> type_expr -> bool
 val iter_type_expr_with_stages:
-        (Env.t -> type_expr -> unit) -> Env.t -> type_expr -> unit
+        (Env.t -> type_expr -> unit) -> Env.t -> (Mode.Alloc.lr -> unit)
+        -> type_expr -> unit
 
 val generalize: type_expr -> unit
 (* Generalize in-place the given type *)
@@ -161,8 +165,13 @@ val lower_variables_only: Env.t -> int -> type_expr -> unit
         (* Lower all variables to the given level *)
 val enforce_current_level: Env.t -> type_expr -> unit
         (* Lower whole type to !current_level *)
+val generalize_structure: type_expr -> unit
+        (* Generalize the structure of a type, lowering variables
+           to !current_level *)
 val generalize_class_signature_spine: class_signature -> unit
        (* Special function to generalize methods during inference *)
+val generalize_class_type_structure: class_type -> unit
+        (* Generalize the structure of a class type *)
 val limited_generalize: type_expr -> inside:type_expr -> unit
         (* Only generalize some part of the type
            Make the remaining of the type non-generalizable *)
@@ -266,7 +275,8 @@ val instance_label_declarations:
 (* Same, but for label declarations and the type parameters from the
    type declaration *)
 val prim_mode :
-        (Mode.allowed * 'r) Mode.Locality.t option -> (Primitive.mode * Primitive.native_repr)
+        (Mode.allowed * 'r) Mode.Locality.t option ->
+        (Primitive.mode * Primitive.native_repr) -> level:int
         -> (Mode.allowed * 'r) Mode.Locality.t
 val instance_prim:
         Env.t ->
@@ -274,6 +284,8 @@ val instance_prim:
         type_expr *
         Mode.Locality.lr option * (Mode.Forkable.lr * Mode.Yielding.lr) option *
         Jkind.Sort.t option
+
+val create_yielding_mode_l : Mode.Yielding.l -> Mode.Yielding.l
 
 (** The join of the yielding modes of the first [arity] parameters of a
     primitive of type [ty]; [Yielding.max] if [ty] has fewer arrows. *)
@@ -283,7 +295,13 @@ val prim_params_yielding:
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)
-val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+val curry_mode_const : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+
+(** Applies the same logic as [curry_mode_const] over
+    the comonadic mode for [m0] and the lr mode [m1] *)
+val curry_mode :
+  (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr ->
+  Alloc.Comonadic.l
 
 val apply:
         ?use_current_level:bool ->
@@ -586,7 +604,8 @@ val nondep_jkind_declaration:
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 
-val remove_mode_and_jkind_variables: type_expr -> unit
+val remove_mode_and_jkind_variables:
+  zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
 val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
@@ -620,10 +639,14 @@ val closed_type_expr: ?env:Env.t -> type_expr -> bool
         (* If env present, expand abbreviations to see if expansion
            eliminates the variable *)
 
-val closed_type_decl: type_declaration -> type_expr option
-val closed_extension_constructor: extension_constructor -> type_expr option
+val closed_type_decl:
+  zap_scope:Alloc.zap_scope ->
+  type_declaration -> type_expr option
+val closed_extension_constructor:
+  zap_scope:Alloc.zap_scope ->
+  extension_constructor -> type_expr option
 val closed_class:
-        type_expr list -> class_signature ->
+        zap_scope:Alloc.zap_scope -> type_expr list -> class_signature ->
         closed_class_failure option
         (* Check whether all type variables are bound *)
 

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -39,7 +39,7 @@ let free_vars ?(param=false) ty =
             end
                 (* XXX: What about Tobject ? *)
         | _ ->
-            iter_type_expr loop ty
+            iter_type_expr loop (Fun.const ()) ty
     in
     loop ty
   end;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3304,7 +3304,7 @@ let enter_unbound_module name reason env =
 let read_signature modname cmi =
   let mty, mode = read_pers_mod modname cmi in
   (* [mode] read from the cmi is always a constant *)
-  Subst.Lazy.force_signature mty, (Mode.Value.zap_to_floor mode).staticity
+  Subst.Lazy.force_signature mty, (Mode.Value.zap_to_floor_exn mode).staticity
 
 let find_import ~chain modname =
   try Persistent_env.find_import !persistent_env modname

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -792,7 +792,8 @@ and try_modtypes ~core ~direction ~loc env subst ~modes
               | Specific ((m, _locks), _) ->
                 Yielding.disallow_right (Value.proj_comonadic Yielding m)
             in
-            Yielding.join (funct_yielding :: param_yielding)
+            Ctype.create_yielding_mode_l
+              (Yielding.join (funct_yielding :: param_yielding))
           in
           Ok
             (Tcoerce_functor(cc_arg, cc_res, application_yielding),

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5486,7 +5486,9 @@ module Comonadic_gen (Obj : Obj) = struct
   let allow_right m = S.allow_right m
 
   let choose_level level =
-    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then level
+    else 0
 
   let newvar level =
     let level = choose_level level in
@@ -5526,11 +5528,9 @@ module Comonadic_gen (Obj : Obj) = struct
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize ~log:None ~current_level obj a
-    else if Language_extension.(is_at_least Mode_polymorphism Beta)
-    then S.generalize_structure ~log:None ~current_level obj a
 
   let generalize_structure ~current_level a =
-    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize_structure ~log:None ~current_level obj a
 
   let instantiate ~copy_scope ~current_level a =
@@ -5679,7 +5679,9 @@ module Monadic_gen (Obj : Obj) = struct
   let allow_right m = S.allow_left m
 
   let choose_level level =
-    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then level
+    else 0
 
   let newvar level =
     let level = choose_level level in
@@ -5717,11 +5719,9 @@ module Monadic_gen (Obj : Obj) = struct
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize ~log:None ~current_level obj a
-    else if Language_extension.(is_at_least Mode_polymorphism Beta)
-    then S.generalize_structure ~log:None ~current_level obj a
 
   let generalize_structure ~current_level a =
-    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize_structure ~log:None ~current_level obj a
 
   let instantiate ~copy_scope ~current_level a =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5526,7 +5526,8 @@ module Comonadic_gen (Obj : Obj) = struct
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize ~log:None ~current_level obj a
-    else S.generalize_structure ~log:None ~current_level obj a
+    else if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then S.generalize_structure ~log:None ~current_level obj a
 
   let generalize_structure ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Beta)
@@ -5718,7 +5719,8 @@ module Monadic_gen (Obj : Obj) = struct
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize ~log:None ~current_level obj a
-    else S.generalize_structure ~log:None ~current_level obj a
+    else if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then S.generalize_structure ~log:None ~current_level obj a
 
   let generalize_structure ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Beta)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5714,7 +5714,7 @@ module Monadic_gen (Obj : Obj) = struct
 
   let generic_level = S.generic_level
 
-  let update_level i a = S.update_level ~log:None i obj a
+  let update_level i a = with_log (S.update_level i obj a)
 
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5547,7 +5547,12 @@ module Comonadic_gen (Obj : Obj) = struct
   let copy_for_saving ~copy_scope a =
     let copy_from_level = 0 in
     let copy_below_level = generic_level + 1 in
-    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~persistent:true obj a
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Save obj a
+
+  let copy_for_restoring ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
   let copy_then_generalize ~copy_scope ~current_level a =
     let copy_from_level = current_level in
@@ -5740,7 +5745,12 @@ module Monadic_gen (Obj : Obj) = struct
   let copy_for_saving ~copy_scope a =
     let copy_from_level = 0 in
     let copy_below_level = generic_level + 1 in
-    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~persistent:true obj a
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Save obj a
+
+  let copy_for_restoring ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
   let copy_then_generalize ~copy_scope ~current_level a =
     let copy_from_level = current_level in
@@ -7169,6 +7179,12 @@ module Value_with (Areality : Areality) = struct
       =
     let monadic1 = Monadic.copy_for_saving ~copy_scope monadic0 in
     let comonadic1 = Comonadic.copy_for_saving ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_for_restoring ~copy_scope
+      { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_for_restoring ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_for_restoring ~copy_scope comonadic0 in
     { monadic = monadic1; comonadic = comonadic1 }
 
   let copy_then_generalize ~copy_scope ~current_level

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -6904,6 +6904,28 @@ module Value_with (Areality : Areality) = struct
 
   let meet_const_morph a = C.Simple (C.Simple_morph.Meet_const a)
 
+  (* only print the interesting parts of the monadic meet; omit max (min due to
+      flipping of Monadic axis) modes *)
+  let monadic_meet_atoms c =
+    let c = merge { monadic = c; comonadic = Comonadic.Const.min } in
+    Const.diff c Const.min
+
+  (* only print the interesting parts of the meet; omit max modes *)
+  let comonadic_meet_atoms c =
+    let c = merge { monadic = Monadic.Const.max; comonadic = c } in
+    Const.diff c Const.max
+
+  let pretty_print_mod : type a.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      Const.Option.t ->
+      unit =
+   fun printm m ppf atoms ->
+    if atoms = Const.Option.none
+    then Fmt.fprintf ppf "%a" printm m
+    else Fmt.fprintf ppf "%a mod %a" printm m Const.Option.partial_print atoms
+
   let pretty_print_monadic_simple_morph : type a d f.
       (Fmt.formatter -> a -> unit) ->
       a ->
@@ -6914,13 +6936,7 @@ module Value_with (Areality : Areality) = struct
     match f with
     | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
     | C.Simple_morph.Meet_const c ->
-      (* only print the interesting parts of the monadic meet; omit max (min due to
-          flipping of Monadic axis) modes *)
-      let c = merge { monadic = c; comonadic = Comonadic.Const.min } in
-      let diff = Const.diff c Const.min in
-      if diff = Const.Option.none
-      then Fmt.fprintf ppf "%a" printm m
-      else Fmt.fprintf ppf "%a . %a" printm m Const.Option.partial_print diff
+      pretty_print_mod printm m ppf (monadic_meet_atoms c)
     | _ ->
       Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_monadic) f printm m
   [@@warning "-4"]
@@ -6937,20 +6953,6 @@ module Value_with (Areality : Areality) = struct
     | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_monadic) f printm m
   [@@warning "-4"]
 
-  let pretty_print_comonadic_meet : type a.
-      (Fmt.formatter -> a -> unit) ->
-      a ->
-      Fmt.formatter ->
-      Comonadic.Const.t ->
-      unit =
-   fun printm m ppf c ->
-    (* only print the interesting parts of the meet; omit max modes *)
-    let c = merge { monadic = Monadic.Const.max; comonadic = c } in
-    let diff = Const.diff c Const.max in
-    if diff = Const.Option.none
-    then Fmt.fprintf ppf "%a" printm m
-    else Fmt.fprintf ppf "%a @@@@ %a" printm m Const.Option.partial_print diff
-
   let pretty_print_comonadic_simple_morph : type a d f.
       (Fmt.formatter -> a -> unit) ->
       a ->
@@ -6960,7 +6962,8 @@ module Value_with (Areality : Areality) = struct
    fun printm m ppf f ->
     match f with
     | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
-    | C.Simple_morph.Meet_const c -> pretty_print_comonadic_meet printm m ppf c
+    | C.Simple_morph.Meet_const c ->
+      pretty_print_mod printm m ppf (comonadic_meet_atoms c)
     | C.Simple_morph.Core C.Core_morph.Monadic_op_to_comonadic_min ->
       Fmt.fprintf ppf "close(%a)" printm m
     | C.Simple_morph.Meet_const_core
@@ -6974,9 +6977,9 @@ module Value_with (Areality : Areality) = struct
           yielding = Yielding.Const.max
         }
       in
-      pretty_print_comonadic_meet
+      pretty_print_mod
         (fun ppf m -> Fmt.fprintf ppf "close(%a)" printm m)
-        m ppf c
+        m ppf (comonadic_meet_atoms c)
     | _ ->
       Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_comonadic) f printm m
   [@@warning "-4"]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5525,6 +5525,10 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let update_level i a = with_log (S.update_level i obj a)
 
+  let generalize_topology ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_topology ~log:None ~current_level a
+
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)
     then S.generalize ~log:None ~current_level obj a
@@ -5715,6 +5719,10 @@ module Monadic_gen (Obj : Obj) = struct
   let generic_level = S.generic_level
 
   let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize_topology ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize_topology ~log:None ~current_level a
 
   let generalize ~current_level a =
     if Language_extension.(is_at_least Mode_polymorphism Alpha)
@@ -7076,6 +7084,11 @@ module Value_with (Areality : Areality) = struct
   let update_level i { monadic = monadic0; comonadic = comonadic0 } =
     Monadic.update_level i monadic0;
     Comonadic.update_level i comonadic0
+
+  let generalize_topology ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_topology ~current_level monadic0;
+    Comonadic.generalize_topology ~current_level comonadic0
 
   let generalize ~current_level { monadic = monadic0; comonadic = comonadic0 } =
     Monadic.generalize ~current_level monadic0;

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4406,6 +4406,8 @@ module S = Solver_mono (Hint_for_solver) (C)
 
 let erase_hints () = S.erase_hints ()
 
+let reset_persistent_id () = S.reset_persistent_id ()
+
 type monadic = C.monadic =
   { uniqueness : C.Uniqueness.t;
     contention : C.Contention.t;
@@ -5313,6 +5315,10 @@ let append_changes : (changes ref -> unit) ref = ref (fun _ -> assert false)
 
 let set_append_changes f = append_changes := f
 
+type copy_scope = S.copy_scope
+
+let with_copy_scope = S.with_copy_scope
+
 type ('a, 'd) mode = ('a, 'd) S.mode
 
 module Error = struct
@@ -5448,6 +5454,10 @@ let equate_from_submode' submode m1 m2 =
     | Ok () -> Ok ())
 [@@inline]
 
+exception Cannot_zap_generic
+
+exception Cannot_get_constant_from_generic
+
 module Comonadic_gen (Obj : Obj) = struct
   open Obj
 
@@ -5475,15 +5485,26 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_right m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.min obj
 
   let max : lr = S.max obj
 
-  let newvar_above m = S.newvar_above obj 0 m
+  let generic_level = S.generic_level
 
-  let newvar_below m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
+
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj a b ~log
@@ -5499,6 +5520,40 @@ module Comonadic_gen (Obj : Obj) = struct
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
   let print_error pp err = Error.print_all pp obj err
+
+  let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+    else S.generalize_structure ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a
+
+  let copy_for_saving ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~persistent:true obj a
+
+  let copy_then_generalize ~copy_scope ~current_level a =
+    let copy_from_level = current_level in
+    let copy_below_level = generic_level in
+    let copy = S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a in
+    S.generalize ~log:None ~current_level obj copy;
+    copy
 
   let join l = S.join obj l
 
@@ -5519,14 +5574,36 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let check_const_or_level_0 m = S.check_const_or_level_0 m
 
-  let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
+  let check_generic a = S.check_generic a
 
-  let zap_to_floor m = with_log (S.zap_to_floor obj m)
+  let iter_covariant a iter = S.iter_covariant obj a iter
+
+  let iter_contravariant a iter = S.iter_contravariant obj a iter
+
+  let zap_to_ceil_force m = with_log (S.zap_to_ceil obj m)
+
+  let zap_to_floor_force m = with_log (S.zap_to_floor obj m)
+
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
 
   let of_const : type l r. ?hint:(l * r) pos Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_generic m then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5552,6 +5629,11 @@ module Comonadic_gen (Obj : Obj) = struct
     let get_loose_floor m = S.get_loose_floor obj m
 
     let get_loose_ceil m = S.get_loose_ceil obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj ceil floor then Some ceil else None
   end
 end
 [@@inline]
@@ -5584,15 +5666,24 @@ module Monadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_left m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.allow_left (S.max obj)
 
   let max : lr = S.allow_right (S.min obj)
 
-  let newvar_above m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
-  let newvar_below m = S.newvar_above obj 0 m
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj b a ~log
@@ -5606,6 +5697,42 @@ module Monadic_gen (Obj : Obj) = struct
     match submode ~pp a b with
     | Ok () -> ()
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
+
+  let generic_level = S.generic_level
+
+  let update_level i a = S.update_level ~log:None i obj a
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+    else S.generalize_structure ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a
+
+  let copy_for_saving ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_below_level = generic_level + 1 in
+    S.copy ~copy_scope ~copy_from_level ~copy_below_level ~persistent:true obj a
+
+  let copy_then_generalize ~copy_scope ~current_level a =
+    let copy_from_level = current_level in
+    let copy_below_level = generic_level in
+    let copy = S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a in
+    S.generalize ~log:None ~current_level obj copy;
+    copy
 
   let print_error pp err = Error.print_all pp obj err
 
@@ -5628,14 +5755,36 @@ module Monadic_gen (Obj : Obj) = struct
 
   let check_const_or_level_0 m = S.check_const_or_level_0 m
 
-  let zap_to_ceil m = with_log (S.zap_to_floor obj m)
+  let check_generic a = S.check_generic a
 
-  let zap_to_floor m = with_log (S.zap_to_ceil obj m)
+  let iter_covariant a iter = S.iter_contravariant obj a iter
+
+  let iter_contravariant a iter = S.iter_covariant obj a iter
+
+  let zap_to_ceil_force m = with_log (S.zap_to_floor obj m)
+
+  let zap_to_floor_force m = with_log (S.zap_to_ceil obj m)
+
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
 
   let of_const : type l r. ?hint:(l * r) neg Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_generic m then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5654,7 +5803,14 @@ module Monadic_gen (Obj : Obj) = struct
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
   module Guts = struct
+    let get_floor m = S.get_ceil obj m
+
     let get_ceil m = S.get_floor obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj ceil floor then Some ceil else None
   end
 end
 [@@inline]
@@ -5676,7 +5832,7 @@ module Locality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 
   module Guts = struct
     let check_const m =
@@ -5710,7 +5866,7 @@ module Regionality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Linearity = struct
@@ -5730,7 +5886,7 @@ module Linearity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Statefulness = struct
@@ -5754,7 +5910,7 @@ module Statefulness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Visibility = struct
@@ -5778,7 +5934,7 @@ module Visibility = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Portability = struct
@@ -5794,16 +5950,17 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_ceil_clamped c m =
+  let zap_to_ceil_clamped_force c m =
     (match submode m (of_const c) with Ok () | Error _ -> ());
-    zap_to_ceil m
+    zap_to_ceil_force m
 
-  let zap_to_legacy ~statefulness m =
+  let zap_to_legacy_force ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful -> zap_to_ceil m
-    | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
-    | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
-    | Statefulness.Const.Stateless -> zap_to_floor m
+    | Statefulness.Const.Stateful -> zap_to_ceil_force m
+    | Statefulness.Const.Reading -> zap_to_ceil_clamped_force Const.Shareable m
+    | Statefulness.Const.Writing ->
+      zap_to_ceil_clamped_force Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor_force m
 end
 
 module Uniqueness = struct
@@ -5823,7 +5980,7 @@ module Uniqueness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Contention = struct
@@ -5839,18 +5996,22 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_floor_clamped c m =
+  let zap_to_floor_clamped_force c m =
     (match submode (of_const c) m with Ok () | Error _ -> ());
-    zap_to_floor m
+    zap_to_floor_force m
 
-  let zap_to_legacy ~visibility ~arg m =
+  let zap_to_legacy_force ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write -> zap_to_floor m
-    | Visibility.Const.Immutable -> zap_to_ceil m
+    | Visibility.Const.Read_write -> zap_to_floor_force m
+    | Visibility.Const.Immutable -> zap_to_ceil_force m
     | Visibility.Const.Read ->
-      if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
+      if arg
+      then zap_to_floor_clamped_force Const.Shared m
+      else zap_to_floor_force m
     | Visibility.Const.Write ->
-      if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
+      if arg
+      then zap_to_floor_clamped_force Const.Corrupted m
+      else zap_to_floor_force m
 end
 
 module Forkable = struct
@@ -5871,9 +6032,9 @@ module Forkable = struct
   let legacy = of_const Const.legacy
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Yielding = struct
@@ -5894,9 +6055,9 @@ module Yielding = struct
   let legacy = of_const Const.legacy
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Staticity = struct
@@ -5916,7 +6077,7 @@ module Staticity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module type Areality = sig
@@ -5924,7 +6085,7 @@ module type Areality = sig
 
   module Obj : Obj with type const = Const.t
 
-  val zap_to_legacy : (Const.t, allowed * 'r) S.mode -> Const.t
+  val zap_to_legacy_force : (Const.t, allowed * 'r) S.mode -> Const.t
 end
 
 module Lattice_Product (L : Lattice) = struct
@@ -6039,16 +6200,18 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy m : Const.t =
-    let areality = proj Areality m |> Areality.zap_to_legacy in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy in
-    let statefulness = proj Statefulness m |> Statefulness.zap_to_legacy in
+  let zap_to_legacy_force m : Const.t =
+    let areality = proj Areality m |> Areality.zap_to_legacy_force in
+    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force in
+    let statefulness =
+      proj Statefulness m |> Statefulness.zap_to_legacy_force
+    in
     let portability =
-      proj Portability m |> Portability.zap_to_legacy ~statefulness
+      proj Portability m |> Portability.zap_to_legacy_force ~statefulness
     in
     let global = Areality.Const.equal areality Areality.Const.legacy in
-    let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
+    let forkable = proj Forkable m |> Forkable.zap_to_legacy_force ~global in
+    let yielding = proj Yielding m |> Yielding.zap_to_legacy_force ~global in
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
@@ -6191,13 +6354,13 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy ~arg m : Const.t =
-    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
-    let visibility = proj Visibility m |> Visibility.zap_to_legacy in
+  let zap_to_legacy_force ~arg m : Const.t =
+    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy_force in
+    let visibility = proj Visibility m |> Visibility.zap_to_legacy_force in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
+      proj Contention m |> Contention.zap_to_legacy_force ~visibility ~arg
     in
-    let staticity = proj Staticity m |> Staticity.zap_to_legacy in
+    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force in
     { uniqueness; contention; visibility; staticity }
 
   let legacy = of_const Const.legacy
@@ -6244,9 +6407,69 @@ type ('mo, 'como) monadic_comonadic =
     comonadic : 'como
   }
 
+module Zap_scope = struct
+  module ModeIdMap = Hashtbl.Make (Int)
+
+  type job = unit -> unit
+
+  type job_list = job list
+
+  type zap_scope =
+    { zap_to_floor_map : job_list ModeIdMap.t;
+      zap_to_ceil_map : job_list ModeIdMap.t;
+      zap_to_legacy_map : job ModeIdMap.t
+    }
+
+  let create () =
+    { zap_to_floor_map = ModeIdMap.create 17;
+      zap_to_ceil_map = ModeIdMap.create 17;
+      zap_to_legacy_map = ModeIdMap.create 17
+    }
+
+  let add_job_to_map map i job =
+    match ModeIdMap.find_opt map i with
+    | Some jobs -> ModeIdMap.replace map i (job :: jobs)
+    | None -> ModeIdMap.add map i [job]
+
+  let add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy zs =
+    if ModeIdMap.mem zs.zap_to_legacy_map i
+    then ()
+    else
+      begin if ModeIdMap.mem zs.zap_to_ceil_map i
+      then begin
+        ModeIdMap.remove zs.zap_to_ceil_map i;
+        ModeIdMap.add zs.zap_to_legacy_map i zap_to_legacy
+      end
+      else add_job_to_map zs.zap_to_floor_map i zap_to_floor
+      end
+
+  let add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy zs =
+    if ModeIdMap.mem zs.zap_to_legacy_map i
+    then ()
+    else
+      begin if ModeIdMap.mem zs.zap_to_floor_map i
+      then begin
+        ModeIdMap.remove zs.zap_to_floor_map i;
+        ModeIdMap.add zs.zap_to_legacy_map i zap_to_legacy
+      end
+      else add_job_to_map zs.zap_to_ceil_map i zap_to_ceil
+      end
+
+  let resolve_zap_scope { zap_to_floor_map; zap_to_ceil_map; zap_to_legacy_map }
+      =
+    ModeIdMap.iter (fun _ f -> f ()) zap_to_legacy_map;
+    ModeIdMap.iter
+      (fun _ jobs -> List.iter (fun f -> f ()) jobs)
+      zap_to_floor_map;
+    ModeIdMap.iter
+      (fun _ jobs -> List.iter (fun f -> f ()) jobs)
+      zap_to_ceil_map
+end
+
 module Value_with (Areality : Areality) = struct
   module Comonadic = Comonadic_with (Areality)
   module Monadic = Monadic
+  module Z = Zap_scope
 
   type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
 
@@ -6569,6 +6792,40 @@ module Value_with (Areality : Areality) = struct
           visibility
           (option_print Staticity.Const.print)
           staticity
+
+      let partial_print ppf
+          { areality;
+            uniqueness;
+            linearity;
+            portability;
+            contention;
+            forkable;
+            yielding;
+            statefulness;
+            visibility;
+            staticity
+          } =
+        let option_to_string print a =
+          Option.map (fun a -> Fmt.asprintf "%a" print a) a
+        in
+        let l =
+          [ option_to_string Areality.Const.print areality;
+            option_to_string Linearity.Const.print linearity;
+            option_to_string Uniqueness.Const.print uniqueness;
+            option_to_string Portability.Const.print portability;
+            option_to_string Contention.Const.print contention;
+            option_to_string Forkable.Const.print forkable;
+            option_to_string Yielding.Const.print yielding;
+            option_to_string Statefulness.Const.print statefulness;
+            option_to_string Visibility.Const.print visibility;
+            option_to_string Staticity.Const.print staticity ]
+        in
+        let l = List.filter_map Fun.id l in
+        Fmt.fprintf ppf "%a"
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf " ")
+             (fun ppf s -> Fmt.fprintf ppf "%s" s))
+          l
     end
 
     let diff m1 m2 =
@@ -6650,6 +6907,8 @@ module Value_with (Areality : Areality) = struct
 
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
 
+  let generic_level = Comonadic.generic_level
+
   include Magic_allow_disallow (struct
     type (_, _, 'd) sided = 'd t
 
@@ -6674,19 +6933,19 @@ module Value_with (Areality : Areality) = struct
       { monadic; comonadic }
   end)
 
-  let newvar () =
-    let comonadic = Comonadic.newvar () in
-    let monadic = Monadic.newvar () in
+  let newvar level =
+    let comonadic = Comonadic.newvar level in
+    let monadic = Monadic.newvar level in
     { comonadic; monadic }
 
-  let newvar_above { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_above comonadic in
-    let monadic, b2 = Monadic.newvar_above monadic in
+  let newvar_above level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_above level comonadic in
+    let monadic, b2 = Monadic.newvar_above level monadic in
     { monadic; comonadic }, b1 || b2
 
-  let newvar_below { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_below comonadic in
-    let monadic, b2 = Monadic.newvar_below monadic in
+  let newvar_below level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_below level comonadic in
+    let monadic, b2 = Monadic.newvar_below level monadic in
     { monadic; comonadic }, b1 || b2
 
   type atom = Atom : 'a Axis.t * 'a -> atom
@@ -6732,6 +6991,55 @@ module Value_with (Areality : Areality) = struct
   let submode_err pp a b =
     Comonadic.submode_err pp a.comonadic b.comonadic;
     Monadic.submode_err pp a.monadic b.monadic
+
+  let update_level i { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.update_level i monadic0;
+    Comonadic.update_level i comonadic0
+
+  let generalize ~current_level { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize ~current_level monadic0;
+    Comonadic.generalize ~current_level comonadic0
+
+  let generalize_structure ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_structure ~current_level monadic0;
+    Comonadic.generalize_structure ~current_level comonadic0
+
+  let instantiate ~copy_scope ~current_level
+      ({ monadic = monadic0; comonadic = comonadic0 } as m) =
+    let monadic1 = Monadic.instantiate ~copy_scope ~current_level monadic0 in
+    let comonadic1 =
+      Comonadic.instantiate ~copy_scope ~current_level comonadic0
+    in
+    if monadic1 == monadic0 && comonadic1 == comonadic0
+    then m
+    else { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_generic ~copy_scope { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_generic ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_generic ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_for_saving ~copy_scope { monadic = monadic0; comonadic = comonadic0 }
+      =
+    let monadic1 = Monadic.copy_for_saving ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_for_saving ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_then_generalize ~copy_scope ~current_level
+      ({ monadic = monadic0; comonadic = comonadic0 } as m) =
+    let monadic1 =
+      Monadic.copy_then_generalize ~copy_scope ~current_level monadic0
+    in
+    let comonadic1 =
+      Comonadic.copy_then_generalize ~copy_scope ~current_level comonadic0
+    in
+    if monadic1 == monadic0 && comonadic1 == comonadic0
+    then m
+    else { monadic = monadic1; comonadic = comonadic1 }
+
+  let check_generic { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_generic monadic0 || Comonadic.check_generic comonadic0
 
   let equate_err pp a b =
     Comonadic.equate_err pp a.comonadic b.comonadic;
@@ -6828,20 +7136,131 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
-  let zap_to_ceil { comonadic; monadic } =
-    let monadic = Monadic.zap_to_ceil monadic in
-    let comonadic = Comonadic.zap_to_ceil comonadic in
+  let zap_to_ceil_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_ceil_force monadic in
+    let comonadic = Comonadic.zap_to_ceil_force comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_floor { comonadic; monadic } =
-    let monadic = Monadic.zap_to_floor monadic in
-    let comonadic = Comonadic.zap_to_floor comonadic in
+  let zap_to_floor_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_floor_force monadic in
+    let comonadic = Comonadic.zap_to_floor_force comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_legacy ~arg { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy ~arg monadic in
-    let comonadic = Comonadic.zap_to_legacy comonadic in
+  let zap_to_ceil_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_generic m then None else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_generic m then None else Some (zap_to_ceil_force m)
+
+  let zap_to_legacy_force ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ~arg monadic in
+    let comonadic = Comonadic.zap_to_legacy_force comonadic in
     merge { monadic; comonadic }
+
+  let zap_to_legacy_exn ~arg m =
+    if check_generic m then raise Cannot_zap_generic;
+    zap_to_legacy_force ~arg m
+
+  let zap_to_legacy ~arg m =
+    if check_generic m then None else Some (zap_to_legacy_force ~arg m)
+
+  type zap_scope =
+    { variables : Z.zap_scope;
+      visible : (bool * (allowed * allowed) t) list ref
+    }
+
+  let zap_to_legacy_obj : type a.
+      a C.obj -> (a, allowed * allowed) S.mode -> unit =
+   fun obj mode ->
+    match (obj : a C.obj) with
+    | Locality -> Locality.zap_to_legacy_force mode |> ignore
+    | Regionality -> Regionality.zap_to_legacy_force mode |> ignore
+    | Uniqueness_op -> Uniqueness.zap_to_legacy_force mode |> ignore
+    | Visibility_op -> Visibility.zap_to_legacy_force mode |> ignore
+    | Linearity -> Linearity.zap_to_legacy_force mode |> ignore
+    | Statefulness -> Statefulness.zap_to_legacy_force mode |> ignore
+    | Staticity_op -> Staticity.zap_to_legacy_force mode |> ignore
+    | Monadic_op -> Monadic.zap_to_legacy_force ~arg:false mode |> ignore
+    | Comonadic_with_regionality ->
+      let module M = Comonadic_with (Regionality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_locality ->
+      let module M = Comonadic_with (Locality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Portability ->
+      Portability.zap_to_legacy_force ~statefulness:Statefulness.Const.legacy
+        mode
+      |> ignore
+    | Contention_op ->
+      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy
+        ~arg:false mode
+      |> ignore
+    | Forkable -> Forkable.zap_to_legacy_force ~global:true mode |> ignore
+    | Yielding -> Yielding.zap_to_legacy_force ~global:true mode |> ignore
+
+  let zap_to_legacy_src_var_monadic m =
+    S.mode_iter Monadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  let zap_to_legacy_src_var_comonadic m =
+    S.mode_iter Comonadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  let add_covariant_to_zap_scope { monadic; comonadic } scope =
+    Monadic.iter_covariant monadic (fun i m ->
+        let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+        Z.add_zap_to_ceil_to_zap_scope i zap_to_floor zap_to_legacy scope);
+    Comonadic.iter_covariant comonadic (fun i m ->
+        let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+        Z.add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy scope)
+
+  let add_contravariant_to_zap_scope { monadic; comonadic } scope =
+    Monadic.iter_contravariant monadic (fun i m ->
+        let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+        Z.add_zap_to_floor_to_zap_scope i zap_to_ceil zap_to_legacy scope);
+    Comonadic.iter_contravariant comonadic (fun i m ->
+        let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+        Z.add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy scope)
+
+  let add_mode_to_zap_scope ~arg m { variables; visible } =
+    if check_generic m
+    then begin
+      add_covariant_to_zap_scope m variables;
+      add_contravariant_to_zap_scope m variables
+    end;
+    visible := (arg, m) :: !visible
+
+  let resolve_zap_scope { variables; visible } =
+    (* we first zap all visible non generic modes to legacy *)
+    List.iter (fun (arg, m) -> zap_to_legacy ~arg m |> ignore) !visible;
+    (* we then iterate over the children of visible generic modes and zap level 0
+    according to the following rules:
+    1) if a mode appears only as an upper bound to generic modes, it is zapped to
+      ceiling
+    2) if a mode appears only as a lower bound to generic modes, it is zapped to
+      floor
+    3) if it appears as both, it is zapped to legacy *)
+    Z.resolve_zap_scope variables
+
+  let create_zap_scope () = { variables = Z.create (); visible = ref [] }
+
+  let with_zap_scope f =
+    let zap_scope = create_zap_scope () in
+    let res = f ~zap_scope in
+    resolve_zap_scope zap_scope;
+    res
 
   (** This is about partially applying [A -> B -> C] to [A] and getting
       [B -> C]. [comonadic] and [monadic] constutute the mode of [A], and we
@@ -6881,6 +7300,14 @@ module Value_with (Areality : Areality) = struct
 
       let disallow_right l = List.map disallow_right l
     end)
+  end
+
+  module Guts = struct
+    let check_const { monadic; comonadic } =
+      let open Misc.Stdlib.Monad.Option.Syntax in
+      let* monadic = Monadic.Guts.check_const monadic in
+      let* comonadic = Comonadic.Guts.check_const comonadic in
+      Some (merge { comonadic; monadic })
   end
 end
 [@@inline]
@@ -7152,6 +7579,15 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
+    let update_level : int -> t -> unit =
+     fun n m ->
+      match m with
+      | Const _c -> ()
+      | Diff (mm, m) ->
+        Mode.update_level n mm;
+        Mode.update_level n m
+      | Undefined -> ()
+
     let apply_left : type r.
         ?is_contained_by:Hint.is_contained_by ->
         t ->
@@ -7182,7 +7618,7 @@ module Modality = struct
            [mm] to construct the floor of [c]. *)
         let cc = Mode.Guts.get_ceil mm in
         let c = Mode.subtract_const cc m in
-        let c = Mode.zap_to_floor c in
+        let c = Mode.zap_to_floor_exn c in
         (* Note that we did not mutate [mm] but simply took its ceil, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7331,6 +7767,15 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
+    let update_level : int -> t -> unit =
+     fun n m ->
+      match m with
+      | Const _c -> ()
+      | Undefined -> ()
+      | Exactly (mm, m) ->
+        Mode.update_level n mm;
+        Mode.update_level n m
+
     let apply_left : type r.
         ?is_contained_by:Hint.is_contained_by ->
         t ->
@@ -7370,7 +7815,7 @@ module Modality = struct
            construct the ceil of [c]. *)
         let cc = Mode.Guts.get_floor mm in
         let c = Mode.imply_const cc m in
-        let c = Mode.zap_to_ceil c in
+        let c = Mode.zap_to_ceil_exn c in
         (* Note that we did not mutate [mm] but simply took its floor, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7395,8 +7840,8 @@ module Modality = struct
            good workaround. *)
         (* CR zqian: Find a better solution *)
         Mode.submode mm Mode.legacy |> ignore;
-        let m = Mode.zap_to_floor m in
-        let mm = Mode.zap_to_ceil mm in
+        let m = Mode.zap_to_floor_exn m in
+        let mm = Mode.zap_to_ceil_exn mm in
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 
@@ -7556,6 +8001,10 @@ module Modality = struct
       | Error (Error (ax, e)) -> Error (Error (Comonadic ax, e)))
 
   let sub l r = try_with_log (sub_log l r)
+
+  let update_level n ({ monadic; comonadic } : t) =
+    Monadic.update_level n monadic;
+    Comonadic.update_level n comonadic
 
   let equate m1 m2 = try_with_log (equate_from_submode sub_log m1 m2)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5554,13 +5554,6 @@ module Comonadic_gen (Obj : Obj) = struct
     let copy_below_level = generic_level + 1 in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
 
-  let copy_then_generalize ~copy_scope ~current_level a =
-    let copy_from_level = current_level in
-    let copy_below_level = generic_level in
-    let copy = S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a in
-    S.generalize ~log:None ~current_level obj copy;
-    copy
-
   let join l = S.join obj l
 
   let meet l = S.meet obj l
@@ -5751,13 +5744,6 @@ module Monadic_gen (Obj : Obj) = struct
     let copy_from_level = 0 in
     let copy_below_level = generic_level + 1 in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~cause:`Restore obj a
-
-  let copy_then_generalize ~copy_scope ~current_level a =
-    let copy_from_level = current_level in
-    let copy_below_level = generic_level in
-    let copy = S.copy ~copy_scope ~copy_from_level ~copy_below_level obj a in
-    S.generalize ~log:None ~current_level obj copy;
-    copy
 
   let print_error pp err = Error.print_all pp obj err
 
@@ -7126,18 +7112,6 @@ module Value_with (Areality : Areality) = struct
     let monadic1 = Monadic.copy_for_restoring ~copy_scope monadic0 in
     let comonadic1 = Comonadic.copy_for_restoring ~copy_scope comonadic0 in
     { monadic = monadic1; comonadic = comonadic1 }
-
-  let copy_then_generalize ~copy_scope ~current_level
-      ({ monadic = monadic0; comonadic = comonadic0 } as m) =
-    let monadic1 =
-      Monadic.copy_then_generalize ~copy_scope ~current_level monadic0
-    in
-    let comonadic1 =
-      Comonadic.copy_then_generalize ~copy_scope ~current_level comonadic0
-    in
-    if monadic1 == monadic0 && comonadic1 == comonadic0
-    then m
-    else { monadic = monadic1; comonadic = comonadic1 }
 
   let check_generic { monadic = monadic0; comonadic = comonadic0 } =
     Monadic.check_generic monadic0 || Comonadic.check_generic comonadic0

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5837,12 +5837,12 @@ module Monadic_gen (Obj : Obj) = struct
     let check_const m =
       let floor = get_floor m in
       let ceil = get_ceil m in
-      if C.le obj ceil floor then Some ceil else None
+      if C.le obj floor ceil then Some ceil else None
 
     let in_bounds c m =
       let floor = get_floor m in
       let ceil = get_ceil m in
-      C.le obj floor c && C.le obj c ceil
+      C.le obj c floor && C.le obj ceil c
   end
 end
 [@@inline]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7215,32 +7215,50 @@ module Value_with (Areality : Areality) = struct
       { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
 
   let add_covariant_to_zap_scope { monadic; comonadic } scope =
-    Monadic.iter_covariant monadic (fun i m ->
-        let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
-        Z.add_zap_to_ceil_to_zap_scope i zap_to_floor zap_to_legacy scope);
-    Comonadic.iter_covariant comonadic (fun i m ->
-        let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
-        Z.add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy scope)
+    let comonadic_upper =
+      Comonadic.Guts.get_floor comonadic |> Comonadic.of_const
+    in
+    let monadic_upper = Monadic.Guts.get_floor monadic |> Monadic.of_const in
+    Monadic.iter_covariant monadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+          let m = Monadic.join [monadic_upper; m] in
+          let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
+          Z.add_zap_to_ceil_to_zap_scope id zap_to_floor zap_to_legacy scope
+        end);
+    Comonadic.iter_covariant comonadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+          let m = Comonadic.join [comonadic_upper; m] in
+          let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
+          Z.add_zap_to_floor_to_zap_scope id zap_to_floor zap_to_legacy scope
+        end)
 
   let add_contravariant_to_zap_scope { monadic; comonadic } scope =
-    Monadic.iter_contravariant monadic (fun i m ->
-        let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
-        Z.add_zap_to_floor_to_zap_scope i zap_to_ceil zap_to_legacy scope);
-    Comonadic.iter_contravariant comonadic (fun i m ->
-        let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
-        Z.add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy scope)
+    let comonadic_upper =
+      Comonadic.Guts.get_ceil comonadic |> Comonadic.of_const
+    in
+    let monadic_lower = Monadic.Guts.get_ceil monadic |> Monadic.of_const in
+    Monadic.iter_contravariant monadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+          let m = Monadic.meet [monadic_lower; m] in
+          let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
+          Z.add_zap_to_floor_to_zap_scope id zap_to_ceil zap_to_legacy scope
+        end);
+    Comonadic.iter_contravariant comonadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+          let m = Comonadic.meet [comonadic_upper; m] in
+          let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
+          Z.add_zap_to_ceil_to_zap_scope id zap_to_ceil zap_to_legacy scope
+        end)
 
-  let add_mode_to_zap_scope ~arg m { variables; visible } =
-    if check_generic m
-    then begin
-      add_covariant_to_zap_scope m variables;
-      add_contravariant_to_zap_scope m variables
-    end;
-    visible := (arg, m) :: !visible
+  let add_mode_to_zap_scope ~arg m { visible } = visible := (arg, m) :: !visible
 
   let resolve_zap_scope { variables; visible } =
     (* we first zap all visible non generic modes to legacy *)
@@ -7252,6 +7270,14 @@ module Value_with (Areality : Areality) = struct
     2) if a mode appears only as a lower bound to generic modes, it is zapped to
       floor
     3) if it appears as both, it is zapped to legacy *)
+    List.iter
+      (fun (_, m) ->
+        if check_generic m
+        then begin
+          add_covariant_to_zap_scope m variables;
+          add_contravariant_to_zap_scope m variables
+        end)
+      !visible;
     Z.resolve_zap_scope variables
 
   let create_zap_scope () = { variables = Z.create (); visible = ref [] }

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5580,9 +5580,15 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let iter_contravariant a iter = S.iter_contravariant obj a iter
 
-  let zap_to_ceil_force m = with_log (S.zap_to_ceil obj m)
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
 
-  let zap_to_floor_force m = with_log (S.zap_to_floor obj m)
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
 
   let zap_to_ceil_exn m =
     if check_generic m then raise Cannot_zap_generic;
@@ -5621,6 +5627,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
     let get_floor m = S.get_floor obj m
 
@@ -5634,6 +5642,11 @@ module Comonadic_gen (Obj : Obj) = struct
       let floor = get_floor m in
       let ceil = get_ceil m in
       if C.le obj ceil floor then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj floor c && C.le obj c ceil
   end
 end
 [@@inline]
@@ -5761,9 +5774,15 @@ module Monadic_gen (Obj : Obj) = struct
 
   let iter_contravariant a iter = S.iter_covariant obj a iter
 
-  let zap_to_ceil_force m = with_log (S.zap_to_floor obj m)
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
 
-  let zap_to_floor_force m = with_log (S.zap_to_ceil obj m)
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
 
   let zap_to_ceil_exn m =
     if check_generic m then raise Cannot_zap_generic;
@@ -5802,6 +5821,8 @@ module Monadic_gen (Obj : Obj) = struct
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
     let get_floor m = S.get_ceil obj m
 
@@ -5811,6 +5832,11 @@ module Monadic_gen (Obj : Obj) = struct
       let floor = get_floor m in
       let ceil = get_ceil m in
       if C.le obj ceil floor then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj floor c && C.le obj c ceil
   end
 end
 [@@inline]
@@ -5950,17 +5976,18 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_ceil_clamped_force c m =
+  let zap_to_ceil_clamped_force ?commit c m =
     (match submode m (of_const c) with Ok () | Error _ -> ());
-    zap_to_ceil_force m
+    zap_to_ceil_force ?commit m
 
-  let zap_to_legacy_force ~statefulness m =
+  let zap_to_legacy_force ?commit ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful -> zap_to_ceil_force m
-    | Statefulness.Const.Reading -> zap_to_ceil_clamped_force Const.Shareable m
+    | Statefulness.Const.Stateful -> zap_to_ceil_force ?commit m
+    | Statefulness.Const.Reading ->
+      zap_to_ceil_clamped_force ?commit Const.Shareable m
     | Statefulness.Const.Writing ->
-      zap_to_ceil_clamped_force Const.Corruptible m
-    | Statefulness.Const.Stateless -> zap_to_floor_force m
+      zap_to_ceil_clamped_force ?commit Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor_force ?commit m
 end
 
 module Uniqueness = struct
@@ -5996,22 +6023,22 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_floor_clamped_force c m =
+  let zap_to_floor_clamped_force ?commit c m =
     (match submode (of_const c) m with Ok () | Error _ -> ());
-    zap_to_floor_force m
+    zap_to_floor_force ?commit m
 
-  let zap_to_legacy_force ~visibility ~arg m =
+  let zap_to_legacy_force ?commit ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write -> zap_to_floor_force m
-    | Visibility.Const.Immutable -> zap_to_ceil_force m
+    | Visibility.Const.Read_write -> zap_to_floor_force ?commit m
+    | Visibility.Const.Immutable -> zap_to_ceil_force ?commit m
     | Visibility.Const.Read ->
       if arg
-      then zap_to_floor_clamped_force Const.Shared m
-      else zap_to_floor_force m
+      then zap_to_floor_clamped_force ?commit Const.Shared m
+      else zap_to_floor_force ?commit m
     | Visibility.Const.Write ->
       if arg
-      then zap_to_floor_clamped_force Const.Corrupted m
-      else zap_to_floor_force m
+      then zap_to_floor_clamped_force ?commit Const.Corrupted m
+      else zap_to_floor_force ?commit m
 end
 
 module Forkable = struct
@@ -6033,8 +6060,10 @@ module Forkable = struct
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
      or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
-  let zap_to_legacy_force ~global =
-    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
+  let zap_to_legacy_force ?commit ~global =
+    match global with
+    | true -> zap_to_floor_force ?commit
+    | false -> zap_to_ceil_force ?commit
 end
 
 module Yielding = struct
@@ -6056,8 +6085,10 @@ module Yielding = struct
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
      or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
-  let zap_to_legacy_force ~global =
-    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
+  let zap_to_legacy_force ?commit ~global =
+    match global with
+    | true -> zap_to_floor_force ?commit
+    | false -> zap_to_ceil_force ?commit
 end
 
 module Staticity = struct
@@ -6085,7 +6116,8 @@ module type Areality = sig
 
   module Obj : Obj with type const = Const.t
 
-  val zap_to_legacy_force : (Const.t, allowed * 'r) S.mode -> Const.t
+  val zap_to_legacy_force :
+    ?commit:bool -> (Const.t, allowed * 'r) S.mode -> Const.t
 end
 
 module Lattice_Product (L : Lattice) = struct
@@ -6200,18 +6232,23 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy_force m : Const.t =
-    let areality = proj Areality m |> Areality.zap_to_legacy_force in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force in
+  let zap_to_legacy_force ?commit m : Const.t =
+    let areality = proj Areality m |> Areality.zap_to_legacy_force ?commit in
+    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force ?commit in
     let statefulness =
-      proj Statefulness m |> Statefulness.zap_to_legacy_force
+      proj Statefulness m |> Statefulness.zap_to_legacy_force ?commit
     in
     let portability =
-      proj Portability m |> Portability.zap_to_legacy_force ~statefulness
+      proj Portability m
+      |> Portability.zap_to_legacy_force ?commit ~statefulness
     in
     let global = Areality.Const.equal areality Areality.Const.legacy in
-    let forkable = proj Forkable m |> Forkable.zap_to_legacy_force ~global in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy_force ~global in
+    let forkable =
+      proj Forkable m |> Forkable.zap_to_legacy_force ?commit ~global
+    in
+    let yielding =
+      proj Yielding m |> Yielding.zap_to_legacy_force ?commit ~global
+    in
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
@@ -6354,13 +6391,17 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy_force ~arg m : Const.t =
-    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy_force in
-    let visibility = proj Visibility m |> Visibility.zap_to_legacy_force in
-    let contention =
-      proj Contention m |> Contention.zap_to_legacy_force ~visibility ~arg
+  let zap_to_legacy_force ?commit ~arg m : Const.t =
+    let uniqueness =
+      proj Uniqueness m |> Uniqueness.zap_to_legacy_force ?commit
     in
-    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force in
+    let visibility =
+      proj Visibility m |> Visibility.zap_to_legacy_force ?commit
+    in
+    let contention =
+      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility ~arg
+    in
+    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }
 
   let legacy = of_const Const.legacy
@@ -6903,6 +6944,108 @@ module Value_with (Areality : Areality) = struct
     let merge = merge
   end
 
+  module C = C
+  module Desc = S.Desc
+
+  let obj_monadic = Monadic.Obj.obj
+
+  let obj_comonadic = Comonadic.Obj.obj
+
+  let get_monadic_desc m = Monadic.desc m
+
+  let get_comonadic_desc m = Comonadic.desc m
+
+  let meet_const_morph a = C.Simple (C.Simple_morph.Meet_const a)
+
+  let pretty_print_monadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c ->
+      (* only print the interesting parts of the monadic meet; omit max (min due to
+          flipping of Monadic axis) modes *)
+      let c = merge { monadic = c; comonadic = Comonadic.Const.min } in
+      let diff = Const.diff c Const.min in
+      if diff = Const.Option.none
+      then Fmt.fprintf ppf "%a" printm m
+      else Fmt.fprintf ppf "%a . %a" printm m Const.Option.partial_print diff
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_monadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_monadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_meet : type a.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      Comonadic.Const.t ->
+      unit =
+   fun printm m ppf c ->
+    (* only print the interesting parts of the meet; omit max modes *)
+    let c = merge { monadic = Monadic.Const.max; comonadic = c } in
+    let diff = Const.diff c Const.max in
+    if diff = Const.Option.none
+    then Fmt.fprintf ppf "%a" printm m
+    else Fmt.fprintf ppf "%a @@@@ %a" printm m Const.Option.partial_print diff
+
+  let pretty_print_comonadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c -> pretty_print_comonadic_meet printm m ppf c
+    | C.Simple_morph.Core C.Core_morph.Monadic_op_to_comonadic_min ->
+      Fmt.fprintf ppf "close(%a)" printm m
+    | C.Simple_morph.Meet_const_core
+        (c, C.Core_morph.Monadic_op_to_comonadic_min) ->
+      (* since the meet is applied to a monadic_to_comonadic_min, we filter out the
+      comonadic only axes *)
+      let c : Comonadic.Const.t =
+        { c with
+          areality = Areality.Const.max;
+          forkable = Forkable.Const.max;
+          yielding = Yielding.Const.max
+        }
+      in
+      pretty_print_comonadic_meet
+        (fun ppf m -> Fmt.fprintf ppf "close(%a)" printm m)
+        m ppf c
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_comonadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_comonadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_comonadic) f printm m
+  [@@warning "-4"]
+
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
@@ -7160,9 +7303,9 @@ module Value_with (Areality : Areality) = struct
   let zap_to_ceil m =
     if check_generic m then None else Some (zap_to_ceil_force m)
 
-  let zap_to_legacy_force ~arg { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy_force ~arg monadic in
-    let comonadic = Comonadic.zap_to_legacy_force comonadic in
+  let zap_to_legacy_force ?commit ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ?commit ~arg monadic in
+    let comonadic = Comonadic.zap_to_legacy_force ?commit comonadic in
     merge { monadic; comonadic }
 
   let zap_to_legacy_exn ~arg m =
@@ -7334,6 +7477,22 @@ module Value_with (Areality : Areality) = struct
       let* monadic = Monadic.Guts.check_const monadic in
       let* comonadic = Comonadic.Guts.check_const comonadic in
       Some (merge { comonadic; monadic })
+
+    let get_legacy ~arg { monadic; comonadic } =
+      let monadic = Monadic.zap_to_legacy_force ~commit:false ~arg monadic in
+      let comonadic = Comonadic.zap_to_legacy_force ~commit:false comonadic in
+      merge { monadic; comonadic }
+
+    let get_ceil { monadic; comonadic } =
+      let monadic = Monadic.Guts.get_ceil monadic in
+      let comonadic = Comonadic.Guts.get_ceil comonadic in
+      merge { monadic; comonadic }
+
+    let in_bounds c { monadic; comonadic } =
+      let c = split c in
+      let monadic = Monadic.Guts.in_bounds c.monadic monadic in
+      let comonadic = Comonadic.Guts.in_bounds c.comonadic comonadic in
+      monadic && comonadic
   end
 end
 [@@inline]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7800,15 +7800,6 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
-    let update_level : int -> t -> unit =
-     fun n m ->
-      match m with
-      | Const _c -> ()
-      | Diff (mm, m) ->
-        Mode.update_level n mm;
-        Mode.update_level n m
-      | Undefined -> ()
-
     let apply_left : type r.
         ?is_contained_by:Hint.is_contained_by ->
         t ->
@@ -7987,15 +7978,6 @@ module Modality = struct
           "inferred modaltiy Exactly should not be on the RHS of sub."
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
-
-    let update_level : int -> t -> unit =
-     fun n m ->
-      match m with
-      | Const _c -> ()
-      | Undefined -> ()
-      | Exactly (mm, m) ->
-        Mode.update_level n mm;
-        Mode.update_level n m
 
     let apply_left : type r.
         ?is_contained_by:Hint.is_contained_by ->
@@ -8222,10 +8204,6 @@ module Modality = struct
       | Error (Error (ax, e)) -> Error (Error (Comonadic ax, e)))
 
   let sub l r = try_with_log (sub_log l r)
-
-  let update_level n ({ monadic; comonadic } : t) =
-    Monadic.update_level n monadic;
-    Comonadic.update_level n comonadic
 
   let equate m1 m2 = try_with_log (equate_from_submode sub_log m1 m2)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7327,9 +7327,30 @@ module Value_with (Areality : Areality) = struct
       | Pco m -> Pco (Comonadic.disallow_right m)
       | Pmon m -> Pmon (Monadic.disallow_right m)
 
+    type packed_morph =
+      | Pmorph_mon : ('a, Monadic.Obj.const, 'd) C.morph -> packed_morph
+      | Pmorph_co : ('a, Comonadic.Obj.const, 'd) C.morph -> packed_morph
+
+    let morph_key_mon (S.Packed_morph f) = Pmorph_mon f
+
+    let morph_key_co (S.Packed_morph f) = Pmorph_co f
+
+    module MorphMap = Map.Make (struct
+      type t = packed_morph
+
+      let compare k1 k2 =
+        match k1, k2 with
+        | Pmorph_mon m1, Pmorph_mon m2 -> C.compare_morph Monadic.Obj.obj m1 m2
+        | Pmorph_co m1, Pmorph_co m2 -> C.compare_morph Comonadic.Obj.obj m1 m2
+        | Pmorph_mon _, Pmorph_co _ -> -1
+        | Pmorph_co _, Pmorph_mon _ -> 1
+    end)
+
     type zap_scope =
-      { zap_to_floor_map : (allowed * disallowed) packed_mode list ModeIdMap.t;
-        zap_to_ceil_map : (disallowed * allowed) packed_mode list ModeIdMap.t;
+      { zap_to_floor_map :
+          (allowed * disallowed) packed_mode MorphMap.t ModeIdMap.t;
+        zap_to_ceil_map :
+          (disallowed * allowed) packed_mode MorphMap.t ModeIdMap.t;
         zap_to_legacy_map : (disallowed * disallowed) packed_mode ModeIdMap.t
       }
 
@@ -7339,12 +7360,15 @@ module Value_with (Areality : Areality) = struct
         zap_to_legacy_map = ModeIdMap.create 17
       }
 
-    let add_packed_to_map map i p =
-      match ModeIdMap.find_opt map i with
-      | Some ps -> ModeIdMap.replace map i (p :: ps)
-      | None -> ModeIdMap.add map i [p]
+    let add_to_morph_map map id morph mode =
+      let morphs =
+        match ModeIdMap.find_opt map id with
+        | Some morphs -> morphs
+        | None -> MorphMap.empty
+      in
+      ModeIdMap.replace map id (MorphMap.add morph mode morphs)
 
-    let add_zap_to_floor_to_zap_scope i p zs =
+    let add_zap_to_floor_to_zap_scope i k p zs =
       if ModeIdMap.mem zs.zap_to_legacy_map i
       then ()
       else
@@ -7353,10 +7377,10 @@ module Value_with (Areality : Areality) = struct
           ModeIdMap.remove zs.zap_to_ceil_map i;
           ModeIdMap.add zs.zap_to_legacy_map i (disallow_left p)
         end
-        else add_packed_to_map zs.zap_to_floor_map i p
+        else add_to_morph_map zs.zap_to_floor_map i k p
         end
 
-    let add_zap_to_ceil_to_zap_scope i p zs =
+    let add_zap_to_ceil_to_zap_scope i k p zs =
       if ModeIdMap.mem zs.zap_to_legacy_map i
       then ()
       else
@@ -7365,7 +7389,7 @@ module Value_with (Areality : Areality) = struct
           ModeIdMap.remove zs.zap_to_floor_map i;
           ModeIdMap.add zs.zap_to_legacy_map i (disallow_right p)
         end
-        else add_packed_to_map zs.zap_to_ceil_map i p
+        else add_to_morph_map zs.zap_to_ceil_map i k p
         end
 
     let resolve_zap_scope
@@ -7377,20 +7401,22 @@ module Value_with (Areality : Areality) = struct
           | Pco m -> zap_to_legacy_src_var_comonadic m)
         zap_to_legacy_map;
       ModeIdMap.iter
-        (fun _ ps ->
-          List.iter
-            (function
+        (fun _ mm ->
+          MorphMap.iter
+            (fun _ p ->
+              match p with
               | Pmon m -> Monadic.zap_to_floor_force m |> ignore
               | Pco m -> Comonadic.zap_to_floor_force m |> ignore)
-            ps)
+            mm)
         zap_to_floor_map;
       ModeIdMap.iter
-        (fun _ ps ->
-          List.iter
-            (function
+        (fun _ mm ->
+          MorphMap.iter
+            (fun _ p ->
+              match p with
               | Pmon m -> Monadic.zap_to_ceil_force m |> ignore
               | Pco m -> Comonadic.zap_to_ceil_force m |> ignore)
-            ps)
+            mm)
         zap_to_ceil_map
   end
 
@@ -7406,16 +7432,16 @@ module Value_with (Areality : Areality) = struct
       Comonadic.Guts.get_floor comonadic |> Comonadic.of_const
     in
     let monadic_upper = Monadic.Guts.get_floor monadic |> Monadic.of_const in
-    Monadic.iter_covariant monadic (fun ~id ~level m ->
+    Monadic.iter_covariant monadic (fun ~id ~level ~morph m ->
         if level <> generic_level
         then
-          Z.add_zap_to_floor_to_zap_scope id
+          Z.add_zap_to_floor_to_zap_scope id (Z.morph_key_mon morph)
             (Z.Pmon (Monadic.join [monadic_upper; m]))
             scope);
-    Comonadic.iter_covariant comonadic (fun ~id ~level m ->
+    Comonadic.iter_covariant comonadic (fun ~id ~level ~morph m ->
         if level <> generic_level
         then
-          Z.add_zap_to_floor_to_zap_scope id
+          Z.add_zap_to_floor_to_zap_scope id (Z.morph_key_co morph)
             (Z.Pco (Comonadic.join [comonadic_upper; m]))
             scope)
 
@@ -7424,16 +7450,16 @@ module Value_with (Areality : Areality) = struct
       Comonadic.Guts.get_ceil comonadic |> Comonadic.of_const
     in
     let monadic_lower = Monadic.Guts.get_ceil monadic |> Monadic.of_const in
-    Monadic.iter_contravariant monadic (fun ~id ~level m ->
+    Monadic.iter_contravariant monadic (fun ~id ~level ~morph m ->
         if level <> generic_level
         then
-          Z.add_zap_to_ceil_to_zap_scope id
+          Z.add_zap_to_ceil_to_zap_scope id (Z.morph_key_mon morph)
             (Z.Pmon (Monadic.meet [monadic_lower; m]))
             scope);
-    Comonadic.iter_contravariant comonadic (fun ~id ~level m ->
+    Comonadic.iter_contravariant comonadic (fun ~id ~level ~morph m ->
         if level <> generic_level
         then
-          Z.add_zap_to_ceil_to_zap_scope id
+          Z.add_zap_to_ceil_to_zap_scope id (Z.morph_key_co morph)
             (Z.Pco (Comonadic.meet [comonadic_upper; m]))
             scope)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -6405,7 +6405,8 @@ module Monadic = struct
       proj Visibility m |> Visibility.zap_to_legacy_force ?commit
     in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility ~arg
+      proj Contention m
+      |> Contention.zap_to_legacy_force ?commit ~visibility ~arg
     in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7531,11 +7531,6 @@ module Value_with (Areality : Areality) = struct
       let* comonadic = Comonadic.Guts.check_const comonadic in
       Some (merge { comonadic; monadic })
 
-    let get_legacy ~arg { monadic; comonadic } =
-      let monadic = Monadic.zap_to_legacy_force ~commit:false ~arg monadic in
-      let comonadic = Comonadic.zap_to_legacy_force ~commit:false comonadic in
-      merge { monadic; comonadic }
-
     let get_ceil { monadic; comonadic } =
       let monadic = Monadic.Guts.get_ceil monadic in
       let comonadic = Comonadic.Guts.get_ceil comonadic in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -6460,69 +6460,9 @@ type ('mo, 'como) monadic_comonadic =
     comonadic : 'como
   }
 
-module Zap_scope = struct
-  module ModeIdMap = Hashtbl.Make (Int)
-
-  type job = unit -> unit
-
-  type job_list = job list
-
-  type zap_scope =
-    { zap_to_floor_map : job_list ModeIdMap.t;
-      zap_to_ceil_map : job_list ModeIdMap.t;
-      zap_to_legacy_map : job ModeIdMap.t
-    }
-
-  let create () =
-    { zap_to_floor_map = ModeIdMap.create 17;
-      zap_to_ceil_map = ModeIdMap.create 17;
-      zap_to_legacy_map = ModeIdMap.create 17
-    }
-
-  let add_job_to_map map i job =
-    match ModeIdMap.find_opt map i with
-    | Some jobs -> ModeIdMap.replace map i (job :: jobs)
-    | None -> ModeIdMap.add map i [job]
-
-  let add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy zs =
-    if ModeIdMap.mem zs.zap_to_legacy_map i
-    then ()
-    else
-      begin if ModeIdMap.mem zs.zap_to_ceil_map i
-      then begin
-        ModeIdMap.remove zs.zap_to_ceil_map i;
-        ModeIdMap.add zs.zap_to_legacy_map i zap_to_legacy
-      end
-      else add_job_to_map zs.zap_to_floor_map i zap_to_floor
-      end
-
-  let add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy zs =
-    if ModeIdMap.mem zs.zap_to_legacy_map i
-    then ()
-    else
-      begin if ModeIdMap.mem zs.zap_to_floor_map i
-      then begin
-        ModeIdMap.remove zs.zap_to_floor_map i;
-        ModeIdMap.add zs.zap_to_legacy_map i zap_to_legacy
-      end
-      else add_job_to_map zs.zap_to_ceil_map i zap_to_ceil
-      end
-
-  let resolve_zap_scope { zap_to_floor_map; zap_to_ceil_map; zap_to_legacy_map }
-      =
-    ModeIdMap.iter (fun _ f -> f ()) zap_to_legacy_map;
-    ModeIdMap.iter
-      (fun _ jobs -> List.iter (fun f -> f ()) jobs)
-      zap_to_floor_map;
-    ModeIdMap.iter
-      (fun _ jobs -> List.iter (fun f -> f ()) jobs)
-      zap_to_ceil_map
-end
-
 module Value_with (Areality : Areality) = struct
   module Comonadic = Comonadic_with (Areality)
   module Monadic = Monadic
-  module Z = Zap_scope
 
   type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
 
@@ -7333,11 +7273,6 @@ module Value_with (Areality : Areality) = struct
   let zap_to_legacy ~arg m =
     if check_generic m then None else Some (zap_to_legacy_force ~arg m)
 
-  type zap_scope =
-    { variables : Z.zap_scope;
-      visible : (bool * (allowed * allowed) t) list ref
-    }
-
   let zap_to_legacy_obj : type a.
       a C.obj -> (a, allowed * allowed) S.mode -> unit =
    fun obj mode ->
@@ -7375,6 +7310,97 @@ module Value_with (Areality : Areality) = struct
     S.mode_iter Comonadic.Obj.obj m
       { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
 
+  module Zap_scope = struct
+    module ModeIdMap = Hashtbl.Make (Int)
+
+    type 'd packed_mode =
+      | Pco of 'd Comonadic.t
+      | Pmon of 'd Monadic.t
+
+    let disallow_left : type l r.
+        (l * r) packed_mode -> (disallowed * r) packed_mode = function
+      | Pco m -> Pco (Comonadic.disallow_left m)
+      | Pmon m -> Pmon (Monadic.disallow_left m)
+
+    let disallow_right : type l r.
+        (l * r) packed_mode -> (l * disallowed) packed_mode = function
+      | Pco m -> Pco (Comonadic.disallow_right m)
+      | Pmon m -> Pmon (Monadic.disallow_right m)
+
+    type zap_scope =
+      { zap_to_floor_map : (allowed * disallowed) packed_mode list ModeIdMap.t;
+        zap_to_ceil_map : (disallowed * allowed) packed_mode list ModeIdMap.t;
+        zap_to_legacy_map : (disallowed * disallowed) packed_mode ModeIdMap.t
+      }
+
+    let create () =
+      { zap_to_floor_map = ModeIdMap.create 17;
+        zap_to_ceil_map = ModeIdMap.create 17;
+        zap_to_legacy_map = ModeIdMap.create 17
+      }
+
+    let add_packed_to_map map i p =
+      match ModeIdMap.find_opt map i with
+      | Some ps -> ModeIdMap.replace map i (p :: ps)
+      | None -> ModeIdMap.add map i [p]
+
+    let add_zap_to_floor_to_zap_scope i p zs =
+      if ModeIdMap.mem zs.zap_to_legacy_map i
+      then ()
+      else
+        begin if ModeIdMap.mem zs.zap_to_ceil_map i
+        then begin
+          ModeIdMap.remove zs.zap_to_ceil_map i;
+          ModeIdMap.add zs.zap_to_legacy_map i (disallow_left p)
+        end
+        else add_packed_to_map zs.zap_to_floor_map i p
+        end
+
+    let add_zap_to_ceil_to_zap_scope i p zs =
+      if ModeIdMap.mem zs.zap_to_legacy_map i
+      then ()
+      else
+        begin if ModeIdMap.mem zs.zap_to_floor_map i
+        then begin
+          ModeIdMap.remove zs.zap_to_floor_map i;
+          ModeIdMap.add zs.zap_to_legacy_map i (disallow_right p)
+        end
+        else add_packed_to_map zs.zap_to_ceil_map i p
+        end
+
+    let resolve_zap_scope
+        { zap_to_floor_map; zap_to_ceil_map; zap_to_legacy_map } =
+      ModeIdMap.iter
+        (fun _ p ->
+          match p with
+          | Pmon m -> zap_to_legacy_src_var_monadic m
+          | Pco m -> zap_to_legacy_src_var_comonadic m)
+        zap_to_legacy_map;
+      ModeIdMap.iter
+        (fun _ ps ->
+          List.iter
+            (function
+              | Pmon m -> Monadic.zap_to_floor_force m |> ignore
+              | Pco m -> Comonadic.zap_to_floor_force m |> ignore)
+            ps)
+        zap_to_floor_map;
+      ModeIdMap.iter
+        (fun _ ps ->
+          List.iter
+            (function
+              | Pmon m -> Monadic.zap_to_ceil_force m |> ignore
+              | Pco m -> Comonadic.zap_to_ceil_force m |> ignore)
+            ps)
+        zap_to_ceil_map
+  end
+
+  module Z = Zap_scope
+
+  type zap_scope =
+    { variables : Z.zap_scope;
+      visible : (bool * (allowed * allowed) t) list ref
+    }
+
   let add_covariant_to_zap_scope { monadic; comonadic } scope =
     let comonadic_upper =
       Comonadic.Guts.get_floor comonadic |> Comonadic.of_const
@@ -7382,20 +7408,16 @@ module Value_with (Areality : Areality) = struct
     let monadic_upper = Monadic.Guts.get_floor monadic |> Monadic.of_const in
     Monadic.iter_covariant monadic (fun ~id ~level m ->
         if level <> generic_level
-        then begin
-          let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
-          let m = Monadic.join [monadic_upper; m] in
-          let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
-          Z.add_zap_to_ceil_to_zap_scope id zap_to_floor zap_to_legacy scope
-        end);
+        then
+          Z.add_zap_to_floor_to_zap_scope id
+            (Z.Pmon (Monadic.join [monadic_upper; m]))
+            scope);
     Comonadic.iter_covariant comonadic (fun ~id ~level m ->
         if level <> generic_level
-        then begin
-          let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
-          let m = Comonadic.join [comonadic_upper; m] in
-          let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
-          Z.add_zap_to_floor_to_zap_scope id zap_to_floor zap_to_legacy scope
-        end)
+        then
+          Z.add_zap_to_floor_to_zap_scope id
+            (Z.Pco (Comonadic.join [comonadic_upper; m]))
+            scope)
 
   let add_contravariant_to_zap_scope { monadic; comonadic } scope =
     let comonadic_upper =
@@ -7404,20 +7426,16 @@ module Value_with (Areality : Areality) = struct
     let monadic_lower = Monadic.Guts.get_ceil monadic |> Monadic.of_const in
     Monadic.iter_contravariant monadic (fun ~id ~level m ->
         if level <> generic_level
-        then begin
-          let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
-          let m = Monadic.meet [monadic_lower; m] in
-          let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
-          Z.add_zap_to_floor_to_zap_scope id zap_to_ceil zap_to_legacy scope
-        end);
+        then
+          Z.add_zap_to_ceil_to_zap_scope id
+            (Z.Pmon (Monadic.meet [monadic_lower; m]))
+            scope);
     Comonadic.iter_contravariant comonadic (fun ~id ~level m ->
         if level <> generic_level
-        then begin
-          let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
-          let m = Comonadic.meet [comonadic_upper; m] in
-          let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
-          Z.add_zap_to_ceil_to_zap_scope id zap_to_ceil zap_to_legacy scope
-        end)
+        then
+          Z.add_zap_to_ceil_to_zap_scope id
+            (Z.Pco (Comonadic.meet [comonadic_upper; m]))
+            scope)
 
   let add_mode_to_zap_scope ~arg m { visible } = visible := (arg, m) :: !visible
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -834,6 +834,12 @@ module type S = sig
         ('a1, 'b, 'l1 * 'r1) morph ->
         ('a0, 'a1) Misc.is_eq
 
+      val compare_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        int
+
       val left_adjoint :
         'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -174,6 +174,8 @@ module type Common = sig
 
   val update_level : int -> ('l * 'r) t -> unit
 
+  val generalize_topology : current_level:int -> ('l * 'r) t -> unit
+
   val generalize : current_level:int -> ('l * 'r) t -> unit
 
   val generalize_structure : current_level:int -> ('l * 'r) t -> unit

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1035,12 +1035,6 @@ module type S = sig
         The copies receive positive ids. *)
     val copy_for_restoring : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
 
-    (** Copies a mode variable and its submodes whose levels are at or above
-        [current_level] and below [generic_level], preserving levels, and then
-        generalizes the copy. *)
-    val copy_then_generalize :
-      copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
-
     module Guts : sig
       (** Returns [Some c] if the given mode has been constrained to constant
           [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -128,7 +128,9 @@ module type Common = sig
 
   val legacy : lr
 
-  val newvar : unit -> ('l * 'r) t
+  val generic_level : int
+
+  val newvar : int -> ('l * 'r) t
 
   (* How to submode
 
@@ -170,6 +172,12 @@ module type Common = sig
   val submode_err :
     Mode_hint.pinpoint -> (allowed * 'r) t -> ('l * allowed) t -> unit
 
+  val update_level : int -> ('l * 'r) t -> unit
+
+  val generalize : current_level:int -> ('l * 'r) t -> unit
+
+  val generalize_structure : current_level:int -> ('l * 'r) t -> unit
+
   (** Similar to [submode_err], but checks the two modes are equal by submoding
       in both directions. *)
   val equate_err : Mode_hint.pinpoint -> lr -> lr -> unit
@@ -187,18 +195,41 @@ module type Common = sig
 
   val meet : ('l * allowed) t list -> right_only t
 
-  val newvar_above : (allowed * 'r) t -> ('l * 'r_) t * bool
+  val newvar_above : int -> (allowed * 'r) t -> ('l * 'r_) t * bool
 
-  val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
+  val newvar_below : int -> ('l * allowed) t -> ('l_ * 'r) t * bool
 
   (** Returns true if the mode is a constant or a mode variable at level 0 *)
   val check_const_or_level_0 : ('l * 'r) t -> bool
 
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
-  val zap_to_ceil : ('l * allowed) t -> Const.t
+  (** Returns true if the mode includes a mode variable at generic level *)
+  val check_generic : ('l * 'r) t -> bool
 
-  val zap_to_floor : (allowed * 'r) t -> Const.t
+  (** zaps all variables to ceil (including generic variables): use with caution
+  *)
+  val zap_to_ceil_force : ('l * allowed) t -> Const.t
+
+  (** zaps all variables to floor (including generic variables): use with
+      caution *)
+  val zap_to_floor_force : (allowed * 'r) t -> Const.t
+
+  (** zaps non-generic variables to ceil, raises a [Cannot_zap_generic] excetion
+      if variable is generic *)
+  val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+  (** zaps non-generic variables to floor, raises a [Cannot_zap_generic]
+      excetion if variable is generic *)
+  val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+  (** zaps non-generic variables to ceil, returns [None] if variable is generic.
+  *)
+  val zap_to_ceil : ('l * allowed) t -> Const.t option
+
+  (** zaps non-generic variables to floor, returns [None] if variable is
+      generic. *)
+  val zap_to_floor : (allowed * 'r) t -> Const.t option
 end
 
 module type Common_axis = sig
@@ -328,6 +359,10 @@ module type S = sig
       on [erase_hint] in [Solver_intf] for details. *)
   val erase_hints : unit -> unit
 
+  (** Resets the counter allocating the (negative) ids of persistent copies of
+      mode variables. (see [Subst.reset_additional_action_id]). *)
+  val reset_persistent_id : unit -> unit
+
   module Hint = Mode_hint
 
   (** Prints a [pinpoint]. Say "a foo" if [definite] is [false], say "the foo"
@@ -349,6 +384,10 @@ module type S = sig
   val undo_changes : changes -> unit
 
   val set_append_changes : (changes ref -> unit) -> unit
+
+  type copy_scope
+
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
 
   type nonrec allowed = allowed
 
@@ -726,6 +765,8 @@ module type S = sig
         val proj : 'a Axis.t -> t -> 'a option
 
         val set : 'a Axis.t -> 'a option -> t -> t
+
+        val partial_print : Fmt.formatter -> t -> unit
       end
 
       val is_max : 'a Axis.t -> 'a -> bool
@@ -768,6 +809,15 @@ module type S = sig
     type simple_error = Error : 'a Axis.t * 'a simple_axerror -> simple_error
 
     type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
+
+    (** Scope containing pending zap jobs *)
+    type zap_scope
+
+    val with_zap_scope : (zap_scope:zap_scope -> 'a) -> 'a
+
+    val create_zap_scope : unit -> zap_scope
+
+    val resolve_zap_scope : zap_scope -> unit
 
     include
       Common
@@ -817,8 +867,21 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    (** [arg] determines co-/contravariance, and is used to infer the most
-        general mode for implied middle values on monadic axes.\
+    (** Registers a mode in the scope, to be zapped to legacy when the scope is
+        resolved. See [zap_to_legacy] for an explanation of [arg]. *)
+    val add_mode_to_zap_scope :
+      arg:bool -> (allowed * allowed) t -> zap_scope -> unit
+
+    (** Zaps non-generic variables to legacy, raises a [Cannot_zap_generic]
+        exception if a variable is generic. See [zap_to_legacy] for an
+        explanation of [arg]. *)
+    val zap_to_legacy_exn : arg:bool -> lr -> Const.t
+
+    (** Zaps non-generic variables to legacy, returns [None] if a variable is
+        generic.
+
+        [arg] determines co-/contravariance, and is used to infer the most
+        general mode for implied middle values on monadic axes.
 
         Consider:
 
@@ -829,7 +892,19 @@ module type S = sig
           (* Implies [read uncontended]. *)
           let zap_ret_read x : _ @ read = ()
         ]} *)
-    val zap_to_legacy : arg:bool -> lr -> Const.t
+    val zap_to_legacy : arg:bool -> lr -> Const.t option
+
+    (** Zaps all variables to legacy (including generic variables): use with
+        caution. See [zap_to_legacy] for an explanation of [arg]. *)
+    val zap_to_legacy_force : arg:bool -> lr -> Const.t
+
+    val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+    val zap_to_ceil_force : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->
@@ -851,6 +926,32 @@ module type S = sig
     (** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C]
     *)
     val partial_apply : (allowed * 'r) t -> l
+
+    (** Copies a mode variable and its submodes from generic level to the
+        current level *)
+    val instantiate :
+      copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Copies a mode variable and its children at generic level, preserving
+        levels *)
+    val copy_generic : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Deeply copies a mode variable and all its children, preserving levels.
+        The copies receive negative ids (mirroring [Subst.newpersty] for types)
+        and are suitable for storing in a cmi file. *)
+    val copy_for_saving : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Copies a mode variable and its submodes whose levels are at or above
+        [current_level] and below [generic_level], preserving levels, and then
+        generalizes the copy. *)
+    val copy_then_generalize :
+      copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
+
+    module Guts : sig
+      (** Returns [Some c] if the given mode has been constrained to constant
+          [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val check_const : (allowed * allowed) t -> Const.t option
+    end
   end
 
   (** The most general mode. Used in most type checking, including in value
@@ -1043,6 +1144,9 @@ module type S = sig
         is the axis on which the modalities disagree. [left] is the projection
         of [t0] on [ax], and [right] is the projection of [t1] on [ax]. *)
     val sub : t -> t -> (unit, error) Result.t
+
+    (** [update_level n t] updates the level of mode variables in [t] to [n] *)
+    val update_level : int -> t -> unit
 
     (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
         [t0 <= t1] and [t1 <= t0]. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1054,11 +1054,6 @@ module type S = sig
           [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
       val check_const : (allowed * allowed) t -> Const.t option
 
-      (** Returns the precise bounds of a mode, as close to legacy as possible.
-          see notes on [get_floor] in [solver_intf.mli] for cautions. See
-          [zap_to_legacy] for an explanation of [arg]. *)
-      val get_legacy : arg:bool -> (allowed * allowed) t -> Const.t
-
       (** Returns the precise ceiling of a mode. see notes on [get_ceil] in
           [solver_intf.mli] for cautions. *)
       val get_ceil : ('l * allowed) t -> Const.t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1031,6 +1031,10 @@ module type S = sig
         and are suitable for storing in a cmi file. *)
     val copy_for_saving : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
 
+    (** Deeply copies a mode variable and all its children, preserving levels.
+        The copies receive positive ids. *)
+    val copy_for_restoring : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
     (** Copies a mode variable and its submodes whose levels are at or above
         [current_level] and below [generic_level], preserving levels, and then
         generalizes the copy. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -207,14 +207,6 @@ module type Common = sig
   (** Returns true if the mode includes a mode variable at generic level *)
   val check_generic : ('l * 'r) t -> bool
 
-  (** zaps all variables to ceil (including generic variables): use with caution
-  *)
-  val zap_to_ceil_force : ('l * allowed) t -> Const.t
-
-  (** zaps all variables to floor (including generic variables): use with
-      caution *)
-  val zap_to_floor_force : (allowed * 'r) t -> Const.t
-
   (** zaps non-generic variables to ceil, raises a [Cannot_zap_generic] excetion
       if variable is generic *)
   val zap_to_ceil_exn : ('l * allowed) t -> Const.t
@@ -819,6 +811,108 @@ module type S = sig
 
     val resolve_zap_scope : zap_scope -> unit
 
+    (** Exposed subset of the monotone Lattices interface *)
+    module C : sig
+      type ('a, 'b, 'd) morph
+
+      type 'a obj
+
+      val le : 'a obj -> 'a -> 'a -> bool
+
+      val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.is_eq
+
+      val src : 'b obj -> ('a, 'b, 'd) morph -> 'a obj
+
+      val id : ('a, 'a, 'd) morph
+
+      val compose :
+        'c obj -> ('b, 'c, 'd) morph -> ('a, 'b, 'd) morph -> ('a, 'c, 'd) morph
+
+      val equal_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        ('a0, 'a1) Misc.is_eq
+
+      val left_adjoint :
+        'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
+
+      val disallow_right :
+        ('a, 'b, 'l * 'r) morph -> ('a, 'b, 'l * disallowed) morph
+
+      val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
+
+      val print_morph : 'b obj -> Fmt.formatter -> ('a, 'b, 'd) morph -> unit
+    end
+
+    (** The exposed description of modes *)
+    module Desc : sig
+      module Var : sig
+        type 'a t
+
+        type ('b, 'd) t_with_morph =
+          | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+        module Head : sig
+          type 'a t =
+            { desc_id : int;
+              desc_upper : 'a;
+              desc_lower : 'a;
+              desc_vlower : ('a, left_only) t_with_morph list;
+              desc_level : int
+            }
+
+          val equal : 'a t -> 'b t -> bool
+
+          val hash : 'a t -> int
+        end
+
+        val force : 'a C.obj -> 'a t -> 'a Head.t
+      end
+
+      type ('b, 'd) morphvar =
+        | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+      type ('a, 'd) t =
+        | Amode : 'a -> ('a, 'l * 'r) t
+        | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+        | Amodejoin :
+            'a * ('a, 'l * disallowed) morphvar list
+            -> ('a, 'l * disallowed) t
+        | Amodemeet :
+            'a * ('a, disallowed * 'r) morphvar list
+            -> ('a, disallowed * 'r) t
+
+      val equal : 'a C.obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+      val print : 'a C.obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+    end
+
+    val obj_monadic : Monadic.Const.t C.obj
+
+    val obj_comonadic : Comonadic.Const.t C.obj
+
+    val get_comonadic_desc : 'd Comonadic.t -> (Comonadic.Const.t, 'd) Desc.t
+
+    val get_monadic_desc :
+      ('l * 'r) Monadic.t -> (Monadic.Const.t, 'r * 'l) Desc.t
+
+    val meet_const_morph : 'a -> ('a, 'a, allowed * disallowed) C.morph
+
+    val pretty_print_monadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Monadic.Const.t, 'f) C.morph ->
+      unit
+
+    val pretty_print_comonadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Comonadic.Const.t, 'f) C.morph ->
+      unit
+
     include
       Common
         with module Const := Const
@@ -896,15 +990,11 @@ module type S = sig
 
     (** Zaps all variables to legacy (including generic variables): use with
         caution. See [zap_to_legacy] for an explanation of [arg]. *)
-    val zap_to_legacy_force : arg:bool -> lr -> Const.t
+    val zap_to_legacy_force : ?commit:bool -> arg:bool -> lr -> Const.t
 
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t
-
-    val zap_to_ceil_force : ('l * allowed) t -> Const.t
-
-    val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->
@@ -951,6 +1041,19 @@ module type S = sig
       (** Returns [Some c] if the given mode has been constrained to constant
           [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
       val check_const : (allowed * allowed) t -> Const.t option
+
+      (** Returns the precise bounds of a mode, as close to legacy as possible.
+          see notes on [get_floor] in [solver_intf.mli] for cautions. See
+          [zap_to_legacy] for an explanation of [arg]. *)
+      val get_legacy : arg:bool -> (allowed * allowed) t -> Const.t
+
+      (** Returns the precise ceiling of a mode. see notes on [get_ceil] in
+          [solver_intf.mli] for cautions. *)
+      val get_ceil : ('l * allowed) t -> Const.t
+
+      (** Checks that a constant is within the precise bounds of a mode. see
+          notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val in_bounds : Const.t -> (allowed * allowed) t -> bool
     end
   end
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1006,6 +1006,8 @@ module type S = sig
         caution. See [zap_to_legacy] for an explanation of [arg]. *)
     val zap_to_legacy_force : ?commit:bool -> arg:bool -> lr -> Const.t
 
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
+
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -927,7 +927,7 @@ module type S = sig
     *)
     val partial_apply : (allowed * 'r) t -> l
 
-    (** Copies a mode variable and its submodes from generic level to the
+    (** Copies a mode variable and its children from generic level to the
         current level *)
     val instantiate :
       copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -692,6 +692,12 @@ module type S = sig
         val zap_to_ceil : 'a Axis.t -> ('a, 'l * allowed) mode -> 'a
       end
 
+      module Guts : sig
+        (** Returns the precise floor of a mode. see notes on [get_floor] in
+            [solver_intf.mli] for cautions. *)
+        val get_floor : (allowed * 'r) t -> Const.t
+      end
+
       val max_with : 'a Axis.t -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
     end
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1246,9 +1246,6 @@ module type S = sig
         of [t0] on [ax], and [right] is the projection of [t1] on [ax]. *)
     val sub : t -> t -> (unit, error) Result.t
 
-    (** [update_level n t] updates the level of mode variables in [t] to [n] *)
-    val update_level : int -> t -> unit
-
     (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
         [t0 <= t1] and [t1 <= t0]. *)
     val equate : t -> t -> (unit, equate_error) Result.t

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -922,6 +922,8 @@ let lower_nongen nglev mty =
       | _ ->
           super.it_do_type_expr it ty
     in
-    let it = {super with it_do_type_expr} in
+  let it_mode_expr m = Mode.Alloc.update_level nglev m in
+  let it_modality m = Mode.Modality.update_level nglev m in
+    let it = {super with it_do_type_expr; it_mode_expr; it_modality} in
     it.it_module_type it mty
   end

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -922,8 +922,8 @@ let lower_nongen nglev mty =
       | _ ->
           super.it_do_type_expr it ty
     in
-  let it_mode_expr m = Mode.Alloc.update_level nglev m in
-  let it_modality m = Mode.Modality.update_level nglev m in
-    let it = {super with it_do_type_expr; it_mode_expr; it_modality} in
-    it.it_module_type it mty
+  let it_mode_expr m =
+    if not (Mode.Alloc.check_generic m) then Mode.Alloc.update_level nglev m in
+  let it = {super with it_do_type_expr; it_mode_expr} in
+  it.it_module_type it mty
   end

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -994,14 +994,23 @@ end
 
 let zap_to_legacy : arg:bool -> Alloc.lr -> Alloc.Const.t =
   fun ~arg m ->
-    Option.value (Alloc.zap_to_legacy ~arg m)
-      ~default:(Alloc.Guts.get_legacy ~arg m)
+    match Alloc.zap_to_legacy ~arg m with
+    | Some c -> c
+    | None ->
+      if mode_polymorphism_printing_enabled ()
+      then Alloc.Guts.get_legacy ~arg m
+      else Alloc.zap_to_legacy_force ~arg m
 
 let curry_mode_const : Alloc.Const.t -> Alloc.lr -> Alloc.Const.t =
   fun alloc_mode marg ->
     let arg_mode =
-      Option.value (Alloc.zap_to_legacy ~arg:true marg)
-      ~default:(Alloc.Guts.get_ceil marg) in
+      match Alloc.zap_to_legacy ~arg:true marg with
+      | Some c -> c
+      | None ->
+        if mode_polymorphism_printing_enabled ()
+        then Alloc.Guts.get_ceil marg
+        else Alloc.zap_to_legacy_force ~arg:true marg
+    in
     curry_mode_const alloc_mode arg_mode
 
 let equate_with_const : Alloc.lr -> Alloc.Const.t -> bool =

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1409,7 +1409,7 @@ end = struct
   (* Find all direct paths (via vlowers) from some
     variable [v] to all other reachable visible variables
     at generic level. *)
-  (* CR ageorges: WARNING: cycles are *not* registered
+  (* WARNING: cycles are *not* registered
       as a separate morphism:
       e.g.: let [w] be a visible generic variable with
             the following (vlower) edges:

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1975,19 +1975,15 @@ end = struct
         m ppf via.comonadic
     | Lower_comonadic { c_via; c_name } ->
       let m = add_named_modevar c_name in
-      Fmt.fprintf ppf "past(%a)"
-        (Alloc.pretty_print_comonadic_morph
-           (fun ppf s -> Fmt.fprintf ppf "%s" s)
-           m)
-        c_via
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "past(%s)" s)
+        m ppf c_via
     | Lower_closing_over_to { cls_target; cls_src; cls_edge } ->
       let m = add_named_modevar cls_edge.name in
       Alloc.pretty_print_comonadic_morph
-        (fun ppf cls ->
-          Alloc.pretty_print_comonadic_morph
-            (fun ppf s -> Fmt.fprintf ppf "%s" s)
-            m ppf cls)
-        cls_target ppf cls_src
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf
+        (C.compose Alloc.obj_comonadic cls_src cls_target)
 
   let partition_edges_into_bounds :
       edges_from:edge list ->

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -882,7 +882,7 @@ let nameable_row row =
 (* This specialized version of [Btype.iter_type_expr] normalizes and
    short-circuits the traversal of the [type_expr], so that it covers only the
    subterms that would be printed by the type printer. *)
-let printer_iter_type_expr f ty =
+let printer_iter_type_expr f fm ty =
   match get_desc ty with
   | Tconstr(p, tyl, _) ->
       let (_p', s) = best_type_path p in
@@ -913,7 +913,7 @@ let printer_iter_type_expr f ty =
   | Tmod (ty, _) ->
       f ty
   | _ ->
-      Btype.iter_type_expr f ty
+      Btype.iter_type_expr f fm ty
 
 let quoted_ident ppf x =
   Style.as_inline_code !Oprint.out_ident ppf x
@@ -1041,7 +1041,7 @@ end = struct
       | Tvar _ | Tunivar _ ->
           add_named_var tty
       | _ ->
-          printer_iter_type_expr add_named_vars ty
+          printer_iter_type_expr add_named_vars (Fun.const ()) ty
     end
 
   let substitute ty =
@@ -1206,13 +1206,13 @@ module Aliases = struct
           if List.memq px !visited_objects then add_proxy px else begin
             if should_visit_object ty then
               visited_objects := px :: !visited_objects;
-            printer_iter_type_expr (mark_loops_rec visited) ty
+            printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
           end
       | Tpoly(ty, tyl) ->
           List.iter add tyl;
           mark_loops_rec visited ty
       | _ ->
-          printer_iter_type_expr (mark_loops_rec visited) ty
+          printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
 
   let mark_loops ty =
     mark_loops_rec [] ty
@@ -1412,7 +1412,7 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy ~arg:false mode in
+        let mode = Alloc.zap_to_legacy_force ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
     | Other _ -> tree
   in
@@ -1442,7 +1442,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
+        let arg_mode = Alloc.zap_to_legacy_force ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -1455,7 +1455,7 @@ let rec tree_of_modal_typexp mode modal ty =
           else
             tree_of_typexp mode arg_mode ty1
         in
-        let acc_mode = curry_mode alloc_mode arg_mode in
+        let acc_mode = curry_mode_const alloc_mode arg_mode in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
         Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
@@ -1701,6 +1701,7 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 and tree_of_ret_typ_mutating acc_mode m ty=
   match get_desc ty with
   | Tarrow _ -> begin
+      let c = Alloc.zap_to_legacy_force ~arg:false m in
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
       match Alloc.equate (Alloc.of_const acc_mode) m with
@@ -1709,11 +1710,10 @@ and tree_of_ret_typ_mutating acc_mode m ty=
       | Error _ ->
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let m = Alloc.zap_to_legacy ~arg:false m in
-        (Orm_parens (tree_of_modes m), m)
+        (Orm_parens (tree_of_modes c), c)
       end
   | _ ->
-    let m = Alloc.zap_to_legacy ~arg:false m in
+    let m = Alloc.zap_to_legacy_force ~arg:false m in
     (Orm_any (tree_of_modes m), m)
 
 and tree_of_typobject_repr fi =
@@ -2706,7 +2706,7 @@ let rec tree_of_modtype ?abbrev = function
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
       let mres =
-        m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
+        m_res |> Mode.Alloc.zap_to_legacy_force ~arg:false |> tree_of_modes
       in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
@@ -2737,7 +2737,7 @@ and tree_of_functor_parameter ?abbrev = function
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
       let marg =
-        m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
+        m_arg |> Mode.Alloc.zap_to_legacy_force ~arg:true |> tree_of_modes
       in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1130,13 +1130,26 @@ end = struct
   determined by two variables and morphism pair. The object
   types are irrelevant, and are thus forgotten. See [edge]
   for more explanation *)
+  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
+  type monadic_morph =
+    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
+  type comonadic_morph =
+    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
+      morphl
+  type closing_over_morph =
+    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
+
   type boxedname =
-  | N :
+  | Simple_name :
       { target : 'c Desc.Var.Head.t;
         src : 'd Desc.Var.Head.t;
-        morph_src : 'a C.obj;
-        morph_dst : 'b C.obj;
-        morph : ('a, 'b, ('l * 'r)) C.morph
+        via : (monadic_morph, comonadic_morph) monadic_comonadic
+      }
+      -> boxedname
+  | Comonadic_name :
+      { target : 'c Desc.Var.Head.t;
+        src : 'd Desc.Var.Head.t;
+        morph : comonadic_morph
       }
       -> boxedname
 
@@ -1153,15 +1166,6 @@ end = struct
       | 0 -> Int.compare v1'.desc_id v2'.desc_id
       | c -> c
   end)
-
-  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
-  type monadic_morph =
-    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
-  type comonadic_morph =
-    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
-      morphl
-  type closing_over_morph =
-    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
 
   module Paths = struct
     module Store (X : sig
@@ -1750,21 +1754,15 @@ end = struct
       -> visible_pair
       -> boxedname =
     fun { monadic = mon0; comonadic = com0 }
-        { monadic = mon_morph; comonadic = com_morph }
+        via
         { monadic = mon1; comonadic = com1 } ->
       match com0, com1 with
       | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
-        N { target = u; src = v;
-            morph_src = Alloc.obj_comonadic;
-            morph_dst = Alloc.obj_comonadic;
-            morph = com_morph }
+        Simple_name { target = u; src = v; via }
       | _, _ ->
         match mon0, mon1 with
         | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
-          N { target = u; src = v;
-              morph_src = Alloc.obj_monadic;
-              morph_dst = Alloc.obj_monadic;
-              morph = mon_morph }
+          Simple_name { target = u; src = v; via }
         | _, _ ->
           fatal_error
             "Out_type.construct_name: edge without variable endpoints"
@@ -1779,10 +1777,7 @@ end = struct
         { comonadic = com1 } ->
       match com0, com1 with
       | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
-        N { target = u; src = v;
-            morph_src = Alloc.obj_comonadic;
-            morph_dst = Alloc.obj_comonadic;
-            morph = com_morph }
+        Comonadic_name { target = u; src = v; morph = com_morph }
       | _, _ ->
         fatal_error
           "Out_type.construct_comonadic_name: edge without variable endpoints"
@@ -1832,7 +1827,51 @@ end = struct
         com_morphs
     else []
 
+  let eq_morph : type a0 a1 b l0 r0 l1 r1.
+      b C.obj
+      -> (a0, b, l0 * r0) C.morph
+      -> (a1, b, l1 * r1) C.morph
+      -> bool =
+    fun obj f g ->
+    match C.equal_morph obj f g with
+    | Is_eq -> true
+    | Is_not_eq -> false
+
+  let eq_boxedname n1 n2 =
+    match n1, n2 with
+    | Simple_name { target = v; src = v'; via = via1 },
+      Simple_name { target = u; src = u'; via = via2 } ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && eq_morph Alloc.obj_monadic via1.monadic via2.monadic
+      && eq_morph Alloc.obj_comonadic via1.comonadic via2.comonadic
+    | Comonadic_name { target = v; src = v'; morph = f },
+      Comonadic_name { target = u; src = u'; morph = g } ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && eq_morph Alloc.obj_comonadic f g
+    | Simple_name _, Comonadic_name _ | Comonadic_name _, Simple_name _ ->
+      false
+
+  let closing_over_composition { cls_target; cls_src; _ } =
+    C.compose Alloc.obj_comonadic cls_src cls_target
+
+  let eq_closing_over e1 e2 =
+    eq_boxedname e1.cls_edge.name e2.cls_edge.name
+    && C.compare_morph Alloc.obj_comonadic
+         (closing_over_composition e1)
+         (closing_over_composition e2)
+       = 0
+
+  let dedup_closing_over edges =
+    List.rev
+      (List.fold_left
+         (fun acc e ->
+           if List.exists (eq_closing_over e) acc then acc else e :: acc)
+         [] edges)
+
   let construct_closing_over_to pair1 =
+    let edges =
     List.concat_map (fun pair0 ->
       let com_morphs =
         construct_comonadic_morphs pair1.comonadic pair0.comonadic
@@ -1849,7 +1888,6 @@ end = struct
         List.concat_map (fun edge ->
           List.concat_map (fun cls_morph ->
             List.map (fun com_morph ->
-              ClosingOver
                 { cls_target = cls_morph;
                   cls_src = com_morph;
                   cls_edge = edge
@@ -1859,6 +1897,8 @@ end = struct
           simple_edges)
         !visible_pairs)
       !visible_pairs
+    in
+    List.map (fun e -> ClosingOver e) (dedup_closing_over edges)
 
   let construct_edges_between pair0 pair1 =
     if not (construct_edge_condition pair0 pair1) then []
@@ -1882,18 +1922,6 @@ end = struct
     fun pair0 ->
       List.concat_map (fun pair1 -> construct_edges_between pair0 pair1)
         !visible_pairs
-
-  let eq_boxedname
-      (N { target = v; src = v'; morph_dst = dstf; morph = f; _ })
-      (N { target = u; src = u'; morph_dst = dstg; morph = g; _ }) =
-    match C.equal_obj dstf dstg with
-    | Is_eq ->
-      Desc.Var.Head.equal v u
-      && Desc.Var.Head.equal v' u'
-      && (match C.equal_morph dstf f g with
-      | Is_eq -> true
-      | Is_not_eq -> false)
-    | Is_not_eq -> false
 
   let pick_name : int -> string = fun i ->
     match i with

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1615,17 +1615,17 @@ end = struct
       | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
         let vobj = C.src dst f in
         let uobj = C.src dst g in
-        let l = C.apply dst f v.desc_upper in
-        let r = C.apply dst g u.desc_lower in
-        if C.le dst l r
-        then [C.id]
+        let src_lower = C.apply dst f v.desc_lower in
+        let target_upper = C.apply dst g u.desc_upper in
+        if C.le dst target_upper src_lower
+        then [C.id] (* [target <= src] already holds by bounds *)
         else Paths.find visible_paths table (K (vobj, v), K (uobj, u))
       | _, _ ->
-        let l = dupper_lr dst src_descr in
-        let r = dlower_lr dst target_descr in
-        if C.le dst l r
-        then [C.id]
-        else [Alloc.meet_const_morph r]
+        let src_lower = dlower_lr dst src_descr in
+        let target_upper = dupper_lr dst target_descr in
+        if C.le dst target_upper src_lower
+        then [C.id] (* [target <= src] already holds by bounds *)
+        else [Alloc.meet_const_morph src_lower]
 
   let construct_closing_over_morphs :
       (Alloc.Comonadic.Const.t, allowed * allowed) Desc.t

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1062,9 +1062,11 @@ end = struct
   type boxedvar =
   | K : 'a C.obj * 'a Desc.Var.Head.t -> boxedvar
   type boxedpath =
-  | P : 'b C.obj
-        * 'a Desc.Var.Head.t
-        * ('a, 'b, (allowed * disallowed)) C.morph
+  | P :
+      { dst : 'b C.obj;
+        var : 'a Desc.Var.Head.t;
+        path : ('a, 'b, (allowed * disallowed)) C.morph
+      }
       -> boxedpath
 
   (** The name of polymorphic mode variables will be
@@ -1072,11 +1074,13 @@ end = struct
   types are irrelevant, and are thus forgotten. See [edge]
   for more explanation *)
   type boxedname =
-  | N : 'c Desc.Var.Head.t
-        * 'd Desc.Var.Head.t
-        * 'a C.obj
-        * 'b C.obj
-        * ('a, 'b, ('l * 'r)) C.morph
+  | N :
+      { target : 'c Desc.Var.Head.t;
+        src : 'd Desc.Var.Head.t;
+        morph_src : 'a C.obj;
+        morph_dst : 'b C.obj;
+        morph : ('a, 'b, ('l * 'r)) C.morph
+      }
       -> boxedname
 
   module VarTbl = Hashtbl.Make (struct
@@ -1103,19 +1107,51 @@ end = struct
     (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
 
   module Paths = struct
-    module Monadic_path_set = Std_set.Make (struct
-      type t = monadic_morph
-      let compare m1 m2 = C.compare_morph Alloc.obj_monadic m1 m2
+    module Store (X : sig
+      type s
+      type d
+      val dst : d C.obj
+    end) =
+    struct
+      module Morph_set = Std_set.Make (struct
+        type t = (X.s, X.d) morphl
+        let compare m1 m2 = C.compare_morph X.dst m1 m2
+      end)
+
+      type t = Morph_set.t VarPairMap.t
+
+      let empty : t = VarPairMap.empty
+
+      let add key path t =
+        let set =
+          match VarPairMap.find_opt key t with
+          | None -> Morph_set.singleton path
+          | Some set -> Morph_set.add path set
+        in
+        VarPairMap.add key set t
+
+      let find key t =
+        match VarPairMap.find_opt key t with
+        | None -> []
+        | Some set -> Morph_set.elements set
+    end
+
+    module Monadic_paths = Store (struct
+      type s = Alloc.Monadic.Const.t
+      type d = Alloc.Monadic.Const.t
+      let dst = Alloc.obj_monadic
     end)
 
-    module Comonadic_path_set = Std_set.Make (struct
-      type t = comonadic_morph
-      let compare m1 m2 = C.compare_morph Alloc.obj_comonadic m1 m2
+    module Comonadic_paths = Store (struct
+      type s = Alloc.Comonadic.Const.t
+      type d = Alloc.Comonadic.Const.t
+      let dst = Alloc.obj_comonadic
     end)
 
-    module Closing_over_path_set = Std_set.Make (struct
-      type t = closing_over_morph
-      let compare m1 m2 = C.compare_morph Alloc.obj_comonadic m1 m2
+    module Closing_over_paths = Store (struct
+      type s = Alloc.Monadic.Const.t
+      type d = Alloc.Comonadic.Const.t
+      let dst = Alloc.obj_comonadic
     end)
 
     type ('s, 'd) table =
@@ -1146,21 +1182,21 @@ end = struct
           a path *)
 
     type t =
-      { mutable monadic : Monadic_path_set.t VarPairMap.t;
-        mutable comonadic : Comonadic_path_set.t VarPairMap.t;
-        mutable closing_over : Closing_over_path_set.t VarPairMap.t
+      { mutable monadic : Monadic_paths.t;
+        mutable comonadic : Comonadic_paths.t;
+        mutable closing_over : Closing_over_paths.t
       }
 
     let create () =
-      { monadic = VarPairMap.empty;
-        comonadic = VarPairMap.empty;
-        closing_over = VarPairMap.empty
+      { monadic = Monadic_paths.empty;
+        comonadic = Comonadic_paths.empty;
+        closing_over = Closing_over_paths.empty
       }
 
     let reset t =
-      t.monadic <- VarPairMap.empty;
-      t.comonadic <- VarPairMap.empty;
-      t.closing_over <- VarPairMap.empty
+      t.monadic <- Monadic_paths.empty;
+      t.comonadic <- Comonadic_paths.empty;
+      t.closing_over <- Closing_over_paths.empty
 
     let src_obj : type s d. (s, d) table -> s C.obj =
       function
@@ -1178,44 +1214,18 @@ end = struct
         t -> (s, d) table -> boxedvar * boxedvar -> (s, d) morphl -> unit =
       fun t table key path ->
       match table with
-      | Monadic ->
-        let set =
-          match VarPairMap.find_opt key t.monadic with
-          | None -> Monadic_path_set.singleton path
-          | Some set -> Monadic_path_set.add path set
-        in
-        t.monadic <- VarPairMap.add key set t.monadic
-      | Comonadic ->
-        let set =
-          match VarPairMap.find_opt key t.comonadic with
-          | None -> Comonadic_path_set.singleton path
-          | Some set -> Comonadic_path_set.add path set
-        in
-        t.comonadic <- VarPairMap.add key set t.comonadic
+      | Monadic -> t.monadic <- Monadic_paths.add key path t.monadic
+      | Comonadic -> t.comonadic <- Comonadic_paths.add key path t.comonadic
       | Closing_over ->
-        let set =
-          match VarPairMap.find_opt key t.closing_over with
-          | None -> Closing_over_path_set.singleton path
-          | Some set -> Closing_over_path_set.add path set
-        in
-        t.closing_over <- VarPairMap.add key set t.closing_over
+        t.closing_over <- Closing_over_paths.add key path t.closing_over
 
     let find : type s d.
         t -> (s, d) table -> boxedvar * boxedvar -> ((s, d) morphl) list =
       fun t table key ->
       match table with
-      | Monadic ->
-        (match VarPairMap.find_opt key t.monadic with
-         | None -> []
-         | Some set -> Monadic_path_set.elements set)
-      | Comonadic ->
-        (match VarPairMap.find_opt key t.comonadic with
-         | None -> []
-         | Some set -> Comonadic_path_set.elements set)
-      | Closing_over ->
-        (match VarPairMap.find_opt key t.closing_over with
-         | None -> []
-         | Some set -> Closing_over_path_set.elements set)
+      | Monadic -> Monadic_paths.find key t.monadic
+      | Comonadic -> Comonadic_paths.find key t.comonadic
+      | Closing_over -> Closing_over_paths.find key t.closing_over
   end
 
   (** Tracks the mapping of monadic and comonadic mode
@@ -1370,8 +1380,6 @@ end = struct
   type memoized = (boxedpath list) VarTbl.t
   type visited = unit VarTbl.t
 
-  exception Cannot_unwrap
-
   (* Find the [b -> Paths.src_obj table] morphism
     associated with some visible variable [v] of object
     type [b] *)
@@ -1396,7 +1404,8 @@ end = struct
                 | Is_eq ->
                   let (f : ((b, s, (allowed * allowed)) C.morph)) = f in
                   Some f
-                | Is_not_eq -> raise Cannot_unwrap
+                | Is_not_eq ->
+                  fatal_error "Out_type.find_visible_morph_opt"
             end
         | Desc.Amode _ -> None
       in
@@ -1419,42 +1428,46 @@ end = struct
       In the future, we might want to register all
       paths. This will require a lattice of morphisms,
       so we can calculate the fixed point of cycle *)
-  let rec find_paths :
+  let rec paths_to_visible :
       type b. memoized:memoized -> visited:visited
-      -> bool -> b C.obj -> b Desc.Var.Head.t
+      -> b C.obj -> b Desc.Var.Head.t
       -> boxedpath list =
-    fun ~memoized ~visited first dst v ->
-      if visible dst v && not first then [P (dst, v, C.id)] else begin
-        if VarTbl.mem visited (K (dst, v)) then [] else begin
-          VarTbl.add visited (K (dst, v)) ();
-          match VarTbl.find_opt memoized (K (dst, v)) with
-          | Some paths -> paths
-          | None ->
-            let paths =
-              List.filter_map (fun (Desc.Var.Amorphvar (w, f)) ->
-                let fsrc = C.src dst f in
-                let w = Desc.Var.force fsrc w in
-                if w.desc_level <> generic_level then None else begin
-                let wpaths = find_paths ~memoized ~visited false fsrc w in
-                Some (List.map (fun (P (gdst, u, g)) ->
+    fun ~memoized ~visited dst v ->
+      if visible dst v then [P { dst; var = v; path = C.id }]
+      else paths_from_vlowers ~memoized ~visited dst v
+
+  and paths_from_vlowers :
+      type b. memoized:memoized -> visited:visited
+      -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~memoized ~visited dst v ->
+      if VarTbl.mem visited (K (dst, v)) then [] else begin
+        VarTbl.add visited (K (dst, v)) ();
+        match VarTbl.find_opt memoized (K (dst, v)) with
+        | Some paths -> paths
+        | None ->
+          let paths =
+            List.concat_map (fun (Desc.Var.Amorphvar (w, f)) ->
+              let fsrc = C.src dst f in
+              let w = Desc.Var.force fsrc w in
+              if w.desc_level <> generic_level then []
+              else
+                List.map (fun (P { dst = gdst; var = u; path = g }) ->
                   match C.equal_obj fsrc gdst with
-                  | Is_eq ->
-                    let fg = C.compose dst f g in
-                    P (dst, u, fg)
-                  | Is_not_eq -> raise Cannot_unwrap) wpaths)
-              end) v.desc_vlower
-            in
-            let paths = List.flatten paths in
-            VarTbl.add memoized (K (dst,v)) paths;
-            paths
-          end
+                  | Is_eq -> P { dst; var = u; path = C.compose dst f g }
+                  | Is_not_eq -> fatal_error "Out_type.paths_from_vlowers")
+                  (paths_to_visible ~memoized ~visited fsrc w))
+              v.desc_vlower
+          in
+          VarTbl.add memoized (K (dst, v)) paths;
+          paths
       end
 
   let find_paths :
       memoized:memoized -> visited:visited
       -> boxedvar -> boxedpath list =
     fun ~memoized ~visited (K (dst, v)) ->
-      find_paths ~memoized ~visited true dst v
+      paths_from_vlowers ~memoized ~visited dst v
 
   (** [find_path_from_description] constructs all morphisms
     from one visible mode variable to another, and records
@@ -1488,7 +1501,7 @@ end = struct
         let v = K (fsrc, v) in
         let visited = VarTbl.create 17 in
         let paths = find_paths ~memoized ~visited v in
-        List.iter (fun (P (gdst, u, g)) ->
+        List.iter (fun (P { dst = gdst; var = u; path = g }) ->
           match C.equal_obj fsrc gdst with
             | Is_eq ->
               let gsrc = C.src gdst g in
@@ -1498,7 +1511,8 @@ end = struct
                 let fgh' = C.compose dst fg h' in
                 Paths.add visible_paths table (v, (K (gsrc, u))) fgh'
               ) (find_visible_morph_opt table gsrc u)
-            | Is_not_eq -> raise Cannot_unwrap
+            | Is_not_eq ->
+              fatal_error "Out_type.find_path_from_description"
           ) paths
 
 
@@ -1697,8 +1711,7 @@ end = struct
       let pairs_ne = not (eq_pair pair0 pair1) in
       compare_dec && check_signature && pairs_ne
 
-  exception Invalid_edge
-  let construct_name_exn :
+  let construct_name :
       visible_pair
       -> (monadic_morph, comonadic_morph) monadic_comonadic
       -> visible_pair
@@ -1708,16 +1721,22 @@ end = struct
         { monadic = mon1; comonadic = com1 } ->
       match com0, com1 with
       | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
-        N (u, v, Alloc.obj_comonadic, Alloc.obj_comonadic, com_morph)
+        N { target = u; src = v;
+            morph_src = Alloc.obj_comonadic;
+            morph_dst = Alloc.obj_comonadic;
+            morph = com_morph }
       | _, _ ->
         match mon0, mon1 with
         | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
-          N (u, v, Alloc.obj_monadic, Alloc.obj_monadic, mon_morph)
-        | _, _ -> raise Invalid_edge
-                  (* edges are only created when one of the morphism
-                  goes from a variable to a variable*)
+          N { target = u; src = v;
+              morph_src = Alloc.obj_monadic;
+              morph_dst = Alloc.obj_monadic;
+              morph = mon_morph }
+        | _, _ ->
+          fatal_error
+            "Out_type.construct_name: edge without variable endpoints"
 
-  let construct_comonadic_name_exn :
+  let construct_comonadic_name :
       visible_pair
       -> comonadic_morph
       -> visible_pair
@@ -1727,140 +1746,113 @@ end = struct
         { comonadic = com1 } ->
       match com0, com1 with
       | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
-        N (u, v, Alloc.obj_comonadic, Alloc.obj_comonadic, com_morph)
-      | _, _ -> raise Invalid_edge
-          (* comonadic edges are only created when one of the morphism
-          goes from a variable to a variable*)
+        N { target = u; src = v;
+            morph_src = Alloc.obj_comonadic;
+            morph_dst = Alloc.obj_comonadic;
+            morph = com_morph }
+      | _, _ ->
+        fatal_error
+          "Out_type.construct_comonadic_name: edge without variable endpoints"
 
-  let construct_simple_between =
-    fun pair0 pair1 ->
-
-      let mon_morphs =
-        construct_monadic_morphs
-          pair0.monadic pair1.monadic
-      in
-      let com_morphs =
-        construct_comonadic_morphs
-          pair1.comonadic pair0.comonadic
-      in
-      let edges =
-        List.fold_left (fun acc com_morph ->
-          List.fold_left (fun acc mon_morph ->
-          let via =
-            { monadic = mon_morph;
-              comonadic = com_morph }
-          in
-          let name =
-            construct_name_exn pair0 via pair1
-          in
-          let edge = { via; name } in
-          edge :: acc )
-          acc mon_morphs)
-        [] com_morphs
-      in
-      edges
+  let construct_simple_between pair0 pair1 =
+    let mon_morphs =
+      construct_monadic_morphs pair0.monadic pair1.monadic
+    in
+    let com_morphs =
+      construct_comonadic_morphs pair1.comonadic pair0.comonadic
+    in
+    List.concat_map (fun com_morph ->
+      List.map (fun mon_morph ->
+        let via = { monadic = mon_morph; comonadic = com_morph } in
+        { via; name = construct_name pair0 via pair1 })
+        mon_morphs)
+      com_morphs
 
   let check_closing_over_candidate pair0 pair1 =
     List.exists
       (fun pair2 ->
         let closing_over_morphs =
-          construct_closing_over_morphs
-            pair1.comonadic pair2.monadic
+          construct_closing_over_morphs pair1.comonadic pair2.monadic
         in
         let edges =
           if construct_edge_condition pair0 pair2
           then construct_simple_between pair0 pair2
-          else [] in
-        edges <> [] && closing_over_morphs <> []
-      ) !visible_pairs
+          else []
+        in
+        not (List.is_empty edges)
+        && not (List.is_empty closing_over_morphs))
+      !visible_pairs
 
-  let construct_comonadic_between =
-    fun pair0 pair1 ->
-      let mon_morphs =
-        construct_monadic_morphs
-          pair0.monadic pair1.monadic
-      in
+  let construct_comonadic_between pair0 pair1 =
+    let mon_morphs =
+      construct_monadic_morphs pair0.monadic pair1.monadic
+    in
+    let com_morphs =
+      construct_comonadic_morphs pair1.comonadic pair0.comonadic
+    in
+    if List.is_empty mon_morphs
+       && not (check_closing_over_candidate pair0 pair1)
+    then
+      List.map (fun com_morph ->
+        let c_name = construct_comonadic_name pair0 com_morph pair1 in
+        Comonadic { c_via = com_morph; c_name })
+        com_morphs
+    else []
+
+  let construct_closing_over_to pair1 =
+    List.concat_map (fun pair0 ->
       let com_morphs =
-        construct_comonadic_morphs
-          pair1.comonadic pair0.comonadic
+        construct_comonadic_morphs pair1.comonadic pair0.comonadic
       in
-      if not (check_closing_over_candidate pair0 pair1) && mon_morphs = [] then
-        List.map (fun com_morph ->
-          let c_name = construct_comonadic_name_exn pair0 com_morph pair1 in
-          Comonadic { c_via = com_morph; c_name }) com_morphs
-      else []
+      List.concat_map (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs pair1.comonadic pair2.monadic
+        in
+        let simple_edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else []
+        in
+        List.concat_map (fun edge ->
+          List.concat_map (fun cls_morph ->
+            List.map (fun com_morph ->
+              ClosingOver
+                { cls_target = cls_morph;
+                  cls_src = com_morph;
+                  cls_edge = edge
+                })
+              com_morphs)
+            closing_over_morphs)
+          simple_edges)
+        !visible_pairs)
+      !visible_pairs
 
-  let construct_closing_over_to =
-    fun pair1 ->
-      List.fold_left (fun acc pair0 ->
-        List.fold_left (fun acc pair2 ->
-            let com_morphs =
-              construct_comonadic_morphs
-                pair1.comonadic pair0.comonadic
-            in
-            let closing_over_morphs =
-              construct_closing_over_morphs
-                pair1.comonadic pair2.monadic
-            in
-            let simple_edges =
-              if (construct_edge_condition pair0 pair2)
-              then construct_simple_between pair0 pair2
-              else []
-            in
-            List.fold_left (fun acc edge ->
-              List.fold_left (fun acc cls_morph ->
-                List.fold_left (fun acc com_morph ->
-                  ClosingOver {
-                    cls_target = cls_morph;
-                    cls_src = com_morph;
-                    cls_edge = edge
-                  } :: acc
-                ) acc com_morphs
-              ) acc closing_over_morphs
-            ) acc simple_edges
-          )
-        acc !visible_pairs)
-      [] !visible_pairs
+  let construct_edges_between pair0 pair1 =
+    if not (construct_edge_condition pair0 pair1) then []
+    else begin
+      let simple = construct_simple_between pair0 pair1 in
+      let comonadic = construct_comonadic_between pair0 pair1 in
+      List.map (fun edge -> Simple edge) simple @ comonadic
+    end
 
   let construct_edges_to :
       visible_pair -> edge list =
     fun pair1 ->
-      let find_edges pair0 =
-        if not (construct_edge_condition pair0 pair1)
-        then []
-        else begin
-          let edges = construct_simple_between pair0 pair1 in
-          let com_morphs = construct_comonadic_between pair0 pair1 in
-          let edges = List.map (fun edge -> Simple edge) edges in
-          edges @ com_morphs
-        end
-      in
       let edges =
-        List.map find_edges !visible_pairs
+        List.concat_map (fun pair0 -> construct_edges_between pair0 pair1)
+          !visible_pairs
       in
-      let close_over = construct_closing_over_to pair1 in
-      close_over @ List.flatten edges
+      construct_closing_over_to pair1 @ edges
 
   let construct_edges_from :
       visible_pair -> edge list =
     fun pair0 ->
-      let find_edges pair1 =
-        if not (construct_edge_condition pair0 pair1)
-        then []
-        else begin
-          let edges = construct_simple_between pair0 pair1 in
-          let com_morphs = construct_comonadic_between pair0 pair1 in
-          let edges = List.map (fun edge -> Simple edge) edges in
-          edges @ com_morphs
-        end
-      in
-      let edges =
-        List.map find_edges !visible_pairs
-      in
-      List.flatten edges
+      List.concat_map (fun pair1 -> construct_edges_between pair0 pair1)
+        !visible_pairs
 
   let eq_boxedname
-      (N (v, v', _, dstf, f)) (N (u, u', _, dstg, g)) =
+      (N { target = v; src = v'; morph_dst = dstf; morph = f; _ })
+      (N { target = u; src = u'; morph_dst = dstg; morph = g; _ }) =
     match C.equal_obj dstf dstg with
     | Is_eq ->
       Desc.Var.Head.equal v u
@@ -1986,11 +1978,11 @@ end = struct
     let edges_lower, edges_upper =
       partition_edges_into_bounds ~edges_from ~edges_to
     in
-    if edges_lower = [] && edges_upper = []
+    if List.is_empty edges_lower && List.is_empty edges_upper
        && lo = "" && hi = ""
     then begin
       let name =
-        construct_name_exn pair
+        construct_name pair
           { monadic = C.id; comonadic = C.id }
           pair
       in
@@ -2014,10 +2006,10 @@ end = struct
             l sep s
       in
       let has_upper =
-        edges_upper <> [] || hi <> ""
+        not (List.is_empty edges_upper) || hi <> ""
       in
       let has_lower =
-        edges_lower <> [] || lo <> ""
+        not (List.is_empty edges_lower) || lo <> ""
       in
       Fmt.fprintf ppf "[%s%a%s%s%a]"
         (if has_upper then "< " else "")

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1248,22 +1248,6 @@ end = struct
   let weak_var_map = ref TypeMap.empty
   let named_weak_vars = ref String.Set.empty
 
-  let reset_names () =
-    names := [];
-    name_subst := [];
-    name_counter := 0;
-    named_vars := [];
-    visited_for_named_vars := [];
-    visited_for_modes := [];
-    visited_for_named_modevars := [];
-    visible_pairs := [];
-    aliased_visible_pairs := [];
-    printed_aliased_visible_pairs := [];
-    modenames := [];
-    Paths.reset visible_paths;
-    VarTbl.reset visible_vars;
-    modename_counter := 0
-
   let add_named_var tty =
     match tty.desc with
       Tvar { name = Some name } | Tunivar { name = Some name } ->
@@ -1964,12 +1948,50 @@ end = struct
     let lower = List.map into_lower_to edges_to in
     lower, upper
 
+  type edges =
+    { lower : edge_as_lower list;
+      upper : edge_as_upper list
+    }
+
+  let edge_table = ref ([] : (visible_pair * edges) list)
+
+  let reset_names () =
+    names := [];
+    name_subst := [];
+    name_counter := 0;
+    named_vars := [];
+    visited_for_named_vars := [];
+    visited_for_modes := [];
+    visited_for_named_modevars := [];
+    visible_pairs := [];
+    aliased_visible_pairs := [];
+    printed_aliased_visible_pairs := [];
+    modenames := [];
+    edge_table := [];
+    Paths.reset visible_paths;
+    VarTbl.reset visible_vars;
+    modename_counter := 0
+
+  let add_visible_edges () =
+    edge_table :=
+      List.map (fun pair ->
+        let lower, upper =
+          partition_edges_into_bounds
+            ~edges_from:(construct_edges_from pair)
+            ~edges_to:(construct_edges_to pair)
+        in
+        pair, { lower; upper })
+        !visible_pairs
+
+  let find_edges pair =
+    match
+      List.find_opt (fun (pair', _) -> eq_pair pair pair') !edge_table
+    with
+    | Some (_, edges) -> edges
+    | None -> { lower = []; upper = [] }
+
   let print_raw_constraints { lo; hi } ppf pair =
-    let edges_to = construct_edges_to pair in
-    let edges_from = construct_edges_from pair in
-    let edges_lower, edges_upper =
-      partition_edges_into_bounds ~edges_from ~edges_to
-    in
+    let { lower = edges_lower; upper = edges_upper } = find_edges pair in
     if List.is_empty edges_lower && List.is_empty edges_upper
        && lo = "" && hi = ""
     then begin
@@ -2151,6 +2173,7 @@ end = struct
       zap_non_generic_modes ty;
       add_named_modevars ty;
       add_visible_paths ();
+      add_visible_edges ();
       Btype.backtrack snap
     end
 end

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1022,6 +1022,54 @@ let equate_with_const : Alloc.lr -> Alloc.Const.t -> bool =
     else
       Alloc.Guts.in_bounds c m
 
+let erase_implied_axes (modes : Mode.Alloc.Const.t) :
+    Mode.Alloc.Const.Option.t =
+  (* [forkable] has implied defaults depending on [areality]: *)
+  let forkable =
+    match modes.areality, modes.forkable with
+    | Local, Unforkable | Global, Forkable -> None
+    | _, _ -> Some modes.forkable
+  in
+
+  (* [yielding] has implied defaults depending on [areality]: *)
+  let yielding =
+    match modes.areality, modes.yielding with
+    | Local, Yielding | Global, Unyielding -> None
+    | _, _ -> Some modes.yielding
+  in
+
+  (* [contention] has implied defaults based on [visibility]: *)
+  let contention =
+    match modes.visibility, modes.contention with
+    | Immutable, Contended
+    | Read, Shared
+    | Write, Corrupted
+    | Read_write, Uncontended -> None
+    | _, _ -> Some modes.contention
+  in
+
+  (* [portability] has implied defaults based on [statefulness]: *)
+  let portability =
+    match modes.statefulness, modes.portability with
+    | Stateless, Portable
+    | Reading, Shareable
+    | Writing, Corruptible
+    | Stateful, Nonportable -> None
+    | _, _ -> Some modes.portability
+  in
+
+  { areality = Some modes.areality;
+    linearity = Some modes.linearity;
+    uniqueness = Some modes.uniqueness;
+    portability;
+    contention;
+    forkable;
+    yielding;
+    statefulness = Some modes.statefulness;
+    visibility = Some modes.visibility;
+    staticity = Some modes.staticity
+  }
+
 module Variable_names : sig
   val reset_names : unit -> unit
 
@@ -1874,6 +1922,11 @@ end = struct
   type 'a interval = { lo: 'a; hi: 'a }
   let construct_raw_bounds { monadic; comonadic } :
       string interval =
+    let bound_diff bound trivial =
+      erase_implied_axes bound
+      |> Alloc.Const.Option.value ~default:trivial
+      |> fun bound -> Alloc.Const.diff bound trivial
+    in
     let mupper = dupper_lr Alloc.obj_monadic monadic in
     let mlower = dlower_lr Alloc.obj_monadic monadic in
     let cupper = dupper_lr Alloc.obj_comonadic comonadic in
@@ -1886,12 +1939,8 @@ end = struct
       Alloc.Const.merge
         { monadic = mlower; comonadic = cupper }
     in
-    let lower =
-      Alloc.Const.diff lower Alloc.Const.min
-    in
-    let upper =
-      Alloc.Const.diff upper Alloc.Const.max
-    in
+    let lower = bound_diff lower Alloc.Const.min in
+    let upper = bound_diff upper Alloc.Const.max in
     { lo = Fmt.asprintf "%a"
              Alloc.Const.Option.partial_print lower;
       hi = Fmt.asprintf "%a"
@@ -2368,43 +2417,13 @@ let out_modalities_of_mod_bounds mod_bounds =
 let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)
   let diff =
-
-    (* [forkable] has implied defaults depending on [areality]: *)
-    let forkable =
-      match modes.areality, modes.forkable with
-      | Local, Unforkable | Global, Forkable -> None
-      | _, _ -> Some modes.forkable
-    in
-
-    (* [yielding] has implied defaults depending on [areality]: *)
-    let yielding =
-      match modes.areality, modes.yielding with
-      | Local, Yielding | Global, Unyielding -> None
-      | _, _ -> Some modes.yielding
-    in
-
-    (* [contention] has implied defaults based on [visibility]: *)
-    let contention =
-      match modes.visibility, modes.contention with
-      | Immutable, Contended
-      | Read, Shared
-      | Write, Corrupted
-      | Read_write, Uncontended -> None
-      | _, _ -> Some modes.contention
-    in
-
-    (* [portability] has implied defaults based on [statefulness]: *)
-    let portability =
-      match modes.statefulness, modes.portability with
-      | Stateless, Portable
-      | Reading, Shareable
-      | Writing, Corruptible
-      | Stateful, Nonportable -> None
-      | _, _ -> Some modes.portability
-    in
-
+    let implied = erase_implied_axes modes in
     let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
-    { diff with forkable; yielding; contention; portability }
+    { diff with
+      forkable = implied.forkable;
+      yielding = implied.yielding;
+      contention = implied.contention;
+      portability = implied.portability }
   in
   (* Step 2: Print the modes *)
   List.filter_map

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -993,20 +993,21 @@ end = struct
 end
 
 (** A mode as seen by printing: either a determined constant, or a
-    comonadic mode kept generic. Along an arrow chain, the accumulated curry
-    mode is a constant until a generic mode variable is encountered. *)
+    generic comonadic mode. Along an arrow chain, the accumulated curry
+    mode is a constant until a generic mode variable is encountered.
+
+    A generic accumulator is the currying fold evaluated twice: the
+    argument modes themselves ([Ctype.curry_mode]), and their constant upper
+    bounds ([Ctype.curry_mode_const]). *)
 type const_or_generic =
   | Const of Alloc.Const.t
-  | Generic of Alloc.Comonadic.l
+  | Generic of Alloc.Comonadic.l * Alloc.Const.t
 
-(** The constant content: exact for [Const], the floor (with legacy
-    monadic) for [Generic]. *)
-let floor_const : const_or_generic -> Alloc.Const.t = function
+(** The upper bound of a const_or_generic: exact for [Const],
+    the constant upper bound for [Generic] *)
+let const_or_generic_upper : const_or_generic -> Alloc.Const.t = function
   | Const c -> c
-  | Generic acc ->
-    Alloc.Const.merge
-      { comonadic = Alloc.Comonadic.Guts.get_floor acc;
-        monadic = Alloc.Monadic.Const.legacy }
+  | Generic (_, bound) -> bound
 
 (** Extends the curry accumulator with the argument mode [marg] of an
     arrow. *)
@@ -1014,14 +1015,18 @@ let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
   fun acc marg ->
     match acc, Alloc.zap_to_legacy ~arg:true marg with
     | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
-    | Generic acc, _ -> Generic (Ctype.curry_mode acc marg)
+    | Generic (acc, bound), _ ->
+      Generic
+        (Ctype.curry_mode acc marg,
+         Ctype.curry_mode_const bound (Alloc.Guts.get_ceil marg))
     | Const acc, None ->
       if mode_polymorphism_printing_enabled ()
       then
         Generic
           (Ctype.curry_mode
              (Alloc.Comonadic.of_const (Alloc.Const.partial_apply acc))
-             marg)
+             marg,
+           Ctype.curry_mode_const acc (Alloc.Guts.get_ceil marg))
       else
         Const
           (Ctype.curry_mode_const acc
@@ -1035,7 +1040,10 @@ let const_or_generic_of_mode : arg:bool -> Alloc.lr -> const_or_generic =
     | Some c -> Const c
     | None ->
       if mode_polymorphism_printing_enabled ()
-      then Generic (Alloc.Comonadic.disallow_right m.comonadic)
+      then
+        Generic
+          (Alloc.Comonadic.disallow_right m.comonadic,
+           Alloc.Guts.get_ceil m)
       else Const (Alloc.zap_to_legacy_force ~arg m)
 
 (** Whether the return mode [m] of an arrow agrees with the constant
@@ -1053,8 +1061,9 @@ let equate_with_curry_bounds : Alloc.lr -> const_or_generic -> bool =
        || not (mode_polymorphism_printing_enabled ())
     then
       Result.is_ok
-        (Alloc.equate m (Alloc.of_const (floor_const acc_mode)))
-    else Alloc.Guts.in_bounds (floor_const acc_mode) m
+        (Alloc.equate m (Alloc.of_const (const_or_generic_upper acc_mode)))
+    else
+      Alloc.Guts.in_bounds (const_or_generic_upper acc_mode) m
 
 let erase_implied_axes (modes : Mode.Alloc.Const.t) :
     Mode.Alloc.Const.Option.t =
@@ -2140,9 +2149,9 @@ end = struct
   let acc_heads (acc : const_or_generic) : boxedhead list =
     match acc with
     | Const _ -> []
-    | Generic mode ->
+    | Generic (acc, _) ->
       let head (Desc.Amorphvar (v, _)) = H v in
-      (match Alloc.get_comonadic_desc mode with
+      (match Alloc.get_comonadic_desc acc with
        | Amode _ -> []
        | Amodevar mv -> [head mv]
        | Amodejoin (_, mvs) -> List.map head mvs)

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1001,26 +1001,56 @@ let zap_to_legacy : arg:bool -> Alloc.lr -> Alloc.Const.t =
       then Alloc.Guts.get_legacy ~arg m
       else Alloc.zap_to_legacy_force ~arg m
 
-let curry_mode_const : Alloc.Const.t -> Alloc.lr -> Alloc.Const.t =
-  fun alloc_mode marg ->
-    let arg_mode =
-      match Alloc.zap_to_legacy ~arg:true marg with
-      | Some c -> c
-      | None ->
-        if mode_polymorphism_printing_enabled ()
-        then Alloc.Guts.get_ceil marg
-        else Alloc.zap_to_legacy_force ~arg:true marg
-    in
-    curry_mode_const alloc_mode arg_mode
+(** The curry mode accumulated along an arrow chain: a constant until a
+    generic mode variable is encountered, then the [Ctype.curry_mode]
+    join. *)
+type curry_acc =
+  | Acc_const of Alloc.Const.t
+  | Acc_var of Alloc.Comonadic.l
 
-let equate_with_const : Alloc.lr -> Alloc.Const.t -> bool =
-  fun m c ->
+(** The floor of the accumulator *)
+let curry_acc_floor : curry_acc -> Alloc.Const.t = function
+  | Acc_const c -> c
+  | Acc_var acc ->
+    Alloc.Const.merge
+      { comonadic = Alloc.Comonadic.Guts.get_floor acc;
+        monadic = Alloc.Monadic.Const.legacy }
+
+(** Extends the accumulator with the argument mode [marg] of an arrow. *)
+let curry_acc_mode : curry_acc -> Alloc.lr -> curry_acc =
+  fun acc marg ->
+    match acc, Alloc.zap_to_legacy ~arg:true marg with
+    | Acc_const acc, Some arg -> Acc_const (Ctype.curry_mode_const acc arg)
+    | Acc_var acc, _ -> Acc_var (Ctype.curry_mode acc marg)
+    | Acc_const acc, None ->
+      if mode_polymorphism_printing_enabled ()
+      then
+        Acc_var
+          (Ctype.curry_mode
+             (Alloc.Comonadic.of_const (Alloc.Const.partial_apply acc))
+             marg)
+      else
+        Acc_const
+          (Ctype.curry_mode_const acc
+             (Alloc.zap_to_legacy_force ~arg:true marg))
+
+(** Whether the return mode [m] of an arrow agrees with the constant
+    content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
+    with the constant (an [Acc_var] contains generic variables and cannot
+    be equated with directly); otherwise a pure bounds check.
+
+    [equate_with_const] additionally checks [m]'s edges;
+    [Variable_names.equate_curry] calls this function alone, so that the
+    mutations happen during preprocessing, before bounds and edges are
+    computed. *)
+let equate_with_curry_bounds : Alloc.lr -> curry_acc -> bool =
+  fun m acc_mode ->
     if not (Alloc.check_generic m)
        || not (mode_polymorphism_printing_enabled ())
     then
-      Result.is_ok (Alloc.equate m (Alloc.of_const c))
-    else
-      Alloc.Guts.in_bounds c m
+      Result.is_ok
+        (Alloc.equate m (Alloc.of_const (curry_acc_floor acc_mode)))
+    else Alloc.Guts.in_bounds (curry_acc_floor acc_mode) m
 
 let erase_implied_axes (modes : Mode.Alloc.Const.t) :
     Mode.Alloc.Const.Option.t =
@@ -1080,6 +1110,15 @@ module Variable_names : sig
 
   val name_of_type : (unit -> string) -> transient_expr -> string
   val name_of_mode : Alloc.lr -> string
+
+  (** Whether the edges on the curry mode [m] are exactly the
+      [past]/[close] edges from [acc], i.e. implied by the currying
+      interpretation. [bounds_implied] says whether the constant bounds of
+      [m] are implied as well ([equate_with_curry_bounds]); the edges into
+      [m] are suppressed (not printed by the other modes) only when both
+      hold, since [m] is then elided. Must be called after [reserve]. *)
+  val curry_edges_implied :
+    bounds_implied:bool -> acc:curry_acc -> Alloc.lr -> bool
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1344,19 +1383,19 @@ end = struct
       match tty.desc with
       | Tarrow ((_l, marg, mret), _ty1, ty2, _) ->
         let _ = zap_to_legacy ~arg:true marg in
-        let acc_mode = curry_mode_const alloc_mode marg in
+        let acc_mode = curry_acc_mode (Acc_const alloc_mode) marg in
         equate_curry acc_mode mret ty2
       | _ ->
         printer_iter_type_expr (zap_non_generic_modes Alloc.Const.legacy)
           (Fun.const ()) ty
     end
 
-  and equate_curry : Alloc.Const.t -> Alloc.lr -> type_expr -> unit =
+  and equate_curry : curry_acc -> Alloc.lr -> type_expr -> unit =
     fun acc_mode mret ty ->
       match get_desc ty with
       | Tarrow _ ->
-          if equate_with_const mret acc_mode then
-            zap_non_generic_modes acc_mode ty
+          if equate_with_curry_bounds mret acc_mode then
+            zap_non_generic_modes (curry_acc_floor acc_mode) ty
           else begin
             let mret = zap_to_legacy ~arg:false mret in
             zap_non_generic_modes mret ty
@@ -2039,6 +2078,21 @@ end = struct
 
   let edge_table = ref ([] : (visible_pair * edges) list)
 
+  type boxedhead = H : 'a Desc.Var.Head.t -> boxedhead
+
+  (* Comonadic heads of elided curry modes; edges into them must not be
+     printed. *)
+  let suppressed_curry_heads = ref ([] : boxedhead list)
+
+  let heads_of_mode (m : Alloc.lr) =
+    match Alloc.get_comonadic_desc m.comonadic with
+    | Amode _ -> []
+    | Amodevar (Amorphvar (v, _)) -> [H v]
+
+  let mem_head : boxedhead list -> 'a Desc.Var.Head.t -> bool =
+    fun heads v ->
+      List.exists (fun (H u) -> Desc.Var.Head.equal u v) heads
+
   let reset_names () =
     names := [];
     name_subst := [];
@@ -2052,11 +2106,13 @@ end = struct
     printed_aliased_visible_pairs := [];
     modenames := [];
     edge_table := [];
+    suppressed_curry_heads := [];
     Paths.reset visible_paths;
     VarTbl.reset visible_vars;
     modename_counter := 0
 
   let add_visible_edges () =
+    suppressed_curry_heads := [];
     edge_table :=
       List.map (fun pair ->
         let lower, upper =
@@ -2074,8 +2130,62 @@ end = struct
     | Some (_, edges) -> edges
     | None -> { lower = []; upper = [] }
 
+  let pair_of_mode ({ monadic; comonadic } : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc monadic in
+    let comonadic = Alloc.get_comonadic_desc comonadic in
+    { monadic; comonadic }
+
+  (* The variable heads of the curry accumulator. *)
+  let acc_heads (acc : curry_acc) : boxedhead list =
+    match acc with
+    | Acc_const _ -> []
+    | Acc_var mode ->
+      let head (Desc.Amorphvar (v, _)) = H v in
+      (match Alloc.get_comonadic_desc mode with
+       | Amode _ -> []
+       | Amodevar mv -> [head mv]
+       | Amodejoin (_, mvs) -> List.map head mvs)
+
+  (* See the signature for the specification. *)
+  let curry_edges_implied ~bounds_implied ~(acc : curry_acc) (m : Alloc.lr) =
+    let pair = pair_of_mode m in
+    let implied =
+      bounds_implied
+      (* an aliased mode is printed at every occurrence *)
+      && (not (List.exists (eq_pair pair) !aliased_visible_pairs))
+      &&
+      let { lower; upper } = find_edges pair in
+      let acc_heads = acc_heads acc in
+      let from_acc = function
+        | Simple_name { src; _ } -> mem_head acc_heads src
+        | Comonadic_name { src; _ } -> mem_head acc_heads src
+      in
+      (* no edges from [m]... *)
+      List.is_empty upper
+      (* ...and every edge into [m] is a [past]/[close] edge from [acc] *)
+      && List.for_all
+           (function
+             | Lower_simple _ -> false
+             | Lower_comonadic { c_name; _ } -> from_acc c_name
+             | Lower_closing_over_to { cls_edge = { name; _ }; _ } ->
+               from_acc name)
+           lower
+    in
+    if implied then
+      suppressed_curry_heads := heads_of_mode m @ !suppressed_curry_heads;
+    implied
+
   let print_raw_constraints { lo; hi } ppf pair =
     let { lower = edges_lower; upper = edges_upper } = find_edges pair in
+    let edges_upper =
+      List.filter
+        (function
+          | Upper_comonadic { c_name = Comonadic_name { target; _ }; _ } ->
+            not (mem_head !suppressed_curry_heads target)
+          | Upper_comonadic { c_name = Simple_name _; _ }
+          | Upper_simple _ -> true)
+        edges_upper
+    in
     if List.is_empty edges_lower && List.is_empty edges_upper
        && lo = "" && hi = ""
     then begin
@@ -2261,6 +2371,19 @@ end = struct
       Btype.backtrack snap
     end
 end
+
+(** Whether the return mode [m] of an arrow can be elided: the arrow is
+    then printed without parens and [m] is not printed. Mutates [m] when it
+    must be zapped (see [equate_with_curry_bounds]). *)
+let equate_with_const : Alloc.lr -> curry_acc -> bool =
+  fun m acc_mode ->
+    if not (Alloc.check_generic m)
+       || not (mode_polymorphism_printing_enabled ())
+    then equate_with_curry_bounds m acc_mode
+    else
+      Variable_names.curry_edges_implied
+        ~bounds_implied:(equate_with_curry_bounds m acc_mode)
+        ~acc:acc_mode m
 
 module Aliases = struct
   let visited_objects = ref ([] : transient_expr list)
@@ -2470,7 +2593,7 @@ let tree_of_modes : Alloc.lr -> zapped:Alloc.Const.t -> string list =
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
   | Arrow_return of
-    { acc : Mode.Alloc.Const.t;
+    { acc : curry_acc;
       mode : Mode.Alloc.lr; }
     (** This is the RHS (say [r]) of an arrow type, where [mode] is the real
         mode of [r]. and:
@@ -2521,7 +2644,8 @@ let rec tree_of_modal_typexp mode modal ty =
    let name = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
    not_arrow (Otyp_var (non_gen, name)) else
 
-  let pr_typ alloc_mode =
+  let pr_typ acc_mode =
+    let alloc_mode = curry_acc_floor acc_mode in
     let tty = Transient_expr.repr ty in
     match tty.desc with
     | Tvar _ ->
@@ -2550,7 +2674,7 @@ let rec tree_of_modal_typexp mode modal ty =
           else
             tree_of_typexp mode arg_mode ty1
         in
-        let acc_mode = curry_mode_const alloc_mode marg in
+        let acc_mode = curry_acc_mode acc_mode marg in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
         Otyp_arrow (lab, tree_of_modes marg ~zapped:arg_mode, t1, t2)
@@ -2706,16 +2830,17 @@ let rec tree_of_modal_typexp mode modal ty =
        doesn't matter.*)
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
     let tree =
-      Otyp_alias {non_gen;  aliased = pr_typ Mode.Alloc.Const.legacy; alias }
+      Otyp_alias
+        {non_gen; aliased = pr_typ (Acc_const Mode.Alloc.Const.legacy); alias}
     in
     not_arrow tree end
   else
     match modal with
     | Arrow_return {acc; mode} ->
-        let rm, alloc_mode = tree_of_ret_typ_mutating acc mode ty in
-        let ty = pr_typ alloc_mode in
+        let rm, acc_mode = tree_of_ret_typ_mutating acc mode ty in
+        let ty = pr_typ acc_mode in
         Otyp_ret (rm, ty)
-    | Other m -> pr_typ m
+    | Other m -> pr_typ (Acc_const m)
 
 and tree_of_typexp mode alloc_mode ty =
   tree_of_modal_typexp mode (Other alloc_mode) ty
@@ -2793,7 +2918,7 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating (acc_mode : Alloc.Const.t) m ty=
+and tree_of_ret_typ_mutating (acc_mode : curry_acc) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
@@ -2804,12 +2929,12 @@ and tree_of_ret_typ_mutating (acc_mode : Alloc.Const.t) m ty=
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
         let zapped = zap_to_legacy ~arg:false m in
-        (Orm_parens (tree_of_modes m ~zapped), zapped)
+        (Orm_parens (tree_of_modes m ~zapped), Acc_const zapped)
       end
     end
   | _ ->
     let acc = zap_to_legacy ~arg:false m in
-    (Orm_any (tree_of_modes m ~zapped:acc), acc)
+    (Orm_any (tree_of_modes m ~zapped:acc), Acc_const acc)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -918,6 +918,13 @@ let printer_iter_type_expr f fm ty =
 let quoted_ident ppf x =
   Style.as_inline_code !Oprint.out_ident ppf x
 
+(* Mode variables for mode polymorphism should only be printed if
+  the following two flags are enabled *)
+let mode_polymorphism_printing_enabled () =
+  Language_extension.(
+    is_at_least Mode_polymorphism Alpha
+    && is_enabled Mode_polymorphism_printing)
+
 module Internal_names : sig
 
   val reset : unit -> unit
@@ -982,6 +989,27 @@ end = struct
 
 end
 
+let zap_to_legacy : arg:bool -> Alloc.lr -> Alloc.Const.t =
+  fun ~arg m ->
+    Option.value (Alloc.zap_to_legacy ~arg m)
+      ~default:(Alloc.Guts.get_legacy ~arg m)
+
+let curry_mode_const : Alloc.Const.t -> Alloc.lr -> Alloc.Const.t =
+  fun alloc_mode marg ->
+    let arg_mode =
+      Option.value (Alloc.zap_to_legacy ~arg:true marg)
+      ~default:(Alloc.Guts.get_ceil marg) in
+    curry_mode_const alloc_mode arg_mode
+
+let equate_with_const : Alloc.lr -> Alloc.Const.t -> bool =
+  fun m c ->
+    if not (Alloc.check_generic m)
+       || not (mode_polymorphism_printing_enabled ())
+    then
+      Result.is_ok (Alloc.equate m (Alloc.of_const c))
+    else
+      Alloc.Guts.in_bounds c m
+
 module Variable_names : sig
   val reset_names : unit -> unit
 
@@ -991,6 +1019,7 @@ module Variable_names : sig
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
   val name_of_type : (unit -> string) -> transient_expr -> string
+  val name_of_mode : Alloc.lr -> string
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1004,6 +1033,13 @@ module Variable_names : sig
      itself for the toplevel *)
   val refresh_weak : unit -> unit
 end = struct
+  type monadic_description =
+    (Alloc.Monadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type comonadic_description =
+    (Alloc.Comonadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type visible_pair =
+    (monadic_description, comonadic_description) monadic_comonadic
+
   (* We map from types to names, but not directly; we also store a substitution,
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
@@ -1013,6 +1049,90 @@ end = struct
   let name_counter = ref 0
   let named_vars = ref ([] : string list)
   let visited_for_named_vars = ref ([] : transient_expr list)
+  let visited_for_modes = ref ([] : transient_expr list)
+  let visited_for_named_modevars = ref ([] : transient_expr list)
+
+  module Desc = Alloc.Desc
+  module C = Alloc.C
+
+  (** Boxed var and morphisms (paths) to use in hashtables *)
+  type boxedvar =
+  | K : 'a C.obj * 'a Desc.Var.Head.t -> boxedvar
+  type boxedpath =
+  | P : 'b C.obj
+        * 'a Desc.Var.Head.t
+        * ('a, 'b, (allowed * disallowed)) C.morph
+      -> boxedpath
+
+  (** The name of polymorphic mode variables will be
+  determined by two variables and morphism pair. The object
+  types are irrelevant, and are thus forgotten. See [edge]
+  for more explanation *)
+  type boxedname =
+  | N : 'c Desc.Var.Head.t
+        * 'd Desc.Var.Head.t
+        * 'a C.obj
+        * 'b C.obj
+        * ('a, 'b, ('l * 'r)) C.morph
+      -> boxedname
+
+  module VarTbl = Hashtbl.Make (struct
+    type t = boxedvar
+    let equal (K (_, v1)) (K (_, v2)) = Desc.Var.Head.equal v1 v2
+    let hash (K (_, v)) = Desc.Var.Head.hash v
+  end)
+
+  module VarPairTbl = Hashtbl.Make (struct
+    type t = boxedvar * boxedvar
+    let equal (K (_, v1), K (_, v1')) (K (_, v2), K (_, v2')) =
+      Desc.Var.Head.equal v1 v2 && Desc.Var.Head.equal v1' v2'
+    let hash (K (_, v), K (_, v')) =
+      Hashtbl.hash (Desc.Var.Head.hash v, Desc.Var.Head.hash v')
+  end)
+
+  (** Tracks the mapping of monadic and comonadic mode
+  descriptions visible in the type *)
+  let visible_pairs = ref ([] : visible_pair list)
+  let aliased_visible_pairs = ref ([] : visible_pair list)
+  let printed_aliased_visible_pairs = ref ([] : (visible_pair * string) list)
+
+  (** Tracks all mode variables that may occur in the above
+  list (for fast visibility checking) *)
+  let visible_vars = VarTbl.create 17
+
+  (** Tracks all paths from a visible monadic mode
+  variable to another. A path is defined as follows:
+    let [(v, f)] and [(u, h)] be two visible monadic
+    morphvars, such that [v] can reach [u] by following
+    vlowers. Let [g] be one such composition of vlower
+    functions. By
+    transitivity, we know the following to be true: [g u <= v].
+
+    A path from [(v, f)] to [(u, h)] is defined as: [f ∘ g ∘ h'],
+    where [h'] is the left adjoint of [h]
+  *)
+  let visible_monadic_paths_tbl = VarPairTbl.create 17
+
+  (** Tracks all paths from a visible comonadic mode
+  variable to another. See description of
+  [visible_monadic_paths_tbl] for a definition of a
+  path *)
+  let visible_comonadic_paths_tbl = VarPairTbl.create 17
+
+  (** Tracks all paths from a visible comonadic mode
+  variable to visible monadic mode variable. Since
+  the path goes from a comonadic to a monadic mode,
+  it will have to go through a "monadic to comonadic"
+  morphism. These paths will correspond to a closing
+  over relation between two mode variables
+
+  See description of [visible_monadic_paths_tbl] for
+  a definition of a path *)
+  let visible_closing_over_paths_tbl = VarPairTbl.create 17
+
+  (** counter used to generate names for polymorphic mode variables *)
+  let modename_counter = ref 0
+  let modenames = ref ([] : (boxedname * string) list)
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
@@ -1023,7 +1143,18 @@ end = struct
     name_subst := [];
     name_counter := 0;
     named_vars := [];
-    visited_for_named_vars := []
+    visited_for_named_vars := [];
+    visited_for_modes := [];
+    visited_for_named_modevars := [];
+    visible_pairs := [];
+    aliased_visible_pairs := [];
+    printed_aliased_visible_pairs := [];
+    modenames := [];
+    VarPairTbl.reset visible_monadic_paths_tbl;
+    VarPairTbl.reset visible_comonadic_paths_tbl;
+    VarPairTbl.reset visible_closing_over_paths_tbl;
+    VarTbl.reset visible_vars;
+    modename_counter := 0
 
   let add_named_var tty =
     match tty.desc with
@@ -1043,6 +1174,849 @@ end = struct
       | _ ->
           printer_iter_type_expr add_named_vars (Fun.const ()) ty
     end
+
+  (* The following preprocessing step zaps non-generic
+    modes to legacy, while equating a derived curry mode
+    with the inferred non-generic return modes. This step
+    should exactly mirror the behavior of
+    [tree_of_typexp]. It is needed so we get the correct
+    precise bounds of mode descriptions
+  *)
+  let rec zap_non_generic_modes : Alloc.Const.t -> type_expr -> unit =
+    fun alloc_mode ty ->
+    let px = proxy ty in
+    if List.memq px !visited_for_modes then () else begin
+      visited_for_modes := px :: !visited_for_modes;
+      let tty = Transient_expr.repr ty in
+      match tty.desc with
+      | Tarrow ((_l, marg, mret), _ty1, ty2, _) ->
+        let _ = zap_to_legacy ~arg:true marg in
+        let acc_mode = curry_mode_const alloc_mode marg in
+        equate_curry acc_mode mret ty2
+      | _ ->
+        printer_iter_type_expr (zap_non_generic_modes Alloc.Const.legacy)
+          (Fun.const ()) ty
+    end
+
+  and equate_curry : Alloc.Const.t -> Alloc.lr -> type_expr -> unit =
+    fun acc_mode mret ty ->
+      match get_desc ty with
+      | Tarrow _ ->
+          if equate_with_const mret acc_mode then
+            zap_non_generic_modes acc_mode ty
+          else begin
+            let mret = zap_to_legacy ~arg:false mret in
+            zap_non_generic_modes mret ty
+          end
+      | _ ->
+        let mret = zap_to_legacy ~arg:false mret in
+        zap_non_generic_modes mret ty
+
+  let zap_non_generic_modes ty =
+    zap_non_generic_modes Alloc.Const.legacy ty
+
+  let eq_pair :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun { monadic = mon0; comonadic = com0 }
+        { monadic = mon1; comonadic = com1 } ->
+    Desc.equal Alloc.obj_monadic mon0 mon1
+    && Desc.equal Alloc.obj_comonadic com0 com1
+
+  (* The following preprocessing step registers all the
+    modes pointed to by a type. Recall that a [Alloc.lr]
+    has two parts: { monadic; comonadic }. We need to
+    register each individual mode variable, as well as
+    the association between the monadic and comonadic
+    parts.
+
+    The former are registered in a VarTbl, the latter
+    in a list of mode descriptions
+    We also use this step to register mode aliases
+  *)
+  let add_visible : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> unit =
+    fun dst desc ->
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let src = C.src dst f in
+        let v = K (src, v) in
+        VarTbl.add visible_vars v ()
+
+  let add_named_modevar : Alloc.lr -> unit =
+    fun ({ monadic; comonadic } as mode) ->
+      if Alloc.check_generic mode then begin
+        let monadic_desc = Alloc.get_monadic_desc monadic in
+        let comonadic_desc = Alloc.get_comonadic_desc comonadic in
+        let pair = { monadic = monadic_desc; comonadic = comonadic_desc } in
+        add_visible Alloc.obj_monadic monadic_desc;
+        add_visible Alloc.obj_comonadic comonadic_desc;
+        if List.exists (eq_pair pair) !visible_pairs then
+          aliased_visible_pairs := pair :: !aliased_visible_pairs
+        else
+          visible_pairs := pair :: !visible_pairs
+      end
+
+  let rec add_named_modevars ty =
+    let px = proxy ty in
+    if not (List.memq px !visited_for_named_modevars) then begin
+      visited_for_named_modevars := px :: !visited_for_named_modevars;
+      printer_iter_type_expr add_named_modevars add_named_modevar ty
+    end
+
+  (* The next preprocessing step registers all direct
+    paths from one visible mode variable to another.
+  *)
+
+  type memoized = (boxedpath list) VarTbl.t
+  type visited = unit VarTbl.t
+
+  exception Cannot_unwrap
+
+  (* Find the [b -> Monadic] morphism associated with
+    some visible variable [v] of object type [b] *)
+  let find_monadic_morph_opt : type b. b C.obj -> b Desc.Var.Head.t
+      -> ((b, Alloc.Monadic.Const.t, (allowed * allowed)) C.morph) option =
+    fun obj v ->
+      let find_match { monadic } =
+        match monadic with
+        | Desc.Amodevar (Amorphvar (u, f)) ->
+            if not (Desc.Var.Head.equal v u) then None else begin
+              let obj' = C.src Alloc.obj_monadic f in
+                match C.equal_obj obj obj' with
+                | Is_eq ->
+                  let (f : ((b, Alloc.Monadic.Const.t,
+                    (allowed * allowed)) C.morph)) = f in
+                  if Desc.Var.Head.equal v u then Some f else None
+                | Is_not_eq -> raise Cannot_unwrap
+            end
+        | Desc.Amode _ -> None
+      in
+      List.find_map find_match !visible_pairs
+
+  (* Find the [b -> Comonadic] morphism associated with
+    some visible variable [v] of object type [b] *)
+  let find_comonadic_morph_opt : type b. b C.obj -> b Desc.Var.Head.t
+      -> ((b, Alloc.Comonadic.Const.t, (allowed * allowed)) C.morph) option =
+    fun obj v ->
+      let find_match { comonadic } =
+        match comonadic with
+        | Desc.Amodevar (Amorphvar (u, f)) ->
+            if not (Desc.Var.Head.equal v u) then None else begin
+              let obj' = C.src Alloc.obj_comonadic f in
+                match C.equal_obj obj obj' with
+                | Is_eq ->
+                  let (f : ((b, Alloc.Comonadic.Const.t,
+                    (allowed * allowed)) C.morph)) = f in
+                  if Desc.Var.Head.equal v u then Some f else None
+                | Is_not_eq -> raise Cannot_unwrap
+            end
+        | Desc.Amode _ -> None
+      in
+      List.find_map find_match !visible_pairs
+
+  let visible : type b. b C.obj -> b Desc.Var.Head.t -> bool =
+    fun obj v ->
+      VarTbl.mem visible_vars (K (obj, v))
+
+  let remove_duplicate_paths : boxedpath list -> boxedpath list =
+    fun paths ->
+      let sort (P (fdst, v, f)) (P (gdst, u, g)) =
+        match C.equal_obj fdst gdst with
+        | Is_not_eq -> 1
+        | Is_eq ->
+          match C.equal_morph fdst f g with
+          | Is_not_eq -> 1
+          | Is_eq -> Int.compare v.desc_id u.desc_id
+      in
+      List.sort_uniq sort paths
+
+  (* Find all direct paths (via vlowers) from some
+    variable [v] to all other reachable visible variables
+    at generic level. *)
+  (* CR ageorges: WARNING: cycles are *not* registered
+      as a separate morphism:
+      e.g.: let [w] be a visible generic variable with
+            the following (vlower) edges:
+            v -f> u1 -g> u2 -g'> u1 -h> w
+            [find_paths v] will return only the direct
+            path [(f ∘ h)]
+      In the future, we might want to register all
+      paths. This will require a lattice of morphisms,
+      so we can calculate the fixed point of cycle *)
+  let rec find_paths :
+      type b. memoized:memoized -> visited:visited
+      -> bool -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~memoized ~visited first dst v ->
+      if visible dst v && not first then [P (dst, v, C.id)] else begin
+        if VarTbl.mem visited (K (dst, v)) then [] else begin
+          VarTbl.add visited (K (dst, v)) ();
+          match VarTbl.find_opt memoized (K (dst, v)) with
+          | Some paths -> paths
+          | None ->
+            let paths =
+              List.filter_map (fun (Desc.Var.Amorphvar (w, f)) ->
+                let fsrc = C.src dst f in
+                let w = Desc.Var.force fsrc w in
+                if w.desc_level <> generic_level then None else begin
+                let wpaths = find_paths ~memoized ~visited false fsrc w in
+                Some (List.map (fun (P (gdst, u, g)) ->
+                  match C.equal_obj fsrc gdst with
+                  | Is_eq ->
+                    let fg = C.compose dst f g in
+                    P (dst, u, fg)
+                  | Is_not_eq -> raise Cannot_unwrap) wpaths)
+              end) v.desc_vlower
+            in
+            (* TODO: we might want to remove duplicates here *)
+            let paths = List.flatten paths in
+            let paths = remove_duplicate_paths paths in
+            VarTbl.add memoized (K (dst,v)) paths;
+            paths
+          end
+      end
+
+  let find_paths :
+      memoized:memoized -> visited:visited
+      -> boxedvar -> boxedpath list =
+    fun ~memoized ~visited (K (dst, v)) ->
+      find_paths ~memoized ~visited true dst v
+
+  (** [find_path_from_description] constructs all morphisms
+    from one visible mode variable to another, and applies
+    an iterator [iter] on them.
+    The [find_morph_opt] parameter takes a variable as
+    input, and returns its associated morphism. The final
+    morphism is constructed as follows:
+      - let the parameter [desc] be a morphvar
+        description [(v, f)]
+      - let g be vlower path from [v] to some [u].
+        (recall g : [u.obj] -> [v.obj])
+      - let [find_morph_opt u] = Some [h]
+    [find_path_from_description] runs [iter] on
+    ([v], [u]) and [fgh'] where [h'] is the left
+    adjoint of [h].
+
+    See [visible_monadic_paths_tbl] for an explanation
+    why this is the morphism we want *)
+  type 'b find_morph_opt =
+    { f : 'a. 'a C.obj
+          -> 'a Desc.Var.Head.t
+          -> (('a, 'b, (allowed * allowed)) C.morph) option; } [@@unboxed]
+  let find_path_from_description :
+      type a b. memoized:memoized
+      -> a C.obj
+      -> b C.obj
+      -> (a, (allowed * allowed)) Desc.t
+      -> b find_morph_opt
+      -> (boxedvar * boxedvar -> (b, a, (allowed * disallowed)) C.morph -> unit)
+      -> unit =
+    fun ~memoized dst bobj desc find_morph_opt iter ->
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let fsrc = C.src dst f in
+        let v = K (fsrc, v) in
+        let visited = VarTbl.create 17 in
+        let paths = find_paths ~memoized ~visited v in
+        List.iter (fun (P (gdst, u, g)) ->
+          match C.equal_obj fsrc gdst with
+            | Is_eq ->
+              let gsrc = C.src gdst g in
+              Option.iter (fun h ->
+                let h' = C.left_adjoint bobj h in
+                let fg = C.compose dst (C.disallow_right f) g in
+                let fgh' = C.compose dst fg h' in
+                iter (v, (K (gsrc, u))) fgh'
+              ) (find_morph_opt.f gsrc u)
+            | Is_not_eq -> raise Cannot_unwrap
+          ) paths
+
+
+  (* The following function is expensive and should be
+  called once during preprocessing. It constructs all
+  morphisms from a visible monadic/comonadic variable to
+  another visible monadic/comonadic variable, and records
+  them in their respective tables *)
+  let add_visible_paths () =
+    let memoized = VarTbl.create 17 in
+    List.iter
+      (fun { monadic; comonadic } ->
+        find_path_from_description ~memoized
+          Alloc.obj_monadic Alloc.obj_monadic monadic
+          { f = find_monadic_morph_opt }
+          (VarPairTbl.add visible_monadic_paths_tbl);
+        find_path_from_description ~memoized
+          Alloc.obj_comonadic Alloc.obj_comonadic
+          comonadic
+          { f = find_comonadic_morph_opt }
+          (VarPairTbl.add visible_comonadic_paths_tbl);
+        find_path_from_description ~memoized
+          Alloc.obj_comonadic Alloc.obj_monadic
+          comonadic
+          { f = find_monadic_morph_opt }
+          (VarPairTbl.add visible_closing_over_paths_tbl)
+      ) !visible_pairs
+
+  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
+  type monadic_morph =
+    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
+  type comonadic_morph =
+    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
+      morphl
+  type closing_over_morph =
+    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
+
+  type simple_edge =
+    { via :
+        (monadic_morph, comonadic_morph)
+          monadic_comonadic;
+        (** The pair of morphisms between the two modes.
+        The monadic morphism gives a path from the
+        monadic part of [src] to the monadic part of
+        [target], the comonadic morphism gives a path
+        from the comonadic part of [target] to the
+        comonadic part of [src] *)
+      name : boxedname;
+        (** When printing, we name edges rather than
+        nodes, such that we can print monadic and
+        comonadic constraints in different bounds, thus
+        only printing left_only morphisms. By default,
+        the name is determined by the comonadic
+        morphism, but if this morphism is trivial (i.e.
+        the bounds can determine it), we use the
+        monadic morphism instead. *)
+    }
+
+  type comonadic_edge =
+    { c_via : comonadic_morph;
+        (** The comonadic morphism between two modes
+        when there is no path between their monadic
+        counterparts. This edge represents a partial
+        constraint between two modes. The morphism
+        gives a path from [target] to [src] *)
+      c_name : boxedname;
+        (** The boxed name of [c_via] *)
+    }
+
+  (** [closing_over_edge] describes a specific pattern
+  that may arise between an argument, a return and a
+  curry-mode.
+
+  Consider the following function (the K-combinator)
+  let k x y = x
+
+  The mode of the argument [x] describes a lower bound on
+  the inner return. But when [k] is partially applied, this
+  mode also describes an upper bound on the closure [k x].
+
+  We want to print such a pattern as follows:
+
+  [k : x @ [< 'm] -> (y @ 'n -> x @ [> 'm]) @ [> close('m)]]
+
+  Where [close('m)] denotes a relation to the comonadic
+  parts of the argument, and the monadic part of the return *)
+
+  (** A [closing_over_edge] describes a relationship between
+  three visible mode variables: [src], [target] and [curry]*)
+  type closing_over_edge =
+    { cls_target : closing_over_morph;
+        (** A path from [curry] to monadic
+        part of [target] *)
+      cls_src : comonadic_morph;
+        (** A path from [curry] to comonadic
+        part of [src] *)
+      cls_edge : simple_edge
+        (** the edge from [src] to [target].
+        The name of a [closing_over_edge]
+        corresponds to the name of [cls_edge]. *)
+    }
+
+  type edge =
+  | Simple of simple_edge
+      (** a constraint between two alloc modes *)
+  | Comonadic of comonadic_edge
+      (** a constraint between the comonadic parts
+      of two alloc modes *)
+  | ClosingOver of closing_over_edge
+      (** a constraint between the monadic part
+      of one mode and the comonadic part of another *)
+
+   let dupper_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_upper
+
+  let dlower_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_lower
+
+  let construct_morphs :
+      type a. a C.obj
+        -> (a, (allowed * allowed)) Desc.t
+        -> (a, (allowed * allowed)) Desc.t
+        -> (boxedvar * boxedvar -> ((a, a) morphl) list)
+        -> ((a, a) morphl) list =
+    fun dst src_descr target_descr get_descr_from_vars ->
+      match src_descr, target_descr with
+      | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+        let vobj = C.src dst f in
+        let uobj = C.src dst g in
+        let l = C.apply dst f v.desc_upper in
+        let r = C.apply dst g u.desc_lower in
+        if C.le dst l r
+        then [C.id]
+        else get_descr_from_vars (K (vobj, v), K (uobj, u))
+      | _, _ ->
+        let l = dupper_lr dst src_descr in
+        let r = dlower_lr dst target_descr in
+        if C.le dst l r
+        then [C.id]
+        else [Alloc.meet_const_morph r]
+
+  let construct_closing_over_morphs :
+      (Alloc.Comonadic.Const.t, allowed * allowed) Desc.t
+      -> (Alloc.Monadic.Const.t, allowed * allowed) Desc.t
+      -> closing_over_morph list =
+    fun src_descr target_descr ->
+    match src_descr, target_descr with
+    | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+      let vobj = C.src Alloc.obj_comonadic f in
+      let uobj = C.src Alloc.obj_monadic g in
+        VarPairTbl.find_all visible_closing_over_paths_tbl
+        (K (vobj, v), K (uobj, u))
+    | _, _ -> []
+
+  let construct_monadic_morphs src_descr target_descr =
+    construct_morphs Alloc.obj_monadic src_descr target_descr
+      (VarPairTbl.find_all visible_monadic_paths_tbl)
+
+  let construct_comonadic_morphs src_descr target_descr =
+    construct_morphs Alloc.obj_comonadic src_descr target_descr
+      (VarPairTbl.find_all visible_comonadic_paths_tbl)
+
+  (* Tests whether the relation between two descriptions can be decided by
+  their bounds. If the following is true for two parts of a mode variable pair,
+  then no constraint needs to be printed *)
+  let descr_compare_dec :
+      type a. a C.obj
+      -> (a, (allowed * allowed)) Desc.t
+      -> (a, (allowed * allowed)) Desc.t
+      -> bool =
+    fun dst a0 a1 ->
+      let upper0 = dupper_lr dst a0 in
+      let lower0 = dlower_lr dst a0 in
+      let upper1 = dupper_lr dst a1 in
+      let lower1 = dlower_lr dst a1 in
+      C.le dst upper0 lower1 ||
+      C.le dst upper1 lower0
+
+  let descr_is_var : type a. (a, (allowed * allowed)) Desc.t -> bool =
+    fun v ->
+      match v with
+      | Amode _ -> false
+      | Amodevar _ -> true
+
+  (** We only want to print a constraint (and thus
+  construct an edge) between [(mon0, com0)] and
+  [(mon1, com1)] if the following is true:
+
+  1) Either [compare mon0 mon1], or
+     [compare com0 com1] can't be decided via bounds
+  2) Either [mon0] and [mon1] are both variables,
+     or [com0] and [com1] are both variables
+  3) [(mon0, com0)] and [(mon1, com1)] are not equal
+  *)
+  let construct_edge_condition :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun ({ monadic = mon0; comonadic = com0 } as pair0)
+        ({ monadic = mon1; comonadic = com1 } as pair1) ->
+      let compare_dec =
+        not (descr_compare_dec
+               Alloc.obj_monadic mon0 mon1)
+        || not (descr_compare_dec
+                  Alloc.obj_comonadic com0 com1)
+      in
+      let check_signature =
+        (descr_is_var mon0 && descr_is_var mon1)
+        || (descr_is_var com0 && descr_is_var com1)
+      in
+      let pairs_ne = not (eq_pair pair0 pair1) in
+      compare_dec && check_signature && pairs_ne
+
+  exception Invalid_edge
+  let construct_name_exn :
+      visible_pair
+      -> (monadic_morph, comonadic_morph) monadic_comonadic
+      -> visible_pair
+      -> boxedname =
+    fun { monadic = mon0; comonadic = com0 }
+        { monadic = mon_morph; comonadic = com_morph }
+        { monadic = mon1; comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        N (u, v, Alloc.obj_comonadic, Alloc.obj_comonadic, com_morph)
+      | _, _ ->
+        match mon0, mon1 with
+        | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+          N (u, v, Alloc.obj_monadic, Alloc.obj_monadic, mon_morph)
+        | _, _ -> raise Invalid_edge
+                  (* edges are only created when one of the morphism
+                  goes from a variable to a variable*)
+
+  let construct_comonadic_name_exn :
+      visible_pair
+      -> comonadic_morph
+      -> visible_pair
+      -> boxedname =
+    fun { comonadic = com0 }
+        com_morph
+        { comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        N (u, v, Alloc.obj_comonadic, Alloc.obj_comonadic, com_morph)
+      | _, _ -> raise Invalid_edge
+          (* comonadic edges are only created when one of the morphism
+          goes from a variable to a variable*)
+
+  let construct_simple_between =
+    fun pair0 pair1 ->
+
+      let mon_morphs =
+        construct_monadic_morphs
+          pair0.monadic pair1.monadic
+      in
+      let com_morphs =
+        construct_comonadic_morphs
+          pair1.comonadic pair0.comonadic
+      in
+      let edges =
+        List.fold_left (fun acc com_morph ->
+          List.fold_left (fun acc mon_morph ->
+          let via =
+            { monadic = mon_morph;
+              comonadic = com_morph }
+          in
+          let name =
+            construct_name_exn pair0 via pair1
+          in
+          let edge = { via; name } in
+          edge :: acc )
+          acc mon_morphs)
+        [] com_morphs
+      in
+      edges
+
+  let check_closing_over_candidate pair0 pair1 =
+    List.exists
+      (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs
+            pair1.comonadic pair2.monadic
+        in
+        let edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else [] in
+        edges <> [] && closing_over_morphs <> []
+      ) !visible_pairs
+
+  let construct_comonadic_between =
+    fun pair0 pair1 ->
+      let mon_morphs =
+        construct_monadic_morphs
+          pair0.monadic pair1.monadic
+      in
+      let com_morphs =
+        construct_comonadic_morphs
+          pair1.comonadic pair0.comonadic
+      in
+      if not (check_closing_over_candidate pair0 pair1) && mon_morphs = [] then
+        List.map (fun com_morph ->
+          let c_name = construct_comonadic_name_exn pair0 com_morph pair1 in
+          Comonadic { c_via = com_morph; c_name }) com_morphs
+      else []
+
+  let construct_closing_over_to =
+    fun pair1 ->
+      List.fold_left (fun acc pair0 ->
+        List.fold_left (fun acc pair2 ->
+            let com_morphs =
+              construct_comonadic_morphs
+                pair1.comonadic pair0.comonadic
+            in
+            let closing_over_morphs =
+              construct_closing_over_morphs
+                pair1.comonadic pair2.monadic
+            in
+            let simple_edges =
+              if (construct_edge_condition pair0 pair2)
+              then construct_simple_between pair0 pair2
+              else []
+            in
+            List.fold_left (fun acc edge ->
+              List.fold_left (fun acc cls_morph ->
+                List.fold_left (fun acc com_morph ->
+                  ClosingOver {
+                    cls_target = cls_morph;
+                    cls_src = com_morph;
+                    cls_edge = edge
+                  } :: acc
+                ) acc com_morphs
+              ) acc closing_over_morphs
+            ) acc simple_edges
+          )
+        acc !visible_pairs)
+      [] !visible_pairs
+
+  let construct_edges_to :
+      visible_pair -> edge list =
+    fun pair1 ->
+      let find_edges pair0 =
+        if not (construct_edge_condition pair0 pair1)
+        then []
+        else begin
+          let edges = construct_simple_between pair0 pair1 in
+          let com_morphs = construct_comonadic_between pair0 pair1 in
+          let edges = List.map (fun edge -> Simple edge) edges in
+          edges @ com_morphs
+        end
+      in
+      let edges =
+        List.map find_edges !visible_pairs
+      in
+      let close_over = construct_closing_over_to pair1 in
+      close_over @ List.flatten edges
+
+  let construct_edges_from :
+      visible_pair -> edge list =
+    fun pair0 ->
+      let find_edges pair1 =
+        if not (construct_edge_condition pair0 pair1)
+        then []
+        else begin
+          let edges = construct_simple_between pair0 pair1 in
+          let com_morphs = construct_comonadic_between pair0 pair1 in
+          let edges = List.map (fun edge -> Simple edge) edges in
+          edges @ com_morphs
+        end
+      in
+      let edges =
+        List.map find_edges !visible_pairs
+      in
+      List.flatten edges
+
+  let eq_boxedname
+      (N (v, v', _, dstf, f)) (N (u, u', _, dstg, g)) =
+    match C.equal_obj dstf dstg with
+    | Is_eq ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && (match C.equal_morph dstf f g with
+      | Is_eq -> true
+      | Is_not_eq -> false)
+    | Is_not_eq -> false
+
+  let pick_name : int -> string = fun i ->
+    match i with
+    | 0 -> "'m"
+    | 1 -> "'n"
+    | 2 -> "'o"
+    | 3 -> "'p"
+    | 4 -> "'q"
+    | _ -> Fmt.asprintf "'mm%d" (i - 5)
+
+  let add_named_modevar name =
+    let mopt =
+      List.find_opt
+        (fun (name', _) -> eq_boxedname name name')
+        !modenames
+    in
+    match mopt with
+    | Some (_, m) -> m
+    | None ->
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      modenames := (name, m) :: !modenames;
+      m
+
+  type 'a interval = { lo: 'a; hi: 'a }
+  let construct_raw_bounds { monadic; comonadic } :
+      string interval =
+    let mupper = dupper_lr Alloc.obj_monadic monadic in
+    let mlower = dlower_lr Alloc.obj_monadic monadic in
+    let cupper = dupper_lr Alloc.obj_comonadic comonadic in
+    let clower = dlower_lr Alloc.obj_comonadic comonadic in
+    let lower =
+      Alloc.Const.merge
+        { monadic = mupper; comonadic = clower }
+    in
+    let upper =
+      Alloc.Const.merge
+        { monadic = mlower; comonadic = cupper }
+    in
+    let lower =
+      Alloc.Const.diff lower Alloc.Const.min
+    in
+    let upper =
+      Alloc.Const.diff upper Alloc.Const.max
+    in
+    { lo = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print lower;
+      hi = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print upper}
+
+  type edge_as_lower =
+  | Lower_simple : simple_edge -> edge_as_lower
+  | Lower_comonadic : comonadic_edge -> edge_as_lower
+  | Lower_closing_over_to : closing_over_edge -> edge_as_lower
+
+  type edge_as_upper =
+  | Upper_simple : simple_edge -> edge_as_upper
+  | Upper_comonadic : comonadic_edge -> edge_as_upper
+
+  let print_raw_upper_bound ppf edge =
+    match edge with
+    | Upper_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_monadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.monadic
+    | Upper_comonadic { c_name } ->
+      let m = add_named_modevar c_name in
+      Fmt.fprintf ppf "%s @@@@ past" m
+
+  let print_raw_lower_bound ppf edge =
+    match edge with
+    | Lower_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.comonadic
+    | Lower_comonadic { c_via; c_name } ->
+      let m = add_named_modevar c_name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf c_via
+    | Lower_closing_over_to { cls_target; cls_src; cls_edge } ->
+      let m = add_named_modevar cls_edge.name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf cls ->
+          Alloc.pretty_print_comonadic_morph
+            (fun ppf s -> Fmt.fprintf ppf "%s" s)
+            m ppf cls)
+        cls_target ppf cls_src
+
+  let partition_edges_into_bounds :
+      edges_from:edge list ->
+      edges_to:edge list ->
+      edge_as_lower list * edge_as_upper list =
+    fun ~edges_from ~edges_to ->
+    let into_lower_from = function
+      | ClosingOver _ -> assert false
+      | Simple e -> Upper_simple e
+      | Comonadic e -> Upper_comonadic e
+    in
+    let into_lower_to = function
+      | ClosingOver e -> Lower_closing_over_to e
+      | Simple e -> Lower_simple e
+      | Comonadic e -> Lower_comonadic e
+    in
+    let upper = List.map into_lower_from edges_from in
+    let lower = List.map into_lower_to edges_to in
+    lower, upper
+
+  let print_raw_constraints { lo; hi } ppf pair =
+    let edges_to = construct_edges_to pair in
+    let edges_from = construct_edges_from pair in
+    let edges_lower, edges_upper =
+      partition_edges_into_bounds ~edges_from ~edges_to
+    in
+    if edges_lower = [] && edges_upper = []
+       && lo = "" && hi = ""
+    then begin
+      let name =
+        construct_name_exn pair
+          { monadic = C.id; comonadic = C.id }
+          pair
+      in
+      Fmt.fprintf ppf "%s" (add_named_modevar name)
+    end
+    else begin
+      let pp_sep sep ppf () =
+        Fmt.fprintf ppf "%s" sep
+      in
+      let pp_bounds pp sep extra ppf items =
+        match items, extra with
+        | [], "" -> ()
+        | [], s -> Fmt.fprintf ppf "%s" s
+        | l, "" ->
+          Fmt.pp_print_list
+            ~pp_sep:(pp_sep sep) pp ppf l
+        | l, s ->
+          Fmt.fprintf ppf "%a%s%s"
+            (Fmt.pp_print_list
+               ~pp_sep:(pp_sep sep) pp)
+            l sep s
+      in
+      let has_upper =
+        edges_upper <> [] || hi <> ""
+      in
+      let has_lower =
+        edges_lower <> [] || lo <> ""
+      in
+      Fmt.fprintf ppf "[%s%a%s%s%a]"
+        (if has_upper then "< " else "")
+        (pp_bounds print_raw_upper_bound
+           " & " hi)
+        edges_upper
+        (if has_upper && has_lower
+         then " " else "")
+        (if has_lower then "> " else "")
+        (pp_bounds print_raw_lower_bound
+           " | " lo)
+        edges_lower
+    end
+
+  let find_mode_already_printed pair =
+    let find (pair_alias, m) =
+      if eq_pair pair pair_alias then Some m else None
+    in
+    List.find_map find !printed_aliased_visible_pairs
+
+  let mode_print_alias ppf pair =
+    if List.exists (eq_pair pair)
+         !aliased_visible_pairs
+    then begin
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      printed_aliased_visible_pairs :=
+        (pair,m) :: !printed_aliased_visible_pairs;
+      Fmt.fprintf ppf "as %s" m
+    end
+
+  let name_of_mode (modes : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc modes.monadic in
+    let comonadic = Alloc.get_comonadic_desc modes.comonadic in
+    let pair = { monadic; comonadic } in
+    match find_mode_already_printed pair with
+    | Some m -> Fmt.asprintf "%s" m
+    | None ->
+        let bounds = construct_raw_bounds pair in
+        Fmt.asprintf "%a%a"
+          (print_raw_constraints bounds) pair
+          mode_print_alias pair
 
   let substitute ty =
     match List.assq ty !name_subst with
@@ -1143,7 +2117,14 @@ end = struct
 
   let reserve ty =
     normalize_type ty;
-    add_named_vars ty
+    add_named_vars ty;
+    if mode_polymorphism_printing_enabled () then begin
+      let snap = Btype.snapshot () in
+      zap_non_generic_modes ty;
+      add_named_modevars ty;
+      add_visible_paths ();
+      Btype.backtrack snap
+    end
 end
 
 module Aliases = struct
@@ -1322,7 +2303,7 @@ let out_modalities_of_mod_bounds mod_bounds =
   Typemode.untransl_mod_bounds mod_bounds
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let tree_of_modes (modes : Mode.Alloc.Const.t) =
+let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)
   let diff =
 
@@ -1371,6 +2352,15 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
       |> Option.map (Fmt.asprintf "%a" (Mode.Alloc.Const.print_axis ax)))
     Mode.Alloc.Axis.all
 
+let tree_of_modes : Alloc.lr -> zapped:Alloc.Const.t -> string list =
+  fun modes ~zapped ->
+    if Alloc.check_generic modes &&
+      mode_polymorphism_printing_enabled () then
+      [ (Fmt.asprintf "%s"
+            (Variable_names.name_of_mode modes))]
+    else
+      tree_of_modes_const zapped
+
 (** The modal context on a type when printing it. This is to reproduce the mode
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
@@ -1412,8 +2402,8 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy_force ~arg:false mode in
-        Otyp_ret (Orm_any (tree_of_modes mode), tree)
+        let mode = zap_to_legacy ~arg:false mode in
+        Otyp_ret (Orm_any (tree_of_modes_const mode), tree)
     | Other _ -> tree
   in
   let ty =
@@ -1442,7 +2432,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy_force ~arg:true marg in
+        let arg_mode = zap_to_legacy ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -1455,10 +2445,10 @@ let rec tree_of_modal_typexp mode modal ty =
           else
             tree_of_typexp mode arg_mode ty1
         in
-        let acc_mode = curry_mode_const alloc_mode arg_mode in
+        let acc_mode = curry_mode_const alloc_mode marg in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
-        Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
+        Otyp_arrow (lab, tree_of_modes marg ~zapped:arg_mode, t1, t2)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->
@@ -1698,23 +2688,23 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating acc_mode m ty=
+and tree_of_ret_typ_mutating (acc_mode : Alloc.Const.t) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
-      let c = Alloc.zap_to_legacy_force ~arg:false m in
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
-      match Alloc.equate (Alloc.of_const acc_mode) m with
-      | Ok () ->
+      if equate_with_const m acc_mode then begin
         (Orm_no_parens, acc_mode)
-      | Error _ ->
+      end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        (Orm_parens (tree_of_modes c), c)
+        let zapped = zap_to_legacy ~arg:false m in
+        (Orm_parens (tree_of_modes m ~zapped), zapped)
       end
+    end
   | _ ->
-    let m = Alloc.zap_to_legacy_force ~arg:false m in
-    (Orm_any (tree_of_modes m), m)
+    let acc = zap_to_legacy ~arg:false m in
+    (Orm_any (tree_of_modes m ~zapped:acc), acc)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -2706,7 +3696,7 @@ let rec tree_of_modtype ?abbrev = function
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
       let mres =
-        m_res |> Mode.Alloc.zap_to_legacy_force ~arg:false |> tree_of_modes
+        m_res |> zap_to_legacy ~arg:false |> tree_of_modes_const
       in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
@@ -2737,7 +3727,7 @@ and tree_of_functor_parameter ?abbrev = function
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
       let marg =
-        m_arg |> Mode.Alloc.zap_to_legacy_force ~arg:true |> tree_of_modes
+        m_arg |> zap_to_legacy ~arg:true |> tree_of_modes_const
       in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1377,8 +1377,7 @@ end = struct
     paths from one visible mode variable to another.
   *)
 
-  type memoized = (boxedpath list) VarTbl.t
-  type visited = unit VarTbl.t
+  type stack = unit VarTbl.t
 
   (* Find the [b -> Paths.src_obj table] morphism
     associated with some visible variable [v] of object
@@ -1429,45 +1428,40 @@ end = struct
       paths. This will require a lattice of morphisms,
       so we can calculate the fixed point of cycle *)
   let rec paths_to_visible :
-      type b. memoized:memoized -> visited:visited
+      type b. stack:stack
       -> b C.obj -> b Desc.Var.Head.t
       -> boxedpath list =
-    fun ~memoized ~visited dst v ->
+    fun ~stack dst v ->
       if visible dst v then [P { dst; var = v; path = C.id }]
-      else paths_from_vlowers ~memoized ~visited dst v
+      else paths_from_vlowers ~stack dst v
 
   and paths_from_vlowers :
-      type b. memoized:memoized -> visited:visited
+      type b. stack:stack
       -> b C.obj -> b Desc.Var.Head.t
       -> boxedpath list =
-    fun ~memoized ~visited dst v ->
-      if VarTbl.mem visited (K (dst, v)) then [] else begin
-        VarTbl.add visited (K (dst, v)) ();
-        match VarTbl.find_opt memoized (K (dst, v)) with
-        | Some paths -> paths
-        | None ->
-          let paths =
-            List.concat_map (fun (Desc.Var.Amorphvar (w, f)) ->
-              let fsrc = C.src dst f in
-              let w = Desc.Var.force fsrc w in
-              if w.desc_level <> generic_level then []
-              else
-                List.map (fun (P { dst = gdst; var = u; path = g }) ->
-                  match C.equal_obj fsrc gdst with
-                  | Is_eq -> P { dst; var = u; path = C.compose dst f g }
-                  | Is_not_eq -> fatal_error "Out_type.paths_from_vlowers")
-                  (paths_to_visible ~memoized ~visited fsrc w))
-              v.desc_vlower
-          in
-          VarTbl.add memoized (K (dst, v)) paths;
-          paths
+    fun ~stack dst v ->
+      if VarTbl.mem stack (K (dst, v)) then [] else begin
+        VarTbl.add stack (K (dst, v)) ();
+        let paths =
+          List.concat_map (fun (Desc.Var.Amorphvar (w, f)) ->
+            let fsrc = C.src dst f in
+            let w = Desc.Var.force fsrc w in
+            if w.desc_level <> generic_level then []
+            else
+              List.map (fun (P { dst = gdst; var = u; path = g }) ->
+                match C.equal_obj fsrc gdst with
+                | Is_eq -> P { dst; var = u; path = C.compose dst f g }
+                | Is_not_eq -> fatal_error "Out_type.paths_from_vlowers")
+                (paths_to_visible ~stack fsrc w))
+            v.desc_vlower
+        in
+        VarTbl.remove stack (K (dst, v));
+        paths
       end
 
-  let find_paths :
-      memoized:memoized -> visited:visited
-      -> boxedvar -> boxedpath list =
-    fun ~memoized ~visited (K (dst, v)) ->
-      paths_from_vlowers ~memoized ~visited dst v
+  let find_paths : boxedvar -> boxedpath list =
+    fun (K (dst, v)) ->
+      paths_from_vlowers ~stack:(VarTbl.create 17) dst v
 
   (** [find_path_from_description] constructs all morphisms
     from one visible mode variable to another, and records
@@ -1487,11 +1481,11 @@ end = struct
     See [Paths.Monadic] for an explanation
     why this is the morphism we want *)
   let find_path_from_description :
-      type s d. memoized:memoized
-      -> (d, (allowed * allowed)) Desc.t
+      type s d.
+      (d, (allowed * allowed)) Desc.t
       -> (s, d) Paths.table
       -> unit =
-    fun ~memoized desc table ->
+    fun desc table ->
       let dst = Paths.dst_obj table in
       let bobj = Paths.src_obj table in
       match desc with
@@ -1499,8 +1493,7 @@ end = struct
       | Amodevar (Amorphvar (v, f)) ->
         let fsrc = C.src dst f in
         let v = K (fsrc, v) in
-        let visited = VarTbl.create 17 in
-        let paths = find_paths ~memoized ~visited v in
+        let paths = find_paths v in
         List.iter (fun (P { dst = gdst; var = u; path = g }) ->
           match C.equal_obj fsrc gdst with
             | Is_eq ->
@@ -1522,12 +1515,11 @@ end = struct
   another visible monadic/comonadic variable, and records
   them in their respective tables *)
   let add_visible_paths () =
-    let memoized = VarTbl.create 17 in
     List.iter
       (fun { monadic; comonadic } ->
-        find_path_from_description ~memoized monadic Paths.Monadic;
-        find_path_from_description ~memoized comonadic Paths.Comonadic;
-        find_path_from_description ~memoized comonadic Paths.Closing_over
+        find_path_from_description monadic Paths.Monadic;
+        find_path_from_description comonadic Paths.Comonadic;
+        find_path_from_description comonadic Paths.Closing_over
       ) !visible_pairs
 
   type simple_edge =

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -992,65 +992,69 @@ end = struct
 
 end
 
-let zap_to_legacy : arg:bool -> Alloc.lr -> Alloc.Const.t =
-  fun ~arg m ->
-    match Alloc.zap_to_legacy ~arg m with
-    | Some c -> c
-    | None ->
-      if mode_polymorphism_printing_enabled ()
-      then Alloc.Guts.get_legacy ~arg m
-      else Alloc.zap_to_legacy_force ~arg m
+(** A mode as seen by printing: either a determined constant, or a
+    comonadic mode kept generic. Along an arrow chain, the accumulated curry
+    mode is a constant until a generic mode variable is encountered. *)
+type const_or_generic =
+  | Const of Alloc.Const.t
+  | Generic of Alloc.Comonadic.l
 
-(** The curry mode accumulated along an arrow chain: a constant until a
-    generic mode variable is encountered, then the [Ctype.curry_mode]
-    join. *)
-type curry_acc =
-  | Acc_const of Alloc.Const.t
-  | Acc_var of Alloc.Comonadic.l
-
-(** The floor of the accumulator *)
-let curry_acc_floor : curry_acc -> Alloc.Const.t = function
-  | Acc_const c -> c
-  | Acc_var acc ->
+(** The constant content: exact for [Const], the floor (with legacy
+    monadic) for [Generic]. *)
+let floor_const : const_or_generic -> Alloc.Const.t = function
+  | Const c -> c
+  | Generic acc ->
     Alloc.Const.merge
       { comonadic = Alloc.Comonadic.Guts.get_floor acc;
         monadic = Alloc.Monadic.Const.legacy }
 
-(** Extends the accumulator with the argument mode [marg] of an arrow. *)
-let curry_acc_mode : curry_acc -> Alloc.lr -> curry_acc =
+(** Extends the curry accumulator with the argument mode [marg] of an
+    arrow. *)
+let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
   fun acc marg ->
     match acc, Alloc.zap_to_legacy ~arg:true marg with
-    | Acc_const acc, Some arg -> Acc_const (Ctype.curry_mode_const acc arg)
-    | Acc_var acc, _ -> Acc_var (Ctype.curry_mode acc marg)
-    | Acc_const acc, None ->
+    | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
+    | Generic acc, _ -> Generic (Ctype.curry_mode acc marg)
+    | Const acc, None ->
       if mode_polymorphism_printing_enabled ()
       then
-        Acc_var
+        Generic
           (Ctype.curry_mode
              (Alloc.Comonadic.of_const (Alloc.Const.partial_apply acc))
              marg)
       else
-        Acc_const
+        Const
           (Ctype.curry_mode_const acc
              (Alloc.zap_to_legacy_force ~arg:true marg))
 
+(** The view of a mode occurrence [m]; zaps [m] when it has to be a
+    constant. *)
+let const_or_generic_of_mode : arg:bool -> Alloc.lr -> const_or_generic =
+  fun ~arg m ->
+    match Alloc.zap_to_legacy ~arg m with
+    | Some c -> Const c
+    | None ->
+      if mode_polymorphism_printing_enabled ()
+      then Generic (Alloc.Comonadic.disallow_right m.comonadic)
+      else Const (Alloc.zap_to_legacy_force ~arg m)
+
 (** Whether the return mode [m] of an arrow agrees with the constant
     content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
-    with the constant (an [Acc_var] contains generic variables and cannot
+    with the constant (a [Generic] contains generic variables and cannot
     be equated with directly); otherwise a pure bounds check.
 
     [equate_with_const] additionally checks [m]'s edges;
     [Variable_names.equate_curry] calls this function alone, so that the
     mutations happen during preprocessing, before bounds and edges are
     computed. *)
-let equate_with_curry_bounds : Alloc.lr -> curry_acc -> bool =
+let equate_with_curry_bounds : Alloc.lr -> const_or_generic -> bool =
   fun m acc_mode ->
     if not (Alloc.check_generic m)
        || not (mode_polymorphism_printing_enabled ())
     then
       Result.is_ok
-        (Alloc.equate m (Alloc.of_const (curry_acc_floor acc_mode)))
-    else Alloc.Guts.in_bounds (curry_acc_floor acc_mode) m
+        (Alloc.equate m (Alloc.of_const (floor_const acc_mode)))
+    else Alloc.Guts.in_bounds (floor_const acc_mode) m
 
 let erase_implied_axes (modes : Mode.Alloc.Const.t) :
     Mode.Alloc.Const.Option.t =
@@ -1118,7 +1122,7 @@ module Variable_names : sig
       [m] are suppressed (not printed by the other modes) only when both
       hold, since [m] is then elided. Must be called after [reserve]. *)
   val curry_edges_implied :
-    bounds_implied:bool -> acc:curry_acc -> Alloc.lr -> bool
+    bounds_implied:bool -> acc:const_or_generic -> Alloc.lr -> bool
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1370,42 +1374,39 @@ end = struct
   (* The following preprocessing step zaps non-generic
     modes to legacy, while equating a derived curry mode
     with the inferred non-generic return modes. This step
-    should exactly mirror the behavior of
-    [tree_of_typexp]. It is needed so we get the correct
-    precise bounds of mode descriptions
+    should exactly mirror the mutations performed by
+    [tree_of_modal_typexp]. It is needed so we get the
+    correct precise bounds of mode descriptions
   *)
-  let rec zap_non_generic_modes : Alloc.Const.t -> type_expr -> unit =
-    fun alloc_mode ty ->
+  let rec zap_non_generic_modes : const_or_generic -> type_expr -> unit =
+    fun acc_mode ty ->
     let px = proxy ty in
     if List.memq px !visited_for_modes then () else begin
       visited_for_modes := px :: !visited_for_modes;
       let tty = Transient_expr.repr ty in
       match tty.desc with
-      | Tarrow ((_l, marg, mret), _ty1, ty2, _) ->
-        let _ = zap_to_legacy ~arg:true marg in
-        let acc_mode = curry_acc_mode (Acc_const alloc_mode) marg in
+      | Tarrow ((_l, marg, mret), ty1, ty2, _) ->
+        zap_non_generic_modes (const_or_generic_of_mode ~arg:true marg) ty1;
+        let acc_mode = curry_acc acc_mode marg in
         equate_curry acc_mode mret ty2
+      | Tpoly (ty, []) | Trepr (ty, []) ->
+        zap_non_generic_modes acc_mode ty
       | _ ->
-        printer_iter_type_expr (zap_non_generic_modes Alloc.Const.legacy)
+        printer_iter_type_expr
+          (zap_non_generic_modes (Const Alloc.Const.legacy))
           (Fun.const ()) ty
     end
 
-  and equate_curry : curry_acc -> Alloc.lr -> type_expr -> unit =
+  and equate_curry : const_or_generic -> Alloc.lr -> type_expr -> unit =
     fun acc_mode mret ty ->
       match get_desc ty with
-      | Tarrow _ ->
-          if equate_with_curry_bounds mret acc_mode then
-            zap_non_generic_modes (curry_acc_floor acc_mode) ty
-          else begin
-            let mret = zap_to_legacy ~arg:false mret in
-            zap_non_generic_modes mret ty
-          end
+      | Tarrow _ when equate_with_curry_bounds mret acc_mode ->
+          zap_non_generic_modes acc_mode ty
       | _ ->
-        let mret = zap_to_legacy ~arg:false mret in
-        zap_non_generic_modes mret ty
+        zap_non_generic_modes (const_or_generic_of_mode ~arg:false mret) ty
 
   let zap_non_generic_modes ty =
-    zap_non_generic_modes Alloc.Const.legacy ty
+    zap_non_generic_modes (Const Alloc.Const.legacy) ty
 
   let eq_pair :
       visible_pair
@@ -2136,10 +2137,10 @@ end = struct
     { monadic; comonadic }
 
   (* The variable heads of the curry accumulator. *)
-  let acc_heads (acc : curry_acc) : boxedhead list =
+  let acc_heads (acc : const_or_generic) : boxedhead list =
     match acc with
-    | Acc_const _ -> []
-    | Acc_var mode ->
+    | Const _ -> []
+    | Generic mode ->
       let head (Desc.Amorphvar (v, _)) = H v in
       (match Alloc.get_comonadic_desc mode with
        | Amode _ -> []
@@ -2147,7 +2148,8 @@ end = struct
        | Amodejoin (_, mvs) -> List.map head mvs)
 
   (* See the signature for the specification. *)
-  let curry_edges_implied ~bounds_implied ~(acc : curry_acc) (m : Alloc.lr) =
+  let curry_edges_implied ~bounds_implied ~(acc : const_or_generic)
+      (m : Alloc.lr) =
     let pair = pair_of_mode m in
     let implied =
       bounds_implied
@@ -2375,7 +2377,7 @@ end
 (** Whether the return mode [m] of an arrow can be elided: the arrow is
     then printed without parens and [m] is not printed. Mutates [m] when it
     must be zapped (see [equate_with_curry_bounds]). *)
-let equate_with_const : Alloc.lr -> curry_acc -> bool =
+let equate_with_const : Alloc.lr -> const_or_generic -> bool =
   fun m acc_mode ->
     if not (Alloc.check_generic m)
        || not (mode_polymorphism_printing_enabled ())
@@ -2580,20 +2582,19 @@ let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
       |> Option.map (Fmt.asprintf "%a" (Mode.Alloc.Const.print_axis ax)))
     Mode.Alloc.Axis.all
 
-let tree_of_modes : Alloc.lr -> zapped:Alloc.Const.t -> string list =
-  fun modes ~zapped ->
-    if Alloc.check_generic modes &&
-      mode_polymorphism_printing_enabled () then
+let tree_of_modes : Alloc.lr -> const_or_generic -> string list =
+  fun modes acc ->
+    match acc with
+    | Generic _ ->
       [ (Fmt.asprintf "%s"
             (Variable_names.name_of_mode modes))]
-    else
-      tree_of_modes_const zapped
+    | Const c -> tree_of_modes_const c
 
 (** The modal context on a type when printing it. This is to reproduce the mode
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
   | Arrow_return of
-    { acc : curry_acc;
+    { acc : const_or_generic;
       mode : Mode.Alloc.lr; }
     (** This is the RHS (say [r]) of an arrow type, where [mode] is the real
         mode of [r]. and:
@@ -2611,7 +2612,7 @@ type modal =
     If [r] is [Tpoly (Tarrow_, [])], it will be treated as NOT an arrow type.
     This gives tedious (but still correct) printing. *)
 
-  | Other of Mode.Alloc.Const.t
+  | Other of const_or_generic
     (** In other cases, the caller has already printed the modes (as the
         constructor argument) on the type. *)
 
@@ -2630,8 +2631,8 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = zap_to_legacy ~arg:false mode in
-        Otyp_ret (Orm_any (tree_of_modes_const mode), tree)
+        let acc = const_or_generic_of_mode ~arg:false mode in
+        Otyp_ret (Orm_any (tree_of_modes mode acc), tree)
     | Other _ -> tree
   in
   let ty =
@@ -2645,7 +2646,6 @@ let rec tree_of_modal_typexp mode modal ty =
    not_arrow (Otyp_var (non_gen, name)) else
 
   let pr_typ acc_mode =
-    let alloc_mode = curry_acc_floor acc_mode in
     let tty = Transient_expr.repr ty in
     match tty.desc with
     | Tvar _ ->
@@ -2661,7 +2661,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = zap_to_legacy ~arg:true marg in
+        let arg_acc = const_or_generic_of_mode ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -2669,15 +2669,15 @@ let rec tree_of_modal_typexp mode modal ty =
             with
             | Tconstr(path, [ty], _)
               when Path.same path Predef.path_option ->
-                tree_of_typexp mode arg_mode ty
+                tree_of_acc_typexp mode arg_acc ty
             | _ -> Otyp_stuff "<hidden>"
           else
-            tree_of_typexp mode arg_mode ty1
+            tree_of_acc_typexp mode arg_acc ty1
         in
-        let acc_mode = curry_acc_mode acc_mode marg in
+        let acc_mode = curry_acc acc_mode marg in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
-        Otyp_arrow (lab, tree_of_modes marg ~zapped:arg_mode, t1, t2)
+        Otyp_arrow (lab, tree_of_modes marg arg_acc, t1, t2)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->
@@ -2719,16 +2719,16 @@ let rec tree_of_modal_typexp mode modal ty =
         tree_of_typobject mode fi !nm
     | Tmod (ty, mod_bounds) ->
         Otyp_mod
-          ( tree_of_typexp mode alloc_mode ty,
+          ( tree_of_acc_typexp mode acc_mode ty,
             out_modalities_of_mod_bounds mod_bounds )
     | Tquote ty ->
         wrap_printing_env_unguarded
           (Env.enter_quote !printing_env)
-          (fun () -> Otyp_quote (tree_of_typexp mode alloc_mode ty))
+          (fun () -> Otyp_quote (tree_of_acc_typexp mode acc_mode ty))
     | Tsplice ty ->
         wrap_printing_env_unguarded
           (Env.enter_splice ~loc:Location.none !printing_env)
-          (fun () -> Otyp_splice (tree_of_typexp mode alloc_mode ty))
+          (fun () -> Otyp_splice (tree_of_acc_typexp mode acc_mode ty))
     | Tquote_eval ty ->
         (* We use [Predef]'s [eval] as the syntax, so we need to quote [ty]. *)
         let ty = newgenty (Tquote ty) in
@@ -2749,7 +2749,7 @@ let rec tree_of_modal_typexp mode modal ty =
     | Tlink _ ->
         fatal_error "Out_type.tree_of_typexp"
     | Tpoly (ty, []) | Trepr (ty, []) ->
-        tree_of_typexp mode alloc_mode ty
+        tree_of_acc_typexp mode acc_mode ty
     | Tpoly (ty, tyl) ->
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
@@ -2760,7 +2760,7 @@ let rec tree_of_modal_typexp mode modal ty =
            printed once when used as proxy *)
         List.iter Aliases.add_delayed tyl;
         let tl = tree_of_univars tyl in
-        let tr = Otyp_poly (tl, tree_of_typexp mode alloc_mode ty) in
+        let tr = Otyp_poly (tl, tree_of_acc_typexp mode acc_mode ty) in
         (* Forget names when we leave scope *)
         Variable_names.remove_names tyl;
         Aliases.delayed := old_delayed; tr
@@ -2795,17 +2795,18 @@ let rec tree_of_modal_typexp mode modal ty =
                List.iter Aliases.add_delayed tyl;
                let sort_names = tree_of_qsvs tyl in
                let tr =
-                Otyp_repr (sort_names, tree_of_typexp mode alloc_mode inner_ty)
-              in
+                 Otyp_repr
+                   (sort_names, tree_of_acc_typexp mode acc_mode inner_ty)
+               in
                Variable_names.remove_names tyl;
                Aliases.delayed := old_delayed;
                tr
              end else
                (* Mismatch: print Trepr and Tpoly separately *)
-               tree_of_typexp mode alloc_mode ty
+               tree_of_acc_typexp mode acc_mode ty
          | _ ->
              (* No type variables, just print the body *)
-             tree_of_typexp mode alloc_mode ty)
+             tree_of_acc_typexp mode acc_mode ty)
     | Tunivar _ ->
         Otyp_var (false, Variable_names.(name_of_type new_name) tty)
     | Tpackage pack ->
@@ -2831,7 +2832,7 @@ let rec tree_of_modal_typexp mode modal ty =
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
     let tree =
       Otyp_alias
-        {non_gen; aliased = pr_typ (Acc_const Mode.Alloc.Const.legacy); alias}
+        {non_gen; aliased = pr_typ (Const Mode.Alloc.Const.legacy); alias}
     in
     not_arrow tree end
   else
@@ -2840,10 +2841,13 @@ let rec tree_of_modal_typexp mode modal ty =
         let rm, acc_mode = tree_of_ret_typ_mutating acc mode ty in
         let ty = pr_typ acc_mode in
         Otyp_ret (rm, ty)
-    | Other m -> pr_typ (Acc_const m)
+    | Other acc_mode -> pr_typ acc_mode
+
+and tree_of_acc_typexp mode acc_mode ty =
+  tree_of_modal_typexp mode (Other acc_mode) ty
 
 and tree_of_typexp mode alloc_mode ty =
-  tree_of_modal_typexp mode (Other alloc_mode) ty
+  tree_of_acc_typexp mode (Const alloc_mode) ty
 
 and tree_of_qtv v jkind =
     (* CR layouts: We ignore nullability here to avoid needlessly printing
@@ -2918,7 +2922,7 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating (acc_mode : curry_acc) m ty=
+and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
@@ -2928,13 +2932,13 @@ and tree_of_ret_typ_mutating (acc_mode : curry_acc) m ty=
       end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let zapped = zap_to_legacy ~arg:false m in
-        (Orm_parens (tree_of_modes m ~zapped), Acc_const zapped)
+        let acc_mode = const_or_generic_of_mode ~arg:false m in
+        (Orm_parens (tree_of_modes m acc_mode), acc_mode)
       end
     end
   | _ ->
-    let acc = zap_to_legacy ~arg:false m in
-    (Orm_any (tree_of_modes m ~zapped:acc), Acc_const acc)
+    let acc_mode = const_or_generic_of_mode ~arg:false m in
+    (Orm_any (tree_of_modes m acc_mode), acc_mode)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -3926,7 +3930,7 @@ let rec tree_of_modtype ?abbrev = function
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
       let mres =
-        m_res |> zap_to_legacy ~arg:false |> tree_of_modes_const
+        m_res |> Alloc.zap_to_legacy_exn ~arg:false |> tree_of_modes_const
       in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
@@ -3957,7 +3961,7 @@ and tree_of_functor_parameter ?abbrev = function
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
       let marg =
-        m_arg |> zap_to_legacy ~arg:true |> tree_of_modes_const
+        m_arg |> Alloc.zap_to_legacy_exn ~arg:true |> tree_of_modes_const
       in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1906,7 +1906,7 @@ end = struct
         m ppf via.monadic
     | Upper_comonadic { c_name } ->
       let m = add_named_modevar c_name in
-      Fmt.fprintf ppf "%s @@@@ past" m
+      Fmt.fprintf ppf "past(%s)" m
 
   let print_raw_lower_bound ppf edge =
     match edge with
@@ -1917,9 +1917,11 @@ end = struct
         m ppf via.comonadic
     | Lower_comonadic { c_via; c_name } ->
       let m = add_named_modevar c_name in
-      Alloc.pretty_print_comonadic_morph
-        (fun ppf s -> Fmt.fprintf ppf "%s" s)
-        m ppf c_via
+      Fmt.fprintf ppf "past(%a)"
+        (Alloc.pretty_print_comonadic_morph
+           (fun ppf s -> Fmt.fprintf ppf "%s" s)
+           m)
+        c_via
     | Lower_closing_over_to { cls_target; cls_src; cls_edge } ->
       let m = add_named_modevar cls_edge.name in
       Alloc.pretty_print_comonadic_morph

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -15,6 +15,9 @@
 
 (* Compute a spanning tree representation of types *)
 
+module Std_map = Map
+module Std_set = Set
+
 open Misc
 open Ctype
 open Longident
@@ -1082,13 +1085,138 @@ end = struct
     let hash (K (_, v)) = Desc.Var.Head.hash v
   end)
 
-  module VarPairTbl = Hashtbl.Make (struct
+  module VarPairMap = Std_map.Make (struct
     type t = boxedvar * boxedvar
-    let equal (K (_, v1), K (_, v1')) (K (_, v2), K (_, v2')) =
-      Desc.Var.Head.equal v1 v2 && Desc.Var.Head.equal v1' v2'
-    let hash (K (_, v), K (_, v')) =
-      Hashtbl.hash (Desc.Var.Head.hash v, Desc.Var.Head.hash v')
+    let compare (K (_, v1), K (_, v1')) (K (_, v2), K (_, v2')) =
+      match Int.compare v1.desc_id v2.desc_id with
+      | 0 -> Int.compare v1'.desc_id v2'.desc_id
+      | c -> c
   end)
+
+  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
+  type monadic_morph =
+    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
+  type comonadic_morph =
+    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
+      morphl
+  type closing_over_morph =
+    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
+
+  module Paths = struct
+    module Monadic_path_set = Std_set.Make (struct
+      type t = monadic_morph
+      let compare m1 m2 = C.compare_morph Alloc.obj_monadic m1 m2
+    end)
+
+    module Comonadic_path_set = Std_set.Make (struct
+      type t = comonadic_morph
+      let compare m1 m2 = C.compare_morph Alloc.obj_comonadic m1 m2
+    end)
+
+    module Closing_over_path_set = Std_set.Make (struct
+      type t = closing_over_morph
+      let compare m1 m2 = C.compare_morph Alloc.obj_comonadic m1 m2
+    end)
+
+    type ('s, 'd) table =
+      | Monadic : (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) table
+          (** Tracks all paths from a visible monadic mode
+          variable to another. A path is defined as follows:
+            let [(v, f)] and [(u, h)] be two visible monadic
+            morphvars, such that [v] can reach [u] by following
+            vlowers. Let [g] be one such composition of vlower
+            functions. By
+            transitivity, we know the following to be true: [g u <= v].
+
+            A path from [(v, f)] to [(u, h)] is defined as: [f ∘ g ∘ h'],
+            where [h'] is the left adjoint of [h] *)
+      | Comonadic : (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t) table
+          (** Tracks all paths from a visible comonadic mode
+          variable to another. See description of
+          [Monadic] for a definition of a path *)
+      | Closing_over : (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) table
+          (** Tracks all paths from a visible comonadic mode
+          variable to visible monadic mode variable. Since
+          the path goes from a comonadic to a monadic mode,
+          it will have to go through a "monadic to comonadic"
+          morphism. These paths will correspond to a closing
+          over relation between two mode variables
+
+          See description of [Monadic] for a definition of
+          a path *)
+
+    type t =
+      { mutable monadic : Monadic_path_set.t VarPairMap.t;
+        mutable comonadic : Comonadic_path_set.t VarPairMap.t;
+        mutable closing_over : Closing_over_path_set.t VarPairMap.t
+      }
+
+    let create () =
+      { monadic = VarPairMap.empty;
+        comonadic = VarPairMap.empty;
+        closing_over = VarPairMap.empty
+      }
+
+    let reset t =
+      t.monadic <- VarPairMap.empty;
+      t.comonadic <- VarPairMap.empty;
+      t.closing_over <- VarPairMap.empty
+
+    let src_obj : type s d. (s, d) table -> s C.obj =
+      function
+      | Monadic -> Alloc.obj_monadic
+      | Comonadic -> Alloc.obj_comonadic
+      | Closing_over -> Alloc.obj_monadic
+
+    let dst_obj : type s d. (s, d) table -> d C.obj =
+      function
+      | Monadic -> Alloc.obj_monadic
+      | Comonadic -> Alloc.obj_comonadic
+      | Closing_over -> Alloc.obj_comonadic
+
+    let add : type s d.
+        t -> (s, d) table -> boxedvar * boxedvar -> (s, d) morphl -> unit =
+      fun t table key path ->
+      match table with
+      | Monadic ->
+        let set =
+          match VarPairMap.find_opt key t.monadic with
+          | None -> Monadic_path_set.singleton path
+          | Some set -> Monadic_path_set.add path set
+        in
+        t.monadic <- VarPairMap.add key set t.monadic
+      | Comonadic ->
+        let set =
+          match VarPairMap.find_opt key t.comonadic with
+          | None -> Comonadic_path_set.singleton path
+          | Some set -> Comonadic_path_set.add path set
+        in
+        t.comonadic <- VarPairMap.add key set t.comonadic
+      | Closing_over ->
+        let set =
+          match VarPairMap.find_opt key t.closing_over with
+          | None -> Closing_over_path_set.singleton path
+          | Some set -> Closing_over_path_set.add path set
+        in
+        t.closing_over <- VarPairMap.add key set t.closing_over
+
+    let find : type s d.
+        t -> (s, d) table -> boxedvar * boxedvar -> ((s, d) morphl) list =
+      fun t table key ->
+      match table with
+      | Monadic ->
+        (match VarPairMap.find_opt key t.monadic with
+         | None -> []
+         | Some set -> Monadic_path_set.elements set)
+      | Comonadic ->
+        (match VarPairMap.find_opt key t.comonadic with
+         | None -> []
+         | Some set -> Comonadic_path_set.elements set)
+      | Closing_over ->
+        (match VarPairMap.find_opt key t.closing_over with
+         | None -> []
+         | Some set -> Closing_over_path_set.elements set)
+  end
 
   (** Tracks the mapping of monadic and comonadic mode
   descriptions visible in the type *)
@@ -1100,35 +1228,7 @@ end = struct
   list (for fast visibility checking) *)
   let visible_vars = VarTbl.create 17
 
-  (** Tracks all paths from a visible monadic mode
-  variable to another. A path is defined as follows:
-    let [(v, f)] and [(u, h)] be two visible monadic
-    morphvars, such that [v] can reach [u] by following
-    vlowers. Let [g] be one such composition of vlower
-    functions. By
-    transitivity, we know the following to be true: [g u <= v].
-
-    A path from [(v, f)] to [(u, h)] is defined as: [f ∘ g ∘ h'],
-    where [h'] is the left adjoint of [h]
-  *)
-  let visible_monadic_paths_tbl = VarPairTbl.create 17
-
-  (** Tracks all paths from a visible comonadic mode
-  variable to another. See description of
-  [visible_monadic_paths_tbl] for a definition of a
-  path *)
-  let visible_comonadic_paths_tbl = VarPairTbl.create 17
-
-  (** Tracks all paths from a visible comonadic mode
-  variable to visible monadic mode variable. Since
-  the path goes from a comonadic to a monadic mode,
-  it will have to go through a "monadic to comonadic"
-  morphism. These paths will correspond to a closing
-  over relation between two mode variables
-
-  See description of [visible_monadic_paths_tbl] for
-  a definition of a path *)
-  let visible_closing_over_paths_tbl = VarPairTbl.create 17
+  let visible_paths = Paths.create ()
 
   (** counter used to generate names for polymorphic mode variables *)
   let modename_counter = ref 0
@@ -1150,9 +1250,7 @@ end = struct
     aliased_visible_pairs := [];
     printed_aliased_visible_pairs := [];
     modenames := [];
-    VarPairTbl.reset visible_monadic_paths_tbl;
-    VarPairTbl.reset visible_comonadic_paths_tbl;
-    VarPairTbl.reset visible_closing_over_paths_tbl;
+    Paths.reset visible_paths;
     VarTbl.reset visible_vars;
     modename_counter := 0
 
@@ -1274,42 +1372,30 @@ end = struct
 
   exception Cannot_unwrap
 
-  (* Find the [b -> Monadic] morphism associated with
-    some visible variable [v] of object type [b] *)
-  let find_monadic_morph_opt : type b. b C.obj -> b Desc.Var.Head.t
-      -> ((b, Alloc.Monadic.Const.t, (allowed * allowed)) C.morph) option =
-    fun obj v ->
-      let find_match { monadic } =
-        match monadic with
-        | Desc.Amodevar (Amorphvar (u, f)) ->
-            if not (Desc.Var.Head.equal v u) then None else begin
-              let obj' = C.src Alloc.obj_monadic f in
-                match C.equal_obj obj obj' with
-                | Is_eq ->
-                  let (f : ((b, Alloc.Monadic.Const.t,
-                    (allowed * allowed)) C.morph)) = f in
-                  if Desc.Var.Head.equal v u then Some f else None
-                | Is_not_eq -> raise Cannot_unwrap
-            end
-        | Desc.Amode _ -> None
+  (* Find the [b -> Paths.src_obj table] morphism
+    associated with some visible variable [v] of object
+    type [b] *)
+  let find_visible_morph_opt : type b s d.
+      (s, d) Paths.table -> b C.obj -> b Desc.Var.Head.t
+      -> ((b, s, (allowed * allowed)) C.morph) option =
+    fun table obj v ->
+      let sobj = Paths.src_obj table in
+      let desc_of_pair (pair : visible_pair)
+          : (s, (allowed * allowed)) Desc.t =
+        match table with
+        | Paths.Monadic -> pair.monadic
+        | Paths.Comonadic -> pair.comonadic
+        | Paths.Closing_over -> pair.monadic
       in
-      List.find_map find_match !visible_pairs
-
-  (* Find the [b -> Comonadic] morphism associated with
-    some visible variable [v] of object type [b] *)
-  let find_comonadic_morph_opt : type b. b C.obj -> b Desc.Var.Head.t
-      -> ((b, Alloc.Comonadic.Const.t, (allowed * allowed)) C.morph) option =
-    fun obj v ->
-      let find_match { comonadic } =
-        match comonadic with
+      let find_match pair =
+        match desc_of_pair pair with
         | Desc.Amodevar (Amorphvar (u, f)) ->
             if not (Desc.Var.Head.equal v u) then None else begin
-              let obj' = C.src Alloc.obj_comonadic f in
+              let obj' = C.src sobj f in
                 match C.equal_obj obj obj' with
                 | Is_eq ->
-                  let (f : ((b, Alloc.Comonadic.Const.t,
-                    (allowed * allowed)) C.morph)) = f in
-                  if Desc.Var.Head.equal v u then Some f else None
+                  let (f : ((b, s, (allowed * allowed)) C.morph)) = f in
+                  Some f
                 | Is_not_eq -> raise Cannot_unwrap
             end
         | Desc.Amode _ -> None
@@ -1319,18 +1405,6 @@ end = struct
   let visible : type b. b C.obj -> b Desc.Var.Head.t -> bool =
     fun obj v ->
       VarTbl.mem visible_vars (K (obj, v))
-
-  let remove_duplicate_paths : boxedpath list -> boxedpath list =
-    fun paths ->
-      let sort (P (fdst, v, f)) (P (gdst, u, g)) =
-        match C.equal_obj fdst gdst with
-        | Is_not_eq -> 1
-        | Is_eq ->
-          match C.equal_morph fdst f g with
-          | Is_not_eq -> 1
-          | Is_eq -> Int.compare v.desc_id u.desc_id
-      in
-      List.sort_uniq sort paths
 
   (* Find all direct paths (via vlowers) from some
     variable [v] to all other reachable visible variables
@@ -1370,9 +1444,7 @@ end = struct
                   | Is_not_eq -> raise Cannot_unwrap) wpaths)
               end) v.desc_vlower
             in
-            (* TODO: we might want to remove duplicates here *)
             let paths = List.flatten paths in
-            let paths = remove_duplicate_paths paths in
             VarTbl.add memoized (K (dst,v)) paths;
             paths
           end
@@ -1385,35 +1457,30 @@ end = struct
       find_paths ~memoized ~visited true dst v
 
   (** [find_path_from_description] constructs all morphisms
-    from one visible mode variable to another, and applies
-    an iterator [iter] on them.
-    The [find_morph_opt] parameter takes a variable as
+    from one visible mode variable to another, and records
+    them in the [table] of [visible_paths].
+    [find_visible_morph_opt table] takes a variable as
     input, and returns its associated morphism. The final
     morphism is constructed as follows:
       - let the parameter [desc] be a morphvar
         description [(v, f)]
       - let g be vlower path from [v] to some [u].
         (recall g : [u.obj] -> [v.obj])
-      - let [find_morph_opt u] = Some [h]
-    [find_path_from_description] runs [iter] on
+      - let [find_visible_morph_opt table u] = Some [h]
+    [find_path_from_description] records
     ([v], [u]) and [fgh'] where [h'] is the left
     adjoint of [h].
 
-    See [visible_monadic_paths_tbl] for an explanation
+    See [Paths.Monadic] for an explanation
     why this is the morphism we want *)
-  type 'b find_morph_opt =
-    { f : 'a. 'a C.obj
-          -> 'a Desc.Var.Head.t
-          -> (('a, 'b, (allowed * allowed)) C.morph) option; } [@@unboxed]
   let find_path_from_description :
-      type a b. memoized:memoized
-      -> a C.obj
-      -> b C.obj
-      -> (a, (allowed * allowed)) Desc.t
-      -> b find_morph_opt
-      -> (boxedvar * boxedvar -> (b, a, (allowed * disallowed)) C.morph -> unit)
+      type s d. memoized:memoized
+      -> (d, (allowed * allowed)) Desc.t
+      -> (s, d) Paths.table
       -> unit =
-    fun ~memoized dst bobj desc find_morph_opt iter ->
+    fun ~memoized desc table ->
+      let dst = Paths.dst_obj table in
+      let bobj = Paths.src_obj table in
       match desc with
       | Amode _ -> ()
       | Amodevar (Amorphvar (v, f)) ->
@@ -1429,8 +1496,8 @@ end = struct
                 let h' = C.left_adjoint bobj h in
                 let fg = C.compose dst (C.disallow_right f) g in
                 let fgh' = C.compose dst fg h' in
-                iter (v, (K (gsrc, u))) fgh'
-              ) (find_morph_opt.f gsrc u)
+                Paths.add visible_paths table (v, (K (gsrc, u))) fgh'
+              ) (find_visible_morph_opt table gsrc u)
             | Is_not_eq -> raise Cannot_unwrap
           ) paths
 
@@ -1444,30 +1511,10 @@ end = struct
     let memoized = VarTbl.create 17 in
     List.iter
       (fun { monadic; comonadic } ->
-        find_path_from_description ~memoized
-          Alloc.obj_monadic Alloc.obj_monadic monadic
-          { f = find_monadic_morph_opt }
-          (VarPairTbl.add visible_monadic_paths_tbl);
-        find_path_from_description ~memoized
-          Alloc.obj_comonadic Alloc.obj_comonadic
-          comonadic
-          { f = find_comonadic_morph_opt }
-          (VarPairTbl.add visible_comonadic_paths_tbl);
-        find_path_from_description ~memoized
-          Alloc.obj_comonadic Alloc.obj_monadic
-          comonadic
-          { f = find_monadic_morph_opt }
-          (VarPairTbl.add visible_closing_over_paths_tbl)
+        find_path_from_description ~memoized monadic Paths.Monadic;
+        find_path_from_description ~memoized comonadic Paths.Comonadic;
+        find_path_from_description ~memoized comonadic Paths.Closing_over
       ) !visible_pairs
-
-  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
-  type monadic_morph =
-    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
-  type comonadic_morph =
-    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
-      morphl
-  type closing_over_morph =
-    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
 
   type simple_edge =
     { via :
@@ -1559,12 +1606,12 @@ end = struct
         C.apply dst f v.desc_lower
 
   let construct_morphs :
-      type a. a C.obj
+      type a. (a, a) Paths.table
         -> (a, (allowed * allowed)) Desc.t
         -> (a, (allowed * allowed)) Desc.t
-        -> (boxedvar * boxedvar -> ((a, a) morphl) list)
         -> ((a, a) morphl) list =
-    fun dst src_descr target_descr get_descr_from_vars ->
+    fun table src_descr target_descr ->
+      let dst = Paths.dst_obj table in
       match src_descr, target_descr with
       | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
         let vobj = C.src dst f in
@@ -1573,7 +1620,7 @@ end = struct
         let r = C.apply dst g u.desc_lower in
         if C.le dst l r
         then [C.id]
-        else get_descr_from_vars (K (vobj, v), K (uobj, u))
+        else Paths.find visible_paths table (K (vobj, v), K (uobj, u))
       | _, _ ->
         let l = dupper_lr dst src_descr in
         let r = dlower_lr dst target_descr in
@@ -1590,17 +1637,14 @@ end = struct
     | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
       let vobj = C.src Alloc.obj_comonadic f in
       let uobj = C.src Alloc.obj_monadic g in
-        VarPairTbl.find_all visible_closing_over_paths_tbl
-        (K (vobj, v), K (uobj, u))
+        Paths.find visible_paths Paths.Closing_over (K (vobj, v), K (uobj, u))
     | _, _ -> []
 
   let construct_monadic_morphs src_descr target_descr =
-    construct_morphs Alloc.obj_monadic src_descr target_descr
-      (VarPairTbl.find_all visible_monadic_paths_tbl)
+    construct_morphs Paths.Monadic src_descr target_descr
 
   let construct_comonadic_morphs src_descr target_descr =
-    construct_morphs Alloc.obj_comonadic src_descr target_descr
-      (VarPairTbl.find_all visible_comonadic_paths_tbl)
+    construct_morphs Paths.Comonadic src_descr target_descr
 
   (* Tests whether the relation between two descriptions can be decided by
   their bounds. If the following is true for two parts of a mode variable pair,

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -668,7 +668,7 @@ and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
 
 and yielding_mode i ppf m =
   line i ppf "yielding_mode %s\n"
-    (match Mode.Yielding.zap_to_floor m with
+    (match Mode.Yielding.zap_to_floor_exn m with
      | Mode.Yielding.Const.Unyielding -> "unyielding"
      | Mode.Yielding.Const.Yielding -> "yielding")
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -603,16 +603,21 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let mode_iter : type a l r. a C.obj -> (a, l * r) mode -> var_iterator -> unit
       =
    fun dst m { iter } ->
-    match m with
-    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+    let iter_morphvar : type l' r'. (a, l' * r') morphvar -> unit =
+     fun (Amorphvar (v, f, _f_hint)) ->
       let src = C.src dst f in
       iter src (Amodevar (Amorphvar (v, C.id, Id)))
-    | _ -> ()
+    in
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv -> iter_morphvar mv
+    | Amodejoin (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
+    | Amodemeet (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
 
   let rec iter_covariant_morphvar : type a r.
       visited:(int, unit) Hashtbl.t ->
       a C.obj ->
-      (int -> (a, allowed * disallowed) mode -> unit) ->
+      (id:int -> level:int -> (a, allowed * disallowed) mode -> unit) ->
       (a, allowed * r) morphvar ->
       unit =
    fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
@@ -628,7 +633,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
           in
           let mu = Amorphvar (u, fg, fg_hint) in
-          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter ~id:u.id ~level:u.level (Amodevar mu);
           iter_covariant_morphvar ~visited dst iter mu)
         v.vlower
     end
@@ -636,7 +641,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let iter_covariant : type a r.
       a C.obj ->
       (a, allowed * r) mode ->
-      (int -> (a, allowed * disallowed) mode -> unit) ->
+      (id:int -> level:int -> (a, allowed * disallowed) mode -> unit) ->
       unit =
    fun dst m iter ->
     match m with
@@ -651,7 +656,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let rec iter_contravariant_morphvar : type a l.
       visited:(int, unit) Hashtbl.t ->
       a C.obj ->
-      (int -> (a, disallowed * allowed) mode -> unit) ->
+      (id:int -> level:int -> (a, disallowed * allowed) mode -> unit) ->
       (a, l * allowed) morphvar ->
       unit =
    fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
@@ -667,7 +672,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
           in
           let mu = Amorphvar (u, fg, fg_hint) in
-          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter ~id:u.id ~level:u.level (Amodevar mu);
           iter_contravariant_morphvar ~visited dst iter mu)
         v.vupper
     end
@@ -675,7 +680,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let iter_contravariant : type a l.
       a C.obj ->
       (a, l * allowed) mode ->
-      (int -> (a, disallowed * allowed) mode -> unit) ->
+      (id:int -> level:int -> (a, disallowed * allowed) mode -> unit) ->
       unit =
    fun dst m iter ->
     match m with

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1486,7 +1486,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     current_level < u.level < generic_level ==>
       Forall v in the reachable set of variables from u:
         v.level = generic_level + (v.level - current_level) *)
-  let rec generalize_topology : type a.
+  let rec generalize_topology_v : type a.
       log:_ -> current_level:int -> a var -> unit =
    fun ~log ~current_level u ->
     if u.level <= current_level || u.level >= generic_level
@@ -1495,7 +1495,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let new_level = generic_level + (u.level - current_level) in
       set_level ~log u new_level;
       let do_gen _ (Amorphvar (v, _f, _f_hint)) =
-        generalize_topology ~log ~current_level v
+        generalize_topology_v ~log ~current_level v
       in
       VarMap.iter do_gen u.vupper;
       VarMap.iter do_gen u.vlower
@@ -1529,7 +1529,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    generalize_topology ~log ~current_level u;
+    generalize_topology_v ~log ~current_level u;
     update_level_v ~log dst generic_level u
 
   (* generalize_structure first moves a variable to generic_level (like generalize does).
@@ -1562,8 +1562,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
    fun ~log dst ~current_level u ->
     (* if the following does not hold:
         current_level < u.level || u.level = generic_level
-      [generalize_topology] and [update_level] do nothing. We check it here to optimize
-      away the subsequent checks *)
+      [generalize_topology_v] and [update_level] do nothing. We check it here
+      to optimize away the subsequent checks *)
     if u.level <= current_level || u.level = generic_level
     then ()
     else begin
@@ -1573,7 +1573,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         set_vlower ~log u VarMap.empty;
         set_vupper ~log u VarMap.empty
       end;
-      generalize_topology ~log ~current_level u;
+      generalize_topology_v ~log ~current_level u;
       update_level_v ~log dst generic_level u;
       let vlower_above_current =
         VarMap.filter
@@ -1600,6 +1600,23 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         create_gencopy ~log dst ~current_level u
       end
     end
+
+  let generalize_topology (type a l r) ~current_level (a : (a, l * r) mode) ~log
+      =
+    match a with
+    | Amodevar (Amorphvar (v, _f, _f_hint)) ->
+      generalize_topology_v ~log ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, _f, _f_hint)) ->
+          generalize_topology_v ~log ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, _f, _f_hint)) ->
+          generalize_topology_v ~log ~current_level v)
+        mvs
 
   let generalize (type a l r) ~current_level (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -2212,5 +2212,127 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
           mvs;
         allow_left (Amodevar mu), true
+
+  (** Exposed description of mode variables, used for printing generic mode
+      variables *)
+  module Desc = struct
+    module Var = struct
+      type 'a t = 'a var
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+      module Head = struct
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        let equal v1 v2 = v1.desc_id = v2.desc_id
+
+        let hash v = Hashtbl.hash v.desc_id
+      end
+
+      let force : 'a C.obj -> 'a var -> 'a Head.t =
+       fun obj v ->
+        let desc_id = v.id in
+        let desc_lower =
+          get_floor obj
+            (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        let desc_upper =
+          get_ceil obj (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        (* let desc_lower = v.lower in
+          let desc_upper = v.upper in *)
+        let desc_vlower =
+          let f (Amorphvar (a, f, _) : _ morphvar) = Amorphvar (a, f) in
+          let vlower = VarMap.map f v.vlower in
+          var_map_to_list vlower
+        in
+        let desc_level = v.level in
+        { desc_id; desc_lower; desc_upper; desc_vlower; desc_level }
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    let equal_morphvar : type a l r.
+        a C.obj -> (a, l * r) morphvar -> (a, l * r) morphvar -> bool =
+     fun obj (Amorphvar (v1, m1)) (Amorphvar (v2, m2)) ->
+      let c = C.compare_morph obj m1 m2 in
+      c = 0 && Var.Head.equal v1 v2
+
+    let equal : type a l r. a C.obj -> (a, l * r) t -> (a, l * r) t -> bool =
+     fun obj m1 m2 ->
+      match m1, m2 with
+      | Amode a1, Amode a2 -> C.equal obj a1 a2
+      | Amodevar mv1, Amodevar mv2 -> equal_morphvar obj mv1 mv2
+      | Amodejoin (a1, mv1), Amodejoin (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | Amodemeet (a1, mv1), Amodejoin (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | _, _ -> false
+
+    let print_var : type a. a C.obj -> Fmt.formatter -> a Var.Head.t -> unit =
+     fun obj ppf { desc_id; desc_upper; desc_lower; desc_level } ->
+      Fmt.fprintf ppf "%x<%d>[%a--%a]" desc_id desc_level (C.print obj)
+        desc_lower (C.print obj) desc_upper
+
+    let print_morphvar : type a l r.
+        a C.obj -> Fmt.formatter -> (a, l * r) morphvar -> unit =
+     fun dst ppf mv ->
+      let (Amorphvar (v, f)) = mv in
+      let src = C.src dst f in
+      Fmt.fprintf ppf "%a(%a)" (C.print_morph dst) f (print_var src) v
+
+    let print : type a l r. a C.obj -> Fmt.formatter -> (a, l * r) t -> unit =
+     fun obj ppf m ->
+      match m with
+      | Amode a -> C.print obj ppf a
+      | Amodevar mv -> print_morphvar obj ppf mv
+      | Amodejoin (a, mvs) ->
+        Fmt.fprintf ppf "join(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+      | Amodemeet (a, mvs) ->
+        Fmt.fprintf ppf "meet(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+  end
+
+  let desc_morphvar : type a l r.
+      a C.obj -> (a, l * r) morphvar -> (a, l * r) Desc.morphvar =
+   fun dst (Amorphvar (v, f, _)) ->
+    let src = C.src dst f in
+    let v = Desc.Var.force src v in
+    Desc.Amorphvar (v, f)
+
+  let desc : type a l r. a C.obj -> (a, l * r) mode -> (a, l * r) Desc.t =
+   fun dst m ->
+    match m with
+    | Amode (a, _, _) -> Desc.Amode a
+    | Amodevar mv -> Desc.Amodevar (desc_morphvar dst mv)
+    | Amodejoin (a, _, mvs) ->
+      Desc.Amodejoin (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
+    | Amodemeet (a, _, mvs) ->
+      Desc.Amodemeet (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
 end
 [@@inline always]

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -586,6 +586,109 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Amodejoin (_, _, mvs) ->
       VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
 
+  let check_generic : type a l r. (a, l * r) mode -> bool =
+   fun m ->
+    match m with
+    | Amode _ -> false
+    | Amodevar mv -> check_level_morphvar mv generic_level
+    | Amodemeet (_, _, mvs) ->
+      VarMap.exists (fun _ mv -> check_level_morphvar mv generic_level) mvs
+    | Amodejoin (_, _, mvs) ->
+      VarMap.exists (fun _ mv -> check_level_morphvar mv generic_level) mvs
+
+  type var_iterator =
+    { iter : 'a. 'a C.obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  let mode_iter : type a l r. a C.obj -> (a, l * r) mode -> var_iterator -> unit
+      =
+   fun dst m { iter } ->
+    match m with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let src = C.src dst f in
+      iter src (Amodevar (Amorphvar (v, C.id, Id)))
+    | _ -> ()
+
+  let rec iter_covariant_morphvar : type a r.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (int -> (a, allowed * disallowed) mode -> unit) ->
+      (a, allowed * r) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_right f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter_covariant_morphvar ~visited dst iter mu)
+        v.vlower
+    end
+
+  let iter_covariant : type a r.
+      a C.obj ->
+      (a, allowed * r) mode ->
+      (int -> (a, allowed * disallowed) mode -> unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_covariant_morphvar ~visited dst iter mv
+    | Amodejoin (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter (fun _ mv -> iter_covariant_morphvar ~visited dst iter mv) mvs
+
+  let rec iter_contravariant_morphvar : type a l.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (int -> (a, disallowed * allowed) mode -> unit) ->
+      (a, l * allowed) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_left f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter_contravariant_morphvar ~visited dst iter mu)
+        v.vupper
+    end
+
+  let iter_contravariant : type a l.
+      a C.obj ->
+      (a, l * allowed) mode ->
+      (int -> (a, disallowed * allowed) mode -> unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_contravariant_morphvar ~visited dst iter mv
+    | Amodemeet (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter
+        (fun _ mv -> iter_contravariant_morphvar ~visited dst iter mv)
+        mvs
+
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
     Amorphvar

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -614,10 +614,17 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Amodejoin (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
     | Amodemeet (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
 
+  type 'b packed_morph =
+    | Packed_morph : ('a, 'b, 'd) C.morph -> 'b packed_morph
+
   let rec iter_covariant_morphvar : type a r.
       visited:(int, unit) Hashtbl.t ->
       a C.obj ->
-      (id:int -> level:int -> (a, allowed * disallowed) mode -> unit) ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, allowed * disallowed) mode ->
+      unit) ->
       (a, allowed * r) morphvar ->
       unit =
    fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
@@ -633,7 +640,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
           in
           let mu = Amorphvar (u, fg, fg_hint) in
-          iter ~id:u.id ~level:u.level (Amodevar mu);
+          iter ~id:u.id ~level:u.level ~morph:(Packed_morph fg) (Amodevar mu);
           iter_covariant_morphvar ~visited dst iter mu)
         v.vlower
     end
@@ -641,7 +648,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let iter_covariant : type a r.
       a C.obj ->
       (a, allowed * r) mode ->
-      (id:int -> level:int -> (a, allowed * disallowed) mode -> unit) ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, allowed * disallowed) mode ->
+      unit) ->
       unit =
    fun dst m iter ->
     match m with
@@ -656,7 +667,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let rec iter_contravariant_morphvar : type a l.
       visited:(int, unit) Hashtbl.t ->
       a C.obj ->
-      (id:int -> level:int -> (a, disallowed * allowed) mode -> unit) ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, disallowed * allowed) mode ->
+      unit) ->
       (a, l * allowed) morphvar ->
       unit =
    fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
@@ -672,7 +687,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
           in
           let mu = Amorphvar (u, fg, fg_hint) in
-          iter ~id:u.id ~level:u.level (Amodevar mu);
+          iter ~id:u.id ~level:u.level ~morph:(Packed_morph fg) (Amodevar mu);
           iter_contravariant_morphvar ~visited dst iter mu)
         v.vupper
     end
@@ -680,7 +695,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let iter_contravariant : type a l.
       a C.obj ->
       (a, l * allowed) mode ->
-      (id:int -> level:int -> (a, disallowed * allowed) mode -> unit) ->
+      (id:int ->
+      level:int ->
+      morph:a packed_morph ->
+      (a, disallowed * allowed) mode ->
+      unit) ->
       unit =
    fun dst m iter ->
     match m with

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -2283,7 +2283,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       | Amodevar mv1, Amodevar mv2 -> equal_morphvar obj mv1 mv2
       | Amodejoin (a1, mv1), Amodejoin (a2, mv2) ->
         C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
-      | Amodemeet (a1, mv1), Amodejoin (a2, mv2) ->
+      | Amodemeet (a1, mv1), Amodemeet (a2, mv2) ->
         C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
       | _, _ -> false
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -47,6 +47,15 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             -> ('a, 'c, 'l * 'r) t
         | Id : ('a, 'a, 'l * 'r) t
             (** Short-hand for [Base (H.id, C.id)] to save memory *)
+        | Adjoint_l :
+            ('a, 'b, 'l2 * allowed) t * ('b, 'a, allowed * disallowed) C.morph
+            -> ('b, 'a, 'l * disallowed) t
+            (** [Adjoint_l (h, m)] is the left adjoint of [h], deferred; [m] is
+                the (already computed) left adjoint of [h]'s morphism. *)
+        | Adjoint_r :
+            ('a, 'b, allowed * 'r2) t * ('b, 'a, disallowed * allowed) C.morph
+            -> ('b, 'a, disallowed * 'r) t
+            (** Right-adjoint analogue of [Adjoint_l]. *)
         constraint 'd = _ * _
       [@@ocaml.warning "-62"]
 
@@ -57,6 +66,56 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        fun m1 m2 ->
         match m1, m2 with Id, m -> m | m, Id -> m | _, _ -> Compose (m1, m2)
 
+      include Magic_allow_disallow (struct
+        type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
+
+        let rec allow_left : type l a b r.
+            (a, b, allowed * r) t -> (a, b, l * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.allow_left morph_hint, C.allow_left morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (allow_left a_morph_hint, allow_left b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+
+        let rec allow_right : type a b l r.
+            (a, b, l * allowed) t -> (a, b, l * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.allow_right morph_hint, C.allow_right morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (allow_right a_morph_hint, allow_right b_morph_hint)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+
+        let rec disallow_left : type a b l r.
+            (a, b, l * r) t -> (a, b, disallowed * r) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.disallow_left morph_hint, C.disallow_left morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (disallow_left a_morph_hint, disallow_left b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+
+        let rec disallow_right : type a b l r.
+            (a, b, l * r) t -> (a, b, l * disallowed) t =
+         fun h ->
+          match h with
+          | Id -> Id
+          | Base (morph_hint, morph) ->
+            Base (H.Morph.disallow_right morph_hint, C.disallow_right morph)
+          | Compose (a_morph_hint, b_morph_hint) ->
+            Compose (disallow_right a_morph_hint, disallow_right b_morph_hint)
+          | Adjoint_l (h, m) -> Adjoint_l (h, m)
+          | Adjoint_r (h, m) -> Adjoint_r (h, m)
+      end)
+
       let rec left_adjoint : type a b l.
           H.Pinpoint.t ->
           b C.obj ->
@@ -64,6 +123,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           H.Pinpoint.t * a C.obj * (b, a, allowed * disallowed) t =
        fun pp b_obj -> function
         | Id -> pp, b_obj, Id
+        | Adjoint_r (h, m) -> pp, C.src b_obj m, disallow_right h
         | Base (small_morph_hint, morph) ->
           let pp, small_morph_hint = H.Morph.left_adjoint pp small_morph_hint in
           ( pp,
@@ -85,6 +145,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           H.Pinpoint.t * a C.obj * (b, a, disallowed * allowed) t =
        fun pp b_obj -> function
         | Id -> pp, b_obj, Id
+        | Adjoint_l (h, m) -> pp, C.src b_obj m, disallow_left h
         | Base (small_morph_hint, morph) ->
           let pp, small_morph_hint =
             H.Morph.right_adjoint pp small_morph_hint
@@ -101,50 +162,6 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           in
           src_pp, src, Compose (g_morph_hint_adj, f_morph_hint_adj)
 
-      include Magic_allow_disallow (struct
-        type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
-
-        let rec allow_left : type l a b r.
-            (a, b, allowed * r) t -> (a, b, l * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.allow_left morph_hint, C.allow_left morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (allow_left a_morph_hint, allow_left b_morph_hint)
-
-        let rec allow_right : type a b l r.
-            (a, b, l * allowed) t -> (a, b, l * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.allow_right morph_hint, C.allow_right morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (allow_right a_morph_hint, allow_right b_morph_hint)
-
-        let rec disallow_left : type a b l r.
-            (a, b, l * r) t -> (a, b, disallowed * r) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.disallow_left morph_hint, C.disallow_left morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (disallow_left a_morph_hint, disallow_left b_morph_hint)
-
-        let rec disallow_right : type a b l r.
-            (a, b, l * r) t -> (a, b, l * disallowed) t =
-         fun h ->
-          match h with
-          | Id -> Id
-          | Base (morph_hint, morph) ->
-            Base (H.Morph.disallow_right morph_hint, C.disallow_right morph)
-          | Compose (a_morph_hint, b_morph_hint) ->
-            Compose (disallow_right a_morph_hint, disallow_right b_morph_hint)
-      end)
-
       let rec populate : type b a l r.
           a C.obj ->
           (b, a, l * r) t ->
@@ -153,6 +170,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        fun obj_a hint cont ->
         match hint with
         | Id -> cont obj_a
+        | Adjoint_l (h, m) ->
+          let obj_b = C.src obj_a m in
+          let _, _, h' = left_adjoint H.Pinpoint.unknown obj_b h in
+          populate obj_a (allow_left h') cont
+        | Adjoint_r (h, m) ->
+          let obj_b = C.src obj_a m in
+          let _, _, h' = right_adjoint H.Pinpoint.unknown obj_b h in
+          populate obj_a (allow_right h') cont
         | Base (morph_hint, morph) ->
           let obj_b = C.src obj_a morph in
           let ahint = cont obj_b in
@@ -1275,7 +1300,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       unit =
    fun ~log pp dst v u f f_hint ->
     let f' = C.left_adjoint dst f in
-    let _, src, f'_hint = Comp_hint.Morph_hint.left_adjoint pp dst f_hint in
+    let src = C.src dst f in
+    let f'_hint = Comp_hint.Morph_hint.Adjoint_l (f_hint, f') in
     let x = Amorphvar (u, f', f'_hint) in
     let key = get_key src x in
     if VarMap.mem key v.vlower
@@ -1315,7 +1341,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       unit =
    fun ~log pp dst v u f f_hint ->
     let f' = C.right_adjoint dst f in
-    let _, src, f'_hint = Comp_hint.Morph_hint.right_adjoint pp dst f_hint in
+    let src = C.src dst f in
+    let f'_hint = Comp_hint.Morph_hint.Adjoint_r (f_hint, f') in
     let x = Amorphvar (u, f', f'_hint) in
     let key = get_key src x in
     if VarMap.mem key v.vupper

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1374,9 +1374,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     decr persistent_id;
     id
 
-  let fresh ?(persistent = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower
-      ?vupper ~level obj =
-    let id = if persistent then next_persistent_id () else next_live_id () in
+  let fresh ?(neg = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper
+      ~level obj =
+    let id = if neg then next_persistent_id () else next_live_id () in
     let upper, upper_hint =
       match upper, upper_hint with
       | None, None -> C.max obj, Comp_hint.Max
@@ -1623,13 +1623,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       copy_from_level:int ->
       copy_below_level:int ->
       copy_to_level:int option ->
-      persistent:bool ->
+      cause:[`Save | `Restore | `Neither] ->
       a C.obj ->
       a var ->
       a var =
-   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~persistent
-       obj v ->
+   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~cause obj
+       v ->
     let in_window = v.level >= copy_from_level && v.level < copy_below_level in
+    if cause = `Restore then assert (v.id < 0);
     if not in_window
     then v
     else
@@ -1644,7 +1645,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         | Some v' -> v'
         | None ->
           let copy =
-            fresh ~persistent ~upper:v.upper ~lower:v.lower ~level:v.level obj
+            fresh ~neg:(cause = `Save) ~upper:v.upper ~lower:v.lower
+              ~level:v.level obj
           in
           set_optcopy ~changes:copy_scope obj ~target_level v (Some copy);
           let vupper =
@@ -1653,7 +1655,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                    ~copy_to_level ~persistent src u
+                    ~copy_to_level ~cause src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1665,7 +1667,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                    ~copy_to_level ~persistent src u
+                    ~copy_to_level ~cause src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1678,8 +1680,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       end
 
   let copy (type a l r) ~copy_scope ~copy_from_level ~copy_below_level
-      ?copy_to_level ?(persistent = false) (obj : a C.obj) (a : (a, l * r) mode)
-      : (a, l * r) mode =
+      ?copy_to_level ?(cause = `Neither) (obj : a C.obj) (a : (a, l * r) mode) :
+      (a, l * r) mode =
     (* We never want to copy variables above [generic_level]. *)
     assert (copy_below_level <= generic_level + 1);
     Option.iter
@@ -1695,7 +1697,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let obj = C.src obj f in
       let vcopy =
         copy_v ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level
-          ~persistent obj v
+          ~cause obj v
       in
       if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
     | Amode _ -> a
@@ -1706,7 +1708,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             let src = C.src obj f in
             let vcopy =
               copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                ~copy_to_level ~persistent src v
+                ~copy_to_level ~cause src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)
@@ -1720,7 +1722,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             let src = C.src obj f in
             let vcopy =
               copy_v ~copy_scope ~copy_from_level ~copy_below_level
-                ~copy_to_level ~persistent src v
+                ~copy_to_level ~cause src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -490,6 +490,52 @@ module type Solver_mono = sig
     val apply :
       'b obj -> ('a, 'b, 'l * 'r) morph -> ('a, 'l * 'r) t -> ('b, 'l * 'r) t
   end
+
+  (** The exposed description of modes *)
+  module Desc : sig
+    module Var : sig
+      type 'a t
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) morph -> ('b, 'd) t_with_morph
+
+      module Head : sig
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        val equal : 'a t -> 'b t -> bool
+
+        val hash : 'a t -> int
+      end
+
+      val force : 'a obj -> 'a t -> 'a Head.t
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    val equal : 'a obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+    val print : 'a obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+  end
+
+  (** Returns the description of a mode. *)
+  val desc : 'a obj -> ('a, 'd) mode -> ('a, 'd) Desc.t
 end
 
 (** Hint module to be provided by the user of the solver. *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -344,7 +344,7 @@ module type Solver_mono = sig
     copy_from_level:int ->
     copy_below_level:int ->
     ?copy_to_level:int ->
-    ?persistent:bool ->
+    ?cause:[`Save | `Restore | `Neither] ->
     'a obj ->
     ('a, 'l * 'r) mode ->
     ('a, 'l * 'r) mode

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -410,7 +410,7 @@ module type Solver_mono = sig
   val iter_covariant :
     'a obj ->
     ('a, allowed * 'r) mode ->
-    (int -> ('a, allowed * disallowed) mode -> unit) ->
+    (id:int -> level:int -> ('a, allowed * disallowed) mode -> unit) ->
     unit
 
   (** Applies an iterator over every reachable contravariant (right-) constraint
@@ -421,7 +421,7 @@ module type Solver_mono = sig
   val iter_contravariant :
     'a obj ->
     ('a, 'l * allowed) mode ->
-    (int -> ('a, disallowed * allowed) mode -> unit) ->
+    (id:int -> level:int -> ('a, disallowed * allowed) mode -> unit) ->
     unit
 
   (** Apply a monotone morphism explained by an optional hint *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -402,6 +402,8 @@ module type Solver_mono = sig
 
   val mode_iter : 'a obj -> ('a, 'l * 'r) mode -> var_iterator -> unit
 
+  type 'b packed_morph = Packed_morph : ('a, 'b, 'd) morph -> 'b packed_morph
+
   (** Applies an iterator over every reachable covariant (left-) constraint
       variable. The iterator is only applied to constraint variables at level 0,
       and exposes the int identifier of the constraint variable. WARNING: the
@@ -410,7 +412,11 @@ module type Solver_mono = sig
   val iter_covariant :
     'a obj ->
     ('a, allowed * 'r) mode ->
-    (id:int -> level:int -> ('a, allowed * disallowed) mode -> unit) ->
+    (id:int ->
+    level:int ->
+    morph:'a packed_morph ->
+    ('a, allowed * disallowed) mode ->
+    unit) ->
     unit
 
   (** Applies an iterator over every reachable contravariant (right-) constraint
@@ -421,7 +427,11 @@ module type Solver_mono = sig
   val iter_contravariant :
     'a obj ->
     ('a, 'l * allowed) mode ->
-    (id:int -> level:int -> ('a, disallowed * allowed) mode -> unit) ->
+    (id:int ->
+    level:int ->
+    morph:'a packed_morph ->
+    ('a, disallowed * allowed) mode ->
+    unit) ->
     unit
 
   (** Apply a monotone morphism explained by an optional hint *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -306,6 +306,13 @@ module type Solver_mono = sig
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
 
+  (** Moves a variable [u] whose level is above [current_level] and below
+      [generic_level] to [generic_level + i], where [i] is the difference
+      between [u.level] and [current_level] (the same is then done to all of
+      [u]'s children) *)
+  val generalize_topology :
+    current_level:int -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
   (** Generalizes a variable whose level is above [current_level], by putting
       its level to [generic_level], and all its children above [current_level]
       to [generic_level + i] for some nonzero [i]. *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -393,6 +393,37 @@ module type Solver_mono = sig
   (** Returns true if the mode is a constant or a mode variable at level 0 *)
   val check_const_or_level_0 : ('a, 'l * 'r) mode -> bool
 
+  (** Returns true if the mode includes a mode variable at generic level *)
+  val check_generic : ('a, 'l * 'r) mode -> bool
+
+  type var_iterator =
+    { iter : 'a. 'a obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  val mode_iter : 'a obj -> ('a, 'l * 'r) mode -> var_iterator -> unit
+
+  (** Applies an iterator over every reachable covariant (left-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_covariant :
+    'a obj ->
+    ('a, allowed * 'r) mode ->
+    (int -> ('a, allowed * disallowed) mode -> unit) ->
+    unit
+
+  (** Applies an iterator over every reachable contravariant (right-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_contravariant :
+    'a obj ->
+    ('a, 'l * allowed) mode ->
+    (int -> ('a, disallowed * allowed) mode -> unit) ->
+    unit
+
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
     'b obj ->

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -443,6 +443,7 @@ let to_subst_by_type_function s p =
 let new_type_id = s_ref (-1)
 let reset_additional_action_id () =
   new_type_id := -1;
+  Mode.reset_persistent_id ();
   Jkind_types.Sort.reset_cmi_sort_id ()
 
 let newpersty desc =

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -302,8 +302,11 @@ let with_additional_action =
         in
         (* CR-someday zqian: preserve the hints *)
         (* modes and modalities should have been zapped already *)
+        (* if a mode is generic we leave it as is *)
         let prepare_mode mode =
-          Mode.Alloc.(mode |> to_const_exn |> of_const)
+          if Mode.Alloc.check_generic mode
+          then mode
+          else Mode.Alloc.(mode |> to_const_exn |> of_const)
         in
         let prepare_modality modality =
           Mode.Modality.(modality |> to_const_exn|> of_const)
@@ -515,7 +518,8 @@ let apply_type_function params args body =
           let t = newgenstub ~scope:(get_scope ty)
             (Jkind.Builtin.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
-          let desc' = copy_type_desc copy desc in
+          let copy_mode m = For_copy.mode_copy_generic copy_scope m in
+          let desc' = copy_type_desc copy copy_mode desc in
           Transient_expr.set_stub_desc t desc';
           t
     in
@@ -678,6 +682,16 @@ let rec typexp copy_scope s ty =
       then newpersty (Tvar {name = None; jkind = stub_jkind})
       else newgenstub ~scope:(get_scope ty) stub_jkind
     in
+    let copy_mode =
+      if should_duplicate_vars || get_id ty < 0
+      then (fun m -> For_copy.mode_copy_for_saving copy_scope m)
+      else (fun m -> m)
+    in
+    let copy_mode_generic =
+      if should_duplicate_vars || get_id ty < 0
+      then (fun m -> For_copy.mode_copy_generic copy_scope m)
+      else (fun m -> m)
+    in
     For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
     let desc =
       if has_fixed_row then
@@ -762,7 +776,8 @@ let rec typexp copy_scope s ty =
           let marg, mret =
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              prepare_mode marg, prepare_mode mret
+              copy_mode_generic (prepare_mode marg),
+              copy_mode_generic (prepare_mode mret)
             | _ -> marg, mret
           in
           let arg = typexp copy_scope s arg in
@@ -772,7 +787,8 @@ let rec typexp copy_scope s ty =
       | Tof_kind jk -> Tof_kind (jkind copy_scope s jk)
       | Tmod (ty, mod_bounds) ->
           Tmod (typexp copy_scope s ty, mod_bounds)
-      | _ -> copy_type_desc (typexp copy_scope s) desc
+      | _ ->
+        copy_type_desc (typexp copy_scope s) copy_mode desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'
@@ -811,7 +827,8 @@ let jkind copy_scope s loc jk =
 *)
 let type_expr s ty =
   let loc = Option.value s.loc ~default:Location.none in
-  For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)
+  For_copy.with_scope (fun copy_scope ->
+    typexp copy_scope s loc ty)
 
 (* For idents that are guaranteed to be local/scoped, such as bound
    signature items and functor parameters. *)

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -40,7 +40,7 @@ type kind_replacement =
 type additional_action =
   | Prepare_for_saving of
       { prepare_jkind : 'l 'r. Location.t -> ('l * 'r) jkind -> ('l * 'r) jkind;
-        prepare_mode : Mode.Alloc.lr -> Mode.Alloc.lr;
+        prepare_mode : For_copy.copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr;
         prepare_modality : Mode.Modality.t -> Mode.Modality.t;
         prepare_ident : Ident.t -> Ident.t
       }
@@ -302,10 +302,10 @@ let with_additional_action =
         in
         (* CR-someday zqian: preserve the hints *)
         (* modes and modalities should have been zapped already *)
-        (* if a mode is generic we leave it as is *)
-        let prepare_mode mode =
+        (* if a mode is generic we copy it persistently for saving *)
+        let prepare_mode copy_scope mode =
           if Mode.Alloc.check_generic mode
-          then mode
+          then For_copy.mode_copy_for_saving copy_scope mode
           else Mode.Alloc.(mode |> to_const_exn |> of_const)
         in
         let prepare_modality modality =
@@ -765,13 +765,13 @@ let rec typexp copy_scope s ty =
       | Tarrow ((label, marg, mret), arg, ret, comm) ->
           let marg, mret =
             if get_id ty < 0 then
-              For_copy.mode_copy_generic copy_scope marg,
-              For_copy.mode_copy_generic copy_scope mret
+              For_copy.mode_copy_for_restoring copy_scope marg,
+              For_copy.mode_copy_for_restoring copy_scope mret
             else
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              For_copy.mode_copy_generic copy_scope (prepare_mode marg),
-              For_copy.mode_copy_generic copy_scope (prepare_mode mret)
+              prepare_mode copy_scope marg,
+              prepare_mode copy_scope mret
             | Duplicate_variables ->
               For_copy.mode_copy_generic copy_scope marg,
               For_copy.mode_copy_generic copy_scope mret

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -682,16 +682,6 @@ let rec typexp copy_scope s ty =
       then newpersty (Tvar {name = None; jkind = stub_jkind})
       else newgenstub ~scope:(get_scope ty) stub_jkind
     in
-    let copy_mode =
-      if should_duplicate_vars || get_id ty < 0
-      then (fun m -> For_copy.mode_copy_for_saving copy_scope m)
-      else (fun m -> m)
-    in
-    let copy_mode_generic =
-      if should_duplicate_vars || get_id ty < 0
-      then (fun m -> For_copy.mode_copy_generic copy_scope m)
-      else (fun m -> m)
-    in
     For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
     let desc =
       if has_fixed_row then
@@ -774,10 +764,17 @@ let rec typexp copy_scope s ty =
           Tlink (typexp copy_scope s t2)
       | Tarrow ((label, marg, mret), arg, ret, comm) ->
           let marg, mret =
+            if get_id ty < 0 then
+              For_copy.mode_copy_generic copy_scope marg,
+              For_copy.mode_copy_generic copy_scope mret
+            else
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              copy_mode_generic (prepare_mode marg),
-              copy_mode_generic (prepare_mode mret)
+              For_copy.mode_copy_generic copy_scope (prepare_mode marg),
+              For_copy.mode_copy_generic copy_scope (prepare_mode mret)
+            | Duplicate_variables ->
+              For_copy.mode_copy_generic copy_scope marg,
+              For_copy.mode_copy_generic copy_scope mret
             | _ -> marg, mret
           in
           let arg = typexp copy_scope s arg in
@@ -788,7 +785,7 @@ let rec typexp copy_scope s ty =
       | Tmod (ty, mod_bounds) ->
           Tmod (typexp copy_scope s ty, mod_bounds)
       | _ ->
-        copy_type_desc (typexp copy_scope s) copy_mode desc
+        copy_type_desc (typexp copy_scope s) (fun _ -> assert false) desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1942,8 +1942,8 @@ let final_decl env define_class
                  , Non_generalizable_class { id; clty; nongen_vars }));
     );
   begin match
-    Alloc.with_zap_scope Ctype.closed_class clty.cty_params
-      (Btype.signature_of_class_type clty.cty_type)
+    Alloc.with_zap_scope (fun ~zap_scope -> Ctype.closed_class ~zap_scope
+      clty.cty_params (Btype.signature_of_class_type clty.cty_type))
   with
     None        -> ()
   | Some reason ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -688,6 +688,8 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
         (fun () ->
            let cty =
              Ctype.with_local_level_generalize_structure_if_principal
+               ~before_generalize:(fun cty ->
+                 Ctype.generalize_structure cty.ctyp_type)
                (fun () -> Typetexp.transl_simple_type ~new_var_jkind:Any val_env
                             ~closed:false Alloc.Const.legacy styp)
            in
@@ -736,6 +738,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
            end;
            let definition =
              Ctype.with_local_level_generalize_structure_if_principal
+               ~before_generalize:Typecore.generalize_structure_exp
                (fun () -> Typecore.type_exp val_env sdefinition)
            in
            begin
@@ -1245,6 +1248,10 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
         raise(Error(spat.ppat_loc, val_env, Polymorphic_class_parameter));
       let (pat, pv, val_env', met_env) =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:begin fun (pat, _, _, _) ->
+            let gen {pat_type = ty} = Ctype.generalize_structure ty in
+            iter_pattern gen pat
+          end
           (fun () ->
             Typecore.type_class_arg_pattern cl_num val_env met_env l spat)
       in
@@ -1310,6 +1317,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       assert (sargs <> []);
       let cl =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun cl ->
+            Ctype.generalize_class_type_structure cl.cl_type)
           (fun () -> class_expr cl_num val_env met_env virt self_scope scl')
       in
       let rec nonopt_labels ls ty_fun =
@@ -1672,6 +1681,7 @@ let initial_env define_class approx
   (* Temporary type for the class constructor *)
   let constr_type =
     Ctype.with_local_level_generalize_structure_if_principal
+      ~before_generalize:Ctype.generalize_structure
       (fun () -> approx cl.pci_expr)
   in
   let dummy_cty = Cty_signature (Ctype.new_class_signature ()) in
@@ -1932,7 +1942,7 @@ let final_decl env define_class
                  , Non_generalizable_class { id; clty; nongen_vars }));
     );
   begin match
-    Ctype.closed_class clty.cty_params
+    Alloc.with_zap_scope Ctype.closed_class clty.cty_params
       (Btype.signature_of_class_type clty.cty_type)
   with
     None        -> ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2417,10 +2417,6 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
     try
       TypePairs.iter
         (fun (t1, t2) ->
-          (* CR ageorges: are these still needed after putting back
-             generalize_structure? *)
-          generalize_structure t1;
-          generalize_structure t2;
           if not (fully_generic t1 && fully_generic t2) then
             let msg =
               Format_doc.doc_printf

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6871,7 +6871,7 @@ and type_expect_
                 ~before_generalize:(fun (exp, _) ->
                   generalize_structure_exp exp)
                 begin fun () ->
-                let mode = Value.newvar 0 in
+                let mode = Value.newvar (Ctype.get_current_level ()) in
                 let exp = type_exp ~recarg env (mode_default mode) sexp in
                 exp, mode
               end

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -307,6 +307,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -6491,7 +6492,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.Comonadic.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr
   }
 
 module Calling_convention_sort : sig
@@ -7512,10 +7513,12 @@ and type_expect_
       let (args, ty_ret, mode_ret, pm, ap_yielding) =
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
-      let ap_mode =
+      let ap_mode_alloc =
         create_allocation_mode_l mode_ret
+        |> Typedtree.create_return_mode
       in
       let mode_ret = Alloc.disallow_right mode_ret in
+      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7534,8 +7537,7 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position,
-                              Typedtree.create_return_mode ap_mode,
+        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode_alloc,
                               ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
@@ -7876,6 +7878,9 @@ and type_expect_
           (Texp_inspected_type (Label_disambiguation ambiguity), loc, [])
             :: record.exp_extra }
       in
+      let modality, _ =
+        Mode.Locality.newvar_above 0
+          (Mode.Alloc.proj_comonadic Areality (value_to_alloc_r2l rmode)) in
       unify_exp ~sexp env record ty_record;
       let record_repres =
         update_labels env Legacy ~representative_label:label ~loc
@@ -7886,10 +7891,7 @@ and type_expect_
         exp_desc = Texp_setfield {
           record;
           record_repres;
-          modality =
-            Locality.disallow_right
-              (Alloc.proj_comonadic Areality
-               (value_to_alloc_r2l rmode));
+          modality;
           lid = label_loc;
           label;
           newval;
@@ -9682,20 +9684,24 @@ and type_function
                   begin match
                     Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
-                    | Ok () -> ()
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality arg_mode)
+                        alloc_mode
                     | Error e ->
                       raise (Error(loc_fun, env,
                         Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.Comonadic.submode
-                      (Alloc.Comonadic.disallow_right closure_mode)
-                      fun_closure_mode
-                  with
-                    | Ok () -> ()
+                      Alloc.Comonadic.submode closure_mode fun_closure_mode
+                    with
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality closure_mode)
+                        alloc_mode
                     | Error e ->
                       raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e))
+                        Uncurried_function_escapes_comonadic e));
                   end;
                   More_args
                     { partial_mode =
@@ -13829,6 +13835,11 @@ let report_error ~loc env =
               but expected to be %a."
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
+    end
+  | Uncurried_function_escapes_locality -> begin
+      Location.errorf ~loc
+        "This function or one of its parameters escape their region@ \
+        when it is partially applied."
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6068,8 +6068,6 @@ let pattern_needs_partial_application_check p =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   with_type_mark begin fun mark ->
-    (* CR ageorges: what should the following behavior be if one of the
-      modes in a Join is generic the rest aren't?*)
     let check_const_mode m =
       if Mode.Alloc.check_generic m then
         Option.is_some (Mode.Alloc.Guts.check_const m)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -12349,10 +12349,6 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let ret_mode =
-      { ret_mode with
-        mode_modes = ret_mode.mode_modes }
-    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -742,7 +742,10 @@ tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
 let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
-  let vmode , _ = Value.newvar_below (alloc_as_value marg) in
+  let vmode , _ =
+    Value.newvar_below
+      (Ctype.get_current_level ()) (alloc_as_value marg)
+  in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
   | Texp_ident { desc = {val_kind =
@@ -828,11 +831,29 @@ let reset_allocations () = allocations := []
 let register_allocation_mode alloc_mode =
   allocations := alloc_mode :: !allocations
 
+let newvar_below_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  then fst (Locality.newvar_below level m)
+  else m
+
+let newvar_above_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  then fst (Locality.newvar_above level m)
+  else m
+
+let create_allocation_mode_l mode =
+  Alloc.proj_comonadic Areality mode
+  |> newvar_above_if_modepoly 0
+  |> Locality.disallow_right
+
+let create_allocation_mode_r mode =
+  Alloc.proj_comonadic Areality mode
+  |> newvar_below_if_modepoly 0
+  |> Locality.disallow_left
+
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode =
-    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
-  in
+  let alloc_mode = create_allocation_mode_r (value_to_alloc_r2g mode) in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -852,9 +873,11 @@ let register_closure_allocation (mode : Value.r) ~loc
   : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
   let (mode : Alloc.lr), _ =
-    Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
+    Alloc.newvar_below (Ctype.get_current_level ())
+      (value_to_alloc_r2g ~allocation mode)
   in
-  let alloc_mode = Alloc.proj_comonadic Areality mode in
+  let locality_mode = Alloc.proj_comonadic Areality mode in
+  let alloc_mode, _ = Locality.newvar_below 0 locality_mode in
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
@@ -879,7 +902,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil mode
+      Locality.zap_to_ceil_exn mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -1259,8 +1282,8 @@ let check_dynamic pp hint expected_mode =
 (** Take [m0] which is the parameter to mutable, and the mode of the RHS (the
     content expression), returns the strongest mode the mutable variable can be.
 *)
-let mutvar_mode ~loc ~env m0 exp_mode =
-  let m = Value.newvar () in
+let mutvar_mode ~loc ~env level m0 exp_mode =
+  let m = Value.newvar level in
   let mode = mode_default m in
   let modalities = Typemode.let_mutable_modalities in
   submode ~loc ~env exp_mode (mode_modality modalities mode);
@@ -1863,7 +1886,9 @@ and build_as_type_and_mode_extra env p ~mode : _ -> _ * _ = function
          If we used [generic_instance] we would lose the sharing between
          [instance ty] and [ty].  *)
       let ty =
-        with_local_level_generalize_structure (fun () -> instance ty)
+        with_local_level_generalize_structure
+          ~before_generalize:generalize_structure
+          (fun () -> instance ty)
       in
       (* This call to unify may only fail due to missing GADT equations *)
       unify_pat_types p.pat_loc env (instance as_ty) (instance ty);
@@ -1915,7 +1940,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
       let priv = (cstr.cstr_private = Private) in
       let mode =
         if priv || pl <> [] then mode
-        else Value.newvar ()
+        else Value.newvar (get_current_level ())
       in
       let keep =
         priv ||
@@ -1936,7 +1961,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
   | Tpat_variant(l, p', _) ->
       let ty = Option.map (build_as_type env) p' in
       let mode =
-        if p' = None then Value.newvar ()
+        if p' = None then Value.newvar (get_current_level ())
         else mode
       in
       let ty =
@@ -1965,7 +1990,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
               fields
           in
           let mode =
-            if all_constant then Value.newvar ()
+            if all_constant then Value.newvar (get_current_level ())
             else mode
           in
           let ty =
@@ -2172,6 +2197,7 @@ let solve_constructor_annotation
   (* Translate the type annotation using these type names. *)
   let cty, ty, force =
     with_local_level_generalize_structure
+      ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
       (fun () ->
          Typetexp.transl_simple_type_delayed !!penv Alloc.Const.legacy sty)
   in
@@ -2296,16 +2322,22 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
       ~expected:expected_ty
   in
 
-  let ty_args, equated_types, existential_ctyp =
-    with_local_level_generalize_structure begin fun () ->
+  let (ty_args, equated_types, existential_ctyp), _ =
+    with_local_level_generalize_structure
+      ~before_generalize:(fun (_, tys) ->
+        List.iter generalize_structure tys)
+      begin fun () ->
       let expected_ty = instance expected_ty in
-      let ty_args, ty_res, equated_types, existential_ctyp =
+      let ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp =
         match existential_styp with
           None ->
             let ty_args, ty_res, _ =
               instance_constructor (Make_existentials_abstract penv) constr
             in
-            ty_args, ty_res, unify_res ty_res expected_ty, None
+            let ty_args_ty =
+              List.map (fun ca -> ca.Types.ca_type) ty_args
+            in
+            ty_args, ty_args_ty, ty_res, unify_res ty_res expected_ty, None
         | Some (name_list, sty) ->
             let existential_treatment =
               if name_list = [] then
@@ -2328,11 +2360,13 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
               List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args
                 ty_args_ty
             in
-            ty_args, ty_res, Lazy.force equated_types, existential_ctyp
+            ty_args, ty_args_ty, ty_res,
+            Lazy.force equated_types, existential_ctyp
       in
       if constr.cstr_existentials <> [] then
         lower_variables_only !!penv penv.Pattern_env.equations_scope ty_res;
-      (ty_args, equated_types, existential_ctyp)
+      (ty_args, equated_types, existential_ctyp),
+      expected_ty :: ty_res :: ty_args_ty
     end
   in
   if !Clflags.principal && not penv.in_counterexample then begin
@@ -2341,6 +2375,10 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
     try
       TypePairs.iter
         (fun (t1, t2) ->
+          (* CR ageorges: are these still needed after putting back
+             generalize_structure? *)
+          generalize_structure t1;
+          generalize_structure t2;
           if not (fully_generic t1 && fully_generic t2) then
             let msg =
               Format_doc.doc_printf
@@ -2359,7 +2397,9 @@ let solve_Ppat_construct tps (penv : Pattern_env.t) loc constr no_existentials
 
 let solve_Ppat_record_field loc penv label label_lid record_ty
       record_form =
-  with_local_level_generalize_structure begin fun () ->
+  with_local_level_generalize_structure
+    ~before_generalize:(fun (_, tys) -> List.iter generalize_structure tys)
+    begin fun () ->
     let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
     begin try
       unify_pat_types_penv loc penv ty_res (instance record_ty)
@@ -2367,8 +2407,9 @@ let solve_Ppat_record_field loc penv label label_lid record_ty
       raise(Error(label_lid.loc, !!penv,
                   Label_mismatch(P record_form, label_lid.txt, err)))
     end;
-    ty_arg
+    ty_arg, [ty_res; ty_arg]
   end
+  |> fst
 
 let solve_Ppat_array loc env (mutability : mutable_flag) expected_ty
   : _ * _ * mutable_flag =
@@ -2405,6 +2446,7 @@ let solve_Ppat_lazy loc env expected_ty =
 let solve_Ppat_constraint tps loc env mode sty expected_ty =
   let cty, ty, force =
     with_local_level_generalize_structure
+      ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
       (fun () -> Typetexp.transl_simple_type_delayed env mode sty)
   in
   tps.tps_pattern_force <- force :: tps.tps_pattern_force;
@@ -3533,8 +3575,11 @@ and type_pat_aux
         match mutable_flag with
         | Immutable -> alloc_mode, Val_reg sort
         | Mutable ->
-            let m0 = Value.Comonadic.newvar () in
-            let mode = mutvar_mode ~loc ~env:!!penv m0 alloc_mode in
+            let m0 = Value.Comonadic.newvar (Ctype.get_current_level ()) in
+            let mode =
+              mutvar_mode ~loc ~env:!!penv
+                (Ctype.get_current_level ()) m0 alloc_mode
+            in
             let kind = Val_mut (m0, sort) in
             mode, kind
       in
@@ -4097,7 +4142,10 @@ let type_pattern_list
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   let pvs, pat =
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:(fun (pvs, _) ->
+        iter_pattern_variables_type generalize_structure pvs)
+      begin fun () ->
       let tps = create_type_pat_state Modules_rejected in
       let nv = newvar (Jkind.Builtin.value ~why:Class_term_argument) in
       let alloc_mode = simple_pat_mode Value.legacy in
@@ -4879,7 +4927,8 @@ let remaining_function_type_for_error ty_ret mode_ret rev_args =
                  (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
              in
              let mode_ret, _ =
-               Alloc.newvar_above (Alloc.join (mode_fun :: closed_args))
+               Alloc.newvar_above (Ctype.get_current_level ())
+               (Alloc.join (mode_fun :: closed_args))
              in
              (ty_ret, mode_ret, closed_args))
       (ty_ret, mode_ret, []) rev_args
@@ -4933,8 +4982,8 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
               then
                 Location.prerr_warning sarg.pexp_loc
                   Warnings.Ignored_extra_argument;
-              let mode_arg = Alloc.newvar () in
-              let mode_ret = Alloc.newvar () in
+              let mode_arg = Alloc.newvar (get_current_level ()) in
+              let mode_ret = Alloc.newvar (get_current_level ()) in
               let kind = (lbl, mode_arg, mode_ret) in
               begin try
                 unify env ty_fun
@@ -5156,7 +5205,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
              let mode_cls, _ =
-               Alloc.newvar_above (Alloc.join
+               Alloc.newvar_above (Ctype.get_current_level ()) (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
@@ -5164,13 +5213,11 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                |> Alloc.proj_comonadic Areality
              in
              let mode_arg =
-               Alloc.disallow_right mode_arg
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_l mode_arg
                |> Typedtree.create_alloc_mode_l
              in
              let mode_ret =
-               Alloc.disallow_right mode_ret
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_l mode_ret
                |> Typedtree.create_return_mode
              in
              register_allocation_mode mode_closure;
@@ -5577,7 +5624,7 @@ let rec approx_type env sty =
         in
         let ret = approx_type env sty in
         let marg = Alloc.of_const arg_mode.mode_modes in
-        let mret = Alloc.newvar () in
+        let mret = Alloc.newvar (get_current_level ()) in
         newty (Tarrow ((p,marg,mret), arg_ty.ctyp_type, ret, commu_ok))
       end
   | Ptyp_arrow (p, arg_sty, sty, arg_mode, _) ->
@@ -5590,7 +5637,7 @@ let rec approx_type env sty =
       in
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
-      let mret = Alloc.newvar () in
+      let mret = Alloc.newvar (get_current_level ()) in
       newty (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
@@ -5957,9 +6004,18 @@ let pattern_needs_partial_application_check p =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   with_type_mark begin fun mark ->
+    (* CR ageorges: what should the following behavior be if one of the
+      modes in a Join is generic the rest aren't?*)
+    let check_const_mode m =
+      if Mode.Alloc.check_generic m then
+        Option.is_some (Mode.Alloc.Guts.check_const m)
+      else true
+    in
+    let checkmode m = if not (check_const_mode m) then raise Exit in
     let rec check ty =
       if try_mark_node mark ty then
-        if get_level ty <= level then raise Exit else iter_type_expr check ty
+        if get_level ty <= level then raise Exit
+        else iter_type_expr check checkmode ty
     in
     try check ty; true with Exit -> false
   end
@@ -5982,7 +6038,7 @@ let contains_variant_either ty =
               (row_fields row);
           iter_row loop row
       | _ ->
-          iter_type_expr loop ty
+          iter_type_expr loop (Fun.const ()) ty
       end
   in
   try loop ty; false with Exit -> true
@@ -6206,8 +6262,23 @@ let with_explanation explanation f =
         raise (Error (loc', env', err))
 
 (* Generalize expressions *)
+let generalize_structure_exp exp = generalize_structure exp.exp_type
+
 let may_lower_contravariant env exp =
   if maybe_expansive exp then lower_contravariant env exp.exp_type
+
+let generalize_structure_type_block_access_result
+      { ba; base_ty; el_ty; modality = _ } =
+  generalize_structure base_ty;
+  generalize_structure el_ty;
+  match ba with
+  | Baccess_field _ -> ()
+  | Baccess_block (_, idx) ->
+    generalize_structure_exp idx
+
+let generalize_structure_type_unboxed_access_result
+      (el_ty, Uaccess_unboxed_field _) =
+  generalize_structure el_ty
 
 let unique_use ~loc ~env mode_l mode_r  =
   if not (Language_extension.is_at_least Unique
@@ -6324,7 +6395,11 @@ let split_function_ty
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
-    with_local_level_generalize_structure_if separate begin fun () ->
+    with_local_level_generalize_structure_if separate
+      ~before_generalize:(fun { ty_arg; ty_ret; _ } ->
+        generalize_structure ty_arg;
+        generalize_structure ty_ret)
+      begin fun () ->
       let force_tpoly =
         (* If [has_poly] is true then we rely on the later call to
            type_pat to enforce the invariant that the parameter type
@@ -6363,14 +6438,15 @@ let split_function_ty
   in
   let ret_value_mode = alloc_as_value ret_mode in
   let expected_inner_mode =
-    if not is_final_val_param then
+    if not is_final_val_param then begin
       (* no need to check mode crossing in this case because ty_res always a
       function *)
       mode_default ret_value_mode
-    else
+    end else begin
       let ret_value_mode = mode_return ret_value_mode in
       let ret_value_mode = expect_mode_cross env ty_ret ret_value_mode in
       ret_value_mode
+    end
   in
   let ty_arg_mono =
     if has_poly then ty_arg
@@ -6386,7 +6462,8 @@ let split_function_ty
   let env_monadic =
     if is_final_val_param
     then arg_mode.monadic
-    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+    else fst (Alloc.Monadic.newvar_above (get_current_level ())
+      arg_mode.monadic)
   in
   let arg_value_mode =
     alloc_to_value_l2r { arg_mode with monadic = env_monadic }
@@ -6526,7 +6603,7 @@ type type_function_result =
 
 and type_function_ret_info =
   { (* The mode the function returns at. *)
-    ret_mode: Mode.Alloc.l modes;
+    ret_mode: return_mode modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
     cases_arg_yielding: Mode.Yielding.l option;
@@ -6601,12 +6678,19 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     | None -> begin
         match pat_tuple_arity spat with
         | Not_local_tuple | Maybe_local_tuple ->
-            let mode = Value.newvar () in
+            let mode = Value.newvar (get_current_level ()) in
             simple_pat_mode mode, mode_default mode
         | Local_tuple locs ->
-            let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+            let modes =
+              List.map
+                (fun loc ->
+                   Value.newvar (get_current_level ()), loc)
+                locs
+            in
             let modes_pat = List.map fst modes in
-            let mode = Value.newvar () in
+            let mode =
+              Value.newvar (get_current_level ())
+            in
             tuple_pat_mode mode modes_pat, mode_tuple mode modes
       end
     | Some mode ->
@@ -6719,8 +6803,11 @@ and type_expect_
         | None -> None
         | Some sexp ->
             let exp, mode =
-              with_local_level_generalize_structure_if_principal begin fun () ->
-                let mode = Value.newvar () in
+              with_local_level_generalize_structure_if_principal
+                ~before_generalize:(fun (exp, _) ->
+                  generalize_structure_exp exp)
+                begin fun () ->
+                let mode = Value.newvar 0 in
                 let exp = type_exp ~recarg env (mode_default mode) sexp in
                 exp, mode
               end
@@ -6772,6 +6859,7 @@ and type_expect_
             let decl = Env.find_type p' env in
             let ty =
               with_local_level_generalize_structure
+                ~before_generalize:generalize_structure
                 (fun () -> newconstr p' (instance_list decl.type_params))
             in
             ty, opt_exp_opath
@@ -7354,12 +7442,12 @@ and type_expect_
         match pm.apply_position with
         | Tail ->
           let mode, _ =
-            Value.(newvar_below
+            Value.(newvar_below (get_current_level ())
               (of_const ~hint_comonadic:Tailcall_function
                 { Const.max with areality = Regional }))
           in
           mode
-        | Nontail | Default -> Value.newvar ()
+        | Nontail | Default -> Value.newvar (get_current_level ())
       in
       let funct_expected_mode = mode_default funct_mode in
       let outer_level = get_current_level () in
@@ -7388,6 +7476,7 @@ and type_expect_
       let type_sfunct sfunct =
         let funct =
           with_local_level_generalize_structure_if_principal
+            ~before_generalize:generalize_structure_exp
             (fun () -> type_exp env funct_expected_mode sfunct)
         in
         let ty = instance funct.exp_type in
@@ -7423,8 +7512,10 @@ and type_expect_
       let (args, ty_ret, mode_ret, pm, ap_yielding) =
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
+      let ap_mode =
+        create_allocation_mode_l mode_ret
+      in
       let mode_ret = Alloc.disallow_right mode_ret in
-      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7479,12 +7570,19 @@ and type_expect_
           let arg_pat_mode, arg_expected_mode =
             match cases_tuple_arity caselist with
             | Not_local_tuple | Maybe_local_tuple ->
-              let mode = Value.newvar () in
+              let mode = Value.newvar (get_current_level ()) in
               simple_pat_mode mode, mode_default mode
             | Local_tuple locs ->
-              let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+              let modes =
+            List.map
+              (fun loc ->
+                 Value.newvar (get_current_level ()), loc)
+              locs
+          in
               let modes_pat = List.map fst modes in
-              let mode = Value.newvar () in
+              let mode =
+            Value.newvar (get_current_level ())
+          in
               tuple_pat_mode mode modes_pat, mode_tuple mode modes
           in
           env, arg_pat_mode, arg_expected_mode, expected_mode
@@ -7883,6 +7981,7 @@ and type_expect_
     let principal = is_principal ty_expected in
     let { ba; base_ty; el_ty; modality } =
       with_local_level_generalize_structure_if_principal
+        ~before_generalize:generalize_structure_type_block_access_result
         (fun () ->
            let res = type_block_access env expected_base_ty principal ba in
            (* This unification is to get a better [base_ty], and is not
@@ -7919,6 +8018,8 @@ and type_expect_
            (* Generalize after each step, otherwise we'll have more
               "non-principal" warnings than desired. *)
            with_local_level_generalize_structure_if_principal
+             ~before_generalize:(fun ((t, _), ua) ->
+               generalize_structure_type_unboxed_access_result (t, ua))
              (fun () ->
                 let (el_ty, ua_modality), ua =
                   type_unboxed_access env loc el_ty ua
@@ -8141,6 +8242,7 @@ and type_expect_
       let pm = position_and_mode env expected_mode sexp in
       let (obj,meth,typ) =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (_, _, typ) -> generalize_structure typ)
           (fun () -> type_send env loc explanation e met.txt)
       in
       let typ, obj_extra =
@@ -8388,6 +8490,7 @@ and type_expect_
   | Pexp_poly(sbody, sty) ->
       let ty, cty =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (ty, _) -> generalize_structure ty)
           begin fun () ->
             match sty with None -> protect_expansion env ty_expected, None
             | Some sty ->
@@ -8413,6 +8516,8 @@ and type_expect_
               with_local_level_generalize begin fun () ->
                 let vars, ty'' =
                   with_local_level_generalize_structure_if_principal
+                    ~before_generalize:(fun (_, ty'') ->
+                      generalize_structure ty'')
                     (fun () -> instance_poly_fixed tl ty')
                 in
                 let exp = type_expect env expected_mode sbody (mk_expected ty'') in
@@ -8533,10 +8638,13 @@ and type_expect_
             let ty_acc = newty (Ttuple [None, ty_acc; None, ty]) in
             loop spat_acc ty_acc Jkind.Sort.scannable rest
       in
-      let op_path, op_desc, op_type, spat_params, ty_params, param_sort,
+      let (op_path, op_desc, op_type, spat_params, ty_params, param_sort,
           ty_func_result, body_sort, ty_result, op_result_sort,
-          ty_andops, sort_andops =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+          ty_andops, sort_andops), _ =
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:
+            (fun (_, tys) -> List.iter generalize_structure tys)
+          begin fun () ->
           let let_loc = slet.pbop_op.loc in
           let op_path, op_desc = type_binding_op_ident env slet.pbop_op in
           let op_type = op_desc.val_type in
@@ -8571,7 +8679,8 @@ and type_expect_
           end;
           (op_path, op_desc, op_type, spat_params, ty_params, param_sort,
            ty_func_result, body_sort, ty_result, op_result_sort,
-           ty_andops, sort_andops)
+           ty_andops, sort_andops),
+           [ty_andops; ty_params; ty_func_result; ty_result]
         end
       in
       let exp, exp_sort, ands =
@@ -8811,6 +8920,7 @@ and type_expect_
         (* The overwritten cell has to be unique
            and should have the areality expected here: *)
         Value.newvar_below
+          (get_current_level ())
           (Value.meet [
             Value.of_const {Value.Const.max with uniqueness = Unique};
             Value.max_with_comonadic Areality
@@ -9072,7 +9182,9 @@ and type_coerce
   match sty with
   | None ->
     let (cty', ty', force) =
-      with_local_level_generalize_structure begin fun () ->
+      with_local_level_generalize_structure
+        ~before_generalize:(fun (_, ty, _) -> generalize_structure ty)
+        begin fun () ->
         Typetexp.transl_simple_type_delayed env type_mode sty'
       end
     in
@@ -9122,14 +9234,17 @@ and type_coerce
       end;
       (arg, ty', Texp_coerce (None, cty'))
   | Some sty ->
-      let cty, ty, force, cty', ty', force' =
-        with_local_level_generalize_structure begin fun () ->
+      let (cty, ty, force, cty', ty', force'), _ =
+        with_local_level_generalize_structure
+          ~before_generalize:(fun (_, tys) ->
+            List.iter generalize_structure tys)
+          begin fun () ->
           let (cty, ty, force) =
             Typetexp.transl_simple_type_delayed env type_mode sty
           and (cty', ty', force') =
             Typetexp.transl_simple_type_delayed env type_mode sty'
           in
-          (cty, ty, force, cty', ty', force')
+          (cty, ty, force, cty', ty', force'), [ty; ty']
         end
       in
       begin try
@@ -9146,7 +9261,9 @@ and type_coerce
 and type_constraint env sty type_mode =
   (* Pretend separate = true, 1% slowdown for lablgtk *)
   let cty =
-    with_local_level_generalize_structure begin fun () ->
+    with_local_level_generalize_structure
+      ~before_generalize:(fun cty -> generalize_structure cty.ctyp_type)
+      begin fun () ->
       Typetexp.transl_simple_type ~new_var_jkind:Any env ~closed:false type_mode
         sty
     end
@@ -9222,7 +9339,7 @@ and type_newtype
         Hashtbl.add seen (get_id t) ();
         match get_desc t with
         | Tconstr (Path.Pident id', _, _) when id == id' -> link_type t ty
-        | _ -> Btype.iter_type_expr replace t
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t
       end
     in
     let ety = Subst.type_expr Subst.identity exp_type in
@@ -9654,8 +9771,7 @@ and type_function
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
       let arg_locality =
-        Alloc.disallow_right arg_mode
-        |> Alloc.proj_comonadic Areality
+        create_allocation_mode_l arg_mode
         |> Typedtree.create_alloc_mode_l
       in
       let param =
@@ -9706,7 +9822,11 @@ and type_function
         | Some _ as x -> x
         | None ->
           let ret_mode =
-            {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
+            create_allocation_mode_l ret_mode
+            |> create_return_mode
+          in
+          let ret_mode =
+            {ret_mode_annots with mode_modes = ret_mode }
           in
           Some { ret_sort ; ret_mode; cases_arg_yielding = None }
       in
@@ -9841,13 +9961,14 @@ and type_label_access
   : 'rep . 'rep record_form -> _ -> _ -> _ -> _ ->
     _ * _ * _ * 'rep gen_label_description * _ * _
   = fun record_form env srecord usage lid ->
-  let mode = Value.newvar () in
+  let mode = Value.newvar (get_current_level ()) in
   let record_jkind, record_sort =
     Jkind.of_new_sort_var ~why:Record_projection
       ~level:(Ctype.get_current_level ())
   in
   let record =
     with_local_level_generalize_structure_if_principal
+      ~before_generalize:generalize_structure_exp
       (fun () ->
          type_expect ~recarg:Allowed env (mode_default mode) srecord
            (mk_expected (newvar record_jkind)))
@@ -9886,7 +10007,9 @@ and solve_Pexp_field
        [update_label], but doing it that way causes principality issues.
        Notably, this call to [update_label] happens inside a local level and the
        [Texp_setfield] call does not. *)
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:(fun (ty_arg, _) -> generalize_structure ty_arg)
+      begin fun () ->
       (* [ty_arg] is the type of field, [ty_res] is the type of record, they
        could share type variables, which are now instantiated *)
       let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
@@ -10191,9 +10314,15 @@ and type_label_exp
     (* raise level to check univars *)
     with_local_level_generalize_if is_poly begin fun () ->
       let unify_as_label ty_expected =
-        with_local_level_generalize_structure_if separate begin fun () ->
+        with_local_level_generalize_structure_if separate
+          ~before_generalize:(fun (_, ty_arg) ->
+            generalize_structure ty_arg)
+          begin fun () ->
           let (vars, ty_arg, ty_res) =
             with_local_level_generalize_structure_if separate
+              ~before_generalize:(fun (_, ty_arg, ty_res) ->
+                generalize_structure ty_arg;
+                generalize_structure ty_res)
               (fun () -> instance_label ~fixed:true label)
           in
           begin try
@@ -10246,15 +10375,19 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     let lv = get_level expty in
     let lv' = get_level expty' in
     match get_desc expty', get_desc expty with
-    | Tarrow((l, marg, mret), ty_arg', ty_res', _),
+    | Tarrow((l, marg', mret'), ty_arg', ty_res', _),
       Tarrow(_, ty_arg,  ty_res,  _)
       when lv' = generic_level || not !Clflags.principal ->
       let ty_res', ty_res, changed = loosen_arrow_modes ty_res' ty_res in
-      let mret, changed' = Alloc.newvar_below mret in
-      let marg, changed'' = Alloc.newvar_above marg in
-      if changed || changed' || changed'' then
-        newty2 ~level:lv' (Tarrow((l, marg, mret), ty_arg', ty_res', commu_ok)),
-        newty2 ~level:lv  (Tarrow((l, marg, mret), ty_arg,  ty_res,  commu_ok)),
+      let mret', changed1 = Alloc.newvar_below (lv) mret' in
+      let marg', changed2 = Alloc.newvar_above (lv) marg' in
+      if changed || changed1 || changed2 then
+        newty2 ~level:lv'
+          (Tarrow((l, marg', mret'), ty_arg', ty_res',
+                  commu_ok)),
+        newty2 ~level:lv
+          (Tarrow((l, marg', mret'), ty_arg, ty_res,
+                  commu_ok)),
         true
       else
         ty', ty, false
@@ -10294,9 +10427,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     Some (safe_expect, lv) ->
       (* apply omittable arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
-      let exp_mode, _ = Value.newvar_below (as_single_mode mode) in
+      let exp_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (as_single_mode mode)
+      in
       let texp =
         with_local_level_generalize_structure_if_principal
+          ~before_generalize:generalize_structure_exp
           (fun () ->
             let expected_mode =
               mode
@@ -10379,7 +10516,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                       staticity = proj_staticity mode;
                       mode = Value.disallow_right mode }}
       in
-      let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in
+      let eta_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (alloc_as_value marg)
+      in
       Regionality.submode_exn
         (Value.proj_comonadic Areality eta_mode) Regionality.regional;
       let type_sort ~why ty =
@@ -10392,12 +10532,11 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       let fc_arg_mode =
-        Alloc.disallow_right marg
-        |> Alloc.proj_comonadic Areality
+        create_allocation_mode_l marg
         |> Typedtree.create_alloc_mode_l
       in
       let fc_ret_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        create_allocation_mode_l mret
         |> Typedtree.create_return_mode
       in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
@@ -10527,6 +10666,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
             with_local_level_generalize begin fun () ->
               let vars, ty_arg' =
                 with_local_level_generalize_structure_if separate
+                  ~before_generalize:(fun (_, ty_arg') ->
+                    generalize_structure ty_arg')
                   begin fun () ->
                   instance_poly_fixed vars ty_arg'
                 end
@@ -10578,8 +10719,10 @@ and type_application env app_loc expected_mode position_and_mode
   | (* Special case for ignore: avoid discarding warning *)
     [Parsetree.Nolabel, sarg] when is_ignore funct ->
       let {ty_arg; arg_mode; ty_ret; ret_mode} =
-        with_local_level_generalize_structure_if_principal (fun () ->
-          filter_arrow_mono env (instance funct.exp_type) Nolabel)
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun { ty_ret; _ } ->
+            generalize_structure ty_ret)
+          (fun () -> filter_arrow_mono env (instance funct.exp_type) Nolabel)
       in
       let type_sort ~why ty =
         match Ctype.type_sort ~why ~fixed:false env ty with
@@ -10618,7 +10761,10 @@ and type_application env app_loc expected_mode position_and_mode
         end
       in
       let ty_ret, mode_ret, args, position_and_mode, ap_yielding =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:(fun (ty_ret, _, _, _, _) ->
+            generalize_structure ty_ret)
+          begin fun () ->
           (* Consider for example the application
                [f n]
              with
@@ -10648,16 +10794,17 @@ and type_application env app_loc expected_mode position_and_mode
           (* The application can never perform a free effect if the function and
              all of its arguments are unyielding. *)
           let ap_yielding =
-            Mode.Value.proj_comonadic Yielding
-              (Mode.Value.join
-                 (funct_mode
-                  :: List.concat_map
-                       (fun (_, arg, _, ~mode_fun) ->
-                          mode_fun ::
-                          (match arg with
-                            | Arg (_, mode_arg, _) -> [mode_arg]
-                            | Omitted _ -> [] ))
-                       args))
+            create_yielding_mode_l
+              (Mode.Value.proj_comonadic Yielding
+                 (Mode.Value.join
+                    (funct_mode
+                     :: List.concat_map
+                          (fun (_, arg, _, ~mode_fun) ->
+                             mode_fun ::
+                             (match arg with
+                               | Arg (_, mode_arg, _) -> [mode_arg]
+                               | Omitted _ -> [] ))
+                          args)))
           in
           let args =
             List.map (fun (lbl, arg, sch, ~mode_fun:_) ->
@@ -10866,9 +11013,18 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
                   (lid.txt, constr.cstr_arity, List.length sargs)));
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let unify_as_construct ty_expected =
-    with_local_level_generalize_structure_if separate begin fun () ->
+    with_local_level_generalize_structure_if separate
+      ~before_generalize:(fun (ty_args, ty_res, _) ->
+        generalize_structure ty_res;
+        List.iter
+          (fun { Types.ca_type = ty; _ } -> generalize_structure ty)
+          ty_args)
+      begin fun () ->
       let ty_args, ty_res, texp =
-        with_local_level_generalize_structure_if separate begin fun () ->
+        with_local_level_generalize_structure_if separate
+          ~before_generalize:(fun (_, ty_res, _) ->
+            generalize_structure ty_res)
+          begin fun () ->
           let (ty_args, ty_res, _) =
             instance_constructor Keep_existentials_flexible constr
           in
@@ -11143,10 +11299,14 @@ and map_half_typed_cases
         map_conts
         (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) cont ->
           let htc =
-            with_local_level_generalize_structure_if_principal begin fun () ->
+            with_local_level_generalize_structure_if_principal
+              ~before_generalize:(fun htc ->
+                iter_pattern_variables_type generalize_structure htc.pat_vars)
+              begin fun () ->
               let ty_arg =
                 (* propagation of pattern *)
                 with_local_level_generalize_structure
+                  ~before_generalize:generalize_structure
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
               let (pat, ext_env, force, pvs, mvs) =
@@ -11427,7 +11587,7 @@ and type_function_cases_expect
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
     let fc_arg_mode =
-      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      create_allocation_mode_l arg_mode
       |> Typedtree.create_alloc_mode_l
     in
     let yielding_mode =
@@ -11463,7 +11623,9 @@ and type_function_cases_expect
     cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+          { mode_modes =
+              create_allocation_mode_l ret_mode |> create_return_mode;
+            mode_desc = [] };
         cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts
   end
@@ -11530,7 +11692,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let entirely_functions = List.for_all vb_is_fun spat_sexp_list in
   let rec_mode_var =
     match rec_flag with
-    | Recursive when entirely_functions -> Some (Value.newvar ())
+    | Recursive when entirely_functions ->
+      Some (Value.newvar (get_current_level ()))
     | Recursive ->
         (* If the definitions are not purely functions, this involves multiple
            allocations pointing to each other. For this to be safe, they are all
@@ -11539,7 +11702,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let m, _ =
           {Value.Const.max with areality = Global}
           |> Value.of_const
-          |> Value.newvar_below
+          |> Value.newvar_below (get_current_level ())
         in
         Some m
     | Nonrecursive -> None
@@ -11555,7 +11718,13 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     with_local_level_generalize begin fun () ->
       if existential_context = At_toplevel then Typetexp.TyVarEnv.reset ();
       let (pat_list, new_env, force, pvs, mvs), sorts =
-        with_local_level_generalize_structure_if_principal begin fun () ->
+        with_local_level_generalize_structure_if_principal
+          ~before_generalize:
+            (fun ((pat_list, _, _, pvs, _), _) ->
+              iter_pattern_variables_type generalize_structure pvs;
+              List.iter
+                (fun (_, pat) -> generalize_structure pat.pat_type) pat_list)
+          begin fun () ->
           let nvs, sorts =
             List.split (List.map (fun _ -> new_rep_var ~why:Let_binding ())
                           spatl)
@@ -11658,6 +11827,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
             | Tpoly (ty, tl) ->
                 let vars, ty' =
                   with_local_level_generalize_structure_if_principal
+                    ~before_generalize:(fun (_, ty') ->
+                      generalize_structure ty')
                     (fun () -> instance_poly_fixed ~keep_names:true tl ty)
                 in
                 let exp =
@@ -11934,9 +12105,12 @@ and type_andops env sarg sands expected_sort expected_ty =
         expected_sort,
         []
     | { pbop_op = sop; pbop_exp = sexp; pbop_loc = loc; _ } :: rest ->
-        let op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
-            ty_result, op_result_sort =
-          with_local_level_generalize_structure_if_principal begin fun () ->
+        let (op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
+            ty_result, op_result_sort), _ =
+          with_local_level_generalize_structure_if_principal
+            ~before_generalize:
+              (fun (_, tys) -> List.iter generalize_structure tys)
+            begin fun () ->
             let op_path, op_desc = type_binding_op_ident env sop in
             let op_type = op_desc.val_type in
             let ty_arg, sort_arg = new_rep_var ~why:Function_argument () in
@@ -11955,7 +12129,7 @@ and type_andops env sarg sands expected_sort expected_ty =
               raise(Error(sop.loc, env, Andop_type_clash(sop.txt, err)))
             end;
             (op_path, op_desc, op_type, ty_arg, sort_arg, ty_rest, sort_rest,
-             ty_result, op_result_sort)
+             ty_result, op_result_sort), [ty_rest; ty_arg; ty_result]
           end
         in
         let let_arg, sort_let_arg, rest =
@@ -12048,7 +12222,9 @@ and type_n_ary_function
                           (Jkind.of_new_sort ~why
                              ~level:(Ctype.get_current_level ()))
                       in
-                      let new_mode_var () = Mode.Alloc.newvar () in
+                      let new_mode_var () =
+                        Mode.Alloc.newvar (get_current_level ())
+                      in
                       (newty
                          (Tarrow
                             ( (arg_label, new_mode_var (), new_mode_var ())
@@ -12106,13 +12282,9 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let ret_mode_modes =
-      Alloc.proj_comonadic Areality ret_mode.mode_modes
-      |> Typedtree.create_return_mode
-    in
     let ret_mode =
       { ret_mode with
-        mode_modes = ret_mode_modes }
+        mode_modes = ret_mode.mode_modes }
     in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
@@ -12132,10 +12304,11 @@ and type_n_ary_function
       | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Yielding.join
-        (Alloc.Comonadic.proj Yielding
-           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
-         :: param_yieldings)
+      create_yielding_mode_l
+        (Yielding.join
+           (Alloc.Comonadic.proj Yielding
+              (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
+            :: param_yieldings))
     in
     re
       { exp_desc =
@@ -12280,7 +12453,9 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
           ~why:Jkind.History.Array_comprehension_element
   in
   let element_ty =
-    with_local_level_generalize_structure_if_principal begin fun () ->
+    with_local_level_generalize_structure_if_principal
+      ~before_generalize:generalize_structure
+      begin fun () ->
       let element_ty = newvar jkind in
       unify_exp_types
         loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5223,7 +5223,18 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let args = (lbl, Arg (exp, sort), sch) :: args in
              (ty_ret, mode_ret, open_args, closed_args, args)
          | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg } ->
-             let arrow_desc = (lbl, mode_arg, mode_ret) in
+             (* Under mode polymorphism we define a new return mode above
+                mode_ret and a new level-0 allocation mode for mode_ret
+                (to know whether then function needs a region to allocate
+                the return value):
+                [mode_ret] < [mode_ret_alloc] < [mode_ret_eta] *)
+             let mode_ret_eta =
+               if Language_extension.(is_at_least Mode_polymorphism Beta)
+               then
+                fst (Alloc.newvar_above (Ctype.get_current_level ()) mode_ret)
+               else mode_ret
+             in
+             let arrow_desc = (lbl, mode_arg, mode_ret_eta) in
              let sort_ret =
                match type_sort ~why:Function_result ~fixed:false env ty_ret with
                | Ok sort -> sort
@@ -5257,9 +5268,21 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                create_allocation_mode_l mode_arg
                |> Typedtree.create_alloc_mode_l
              in
+             (* [mode_ret] < [mode_ret_alloc] < [mode_ret_eta]*)
+             let mode_ret_alloc =
+              if Language_extension.(is_at_least Mode_polymorphism Beta)
+              then begin
+                let m = Locality.newvar 0 in
+                Locality.submode_exn
+                  (Alloc.proj_comonadic Areality mode_ret) m;
+                Locality.submode_exn
+                  m (Alloc.proj_comonadic Areality mode_ret_eta);
+                m
+              end else Alloc.proj_comonadic Areality mode_ret
+            in
              let mode_ret =
-               create_allocation_mode_l mode_ret
-               |> Typedtree.create_return_mode
+              Typedtree.create_return_mode
+                (Locality.disallow_right mode_ret_alloc)
              in
              register_allocation_mode mode_closure;
              let arg =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -480,6 +480,12 @@ type expected_mode =
 
         Each location points to the corresponding sub-pattern of [Ppat_tuple].
     *)
+
+    return_from_exclave : bool ref option;
+    (** Indicates whether the expected mode is for an exclave expression in tail
+        position. The field is a bool ref so that it is preserved across all
+        copies.
+    *)
   }
 
 type position_and_mode = {
@@ -488,11 +494,13 @@ type position_and_mode = {
   region_mode : Regionality.r option;
   (** INVARIANT: [Some m] iff [apply_position] is [Tail], where [m] is the mode
      of the surrounding region *)
+  return_from_exclave : bool ref option;
 }
 
 let position_and_mode_default = {
   apply_position = Default;
   region_mode = None;
+  return_from_exclave = None;
 }
 
 (** Decides the runtime tail call behaviour based on lexical structures and user
@@ -511,14 +519,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   | RTail (m ,FTail) -> begin
       match requested with
       | Some `Tail | Some `Tail_if_possible | None ->
-          {apply_position = Tail; region_mode = Some m}
-      | Some `Nontail -> {apply_position = Nontail; region_mode = None}
+          { apply_position = Tail;
+            region_mode = Some m;
+            return_from_exclave = expected_mode.return_from_exclave }
+      | Some `Nontail ->
+          { apply_position = Nontail;
+            region_mode = None;
+            return_from_exclave = None }
     end
   | RNontail | RTail(_, FNontail) -> begin
       match requested with
       | None | Some `Tail_if_possible ->
-          {apply_position = Default; region_mode = None}
-      | Some `Nontail -> {apply_position = Nontail; region_mode = None}
+          { apply_position = Default;
+            region_mode = None;
+            return_from_exclave = None }
+      | Some `Nontail ->
+          { apply_position = Nontail;
+            region_mode = None;
+            return_from_exclave = None }
       | Some `Tail -> fail `Not_a_tailcall
   end
 
@@ -553,7 +571,8 @@ let mode_default mode =
   { position = RNontail;
     mode = Value.disallow_left mode;
     strictly_local = false;
-    tuple_modes = None }
+    tuple_modes = None;
+    return_from_exclave = None }
 
 let mode_legacy = mode_default Value.legacy
 
@@ -657,7 +676,7 @@ let mode_max_with_position position =
 
 (** Take the expected mode of [exclave_ exp], return the expected mode of [exp].
     [expected_mode] must be higher than [regional]. *)
-let mode_exclave expected_mode =
+let mode_exclave (expected_mode : expected_mode) =
   let mode =
      as_single_mode expected_mode
      (* if we expect an exclave to be [regional], then inside the exclave the
@@ -665,14 +684,23 @@ let mode_exclave expected_mode =
      |> value_to_alloc_r2l
      |> alloc_as_value
   in
+  Option.iter (fun excl -> excl := true) expected_mode.return_from_exclave;
   { (mode_default mode)
-    with strictly_local = true
+    with strictly_local = true;
+         return_from_exclave = expected_mode.return_from_exclave
   }
 
 let mode_strictly_local expected_mode =
   { expected_mode
     with strictly_local = true
   }
+
+let mode_return_from_exclave (expected_mode : expected_mode) =
+  match expected_mode.return_from_exclave with
+  | Some r -> r, expected_mode
+  | None ->
+    let r = ref false in
+    r, { expected_mode with return_from_exclave = Some r }
 
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
@@ -754,7 +782,9 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
                 kind = Id_prim _; _ }, 1, Tail ->
      (* RHS of (&&) and (||) is at the tail of function region if the
         application is. The argument mode is not constrained otherwise. *)
-     mode_with_position vmode (RTail (Option.get position_and_mode.region_mode, FTail)),
+     { (mode_with_position vmode
+          (RTail (Option.get position_and_mode.region_mode, FTail)))
+       with return_from_exclave = position_and_mode.return_from_exclave },
      vmode
   | Texp_ident { kind = Id_prim _; _ }, _, _ ->
      (* Other primitives cannot be tail-called *)
@@ -846,6 +876,17 @@ let create_allocation_mode_l mode =
   Alloc.proj_comonadic Areality mode
   |> newvar_above_if_modepoly 0
   |> Locality.disallow_right
+
+let create_function_return_mode
+    ~return_from_exclave ret_mode : return_mode =
+  let ret_mode =
+    if Language_extension.(is_at_least Mode_polymorphism Beta) then
+      if return_from_exclave
+      then Locality.disallow_right Locality.local
+      else Locality.disallow_right Locality.global
+    else create_allocation_mode_l ret_mode
+  in
+  Typedtree.create_return_mode ret_mode
 
 let create_allocation_mode_r mode =
   Alloc.proj_comonadic Areality mode
@@ -5210,8 +5251,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
-               Alloc.disallow_left mode_cls
-               |> Alloc.proj_comonadic Areality
+               create_allocation_mode_r mode_cls
              in
              let mode_arg =
                create_allocation_mode_l mode_arg
@@ -7513,12 +7553,8 @@ and type_expect_
       let (args, ty_ret, mode_ret, pm, ap_yielding) =
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
-      let ap_mode_alloc =
-        create_allocation_mode_l mode_ret
-        |> Typedtree.create_return_mode
-      in
       let mode_ret = Alloc.disallow_right mode_ret in
-      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
+      let ap_mode = create_allocation_mode_l mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7537,8 +7573,9 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode_alloc,
-                              ap_yielding, zero_alloc);
+        exp_desc = Texp_apply(funct, args, pm.apply_position,
+                    Typedtree.create_return_mode ap_mode,
+                    ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
         exp_attributes = sexp.pexp_attributes;
@@ -9624,6 +9661,9 @@ and type_function
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
       in
+      let excl, expected_inner_mode =
+        mode_return_from_exclave expected_inner_mode
+      in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry,
            ext_env, inner_calling_convention_sorts), partial =
         (* Check everything else in the scope of the parameter. *)
@@ -9823,14 +9863,14 @@ and type_function
         in
         arg_ccs :: ret_ccs @ inner_calling_convention_sorts
       in
+      let return_from_exclave = !excl in
+      let ret_mode =
+        create_function_return_mode ~return_from_exclave ret_mode
+      in
       let ret_info =
         match ret_info with
         | Some _ as x -> x
         | None ->
-          let ret_mode =
-            create_allocation_mode_l ret_mode
-            |> create_return_mode
-          in
           let ret_mode =
             {ret_mode_annots with mode_modes = ret_mode }
           in
@@ -11581,6 +11621,9 @@ and type_function_cases_expect
         ~ret_mode_annots:Mode.Alloc.Const.Option.none
         ~is_first_val_param:first ~is_final_val_param:true
     in
+    let excl, expected_inner_mode =
+      mode_return_from_exclave expected_inner_mode
+    in
     let cases, partial =
       type_cases Value env
         expected_pat_mode expected_inner_mode ty_arg_mono arg_sort
@@ -11626,11 +11669,12 @@ and type_function_cases_expect
         { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
+    let return_from_exclave = !excl in
     cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
           { mode_modes =
-              create_allocation_mode_l ret_mode |> create_return_mode;
+              create_function_return_mode ~return_from_exclave ret_mode;
             mode_desc = [] };
         cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -863,12 +863,12 @@ let register_allocation_mode alloc_mode =
   allocations := alloc_mode :: !allocations
 
 let newvar_below_if_modepoly level m =
-  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  if Language_extension.(is_at_least Mode_polymorphism Alpha)
   then fst (Locality.newvar_below level m)
   else m
 
 let newvar_above_if_modepoly level m =
-  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  if Language_extension.(is_at_least Mode_polymorphism Alpha)
   then fst (Locality.newvar_above level m)
   else m
 
@@ -880,7 +880,7 @@ let create_allocation_mode_l mode =
 let create_function_return_mode
     ~return_from_exclave ret_mode : return_mode =
   let ret_mode =
-    if Language_extension.(is_at_least Mode_polymorphism Beta) then
+    if Language_extension.(is_at_least Mode_polymorphism Alpha) then
       if return_from_exclave
       then Locality.disallow_right Locality.local
       else Locality.disallow_right Locality.global
@@ -5229,7 +5229,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                 the return value):
                 [mode_ret] < [mode_ret_alloc] < [mode_ret_eta] *)
              let mode_ret_eta =
-               if Language_extension.(is_at_least Mode_polymorphism Beta)
+               if Language_extension.(is_at_least Mode_polymorphism Alpha)
                then
                 fst (Alloc.newvar_above (Ctype.get_current_level ()) mode_ret)
                else mode_ret
@@ -5270,7 +5270,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              in
              (* [mode_ret] < [mode_ret_alloc] < [mode_ret_eta]*)
              let mode_ret_alloc =
-              if Language_extension.(is_at_least Mode_polymorphism Beta)
+              if Language_extension.(is_at_least Mode_polymorphism Alpha)
               then begin
                 let m = Locality.newvar 0 in
                 Locality.submode_exn

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -174,6 +174,7 @@ val type_option_some:
 val type_option_none:
         Env.t -> type_expr -> Location.t -> Typedtree.expression
 val generalizable: int -> type_expr -> bool
+val generalize_structure_exp: Typedtree.expression -> unit
 val reset_delayed_checks: unit -> unit
 val force_delayed_checks: unit -> unit
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -381,6 +381,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1013,7 +1013,10 @@ let transl_declaration env sdecl (id, uid) =
          traverses inside of any type constructors in the [with]-bound. It's
          also necessary because the variables here are at generic level, and so
          any containers of them should be, too! *)
-      Ctype.with_local_level_generalize_structure begin fun () ->
+      Ctype.with_local_level_generalize_structure
+        ~before_generalize:(fun cty ->
+          Ctype.generalize_structure cty.ctyp_type)
+        begin fun () ->
         Typetexp.transl_simple_type env ~new_var_jkind:Any
           ~closed:true Mode.Alloc.Const.legacy sty
       end
@@ -1564,7 +1567,8 @@ let rec check_constraints_rec env loc visited ty =
       check_constraints_rec env loc visited ty
   | _ ->
       Ctype.iter_type_expr_with_stages
-        (fun env -> check_constraints_rec env loc visited) env ty
+        (fun env -> check_constraints_rec env loc visited) env
+        (Fun.const ()) ty
   end
 
 let check_constraints_labels env visited l pl =
@@ -3217,7 +3221,8 @@ let check_well_founded ~abs_env env loc path to_check visited ty0 =
               List.iter (check_subtype parents trace ty env) tyl
         end
     | _ ->
-        Ctype.iter_type_expr_with_stages (check_subtype parents trace ty) env ty
+        Ctype.iter_type_expr_with_stages
+          (check_subtype parents trace ty) env (Fun.const ()) ty
   and check_subtype parents trace outer_ty env inner_ty =
       check parents (Contains (outer_ty, inner_ty) :: trace) env inner_ty
   in
@@ -3564,7 +3569,7 @@ let check_regularity ~abs_env env loc path decl to_check =
           check_regular cpath args prev_exp trace env ty
       | _ ->
           Ctype.iter_type_expr_with_stages
-            (check_subtype cpath args prev_exp trace ty) env ty
+            (check_subtype cpath args prev_exp trace ty) env (Fun.const ()) ty
     end
     and check_subtype cpath args prev_exp trace outer_ty env inner_ty =
       let trace = Contains (outer_ty, inner_ty) :: trace in
@@ -3992,7 +3997,7 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
-       match Ctype.closed_type_decl decl with
+       match Mode.Alloc.with_zap_scope Ctype.closed_type_decl decl with
          Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
@@ -4278,7 +4283,10 @@ let transl_type_extension extend env loc styext =
   (* Check that all type variables are closed *)
   List.iter
     (fun (ext, _shape) ->
-       match Ctype.closed_extension_constructor ext.ext_type with
+       match Mode.Alloc.with_zap_scope
+               Ctype.closed_extension_constructor
+               ext.ext_type
+       with
          Some ty ->
            raise(Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
        | None -> ())
@@ -4334,7 +4342,10 @@ let transl_exception env sext =
       end
   in
   (* Check that all type variables are closed *)
-  begin match Ctype.closed_extension_constructor ext.ext_type with
+  begin match
+    Mode.Alloc.with_zap_scope
+      Ctype.closed_extension_constructor ext.ext_type
+  with
     Some ty ->
       raise (Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
   | None -> ()
@@ -4693,7 +4704,10 @@ let check_unboxable env loc ty =
       | _ -> acc
     with Not_found -> acc
   in
-  let all_unboxable_types = Btype.fold_type_expr check_type Path.Set.empty ty in
+  let all_unboxable_types =
+    Btype.fold_type_expr check_type
+      (fun a _ -> a) Path.Set.empty ty
+  in
   Path.Set.fold
     (fun p () ->
        Location.prerr_warning loc
@@ -5138,7 +5152,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   in
   Option.iter (fun p -> set_private_row env sdecl.ptype_loc p new_sig_decl)
     fixed_row_path;
-  begin match Ctype.closed_type_decl new_sig_decl with None -> ()
+  begin match
+    Mode.Alloc.with_zap_scope
+      Ctype.closed_type_decl new_sig_decl
+  with None -> ()
   | Some ty -> raise(Error(loc, Unbound_type_var(ty, new_sig_decl)))
   end;
   let new_sig_decl = name_recursion sdecl id new_sig_decl in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3997,7 +3997,8 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
-       match Mode.Alloc.with_zap_scope Ctype.closed_type_decl decl with
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+          Ctype.closed_type_decl ~zap_scope decl) with
          Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
@@ -4283,9 +4284,9 @@ let transl_type_extension extend env loc styext =
   (* Check that all type variables are closed *)
   List.iter
     (fun (ext, _shape) ->
-       match Mode.Alloc.with_zap_scope
-               Ctype.closed_extension_constructor
-               ext.ext_type
+       match Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+               Ctype.closed_extension_constructor ~zap_scope
+               ext.ext_type)
        with
          Some ty ->
            raise(Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
@@ -4343,8 +4344,8 @@ let transl_exception env sext =
   in
   (* Check that all type variables are closed *)
   begin match
-    Mode.Alloc.with_zap_scope
-      Ctype.closed_extension_constructor ext.ext_type
+    Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+        Ctype.closed_extension_constructor ~zap_scope ext.ext_type)
   with
     Some ty ->
       raise (Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
@@ -5154,7 +5155,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     fixed_row_path;
   begin match
     Mode.Alloc.with_zap_scope
-      Ctype.closed_type_decl new_sig_decl
+      (fun ~zap_scope -> Ctype.closed_type_decl ~zap_scope new_sig_decl)
   with None -> ()
   | Some ty -> raise(Error(loc, Unbound_type_var(ty, new_sig_decl)))
   end;

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -169,13 +169,13 @@ let compute_variance_type env ~check (required, loc) decl tyl =
             | Tconstr _ ->
                 let old = !visited in
                 begin try
-                  Ctype.iter_type_expr_with_stages check env ty
+                  Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
                 with Exit ->
                   visited := old;
                   let ty' = Ctype.expand_head_opt env ty in
                   if eq_type ty ty' then raise Exit else check env ty'
                 end
-            | _ -> Ctype.iter_type_expr_with_stages check env ty
+            | _ -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
           end
         in
         try check env ty; compute_variance env tvl injective ty
@@ -247,7 +247,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                      , Bad_variance ( variance_error
                                     , (c1,n1,false)
                                     , (c2,n2,false))))
-        | None -> Ctype.iter_type_expr_with_stages check env ty
+        | None -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
       end
     in
     List.iter (fun (_,ty) -> check env ty) tyl;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -84,7 +84,7 @@ module Unique_barrier = struct
 
   let enable barrier = match !barrier with
     | Not_computed ->
-      barrier := Enabled (Uniqueness.newvar ())
+      barrier := Enabled (Uniqueness.newvar 0)
     | _ -> Misc.fatal_error "Unique barrier was enabled twice"
 
   (* Due to or-patterns a barrier may have several upper bounds. *)
@@ -96,7 +96,7 @@ module Unique_barrier = struct
   let resolve barrier =
     match !barrier with
     | Enabled uniq ->
-      let zapped = Uniqueness.zap_to_ceil uniq in
+      let zapped = Uniqueness.zap_to_ceil_exn uniq in
       barrier := Resolved zapped;
       zapped
     | Resolved barrier -> barrier
@@ -137,7 +137,7 @@ type alloc_mode_r = Mode.Locality.r
 let create_alloc_mode_r m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
+let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil_exn m
 
 let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
 
@@ -151,7 +151,7 @@ type alloc_mode_l = Mode.Locality.l
 let create_alloc_mode_l m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor_exn m
 
 let alloc_mode_l_map f m = f m
 
@@ -163,7 +163,7 @@ type return_mode = Mode.Locality.l
 let create_return_mode m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
-let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+let return_mode_zap_to_floor_exn m = Mode.Locality.zap_to_floor_exn m
 
 let print_return_mode ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -140,7 +140,7 @@ type return_mode
 
 val create_return_mode : Mode.Locality.l -> return_mode
 
-val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+val return_mode_zap_to_floor_exn : return_mode -> Mode.Locality.Const.t
 
 val print_return_mode : Format.formatter -> return_mode -> unit
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -108,7 +108,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
-  let mode = Mode.Value.newvar () in
+  let mode = Mode.Value.newvar 0 in
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
   Value.submode_exn (min |> Alloc.of_const |> alloc_as_value) mode;
@@ -121,7 +121,7 @@ let register_allocation loc : Alloc.lr * Value.lr =
       ~hint_comonadic:Module_allocated_on_heap
       { Alloc.Const.max with areality = Global }
   in
-  let alloc_mode, _ = Alloc.newvar_below upper_bound in
+  let alloc_mode, _ = Alloc.newvar_below 0 upper_bound in
   let closed_over_mode =
     alloc_as_value ~allocation:({loc; txt = Unknown}) alloc_mode
   in
@@ -173,7 +173,7 @@ let infer_modalities pp ~loc_md item ~md_mode ~mode =
       To achieve that, the mode of [foo] to be exposed as [M.foo] should be a
       flexible mode variable weaker than its actual mode.
     *)
-    let mode, _ = Mode.Value.newvar_above mode in
+    let mode, _ = Mode.Value.newvar_above (Ctype.get_current_level ()) mode in
     (* Upon construction, for comonadic (prescriptive) axes, module
     must be weaker than the values therein, for otherwise operations
     would be allowed to performed on the module (and extended to the
@@ -254,7 +254,8 @@ let extract_sig_functor_open funct_body env loc mty sig_acc md_mode
     let yielding m =
       Yielding.disallow_right (Value.proj_comonadic Yielding m)
     in
-    Yielding.join [yielding funct_mode; yielding md_mode]
+    Ctype.create_yielding_mode_l
+      (Yielding.join [yielding funct_mode; yielding md_mode])
   in
   match Mtype.scrape_alias env mty with
   | Mty_functor (Named (param, mty_param, mm_param),mty_result,mm_result)
@@ -2839,19 +2840,31 @@ let check_nongen_signature_item env sig_item =
 let check_nongen_signature env sg =
   List.iter (check_nongen_signature_item env) sg
 
-let remove_functor_mode_variables = function
+let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
-      Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
+      let zap_mode ~arg mode =
+        if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope ~arg mode zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force ~arg mode |> ignore
+         end
+      in
+      zap_mode ~arg:false mres;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
+      | Named (_, _, marg) -> zap_mode ~arg:true marg
       end
   | _ -> ()
 
 let remove_mode_and_jkind_variables env sg =
-  let rm_ty _env ty = Ctype.remove_mode_and_jkind_variables ty; None in
-  let rm_mty _env mty = remove_functor_mode_variables mty in
-  List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore
+  Mode.Alloc.with_zap_scope(fun ~zap_scope ->
+    let rm_ty _env ty =
+      Ctype.remove_mode_and_jkind_variables
+        ty ~zap_scope;
+      None
+    in
+    let rm_mty _env mty = remove_functor_mode_variables ~zap_scope mty in
+    List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore)
 
 (* Helpers for typing recursive modules *)
 
@@ -3285,7 +3298,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
         type_module ~strengthen:true ~funct_body None newenv sbody
       in
       let body_mode = mode_without_locks_exn body.mod_mode in
-      let ret_mode = Alloc.newvar () in
+      let ret_mode = Alloc.newvar 0 in
       Value.submode_exn body_mode (ret_mode |> alloc_as_value);
       (* Apply currying constraints if the body is a functor,
          similar to constraints for functions. *)
@@ -3337,15 +3350,22 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
       },
       final_shape
   | Pmod_unpack sexp ->
-      let mode = Value.newvar () in
+      let mode = Value.newvar 0 in
       let exp =
         Ctype.with_local_level_generalize_structure_if_principal
+          ~before_generalize:Typecore.generalize_structure_exp
           (fun () -> Typecore.type_exp env sexp
             ~mode:(Value.disallow_left mode))
       in
       let mty =
         match get_desc (Ctype.expand_head env exp.exp_type) with
           Tpackage pack ->
+            (* CR ageorges: should we remove modes here? *)
+            List.iter
+              (fun (_n, t) ->
+                 Mode.Alloc.with_zap_scope
+                   Ctype.remove_mode_and_jkind_variables t)
+              pack.pack_cstrs;
             check_package_closed ~loc:smod.pmod_loc ~env ~typ:exp.exp_type
               pack.pack_cstrs;
             if !Clflags.principal &&
@@ -3482,8 +3502,9 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
      argument (the argument's mode). *)
   let functor_application_yielding ~funct ~arg_mode =
     let yielding m = Value.proj_comonadic Yielding m in
-    Yielding.join
-      [yielding (mode_without_locks_exn funct.mod_mode); yielding arg_mode]
+    Ctype.create_yielding_mode_l
+      (Yielding.join
+         [yielding (mode_without_locks_exn funct.mod_mode); yielding arg_mode])
   in
   (* CR modes: Apply currying constraints if the application is partial
      and returns a functor, similar to constraints for functions.
@@ -4223,7 +4244,8 @@ let remove_mode_and_jkind_variables_for_toplevel str =
                          vb_expr = exp}])) }] ->
      (* These types are printed by the toplevel,
         even though they do not appear in sg *)
-     Ctype.remove_mode_and_jkind_variables exp.exp_type
+     Mode.Alloc.with_zap_scope
+       Ctype.remove_mode_and_jkind_variables exp.exp_type
   | _ -> ()
 
 let type_toplevel_phrase env sig_acc s =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3364,7 +3364,8 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
             List.iter
               (fun (_n, t) ->
                  Mode.Alloc.with_zap_scope
-                   Ctype.remove_mode_and_jkind_variables t)
+                   (fun ~zap_scope ->
+                      Ctype.remove_mode_and_jkind_variables ~zap_scope t))
               pack.pack_cstrs;
             check_package_closed ~loc:smod.pmod_loc ~env ~typ:exp.exp_type
               pack.pack_cstrs;
@@ -4245,7 +4246,8 @@ let remove_mode_and_jkind_variables_for_toplevel str =
      (* These types are printed by the toplevel,
         even though they do not appear in sg *)
      Mode.Alloc.with_zap_scope
-       Ctype.remove_mode_and_jkind_variables exp.exp_type
+       (fun ~zap_scope ->
+          Ctype.remove_mode_and_jkind_variables ~zap_scope exp.exp_type)
   | _ -> ()
 
 let type_toplevel_phrase env sig_acc s =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2812,8 +2812,9 @@ and nongen_signature_item env f g = function
       nongen_modtype env f g md.md_type
   | _ -> None
 
-let check_nongen_modtype env loc mty =
-  nongen_modtype env Ctype.nongen_vars_in_schema (fun _ _ -> ()) mty
+let check_nongen_modtype ~zap_scope env loc mty =
+  nongen_modtype env (Ctype.nongen_vars_in_schema ~zap_scope) (fun _ _ -> ())
+    mty
   |> Option.iter (fun (vars, item) ->
       let vars = Btype.TypeSet.elements vars in
       let error =
@@ -2822,10 +2823,10 @@ let check_nongen_modtype env loc mty =
       raise(Error(loc, env, error))
     )
 
-let check_nongen_signature_item env sig_item =
+let check_nongen_signature_item ~zap_scope env sig_item =
   match sig_item with
     Sig_value(_id, vd, _) ->
-      Ctype.nongen_vars_in_schema env vd.val_type
+      Ctype.nongen_vars_in_schema ~zap_scope env vd.val_type
       |> Option.iter (fun vars ->
           let vars = Btype.TypeSet.elements vars in
           let error =
@@ -2834,11 +2835,12 @@ let check_nongen_signature_item env sig_item =
           raise (Error (vd.val_loc, env, error))
         )
   | Sig_module (_id, _, md, _, _) ->
-      check_nongen_modtype env md.md_loc md.md_type
+      check_nongen_modtype ~zap_scope env md.md_loc md.md_type
   | _ -> ()
 
 let check_nongen_signature env sg =
-  List.iter (check_nongen_signature_item env) sg
+  Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+      List.iter (check_nongen_signature_item ~zap_scope env) sg)
 
 let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
@@ -4315,7 +4317,9 @@ let type_module_type_of env smod =
   in
   let mty = Mtype.scrape_for_type_of ~remove_aliases env tmty.mod_type in
   (* PR#5036: must not contain non-generalized type variables *)
-  if not skip_nongen_check then check_nongen_modtype env smod.pmod_loc mty;
+  if not skip_nongen_check then
+    Mode.Alloc.with_zap_scope (fun ~zap_scope ->
+       check_nongen_modtype ~zap_scope env smod.pmod_loc mty);
   let zap_modality = Ctype.zap_modalities_to_floor_if_modes_enabled_at Stable in
   let mty =
     remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3362,13 +3362,6 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
       let mty =
         match get_desc (Ctype.expand_head env exp.exp_type) with
           Tpackage pack ->
-            (* CR ageorges: should we remove modes here? *)
-            List.iter
-              (fun (_n, t) ->
-                 Mode.Alloc.with_zap_scope
-                   (fun ~zap_scope ->
-                      Ctype.remove_mode_and_jkind_variables ~zap_scope t))
-              pack.pack_cstrs;
             check_package_closed ~loc:smod.pmod_loc ~env ~typ:exp.exp_type
               pack.pack_cstrs;
             if !Clflags.principal &&

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1754,7 +1754,8 @@ let transl_type_scheme_mono env styp =
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
-  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
+  Alloc.with_zap_scope (fun ~zap_scope ->
+    remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =
@@ -1778,7 +1779,8 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ~before_generalize:(fun (_,_,typ) -> generalize_ctyp typ)
   in
   let _ : _ list = TyVarEnv.instance_poly_univars env loc univars in
-  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
+  Alloc.with_zap_scope (fun ~zap_scope ->
+    remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
     ctyp_env = env;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -999,7 +999,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode.mode_modes arg
           in
-          let acc_mode = curry_mode acc_mode arg_mode.mode_modes in
+          let acc_mode = curry_mode_const acc_mode arg_mode.mode_modes in
           let ret_mode =
             match rest with
             | [] -> ret_mode
@@ -1475,7 +1475,9 @@ and transl_type_alias env ~row_context ~policy mode attrs styp_loc styp name_opt
         cty, jkind_annot
       with Not_found ->
         let t, ty, jkind_annot =
-          with_local_level_generalize_structure_if_principal begin fun () ->
+          with_local_level_generalize_structure_if_principal
+            ~before_generalize:(fun (t, _, _) -> generalize_structure t)
+            begin fun () ->
             let jkind, rigid =
               jkind_for_fresh_var env alias alias_loc attrs jkind_annot_opt
             in
@@ -1685,7 +1687,7 @@ let rec make_fixed_univars mark ty =
                   ~fixed:(Some (Univar more))));
         Btype.iter_row (make_fixed_univars mark) row
     | _ ->
-        Btype.iter_type_expr (make_fixed_univars mark) ty
+        Btype.iter_type_expr (make_fixed_univars mark) (Fun.const ()) ty
     end
 
 let make_fixed_univars ty =
@@ -1752,7 +1754,7 @@ let transl_type_scheme_mono env styp =
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =
@@ -1776,7 +1778,7 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ~before_generalize:(fun (_,_,typ) -> generalize_ctyp typ)
   in
   let _ : _ list = TyVarEnv.instance_poly_univars env loc univars in
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
     ctyp_env = env;
@@ -1850,7 +1852,7 @@ let transl_type_scheme_newlayout env attrs loc vars inner_type =
               Types.set_var_jkind t jkind
             | None -> ())
           | _ -> ())
-        | _ -> Btype.iter_type_expr replace t)
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t)
       end
     in
     let ety = Subst.type_expr Subst.identity ty in

--- a/utils/language_extension_kernel.ml
+++ b/utils/language_extension_kernel.ml
@@ -9,6 +9,7 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -27,6 +28,7 @@ let to_string : type a. a t -> string = function
   | Mode -> "mode"
   | Unique -> "unique"
   | Overwriting -> "overwriting"
+  | Mode_polymorphism -> "mode_polymorphism"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"

--- a/utils/language_extension_kernel.ml
+++ b/utils/language_extension_kernel.ml
@@ -10,6 +10,7 @@ type _ t =
   | Unique : maturity t
   | Overwriting : unit t
   | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -29,6 +30,7 @@ let to_string : type a. a t -> string = function
   | Unique -> "unique"
   | Overwriting -> "overwriting"
   | Mode_polymorphism -> "mode_polymorphism"
+  | Mode_polymorphism_printing -> "mode_polymorphism_printing"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"

--- a/utils/language_extension_kernel.mli
+++ b/utils/language_extension_kernel.mli
@@ -20,6 +20,7 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/utils/language_extension_kernel.mli
+++ b/utils/language_extension_kernel.mli
@@ -21,6 +21,7 @@ type _ t =
   | Unique : maturity t
   | Overwriting : unit t
   | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -10,8 +10,8 @@ let count_language_extensions typing_input =
     | Comprehensions | Include_functor | Immutable_arrays | Module_strengthening
       ->
       Language_extension_kernel.to_string lang_ext
-    | Mode | Unique | Polymorphic_parameters | Layouts | SIMD | Small_numbers
-    | Instances | Overwriting | Let_mutable | Layout_poly
+    | Mode | Unique | Mode_polymorphism | Polymorphic_parameters | Layouts
+    | SIMD | Small_numbers | Instances | Overwriting | Let_mutable | Layout_poly
     | Runtime_metaprogramming ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -10,9 +10,9 @@ let count_language_extensions typing_input =
     | Comprehensions | Include_functor | Immutable_arrays | Module_strengthening
       ->
       Language_extension_kernel.to_string lang_ext
-    | Mode | Unique | Mode_polymorphism | Polymorphic_parameters | Layouts
-    | SIMD | Small_numbers | Instances | Overwriting | Let_mutable | Layout_poly
-    | Runtime_metaprogramming ->
+    | Mode | Unique | Mode_polymorphism | Mode_polymorphism_printing
+    | Polymorphic_parameters | Layouts | SIMD | Small_numbers | Instances
+    | Overwriting | Let_mutable | Layout_poly | Runtime_metaprogramming ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."
           (Language_extension_kernel.to_string lang_ext)


### PR DESCRIPTION
Integrates all the level-relation operations into type inference to support mode polymorphism. Mode polymorphic variables are functional, and can be printed behind a dedicated extension flag (see below).

The integration applies `update-level`, `generalize`, `generalize-structure`, and `instantiate` in parallel with type inference.

We introduce a new flag that turns on the feature:

```-extension mode_polymorphism_alpha```

The `mode_polymorphism` and `mode_polymorphism_beta` flags do nothing: all mode variables are allocated at level 0, and zapping behaves as before. In particular, `-extension-universe beta` does not enable any part of mode polymorphism.

To implement copying, the existing copy scope in `btype.ml` is extended to include the mode copy scope. `Subst` also copies generic mode variables: duplicating variables copies them through the copy scope, and saving to (resp. restoring from) cmi files copies them persistently via `mode_copy_for_saving` (resp. `mode_copy_for_restoring`).

New mode variables are allocated either at level 0 whenever a mode variable should not be generalized --- such as allocation modes --- or at the current level.

Finally, under mode polymorphism, `Typedtree.return_mode` is derived from the `exclave_` bit rather than from the function's return mode: it is `local` if the function returns via `exclave_`, and `global` otherwise. This ensures that the application mode of an application that does not allocate is never inferred to be `local` (see `fatal_application_modes.ml`).

Mode polymorphism is tested in the folder `typing-mode-polymorphism`:
- `basic.ml`: basic polymorphism, bounds over multiple mode axes, closing over mode variables, mode crossing, and interaction with `local`
- `functions.ml`: function application, higher-order functions, composition, chained applications, recursive functions, and sequencing
- `currying.ml`: dependencies between arguments, curry modes and inner returns, eta-expansion, and uniqueness and portability of partial applications
- `labelled_args.ml`: labelled, omitted and optional arguments, and their partial applications
- `records.ml`: record allocations and projections; mutable fields are not mode polymorphic, immutable fields are
- `tuples.ml`: tuple allocations and their interaction with `exclave_`
- `modules.ml`: mode polymorphic values in structures and inferred signatures
- `alloc_mode.ml`: a `-dlambda` test checking that field mutations compile to `caml_modify_local` unless the record is known to be global, and similar examples related to `apply[yielding]`
- `fatal_application_modes.ml`: a native regression test checking that applications that do not allocate are not inferred to run at a `local` application mode
- `toplevel_zap_scope.ml`: zapping of top-level definitions
- `performance.ml`: known pathological performance patterns
- `mode_polymorphism_printing.ml`: printing of polymorphic mode variables

Notable changes:
- generic mode variables are retained in structures: `lower_nongen` no longer lowers generic modes, so values keep their mode polymorphism in inferred module signatures, e.g. `module M : sig val id : 'a @ [< 'm] -> 'a @ [> 'm] end`.
- modes are not generalized in class definitions, which keep the legacy behavior.
- mode polymorphism is not excluded from extension universes, so `-extension-universe alpha` enables it (`-extension-universe beta` does not, see above). A few pre-existing tests running under the alpha universe were adapted as a result (`typing-unique/overwriting.ml`, `typing-unique/overwriting_proj_push_down_bug.ml`, `parsetree/source_jane_street.ml`, `typing-layouts-or-null/immediate.ml`).
- generic mode variables should (almost) never be mutated: that means regular calls to `zap_to_X` do nothing on generic mode variables. There are two exceptions: (1) if the mode_polymorphism_alpha extension is not turned on, generic modes are zapped during `remove_mode_and_jkind_variables`, and (2) polymorphic mode variables are printed as their zapped versions. To zap generic mode variables, use `zap_to_X_force`.

Since generic mode variables are no longer zapped, it is important to instead determine the level 0 modes they might point to. If a mode appears only as a lower bound to generic modes in the typed expression, it is zapped to floor, if it appears only as an upper bound to generic modes, it is zapped to ceiling, and if it appears as both, it is zapped to legacy. This is implemented with zap scopes: pending zap jobs are collected in a `zap_scope` and resolved together once the enclosing definition has been fully processed, so that all occurrences of a mode are taken into account.

Printing of mode polymorphic variables is not turned on by default. We introduce the following flag to print them:
``` -extension mode_polymorphism_printing ```

Printing is an early version of printing, and is included in this PR to observe the effects of mode polymorphism in tests.

The goal is to print polymorphic mode variables and their constraints. In general, mode variables is printed in `[...]` containing its lower and upper bounds and constraints as follows: `[< ... & ... > ... | ...]`. Lower and upper bounds refer to the constant bounds on the polymorphic variable, and constraints might refer to other mode variables.

If a mode variable has no bounds or constraints, it is printed as a fresh mode variable name: `'m`, `'n`, `'o`, etc.

Printing mode variables requires an expensive pre-processing step, which is only applied when both `-extension mode_polymorphism_alpha` and `-extension mode_polymorphism_printing` are on.

Below are some examples:
- `val id : 'a @ [< 'm] -> 'a @ [> 'm]`

- `let fst x y = x` involves currying, and gets printed to `val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]`. The argument is bounded by `global` since the allocation of the closure `fst x` is here decided to be global, and the closure closes over the argument.

Where `close('m)` refers to the meet between the comonadic parts of `'m` and the monadic part `'m`, taken to its dual comonadic counterpart. Note that `'m` describes an upper bound in the argument, and a lower bound on the inner return.

If the curry mode does not flow in both directions, we print the following constraint:

- `let snd x y = y : 'a @ [< 'm @@ past & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm]`

Where `'m @@ past` refers to the comonadic part of `'m` only, and can be read as "mod past", or "modulo past", or "mod monadic".

- `let fst x = fun y -> x` prints identically to `let fst x y = x`: the explicit closure introduces no additional constraints.

- let `type 'a mytyp = { a : 'a @@ portable }` then `let f x = x.a` is inferred and printed as `val f : 'a mytyp @ [< 'm] -> 'a @ [> 'm @@ portable]`. Here `@@ portable` stands for a meet, and the type expresses the output is lower bounded by `'m`, except for the portability axis, which is lower bounded by `portable`.
