### PR TITLE
Printing of polymorphic mode variables

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -35,7 +35,9 @@ let dummy_value_mode = Value.disallow_right Value.legacy
 
 let dummy_scannable_sort = Jkind.Sort.scannable
 
-let dummy_alloc_mode = Alloc.disallow_left Alloc.legacy
+let dummy_alloc_mode_r = Locality.disallow_left Locality.legacy
+
+let dummy_alloc_mode_l = Locality.disallow_right Locality.legacy
 
 let dummy_ctor_repres = Constructor_uniform_value
 
@@ -61,7 +63,7 @@ let mkTexp_ident ?id:(kind, unique_use = Id_value, aliased_many_use)
 type nonrec apply_arg = apply_arg
 
 type texp_apply_identifier =
-  apply_position * Locality.l * Builtin_attributes.zero_alloc_assume option
+  apply_position * alloc_mode_l * Builtin_attributes.zero_alloc_assume option
 
 let mkTexp_apply
     ?id:(pos, mode, za = Default, Locality.disallow_right Locality.legacy, None)
@@ -71,27 +73,28 @@ let mkTexp_apply
   in
   Texp_apply (exp, args, pos, mode, za)
 
-type texp_tuple_identifier = string option list * alloc_mode
+type texp_tuple_identifier = string option list * alloc_mode_r
 
 let mkTexp_tuple ?id exps =
   let labels, alloc =
     match id with
-    | None -> List.map (fun _ -> None) exps, dummy_alloc_mode
+    | None -> List.map (fun _ -> None) exps, dummy_alloc_mode_r
     | Some id -> id
   in
   let exps = List.combine labels exps in
   Texp_tuple (exps, alloc)
 
-type texp_construct_identifier = alloc_mode option * constructor_representation
+type texp_construct_identifier =
+  alloc_mode_r option * constructor_representation
 
 type texp_construct_arg_identifier = Jkind.Sort.t
 
 let mkTexp_construct
-    ?id:(mode, repres = Some dummy_alloc_mode, dummy_ctor_repres)
+    ?id:(mode, repres = Some dummy_alloc_mode_r, dummy_ctor_repres)
     (name, desc, args) =
   Texp_construct (name, desc, repres, args, mode)
 
-type texp_record_identifier = Types.record_representation * alloc_mode option
+type texp_record_identifier = Types.record_representation * alloc_mode_r option
 
 type texp_record_field_identifier = Jkind.Sort.t
 
@@ -103,7 +106,7 @@ let mkTexp_record ~id:(representation, alloc_mode) (fields, extended_expression)
 
 type texp_function_param_identifier =
   { param_sort : Jkind.Sort.t;
-    param_mode : Alloc.l;
+    param_mode : alloc_mode_l;
     param_curry : function_curry;
     param_newtypes :
       (Ident.t
@@ -123,7 +126,7 @@ type texp_function_param =
   }
 
 type texp_function_cases_identifier =
-  { last_arg_mode : Alloc.l;
+  { last_arg_mode : alloc_mode_l;
     last_arg_sort : Jkind.Sort.t;
     last_arg_exp_extra : exp_extra list;
     last_arg_attributes : attributes;
@@ -146,14 +149,14 @@ type texp_function =
   }
 
 type texp_function_identifier =
-  { alloc_mode : alloc_mode;
+  { alloc_mode : alloc_mode_r;
     ret_sort : Jkind.sort;
-    ret_mode : Alloc.l;
+    ret_mode : alloc_mode_l;
     zero_alloc : Zero_alloc.t
   }
 
 let texp_function_cases_identifier_defaults =
-  { last_arg_mode = Alloc.disallow_right Alloc.legacy;
+  { last_arg_mode = dummy_alloc_mode_l;
     last_arg_sort = Jkind.Sort.scannable;
     last_arg_exp_extra = [];
     last_arg_attributes = [];
@@ -163,15 +166,15 @@ let texp_function_cases_identifier_defaults =
 
 let texp_function_param_identifier_defaults =
   { param_sort = Jkind.Sort.scannable;
-    param_mode = Alloc.disallow_right Alloc.legacy;
-    param_curry = More_args { partial_mode = Alloc.disallow_right Alloc.legacy };
+    param_mode = dummy_alloc_mode_l;
+    param_curry = More_args { partial_mode = dummy_alloc_mode_l };
     param_newtypes = []
   }
 
 let texp_function_defaults =
-  { alloc_mode = dummy_alloc_mode;
+  { alloc_mode = dummy_alloc_mode_r;
     ret_sort = Jkind.Sort.scannable;
-    ret_mode = Alloc.disallow_right Alloc.legacy;
+    ret_mode = dummy_alloc_mode_l;
     zero_alloc = Zero_alloc.default
   }
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -330,7 +330,10 @@ let can_apply_primitive p pmode pos args =
     else if nargs < p.prim_arity then false
     else if pos <> Typedtree.Tail then true
     else begin
-      let return_mode = Ctype.prim_mode pmode p.prim_native_repr_res in
+      (* CR ageorges: what level to choose here *)
+      let return_mode =
+        Ctype.prim_mode pmode p.prim_native_repr_res ~level:0
+      in
       is_heap_mode (transl_locality_mode_l return_mode)
     end
   end

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -167,7 +167,7 @@ let function_attribute_disallowing_arity_fusion =
 (** [curried_function_kind p] checks the well-formedness of the list and returns
   the corresponding [curried_function_kind]. *)
 let curried_function_kind
-    : (function_curry * Mode.Alloc.l) list
+    : (function_curry * Typedtree.alloc_mode_l) list
       -> return_mode:locality_mode
       -> mode:locality_mode
       -> curried_function_kind
@@ -274,7 +274,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         (function (Texp_poly _, _, _) -> true | _ -> false)
         exp_extra
     ->
-      begin match transl_alloc_mode method_.alloc_mode with
+      begin match transl_alloc_mode_r method_.alloc_mode with
       | Alloc_heap -> ()
       | Alloc_local ->
           (* If we support locally-allocated objects, we'll also have to
@@ -286,7 +286,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         { self_param
           with fp_curry = More_args
             { partial_mode =
-              Mode.Alloc.disallow_right Mode.Alloc.legacy }
+              Mode.Locality.disallow_right Mode.Locality.legacy }
         }
       in
       let return_sort = Jkind.Sort.default_for_transl_and_get method_.ret_sort in
@@ -466,7 +466,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let inlined = Translattribute.get_inlined_attribute funct in
         let specialised = Translattribute.get_specialised_attribute funct in
         let position = transl_apply_position pos in
-        let mode = transl_locality_mode_l ap_mode in
+        let mode = transl_alloc_mode_l ap_mode in
         let result_layout = layout_exp sort e in
         event_after ~scopes e
           (transl_apply ~scopes ~tailcall ~inlined ~specialised
@@ -481,7 +481,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let specialised = Translattribute.get_specialised_attribute funct in
       let result_layout = layout_exp sort e in
       let position = transl_apply_position position in
-      let mode = transl_locality_mode_l ap_mode in
+      let mode = transl_alloc_mode_l ap_mode in
       let assume_zero_alloc =
         zero_alloc_of_application ~num_args:(List.length oargs) zero_alloc funct
       in
@@ -516,7 +516,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable,
                          Lambda.block_shape_of_value_kinds (Some shape),
-                         transl_alloc_mode alloc_mode),
+                         transl_alloc_mode_r alloc_mode),
               ll,
               (of_location ~scopes e.exp_loc))
       end
@@ -590,7 +590,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           begin match constant with
           | Some constant -> Lconst constant
           | None ->
-              let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
+              let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
               let makeblock =
                 match shape with
                 | Constructor_uniform_value ->
@@ -623,7 +623,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                that the list is empty *)
             lam)
           else
-            let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
+            let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
             (* CR mshinwell: why are we using generic_value and not an immediate
                value kind for the poly variant hash? *)
             let makeblock =
@@ -672,13 +672,13 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                                    extract_constant lam]))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, All_value,
-                             transl_alloc_mode alloc_mode),
+                             transl_alloc_mode_r alloc_mode),
                   [tagged_immediate tag; lam],
                   of_location ~scopes e.exp_loc)
       end
   | Texp_record {fields; representation; extended_expression; alloc_mode} ->
       transl_record ~scopes e.exp_loc e.exp_env
-        (Option.map transl_alloc_mode alloc_mode)
+        (Option.map transl_alloc_mode_r alloc_mode)
         fields representation extended_expression
   | Texp_record_unboxed_product
         {fields; representation; extended_expression } ->
@@ -701,7 +701,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       let (arg, lbl) = transl_atomic_loc ~scopes arg arg_sort lbl repres in
       let loc = of_location ~scopes e.exp_loc in
-      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode alloc_mode),
+      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode_r alloc_mode),
              [arg; lbl], loc)
   | Texp_field { record = arg; record_sort = arg_sort; record_repres;
                  lid = _; label = lbl; boxing = float;
@@ -733,7 +733,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             | Boxing (alloc_mode, _) -> alloc_mode
             | Non_boxing _ -> assert false
           in
-          let mode = transl_alloc_mode alloc_mode in
+          let mode = transl_alloc_mode_r alloc_mode in
           Some (Pfloatfield (lbl.lbl_pos, sem, mode), [targ])
         | Record_ufloat ->
           Some (Pufloatfield (lbl.lbl_pos, sem), [targ])
@@ -769,7 +769,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                 if i <> lbl.lbl_pos then Lambda.alloc_heap
                 else
                   match float with
-                    | Boxing (mode, _) -> transl_alloc_mode mode
+                    | Boxing (mode, _) -> transl_alloc_mode_r mode
                     | Non_boxing _ ->
                         Misc.fatal_error
                           "expected typechecking to make [float] boxing mode\
@@ -891,7 +891,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       Lprim(prim, args, of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
-      let mode = transl_alloc_mode alloc_mode in
+      let mode = transl_alloc_mode_r alloc_mode in
       let element_sort = Jkind.Sort.default_for_transl_and_get element_sort in
       let kind = array_kind e in
       let ll =
@@ -1975,7 +1975,7 @@ and transl_function ~in_new_scope ~scopes e params body
       ~alloc_mode ~ret_mode:sreturn_mode ~ret_sort:sreturn_sort ~region:sregion
       ~zero_alloc =
   let attrs = e.exp_attributes in
-  let mode = transl_alloc_mode alloc_mode in
+  let mode = transl_alloc_mode_r alloc_mode in
   let zero_alloc = Zero_alloc.get zero_alloc in
   let assume_zero_alloc =
     match zero_alloc with
@@ -2623,7 +2623,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
          bytecode means unboxed tuple are slightly worse than normal tuples
          there. Consider adding it for unboxed tuples. *)
       assert (static_handlers = []);
-      let mode = transl_alloc_mode alloc_mode in
+      let mode = transl_alloc_mode_r alloc_mode in
       let argl =
         List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
       in
@@ -2642,7 +2642,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
             argl
           |> List.split
         in
-        let mode = transl_alloc_mode alloc_mode in
+        let mode = transl_alloc_mode_r alloc_mode in
         static_catch (transl_list ~scopes argl) val_ids
           (Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
              lvars mode val_cases partial)
@@ -2739,7 +2739,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
                 { fc_cases = [case]; fc_param = param;
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = []; fc_attributes = [];
-                  fc_arg_mode = Mode.Alloc.disallow_right Mode.Alloc.legacy;
+                  fc_arg_mode =
+                    Mode.Locality.disallow_right Mode.Locality.legacy;
                   fc_arg_sort = param_sort; fc_env = env;
                   fc_ret_type = case.c_rhs.exp_type;
                 }))

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -22,20 +22,13 @@ let transl_locality_mode = function
 let transl_locality_mode_l locality =
   Locality.zap_to_floor locality |> transl_locality_mode
 
-let transl_locality_mode_r locality =
-  (* r mode are for allocations; [optimise_allocations] should have pushed it
-     to ceil and determined; here we push it again just to get the constant. *)
-  Locality.zap_to_ceil locality |> transl_locality_mode
+let transl_alloc_mode_l (mode : Typedtree.alloc_mode_l) =
+  Locality.zap_to_floor mode |> transl_locality_mode
 
-let transl_alloc_mode_l mode =
-  (* we only take the locality axis *)
-  Alloc.proj_comonadic Areality mode |> transl_locality_mode_l
-
-let transl_alloc_mode_r mode =
-  (* we only take the locality axis *)
-  Alloc.proj_comonadic Areality mode |> transl_locality_mode_r
-
-let transl_alloc_mode (mode : Typedtree.alloc_mode) = transl_alloc_mode_r mode
+let transl_alloc_mode_r (mode : Typedtree.alloc_mode_r) =
+  (* alloc modes are for allocations; [optimise_allocations] should have pushed it
+   to ceil and determined; here we push it again just to get the constant. *)
+  Locality.zap_to_ceil mode |> transl_locality_mode
 
 let transl_modify_mode locality =
   match Locality.zap_to_floor locality with

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -20,18 +20,18 @@ let transl_locality_mode = function
   | Locality.Const.Local -> alloc_local
 
 let transl_locality_mode_l locality =
-  Locality.zap_to_floor locality |> transl_locality_mode
+  Locality.zap_to_floor_exn locality |> transl_locality_mode
 
 let transl_alloc_mode_l (mode : Typedtree.alloc_mode_l) =
-  Locality.zap_to_floor mode |> transl_locality_mode
+  Locality.zap_to_floor_exn mode |> transl_locality_mode
 
 let transl_alloc_mode_r (mode : Typedtree.alloc_mode_r) =
   (* alloc modes are for allocations; [optimise_allocations] should have pushed it
    to ceil and determined; here we push it again just to get the constant. *)
-  Locality.zap_to_ceil mode |> transl_locality_mode
+  Locality.zap_to_ceil_exn mode |> transl_locality_mode
 
 let transl_modify_mode locality =
-  match Locality.zap_to_floor locality with
+  match Locality.zap_to_floor_exn locality with
   | Global -> modify_heap
   | Local -> modify_maybe_stack
 

--- a/lambda/translmode.mli
+++ b/lambda/translmode.mli
@@ -16,11 +16,9 @@ open Mode
 
 val transl_locality_mode_l : (allowed * 'r) Locality.t -> Lambda.locality_mode
 
-val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.locality_mode
+val transl_alloc_mode_l : Typedtree.alloc_mode_l -> Lambda.locality_mode
 
-val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.locality_mode
-
-val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.locality_mode
+val transl_alloc_mode_r : Typedtree.alloc_mode_r -> Lambda.locality_mode
 
 val transl_modify_mode : (allowed * 'r) Locality.t -> Lambda.modify_mode
 

--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -168,7 +168,7 @@ let subst_type env t =
   let rec iter t =
     if List.memq t !deja_vu then () else begin
       deja_vu := t :: !deja_vu;
-      Btype.iter_type_expr iter t;
+      Btype.iter_type_expr iter (Fun.const ()) t;
       let open Types in
       match get_desc t with
       | Tconstr (p, [_], _) when Path.same p Predef.path_option ->

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -486,6 +486,12 @@ let is_at_least (type a) (extn : a t) (value : a) =
   in
   check !extensions
 
+(* special checking for mode polymorphism to turn it on by default *)
+let debug = ref false
+
+let is_at_least_mode_poly (value : maturity) =
+  if !debug then true else is_at_least Mode_polymorphism value
+
 let is_enabled extn =
   let rec check : extn_pair list -> bool = function
     | [] -> false

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -65,6 +65,7 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Unique -> (module Maturity)
   | Overwriting -> (module Unit)
   | Mode_polymorphism -> (module Maturity)
+  | Mode_polymorphism_printing -> (module Unit)
   | Include_functor -> (module Unit)
   | Polymorphic_parameters -> (module Unit)
   | Immutable_arrays -> (module Unit)
@@ -87,7 +88,8 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
 *)
 (* CR ageorges: is mode polymorphism erasable? *)
 let is_erasable : type a. a t -> bool = function
-  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism ->
+  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism
+  | Mode_polymorphism_printing ->
     true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
@@ -101,23 +103,24 @@ let maturity_of_unique_for_destruction = Alpha
 module Exist_pair = struct
   type t = Pair : 'a language_extension * 'a -> t
 
-  let maturity : t -> Maturity.t = function
-    | Pair (Comprehensions, ()) -> Beta
-    | Pair (Mode, m) -> m
-    | Pair (Unique, m) -> m
-    | Pair (Overwriting, ()) -> Alpha
-    | Pair (Mode_polymorphism, m) -> m
-    | Pair (Include_functor, ()) -> Stable
-    | Pair (Polymorphic_parameters, ()) -> Stable
-    | Pair (Immutable_arrays, ()) -> Stable
-    | Pair (Module_strengthening, ()) -> Stable
-    | Pair (Layouts, m) -> m
-    | Pair (SIMD, m) -> m
-    | Pair (Small_numbers, m) -> m
-    | Pair (Instances, ()) -> Stable
-    | Pair (Let_mutable, ()) -> Stable
-    | Pair (Layout_poly, m) -> m
-    | Pair (Runtime_metaprogramming, ()) -> Beta
+  let maturity : t -> Maturity.t option = function
+    | Pair (Comprehensions, ()) -> Some Beta
+    | Pair (Mode, m) -> Some m
+    | Pair (Unique, m) -> Some m
+    | Pair (Overwriting, ()) -> Some Alpha
+    | Pair (Mode_polymorphism, m) -> Some m
+    | Pair (Mode_polymorphism_printing, ()) -> None
+    | Pair (Include_functor, ()) -> Some Stable
+    | Pair (Polymorphic_parameters, ()) -> Some Stable
+    | Pair (Immutable_arrays, ()) -> Some Stable
+    | Pair (Module_strengthening, ()) -> Some Stable
+    | Pair (Layouts, m) -> Some m
+    | Pair (SIMD, m) -> Some m
+    | Pair (Small_numbers, m) -> Some m
+    | Pair (Instances, ()) -> Some Stable
+    | Pair (Let_mutable, ()) -> Some Stable
+    | Pair (Layout_poly, m) -> Some m
+    | Pair (Runtime_metaprogramming, ()) -> Some Beta
 
   let is_erasable : t -> bool = function Pair (ext, _) -> is_erasable ext
 
@@ -135,7 +138,8 @@ module Exist_pair = struct
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
-           | Let_mutable | Runtime_metaprogramming ) as ext),
+           | Let_mutable | Runtime_metaprogramming | Mode_polymorphism_printing
+             ) as ext),
           _ ) ->
       to_string ext
 
@@ -152,6 +156,8 @@ module Exist_pair = struct
     | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
     | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
     | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
+    | "mode_polymorphism_printing" ->
+      Some (Pair (Mode_polymorphism_printing, ()))
     | "unique" -> Some (Pair (Unique, Stable))
     | "unique_beta" -> Some (Pair (Unique, Beta))
     | "unique_alpha" -> Some (Pair (Unique, Alpha))
@@ -186,6 +192,7 @@ let all_extensions =
     Pack Mode;
     Pack Unique;
     Pack Mode_polymorphism;
+    Pack Mode_polymorphism_printing;
     Pack Overwriting;
     Pack Include_functor;
     Pack Polymorphic_parameters;
@@ -228,6 +235,7 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Unique, Unique -> Some Refl
   | Overwriting, Overwriting -> Some Refl
   | Mode_polymorphism, Mode_polymorphism -> Some Refl
+  | Mode_polymorphism_printing, Mode_polymorphism_printing -> Some Refl
   | Include_functor, Include_functor -> Some Refl
   | Polymorphic_parameters, Polymorphic_parameters -> Some Refl
   | Immutable_arrays, Immutable_arrays -> Some Refl
@@ -242,7 +250,8 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming | Mode_polymorphism ),
+      | Runtime_metaprogramming | Mode_polymorphism | Mode_polymorphism_printing
+        ),
       _ ) ->
     None
 
@@ -335,14 +344,14 @@ end = struct
     | Alpha -> "flag -extension-universe alpha (default CLI option)"
 
   let is_allowed_in t extn_pair =
-    match t with
-    | No_extensions -> false
-    | Upstream_compatible ->
-      Exist_pair.is_erasable extn_pair
-      && Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Stable -> Maturity.compare (Exist_pair.maturity extn_pair) Stable <= 0
-    | Beta -> Maturity.compare (Exist_pair.maturity extn_pair) Beta <= 0
-    | Alpha -> true
+    match t, Exist_pair.maturity extn_pair with
+    | No_extensions, _ -> false
+    | _, None -> true
+    | Upstream_compatible, Some maturity ->
+      Exist_pair.is_erasable extn_pair && Maturity.compare maturity Stable <= 0
+    | Stable, Some maturity -> Maturity.compare maturity Stable <= 0
+    | Beta, Some maturity -> Maturity.compare maturity Beta <= 0
+    | Alpha, Some _ -> true
 
   let is_allowed extn_pair = is_allowed_in !universe extn_pair
 
@@ -362,7 +371,11 @@ end = struct
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
       let allowed_levels =
-        Ops.all |> List.filter (fun lvl -> is_allowed_in t (Pair (extn, lvl)))
+        Ops.all
+        |> List.filter (fun lvl ->
+            match Exist_pair.maturity (Pair (extn, lvl)) with
+            | None -> false
+            | Some _ -> is_allowed_in t (Pair (extn, lvl)))
       in
       match allowed_levels with
       | [] -> None

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -64,6 +64,7 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Mode -> (module Maturity)
   | Unique -> (module Maturity)
   | Overwriting -> (module Unit)
+  | Mode_polymorphism -> (module Maturity)
   | Include_functor -> (module Unit)
   | Polymorphic_parameters -> (module Unit)
   | Immutable_arrays -> (module Unit)
@@ -84,8 +85,10 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
 
    But we've decided to punt on this issue in the short term.
 *)
+(* CR ageorges: is mode polymorphism erasable? *)
 let is_erasable : type a. a t -> bool = function
-  | Mode | Unique | Overwriting | Layouts | Layout_poly -> true
+  | Mode | Unique | Overwriting | Layouts | Layout_poly | Mode_polymorphism ->
+    true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
   | Runtime_metaprogramming ->
@@ -103,6 +106,7 @@ module Exist_pair = struct
     | Pair (Mode, m) -> m
     | Pair (Unique, m) -> m
     | Pair (Overwriting, ()) -> Alpha
+    | Pair (Mode_polymorphism, m) -> m
     | Pair (Include_functor, ()) -> Stable
     | Pair (Polymorphic_parameters, ()) -> Stable
     | Pair (Immutable_arrays, ()) -> Stable
@@ -126,6 +130,8 @@ module Exist_pair = struct
     | Pair (SIMD, m) -> to_string SIMD ^ "_" ^ maturity_to_string m
     | Pair (Layout_poly, m) ->
       to_string Layout_poly ^ "_" ^ maturity_to_string m
+    | Pair (Mode_polymorphism, m) ->
+      to_string Mode_polymorphism ^ "_" ^ maturity_to_string m
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
@@ -143,6 +149,9 @@ module Exist_pair = struct
     | "mode" -> Some (Pair (Mode, Stable))
     | "mode_beta" -> Some (Pair (Mode, Beta))
     | "mode_alpha" -> Some (Pair (Mode, Alpha))
+    | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
+    | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
+    | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
     | "unique" -> Some (Pair (Unique, Stable))
     | "unique_beta" -> Some (Pair (Unique, Beta))
     | "unique_alpha" -> Some (Pair (Unique, Alpha))
@@ -176,6 +185,7 @@ let all_extensions =
   [ Pack Comprehensions;
     Pack Mode;
     Pack Unique;
+    Pack Mode_polymorphism;
     Pack Overwriting;
     Pack Include_functor;
     Pack Polymorphic_parameters;
@@ -217,6 +227,7 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Mode, Mode -> Some Refl
   | Unique, Unique -> Some Refl
   | Overwriting, Overwriting -> Some Refl
+  | Mode_polymorphism, Mode_polymorphism -> Some Refl
   | Include_functor, Include_functor -> Some Refl
   | Polymorphic_parameters, Polymorphic_parameters -> Some Refl
   | Immutable_arrays, Immutable_arrays -> Some Refl
@@ -231,7 +242,7 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming ),
+      | Runtime_metaprogramming | Mode_polymorphism ),
       _ ) ->
     None
 
@@ -347,6 +358,8 @@ end = struct
         (compiler_options !universe)
         ()
 
+  (* CR ageorges: Mode_polymorphism is omitted from universe to ensure
+  it is not enabled by -extension-universe alpha/beta. TODO: add when ready *)
   let allowed_extensions_in t =
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
@@ -359,7 +372,12 @@ end = struct
         let max_allowed_lvl = List.fold_left Ops.max lvl lvls in
         Some (Pair (extn, max_allowed_lvl))
     in
-    List.filter_map maximal_in_universe all_extensions
+    let all =
+      List.filter
+        (fun (Pack extn) -> not (equal extn Mode_polymorphism))
+        all_extensions
+    in
+    List.filter_map maximal_in_universe all
 end
 
 (*****************************************)

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -358,8 +358,6 @@ end = struct
         (compiler_options !universe)
         ()
 
-  (* CR ageorges: Mode_polymorphism is omitted from universe to ensure
-  it is not enabled by -extension-universe alpha/beta. TODO: add when ready *)
   let allowed_extensions_in t =
     let maximal_in_universe (Pack extn) =
       let (module Ops) = get_level_ops extn in
@@ -372,12 +370,7 @@ end = struct
         let max_allowed_lvl = List.fold_left Ops.max lvl lvls in
         Some (Pair (extn, max_allowed_lvl))
     in
-    let all =
-      List.filter
-        (fun (Pack extn) -> not (equal extn Mode_polymorphism))
-        all_extensions
-    in
-    List.filter_map maximal_in_universe all
+    List.filter_map maximal_in_universe all_extensions
 end
 
 (*****************************************)

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -21,6 +21,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -22,6 +22,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Unique : maturity t
   | Overwriting : unit t
   | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -137,6 +137,12 @@ val is_enabled : 'a t -> bool
 (** Check if a language extension is enabled at least at the given level *)
 val is_at_least : 'a t -> 'a -> bool
 
+(* CR ageorges: TODO: remove *)
+
+(** Check if mode polymorphism is enabled at the given level: used for debugging
+*)
+val is_at_least_mode_poly : maturity -> bool
+
 (** Tooling support: Temporarily enable and disable language extensions; these
     operations are idempotent. Calls to [set], [enable], [disable] inside the
     body of the function argument will also be rolled back when the function

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;imply_const(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,10 +90,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
           global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,10 +90,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode id(modevar#8<3>[global,many,portable,forkable,unyielding,stateful .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#9<4>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
           global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,15 +90,15 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#2<1>[global,many,portable,forkable,unyielding,stateful .. local,many,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode id(modevar#8<3>[global,many,portable,forkable,unyielding,stateful .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#9<4>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
-          global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          alloc_mode global
+          global
           []
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          locality_mode global
           value
             [
               <case>

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           alloc_mode global

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#2<1>[global,many,portable,forkable,unyielding,stateful .. local,many,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           alloc_mode global

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;imply_const(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
           alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,10 +90,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode id(modevar#8<3>[global,many,portable,forkable,unyielding,stateful .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#9<4>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
           global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,10 +90,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
           global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,15 +90,15 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#2<1>[global,many,portable,forkable,unyielding,stateful .. local,many,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
-          alloc_mode id(modevar#8<3>[global,many,portable,forkable,unyielding,stateful .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#9<4>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
-          global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          alloc_mode global
+          global
           []
           []
           Tfunction_cases 
-          alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          locality_mode global
           value
             [
               <case>

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#2<1>[global,many,portable,forkable,unyielding,stateful .. local,many,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
           alloc_mode global

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<3>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
           alloc_mode global

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -551,8 +551,8 @@ val f :
   string ->
   'd @ local ->
   'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
-  int array * string * (int -> (int -> int) @ local) *
-  (int -> (int -> int) @ local) @ local contended = <fun>
+  int array * string * (int -> int -> int) * (int -> int -> int) @ local
+  contended = <fun>
 |}]
 
 let f1 (_ @ local) = ()

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,5 @@
-File "source_jane_street.ml", line 171, characters 0-24:
-171 | type t = #(int * float#)
+File "source_jane_street.ml", line 180, characters 0-24:
+180 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name "t".
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -133,7 +133,7 @@ type succeeds = t_immediate_or_null accepts_nonfloat
 let f (x : int or_null @ local) (g : int or_null -> unit) = g x [@nontail]
 
 [%%expect{|
-val f : int or_null @ local -> ((int or_null -> unit) -> unit) = <fun>
+val f : int or_null @ local -> (int or_null -> unit) -> unit = <fun>
 |}, Principal{|
 val f : int or_null @ local -> (int or_null -> unit) -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -129,6 +129,8 @@ Error: This value is "local"
          because it is the field "left" of the record at line 3, characters 6-25
          which is "local"
          because it is allocated at line 2, characters 10-25 containing data
+         which is "local" to the parent region
+         because it is a record whose field "left" is the expression at line 2, characters 12-16
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
          because it is a function return value.

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -129,8 +129,6 @@ Error: This value is "local"
          because it is the field "left" of the record at line 3, characters 6-25
          which is "local"
          because it is allocated at line 2, characters 10-25 containing data
-         which is "local" to the parent region
-         because it is a record whose field "left" is the expression at line 2, characters 12-16
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
          because it is a function return value.

--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -161,8 +161,7 @@ Line 2, characters 13-14:
                  ^
 Error: This value is "local" to the parent region
        but is expected to be "global"
-         because it is an element of the array at line 2, characters 11-19
-         which is expected to be "global".
+         because it is an element (with some modality) of the array at line 2, characters 11-19.
 |}]
 
 (* after discussion with sdolan, we agree that

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -2588,11 +2588,7 @@ Line 2, characters 8-9:
             ^
 Error: This value is "local" to the parent region
        but is expected to be "global"
-         because it is contained (via constructor "GFoo") in the value at line 2, characters 2-17
-         which is expected to be "global" because it is an allocation
-         which is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+         because it is contained (via constructor "GFoo") (with some modality) in the value at line 2, characters 2-17.
 |}]
 
 let f =

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1723,8 +1723,6 @@ Error: This value is "local"
          because it is an element of the tuple at line 3, characters 8-10
          which is "local"
          because it is allocated at line 2, characters 11-15 containing data
-         which is "local" to the parent region
-         because it is a tuple that contains the expression at line 2, characters 11-12
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "global".
 |}]
@@ -1743,8 +1741,6 @@ Error: This value is "local"
          because it is an element of the tuple at line 4, characters 15-17
          which is "local"
          because it is allocated at line 2, characters 8-12 containing data
-         which is "local" to the parent region
-         because it is a tuple that contains the expression at line 2, characters 8-9
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "global".
 |}]

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1092,9 +1092,7 @@ Line 4, characters 2-5:
 4 |   foo ()
       ^^^
 Error: This value is "local"
-         because it closes over the value "r" at line 3, characters 22-23
-         which is "local".
-       However, the highlighted expression is expected to be "local" to the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
          because it is the function in a tail call.
 |}]
 

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1092,7 +1092,9 @@ Line 4, characters 2-5:
 4 |   foo ()
       ^^^
 Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
+         because it closes over the value "r" at line 3, characters 22-23
+         which is "local".
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
          because it is the function in a tail call.
 |}]
 

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1723,6 +1723,8 @@ Error: This value is "local"
          because it is an element of the tuple at line 3, characters 8-10
          which is "local"
          because it is allocated at line 2, characters 11-15 containing data
+         which is "local" to the parent region
+         because it is a tuple that contains the expression at line 2, characters 11-12
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "global".
 |}]
@@ -1741,6 +1743,8 @@ Error: This value is "local"
          because it is an element of the tuple at line 4, characters 15-17
          which is "local"
          because it is allocated at line 2, characters 8-12 containing data
+         which is "local" to the parent region
+         because it is a tuple that contains the expression at line 2, characters 8-9
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "global".
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -1,0 +1,172 @@
+(* TEST
+ flags += "-dlambda -extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(* MUTABLE RECORD FIELDS *)
+
+(* If mutating a record field can be done on both local and global
+  records, it must be compiled to caml_modify_local.
+  Only when the record is always global can be compiled as caml_modify *)
+
+type 'a myref = { mutable i : 'a }
+[%%expect{|
+0
+type 'a myref = { mutable i : 'a; }
+|}]
+
+(* CR ageorges: the following can accept stack locations but
+  uses setfield_ptr(maybe-stack). This is a soundness bug *)
+
+(* Must be [setfield_ptr(maybe-stack)] *)
+let foo r x = r.i <- x
+[%%expect{|
+(let
+  (foo/288 =
+     (function {nlocal = 1} r/290[L] x/291 : int
+       (setfield_ptr 0 r/290 x/291)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/288))
+val foo : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let foo (r @ local) x = r.i <- x
+[%%expect{|
+(let
+  (foo/292 =
+     (function {nlocal = 1} r/293[L] x/294 : int
+       (setfield_ptr(maybe-stack) 0 r/293 x/294)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/292))
+val foo : 'a myref @ local -> 'a -> unit = <fun>
+|}]
+
+(* Can be [setfield_ptr] *)
+let foo (r @ global) x = r.i <- x
+[%%expect{|
+(let
+  (foo/295 =
+     (function {nlocal = 1} r/296 x/297 : int (setfield_ptr 0 r/296 x/297)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/295))
+val foo : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let foo () =
+  let r = { i = "bar" } in
+  let store r = r.i <- "foobar" in
+  fun () -> store r
+[%%expect{|
+(let
+  (foo/298 =
+     (function {nlocal = 1} param/304[L][value<int>] : local
+       (let
+         (r/299 = (makemutable 0 (*) "bar")
+          store/300 =
+            (function {nlocal = 0} r/302 : int
+              (setfield_ptr 0 r/302 "foobar")))
+         (function {nlocal = 1} param/303[L][value<int>] : int
+           (apply store/300 r/299)))))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/298))
+val foo : unit -> unit -> unit = <fun>
+|}]
+
+let foo () =
+  let r @ local = { i = "bar" } in
+  let store r = r.i <- "foobar" in
+  store
+[%%expect{|
+Line 2, characters 6-7:
+2 |   let r @ local = { i = "bar" } in
+          ^
+Warning 26 [unused-var]: unused variable r.
+(let
+  (foo/306 =
+     (function {nlocal = 1} param/311[L][value<int>] : local
+       (region
+         (let (r/307 =mut "bar")
+           (function {nlocal = 1} r/310[L] : int
+             (setfield_ptr 0 r/310 "foobar"))))))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/306))
+
+val foo : unit -> string myref -> unit = <fun>
+|}]
+
+let foo () =
+  let r @ global = { i = "bar" } in
+  let store r = r.i <- "foobar" in
+  fun () -> store r
+[%%expect{|
+(let
+  (foo/313 =
+     (function {nlocal = 1} param/319[L][value<int>] : local
+       (let
+         (r/314 = (makemutable 0 (*) "bar")
+          store/315 =
+            (function {nlocal = 0} r/317 : int
+              (setfield_ptr 0 r/317 "foobar")))
+         (function {nlocal = 1} param/318[L][value<int>] : int
+           (apply store/315 r/314)))))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/313))
+val foo : unit -> unit -> unit = <fun>
+|}]
+
+
+(* FUNCTIONS *)
+
+(* In order to soundly choose the allocation of a return value, functions default
+  to global returns, unless a return is explicitly set to local, in which case it must
+  be always local.
+
+  The following tests assert the locality of returned functions *)
+
+(* CR ageorges: the following two functions return local functions.
+  This will cause a crash if applied as global, (see [foo] below),
+  and is unsound *)
+
+let fst x = fun y -> x
+[%%expect{|
+(let
+  (fst/321 =
+     (function {nlocal = 1} x/322? : local
+       (function {nlocal = 1} y/323[L]? : local x/322)))
+  (apply (field_imm 1 (global Toploop!)) "fst" fst/321))
+val fst : 'a -> 'b -> 'a = <fun>
+|}]
+
+let fst' x y = x
+[%%expect{|
+(let (fst'/324 = (function {nlocal = 1} x/326[L]? y/327[L]? : local x/326))
+  (apply (field_imm 1 (global Toploop!)) "fst'" fst'/324))
+val fst' : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* if explicitly annotated, the returned function is local [function[L]],
+  the inner [x] is returned locally *)
+let fst_local (x @ local) = exclave_ fun y -> x
+[%%expect{|
+(let
+  (fst_local/328 =
+     (function {nlocal = 1} x/330[L]? : local
+       (function[L] {nlocal = 1} y/331[L]? : local x/330)))
+  (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/328))
+val fst_local : 'a @ local -> 'b -> 'a @ local = <fun>
+|}]
+
+let foo = fst 42
+[%%expect{|
+(let
+  (fst/321 =? (apply (field_imm 0 (global Toploop!)) "fst")
+   foo/332 = (apply fst/321 42))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/332))
+val foo : '_weak1 -> int = <fun>
+|}]
+
+let foo () =
+  exclave_ (fst_local 42)
+[%%expect{|
+(let
+  (fst_local/328 =? (apply (field_imm 0 (global Toploop!)) "fst_local")
+   foo/333 =
+     (function {nlocal = 1} param/334[L][value<int>] : local
+       (apply[L] fst_local/328 42)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/333))
+val foo : unit -> ('a -> int @ local) @ local = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += "-dlambda -extension mode_polymorphism_alpha";
+ flags += "-dlambda -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
 *)
 
@@ -23,7 +23,10 @@ let foo r x = r.i <- x
      (function {nlocal = 1} r/290[L] x/291 : int
        (setfield_ptr(maybe-stack) 0 r/290 x/291)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/288))
-val foo : 'a myref -> 'a -> unit = <fun>
+val foo :
+  'a myref @ [< 'm @@ past & global corrupted] ->
+  ('a @ [< global many uncontended] -> unit @ 'n) @ [> 'm | corruptible] =
+  <fun>
 |}]
 
 let foo (r @ local) x = r.i <- x
@@ -33,7 +36,10 @@ let foo (r @ local) x = r.i <- x
      (function {nlocal = 2} r/293[L] x/294 : int
        (setfield_ptr(maybe-stack) 0 r/293 x/294)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/292))
-val foo : 'a myref @ local -> 'a -> unit = <fun>
+val foo :
+  'a myref @ [< 'm @@ past & corrupted > local] ->
+  ('a @ [< global many uncontended] -> unit @ 'n) @ [> 'm | local corruptible] =
+  <fun>
 |}]
 
 (* Can be [setfield_ptr] *)
@@ -43,7 +49,10 @@ let foo (r @ global) x = r.i <- x
   (foo/295 =
      (function {nlocal = 1} r/296 x/297 : int (setfield_ptr 0 r/296 x/297)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/295))
-val foo : 'a myref -> 'a -> unit = <fun>
+val foo :
+  'a myref @ [< 'm @@ past & global corrupted] ->
+  ('a @ [< global many uncontended] -> unit @ 'n) @ [> 'm | corruptible] =
+  <fun>
 |}]
 
 let foo () =
@@ -62,7 +71,7 @@ let foo () =
          (function {nlocal = 1} param/303[L][value<int>] : int
            (apply store/300 r/299)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/298))
-val foo : unit -> unit -> unit = <fun>
+val foo : unit @ 'o -> (unit @ 'n -> unit @ 'm) @ [> corruptible] = <fun>
 |}]
 
 let foo () =
@@ -83,7 +92,8 @@ Warning 26 [unused-var]: unused variable r.
              (setfield_ptr(maybe-stack) 0 r/310 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/306))
 
-val foo : unit -> string myref -> unit = <fun>
+val foo : unit @ 'o -> (string myref @ [< corrupted] -> unit @ 'n) @ 'm =
+  <fun>
 |}]
 
 let foo () =
@@ -102,7 +112,7 @@ let foo () =
          (function {nlocal = 1} param/318[L][value<int>] : int
            (apply store/315 r/314)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/313))
-val foo : unit -> unit -> unit = <fun>
+val foo : unit @ 'o -> (unit @ 'n -> unit @ 'm) @ [> corruptible] = <fun>
 |}]
 
 
@@ -121,14 +131,16 @@ let fst x = fun y -> x
      (function {nlocal = 1} x/322? : local
        (function {nlocal = 1} y/323[L]? : local x/322)))
   (apply (field_imm 1 (global Toploop!)) "fst" fst/321))
-val fst : 'a -> 'b -> 'a = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let fst' x y = x
 [%%expect{|
 (let (fst'/324 = (function {nlocal = 1} x/326[L]? y/327[L]? : local x/326))
   (apply (field_imm 1 (global Toploop!)) "fst'" fst'/324))
-val fst' : 'a -> 'b -> 'a = <fun>
+val fst' : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* if explicitly annotated, the returned function is local [function[L]],
@@ -140,7 +152,9 @@ let fst_local (x @ local) = exclave_ fun y -> x
      (function {nlocal = 1} x/330[L]? : local
        (function[L] {nlocal = 1} y/331[L]? : local x/330)))
   (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/328))
-val fst_local : 'a @ local -> 'b -> 'a @ local = <fun>
+val fst_local :
+  'a @ [< 'm > local] ->
+  ('b @ 'n -> 'a @ [> 'm | local]) @ [> close('m) | local] = <fun>
 |}]
 
 let foo = fst 42
@@ -149,7 +163,7 @@ let foo = fst 42
   (fst/321 =? (apply (field_imm 0 (global Toploop!)) "fst")
    foo/332 = (apply fst/321 42))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/332))
-val foo : '_weak1 -> int = <fun>
+val foo : '_weak1 -> int @ [> aliased] = <fun>
 |}]
 
 let foo () =
@@ -161,5 +175,5 @@ let foo () =
      (function {nlocal = 1} param/334[L][value<int>] : local
        (apply[L] fst_local/328 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/333))
-val foo : unit -> ('a -> int @ local) @ local = <fun>
+val foo : unit @ 'n -> ('a @ 'm -> int @ [> local]) @ [> local] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -15,16 +15,13 @@ type 'a myref = { mutable i : 'a }
 type 'a myref = { mutable i : 'a; }
 |}]
 
-(* CR ageorges: the following can accept stack locations but
-  uses setfield_ptr(maybe-stack). This is a soundness bug *)
-
 (* Must be [setfield_ptr(maybe-stack)] *)
 let foo r x = r.i <- x
 [%%expect{|
 (let
   (foo/288 =
      (function {nlocal = 1} r/290[L] x/291 : int
-       (setfield_ptr 0 r/290 x/291)))
+       (setfield_ptr(maybe-stack) 0 r/290 x/291)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/288))
 val foo : 'a myref -> 'a -> unit = <fun>
 |}]
@@ -33,7 +30,7 @@ let foo (r @ local) x = r.i <- x
 [%%expect{|
 (let
   (foo/292 =
-     (function {nlocal = 1} r/293[L] x/294 : int
+     (function {nlocal = 2} r/293[L] x/294 : int
        (setfield_ptr(maybe-stack) 0 r/293 x/294)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/292))
 val foo : 'a myref @ local -> 'a -> unit = <fun>
@@ -83,7 +80,7 @@ Warning 26 [unused-var]: unused variable r.
        (region
          (let (r/307 =mut "bar")
            (function {nlocal = 1} r/310[L] : int
-             (setfield_ptr 0 r/310 "foobar"))))))
+             (setfield_ptr(maybe-stack) 0 r/310 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/306))
 
 val foo : unit -> string myref -> unit = <fun>
@@ -116,10 +113,6 @@ val foo : unit -> unit -> unit = <fun>
   be always local.
 
   The following tests assert the locality of returned functions *)
-
-(* CR ageorges: the following two functions return local functions.
-  This will cause a crash if applied as global, (see [foo] below),
-  and is unsound *)
 
 let fst x = fun y -> x
 [%%expect{|

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -1,0 +1,295 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* BASIC POLYMORPHISM *)
+
+let foo =
+  let foo x = x in
+  let x = ref 42 in
+  let x = foo x in
+  let (y @ contended) = ref !x in
+  let _ = foo y in
+  foo
+[%%expect{|
+val foo : '_weak1 -> '_weak1 = <fun>
+|}]
+
+let id x = x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+|}]
+
+let () =
+  let x = ref 42 in
+  let x = id x in
+  let (y @ contended) = ref !x in
+  let _ = id y in
+  ()
+[%%expect{|
+|}]
+
+(* instantiation [id] does not make it less polymorphic *)
+let foo (x @ portable) = id x
+let id' = id
+[%%expect{|
+val foo : 'a @ portable -> 'a = <fun>
+val id' : 'a -> 'a = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  let x = id' x in
+  use_portable x
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable x
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let bar (c @ unique) =
+  use_unique (id c)
+[%%expect{|
+val bar : 'a @ unique -> unit = <fun>
+|}]
+
+let bar (c @ local) =
+  let _ = use_unique (id c) in
+  ()
+[%%expect{|
+val bar : 'a @ local unique -> unit = <fun>
+|}]
+
+let bar (x @ aliased) =
+  let x = id x in
+  let _ = use_unique x in
+  ()
+[%%expect{|
+Line 3, characters 21-22:
+3 |   let _ = use_unique x in
+                         ^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+let bar (x @ many) =
+  let y @ once = x in
+  let y = id y in
+  (y, y)
+[%%expect{|
+Line 4, characters 6-7:
+4 |   (y, y)
+          ^
+Error: This value is used here,
+       but it is defined as once and is also being used at:
+Line 4, characters 3-4:
+4 |   (y, y)
+       ^
+
+|}]
+
+(* the result of a mode polymorphic function can't be static *)
+let foo (x @ static) =
+  let x = id x in
+  use_static x
+[%%expect{|
+Line 3, characters 13-14:
+3 |   use_static x
+                 ^
+Error: This value is "dynamic"
+         because function applications are always dynamic.
+       However, the highlighted expression is expected to be "static".
+|}]
+
+(* mode polymorphism allows us to combine take combine the bounds of two
+functions via joins *)
+let f (x : string) = x
+let g (x : string @ local) = x
+let which = function
+  | false -> f
+  | true -> g
+[%%expect{|
+val f : string -> string = <fun>
+val g : string @ local -> string @ local = <fun>
+val which : bool -> string @ local -> string @ local = <fun>
+|}]
+
+(* The least upper bound between local and global is local *)
+let foo (x @ global) =
+  let f = which true in
+  let y @ global = "global" in
+  use_global (f y) (* y is weakened to local before it's applied to f *)
+[%%expect{|
+Line 4, characters 13-18:
+4 |   use_global (f y) (* y is weakened to local before it's applied to f *)
+                 ^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let foo (x @ global) =
+  let f = which false in
+  let y @ global = "global" in
+  use_global (f y) (* y is weakened to local before it's applied to f *)
+[%%expect{|
+Line 4, characters 13-18:
+4 |   use_global (f y) (* y is weakened to local before it's applied to f *)
+                 ^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* mode variables used at some mode imposes a bound on them *)
+let id x = use_portable x; x
+[%%expect{|
+val id : 'a @ portable -> 'a = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  id x
+[%%expect{|
+Line 2, characters 5-6:
+2 |   id x
+         ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* but they remain polymorphic on the other axes *)
+
+let foo (x @ contended) (y @ uncontended) =
+  let x = id x in
+  let y = id y in
+  use_uncontended y; (* this use succeeds *)
+  use_uncontended x (* this use fails *)
+[%%expect{|
+Line 5, characters 18-19:
+5 |   use_uncontended x (* this use fails *)
+                      ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]
+
+(* CLOSING OVER MODE VARIABLES *)
+(* Basic closing-over behavior. See [currying.ml] for more intricate patterns *)
+
+let close_over x = fun () -> x
+[%%expect{|
+val close_over : 'a -> unit -> 'a = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let const_x = close_over x in
+  let const_y = close_over y in
+  use_portable (const_x ());
+  use_portable (const_y ())
+[%%expect{|
+Line 5, characters 15-27:
+5 |   use_portable (const_y ())
+                   ^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let close_over x = fun () -> fun () -> x
+[%%expect{|
+val close_over : 'a -> unit -> unit -> 'a = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let const_x = close_over x in
+  let const_y = close_over y in
+  use_portable (const_x () ());
+  use_portable (const_y () ())
+[%%expect{|
+Line 5, characters 15-30:
+5 |   use_portable (const_y () ())
+                   ^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* partially applying a nested closure similarly depends on input mode *)
+let foo (x @ portable) =
+  let const_x = close_over x in
+  use_portable (const_x ())
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (x @ portable) =
+  use_portable (close_over x)
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+(* MODE CROSSING *)
+
+(* mode crossing is stronger than mode polymorphism *)
+let foo (x : int @ portable) (y : int @ nonportable) =
+  let x = id x in
+  let y = id y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+val foo : int @ portable -> int -> unit = <fun>
+|}]
+
+(* LOCAL AND MODE POLYMORPHISM *)
+
+(* local values stay local through id - can't return without exclave_ *)
+let foo (local_ x) =
+  let y = id x in
+  y
+[%%expect{|
+Line 3, characters 2-3:
+3 |   y
+      ^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}]
+
+(* with exclave_ it works *)
+let foo (local_ x) = exclave_
+  let y = id x in
+  y
+[%%expect{|
+val foo : 'a @ local portable -> 'a @ local = <fun>
+|}]
+
+(* local input stays local through id *)
+let foo () =
+  let x @ local = "hello" in
+  let y = id x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* MULTIPLE MODE AXES *)
+
+(* Bounds can be imposed on multiple axes *)
+let foo (x @ global portable) =
+  use_global (id x);
+  use_portable (id x)
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,11 +9,11 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ 'n -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* BASIC POLYMORPHISM *)
@@ -32,12 +26,12 @@ let foo =
   let _ = foo y in
   foo
 [%%expect{|
-val foo : '_weak1 -> '_weak1 = <fun>
+val foo : '_weak1 -> '_weak1 @ [> aliased nonportable] = <fun>
 |}]
 
 let id x = x
 [%%expect{|
-val id : 'a -> 'a = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -53,8 +47,8 @@ let () =
 let foo (x @ portable) = id x
 let id' = id
 [%%expect{|
-val foo : 'a @ portable -> 'a = <fun>
-val id' : 'a -> 'a = <fun>
+val foo : 'a @ [< 'm & global portable] -> 'a @ [> 'm] = <fun>
+val id' : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo (x @ nonportable) =
@@ -70,14 +64,14 @@ Error: This value is "nonportable" but is expected to be "portable".
 let bar (c @ unique) =
   use_unique (id c)
 [%%expect{|
-val bar : 'a @ unique -> unit = <fun>
+val bar : 'a @ [< global unique] -> unit @ 'm = <fun>
 |}]
 
 let bar (c @ local) =
   let _ = use_unique (id c) in
   ()
 [%%expect{|
-val bar : 'a @ local unique -> unit = <fun>
+val bar : 'a @ [< unique > local] -> unit @ 'm = <fun>
 |}]
 
 let bar (x @ aliased) =
@@ -128,9 +122,15 @@ let which = function
   | false -> f
   | true -> g
 [%%expect{|
-val f : string -> string = <fun>
-val g : string @ portable -> string = <fun>
-val which : bool -> string @ portable -> string = <fun>
+val f : string @ [< 'm . contended] -> string @ [> 'm @@ many portable] =
+  <fun>
+val g :
+  string @ [< 'm . contended & portable] -> string @ [> 'm @@ many portable] =
+  <fun>
+val which :
+  bool @ 'n ->
+  (string @ [< 'm . contended & portable] -> string @ [> 'm @@ many portable]) @ [> aliased nonportable] =
+  <fun>
 |}]
 
 (* The least upper bound between portable and nonportable is nonportable *)
@@ -138,20 +138,20 @@ let foo (x @ portable) =
   let f = which true in
   use_portable (f x) (* x is weakened to nonportable before it's applied to f *)
 [%%expect{|
-val foo : string @ portable -> unit = <fun>
+val foo : string @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 let foo (x @ portable) =
   let f = which false in
   use_global (f x) (* x is weakened to nonportable before it's applied to f *)
 [%%expect{|
-val foo : string @ portable -> unit = <fun>
+val foo : string @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 (* mode variables used at some mode imposes a bound on them *)
 let id x = use_portable x; x
 [%%expect{|
-val id : 'a @ portable -> 'a = <fun>
+val id : 'a @ [< 'm & many portable] -> 'a @ [> 'm | aliased] = <fun>
 |}]
 
 let foo (x @ nonportable) =
@@ -182,7 +182,8 @@ Error: This value is "contended" but is expected to be "uncontended".
 
 let close_over x = fun () -> x
 [%%expect{|
-val close_over : 'a -> unit -> 'a = <fun>
+val close_over :
+  'a @ [< 'm & global] -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -199,7 +200,10 @@ Error: This value is "nonportable" but is expected to be "portable".
 
 let close_over x = fun () -> fun () -> x
 [%%expect{|
-val close_over : 'a -> unit -> unit -> 'a = <fun>
+val close_over :
+  'a @ [< 'm & global] ->
+  (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -219,13 +223,13 @@ let foo (x @ portable) =
   let const_x = close_over x in
   use_portable (const_x ())
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 let foo (x @ portable) =
   use_portable (close_over x)
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 (* MODE CROSSING *)
@@ -237,7 +241,9 @@ let foo (x : int @ portable) (y : int @ nonportable) =
   use_portable x;
   use_portable y
 [%%expect{|
-val foo : int @ portable -> int -> unit = <fun>
+val foo :
+  int @ [< 'm @@ past & global portable] ->
+  (int @ [> nonportable] -> unit @ 'n) @ [> 'm] = <fun>
 |}]
 
 (* LOCAL AND MODE POLYMORPHISM *)
@@ -260,9 +266,9 @@ let id x = x
 let id_local (x @ local) = x
 let id_exclave x = exclave_ x
 [%%expect{|
-val id : 'a -> 'a = <fun>
-val id_local : 'a @ local -> 'a @ local = <fun>
-val id_exclave : 'a -> 'a @ local = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+val id_local : 'a @ [< 'm > local] -> 'a @ [> 'm | local] = <fun>
+val id_exclave : 'a @ [< 'm] -> 'a @ [> 'm | local] = <fun>
 |}]
 
 (* Functions impose a default global bound over return values. As a result, [id]
@@ -287,7 +293,7 @@ let foo () =
   let z = id y in
   use_global z (* ought to fail since id defaults to local and weakens to y *)
 [%%expect{|
-val foo : unit -> unit = <fun>
+val foo : unit @ 'n -> unit @ 'm = <fun>
 |}]
 
 (* if return values are only used as global it allocates on the heap *)
@@ -297,7 +303,7 @@ let foo () =
   let z = id y in
   use_global z (* succeeds *)
 [%%expect{|
-val foo : unit -> unit = <fun>
+val foo : unit @ 'n -> unit @ 'm = <fun>
 |}]
 
 (* local values stay local through id_local - can't return without exclave_ *)
@@ -319,7 +325,7 @@ let foo (local_ x) = exclave_
   let y = id_local x in
   y
 [%%expect{|
-val foo : 'a @ local -> 'a @ local = <fun>
+val foo : 'a @ [< 'm > local] -> 'a @ [> 'm | local] = <fun>
 |}]
 
 (* MULTIPLE MODE AXES *)
@@ -329,5 +335,5 @@ let foo (x @ uncontended portable) =
   use_uncontended (id x);
   use_portable (id x)
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global many portable uncontended] -> unit @ 'm = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -123,37 +123,29 @@ Error: This value is "dynamic"
 (* mode polymorphism allows us to combine take combine the bounds of two
 functions via joins *)
 let f (x : string) = x
-let g (x : string @ local) = x
+let g (x : string @ portable) = x
 let which = function
   | false -> f
   | true -> g
 [%%expect{|
 val f : string -> string = <fun>
-val g : string @ local -> string @ local = <fun>
-val which : bool -> string @ local -> string @ local = <fun>
+val g : string @ portable -> string = <fun>
+val which : bool -> string @ portable -> string = <fun>
 |}]
 
-(* The least upper bound between local and global is local *)
-let foo (x @ global) =
+(* The least upper bound between portable and nonportable is nonportable *)
+let foo (x @ portable) =
   let f = which true in
-  let y @ global = "global" in
-  use_global (f y) (* y is weakened to local before it's applied to f *)
+  use_portable (f x) (* x is weakened to nonportable before it's applied to f *)
 [%%expect{|
-Line 4, characters 13-18:
-4 |   use_global (f y) (* y is weakened to local before it's applied to f *)
-                 ^^^^^
-Error: This value is "local" but is expected to be "global".
+val foo : string @ portable -> unit = <fun>
 |}]
 
-let foo (x @ global) =
+let foo (x @ portable) =
   let f = which false in
-  let y @ global = "global" in
-  use_global (f y) (* y is weakened to local before it's applied to f *)
+  use_global (f x) (* x is weakened to nonportable before it's applied to f *)
 [%%expect{|
-Line 4, characters 13-18:
-4 |   use_global (f y) (* y is weakened to local before it's applied to f *)
-                 ^^^^^
-Error: This value is "local" but is expected to be "global".
+val foo : string @ portable -> unit = <fun>
 |}]
 
 (* mode variables used at some mode imposes a bound on them *)
@@ -250,9 +242,67 @@ val foo : int @ portable -> int -> unit = <fun>
 
 (* LOCAL AND MODE POLYMORPHISM *)
 
-(* local values stay local through id - can't return without exclave_ *)
-let foo (local_ x) =
+(* When translating a function, the compiler must decide where to allocate the return
+  value. If we allow the return value to be polymorphic, we must either forego all
+  optimisations and default to heap allocations in all cases, or we limit polymorphism
+  over return values.
+
+  If we don't, we might encounter a soundness issue, where a return value is used as
+  [global] but the compiler chose to allocate it on the stack.
+
+  The following tests show the limits of polymorphism over locality
+*)
+
+(* identity forces the return value to be global *)
+let id x = x
+
+(* but we can still annotate the function to (always) return a local value *)
+let id_local (x @ local) = x
+let id_exclave x = exclave_ x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+val id_local : 'a @ local -> 'a @ local = <fun>
+val id_exclave : 'a -> 'a @ local = <fun>
+|}]
+
+(* Functions impose a default global bound over return values. As a result, [id]
+  only accepts global values  *)
+let foo () =
+  let x @ local = "hello" in
   let y = id x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* When defined locally, [id] can be made to default to local values instead *)
+let foo () =
+  let id x = x in
+  let x @ local = "local" in
+  let y @ global = "global" in
+  let _ = id x in
+  let z = id y in
+  use_global z (* ought to fail since id defaults to local and weakens to y *)
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+(* if return values are only used as global it allocates on the heap *)
+let foo () =
+  let id x = x in
+  let y @ global = "global" in
+  let z = id y in
+  use_global z (* succeeds *)
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+(* local values stay local through id_local - can't return without exclave_ *)
+let foo (local_ x) =
+  let y = id_local x in
   y
 [%%expect{|
 Line 3, characters 2-3:
@@ -266,29 +316,17 @@ Error: This value is "local"
 
 (* with exclave_ it works *)
 let foo (local_ x) = exclave_
-  let y = id x in
+  let y = id_local x in
   y
 [%%expect{|
-val foo : 'a @ local portable -> 'a @ local = <fun>
-|}]
-
-(* local input stays local through id *)
-let foo () =
-  let x @ local = "hello" in
-  let y = id x in
-  use_global y
-[%%expect{|
-Line 4, characters 13-14:
-4 |   use_global y
-                 ^
-Error: This value is "local" but is expected to be "global".
+val foo : 'a @ local -> 'a @ local = <fun>
 |}]
 
 (* MULTIPLE MODE AXES *)
 
 (* Bounds can be imposed on multiple axes *)
-let foo (x @ global portable) =
-  use_global (id x);
+let foo (x @ uncontended portable) =
+  use_uncontended (id x);
   use_portable (id x)
 [%%expect{|
 val foo : 'a @ portable -> unit = <fun>

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -47,12 +47,11 @@ let foo =
   let clocal @ local = "local" in
   let foo = fst cglobal in
   let bar = fst clocal in
-  use_global foo;
-  use_global bar
+  ()
 [%%expect{|
-Line 7, characters 13-16:
-7 |   use_global bar
-                 ^^^
+Line 5, characters 16-22:
+5 |   let bar = fst clocal in
+                    ^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
@@ -92,25 +91,28 @@ let many_arguments x y z s t = y
 val many_arguments : 'a -> 'b -> 'c -> 'd -> 'e -> 'b = <fun>
 |}]
 
-let foo =
-  let x @ local = "local" in
-  let y @ global = "global" in
+let foo (x @ portable) (y @ uncontended) =
   let y = many_arguments x y () () () in
-  use_global y
+  use_uncontended y
 [%%expect{|
-val foo : unit = ()
+val foo : 'a @ portable -> 'b -> unit = <fun>
 |}]
 
-let foo =
-  let x @ local = "local" in
-  let y @ global = "global" in
+let foo (x @ portable) (y @ uncontended) =
   let f = many_arguments x y in
-  use_global f
+  use_portable f
 [%%expect{|
-Line 5, characters 13-14:
-5 |   use_global f
-                 ^
-Error: This value is "local" but is expected to be "global".
+val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let f = many_arguments x y in
+  use_portable f
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable f
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 let foo =

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,11 +9,11 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ 'n -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* [fst] is the K-combinator and displays an interesting bi-directional dependency
@@ -27,16 +21,20 @@ val use_global : 'a -> unit = <fun>
 
   Its signature should look like the following:
 
-    val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+    val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
 
   Where close('m) refers to the meet between the comonadic parts of 'm and the
   monadic part 'm, taken to its dual comonadic counterpart. Note that 'm describes
   an upper bound in the argument, and a lower bound on the inner return.
+
+  Because of partial application, the inner closure needs to be allocated somewhere. The
+  default is to heap-allocate it, hence the global restriction on the first parameter.
 *)
 
 let fst x y = x
 [%%expect{|
-val fst : 'a -> 'b -> 'a = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* n-ary functions will impose locality bounds on arguments, since the middle end
@@ -58,14 +56,16 @@ Error: This value is "local" but is expected to be "global".
 let bar (x @ once) =
   fst x
 [%%expect{|
-val bar : 'a @ once -> 'b -> 'a @ once = <fun>
+val bar :
+  'a @ [< 'm & global > once] ->
+  ('b @ 'n -> 'a @ [> 'm | once]) @ [> close('m) | once] = <fun>
 |}]
 
 let bar (x @ unique) =
   let x = fst x () in
   use_unique x
 [%%expect{|
-val bar : 'a @ unique -> unit = <fun>
+val bar : 'a @ [< global unique] -> unit @ 'm = <fun>
 |}]
 
 (* The returned closure is nonportable *)
@@ -88,21 +88,30 @@ Error: The value "bar1" is "nonportable"
 
 let many_arguments x y z s t = y
 [%%expect{|
-val many_arguments : 'a -> 'b -> 'c -> 'd -> 'e -> 'b = <fun>
+val many_arguments :
+  'a @ [< 'm @@ past & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'o @@ past & global] ->
+    ('d @ [< 'p @@ past & global] -> ('e @ 'q -> 'b @ [> 'n]) @ [> 'p]) @ [> 'o]) @ [> close('n)]) @ [> 'm] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
   let y = many_arguments x y () () () in
   use_uncontended y
 [%%expect{|
-val foo : 'a @ portable -> 'b -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global uncontended] -> unit @ 'n) @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
   let f = many_arguments x y in
   use_portable f
 [%%expect{|
-val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global portable uncontended] -> unit @ 'n) @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -129,7 +138,8 @@ val foo : unit = ()
 
 let fst x = fun y -> x
 [%%expect{|
-val fst : 'a -> 'b -> 'a = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* x is < global as before *)
@@ -164,7 +174,7 @@ let bar (x @ unique) =
   let x = fst x in
   use_unique x
 [%%expect{|
-val bar : 'a @ unique -> unit = <fun>
+val bar : 'a @ [< global unique] -> unit @ 'm = <fun>
 |}]
 
 let bar (x @ unique) =
@@ -189,7 +199,7 @@ let var (x @ portable) =
   let x = fst x () in
   use_portable x
 [%%expect{|
-val var : 'a @ portable -> unit = <fun>
+val var : 'a @ [< global portable] -> unit @ 'm = <fun>
 |}]
 let var (x @ nonportable) =
   let x = fst x () in
@@ -206,7 +216,7 @@ let var (x @ uncontended) =
   let x = fst x () in
   use_uncontended x
 [%%expect{|
-val var : 'a -> unit = <fun>
+val var : 'a @ [< global uncontended] -> unit @ 'm = <fun>
 |}]
 let var (x @ contended) =
   let x = fst x () in
@@ -238,13 +248,17 @@ Error: The value "bar1" is "nonportable"
 (* deeply nested closures should still propagate modes *)
 let nest x = fun () -> fun () -> fun () -> x
 [%%expect{|
-val nest : 'a -> unit -> unit -> unit -> 'a = <fun>
+val nest :
+  'a @ [< 'm & global] ->
+  (unit @ 'p ->
+   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo (x @ portable) =
   use_portable (nest x () () ())
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 let foo (x @ nonportable) =

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -1,0 +1,255 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* [fst] is the K-combinator and displays an interesting bi-directional dependency
+  between the curry mode, the argument, and the inner return
+
+  Its signature should look like the following:
+
+    val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+
+  Where close('m) refers to the meet between the comonadic parts of 'm and the
+  monadic part 'm, taken to its dual comonadic counterpart. Note that 'm describes
+  an upper bound in the argument, and a lower bound on the inner return.
+*)
+
+let fst x y = x
+[%%expect{|
+val fst : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* n-ary functions will impose locality bounds on arguments, since the middle end
+  must know where to allocate closures of partially applied functions *)
+
+let foo =
+  let cglobal = "global" in
+  let clocal @ local = "local" in
+  let foo = fst cglobal in
+  let bar = fst clocal in
+  use_global foo;
+  use_global bar
+[%%expect{|
+Line 7, characters 13-16:
+7 |   use_global bar
+                 ^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let bar (x @ once) =
+  fst x
+[%%expect{|
+val bar : 'a @ once -> 'b -> 'a @ once = <fun>
+|}]
+
+let bar (x @ unique) =
+  let x = fst x () in
+  use_unique x
+[%%expect{|
+val bar : 'a @ unique -> unit = <fun>
+|}]
+
+(* The returned closure is nonportable *)
+
+let () =
+  let c = ref 42 in
+  let f = fun () -> !c in
+  let bar1 = fst f in
+  let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+  ()
+[%%expect{|
+Line 5, characters 56-60:
+5 |   let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+                                                            ^^^^
+Error: The value "bar1" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at line 5, characters 38-69
+         which is expected to be "portable".
+|}]
+
+let many_arguments x y z s t = y
+[%%expect{|
+val many_arguments : 'a -> 'b -> 'c -> 'd -> 'e -> 'b = <fun>
+|}]
+
+let foo =
+  let x @ local = "local" in
+  let y @ global = "global" in
+  let y = many_arguments x y () () () in
+  use_global y
+[%%expect{|
+val foo : unit = ()
+|}]
+
+let foo =
+  let x @ local = "local" in
+  let y @ global = "global" in
+  let f = many_arguments x y in
+  use_global f
+[%%expect{|
+Line 5, characters 13-14:
+5 |   use_global f
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let foo =
+  let x @ global = "local" in
+  let y @ global = "global" in
+  let f = many_arguments x y in
+  use_global f
+[%%expect{|
+val foo : unit = ()
+|}]
+
+
+(* Let's eta-expand [fst] *)
+
+let fst x = fun y -> x
+[%%expect{|
+val fst : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* x is < global as before *)
+let () =
+  let c @ local = ref 42 in
+  fst c
+[%%expect{|
+Line 3, characters 6-7:
+3 |   fst c
+          ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* once argument yields a once closure *)
+let bar (x @ once) =
+  let x = (fst x) in
+  (x, x)
+[%%expect{|
+Line 3, characters 6-7:
+3 |   (x, x)
+          ^
+Error: This value is used here,
+       but it is defined as once and is also being used at:
+Line 3, characters 3-4:
+3 |   (x, x)
+       ^
+
+|}]
+
+(* unique argument yields unique and once result *)
+let bar (x @ unique) =
+  let x = fst x in
+  use_unique x
+[%%expect{|
+val bar : 'a @ unique -> unit = <fun>
+|}]
+
+let bar (x @ unique) =
+  let x = fst x in
+  let (f, g) = (x, x) in
+  use_unique (f ());
+  use_unique (g ())
+[%%expect{|
+Line 5, characters 14-15:
+5 |   use_unique (g ())
+                  ^
+Error: This value is used here,
+       but it is defined as once and has already been used at:
+Line 4, characters 14-15:
+4 |   use_unique (f ());
+                  ^
+
+|}]
+
+(* returned value matches input portability *)
+let var (x @ portable) =
+  let x = fst x () in
+  use_portable x
+[%%expect{|
+val var : 'a @ portable -> unit = <fun>
+|}]
+let var (x @ nonportable) =
+  let x = fst x () in
+  use_portable x
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable x
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* returned value matches input contention *)
+let var (x @ uncontended) =
+  let x = fst x () in
+  use_uncontended x
+[%%expect{|
+val var : 'a -> unit = <fun>
+|}]
+let var (x @ contended) =
+  let x = fst x () in
+  use_uncontended x
+[%%expect{|
+Line 3, characters 18-19:
+3 |   use_uncontended x
+                      ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]
+
+(* The returned closure is nonportable *)
+let () =
+  let c = ref 42 in
+  let f = fun () -> !c in
+  let bar1 = fst f in
+  let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+  ()
+[%%expect{|
+Line 5, characters 56-60:
+5 |   let _ : (unit -> unit) @ portable = fun () -> let _ = bar1 () in () in
+                                                            ^^^^
+Error: The value "bar1" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at line 5, characters 38-69
+         which is expected to be "portable".
+|}]
+
+(* deeply nested closures should still propagate modes *)
+let nest x = fun () -> fun () -> fun () -> x
+[%%expect{|
+val nest : 'a -> unit -> unit -> unit -> 'a = <fun>
+|}]
+
+let foo (x @ portable) =
+  use_portable (nest x () () ())
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  use_portable (nest x () () ())
+[%%expect{|
+Line 2, characters 15-32:
+2 |   use_portable (nest x () () ())
+                   ^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -1,0 +1,217 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* FUNCTION APPLICATION *)
+
+(* mode polymorphism is preserved across function applications *)
+let id x = x
+let id' x = id x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+val id' : 'a -> 'a = <fun>
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let x = id' x in
+  let y = id' y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 5, characters 15-16:
+5 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* [id'] imposes a global bound on its argument *)
+let foo (x @ local) =
+  let y = id' x in ()
+[%%expect{|
+Line 2, characters 14-15:
+2 |   let y = id' x in ()
+                  ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+(* HIGHER-ORDER FUNCTIONS *)
+
+let foo (x @ portable) (y @ nonportable) =
+  let x = (fun x -> x) x in
+  let y = (fun y -> y) y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 5, characters 15-16:
+5 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* higher-order application should propagate mode constraints *)
+let apply f = fun x -> f x
+[%%expect{|
+val apply : ('a -> 'b) -> 'a -> 'b = <fun>
+|}]
+
+let foo (x @ unique) (y @ aliased) =
+  let x = apply id x in
+  let y = apply id y in
+  use_unique x;
+  use_unique y
+[%%expect{|
+Line 5, characters 13-14:
+5 |   use_unique y
+                 ^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+let foo (x @ portable) (y @ nonportable) =
+  let id x = x in
+  let x = apply id x in
+  let y = apply id y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 6, characters 15-16:
+6 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* COMPOSITION *)
+
+let compose f g x = f (g x)
+[%%expect{|
+val compose : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b = <fun>
+|}]
+
+(* mode polymorphism propagates through composition *)
+
+let foo (x @ portable) (y @ nonportable) =
+  let x = compose id id x in
+  let y = compose id id y in
+  use_portable x;
+  use_portable y
+[%%expect{|
+Line 5, characters 15-16:
+5 |   use_portable y
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* CHAINING APPLICATIONS *)
+
+(* mode constraints propagate through a chain of polymorphic applications *)
+let chain x =
+  let y = id x in
+  let z = id y in
+  z
+[%%expect{|
+val chain : 'a -> 'a = <fun>
+|}]
+
+let foo (x @ unique) = use_unique (chain x)
+[%%expect{|
+val foo : 'a @ unique -> unit = <fun>
+|}]
+
+let foo (x @ portable) = use_portable (chain x)
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+(* RECURSIVE FUNCTIONS *)
+
+let rec recursive x n =
+  if n <= 0 then x else recursive x (n - 1)
+[%%expect{|
+val recursive : 'a -> int -> 'a = <fun>
+|}]
+
+let foo (x @ portable) =
+  let x = recursive x 10 in
+  use_portable x
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let recursive' = recursive
+[%%expect{|
+val recursive' : 'a -> int -> 'a = <fun>
+|}]
+
+let foo (x @ nonportable) =
+  let x = recursive x 10 in
+  use_portable x
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable x
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let rec map f = function
+  | [] -> []
+  | x :: xs -> f x :: map f xs
+[%%expect{|
+val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
+|}]
+
+let foo (y @ portable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo (y @ nonportable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+Line 5, characters 15-17:
+5 |   use_portable lg
+                   ^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* SEQUENCING *)
+
+(* using a value and returning it *)
+let use_and_return x = ignore x; x
+[%%expect{|
+val use_and_return : 'a -> 'a = <fun>
+|}]
+
+(* contended values cannot be use_and_returned due to uncontended bound *)
+let foo (x @ contended) = use_and_return x
+[%%expect{|
+Line 1, characters 41-42:
+1 | let foo (x @ contended) = use_and_return x
+                                             ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,11 +9,11 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ 'n -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* FUNCTION APPLICATION *)
@@ -28,8 +22,8 @@ val use_global : 'a -> unit = <fun>
 let id x = x
 let id' x = id x
 [%%expect{|
-val id : 'a -> 'a = <fun>
-val id' : 'a -> 'a = <fun>
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+val id' : 'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -71,7 +65,9 @@ Error: This value is "nonportable" but is expected to be "portable".
 (* higher-order application should propagate mode constraints *)
 let apply f = fun x -> f x
 [%%expect{|
-val apply : ('a -> 'b) -> 'a -> 'b = <fun>
+val apply :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm]) @ [> 'o] = <fun>
 |}]
 
 let foo (x @ unique) (y @ aliased) =
@@ -103,7 +99,11 @@ Error: This value is "nonportable" but is expected to be "portable".
 
 let compose f g x = f (g x)
 [%%expect{|
-val compose : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b = <fun>
+val compose :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< 'q @@ past & global] ->
+   ('c @ [< 'p] -> 'b @ [> 'm]) @ [> 'q]) @ [> 'o] =
+  <fun>
 |}]
 
 (* mode polymorphism propagates through composition *)
@@ -128,17 +128,17 @@ let chain x =
   let z = id y in
   z
 [%%expect{|
-val chain : 'a -> 'a = <fun>
+val chain : 'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
 |}]
 
 let foo (x @ unique) = use_unique (chain x)
 [%%expect{|
-val foo : 'a @ unique -> unit = <fun>
+val foo : 'a @ [< global unique] -> unit @ 'm = <fun>
 |}]
 
 let foo (x @ portable) = use_portable (chain x)
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 (* RECURSIVE FUNCTIONS *)
@@ -146,19 +146,25 @@ val foo : 'a @ portable -> unit = <fun>
 let rec recursive x n =
   if n <= 0 then x else recursive x (n - 1)
 [%%expect{|
-val recursive : 'a -> int -> 'a = <fun>
+val recursive :
+  'a @ [< 'm & global] ->
+  (int @ [< many uncontended] -> 'a @ [< global > 'm]) @ [> close('m) | close('m) | nonportable] =
+  <fun>
 |}]
 
 let foo (x @ portable) =
   let x = recursive x 10 in
   use_portable x
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global portable] -> unit @ 'm = <fun>
 |}]
 
 let recursive' = recursive
 [%%expect{|
-val recursive' : 'a -> int -> 'a = <fun>
+val recursive' :
+  'a @ [< 'm & global] ->
+  (int @ [< many uncontended] -> 'a @ [< global > 'm]) @ [> close('m) | close('m) | nonportable] =
+  <fun>
 |}]
 
 let foo (x @ nonportable) =
@@ -175,7 +181,10 @@ let rec map f = function
   | [] -> []
   | x :: xs -> f x :: map f xs
 [%%expect{|
-val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
+val map :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & 'p @@ past & global many > aliased] ->
+  ('a list @ [< 'n] -> 'b list @ [< global > 'm]) @ [> 'o | 'p | nonportable] =
+  <fun>
 |}]
 
 let foo (y @ portable) =
@@ -184,7 +193,28 @@ let foo (y @ portable) =
   let lg = map g l in
   use_portable lg
 [%%expect{|
-val foo : 'a @ portable -> unit = <fun>
+val foo : 'a @ [< global many portable] -> unit @ 'm = <fun>
+|}]
+
+let foo (y @ nonportable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+Line 5, characters 15-17:
+5 |   use_portable lg
+                   ^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let foo (y @ portable) =
+  let g () = y in
+  let l = [(); (); ()] in
+  let lg = map g l in
+  use_portable lg
+[%%expect{|
+val foo : 'a @ [< global many portable] -> unit @ 'm = <fun>
 |}]
 
 let foo (y @ nonportable) =
@@ -204,7 +234,8 @@ Error: This value is "nonportable" but is expected to be "portable".
 (* using a value and returning it *)
 let use_and_return x = ignore x; x
 [%%expect{|
-val use_and_return : 'a -> 'a = <fun>
+val use_and_return :
+  'a @ [< 'm & global many uncontended] -> 'a @ [> 'm | aliased] = <fun>
 |}]
 
 (* contended values cannot be use_and_returned due to uncontended bound *)

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -1,0 +1,197 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+let id ~label1 = label1
+[%%expect{|
+val id : label1:'a -> 'a = <fun>
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let y = id ~label1:x in
+  use_uncontended y
+[%%expect{|
+|}]
+
+let fst ~label1 ~label2 = label1
+[%%expect{|
+val fst : label1:'a -> label2:'b -> 'a = <fun>
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let f = fst ~label1:x in
+  use_uncontended (f ~label2:())
+[%%expect{|
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let f = fst ~label2:() in
+  use_uncontended (f ~label1:x)
+[%%expect{|
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = fst ~label1:x ~label2:() in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = fst ~label1:x ~label2:() in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = fst ~label2:() ~label2:x in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = fst ~label2:() ~label2:x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let snd ~label1 ~label2 = label2
+[%%expect{|
+val snd : label1:'a -> label2:'b -> 'b = <fun>
+|}]
+
+let () =
+  let (x @ uncontended) = "uncontended" in
+  let f = snd ~label2:x in
+  use_uncontended (f ~label1:())
+[%%expect{|
+|}]
+
+let foo = fst ~label2:()
+[%%expect{|
+val foo : label1:'a -> 'a = <fun>
+|}]
+
+(* partially applying a labelled function yield
+the correct close-over behavior *)
+(* [foo] closes over a local variable and should thus be local *)
+let () =
+  let (label2 @ local) = "local" in
+  let foo = fst ~label2 in
+  use_global foo
+[%%expect{|
+Line 4, characters 13-16:
+4 |   use_global foo
+                 ^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let () =
+  let label2 = "global" in
+  let foo = fst ~label2 in
+  use_global foo
+[%%expect{|
+|}]
+
+let foo = fun x -> fst ~label1:x
+[%%expect{|
+val foo : 'a -> label2:'b -> 'a = <fun>
+|}]
+
+let foo ?label1 x = x
+[%%expect{|
+val foo : ?label1:'a -> 'b -> 'b = <fun>
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let foo x ?label1 = x
+[%%expect{|
+val foo : 'a -> ?label1:'b -> 'a = <fun>
+|}]
+
+let () =
+  let (x @ global) = "global" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+|}]
+
+let () =
+  let (x @ local) = "local" in
+  let y = foo x in
+  use_global y
+[%%expect{|
+Line 4, characters 13-14:
+4 |   use_global y
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let bar (x @ nonportable) =
+  let f = foo x in
+  use_portable f
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable f
+                   ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let bar (x @ uncontended) =
+  let f = foo x in
+  let y = f ~label1:() in
+  use_portable y
+[%%expect{|
+val bar : 'a @ portable -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -65,9 +65,9 @@ let () =
   let y = fst ~label1:x ~label2:() in
   use_global y
 [%%expect{|
-Line 4, characters 13-14:
-4 |   use_global y
-                 ^
+Line 3, characters 22-23:
+3 |   let y = fst ~label1:x ~label2:() in
+                          ^
 Error: This value is "local" but is expected to be "global".
 |}]
 
@@ -172,9 +172,9 @@ let () =
   let y = foo x in
   use_global y
 [%%expect{|
-Line 4, characters 13-14:
-4 |   use_global y
-                 ^
+Line 3, characters 14-15:
+3 |   let y = foo x in
+                  ^
 Error: This value is "local" but is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,16 +9,16 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ 'n -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 let id ~label1 = label1
 [%%expect{|
-val id : label1:'a -> 'a = <fun>
+val id : label1:'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -36,7 +30,9 @@ let () =
 
 let fst ~label1 ~label2 = label1
 [%%expect{|
-val fst : label1:'a -> label2:'b -> 'a = <fun>
+val fst :
+  label1:'a @ [< 'm & global] ->
+  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
 |}]
 
 let () =
@@ -91,7 +87,9 @@ Error: This value is "local" but is expected to be "global".
 
 let snd ~label1 ~label2 = label2
 [%%expect{|
-val snd : label1:'a -> label2:'b -> 'b = <fun>
+val snd :
+  label1:'a @ [< 'm @@ past & global] ->
+  (label2:'b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -103,7 +101,7 @@ let () =
 
 let foo = fst ~label2:()
 [%%expect{|
-val foo : label1:'a -> 'a = <fun>
+val foo : label1:'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
 |}]
 
 (* partially applying a labelled function yield
@@ -129,12 +127,16 @@ let () =
 
 let foo = fun x -> fst ~label1:x
 [%%expect{|
-val foo : 'a -> label2:'b -> 'a = <fun>
+val foo :
+  'a @ [< 'm & global] -> (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo ?label1 x = x
 [%%expect{|
-val foo : ?label1:'a -> 'b -> 'b = <fun>
+val foo :
+  ?label1:'a @ [< 'm @@ past & global] ->
+  ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] = <fun>
 |}]
 
 let () =
@@ -157,7 +159,9 @@ Error: This value is "local" but is expected to be "global".
 
 let foo x ?label1 = x
 [%%expect{|
-val foo : 'a -> ?label1:'b -> 'a = <fun>
+val foo :
+  'a @ [< 'm & global] -> (?label1:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let () =
@@ -193,5 +197,5 @@ let bar (x @ uncontended) =
   let y = f ~label1:() in
   use_portable y
 [%%expect{|
-val bar : 'a @ portable -> unit = <fun>
+val bar : 'a @ [< global portable uncontended] -> unit @ 'm = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -1,0 +1,653 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests printing of poymorphic mode variables
+*)
+
+
+let id x = x
+[%%expect{|
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo x = 42
+[%%expect{|
+val foo : 'a @ 'n -> int @ 'm = <fun>
+|}]
+
+(* CR ageorges: Is there a way to explain the following? id is instantiated, but foo is
+  generalized with more bounds that necessary? *)
+let foo x = id x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo f x = f x
+[%%expect{|
+val foo :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm]) @ [> 'o] = <fun>
+|}, Principal{|
+val foo :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm]) @ [> 'o] = <fun>
+|}]
+
+let foo =
+  let id x = x in
+  fun x -> id x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> 'a @ [> 'm] = <fun>
+|}]
+
+(* CR ageorges: make the printer aware of mode crossing/jkinds *)
+let foo a b = a + b
+[%%expect{|
+val foo : int @ 'p -> (int @ 'o -> int @ 'n) @ 'm = <fun>
+|}, Principal{|
+val foo : int @ [< 'm @@ past & global] -> (int @ 'o -> int @ 'n) @ [> 'm] =
+  <fun>
+|}]
+
+
+(* records *)
+
+type ('a,'b) mytypemod = { x : 'a; y : 'b @@ portable }
+
+let foo t = t.x
+[%%expect{|
+type ('a, 'b) mytypemod = { x : 'a; y : 'b @@ portable; }
+val foo : ('a, 'b) mytypemod @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo t = t.y
+[%%expect{|
+val foo : ('a, 'b) mytypemod @ [< 'm] -> 'b @ [> 'm @@ portable] = <fun>
+|}]
+
+let foo x z = x.y
+[%%expect{|
+val foo :
+  ('a, 'b) mytypemod @ [< 'm & global] ->
+  ('c @ 'n -> 'b @ [> 'm @@ portable]) @ [> close('m)] = <fun>
+|}]
+
+
+let x =
+  let foo x = x in
+  let _ @ contended = foo (ref 42 : _ @ contended ) in
+  let _ @ uncontended = foo  (ref 41 : _ @ uncontended) in
+  foo
+[%%expect{|
+val x : '_weak1 -> '_weak1 @ [> aliased nonportable] = <fun>
+|}]
+
+type ('a,'b) mytype = { x : 'a; y : 'b }
+[%%expect{|
+type ('a, 'b) mytype = { x : 'a; y : 'b; }
+|}]
+
+let foo x y = { x; y }
+[%%expect{|
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo x = fun y -> { x; y }
+[%%expect{|
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo x = { x; y = 42 }
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> ('a, int) mytype @ [> 'm] = <fun>
+|}]
+
+let foo r = { r with y = 42 }
+[%%expect{|
+val foo :
+  ('a, 'b) mytype @ [< global many uncontended] ->
+  ('a, int) mytype @ [> aliased nonportable] = <fun>
+|}]
+
+type 'a myref = { mutable x : 'a }
+[%%expect{|
+type 'a myref = { mutable x : 'a; }
+|}]
+
+let create a = { x = a }
+[%%expect{|
+val create :
+  'a @ [< global many > 'm] -> 'a myref @ [< 'm @@ past > nonportable] =
+  <fun>
+|}]
+
+let read r = r.x
+[%%expect{|
+val read : 'a myref @ [< 'm & shared] -> 'a @ [> 'm @@ global many | aliased] =
+  <fun>
+|}]
+
+let store r = fun a -> r.x <- a
+[%%expect{|
+val store :
+  'a myref @ [< 'm @@ past & global corrupted] ->
+  ('a @ [< global many uncontended] -> unit @ 'n) @ [> 'm | corruptible] =
+  <fun>
+|}]
+
+(* products *)
+
+let dupl x = (x, x)
+[%%expect{|
+val dupl : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased] = <fun>
+|}]
+
+let prod x y = (x, y)
+[%%expect{|
+val prod :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let prod_eta x = fun y -> (x, y)
+[%%expect{|
+val prod_eta :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let fst (a, _) = a
+let snd (_, b) = b
+[%%expect{|
+val fst : 'a * 'b @ [< 'm] -> 'a @ [> 'm] = <fun>
+val snd : 'a * 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+|}]
+
+let foo x = fun y ->
+  let x' = fst (x,y) in
+  let y' = snd (x,y) in
+  (x', y')
+[%%expect{|
+val foo :
+  'a @ [< 'm & global many] ->
+  ('b @ [< 'n & global many] -> 'a * 'b @ [> 'n | 'm | aliased]) @ [> close('m) | nonportable] =
+  <fun>
+|}]
+
+(* currying *)
+
+let foo x y = x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo x y = y
+[%%expect{|
+val foo :
+  'a @ [< 'm @@ past & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm] =
+  <fun>
+|}]
+
+let foo x y = id x
+[%%expect{|
+val foo : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let foo f = fun x -> fun y -> f x y
+[%%expect{|
+val foo :
+  ('a @ [< 'm @@ past > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('a @ [< 'q & global] ->
+   ('b @ [< 'p] -> 'c @ [> 'o]) @ [> close('q) | 'mm1]) @ [> 'mm0] =
+  <fun>
+|}]
+
+let fst x = fun y -> x
+[%%expect{|
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+let snd x = fun y -> y
+[%%expect{|
+val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
+|}]
+
+let foo x y = ref x
+[%%expect{|
+val foo :
+  'a @ [< global many uncontended > 'm] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable]) @ [< 'm @@ past > nonportable] =
+  <fun>
+|}]
+
+let foo (x @ aliased) y = ref x
+[%%expect{|
+val foo :
+  'a @ [< global many uncontended > 'm | aliased] ->
+  ('b @ 'n -> 'a ref @ [> aliased nonportable]) @ [< 'm @@ past > nonportable] =
+  <fun>
+|}]
+
+let foo (x @ contended) y = x
+[%%expect{|
+val foo :
+  'a @ [< 'm & global > contended] ->
+  ('b @ 'n -> 'a @ [> 'm | contended]) @ [> close('m)] = <fun>
+|}]
+
+let foo x y z = 42
+[%%expect{|
+val foo :
+  'a @ [< 'm @@ past & global] ->
+  ('b @ [< 'n @@ past & global] -> ('c @ 'p -> int @ 'o) @ [> 'n]) @ [> 'm] =
+  <fun>
+|}]
+
+let foo x y = (x, y)
+[%%expect{|
+val foo :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+let foo x y z = (y,z)
+[%%expect{|
+val foo :
+  'a @ [< 'm @@ past & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'o & global] -> 'b * 'c @ [> 'o | 'n]) @ [> close('n)]) @ [> 'm] =
+  <fun>
+|}]
+
+(* annotations *)
+
+(* CR ageorges: if a mode variable is fully determined (its bounds are equal) consider
+  printing it as a constant rather than variable *)
+let legacy_id (x @ global many aliased nonportable uncontended forkable unyielding stateful read_write dynamic) = x
+[%%expect{|
+val legacy_id :
+  'a @ [< global many uncontended > aliased nonportable] ->
+  'a @ [> aliased nonportable] = <fun>
+|}]
+
+let foo (x @ local) = x
+[%%expect{|
+val foo : 'a @ [< 'm > local] -> 'a @ [> 'm | local] = <fun>
+|}]
+
+let foo x = exclave_ x
+[%%expect{|
+val foo : 'a @ [< 'm] -> 'a @ [> 'm | local] = <fun>
+|}]
+
+let foo (x @ portable) = x
+[%%expect{|
+val foo : 'a @ [< 'm & portable] -> 'a @ [> 'm] = <fun>
+|}]
+
+let foo : (unit -> unit) @ portable = fun () -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let foo (y @ unique) (z @ portable) = z
+[%%expect{|
+val foo :
+  'a @ [< 'm @@ past & global unique] ->
+  ('b @ [< 'n & portable] -> 'b @ [> 'n]) @ [> 'm] = <fun>
+|}]
+
+let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
+[%%expect{|
+val foo :
+  'a @ [< 'm > local] ->
+  ('b @ [< 'n & unique] ->
+   ('c @ [< 'o & portable] -> 'a * 'b * 'c @ [> 'o | 'n | 'm | local]) @ [> close('n) | local]) @ [> close('m) | local] =
+  <fun>
+|}]
+
+(* if a type is annotated, mode crossing has an effect on the bounds of mode variable *)
+
+type intref = { mutable v : int }
+
+let foo (x : intref) (f : intref @ local -> int) = f x
+[%%expect{|
+type intref = { mutable v : int; }
+val foo :
+  intref @ [< 'm @@ past & global uncontended] ->
+  ((intref @ local -> int) @ 'o -> int @ 'n) @ [> 'm | nonportable] = <fun>
+|}]
+
+(* CR ageorges: ideally we want to apply mode crossing reguardless of principality *)
+let foo (f : int -> int) x y = f
+[%%expect{|
+val foo :
+  (int -> int) @ [< 'o . aliased contended & 'm @@ past & global] ->
+  ('a @ [< 'n @@ past & global] ->
+   ('b @ 'p -> (int -> int) @ [> 'o]) @ [> 'n]) @ [> 'm] =
+  <fun>
+|}, Principal{|
+val foo :
+  (int -> int) @ [< 'm . aliased contended & global] ->
+  ('a @ [< 'n @@ past & global] ->
+   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> 'n]) @ [> close('m) @@ many portable] =
+  <fun>
+|}]
+
+let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
+[%%expect{|
+val foo :
+  (intref @ local -> int) @ [< 'm @@ past & global] ->
+  (intref @ [< 'n @@ past & global uncontended] ->
+   (intref @ 'p -> int @ 'o) @ [> 'n @@ many portable | nonportable]) @ [> 'm] =
+  <fun>
+|}, Principal{|
+val foo :
+  (intref @ local -> int) @ [< 'm @@ past & global] ->
+  (intref @ [< 'n @@ past & global uncontended] ->
+   (intref @ 'p -> int @ 'o) @ [> 'n | nonportable]) @ [> 'm] =
+  <fun>
+|}]
+
+(* aliases of non-polymorphic functions *)
+
+let map = List.map
+[%%expect{|
+val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
+|}]
+
+let map f l = List.map f l
+[%%expect{|
+val map :
+  ('a @ [< 'm @@ past > aliased nonportable] ->
+   'b @ [< global many uncontended]) @ [< 'n @@ past & global many > 'o | 'm] ->
+  ('a list @ [< global many uncontended] ->
+   'b list @ [< 'o @@ past > aliased nonportable]) @ [> 'n] =
+  <fun>
+|}, Principal{|
+val map :
+  ('a @ [< 'm @@ past > aliased nonportable] ->
+   'b @ [< global many uncontended]) @ [< 'n @@ past & global many > 'o | 'm] ->
+  ('a list @ [< global many uncontended] ->
+   'b list @ [< 'o @@ past > aliased nonportable]) @ [> 'n] =
+  <fun>
+|}]
+
+let map_eta f = fun l -> List.map f l
+[%%expect{|
+val map_eta :
+  ('a @ [< 'm @@ past > aliased nonportable] ->
+   'b @ [< global many uncontended]) @ [< 'n @@ past & global many > 'o | 'm] ->
+  ('a list @ [< global many uncontended] ->
+   'b list @ [< 'o @@ past > aliased nonportable]) @ [> 'n] =
+  <fun>
+|}]
+
+(* modules *)
+
+ module Counter : sig
+  type t
+
+  val incr : t -> t
+
+  val to_int : t -> int
+end = struct
+  type t = int
+
+  let incr n = n + 1
+
+  let to_int = fun n -> n
+ end
+ [%%expect{|
+module Counter : sig type t val incr : t -> t val to_int : t -> int end
+|}]
+
+let incr n = Counter.incr n
+[%%expect{|
+val incr :
+  Counter.t @ [< global many uncontended] ->
+  Counter.t @ [> aliased nonportable] = <fun>
+|}]
+
+let incr = Counter.incr
+[%%expect{|
+val incr : Counter.t -> Counter.t = <fun>
+|}]
+
+let incr n = n + 1
+[%%expect{|
+val incr : int @ 'n -> int @ 'm = <fun>
+|}]
+
+let id x = x
+[%%expect{|
+val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+module Foo : sig
+  type t
+
+  val id_portable : t @ portable -> t @ portable
+
+  val id_nonportable : t -> t
+
+  val bar : t @ portable -> t
+end = struct
+  type t = unit -> unit
+
+  let id_portable = id
+
+  let id_nonportable = id
+
+  let bar = id
+end
+[%%expect{|
+module Foo :
+  sig
+    type t
+    val id_portable : t @ portable -> t @ portable
+    val id_nonportable : t -> t
+    val bar : t @ portable -> t
+  end
+|}]
+
+(* CR ageorges: remove duplicates in [< 'm & 'm] and [> 'm | 'm] *)
+module Foo : sig
+  type t
+
+  val illegal : t -> t @ portable
+end = struct
+  type t = unit -> unit
+
+  let illegal = id
+end
+[%%expect{|
+Lines 5-9, characters 6-3:
+5 | ......struct
+6 |   type t = unit -> unit
+7 |
+8 |   let illegal = id
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = unit -> unit
+           val illegal : 'a @ [< 'm] -> 'a @ [> 'm]
+         end
+       is not included in
+         sig type t val illegal : t -> t @ portable end
+       Values do not match:
+         val illegal : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val illegal : t -> t @ portable
+       The type
+         "t @ [< 'm & 'm & 'm & 'm > nonportable] ->
+         t @ [> 'm | 'm | 'm | 'm | nonportable]"
+       is not compatible with the type "t -> t @ portable"
+|}]
+
+(* variant types *)
+
+type 'a option' = None' | Some' of 'a
+
+let wrap x = Some' x
+[%%expect{|
+type 'a option' = None' | Some' of 'a
+val wrap : 'a @ [< 'm & global] -> 'a option' @ [> 'm] = <fun>
+|}]
+
+let unwrap_or default = function
+  | None' -> default
+  | Some' x -> x
+[%%expect{|
+val unwrap_or :
+  'a @ [< 'm & global] ->
+  ('a option' @ [< 'n] -> 'a @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+type ('a, 'b) either = Left of 'a | Right of 'b
+
+let map_left f = function
+  | Left x -> Left (f x)
+  | Right y -> Right y
+[%%expect{|
+type ('a, 'b) either = Left of 'a | Right of 'b
+val map_left :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  (('a, 'c) either @ [< 'p & 'n & global] -> ('b, 'c) either @ [> 'p | 'm]) @ [> 'o] =
+  <fun>
+|}]
+
+(* recursive functions *)
+
+let rec length = function
+  | [] -> 0
+  | _ :: tl -> 1 + length tl
+[%%expect{|
+val length : 'a list @ 'n -> int @ 'm = <fun>
+|}]
+
+let rec map f = function
+  | [] -> []
+  | x :: xs -> f x :: map f xs
+[%%expect{|
+val map :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & 'p @@ past & global many > aliased] ->
+  ('a list @ [< 'n] -> 'b list @ [< global > 'm]) @ [> 'o | 'p | nonportable] =
+  <fun>
+|}]
+
+(* if/then/else *)
+
+let choose b x y = if b then x else y
+[%%expect{|
+val choose :
+  bool @ [< 'm @@ past & global] ->
+  ('a @ [< 'n & global] -> ('a @ [< 'o] -> 'a @ [> 'o | 'n]) @ [> close('n)]) @ [> 'm] =
+  <fun>
+|}]
+
+(* nested closures *)
+
+let nest x = fun () -> fun () -> fun () -> x
+[%%expect{|
+val nest :
+  'a @ [< 'm & global] ->
+  (unit @ 'p ->
+   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
+|}]
+
+(* sequencing: using x then returning it *)
+
+let use_and_return x = ignore x; x
+[%%expect{|
+val use_and_return :
+  'a @ [< 'm & global many uncontended] -> 'a @ [> 'm | aliased] = <fun>
+|}]
+
+(* multiple distinct mode variables *)
+
+let swap (a, b) = (b, a)
+[%%expect{|
+val swap : 'a * 'b @ [< 'm & global] -> 'b * 'a @ [> 'm] = <fun>
+|}]
+
+let both_id x y = (x, y)
+[%%expect{|
+val both_id :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
+|}]
+
+(* let bindings preserving modes *)
+
+let let_chain x =
+  let a = x in
+  let b = a in
+  let c = b in
+  c
+[%%expect{|
+val let_chain : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
+|}]
+
+(* mode polymorphism with option type *)
+
+let map_option f = function
+  | None -> None
+  | Some x -> Some (f x)
+[%%expect{|
+val map_option :
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('a option @ [< 'n] -> 'b option @ [> 'm]) @ [> 'o] = <fun>
+|}]
+
+(* Currying over three arguments *)
+
+let triple x y z = (x, y, z)
+[%%expect{|
+val triple :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'o & global] -> 'a * 'b * 'c @ [> 'o | 'n | 'm]) @ [> close('n)]) @ [> close('m)] =
+  <fun>
+|}]
+
+let flip f (x, y) = f (y, x)
+[%%expect{|
+val flip :
+  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< 'o @@ past & global] ->
+  ('b * 'a @ [< 'n & global] -> 'c @ [> 'm]) @ [> 'o] = <fun>
+|}]
+
+let flip f x y = f y x
+[%%expect{|
+val flip :
+  ('a @ [< 'm @@ past > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'n @@ past & 'mm0 @@ past & global] ->
+  ('b @ [< 'p & global] -> ('a @ [< 'q] -> 'c @ [> 'o]) @ [> close('p)]) @ [> 'mm0] =
+  <fun>
+|}]
+
+
+let flip f = fun x -> fun y -> f y x
+[%%expect{|
+val flip :
+  ('a @ [< 'm @@ past > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> 'm | 'n]) @ [< 'mm1 @@ past & 'n @@ past & 'mm0 @@ past & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o]) @ [> close('p) | 'mm1]) @ [> 'mm0] =
+  <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -1,0 +1,129 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+type 'a myref = { mutable i : 'a }
+let alloc x = { i = x }
+[%%expect{|
+type 'a myref = { mutable i : 'a; }
+val alloc : 'a -> 'a myref = <fun>
+|}]
+
+let store_any x y = x.i <- y
+[%%expect{|
+val store_any : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let store_global (x @ global) y = x.i <- y
+[%%expect{|
+val store_global : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let () =
+  let (x @ local) = { i = "local" } in
+  let (x' @ global) = { i = "global" } in
+  store_any x "test";
+  store_any x' "test";
+  store_global x "should fail"
+[%%expect{|
+Line 4, characters 12-13:
+4 |   store_any x "test";
+                ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* mutable fields are not polymorphic *)
+let foo () =
+  let x @ unique = alloc 42 in
+  let z @ aliased = alloc 42 in
+  let yunique = alloc x in
+  let yaliased = alloc z in
+  use_unique yunique.i;
+  use_unique yaliased.i
+[%%expect{|
+Line 6, characters 13-22:
+6 |   use_unique yunique.i;
+                 ^^^^^^^^^
+Error: This value is "aliased"
+         because it is the field "i" (with some modality) of the record at line 6, characters 13-20.
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+type 'a myrecord = { j : 'a }
+let create x = { j = x }
+[%%expect{|
+type 'a myrecord = { j : 'a; }
+val create : 'a -> 'a myrecord = <fun>
+|}]
+
+(* but immutable fields are *)
+let foo () =
+  let x @ unique = create 42 in
+  let z @ aliased = create 42 in
+  let yunique = create x in
+  let yaliased = create z in
+  use_unique yunique.j;
+  use_unique yaliased.j
+
+[%%expect{|
+Line 7, characters 13-23:
+7 |   use_unique yaliased.j
+                 ^^^^^^^^^^
+Error: This value is "aliased"
+         because it is the field "j" of the record at line 7, characters 13-21
+         which is "aliased".
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+(* CR ageorges: principality issue with portable refs *)
+let foo () =
+  use_portable (alloc 42)
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}, Principal{|
+Line 2, characters 15-25:
+2 |   use_portable (alloc 42)
+                   ^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let foo (x @ local) = alloc x
+[%%expect{|
+Line 1, characters 28-29:
+1 | let foo (x @ local) = alloc x
+                                ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+let foo (x @ once) = alloc x
+[%%expect{|
+Line 1, characters 27-28:
+1 | let foo (x @ once) = alloc x
+                               ^
+Error: This value is "once" but is expected to be "many".
+|}]
+
+let foo (x @ contended) = alloc x
+[%%expect{|
+val foo : 'a @ contended -> 'a myref @ contended = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,28 +9,36 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ 'n -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 type 'a myref = { mutable i : 'a }
 let alloc x = { i = x }
 [%%expect{|
 type 'a myref = { mutable i : 'a; }
-val alloc : 'a -> 'a myref = <fun>
+val alloc :
+  'a @ [< global many > 'm] -> 'a myref @ [< 'm @@ past > nonportable] =
+  <fun>
 |}]
 
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
-val store_local : 'a myref @ local -> 'a -> unit = <fun>
+val store_local :
+  'a myref @ [< 'm @@ past & corrupted > local] ->
+  ('a @ [< global many uncontended] -> unit @ 'n) @ [> 'm | local corruptible] =
+  <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
-val store_global : 'a myref -> 'a -> unit = <fun>
+val store_global :
+  'a myref @ [< 'm @@ past & global corrupted] ->
+  ('a @ [< global many uncontended] -> unit @ 'n) @ [> 'm | corruptible] =
+  <fun>
 |}]
 
 let () =
@@ -73,7 +75,7 @@ type 'a myrecord = { j : 'a }
 let create x = { j = x }
 [%%expect{|
 type 'a myrecord = { j : 'a; }
-val create : 'a -> 'a myrecord = <fun>
+val create : 'a @ [< 'm & global] -> 'a myrecord @ [> 'm] = <fun>
 |}]
 
 (* but immutable fields are *)
@@ -99,7 +101,7 @@ Error: This value is "aliased"
 let foo () =
   use_portable (alloc 42)
 [%%expect{|
-val foo : unit -> unit = <fun>
+val foo : unit @ 'n -> unit @ 'm = <fun>
 |}, Principal{|
 Line 2, characters 15-25:
 2 |   use_portable (alloc 42)
@@ -125,5 +127,7 @@ Error: This value is "once" but is expected to be "many".
 
 let foo (x @ contended) = alloc x
 [%%expect{|
-val foo : 'a @ contended -> 'a myref @ contended = <fun>
+val foo :
+  'a @ [< global many > 'm | contended] ->
+  'a myref @ [< 'm @@ past > nonportable contended] = <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -29,9 +29,9 @@ type 'a myref = { mutable i : 'a; }
 val alloc : 'a -> 'a myref = <fun>
 |}]
 
-let store_any x y = x.i <- y
+let store_local (x @ local) y = x.i <- y
 [%%expect{|
-val store_any : 'a myref -> 'a -> unit = <fun>
+val store_local : 'a myref @ local -> 'a -> unit = <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
@@ -42,13 +42,13 @@ val store_global : 'a myref -> 'a -> unit = <fun>
 let () =
   let (x @ local) = { i = "local" } in
   let (x' @ global) = { i = "global" } in
-  store_any x "test";
-  store_any x' "test";
+  store_local x "test";
+  store_local x' "test";
   store_global x "should fail"
 [%%expect{|
-Line 4, characters 12-13:
-4 |   store_any x "test";
-                ^
+Line 6, characters 15-16:
+6 |   store_global x "should fail"
+                   ^
 Error: This value is "local" but is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -1,0 +1,164 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped in order to be printed
+*)
+
+let use_uncontended (x @ uncontended) = ()
+let use_portable (x @ portable) = ()
+let use_unique (x @ unique) = ()
+let use_static (x @ static) = ()
+let use_global (x @ global) = ()
+[%%expect{|
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_static : 'a -> unit = <fun>
+val use_global : 'a -> unit = <fun>
+|}]
+
+(* Since a tuple is returned in tail-position, its allocation will be global *)
+let prod x y = (x, y)
+[%%expect{|
+val prod : 'a -> 'b -> 'a * 'b = <fun>
+|}]
+
+(* With exclave_ the tuple is local *)
+let prod_local x y = exclave_ (x, y)
+[%%expect{|
+val prod_local : 'a -> 'b -> 'a * 'b @ local = <fun>
+|}]
+
+(* [prod] is polymorphic on the other axes *)
+let foo (x @ portable) (y @ portable) =
+  let (b, a) = prod x y in
+  use_portable b;
+  use_portable a
+[%%expect{|
+val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+|}]
+
+(* But the returned tuple will be the meet of its arguments *)
+let foo (x @ portable) (y @ nonportable) =
+  let (b, a) = prod x y in
+  use_portable b
+[%%expect{|
+Line 3, characters 15-16:
+3 |   use_portable b
+                   ^
+Error: This value is "nonportable"
+         because it is an element of the tuple at line 2, characters 15-23
+         which is "nonportable".
+       However, the highlighted expression is expected to be "portable".
+|}]
+
+let dupl x = (x, x)
+[%%expect{|
+val dupl : 'a -> 'a * 'a = <fun>
+|}]
+
+(* The arguments must be global *)
+let foo (x @ local) (y @ global) =
+    let _ = prod x y in ()
+[%%expect{|
+Line 2, characters 17-18:
+2 |     let _ = prod x y in ()
+                     ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+let foo (y @ local) (x @ global) =
+    let _ = prod y x in ()
+[%%expect{|
+Line 2, characters 17-18:
+2 |     let _ = prod y x in ()
+                     ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+(* They can be local using exclave_ *)
+let foo (x @ local) (y @ local) =
+  let p = prod_local x y in
+  use_global (fst p) (* but the elements of the product are local *)
+[%%expect{|
+Line 3, characters 13-20:
+3 |   use_global (fst p) (* but the elements of the product are local *)
+                 ^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* [dupl] uses an argument twice and the polymorphic mode must be many *)
+let foo (x @ once) =
+  let p = dupl x in ()
+[%%expect{|
+Line 2, characters 15-16:
+2 |   let p = dupl x in ()
+                   ^
+Error: This value is "once" but is expected to be "many".
+|}]
+
+(* [dupl] makes unique arguments aliased *)
+let foo (x @ unique) =
+  let p = dupl x in
+  use_unique (fst p)
+[%%expect{|
+Line 3, characters 13-20:
+3 |   use_unique (fst p)
+                 ^^^^^^^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+(* mode polymorphism works over tuples *)
+let swap (a, b) = (b, a)
+[%%expect{|
+val swap : 'a * 'b -> 'b * 'a = <fun>
+|}]
+
+let swap_local (a, b) = exclave_ (b, a)
+[%%expect{|
+val swap_local : 'a * 'b -> 'b * 'a @ local = <fun>
+|}]
+
+let foo (x @ portable) (y @ portable) =
+  let p = swap (x, y) in
+  use_portable p
+[%%expect{|
+val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+|}]
+
+let foo (x @ local) (y @ local) =
+  let _ = swap (x, y) in ()
+[%%expect{|
+Line 2, characters 16-17:
+2 |   let _ = swap (x, y) in ()
+                    ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is an element of the tuple at line 2, characters 15-21
+         which is expected to be "global".
+|}]
+
+let foo (x @ global) (y @ local) =
+  let p = swap_local (x, y) in
+  use_global (snd p)
+[%%expect{|
+Line 3, characters 13-20:
+3 |   use_global (snd p)
+                 ^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let foo (x @ global) (y @ global) =
+  let p = swap_local (x, y) in
+  use_global p
+[%%expect{|
+Line 3, characters 13-14:
+3 |   use_global p
+                 ^
+Error: This value is "local" but is expected to be "global".
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -29,9 +29,9 @@ val prod : 'a -> 'b -> 'a * 'b = <fun>
 |}]
 
 (* With exclave_ the tuple is local *)
-let prod_local x y = exclave_ (x, y)
+let prod_local (x @ local) (y @ local) = exclave_ (x, y)
 [%%expect{|
-val prod_local : 'a -> 'b -> 'a * 'b @ local = <fun>
+val prod_local : 'a @ local -> 'b @ local -> 'a * 'b @ local = <fun>
 |}]
 
 (* [prod] is polymorphic on the other axes *)

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -1,12 +1,6 @@
 (* TEST
- flags += "-extension mode_polymorphism_alpha";
+ flags += "-extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
  expect;
-*)
-
-(*
- * This file tests that mode polymorphism works, without printing mode variables.
- * The modes printed are not always representative of the underlying modes: they have
- * been zapped in order to be printed
 *)
 
 let use_uncontended (x @ uncontended) = ()
@@ -15,23 +9,28 @@ let use_unique (x @ unique) = ()
 let use_static (x @ static) = ()
 let use_global (x @ global) = ()
 [%%expect{|
-val use_uncontended : 'a -> unit = <fun>
-val use_portable : 'a @ portable -> unit = <fun>
-val use_unique : 'a @ unique -> unit = <fun>
-val use_static : 'a -> unit = <fun>
-val use_global : 'a -> unit = <fun>
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+val use_static : 'a @ 'n -> unit @ 'm = <fun>
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 |}]
 
 (* Since a tuple is returned in tail-position, its allocation will be global *)
 let prod x y = (x, y)
 [%%expect{|
-val prod : 'a -> 'b -> 'a * 'b = <fun>
+val prod :
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 (* With exclave_ the tuple is local *)
 let prod_local (x @ local) (y @ local) = exclave_ (x, y)
 [%%expect{|
-val prod_local : 'a @ local -> 'b @ local -> 'a * 'b @ local = <fun>
+val prod_local :
+  'a @ [< 'm > local] ->
+  ('b @ [< 'n > local] -> 'a * 'b @ [> 'n | 'm | local]) @ [> close('m) | local] =
+  <fun>
 |}]
 
 (* [prod] is polymorphic on the other axes *)
@@ -40,7 +39,9 @@ let foo (x @ portable) (y @ portable) =
   use_portable b;
   use_portable a
 [%%expect{|
-val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global portable] -> unit @ 'n) @ [> 'm] = <fun>
 |}]
 
 (* But the returned tuple will be the meet of its arguments *)
@@ -59,7 +60,7 @@ Error: This value is "nonportable"
 
 let dupl x = (x, x)
 [%%expect{|
-val dupl : 'a -> 'a * 'a = <fun>
+val dupl : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased] = <fun>
 |}]
 
 (* The arguments must be global *)
@@ -116,19 +117,21 @@ Error: This value is "aliased" but is expected to be "unique".
 (* mode polymorphism works over tuples *)
 let swap (a, b) = (b, a)
 [%%expect{|
-val swap : 'a * 'b -> 'b * 'a = <fun>
+val swap : 'a * 'b @ [< 'm & global] -> 'b * 'a @ [> 'm] = <fun>
 |}]
 
 let swap_local (a, b) = exclave_ (b, a)
 [%%expect{|
-val swap_local : 'a * 'b -> 'b * 'a @ local = <fun>
+val swap_local : 'a * 'b @ [< 'm] -> 'b * 'a @ [> 'm | local] = <fun>
 |}]
 
 let foo (x @ portable) (y @ portable) =
   let p = swap (x, y) in
   use_portable p
 [%%expect{|
-val foo : 'a @ portable -> 'b @ portable -> unit = <fun>
+val foo :
+  'a @ [< 'm @@ past & global portable] ->
+  ('b @ [< global portable] -> unit @ 'n) @ [> 'm] = <fun>
 |}]
 
 let foo (x @ local) (y @ local) =

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -487,7 +487,7 @@ let f (g @ unique) x =
 [%%expect{|
 val f : ('a -> 'a -> 'b) @ unique -> ('a -> 'b) = <fun>
 |}, Principal{|
-val f : ('a -> 'a -> 'b) @ unique -> 'a -> 'b = <fun>
+val f : ('a -> 'a -> 'b) @ unique -> ('a -> 'b) = <fun>
 |}]
 
 let f (g @ once) x =

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -434,37 +434,74 @@ Error: This function when partially applied returns a value which is "nonportabl
        but expected to be "portable".
 |}]
 
-(* closing over uncontended gives nonportable *)
-let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> ()
+(* closing over an uncontended use of a variable gives nonportable *)
+let use_uncontended (x @ uncontended) = ()
 [%%expect{|
-Line 1, characters 67-81:
-1 | let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> ()
-                                                                       ^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "nonportable",
-       but expected to be "portable".
+val use_uncontended : 'a -> unit = <fun>
 |}]
 
-(* closing over shared gives shareable *)
+let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> use_uncontended a
+[%%expect{|
+Line 1, characters 71-72:
+1 | let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> use_uncontended a
+                                                                           ^
+Error: The pattern is "contended"
+         because it is used inside the function at line 1, characters 67-96
+         which is expected to be "portable".
+       However, the pattern highlighted is expected to be "uncontended".
+|}]
+
+(* closing over an uncontended variable without using it can be portable *)
+let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> a
+[%%expect{|
+val foo : unit @ portable -> (unit -> unit) @ portable = <fun>
+|}]
+
+(* closing over shared uses gives shareable *)
+let use_shared (x @ shared) = ()
+[%%expect{|
+val use_shared : 'a @ shared -> unit = <fun>
+|}]
+
+let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> use_shared a
+[%%expect{|
+Line 1, characters 66-67:
+1 | let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> use_shared a
+                                                                      ^
+Error: The pattern is "contended"
+         because it is used inside the function at line 1, characters 62-86
+         which is expected to be "portable".
+       However, the pattern highlighted is expected to be "shared" or "uncontended".
+|}]
+
+(* closing over a shared variable without using it can be portable *)
 let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> ()
 [%%expect{|
-Line 1, characters 62-76:
-1 | let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> ()
-                                                                  ^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "shareable",
-       but expected to be "portable".
+val foo : 'a @ portable shared -> (unit -> unit) @ portable = <fun>
 |}]
 
-(* closing over corrupted gives corruptible *)
+(* closing over corrupted use gives corruptible *)
+let use_corrupted (x @ corrupted) = ()
+[%%expect{|
+val use_corrupted : 'a @ corrupted -> unit = <fun>
+|}]
+
+let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> use_corrupted a
+[%%expect{|
+Line 1, characters 69-70:
+1 | let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> use_corrupted a
+                                                                         ^
+Error: The pattern is "contended"
+         because it is used inside the function at line 1, characters 65-92
+         which is expected to be "portable".
+       However, the pattern highlighted is expected to be "corrupted" or "uncontended".
+|}]
+
+(* closing over corrupted without using it can be portable *)
 let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> ()
 [%%expect{|
-Line 1, characters 65-79:
-1 | let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> ()
-                                                                     ^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "corruptible",
-       but expected to be "portable".
+val foo : 'a @ portable corrupted -> (unit -> unit) @ portable = <fun>
 |}]
-(* CR modes: These four tests are in principle fine to allow (they don't cause a data
-   race), since a is never used *)
 
 let foo : ('a @ contended portable -> (string -> string) @ portable) @ nonportable contended = fun a b -> best_bytes ()
 (* CR layouts v2.8: arrows should cross contention. Internal ticket 5121. *)

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -2259,10 +2259,10 @@ Error: Signature mismatch:
          val f : unit -> unit (* in a structure at stateful *)
        is not included in
          val f : unit -> unit @@ stateless (* in a structure at stateful *)
-       The first is weaker than "writing"
-         because it contains a usage (of the value "r" at line 5, characters 25-26)
-         which is expected to be "write" or "read_write"
-         because its mutable field "contents" is being written.
+       The first is weaker than "reading"
+         because it contains a usage (of the value "r" at line 5, characters 13-14)
+         which is expected to be "read" or "read_write"
+         because its mutable field "contents" is being read.
        However, the second is "stateless".
 |}]
 

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -744,31 +744,37 @@ Error: This value is "reading"
 let foo : int Atomic.t @ read_write -> (unit -> int) @ stateless =
     fun a () -> Atomic.exchange a 2
 [%%expect{|
-Line 2, characters 4-35:
+Line 2, characters 8-9:
 2 |     fun a () -> Atomic.exchange a 2
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "stateful",
-       but expected to be "stateless".
+            ^
+Error: The pattern is "immutable"
+         because it is used inside the function at line 2, characters 4-35
+         which is expected to be "stateless".
+       However, the pattern highlighted is expected to be "read_write".
 |}]
 
 let foo : int Atomic.t @ write -> (unit -> unit) @ stateless =
     fun a () -> Atomic.set a 2
 [%%expect{|
-Line 2, characters 4-30:
+Line 2, characters 8-9:
 2 |     fun a () -> Atomic.set a 2
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "writing",
-       but expected to be "stateless".
+            ^
+Error: The pattern is "immutable"
+         because it is used inside the function at line 2, characters 4-30
+         which is expected to be "stateless".
+       However, the pattern highlighted is expected to be "write" or "read_write".
 |}]
 
 let foo : int Atomic.t @ read -> (unit -> int) @ stateless =
     fun a () -> Atomic.get a
 [%%expect{|
-Line 2, characters 4-28:
+Line 2, characters 8-9:
 2 |     fun a () -> Atomic.get a
-        ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "reading",
-       but expected to be "stateless".
+            ^
+Error: The pattern is "immutable"
+         because it is used inside the function at line 2, characters 4-28
+         which is expected to be "stateless".
+       However, the pattern highlighted is expected to be "read" or "read_write".
 |}]
 
 let foo @ stateless =
@@ -2259,10 +2265,10 @@ Error: Signature mismatch:
          val f : unit -> unit (* in a structure at stateful *)
        is not included in
          val f : unit -> unit @@ stateless (* in a structure at stateful *)
-       The first is weaker than "reading"
-         because it contains a usage (of the value "r" at line 5, characters 13-14)
-         which is expected to be "read" or "read_write"
-         because its mutable field "contents" is being read.
+       The first is weaker than "writing"
+         because it contains a usage (of the value "r" at line 5, characters 25-26)
+         which is expected to be "write" or "read_write"
+         because its mutable field "contents" is being written.
        However, the second is "stateless".
 |}]
 

--- a/testsuite/tests/typing-modes/test_morph_compose.ml
+++ b/testsuite/tests/typing-modes/test_morph_compose.ml
@@ -4,7 +4,15 @@
 *)
 
 let () =
-  Printf.printf
-    "running allowed composition checks with partial coverage (spanning values \
-     cover each axis element at least once; not every product combination)\n%!";
-  Mode.For_testing.check_jobs ~full:false () |> List.iter (fun job -> job ())
+  Mode.For_testing.check_composition_jobs ~full:false ()
+  |> List.iter (fun job ->
+    match job () with
+    | Ok () -> ()
+    | Error error ->
+      failwith
+        (Format_doc.asprintf "%a"
+           Mode.For_testing.print_error
+           error));
+  print_endline
+    "All partial-coverage morphism composition checks succeeded: composed \
+     morphisms agree with applying each morphism in sequence."

--- a/testsuite/tests/typing-modes/test_morph_compose.ml
+++ b/testsuite/tests/typing-modes/test_morph_compose.ml
@@ -1,0 +1,10 @@
+(* TEST
+ include ocamlcommon;
+ native;
+*)
+
+let () =
+  Printf.printf
+    "running allowed composition checks with partial coverage (spanning values \
+     cover each axis element at least once; not every product combination)\n%!";
+  Mode.For_testing.check_jobs ~full:false () |> List.iter (fun job -> job ())

--- a/testsuite/tests/typing-modes/test_morph_compose.reference
+++ b/testsuite/tests/typing-modes/test_morph_compose.reference
@@ -1,0 +1,1 @@
+running allowed composition checks with partial coverage (spanning values cover each axis element at least once; not every product combination)

--- a/testsuite/tests/typing-modes/test_morph_compose.reference
+++ b/testsuite/tests/typing-modes/test_morph_compose.reference
@@ -1,1 +1,1 @@
-running allowed composition checks with partial coverage (spanning values cover each axis element at least once; not every product combination)
+All partial-coverage morphism composition checks succeeded: composed morphisms agree with applying each morphism in sequence.

--- a/testsuite/tests/typing-unique/borrow.ml
+++ b/testsuite/tests/typing-unique/borrow.ml
@@ -17,7 +17,7 @@ let local_aliased_use (local_ a) = ()
 val local_aliased_use : 'a @ local -> unit = <fun>
 |}]
 
-let unique_aliased_use (x @ local unique) (local_ y) = ()
+let unique_aliased_use (x @ local unique) (local_ y) = unique_use x; ()
 [%%expect{|
 val unique_aliased_use : 'a @ local unique -> 'b @ local -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -37,14 +37,14 @@ Uncaught exception: Misc.Fatal_error
 (*************************************)
 (* Checking uniqueness of overwrites *)
 
-let id = function x -> x
+let use_aliased (x @ aliased) = x
 
 let overwrite_shared (r : record_update) =
-  let r = id r in
+  let r = use_aliased r in
   let x = overwrite_ r with { x = "foo" } in
   x.x
 [%%expect{|
-val id : 'a -> 'a = <fun>
+val use_aliased : 'a -> 'a = <fun>
 Line 5, characters 21-22:
 5 |   let x = overwrite_ r with { x = "foo" } in
                          ^

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -15,16 +15,16 @@ type record = { x : string; y : string @@ many aliased }
 type record = { x : string; y : string @@ many aliased; }
 |}]
 
-let aliased_use x = x
+let aliased_use (x @ aliased global) = x
 [%%expect{|
-(let (aliased_use/290 = (function {nlocal = 0} x/292? x/292))
+(let (aliased_use/290 = (function {nlocal = 1} x/292? : local x/292))
   (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/290))
 val aliased_use : 'a -> 'a = <fun>
 |}]
 
-let unique_use (x @ unique) = x
+let unique_use (x @ unique global) = x
 [%%expect{|
-(let (unique_use/293 = (function {nlocal = 0} x/295? x/295))
+(let (unique_use/293 = (function {nlocal = 1} x/295? : local x/295))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/293))
 val unique_use : 'a @ unique -> 'a = <fun>
 |}]
@@ -38,7 +38,7 @@ let proj_aliased r =
 (let
   (aliased_use/290 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    proj_aliased/296 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/298[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -60,7 +60,7 @@ let proj_unique r =
 (let
   (unique_use/293 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    proj_unique/301 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/303[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -85,7 +85,7 @@ let match_aliased r =
 (let
   (aliased_use/290 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_aliased/306 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/308[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -108,7 +108,7 @@ let match_unique r =
 (let
   (unique_use/293 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_unique/312 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/314[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -134,7 +134,7 @@ let match_mini_anf_aliased r =
 (let
   (aliased_use/290 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_mini_anf_aliased/318 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/320[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -161,7 +161,7 @@ let match_mini_anf_unique r =
 (let
   (unique_use/293 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_mini_anf_unique/328 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/330[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -189,7 +189,7 @@ let match_anf_aliased r =
 (let
   (aliased_use/290 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_anf_aliased/338 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/340[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -222,7 +222,7 @@ let match_anf_unique r =
 (let
   (unique_use/293 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_anf_unique/350 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/352[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
@@ -266,7 +266,7 @@ let swap_inner (t : tree) =
 [%%expect{|
 (let
   (swap_inner/368 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        t/370[value<
               (consts (0))
                (non_consts ([0:
@@ -286,38 +286,13 @@ let swap_inner (t : tree) =
                          (consts (0)) (non_consts ([0: *, value<int>, *]))>]))
        (catch
          (if t/370
-           (let (*match*/379 =a? (field_imm 0 t/370))
+           (let (*match*/379 =o? (field_mut 0 t/370))
              (if *match*/379
-               (let (*match*/383 =a? (field_imm 2 t/370))
+               (let
+                 (lr/371 =o? (field_mut 2 *match*/379)
+                  *match*/383 =o? (field_mut 2 t/370))
                  (if *match*/383
-                   (makeblock 0 (value<
-                                  (consts (0))
-                                   (non_consts ([0:
-                                                 value<
-                                                  (consts (0))
-                                                   (non_consts ([0: *,
-                                                                 value<int>,
-                                                                 *]))>,
-                                                 value<int>,
-                                                 value<
-                                                  (consts (0))
-                                                   (non_consts ([0: *,
-                                                                 value<int>,
-                                                                 *]))>]))>,
-                     value<int>,value<
-                                 (consts (0))
-                                  (non_consts ([0:
-                                                value<
-                                                 (consts (0))
-                                                  (non_consts ([0: *,
-                                                                value<int>,
-                                                                *]))>,
-                                                value<int>,
-                                                value<
-                                                 (consts (0))
-                                                  (non_consts ([0: *,
-                                                                value<int>,
-                                                                *]))>]))>)
+                   (let (rl/373 =o? (field_mut 0 *match*/383))
                      (makeblock 0 (value<
                                     (consts (0))
                                      (non_consts ([0:
@@ -346,39 +321,67 @@ let swap_inner (t : tree) =
                                                     (non_consts ([0: *,
                                                                   value<int>,
                                                                   *]))>]))>)
-                       (field_imm 0 *match*/379) (field_int 1 *match*/379)
-                       (field_imm 0 *match*/383))
-                     (field_int 1 t/370)
-                     (makeblock 0 (value<
-                                    (consts (0))
-                                     (non_consts ([0:
-                                                   value<
-                                                    (consts (0))
-                                                     (non_consts ([0: *,
-                                                                   value<int>,
-                                                                   *]))>,
-                                                   value<int>,
-                                                   value<
-                                                    (consts (0))
-                                                     (non_consts ([0: *,
-                                                                   value<int>,
-                                                                   *]))>]))>,
-                       value<int>,value<
-                                   (consts (0))
-                                    (non_consts ([0:
-                                                  value<
-                                                   (consts (0))
-                                                    (non_consts ([0: *,
-                                                                  value<int>,
-                                                                  *]))>,
-                                                  value<int>,
-                                                  value<
-                                                   (consts (0))
-                                                    (non_consts ([0: *,
-                                                                  value<int>,
-                                                                  *]))>]))>)
-                       (field_imm 2 *match*/379) (field_int 1 *match*/383)
-                       (field_imm 2 *match*/383)))
+                       (makeblock 0 (value<
+                                      (consts (0))
+                                       (non_consts ([0:
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                     value<int>,
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>,
+                         value<int>,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                    value<int>,
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>)
+                         (field_imm 0 *match*/379) (field_int 1 *match*/379)
+                         rl/373)
+                       (field_int 1 t/370)
+                       (makeblock 0 (value<
+                                      (consts (0))
+                                       (non_consts ([0:
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                     value<int>,
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>,
+                         value<int>,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>,
+                                                    value<int>,
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: *,
+                                                                    value<
+                                                                    int>, *]))>]))>)
+                         lr/371 (field_int 1 *match*/383)
+                         (field_imm 2 *match*/383))))
                    (exit 19)))
                (exit 19)))
            (exit 19))
@@ -416,7 +419,7 @@ let match_guard r =
   (unique_use/293 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    aliased_use/290 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_guard/386 =
-     (function {nlocal = 0}
+     (function {nlocal = 1}
        r/388[value<(consts ()) (non_consts ([0: *, *]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -448,7 +448,7 @@ let curry =
   foo ~a:3 ~c:4
 [%%expect{|
 val curry :
-  b:'_weak3 @ unique -> d:'_weak4 @ unique -> int * '_weak3 * int * '_weak4 =
+  b:'_weak3 @ unique -> (d:'_weak4 @ unique -> int * '_weak3 * int * '_weak4) =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -368,7 +368,7 @@ val inf6 : 'a @ unique -> 'a = <fun>
 
 let unique_default_args ?(x @ unique = 1.0) () = x
 [%%expect{|
-val unique_default_args : ?x:float @ unique -> unit -> float = <fun>
+val unique_default_args : ?x:float @ unique -> (unit -> float) = <fun>
 |}]
 
 (* Unique Local *)
@@ -507,7 +507,7 @@ type box = { x : int; }
 
 let curry (b1 : box @ unique) (b2 : box @ unique) = ()
 [%%expect{|
-val curry : box @ unique -> box @ unique -> unit = <fun>
+val curry : box @ unique -> (box @ unique -> unit) = <fun>
 |}]
 
 let curry : box @ unique -> box @ unique -> unit = fun b1 b2 -> ()
@@ -515,22 +515,31 @@ let curry : box @ unique -> box @ unique -> unit = fun b1 b2 -> ()
 val curry : box @ unique -> box @ unique -> unit = <fun>
 |}]
 
-let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> ()
+let use_unique (x @ unique) = ()
 [%%expect{|
-Line 1, characters 53-68:
-1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> ()
-                                                         ^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "once",
-       but expected to be "many".
+val use_unique : 'a @ unique -> unit = <fun>
 |}]
 
-let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> ()
+let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> use_unique b1; ()
 [%%expect{|
-Line 1, characters 53-82:
-1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> ()
-                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "once",
-       but expected to be "many".
+Line 1, characters 57-59:
+1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> use_unique b1; ()
+                                                             ^^
+Error: The pattern is "aliased"
+         because it is used inside the function at line 1, characters 53-83
+         which is expected to be "many".
+       However, the pattern highlighted is expected to be "unique".
+|}]
+
+let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> use_unique b1; ()
+[%%expect{|
+Line 1, characters 57-59:
+1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> use_unique b1; ()
+                                                             ^^
+Error: The pattern is "aliased"
+         because it is used inside the function at line 1, characters 53-97
+         which is expected to be "many".
+       However, the pattern highlighted is expected to be "unique".
 |}]
 
 (* For nested functions, inner functions are not constrained *)

--- a/testsuite/tests/typing-unique/unique_documentation.ml
+++ b/testsuite/tests/typing-unique/unique_documentation.ml
@@ -308,14 +308,14 @@ let check_tuple x y z =
     | p, q, r -> free p
   in m, y, y
 [%%expect{|
-val check_tuple : t @ unique -> 'a -> 'b -> unit * 'a * 'a = <fun>
+val check_tuple : t @ unique -> 'a -> ('b -> unit * 'a * 'a) = <fun>
 |}]
 
 let okay x y z =
   match x, y, z with
   | p, q, r -> free x.field1; free p.field2
 [%%expect{|
-val okay : t @ unique -> 'a -> 'b -> unit = <fun>
+val okay : t @ unique -> 'a -> ('b -> unit) = <fun>
 |}]
 
 let bad x y z =

--- a/typing/allowance.ml
+++ b/typing/allowance.ml
@@ -22,6 +22,8 @@ type right_only = disallowed * allowed
 
 type both = allowed * allowed
 
+type neither = disallowed * disallowed
+
 type 'a pos = 'b * 'c constraint 'a = 'b * 'c
 
 type 'a neg = 'c * 'b constraint 'a = 'b * 'c

--- a/typing/allowance.mli
+++ b/typing/allowance.mli
@@ -47,6 +47,8 @@ type right_only = disallowed * allowed
 
 type both = allowed * allowed
 
+type neither = disallowed * disallowed
+
 (** Arrange the permissions appropriately for a positive lattice, by doing
     nothing. *)
 type 'a pos = 'b * 'c constraint 'a = 'b * 'c

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -109,7 +109,7 @@ end
 
 (**** Type level management ****)
 
-let generic_level = Ident.highest_scope
+let generic_level = Mode.Alloc.generic_level
 let lowest_level = Ident.lowest_scope
 
 (**** Some type creators ****)
@@ -287,11 +287,13 @@ let iter_row f row =
   fold_row (fun () v -> f v) () row
 
 
-let fold_type_expr f init ty =
+let fold_type_expr f fm init ty =
   match get_desc ty with
     Tvar _              -> init
-  | Tarrow (_, ty1, ty2, _) ->
-      let result = f init ty1 in
+  | Tarrow ((_, m1, m2), ty1, ty2, _) ->
+      let result = fm init m1 in
+      let result = fm result m2 in
+      let result = f result ty1 in
       f result ty2
   | Ttuple l            -> List.fold_left f init (List.map snd l)
   | Tunboxed_tuple l    -> List.fold_left f init (List.map snd l)
@@ -322,8 +324,8 @@ let fold_type_expr f init ty =
     List.fold_left (fun result (_n, ty) -> f result ty) init fl
   | Tof_kind _ -> init
 
-let iter_type_expr f ty =
-  fold_type_expr (fun () v -> f v) () ty
+let iter_type_expr f fm ty =
+  fold_type_expr (fun () v -> f v) (fun () v -> fm v) () ty
 
 let rec iter_abbrev f = function
     Mnil                   -> ()
@@ -360,10 +362,11 @@ let iter_type_expr_kind f = function
                   (**********************************)
 
 let rec mark_type mark ty =
-  if try_mark_node mark ty then iter_type_expr (mark_type mark) ty
+  if try_mark_node mark ty then
+    iter_type_expr (mark_type mark) (Fun.const ()) ty
 
 let mark_type_params mark ty =
-  iter_type_expr (mark_type mark) ty
+  iter_type_expr (mark_type mark) (Fun.const ()) ty
 
                   (**********************************)
                   (*  (Object-oriented) iterator    *)
@@ -388,6 +391,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -406,7 +411,7 @@ let type_iterators_without_type_expr =
     | Sig_class_type (_, ctd, _, _) -> it.it_class_type_declaration it ctd
     | Sig_jkind (_ , jkd, _)        -> it.it_jkind_declaration it jkd
   and it_value_description it vd =
-    it.it_type_expr it vd.val_type
+    it.it_type_expr it vd.val_type;
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
@@ -466,19 +471,22 @@ let type_iterators_without_type_expr =
   and it_type_kind it kind =
     iter_type_expr_kind (it.it_type_expr it) kind
   and it_path _p = ()
+  and it_mode_expr _m = ()
+  and it_modality _m = ()
   in
   { it_path; it_type_expr = (fun _ _ -> ()); it_do_type_expr = (fun _ _ -> ());
     it_type_kind; it_class_type; it_functor_param; it_module_type;
     it_signature; it_class_type_declaration; it_class_declaration;
     it_jkind_declaration;
     it_modtype_declaration; it_module_declaration; it_extension_constructor;
-    it_type_declaration; it_value_description; it_signature_item; }
+    it_type_declaration; it_value_description;
+    it_signature_item; it_mode_expr; it_modality }
 
 let type_iterators mark =
   let it_type_expr it ty =
     if try_mark_node mark ty then it.it_do_type_expr it ty
   and it_do_type_expr it ty =
-    iter_type_expr (it.it_type_expr it) ty;
+    iter_type_expr (it.it_type_expr it) (it.it_mode_expr) ty;
     match get_desc ty with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
@@ -530,11 +538,12 @@ let instance_jkind (t : jkind_lr) : jkind_lr =
   | Layout l ->
     { t with jkind = { t.jkind with base = Layout (instance_layout l) } }
 
-let rec copy_type_desc ?(keep_names=false) f = function
+let rec copy_type_desc ?(keep_names=false) f fm = function
     Tvar { name; jkind } ->
      let jkind = instance_jkind jkind in
      if keep_names then Tvar { name; jkind } else Tvar { name=None; jkind }
-  | Tarrow (p, ty1, ty2, c)-> Tarrow (p, f ty1, f ty2, copy_commu c)
+  | Tarrow ((p, m1, m2), ty1, ty2, c)->
+    Tarrow ((p, fm m1, fm m2), f ty1, f ty2, copy_commu c)
   | Ttuple l            -> Ttuple (List.map (fun (label, t) -> label, f t) l)
   | Tunboxed_tuple l    ->
     Tunboxed_tuple (List.map (fun (label, t) -> label, f t) l)
@@ -550,7 +559,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tfield (p, field_kind_internal_repr k, f ty1, f ty2)
       (* the kind is kept shared, with indirections removed for performance *)
   | Tnil                -> Tnil
-  | Tlink ty            -> copy_type_desc f (get_desc ty)
+  | Tlink ty            -> copy_type_desc f fm (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
@@ -567,11 +576,21 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_duplicate: copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
     mutable saved_desc : (transient_expr * type_desc) list;
     (* Save association of generic nodes with their description. *)
+    saved_mode_changes : Mode.copy_scope;
   }
 
   let redirect_desc copy_scope ty desc =
@@ -579,13 +598,26 @@ end = struct
     copy_scope.saved_desc <- (ty, ty.desc) :: copy_scope.saved_desc;
     Transient_expr.set_desc ty desc
 
+  let mode_instantiate copy_scope ~current_level m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.instantiate ~copy_scope ~current_level m
+
+  let mode_copy_generic copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_generic ~copy_scope m
+
+  let mode_duplicate copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.duplicate ~copy_scope m
+
   (* Restore type descriptions. *)
   let cleanup { saved_desc; _ } =
     List.iter (fun (ty, desc) -> Transient_expr.set_desc ty desc) saved_desc
 
   let with_scope f =
-    let scope = { saved_desc = [] } in
-    Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope)
+    Mode.with_copy_scope (fun ms ->
+      let scope = { saved_desc = []; saved_mode_changes = ms } in
+      Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope))
 
 end
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -138,15 +138,20 @@ val set_static_row_name: type_declaration -> Path.t -> unit
 
 (**** Utilities for type traversal ****)
 
-val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
+val iter_type_expr:
+  (type_expr -> unit) -> (Mode.Alloc.lr -> unit) ->
+  type_expr -> unit
         (* Iteration on types *)
-val fold_type_expr: ('a -> type_expr -> 'a) -> 'a -> type_expr -> 'a
+val fold_type_expr:
+  ('a -> type_expr -> 'a) -> ('a -> Mode.Alloc.lr -> 'a) ->
+  'a -> type_expr -> 'a
 val iter_row: (type_expr -> unit) -> row_desc -> unit
         (* Iteration on types in a row *)
 val fold_row: ('a -> type_expr -> 'a) -> 'a -> row_desc -> 'a
 val iter_abbrev: (type_expr -> unit) -> abbrev_memo -> unit
         (* Iteration on types in an abbreviation list *)
-val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
+val iter_type_expr_kind: (type_expr -> unit) ->
+  (type_decl_kind -> unit)
 
 val iter_type_expr_cstr_args: (type_expr -> unit) ->
   (constructor_arguments -> unit)
@@ -181,6 +186,8 @@ type 'a type_iterators =
     it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: 'a type_iterators -> 'a;
     it_type_expr: 'a type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.t -> unit;
     it_path: Path.t -> unit; }
 
 type type_iterators_full = (type_expr -> unit) type_iterators
@@ -197,7 +204,8 @@ val type_iterators_without_type_expr: type_iterators_without_type_expr
 (**** Utilities for copying ****)
 
 val copy_type_desc:
-    ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc
+    ?keep_names:bool -> (type_expr -> type_expr) ->
+    (Mode.Alloc.lr -> Mode.Alloc.lr) -> type_desc -> type_desc
         (* Copy on types *)
 val copy_row:
     (type_expr -> type_expr) ->
@@ -216,6 +224,20 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
         (* Temporarily change a type description *)
+
+  val mode_instantiate :
+    copy_scope -> current_level:int ->
+    Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Instantiates a generic mode variable to level [current_level] *)
+
+  val mode_copy_generic :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Copies the generic parts of a mode variable
+           without changing its level *)
+
+  val mode_duplicate :
+    copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+        (* Copies a mode variable without changing its level *)
 
   val with_scope: (copy_scope -> 'a) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8577,10 +8577,9 @@ let check_constructor_crossing_destruction
         (fun () -> Ok min_bound))
     env lid tag ~res ~args held_locks
 
-let apply_is_contained_by is_contained_by ?(modalities = Modality.Const.id)
-  mode =
-  let hint =
-    { monadic = Hint.Is_contained_by (Monadic, is_contained_by);
-      comonadic = Hint.Is_contained_by (Comonadic, is_contained_by) }
-  in
-  Modality.Const.apply ~hint modalities mode
+let apply_left_is_contained_by is_contained_by ?(modalities = Modality.Const.id)
+  mode = Modality.Const.apply_left ~is_contained_by modalities mode
+
+let apply_right_is_contained_by is_contained_by
+  ?(modalities = Modality.Const.id) mode =
+  Modality.Const.apply_right ~is_contained_by modalities mode

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -443,7 +443,7 @@ let decr_stage env =
 let incr_stage env =
   Env.enter_quotation env
 
-let iter_type_expr_with_stages f env ty =
+let iter_type_expr_with_stages f env fm ty =
   match get_desc ty with
   | Tquote ty ->
     f (incr_stage env) ty
@@ -452,7 +452,7 @@ let iter_type_expr_with_stages f env ty =
   | Tquote_eval ty ->
     f (incr_stage env) ty
   | _ ->
-    iter_type_expr (f env) ty
+    iter_type_expr (f env) fm ty
 
 (* CR metaprogramming jbachurski: We use this to adjust the environment while
    printing error messages. The original type may have been well-staged,
@@ -477,6 +477,7 @@ let contains_toplevel_splice stage ty =
       in
       fold_type_expr
         (fun x y -> x || loop (acc + offset) y)
+        (fun a _ -> a)
         (acc < 0) ty
     end
   in
@@ -678,7 +679,7 @@ let rec filter_row_fields erase = function
       | _ -> p :: fi
 
 (* Ensure all mode variables are fully determined *)
-let remove_mode_and_jkind_variables ty =
+let remove_mode_and_jkind_variables ~zap_scope ty =
   let visited = ref TypeSet.empty in
   let rec go ty =
     if TypeSet.mem ty !visited then () else begin
@@ -687,10 +688,15 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-         let _ = Alloc.zap_to_legacy marg in
-         let _ = Alloc.zap_to_legacy mret in
+         if Language_extension.(is_at_least Mode_polymorphism Beta) then begin
+          Alloc.add_mode_to_zap_scope marg zap_scope;
+          Alloc.add_mode_to_zap_scope mret zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force marg |> ignore;
+          Alloc.zap_to_legacy_force mret |> ignore
+         end;
          go targ; go tret
-      | _ -> iter_type_expr go ty
+      | _ -> iter_type_expr go (Fun.const ()) ty
     end
   in go ty
 
@@ -746,7 +752,7 @@ let[@inline] free_vars ~zero ~add_one ?env mark tys =
           if static_row row then acc
           else fv ~kind:Row_variable acc (row_more row)
       | _    ->
-          fold_type_expr (fv ~kind) acc ty
+          fold_type_expr (fv ~kind) (fun acc _ -> acc) acc ty
   in
   List.fold_left (fv ~kind:Type_variable) zero tys
 
@@ -792,20 +798,20 @@ let closed_type_expr ?env ty =
     try closed_type ?env mark ty; true
     with Non_closed _ -> false)
 
-let close_type mark ty =
-  remove_mode_and_jkind_variables ty;
+let close_type ~zap_scope mark ty =
+  remove_mode_and_jkind_variables ~zap_scope ty;
   closed_type mark ty
 
 let closed_parameterized_type params ty =
   with_type_mark begin fun mark ->
     List.iter (mark_type mark) params;
-    try close_type mark ty; true with Non_closed _ -> false
+    try Alloc.with_zap_scope close_type mark ty; true with Non_closed _ -> false
   end
 
-let closed_type_decl decl =
+let closed_type_decl ~zap_scope decl =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) decl.type_params;
-    List.iter remove_mode_and_jkind_variables decl.type_params;
+    List.iter (remove_mode_and_jkind_variables ~zap_scope) decl.type_params;
     begin match decl.type_kind with
       Type_abstract _ ->
         ()
@@ -819,30 +825,32 @@ let closed_type_decl decl =
                    them. Test case: typing-layouts-gadt-sort-var/test.ml *)
                 begin match cd_args with
                 | Cstr_tuple l -> List.iter (fun ca ->
-                    remove_mode_and_jkind_variables ca.ca_type) l
+                    remove_mode_and_jkind_variables ~zap_scope ca.ca_type) l
                 | Cstr_record l -> List.iter (fun l ->
-                    remove_mode_and_jkind_variables l.ld_type) l
+                    remove_mode_and_jkind_variables ~zap_scope l.ld_type) l
                 end;
-                remove_mode_and_jkind_variables res_ty
-            | None -> List.iter (close_type mark) (tys_of_constr_args cd_args)
+                remove_mode_and_jkind_variables ~zap_scope res_ty
+            | None ->
+              List.iter (close_type mark ~zap_scope)
+                (tys_of_constr_args cd_args)
           )
           v
     | Type_record(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_record_unboxed_product(r, _rep, _) ->
-        List.iter (fun l -> close_type mark l.ld_type) r
+        List.iter (fun l -> close_type mark ~zap_scope l.ld_type) r
     | Type_open -> ()
     end;
     begin match decl.type_manifest with
       None    -> ()
-    | Some ty -> close_type mark ty
+    | Some ty -> close_type mark ~zap_scope ty
     end;
     None
   with Non_closed (ty, _) ->
     Some ty
   end
 
-let closed_extension_constructor ext =
+let closed_extension_constructor ~zap_scope ext =
   with_type_mark begin fun mark -> try
     List.iter (mark_type mark) ext.ext_type_params;
     begin match ext.ext_ret_type with
@@ -850,10 +858,12 @@ let closed_extension_constructor ext =
         (* gadts cannot have free type variables, but they might
            have undefaulted sort variables; these lines default
            them. Test case: typing-layouts-gadt-sort-var/test_extensible.ml *)
-        iter_type_expr_cstr_args remove_mode_and_jkind_variables ext.ext_args;
-        remove_mode_and_jkind_variables res_ty
+        iter_type_expr_cstr_args
+          (remove_mode_and_jkind_variables ~zap_scope)
+          ext.ext_args;
+        remove_mode_and_jkind_variables ~zap_scope res_ty
     | None ->
-        iter_type_expr_cstr_args (close_type mark) ext.ext_args
+        iter_type_expr_cstr_args (close_type mark ~zap_scope) ext.ext_args
     end;
     None
   with Non_closed (ty, _) ->
@@ -867,7 +877,7 @@ type closed_class_failure = {
 }
 exception CCFailure of closed_class_failure
 
-let closed_class params sign =
+let closed_class ~zap_scope params sign =
   with_type_mark begin fun mark ->
   List.iter (mark_type mark) params;
   ignore (try_mark_node mark sign.csig_self_row);
@@ -875,7 +885,8 @@ let closed_class params sign =
     Meths.iter
       (fun lab (priv, _, ty) ->
         if priv = Mpublic then begin
-          try close_type mark ty with Non_closed (ty0, variable_kind) ->
+          try close_type ~zap_scope mark ty
+          with Non_closed (ty0, variable_kind) ->
             raise (CCFailure {
               free_variable = (ty0, variable_kind);
               meth = lab;
@@ -906,10 +917,11 @@ let duplicate_class_type ty =
                          (*  Type level manipulation  *)
                          (*****************************)
 
+(* CR ageorges: lower the level of mode variables as well? *)
 let rec lower_all ty =
   if get_level ty > !current_level then begin
     set_level ty !current_level;
-    iter_type_expr lower_all ty
+    iter_type_expr lower_all (Fun.const ()) ty
   end
 
 (*
@@ -921,7 +933,8 @@ let rec lower_all ty =
 *)
 let rec generalize stage_offset ty =
   let level = get_level ty in
-  if (level > !current_level) && (level <> generic_level) then begin
+  let current_level = !current_level in
+  if (level > current_level) && (level <> generic_level) then begin
     set_level ty generic_level;
     begin match get_desc ty with
     (* Keep track of [stage_offset] *)
@@ -934,7 +947,7 @@ let rec generalize stage_offset ty =
     (* Normalize the variable to be at [stage_offset = 0] *)
     | Tvar name ->
         update_variable_stage stage_offset ty name.name name.jkind;
-        Jkind.generalize ~current_level:!current_level name.jkind
+        Jkind.generalize ~current_level name.jkind
     (* Do not generalize cross-stage row-polymorphic types, as we cannot
        quote or splice row variables.
        Weak type variables that arise here are considered cross-stage,
@@ -948,10 +961,13 @@ let rec generalize stage_offset ty =
         lower_all ty
     (* recur into abbrev for the speed *)
     | Tconstr (_, _, abbrev) ->
+        let mgen m = Mode.Alloc.generalize ~current_level m in
         iter_abbrev (generalize stage_offset) !abbrev;
-        iter_type_expr (generalize stage_offset) ty
+        iter_type_expr (generalize stage_offset) mgen ty
     | _ ->
-        iter_type_expr (generalize stage_offset) ty
+
+      let mgen m = Mode.Alloc.generalize ~current_level m in
+      iter_type_expr (generalize stage_offset) mgen ty
     end;
   end
 
@@ -963,17 +979,19 @@ let generalize ty =
 
 let rec generalize_structure ty =
   let level = get_level ty in
+  let current_level = !current_level in
   if level <> generic_level then begin
-    if is_Tvar ty && level > !current_level then
-      set_level ty !current_level
-    else if level > !current_level then begin
+    if is_Tvar ty && level > current_level then
+      set_level ty current_level
+    else if level > current_level then begin
       begin match get_desc ty with
         Tconstr (_, _, abbrev) ->
           abbrev := Mnil
       | _ -> ()
       end;
       set_level ty generic_level;
-      iter_type_expr generalize_structure ty
+      let mgen m = Mode.Alloc.generalize_structure ~current_level m in
+      iter_type_expr generalize_structure mgen ty
     end
   end
 
@@ -985,10 +1003,13 @@ let generalize_structure ty =
 
 let rec generalize_spine ty =
   let level = get_level ty in
-  if level < !current_level || level = generic_level then () else
+  let current_level = !current_level in
+  if level < current_level || level = generic_level then () else
   match get_desc ty with
-    Tarrow (_, ty1, ty2, _) ->
+    Tarrow ((_, m1, m2), ty1, ty2, _) ->
       set_level ty generic_level;
+      Mode.Alloc.generalize ~current_level m1;
+      Mode.Alloc.generalize ~current_level m2;
       generalize_spine ty1;
       generalize_spine ty2;
   | Tpoly (ty', _) ->
@@ -1008,6 +1029,9 @@ let rec generalize_spine ty =
       memo := Mnil;
       List.iter generalize_spine tyl
   | _ -> ()
+
+let generalize_spine ty =
+  generalize_spine ty
 
 let forward_try_expand_safe = (* Forward declaration *)
   ref (fun _env _ty -> assert false)
@@ -1053,7 +1077,7 @@ let rec check_scope_escape mark env level ty =
           (newty2 ~level:orig_level (Tpackage (p', fl)))
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> check_scope_escape mark env level) env ty
+          (fun env -> check_scope_escape mark env level) env (Fun.const ()) ty
     end;
   end
 
@@ -1069,7 +1093,8 @@ let rec update_scope scope ty =
     if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
     (* Only recurse in principal mode as this is not necessary for soundness *)
-    if !Clflags.principal then iter_type_expr (update_scope scope) ty
+    if !Clflags.principal then
+      iter_type_expr (update_scope scope) (Fun.const ()) ty
   end
 
 let update_scope_for tr_exn scope ty =
@@ -1115,7 +1140,8 @@ let rec update_level env level expand ty =
           update_level env level expand ty'
         with Cannot_expand ->
           set_level ty level;
-          iter_type_expr (update_level env level expand) ty
+          iter_type_expr (update_level env level expand)
+            (Mode.Alloc.update_level level) ty
         end
     | Tpackage (p, fl) when level < Path.scope p ->
         let p' = normalize_package_path env p in
@@ -1133,7 +1159,8 @@ let rec update_level env level expand ty =
         | _ -> ()
         end;
         set_level ty level;
-        iter_type_expr (update_level env level expand) ty
+        iter_type_expr (update_level env level expand)
+          (Mode.Alloc.update_level level) ty
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && level < get_scope ty1 ->
         raise_escape_exn Self
@@ -1141,7 +1168,8 @@ let rec update_level env level expand ty =
         set_level ty level;
         (* XXX what about abbreviations in Tconstr ? *)
         iter_type_expr_with_stages
-          (fun env -> update_level env level expand) env ty
+          (fun env -> update_level env level expand) env
+          (Mode.Alloc.update_level level) ty
   end
 
 (* First try without expanding, then expand everything,
@@ -1203,12 +1231,15 @@ let rec lower_contravariant env var_level visited contra ty =
           else not_expanded ()
     | Tpackage (_, fl) ->
         List.iter (fun (_n, ty) -> lower_rec true ty) fl
-    | Tarrow (_, t1, t2, _) ->
+    | Tarrow ((_, m1, m2), t1, t2, _) ->
+        Mode.Alloc.update_level var_level m1;
+        if contra then Mode.Alloc.update_level var_level m2;
         lower_rec true t1;
         lower_rec contra t2
     | _ ->
         iter_type_expr_with_stages
-          (fun env -> lower_contravariant env var_level visited contra) env ty
+          (fun env -> lower_contravariant env var_level visited contra)
+          env (Fun.const ()) ty
   end
 
 let lower_variables_only env level ty =
@@ -1258,7 +1289,7 @@ let limited_generalize ty0 ty =
           (* XXX: why generic_level needs to be a root *)
           if (level = generic_level) || eq_type ty ty0 then
             roots := ty :: !roots;
-          iter_type_expr (inverse [ty]) ty
+          iter_type_expr (inverse [ty]) (Fun.const ()) ty
         end
   in
 
@@ -1302,7 +1333,7 @@ let rec inv_type hash pty ty =
   with Not_found ->
     let inv = { inv_type = ty; inv_parents = pty } in
     TypeHash.add hash ty inv;
-    iter_type_expr (inv_type hash [inv]) ty
+    iter_type_expr (inv_type hash [inv]) (Fun.const ()) ty
 
 let compute_univars ty =
   let inverted = TypeHash.create 17 in
@@ -1332,7 +1363,8 @@ let fully_generic ty =
   with_type_mark begin fun mark ->
     let rec aux ty =
       if try_mark_node mark ty then
-        if get_level ty = generic_level then iter_type_expr aux ty
+        if get_level ty = generic_level then
+          iter_type_expr aux (Fun.const ()) ty
         else raise Exit
     in
     try aux ty; true with Exit -> false
@@ -1486,7 +1518,11 @@ let rec copy ?partial ?keep_names copy_scope ty =
           Tunivar { name; jkind = Jkind.instance jkind }
       | Tobject (ty1, _) when partial <> None ->
           Tobject (copy ty1, ref None)
-      | _ -> copy_type_desc ?keep_names copy desc
+      | _ ->
+        let copy_mode =
+          For_copy.mode_instantiate copy_scope ~current_level:!current_level
+        in
+        copy_type_desc ?keep_names copy copy_mode desc
     in
     Transient_expr.set_stub_desc t desc';
     t
@@ -1784,7 +1820,11 @@ let copy_sep ~copy_scope ~fixed ~partial ~bound_univars
             Tfield (p, field_kind_internal_repr k,
                     copy_rec ~may_share:true ty1,
                     copy_rec ~may_share:false ty2)
-        | desc -> copy_type_desc (copy_rec ~may_share:true) desc
+        | desc ->
+          let copy_mode =
+            For_copy.mode_instantiate copy_scope ~current_level:!current_level
+          in
+          copy_type_desc (copy_rec ~may_share:true) copy_mode desc
       in
       Transient_expr.set_stub_desc t desc';
       t
@@ -1925,9 +1965,9 @@ let prim_mode' mvars = function
     | None -> assert false
 
 (* Exported version. *)
-let prim_mode mvar prim =
+let prim_mode mvar prim ~level =
   let mvar = Option.map
-    (fun mvar_l -> mvar_l, (Forkable.newvar (), Yielding.newvar ())) mvar
+    (fun mvar_l -> mvar_l, (Forkable.newvar level, Yielding.newvar level)) mvar
   in
   fst (prim_mode' mvar prim)
 
@@ -1937,7 +1977,7 @@ let prim_mode mvar prim =
 let with_locality_and_forkable_yielding (locality, fy) m =
   let forkable = Option.map fst fy in
   let yielding = Option.map snd fy in
-  let m' = Alloc.newvar () in
+  let m' = Alloc.newvar 0 in
   Locality.equate_exn (Alloc.proj_comonadic Areality m') locality;
   let forkable =
     Option.value ~default:(Alloc.proj_comonadic Forkable m) forkable
@@ -1964,7 +2004,12 @@ comonadic axes of [B -> C] reflect that.
 On the other hand, the monadic axes of [fun b -> ...] won't be constrained by
 this (but maybe constrained by other things); therefore, we take it to be legacy
 for compatibility. *)
-let curry_mode alloc arg : Alloc.Const.t =
+let curry_mode (type r)
+    (alloc : (allowed * r) Alloc.Comonadic.t)
+    (arg : Alloc.lr) : Alloc.Comonadic.l =
+  Alloc.Comonadic.join
+    [(Alloc.close_over arg).comonadic; (Alloc.Comonadic.disallow_right alloc)]
+let curry_mode_const alloc arg : Alloc.Const.t =
   let acc =
     Alloc.Comonadic.Const.join
       (Alloc.Const.close_over arg)
@@ -1987,9 +2032,14 @@ let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
      in
      let mret =
        match locals with
-       | [] -> with_locality_and_forkable_yielding (loc, yld) mret
+       | [] ->
+         with_locality_and_forkable_yielding
+           (loc, yld) mret
        | _ :: _ ->
-          let mret', _ = Alloc.newvar_above macc in (* curried arrow *)
+          (* curried arrow *)
+          let mret', _ =
+            Alloc.newvar_above (get_current_level ()) macc
+          in
           mret'
      in
      let ret = instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ret in
@@ -2055,7 +2105,7 @@ let instance_prim_layout env (desc : Primitive.description) ty =
           | _ -> ())
         | _ -> ()
         end;
-        iter_type_expr (inner mark) ty
+        iter_type_expr (inner mark) (Fun.const ()) ty
       end
     in
     with_type_mark (fun mark -> inner mark ty);
@@ -2072,8 +2122,8 @@ let instance_prim_mode (desc : Primitive.description) ty =
   let is_poly = function Primitive.Prim_poly, _ -> true | _ -> false in
   if is_poly desc.prim_native_repr_res ||
        List.exists is_poly desc.prim_native_repr_args then
-    let mode_l = Locality.newvar () in
-    let mode_fy = Forkable.newvar (), Yielding.newvar () in
+    let mode_l = Locality.newvar 0 in
+    let mode_fy = Forkable.newvar 0, Yielding.newvar 0 in
     let finalret =
       prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res
     in
@@ -3499,7 +3549,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
         set_type_desc ty (Tunivar {r with jkind = new_jkind})
       | _ -> ()
       end;
-      iter_type_expr (inner mark) ty
+      iter_type_expr (inner mark) (Fun.const ()) ty
     end
   in
   with_type_mark (fun mark -> inner mark ty)
@@ -3577,7 +3627,9 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
         begin try
           if TypeSet.mem ty parents then raise Occur;
           let parents = TypeSet.add ty parents in
-          iter_type_expr (occur_rec env visited allow_recursive parents ty0) ty
+          iter_type_expr
+            (occur_rec env visited allow_recursive parents ty0)
+            (Fun.const ()) ty
         with Occur -> try
           let ty' = try_expand_head try_expand_safe env ty in
           (* This call used to be inlined, but there seems no reason for it.
@@ -3593,7 +3645,8 @@ let rec occur_rec env visited allow_recursive parents ty0 ty =
           let parents = TypeSet.add ty parents in
           iter_type_expr_with_stages
             (fun env -> occur_rec env visited allow_recursive parents ty0)
-            env ty
+            env
+            (Fun.const ()) ty
         end
     end;
     ignore (try_mark_node visited ty)
@@ -3663,8 +3716,10 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
           let visited = get_id ty :: visited in
           iter_type_expr_with_stages
             (fun env ->
-              local_non_recursive_abbrev ~allow_rec true visited env p)
-            env ty
+              local_non_recursive_abbrev
+               ~allow_rec true visited env p)
+            env
+            (Fun.const ()) ty
   end
 
 let local_non_recursive_abbrev uenv p ty =
@@ -3768,7 +3823,9 @@ let occur_univar ?(inj_only=false) env ty =
           with Not_found ->
             if not inj_only then List.iter (occur_rec env bound) tl
           end
-      | _ -> iter_type_expr_with_stages (fun env -> occur_rec env bound) env ty
+      | _ ->
+          iter_type_expr_with_stages
+            (fun env -> occur_rec env bound) env (Fun.const ()) ty
   in
   occur_rec env TypeSet.empty ty
   end
@@ -3822,7 +3879,7 @@ let univars_escape env univar_pairs vl ty =
             List.iter (occur env) tl
           end
       | _ ->
-          iter_type_expr_with_stages occur env t
+          iter_type_expr_with_stages occur env (Fun.const ()) t
     end
   in
   occur env ty
@@ -3948,7 +4005,7 @@ let unexpanded_diff ~got ~expected =
 let rec deep_occur_rec mark t0 ty =
   if get_level ty >= get_level t0 && try_mark_node mark ty then begin
     if eq_type ty t0 then raise Occur;
-    iter_type_expr (deep_occur_rec mark t0) ty
+    iter_type_expr (deep_occur_rec mark t0) (Fun.const ()) ty
   end
 
 (* Return whether [t0] occurs in any type in [tyl]. Objects are also traversed. *)
@@ -4020,7 +4077,7 @@ let reify uenv t =
           end;
           iter_row iterator r
       | _ ->
-          iter_type_expr iterator ty
+          iter_type_expr iterator (Fun.const ()) ty
     end
   in
   iterator t
@@ -4440,7 +4497,7 @@ let find_lowest_level ty =
       if try_mark_node mark ty then begin
         let level = get_level ty in
         if level < !lowest then lowest := level;
-        iter_type_expr find ty
+        iter_type_expr find (Fun.const ()) ty
       end
     in find ty
   end;
@@ -5510,8 +5567,8 @@ let filter_arrow env t l ~force_tpoly =
       end
     in
     let ty_ret = newvar2 level k_res in
-    let arg_mode = Alloc.newvar () in
-    let ret_mode = Alloc.newvar () in
+    let arg_mode = Alloc.newvar level in
+    let ret_mode = Alloc.newvar level in
     let t' =
       newty2 ~level (Tarrow ((l, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok))
     in
@@ -5955,7 +6012,7 @@ let moregen_occur env level ty =
       let lv = get_level ty in
       if lv <= level then () else
       if is_Tvar ty && lv >= generic_level - 1 then raise Occur else
-      if try_mark_node mark ty then iter_type_expr occur ty
+      if try_mark_node mark ty then iter_type_expr occur (Fun.const ()) ty
     in
     try
       occur ty
@@ -6537,7 +6594,7 @@ let rec rigidify_rec mark vars ty =
         if not (static_row row) then
           rigidify_rec mark vars (row_more row)
     | _ ->
-        iter_type_expr (rigidify_rec mark vars) ty
+        iter_type_expr (rigidify_rec mark vars) (Fun.const ()) ty
     end
 
 type var = { name : string option
@@ -7254,19 +7311,19 @@ let find_cltype_for_path env p =
 let has_constr_row' env t =
   has_constr_row (expand_abbrev env t)
 
-let build_submode_pos m =
-  let m', changed = Alloc.newvar_below m in
+let build_submode_pos level m =
+  let m', changed = Alloc.newvar_below level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
-let build_submode_neg m =
-  let m', changed = Alloc.newvar_above m in
+let build_submode_neg level m =
+  let m', changed = Alloc.newvar_above level m in
   let c = if changed then Changed else Unchanged in
   m', c
 
-let build_submode posi m =
-  if posi then build_submode_pos (Alloc.allow_left m)
-  else build_submode_neg (Alloc.allow_right m)
+let build_submode posi level m =
+  if posi then build_submode_pos level (Alloc.allow_left m)
+  else build_submode_neg level (Alloc.allow_right m)
 
 let rec build_subtype env (visited : transient_expr list)
     (loops : (int * type_expr) list) posi level t =
@@ -7297,15 +7354,15 @@ let rec build_subtype env (visited : transient_expr list)
           let posi_arg = not posi in
           if posi_arg then begin
             let a = cross_right_alloc env t1 a in
-            build_submode_pos a
+            build_submode_pos level a
           end else begin
             let a = cross_left_alloc env t1 a in
-            build_submode_neg a
+            build_submode_neg level a
           end
         end else a, Unchanged
       in
       let (r', c4) =
-        if level > 2 then build_submode posi r else r, Unchanged
+        if level > 2 then build_submode posi level r else r, Unchanged
       in
       let c = max_change c1 (max_change c2 (max_change c3 c4)) in
       if c > Unchanged
@@ -7859,6 +7916,7 @@ let add_nongen_vars_in_schema =
           let (_, unexpanded_candidate) as unexpanded_candidate' =
             fold_type_expr
               (loop env)
+              (fun a _ -> a)
               (visited, weak_set)
               ty
           in
@@ -7890,11 +7948,11 @@ let add_nongen_vars_in_schema =
           then loop env (visited, weak_set) (row_more row)
           else (visited, weak_set)
       | _ ->
-          fold_type_expr (loop env) (visited, weak_set) ty
+          fold_type_expr (loop env) (fun a _ -> a) (visited, weak_set) ty
     end
   in
   fun env acc ty ->
-    remove_mode_and_jkind_variables ty;
+    Alloc.with_zap_scope (remove_mode_and_jkind_variables ty);
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 
@@ -8013,7 +8071,7 @@ let rec normalize_type_rec mark ty =
         set_type_desc fi (get_desc fi')
     | _ -> ()
     end;
-    iter_type_expr (normalize_type_rec mark) ty;
+    iter_type_expr (normalize_type_rec mark) (Fun.const ()) ty;
   end
 
 let normalize_type ty =
@@ -8146,7 +8204,7 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
                 Tvariant (set_row_name row None)
             | _ -> Tvariant row
           end
-      | desc -> copy_type_desc (nondep_type_rec env ids) desc
+      | desc -> copy_type_desc (nondep_type_rec env ids) Fun.id desc
     with
     | desc ->
       Transient_expr.set_stub_desc ty' desc;
@@ -8353,7 +8411,8 @@ let rec collapse_conj env visited ty =
         (row_fields row);
       iter_row (collapse_conj env visited) row
   | _ ->
-      iter_type_expr_with_stages (fun env -> collapse_conj env visited) env ty
+      iter_type_expr_with_stages
+        (fun env -> collapse_conj env visited) env (Fun.const ()) ty
 
 let collapse_conj_params env params =
   List.iter (collapse_conj env []) params

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -688,7 +688,7 @@ let remove_mode_and_jkind_variables ~zap_scope ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-         if Language_extension.(is_at_least Mode_polymorphism Beta) then begin
+         if Language_extension.(is_at_least_mode_poly Beta) then begin
           Alloc.add_mode_to_zap_scope marg zap_scope;
           Alloc.add_mode_to_zap_scope mret zap_scope
          end else begin

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -301,18 +301,20 @@ module Pattern_env : sig
     { mutable env : Env.t;
       equations_scope : int;
       allow_recursive_equations : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+      mutable env_alloc_mode : Typedtree.alloc_mode_r option; }
+  val make:
+    ?env_alloc_mode:Typedtree.alloc_mode_r
+    -> Env.t -> equations_scope:int
     -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Typedtree.alloc_mode_r option -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
       allow_recursive_equations : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
+      mutable env_alloc_mode : Typedtree.alloc_mode_r option; }
   let make ?env_alloc_mode env ~equations_scope ~allow_recursive_equations =
     { env;
       equations_scope;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -892,6 +892,10 @@ val check_constructor_crossing_destruction :
 
 (** Takes the mode of a container, a child's relation to it, and an optional
     modality, returns the mode of the child. *)
-val apply_is_contained_by : Mode.Hint.is_contained_by
+val apply_left_is_contained_by : Mode.Hint.is_contained_by
   -> ?modalities:Mode.Modality.Const.t
-  -> ('l * 'r) Mode.Value.t -> ('l * 'r) Mode.Value.t
+  -> (allowed * 'r) Mode.Value.t -> Mode.Value.l
+
+val apply_right_is_contained_by : Mode.Hint.is_contained_by
+  -> ?modalities:Mode.Modality.Const.t
+  -> ('l * allowed) Mode.Value.t -> Mode.Value.r

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -140,7 +140,8 @@ val filter_row_fields:
 
 val contains_toplevel_splice: int -> type_expr -> bool
 val iter_type_expr_with_stages:
-        (Env.t -> type_expr -> unit) -> Env.t -> type_expr -> unit
+        (Env.t -> type_expr -> unit) -> Env.t -> (Mode.Alloc.lr -> unit)
+        -> type_expr -> unit
 
 val generalize: type_expr -> unit
         (* Generalize in-place the given type *)
@@ -259,7 +260,8 @@ val instance_label_declarations:
         (* Same, but for label declarations and the type parameters from the
            type declaration *)
 val prim_mode :
-        (Mode.allowed * 'r) Mode.Locality.t option -> (Primitive.mode * Primitive.native_repr)
+        (Mode.allowed * 'r) Mode.Locality.t option ->
+        (Primitive.mode * Primitive.native_repr) -> level:int
         -> (Mode.allowed * 'r) Mode.Locality.t
 val instance_prim:
         Env.t ->
@@ -271,7 +273,13 @@ val instance_prim:
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)
-val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+val curry_mode_const : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+
+(** Applies the same logic as [curry_mode_const] over
+    the comonadic mode for [m0] and the lr mode [m1] *)
+val curry_mode :
+  (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr ->
+  Alloc.Comonadic.l
 
 val apply:
         ?use_current_level:bool ->
@@ -567,7 +575,8 @@ val nondep_jkind_declaration:
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 
-val remove_mode_and_jkind_variables: type_expr -> unit
+val remove_mode_and_jkind_variables:
+  zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
 val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
@@ -601,10 +610,14 @@ val closed_type_expr: ?env:Env.t -> type_expr -> bool
         (* If env present, expand abbreviations to see if expansion
            eliminates the variable *)
 
-val closed_type_decl: type_declaration -> type_expr option
-val closed_extension_constructor: extension_constructor -> type_expr option
+val closed_type_decl:
+  zap_scope:Alloc.zap_scope ->
+  type_declaration -> type_expr option
+val closed_extension_constructor:
+  zap_scope:Alloc.zap_scope ->
+  extension_constructor -> type_expr option
 val closed_class:
-        type_expr list -> class_signature ->
+        zap_scope:Alloc.zap_scope -> type_expr list -> class_signature ->
         closed_class_failure option
         (* Check whether all type variables are bound *)
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -198,15 +198,17 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       allow_recursive_equations : bool;
       (* true iff checking counter examples *)
-      mutable env_alloc_mode : Mode.Alloc.r option;
+      mutable env_alloc_mode : Typedtree.alloc_mode_r option;
       (** [Some m] if the pattern is under [let poly_], where [m] is the
          allocation mode of the captured environment *)
     }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+  val make:
+    ?env_alloc_mode:Typedtree.alloc_mode_r
+    -> Env.t -> equations_scope:int
     -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Typedtree.alloc_mode_r option -> unit
 end
 
 type existential_treatment =

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -38,7 +38,7 @@ let free_vars ?(param=false) ty =
           end
         (* XXX: What about Tobject ? *)
         | _ ->
-            iter_type_expr loop ty
+            iter_type_expr loop (Fun.const ()) ty
     in
     loop ty
   end;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1081,7 +1081,7 @@ module Normalize_mode = struct
     | Assert_normalized, true -> modality, mode
     | (Normalize | Normalize_exn), false ->
         Mode.Modality.undefined,
-        Mode.Modality.apply ~hint:{monadic = Unknown; comonadic = Unknown}
+        Mode.Modality.apply_left
           modality mode
     | Assert_normalized, false ->
         Misc.fatal_error "mode is not already normalized but expected otherwise"
@@ -4671,7 +4671,7 @@ let lookup_settable_variable ?(use=true) ~loc name env =
           let mode =
             m0
             |> walk_locks_for_mutable_mode ~errors:true ~loc ~env locks
-            |> Mode.Modality.Const.apply
+            |> Mode.Modality.Const.apply_right
                 Typemode.let_mutable_modalities
           in
           mutate_value ~use ~loc path vda;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -89,8 +89,8 @@ let child_modes_with_modalities id ~modalities:(moda0, moda1) = function
       (* For children, we only check modality inclusion *)
       Ok All
     | Some moda1 ->
-      let m0 = Mode.Modality.apply moda0 m0 in
-      let m1 = Mode.Modality.Const.apply moda1 m1 in
+      let m0 = Mode.Modality.apply_left moda0 m0 in
+      let m1 = Mode.Modality.Const.apply_right moda1 m1 in
       Ok (Specific ((m0, c), m1))
     end
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -251,7 +251,7 @@ let value_descriptions ~loc env name
         let mode_l1 =
           Option.map
             (fun m ->
-              if Language_extension.(is_at_least Mode_polymorphism Beta)
+              if Language_extension.(is_at_least_mode_poly Beta)
               then fst (Mode.Locality.newvar_above 0 m)
               else m) mode_l1
         in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -248,6 +248,13 @@ let value_descriptions ~loc env name
         let ty1, mode_l1, _, sort1 = Ctype.instance_prim env p1 vd1.val_type in
         (try moregeneral_lpoly env val_lpoly1 val_lpoly2 ty1 vd2.val_type
          with Ctype.Moregen err -> raise (Dont_match (Type err)));
+        let mode_l1 =
+          Option.map
+            (fun m ->
+              if Language_extension.(is_at_least Mode_polymorphism Beta)
+              then fst (Mode.Locality.newvar_above 0 m)
+              else m) mode_l1
+        in
         let pc =
           {pc_desc = p1; pc_type = vd2.Types.val_type;
            pc_poly_mode = Option.map Mode.Locality.disallow_right mode_l1;

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1533,56 +1533,57 @@ module Lattices_mono = struct
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
-    type 'a from = Ps : ('a, 'b) t -> 'a from
+    type 'a from = From : ('a, 'b) t -> 'a from
 
     let from : type a. a obj -> a from list = function
       | Comonadic_with_locality ->
-        [ Ps Areality;
-          Ps Forkable;
-          Ps Yielding;
-          Ps Linearity;
-          Ps Statefulness;
-          Ps Portability ]
+        [ From Areality;
+          From Forkable;
+          From Yielding;
+          From Linearity;
+          From Statefulness;
+          From Portability ]
       | Comonadic_with_regionality ->
-        [ Ps Areality;
-          Ps Forkable;
-          Ps Yielding;
-          Ps Linearity;
-          Ps Statefulness;
-          Ps Portability ]
-      | Monadic_op -> [Ps Uniqueness; Ps Visibility; Ps Contention; Ps Staticity]
+        [ From Areality;
+          From Forkable;
+          From Yielding;
+          From Linearity;
+          From Statefulness;
+          From Portability ]
+      | Monadic_op ->
+        [From Uniqueness; From Visibility; From Contention; From Staticity]
       | Locality | Regionality | Uniqueness_op | Linearity | Portability
       | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
       | Staticity_op ->
         []
 
-    type 'b to_ = Pb : 'a obj * ('a, 'b) t -> 'b to_
+    type 'b to_ = To : 'a obj * ('a, 'b) t -> 'b to_
 
     let to_ : type b. b obj -> b to_ list = function
       | Comonadic_with_locality -> []
       | Comonadic_with_regionality -> []
       | Monadic_op -> []
-      | Locality -> [Pb (Comonadic_with_locality, Areality)]
-      | Regionality -> [Pb (Comonadic_with_regionality, Areality)]
-      | Uniqueness_op -> [Pb (Monadic_op, Uniqueness)]
+      | Locality -> [To (Comonadic_with_locality, Areality)]
+      | Regionality -> [To (Comonadic_with_regionality, Areality)]
+      | Uniqueness_op -> [To (Monadic_op, Uniqueness)]
       | Linearity ->
-        [ Pb (Comonadic_with_locality, Linearity);
-          Pb (Comonadic_with_regionality, Linearity) ]
+        [ To (Comonadic_with_locality, Linearity);
+          To (Comonadic_with_regionality, Linearity) ]
       | Portability ->
-        [ Pb (Comonadic_with_locality, Portability);
-          Pb (Comonadic_with_regionality, Portability) ]
+        [ To (Comonadic_with_locality, Portability);
+          To (Comonadic_with_regionality, Portability) ]
       | Forkable ->
-        [ Pb (Comonadic_with_locality, Forkable);
-          Pb (Comonadic_with_regionality, Forkable) ]
+        [ To (Comonadic_with_locality, Forkable);
+          To (Comonadic_with_regionality, Forkable) ]
       | Yielding ->
-        [ Pb (Comonadic_with_locality, Yielding);
-          Pb (Comonadic_with_regionality, Yielding) ]
+        [ To (Comonadic_with_locality, Yielding);
+          To (Comonadic_with_regionality, Yielding) ]
       | Statefulness ->
-        [ Pb (Comonadic_with_locality, Statefulness);
-          Pb (Comonadic_with_regionality, Statefulness) ]
-      | Contention_op -> [Pb (Monadic_op, Contention)]
-      | Visibility_op -> [Pb (Monadic_op, Visibility)]
-      | Staticity_op -> [Pb (Monadic_op, Staticity)]
+        [ To (Comonadic_with_locality, Statefulness);
+          To (Comonadic_with_regionality, Statefulness) ]
+      | Contention_op -> [To (Monadic_op, Contention)]
+      | Visibility_op -> [To (Monadic_op, Visibility)]
+      | Staticity_op -> [To (Monadic_op, Staticity)]
 
     type ('a, 'p) owner =
       | Monadic : (Monadic_op.t, 'p) t -> (Monadic_op.t, 'p) owner
@@ -1652,7 +1653,8 @@ module Lattices_mono = struct
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
-       further, but we never need the missing operation). *)
+	       further, but we never need the missing operation). *)
+    (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
           (** Maps local to regional, global to global *)
@@ -1945,6 +1947,7 @@ module Lattices_mono = struct
   end
 
   module Core_morph = struct
+    (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Locality_restricted :
           ('a, 'b, 'l * 'r) Locality_morph.t
@@ -2740,10 +2743,9 @@ module Lattices_mono = struct
       | _, _, _, _, _ -> .
     [@@warning "-4"]
 
-    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
-    [@@unboxed]
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
 
-    let left_to : type b. b obj -> (b, left_only) packed_to list = function
+    let left_to : type b. b obj -> (b, left_only) to_ list = function
       | Locality -> [To (Locality_restricted Regional_to_local)]
       | Regionality ->
         [ To (Locality_restricted Local_to_regional);
@@ -2771,7 +2773,7 @@ module Lattices_mono = struct
           To (Locality_full Regional_to_local_regionality);
           To Monadic_to_comonadic_min ]
 
-    let right_to : type b. b obj -> (b, right_only) packed_to list = function
+    let right_to : type b. b obj -> (b, right_only) to_ list = function
       | Locality ->
         [ To (Locality_restricted Regional_to_local);
           To (Locality_restricted Regional_to_global) ]
@@ -2827,6 +2829,7 @@ module Lattices_mono = struct
   let max_with dst ax a = Axis.set ax a (max dst)
 
   module Simple_morph = struct
+    (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Id : ('a, 'a, 'd) t  (** identity morphism *)
       | Core : ('a, 'b, 'd) Core_morph.t -> ('a, 'b, 'd) t
@@ -3395,10 +3398,9 @@ module Lattices_mono = struct
 
     let ( let+ ) xs f = List.map f xs
 
-    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
-    [@@unboxed]
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
 
-    let left_to : type b. full:bool -> b obj -> (b, left_only) packed_to list =
+    let left_to : type b. full:bool -> b obj -> (b, left_only) to_ list =
      fun ~full dst ->
       let constants =
         List.map (fun c -> To (Meet_const c)) (get_elements ~full dst)
@@ -3412,8 +3414,7 @@ module Lattices_mono = struct
       in
       (To Id :: core_morphs) @ constants @ meet_const_cores
 
-    let right_to : type b. full:bool -> b obj -> (b, right_only) packed_to list
-        =
+    let right_to : type b. full:bool -> b obj -> (b, right_only) to_ list =
      fun ~full dst ->
       let constants =
         List.map (fun c -> To (Imply_const c)) (get_elements ~full dst)
@@ -3429,6 +3430,7 @@ module Lattices_mono = struct
       (To Id :: core_morphs) @ constants @ core_imply_consts
   end
 
+  (* New morphisms must be added to [left_to] and [right_to]. *)
   type ('a, 'b, 'd) morph =
     | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) morph
     | Const_max : 'a obj -> ('a, 'c, disallowed * 'r) morph
@@ -4014,9 +4016,9 @@ module Lattices_mono = struct
 
   let ( let+ ) xs f = List.map f xs
 
-  type 'b packed_to = To : ('a, 'b, neither) morph -> 'b packed_to [@@unboxed]
+  type 'b to_ = To : ('a, 'b, neither) morph -> 'b to_ [@@unboxed]
 
-  let generate_left_morphs_to : type b. full:bool -> b obj -> b packed_to list =
+  let left_to : type b. full:bool -> b obj -> b to_ list =
    fun ~full dst ->
     let simple_morphs = Simple_morph.left_to ~full dst in
     let simple =
@@ -4027,11 +4029,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let src = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.to_ src in
+      let+ (Axis.To (src, ax)) = Axis.to_ src in
       To (disallow_left (Simple_proj (m, ax, src)))
     in
     let min_with =
-      let* (Axis.Ps ax) = Axis.from dst in
+      let* (Axis.From ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
       To (disallow_left (Min_with_simple (ax, m)))
@@ -4041,8 +4043,7 @@ module Lattices_mono = struct
     in
     simple @ projections @ min_with @ const_min
 
-  let generate_right_morphs_to : type b. full:bool -> b obj -> b packed_to list
-      =
+  let right_to : type b. full:bool -> b obj -> b to_ list =
    fun ~full dst ->
     let simple_morphs = Simple_morph.right_to ~full dst in
     let simple =
@@ -4053,11 +4054,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let projected = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.to_ projected in
+      let+ (Axis.To (src, ax)) = Axis.to_ projected in
       To (disallow_right (Simple_proj (m, ax, src)))
     in
     let max_with =
-      let* (Axis.Ps ax) = Axis.from dst in
+      let* (Axis.From ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
       To (disallow_right (Max_with_simple (ax, m)))
@@ -4067,8 +4068,7 @@ module Lattices_mono = struct
     in
     simple @ projections @ max_with @ const_max
 
-  let generate_morphs_to ~full dst =
-    generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
+  let generate_morphs_to ~full dst = left_to ~full dst @ right_to ~full dst
 
   type 'a covered =
     { full_coverage : 'a;
@@ -4112,7 +4112,7 @@ module Lattices_mono = struct
   let morphs_to_comonadic_with_regionality =
     morphs_to_obj Comonadic_with_regionality
 
-  let morphs_to : type b. full:bool -> b obj -> b packed_to list =
+  let morphs_to : type b. full:bool -> b obj -> b to_ list =
    fun ~full -> function
     | Locality -> force_by_coverage ~full morphs_to_locality
     | Regionality -> force_by_coverage ~full morphs_to_regionality

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3809,29 +3809,72 @@ module For_testing = struct
   let values_for_check_staticity_op = [Staticity.Static; Staticity.Dynamic]
 
   let values_for_check_monadic_op =
-    let* uniqueness = values_for_check_uniqueness_op in
-    let* contention = values_for_check_contention_op in
-    let* visibility = values_for_check_visibility_op in
-    let+ staticity = values_for_check_staticity_op in
-    { uniqueness; contention; visibility; staticity }
+    let with_base base =
+      List.concat
+        [ List.map
+            (fun uniqueness -> { base with uniqueness })
+            values_for_check_uniqueness_op;
+          List.map
+            (fun contention -> { base with contention })
+            values_for_check_contention_op;
+          List.map
+            (fun visibility -> { base with visibility })
+            values_for_check_visibility_op;
+          List.map
+            (fun staticity -> { base with staticity })
+            values_for_check_staticity_op ]
+    in
+    with_base Monadic_op.min @ with_base Monadic_op.max
 
   let values_for_check_comonadic_with_locality =
-    let* areality = values_for_check_locality in
-    let* linearity = values_for_check_linearity in
-    let* portability = values_for_check_portability in
-    let* forkable = values_for_check_forkable in
-    let* yielding = values_for_check_yielding in
-    let+ statefulness = values_for_check_statefulness in
-    { areality; linearity; portability; forkable; yielding; statefulness }
+    let with_base base =
+      List.concat
+        [ List.map
+            (fun areality -> { base with areality })
+            values_for_check_locality;
+          List.map
+            (fun linearity -> { base with linearity })
+            values_for_check_linearity;
+          List.map
+            (fun portability -> { base with portability })
+            values_for_check_portability;
+          List.map
+            (fun forkable -> { base with forkable })
+            values_for_check_forkable;
+          List.map
+            (fun yielding -> { base with yielding })
+            values_for_check_yielding;
+          List.map
+            (fun statefulness -> { base with statefulness })
+            values_for_check_statefulness ]
+    in
+    with_base Comonadic_with_locality.min
+    @ with_base Comonadic_with_locality.max
 
   let values_for_check_comonadic_with_regionality =
-    let* areality = values_for_check_regionality in
-    let* linearity = values_for_check_linearity in
-    let* portability = values_for_check_portability in
-    let* forkable = values_for_check_forkable in
-    let* yielding = values_for_check_yielding in
-    let+ statefulness = values_for_check_statefulness in
-    { areality; linearity; portability; forkable; yielding; statefulness }
+    let with_base base =
+      List.concat
+        [ List.map
+            (fun areality -> { base with areality })
+            values_for_check_regionality;
+          List.map
+            (fun linearity -> { base with linearity })
+            values_for_check_linearity;
+          List.map
+            (fun portability -> { base with portability })
+            values_for_check_portability;
+          List.map
+            (fun forkable -> { base with forkable })
+            values_for_check_forkable;
+          List.map
+            (fun yielding -> { base with yielding })
+            values_for_check_yielding;
+          List.map
+            (fun statefulness -> { base with statefulness })
+            values_for_check_statefulness ]
+    in
+    with_base Comonadic_with_regionality.min
+    @ with_base Comonadic_with_regionality.max
 
   let all_values_for_check : type a. a obj -> a list = function
     | Locality -> values_for_check_locality
@@ -4148,62 +4191,21 @@ module For_testing = struct
           failwith msg)
       (all_values_for_check src)
 
-  let domain_count_for_jobs job_count =
-    Int.min (Domain.recommended_domain_count ()) job_count
-
-  let run_jobs_in_parallel jobs =
-    let job_count = Array.length jobs in
-    let domain_count = domain_count_for_jobs job_count in
-    if domain_count <= 1
-    then Array.iter (fun job -> job ()) jobs
-    else
-      let worker worker_index =
-        let rec loop job_index =
-          if job_index < job_count
-          then (
-            jobs.(job_index) ();
-            loop (job_index + domain_count))
-        in
-        match loop worker_index with
-        | () -> None
-        | exception exn -> Some (exn, Printexc.get_raw_backtrace ())
-      in
-      let domains =
-        Array.init (domain_count - 1) (fun worker_index ->
-            (Domain.spawn
-            [@ocaml.alert "-do_not_spawn_domains"]
-            [@ocaml.alert "-unsafe_multidomain"]) (fun () ->
-                worker (worker_index + 1)))
-      in
-      let first_error =
-        Array.fold_left
-          (fun first_error domain ->
-            match first_error, Domain.join domain with
-            | Some _, _ -> first_error
-            | None, error -> error)
-          (worker 0) domains
-      in
-      match first_error with
-      | None -> ()
-      | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+  let run_jobs jobs = List.iter (fun job -> job ()) jobs
 
   let check_jobs () =
-    let jobs =
-      let* (Obj dst) = all_objs in
-      let+ (Morph_to (mid, f)) = morphs_to dst in
-      let morphs_to_mid = morphs_to mid in
-      fun () ->
-        List.iter
-          (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
-          morphs_to_mid
-    in
-    Array.of_list jobs
+    let* (Obj dst) = all_objs in
+    let+ (Morph_to (mid, f)) = morphs_to dst in
+    let morphs_to_mid = morphs_to mid in
+    fun () ->
+      List.iter
+        (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
+        morphs_to_mid
 
   let check_all_allowed_compositions () =
     let jobs = check_jobs () in
-    Printf.printf "allowed checks running on %d domain(s)\n%!"
-      (domain_count_for_jobs (Array.length jobs));
-    run_jobs_in_parallel jobs
+    Printf.printf "running allowed composition checks\n%!";
+    run_jobs jobs
 end
 
 module C = Lattices_mono

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4207,6 +4207,38 @@ module For_testing = struct
 
   let ( let+ ) xs f = List.map f xs
 
+  type error =
+    | Composition_check_failed :
+        { source : 'a obj;
+          middle : 'b obj;
+          target : 'c obj;
+          f : ('b, 'c, neither) morph;
+          g : ('a, 'b, neither) morph;
+          result : ('a, 'c, neither) morph;
+          input : 'a;
+          expected : 'c;
+          actual : 'c
+        }
+        -> error
+
+  let print_error ppf
+      (Composition_check_failed
+         { source; middle; target; f; g; result; input; expected; actual }) =
+    Fmt.fprintf ppf
+      "@[<v>Lattices_mono compose check failed:@,\
+       source: %a@,\
+       middle: %a@,\
+       target: %a@,\
+       f: %a@,\
+       g: %a@,\
+       result: %a@,\
+       input: %a@,\
+       expected: %a@,\
+       actual: %a@]"
+      print_obj source print_obj middle print_obj target (print_morph target) f
+      (print_morph middle) g (print_morph target) result (print source) input
+      (print target) expected (print target) actual
+
   let check_compose : type a b c.
       full:bool ->
       a obj ->
@@ -4214,45 +4246,48 @@ module For_testing = struct
       c obj ->
       (b, c, neither) morph ->
       (a, b, neither) morph ->
-      unit =
+      (unit, error) result =
    fun ~full src mid dst f g ->
     let result = compose dst f g in
-    List.iter
-      (fun input ->
+    let rec check_inputs = function
+      | [] -> Ok ()
+      | input :: inputs ->
         let expected = apply dst f (apply mid g input) in
         let actual = apply dst result input in
         if not (equal dst expected actual)
         then
-          let msg =
-            Fmt.asprintf
-              "@[<v>Lattices_mono compose check failed:@,\
-               source: %a@,\
-               middle: %a@,\
-               target: %a@,\
-               f: %a@,\
-               g: %a@,\
-               result: %a@,\
-               input: %a@,\
-               expected: %a@,\
-               actual: %a@]"
-              print_obj src print_obj mid print_obj dst (print_morph dst) f
-              (print_morph mid) g (print_morph dst) result (print src) input
-              (print dst) expected (print dst) actual
-          in
-          failwith msg)
-      (get_elements ~full src)
+          Error
+            (Composition_check_failed
+               { source = src;
+                 middle = mid;
+                 target = dst;
+                 f;
+                 g;
+                 result;
+                 input;
+                 expected;
+                 actual
+               })
+        else check_inputs inputs
+    in
+    check_inputs (get_elements ~full src)
 
-  let check_jobs ~full () =
+  let check_composition_jobs ~full () =
     let* (Obj dst) = all_objs in
     let+ (To f) = morphs_to ~full dst in
     let mid = src dst f in
     let morphs_to_mid = morphs_to ~full mid in
     fun () ->
-      List.iter
-        (fun (To g) ->
+      let rec check_morphs = function
+        | [] -> Ok ()
+        | To g :: morphs ->
           let src = src mid g in
-          check_compose ~full src mid dst f g)
-        morphs_to_mid
+          begin match check_compose ~full src mid dst f g with
+          | Ok () -> check_morphs morphs
+          | Error _ as error -> error
+          end
+      in
+      check_morphs morphs_to_mid
 end
 
 module C = Lattices_mono

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -458,8 +458,6 @@ module Lattices = struct
     include Heyting with type t := t
 
     val areality : t areality
-
-    val all : t list
   end
 
   module Locality = struct
@@ -479,7 +477,7 @@ module Lattices = struct
 
     let legacy = Global
 
-    let all = [Global; Local]
+    let all = lazy [Global; Local]
 
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
@@ -506,7 +504,7 @@ module Lattices = struct
 
     let legacy = Global
 
-    let all = [Global; Regional; Local]
+    let all = lazy [Global; Regional; Local]
 
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
@@ -533,7 +531,7 @@ module Lattices = struct
 
     let legacy = Aliased
 
-    let all = [Unique; Aliased]
+    let all = lazy [Unique; Aliased]
 
     let print ppf = function
       | Aliased -> Fmt.fprintf ppf "aliased"
@@ -557,7 +555,7 @@ module Lattices = struct
 
     let legacy = Many
 
-    let all = [Many; Once]
+    let all = lazy [Many; Once]
 
     let print ppf = function
       | Once -> Fmt.fprintf ppf "once"
@@ -586,7 +584,7 @@ module Lattices = struct
 
     let legacy = Nonportable
 
-    let all = [Portable; Shareable; Corruptible; Nonportable]
+    let all = lazy [Portable; Shareable; Corruptible; Nonportable]
 
     let print ppf = function
       | Portable -> Fmt.fprintf ppf "portable"
@@ -617,7 +615,7 @@ module Lattices = struct
 
     let legacy = Uncontended
 
-    let all = [Uncontended; Corrupted; Shared; Contended]
+    let all = lazy [Uncontended; Corrupted; Shared; Contended]
 
     let print ppf = function
       | Contended -> Fmt.fprintf ppf "contended"
@@ -643,7 +641,7 @@ module Lattices = struct
 
     let legacy = Forkable
 
-    let all = [Forkable; Unforkable]
+    let all = lazy [Forkable; Unforkable]
 
     let print ppf = function
       | Unforkable -> Fmt.fprintf ppf "unforkable"
@@ -667,7 +665,7 @@ module Lattices = struct
 
     let legacy = Unyielding
 
-    let all = [Unyielding; Yielding]
+    let all = lazy [Unyielding; Yielding]
 
     let print ppf = function
       | Yielding -> Fmt.fprintf ppf "yielding"
@@ -696,7 +694,7 @@ module Lattices = struct
 
     let legacy = Stateful
 
-    let all = [Stateless; Writing; Reading; Stateful]
+    let all = lazy [Stateless; Writing; Reading; Stateful]
 
     let print ppf = function
       | Stateless -> Fmt.fprintf ppf "stateless"
@@ -727,7 +725,7 @@ module Lattices = struct
 
     let legacy = Read_write
 
-    let all = [Read_write; Read; Write; Immutable]
+    let all = lazy [Read_write; Read; Write; Immutable]
 
     let print ppf = function
       | Immutable -> Fmt.fprintf ppf "immutable"
@@ -753,7 +751,7 @@ module Lattices = struct
 
     let legacy = Dynamic
 
-    let all = [Static; Dynamic]
+    let all = lazy [Static; Dynamic]
 
     let print ppf = function
       | Dynamic -> Fmt.fprintf ppf "dynamic"
@@ -796,10 +794,10 @@ module Lattices = struct
       lazy
         (let ( let* ) xs f = List.concat_map f xs in
          let ( let+ ) xs f = List.map f xs in
-         let* uniqueness = Uniqueness.all in
-         let* contention = Contention.all in
-         let* visibility = Visibility.all in
-         let+ staticity = Staticity.all in
+         let* uniqueness = Lazy.force Uniqueness.all in
+         let* contention = Lazy.force Contention.all in
+         let* visibility = Lazy.force Visibility.all in
+         let+ staticity = Lazy.force Staticity.all in
          { uniqueness; contention; visibility; staticity })
 
     (** Product values that cover every element of every axis at least once,
@@ -809,13 +807,13 @@ module Lattices = struct
         (let with_base base =
            let ( let+ ) xs f = List.map f xs in
            List.concat
-             [ (let+ uniqueness = Uniqueness.all in
+             [ (let+ uniqueness = Lazy.force Uniqueness.all in
                 { base with uniqueness });
-               (let+ contention = Contention.all in
+               (let+ contention = Lazy.force Contention.all in
                 { base with contention });
-               (let+ visibility = Visibility.all in
+               (let+ visibility = Lazy.force Visibility.all in
                 { base with visibility });
-               (let+ staticity = Staticity.all in
+               (let+ staticity = Lazy.force Staticity.all in
                 { base with staticity }) ]
          in
          with_base min @ with_base max)
@@ -945,12 +943,12 @@ module Lattices = struct
       lazy
         (let ( let* ) xs f = List.concat_map f xs in
          let ( let+ ) xs f = List.map f xs in
-         let* areality = Areality.all in
-         let* linearity = Linearity.all in
-         let* portability = Portability.all in
-         let* forkable = Forkable.all in
-         let* yielding = Yielding.all in
-         let+ statefulness = Statefulness.all in
+         let* areality = Lazy.force Areality.all in
+         let* linearity = Lazy.force Linearity.all in
+         let* portability = Lazy.force Portability.all in
+         let* forkable = Lazy.force Forkable.all in
+         let* yielding = Lazy.force Yielding.all in
+         let+ statefulness = Lazy.force Statefulness.all in
          { areality; linearity; portability; forkable; yielding; statefulness })
 
     (** Product values that cover every element of every axis at least once,
@@ -960,17 +958,17 @@ module Lattices = struct
         (let with_base base =
            let ( let+ ) xs f = List.map f xs in
            List.concat
-             [ (let+ areality = Areality.all in
+             [ (let+ areality = Lazy.force Areality.all in
                 { base with areality });
-               (let+ linearity = Linearity.all in
+               (let+ linearity = Lazy.force Linearity.all in
                 { base with linearity });
-               (let+ portability = Portability.all in
+               (let+ portability = Lazy.force Portability.all in
                 { base with portability });
-               (let+ forkable = Forkable.all in
+               (let+ forkable = Lazy.force Forkable.all in
                 { base with forkable });
-               (let+ yielding = Yielding.all in
+               (let+ yielding = Lazy.force Yielding.all in
                 { base with yielding });
-               (let+ statefulness = Statefulness.all in
+               (let+ statefulness = Lazy.force Statefulness.all in
                 { base with statefulness }) ]
          in
          with_base min @ with_base max)
@@ -1588,30 +1586,31 @@ module Lattices_mono = struct
       Obj Comonadic_with_regionality ]
 
   let get_elements : type a. full:bool -> a obj -> a list =
-   fun ~full -> function
-    | Locality -> Locality.all
-    | Regionality -> Regionality.all
-    | Uniqueness_op -> Uniqueness.all
-    | Linearity -> Linearity.all
-    | Portability -> Portability.all
-    | Forkable -> Forkable.all
-    | Yielding -> Yielding.all
-    | Statefulness -> Statefulness.all
-    | Contention_op -> Contention.all
-    | Visibility_op -> Visibility.all
-    | Staticity_op -> Staticity.all
-    | Monadic_op ->
-      Lazy.force (if full then Monadic.all else Monadic.spanning_elements)
-    | Comonadic_with_locality ->
-      Lazy.force
-        (if full
-         then Comonadic_with_locality.all
-         else Comonadic_with_locality.spanning_elements)
-    | Comonadic_with_regionality ->
-      Lazy.force
-        (if full
-         then Comonadic_with_regionality.all
-         else Comonadic_with_regionality.spanning_elements)
+   fun ~full obj ->
+    let elements : a list Lazy.t =
+      match obj with
+      | Locality -> Locality.all
+      | Regionality -> Regionality.all
+      | Uniqueness_op -> Uniqueness.all
+      | Linearity -> Linearity.all
+      | Portability -> Portability.all
+      | Forkable -> Forkable.all
+      | Yielding -> Yielding.all
+      | Statefulness -> Statefulness.all
+      | Contention_op -> Contention.all
+      | Visibility_op -> Visibility.all
+      | Staticity_op -> Staticity.all
+      | Monadic_op -> if full then Monadic.all else Monadic.spanning_elements
+      | Comonadic_with_locality ->
+        if full
+        then Comonadic_with_locality.all
+        else Comonadic_with_locality.spanning_elements
+      | Comonadic_with_regionality ->
+        if full
+        then Comonadic_with_regionality.all
+        else Comonadic_with_regionality.spanning_elements
+    in
+    Lazy.force elements
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
@@ -6025,6 +6024,14 @@ module Value_with (Areality : Areality) = struct
     let legacy =
       merge
         { comonadic = Comonadic.Const.legacy; monadic = Monadic.Const.legacy }
+
+    let all =
+      lazy
+        (let ( let* ) xs f = List.concat_map f xs in
+         let ( let+ ) xs f = List.map f xs in
+         let* comonadic = Lazy.force Comonadic.Const.all in
+         let+ monadic = Lazy.force Monadic.Const.all in
+         merge { comonadic; monadic })
 
     let meet m1 m2 =
       let m1 = split m1 in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2382,12 +2382,6 @@ module Lattices_mono = struct
     (* Commutes a meet through a morphism from the right, such that:
        [apply dst m (meet_const c x)] is equivalent to
        [meet_const (commute_meet_const_from_right dst m c) (apply dst m x)]
-
-       PRECONDITION: All [Core_morph.t] preserves binary meets:
-        m(x meet y) == m(x) meet m(y). Without this precondition,
-        [commute_meet_const_from_right] may no longer be implementable, and
-        we will need to change the implementation of [Simple_morph.compose], as well as
-        add the missing cases in [Simple_morph.t].
     *)
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
@@ -2397,7 +2391,7 @@ module Lattices_mono = struct
         | Local_to_regional | Regional_to_local | Locality_as_regionality
         | Regional_to_global | Local_to_regional_regionality
         | Regional_to_local_regionality | Regional_to_global_regionality ->
-          (* same explanation as below *)
+          (* See explanation below *)
           apply dst m c
       in
       match m with
@@ -2408,7 +2402,14 @@ module Lattices_mono = struct
       | Visibility_op_to_statefulness | Statefulness_to_visibility_op
       | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
       | Monadic_to_comonadic_max | Comonadic_to_monadic_max _ ->
-        (* If all morphisms preserve binary meets, the correctness argument
+        (* The following proof depends on the fact that [Core_morph.t] preserves binary
+           meets: m(x meet y) == m(x) meet m(y).
+
+           Without this condition, [commute_meet_const_from_right] may no longer be
+           implementable, and we will need to change the implementation of
+           [Simple_morph.compose], as well as add the missing cases in [Simple_morph.t].
+
+           If all morphisms preserve binary meets, the correctness argument
            goes as follows:
 
            Consider [apply dst m (meet_const c x)].

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2749,31 +2749,23 @@ module Lattices_mono = struct
         if c <> 0 then c else Core_morph.compare m1 m2
       | Meet_const_core _, _ -> -1
       | _, Meet_const_core _ -> 1
-      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) -> (
+      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) ->
         let c = Core_morph.compare m1 m2 in
         if c <> 0
         then c
         else
-          match Core_morph.equal m1 m2 with
-          | Misc.Is_not_eq ->
-            Misc.fatal_error
-              "Mode.Lattices_mono.Simple_morph.compare: inconsistent core \
-               morph equality"
-          | Misc.Is_eq ->
-            let src = Core_morph.src m1 in
-            compare_total src c1 c2)
+          let Refl = Core_morph.equal m1 m2 |> Misc.get_eq_exn in
+          let src = Core_morph.src m1 in
+          compare_total src c1 c2
       | Core_imply_const _, _ -> -1
       | _, Core_imply_const _ -> 1
-      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+      | Compose (mb1, ma1), Compose (mb2, ma2) ->
         let c = compare dst mb1 mb2 in
         if c <> 0
         then c
         else
-          match equal dst mb1 mb2 with
-          | Misc.Is_not_eq ->
-            Misc.fatal_error
-              "Mode.Lattices_mono.Simple_morph.compare: inconsistent equality"
-          | Misc.Is_eq -> compare (src dst mb1) ma1 ma2)
+          let Refl = equal dst mb1 mb2 |> Misc.get_eq_exn in
+          compare (src dst mb1) ma1 ma2
       | Compose _, _ -> .
       | _, Compose _ -> .
 
@@ -3425,61 +3417,45 @@ module Lattices_mono = struct
       if c <> 0 then c else compare_total dst c1 c2
     | Const _, _ -> -1
     | _, Const _ -> 1
-    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
+    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) ->
       let c = compare_obj src1 src2 in
       if c <> 0
       then c
       else
-        match equal_obj src1 src2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent object equality"
-        | Misc.Is_eq -> (
-          let c = Axis.compare ax1 ax2 in
-          if c <> 0
-          then c
-          else
-            match Axis.equal ax1 ax2 with
-            | Misc.Is_not_eq ->
-              Misc.fatal_error
-                "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
-            | Misc.Is_eq -> Simple_morph.compare dst m1 m2))
+        let Refl = equal_obj src1 src2 |> Misc.get_eq_exn in
+        let c = Axis.compare ax1 ax2 in
+        if c <> 0
+        then c
+        else
+          let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+          Simple_morph.compare dst m1 m2
     | Simple_proj _, _ -> -1
     | _, Simple_proj _ -> 1
-    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) ->
       let c = Axis.compare ax1 ax2 in
       if c <> 0
       then c
       else
-        match Axis.equal ax1 ax2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
-        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+        let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+        Simple_morph.compare (proj_obj ax1 dst) m1 m2
     | Max_with_simple _, _ -> -1
     | _, Max_with_simple _ -> 1
-    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) ->
       let c = Axis.compare ax1 ax2 in
       if c <> 0
       then c
       else
-        match Axis.equal ax1 ax2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
-        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+        let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+        Simple_morph.compare (proj_obj ax1 dst) m1 m2
     | Min_with_simple _, _ -> -1
     | _, Min_with_simple _ -> 1
-    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+    | Compose (mb1, ma1), Compose (mb2, ma2) ->
       let c = compare_morph dst mb1 mb2 in
       if c <> 0
       then c
       else
-        match equal_morph dst mb1 mb2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent equality"
-        | Misc.Is_eq -> compare_morph (src dst mb1) ma1 ma2)
+        let Refl = equal_morph dst mb1 mb2 |> Misc.get_eq_exn in
+        compare_morph (src dst mb1) ma1 ma2
     | Compose _, _ -> .
     | _, Compose _ -> .
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1515,9 +1515,9 @@ module Lattices_mono = struct
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
-    type 'a packed_small = Ps : ('a, 'b) t -> 'a packed_small
+    type 'a from = Ps : ('a, 'b) t -> 'a from
 
-    let all : type a. a obj -> a packed_small list = function
+    let from : type a. a obj -> a from list = function
       | Comonadic_with_locality ->
         [ Ps Areality;
           Ps Forkable;
@@ -1538,9 +1538,9 @@ module Lattices_mono = struct
       | Staticity_op ->
         []
 
-    type 'b packed_big = Pb : 'a obj * ('a, 'b) t -> 'b packed_big
+    type 'b to_ = Pb : 'a obj * ('a, 'b) t -> 'b to_
 
-    let axis_to : type b. b obj -> b packed_big list = function
+    let to_ : type b. b obj -> b to_ list = function
       | Comonadic_with_locality -> []
       | Comonadic_with_regionality -> []
       | Monadic_op -> []
@@ -3974,11 +3974,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let src = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.axis_to src in
+      let+ (Axis.Pb (src, ax)) = Axis.to_ src in
       To (disallow_left (Simple_proj (m, ax, src)))
     in
     let min_with =
-      let* (Axis.Ps ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
       To (disallow_left (Min_with_simple (ax, m)))
@@ -4000,11 +4000,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let projected = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
+      let+ (Axis.Pb (src, ax)) = Axis.to_ projected in
       To (disallow_right (Simple_proj (m, ax, src)))
     in
     let max_with =
-      let* (Axis.Ps ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
       To (disallow_right (Max_with_simple (ax, m)))

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2372,10 +2372,27 @@ module Lattices_mono = struct
     let commute_imply_from_left : type a b l.
         b obj -> b -> (a, b, l * allowed) t -> a =
      fun dst c m ->
-      (* As all our morphisms preserve binary meets, implications can be
-         pushed inside of [m] by applying the left adjoint of [m] to the
-         implicant. *)
-      apply (src m) (left_adjoint dst m) c
+      (* The correctness argument for [commute_imply_from_the_left] follows from the
+         correctness argument for [commute_meet_const_from_the_right] as follows:
+
+         Consider [imply_const c (apply dst m x)]. Recall that [imply_const] is only
+         allowed on the right-hand side of a constraint; say
+         [y < imply_const c (apply dst m x)]
+         <=> [meet_const c y < apply dst m x] ;; the left adjoint of imply is meet.
+         <=> [apply src m' (meet_const c y) < x] ;; where [m'] is the left adoint of [m]
+
+         We can now apply the correctness criteria of [commute_meet_const_from_right] and
+         commute the meet through [m']:
+         <=> [meet_const (commute_meet_const_from_right src m' c) (apply src m' y) < x]
+         <=> [apply src m' y < imply_const (commute_meet_const_from_right src m' c) x]
+          ;; the right adjoint of meet is imply
+         <=> [y < apply dst m (imply_const (commute_meet_const_from_right src m' c) x)]
+          ;; the right adjoint of [m'] is [m]
+
+         We have [apply dst m (imply_const (commute_meet_const_from_right src m' c) x)]
+         equivalent to [imply_const c (apply dst m x)] as desired.
+      *)
+      commute_meet_const_from_right (src m) (left_adjoint dst m) c
 
     type ('a, 'b, 'd) compose_proj_result =
       | Proj_core :

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1634,7 +1634,13 @@ module Lattices_mono = struct
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
-       further, but we never need the missing operation) *)
+       further, but we never need the missing operation).
+
+      INVARIANT: each locality morphism below must preserve binary meets:
+        lm(x meet y) == lm(x) meet lm(y). If the invariant is broken,
+        [commute_meet_const_from_right] may no longer be correct (or implementable), and
+        we may need to change [Simple_morph.compose] and add the missing case in
+        [Simple_morph.t] *)
     type ('a, 'b, 'd) t =
       | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
           (** Maps local to regional, global to global *)
@@ -1941,6 +1947,11 @@ module Lattices_mono = struct
   end
 
   module Core_morph = struct
+    (* INVARIANT: each core morphism below must preserve binary meets:
+        cm(x meet y) == cm(x) meet cm(y). If the invariant is broken,
+        [commute_meet_const_from_right] may no longer be correct (or implementable), and
+        we may need to change [Simple_morph.compose] and add the missing case in
+        [Simple_morph.t] *)
     type ('a, 'b, 'd) t =
       | Locality_restricted :
           ('a, 'b, 'l * 'r) Locality_morph.t
@@ -2362,7 +2373,15 @@ module Lattices_mono = struct
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
      fun dst m c ->
-      (* All our morphisms preserve binary meets *)
+      (* All morphisms preserve binary meets. The correctness argument
+         thus goes as follows:
+
+         Consider [apply dst m (meet_const c x)].
+         [apply dst m (meet_const c x)]
+         == meet (apply dst m c) (apply dst m x) ;; [m] preserves binary meets
+         == meet_const (apply dst m c) (apply dst m x) ;; by definition of meet_const
+
+         The correct result for [commute_meet_const_from_right] is thus [apply dst m c] *)
       apply dst m c
 
     (* Commutes an implication through a morphism from the left, such that:

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1927,35 +1927,21 @@ module Lattices_mono = struct
       | Regional_to_global_regionality, Local_to_regional_regionality ->
         Disallowed
 
-    let id_with_regional_to_locality : type a b l r.
-        (Regionality.t, Locality.t, l * r) t ->
+    (** Closest-to-identity morphism between comonadic_with axes, mapping
+        Regional to Local when the source source object is
+        Comonadic_with_regionality and the target is Comonadic_with_locality *)
+    let id_r2l : type a b l r.
         a comonadic_with obj ->
         b comonadic_with obj ->
         (a, b, l * r) compose_result =
-     fun regional_to_locality src dst ->
+     fun src dst ->
       match src, dst with
       | Comonadic_with_regionality, Comonadic_with_locality ->
-        Morph regional_to_locality
+        Morph Regional_to_local
       | Comonadic_with_locality, Comonadic_with_regionality ->
         Morph Locality_as_regionality
       | Comonadic_with_regionality, Comonadic_with_regionality -> Id
       | Comonadic_with_locality, Comonadic_with_locality -> Id
-
-    (** Closest-to-identity morphism between comonadic_with axes, using r2g for
-        regionality-to-locality. *)
-    let id_r2g : type a b.
-        a comonadic_with obj ->
-        b comonadic_with obj ->
-        (a, b, disallowed * allowed) compose_result =
-     fun src dst -> id_with_regional_to_locality Regional_to_global src dst
-
-    (** Closest-to-identity morphism between comonadic_with axes, using r2l for
-        regionality-to-locality. *)
-    let id_r2l : type a b.
-        a comonadic_with obj ->
-        b comonadic_with obj ->
-        (a, b, allowed * disallowed) compose_result =
-     fun src dst -> id_with_regional_to_locality Regional_to_local src dst
   end
 
   module Core_morph = struct
@@ -2678,31 +2664,14 @@ module Lattices_mono = struct
       | Locality_morph.Disallowed -> Disallowed
 
     (** Closest-to-identity morphism between full product objects, as enforced
-        by the [Axis.t] arguments. Uses r2g for comonadic areality and plain
-        identity for monadic axes. *)
-    let id_r2g : type a b p.
+        by the [Axis.t] arguments. No guarantees can be made over the behavior
+        of the Areality axis if the source and target Areality differ. *)
+    let id_except_for_areality : type l r a b p.
         a obj ->
         b obj ->
         (a, p) Axis.t ->
         (b, p) Axis.t ->
-        (a, b, disallowed * allowed) compose_result =
-     fun src dst ax0 ax1 ->
-      match Axis.owner src ax0, Axis.owner dst ax1 with
-      | Axis.Monadic _, Axis.Monadic _ -> Id
-      | Axis.Comonadic (src, _), Axis.Comonadic (dst, _) ->
-        Locality_morph.id_r2g src dst |> lift_locality_compose_result
-      | Axis.Monadic _, Axis.Comonadic _ -> .
-      | Axis.Comonadic _, Axis.Monadic _ -> .
-
-    (** Closest-to-identity morphism between full product objects, as enforced
-        by the [Axis.t] arguments. Uses r2l for comonadic areality and plain
-        identity for monadic axes. *)
-    let id_r2l : type a b p.
-        a obj ->
-        b obj ->
-        (a, p) Axis.t ->
-        (b, p) Axis.t ->
-        (a, b, allowed * disallowed) compose_result =
+        (a, b, l * r) compose_result =
      fun src dst ax0 ax1 ->
       match Axis.owner src ax0, Axis.owner dst ax1 with
       | Axis.Monadic _, Axis.Monadic _ -> Id
@@ -2711,15 +2680,17 @@ module Lattices_mono = struct
       | Axis.Monadic _, Axis.Comonadic _ -> .
       | Axis.Comonadic _, Axis.Monadic _ -> .
 
-    (** Lift a core morphism between projected axes to a core morphism between
-        the enclosing objects. Goes to max for axes with no dual. *)
-    let lift_max : type a b p q.
+    (** Takes a core morphism between projected axes to a core morphism between
+        product axes, such that the behavior on the projected axes is preserved.
+        There are no guarantees for all other axes in the product. Produces a
+        morphism that is not allowed on the left. *)
+    let lift_r : type l r a b p q.
         a obj ->
         b obj ->
-        (p, q, disallowed * allowed) t ->
+        (p, q, l * r) t ->
         (a, p) Axis.t ->
         (b, q) Axis.t ->
-        (a, b, disallowed * allowed) compose_result =
+        (a, b, disallowed * r) compose_result =
      fun src dst m ax0 ax1 ->
       match m, ax0, ax1, src, dst with
       | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
@@ -2735,19 +2706,21 @@ module Lattices_mono = struct
       | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
         Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
       | Locality_restricted lm, Areality, Areality, _, _ ->
-        Morph (Locality_full lm)
+        Morph (Locality_full (Locality_morph.disallow_left lm))
       | _, _, _, _, _ -> .
     [@@warning "-4"]
 
-    (** Lift a core morphism between projected axes to a core morphism between
-        the enclosing objects. Goes to min for axes with no dual. *)
-    let lift_min : type a b p q.
+    (** Takes a core morphism between projected axes to a core morphism between
+        product axes, such that the behavior on the projected axes is preserved.
+        There are no guarantees for all other axes in the product. Produces a
+        morphism that is not allowed on the right. *)
+    let lift_l : type l r a b p q.
         a obj ->
         b obj ->
-        (p, q, allowed * disallowed) t ->
+        (p, q, l * r) t ->
         (a, p) Axis.t ->
         (b, q) Axis.t ->
-        (a, b, allowed * disallowed) compose_result =
+        (a, b, l * disallowed) compose_result =
      fun src dst m ax0 ax1 ->
       match m, ax0, ax1, src, dst with
       | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
@@ -2763,7 +2736,7 @@ module Lattices_mono = struct
       | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
         Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
       | Locality_restricted lm, Areality, Areality, _, _ ->
-        Morph (Locality_full lm)
+        Morph (Locality_full (Locality_morph.disallow_right lm))
       | _, _, _, _, _ -> .
     [@@warning "-4"]
 
@@ -3360,25 +3333,29 @@ module Lattices_mono = struct
         (b, q) Axis.t ->
         (a, b, disallowed * allowed) t =
      fun src dst m ax0 ax1 ->
-      let m : (a, b, disallowed * allowed) t =
-        match m with
-        | Id -> Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
-        | Core m ->
-          Core_morph.lift_max src dst m ax0 ax1 |> lift_core_compose_result_r
-        | Imply_const c ->
-          let c = Axis.set ax1 c (arbitrary dst) in
-          let m =
-            Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
-          in
-          compose dst (Imply_const c) m
-        | Core_imply_const (m, c) ->
-          let m = lift_max src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax0 c (arbitrary src) in
-          compose dst m (Imply_const c)
+      let push_to_max m =
+        let q_obj = proj_obj ax1 dst in
+        let c = min_with dst ax1 (max q_obj) in
+        compose dst (Imply_const c) m
       in
-      let q_obj = proj_obj ax1 dst in
-      let c = min_with dst ax1 (max q_obj) in
-      compose dst (Imply_const c) m
+      match m with
+      | Id ->
+        Core_morph.id_except_for_areality src dst ax0 ax1
+        |> lift_core_compose_result_r |> push_to_max
+      | Core m ->
+        Core_morph.lift_r src dst m ax0 ax1
+        |> lift_core_compose_result_r |> push_to_max
+      | Imply_const c ->
+        let c = Axis.set ax1 c (min dst) in
+        let m =
+          Core_morph.id_except_for_areality src dst ax0 ax1
+          |> lift_core_compose_result_r
+        in
+        compose dst (Imply_const c) m
+      | Core_imply_const (m, c) ->
+        let m = lift_max src dst (Core m) ax0 ax1 in
+        let c = Axis.set ax0 c (arbitrary src) in
+        compose dst m (Imply_const c)
     [@@warning "-4"]
 
     let rec lift_min : type a b p q.
@@ -3389,25 +3366,29 @@ module Lattices_mono = struct
         (b, q) Axis.t ->
         (a, b, allowed * disallowed) t =
      fun src dst m ax0 ax1 ->
-      let m : (a, b, allowed * disallowed) t =
-        match m with
-        | Id -> Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
-        | Core m ->
-          Core_morph.lift_min src dst m ax0 ax1 |> lift_core_compose_result_l
-        | Meet_const c ->
-          let c = Axis.set ax1 c (arbitrary dst) in
-          let m =
-            Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
-          in
-          compose dst (Meet_const c) m
-        | Meet_const_core (c, m) ->
-          let m = lift_min src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax1 c (arbitrary dst) in
-          compose dst (Meet_const c) m
+      let push_to_min m =
+        let q_obj = proj_obj ax1 dst in
+        let c = min_with dst ax1 (max q_obj) in
+        compose dst (Meet_const c) m
       in
-      let q_obj = proj_obj ax1 dst in
-      let c = min_with dst ax1 (max q_obj) in
-      compose dst (Meet_const c) m
+      match m with
+      | Id ->
+        Core_morph.id_except_for_areality src dst ax0 ax1
+        |> lift_core_compose_result_l |> push_to_min
+      | Core m ->
+        Core_morph.lift_l src dst m ax0 ax1
+        |> lift_core_compose_result_l |> push_to_min
+      | Meet_const c ->
+        let c = Axis.set ax1 c (min dst) in
+        let m =
+          Core_morph.id_except_for_areality src dst ax0 ax1
+          |> lift_core_compose_result_l
+        in
+        compose dst (Meet_const c) m
+      | Meet_const_core (c, m) ->
+        let m = lift_min src dst (Core m) ax0 ax1 in
+        let c = Axis.set ax1 c (arbitrary dst) in
+        compose dst (Meet_const c) m
     [@@warning "-4"]
 
     let ( let* ) xs f = List.concat_map f xs

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1156,15 +1156,16 @@ module Lattices = struct
     | Comonadic_with_locality -> Locality
     | Comonadic_with_regionality -> Regionality
 
-  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
-   fun a0 ->
-    match a0 with
-    | Locality -> Comonadic_with_locality
-    | Regionality -> Comonadic_with_regionality
+  let to_areality : type a. a obj -> a areality = function
+    | Locality -> Locality
+    | Regionality -> Regionality
     | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
     | Comonadic_with_locality | Contention_op | Visibility_op | Portability
     | Forkable | Yielding | Statefulness | Staticity_op ->
       assert false
+
+  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
+   fun a0 -> to_areality a0 |> areality_comonadic_obj
 
   let is_opposite : type a. a obj -> bool = function
     | Locality -> false

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3391,7 +3391,9 @@ module Lattices_mono = struct
         Max_with_simple
           (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
       | Const_max_core -> Const_max a_obj
-      | And_max_id ax1 -> Max_with_simple (ax1, m1)
+      | And_max_id ax1 ->
+        let obj0 = proj_obj ax1 dst in
+        Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
       | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
       end
     | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
@@ -3430,7 +3432,10 @@ module Lattices_mono = struct
         Min_with_simple
           (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
       | Const_min_core -> Const_min a_obj
-      | And_min_id ax1 -> Min_with_simple (ax1, m1)
+      | And_min_id ax1 ->
+        let obj0 = proj_obj ax1 dst in
+        let c0 = Axis.proj ax1 c0 in
+        Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
       | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
       end
     | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3744,6 +3744,468 @@ module Lattices_mono = struct
   end
 end
 
+module For_testing = struct
+  open Lattices_mono
+
+  type packed_obj = Obj : 'a obj -> packed_obj
+
+  let all_objs =
+    [ Obj Locality;
+      Obj Regionality;
+      Obj Uniqueness_op;
+      Obj Linearity;
+      Obj Portability;
+      Obj Forkable;
+      Obj Yielding;
+      Obj Statefulness;
+      Obj Contention_op;
+      Obj Visibility_op;
+      Obj Staticity_op;
+      Obj Monadic_op;
+      Obj Comonadic_with_locality;
+      Obj Comonadic_with_regionality ]
+
+  let ( let* ) xs f = List.concat_map f xs
+
+  let ( let+ ) xs f = List.map f xs
+
+  let values_for_check_locality = [Locality.Global; Locality.Local]
+
+  let values_for_check_regionality =
+    [Regionality.Global; Regionality.Regional; Regionality.Local]
+
+  let values_for_check_uniqueness_op = [Uniqueness.Unique; Uniqueness.Aliased]
+
+  let values_for_check_linearity = [Linearity.Many; Linearity.Once]
+
+  let values_for_check_portability =
+    [ Portability.Portable;
+      Portability.Shareable;
+      Portability.Corruptible;
+      Portability.Nonportable ]
+
+  let values_for_check_forkable = [Forkable.Forkable; Forkable.Unforkable]
+
+  let values_for_check_yielding = [Yielding.Unyielding; Yielding.Yielding]
+
+  let values_for_check_statefulness =
+    [ Statefulness.Stateless;
+      Statefulness.Writing;
+      Statefulness.Reading;
+      Statefulness.Stateful ]
+
+  let values_for_check_contention_op =
+    [ Contention.Uncontended;
+      Contention.Corrupted;
+      Contention.Shared;
+      Contention.Contended ]
+
+  let values_for_check_visibility_op =
+    [ Visibility.Read_write;
+      Visibility.Read;
+      Visibility.Write;
+      Visibility.Immutable ]
+
+  let values_for_check_staticity_op = [Staticity.Static; Staticity.Dynamic]
+
+  let values_for_check_monadic_op =
+    let* uniqueness = values_for_check_uniqueness_op in
+    let* contention = values_for_check_contention_op in
+    let* visibility = values_for_check_visibility_op in
+    let+ staticity = values_for_check_staticity_op in
+    { uniqueness; contention; visibility; staticity }
+
+  let values_for_check_comonadic_with_locality =
+    let* areality = values_for_check_locality in
+    let* linearity = values_for_check_linearity in
+    let* portability = values_for_check_portability in
+    let* forkable = values_for_check_forkable in
+    let* yielding = values_for_check_yielding in
+    let+ statefulness = values_for_check_statefulness in
+    { areality; linearity; portability; forkable; yielding; statefulness }
+
+  let values_for_check_comonadic_with_regionality =
+    let* areality = values_for_check_regionality in
+    let* linearity = values_for_check_linearity in
+    let* portability = values_for_check_portability in
+    let* forkable = values_for_check_forkable in
+    let* yielding = values_for_check_yielding in
+    let+ statefulness = values_for_check_statefulness in
+    { areality; linearity; portability; forkable; yielding; statefulness }
+
+  let all_values_for_check : type a. a obj -> a list = function
+    | Locality -> values_for_check_locality
+    | Regionality -> values_for_check_regionality
+    | Uniqueness_op -> values_for_check_uniqueness_op
+    | Linearity -> values_for_check_linearity
+    | Portability -> values_for_check_portability
+    | Forkable -> values_for_check_forkable
+    | Yielding -> values_for_check_yielding
+    | Statefulness -> values_for_check_statefulness
+    | Contention_op -> values_for_check_contention_op
+    | Visibility_op -> values_for_check_visibility_op
+    | Staticity_op -> values_for_check_staticity_op
+    | Monadic_op -> values_for_check_monadic_op
+    | Comonadic_with_locality -> values_for_check_comonadic_with_locality
+    | Comonadic_with_regionality -> values_for_check_comonadic_with_regionality
+
+  type 'a packed_axis = Axis : ('a, 'b) Axis.t -> 'a packed_axis
+
+  let axes : type a. a obj -> a packed_axis list = function
+    | Comonadic_with_locality ->
+      [ Axis Areality;
+        Axis Forkable;
+        Axis Yielding;
+        Axis Linearity;
+        Axis Statefulness;
+        Axis Portability ]
+    | Comonadic_with_regionality ->
+      [ Axis Areality;
+        Axis Forkable;
+        Axis Yielding;
+        Axis Linearity;
+        Axis Statefulness;
+        Axis Portability ]
+    | Monadic_op ->
+      [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
+    | Locality | Regionality | Uniqueness_op | Linearity | Portability
+    | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
+    | Staticity_op ->
+      []
+
+  type ('b, 'd) packed_core_to =
+    | Core_to : 'a obj * ('a, 'b, 'd) Core_morph.t -> ('b, 'd) packed_core_to
+
+  let core_to : type a b d. (a, b, d) Core_morph.t -> (b, d) packed_core_to =
+   fun m -> Core_to (Core_morph.src m, m)
+
+  let left_cores_to : type b. b obj -> (b, left_only) packed_core_to list =
+    function
+    | Locality -> [core_to (Locality_restricted Regional_to_local)]
+    | Regionality ->
+      [ core_to (Locality_restricted Local_to_regional);
+        core_to (Locality_restricted Locality_as_regionality);
+        core_to (Locality_restricted Local_to_regional_regionality);
+        core_to (Locality_restricted Regional_to_local_regionality) ]
+    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
+    | Linearity -> [core_to Uniqueness_op_to_linearity]
+    | Portability -> [core_to Contention_op_to_portability]
+    | Forkable -> []
+    | Yielding -> []
+    | Statefulness -> [core_to Visibility_op_to_statefulness]
+    | Contention_op -> [core_to Portability_to_contention_op]
+    | Visibility_op -> [core_to Statefulness_to_visibility_op]
+    | Staticity_op -> []
+    | Monadic_op ->
+      [ core_to (Comonadic_to_monadic_min Locality);
+        core_to (Comonadic_to_monadic_min Regionality) ]
+    | Comonadic_with_locality ->
+      [ core_to (Locality_full Regional_to_local);
+        core_to Monadic_to_comonadic_min ]
+    | Comonadic_with_regionality ->
+      [ core_to (Locality_full Local_to_regional);
+        core_to (Locality_full Locality_as_regionality);
+        core_to (Locality_full Local_to_regional_regionality);
+        core_to (Locality_full Regional_to_local_regionality);
+        core_to Monadic_to_comonadic_min ]
+
+  let right_cores_to : type b. b obj -> (b, right_only) packed_core_to list =
+    function
+    | Locality ->
+      [ core_to (Locality_restricted Regional_to_local);
+        core_to (Locality_restricted Regional_to_global) ]
+    | Regionality ->
+      [ core_to (Locality_restricted Locality_as_regionality);
+        core_to (Locality_restricted Regional_to_local_regionality);
+        core_to (Locality_restricted Regional_to_global_regionality) ]
+    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
+    | Linearity -> [core_to Uniqueness_op_to_linearity]
+    | Portability -> [core_to Contention_op_to_portability]
+    | Forkable -> []
+    | Yielding -> []
+    | Statefulness -> [core_to Visibility_op_to_statefulness]
+    | Contention_op -> [core_to Portability_to_contention_op]
+    | Visibility_op -> [core_to Statefulness_to_visibility_op]
+    | Staticity_op -> []
+    | Monadic_op ->
+      [ core_to (Comonadic_to_monadic_max Locality);
+        core_to (Comonadic_to_monadic_max Regionality) ]
+    | Comonadic_with_locality ->
+      [ core_to (Locality_full Regional_to_local);
+        core_to (Locality_full Regional_to_global);
+        core_to Monadic_to_comonadic_max ]
+    | Comonadic_with_regionality ->
+      [ core_to (Locality_full Locality_as_regionality);
+        core_to (Locality_full Regional_to_local_regionality);
+        core_to (Locality_full Regional_to_global_regionality);
+        core_to Monadic_to_comonadic_max ]
+
+  type ('b, 'd) packed_simple_to =
+    | Simple_to :
+        'a obj * ('a, 'b, 'd) Simple_morph.t
+        -> ('b, 'd) packed_simple_to
+
+  let simple_to : type a b d.
+      b obj -> (a, b, d) Simple_morph.t -> (b, d) packed_simple_to =
+   fun dst m -> Simple_to (Simple_morph.src dst m, m)
+
+  let simple_left_to : type b. b obj -> (b, left_only) packed_simple_to list =
+   fun dst ->
+    let constants =
+      List.map
+        (fun c -> simple_to dst (Simple_morph.Meet_const c))
+        (all_values_for_check dst)
+    in
+    let cores = left_cores_to dst in
+    let core_morphs =
+      List.map
+        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
+        cores
+    in
+    let meet_const_cores =
+      let* c = all_values_for_check dst in
+      let+ (Core_to (_, m)) = cores in
+      simple_to dst (Simple_morph.Meet_const_core (c, m))
+    in
+    (simple_to dst Id :: core_morphs) @ constants @ meet_const_cores
+
+  let simple_right_to : type b. b obj -> (b, right_only) packed_simple_to list =
+   fun dst ->
+    let constants =
+      List.map
+        (fun c -> simple_to dst (Simple_morph.Imply_const c))
+        (all_values_for_check dst)
+    in
+    let cores = right_cores_to dst in
+    let core_morphs =
+      List.map
+        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
+        cores
+    in
+    let core_imply_consts =
+      let* (Core_to (src, m)) = cores in
+      let+ c = all_values_for_check src in
+      simple_to dst (Simple_morph.Core_imply_const (m, c))
+    in
+    (simple_to dst Id :: core_morphs) @ constants @ core_imply_consts
+
+  let filter_simple_src : type a b d.
+      a obj -> (b, d) packed_simple_to list -> (a, b, d) Simple_morph.t list =
+   fun src simple_morphs ->
+    let filter : (b, d) packed_simple_to -> (a, b, d) Simple_morph.t option =
+     fun (Simple_to (src', m)) ->
+      match equal_obj src src' with
+      | Misc.Is_eq -> Some m
+      | Misc.Is_not_eq -> None
+    in
+    List.filter_map filter simple_morphs
+
+  let simple_left_from_to src dst = filter_simple_src src (simple_left_to dst)
+
+  let simple_right_from_to src dst = filter_simple_src src (simple_right_to dst)
+
+  type 'b packed_morph_to =
+    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
+
+  let left_morph_to : type a b.
+      a obj -> (a, b, left_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_left morph)
+
+  let right_morph_to : type a b.
+      a obj -> (a, b, right_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_right morph)
+
+  let generate_left_morphs_to : type b. b obj -> b packed_morph_to list =
+   fun dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_to (src, m)) -> left_morph_to src (Simple m))
+        (simple_left_to dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis ax) = axes src in
+      let projected = proj_obj ax src in
+      let+ m = simple_left_from_to projected dst in
+      left_morph_to src (Simple_proj (m, ax, src))
+    in
+    let min_with =
+      let* (Axis ax) = axes dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_to (src, m)) = simple_left_to projected in
+      left_morph_to src (Min_with_simple (ax, m))
+    in
+    let const_min =
+      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+    in
+    simple_morphs @ projections @ min_with @ const_min
+
+  let generate_right_morphs_to : type b. b obj -> b packed_morph_to list =
+   fun dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_to (src, m)) -> right_morph_to src (Simple m))
+        (simple_right_to dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis ax) = axes src in
+      let projected = proj_obj ax src in
+      let+ m = simple_right_from_to projected dst in
+      right_morph_to src (Simple_proj (m, ax, src))
+    in
+    let max_with =
+      let* (Axis ax) = axes dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_to (src, m)) = simple_right_to projected in
+      right_morph_to src (Max_with_simple (ax, m))
+    in
+    let const_max =
+      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+    in
+    simple_morphs @ projections @ max_with @ const_max
+
+  let generate_morphs_to dst =
+    generate_left_morphs_to dst @ generate_right_morphs_to dst
+
+  let morphs_to_locality = generate_morphs_to Locality
+
+  let morphs_to_regionality = generate_morphs_to Regionality
+
+  let morphs_to_uniqueness_op = generate_morphs_to Uniqueness_op
+
+  let morphs_to_linearity = generate_morphs_to Linearity
+
+  let morphs_to_portability = generate_morphs_to Portability
+
+  let morphs_to_forkable = generate_morphs_to Forkable
+
+  let morphs_to_yielding = generate_morphs_to Yielding
+
+  let morphs_to_statefulness = generate_morphs_to Statefulness
+
+  let morphs_to_contention_op = generate_morphs_to Contention_op
+
+  let morphs_to_visibility_op = generate_morphs_to Visibility_op
+
+  let morphs_to_staticity_op = generate_morphs_to Staticity_op
+
+  let morphs_to_monadic_op = generate_morphs_to Monadic_op
+
+  let morphs_to_comonadic_with_locality =
+    generate_morphs_to Comonadic_with_locality
+
+  let morphs_to_comonadic_with_regionality =
+    generate_morphs_to Comonadic_with_regionality
+
+  let morphs_to : type b. b obj -> b packed_morph_to list = function
+    | Locality -> morphs_to_locality
+    | Regionality -> morphs_to_regionality
+    | Uniqueness_op -> morphs_to_uniqueness_op
+    | Linearity -> morphs_to_linearity
+    | Portability -> morphs_to_portability
+    | Forkable -> morphs_to_forkable
+    | Yielding -> morphs_to_yielding
+    | Statefulness -> morphs_to_statefulness
+    | Contention_op -> morphs_to_contention_op
+    | Visibility_op -> morphs_to_visibility_op
+    | Staticity_op -> morphs_to_staticity_op
+    | Monadic_op -> morphs_to_monadic_op
+    | Comonadic_with_locality -> morphs_to_comonadic_with_locality
+    | Comonadic_with_regionality -> morphs_to_comonadic_with_regionality
+
+  let check_compose : type a b c.
+      a obj ->
+      b obj ->
+      c obj ->
+      (b, c, neither) morph ->
+      (a, b, neither) morph ->
+      unit =
+   fun src mid dst f g ->
+    let result = compose dst f g in
+    List.iter
+      (fun input ->
+        let expected = apply dst f (apply mid g input) in
+        let actual = apply dst result input in
+        if not (equal dst expected actual)
+        then
+          let msg =
+            Fmt.asprintf
+              "@[<v>Lattices_mono compose check failed:@,\
+               source: %a@,\
+               middle: %a@,\
+               target: %a@,\
+               f: %a@,\
+               g: %a@,\
+               result: %a@,\
+               input: %a@,\
+               expected: %a@,\
+               actual: %a@]"
+              print_obj src print_obj mid print_obj dst (print_morph dst) f
+              (print_morph mid) g (print_morph dst) result (print src) input
+              (print dst) expected (print dst) actual
+          in
+          failwith msg)
+      (all_values_for_check src)
+
+  let domain_count_for_jobs job_count =
+    Int.min (Domain.recommended_domain_count ()) job_count
+
+  let run_jobs_in_parallel jobs =
+    let job_count = Array.length jobs in
+    let domain_count = domain_count_for_jobs job_count in
+    if domain_count <= 1
+    then Array.iter (fun job -> job ()) jobs
+    else
+      let worker worker_index =
+        let rec loop job_index =
+          if job_index < job_count
+          then (
+            jobs.(job_index) ();
+            loop (job_index + domain_count))
+        in
+        match loop worker_index with
+        | () -> None
+        | exception exn -> Some (exn, Printexc.get_raw_backtrace ())
+      in
+      let domains =
+        Array.init (domain_count - 1) (fun worker_index ->
+            (Domain.spawn
+            [@ocaml.alert "-do_not_spawn_domains"]
+            [@ocaml.alert "-unsafe_multidomain"]) (fun () ->
+                worker (worker_index + 1)))
+      in
+      let first_error =
+        Array.fold_left
+          (fun first_error domain ->
+            match first_error, Domain.join domain with
+            | Some _, _ -> first_error
+            | None, error -> error)
+          (worker 0) domains
+      in
+      match first_error with
+      | None -> ()
+      | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+
+  let check_jobs () =
+    let jobs =
+      let* (Obj dst) = all_objs in
+      let+ (Morph_to (mid, f)) = morphs_to dst in
+      let morphs_to_mid = morphs_to mid in
+      fun () ->
+        List.iter
+          (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
+          morphs_to_mid
+    in
+    Array.of_list jobs
+
+  let check_all_allowed_compositions () =
+    let jobs = check_jobs () in
+    Printf.printf "allowed checks running on %d domain(s)\n%!"
+      (domain_count_for_jobs (Array.length jobs));
+    run_jobs_in_parallel jobs
+end
+
 module C = Lattices_mono
 module S = Solver_mono (Hint_for_solver) (C)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1517,29 +1517,56 @@ module Lattices_mono = struct
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
-    type 'a packed = Axis : ('a, 'b) t -> 'a packed
+    type 'a packed_small = Ps : ('a, 'b) t -> 'a packed_small
 
-    let all : type a. a obj -> a packed list = function
+    let all : type a. a obj -> a packed_small list = function
       | Comonadic_with_locality ->
-        [ Axis Areality;
-          Axis Forkable;
-          Axis Yielding;
-          Axis Linearity;
-          Axis Statefulness;
-          Axis Portability ]
+        [ Ps Areality;
+          Ps Forkable;
+          Ps Yielding;
+          Ps Linearity;
+          Ps Statefulness;
+          Ps Portability ]
       | Comonadic_with_regionality ->
-        [ Axis Areality;
-          Axis Forkable;
-          Axis Yielding;
-          Axis Linearity;
-          Axis Statefulness;
-          Axis Portability ]
-      | Monadic_op ->
-        [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
+        [ Ps Areality;
+          Ps Forkable;
+          Ps Yielding;
+          Ps Linearity;
+          Ps Statefulness;
+          Ps Portability ]
+      | Monadic_op -> [Ps Uniqueness; Ps Visibility; Ps Contention; Ps Staticity]
       | Locality | Regionality | Uniqueness_op | Linearity | Portability
       | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
       | Staticity_op ->
         []
+
+    type 'b packed_big = Pb : 'a obj * ('a, 'b) t -> 'b packed_big
+
+    let axis_to : type b. b obj -> b packed_big list = function
+      | Comonadic_with_locality -> []
+      | Comonadic_with_regionality -> []
+      | Monadic_op -> []
+      | Locality -> [Pb (Comonadic_with_locality, Areality)]
+      | Regionality -> [Pb (Comonadic_with_regionality, Areality)]
+      | Uniqueness_op -> [Pb (Monadic_op, Uniqueness)]
+      | Linearity ->
+        [ Pb (Comonadic_with_locality, Linearity);
+          Pb (Comonadic_with_regionality, Linearity) ]
+      | Portability ->
+        [ Pb (Comonadic_with_locality, Portability);
+          Pb (Comonadic_with_regionality, Portability) ]
+      | Forkable ->
+        [ Pb (Comonadic_with_locality, Forkable);
+          Pb (Comonadic_with_regionality, Forkable) ]
+      | Yielding ->
+        [ Pb (Comonadic_with_locality, Yielding);
+          Pb (Comonadic_with_regionality, Yielding) ]
+      | Statefulness ->
+        [ Pb (Comonadic_with_locality, Statefulness);
+          Pb (Comonadic_with_regionality, Statefulness) ]
+      | Contention_op -> [Pb (Monadic_op, Contention)]
+      | Visibility_op -> [Pb (Monadic_op, Visibility)]
+      | Staticity_op -> [Pb (Monadic_op, Staticity)]
   end
 
   type packed_obj = Obj : 'a obj -> packed_obj
@@ -3286,21 +3313,6 @@ module Lattices_mono = struct
         to_ dst (Core_imply_const (m, c))
       in
       (to_ dst Id :: core_morphs) @ constants @ core_imply_consts
-
-    let filter_src : type a b d.
-        a obj -> (b, d) packed_to list -> (a, b, d) t list =
-     fun src simple_morphs ->
-      let filter : (b, d) packed_to -> (a, b, d) t option =
-       fun (To (src', m)) ->
-        match equal_obj src src' with
-        | Misc.Is_eq -> Some m
-        | Misc.Is_not_eq -> None
-      in
-      List.filter_map filter simple_morphs
-
-    let left_from_to ~full src dst = filter_src src (left_to ~full dst)
-
-    let right_from_to ~full src dst = filter_src src (right_to ~full dst)
   end
 
   type ('a, 'b, 'd) morph =
@@ -3918,20 +3930,19 @@ module Lattices_mono = struct
   let generate_left_morphs_to : type b.
       full:bool -> b obj -> b packed_morph_to list =
    fun ~full dst ->
-    let simple_morphs =
+    let simple_morphs = Simple_morph.left_to ~full dst in
+    let simple =
       List.map
         (fun (Simple_morph.To (src, m)) -> left_morph_to src (Simple m))
-        (Simple_morph.left_to ~full dst)
+        simple_morphs
     in
     let projections =
-      let* (Obj src) = all_objs in
-      let* (Axis.Axis ax) = Axis.all src in
-      let projected = proj_obj ax src in
-      let+ m = Simple_morph.left_from_to ~full projected dst in
+      let* (Simple_morph.To (projected, m)) = simple_morphs in
+      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
       left_morph_to src (Simple_proj (m, ax, src))
     in
     let min_with =
-      let* (Axis.Axis ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To (src, m)) = Simple_morph.left_to ~full projected in
       left_morph_to src (Min_with_simple (ax, m))
@@ -3939,25 +3950,24 @@ module Lattices_mono = struct
     let const_min =
       List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
     in
-    simple_morphs @ projections @ min_with @ const_min
+    simple @ projections @ min_with @ const_min
 
   let generate_right_morphs_to : type b.
       full:bool -> b obj -> b packed_morph_to list =
    fun ~full dst ->
-    let simple_morphs =
+    let simple_morphs = Simple_morph.right_to ~full dst in
+    let simple =
       List.map
         (fun (Simple_morph.To (src, m)) -> right_morph_to src (Simple m))
-        (Simple_morph.right_to ~full dst)
+        simple_morphs
     in
     let projections =
-      let* (Obj src) = all_objs in
-      let* (Axis.Axis ax) = Axis.all src in
-      let projected = proj_obj ax src in
-      let+ m = Simple_morph.right_from_to ~full projected dst in
+      let* (Simple_morph.To (projected, m)) = simple_morphs in
+      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
       right_morph_to src (Simple_proj (m, ax, src))
     in
     let max_with =
-      let* (Axis.Axis ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To (src, m)) = Simple_morph.right_to ~full projected in
       right_morph_to src (Max_with_simple (ax, m))
@@ -3965,7 +3975,7 @@ module Lattices_mono = struct
     let const_max =
       List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
     in
-    simple_morphs @ projections @ max_with @ const_max
+    simple @ projections @ max_with @ const_max
 
   let generate_morphs_to ~full dst =
     generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
@@ -4212,8 +4222,6 @@ module For_testing = struct
           failwith msg)
       (get_elements ~full src)
 
-  let run_jobs jobs = List.iter (fun job -> job ()) jobs
-
   let check_jobs ~full () =
     let* (Obj dst) = all_objs in
     let+ (Morph_to (mid, f)) = morphs_to ~full dst in
@@ -4222,11 +4230,6 @@ module For_testing = struct
       List.iter
         (fun (Morph_to (src, g)) -> check_compose ~full src mid dst f g)
         morphs_to_mid
-
-  let check_all_allowed_compositions ~full () =
-    let jobs = check_jobs ~full () in
-    Printf.printf "running allowed composition checks\n%!";
-    run_jobs jobs
 end
 
 module C = Lattices_mono

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1944,6 +1944,23 @@ module Lattices_mono = struct
         Morph Locality_as_regionality
       | Comonadic_with_regionality, Comonadic_with_regionality -> Id
       | Comonadic_with_locality, Comonadic_with_locality -> Id
+
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
+
+    let left_to : type b. b areality -> (b, left_only) to_ list = function
+      | Locality -> [To Regional_to_local]
+      | Regionality ->
+        [ To Local_to_regional;
+          To Locality_as_regionality;
+          To Local_to_regional_regionality;
+          To Regional_to_local_regionality ]
+
+    let right_to : type b. b areality -> (b, right_only) to_ list = function
+      | Locality -> [To Regional_to_local; To Regional_to_global]
+      | Regionality ->
+        [ To Locality_as_regionality;
+          To Regional_to_local_regionality;
+          To Regional_to_global_regionality ]
   end
 
   module Core_morph = struct
@@ -2745,13 +2762,15 @@ module Lattices_mono = struct
 
     type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
 
+    let ( let+ ) xs f = List.map f xs
+
     let left_to : type b. b obj -> (b, left_only) to_ list = function
-      | Locality -> [To (Locality_restricted Regional_to_local)]
+      | Locality ->
+        let+ (Locality_morph.To lm) = Locality_morph.left_to Locality in
+        To (Locality_restricted lm)
       | Regionality ->
-        [ To (Locality_restricted Local_to_regional);
-          To (Locality_restricted Locality_as_regionality);
-          To (Locality_restricted Local_to_regional_regionality);
-          To (Locality_restricted Regional_to_local_regionality) ]
+        let+ (Locality_morph.To lm) = Locality_morph.left_to Regionality in
+        To (Locality_restricted lm)
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2765,22 +2784,21 @@ module Lattices_mono = struct
         [ To (Comonadic_to_monadic_min Locality);
           To (Comonadic_to_monadic_min Regionality) ]
       | Comonadic_with_locality ->
-        [To (Locality_full Regional_to_local); To Monadic_to_comonadic_min]
+        (let+ (Locality_morph.To lm) = Locality_morph.left_to Locality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_min]
       | Comonadic_with_regionality ->
-        [ To (Locality_full Local_to_regional);
-          To (Locality_full Locality_as_regionality);
-          To (Locality_full Local_to_regional_regionality);
-          To (Locality_full Regional_to_local_regionality);
-          To Monadic_to_comonadic_min ]
+        (let+ (Locality_morph.To lm) = Locality_morph.left_to Regionality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_min]
 
     let right_to : type b. b obj -> (b, right_only) to_ list = function
       | Locality ->
-        [ To (Locality_restricted Regional_to_local);
-          To (Locality_restricted Regional_to_global) ]
+        let+ (Locality_morph.To lm) = Locality_morph.right_to Locality in
+        To (Locality_restricted lm)
       | Regionality ->
-        [ To (Locality_restricted Locality_as_regionality);
-          To (Locality_restricted Regional_to_local_regionality);
-          To (Locality_restricted Regional_to_global_regionality) ]
+        let+ (Locality_morph.To lm) = Locality_morph.right_to Regionality in
+        To (Locality_restricted lm)
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2794,14 +2812,13 @@ module Lattices_mono = struct
         [ To (Comonadic_to_monadic_max Locality);
           To (Comonadic_to_monadic_max Regionality) ]
       | Comonadic_with_locality ->
-        [ To (Locality_full Regional_to_local);
-          To (Locality_full Regional_to_global);
-          To Monadic_to_comonadic_max ]
+        (let+ (Locality_morph.To lm) = Locality_morph.right_to Locality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_max]
       | Comonadic_with_regionality ->
-        [ To (Locality_full Locality_as_regionality);
-          To (Locality_full Regional_to_local_regionality);
-          To (Locality_full Regional_to_global_regionality);
-          To Monadic_to_comonadic_max ]
+        (let+ (Locality_morph.To lm) = Locality_morph.right_to Regionality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_max]
   end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5275,15 +5275,15 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_right m
 
-  let newvar () = S.newvar obj
+  let newvar () = S.newvar obj 0
 
   let min : lr = S.min obj
 
   let max : lr = S.max obj
 
-  let newvar_above m = S.newvar_above obj m
+  let newvar_above m = S.newvar_above obj 0 m
 
-  let newvar_below m = S.newvar_below obj m
+  let newvar_below m = S.newvar_below obj 0 m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj a b ~log
@@ -5377,15 +5377,15 @@ module Monadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_left m
 
-  let newvar () = S.newvar obj
+  let newvar () = S.newvar obj 0
 
   let min : lr = S.allow_left (S.max obj)
 
   let max : lr = S.allow_right (S.min obj)
 
-  let newvar_above m = S.newvar_below obj m
+  let newvar_above m = S.newvar_below obj 0 m
 
-  let newvar_below m = S.newvar_above obj m
+  let newvar_below m = S.newvar_above obj 0 m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj b a ~log

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7474,9 +7474,12 @@ module Crossing = struct
       Mode.subtract_const_unhint c
         (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
-    let apply_right (Modality (Join_const c)) m =
+    let apply_right_unhint (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
       Mode.join_const_unhint c m
+
+    let apply_right t m =
+      Monadic.hint ~hint:Crossing (apply_right_unhint t (S.Unhint.unhint m))
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Join_const c)) : a Atom.t
         =
@@ -7569,9 +7572,14 @@ module Crossing = struct
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
-    let apply_left (Modality (Meet_const c)) m =
+    let apply_left_unhint (Modality (Meet_const c)) m =
       (* The left adjoint of meet is a restriction of identity *)
       Mode.meet_const_unhint c m
+
+    let apply_left t m =
+      Alloc.Comonadic.hint ~hint:Crossing
+        (comonadic_locality_as_regionality (S.Unhint.unhint m)
+        |> apply_left_unhint t |> comonadic_regional_to_local)
 
     let apply_right (Modality (Meet_const c)) m =
       Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
@@ -7690,7 +7698,7 @@ module Crossing = struct
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
     let comonadic =
-      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+      Comonadic.apply_left_unhint t.comonadic (S.Unhint.unhint comonadic)
     in
     { monadic; comonadic }
 
@@ -7699,7 +7707,9 @@ module Crossing = struct
       (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
+    let monadic =
+      Monadic.apply_right_unhint t.monadic (S.Unhint.unhint monadic)
+    in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
@@ -7730,10 +7740,10 @@ module Crossing = struct
 
   let apply_left_right_alloc t m =
     let { monadic; comonadic } = Alloc.unhint m in
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right_unhint t.monadic monadic in
     let comonadic =
       comonadic |> comonadic_locality_as_regionality
-      |> Comonadic.apply_left t.comonadic
+      |> Comonadic.apply_left_unhint t.comonadic
       |> comonadic_regional_to_local
       (* the left adjoint of [locality_as_regionality]*)
     in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5115,6 +5115,10 @@ let append_changes : (changes ref -> unit) ref = ref (fun _ -> assert false)
 
 let set_append_changes f = append_changes := f
 
+type copy_scope = S.copy_scope
+
+let with_copy_scope = S.with_copy_scope
+
 type ('a, 'd) mode = ('a, 'd) S.mode
 
 module Error = struct
@@ -5248,6 +5252,10 @@ let equate_from_submode' submode m1 m2 =
     | Ok () -> Ok ())
 [@@inline]
 
+exception Cannot_zap_generic
+
+exception Cannot_get_constant_from_generic
+
 module Comonadic_gen (Obj : Obj) = struct
   open Obj
 
@@ -5275,15 +5283,26 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_right m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.min obj
 
   let max : lr = S.max obj
 
-  let newvar_above m = S.newvar_above obj 0 m
+  let generic_level = S.generic_level
 
-  let newvar_below m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
+
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj a b ~log
@@ -5300,6 +5319,32 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let print_error pp err = Error.print_all pp obj err
 
+  let update_level i a = with_log (S.update_level i obj a)
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+    else S.generalize_structure ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_to_level = Stdlib.max_int in
+    S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
+
+  let duplicate ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_to_level = Stdlib.max_int in
+    S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
+
   let join l = S.join obj l
 
   let meet l = S.meet obj l
@@ -5312,14 +5357,41 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
 
-  let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
+  let check_level a i = S.check_level a i
 
-  let zap_to_floor m = with_log (S.zap_to_floor obj m)
+  let check_level_var a i = S.check_level_var a i
+
+  let iter_covariant a iter = S.iter_covariant obj a iter
+
+  let iter_contravariant a iter = S.iter_contravariant obj a iter
+
+  let zap_to_ceil_force m = with_log (S.zap_to_ceil obj m)
+
+  let zap_to_floor_force m = with_log (S.zap_to_floor obj m)
+
+  let zap_to_ceil_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_ceil m =
+    if check_level_var m generic_level then None else Some (zap_to_ceil_force m)
+
+  let zap_to_floor m =
+    if check_level_var m generic_level
+    then None
+    else Some (zap_to_floor_force m)
 
   let of_const : type l r. ?hint:(l * r) pos Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_level_var m generic_level
+    then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5345,6 +5417,11 @@ module Comonadic_gen (Obj : Obj) = struct
     let get_loose_floor m = S.get_loose_floor obj m
 
     let get_loose_ceil m = S.get_loose_ceil obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj ceil floor then Some ceil else None
   end
 end
 [@@inline]
@@ -5377,15 +5454,24 @@ module Monadic_gen (Obj : Obj) = struct
 
   let allow_right m = S.allow_left m
 
-  let newvar () = S.newvar obj 0
+  let choose_level level =
+    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+
+  let newvar level =
+    let level = choose_level level in
+    S.newvar obj level
 
   let min : lr = S.allow_left (S.max obj)
 
   let max : lr = S.allow_right (S.min obj)
 
-  let newvar_above m = S.newvar_below obj 0 m
+  let newvar_above level m =
+    let level = choose_level level in
+    S.newvar_below obj level m
 
-  let newvar_below m = S.newvar_above obj 0 m
+  let newvar_below level m =
+    let level = choose_level level in
+    S.newvar_above obj level m
 
   let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
     S.submode pp obj b a ~log
@@ -5399,6 +5485,34 @@ module Monadic_gen (Obj : Obj) = struct
     match submode ~pp a b with
     | Ok () -> ()
     | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
+
+  let generic_level = S.generic_level
+
+  let update_level i a = S.update_level ~log:None i obj a
+
+  let generalize ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    then S.generalize ~log:None ~current_level obj a
+    else S.generalize_structure ~log:None ~current_level obj a
+
+  let generalize_structure ~current_level a =
+    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    then S.generalize_structure ~log:None ~current_level obj a
+
+  let instantiate ~copy_scope ~current_level a =
+    let copy_from_level = generic_level in
+    let copy_to_level = current_level in
+    S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
+
+  let copy_generic ~copy_scope a =
+    let copy_from_level = generic_level in
+    let copy_to_level = Stdlib.max_int in
+    S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
+
+  let duplicate ~copy_scope a =
+    let copy_from_level = 0 in
+    let copy_to_level = Stdlib.max_int in
+    S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
 
   let print_error pp err = Error.print_all pp obj err
 
@@ -5414,14 +5528,41 @@ module Monadic_gen (Obj : Obj) = struct
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
 
-  let zap_to_ceil m = with_log (S.zap_to_floor obj m)
+  let check_level a i = S.check_level a i
 
-  let zap_to_floor m = with_log (S.zap_to_ceil obj m)
+  let check_level_var a i = S.check_level_var a i
+
+  let iter_covariant a iter = S.iter_contravariant obj a iter
+
+  let iter_contravariant a iter = S.iter_covariant obj a iter
+
+  let zap_to_ceil_force m = with_log (S.zap_to_floor obj m)
+
+  let zap_to_floor_force m = with_log (S.zap_to_ceil obj m)
+
+  let zap_to_ceil_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_level_var m generic_level
+    then None
+    else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_level_var m generic_level then None else Some (zap_to_ceil_force m)
 
   let of_const : type l r. ?hint:(l * r) neg Hint.const -> const -> (l * r) t =
    fun ?hint a -> S.of_const ?hint obj a
 
-  let to_const_exn m = S.to_const_exn obj m
+  let to_const_exn m =
+    if check_level_var m generic_level
+    then raise Cannot_get_constant_from_generic;
+    S.to_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -5440,7 +5581,14 @@ module Monadic_gen (Obj : Obj) = struct
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
   module Guts = struct
+    let get_floor m = S.get_ceil obj m
+
     let get_ceil m = S.get_floor obj m
+
+    let check_const m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      if C.le obj ceil floor then Some ceil else None
   end
 end
 [@@inline]
@@ -5462,7 +5610,7 @@ module Locality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 
   module Guts = struct
     let check_const m =
@@ -5496,7 +5644,7 @@ module Regionality = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Linearity = struct
@@ -5516,7 +5664,7 @@ module Linearity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Statefulness = struct
@@ -5540,7 +5688,7 @@ module Statefulness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Visibility = struct
@@ -5564,7 +5712,7 @@ module Visibility = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy_force = zap_to_floor_force
 end
 
 module Portability = struct
@@ -5581,12 +5729,12 @@ module Portability = struct
   let legacy = of_const Const.legacy
 
   (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
-  let zap_to_legacy ~statefulness =
+  let zap_to_legacy_force ~statefulness =
     match statefulness with
     | Statefulness.Const.Stateful | Statefulness.Const.Reading
     | Statefulness.Const.Writing ->
-      zap_to_ceil
-    | Statefulness.Const.Stateless -> zap_to_floor
+      zap_to_ceil_force
+    | Statefulness.Const.Stateless -> zap_to_floor_force
 end
 
 module Uniqueness = struct
@@ -5606,7 +5754,7 @@ module Uniqueness = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module Contention = struct
@@ -5623,12 +5771,12 @@ module Contention = struct
   let legacy = of_const Const.legacy
 
   (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
-  let zap_to_legacy ~visibility =
+  let zap_to_legacy_force ~visibility =
     match visibility with
     | Visibility.Const.Read_write | Visibility.Const.Read
     | Visibility.Const.Write ->
-      zap_to_floor
-    | Visibility.Const.Immutable -> zap_to_ceil
+      zap_to_floor_force
+    | Visibility.Const.Immutable -> zap_to_ceil_force
 end
 
 module Forkable = struct
@@ -5649,9 +5797,9 @@ module Forkable = struct
   let legacy = of_const Const.legacy
 
   (* [forkable] is the default for [global]s and [unforkable] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Yielding = struct
@@ -5672,9 +5820,9 @@ module Yielding = struct
   let legacy = of_const Const.legacy
 
   (* [unyielding] is the default for [global]s and [yielding] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+     or [regional] values, so we vary [zap_to_legacy_force] accordingly. *)
+  let zap_to_legacy_force ~global =
+    match global with true -> zap_to_floor_force | false -> zap_to_ceil_force
 end
 
 module Staticity = struct
@@ -5694,7 +5842,7 @@ module Staticity = struct
 
   let legacy = of_const Const.legacy
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy_force = zap_to_ceil_force
 end
 
 module type Areality = sig
@@ -5702,7 +5850,7 @@ module type Areality = sig
 
   module Obj : Obj with type const = Const.t
 
-  val zap_to_legacy : (Const.t, allowed * 'r) S.mode -> Const.t
+  val zap_to_legacy_force : (Const.t, allowed * 'r) S.mode -> Const.t
 end
 
 module Lattice_Product (L : Lattice) = struct
@@ -5817,16 +5965,18 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy m : Const.t =
-    let areality = proj Areality m |> Areality.zap_to_legacy in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy in
-    let statefulness = proj Statefulness m |> Statefulness.zap_to_legacy in
+  let zap_to_legacy_force m : Const.t =
+    let areality = proj Areality m |> Areality.zap_to_legacy_force in
+    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force in
+    let statefulness =
+      proj Statefulness m |> Statefulness.zap_to_legacy_force
+    in
     let portability =
-      proj Portability m |> Portability.zap_to_legacy ~statefulness
+      proj Portability m |> Portability.zap_to_legacy_force ~statefulness
     in
     let global = Areality.Const.equal areality Areality.Const.legacy in
-    let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
+    let forkable = proj Forkable m |> Forkable.zap_to_legacy_force ~global in
+    let yielding = proj Yielding m |> Yielding.zap_to_legacy_force ~global in
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
@@ -5962,13 +6112,13 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy m : Const.t =
-    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
-    let visibility = proj Visibility m |> Visibility.zap_to_legacy in
+  let zap_to_legacy_force m : Const.t =
+    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy_force in
+    let visibility = proj Visibility m |> Visibility.zap_to_legacy_force in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility
+      proj Contention m |> Contention.zap_to_legacy_force ~visibility
     in
-    let staticity = proj Staticity m |> Staticity.zap_to_legacy in
+    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force in
     { uniqueness; contention; visibility; staticity }
 
   let legacy = of_const Const.legacy
@@ -6008,9 +6158,69 @@ type ('mo, 'como) monadic_comonadic =
     comonadic : 'como
   }
 
+module Zap_scope = struct
+  module ModeIdMap = Hashtbl.Make (Int)
+
+  type job = unit -> unit
+
+  type job_list = job list
+
+  type zap_scope =
+    { zap_to_floor_map : job_list ModeIdMap.t;
+      zap_to_ceil_map : job_list ModeIdMap.t;
+      zap_to_legacy_map : job ModeIdMap.t
+    }
+
+  let create () =
+    { zap_to_floor_map = ModeIdMap.create 17;
+      zap_to_ceil_map = ModeIdMap.create 17;
+      zap_to_legacy_map = ModeIdMap.create 17
+    }
+
+  let add_job_to_map map i job =
+    match ModeIdMap.find_opt map i with
+    | Some jobs -> ModeIdMap.replace map i (job :: jobs)
+    | None -> ModeIdMap.add map i [job]
+
+  let add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy zs =
+    if ModeIdMap.mem zs.zap_to_legacy_map i
+    then ()
+    else
+      begin if ModeIdMap.mem zs.zap_to_ceil_map i
+      then begin
+        ModeIdMap.remove zs.zap_to_ceil_map i;
+        ModeIdMap.add zs.zap_to_legacy_map i zap_to_legacy
+      end
+      else add_job_to_map zs.zap_to_floor_map i zap_to_floor
+      end
+
+  let add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy zs =
+    if ModeIdMap.mem zs.zap_to_legacy_map i
+    then ()
+    else
+      begin if ModeIdMap.mem zs.zap_to_floor_map i
+      then begin
+        ModeIdMap.remove zs.zap_to_floor_map i;
+        ModeIdMap.add zs.zap_to_legacy_map i zap_to_legacy
+      end
+      else add_job_to_map zs.zap_to_ceil_map i zap_to_ceil
+      end
+
+  let resolve_zap_scope { zap_to_floor_map; zap_to_ceil_map; zap_to_legacy_map }
+      =
+    ModeIdMap.iter (fun _ f -> f ()) zap_to_legacy_map;
+    ModeIdMap.iter
+      (fun _ jobs -> List.iter (fun f -> f ()) jobs)
+      zap_to_floor_map;
+    ModeIdMap.iter
+      (fun _ jobs -> List.iter (fun f -> f ()) jobs)
+      zap_to_ceil_map
+end
+
 module Value_with (Areality : Areality) = struct
   module Comonadic = Comonadic_with (Areality)
   module Monadic = Monadic
+  module Z = Zap_scope
 
   type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
 
@@ -6337,6 +6547,25 @@ module Value_with (Areality : Areality) = struct
           visibility
           (option_print Staticity.Const.print)
           staticity
+
+      let partial_print ppf
+          { areality; uniqueness; linearity; portability; contention } =
+        let option_to_string print a =
+          Option.map (fun a -> Fmt.asprintf "%a" print a) a
+        in
+        let l =
+          [ option_to_string Areality.Const.print areality;
+            option_to_string Linearity.Const.print linearity;
+            option_to_string Uniqueness.Const.print uniqueness;
+            option_to_string Portability.Const.print portability;
+            option_to_string Contention.Const.print contention ]
+        in
+        let l = List.filter_map Fun.id l in
+        Fmt.fprintf ppf "%a"
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf " ")
+             (fun ppf s -> Fmt.fprintf ppf "%s" s))
+          l
     end
 
     let diff m1 m2 =
@@ -6418,6 +6647,8 @@ module Value_with (Areality : Areality) = struct
 
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
 
+  let generic_level = Comonadic.generic_level
+
   include Magic_allow_disallow (struct
     type (_, _, 'd) sided = 'd t
 
@@ -6442,19 +6673,19 @@ module Value_with (Areality : Areality) = struct
       { monadic; comonadic }
   end)
 
-  let newvar () =
-    let comonadic = Comonadic.newvar () in
-    let monadic = Monadic.newvar () in
+  let newvar level =
+    let comonadic = Comonadic.newvar level in
+    let monadic = Monadic.newvar level in
     { comonadic; monadic }
 
-  let newvar_above { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_above comonadic in
-    let monadic, b2 = Monadic.newvar_above monadic in
+  let newvar_above level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_above level comonadic in
+    let monadic, b2 = Monadic.newvar_above level monadic in
     { monadic; comonadic }, b1 || b2
 
-  let newvar_below { comonadic; monadic } =
-    let comonadic, b1 = Comonadic.newvar_below comonadic in
-    let monadic, b2 = Monadic.newvar_below monadic in
+  let newvar_below level { comonadic; monadic } =
+    let comonadic, b1 = Comonadic.newvar_below level comonadic in
+    let monadic, b2 = Monadic.newvar_below level monadic in
     { monadic; comonadic }, b1 || b2
 
   type atom = Atom : 'a Axis.t * 'a -> atom
@@ -6496,6 +6727,45 @@ module Value_with (Areality : Areality) = struct
   let submode_err pp a b =
     Comonadic.submode_err pp a.comonadic b.comonadic;
     Monadic.submode_err pp a.monadic b.monadic
+
+  let update_level i { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.update_level i monadic0;
+    Comonadic.update_level i comonadic0
+
+  let generalize ~current_level { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize ~current_level monadic0;
+    Comonadic.generalize ~current_level comonadic0
+
+  let generalize_structure ~current_level
+      { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.generalize_structure ~current_level monadic0;
+    Comonadic.generalize_structure ~current_level comonadic0
+
+  let instantiate ~copy_scope ~current_level
+      ({ monadic = monadic0; comonadic = comonadic0 } as m) =
+    let monadic1 = Monadic.instantiate ~copy_scope ~current_level monadic0 in
+    let comonadic1 =
+      Comonadic.instantiate ~copy_scope ~current_level comonadic0
+    in
+    if monadic1 == monadic0 && comonadic1 == comonadic0
+    then m
+    else { monadic = monadic1; comonadic = comonadic1 }
+
+  let copy_generic ~copy_scope { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.copy_generic ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.copy_generic ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let duplicate ~copy_scope { monadic = monadic0; comonadic = comonadic0 } =
+    let monadic1 = Monadic.duplicate ~copy_scope monadic0 in
+    let comonadic1 = Comonadic.duplicate ~copy_scope comonadic0 in
+    { monadic = monadic1; comonadic = comonadic1 }
+
+  let check_level { monadic = monadic0; comonadic = comonadic0 } i =
+    Monadic.check_level monadic0 i && Comonadic.check_level comonadic0 i
+
+  let check_level_var { monadic = monadic0; comonadic = comonadic0 } i =
+    Monadic.check_level_var monadic0 i || Comonadic.check_level_var comonadic0 i
 
   let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
 
@@ -6588,20 +6858,132 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
-  let zap_to_ceil { comonadic; monadic } =
-    let monadic = Monadic.zap_to_ceil monadic in
-    let comonadic = Comonadic.zap_to_ceil comonadic in
+  let zap_to_ceil_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_ceil_force monadic in
+    let comonadic = Comonadic.zap_to_ceil_force comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_floor { comonadic; monadic } =
-    let monadic = Monadic.zap_to_floor monadic in
-    let comonadic = Comonadic.zap_to_floor comonadic in
+  let zap_to_floor_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_floor_force monadic in
+    let comonadic = Comonadic.zap_to_floor_force comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_legacy { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy monadic in
-    let comonadic = Comonadic.zap_to_legacy comonadic in
+  let zap_to_ceil_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_ceil_force m
+
+  let zap_to_floor_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_floor_force m
+
+  let zap_to_floor m =
+    if check_level_var m generic_level
+    then None
+    else Some (zap_to_floor_force m)
+
+  let zap_to_ceil m =
+    if check_level_var m generic_level then None else Some (zap_to_ceil_force m)
+
+  let zap_to_legacy_force { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force monadic in
+    let comonadic = Comonadic.zap_to_legacy_force comonadic in
     merge { monadic; comonadic }
+
+  let zap_to_legacy_exn m =
+    if check_level_var m generic_level then raise Cannot_zap_generic;
+    zap_to_legacy_force m
+
+  let zap_to_legacy m =
+    if check_level_var m generic_level
+    then None
+    else Some (zap_to_legacy_force m)
+
+  type zap_scope =
+    { variables : Z.zap_scope;
+      visible : (allowed * allowed) t list ref
+    }
+
+  let zap_to_legacy_obj : type a.
+      a C.obj -> (a, allowed * allowed) S.mode -> unit =
+   fun obj mode ->
+    match (obj : a C.obj) with
+    | Locality -> Locality.zap_to_legacy_force mode |> ignore
+    | Regionality -> Regionality.zap_to_legacy_force mode |> ignore
+    | Uniqueness_op -> Uniqueness.zap_to_legacy_force mode |> ignore
+    | Visibility_op -> Visibility.zap_to_legacy_force mode |> ignore
+    | Linearity -> Linearity.zap_to_legacy_force mode |> ignore
+    | Statefulness -> Statefulness.zap_to_legacy_force mode |> ignore
+    | Staticity_op -> Staticity.zap_to_legacy_force mode |> ignore
+    | Monadic_op -> Monadic.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_regionality ->
+      let module M = Comonadic_with (Regionality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Comonadic_with_locality ->
+      let module M = Comonadic_with (Locality) in
+      M.zap_to_legacy_force mode |> ignore
+    | Portability ->
+      Portability.zap_to_legacy_force ~statefulness:Statefulness.Const.legacy
+        mode
+      |> ignore
+    | Contention_op ->
+      Contention.zap_to_legacy_force ~visibility:Visibility.Const.legacy mode
+      |> ignore
+    | Forkable -> Forkable.zap_to_legacy_force ~global:true mode |> ignore
+    | Yielding -> Yielding.zap_to_legacy_force ~global:true mode |> ignore
+
+  let zap_to_legacy_src_var_monadic m =
+    S.mode_iter Monadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  let zap_to_legacy_src_var_comonadic m =
+    S.mode_iter Comonadic.Obj.obj m
+      { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
+
+  let add_covariant_to_zap_scope { monadic; comonadic } scope =
+    Monadic.iter_covariant monadic (fun i m ->
+        let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+        Z.add_zap_to_ceil_to_zap_scope i zap_to_floor zap_to_legacy scope);
+    Comonadic.iter_covariant comonadic (fun i m ->
+        let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+        Z.add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy scope)
+
+  let add_contravariant_to_zap_scope { monadic; comonadic } scope =
+    Monadic.iter_contravariant monadic (fun i m ->
+        let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+        Z.add_zap_to_floor_to_zap_scope i zap_to_ceil zap_to_legacy scope);
+    Comonadic.iter_contravariant comonadic (fun i m ->
+        let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
+        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+        Z.add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy scope)
+
+  let add_mode_to_zap_scope m { variables; visible } =
+    if check_level_var m generic_level
+    then begin
+      add_covariant_to_zap_scope m variables;
+      add_contravariant_to_zap_scope m variables
+    end;
+    visible := m :: !visible
+
+  let resolve_zap_scope { variables; visible } =
+    (* we first zap all visible non generic modes to legacy *)
+    List.iter (fun m -> zap_to_legacy m |> ignore) !visible;
+    (* we then iterate over the children of visible generic modes and zap level 0
+    according to the following rules:
+    1) if a mode appears only as an upper bound to generic modes, it is zapped to
+      ceiling
+    2) if a mode appears only as a lower bound to generic modes, it is zapped to
+      floor
+    3) if it appears as both, it is zapped to legacy *)
+    Z.resolve_zap_scope variables
+
+  let with_zap_scope f =
+    let zap_scope = { variables = Z.create (); visible = ref [] } in
+    let res = f ~zap_scope in
+    resolve_zap_scope zap_scope;
+    res
 
   (** This is about partially applying [A -> B -> C] to [A] and getting
       [B -> C]. [comonadic] and [monadic] constutute the mode of [A], and we
@@ -6641,6 +7023,14 @@ module Value_with (Areality : Areality) = struct
 
       let disallow_right l = List.map disallow_right l
     end)
+  end
+
+  module Guts = struct
+    let check_const { monadic; comonadic } =
+      let open Misc.Stdlib.Monad.Option.Syntax in
+      let* monadic = Monadic.Guts.check_const monadic in
+      let* comonadic = Comonadic.Guts.check_const comonadic in
+      Some (merge { comonadic; monadic })
   end
 end
 [@@inline]
@@ -6947,6 +7337,15 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
+    let update_level : int -> t -> unit =
+     fun n m ->
+      match m with
+      | Const _c -> ()
+      | Diff (mm, m) ->
+        Mode.update_level n mm;
+        Mode.update_level n m
+      | Undefined -> ()
+
     let apply_left : type r.
         ?is_contained_by:Hint.is_contained_by ->
         t ->
@@ -6977,7 +7376,7 @@ module Modality = struct
            [mm] to construct the floor of [c]. *)
         let cc = Mode.Guts.get_ceil mm in
         let c = Mode.subtract_const cc m in
-        let c = Mode.zap_to_floor c in
+        let c = Mode.zap_to_floor_exn c in
         (* Note that we did not mutate [mm] but simply took its ceil, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7126,6 +7525,15 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
+    let update_level : int -> t -> unit =
+     fun n m ->
+      match m with
+      | Const _c -> ()
+      | Undefined -> ()
+      | Exactly (mm, m) ->
+        Mode.update_level n mm;
+        Mode.update_level n m
+
     let apply_left : type r.
         ?is_contained_by:Hint.is_contained_by ->
         t ->
@@ -7165,7 +7573,7 @@ module Modality = struct
            construct the ceil of [c]. *)
         let cc = Mode.Guts.get_floor mm in
         let c = Mode.imply_const cc m in
-        let c = Mode.zap_to_ceil c in
+        let c = Mode.zap_to_ceil_exn c in
         (* Note that we did not mutate [mm] but simply took its floor, which
            might be mutated later. To satisfy the coherence condition (see the
            comment in the mli), we want to:
@@ -7190,8 +7598,8 @@ module Modality = struct
            good workaround. *)
         (* CR zqian: Find a better solution *)
         Mode.submode mm Mode.legacy |> ignore;
-        let m = Mode.zap_to_floor m in
-        let mm = Mode.zap_to_ceil mm in
+        let m = Mode.zap_to_floor_exn m in
+        let mm = Mode.zap_to_ceil_exn mm in
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 
@@ -7339,6 +7747,10 @@ module Modality = struct
       | Error (Error (ax, e)) -> Error (Error (Comonadic ax, e)))
 
   let sub l r = try_with_log (sub_log l r)
+
+  let update_level n ({ monadic; comonadic } : t) =
+    Monadic.update_level n monadic;
+    Comonadic.update_level n comonadic
 
   let equate m1 m2 = try_with_log (equate_from_submode sub_log m1 m2)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1686,31 +1686,18 @@ module Lattices_mono = struct
       | Regional_to_local_regionality -> Comonadic_with_regionality
       | Regional_to_global_regionality -> Comonadic_with_regionality
 
-    let compare : type a1 l1 r1 a2 b l2 r2.
+    let ord : type a b d. (a, b, d) t -> int = function
+      | Local_to_regional -> 0
+      | Regional_to_local -> 1
+      | Locality_as_regionality -> 2
+      | Regional_to_global -> 3
+      | Local_to_regional_regionality -> 4
+      | Regional_to_local_regionality -> 5
+      | Regional_to_global_regionality -> 6
+
+    let compare_total : type a1 l1 r1 a2 b l2 r2.
         (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> int =
-     fun m1 m2 ->
-      match m1, m2 with
-      | Local_to_regional, Local_to_regional -> 0
-      | Local_to_regional, _ -> -1
-      | _, Local_to_regional -> 1
-      | Regional_to_local, Regional_to_local -> 0
-      | Regional_to_local, _ -> -1
-      | _, Regional_to_local -> 1
-      | Locality_as_regionality, Locality_as_regionality -> 0
-      | Locality_as_regionality, _ -> -1
-      | _, Locality_as_regionality -> 1
-      | Regional_to_global, Regional_to_global -> 0
-      | Regional_to_global, _ -> .
-      | _, Regional_to_global -> .
-      | Local_to_regional_regionality, Local_to_regional_regionality -> 0
-      | Local_to_regional_regionality, _ -> -1
-      | _, Local_to_regional_regionality -> 1
-      | Regional_to_local_regionality, Regional_to_local_regionality -> 0
-      | Regional_to_local_regionality, _ -> -1
-      | _, Regional_to_local_regionality -> 1
-      | Regional_to_global_regionality, Regional_to_global_regionality -> 0
-      | Regional_to_global_regionality, _ -> .
-      | _, Regional_to_global_regionality -> .
+     fun m1 m2 -> Int.compare (ord m1) (ord m2)
 
     let equal : type a1 l1 r1 a2 b l2 r2.
         (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> (a1, a2) Misc.is_eq =
@@ -1840,13 +1827,13 @@ module Lattices_mono = struct
       | Regional_to_global -> Not_allowed_left
       | Regional_to_global_regionality -> Not_allowed_left
 
-    type ('a, 'b, 'd) composition =
-      | Id : ('a, 'a, 'd) composition
-      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) composition
-      | Disallowed : ('a, 'b, neither) composition
+    type ('a, 'b, 'd) compose_result =
+      | Id : ('a, 'a, 'd) compose_result
+      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) compose_result
+      | Disallowed : ('a, 'b, neither) compose_result
 
     let compose : type a b c d.
-        (b, c, d) t -> (a, b, d) t -> (a, c, d) composition =
+        (b, c, d) t -> (a, b, d) t -> (a, c, d) compose_result =
      fun m1 m2 ->
       match m1, m2 with
       | Local_to_regional, Regional_to_local ->
@@ -2014,14 +2001,15 @@ module Lattices_mono = struct
       | Monadic_to_comonadic_max -> Monadic_op
       | Comonadic_to_monadic_max ar -> areality_comonadic_obj ar
 
-    let compare : type a1 d1 a2 b d2. (a1, b, d1) t -> (a2, b, d2) t -> int =
+    let compare_total : type a1 d1 a2 b d2.
+        (a1, b, d1) t -> (a2, b, d2) t -> int =
      fun m1 m2 ->
       match m1, m2 with
       | Locality_restricted l1, Locality_restricted l2 ->
-        Locality_morph.compare l1 l2
+        Locality_morph.compare_total l1 l2
       | Locality_restricted _, _ -> .
       | _, Locality_restricted _ -> .
-      | Locality_full l1, Locality_full l2 -> Locality_morph.compare l1 l2
+      | Locality_full l1, Locality_full l2 -> Locality_morph.compare_total l1 l2
       | Locality_full _, _ -> -1
       | _, Locality_full _ -> 1
       | Uniqueness_op_to_linearity, Uniqueness_op_to_linearity -> 0
@@ -2349,11 +2337,11 @@ module Lattices_mono = struct
       | Proj_const_max : 'a obj -> ('a, 'b, disallowed * 'r) compose_proj_result
       | Proj_const_min : 'a obj -> ('a, 'b, 'l * disallowed) compose_proj_result
 
-    let compose_projection_locality_morph : type a b p l r.
-        (a, b, l * r) Locality_morph.t ->
+    let compose_projection_locality_full : type a b p l r.
         (b comonadic_with, p) Axis.t ->
+        (a, b, l * r) Locality_morph.t ->
         (a comonadic_with, p, l * r) compose_proj_result =
-     fun lm1 ax0 ->
+     fun ax0 lm1 ->
       let src = Locality_morph.src_full lm1 in
       match ax0 with
       | Forkable -> Proj_id (Forkable, src)
@@ -2419,7 +2407,7 @@ module Lattices_mono = struct
             areality_comonadic_obj areality )
       | Comonadic_to_monadic_max areality, Staticity ->
         Proj_const_max (areality_comonadic_obj areality)
-      | Locality_full lm, (_ as ax0) -> compose_projection_locality_morph lm ax0
+      | Locality_full lm, (_ as ax0) -> compose_projection_locality_full ax0 lm
       | _, _ -> .
     [@@warning "-4"]
 
@@ -2433,7 +2421,7 @@ module Lattices_mono = struct
           -> ('q, 'c comonadic_with, 'd) compose_and_max_result
       | Disallowed : ('a, 'b, neither) compose_and_max_result
 
-    let compose_max_with_simple_locality_morph : type b c q r.
+    let compose_locality_full_max_with : type b c q r.
         (b, c, disallowed * r) Locality_morph.t ->
         (b comonadic_with, q) Axis.t ->
         (q, c comonadic_with, disallowed * r) compose_and_max_result =
@@ -2476,11 +2464,11 @@ module Lattices_mono = struct
           And_max_id Portability)
       | Areality -> And_max_core (Areality, Locality_restricted lm1)
 
-    let compose_max_with_simple_core : type b c q r.
-        (b, q) Axis.t ->
+    let compose_core_max_with : type b c q r.
         (b, c, disallowed * r) t ->
+        (b, q) Axis.t ->
         (q, c, disallowed * r) compose_and_max_result =
-     fun ax1 m0 ->
+     fun m0 ax1 ->
       match (m0 : (b, c, disallowed * r) t), (ax1 : (b, q) Axis.t) with
       | Comonadic_to_monadic_max _, Portability ->
         And_max_core (Contention, Portability_to_contention_op)
@@ -2498,8 +2486,7 @@ module Lattices_mono = struct
         And_max_core (Statefulness, Visibility_op_to_statefulness)
       | Monadic_to_comonadic_max, Uniqueness ->
         And_max_core (Linearity, Uniqueness_op_to_linearity)
-      | Locality_full lm, (_ as ax0) ->
-        compose_max_with_simple_locality_morph lm ax0
+      | Locality_full lm, (_ as ax0) -> compose_locality_full_max_with lm ax0
       | Monadic_to_comonadic_min, _ -> Disallowed
       | Comonadic_to_monadic_min _, _ -> Disallowed
       | _, _ -> .
@@ -2515,7 +2502,7 @@ module Lattices_mono = struct
           -> ('q, 'c comonadic_with, 'd) compose_and_min_result
       | Disallowed : ('a, 'b, neither) compose_and_min_result
 
-    let compose_min_with_simple_locality_morph : type b c q l.
+    let compose_locality_full_min_with : type b c q l.
         (b, c, l * disallowed) Locality_morph.t ->
         (b comonadic_with, q) Axis.t ->
         (q, c comonadic_with, l * disallowed) compose_and_min_result =
@@ -2528,11 +2515,11 @@ module Lattices_mono = struct
       | Portability -> And_min_id Portability
       | Areality -> And_min_core (Areality, Locality_restricted lm1)
 
-    let compose_min_with_simple_core : type b c q l.
-        (b, q) Axis.t ->
+    let compose_core_min_with : type b c q l.
         (b, c, l * disallowed) t ->
+        (b, q) Axis.t ->
         (q, c, l * disallowed) compose_and_min_result =
-     fun ax1 m0 ->
+     fun m0 ax1 ->
       match (m0 : (b, c, l * disallowed) t), (ax1 : (b, q) Axis.t) with
       | Comonadic_to_monadic_min _, Portability ->
         And_min_core (Contention, Portability_to_contention_op)
@@ -2550,8 +2537,7 @@ module Lattices_mono = struct
         And_min_core (Statefulness, Visibility_op_to_statefulness)
       | Monadic_to_comonadic_min, Uniqueness ->
         And_min_core (Linearity, Uniqueness_op_to_linearity)
-      | Locality_full lm, (_ as ax0) ->
-        compose_min_with_simple_locality_morph lm ax0
+      | Locality_full lm, (_ as ax0) -> compose_locality_full_min_with lm ax0
       | Monadic_to_comonadic_max, _ -> Disallowed
       | Comonadic_to_monadic_max _, _ -> Disallowed
       | _, _ -> .
@@ -2728,44 +2714,44 @@ module Lattices_mono = struct
 
     let equal_val = equal
 
-    let rec compare : type a1 d1 a2 b d2.
+    let rec compare_total : type a1 d1 a2 b d2.
         b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
      fun dst m1 m2 ->
       match m1, m2 with
       | Id, Id -> 0
       | Id, _ -> -1
       | _, Id -> 1
-      | Core m1, Core m2 -> Core_morph.compare m1 m2
+      | Core m1, Core m2 -> Core_morph.compare_total m1 m2
       | Core _, _ -> -1
       | _, Core _ -> 1
-      | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
+      | Meet_const c1, Meet_const c2 -> Lattices.compare_total dst c1 c2
       | Meet_const _, _ -> -1
       | _, Meet_const _ -> 1
-      | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
+      | Imply_const c1, Imply_const c2 -> Lattices.compare_total dst c1 c2
       | Imply_const _, _ -> -1
       | _, Imply_const _ -> 1
       | Meet_const_core (c1, m1), Meet_const_core (c2, m2) ->
-        let c = compare_total dst c1 c2 in
-        if c <> 0 then c else Core_morph.compare m1 m2
+        let c = Lattices.compare_total dst c1 c2 in
+        if c <> 0 then c else Core_morph.compare_total m1 m2
       | Meet_const_core _, _ -> -1
       | _, Meet_const_core _ -> 1
       | Core_imply_const (m1, c1), Core_imply_const (m2, c2) ->
-        let c = Core_morph.compare m1 m2 in
+        let c = Core_morph.compare_total m1 m2 in
         if c <> 0
         then c
         else
           let Refl = Core_morph.equal m1 m2 |> Misc.get_eq_exn in
           let src = Core_morph.src m1 in
-          compare_total src c1 c2
+          Lattices.compare_total src c1 c2
       | Core_imply_const _, _ -> -1
       | _, Core_imply_const _ -> 1
       | Compose (mb1, ma1), Compose (mb2, ma2) ->
-        let c = compare dst mb1 mb2 in
+        let c = compare_total dst mb1 mb2 in
         if c <> 0
         then c
         else
           let Refl = equal dst mb1 mb2 |> Misc.get_eq_exn in
-          compare (src dst mb1) ma1 ma2
+          compare_total (src dst mb1) ma1 ma2
       | Compose _, _ -> .
       | _, Compose _ -> .
 
@@ -3403,7 +3389,7 @@ module Lattices_mono = struct
       b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> int =
    fun dst m1 m2 ->
     match m1, m2 with
-    | Simple m1, Simple m2 -> Simple_morph.compare dst m1 m2
+    | Simple m1, Simple m2 -> Simple_morph.compare_total dst m1 m2
     | Simple _, _ -> -1
     | _, Simple _ -> 1
     | Const_max obj1, Const_max obj2 -> compare_obj obj1 obj2
@@ -3428,7 +3414,7 @@ module Lattices_mono = struct
         then c
         else
           let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-          Simple_morph.compare dst m1 m2
+          Simple_morph.compare_total dst m1 m2
     | Simple_proj _, _ -> -1
     | _, Simple_proj _ -> 1
     | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) ->
@@ -3437,7 +3423,7 @@ module Lattices_mono = struct
       then c
       else
         let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-        Simple_morph.compare (proj_obj ax1 dst) m1 m2
+        Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
     | Max_with_simple _, _ -> -1
     | _, Max_with_simple _ -> 1
     | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) ->
@@ -3446,7 +3432,7 @@ module Lattices_mono = struct
       then c
       else
         let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-        Simple_morph.compare (proj_obj ax1 dst) m1 m2
+        Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
     | Min_with_simple _, _ -> -1
     | _, Min_with_simple _ -> 1
     | Compose (mb1, ma1), Compose (mb2, ma2) ->
@@ -3681,7 +3667,7 @@ module Lattices_mono = struct
     match sm0 with
     | Id -> Max_with_simple (ax1, m1)
     | Core m0 ->
-      begin match Core_morph.compose_max_with_simple_core ax1 m0 with
+      begin match Core_morph.compose_core_max_with m0 ax1 with
       | And_max_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
@@ -3695,7 +3681,7 @@ module Lattices_mono = struct
       Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
     | Core_imply_const (m0, c0) -> begin
       let c0 = Axis.proj ax1 c0 in
-      match Core_morph.compose_max_with_simple_core ax1 m0 with
+      match Core_morph.compose_core_max_with m0 ax1 with
       | And_max_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         Max_with_simple
@@ -3722,7 +3708,7 @@ module Lattices_mono = struct
     match sm0 with
     | Id -> Min_with_simple (ax1, m1)
     | Core m0 ->
-      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      begin match Core_morph.compose_core_min_with m0 ax1 with
       | And_min_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
@@ -3735,7 +3721,7 @@ module Lattices_mono = struct
       let obj0 = proj_obj ax1 dst in
       Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
     | Meet_const_core (c0, m0) ->
-      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      begin match Core_morph.compose_core_min_with m0 ax1 with
       | And_min_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         let c0 = Axis.proj ax1 c0 in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -189,6 +189,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Lpoly_inst -> Lpoly_inst
+        | Contained_by c -> Contained_by c
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -209,6 +210,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Escape_region x -> Escape_region x
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
+        | Contained_by c -> Contained_by c
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -235,6 +237,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Lpoly_inst -> Lpoly_inst
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
+        | Contained_by c -> Contained_by c
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -261,6 +264,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Quoted_computation -> Quoted_computation
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
+        | Contained_by c -> Contained_by c
     end)
   end
 end
@@ -420,18 +424,44 @@ module Lattices = struct
   end
   [@@inline]
 
-  (* Make the type of [Locality] and [Regionality] below distinguishable,
-     so that we can be sure [Comonadic_with] is applied correctly. *)
+  type locality =
+    | Global
+    | Local
+
+  type regionality =
+    | Global
+    | Regional
+    | Local
+
+  type 'a areality =
+    | Locality : locality areality
+    | Regionality : regionality areality
+
+  let compare_areality : type a b. a areality -> b areality -> int =
+   fun a b ->
+    match a, b with
+    | Locality, Locality -> 0
+    | Locality, _ -> -1
+    | _, Locality -> 1
+    | Regionality, Regionality -> 0
+
+  let equal_areality : type a b. a areality -> b areality -> (a, b) Misc.is_eq =
+   fun a b ->
+    match a, b with
+    | Locality, Locality -> Misc.Is_eq
+    | Regionality, Regionality -> Misc.Is_eq
+    | (Locality | Regionality), _ -> Misc.Is_not_eq
+
   module type Areality = sig
     include Const
 
     include Heyting with type t := t
 
-    val _is_areality : unit
+    val areality : t areality
   end
 
   module Locality = struct
-    type t =
+    type t = locality =
       | Global
       | Local
 
@@ -451,11 +481,11 @@ module Lattices = struct
       | Global -> Fmt.fprintf ppf "global"
       | Local -> Fmt.fprintf ppf "local"
 
-    let _is_areality = ()
+    let areality = Locality
   end
 
   module Regionality = struct
-    type t =
+    type t = regionality =
       | Global
       | Regional
       | Local
@@ -477,7 +507,7 @@ module Lattices = struct
       | Regional -> Fmt.fprintf ppf "regional"
       | Local -> Fmt.fprintf ppf "local"
 
-    let _is_areality = ()
+    let areality = Regionality
   end
 
   module Uniqueness = struct
@@ -1030,6 +1060,26 @@ module Lattices = struct
     | Comonadic_with_regionality : Comonadic_with_regionality.t obj
     | Comonadic_with_locality : Comonadic_with_locality.t obj
 
+  let areality_comonadic_obj : type a. a areality -> a comonadic_with obj =
+    function
+    | Locality -> Comonadic_with_locality
+    | Regionality -> Comonadic_with_regionality
+
+  let comonadic_obj_areality : type a. a comonadic_with obj -> a areality =
+    function
+    | Comonadic_with_locality -> Locality
+    | Comonadic_with_regionality -> Regionality
+
+  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
+   fun a0 ->
+    match a0 with
+    | Locality -> Comonadic_with_locality
+    | Regionality -> Comonadic_with_regionality
+    | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
+    | Comonadic_with_locality | Contention_op | Visibility_op | Portability
+    | Forkable | Yielding | Statefulness | Staticity_op ->
+      assert false
+
   let is_opposite : type a. a obj -> bool = function
     | Locality -> false
     | Regionality -> false
@@ -1380,156 +1430,921 @@ module Lattices_mono = struct
       | Staticity -> { t with staticity = r }
   end
 
-  type ('a, 'b, 'd) morph =
-    | Id : ('a, 'a, 'l * 'r) morph  (** identity morphism *)
-    | Meet_const : 'a -> ('a, 'a, 'l * 'r) morph
-        (** Meet the input with the parameter *)
-    | Imply_const : 'a -> ('a, 'a, disallowed * 'r) morph
-        (** The right adjoint of [Meet_const] *)
-    | Proj : 't obj * ('t, 'r_) Axis.t -> ('t, 'r_, 'l * 'r) morph
-        (** Project from a product to an axis *)
-    | Max_with : ('t, 'r_) Axis.t -> ('r_, 't, disallowed * 'r) morph
-        (** Combine an axis with maxima along other axes *)
-    | Min_with : ('t, 'r_) Axis.t -> ('r_, 't, 'l * disallowed) morph
-        (** Combine an axis with minima along other axes *)
-    | Map_comonadic :
-        ('a1, 'a2, 'l * 'r) morph
-        -> ('a1 comonadic_with, 'a2 comonadic_with, 'l * 'r) morph
-        (** Lift an morphism on areality to a morphism on the comonadic fragment
-        *)
-    | Monadic_to_comonadic_min :
-        (Monadic_op.t, 'a comonadic_with, 'l * disallowed) morph
-        (** Dualize the monadic fragment to the comonadic fragment. The areality
-            is set to min. *)
-    | Comonadic_to_monadic_min :
-        'a comonadic_with obj
-        -> ('a comonadic_with, Monadic_op.t, 'l * disallowed) morph
-        (** Dualize the comonadic fragment to the monadic fragment. The
-            staticity_op is set to min. *)
-    | Monadic_to_comonadic_max :
-        (Monadic_op.t, 'a comonadic_with, disallowed * 'r) morph
-        (** Dualize the monadic fragment to the comonadic fragment. The areality
-            is set to max. *)
-    | Comonadic_to_monadic_max :
-        'a comonadic_with obj
-        -> ('a comonadic_with, Monadic_op.t, disallowed * 'r) morph
-        (** Dualize the comonadic fragment to the monadic fragment. The
-            staticity_op is set to max. *)
-    (* Following is a chain of adjunction (complete and cannot extend in
-       either direction) *)
-    | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) morph
-        (** Maps local to regional, global to global *)
-    | Regional_to_local : (Regionality.t, Locality.t, 'l * 'r) morph
-        (** Maps regional to local, identity otherwise *)
-    | Locality_as_regionality : (Locality.t, Regionality.t, 'l * 'r) morph
-        (** Inject locality into regionality *)
-    | Regional_to_global : (Regionality.t, Locality.t, 'l * 'r) morph
-        (** Maps regional to global, identity otherwise *)
-    | Global_to_regional : (Locality.t, Regionality.t, disallowed * 'r) morph
-        (** Maps global to regional, local to local *)
-    | Compose :
-        ('b, 'c, 'l * 'r) morph * ('a, 'b, 'l * 'r) morph
-        -> ('a, 'c, 'l * 'r) morph  (** Compoistion of two morphisms *)
-    constraint 'd = _ * _
-  [@@ocaml.warning "-62"]
+  module Locality_morph = struct
+    (* Following is a chain of adjunctions (this can be extended one
+       further, but we never need the missing operation) *)
+    type ('a, 'b, 'd) t =
+      | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
+          (** Maps local to regional, global to global *)
+      | Regional_to_local : (Regionality.t, Locality.t, 'l * 'r) t
+          (** Maps regional to local, identity otherwise *)
+      | Locality_as_regionality : (Locality.t, Regionality.t, 'l * 'r) t
+          (** Inject locality into regionality *)
+      | Regional_to_global : (Regionality.t, Locality.t, disallowed * 'r) t
+          (** Maps regional to global, identity otherwise *)
+      (* Versions of the above morphisms operating on regionality. *)
+      | Local_to_regional_regionality :
+          (Regionality.t, Regionality.t, 'l * disallowed) t
+          (** Maps regional to local, identity otherwise. *)
+      | Regional_to_local_regionality :
+          (Regionality.t, Regionality.t, 'l * 'r) t
+          (** Maps regional to local, identity otherwise. *)
+      | Regional_to_global_regionality :
+          (Regionality.t, Regionality.t, disallowed * 'r) t
+          (** Maps regional to global, identity otherwise. *)
 
-  include Magic_allow_disallow (struct
-    type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph constraint 'd = 'l * 'r
+    let local_to_regional = function
+      | Locality.Global -> Regionality.Global
+      | Locality.Local -> Regionality.Regional
 
-    let rec allow_left : type a b l r.
-        (a, b, allowed * r) morph -> (a, b, l * r) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Min_with ax -> Min_with ax
-      | Meet_const c -> Meet_const c
-      | Compose (f, g) ->
-        let f = allow_left f in
-        let g = allow_left g in
-        Compose (f, g)
-      | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
-      | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
+    let regional_to_local = function
+      | Regionality.Global -> Locality.Global
+      | Regionality.Regional -> Locality.Local
+      | Regionality.Local -> Locality.Local
+
+    let locality_as_regionality = function
+      | Locality.Global -> Regionality.Global
+      | Locality.Local -> Regionality.Local
+
+    let regional_to_global = function
+      | Regionality.Global -> Locality.Global
+      | Regionality.Regional -> Locality.Global
+      | Regionality.Local -> Locality.Local
+
+    let local_to_regional_regionality = function
+      | Regionality.Global -> Regionality.Global
+      | Regionality.Regional -> Regionality.Regional
+      | Regionality.Local -> Regionality.Regional
+
+    let regional_to_local_regionality = function
+      | Regionality.Global -> Regionality.Global
+      | Regionality.Regional -> Regionality.Local
+      | Regionality.Local -> Regionality.Local
+
+    let regional_to_global_regionality = function
+      | Regionality.Global -> Regionality.Global
+      | Regionality.Regional -> Regionality.Global
+      | Regionality.Local -> Regionality.Local
+
+    let src_restricted : type a b d. (a, b, d) t -> a obj = function
+      | Local_to_regional -> Locality
+      | Regional_to_local -> Regionality
+      | Locality_as_regionality -> Locality
+      | Regional_to_global -> Regionality
+      | Local_to_regional_regionality -> Regionality
+      | Regional_to_local_regionality -> Regionality
+      | Regional_to_global_regionality -> Regionality
+
+    let src_full : type a b d. (a, b, d) t -> a comonadic_with obj = function
+      | Local_to_regional -> Comonadic_with_locality
+      | Regional_to_local -> Comonadic_with_regionality
+      | Locality_as_regionality -> Comonadic_with_locality
+      | Regional_to_global -> Comonadic_with_regionality
+      | Local_to_regional_regionality -> Comonadic_with_regionality
+      | Regional_to_local_regionality -> Comonadic_with_regionality
+      | Regional_to_global_regionality -> Comonadic_with_regionality
+
+    let compare : type a1 l1 r1 a2 b l2 r2.
+        (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> int =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Local_to_regional, Local_to_regional -> 0
+      | Local_to_regional, _ -> -1
+      | _, Local_to_regional -> 1
+      | Regional_to_local, Regional_to_local -> 0
+      | Regional_to_local, _ -> -1
+      | _, Regional_to_local -> 1
+      | Locality_as_regionality, Locality_as_regionality -> 0
+      | Locality_as_regionality, _ -> -1
+      | _, Locality_as_regionality -> 1
+      | Regional_to_global, Regional_to_global -> 0
+      | Regional_to_global, _ -> .
+      | _, Regional_to_global -> .
+      | Local_to_regional_regionality, Local_to_regional_regionality -> 0
+      | Local_to_regional_regionality, _ -> -1
+      | _, Local_to_regional_regionality -> 1
+      | Regional_to_local_regionality, Regional_to_local_regionality -> 0
+      | Regional_to_local_regionality, _ -> -1
+      | _, Regional_to_local_regionality -> 1
+      | Regional_to_global_regionality, Regional_to_global_regionality -> 0
+      | Regional_to_global_regionality, _ -> .
+      | _, Regional_to_global_regionality -> .
+
+    let equal : type a1 l1 r1 a2 b l2 r2.
+        (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> (a1, a2) Misc.is_eq =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Local_to_regional, Local_to_regional -> Misc.Is_eq
+      | Regional_to_local, Regional_to_local -> Misc.Is_eq
+      | Locality_as_regionality, Locality_as_regionality -> Misc.Is_eq
+      | Regional_to_global, Regional_to_global -> Misc.Is_eq
+      | Local_to_regional_regionality, Local_to_regional_regionality ->
+        Misc.Is_eq
+      | Regional_to_local_regionality, Regional_to_local_regionality ->
+        Misc.Is_eq
+      | Regional_to_global_regionality, Regional_to_global_regionality ->
+        Misc.Is_eq
+      | ( ( Local_to_regional | Regional_to_local | Locality_as_regionality
+          | Regional_to_global | Local_to_regional_regionality
+          | Regional_to_local_regionality | Regional_to_global_regionality ),
+          _ ) ->
+        Misc.Is_not_eq
+
+    let print : type a b d. Fmt.formatter -> (a, b, d) t -> unit =
+     fun ppf -> function
+      | Local_to_regional -> Fmt.fprintf ppf "local_to_regional"
+      | Regional_to_local -> Fmt.fprintf ppf "regional_to_local"
+      | Locality_as_regionality -> Fmt.fprintf ppf "locality_as_regionality"
+      | Regional_to_global -> Fmt.fprintf ppf "regional_to_global"
+      | Local_to_regional_regionality ->
+        Fmt.fprintf ppf "local_to_regional_regionality"
+      | Regional_to_local_regionality ->
+        Fmt.fprintf ppf "regional_to_local_regionality"
+      | Regional_to_global_regionality ->
+        Fmt.fprintf ppf "regional_to_global_regionality"
+
+    let apply : type a b d. (a, b, d) t -> a -> b =
+     fun f a ->
+      match f with
+      | Local_to_regional -> local_to_regional a
+      | Regional_to_local -> regional_to_local a
+      | Locality_as_regionality -> locality_as_regionality a
+      | Regional_to_global -> regional_to_global a
+      | Local_to_regional_regionality -> local_to_regional_regionality a
+      | Regional_to_local_regionality -> regional_to_local_regionality a
+      | Regional_to_global_regionality -> regional_to_global_regionality a
+
+    let right_adjoint : type a b r.
+        (a, b, allowed * r) t -> (b, a, disallowed * allowed) t = function
+      | Local_to_regional -> Regional_to_local
+      | Regional_to_local -> Locality_as_regionality
+      | Locality_as_regionality -> Regional_to_global
+      | Local_to_regional_regionality -> Regional_to_local_regionality
+      | Regional_to_local_regionality -> Regional_to_global_regionality
+
+    let left_adjoint : type a b l.
+        (a, b, l * allowed) t -> (b, a, allowed * disallowed) t = function
+      | Regional_to_local -> Local_to_regional
+      | Locality_as_regionality -> Regional_to_local
+      | Regional_to_global -> Locality_as_regionality
+      | Regional_to_local_regionality -> Local_to_regional_regionality
+      | Regional_to_global_regionality -> Regional_to_local_regionality
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+      function
       | Local_to_regional -> Local_to_regional
       | Locality_as_regionality -> Locality_as_regionality
       | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = allow_left f in
-        Map_comonadic f
+      | Local_to_regional_regionality -> Local_to_regional_regionality
+      | Regional_to_local_regionality -> Regional_to_local_regionality
 
-    let rec allow_right : type a b l r.
-        (a, b, l * allowed) morph -> (a, b, l * r) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Max_with ax -> Max_with ax
-      | Meet_const c -> Meet_const c
-      | Imply_const c -> Imply_const c
-      | Compose (f, g) ->
-        let f = allow_right f in
-        let g = allow_right g in
-        Compose (f, g)
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+      function
+      | Regional_to_local -> Regional_to_local
+      | Locality_as_regionality -> Locality_as_regionality
+      | Regional_to_global -> Regional_to_global
+      | Regional_to_local_regionality -> Regional_to_local_regionality
+      | Regional_to_global_regionality -> Regional_to_global_regionality
+
+    let disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Local_to_regional -> Local_to_regional
+      | Regional_to_local -> Regional_to_local
+      | Locality_as_regionality -> Locality_as_regionality
+      | Regional_to_global -> Regional_to_global
+      | Local_to_regional_regionality -> Local_to_regional_regionality
+      | Regional_to_local_regionality -> Regional_to_local_regionality
+      | Regional_to_global_regionality -> Regional_to_global_regionality
+
+    let disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Local_to_regional -> Local_to_regional
+      | Regional_to_local -> Regional_to_local
+      | Locality_as_regionality -> Locality_as_regionality
+      | Regional_to_global -> Regional_to_global
+      | Local_to_regional_regionality -> Local_to_regional_regionality
+      | Regional_to_local_regionality -> Regional_to_local_regionality
+      | Regional_to_global_regionality -> Regional_to_global_regionality
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_right = function
+      | Regional_to_local as m -> Allowed_right m
+      | Locality_as_regionality as m -> Allowed_right m
+      | Regional_to_global as m -> Allowed_right m
+      | Regional_to_local_regionality as m -> Allowed_right m
+      | Regional_to_global_regionality as m -> Allowed_right m
+      | Local_to_regional -> Not_allowed_right
+      | Local_to_regional_regionality -> Not_allowed_right
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_left = function
+      | Local_to_regional as m -> Allowed_left m
+      | Regional_to_local as m -> Allowed_left m
+      | Locality_as_regionality as m -> Allowed_left m
+      | Local_to_regional_regionality as m -> Allowed_left m
+      | Regional_to_local_regionality as m -> Allowed_left m
+      | Regional_to_global -> Not_allowed_left
+      | Regional_to_global_regionality -> Not_allowed_left
+
+    type ('a, 'b, 'd) composition =
+      | Id : ('a, 'a, 'd) composition
+      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) composition
+      | Disallowed : ('a, 'b, neither) composition
+
+    let compose : type a b c d.
+        (b, c, d) t -> (a, b, d) t -> (a, c, d) composition =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Local_to_regional, Regional_to_local ->
+        Morph Local_to_regional_regionality
+      | Regional_to_local, Local_to_regional -> Id
+      | Regional_to_local, Locality_as_regionality -> Id
+      | Regional_to_local, Local_to_regional_regionality ->
+        Morph Regional_to_local
+      | Regional_to_local, Regional_to_local_regionality ->
+        Morph Regional_to_local
+      | Regional_to_local, Regional_to_global_regionality ->
+        Morph Regional_to_global
+      | Locality_as_regionality, Regional_to_local ->
+        Morph Regional_to_local_regionality
+      | Locality_as_regionality, Regional_to_global ->
+        Morph Regional_to_global_regionality
+      | Regional_to_global, Locality_as_regionality -> Id
+      | Regional_to_global, Regional_to_local_regionality ->
+        Morph Regional_to_local
+      | Regional_to_global, Regional_to_global_regionality ->
+        Morph Regional_to_global
+      | Local_to_regional_regionality, Local_to_regional ->
+        Morph Local_to_regional
+      | Local_to_regional_regionality, Locality_as_regionality ->
+        Morph Local_to_regional
+      | Local_to_regional_regionality, Local_to_regional_regionality ->
+        Morph Local_to_regional_regionality
+      | Local_to_regional_regionality, Regional_to_local_regionality ->
+        Morph Local_to_regional_regionality
+      | Regional_to_local_regionality, Local_to_regional ->
+        Morph Locality_as_regionality
+      | Regional_to_local_regionality, Locality_as_regionality ->
+        Morph Locality_as_regionality
+      | Regional_to_local_regionality, Local_to_regional_regionality ->
+        Morph Regional_to_local_regionality
+      | Regional_to_local_regionality, Regional_to_local_regionality ->
+        Morph Regional_to_local_regionality
+      | Regional_to_local_regionality, Regional_to_global_regionality ->
+        Morph Regional_to_global_regionality
+      | Regional_to_global_regionality, Locality_as_regionality ->
+        Morph Locality_as_regionality
+      | Regional_to_global_regionality, Regional_to_local_regionality ->
+        Morph Regional_to_local_regionality
+      | Regional_to_global_regionality, Regional_to_global_regionality ->
+        Morph Regional_to_global_regionality
+      (* Operations that cannot appear on the same side *)
+      | Local_to_regional, Regional_to_global -> Disallowed
+      | Regional_to_global, Local_to_regional -> Disallowed
+      | Regional_to_global, Local_to_regional_regionality -> Disallowed
+      | Local_to_regional_regionality, Regional_to_global_regionality ->
+        Disallowed
+      | Regional_to_global_regionality, Local_to_regional -> Disallowed
+      | Regional_to_global_regionality, Local_to_regional_regionality ->
+        Disallowed
+  end
+
+  module Core_morph = struct
+    type ('a, 'b, 'd) t =
+      | Locality_restricted :
+          ('a, 'b, 'l * 'r) Locality_morph.t
+          -> ('a, 'b, 'l * 'r) t
+      | Locality_full :
+          ('a, 'b, 'l * 'r) Locality_morph.t
+          -> ('a comonadic_with, 'b comonadic_with, 'l * 'r) t
+      | Uniqueness_op_to_linearity : (Uniqueness_op.t, Linearity.t, 'l * 'r) t
+      | Linearity_to_uniqueness_op : (Linearity.t, Uniqueness_op.t, 'l * 'r) t
+      | Contention_op_to_portability :
+          (Contention_op.t, Portability.t, 'l * 'r) t
+      | Portability_to_contention_op :
+          (Portability.t, Contention_op.t, 'l * 'r) t
+      | Visibility_op_to_statefulness :
+          (Visibility_op.t, Statefulness.t, 'l * 'r) t
+      | Statefulness_to_visibility_op :
+          (Statefulness.t, Visibility_op.t, 'l * 'r) t
+      | Monadic_to_comonadic_min :
+          (Monadic_op.t, 'a comonadic_with, 'l * disallowed) t
+          (** Dualize the monadic fragment to the comonadic fragment. The
+              areality is set to min. *)
+      | Comonadic_to_monadic_min :
+          'a areality
+          -> ('a comonadic_with, Monadic_op.t, 'l * disallowed) t
+          (** Dualize the comonadic fragment to the monadic fragment. The
+              areality axis is ignored, the staticity axis is set to min. *)
+      | Monadic_to_comonadic_max :
+          (Monadic_op.t, 'a comonadic_with, disallowed * 'r) t
+          (** Dualize the monadic fragment to the comonadic fragment. The
+              areality is set to max. *)
+      | Comonadic_to_monadic_max :
+          'a areality
+          -> ('a comonadic_with, Monadic_op.t, disallowed * 'r) t
+          (** Dualize the comonadic fragment to the monadic fragment. The
+              areality axis is ignored. *)
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+      function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.allow_left m)
+      | Locality_full m -> Locality_full (Locality_morph.allow_left m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
+      | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
+      | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
+
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+      function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.allow_right m)
+      | Locality_full m -> Locality_full (Locality_morph.allow_right m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
       | Comonadic_to_monadic_max a -> Comonadic_to_monadic_max a
       | Monadic_to_comonadic_max -> Monadic_to_comonadic_max
-      | Global_to_regional -> Global_to_regional
-      | Locality_as_regionality -> Locality_as_regionality
-      | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = allow_right f in
-        Map_comonadic f
 
-    let rec disallow_left : type a b l r.
-        (a, b, l * r) morph -> (a, b, disallowed * r) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Min_with ax -> Min_with ax
-      | Max_with ax -> Max_with ax
-      | Meet_const c -> Meet_const c
-      | Imply_const c -> Imply_const c
-      | Compose (f, g) ->
-        let f = disallow_left f in
-        let g = disallow_left g in
-        Compose (f, g)
+    let disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.disallow_left m)
+      | Locality_full m -> Locality_full (Locality_morph.disallow_left m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
       | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
       | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
       | Monadic_to_comonadic_max -> Monadic_to_comonadic_max
       | Comonadic_to_monadic_max a -> Comonadic_to_monadic_max a
-      | Local_to_regional -> Local_to_regional
-      | Global_to_regional -> Global_to_regional
-      | Locality_as_regionality -> Locality_as_regionality
-      | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = disallow_left f in
-        Map_comonadic f
 
-    let rec disallow_right : type a b l r.
-        (a, b, l * r) morph -> (a, b, l * disallowed) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Min_with ax -> Min_with ax
-      | Max_with ax -> Max_with ax
-      | Meet_const c -> Meet_const c
-      | Imply_const c -> Imply_const c
-      | Compose (f, g) ->
-        let f = disallow_right f in
-        let g = disallow_right g in
-        Compose (f, g)
+    let disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.disallow_right m)
+      | Locality_full m -> Locality_full (Locality_morph.disallow_right m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
       | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
       | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
       | Monadic_to_comonadic_max -> Monadic_to_comonadic_max
       | Comonadic_to_monadic_max a -> Comonadic_to_monadic_max a
-      | Local_to_regional -> Local_to_regional
-      | Global_to_regional -> Global_to_regional
-      | Locality_as_regionality -> Locality_as_regionality
-      | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = disallow_right f in
-        Map_comonadic f
-  end)
 
-  let set_areality : type a1 a2. a2 -> a1 comonadic_with -> a2 comonadic_with =
-   fun r t -> { t with areality = r }
+    let src : type a b d. (a, b, d) t -> a obj = function
+      | Locality_restricted m -> Locality_morph.src_restricted m
+      | Locality_full m -> Locality_morph.src_full m
+      | Uniqueness_op_to_linearity -> Uniqueness_op
+      | Linearity_to_uniqueness_op -> Linearity
+      | Contention_op_to_portability -> Contention_op
+      | Portability_to_contention_op -> Portability
+      | Visibility_op_to_statefulness -> Visibility_op
+      | Statefulness_to_visibility_op -> Statefulness
+      | Monadic_to_comonadic_min -> Monadic_op
+      | Comonadic_to_monadic_min ar -> areality_comonadic_obj ar
+      | Monadic_to_comonadic_max -> Monadic_op
+      | Comonadic_to_monadic_max ar -> areality_comonadic_obj ar
+
+    let compare : type a1 d1 a2 b d2. (a1, b, d1) t -> (a2, b, d2) t -> int =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Locality_restricted l1, Locality_restricted l2 ->
+        Locality_morph.compare l1 l2
+      | Locality_restricted _, _ -> .
+      | _, Locality_restricted _ -> .
+      | Locality_full l1, Locality_full l2 -> Locality_morph.compare l1 l2
+      | Locality_full _, _ -> -1
+      | _, Locality_full _ -> 1
+      | Uniqueness_op_to_linearity, Uniqueness_op_to_linearity -> 0
+      | Uniqueness_op_to_linearity, _ -> .
+      | _, Uniqueness_op_to_linearity -> .
+      | Linearity_to_uniqueness_op, Linearity_to_uniqueness_op -> 0
+      | Linearity_to_uniqueness_op, _ -> .
+      | _, Linearity_to_uniqueness_op -> .
+      | Contention_op_to_portability, Contention_op_to_portability -> 0
+      | Contention_op_to_portability, _ -> .
+      | _, Contention_op_to_portability -> .
+      | Portability_to_contention_op, Portability_to_contention_op -> 0
+      | Portability_to_contention_op, _ -> .
+      | _, Portability_to_contention_op -> .
+      | Visibility_op_to_statefulness, Visibility_op_to_statefulness -> 0
+      | Visibility_op_to_statefulness, _ -> .
+      | _, Visibility_op_to_statefulness -> .
+      | Statefulness_to_visibility_op, Statefulness_to_visibility_op -> 0
+      | Statefulness_to_visibility_op, _ -> .
+      | _, Statefulness_to_visibility_op -> .
+      | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> 0
+      | Monadic_to_comonadic_min, _ -> -1
+      | _, Monadic_to_comonadic_min -> 1
+      | Comonadic_to_monadic_min ar1, Comonadic_to_monadic_min ar2 ->
+        compare_areality ar1 ar2
+      | Comonadic_to_monadic_min _, _ -> -1
+      | _, Comonadic_to_monadic_min _ -> 1
+      | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> 0
+      | Monadic_to_comonadic_max, _ -> .
+      | _, Monadic_to_comonadic_max -> .
+      | Comonadic_to_monadic_max ar1, Comonadic_to_monadic_max ar2 ->
+        compare_areality ar1 ar2
+      | Comonadic_to_monadic_max _, _ -> .
+      | _, Comonadic_to_monadic_max _ -> .
+
+    let equal : type a1 d1 a2 b d2.
+        (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Locality_restricted l1, Locality_restricted l2 ->
+        Locality_morph.equal l1 l2
+      | Locality_restricted _, _ -> .
+      | _, Locality_restricted _ -> .
+      | Locality_full l1, Locality_full l2 -> (
+        match Locality_morph.equal l1 l2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq)
+      | Uniqueness_op_to_linearity, Uniqueness_op_to_linearity -> Misc.Is_eq
+      | Uniqueness_op_to_linearity, _ -> .
+      | _, Uniqueness_op_to_linearity -> .
+      | Linearity_to_uniqueness_op, Linearity_to_uniqueness_op -> Misc.Is_eq
+      | Linearity_to_uniqueness_op, _ -> .
+      | _, Linearity_to_uniqueness_op -> .
+      | Contention_op_to_portability, Contention_op_to_portability -> Misc.Is_eq
+      | Contention_op_to_portability, _ -> .
+      | _, Contention_op_to_portability -> .
+      | Portability_to_contention_op, Portability_to_contention_op -> Misc.Is_eq
+      | Portability_to_contention_op, _ -> .
+      | _, Portability_to_contention_op -> .
+      | Visibility_op_to_statefulness, Visibility_op_to_statefulness ->
+        Misc.Is_eq
+      | Visibility_op_to_statefulness, _ -> .
+      | _, Visibility_op_to_statefulness -> .
+      | Statefulness_to_visibility_op, Statefulness_to_visibility_op ->
+        Misc.Is_eq
+      | Statefulness_to_visibility_op, _ -> .
+      | _, Statefulness_to_visibility_op -> .
+      | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Misc.Is_eq
+      | Monadic_to_comonadic_min, _ -> Misc.Is_not_eq
+      | _, Monadic_to_comonadic_min -> Misc.Is_not_eq
+      | Comonadic_to_monadic_min ar1, Comonadic_to_monadic_min ar2 -> (
+        match equal_areality ar1 ar2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq)
+      | Comonadic_to_monadic_min _, _ -> Misc.Is_not_eq
+      | _, Comonadic_to_monadic_min _ -> Misc.Is_not_eq
+      | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Misc.Is_eq
+      | Monadic_to_comonadic_max, _ -> Misc.Is_not_eq
+      | _, Monadic_to_comonadic_max -> Misc.Is_not_eq
+      | Comonadic_to_monadic_max ar1, Comonadic_to_monadic_max ar2 -> (
+        match equal_areality ar1 ar2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq)
+      | Comonadic_to_monadic_max _, _ -> .
+      | _, Comonadic_to_monadic_max _ -> .
+
+    let print : type a b d. Fmt.formatter -> (a, b, d) t -> unit =
+     fun ppf -> function
+      | Locality_restricted l -> Locality_morph.print ppf l
+      | Locality_full l -> Fmt.fprintf ppf "%a_full" Locality_morph.print l
+      | Uniqueness_op_to_linearity ->
+        Fmt.fprintf ppf "uniqueness_op_to_linearity"
+      | Linearity_to_uniqueness_op ->
+        Fmt.fprintf ppf "linearity_to_uniqueness_op"
+      | Contention_op_to_portability ->
+        Fmt.fprintf ppf "contention_op_to_portability"
+      | Portability_to_contention_op ->
+        Fmt.fprintf ppf "portability_to_contention_op"
+      | Visibility_op_to_statefulness ->
+        Fmt.fprintf ppf "visibility_op_to_statefulness"
+      | Statefulness_to_visibility_op ->
+        Fmt.fprintf ppf "statefulnes_to_visibility_op"
+      | Monadic_to_comonadic_min -> Fmt.fprintf ppf "monadic_to_comonadic_min"
+      | Comonadic_to_monadic_min _ -> Fmt.fprintf ppf "comonadic_to_monadic_min"
+      | Monadic_to_comonadic_max -> Fmt.fprintf ppf "monadic_to_comonadic_max"
+      | Comonadic_to_monadic_max _ -> Fmt.fprintf ppf "comonadic_to_monadic_max"
+
+    let uniqueness_op_to_linearity = function
+      | Uniqueness.Unique -> Linearity.Once
+      | Uniqueness.Aliased -> Linearity.Many
+
+    let linearity_to_uniqueness_op = function
+      | Linearity.Many -> Uniqueness.Aliased
+      | Linearity.Once -> Uniqueness.Unique
+
+    let contention_op_to_portability = function
+      | Contention.Contended -> Portability.Portable
+      | Contention.Shared -> Portability.Shareable
+      | Contention.Corrupted -> Portability.Corruptible
+      | Contention.Uncontended -> Portability.Nonportable
+
+    let portability_to_contention_op = function
+      | Portability.Portable -> Contention.Contended
+      | Portability.Shareable -> Contention.Shared
+      | Portability.Corruptible -> Contention.Corrupted
+      | Portability.Nonportable -> Contention.Uncontended
+
+    let visibility_op_to_statefulness = function
+      | Visibility.Immutable -> Statefulness.Stateless
+      | Visibility.Read -> Statefulness.Reading
+      | Visibility.Write -> Statefulness.Writing
+      | Visibility.Read_write -> Statefulness.Stateful
+
+    let statefulness_to_visibility_op = function
+      | Statefulness.Stateless -> Visibility.Immutable
+      | Statefulness.Writing -> Visibility.Write
+      | Statefulness.Reading -> Visibility.Read
+      | Statefulness.Stateful -> Visibility.Read_write
+
+    let monadic_to_comonadic_min : type a.
+        a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
+     fun obj m ->
+      let areality : a =
+        match obj with
+        | Comonadic_with_locality -> Locality.min
+        | Comonadic_with_regionality -> Regionality.min
+      in
+      let linearity = uniqueness_op_to_linearity m.uniqueness in
+      let portability = contention_op_to_portability m.contention in
+      let forkable = Forkable.min in
+      let yielding = Yielding.min in
+      let statefulness = visibility_op_to_statefulness m.visibility in
+      { areality; linearity; portability; forkable; yielding; statefulness }
+
+    let comonadic_to_monadic_min : type a.
+        a areality -> a comonadic_with -> Monadic_op.t =
+     fun _ m ->
+      let uniqueness = linearity_to_uniqueness_op m.linearity in
+      let contention = portability_to_contention_op m.portability in
+      let visibility = statefulness_to_visibility_op m.statefulness in
+      let staticity = Staticity_op.min in
+      { uniqueness; contention; visibility; staticity }
+
+    let monadic_to_comonadic_max : type a.
+        a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
+     fun obj m ->
+      let areality : a =
+        match obj with
+        | Comonadic_with_locality -> Locality.max
+        | Comonadic_with_regionality -> Regionality.max
+      in
+      let linearity = uniqueness_op_to_linearity m.uniqueness in
+      let portability = contention_op_to_portability m.contention in
+      let forkable = Forkable.max in
+      let yielding = Yielding.max in
+      let statefulness = visibility_op_to_statefulness m.visibility in
+      { areality; linearity; portability; forkable; yielding; statefulness }
+
+    let comonadic_to_monadic_max : type a.
+        a areality -> a comonadic_with -> Monadic_op.t =
+     fun _ m ->
+      let uniqueness = linearity_to_uniqueness_op m.linearity in
+      let contention = portability_to_contention_op m.portability in
+      let visibility = statefulness_to_visibility_op m.statefulness in
+      let staticity = Staticity_op.max in
+      { uniqueness; contention; visibility; staticity }
+
+    let apply : type a b d. b obj -> (a, b, d) t -> a -> b =
+     fun dst f a ->
+      match f with
+      | Locality_restricted m -> Locality_morph.apply m a
+      | Locality_full m ->
+        let areality = Locality_morph.apply m a.areality in
+        { a with areality }
+      | Uniqueness_op_to_linearity -> uniqueness_op_to_linearity a
+      | Linearity_to_uniqueness_op -> linearity_to_uniqueness_op a
+      | Contention_op_to_portability -> contention_op_to_portability a
+      | Portability_to_contention_op -> portability_to_contention_op a
+      | Visibility_op_to_statefulness -> visibility_op_to_statefulness a
+      | Statefulness_to_visibility_op -> statefulness_to_visibility_op a
+      | Monadic_to_comonadic_min -> monadic_to_comonadic_min dst a
+      | Comonadic_to_monadic_min ar -> comonadic_to_monadic_min ar a
+      | Monadic_to_comonadic_max -> monadic_to_comonadic_max dst a
+      | Comonadic_to_monadic_max ar -> comonadic_to_monadic_max ar a
+
+    let right_adjoint : type a b r.
+        b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
+     fun dst -> function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.right_adjoint m)
+      | Locality_full m -> Locality_full (Locality_morph.right_adjoint m)
+      | Uniqueness_op_to_linearity -> Linearity_to_uniqueness_op
+      | Linearity_to_uniqueness_op -> Uniqueness_op_to_linearity
+      | Contention_op_to_portability -> Portability_to_contention_op
+      | Portability_to_contention_op -> Contention_op_to_portability
+      | Visibility_op_to_statefulness -> Statefulness_to_visibility_op
+      | Statefulness_to_visibility_op -> Visibility_op_to_statefulness
+      | Monadic_to_comonadic_min ->
+        Comonadic_to_monadic_max (comonadic_obj_areality dst)
+      | Comonadic_to_monadic_min _ -> Monadic_to_comonadic_max
+
+    let left_adjoint : type a b l.
+        b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
+     fun dst -> function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.left_adjoint m)
+      | Locality_full m -> Locality_full (Locality_morph.left_adjoint m)
+      | Uniqueness_op_to_linearity -> Linearity_to_uniqueness_op
+      | Linearity_to_uniqueness_op -> Uniqueness_op_to_linearity
+      | Contention_op_to_portability -> Portability_to_contention_op
+      | Portability_to_contention_op -> Contention_op_to_portability
+      | Visibility_op_to_statefulness -> Statefulness_to_visibility_op
+      | Statefulness_to_visibility_op -> Visibility_op_to_statefulness
+      | Monadic_to_comonadic_max ->
+        Comonadic_to_monadic_min (comonadic_obj_areality dst)
+      | Comonadic_to_monadic_max _ -> Monadic_to_comonadic_min
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_right = function
+      | Locality_restricted lm ->
+        begin match Locality_morph.maybe_allowed_right lm with
+        | Allowed_right lm -> Allowed_right (Locality_restricted lm)
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Locality_full lm ->
+        begin match Locality_morph.maybe_allowed_right lm with
+        | Allowed_right lm -> Allowed_right (Locality_full lm)
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Uniqueness_op_to_linearity as m -> Allowed_right m
+      | Linearity_to_uniqueness_op as m -> Allowed_right m
+      | Contention_op_to_portability as m -> Allowed_right m
+      | Portability_to_contention_op as m -> Allowed_right m
+      | Visibility_op_to_statefulness as m -> Allowed_right m
+      | Statefulness_to_visibility_op as m -> Allowed_right m
+      | Monadic_to_comonadic_min -> Not_allowed_right
+      | Comonadic_to_monadic_min _ -> Not_allowed_right
+      | Monadic_to_comonadic_max as m -> Allowed_right m
+      | Comonadic_to_monadic_max a -> Allowed_right (Comonadic_to_monadic_max a)
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_left = function
+      | Locality_restricted lm ->
+        begin match Locality_morph.maybe_allowed_left lm with
+        | Allowed_left lm -> Allowed_left (Locality_restricted lm)
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Locality_full lm ->
+        begin match Locality_morph.maybe_allowed_left lm with
+        | Allowed_left lm -> Allowed_left (Locality_full lm)
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Uniqueness_op_to_linearity as m -> Allowed_left m
+      | Linearity_to_uniqueness_op as m -> Allowed_left m
+      | Contention_op_to_portability as m -> Allowed_left m
+      | Portability_to_contention_op as m -> Allowed_left m
+      | Visibility_op_to_statefulness as m -> Allowed_left m
+      | Statefulness_to_visibility_op as m -> Allowed_left m
+      | Monadic_to_comonadic_min as m -> Allowed_left m
+      | Comonadic_to_monadic_min a -> Allowed_left (Comonadic_to_monadic_min a)
+      | Monadic_to_comonadic_max -> Not_allowed_left
+      | Comonadic_to_monadic_max _ -> Not_allowed_left
+
+    (* Commutes a meet through a morphism from the right, such that:
+       [apply dst m (meet_const c x)] is equivalent to
+       [meet_const (commute_meet_const_from_right dst m c) (apply dst m x)]
+    *)
+    let commute_meet_const_from_right : type a b d.
+        b obj -> (a, b, d) t -> a -> b =
+     fun dst m c ->
+      (* All our morphisms preserve binary meets *)
+      apply dst m c
+
+    (* Commutes an implication through a morphism from the left, such that:
+       [apply dst m (meet_const c x)] is equivalent to
+       [meet_const (commute_imply_from_left dst m c) (apply dst m x)]
+    *)
+    let commute_imply_from_left : type a b l.
+        b obj -> b -> (a, b, l * allowed) t -> a =
+     fun dst c m ->
+      (* As all our morphisms preserve binary meets, implications can be
+         pushed inside of [m] by applying the left adjoint of [m] to the
+         implicant. *)
+      apply (src m) (left_adjoint dst m) c
+
+    type ('a, 'b, 'd) compose_proj_result =
+      | Proj_core :
+          ('p, 'b, 'd) t * ('a, 'p) Axis.t * 'a obj
+          -> ('a, 'b, 'd) compose_proj_result
+      | Proj_id :
+          ('a comonadic_with, 'p) Axis.t * 'a comonadic_with obj
+          -> ('a comonadic_with, 'p, 'd) compose_proj_result
+      | Proj_const_max : 'a obj -> ('a, 'b, disallowed * 'r) compose_proj_result
+      | Proj_const_min : 'a obj -> ('a, 'b, 'l * disallowed) compose_proj_result
+
+    let compose_projection_locality_morph : type a b p l r.
+        (a, b, l * r) Locality_morph.t ->
+        (b comonadic_with, p) Axis.t ->
+        (a comonadic_with, p, l * r) compose_proj_result =
+     fun lm1 ax0 ->
+      let src = Locality_morph.src_full lm1 in
+      match ax0 with
+      | Forkable -> Proj_id (Forkable, src)
+      | Yielding -> Proj_id (Yielding, src)
+      | Linearity -> Proj_id (Linearity, src)
+      | Statefulness -> Proj_id (Statefulness, src)
+      | Portability -> Proj_id (Portability, src)
+      | Areality -> Proj_core (Locality_restricted lm1, Areality, src)
+
+    let compose_projection_core : type a b p d.
+        (b, p) Axis.t -> (a, b, d) t -> (a, p, d) compose_proj_result =
+     fun ax0 m1 ->
+      match (m1 : (a, b, d) t), (ax0 : (b, p) Axis.t) with
+      | Monadic_to_comonadic_min, Areality -> Proj_const_min Monadic_op
+      | Monadic_to_comonadic_min, Forkable -> Proj_const_min Monadic_op
+      | Monadic_to_comonadic_min, Yielding -> Proj_const_min Monadic_op
+      | Monadic_to_comonadic_min, Linearity ->
+        Proj_core (Uniqueness_op_to_linearity, Uniqueness, Monadic_op)
+      | Monadic_to_comonadic_min, Statefulness ->
+        Proj_core (Visibility_op_to_statefulness, Visibility, Monadic_op)
+      | Monadic_to_comonadic_min, Portability ->
+        Proj_core (Contention_op_to_portability, Contention, Monadic_op)
+      | Comonadic_to_monadic_min areality, Uniqueness ->
+        Proj_core
+          ( Linearity_to_uniqueness_op,
+            Linearity,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_min areality, Visibility ->
+        Proj_core
+          ( Statefulness_to_visibility_op,
+            Statefulness,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_min areality, Contention ->
+        Proj_core
+          ( Portability_to_contention_op,
+            Portability,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_min areality, Staticity ->
+        Proj_const_min (areality_comonadic_obj areality)
+      | Monadic_to_comonadic_max, Areality -> Proj_const_max Monadic_op
+      | Monadic_to_comonadic_max, Forkable -> Proj_const_max Monadic_op
+      | Monadic_to_comonadic_max, Yielding -> Proj_const_max Monadic_op
+      | Monadic_to_comonadic_max, Linearity ->
+        Proj_core (Uniqueness_op_to_linearity, Uniqueness, Monadic_op)
+      | Monadic_to_comonadic_max, Statefulness ->
+        Proj_core (Visibility_op_to_statefulness, Visibility, Monadic_op)
+      | Monadic_to_comonadic_max, Portability ->
+        Proj_core (Contention_op_to_portability, Contention, Monadic_op)
+      | Comonadic_to_monadic_max areality, Uniqueness ->
+        Proj_core
+          ( Linearity_to_uniqueness_op,
+            Linearity,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_max areality, Visibility ->
+        Proj_core
+          ( Statefulness_to_visibility_op,
+            Statefulness,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_max areality, Contention ->
+        Proj_core
+          ( Portability_to_contention_op,
+            Portability,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_max areality, Staticity ->
+        Proj_const_max (areality_comonadic_obj areality)
+      | Locality_full lm, (_ as ax0) -> compose_projection_locality_morph lm ax0
+      | _, _ -> .
+    [@@warning "-4"]
+
+    type ('a, 'b, 'd) compose_and_max_result =
+      | And_max_core :
+          ('s, 'q) Axis.t * ('p, 'q, disallowed * 'r) t
+          -> ('p, 's, disallowed * 'r) compose_and_max_result
+      | Const_max_core : ('a, 'b, disallowed * 'r) compose_and_max_result
+      | And_max_id :
+          ('c comonadic_with, 'q) Axis.t
+          -> ('q, 'c comonadic_with, 'd) compose_and_max_result
+      | Disallowed : ('a, 'b, neither) compose_and_max_result
+
+    let compose_max_with_simple_locality_morph : type b c q r.
+        (b, c, disallowed * r) Locality_morph.t ->
+        (b comonadic_with, q) Axis.t ->
+        (q, c comonadic_with, disallowed * r) compose_and_max_result =
+     fun lm1 ax0 ->
+      match ax0 with
+      | Forkable -> And_max_id Forkable
+      | Yielding -> And_max_id Yielding
+      | Linearity -> And_max_id Linearity
+      | Statefulness -> And_max_id Statefulness
+      | Portability -> And_max_id Portability
+      | Areality -> And_max_core (Areality, Locality_restricted lm1)
+
+    let compose_max_with_simple_core : type b c q r.
+        (b, q) Axis.t ->
+        (b, c, disallowed * r) t ->
+        (q, c, disallowed * r) compose_and_max_result =
+     fun ax1 m0 ->
+      match (m0 : (b, c, disallowed * r) t), (ax1 : (b, q) Axis.t) with
+      | Comonadic_to_monadic_max _, Portability ->
+        And_max_core (Contention, Portability_to_contention_op)
+      | Comonadic_to_monadic_max _, Statefulness ->
+        And_max_core (Visibility, Statefulness_to_visibility_op)
+      | Comonadic_to_monadic_max _, Linearity ->
+        And_max_core (Uniqueness, Linearity_to_uniqueness_op)
+      | Comonadic_to_monadic_max _, Yielding -> Const_max_core
+      | Comonadic_to_monadic_max _, Forkable -> Const_max_core
+      | Comonadic_to_monadic_max _, Areality -> Const_max_core
+      | Monadic_to_comonadic_max, Staticity -> Const_max_core
+      | Monadic_to_comonadic_max, Contention ->
+        And_max_core (Portability, Contention_op_to_portability)
+      | Monadic_to_comonadic_max, Visibility ->
+        And_max_core (Statefulness, Visibility_op_to_statefulness)
+      | Monadic_to_comonadic_max, Uniqueness ->
+        And_max_core (Linearity, Uniqueness_op_to_linearity)
+      | Locality_full lm, (_ as ax0) ->
+        compose_max_with_simple_locality_morph lm ax0
+      | Monadic_to_comonadic_min, _ -> Disallowed
+      | Comonadic_to_monadic_min _, _ -> Disallowed
+      | _, _ -> .
+    [@@warning "-4"]
+
+    type ('a, 'b, 'd) compose_and_min_result =
+      | And_min_core :
+          ('s, 'q) Axis.t * ('p, 'q, 'l * disallowed) t
+          -> ('p, 's, 'l * disallowed) compose_and_min_result
+      | Const_min_core : ('a, 'b, 'l * disallowed) compose_and_min_result
+      | And_min_id :
+          ('c comonadic_with, 'q) Axis.t
+          -> ('q, 'c comonadic_with, 'd) compose_and_min_result
+      | Disallowed : ('a, 'b, neither) compose_and_min_result
+
+    let compose_min_with_simple_locality_morph : type b c q l.
+        (b, c, l * disallowed) Locality_morph.t ->
+        (b comonadic_with, q) Axis.t ->
+        (q, c comonadic_with, l * disallowed) compose_and_min_result =
+     fun lm1 ax0 ->
+      match ax0 with
+      | Forkable -> And_min_id Forkable
+      | Yielding -> And_min_id Yielding
+      | Linearity -> And_min_id Linearity
+      | Statefulness -> And_min_id Statefulness
+      | Portability -> And_min_id Portability
+      | Areality -> And_min_core (Areality, Locality_restricted lm1)
+
+    let compose_min_with_simple_core : type b c q l.
+        (b, q) Axis.t ->
+        (b, c, l * disallowed) t ->
+        (q, c, l * disallowed) compose_and_min_result =
+     fun ax1 m0 ->
+      match (m0 : (b, c, l * disallowed) t), (ax1 : (b, q) Axis.t) with
+      | Comonadic_to_monadic_min _, Portability ->
+        And_min_core (Contention, Portability_to_contention_op)
+      | Comonadic_to_monadic_min _, Statefulness ->
+        And_min_core (Visibility, Statefulness_to_visibility_op)
+      | Comonadic_to_monadic_min _, Linearity ->
+        And_min_core (Uniqueness, Linearity_to_uniqueness_op)
+      | Comonadic_to_monadic_min _, Yielding -> Const_min_core
+      | Comonadic_to_monadic_min _, Forkable -> Const_min_core
+      | Comonadic_to_monadic_min _, Areality -> Const_min_core
+      | Monadic_to_comonadic_min, Staticity -> Const_min_core
+      | Monadic_to_comonadic_min, Contention ->
+        And_min_core (Portability, Contention_op_to_portability)
+      | Monadic_to_comonadic_min, Visibility ->
+        And_min_core (Statefulness, Visibility_op_to_statefulness)
+      | Monadic_to_comonadic_min, Uniqueness ->
+        And_min_core (Linearity, Uniqueness_op_to_linearity)
+      | Locality_full lm, (_ as ax0) ->
+        compose_min_with_simple_locality_morph lm ax0
+      | Monadic_to_comonadic_max, _ -> Disallowed
+      | Comonadic_to_monadic_max _, _ -> Disallowed
+      | _, _ -> .
+    [@@warning "-4"]
+  end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
    fun ax obj ->
@@ -1551,338 +2366,1222 @@ module Lattices_mono = struct
     | Visibility, Monadic_op -> Visibility_op
     | Staticity, Monadic_op -> Staticity_op
 
-  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
-   fun a0 ->
-    match a0 with
-    | Locality -> Comonadic_with_locality
-    | Regionality -> Comonadic_with_regionality
-    | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
-    | Comonadic_with_locality | Contention_op | Visibility_op | Portability
-    | Forkable | Yielding | Statefulness | Staticity_op ->
-      assert false
+  let min_with dst ax a = Axis.set ax a (min dst)
 
-  let rec src : type a b l r. b obj -> (a, b, l * r) morph -> a obj =
+  let max_with dst ax a = Axis.set ax a (max dst)
+
+  module Simple_morph = struct
+    type ('a, 'b, 'd) t =
+      | Id : ('a, 'a, 'd) t  (** identity morphism *)
+      | Core : ('a, 'b, 'd) Core_morph.t -> ('a, 'b, 'd) t
+      | Meet_const : 'a -> ('a, 'a, 'l * disallowed) t
+          (** Meet the input with the parameter *)
+      | Imply_const : 'a -> ('a, 'a, disallowed * 'r) t
+          (** The right adjoint of [Meet_const] *)
+      | Meet_const_core :
+          'b * ('a, 'b, 'l * disallowed) Core_morph.t
+          -> ('a, 'b, 'l * disallowed) t
+          (** Composition of [Core] and [Meet_const]. We only need to include
+              one order of composition because currently all our core left
+              morphisms preserve binary meets. *)
+      | Core_imply_const :
+          ('a, 'b, disallowed * 'r) Core_morph.t * 'a
+          -> ('a, 'b, disallowed * 'r) t
+          (** Composition of [Core] and [Imply_const]. We only need to include
+              one order of composition because currently all our core right
+              morphisms commute with implication. *)
+      | Compose :
+          ('b, 'c, neither) t * ('a, 'b, neither) t
+          -> ('a, 'c, neither) t
+          (** Compoistion of two morphisms. We don't allow compositions to
+              appear on either side to ensure that there are a finite number of
+              morphisms we can encounter in practice. *)
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+      function
+      | Id -> Id
+      | Core m -> Core (Core_morph.allow_left m)
+      | Meet_const c -> Meet_const c
+      | Meet_const_core (c, m) -> Meet_const_core (c, Core_morph.allow_left m)
+
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+      function
+      | Id -> Id
+      | Core m -> Core (Core_morph.allow_right m)
+      | Imply_const c -> Imply_const c
+      | Core_imply_const (m, c) -> Core_imply_const (Core_morph.allow_right m, c)
+
+    let rec disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Id -> Id
+      | Core m -> Core (Core_morph.disallow_left m)
+      | Meet_const c -> Meet_const c
+      | Imply_const c -> Imply_const c
+      | Meet_const_core (c, m) -> Meet_const_core (c, Core_morph.disallow_left m)
+      | Core_imply_const (m, c) ->
+        Core_imply_const (Core_morph.disallow_left m, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_left mb in
+        let ma = disallow_left ma in
+        Compose (mb, ma)
+
+    let rec disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Id -> Id
+      | Core m -> Core (Core_morph.disallow_right m)
+      | Meet_const c -> Meet_const c
+      | Imply_const c -> Imply_const c
+      | Meet_const_core (c, m) ->
+        Meet_const_core (c, Core_morph.disallow_right m)
+      | Core_imply_const (m, c) ->
+        Core_imply_const (Core_morph.disallow_right m, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_right mb in
+        let ma = disallow_right ma in
+        Compose (mb, ma)
+
+    let rec src : type a b d. b obj -> (a, b, d) t -> a obj =
+     fun dst f ->
+      match f with
+      | Id -> dst
+      | Core m -> Core_morph.src m
+      | Meet_const _ -> dst
+      | Imply_const _ -> dst
+      | Meet_const_core (_, m) -> Core_morph.src m
+      | Core_imply_const (m, _) -> Core_morph.src m
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        src mid ma
+
+    let equal_val = equal
+
+    let rec compare : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Id, Id -> 0
+      | Id, _ -> -1
+      | _, Id -> 1
+      | Core m1, Core m2 -> Core_morph.compare m1 m2
+      | Core _, _ -> -1
+      | _, Core _ -> 1
+      | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
+      | Meet_const _, _ -> -1
+      | _, Meet_const _ -> 1
+      | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
+      | Imply_const _, _ -> -1
+      | _, Imply_const _ -> 1
+      | Meet_const_core (c1, m1), Meet_const_core (c2, m2) ->
+        let c = compare_total dst c1 c2 in
+        if c <> 0 then c else Core_morph.compare m1 m2
+      | Meet_const_core _, _ -> -1
+      | _, Meet_const_core _ -> 1
+      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) -> (
+        let c = Core_morph.compare m1 m2 in
+        if c <> 0
+        then c
+        else
+          match Core_morph.equal m1 m2 with
+          | Misc.Is_not_eq ->
+            Misc.fatal_error
+              "Mode.Lattices_mono.Simple_morph.compare: inconsistent core \
+               morph equality"
+          | Misc.Is_eq ->
+            let src = Core_morph.src m1 in
+            compare_total src c1 c2)
+      | Core_imply_const _, _ -> -1
+      | _, Core_imply_const _ -> 1
+      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+        let c = compare dst mb1 mb2 in
+        if c <> 0
+        then c
+        else
+          match equal dst mb1 mb2 with
+          | Misc.Is_not_eq ->
+            Misc.fatal_error
+              "Mode.Lattices_mono.Simple_morph.compare: inconsistent equality"
+          | Misc.Is_eq -> compare (src dst mb1) ma1 ma2)
+      | Compose _, _ -> .
+      | _, Compose _ -> .
+
+    and equal : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Id, Id -> Misc.Is_eq
+      | Core m1, Core m2 -> Core_morph.equal m1 m2
+      | Meet_const c1, Meet_const c2 ->
+        if equal_val dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
+      | Imply_const c1, Imply_const c2 ->
+        if equal_val dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
+      | Meet_const_core (c1, m1), Meet_const_core (c2, m2) ->
+        if equal_val dst c1 c2 then Core_morph.equal m1 m2 else Misc.Is_not_eq
+      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) -> (
+        match Core_morph.equal m1 m2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq ->
+          if equal_val (Core_morph.src m1) c1 c2
+          then Misc.Is_eq
+          else Misc.Is_not_eq)
+      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+        match equal dst mb1 mb2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> equal (src dst mb1) ma1 ma2)
+      | ( ( Id | Core _ | Meet_const _ | Imply_const _ | Meet_const_core _
+          | Core_imply_const _ | Compose _ ),
+          _ ) ->
+        Misc.Is_not_eq
+
+    let print_val = print
+
+    let rec print : type a b d. b obj -> Fmt.formatter -> (a, b, d) t -> unit =
+     fun dst ppf -> function
+      | Id -> Fmt.fprintf ppf "id"
+      | Core m -> Core_morph.print ppf m
+      | Meet_const c -> Fmt.fprintf ppf "meet(%a)" (print_val dst) c
+      | Imply_const c -> Fmt.fprintf ppf "imply(%a)" (print_val dst) c
+      | Meet_const_core (c, m) ->
+        Fmt.fprintf ppf "meet(%a) . %a" (print_val dst) c Core_morph.print m
+      | Core_imply_const (m, c) ->
+        Fmt.fprintf ppf "%a . imply(%a)" Core_morph.print m
+          (print_val (Core_morph.src m))
+          c
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        Fmt.fprintf ppf "%a . %a" (print dst) mb (print mid) ma
+
+    let rec apply : type a b d. b obj -> (a, b, d) t -> a -> b =
+     fun dst f a ->
+      match f with
+      | Id -> a
+      | Core m -> Core_morph.apply dst m a
+      | Meet_const c -> meet dst c a
+      | Imply_const c -> imply dst c a
+      | Meet_const_core (c, m) -> meet dst c (Core_morph.apply dst m a)
+      | Core_imply_const (m, c) ->
+        Core_morph.apply dst m (imply (Core_morph.src m) c a)
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        apply dst mb (apply mid ma a)
+
+    let right_adjoint : type a b r.
+        b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
+     fun dst f ->
+      match f with
+      | Id -> Id
+      | Core m -> Core (Core_morph.right_adjoint dst m)
+      | Meet_const c -> Imply_const c
+      | Meet_const_core (c, m) ->
+        Core_imply_const (Core_morph.right_adjoint dst m, c)
+
+    let left_adjoint : type a b l.
+        b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
+     fun dst f ->
+      match f with
+      | Id -> Id
+      | Core m -> Core (Core_morph.left_adjoint dst m)
+      | Imply_const c -> Meet_const c
+      | Core_imply_const (m, c) ->
+        Meet_const_core (c, Core_morph.left_adjoint dst m)
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * r) maybe_allowed_right = function
+      | Id -> Allowed_right Id
+      | Core m ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Core m)
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Meet_const _ -> Not_allowed_right
+      | Imply_const c -> Allowed_right (Imply_const c)
+      | Meet_const_core _ -> Not_allowed_right
+      | Core_imply_const (m, c) ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Core_imply_const (m, c))
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Compose _ -> Not_allowed_right
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b l r.
+        (a, b, l * r) t -> (a, b, l * r) maybe_allowed_left = function
+      | Id -> Allowed_left Id
+      | Core m ->
+        begin match Core_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Core m)
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Meet_const c -> Allowed_left (Meet_const c)
+      | Imply_const _ -> Not_allowed_left
+      | Meet_const_core (c, m) ->
+        begin match Core_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Meet_const_core (c, m))
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Core_imply_const _ -> Not_allowed_left
+      | Compose _ -> Not_allowed_left
+
+    let compose_meet_const_left : type a b l.
+        b obj -> b -> (a, b, l * disallowed) t -> (a, b, l * disallowed) t =
+     fun dst c m ->
+      match m with
+      | Id -> Meet_const c
+      | Core m -> Meet_const_core (c, m)
+      | Meet_const c' -> Meet_const (meet dst c c')
+      | Meet_const_core (c', m) -> Meet_const_core (meet dst c c', m)
+      | Imply_const _ as m -> Compose (Meet_const c, m)
+      | Core_imply_const _ as m -> Compose (Meet_const c, m)
+      | Compose _ as m -> Compose (Meet_const c, m)
+
+    let compose_imply_const_right : type a b r.
+        b obj -> (a, b, disallowed * r) t -> a -> (a, b, disallowed * r) t =
+     fun dst m c ->
+      match m with
+      | Id -> Imply_const c
+      | Core m -> Core_imply_const (m, c)
+      | Imply_const c' -> Imply_const (meet dst c c')
+      | Core_imply_const (m, c') ->
+        Core_imply_const (m, meet (Core_morph.src m) c' c)
+      | Meet_const _ as m -> Compose (m, Imply_const c)
+      | Meet_const_core _ as m -> Compose (m, Imply_const c)
+      | Compose _ as m -> Compose (m, Imply_const c)
+
+    let compose_meet_const_right : type a b l.
+        b obj -> (a, b, l * disallowed) t -> a -> (a, b, l * disallowed) t =
+     fun dst m c ->
+      match m with
+      | Id -> Meet_const c
+      | Core m ->
+        let c = Core_morph.commute_meet_const_from_right dst m c in
+        Meet_const_core (c, m)
+      | Meet_const c' -> Meet_const (meet dst c' c)
+      | Meet_const_core (c', m) ->
+        let c = Core_morph.commute_meet_const_from_right dst m c in
+        Meet_const_core (meet dst c' c, m)
+      | Imply_const _ as m -> Compose (m, Meet_const c)
+      | Core_imply_const _ as m -> Compose (m, Meet_const c)
+      | Compose _ as m -> Compose (m, Meet_const c)
+
+    let compose_imply_const_left : type a b r.
+        b obj -> b -> (a, b, disallowed * r) t -> (a, b, disallowed * r) t =
+     fun dst c m ->
+      match m with
+      | Id -> Imply_const c
+      | Core m ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Not_allowed_right -> Compose (Imply_const c, Core m)
+        | Allowed_right m' ->
+          let c = Core_morph.commute_imply_from_left dst c m' in
+          Core_imply_const (m, c)
+        end
+      | Imply_const c' -> Imply_const (meet dst c c')
+      | Core_imply_const (m, c') ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Not_allowed_right -> Compose (Imply_const c, Core_imply_const (m, c'))
+        | Allowed_right m' ->
+          let c = Core_morph.commute_imply_from_left dst c m' in
+          Core_imply_const (m, meet (Core_morph.src m) c c')
+        end
+      | Meet_const _ as m -> Compose (Imply_const c, m)
+      | Meet_const_core _ as m -> Compose (Imply_const c, m)
+      | Compose _ as m -> Compose (Imply_const c, m)
+
+    let compose_core : type a b c d.
+        c obj -> (b, c, d) Core_morph.t -> (a, b, d) Core_morph.t -> (a, c, d) t
+        =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Locality_restricted lm1, Locality_restricted lm2 ->
+        begin match Locality_morph.compose lm1 lm2 with
+        | Id -> Id
+        | Morph lm -> Core (Locality_restricted lm)
+        | Disallowed -> Compose (Core m1, Core m2)
+        end
+      | Locality_full lm1, Locality_full lm2 ->
+        begin match Locality_morph.compose lm1 lm2 with
+        | Id -> Id
+        | Morph lm -> Core (Locality_full lm)
+        | Disallowed -> Compose (Core m1, Core m2)
+        end
+      | Uniqueness_op_to_linearity, Linearity_to_uniqueness_op -> Id
+      | Linearity_to_uniqueness_op, Uniqueness_op_to_linearity -> Id
+      | Contention_op_to_portability, Portability_to_contention_op -> Id
+      | Portability_to_contention_op, Contention_op_to_portability -> Id
+      | Visibility_op_to_statefulness, Statefulness_to_visibility_op -> Id
+      | Statefulness_to_visibility_op, Visibility_op_to_statefulness -> Id
+      | Comonadic_to_monadic_min areality, Monadic_to_comonadic_min ->
+        let c =
+          match areality with
+          | Locality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Locality)
+              Comonadic_with_locality.max
+          | Regionality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Regionality)
+              Comonadic_with_regionality.max
+        in
+        Meet_const c
+      | Monadic_to_comonadic_min, Comonadic_to_monadic_min areality -> begin
+        let c = Core_morph.apply dst Monadic_to_comonadic_min Monadic_op.max in
+        match areality, dst with
+        | Locality, Comonadic_with_locality -> Meet_const c
+        | Regionality, Comonadic_with_locality ->
+          Meet_const_core (c, Locality_full Regional_to_local)
+        | Locality, Comonadic_with_regionality ->
+          Meet_const_core (c, Locality_full Locality_as_regionality)
+        | Regionality, Comonadic_with_regionality -> Meet_const c
+        end
+      | Monadic_to_comonadic_max, Comonadic_to_monadic_max areality -> begin
+        let src = areality_comonadic_obj areality in
+        let c = Core_morph.apply src Monadic_to_comonadic_min Monadic_op.max in
+        match areality, dst with
+        | Locality, Comonadic_with_locality -> Imply_const c
+        | Regionality, Comonadic_with_locality ->
+          Core_imply_const (Locality_full Regional_to_local, c)
+        | Locality, Comonadic_with_regionality ->
+          Core_imply_const (Locality_full Locality_as_regionality, c)
+        | Regionality, Comonadic_with_regionality -> Imply_const c
+        end
+      | Comonadic_to_monadic_max areality, Monadic_to_comonadic_max ->
+        let c =
+          match areality with
+          | Locality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Locality)
+              Comonadic_with_locality.max
+          | Regionality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Regionality)
+              Comonadic_with_regionality.max
+        in
+        Imply_const c
+      | Comonadic_to_monadic_min _, Monadic_to_comonadic_max ->
+        Compose (Core m1, Core m2)
+      | Monadic_to_comonadic_max, Comonadic_to_monadic_min _ ->
+        Compose (Core m1, Core m2)
+      | Comonadic_to_monadic_max _, Monadic_to_comonadic_min ->
+        Compose (Core m1, Core m2)
+      | Monadic_to_comonadic_min, Comonadic_to_monadic_max _ ->
+        Compose (Core m1, Core m2)
+      | Comonadic_to_monadic_min _, Locality_full m2 ->
+        let src = Locality_morph.src_full m2 in
+        Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Comonadic_to_monadic_max _, Locality_full m2 ->
+        let src = Locality_morph.src_full m2 in
+        Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Locality_full lm1, Monadic_to_comonadic_min ->
+        begin match Locality_morph.maybe_allowed_left lm1 with
+        | Allowed_left _ ->
+          (* Has a right adjoint so it preserves min *)
+          Core Monadic_to_comonadic_min
+        | Not_allowed_left -> Compose (Core m1, Core Monadic_to_comonadic_min)
+        end
+      | Locality_full lm1, Monadic_to_comonadic_max ->
+        begin match Locality_morph.maybe_allowed_right lm1 with
+        | Allowed_right _ ->
+          (* Has a left adjoint so it preserves max *)
+          Core Monadic_to_comonadic_max
+        | Not_allowed_right -> Compose (Core m1, Core Monadic_to_comonadic_max)
+        end
+      | Locality_restricted _, _ -> .
+      | _, Locality_restricted _ -> .
+      | Locality_full _, _ -> .
+      | _, Locality_full _ -> .
+
+    let compose_core_right : type a b c d.
+        c obj -> (b, c, d) t -> (a, b, d) Core_morph.t -> (a, c, d) t =
+     fun dst m1 m2 ->
+      match m1 with
+      | Id -> Core m2
+      | Core m1 -> compose_core dst m1 m2
+      | Imply_const c1 ->
+        begin match Core_morph.maybe_allowed_right m2 with
+        | Not_allowed_right -> Compose (Imply_const c1, Core m2)
+        | Allowed_right m2' ->
+          let c1 = Core_morph.commute_imply_from_left dst c1 m2' in
+          Core_imply_const (m2, c1)
+        end
+      | Core_imply_const (m1, c1) ->
+        begin match Core_morph.maybe_allowed_right m2 with
+        | Not_allowed_right -> Compose (Core_imply_const (m1, c1), Core m2)
+        | Allowed_right m2' ->
+          let mid = Core_morph.src m1 in
+          let c1 = Core_morph.commute_imply_from_left mid c1 m2' in
+          let m = compose_core dst m1 m2 in
+          compose_imply_const_right dst m c1
+        end
+      | Meet_const c1 -> Meet_const_core (c1, m2)
+      | Meet_const_core (c1, m1) ->
+        compose_meet_const_left dst c1 (compose_core dst m1 m2)
+      | Compose _ as m1 -> Compose (m1, Core m2)
+
+    let compose_core_left : type a b c d.
+        c obj -> (b, c, d) Core_morph.t -> (a, b, d) t -> (a, c, d) t =
+     fun dst m1 m2 ->
+      match m2 with
+      | Id -> Core m1
+      | Core m2 -> compose_core dst m1 m2
+      | Imply_const c2 -> Core_imply_const (m1, c2)
+      | Core_imply_const (m2, c2) ->
+        compose_imply_const_right dst (compose_core dst m1 m2) c2
+      | Meet_const c2 ->
+        let c2 = Core_morph.commute_meet_const_from_right dst m1 c2 in
+        Meet_const_core (c2, m1)
+      | Meet_const_core (c2, m2) ->
+        let c2 = Core_morph.commute_meet_const_from_right dst m1 c2 in
+        let m = compose_core dst m1 m2 in
+        compose_meet_const_left dst c2 m
+      | Compose _ as m2 -> Compose (Core m1, m2)
+
+    let compose : type a b c d.
+        c obj -> (b, c, d) t -> (a, b, d) t -> (a, c, d) t =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | m1, Id -> m1
+      | Id, m2 -> m2
+      | m1, Meet_const c2 -> compose_meet_const_right dst m1 c2
+      | Meet_const c1, m2 -> compose_meet_const_left dst c1 m2
+      | m1, Imply_const c2 -> compose_imply_const_right dst m1 c2
+      | Imply_const c1, m2 -> compose_imply_const_left dst c1 m2
+      | m1, Core m2 -> compose_core_right dst m1 m2
+      | Core m1, m2 -> compose_core_left dst m1 m2
+      | m1, Meet_const_core (c2, m2) ->
+        compose_core_right dst (compose_meet_const_right dst m1 c2) m2
+      | Meet_const_core (c1, m1), m2 ->
+        compose_meet_const_left dst c1 (compose_core_left dst m1 m2)
+      | m1, Core_imply_const (m2, c2) ->
+        compose_imply_const_right dst (compose_core_right dst m1 m2) c2
+      | Core_imply_const (m1, c1), m2 ->
+        let mid = Core_morph.src m1 in
+        compose_core_left dst m1 (compose_imply_const_left mid c1 m2)
+      | (Compose _ as m1), m2 -> Compose (m1, m2)
+      | _, Compose _ -> .
+
+    let rec lift_max : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, disallowed * allowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, disallowed * allowed) t =
+     fun src dst m ax0 ax1 ->
+      let m : (a, b, disallowed * allowed) t =
+        match m with
+        | Id ->
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            Core (Locality_full Regional_to_global)
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            Core (Locality_full Locality_as_regionality)
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
+          | Monadic_op, Monadic_op, _, _ -> Id
+          | _, _, _, _ -> .
+          end
+        | Core m ->
+          begin match m, ax0, ax1, src, dst with
+          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+            Core Monadic_to_comonadic_max
+          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+          | Contention_op_to_portability, Contention, Portability, _, _ ->
+            Core Monadic_to_comonadic_max
+          | Portability_to_contention_op, Portability, Contention, _, _ ->
+            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+            Core Monadic_to_comonadic_max
+          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+          | Locality_restricted lm, Areality, Areality, _, _ ->
+            Core (Locality_full lm)
+          | _, _, _, _, _ -> .
+          end
+        | Imply_const c ->
+          let c = Axis.set ax1 c (max dst) in
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            compose dst (Imply_const c)
+              (Core (Locality_full Regional_to_global))
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            compose dst (Imply_const c)
+              (Core (Locality_full Locality_as_regionality))
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
+            Imply_const c
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
+            Imply_const c
+          | Monadic_op, Monadic_op, _, _ -> Imply_const c
+          | _, _, _, _ -> .
+          end
+        | Core_imply_const (m, c) ->
+          let m = lift_max src dst (Core m) ax0 ax1 in
+          let c = Axis.set ax0 c (max src) in
+          compose dst m (Imply_const c)
+      in
+      let q_obj = proj_obj ax1 dst in
+      let c = min_with dst ax1 (max q_obj) in
+      compose dst (Imply_const c) m
+    [@@warning "-4"]
+
+    let rec lift_min : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, allowed * disallowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, allowed * disallowed) t =
+     fun src dst m ax0 ax1 ->
+      let m : (a, b, allowed * disallowed) t =
+        match m with
+        | Id ->
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            Core (Locality_full Regional_to_local)
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            Core (Locality_full Locality_as_regionality)
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
+          | Monadic_op, Monadic_op, _, _ -> Id
+          | _, _, _, _ -> .
+          end
+        | Core m ->
+          begin match m, ax0, ax1, src, dst with
+          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+            Core Monadic_to_comonadic_min
+          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+          | Contention_op_to_portability, Contention, Portability, _, _ ->
+            Core Monadic_to_comonadic_min
+          | Portability_to_contention_op, Portability, Contention, _, _ ->
+            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+            Core Monadic_to_comonadic_min
+          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+          | Locality_restricted lm, Areality, Areality, _, _ ->
+            Core (Locality_full lm)
+          | _, _, _, _, _ -> .
+          end
+        | Meet_const c ->
+          let c = Axis.set ax1 c (min dst) in
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            compose dst (Meet_const c) (Core (Locality_full Regional_to_local))
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            compose dst (Meet_const c)
+              (Core (Locality_full Locality_as_regionality))
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
+            Meet_const c
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
+            Meet_const c
+          | Monadic_op, Monadic_op, _, _ -> Meet_const c
+          | _, _, _, _ -> .
+          end
+        | Meet_const_core (c, m) ->
+          let m = lift_min src dst (Core m) ax0 ax1 in
+          let c = Axis.set ax1 c (min dst) in
+          compose dst (Meet_const c) m
+      in
+      let q_obj = proj_obj ax1 dst in
+      let c = min_with dst ax1 (max q_obj) in
+      compose dst (Meet_const c) m
+    [@@warning "-4"]
+  end
+
+  type ('a, 'b, 'd) morph =
+    | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) morph
+    | Const_max : 'a obj -> ('a, 'c, disallowed * 'r) morph
+        (** Discards an arbitrary input and apply a simple morphism to the
+            maximum of a lattice *)
+    | Const_min : 'a obj -> ('a, 'c, 'l * disallowed) morph
+        (** Discards an arbitrary input and apply a simple morphism to the
+            minimum of a lattice *)
+    | Const : 'a obj * 'c -> ('a, 'c, neither) morph
+        (** A constant function on any constant: we don't allow arbitrary
+            constant functions to appear on either side *)
+    | Simple_proj :
+        ('p, 'q, 'd) Simple_morph.t * ('s, 'p) Axis.t * 's obj
+        -> ('s, 'q, 'd) morph
+        (** Composition of projecting out an axis and a simple morphism. *)
+    | Max_with_simple :
+        ('s, 'q) Axis.t * ('p, 'q, disallowed * 'r) Simple_morph.t
+        -> ('p, 's, disallowed * 'r) morph
+        (** Composition of a morphism and combining an axis with the maxima
+            along other axes. *)
+    | Min_with_simple :
+        ('s, 'q) Axis.t * ('p, 'q, 'l * disallowed) Simple_morph.t
+        -> ('p, 's, 'l * disallowed) morph
+        (** Composition of a morphism and combining an axis with the minima
+            along other axes. *)
+    | Compose :
+        ('b, 'c, neither) morph * ('a, 'b, neither) morph
+        -> ('a, 'c, neither) morph
+        (** Compoistion of two morphisms. We don't allow compositions to appear
+            on either side to ensure that there are a finite number of morphisms
+            we can encounter in practice. *)
+
+  include Magic_allow_disallow (struct
+    type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph constraint 'd = _ * _
+
+    let allow_left : type a b l r.
+        (a, b, allowed * r) morph -> (a, b, l * r) morph = function
+      | Simple m -> Simple (Simple_morph.allow_left m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.allow_left m, ax, src)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.allow_left m)
+      | Const_min src -> Const_min src
+
+    let allow_right : type a b l r.
+        (a, b, l * allowed) morph -> (a, b, l * r) morph = function
+      | Simple m -> Simple (Simple_morph.allow_right m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.allow_right m, ax, src)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.allow_right m)
+      | Const_max src -> Const_max src
+
+    let rec disallow_left : type a b l r.
+        (a, b, l * r) morph -> (a, b, disallowed * r) morph = function
+      | Simple m -> Simple (Simple_morph.disallow_left m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.disallow_left m, ax, src)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.disallow_left m)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.disallow_left m)
+      | Const_max src -> Const_max src
+      | Const_min src -> Const_min src
+      | Const (src, c) -> Const (src, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_left mb in
+        let ma = disallow_left ma in
+        Compose (mb, ma)
+
+    let rec disallow_right : type a b l r.
+        (a, b, l * r) morph -> (a, b, l * disallowed) morph = function
+      | Simple m -> Simple (Simple_morph.disallow_right m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.disallow_right m, ax, src)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.disallow_right m)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.disallow_right m)
+      | Const_max src -> Const_max src
+      | Const_min src -> Const_min src
+      | Const (src, c) -> Const (src, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_right mb in
+        let ma = disallow_right ma in
+        Compose (mb, ma)
+  end)
+
+  let rec src : type a b d. b obj -> (a, b, d) morph -> a obj =
    fun dst f ->
     match f with
-    | Id -> dst
-    | Proj (src, _) -> src
-    | Max_with ax -> proj_obj ax dst
-    | Min_with ax -> proj_obj ax dst
-    | Meet_const _ -> dst
-    | Imply_const _ -> dst
-    | Compose (f, g) ->
-      let mid = src dst f in
-      src mid g
-    | Monadic_to_comonadic_min -> Monadic_op
-    | Comonadic_to_monadic_min src -> src
-    | Comonadic_to_monadic_max src -> src
-    | Monadic_to_comonadic_max -> Monadic_op
-    | Local_to_regional -> Locality
-    | Locality_as_regionality -> Locality
-    | Global_to_regional -> Locality
-    | Regional_to_local -> Regionality
-    | Regional_to_global -> Regionality
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let src0 = src dst0 f in
-      comonadic_with_obj src0
+    | Simple m -> Simple_morph.src dst m
+    | Simple_proj (_, _, src) -> src
+    | Max_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+    | Min_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+    | Const_min src -> src
+    | Const_max src -> src
+    | Const (src, _) -> src
+    | Compose (mb, ma) ->
+      let mid = src dst mb in
+      src mid ma
 
-  let rec compare_morph : type a1 l1 r1 a2 b l2 r2.
-      b obj -> (a1, b, l1 * r1) morph -> (a2, b, l2 * r2) morph -> int =
-   fun dst f1 f2 ->
-    match f1, f2 with
-    | Id, Id -> 0
-    | Id, _ -> -1
-    | _, Id -> 1
-    | Proj (src1, ax1), Proj (src2, ax2) -> (
+  let rec compare_morph : type a1 d1 a2 b d2.
+      b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> int =
+   fun dst m1 m2 ->
+    match m1, m2 with
+    | Simple m1, Simple m2 -> Simple_morph.compare dst m1 m2
+    | Simple _, _ -> -1
+    | _, Simple _ -> 1
+    | Const_max obj1, Const_max obj2 -> compare_obj obj1 obj2
+    | Const_max _, _ -> -1
+    | _, Const_max _ -> 1
+    | Const_min obj1, Const_min obj2 -> compare_obj obj1 obj2
+    | Const_min _, _ -> -1
+    | _, Const_min _ -> 1
+    | Const (obj1, c1), Const (obj2, c2) ->
+      let c = compare_obj obj1 obj2 in
+      if c <> 0 then c else compare_total dst c1 c2
+    | Const _, _ -> -1
+    | _, Const _ -> 1
+    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
       let c = compare_obj src1 src2 in
       if c <> 0
       then c
       else
         match equal_obj src1 src2 with
-        | Misc.Is_eq -> Axis.compare ax1 ax2
         | Misc.Is_not_eq ->
           Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent object equality")
-    | Proj _, _ -> -1
-    | _, Proj _ -> 1
-    | Max_with ax1, Max_with ax2 -> Axis.compare ax1 ax2
-    | Max_with _, _ -> -1
-    | _, Max_with _ -> 1
-    | Min_with ax1, Min_with ax2 -> Axis.compare ax1 ax2
-    | Min_with _, _ -> -1
-    | _, Min_with _ -> 1
-    | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
-    | Meet_const _, _ -> -1
-    | _, Meet_const _ -> 1
-    | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
-    | Imply_const _, _ -> -1
-    | _, Imply_const _ -> 1
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> 0
-    | Monadic_to_comonadic_min, _ -> -1
-    | _, Monadic_to_comonadic_min -> 1
-    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
-      compare_obj a1 a2
-    | Comonadic_to_monadic_min _, _ -> -1
-    | _, Comonadic_to_monadic_min _ -> 1
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> 0
-    | Monadic_to_comonadic_max, _ -> -1
-    | _, Monadic_to_comonadic_max -> 1
-    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
-      compare_obj a1 a2
-    | Comonadic_to_monadic_max _, _ -> -1
-    | _, Comonadic_to_monadic_max _ -> 1
-    | Local_to_regional, Local_to_regional -> 0
-    | Local_to_regional, _ -> -1
-    | _, Local_to_regional -> 1
-    | Locality_as_regionality, Locality_as_regionality -> 0
-    | Locality_as_regionality, _ -> -1
-    | _, Locality_as_regionality -> 1
-    | Global_to_regional, Global_to_regional -> 0
-    | Global_to_regional, _ -> -1
-    | _, Global_to_regional -> 1
-    | Regional_to_local, Regional_to_local -> 0
-    | Regional_to_local, _ -> -1
-    | _, Regional_to_local -> 1
-    | Regional_to_global, Regional_to_global -> 0
-    | Regional_to_global, _ -> -1
-    | _, Regional_to_global -> 1
-    | Compose (f1, g1), Compose (f2, g2) -> (
-      let c = compare_morph dst f1 f2 in
+            "Mode.Lattices_mono.compare_morph: inconsistent object equality"
+        | Misc.Is_eq -> (
+          let c = Axis.compare ax1 ax2 in
+          if c <> 0
+          then c
+          else
+            match Axis.equal ax1 ax2 with
+            | Misc.Is_not_eq ->
+              Misc.fatal_error
+                "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
+            | Misc.Is_eq -> Simple_morph.compare dst m1 m2))
+    | Simple_proj _, _ -> -1
+    | _, Simple_proj _ -> 1
+    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+      let c = Axis.compare ax1 ax2 in
       if c <> 0
       then c
       else
-        match equal_morph dst f1 f2 with
-        | Misc.Is_eq -> compare_morph (src dst f1) g1 g2
+        match Axis.equal ax1 ax2 with
         | Misc.Is_not_eq ->
           Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent equality")
-    | Compose _, _ -> -1
-    | _, Compose _ -> 1
-    | Map_comonadic f, Map_comonadic g ->
-      compare_morph (proj_obj Areality dst) f g
+            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
+        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+    | Max_with_simple _, _ -> -1
+    | _, Max_with_simple _ -> 1
+    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+      let c = Axis.compare ax1 ax2 in
+      if c <> 0
+      then c
+      else
+        match Axis.equal ax1 ax2 with
+        | Misc.Is_not_eq ->
+          Misc.fatal_error
+            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
+        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+    | Min_with_simple _, _ -> -1
+    | _, Min_with_simple _ -> 1
+    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+      let c = compare_morph dst mb1 mb2 in
+      if c <> 0
+      then c
+      else
+        match equal_morph dst mb1 mb2 with
+        | Misc.Is_not_eq ->
+          Misc.fatal_error
+            "Mode.Lattices_mono.compare_morph: inconsistent equality"
+        | Misc.Is_eq -> compare_morph (src dst mb1) ma1 ma2)
+    | Compose _, _ -> .
+    | _, Compose _ -> .
 
-  and equal_morph : type a1 l1 r1 a2 b l2 r2.
-      b obj ->
-      (a1, b, l1 * r1) morph ->
-      (a2, b, l2 * r2) morph ->
-      (a1, a2) Misc.is_eq =
-   fun dst f1 f2 ->
-    match f1, f2 with
-    | Id, Id -> Misc.Is_eq
-    | Proj (src1, ax1), Proj (src2, ax2) -> (
+  and equal_morph : type a1 d1 a2 b d2.
+      b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> (a1, a2) Misc.is_eq =
+   fun dst m1 m2 ->
+    match m1, m2 with
+    | Simple m1, Simple m2 -> Simple_morph.equal dst m1 m2
+    | Const_max obj1, Const_max obj2 -> equal_obj obj1 obj2
+    | Const_min obj1, Const_min obj2 -> equal_obj obj1 obj2
+    | Const (obj1, c1), Const (obj2, c2) -> (
+      match equal_obj obj1 obj2 with
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq)
+    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
       match equal_obj src1 src2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
       | Misc.Is_eq -> (
         match Axis.equal ax1 ax2 with
-        | Misc.Is_eq -> Misc.Is_eq
-        | Misc.Is_not_eq -> Misc.Is_not_eq))
-    | Max_with ax1, Max_with ax2 -> Axis.equal ax1 ax2
-    | Min_with ax1, Min_with ax2 -> Axis.equal ax1 ax2
-    | Meet_const c1, Meet_const c2 ->
-      if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
-    | Imply_const c1, Imply_const c2 ->
-      if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Misc.Is_eq
-    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
-      equal_obj a1 a2
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Misc.Is_eq
-    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
-      equal_obj a1 a2
-    | Local_to_regional, Local_to_regional -> Misc.Is_eq
-    | Locality_as_regionality, Locality_as_regionality -> Misc.Is_eq
-    | Global_to_regional, Global_to_regional -> Misc.Is_eq
-    | Regional_to_local, Regional_to_local -> Misc.Is_eq
-    | Regional_to_global, Regional_to_global -> Misc.Is_eq
-    | Compose (f1, g1), Compose (f2, g2) -> (
-      match equal_morph dst f1 f2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> (
+          match Simple_morph.equal dst m1 m2 with
+          | Misc.Is_eq -> Misc.Is_eq
+          | Misc.Is_not_eq -> Misc.Is_not_eq)))
+    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+      match Axis.equal ax1 ax2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> equal_morph (src dst f1) g1 g2)
-    | Map_comonadic f, Map_comonadic g ->
-      begin match equal_morph (proj_obj Areality dst) f g with
+      | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+      match Axis.equal ax1 ax2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> Misc.Is_eq
-      end
-    | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_const _ | Imply_const _
-        | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
-        | Monadic_to_comonadic_max | Comonadic_to_monadic_max _
-        | Local_to_regional | Locality_as_regionality | Global_to_regional
-        | Regional_to_local | Regional_to_global | Compose _ | Map_comonadic _
-          ),
+      | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+      match equal_morph dst mb1 mb2 with
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> equal_morph (src dst mb1) ma1 ma2)
+    | ( ( Simple _ | Const_max _ | Const_min _ | Const _ | Simple_proj _
+        | Max_with_simple _ | Min_with_simple _ | Compose _ ),
         _ ) ->
       Misc.Is_not_eq
 
-  let rec print_morph : type a b l r.
-      b obj -> Fmt.formatter -> (a, b, l * r) morph -> unit =
+  let rec print_morph : type a b d.
+      b obj -> Fmt.formatter -> (a, b, d) morph -> unit =
    fun dst ppf -> function
-    | Id -> Fmt.fprintf ppf "id"
-    | Meet_const c -> Fmt.fprintf ppf "meet_const(%a)" (print dst) c
-    | Imply_const c -> Fmt.fprintf ppf "imply_const(%a)" (print dst) c
-    | Proj (_, ax) -> Fmt.fprintf ppf "proj_%a" Axis.print ax
-    | Max_with ax -> Fmt.fprintf ppf "max_with_%a" Axis.print ax
-    | Min_with ax -> Fmt.fprintf ppf "min_with_%a" Axis.print ax
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      Fmt.fprintf ppf "map_comonadic(%a)" (print_morph dst0) f
-    | Monadic_to_comonadic_min -> Fmt.fprintf ppf "monadic_to_comonadic_min"
-    | Comonadic_to_monadic_min _ -> Fmt.fprintf ppf "comonadic_to_monadic_min"
-    | Comonadic_to_monadic_max _ -> Fmt.fprintf ppf "comonadic_to_monadic_max"
-    | Monadic_to_comonadic_max -> Fmt.fprintf ppf "monadic_to_comonadic_max"
-    | Local_to_regional -> Fmt.fprintf ppf "local_to_regional"
-    | Regional_to_local -> Fmt.fprintf ppf "regional_to_local"
-    | Locality_as_regionality -> Fmt.fprintf ppf "locality_as_regionality"
-    | Regional_to_global -> Fmt.fprintf ppf "regional_to_global"
-    | Global_to_regional -> Fmt.fprintf ppf "global_to_regional"
-    | Compose (f1, f2) ->
-      let mid = src dst f1 in
-      Fmt.fprintf ppf "%a ∘ %a" (print_morph dst) f1 (print_morph mid) f2
+    | Simple m -> Simple_morph.print dst ppf m
+    | Simple_proj (Id, ax, src) ->
+      Fmt.fprintf ppf "proj_%a" print_obj (proj_obj ax src)
+    | Simple_proj (m, ax, src) ->
+      Fmt.fprintf ppf "%a . proj_%a" (Simple_morph.print dst) m print_obj
+        (proj_obj ax src)
+    | Max_with_simple (ax, Id) ->
+      Fmt.fprintf ppf "max_with_%a" print_obj (proj_obj ax dst)
+    | Max_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Fmt.fprintf ppf "max_with_%a . %a" print_obj mid (Simple_morph.print mid)
+        m
+    | Min_with_simple (ax, Id) ->
+      Fmt.fprintf ppf "min_with_%a" print_obj (proj_obj ax dst)
+    | Min_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Fmt.fprintf ppf "min_with_%a . %a" print_obj mid (Simple_morph.print mid)
+        m
+    | Const_max _ -> Fmt.fprintf ppf "const_%a" (print dst) (max dst)
+    | Const_min _ -> Fmt.fprintf ppf "const_%a" (print dst) (min dst)
+    | Const (_, c) -> Fmt.fprintf ppf "const_%a" (print dst) c
+    | Compose (mb, ma) ->
+      let mid = src dst mb in
+      Fmt.fprintf ppf "%a . %a" (print_morph dst) mb (print_morph mid) ma
+  [@@warning "-4"]
 
-  let id = Id
+  let id = Simple Id
 
-  let linear_to_unique = function
-    | Linearity.Many -> Uniqueness.Aliased
-    | Linearity.Once -> Uniqueness.Unique
-
-  let unique_to_linear = function
-    | Uniqueness.Unique -> Linearity.Once
-    | Uniqueness.Aliased -> Linearity.Many
-
-  let portable_to_contended = function
-    | Portability.Portable -> Contention.Contended
-    | Portability.Shareable -> Contention.Shared
-    | Portability.Corruptible -> Contention.Corrupted
-    | Portability.Nonportable -> Contention.Uncontended
-
-  let contended_to_portable = function
-    | Contention.Contended -> Portability.Portable
-    | Contention.Shared -> Portability.Shareable
-    | Contention.Corrupted -> Portability.Corruptible
-    | Contention.Uncontended -> Portability.Nonportable
-
-  let local_to_regional = function
-    | Locality.Global -> Regionality.Global
-    | Locality.Local -> Regionality.Regional
-
-  let regional_to_local = function
-    | Regionality.Local -> Locality.Local
-    | Regionality.Regional -> Locality.Local
-    | Regionality.Global -> Locality.Global
-
-  let locality_as_regionality = function
-    | Locality.Local -> Regionality.Local
-    | Locality.Global -> Regionality.Global
-
-  let regional_to_global = function
-    | Regionality.Local -> Locality.Local
-    | Regionality.Regional -> Locality.Global
-    | Regionality.Global -> Locality.Global
-
-  let global_to_regional = function
-    | Locality.Local -> Regionality.Local
-    | Locality.Global -> Regionality.Regional
-
-  let statefulness_to_visibility = function
-    | Statefulness.Stateless -> Visibility.Immutable
-    | Statefulness.Writing -> Visibility.Write
-    | Statefulness.Reading -> Visibility.Read
-    | Statefulness.Stateful -> Visibility.Read_write
-
-  let visibility_to_statefulness = function
-    | Visibility.Immutable -> Statefulness.Stateless
-    | Visibility.Read -> Statefulness.Reading
-    | Visibility.Write -> Statefulness.Writing
-    | Visibility.Read_write -> Statefulness.Stateful
-
-  let min_with dst ax a = Axis.set ax a (min dst)
-
-  let max_with dst ax a = Axis.set ax a (max dst)
-
-  let monadic_to_comonadic_min : type a.
-      a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
-   fun obj m ->
-    let areality : a =
-      match obj with
-      | Comonadic_with_locality -> Locality.min
-      | Comonadic_with_regionality -> Regionality.min
-    in
-    let linearity = unique_to_linear m.uniqueness in
-    let portability = contended_to_portable m.contention in
-    let forkable = Forkable.min in
-    let yielding = Yielding.min in
-    let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; forkable; yielding; statefulness }
-
-  let comonadic_to_monadic_min : type a.
-      a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
-   fun _ m ->
-    let uniqueness = linear_to_unique m.linearity in
-    let contention = portable_to_contended m.portability in
-    let visibility = statefulness_to_visibility m.statefulness in
-    let staticity = Staticity_op.min in
-    { uniqueness; contention; visibility; staticity }
-
-  let comonadic_to_monadic_max : type a.
-      a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
-   fun _ m ->
-    let uniqueness = linear_to_unique m.linearity in
-    let contention = portable_to_contended m.portability in
-    let visibility = statefulness_to_visibility m.statefulness in
-    let staticity = Staticity_op.max in
-    { uniqueness; contention; visibility; staticity }
-
-  let monadic_to_comonadic_max : type a.
-      a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
-   fun obj m ->
-    let areality : a =
-      match obj with
-      | Comonadic_with_locality -> Locality.max
-      | Comonadic_with_regionality -> Regionality.max
-    in
-    let linearity = unique_to_linear m.uniqueness in
-    let portability = contended_to_portable m.contention in
-    let forkable = Forkable.max in
-    let yielding = Yielding.max in
-    let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; forkable; yielding; statefulness }
-
-  let rec apply : type a b l r. b obj -> (a, b, l * r) morph -> a -> b =
+  let rec apply : type a b d. b obj -> (a, b, d) morph -> a -> b =
    fun dst f a ->
     match f with
-    | Compose (f, g) ->
-      let mid = src dst f in
-      let g' = apply mid g in
-      let f' = apply dst f in
-      f' (g' a)
-    | Id -> a
-    | Proj (_, ax) -> Axis.proj ax a
-    | Max_with ax -> max_with dst ax a
-    | Min_with ax -> min_with dst ax a
-    | Meet_const c -> meet dst c a
-    | Imply_const c -> imply dst c a
-    | Monadic_to_comonadic_min -> monadic_to_comonadic_min dst a
-    | Comonadic_to_monadic_min src -> comonadic_to_monadic_min src a
-    | Comonadic_to_monadic_max src -> comonadic_to_monadic_max src a
-    | Monadic_to_comonadic_max -> monadic_to_comonadic_max dst a
-    | Local_to_regional -> local_to_regional a
-    | Regional_to_local -> regional_to_local a
-    | Locality_as_regionality -> locality_as_regionality a
-    | Regional_to_global -> regional_to_global a
-    | Global_to_regional -> global_to_regional a
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let a0 = Axis.proj Areality a in
-      set_areality (apply dst0 f a0) a
+    | Simple m -> Simple_morph.apply dst m a
+    | Simple_proj (m, ax, _) -> Simple_morph.apply dst m (Axis.proj ax a)
+    | Max_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      max_with dst ax (Simple_morph.apply mid m a)
+    | Min_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      min_with dst ax (Simple_morph.apply mid m a)
+    | Const_max _ -> max dst
+    | Const_min _ -> min dst
+    | Const (_, c) -> c
+    | Compose (mb, ma) ->
+      let mid = src dst mb in
+      apply dst mb (apply mid ma a)
+
+  let right_adjoint : type a b r.
+      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
+   fun dst f ->
+    match f with
+    | Simple m -> Simple (Simple_morph.right_adjoint dst m)
+    | Simple_proj (m, ax, _) ->
+      Max_with_simple (ax, Simple_morph.right_adjoint dst m)
+    | Min_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Simple_proj (Simple_morph.right_adjoint mid m, ax, dst)
+    | Const_min _ -> Const_max dst
+
+  let left_adjoint : type a b l.
+      b obj -> (a, b, l * allowed) morph -> (b, a, allowed * disallowed) morph =
+   fun dst f ->
+    match f with
+    | Simple m -> Simple (Simple_morph.left_adjoint dst m)
+    | Simple_proj (m, ax, _) ->
+      Min_with_simple (ax, Simple_morph.left_adjoint dst m)
+    | Max_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
+    | Const_max _ -> Const_min dst
+
+  let compose_simple_with_proj_core : type a c p d.
+      c obj ->
+      (p, c, d) Simple_morph.t ->
+      (a, p, d) Core_morph.compose_proj_result ->
+      (a, c, d) morph =
+   fun dst m0 pm1 ->
+    match pm1 with
+    | Proj_core (m1, ax1, obj1) ->
+      Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
+    | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
+    | Proj_const_max obj1 -> Const_max obj1
+    | Proj_const_min obj1 -> Const_min obj1
+
+  let compose_simple_with_proj_meet_const_core : type a c p l.
+      c obj ->
+      (p, c, l * disallowed) Simple_morph.t ->
+      p ->
+      (a, p, l * disallowed) Core_morph.compose_proj_result ->
+      (a, c, l * disallowed) morph =
+   fun dst m0 c1 pm1 ->
+    match pm1 with
+    | Proj_core (m1, ax1, obj1) ->
+      Simple_proj
+        (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
+    | Proj_id (ax1, obj1) ->
+      Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
+    | Proj_const_max obj1 -> Const_max obj1
+    | Proj_const_min obj1 -> Const_min obj1
+
+  let compose_simple_with_proj_core_imply_const : type a c p r.
+      c obj ->
+      (p, c, disallowed * r) Simple_morph.t ->
+      a ->
+      (a, p, disallowed * r) Core_morph.compose_proj_result ->
+      (a, c, disallowed * r) morph =
+   fun dst m0 c1 pm1 ->
+    match pm1 with
+    | Proj_core (m1, ax1, obj1) ->
+      let c1 = Axis.proj ax1 c1 in
+      Simple_proj
+        (Simple_morph.compose dst m0 (Core_imply_const (m1, c1)), ax1, obj1)
+    | Proj_id (ax1, obj1) ->
+      let c1 = Axis.proj ax1 c1 in
+      Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
+    | Proj_const_max obj1 -> Const_max obj1
+    | Proj_const_min obj1 -> Const_min obj1
+
+  let compose_simple_proj_with_simple : type a b c p d.
+      c obj ->
+      (p, c, d) Simple_morph.t ->
+      (b, p) Axis.t ->
+      b obj ->
+      (a, b, d) Simple_morph.t ->
+      (a, c, d) morph =
+   fun dst m0 ax0 obj0 m1 ->
+    match m1 with
+    | Id -> Simple_proj (m0, ax0, obj0)
+    | Core m1 ->
+      let pm1 = Core_morph.compose_projection_core ax0 m1 in
+      compose_simple_with_proj_core dst m0 pm1
+    | Meet_const c1 ->
+      let c1 = Axis.proj ax0 c1 in
+      Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
+    | Imply_const c1 ->
+      let c1 = Axis.proj ax0 c1 in
+      Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax0, obj0)
+    | Meet_const_core (c1, m1) ->
+      let c1 = Axis.proj ax0 c1 in
+      let pm1 = Core_morph.compose_projection_core ax0 m1 in
+      compose_simple_with_proj_meet_const_core dst m0 c1 pm1
+    | Core_imply_const (m1, c1) ->
+      let pm1 = Core_morph.compose_projection_core ax0 m1 in
+      compose_simple_with_proj_core_imply_const dst m0 c1 pm1
+    | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
+
+  let compose_simple_with_and_max : type a b c q r.
+      c obj ->
+      (b, c, disallowed * r) Simple_morph.t ->
+      (b, q) Axis.t ->
+      (a, q, disallowed * r) Simple_morph.t ->
+      (a, c, disallowed * r) morph =
+   fun dst sm0 ax1 m1 ->
+    let b_obj = Simple_morph.src dst sm0 in
+    let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+    match sm0 with
+    | Id -> Max_with_simple (ax1, m1)
+    | Core m0 ->
+      begin match Core_morph.compose_max_with_simple_core ax1 m0 with
+      | And_max_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+      | Const_max_core -> Const_max a_obj
+      | And_max_id ax1 -> Max_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      end
+    | Imply_const c0 ->
+      let c0 = Axis.proj ax1 c0 in
+      let obj0 = proj_obj ax1 dst in
+      Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
+    | Core_imply_const (m0, c0) -> begin
+      let c0 = Axis.proj ax1 c0 in
+      match Core_morph.compose_max_with_simple_core ax1 m0 with
+      | And_max_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        Max_with_simple
+          (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
+      | Const_max_core -> Const_max a_obj
+      | And_max_id ax1 -> Max_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      end
+    | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+    | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+    | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+
+  let compose_simple_with_and_min : type a b c q l.
+      c obj ->
+      (b, c, l * disallowed) Simple_morph.t ->
+      (b, q) Axis.t ->
+      (a, q, l * disallowed) Simple_morph.t ->
+      (a, c, l * disallowed) morph =
+   fun dst sm0 ax1 m1 ->
+    let b_obj = Simple_morph.src dst sm0 in
+    let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+    match sm0 with
+    | Id -> Min_with_simple (ax1, m1)
+    | Core m0 ->
+      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      | And_min_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+      | Const_min_core -> Const_min a_obj
+      | And_min_id ax1 -> Min_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      end
+    | Meet_const c0 ->
+      let c0 = Axis.proj ax1 c0 in
+      let obj0 = proj_obj ax1 dst in
+      Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
+    | Meet_const_core (c0, m0) ->
+      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      | And_min_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        let c0 = Axis.proj ax1 c0 in
+        Min_with_simple
+          (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
+      | Const_min_core -> Const_min a_obj
+      | And_min_id ax1 -> Min_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      end
+    | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+    | Core_imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+    | Compose _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+
+  let refute_compose_and_with : type a b c q0 q1 d.
+      c obj ->
+      (c, q0) Axis.t ->
+      (b, q0, d) Simple_morph.t ->
+      (b, q1) Axis.t ->
+      (b, c, d) morph ->
+      (a, b, d) morph ->
+      (a, c, d) morph =
+   fun dst ax0 m0' ax1 m0 m1 ->
+    match ax0, m0', ax1, dst with
+    | _, Core (Locality_restricted _), _, _ -> .
+    | _, Meet_const_core (_, Locality_restricted _), _, _ -> .
+    | _, Core_imply_const (Locality_restricted _, _), _, _ -> .
+    | _, Compose _, _, _ -> Compose (m0, m1)
+    | _, _, _, _ -> .
+  [@@warning "-4"]
+
+  let compose : type a b c d.
+      c obj -> (b, c, d) morph -> (a, b, d) morph -> (a, c, d) morph =
+   fun dst m0 m1 ->
+    match m0, m1 with
+    | Simple m0, Simple m1 -> Simple (Simple_morph.compose dst m0 m1)
+    | Const_max b_obj, _ -> Const_max (src b_obj m1)
+    | Const_min b_obj, _ -> Const_min (src b_obj m1)
+    | Const (b_obj, c), _ -> Const (src b_obj m1, c)
+    | Simple m0, Simple_proj (m1, ax1, obj1) ->
+      Simple_proj (Simple_morph.compose dst m0 m1, ax1, obj1)
+    | Simple_proj (m0, ax0, obj0), Simple m1 ->
+      compose_simple_proj_with_simple dst m0 ax0 obj0 m1
+    | Max_with_simple (ax0, m0), Simple m1 ->
+      let dst = proj_obj ax0 dst in
+      Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
+    | Simple m0, Max_with_simple (ax1, m1) ->
+      compose_simple_with_and_max dst m0 ax1 m1
+    | Min_with_simple (ax0, m0), Simple m1 ->
+      let dst = proj_obj ax0 dst in
+      Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
+    | Simple m0, Min_with_simple (ax1, m1) ->
+      compose_simple_with_and_min dst m0 ax1 m1
+    | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
+      begin match Axis.equal ax0 ax1 with
+      | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+      | Misc.Is_not_eq ->
+        let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
+        let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+        Const_max a_obj
+      end
+    | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
+      begin match Axis.equal ax0 ax1 with
+      | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+      | Misc.Is_not_eq ->
+        let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
+        let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+        Const_min a_obj
+      end
+    | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
+      ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = src dst (Max_with_simple (ax0, m0)) in
+      let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
+      let m0m1 = Simple_morph.compose q_obj m0 m1 in
+      begin match Simple_morph.maybe_allowed_right m0m1 with
+      | Allowed_right m0m1 ->
+        allow_right (Simple (Simple_morph.lift_max a_obj dst m0m1 ax1 ax0))
+      | Not_allowed_right -> Compose (m0', m1')
+      end
+    | (Min_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
+      ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = src dst (Min_with_simple (ax0, m0)) in
+      let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
+      let m0m1 = Simple_morph.compose q_obj m0 m1 in
+      begin match Simple_morph.maybe_allowed_left m0m1 with
+      | Allowed_left m0m1 ->
+        allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
+      | Not_allowed_left -> Compose (m0', m1')
+      end
+    | Simple m0, Const_max a_obj ->
+      begin match Simple_morph.maybe_allowed_right m0 with
+      | Allowed_right _ -> Const_max a_obj
+      | Not_allowed_right ->
+        let b_obj = Simple_morph.src dst m0 in
+        Const (a_obj, Simple_morph.apply dst m0 (max b_obj))
+      end
+    | Simple m0, Const_min a_obj ->
+      begin match Simple_morph.maybe_allowed_left m0 with
+      | Allowed_left _ -> Const_min a_obj
+      | Not_allowed_left ->
+        let b_obj = Simple_morph.src dst m0 in
+        Const (a_obj, Simple_morph.apply dst m0 (min b_obj))
+      end
+    | Simple_proj (_m0, _ax0, _obj0), Const_max obj1 -> Const_max obj1
+    | Simple_proj (_m0, _ax0, _obj0), Const_min obj1 -> Const_min obj1
+    | Min_with_simple (ax0, m0), Const_max obj1 ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = Simple_morph.src q_obj m0 in
+      Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+    | Min_with_simple (ax0, m0), Const_min obj1 ->
+      begin match Simple_morph.maybe_allowed_left m0 with
+      | Allowed_left _ -> Const_min obj1
+      | Not_allowed_left ->
+        let q_obj = proj_obj ax0 dst in
+        let b_obj = Simple_morph.src q_obj m0 in
+        Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+      end
+    | Max_with_simple (ax0, m0), Const_max obj1 ->
+      begin match Simple_morph.maybe_allowed_right m0 with
+      | Allowed_right _ -> Const_max obj1
+      | Not_allowed_right ->
+        let q_obj = proj_obj ax0 dst in
+        let b_obj = Simple_morph.src q_obj m0 in
+        Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+      end
+    | Max_with_simple (ax0, m0), Const_min obj1 ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = Simple_morph.src q_obj m0 in
+      Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+    | (_ as m0), Const (obj1, c1) -> Const (obj1, apply dst m0 c1)
+    | (_ as m0), Compose (m1, m2) -> Compose (Compose (m0, m1), m2)
+    | Compose (m0, m1), (_ as m2) -> Compose (Compose (m0, m1), m2)
+    (* The remaining cases are unreachable by looking at the axes and objects *)
+    | _, Simple_proj (Core (Locality_restricted _), _, _) -> .
+    | _, Simple_proj (Meet_const_core (_, Locality_restricted _), _, _) -> .
+    | _, Simple_proj (Core_imply_const (Locality_restricted _, _), _, _) -> .
+    | _, Simple_proj (Compose _, _, _) -> Compose (m0, m1)
+    | Max_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | Max_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | Min_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | Min_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | _, _ -> .
+  [@@warning "-4"]
 
   module For_hint = struct
     (** Describes the portion of the input that's responsible for a portion of
         the output of a morphism *)
     type 'a responsible_axis =
-      | NoneResponsible : 'a responsible_axis
+      | None_responsible : 'a responsible_axis
           (** The input is not responsible for the output; instead, the morphism
               is solely responsible for the output. *)
-      | SourceIsSingle : 'a responsible_axis
-          (** The input of the morphism is single axis, and is responsible for
-              the output. *)
+      | All_responsible : 'a responsible_axis
+          (** The input of the morphism is all responsible for the output. *)
       | Axis : ('a, 'a_x) Axis.t -> 'a responsible_axis
           (** The specified axis of the input object is responsible for the
               output. *)
@@ -1897,265 +3596,103 @@ module Lattices_mono = struct
        no axis of [a] being responsible, in which case the morphism is solely
        respoonsible. *)
 
-    (** Given a morphism either from a single axis to a single axis, or from a
-        product object to a single axis, return the portion of the input that's
-        responsible for the output. *)
-    let rec find_responsible_axis_single : type a b l r.
-        (a, b, l * r) morph -> a responsible_axis = function
-      | Proj (_a_obj, ax) -> Axis ax
-      | Compose (g, f) -> (
-        match find_responsible_axis_single g with
-        | NoneResponsible -> NoneResponsible
-        | SourceIsSingle -> find_responsible_axis_single f
-        | Axis c_ax -> find_responsible_axis_prod f c_ax)
-      | Id | Meet_const _ | Imply_const _ -> SourceIsSingle
-      | Max_with _ | Min_with _ | Map_comonadic _ | Monadic_to_comonadic_min
-      | Comonadic_to_monadic_min _ | Monadic_to_comonadic_max
-      | Comonadic_to_monadic_max _ ->
-        assert false
-      | Local_to_regional | Regional_to_local | Locality_as_regionality
-      | Regional_to_global | Global_to_regional ->
-        SourceIsSingle
+    let find_responsible_axis_proj_core : type a b b_ax l r.
+        (a, b, l * r) Core_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
+     fun m ax ->
+      match m, ax with
+      | Locality_restricted _, _ -> .
+      | Uniqueness_op_to_linearity, _ -> .
+      | Linearity_to_uniqueness_op, _ -> .
+      | Contention_op_to_portability, _ -> .
+      | Portability_to_contention_op, _ -> .
+      | Visibility_op_to_statefulness, _ -> .
+      | Statefulness_to_visibility_op, _ -> .
+      | Locality_full _, (Areality as ax) -> Axis ax
+      | Locality_full _, (Forkable as ax) -> Axis ax
+      | Locality_full _, (Yielding as ax) -> Axis ax
+      | Locality_full _, (Linearity as ax) -> Axis ax
+      | Locality_full _, (Statefulness as ax) -> Axis ax
+      | Locality_full _, (Portability as ax) -> Axis ax
+      | Locality_full _, _ -> .
+      | Monadic_to_comonadic_min, Areality -> None_responsible
+      | Monadic_to_comonadic_min, Forkable -> None_responsible
+      | Monadic_to_comonadic_min, Yielding -> None_responsible
+      | Monadic_to_comonadic_min, Linearity -> Axis Uniqueness
+      | Monadic_to_comonadic_min, Statefulness -> Axis Visibility
+      | Monadic_to_comonadic_min, Portability -> Axis Contention
+      | Comonadic_to_monadic_min _, Uniqueness -> Axis Linearity
+      | Comonadic_to_monadic_min _, Visibility -> Axis Statefulness
+      | Comonadic_to_monadic_min _, Contention -> Axis Portability
+      | Comonadic_to_monadic_min _, Staticity -> None_responsible
+      | Monadic_to_comonadic_max, Areality -> None_responsible
+      | Monadic_to_comonadic_max, Forkable -> None_responsible
+      | Monadic_to_comonadic_max, Yielding -> None_responsible
+      | Monadic_to_comonadic_max, Linearity -> Axis Uniqueness
+      | Monadic_to_comonadic_max, Statefulness -> Axis Visibility
+      | Monadic_to_comonadic_max, Portability -> Axis Contention
+      | Comonadic_to_monadic_max _, Uniqueness -> Axis Linearity
+      | Comonadic_to_monadic_max _, Visibility -> Axis Statefulness
+      | Comonadic_to_monadic_max _, Contention -> Axis Portability
+      | Comonadic_to_monadic_max _, Staticity -> None_responsible
 
-    (** Given a morphism either from a single axis to a product, or from a
-        product to a product, return the portion of the input that's responsible
-        for the specified axis of the output. *)
-    and find_responsible_axis_prod : type a b b_ax l r.
+    let rec find_responsible_axis_proj_simple : type a b b_ax l r.
+        (a, b, l * r) Simple_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
+     fun m ax ->
+      match m with
+      | Id -> Axis ax
+      | Meet_const _ -> Axis ax
+      | Imply_const _ -> Axis ax
+      | Core m
+      | Meet_const_core (_, (m : (_, _, l * r) Core_morph.t))
+      | Core_imply_const ((m : (_, _, l * r) Core_morph.t), _) ->
+        find_responsible_axis_proj_core m ax
+      | Compose (mb, ma) ->
+        begin match find_responsible_axis_proj_simple mb ax with
+        | None_responsible -> None_responsible
+        | All_responsible -> All_responsible
+        | Axis ax -> find_responsible_axis_proj_simple ma ax
+        end
+
+    (** Given a morphism and an axis, return the portion of the input that's
+        responsible for the specified axis of the output. *)
+    let rec find_responsible_axis_proj : type a b b_ax l r.
         (a, b, l * r) morph -> (b, b_ax) Axis.t -> a responsible_axis =
      fun m ax ->
-      let handle_monadic_to_comonadic (type x y)
-          (ax : (x comonadic_with, y) Axis.t) =
-        (* See [Lattices_mono.monadic_to_comonadic_min] for why these are as they are *)
-        match ax with
-        | Areality -> NoneResponsible
-        | Linearity -> Axis Uniqueness
-        | Portability -> Axis Contention
-        | Forkable -> NoneResponsible
-        | Yielding -> NoneResponsible
-        | Statefulness -> Axis Visibility
-      in
-      let handle_comonadic_to_monadic (type y) (ax : (monadic, y) Axis.t) =
-        (* See [Lattices_mono.comonadic_to_monadic_min] for why these are as they are *)
-        match ax with
-        | Uniqueness -> Axis Linearity
-        | Contention -> Axis Portability
-        | Visibility -> Axis Statefulness
-        | Staticity -> NoneResponsible
-      in
-      match m, ax with
-      | Compose (g, f), ax -> (
-        (* Operates similarly to the equivalent branch in [find_responsible_axis_single] *)
-        match find_responsible_axis_prod g ax with
-        | NoneResponsible -> NoneResponsible
-        | SourceIsSingle -> find_responsible_axis_single f
-        | Axis c_ax -> find_responsible_axis_prod f c_ax)
-      | Id, ax -> Axis ax
-      | Meet_const _, ax -> Axis ax
-      | Imply_const _, ax -> Axis ax
-      | Map_comonadic _, ax -> (
-        (* The [Map_comonadic] morphism applies a morphsim to the areality axis and
-           the result is put back into the areality axis. See [Lattices_mono.apply] *)
-        match ax with
-        | Areality -> Axis Areality
-        | Forkable -> Axis Forkable
-        | Yielding -> Axis Yielding
-        | Linearity -> Axis Linearity
-        | Statefulness -> Axis Statefulness
-        | Portability -> Axis Portability)
-      | Max_with m_ax, ax | Min_with m_ax, ax -> (
-        match Axis.equal m_ax ax with
-        | Is_not_eq -> NoneResponsible
-        | Is_eq -> SourceIsSingle)
-      | Monadic_to_comonadic_min, ax -> handle_monadic_to_comonadic ax
-      | Monadic_to_comonadic_max, ax -> handle_monadic_to_comonadic ax
-      | Comonadic_to_monadic_min _, ax -> handle_comonadic_to_monadic ax
-      | Comonadic_to_monadic_max _, ax -> handle_comonadic_to_monadic ax
-      | Proj _, _
-      | Local_to_regional, _
-      | Regional_to_local, _
-      | Locality_as_regionality, _
-      | Regional_to_global, _
-      | Global_to_regional, _ ->
-        .
+      match m with
+      | Simple m -> find_responsible_axis_proj_simple m ax
+      | Simple_proj (_, ax, _) -> Axis ax
+      | Max_with_simple (m_ax, _) ->
+        begin match Axis.equal m_ax ax with
+        | Misc.Is_not_eq -> None_responsible
+        | Misc.Is_eq -> All_responsible
+        end
+      | Min_with_simple (m_ax, _) ->
+        begin match Axis.equal m_ax ax with
+        | Misc.Is_not_eq -> None_responsible
+        | Misc.Is_eq -> All_responsible
+        end
+      | Const_max _ | Const_min _ | Const _ -> None_responsible
+      | Compose (mb, ma) ->
+        begin match find_responsible_axis_proj mb ax with
+        | None_responsible -> None_responsible
+        | All_responsible -> All_responsible
+        | Axis ax -> find_responsible_axis_proj ma ax
+        end
+
+    (** Given a morphism return the portion of the input that's responsible for
+        all of the output. *)
+    let rec find_responsible_axis_all : type a b l r.
+        (a, b, l * r) morph -> a responsible_axis = function
+      | Simple _ -> All_responsible
+      | Simple_proj (_, ax, _) -> Axis ax
+      | Max_with_simple _ | Min_with_simple _ -> All_responsible
+      | Const_max _ | Const_min _ | Const _ -> None_responsible
+      | Compose (mb, ma) -> (
+        match find_responsible_axis_all mb with
+        | None_responsible -> None_responsible
+        | All_responsible -> find_responsible_axis_all ma
+        | Axis ax -> find_responsible_axis_proj ma ax)
   end
-
-  (** Compose m1 after m2. Returns [Some f] if the composition can be
-      represented by [f] instead of [Compose m1 m2]. [None] otherwise. *)
-  let rec maybe_compose : type a b c l r.
-      c obj ->
-      (b, c, l * r) morph ->
-      (a, b, l * r) morph ->
-      (a, c, l * r) morph option =
-   fun dst m1 m2 ->
-    let is_max c = le dst (max dst) c in
-    let is_mid_max c =
-      let mid = src dst m1 in
-      le mid (max mid) c
-    in
-    match m1, m2 with
-    | Id, m -> Some m
-    | m, Id -> Some m
-    | Meet_const c1, Meet_const c2 -> Some (Meet_const (meet dst c1 c2))
-    | Imply_const c1, Imply_const c2 -> Some (Imply_const (meet dst c1 c2))
-    | Imply_const c1, Meet_const c2 when le dst c1 c2 -> Some (Imply_const c1)
-    | Meet_const c1, m2 when is_max c1 -> Some m2
-    | Imply_const c1, m2 when is_max c1 -> Some m2
-    | m2, Meet_const c1 when is_mid_max c1 -> Some m2
-    | m2, Imply_const c1 when is_mid_max c1 -> Some m2
-    | Compose (f1, f2), g -> (
-      let mid = src dst f1 in
-      match maybe_compose mid f2 g with
-      | Some m -> Some (compose dst f1 m)
-      (* the check needed to prevent infinite loop *)
-      | None -> None)
-    | f, Compose (g1, g2) -> (
-      match maybe_compose dst f g1 with
-      | Some m -> Some (compose dst m g2)
-      | None -> None)
-    | Proj (mid, ax), Meet_const c ->
-      Some (compose dst (Meet_const (Axis.proj ax c)) (Proj (mid, ax)))
-    | Proj (_, ax1), Max_with ax2 -> (
-      match Axis.equal ax1 ax2 with Is_not_eq -> None | Is_eq -> Some Id)
-    | Proj (_, ax1), Min_with ax2 -> (
-      match Axis.equal ax1 ax2 with Is_not_eq -> None | Is_eq -> Some Id)
-    | Proj (mid, ax), Map_comonadic f -> (
-      let src' = src mid m2 in
-      match ax with
-      | Areality -> Some (compose dst f (Proj (src', Areality)))
-      | Linearity -> Some (Proj (src', Linearity))
-      | Portability -> Some (Proj (src', Portability))
-      | Forkable -> Some (Proj (src', Forkable))
-      | Yielding -> Some (Proj (src', Yielding))
-      | Statefulness -> Some (Proj (src', Statefulness)))
-    | Proj _, Monadic_to_comonadic_min -> None
-    | Proj _, Monadic_to_comonadic_max -> None
-    | Proj _, Comonadic_to_monadic_min _ -> None
-    | Proj _, Comonadic_to_monadic_max _ -> None
-    | Map_comonadic f, Map_comonadic g ->
-      let dst0 = proj_obj Areality dst in
-      Some (Map_comonadic (compose dst0 f g))
-    | Regional_to_local, Local_to_regional -> Some Id
-    | Regional_to_local, Global_to_regional ->
-      Some (Imply_const Locality.Global)
-    | Regional_to_local, Locality_as_regionality -> Some Id
-    | Regional_to_local, Meet_const c ->
-      Some (compose dst (Meet_const (regional_to_local c)) Regional_to_local)
-    | Regional_to_global, Meet_const c ->
-      Some (compose dst (Meet_const (regional_to_global c)) Regional_to_global)
-    | Local_to_regional, Meet_const c ->
-      Some (compose dst (Meet_const (local_to_regional c)) Local_to_regional)
-    | Global_to_regional, Meet_const c ->
-      Some (compose dst (Meet_const (global_to_regional c)) Global_to_regional)
-    | Locality_as_regionality, Meet_const c ->
-      Some
-        (compose dst
-           (Meet_const (locality_as_regionality c))
-           Locality_as_regionality)
-    | Map_comonadic f, Meet_const c ->
-      let dst0 = proj_obj Areality dst in
-      let areality = Axis.proj Areality c in
-      Some
-        (compose dst
-           (Meet_const (set_areality (max dst0) c))
-           (Map_comonadic (compose dst0 f (Meet_const areality))))
-    | Map_comonadic f, Imply_const c ->
-      let dst0 = proj_obj Areality dst in
-      let areality = Axis.proj Areality c in
-      Some
-        (compose dst
-           (Imply_const (set_areality (max dst0) c))
-           (Map_comonadic (compose dst0 f (Imply_const areality))))
-    | Regional_to_global, Locality_as_regionality -> Some Id
-    | Regional_to_global, Local_to_regional -> Some (Meet_const Locality.Global)
-    | Local_to_regional, Regional_to_local -> None
-    | Local_to_regional, Regional_to_global -> None
-    | Locality_as_regionality, Regional_to_local -> None
-    | Locality_as_regionality, Regional_to_global -> None
-    | Global_to_regional, Regional_to_local -> None
-    | Regional_to_global, Global_to_regional -> Some Id
-    | Global_to_regional, Regional_to_global -> None
-    | Min_with _, _ -> None
-    | Max_with _, _ -> None
-    | _, Meet_const _ -> None
-    | Meet_const _, _ -> None
-    | _, Imply_const _ -> None
-    | Imply_const _, _ -> None
-    | _, Proj _ -> None
-    | Map_comonadic _, _ -> None
-    | Monadic_to_comonadic_min, _ -> None
-    | Monadic_to_comonadic_max, _ -> None
-    | Comonadic_to_monadic_min _, _ -> None
-    | Comonadic_to_monadic_max _, _ -> None
-    | ( Proj _,
-        ( Local_to_regional | Regional_to_local | Locality_as_regionality
-        | Regional_to_global | Global_to_regional ) ) ->
-      .
-    | ( ( Local_to_regional | Regional_to_local | Locality_as_regionality
-        | Regional_to_global | Global_to_regional ),
-        Min_with _ ) ->
-      .
-    | ( ( Local_to_regional | Regional_to_local | Locality_as_regionality
-        | Regional_to_global | Global_to_regional ),
-        Max_with _ ) ->
-      .
-
-  and compose : type a b c l r.
-      c obj -> (b, c, l * r) morph -> (a, b, l * r) morph -> (a, c, l * r) morph
-      =
-   fun dst f g ->
-    match maybe_compose dst f g with Some m -> m | None -> Compose (f, g)
-
-  let rec left_adjoint : type a b l.
-      b obj -> (a, b, l * allowed) morph -> (b, a, allowed * disallowed) morph =
-   fun dst f ->
-    match f with
-    | Id -> Id
-    | Proj (_, ax) -> Min_with ax
-    | Max_with ax -> Proj (dst, ax)
-    | Compose (f, g) ->
-      let mid = src dst f in
-      let f' = left_adjoint dst f in
-      let g' = left_adjoint mid g in
-      Compose (g', f')
-    | Meet_const _c ->
-      (* The downward closure of [Meet_const c]'s image is all [x <= c].
-         For those, [x <= meet c y] is equivalent to [x <= y]. *)
-      Id
-    | Imply_const c -> Meet_const c
-    | Comonadic_to_monadic_max _ -> Monadic_to_comonadic_min
-    | Monadic_to_comonadic_max -> Comonadic_to_monadic_min dst
-    | Global_to_regional -> Regional_to_global
-    | Regional_to_global -> Locality_as_regionality
-    | Locality_as_regionality -> Regional_to_local
-    | Regional_to_local -> Local_to_regional
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let f' = left_adjoint dst0 f in
-      Map_comonadic f'
-
-  and right_adjoint : type a b r.
-      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
-   fun dst f ->
-    match f with
-    | Id -> Id
-    | Proj (_, ax) -> Max_with ax
-    | Min_with ax -> Proj (dst, ax)
-    | Compose (f, g) ->
-      let mid = src dst f in
-      let f' = right_adjoint dst f in
-      let g' = right_adjoint mid g in
-      Compose (g', f')
-    | Meet_const c -> Imply_const c
-    | Comonadic_to_monadic_min _ -> Monadic_to_comonadic_max
-    | Monadic_to_comonadic_min -> Comonadic_to_monadic_max dst
-    | Local_to_regional -> Regional_to_local
-    | Regional_to_local -> Locality_as_regionality
-    | Locality_as_regionality -> Regional_to_global
-    | Regional_to_global -> Global_to_regional
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let f' = right_adjoint dst0 f in
-      Map_comonadic f'
 end
 
 module C = Lattices_mono
@@ -2276,24 +3813,24 @@ module Report = struct
      fun obj side a morph_hint morph ~other ahint res ->
       let src = C.src obj morph in
       match res with
-      | NoneResponsible -> a, Irrelevant
-      | SourceIsSingle ->
+      | None_responsible -> a, Irrelevant
+      | All_responsible ->
         let morph' = adjoint obj side morph in
         let other = C.apply src morph' other in
-        let ahint = hint_axis src side ~other ahint in
+        let ahint = hint_all src side ~other ahint in
         let ma = C.apply obj morph (fst ahint) in
         ma, Apply (morph_hint, src, ahint)
       | Axis ax ->
         let b, hint = ahint in
         let morph' = adjoint obj side morph in
         let other = C.apply src morph' other in
-        let x, hint = hint_prod src side ax ~other (b, hint) in
+        let x, hint = hint_proj src side ax ~other (b, hint) in
         let b = C.Axis.set ax x b in
         let a = C.apply obj morph b in
         let src = C.proj_obj ax src in
         a, Apply (morph_hint, src, (x, hint))
 
-    and hint_prod : type t a l r.
+    and hint_proj : type t a l r.
         t C.obj ->
         (l * r) side ->
         (t, a) Axis.t ->
@@ -2305,7 +3842,7 @@ module Report = struct
       | Apply (morph_hint, morph, ahint) ->
         let t, hint =
           hint_apply obj side a morph_hint morph ~other ahint
-            (C.For_hint.find_responsible_axis_prod morph ax)
+            (C.For_hint.find_responsible_axis_proj morph ax)
         in
         Axis.proj ax t, hint
       | Const c -> Axis.proj ax a, Const c
@@ -2319,11 +3856,11 @@ module Report = struct
           | `First -> a1, hint1
           | `Second -> a2, hint2
         in
-        hint_prod obj side ax ~other chosen_ahint
+        hint_proj obj side ax ~other chosen_ahint
 
     (** Given a solver hint on a single axis lattice, returns a human-readible
         hint. *)
-    and hint_axis : type a l r.
+    and hint_all : type a l r.
         a C.obj ->
         (l * r) side ->
         other:a ->
@@ -2333,7 +3870,7 @@ module Report = struct
       match hint with
       | Apply (morph_hint, morph, ahint) ->
         hint_apply obj side a morph_hint morph ~other ahint
-          (C.For_hint.find_responsible_axis_single morph)
+          (C.For_hint.find_responsible_axis_all morph)
       | Const c -> a, Const c
       | Branch (b, (a1, hint1), (a2, hint2)) ->
         let chosen_ahint =
@@ -2341,9 +3878,9 @@ module Report = struct
           | `First -> a1, hint1
           | `Second -> a2, hint2
         in
-        hint_axis obj side ~other chosen_ahint
+        hint_all obj side ~other chosen_ahint
 
-    let hint_prod_loosening : type t a l r.
+    let hint_proj_loosening : type t a l r.
         t C.obj ->
         (l * r) side ->
         (t, a) Axis.t ->
@@ -2352,7 +3889,7 @@ module Report = struct
         loosening * (a, l * r) ahint =
      fun obj side ax ~other ((t, _) as ahint) ->
       let axis_obj = C.proj_obj ax obj in
-      let a, hint = hint_prod obj side ax ~other ahint in
+      let a, hint = hint_proj obj side ax ~other ahint in
       let loosening =
         if Misc.Le_result.equal ~le:(C.le axis_obj) a (Axis.proj ax t)
         then Not_loosened
@@ -2360,14 +3897,14 @@ module Report = struct
       in
       loosening, (a, hint)
 
-    let hint_axis_loosening : type a l r.
+    let hint_all_loosening : type a l r.
         a C.obj ->
         (l * r) side ->
         other:a ->
         (a, l * r) S.ahint ->
         loosening * (a, l * r) ahint =
      fun obj side ~other ((original, _) as ahint) ->
-      let a, hint = hint_axis obj side ~other ahint in
+      let a, hint = hint_all obj side ~other ahint in
       let loosening =
         if Misc.Le_result.equal ~le:(C.le obj) a original
         then Not_loosened
@@ -2375,20 +3912,20 @@ module Report = struct
       in
       loosening, (a, hint)
 
-    let error_prod : type r a. r C.obj -> (r, a) Axis.t -> r S.error -> a t =
+    let error_proj : type r a. r C.obj -> (r, a) Axis.t -> r S.error -> a t =
      fun obj axis { left; right } ->
-      let left = hint_prod_loosening obj Left axis ~other:(fst right) left in
+      let left = hint_proj_loosening obj Left axis ~other:(fst right) left in
       let right =
-        hint_prod_loosening obj Right axis
+        hint_proj_loosening obj Right axis
           ~other:(Axis.set axis (fst (snd left)) (fst right))
           right
       in
       { left; right }
 
-    let error_axis : type a. a C.obj -> a S.error -> a t =
+    let error_all : type a. a C.obj -> a S.error -> a t =
      fun obj { left; right } ->
-      let left = hint_axis_loosening obj Left ~other:(fst right) left in
-      let right = hint_axis_loosening obj Right ~other:(fst (snd left)) right in
+      let left = hint_all_loosening obj Left ~other:(fst right) left in
+      let right = hint_all_loosening obj Right ~other:(fst (snd left)) right in
       { left; right }
   end
 
@@ -2501,6 +4038,34 @@ module Report = struct
       (Location.Doc.loc ~capitalize_first:false)
       loc
 
+  let print_containing maybe_modality { containing; container } =
+    let container = fst container in
+    match containing with
+    | Tuple ->
+      Fmt.dprintf "is an element of the tuple at %a"
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Record (s, moda) ->
+      Fmt.dprintf "is the field %a%a of the record at %a" Misc.Style.inline_code
+        s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Array moda ->
+      Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Constructor (s, moda) ->
+      Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
+        Misc.Style.inline_code s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Structure (x, moda) ->
+      Fmt.dprintf "is %t%a in the structure at %a"
+        (print_structure_item ~capitalize:false x)
+        maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+
   (** Given a pinpoint and a const, where the pinpoint has been expressed,
       prints the const to explain the mode on the pinpoint. *)
   let print_const (type l r) ((_, pp_desc) : pinpoint) ppf :
@@ -2569,6 +4134,9 @@ module Report = struct
       Fmt.pp_print_string ppf
         "it is layout-polymorphic and being instantiated here"
     | Spliced _ -> Fmt.fprintf ppf "it is spliced"
+    | Contained_by c ->
+      let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
+      Fmt.fprintf ppf "it %t" (print_containing print_mod c)
 
   let print_allocation_l : allocation -> Fmt.formatter -> unit =
    fun { txt; loc } ->
@@ -2803,7 +4371,16 @@ module Report = struct
    fun a_obj b_obj a b ->
     match C.equal_obj a_obj b_obj with
     | Misc.Is_eq -> Misc.Le_result.equal ~le:(C.le a_obj) a b
-    | Misc.Is_not_eq -> false
+    | Misc.Is_not_eq -> (
+      match a_obj, b_obj with
+      | Locality, Regionality ->
+        Misc.Le_result.equal ~le:(C.le b_obj)
+          (C.Locality_morph.apply Locality_as_regionality a)
+          b
+      | Regionality, Locality ->
+        Misc.Le_result.equal ~le:(C.le a_obj) a
+          (C.Locality_morph.apply Locality_as_regionality b)
+      | _, _ -> false)
 
   let rec print_ahint : type a l r.
       ?sub:bool ->
@@ -2909,27 +4486,27 @@ module Error = struct
   type 'a t = 'a S.error_raw
 
   type packed =
-    | Product : 'r C.obj * ('r, 'a) Axis.t * 'r t -> packed
-    | Axis : 'a C.obj * 'a t -> packed
+    | Proj : 'r C.obj * ('r, 'a) Axis.t * 'r t -> packed
+    | All : 'a C.obj * 'a t -> packed
 
-  let print_product : type r a.
+  let print_proj : type r a.
       Hint.pinpoint -> r C.obj -> (r, a) Axis.t -> r t -> print_error =
    fun pp obj ax err ->
     let err = S.populate_error obj err in
-    let err = Report.Of_solver.error_prod obj ax err in
+    let err = Report.Of_solver.error_proj obj ax err in
     let obj = C.proj_obj ax obj in
     Report.print pp obj err
 
-  let print_axis : type a. Hint.pinpoint -> a C.obj -> a t -> print_error =
+  let print_all : type a. Hint.pinpoint -> a C.obj -> a t -> print_error =
    fun pp obj err ->
     let err = S.populate_error obj err in
-    let err = Report.Of_solver.error_axis obj err in
+    let err = Report.Of_solver.error_all obj err in
     Report.print pp obj err
 
   let print_packed : Hint.pinpoint -> packed -> print_error =
    fun pp -> function
-    | Product (obj, ax, err) -> print_product pp obj ax err
-    | Axis (obj, err) -> print_axis pp obj err
+    | Proj (obj, ax, err) -> print_proj pp obj ax err
+    | All (obj, err) -> print_all pp obj err
 
   let print_packed_simple_context : Hint.pinpoint -> packed -> Location.error =
    fun pp packed ->
@@ -3039,7 +4616,7 @@ let equate_from_submode' submode m1 m2 =
 module Comonadic_gen (Obj : Obj) = struct
   open Obj
 
-  type 'd t = (const, 'l * 'r) S.mode constraint 'd = 'l * 'r
+  type 'd t = (const, 'd) S.mode
 
   type l = (allowed * disallowed) t
 
@@ -3065,9 +4642,9 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let newvar () = S.newvar obj
 
-  let min = S.min obj
+  let min : lr = S.min obj
 
-  let max = S.max obj
+  let max : lr = S.max obj
 
   let newvar_above m = S.newvar_above obj m
 
@@ -3084,9 +4661,9 @@ module Comonadic_gen (Obj : Obj) = struct
   let submode_err pp a b =
     match submode ~pp a b with
     | Ok () -> ()
-    | Error e -> raise (Submode_error_simple_context (pp, Axis (obj, e)))
+    | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
-  let print_error pp err = Error.print_axis pp obj err
+  let print_error pp err = Error.print_all pp obj err
 
   let join l = S.join obj l
 
@@ -3117,11 +4694,11 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let apply_hint hint m = wrap ~hint Fun.id m
 
-  let meet_const_unhint c m = S.Unhint.apply obj (Meet_const c) m
+  let meet_const_unhint c m = S.Unhint.apply obj (Simple (Meet_const c)) m
 
-  let meet_const ?hint c m = wrap ?hint (meet_const_unhint c) m
+  let meet_const ?hint c m = wrap ?hint (meet_const_unhint c) (disallow_right m)
 
-  let imply_const_unhint c m = S.Unhint.apply obj (Imply_const c) m
+  let imply_const_unhint c m = S.Unhint.apply obj (Simple (Imply_const c)) m
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
@@ -3167,9 +4744,9 @@ module Monadic_gen (Obj : Obj) = struct
 
   let newvar () = S.newvar obj
 
-  let min = S.max obj
+  let min : lr = S.allow_left (S.max obj)
 
-  let max = S.min obj
+  let max : lr = S.allow_right (S.min obj)
 
   let newvar_above m = S.newvar_below obj m
 
@@ -3186,9 +4763,9 @@ module Monadic_gen (Obj : Obj) = struct
   let submode_err pp a b =
     match submode ~pp a b with
     | Ok () -> ()
-    | Error e -> raise (Submode_error_simple_context (pp, Axis (obj, e)))
+    | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
-  let print_error pp err = Error.print_axis pp obj err
+  let print_error pp err = Error.print_all pp obj err
 
   let join l = S.meet obj l
 
@@ -3219,11 +4796,11 @@ module Monadic_gen (Obj : Obj) = struct
 
   let apply_hint hint m = wrap ~hint Fun.id m
 
-  let join_const_unhint c m = S.Unhint.apply Obj.obj (Meet_const c) m
+  let join_const_unhint c m = S.Unhint.apply Obj.obj (Simple (Meet_const c)) m
 
-  let join_const ?hint c m = wrap ?hint (join_const_unhint c) m
+  let join_const ?hint c m = wrap ?hint (join_const_unhint c) (disallow_left m)
 
-  let subtract_const_unhint c m = S.Unhint.apply obj (Imply_const c) m
+  let subtract_const_unhint c m = S.Unhint.apply obj (Simple (Imply_const c)) m
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
@@ -3485,13 +5062,6 @@ module Staticity = struct
   let zap_to_legacy = zap_to_ceil
 end
 
-let regional_to_local m = S.apply Locality.Obj.obj C.Regional_to_local m
-
-let locality_as_regionality m =
-  S.apply Regionality.Obj.obj C.Locality_as_regionality m
-
-let regional_to_global m = S.apply Locality.Obj.obj C.Regional_to_global m
-
 module type Areality = sig
   module Const : C.Areality
 
@@ -3591,7 +5161,8 @@ module Comonadic_with (Areality : Areality) = struct
     end
   end
 
-  let proj ax m = S.apply ~hint:Skip (proj_obj ax) (Proj (Obj.obj, ax)) m
+  let proj ax m =
+    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Id, ax, Obj.obj)) m
 
   module Per_axis = struct
     let zap_to_floor ax m =
@@ -3604,12 +5175,12 @@ module Comonadic_with (Areality : Areality) = struct
   end
 
   let min_with ax m =
-    S.apply ~hint:Skip Obj.obj (Min_with ax) (S.disallow_right m)
+    S.apply ~hint:Skip Obj.obj (Min_with_simple (ax, Id)) (disallow_right m)
 
   let max_with ax m =
-    S.apply ~hint:Skip Obj.obj (Max_with ax) (S.disallow_left m)
+    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (disallow_left m)
 
-  let meet_const_with ax c m = meet_const (Const.max_with ax c) m
+  let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
   let zap_to_legacy m : Const.t =
     let areality = proj Areality m |> Areality.zap_to_legacy in
@@ -3618,7 +5189,7 @@ module Comonadic_with (Areality : Areality) = struct
     let portability =
       proj Portability m |> Portability.zap_to_legacy ~statefulness
     in
-    let global = Areality.Const.(equal areality legacy) in
+    let global = Areality.Const.equal areality Areality.Const.legacy in
     let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
     let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
     { areality; linearity; portability; forkable; yielding; statefulness }
@@ -3647,11 +5218,11 @@ module Comonadic_with (Areality : Areality) = struct
     | Ok () -> ()
     | Error e ->
       let (Error (ax, _)) = to_simple_error e in
-      raise (Submode_error_simple_context (pp, Product (Obj.obj, ax, e)))
+      raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
 
   let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
-    Error.print_product pp Obj.obj ax err
+    Error.print_proj pp Obj.obj ax err
 end
 [@@inline]
 
@@ -3736,7 +5307,8 @@ module Monadic = struct
     end
   end
 
-  let proj ax m = S.apply ~hint:Skip (proj_obj ax) (Proj (Obj.obj, ax)) m
+  let proj ax m =
+    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Id, ax, Obj.obj)) m
 
   module Per_axis = struct
     let zap_to_floor ax m =
@@ -3750,10 +5322,10 @@ module Monadic = struct
 
   (* The monadic fragment is inverted. *)
 
-  let join_const_with ax c m = join_const (Const.min_with ax c) m
+  let join_const_with ax c m = join_const (C.min_with Obj.obj ax c) m
 
   let min_with ax m =
-    S.apply ~hint:Skip Obj.obj (Max_with ax) (S.disallow_left m)
+    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
@@ -3789,11 +5361,11 @@ module Monadic = struct
     | Ok () -> ()
     | Error e ->
       let (Error (ax, _)) = to_simple_error e in
-      raise (Submode_error_simple_context (pp, Product (Obj.obj, ax, e)))
+      raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
 
   let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
-    Error.print_product pp Obj.obj ax err
+    Error.print_proj pp Obj.obj ax err
 end
 
 type ('mo, 'como) monadic_comonadic =
@@ -3933,11 +5505,6 @@ module Value_with (Areality : Areality) = struct
     t |> unhint |> f |> hint ?monadic ?comonadic
 
   module Const = struct
-    let comonadic_to_monadic_min = C.comonadic_to_monadic_min Comonadic.Obj.obj
-
-    module Monadic = Monadic.Const
-    module Comonadic = Comonadic.Const
-
     (* CR-soon zqian: make a functor [Mode.Value.Const.Make] to generalize over any type
        operator applied on each mode constants. *)
     type t =
@@ -3953,40 +5520,45 @@ module Value_with (Areality : Areality) = struct
         Staticity.Const.t )
       modes
 
-    let min = merge { comonadic = Comonadic.min; monadic = Monadic.min }
+    let min =
+      merge { comonadic = Comonadic.Const.min; monadic = Monadic.Const.min }
 
-    let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
+    let max =
+      merge { comonadic = Comonadic.Const.max; monadic = Monadic.Const.max }
 
     let le m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      Comonadic.le m1.comonadic m2.comonadic && Monadic.le m1.monadic m2.monadic
+      Comonadic.Const.le m1.comonadic m2.comonadic
+      && Monadic.Const.le m1.monadic m2.monadic
 
     let equal m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      Comonadic.equal m1.comonadic m2.comonadic
-      && Monadic.equal m1.monadic m2.monadic
+      Comonadic.Const.equal m1.comonadic m2.comonadic
+      && Monadic.Const.equal m1.monadic m2.monadic
 
     let print ppf m =
       let { monadic; comonadic } = split m in
-      Fmt.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
+      Fmt.fprintf ppf "%a,%a" Comonadic.Const.print comonadic
+        Monadic.Const.print monadic
 
     let legacy =
-      merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
+      merge
+        { comonadic = Comonadic.Const.legacy; monadic = Monadic.Const.legacy }
 
     let meet m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      let monadic = Monadic.meet m1.monadic m2.monadic in
-      let comonadic = Comonadic.meet m1.comonadic m2.comonadic in
+      let monadic = Monadic.Const.meet m1.monadic m2.monadic in
+      let comonadic = Comonadic.Const.meet m1.comonadic m2.comonadic in
       merge { monadic; comonadic }
 
     let join m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      let monadic = Monadic.join m1.monadic m2.monadic in
-      let comonadic = Comonadic.join m1.comonadic m2.comonadic in
+      let monadic = Monadic.Const.join m1.monadic m2.monadic in
+      let comonadic = Comonadic.Const.join m1.comonadic m2.comonadic in
       merge { monadic; comonadic }
 
     module Option = struct
@@ -4152,13 +5724,17 @@ module Value_with (Areality : Areality) = struct
         staticity
       }
 
+    let comonadic_to_monadic_min =
+      C.Core_morph.comonadic_to_monadic_min Areality.Const.areality
+
+    let monadic_to_comonadic_min =
+      C.Core_morph.monadic_to_comonadic_min
+        (C.comonadic_with_obj Areality.Obj.obj)
+
     (** See [Alloc.close_over] for explanation. *)
     let close_over m =
       let { monadic; comonadic } = split m in
-      Comonadic.join comonadic
-        (C.monadic_to_comonadic_min
-           (C.comonadic_with_obj Areality.Obj.obj)
-           monadic)
+      Comonadic.Const.join comonadic (monadic_to_comonadic_min monadic)
 
     (** See [Alloc.partial_apply] for explanation. *)
     let partial_apply m =
@@ -4173,16 +5749,16 @@ module Value_with (Areality : Areality) = struct
     let le_axis : type a. a Axis.t -> a -> a -> bool =
      fun ax m1 m2 ->
       match ax with
-      | Comonadic ax -> Comonadic.Per_axis.le ax m1 m2
-      | Monadic ax -> Monadic.Per_axis.le ax m1 m2
+      | Comonadic ax -> Comonadic.Const.Per_axis.le ax m1 m2
+      | Monadic ax -> Monadic.Const.Per_axis.le ax m1 m2
 
     let min_axis : type a. a Axis.t -> a = function
-      | Comonadic ax -> Comonadic.Per_axis.min ax
-      | Monadic ax -> Monadic.Per_axis.min ax
+      | Comonadic ax -> Comonadic.Const.Per_axis.min ax
+      | Monadic ax -> Monadic.Const.Per_axis.min ax
 
     let max_axis : type a. a Axis.t -> a = function
-      | Comonadic ax -> Comonadic.Per_axis.max ax
-      | Monadic ax -> Monadic.Per_axis.max ax
+      | Comonadic ax -> Comonadic.Const.Per_axis.max ax
+      | Monadic ax -> Monadic.Const.Per_axis.max ax
 
     let is_max : type a. a Axis.t -> a -> bool =
      fun ax m -> le_axis ax (max_axis ax) m
@@ -4200,7 +5776,7 @@ module Value_with (Areality : Areality) = struct
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
 
   include Magic_allow_disallow (struct
-    type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
+    type (_, _, 'd) sided = 'd t
 
     let allow_left { monadic; comonadic } =
       let monadic = Monadic.allow_left monadic in
@@ -4316,9 +5892,11 @@ module Value_with (Areality : Areality) = struct
 
   let join_const_with ax c { monadic; comonadic } =
     let monadic = Monadic.join_const_with ax c monadic in
+    let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
   let meet_const_with ax c { monadic; comonadic } =
+    let monadic = Monadic.disallow_right monadic in
     let comonadic = Comonadic.meet_const_with ax c comonadic in
     { comonadic; monadic }
 
@@ -4345,22 +5923,26 @@ module Value_with (Areality : Areality) = struct
     { comonadic; monadic }
 
   let comonadic_to_monadic_min ?hint m =
-    S.apply ?hint Monadic.Obj.obj (Comonadic_to_monadic_max Comonadic.Obj.obj)
+    S.apply ?hint Monadic.Obj.obj
+      (Simple (Core (Comonadic_to_monadic_max Areality.Const.areality)))
       (Comonadic.disallow_left m)
 
   let monadic_to_comonadic_min m =
-    S.apply Comonadic.Obj.obj Monadic_to_comonadic_min (Monadic.disallow_left m)
+    S.apply Comonadic.Obj.obj (Simple (Core Monadic_to_comonadic_min))
+      (Monadic.disallow_left m)
 
   let monadic_to_comonadic_max m =
-    S.apply Comonadic.Obj.obj Monadic_to_comonadic_max
+    S.apply Comonadic.Obj.obj (Simple (Core Monadic_to_comonadic_max))
       (Monadic.disallow_right m)
 
   let meet_const c { comonadic; monadic } =
+    let monadic = Monadic.disallow_right monadic in
     let comonadic = Comonadic.meet_const c comonadic in
     { monadic; comonadic }
 
   let join_const c { comonadic; monadic } =
     let monadic = Monadic.join_const c monadic in
+    let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
   let zap_to_ceil { comonadic; monadic } =
@@ -4384,9 +5966,9 @@ module Value_with (Areality : Areality) = struct
   let close_over { comonadic; monadic } =
     let comonadic = Comonadic.disallow_right comonadic in
     (* The comonadic of the returned function is constrained by the monadic of the closed argument via the dualizing morphism. *)
-    let comonadic1 = monadic_to_comonadic_min monadic in
+    let comonadic_dual = monadic_to_comonadic_min monadic in
     (* It's also constrained by the comonadic of the closed argument. *)
-    let comonadic = Comonadic.join [comonadic; comonadic1] in
+    let comonadic = Comonadic.join [comonadic; comonadic_dual] in
     (* The closure will access [A] at the specified monadic modes, and thus the
        monadic mode of the closure itself is not constrained by it. *)
     let monadic = Monadic.disallow_right Monadic.min in
@@ -4406,7 +5988,7 @@ module Value_with (Areality : Areality) = struct
     type nonrec 'd t = 'd t list
 
     include Magic_allow_disallow (struct
-      type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
+      type (_, _, 'd) sided = 'd t
 
       let allow_left l = List.map allow_left l
 
@@ -4424,6 +6006,8 @@ module Value = Value_with (Regionality)
 module Alloc = Value_with (Locality)
 
 module Const = struct
+  let locality_as_regionality = C.Locality_morph.apply Locality_as_regionality
+
   let alloc_as_value
       ({ areality;
          linearity;
@@ -4437,7 +6021,7 @@ module Const = struct
          staticity
        } :
         Alloc.Const.t) : Value.Const.t =
-    let areality = C.locality_as_regionality areality in
+    let areality = locality_as_regionality areality in
     { areality;
       linearity;
       portability;
@@ -4471,34 +6055,43 @@ module Const = struct
       | Left Refl -> P (Comonadic Areality)
       | Right ax -> P ax
   end
-
-  let locality_as_regionality = C.locality_as_regionality
 end
 
 (* CR-someday zqian: all the function that converts between [Alloc] and [Value] should
    operate on [Unhint] so they can be composed and assigned hint as a whole. *)
 
 let comonadic_locality_as_regionality comonadic =
-  S.Unhint.apply Value.Comonadic.Obj.obj (Map_comonadic Locality_as_regionality)
-    comonadic
+  S.Unhint.apply Value.Comonadic.Obj.obj
+    (Simple (Core (Locality_full Locality_as_regionality))) comonadic
 
 let comonadic_regional_to_local comonadic =
-  S.Unhint.apply Alloc.Comonadic.Obj.obj (Map_comonadic Regional_to_local)
-    comonadic
+  S.Unhint.apply Alloc.Comonadic.Obj.obj
+    (Simple (Core (Locality_full Regional_to_local))) comonadic
+
+let locality_as_regionality_unhint l =
+  S.Unhint.apply C.Regionality
+    (Simple (Core (Locality_restricted Locality_as_regionality))) l
+
+let locality_as_regionality m =
+  m |> Locality.unhint |> locality_as_regionality_unhint |> Regionality.hint
 
 let alloc_as_value_unhint m =
   let { comonadic; monadic } = m in
-  let comonadic = comonadic_locality_as_regionality comonadic in
+  let comonadic =
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+  in
   { comonadic; monadic }
 
-let alloc_as_value m =
-  m |> Alloc.unhint |> alloc_as_value_unhint |> Value.hint ~monadic:Skip
+let alloc_as_value ?hint m =
+  m |> Alloc.unhint |> alloc_as_value_unhint
+  |> Value.hint ~monadic:Skip ?comonadic:hint
 
 let alloc_to_value_l2r_unhint m =
   let { comonadic; monadic } = m in
   let comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj (Map_comonadic Local_to_regional)
-      comonadic
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Local_to_regional))) comonadic
   in
   { comonadic; monadic }
 
@@ -4509,26 +6102,31 @@ let alloc_to_value_l2r m =
 let value_to_alloc_r2g_unhint m =
   let { comonadic; monadic } = m in
   let comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj (Map_comonadic Regional_to_global)
-      comonadic
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_global))) comonadic
   in
   { comonadic; monadic }
 
-let value_to_alloc_r2g m =
-  m |> Value.unhint |> value_to_alloc_r2g_unhint |> Alloc.hint ~monadic:Skip
+let value_to_alloc_r2g ?hint m =
+  m |> Value.disallow_left |> Value.unhint |> value_to_alloc_r2g_unhint
+  |> Alloc.hint ~monadic:Skip ?comonadic:hint
 
 let value_r2g ?hint m =
   Value.wrap ~monadic:Skip ?comonadic:hint
     (fun m -> m |> value_to_alloc_r2g_unhint |> alloc_as_value_unhint)
-    m
+    (Value.disallow_left m)
 
 let value_to_alloc_r2l_unhint m =
   let { comonadic; monadic } = m in
-  let comonadic = comonadic_regional_to_local comonadic in
+  let comonadic =
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_local))) comonadic
+  in
   { comonadic; monadic }
 
-let value_to_alloc_r2l m =
-  m |> Value.unhint |> value_to_alloc_r2l_unhint |> Alloc.hint ~monadic:Skip
+let value_to_alloc_r2l ?hint m =
+  m |> Value.unhint |> value_to_alloc_r2l_unhint
+  |> Alloc.hint ~monadic:Skip ?comonadic:hint
 
 module Modality = struct
   (* Inferred modalities
@@ -4625,11 +6223,41 @@ module Modality = struct
         match then_, t with
         | Join_const c1, Join_const c2 -> Join_const (Mode.Const.join c1 c2)
 
-      let apply : type l r.
-          ?hint:(l * r) neg Hint.morph -> t -> (l * r) Mode.t -> (l * r) Mode.t
-          =
-       fun ?(hint = Hint.Unknown) t x ->
-        match t with Join_const c -> Mode.join_const ~hint c x
+      let apply_right : type l.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (l * allowed) Mode.t ->
+          Mode.r =
+       fun ?is_contained_by t x ->
+        match t with
+        | Join_const c ->
+          let hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Monadic, c))
+              is_contained_by
+          in
+          Mode.join_const ?hint c (Mode.disallow_left x)
+
+      let apply_left : type r.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (allowed * r) Mode.t ->
+          Mode.l =
+       fun ?is_contained_by t x ->
+        match t with
+        | Join_const c ->
+          let morph_hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Monadic, c))
+              is_contained_by
+          in
+          let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
+          let hint =
+            Option.map (fun c -> Hint.Contained_by c) is_contained_by
+          in
+          Mode.join
+            [ Mode.disallow_right (Mode.of_const ?hint c);
+              Mode.disallow_right (Mode.apply_hint morph_hint x) ]
 
       let proj ax (Join_const c) : _ Atom.t = Join_const (Axis.proj ax c)
 
@@ -4652,7 +6280,9 @@ module Modality = struct
         (* Check that for any x >= mm, join(x, m) <= join(x, c), which (by
            definition of join) is equivalent to m <= join(x, c). This has to
            hold for all x >= mm, so we check m <= join(mm, c). *)
-        match Mode.submode_log m (Mode.join_const c mm) ~log with
+        match
+          Mode.submode_log m (Mode.join_const c (Mode.disallow_left mm)) ~log
+        with
         | Ok () -> Ok ()
         | Error err ->
           let (Error (ax, { left; _ })) = Mode.to_simple_error err in
@@ -4674,14 +6304,14 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
-    let apply : type r.
-        ?hint:(allowed * r) neg Hint.morph ->
+    let apply_left : type r.
+        ?is_contained_by:Hint.is_contained_by ->
         t ->
         (allowed * r) Mode.t ->
         Mode.l =
-     fun ?hint t x ->
+     fun ?is_contained_by t x ->
       match t with
-      | Const c -> Const.apply ?hint c x |> Mode.disallow_right
+      | Const c -> Const.apply_left ?is_contained_by c x |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
       | Diff (_, m) -> Mode.join [Mode.allow_right m; x]
@@ -4715,7 +6345,7 @@ module Modality = struct
            [subtract_mm m <= c], equivalently [m <= join_mm c], which is
            achieved by the following [submode].
         *)
-        Mode.submode_exn m (Mode.join_const c mm);
+        Mode.submode_exn m (Mode.join_const c (Mode.disallow_left mm));
         Const.Join_const c
 
     let zap_to_id = zap_to_floor
@@ -4771,11 +6401,41 @@ module Modality = struct
         match then_, t with
         | Meet_const c1, Meet_const c2 -> Meet_const (Mode.Const.meet c1 c2)
 
-      let apply : type l r.
-          ?hint:(l * r) pos Hint.morph -> t -> (l * r) Mode.t -> (l * r) Mode.t
-          =
-       fun ?(hint = Hint.Unknown) t x ->
-        match t with Meet_const c -> Mode.meet_const ~hint c x
+      let apply_left : type r.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (allowed * r) Mode.t ->
+          Mode.l =
+       fun ?is_contained_by t x ->
+        match t with
+        | Meet_const c ->
+          let hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Comonadic, c))
+              is_contained_by
+          in
+          Mode.meet_const ?hint c (Mode.disallow_right x)
+
+      let apply_right : type l.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (l * allowed) Mode.t ->
+          Mode.r =
+       fun ?is_contained_by t x ->
+        match t with
+        | Meet_const c ->
+          let morph_hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Comonadic, c))
+              is_contained_by
+          in
+          let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
+          let hint =
+            Option.map (fun c -> Hint.Contained_by c) is_contained_by
+          in
+          Mode.meet
+            [ Mode.disallow_left (Mode.of_const ?hint c);
+              Mode.disallow_left (Mode.apply_hint morph_hint x) ]
 
       let proj ax (Meet_const c) : _ Atom.t = Meet_const (Axis.proj ax c)
 
@@ -4823,14 +6483,14 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
-    let apply : type r.
-        ?hint:(allowed * r) pos Hint.morph ->
+    let apply_left : type r.
+        ?is_contained_by:Hint.is_contained_by ->
         t ->
         (allowed * r) Mode.t ->
         Mode.l =
-     fun ?hint t x ->
+     fun ?is_contained_by t x ->
       match t with
-      | Const c -> Const.apply ?hint c x |> Mode.disallow_right
+      | Const c -> Const.apply_left ?is_contained_by c x |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
       | Exactly (_mm, m) ->
@@ -4873,7 +6533,7 @@ module Modality = struct
            [imply_mm m >= c], equivalently [m >= meet_mm c], which is achieved
            by the following [submode].
         *)
-        Mode.submode_exn (Mode.meet_const c mm) m;
+        Mode.submode_exn (Mode.meet_const c (Mode.disallow_right mm)) m;
         Const.Meet_const c
 
     let zap_to_id = zap_to_ceil
@@ -4969,16 +6629,17 @@ module Modality = struct
 
     let equate = equate_from_submode' sub
 
-    let apply ?hint t { monadic; comonadic } =
-      let monadic =
-        Monadic.apply
-          ?hint:(Option.map (fun { monadic; _ } -> monadic) hint)
-          t.monadic monadic
-      in
+    let apply_left ?is_contained_by t { monadic; comonadic } =
+      let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
       let comonadic =
-        Comonadic.apply
-          ?hint:(Option.map (fun { comonadic; _ } -> comonadic) hint)
-          t.comonadic comonadic
+        Comonadic.apply_left ?is_contained_by t.comonadic comonadic
+      in
+      { monadic; comonadic }
+
+    let apply_right ?is_contained_by t { monadic; comonadic } =
+      let monadic = Monadic.apply_right ?is_contained_by t.monadic monadic in
+      let comonadic =
+        Comonadic.apply_right ?is_contained_by t.comonadic comonadic
       in
       { monadic; comonadic }
 
@@ -5019,16 +6680,10 @@ module Modality = struct
     | _ -> false
   [@@ocaml.warning "-4"]
 
-  let apply ?hint t { monadic; comonadic } =
-    let monadic =
-      Monadic.apply
-        ?hint:(Option.map (fun { monadic; _ } -> monadic) hint)
-        t.monadic monadic
-    in
+  let apply_left ?is_contained_by t { monadic; comonadic } =
+    let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
     let comonadic =
-      Comonadic.apply
-        ?hint:(Option.map (fun { comonadic; _ } -> comonadic) hint)
-        t.comonadic comonadic
+      Comonadic.apply_left ?is_contained_by t.comonadic comonadic
     in
     { monadic; comonadic }
 
@@ -5089,7 +6744,7 @@ module Crossing = struct
   (* The mode crossing capability of a type [t] is characterized by a monotone
      function [f] from modes to some lattice [L], in the following way:
 
-     To check [e : t @ m1<= m2], we should instead check [f m1 <= f m2] to
+     To check [e : t @ m1 <= m2], we should instead check [f m1 <= f m2] to
      allow more programs.
 
      For example, if [f] is the identity function, then [t] does not cross modes
@@ -5173,7 +6828,8 @@ module Crossing = struct
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
     let apply_left (Modality (Join_const c)) m =
-      Mode.subtract_const_unhint c (Mode.join_const_unhint c m)
+      Mode.subtract_const_unhint c
+        (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
     let apply_right (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
@@ -5275,7 +6931,7 @@ module Crossing = struct
       Mode.meet_const_unhint c m
 
     let apply_right (Modality (Meet_const c)) m =
-      Mode.imply_const_unhint c (Mode.meet_const_unhint c m)
+      Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
 
     let le (Modality (Meet_const c1)) (Modality (Meet_const c2)) =
       Mode.Const.le c1 c2
@@ -5390,21 +7046,23 @@ module Crossing = struct
 
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
-    let comonadic = Comonadic.apply_left t.comonadic comonadic in
+    let comonadic =
+      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+    in
     { monadic; comonadic }
 
   let apply_left t m =
-    m |> Value.disallow_right |> Value.unhint |> apply_left_unhint t
-    |> Value.hint ~monadic:Crossing ~comonadic:Crossing
+    Value.hint ~monadic:Crossing ~comonadic:Crossing
+      (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
   let apply_right t m =
-    m |> Value.disallow_left |> Value.unhint |> apply_right_unhint t
-    |> Value.hint ~monadic:Crossing ~comonadic:Crossing
+    Value.hint ~monadic:Crossing ~comonadic:Crossing
+      (apply_right_unhint t (Value.disallow_left m))
 
   (* Our mode crossing is for [Value] modes, but can be extended to [Alloc]
      modes via [alloc_as_value], defined as follows:
@@ -5420,13 +7078,11 @@ module Crossing = struct
      [regional_to_local] the left adjoint. *)
 
   let apply_left_alloc t m =
-    m |> Alloc.unhint |> alloc_as_value_unhint |> apply_left_unhint t
-    |> value_to_alloc_r2l_unhint
+    m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
 
   let apply_right_alloc t m =
-    m |> Alloc.unhint |> alloc_as_value_unhint |> apply_right_unhint t
-    |> value_to_alloc_r2g_unhint
+    m |> alloc_as_value |> apply_right_unhint t |> value_to_alloc_r2g_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
 
   let apply_left_right_alloc t m =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3284,7 +3284,7 @@ module Lattices_mono = struct
       Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
     | Const_max _ -> Const_min dst
 
-  let compose_simple_with_proj_core : type a c p d.
+  let compose_simple_proj_core : type a c p d.
       c obj ->
       (p, c, d) Simple_morph.t ->
       (a, p, d) Core_morph.compose_proj_result ->
@@ -3297,7 +3297,7 @@ module Lattices_mono = struct
     | Proj_const_max obj1 -> Const_max obj1
     | Proj_const_min obj1 -> Const_min obj1
 
-  let compose_simple_with_proj_meet_const_core : type a c p l.
+  let compose_simple_proj_meet_const_core : type a c p l.
       c obj ->
       (p, c, l * disallowed) Simple_morph.t ->
       p ->
@@ -3313,7 +3313,7 @@ module Lattices_mono = struct
     | Proj_const_max obj1 -> Const_max obj1
     | Proj_const_min obj1 -> Const_min obj1
 
-  let compose_simple_with_proj_core_imply_const : type a c p r.
+  let compose_simple_proj_core_imply_const : type a c p r.
       c obj ->
       (p, c, disallowed * r) Simple_morph.t ->
       a ->
@@ -3343,7 +3343,7 @@ module Lattices_mono = struct
     | Id -> Simple_proj (m0, ax0, obj0)
     | Core m1 ->
       let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_with_proj_core dst m0 pm1
+      compose_simple_proj_core dst m0 pm1
     | Meet_const c1 ->
       let c1 = Axis.proj ax0 c1 in
       Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
@@ -3353,13 +3353,13 @@ module Lattices_mono = struct
     | Meet_const_core (c1, m1) ->
       let c1 = Axis.proj ax0 c1 in
       let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_with_proj_meet_const_core dst m0 c1 pm1
+      compose_simple_proj_meet_const_core dst m0 c1 pm1
     | Core_imply_const (m1, c1) ->
       let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_with_proj_core_imply_const dst m0 c1 pm1
+      compose_simple_proj_core_imply_const dst m0 c1 pm1
     | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
 
-  let compose_simple_with_and_max : type a b c q r.
+  let compose_simple_max_with_simple : type a b c q r.
       c obj ->
       (b, c, disallowed * r) Simple_morph.t ->
       (b, q) Axis.t ->
@@ -3398,7 +3398,7 @@ module Lattices_mono = struct
     | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
     | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
 
-  let compose_simple_with_and_min : type a b c q l.
+  let compose_simple_min_with_simple : type a b c q l.
       c obj ->
       (b, c, l * disallowed) Simple_morph.t ->
       (b, q) Axis.t ->
@@ -3470,12 +3470,12 @@ module Lattices_mono = struct
       let dst = proj_obj ax0 dst in
       Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
     | Simple m0, Max_with_simple (ax1, m1) ->
-      compose_simple_with_and_max dst m0 ax1 m1
+      compose_simple_max_with_simple dst m0 ax1 m1
     | Min_with_simple (ax0, m0), Simple m1 ->
       let dst = proj_obj ax0 dst in
       Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
     | Simple m0, Min_with_simple (ax1, m1) ->
-      compose_simple_with_and_min dst m0 ax1 m1
+      compose_simple_min_with_simple dst m0 ax1 m1
     | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
       begin match Axis.equal ax0 ax1 with
       | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -6940,32 +6940,50 @@ module Value_with (Areality : Areality) = struct
       { iter = (fun obj msrc -> zap_to_legacy_obj obj msrc) }
 
   let add_covariant_to_zap_scope { monadic; comonadic } scope =
-    Monadic.iter_covariant monadic (fun i m ->
-        let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
-        Z.add_zap_to_ceil_to_zap_scope i zap_to_floor zap_to_legacy scope);
-    Comonadic.iter_covariant comonadic (fun i m ->
-        let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
-        Z.add_zap_to_floor_to_zap_scope i zap_to_floor zap_to_legacy scope)
+    let comonadic_upper =
+      Comonadic.Guts.get_floor comonadic |> Comonadic.of_const
+    in
+    let monadic_upper = Monadic.Guts.get_floor monadic |> Monadic.of_const in
+    Monadic.iter_covariant monadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+          let m = Monadic.join [monadic_upper; m] in
+          let zap_to_floor () = Monadic.zap_to_floor_force m |> ignore in
+          Z.add_zap_to_ceil_to_zap_scope id zap_to_floor zap_to_legacy scope
+        end);
+    Comonadic.iter_covariant comonadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+          let m = Comonadic.join [comonadic_upper; m] in
+          let zap_to_floor () = Comonadic.zap_to_floor_force m |> ignore in
+          Z.add_zap_to_floor_to_zap_scope id zap_to_floor zap_to_legacy scope
+        end)
 
   let add_contravariant_to_zap_scope { monadic; comonadic } scope =
-    Monadic.iter_contravariant monadic (fun i m ->
-        let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
-        Z.add_zap_to_floor_to_zap_scope i zap_to_ceil zap_to_legacy scope);
-    Comonadic.iter_contravariant comonadic (fun i m ->
-        let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
-        let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
-        Z.add_zap_to_ceil_to_zap_scope i zap_to_ceil zap_to_legacy scope)
+    let comonadic_upper =
+      Comonadic.Guts.get_ceil comonadic |> Comonadic.of_const
+    in
+    let monadic_lower = Monadic.Guts.get_ceil monadic |> Monadic.of_const in
+    Monadic.iter_contravariant monadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_monadic m in
+          let m = Monadic.meet [monadic_lower; m] in
+          let zap_to_ceil () = Monadic.zap_to_ceil_force m |> ignore in
+          Z.add_zap_to_floor_to_zap_scope id zap_to_ceil zap_to_legacy scope
+        end);
+    Comonadic.iter_contravariant comonadic (fun ~id ~level m ->
+        if level <> generic_level
+        then begin
+          let zap_to_legacy () = zap_to_legacy_src_var_comonadic m in
+          let m = Comonadic.meet [comonadic_upper; m] in
+          let zap_to_ceil () = Comonadic.zap_to_ceil m |> ignore in
+          Z.add_zap_to_ceil_to_zap_scope id zap_to_ceil zap_to_legacy scope
+        end)
 
-  let add_mode_to_zap_scope m { variables; visible } =
-    if check_level_var m generic_level
-    then begin
-      add_covariant_to_zap_scope m variables;
-      add_contravariant_to_zap_scope m variables
-    end;
-    visible := m :: !visible
+  let add_mode_to_zap_scope m { visible } = visible := m :: !visible
 
   let resolve_zap_scope { variables; visible } =
     (* we first zap all visible non generic modes to legacy *)
@@ -6977,6 +6995,14 @@ module Value_with (Areality : Areality) = struct
     2) if a mode appears only as a lower bound to generic modes, it is zapped to
       floor
     3) if it appears as both, it is zapped to legacy *)
+    List.iter
+      (fun m ->
+        if check_level_var m generic_level
+        then begin
+          add_covariant_to_zap_scope m variables;
+          add_contravariant_to_zap_scope m variables
+        end)
+      !visible;
     Z.resolve_zap_scope variables
 
   let with_zap_scope f =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -458,6 +458,8 @@ module Lattices = struct
     include Heyting with type t := t
 
     val areality : t areality
+
+    val all : t list
   end
 
   module Locality = struct
@@ -476,6 +478,8 @@ module Lattices = struct
     end)
 
     let legacy = Global
+
+    let all = [Global; Local]
 
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
@@ -502,6 +506,8 @@ module Lattices = struct
 
     let legacy = Global
 
+    let all = [Global; Regional; Local]
+
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
       | Regional -> Fmt.fprintf ppf "regional"
@@ -527,6 +533,8 @@ module Lattices = struct
 
     let legacy = Aliased
 
+    let all = [Unique; Aliased]
+
     let print ppf = function
       | Aliased -> Fmt.fprintf ppf "aliased"
       | Unique -> Fmt.fprintf ppf "unique"
@@ -548,6 +556,8 @@ module Lattices = struct
     end)
 
     let legacy = Many
+
+    let all = [Many; Once]
 
     let print ppf = function
       | Once -> Fmt.fprintf ppf "once"
@@ -575,6 +585,8 @@ module Lattices = struct
     end)
 
     let legacy = Nonportable
+
+    let all = [Portable; Shareable; Corruptible; Nonportable]
 
     let print ppf = function
       | Portable -> Fmt.fprintf ppf "portable"
@@ -605,6 +617,8 @@ module Lattices = struct
 
     let legacy = Uncontended
 
+    let all = [Uncontended; Corrupted; Shared; Contended]
+
     let print ppf = function
       | Contended -> Fmt.fprintf ppf "contended"
       | Corrupted -> Fmt.fprintf ppf "corrupted"
@@ -629,6 +643,8 @@ module Lattices = struct
 
     let legacy = Forkable
 
+    let all = [Forkable; Unforkable]
+
     let print ppf = function
       | Unforkable -> Fmt.fprintf ppf "unforkable"
       | Forkable -> Fmt.fprintf ppf "forkable"
@@ -650,6 +666,8 @@ module Lattices = struct
     end)
 
     let legacy = Unyielding
+
+    let all = [Unyielding; Yielding]
 
     let print ppf = function
       | Yielding -> Fmt.fprintf ppf "yielding"
@@ -677,6 +695,8 @@ module Lattices = struct
     end)
 
     let legacy = Stateful
+
+    let all = [Stateless; Writing; Reading; Stateful]
 
     let print ppf = function
       | Stateless -> Fmt.fprintf ppf "stateless"
@@ -707,6 +727,8 @@ module Lattices = struct
 
     let legacy = Read_write
 
+    let all = [Read_write; Read; Write; Immutable]
+
     let print ppf = function
       | Immutable -> Fmt.fprintf ppf "immutable"
       | Read -> Fmt.fprintf ppf "read"
@@ -730,6 +752,8 @@ module Lattices = struct
     end)
 
     let legacy = Dynamic
+
+    let all = [Static; Dynamic]
 
     let print ppf = function
       | Dynamic -> Fmt.fprintf ppf "dynamic"
@@ -766,6 +790,35 @@ module Lattices = struct
       let visibility = Visibility.legacy in
       let staticity = Staticity.legacy in
       { uniqueness; contention; visibility; staticity }
+
+    (** All product values, including every combination of axis values. *)
+    let all =
+      lazy
+        (let ( let* ) xs f = List.concat_map f xs in
+         let ( let+ ) xs f = List.map f xs in
+         let* uniqueness = Uniqueness.all in
+         let* contention = Contention.all in
+         let* visibility = Visibility.all in
+         let+ staticity = Staticity.all in
+         { uniqueness; contention; visibility; staticity })
+
+    (** Product values that cover every element of every axis at least once,
+        without enumerating every product combination. *)
+    let spanning_elements =
+      lazy
+        (let with_base base =
+           let ( let+ ) xs f = List.map f xs in
+           List.concat
+             [ (let+ uniqueness = Uniqueness.all in
+                { base with uniqueness });
+               (let+ contention = Contention.all in
+                { base with contention });
+               (let+ visibility = Visibility.all in
+                { base with visibility });
+               (let+ staticity = Staticity.all in
+                { base with staticity }) ]
+         in
+         with_base min @ with_base max)
 
     let le m1 m2 =
       let { uniqueness = uniqueness1;
@@ -886,6 +939,41 @@ module Lattices = struct
       let yielding = Yielding.legacy in
       let statefulness = Statefulness.legacy in
       { areality; linearity; portability; forkable; yielding; statefulness }
+
+    (** All product values, including every combination of axis values. *)
+    let all =
+      lazy
+        (let ( let* ) xs f = List.concat_map f xs in
+         let ( let+ ) xs f = List.map f xs in
+         let* areality = Areality.all in
+         let* linearity = Linearity.all in
+         let* portability = Portability.all in
+         let* forkable = Forkable.all in
+         let* yielding = Yielding.all in
+         let+ statefulness = Statefulness.all in
+         { areality; linearity; portability; forkable; yielding; statefulness })
+
+    (** Product values that cover every element of every axis at least once,
+        without enumerating every product combination. *)
+    let spanning_elements =
+      lazy
+        (let with_base base =
+           let ( let+ ) xs f = List.map f xs in
+           List.concat
+             [ (let+ areality = Areality.all in
+                { base with areality });
+               (let+ linearity = Linearity.all in
+                { base with linearity });
+               (let+ portability = Portability.all in
+                { base with portability });
+               (let+ forkable = Forkable.all in
+                { base with forkable });
+               (let+ yielding = Yielding.all in
+                { base with yielding });
+               (let+ statefulness = Statefulness.all in
+                { base with statefulness }) ]
+         in
+         with_base min @ with_base max)
 
     let le m1 m2 =
       let { areality = areality1;
@@ -1428,7 +1516,75 @@ module Lattices_mono = struct
       | Contention -> { t with contention = r }
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
+
+    type 'a packed = Axis : ('a, 'b) t -> 'a packed
+
+    let all : type a. a obj -> a packed list = function
+      | Comonadic_with_locality ->
+        [ Axis Areality;
+          Axis Forkable;
+          Axis Yielding;
+          Axis Linearity;
+          Axis Statefulness;
+          Axis Portability ]
+      | Comonadic_with_regionality ->
+        [ Axis Areality;
+          Axis Forkable;
+          Axis Yielding;
+          Axis Linearity;
+          Axis Statefulness;
+          Axis Portability ]
+      | Monadic_op ->
+        [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
+      | Locality | Regionality | Uniqueness_op | Linearity | Portability
+      | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
+      | Staticity_op ->
+        []
   end
+
+  type packed_obj = Obj : 'a obj -> packed_obj
+
+  let all_objs =
+    [ Obj Locality;
+      Obj Regionality;
+      Obj Uniqueness_op;
+      Obj Linearity;
+      Obj Portability;
+      Obj Forkable;
+      Obj Yielding;
+      Obj Statefulness;
+      Obj Contention_op;
+      Obj Visibility_op;
+      Obj Staticity_op;
+      Obj Monadic_op;
+      Obj Comonadic_with_locality;
+      Obj Comonadic_with_regionality ]
+
+  let get_elements : type a. full:bool -> a obj -> a list =
+   fun ~full -> function
+    | Locality -> Locality.all
+    | Regionality -> Regionality.all
+    | Uniqueness_op -> Uniqueness.all
+    | Linearity -> Linearity.all
+    | Portability -> Portability.all
+    | Forkable -> Forkable.all
+    | Yielding -> Yielding.all
+    | Statefulness -> Statefulness.all
+    | Contention_op -> Contention.all
+    | Visibility_op -> Visibility.all
+    | Staticity_op -> Staticity.all
+    | Monadic_op ->
+      Lazy.force (if full then Monadic.all else Monadic.spanning_elements)
+    | Comonadic_with_locality ->
+      Lazy.force
+        (if full
+         then Comonadic_with_locality.all
+         else Comonadic_with_locality.spanning_elements)
+    | Comonadic_with_regionality ->
+      Lazy.force
+        (if full
+         then Comonadic_with_regionality.all
+         else Comonadic_with_regionality.spanning_elements)
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
@@ -2374,6 +2530,70 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_max _, _ -> Disallowed
       | _, _ -> .
     [@@warning "-4"]
+
+    type ('b, 'd) packed_to =
+      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
+
+    let to_ : type a b d. (a, b, d) t -> (b, d) packed_to =
+     fun m -> To (src m, m)
+
+    let left_to : type b. b obj -> (b, left_only) packed_to list = function
+      | Locality -> [to_ (Locality_restricted Regional_to_local)]
+      | Regionality ->
+        [ to_ (Locality_restricted Local_to_regional);
+          to_ (Locality_restricted Locality_as_regionality);
+          to_ (Locality_restricted Local_to_regional_regionality);
+          to_ (Locality_restricted Regional_to_local_regionality) ]
+      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
+      | Linearity -> [to_ Uniqueness_op_to_linearity]
+      | Portability -> [to_ Contention_op_to_portability]
+      | Forkable -> []
+      | Yielding -> []
+      | Statefulness -> [to_ Visibility_op_to_statefulness]
+      | Contention_op -> [to_ Portability_to_contention_op]
+      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Staticity_op -> []
+      | Monadic_op ->
+        [ to_ (Comonadic_to_monadic_min Locality);
+          to_ (Comonadic_to_monadic_min Regionality) ]
+      | Comonadic_with_locality ->
+        [to_ (Locality_full Regional_to_local); to_ Monadic_to_comonadic_min]
+      | Comonadic_with_regionality ->
+        [ to_ (Locality_full Local_to_regional);
+          to_ (Locality_full Locality_as_regionality);
+          to_ (Locality_full Local_to_regional_regionality);
+          to_ (Locality_full Regional_to_local_regionality);
+          to_ Monadic_to_comonadic_min ]
+
+    let right_to : type b. b obj -> (b, right_only) packed_to list = function
+      | Locality ->
+        [ to_ (Locality_restricted Regional_to_local);
+          to_ (Locality_restricted Regional_to_global) ]
+      | Regionality ->
+        [ to_ (Locality_restricted Locality_as_regionality);
+          to_ (Locality_restricted Regional_to_local_regionality);
+          to_ (Locality_restricted Regional_to_global_regionality) ]
+      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
+      | Linearity -> [to_ Uniqueness_op_to_linearity]
+      | Portability -> [to_ Contention_op_to_portability]
+      | Forkable -> []
+      | Yielding -> []
+      | Statefulness -> [to_ Visibility_op_to_statefulness]
+      | Contention_op -> [to_ Portability_to_contention_op]
+      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Staticity_op -> []
+      | Monadic_op ->
+        [ to_ (Comonadic_to_monadic_max Locality);
+          to_ (Comonadic_to_monadic_max Regionality) ]
+      | Comonadic_with_locality ->
+        [ to_ (Locality_full Regional_to_local);
+          to_ (Locality_full Regional_to_global);
+          to_ Monadic_to_comonadic_max ]
+      | Comonadic_with_regionality ->
+        [ to_ (Locality_full Locality_as_regionality);
+          to_ (Locality_full Regional_to_local_regionality);
+          to_ (Locality_full Regional_to_global_regionality);
+          to_ Monadic_to_comonadic_max ]
   end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
@@ -3023,6 +3243,64 @@ module Lattices_mono = struct
       let c = min_with dst ax1 (max q_obj) in
       compose dst (Meet_const c) m
     [@@warning "-4"]
+
+    let ( let* ) xs f = List.concat_map f xs
+
+    let ( let+ ) xs f = List.map f xs
+
+    type ('b, 'd) packed_to =
+      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
+
+    let to_ : type a b d. b obj -> (a, b, d) t -> (b, d) packed_to =
+     fun dst m -> To (src dst m, m)
+
+    let left_to : type b. full:bool -> b obj -> (b, left_only) packed_to list =
+     fun ~full dst ->
+      let constants =
+        List.map (fun c -> to_ dst (Meet_const c)) (get_elements ~full dst)
+      in
+      let cores = Core_morph.left_to dst in
+      let core_morphs =
+        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
+      in
+      let meet_const_cores =
+        let* c = get_elements ~full dst in
+        let+ (Core_morph.To (_, m)) = cores in
+        to_ dst (Meet_const_core (c, m))
+      in
+      (to_ dst Id :: core_morphs) @ constants @ meet_const_cores
+
+    let right_to : type b. full:bool -> b obj -> (b, right_only) packed_to list
+        =
+     fun ~full dst ->
+      let constants =
+        List.map (fun c -> to_ dst (Imply_const c)) (get_elements ~full dst)
+      in
+      let cores = Core_morph.right_to dst in
+      let core_morphs =
+        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
+      in
+      let core_imply_consts =
+        let* (Core_morph.To (src, m)) = cores in
+        let+ c = get_elements ~full src in
+        to_ dst (Core_imply_const (m, c))
+      in
+      (to_ dst Id :: core_morphs) @ constants @ core_imply_consts
+
+    let filter_src : type a b d.
+        a obj -> (b, d) packed_to list -> (a, b, d) t list =
+     fun src simple_morphs ->
+      let filter : (b, d) packed_to -> (a, b, d) t option =
+       fun (To (src', m)) ->
+        match equal_obj src src' with
+        | Misc.Is_eq -> Some m
+        | Misc.Is_not_eq -> None
+      in
+      List.filter_map filter simple_morphs
+
+    let left_from_to ~full src dst = filter_src src (left_to ~full dst)
+
+    let right_from_to ~full src dst = filter_src src (right_to ~full dst)
   end
 
   type ('a, 'b, 'd) morph =
@@ -3622,6 +3900,154 @@ module Lattices_mono = struct
     | _, _ -> .
   [@@warning "-4"]
 
+  let ( let* ) xs f = List.concat_map f xs
+
+  let ( let+ ) xs f = List.map f xs
+
+  type 'b packed_morph_to =
+    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
+
+  let left_morph_to : type a b.
+      a obj -> (a, b, left_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_left morph)
+
+  let right_morph_to : type a b.
+      a obj -> (a, b, right_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_right morph)
+
+  let generate_left_morphs_to : type b.
+      full:bool -> b obj -> b packed_morph_to list =
+   fun ~full dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_morph.To (src, m)) -> left_morph_to src (Simple m))
+        (Simple_morph.left_to ~full dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis.Axis ax) = Axis.all src in
+      let projected = proj_obj ax src in
+      let+ m = Simple_morph.left_from_to ~full projected dst in
+      left_morph_to src (Simple_proj (m, ax, src))
+    in
+    let min_with =
+      let* (Axis.Axis ax) = Axis.all dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_morph.To (src, m)) = Simple_morph.left_to ~full projected in
+      left_morph_to src (Min_with_simple (ax, m))
+    in
+    let const_min =
+      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+    in
+    simple_morphs @ projections @ min_with @ const_min
+
+  let generate_right_morphs_to : type b.
+      full:bool -> b obj -> b packed_morph_to list =
+   fun ~full dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_morph.To (src, m)) -> right_morph_to src (Simple m))
+        (Simple_morph.right_to ~full dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis.Axis ax) = Axis.all src in
+      let projected = proj_obj ax src in
+      let+ m = Simple_morph.right_from_to ~full projected dst in
+      right_morph_to src (Simple_proj (m, ax, src))
+    in
+    let max_with =
+      let* (Axis.Axis ax) = Axis.all dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_morph.To (src, m)) = Simple_morph.right_to ~full projected in
+      right_morph_to src (Max_with_simple (ax, m))
+    in
+    let const_max =
+      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+    in
+    simple_morphs @ projections @ max_with @ const_max
+
+  let generate_morphs_to ~full dst =
+    generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
+
+  let force_by_coverage ~full (full_list, partial_list) =
+    Lazy.force (if full then full_list else partial_list)
+
+  let morphs_to_locality =
+    ( lazy (generate_morphs_to ~full:true Locality),
+      lazy (generate_morphs_to ~full:false Locality) )
+
+  let morphs_to_regionality =
+    ( lazy (generate_morphs_to ~full:true Regionality),
+      lazy (generate_morphs_to ~full:false Regionality) )
+
+  let morphs_to_uniqueness_op =
+    ( lazy (generate_morphs_to ~full:true Uniqueness_op),
+      lazy (generate_morphs_to ~full:false Uniqueness_op) )
+
+  let morphs_to_linearity =
+    ( lazy (generate_morphs_to ~full:true Linearity),
+      lazy (generate_morphs_to ~full:false Linearity) )
+
+  let morphs_to_portability =
+    ( lazy (generate_morphs_to ~full:true Portability),
+      lazy (generate_morphs_to ~full:false Portability) )
+
+  let morphs_to_forkable =
+    ( lazy (generate_morphs_to ~full:true Forkable),
+      lazy (generate_morphs_to ~full:false Forkable) )
+
+  let morphs_to_yielding =
+    ( lazy (generate_morphs_to ~full:true Yielding),
+      lazy (generate_morphs_to ~full:false Yielding) )
+
+  let morphs_to_statefulness =
+    ( lazy (generate_morphs_to ~full:true Statefulness),
+      lazy (generate_morphs_to ~full:false Statefulness) )
+
+  let morphs_to_contention_op =
+    ( lazy (generate_morphs_to ~full:true Contention_op),
+      lazy (generate_morphs_to ~full:false Contention_op) )
+
+  let morphs_to_visibility_op =
+    ( lazy (generate_morphs_to ~full:true Visibility_op),
+      lazy (generate_morphs_to ~full:false Visibility_op) )
+
+  let morphs_to_staticity_op =
+    ( lazy (generate_morphs_to ~full:true Staticity_op),
+      lazy (generate_morphs_to ~full:false Staticity_op) )
+
+  let morphs_to_monadic_op =
+    ( lazy (generate_morphs_to ~full:true Monadic_op),
+      lazy (generate_morphs_to ~full:false Monadic_op) )
+
+  let morphs_to_comonadic_with_locality =
+    ( lazy (generate_morphs_to ~full:true Comonadic_with_locality),
+      lazy (generate_morphs_to ~full:false Comonadic_with_locality) )
+
+  let morphs_to_comonadic_with_regionality =
+    ( lazy (generate_morphs_to ~full:true Comonadic_with_regionality),
+      lazy (generate_morphs_to ~full:false Comonadic_with_regionality) )
+
+  let morphs_to : type b. full:bool -> b obj -> b packed_morph_to list =
+   fun ~full -> function
+    | Locality -> force_by_coverage ~full morphs_to_locality
+    | Regionality -> force_by_coverage ~full morphs_to_regionality
+    | Uniqueness_op -> force_by_coverage ~full morphs_to_uniqueness_op
+    | Linearity -> force_by_coverage ~full morphs_to_linearity
+    | Portability -> force_by_coverage ~full morphs_to_portability
+    | Forkable -> force_by_coverage ~full morphs_to_forkable
+    | Yielding -> force_by_coverage ~full morphs_to_yielding
+    | Statefulness -> force_by_coverage ~full morphs_to_statefulness
+    | Contention_op -> force_by_coverage ~full morphs_to_contention_op
+    | Visibility_op -> force_by_coverage ~full morphs_to_visibility_op
+    | Staticity_op -> force_by_coverage ~full morphs_to_staticity_op
+    | Monadic_op -> force_by_coverage ~full morphs_to_monadic_op
+    | Comonadic_with_locality ->
+      force_by_coverage ~full morphs_to_comonadic_with_locality
+    | Comonadic_with_regionality ->
+      force_by_coverage ~full morphs_to_comonadic_with_regionality
+
   module For_hint = struct
     (** Describes the portion of the input that's responsible for a portion of
         the output of a morphism *)
@@ -3747,474 +4173,19 @@ end
 module For_testing = struct
   open Lattices_mono
 
-  type packed_obj = Obj : 'a obj -> packed_obj
-
-  let all_objs =
-    lazy
-      [ Obj Locality;
-        Obj Regionality;
-        Obj Uniqueness_op;
-        Obj Linearity;
-        Obj Portability;
-        Obj Forkable;
-        Obj Yielding;
-        Obj Statefulness;
-        Obj Contention_op;
-        Obj Visibility_op;
-        Obj Staticity_op;
-        Obj Monadic_op;
-        Obj Comonadic_with_locality;
-        Obj Comonadic_with_regionality ]
-
   let ( let* ) xs f = List.concat_map f xs
 
   let ( let+ ) xs f = List.map f xs
 
-  let values_for_check_locality = lazy [Locality.Global; Locality.Local]
-
-  let values_for_check_regionality =
-    lazy [Regionality.Global; Regionality.Regional; Regionality.Local]
-
-  let values_for_check_uniqueness_op =
-    lazy [Uniqueness.Unique; Uniqueness.Aliased]
-
-  let values_for_check_linearity = lazy [Linearity.Many; Linearity.Once]
-
-  let values_for_check_portability =
-    lazy
-      [ Portability.Portable;
-        Portability.Shareable;
-        Portability.Corruptible;
-        Portability.Nonportable ]
-
-  let values_for_check_forkable = lazy [Forkable.Forkable; Forkable.Unforkable]
-
-  let values_for_check_yielding = lazy [Yielding.Unyielding; Yielding.Yielding]
-
-  let values_for_check_statefulness =
-    lazy
-      [ Statefulness.Stateless;
-        Statefulness.Writing;
-        Statefulness.Reading;
-        Statefulness.Stateful ]
-
-  let values_for_check_contention_op =
-    lazy
-      [ Contention.Uncontended;
-        Contention.Corrupted;
-        Contention.Shared;
-        Contention.Contended ]
-
-  let values_for_check_visibility_op =
-    lazy
-      [ Visibility.Read_write;
-        Visibility.Read;
-        Visibility.Write;
-        Visibility.Immutable ]
-
-  let values_for_check_staticity_op = lazy [Staticity.Static; Staticity.Dynamic]
-
-  let values_for_check_monadic_op =
-    lazy
-      (let values_for_check_uniqueness_op =
-         Lazy.force values_for_check_uniqueness_op
-       in
-       let values_for_check_contention_op =
-         Lazy.force values_for_check_contention_op
-       in
-       let values_for_check_visibility_op =
-         Lazy.force values_for_check_visibility_op
-       in
-       let values_for_check_staticity_op =
-         Lazy.force values_for_check_staticity_op
-       in
-       let with_base base =
-         List.concat
-           [ List.map
-               (fun uniqueness -> { base with uniqueness })
-               values_for_check_uniqueness_op;
-             List.map
-               (fun contention -> { base with contention })
-               values_for_check_contention_op;
-             List.map
-               (fun visibility -> { base with visibility })
-               values_for_check_visibility_op;
-             List.map
-               (fun staticity -> { base with staticity })
-               values_for_check_staticity_op ]
-       in
-       with_base Monadic_op.min @ with_base Monadic_op.max)
-
-  let values_for_check_comonadic_with_locality =
-    lazy
-      (let values_for_check_locality = Lazy.force values_for_check_locality in
-       let values_for_check_linearity = Lazy.force values_for_check_linearity in
-       let values_for_check_portability =
-         Lazy.force values_for_check_portability
-       in
-       let values_for_check_forkable = Lazy.force values_for_check_forkable in
-       let values_for_check_yielding = Lazy.force values_for_check_yielding in
-       let values_for_check_statefulness =
-         Lazy.force values_for_check_statefulness
-       in
-       let with_base base =
-         List.concat
-           [ List.map
-               (fun areality -> { base with areality })
-               values_for_check_locality;
-             List.map
-               (fun linearity -> { base with linearity })
-               values_for_check_linearity;
-             List.map
-               (fun portability -> { base with portability })
-               values_for_check_portability;
-             List.map
-               (fun forkable -> { base with forkable })
-               values_for_check_forkable;
-             List.map
-               (fun yielding -> { base with yielding })
-               values_for_check_yielding;
-             List.map
-               (fun statefulness -> { base with statefulness })
-               values_for_check_statefulness ]
-       in
-       with_base Comonadic_with_locality.min
-       @ with_base Comonadic_with_locality.max)
-
-  let values_for_check_comonadic_with_regionality =
-    lazy
-      (let values_for_check_regionality =
-         Lazy.force values_for_check_regionality
-       in
-       let values_for_check_linearity = Lazy.force values_for_check_linearity in
-       let values_for_check_portability =
-         Lazy.force values_for_check_portability
-       in
-       let values_for_check_forkable = Lazy.force values_for_check_forkable in
-       let values_for_check_yielding = Lazy.force values_for_check_yielding in
-       let values_for_check_statefulness =
-         Lazy.force values_for_check_statefulness
-       in
-       let with_base base =
-         List.concat
-           [ List.map
-               (fun areality -> { base with areality })
-               values_for_check_regionality;
-             List.map
-               (fun linearity -> { base with linearity })
-               values_for_check_linearity;
-             List.map
-               (fun portability -> { base with portability })
-               values_for_check_portability;
-             List.map
-               (fun forkable -> { base with forkable })
-               values_for_check_forkable;
-             List.map
-               (fun yielding -> { base with yielding })
-               values_for_check_yielding;
-             List.map
-               (fun statefulness -> { base with statefulness })
-               values_for_check_statefulness ]
-       in
-       with_base Comonadic_with_regionality.min
-       @ with_base Comonadic_with_regionality.max)
-
-  let all_values_for_check : type a. a obj -> a list = function
-    | Locality -> Lazy.force values_for_check_locality
-    | Regionality -> Lazy.force values_for_check_regionality
-    | Uniqueness_op -> Lazy.force values_for_check_uniqueness_op
-    | Linearity -> Lazy.force values_for_check_linearity
-    | Portability -> Lazy.force values_for_check_portability
-    | Forkable -> Lazy.force values_for_check_forkable
-    | Yielding -> Lazy.force values_for_check_yielding
-    | Statefulness -> Lazy.force values_for_check_statefulness
-    | Contention_op -> Lazy.force values_for_check_contention_op
-    | Visibility_op -> Lazy.force values_for_check_visibility_op
-    | Staticity_op -> Lazy.force values_for_check_staticity_op
-    | Monadic_op -> Lazy.force values_for_check_monadic_op
-    | Comonadic_with_locality ->
-      Lazy.force values_for_check_comonadic_with_locality
-    | Comonadic_with_regionality ->
-      Lazy.force values_for_check_comonadic_with_regionality
-
-  type 'a packed_axis = Axis : ('a, 'b) Axis.t -> 'a packed_axis
-
-  let axes : type a. a obj -> a packed_axis list = function
-    | Comonadic_with_locality ->
-      [ Axis Areality;
-        Axis Forkable;
-        Axis Yielding;
-        Axis Linearity;
-        Axis Statefulness;
-        Axis Portability ]
-    | Comonadic_with_regionality ->
-      [ Axis Areality;
-        Axis Forkable;
-        Axis Yielding;
-        Axis Linearity;
-        Axis Statefulness;
-        Axis Portability ]
-    | Monadic_op ->
-      [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
-    | Locality | Regionality | Uniqueness_op | Linearity | Portability
-    | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
-    | Staticity_op ->
-      []
-
-  type ('b, 'd) packed_core_to =
-    | Core_to : 'a obj * ('a, 'b, 'd) Core_morph.t -> ('b, 'd) packed_core_to
-
-  let core_to : type a b d. (a, b, d) Core_morph.t -> (b, d) packed_core_to =
-   fun m -> Core_to (Core_morph.src m, m)
-
-  let left_cores_to : type b. b obj -> (b, left_only) packed_core_to list =
-    function
-    | Locality -> [core_to (Locality_restricted Regional_to_local)]
-    | Regionality ->
-      [ core_to (Locality_restricted Local_to_regional);
-        core_to (Locality_restricted Locality_as_regionality);
-        core_to (Locality_restricted Local_to_regional_regionality);
-        core_to (Locality_restricted Regional_to_local_regionality) ]
-    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
-    | Linearity -> [core_to Uniqueness_op_to_linearity]
-    | Portability -> [core_to Contention_op_to_portability]
-    | Forkable -> []
-    | Yielding -> []
-    | Statefulness -> [core_to Visibility_op_to_statefulness]
-    | Contention_op -> [core_to Portability_to_contention_op]
-    | Visibility_op -> [core_to Statefulness_to_visibility_op]
-    | Staticity_op -> []
-    | Monadic_op ->
-      [ core_to (Comonadic_to_monadic_min Locality);
-        core_to (Comonadic_to_monadic_min Regionality) ]
-    | Comonadic_with_locality ->
-      [ core_to (Locality_full Regional_to_local);
-        core_to Monadic_to_comonadic_min ]
-    | Comonadic_with_regionality ->
-      [ core_to (Locality_full Local_to_regional);
-        core_to (Locality_full Locality_as_regionality);
-        core_to (Locality_full Local_to_regional_regionality);
-        core_to (Locality_full Regional_to_local_regionality);
-        core_to Monadic_to_comonadic_min ]
-
-  let right_cores_to : type b. b obj -> (b, right_only) packed_core_to list =
-    function
-    | Locality ->
-      [ core_to (Locality_restricted Regional_to_local);
-        core_to (Locality_restricted Regional_to_global) ]
-    | Regionality ->
-      [ core_to (Locality_restricted Locality_as_regionality);
-        core_to (Locality_restricted Regional_to_local_regionality);
-        core_to (Locality_restricted Regional_to_global_regionality) ]
-    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
-    | Linearity -> [core_to Uniqueness_op_to_linearity]
-    | Portability -> [core_to Contention_op_to_portability]
-    | Forkable -> []
-    | Yielding -> []
-    | Statefulness -> [core_to Visibility_op_to_statefulness]
-    | Contention_op -> [core_to Portability_to_contention_op]
-    | Visibility_op -> [core_to Statefulness_to_visibility_op]
-    | Staticity_op -> []
-    | Monadic_op ->
-      [ core_to (Comonadic_to_monadic_max Locality);
-        core_to (Comonadic_to_monadic_max Regionality) ]
-    | Comonadic_with_locality ->
-      [ core_to (Locality_full Regional_to_local);
-        core_to (Locality_full Regional_to_global);
-        core_to Monadic_to_comonadic_max ]
-    | Comonadic_with_regionality ->
-      [ core_to (Locality_full Locality_as_regionality);
-        core_to (Locality_full Regional_to_local_regionality);
-        core_to (Locality_full Regional_to_global_regionality);
-        core_to Monadic_to_comonadic_max ]
-
-  type ('b, 'd) packed_simple_to =
-    | Simple_to :
-        'a obj * ('a, 'b, 'd) Simple_morph.t
-        -> ('b, 'd) packed_simple_to
-
-  let simple_to : type a b d.
-      b obj -> (a, b, d) Simple_morph.t -> (b, d) packed_simple_to =
-   fun dst m -> Simple_to (Simple_morph.src dst m, m)
-
-  let simple_left_to : type b. b obj -> (b, left_only) packed_simple_to list =
-   fun dst ->
-    let constants =
-      List.map
-        (fun c -> simple_to dst (Simple_morph.Meet_const c))
-        (all_values_for_check dst)
-    in
-    let cores = left_cores_to dst in
-    let core_morphs =
-      List.map
-        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
-        cores
-    in
-    let meet_const_cores =
-      let* c = all_values_for_check dst in
-      let+ (Core_to (_, m)) = cores in
-      simple_to dst (Simple_morph.Meet_const_core (c, m))
-    in
-    (simple_to dst Id :: core_morphs) @ constants @ meet_const_cores
-
-  let simple_right_to : type b. b obj -> (b, right_only) packed_simple_to list =
-   fun dst ->
-    let constants =
-      List.map
-        (fun c -> simple_to dst (Simple_morph.Imply_const c))
-        (all_values_for_check dst)
-    in
-    let cores = right_cores_to dst in
-    let core_morphs =
-      List.map
-        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
-        cores
-    in
-    let core_imply_consts =
-      let* (Core_to (src, m)) = cores in
-      let+ c = all_values_for_check src in
-      simple_to dst (Simple_morph.Core_imply_const (m, c))
-    in
-    (simple_to dst Id :: core_morphs) @ constants @ core_imply_consts
-
-  let filter_simple_src : type a b d.
-      a obj -> (b, d) packed_simple_to list -> (a, b, d) Simple_morph.t list =
-   fun src simple_morphs ->
-    let filter : (b, d) packed_simple_to -> (a, b, d) Simple_morph.t option =
-     fun (Simple_to (src', m)) ->
-      match equal_obj src src' with
-      | Misc.Is_eq -> Some m
-      | Misc.Is_not_eq -> None
-    in
-    List.filter_map filter simple_morphs
-
-  let simple_left_from_to src dst = filter_simple_src src (simple_left_to dst)
-
-  let simple_right_from_to src dst = filter_simple_src src (simple_right_to dst)
-
-  type 'b packed_morph_to =
-    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
-
-  let left_morph_to : type a b.
-      a obj -> (a, b, left_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_left morph)
-
-  let right_morph_to : type a b.
-      a obj -> (a, b, right_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_right morph)
-
-  let generate_left_morphs_to : type b. b obj -> b packed_morph_to list =
-   fun dst ->
-    let simple_morphs =
-      List.map
-        (fun (Simple_to (src, m)) -> left_morph_to src (Simple m))
-        (simple_left_to dst)
-    in
-    let projections =
-      let* (Obj src) = Lazy.force all_objs in
-      let* (Axis ax) = axes src in
-      let projected = proj_obj ax src in
-      let+ m = simple_left_from_to projected dst in
-      left_morph_to src (Simple_proj (m, ax, src))
-    in
-    let min_with =
-      let* (Axis ax) = axes dst in
-      let projected = proj_obj ax dst in
-      let+ (Simple_to (src, m)) = simple_left_to projected in
-      left_morph_to src (Min_with_simple (ax, m))
-    in
-    let const_min =
-      List.map
-        (fun (Obj src) -> left_morph_to src (Const_min src))
-        (Lazy.force all_objs)
-    in
-    simple_morphs @ projections @ min_with @ const_min
-
-  let generate_right_morphs_to : type b. b obj -> b packed_morph_to list =
-   fun dst ->
-    let simple_morphs =
-      List.map
-        (fun (Simple_to (src, m)) -> right_morph_to src (Simple m))
-        (simple_right_to dst)
-    in
-    let projections =
-      let* (Obj src) = Lazy.force all_objs in
-      let* (Axis ax) = axes src in
-      let projected = proj_obj ax src in
-      let+ m = simple_right_from_to projected dst in
-      right_morph_to src (Simple_proj (m, ax, src))
-    in
-    let max_with =
-      let* (Axis ax) = axes dst in
-      let projected = proj_obj ax dst in
-      let+ (Simple_to (src, m)) = simple_right_to projected in
-      right_morph_to src (Max_with_simple (ax, m))
-    in
-    let const_max =
-      List.map
-        (fun (Obj src) -> right_morph_to src (Const_max src))
-        (Lazy.force all_objs)
-    in
-    simple_morphs @ projections @ max_with @ const_max
-
-  let generate_morphs_to dst =
-    generate_left_morphs_to dst @ generate_right_morphs_to dst
-
-  let morphs_to_locality = lazy (generate_morphs_to Locality)
-
-  let morphs_to_regionality = lazy (generate_morphs_to Regionality)
-
-  let morphs_to_uniqueness_op = lazy (generate_morphs_to Uniqueness_op)
-
-  let morphs_to_linearity = lazy (generate_morphs_to Linearity)
-
-  let morphs_to_portability = lazy (generate_morphs_to Portability)
-
-  let morphs_to_forkable = lazy (generate_morphs_to Forkable)
-
-  let morphs_to_yielding = lazy (generate_morphs_to Yielding)
-
-  let morphs_to_statefulness = lazy (generate_morphs_to Statefulness)
-
-  let morphs_to_contention_op = lazy (generate_morphs_to Contention_op)
-
-  let morphs_to_visibility_op = lazy (generate_morphs_to Visibility_op)
-
-  let morphs_to_staticity_op = lazy (generate_morphs_to Staticity_op)
-
-  let morphs_to_monadic_op = lazy (generate_morphs_to Monadic_op)
-
-  let morphs_to_comonadic_with_locality =
-    lazy (generate_morphs_to Comonadic_with_locality)
-
-  let morphs_to_comonadic_with_regionality =
-    lazy (generate_morphs_to Comonadic_with_regionality)
-
-  let morphs_to : type b. b obj -> b packed_morph_to list = function
-    | Locality -> Lazy.force morphs_to_locality
-    | Regionality -> Lazy.force morphs_to_regionality
-    | Uniqueness_op -> Lazy.force morphs_to_uniqueness_op
-    | Linearity -> Lazy.force morphs_to_linearity
-    | Portability -> Lazy.force morphs_to_portability
-    | Forkable -> Lazy.force morphs_to_forkable
-    | Yielding -> Lazy.force morphs_to_yielding
-    | Statefulness -> Lazy.force morphs_to_statefulness
-    | Contention_op -> Lazy.force morphs_to_contention_op
-    | Visibility_op -> Lazy.force morphs_to_visibility_op
-    | Staticity_op -> Lazy.force morphs_to_staticity_op
-    | Monadic_op -> Lazy.force morphs_to_monadic_op
-    | Comonadic_with_locality -> Lazy.force morphs_to_comonadic_with_locality
-    | Comonadic_with_regionality ->
-      Lazy.force morphs_to_comonadic_with_regionality
-
   let check_compose : type a b c.
+      full:bool ->
       a obj ->
       b obj ->
       c obj ->
       (b, c, neither) morph ->
       (a, b, neither) morph ->
       unit =
-   fun src mid dst f g ->
+   fun ~full src mid dst f g ->
     let result = compose dst f g in
     List.iter
       (fun input ->
@@ -4239,21 +4210,21 @@ module For_testing = struct
               (print dst) expected (print dst) actual
           in
           failwith msg)
-      (all_values_for_check src)
+      (get_elements ~full src)
 
   let run_jobs jobs = List.iter (fun job -> job ()) jobs
 
-  let check_jobs () =
-    let* (Obj dst) = Lazy.force all_objs in
-    let+ (Morph_to (mid, f)) = morphs_to dst in
-    let morphs_to_mid = morphs_to mid in
+  let check_jobs ~full () =
+    let* (Obj dst) = all_objs in
+    let+ (Morph_to (mid, f)) = morphs_to ~full dst in
+    let morphs_to_mid = morphs_to ~full mid in
     fun () ->
       List.iter
-        (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
+        (fun (Morph_to (src, g)) -> check_compose ~full src mid dst f g)
         morphs_to_mid
 
-  let check_all_allowed_compositions () =
-    let jobs = check_jobs () in
+  let check_all_allowed_compositions ~full () =
+    let jobs = check_jobs ~full () in
     Printf.printf "running allowed composition checks\n%!";
     run_jobs jobs
 end

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1357,6 +1357,23 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.print
     | Comonadic_with_regionality -> Comonadic_with_regionality.print
 
+  (* Returns an arbitrary element of a given object *)
+  let arbitrary : type a. a obj -> a = function
+    | Locality -> Locality.min
+    | Regionality -> Regionality.min
+    | Uniqueness_op -> Uniqueness_op.min
+    | Contention_op -> Contention_op.min
+    | Visibility_op -> Visibility_op.min
+    | Linearity -> Linearity.min
+    | Portability -> Portability.min
+    | Forkable -> Forkable.min
+    | Yielding -> Yielding.min
+    | Statefulness -> Statefulness.min
+    | Staticity_op -> Staticity_op.min
+    | Monadic_op -> Monadic_op.min
+    | Comonadic_with_locality -> Comonadic_with_locality.min
+    | Comonadic_with_regionality -> Comonadic_with_regionality.min
+
   let compare_obj : type a b. a obj -> b obj -> int =
    fun a b ->
     match a, b with
@@ -3349,14 +3366,14 @@ module Lattices_mono = struct
         | Core m ->
           Core_morph.lift_max src dst m ax0 ax1 |> lift_core_compose_result_r
         | Imply_const c ->
-          let c = Axis.set ax1 c (max dst) in
+          let c = Axis.set ax1 c (arbitrary dst) in
           let m =
             Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
           in
           compose dst (Imply_const c) m
         | Core_imply_const (m, c) ->
           let m = lift_max src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax0 c (max src) in
+          let c = Axis.set ax0 c (arbitrary src) in
           compose dst m (Imply_const c)
       in
       let q_obj = proj_obj ax1 dst in
@@ -3378,14 +3395,14 @@ module Lattices_mono = struct
         | Core m ->
           Core_morph.lift_min src dst m ax0 ax1 |> lift_core_compose_result_l
         | Meet_const c ->
-          let c = Axis.set ax1 c (min dst) in
+          let c = Axis.set ax1 c (arbitrary dst) in
           let m =
             Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
           in
           compose dst (Meet_const c) m
         | Meet_const_core (c, m) ->
           let m = lift_min src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax1 c (min dst) in
+          let c = Axis.set ax1 c (arbitrary dst) in
           compose dst (Meet_const c) m
       in
       let q_obj = proj_obj ax1 dst in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5337,7 +5337,7 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let copy_generic ~copy_scope a =
     let copy_from_level = generic_level in
-    let copy_to_level = Stdlib.max_int in
+    let copy_to_level = generic_level in
     S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
 
   let duplicate ~copy_scope a =
@@ -5506,7 +5506,7 @@ module Monadic_gen (Obj : Obj) = struct
 
   let copy_generic ~copy_scope a =
     let copy_from_level = generic_level in
-    let copy_to_level = Stdlib.max_int in
+    let copy_to_level = generic_level in
     S.copy ~copy_scope ~copy_from_level ~copy_to_level obj a
 
   let duplicate ~copy_scope a =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3750,147 +3750,192 @@ module For_testing = struct
   type packed_obj = Obj : 'a obj -> packed_obj
 
   let all_objs =
-    [ Obj Locality;
-      Obj Regionality;
-      Obj Uniqueness_op;
-      Obj Linearity;
-      Obj Portability;
-      Obj Forkable;
-      Obj Yielding;
-      Obj Statefulness;
-      Obj Contention_op;
-      Obj Visibility_op;
-      Obj Staticity_op;
-      Obj Monadic_op;
-      Obj Comonadic_with_locality;
-      Obj Comonadic_with_regionality ]
+    lazy
+      [ Obj Locality;
+        Obj Regionality;
+        Obj Uniqueness_op;
+        Obj Linearity;
+        Obj Portability;
+        Obj Forkable;
+        Obj Yielding;
+        Obj Statefulness;
+        Obj Contention_op;
+        Obj Visibility_op;
+        Obj Staticity_op;
+        Obj Monadic_op;
+        Obj Comonadic_with_locality;
+        Obj Comonadic_with_regionality ]
 
   let ( let* ) xs f = List.concat_map f xs
 
   let ( let+ ) xs f = List.map f xs
 
-  let values_for_check_locality = [Locality.Global; Locality.Local]
+  let values_for_check_locality = lazy [Locality.Global; Locality.Local]
 
   let values_for_check_regionality =
-    [Regionality.Global; Regionality.Regional; Regionality.Local]
+    lazy [Regionality.Global; Regionality.Regional; Regionality.Local]
 
-  let values_for_check_uniqueness_op = [Uniqueness.Unique; Uniqueness.Aliased]
+  let values_for_check_uniqueness_op =
+    lazy [Uniqueness.Unique; Uniqueness.Aliased]
 
-  let values_for_check_linearity = [Linearity.Many; Linearity.Once]
+  let values_for_check_linearity = lazy [Linearity.Many; Linearity.Once]
 
   let values_for_check_portability =
-    [ Portability.Portable;
-      Portability.Shareable;
-      Portability.Corruptible;
-      Portability.Nonportable ]
+    lazy
+      [ Portability.Portable;
+        Portability.Shareable;
+        Portability.Corruptible;
+        Portability.Nonportable ]
 
-  let values_for_check_forkable = [Forkable.Forkable; Forkable.Unforkable]
+  let values_for_check_forkable = lazy [Forkable.Forkable; Forkable.Unforkable]
 
-  let values_for_check_yielding = [Yielding.Unyielding; Yielding.Yielding]
+  let values_for_check_yielding = lazy [Yielding.Unyielding; Yielding.Yielding]
 
   let values_for_check_statefulness =
-    [ Statefulness.Stateless;
-      Statefulness.Writing;
-      Statefulness.Reading;
-      Statefulness.Stateful ]
+    lazy
+      [ Statefulness.Stateless;
+        Statefulness.Writing;
+        Statefulness.Reading;
+        Statefulness.Stateful ]
 
   let values_for_check_contention_op =
-    [ Contention.Uncontended;
-      Contention.Corrupted;
-      Contention.Shared;
-      Contention.Contended ]
+    lazy
+      [ Contention.Uncontended;
+        Contention.Corrupted;
+        Contention.Shared;
+        Contention.Contended ]
 
   let values_for_check_visibility_op =
-    [ Visibility.Read_write;
-      Visibility.Read;
-      Visibility.Write;
-      Visibility.Immutable ]
+    lazy
+      [ Visibility.Read_write;
+        Visibility.Read;
+        Visibility.Write;
+        Visibility.Immutable ]
 
-  let values_for_check_staticity_op = [Staticity.Static; Staticity.Dynamic]
+  let values_for_check_staticity_op = lazy [Staticity.Static; Staticity.Dynamic]
 
   let values_for_check_monadic_op =
-    let with_base base =
-      List.concat
-        [ List.map
-            (fun uniqueness -> { base with uniqueness })
-            values_for_check_uniqueness_op;
-          List.map
-            (fun contention -> { base with contention })
-            values_for_check_contention_op;
-          List.map
-            (fun visibility -> { base with visibility })
-            values_for_check_visibility_op;
-          List.map
-            (fun staticity -> { base with staticity })
-            values_for_check_staticity_op ]
-    in
-    with_base Monadic_op.min @ with_base Monadic_op.max
+    lazy
+      (let values_for_check_uniqueness_op =
+         Lazy.force values_for_check_uniqueness_op
+       in
+       let values_for_check_contention_op =
+         Lazy.force values_for_check_contention_op
+       in
+       let values_for_check_visibility_op =
+         Lazy.force values_for_check_visibility_op
+       in
+       let values_for_check_staticity_op =
+         Lazy.force values_for_check_staticity_op
+       in
+       let with_base base =
+         List.concat
+           [ List.map
+               (fun uniqueness -> { base with uniqueness })
+               values_for_check_uniqueness_op;
+             List.map
+               (fun contention -> { base with contention })
+               values_for_check_contention_op;
+             List.map
+               (fun visibility -> { base with visibility })
+               values_for_check_visibility_op;
+             List.map
+               (fun staticity -> { base with staticity })
+               values_for_check_staticity_op ]
+       in
+       with_base Monadic_op.min @ with_base Monadic_op.max)
 
   let values_for_check_comonadic_with_locality =
-    let with_base base =
-      List.concat
-        [ List.map
-            (fun areality -> { base with areality })
-            values_for_check_locality;
-          List.map
-            (fun linearity -> { base with linearity })
-            values_for_check_linearity;
-          List.map
-            (fun portability -> { base with portability })
-            values_for_check_portability;
-          List.map
-            (fun forkable -> { base with forkable })
-            values_for_check_forkable;
-          List.map
-            (fun yielding -> { base with yielding })
-            values_for_check_yielding;
-          List.map
-            (fun statefulness -> { base with statefulness })
-            values_for_check_statefulness ]
-    in
-    with_base Comonadic_with_locality.min
-    @ with_base Comonadic_with_locality.max
+    lazy
+      (let values_for_check_locality = Lazy.force values_for_check_locality in
+       let values_for_check_linearity = Lazy.force values_for_check_linearity in
+       let values_for_check_portability =
+         Lazy.force values_for_check_portability
+       in
+       let values_for_check_forkable = Lazy.force values_for_check_forkable in
+       let values_for_check_yielding = Lazy.force values_for_check_yielding in
+       let values_for_check_statefulness =
+         Lazy.force values_for_check_statefulness
+       in
+       let with_base base =
+         List.concat
+           [ List.map
+               (fun areality -> { base with areality })
+               values_for_check_locality;
+             List.map
+               (fun linearity -> { base with linearity })
+               values_for_check_linearity;
+             List.map
+               (fun portability -> { base with portability })
+               values_for_check_portability;
+             List.map
+               (fun forkable -> { base with forkable })
+               values_for_check_forkable;
+             List.map
+               (fun yielding -> { base with yielding })
+               values_for_check_yielding;
+             List.map
+               (fun statefulness -> { base with statefulness })
+               values_for_check_statefulness ]
+       in
+       with_base Comonadic_with_locality.min
+       @ with_base Comonadic_with_locality.max)
 
   let values_for_check_comonadic_with_regionality =
-    let with_base base =
-      List.concat
-        [ List.map
-            (fun areality -> { base with areality })
-            values_for_check_regionality;
-          List.map
-            (fun linearity -> { base with linearity })
-            values_for_check_linearity;
-          List.map
-            (fun portability -> { base with portability })
-            values_for_check_portability;
-          List.map
-            (fun forkable -> { base with forkable })
-            values_for_check_forkable;
-          List.map
-            (fun yielding -> { base with yielding })
-            values_for_check_yielding;
-          List.map
-            (fun statefulness -> { base with statefulness })
-            values_for_check_statefulness ]
-    in
-    with_base Comonadic_with_regionality.min
-    @ with_base Comonadic_with_regionality.max
+    lazy
+      (let values_for_check_regionality =
+         Lazy.force values_for_check_regionality
+       in
+       let values_for_check_linearity = Lazy.force values_for_check_linearity in
+       let values_for_check_portability =
+         Lazy.force values_for_check_portability
+       in
+       let values_for_check_forkable = Lazy.force values_for_check_forkable in
+       let values_for_check_yielding = Lazy.force values_for_check_yielding in
+       let values_for_check_statefulness =
+         Lazy.force values_for_check_statefulness
+       in
+       let with_base base =
+         List.concat
+           [ List.map
+               (fun areality -> { base with areality })
+               values_for_check_regionality;
+             List.map
+               (fun linearity -> { base with linearity })
+               values_for_check_linearity;
+             List.map
+               (fun portability -> { base with portability })
+               values_for_check_portability;
+             List.map
+               (fun forkable -> { base with forkable })
+               values_for_check_forkable;
+             List.map
+               (fun yielding -> { base with yielding })
+               values_for_check_yielding;
+             List.map
+               (fun statefulness -> { base with statefulness })
+               values_for_check_statefulness ]
+       in
+       with_base Comonadic_with_regionality.min
+       @ with_base Comonadic_with_regionality.max)
 
   let all_values_for_check : type a. a obj -> a list = function
-    | Locality -> values_for_check_locality
-    | Regionality -> values_for_check_regionality
-    | Uniqueness_op -> values_for_check_uniqueness_op
-    | Linearity -> values_for_check_linearity
-    | Portability -> values_for_check_portability
-    | Forkable -> values_for_check_forkable
-    | Yielding -> values_for_check_yielding
-    | Statefulness -> values_for_check_statefulness
-    | Contention_op -> values_for_check_contention_op
-    | Visibility_op -> values_for_check_visibility_op
-    | Staticity_op -> values_for_check_staticity_op
-    | Monadic_op -> values_for_check_monadic_op
-    | Comonadic_with_locality -> values_for_check_comonadic_with_locality
-    | Comonadic_with_regionality -> values_for_check_comonadic_with_regionality
+    | Locality -> Lazy.force values_for_check_locality
+    | Regionality -> Lazy.force values_for_check_regionality
+    | Uniqueness_op -> Lazy.force values_for_check_uniqueness_op
+    | Linearity -> Lazy.force values_for_check_linearity
+    | Portability -> Lazy.force values_for_check_portability
+    | Forkable -> Lazy.force values_for_check_forkable
+    | Yielding -> Lazy.force values_for_check_yielding
+    | Statefulness -> Lazy.force values_for_check_statefulness
+    | Contention_op -> Lazy.force values_for_check_contention_op
+    | Visibility_op -> Lazy.force values_for_check_visibility_op
+    | Staticity_op -> Lazy.force values_for_check_staticity_op
+    | Monadic_op -> Lazy.force values_for_check_monadic_op
+    | Comonadic_with_locality ->
+      Lazy.force values_for_check_comonadic_with_locality
+    | Comonadic_with_regionality ->
+      Lazy.force values_for_check_comonadic_with_regionality
 
   type 'a packed_axis = Axis : ('a, 'b) Axis.t -> 'a packed_axis
 
@@ -4066,7 +4111,7 @@ module For_testing = struct
         (simple_left_to dst)
     in
     let projections =
-      let* (Obj src) = all_objs in
+      let* (Obj src) = Lazy.force all_objs in
       let* (Axis ax) = axes src in
       let projected = proj_obj ax src in
       let+ m = simple_left_from_to projected dst in
@@ -4079,7 +4124,9 @@ module For_testing = struct
       left_morph_to src (Min_with_simple (ax, m))
     in
     let const_min =
-      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+      List.map
+        (fun (Obj src) -> left_morph_to src (Const_min src))
+        (Lazy.force all_objs)
     in
     simple_morphs @ projections @ min_with @ const_min
 
@@ -4091,7 +4138,7 @@ module For_testing = struct
         (simple_right_to dst)
     in
     let projections =
-      let* (Obj src) = all_objs in
+      let* (Obj src) = Lazy.force all_objs in
       let* (Axis ax) = axes src in
       let projected = proj_obj ax src in
       let+ m = simple_right_from_to projected dst in
@@ -4104,58 +4151,61 @@ module For_testing = struct
       right_morph_to src (Max_with_simple (ax, m))
     in
     let const_max =
-      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+      List.map
+        (fun (Obj src) -> right_morph_to src (Const_max src))
+        (Lazy.force all_objs)
     in
     simple_morphs @ projections @ max_with @ const_max
 
   let generate_morphs_to dst =
     generate_left_morphs_to dst @ generate_right_morphs_to dst
 
-  let morphs_to_locality = generate_morphs_to Locality
+  let morphs_to_locality = lazy (generate_morphs_to Locality)
 
-  let morphs_to_regionality = generate_morphs_to Regionality
+  let morphs_to_regionality = lazy (generate_morphs_to Regionality)
 
-  let morphs_to_uniqueness_op = generate_morphs_to Uniqueness_op
+  let morphs_to_uniqueness_op = lazy (generate_morphs_to Uniqueness_op)
 
-  let morphs_to_linearity = generate_morphs_to Linearity
+  let morphs_to_linearity = lazy (generate_morphs_to Linearity)
 
-  let morphs_to_portability = generate_morphs_to Portability
+  let morphs_to_portability = lazy (generate_morphs_to Portability)
 
-  let morphs_to_forkable = generate_morphs_to Forkable
+  let morphs_to_forkable = lazy (generate_morphs_to Forkable)
 
-  let morphs_to_yielding = generate_morphs_to Yielding
+  let morphs_to_yielding = lazy (generate_morphs_to Yielding)
 
-  let morphs_to_statefulness = generate_morphs_to Statefulness
+  let morphs_to_statefulness = lazy (generate_morphs_to Statefulness)
 
-  let morphs_to_contention_op = generate_morphs_to Contention_op
+  let morphs_to_contention_op = lazy (generate_morphs_to Contention_op)
 
-  let morphs_to_visibility_op = generate_morphs_to Visibility_op
+  let morphs_to_visibility_op = lazy (generate_morphs_to Visibility_op)
 
-  let morphs_to_staticity_op = generate_morphs_to Staticity_op
+  let morphs_to_staticity_op = lazy (generate_morphs_to Staticity_op)
 
-  let morphs_to_monadic_op = generate_morphs_to Monadic_op
+  let morphs_to_monadic_op = lazy (generate_morphs_to Monadic_op)
 
   let morphs_to_comonadic_with_locality =
-    generate_morphs_to Comonadic_with_locality
+    lazy (generate_morphs_to Comonadic_with_locality)
 
   let morphs_to_comonadic_with_regionality =
-    generate_morphs_to Comonadic_with_regionality
+    lazy (generate_morphs_to Comonadic_with_regionality)
 
   let morphs_to : type b. b obj -> b packed_morph_to list = function
-    | Locality -> morphs_to_locality
-    | Regionality -> morphs_to_regionality
-    | Uniqueness_op -> morphs_to_uniqueness_op
-    | Linearity -> morphs_to_linearity
-    | Portability -> morphs_to_portability
-    | Forkable -> morphs_to_forkable
-    | Yielding -> morphs_to_yielding
-    | Statefulness -> morphs_to_statefulness
-    | Contention_op -> morphs_to_contention_op
-    | Visibility_op -> morphs_to_visibility_op
-    | Staticity_op -> morphs_to_staticity_op
-    | Monadic_op -> morphs_to_monadic_op
-    | Comonadic_with_locality -> morphs_to_comonadic_with_locality
-    | Comonadic_with_regionality -> morphs_to_comonadic_with_regionality
+    | Locality -> Lazy.force morphs_to_locality
+    | Regionality -> Lazy.force morphs_to_regionality
+    | Uniqueness_op -> Lazy.force morphs_to_uniqueness_op
+    | Linearity -> Lazy.force morphs_to_linearity
+    | Portability -> Lazy.force morphs_to_portability
+    | Forkable -> Lazy.force morphs_to_forkable
+    | Yielding -> Lazy.force morphs_to_yielding
+    | Statefulness -> Lazy.force morphs_to_statefulness
+    | Contention_op -> Lazy.force morphs_to_contention_op
+    | Visibility_op -> Lazy.force morphs_to_visibility_op
+    | Staticity_op -> Lazy.force morphs_to_staticity_op
+    | Monadic_op -> Lazy.force morphs_to_monadic_op
+    | Comonadic_with_locality -> Lazy.force morphs_to_comonadic_with_locality
+    | Comonadic_with_regionality ->
+      Lazy.force morphs_to_comonadic_with_regionality
 
   let check_compose : type a b c.
       a obj ->
@@ -4194,7 +4244,7 @@ module For_testing = struct
   let run_jobs jobs = List.iter (fun job -> job ()) jobs
 
   let check_jobs () =
-    let* (Obj dst) = all_objs in
+    let* (Obj dst) = Lazy.force all_objs in
     let+ (Morph_to (mid, f)) = morphs_to dst in
     let morphs_to_mid = morphs_to mid in
     fun () ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2366,8 +2366,8 @@ module Lattices_mono = struct
       apply dst m c
 
     (* Commutes an implication through a morphism from the left, such that:
-       [apply dst m (meet_const c x)] is equivalent to
-       [meet_const (commute_imply_from_left dst m c) (apply dst m x)]
+       [imply_const c (apply dst m x)] is equivalent to
+       [apply dst m (imply_const (commute_imply_from_left dst c m) x)]
     *)
     let commute_imply_from_left : type a b l.
         b obj -> b -> (a, b, l * allowed) t -> a =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5365,9 +5365,15 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let iter_contravariant a iter = S.iter_contravariant obj a iter
 
-  let zap_to_ceil_force m = with_log (S.zap_to_ceil obj m)
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
 
-  let zap_to_floor_force m = with_log (S.zap_to_floor obj m)
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
 
   let zap_to_ceil_exn m =
     if check_level_var m generic_level then raise Cannot_zap_generic;
@@ -5409,6 +5415,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
     let get_floor m = S.get_floor obj m
 
@@ -5422,6 +5430,11 @@ module Comonadic_gen (Obj : Obj) = struct
       let floor = get_floor m in
       let ceil = get_ceil m in
       if C.le obj ceil floor then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj floor c && C.le obj c ceil
   end
 end
 [@@inline]
@@ -5536,9 +5549,15 @@ module Monadic_gen (Obj : Obj) = struct
 
   let iter_contravariant a iter = S.iter_covariant obj a iter
 
-  let zap_to_ceil_force m = with_log (S.zap_to_floor obj m)
+  let zap_to_ceil_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_floor obj m)
+    else S.zap_to_floor ~log:None obj m
 
-  let zap_to_floor_force m = with_log (S.zap_to_ceil obj m)
+  let zap_to_floor_force ?(commit = true) m =
+    if commit
+    then with_log (S.zap_to_ceil obj m)
+    else S.zap_to_ceil ~log:None obj m
 
   let zap_to_ceil_exn m =
     if check_level_var m generic_level then raise Cannot_zap_generic;
@@ -5580,6 +5599,8 @@ module Monadic_gen (Obj : Obj) = struct
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
+  let desc a = S.desc obj a
+
   module Guts = struct
     let get_floor m = S.get_ceil obj m
 
@@ -5589,6 +5610,11 @@ module Monadic_gen (Obj : Obj) = struct
       let floor = get_floor m in
       let ceil = get_ceil m in
       if C.le obj ceil floor then Some ceil else None
+
+    let in_bounds c m =
+      let floor = get_floor m in
+      let ceil = get_ceil m in
+      C.le obj floor c && C.le obj c ceil
   end
 end
 [@@inline]
@@ -5850,7 +5876,8 @@ module type Areality = sig
 
   module Obj : Obj with type const = Const.t
 
-  val zap_to_legacy_force : (Const.t, allowed * 'r) S.mode -> Const.t
+  val zap_to_legacy_force :
+    ?commit:bool -> (Const.t, allowed * 'r) S.mode -> Const.t
 end
 
 module Lattice_Product (L : Lattice) = struct
@@ -5965,18 +5992,23 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy_force m : Const.t =
-    let areality = proj Areality m |> Areality.zap_to_legacy_force in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force in
+  let zap_to_legacy_force ?commit m : Const.t =
+    let areality = proj Areality m |> Areality.zap_to_legacy_force ?commit in
+    let linearity = proj Linearity m |> Linearity.zap_to_legacy_force ?commit in
     let statefulness =
-      proj Statefulness m |> Statefulness.zap_to_legacy_force
+      proj Statefulness m |> Statefulness.zap_to_legacy_force ?commit
     in
     let portability =
-      proj Portability m |> Portability.zap_to_legacy_force ~statefulness
+      proj Portability m
+      |> Portability.zap_to_legacy_force ?commit ~statefulness
     in
     let global = Areality.Const.equal areality Areality.Const.legacy in
-    let forkable = proj Forkable m |> Forkable.zap_to_legacy_force ~global in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy_force ~global in
+    let forkable =
+      proj Forkable m |> Forkable.zap_to_legacy_force ?commit ~global
+    in
+    let yielding =
+      proj Yielding m |> Yielding.zap_to_legacy_force ?commit ~global
+    in
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
@@ -6112,13 +6144,17 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy_force m : Const.t =
-    let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy_force in
-    let visibility = proj Visibility m |> Visibility.zap_to_legacy_force in
-    let contention =
-      proj Contention m |> Contention.zap_to_legacy_force ~visibility
+  let zap_to_legacy_force ?commit m : Const.t =
+    let uniqueness =
+      proj Uniqueness m |> Uniqueness.zap_to_legacy_force ?commit
     in
-    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force in
+    let visibility =
+      proj Visibility m |> Visibility.zap_to_legacy_force ?commit
+    in
+    let contention =
+      proj Contention m |> Contention.zap_to_legacy_force ?commit ~visibility
+    in
+    let staticity = proj Staticity m |> Staticity.zap_to_legacy_force ?commit in
     { uniqueness; contention; visibility; staticity }
 
   let legacy = of_const Const.legacy
@@ -6643,6 +6679,108 @@ module Value_with (Areality : Areality) = struct
     let merge = merge
   end
 
+  module C = C
+  module Desc = S.Desc
+
+  let obj_monadic = Monadic.Obj.obj
+
+  let obj_comonadic = Comonadic.Obj.obj
+
+  let get_monadic_desc m = Monadic.desc m
+
+  let get_comonadic_desc m = Comonadic.desc m
+
+  let meet_const_morph a = C.Simple (C.Simple_morph.Meet_const a)
+
+  let pretty_print_monadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c ->
+      (* only print the interesting parts of the monadic meet; omit max (min due to
+          flipping of Monadic axis) modes *)
+      let c = merge { monadic = c; comonadic = Comonadic.Const.min } in
+      let diff = Const.diff c Const.min in
+      if diff = Const.Option.none
+      then Fmt.fprintf ppf "%a" printm m
+      else Fmt.fprintf ppf "%a . %a" printm m Const.Option.partial_print diff
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_monadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Monadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_monadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_monadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_meet : type a.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      Comonadic.Const.t ->
+      unit =
+   fun printm m ppf c ->
+    (* only print the interesting parts of the meet; omit max modes *)
+    let c = merge { monadic = Monadic.Const.max; comonadic = c } in
+    let diff = Const.diff c Const.max in
+    if diff = Const.Option.none
+    then Fmt.fprintf ppf "%a" printm m
+    else Fmt.fprintf ppf "%a @@@@ %a" printm m Const.Option.partial_print diff
+
+  let pretty_print_comonadic_simple_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.Simple_morph.t ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple_morph.Id -> Fmt.fprintf ppf "%a" printm m
+    | C.Simple_morph.Meet_const c -> pretty_print_comonadic_meet printm m ppf c
+    | C.Simple_morph.Core C.Core_morph.Monadic_to_comonadic_min ->
+      Fmt.fprintf ppf "close(%a)" printm m
+    | C.Simple_morph.Meet_const_core (c, C.Core_morph.Monadic_to_comonadic_min)
+      ->
+      (* since the meet is applied to a monadic_to_comonadic_min, we filter out the
+      comonadic only axes *)
+      let c : Comonadic.Const.t =
+        { c with
+          areality = Areality.Const.max;
+          forkable = Forkable.Const.max;
+          yielding = Yielding.Const.max
+        }
+      in
+      pretty_print_comonadic_meet
+        (fun ppf m -> Fmt.fprintf ppf "close(%a)" printm m)
+        m ppf c
+    | _ ->
+      Fmt.fprintf ppf "%a(%a)" (C.Simple_morph.print obj_comonadic) f printm m
+  [@@warning "-4"]
+
+  let pretty_print_comonadic_morph : type a d f.
+      (Fmt.formatter -> a -> unit) ->
+      a ->
+      Fmt.formatter ->
+      (d, Comonadic.Const.t, f) C.morph ->
+      unit =
+   fun printm m ppf f ->
+    match f with
+    | C.Simple f -> pretty_print_comonadic_simple_morph printm m ppf f
+    | _ -> Fmt.fprintf ppf "%a(%a)" (C.print_morph obj_comonadic) f printm m
+  [@@warning "-4"]
+
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
@@ -6884,9 +7022,9 @@ module Value_with (Areality : Areality) = struct
   let zap_to_ceil m =
     if check_level_var m generic_level then None else Some (zap_to_ceil_force m)
 
-  let zap_to_legacy_force { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy_force monadic in
-    let comonadic = Comonadic.zap_to_legacy_force comonadic in
+  let zap_to_legacy_force ?commit { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy_force ?commit monadic in
+    let comonadic = Comonadic.zap_to_legacy_force ?commit comonadic in
     merge { monadic; comonadic }
 
   let zap_to_legacy_exn m =
@@ -7057,6 +7195,22 @@ module Value_with (Areality : Areality) = struct
       let* monadic = Monadic.Guts.check_const monadic in
       let* comonadic = Comonadic.Guts.check_const comonadic in
       Some (merge { comonadic; monadic })
+
+    let get_legacy { monadic; comonadic } =
+      let monadic = Monadic.zap_to_legacy_force ~commit:false monadic in
+      let comonadic = Comonadic.zap_to_legacy_force ~commit:false comonadic in
+      merge { monadic; comonadic }
+
+    let get_ceil { monadic; comonadic } =
+      let monadic = Monadic.Guts.get_ceil monadic in
+      let comonadic = Comonadic.Guts.get_ceil comonadic in
+      merge { monadic; comonadic }
+
+    let in_bounds c { monadic; comonadic } =
+      let c = split c in
+      let monadic = Monadic.Guts.in_bounds c.monadic monadic in
+      let comonadic = Comonadic.Guts.in_bounds c.comonadic comonadic in
+      monadic && comonadic
   end
 end
 [@@inline]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2392,21 +2392,17 @@ module Lattices_mono = struct
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
      fun dst m c ->
+      let commute_locality_morph : type r s d. (r, s, d) Locality_morph.t -> b =
+        function
+        | Local_to_regional | Regional_to_local | Locality_as_regionality
+        | Regional_to_global | Local_to_regional_regionality
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          (* same explanation as below *)
+          apply dst m c
+      in
       match m with
-      | Locality_restricted Local_to_regional
-      | Locality_restricted Regional_to_local
-      | Locality_restricted Locality_as_regionality
-      | Locality_restricted Regional_to_global
-      | Locality_restricted Local_to_regional_regionality
-      | Locality_restricted Regional_to_local_regionality
-      | Locality_restricted Regional_to_global_regionality
-      | Locality_full Local_to_regional
-      | Locality_full Regional_to_local
-      | Locality_full Locality_as_regionality
-      | Locality_full Regional_to_global
-      | Locality_full Local_to_regional_regionality
-      | Locality_full Regional_to_local_regionality
-      | Locality_full Regional_to_global_regionality
+      | Locality_restricted lm -> commute_locality_morph lm
+      | Locality_full lm -> commute_locality_morph lm
       | Uniqueness_op_to_linearity | Linearity_to_uniqueness_op
       | Contention_op_to_portability | Portability_to_contention_op
       | Visibility_op_to_statefulness | Statefulness_to_visibility_op

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4038,106 +4038,6 @@ module Report = struct
       (Location.Doc.loc ~capitalize_first:false)
       loc
 
-  let print_containing maybe_modality { containing; container } =
-    let container = fst container in
-    match containing with
-    | Tuple ->
-      Fmt.dprintf "is an element of the tuple at %a"
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Record (s, moda) ->
-      Fmt.dprintf "is the field %a%a of the record at %a" Misc.Style.inline_code
-        s maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Array moda ->
-      Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Constructor (s, moda) ->
-      Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
-        Misc.Style.inline_code s maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Structure (x, moda) ->
-      Fmt.dprintf "is %t%a in the structure at %a"
-        (print_structure_item ~capitalize:false x)
-        maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-
-  (** Given a pinpoint and a const, where the pinpoint has been expressed,
-      prints the const to explain the mode on the pinpoint. *)
-  let print_const (type l r) ((_, pp_desc) : pinpoint) ppf :
-      (l * r) const -> unit = function
-    | Unknown -> Misc.fatal_error "Unknown hint should not be printed"
-    | Lazy_allocated_on_heap ->
-      (match pp_desc with
-      | Lazy ->
-        (* if we already said it's a lazy, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "lazy expressions always need"
-      | _ -> Fmt.pp_print_string ppf "it is a lazy expression and thus needs");
-      Fmt.pp_print_string ppf " to be allocated on the heap"
-    | Legacy m ->
-      (match pp_desc, m with
-      | ( (Ident { category = Class; _ } | Class | Structure_item (Class, _)),
-          Class ) ->
-        (* if we already said it's a class, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "classes are always"
-      | _ ->
-        Fmt.fprintf ppf "it is %t and thus always"
-          (print_legacy m ~definite:false ~capitalize:false));
-      Fmt.pp_print_string ppf " at the legacy modes"
-    | Toplevel_expression ->
-      Fmt.pp_print_string ppf "it is a top-level expression"
-    | Tailcall_function ->
-      Fmt.pp_print_string ppf "it is the function in a tail call"
-    | Tailcall_argument ->
-      Fmt.pp_print_string ppf "it is an argument in a tail call"
-    | Mutable_read m ->
-      Fmt.fprintf ppf "its %a is being read" print_mutable_part m
-    | Mutable_write m ->
-      Fmt.fprintf ppf "its %a is being written" print_mutable_part m
-    | Lazy_forced -> (
-      match pp_desc with
-      | Lazy ->
-        (* if we already said it's a lazy, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "it is being forced"
-      | _ -> Fmt.pp_print_string ppf "it is a lazy value being forced")
-    | Function_return ->
-      Fmt.fprintf ppf
-        "it is a function return value.@ Hint: Use exclave_ to return a local \
-         value"
-    | Stack_expression ->
-      Fmt.fprintf ppf "it is %a-allocated" Misc.Style.inline_code "stack_"
-    | Module_allocated_on_heap ->
-      (match pp_desc with
-      | Ident { category = Module; _ }
-      | Functor | Module | Structure
-      | Structure_item (Module, _) ->
-        (* if we already said it's a module, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "modules always need"
-      | _ -> Fmt.pp_print_string ppf "it is a module and thus needs");
-      Fmt.pp_print_string ppf " to be allocated on the heap"
-    | Is_used_in pp ->
-      let print_pp = print_pinpoint pp |> Option.get in
-      Fmt.fprintf ppf "it is used in %t"
-        (print_pp ~definite:false ~capitalize:false)
-    | Always_dynamic x ->
-      Fmt.fprintf ppf "%t are always dynamic" (print_always_dynamic x)
-    | Branching -> Fmt.fprintf ppf "it has branches"
-    | Borrowed _ -> Fmt.fprintf ppf "it is borrowed"
-    | Escape_region reg ->
-      Fmt.fprintf ppf "it escapes %t" (print_region ~capitalize:false reg)
-    | Quoted_computation -> Fmt.fprintf ppf "it is the quote of a computation"
-    | Lpoly_inst ->
-      Fmt.pp_print_string ppf
-        "it is layout-polymorphic and being instantiated here"
-    | Spliced _ -> Fmt.fprintf ppf "it is spliced"
-    | Contained_by c ->
-      let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
-      Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-
   let print_allocation_l : allocation -> Fmt.formatter -> unit =
    fun { txt; loc } ->
     match txt with
@@ -4225,6 +4125,34 @@ module Report = struct
         in
         pr, contained)
 
+  let print_containing maybe_modality { containing; container } =
+    let container = fst container in
+    match containing with
+    | Tuple ->
+      Fmt.dprintf "is an element of the tuple at %a"
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Record (s, moda) ->
+      Fmt.dprintf "is the field %a%a of the record at %a" Misc.Style.inline_code
+        s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Array moda ->
+      Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Constructor (s, moda) ->
+      Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
+        Misc.Style.inline_code s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Structure (x, moda) ->
+      Fmt.dprintf "is %t%a in the structure at %a"
+        (print_structure_item ~capitalize:false x)
+        maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+
   let print_is_contained_by :
       fixpoint:bool -> is_contained_by -> (Fmt.formatter -> unit) * pinpoint =
    fun ~fixpoint { containing; container } ->
@@ -4232,35 +4160,80 @@ module Report = struct
     (* CR-someday zqian: Use the full [container] to improve the printing below.
        E.g., insted of printing "the tuple at XXX", we can print "the tuple
        pattern at XXX" or "the tuple expression at XXX". *)
-    let container = fst container in
-    let pr =
-      match containing with
-      | Tuple ->
-        Fmt.dprintf "is an element of the tuple at %a"
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Record (s, moda) ->
-        Fmt.dprintf "is the field %a%a of the record at %a"
-          Misc.Style.inline_code s maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Array moda ->
-        Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Constructor (s, moda) ->
-        Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
-          Misc.Style.inline_code s maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Structure (x, moda) ->
-        Fmt.dprintf "is %t%a in the structure at %a"
-          (print_structure_item ~capitalize:false x)
-          maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-    in
+    let pr = print_containing maybe_modality { containing; container } in
     pr, pp
+
+  (** Given a pinpoint and a const, where the pinpoint has been expressed,
+      prints the const to explain the mode on the pinpoint. *)
+  let print_const (type l r) ((_, pp_desc) : pinpoint) ppf :
+      (l * r) const -> unit = function
+    | Unknown -> Misc.fatal_error "Unknown hint should not be printed"
+    | Lazy_allocated_on_heap ->
+      (match pp_desc with
+      | Lazy ->
+        (* if we already said it's a lazy, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "lazy expressions always need"
+      | _ -> Fmt.pp_print_string ppf "it is a lazy expression and thus needs");
+      Fmt.pp_print_string ppf " to be allocated on the heap"
+    | Legacy m ->
+      (match pp_desc, m with
+      | ( (Ident { category = Class; _ } | Class | Structure_item (Class, _)),
+          Class ) ->
+        (* if we already said it's a class, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "classes are always"
+      | _ ->
+        Fmt.fprintf ppf "it is %t and thus always"
+          (print_legacy m ~definite:false ~capitalize:false));
+      Fmt.pp_print_string ppf " at the legacy modes"
+    | Toplevel_expression ->
+      Fmt.pp_print_string ppf "it is a top-level expression"
+    | Tailcall_function ->
+      Fmt.pp_print_string ppf "it is the function in a tail call"
+    | Tailcall_argument ->
+      Fmt.pp_print_string ppf "it is an argument in a tail call"
+    | Mutable_read m ->
+      Fmt.fprintf ppf "its %a is being read" print_mutable_part m
+    | Mutable_write m ->
+      Fmt.fprintf ppf "its %a is being written" print_mutable_part m
+    | Lazy_forced -> (
+      match pp_desc with
+      | Lazy ->
+        (* if we already said it's a lazy, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "it is being forced"
+      | _ -> Fmt.pp_print_string ppf "it is a lazy value being forced")
+    | Function_return ->
+      Fmt.fprintf ppf
+        "it is a function return value.@ Hint: Use exclave_ to return a local \
+         value"
+    | Stack_expression ->
+      Fmt.fprintf ppf "it is %a-allocated" Misc.Style.inline_code "stack_"
+    | Module_allocated_on_heap ->
+      (match pp_desc with
+      | Ident { category = Module; _ }
+      | Functor | Module | Structure
+      | Structure_item (Module, _) ->
+        (* if we already said it's a module, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "modules always need"
+      | _ -> Fmt.pp_print_string ppf "it is a module and thus needs");
+      Fmt.pp_print_string ppf " to be allocated on the heap"
+    | Is_used_in pp ->
+      let print_pp = print_pinpoint pp |> Option.get in
+      Fmt.fprintf ppf "it is used in %t"
+        (print_pp ~definite:false ~capitalize:false)
+    | Always_dynamic x ->
+      Fmt.fprintf ppf "%t are always dynamic" (print_always_dynamic x)
+    | Branching -> Fmt.fprintf ppf "it has branches"
+    | Borrowed _ -> Fmt.fprintf ppf "it is borrowed"
+    | Escape_region reg ->
+      Fmt.fprintf ppf "it escapes %t" (print_region ~capitalize:false reg)
+    | Quoted_computation -> Fmt.fprintf ppf "it is the quote of a computation"
+    | Lpoly_inst ->
+      Fmt.pp_print_string ppf
+        "it is layout-polymorphic and being instantiated here"
+    | Spliced _ -> Fmt.fprintf ppf "it is spliced"
+    | Contained_by c ->
+      let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
+      Fmt.fprintf ppf "it %t" (print_containing print_mod c)
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2257,11 +2257,41 @@ module Lattices_mono = struct
         (q, c comonadic_with, disallowed * r) compose_and_max_result =
      fun lm1 ax0 ->
       match ax0 with
-      | Forkable -> And_max_id Forkable
-      | Yielding -> And_max_id Yielding
-      | Linearity -> And_max_id Linearity
-      | Statefulness -> And_max_id Statefulness
-      | Portability -> And_max_id Portability
+      | Forkable -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Forkable)
+      | Yielding -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Yielding)
+      | Linearity -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Linearity)
+      | Statefulness -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Statefulness)
+      | Portability -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Portability)
       | Areality -> And_max_core (Areality, Locality_restricted lm1)
 
     let compose_max_with_simple_core : type b c q r.
@@ -3284,6 +3314,30 @@ module Lattices_mono = struct
       Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
     | Const_max _ -> Const_min dst
 
+  let const_max_or_apply : type a c p r.
+      c obj ->
+      (p, c, disallowed * r) Simple_morph.t ->
+      a obj ->
+      (a, c, disallowed * r) morph =
+   fun dst m obj ->
+    match Simple_morph.maybe_allowed_right m with
+    | Allowed_right _ -> Const_max obj
+    | Not_allowed_right ->
+      let src = Simple_morph.src dst m in
+      Const (obj, Simple_morph.apply dst m (max src))
+
+  let const_min_or_apply : type a c p l.
+      c obj ->
+      (p, c, l * disallowed) Simple_morph.t ->
+      a obj ->
+      (a, c, l * disallowed) morph =
+   fun dst m obj ->
+    match Simple_morph.maybe_allowed_left m with
+    | Allowed_left _ -> Const_min obj
+    | Not_allowed_left ->
+      let src = Simple_morph.src dst m in
+      Const (obj, Simple_morph.apply dst m (min src))
+
   let compose_simple_proj_core : type a c p d.
       c obj ->
       (p, c, d) Simple_morph.t ->
@@ -3294,8 +3348,8 @@ module Lattices_mono = struct
     | Proj_core (m1, ax1, obj1) ->
       Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
     | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
-    | Proj_const_max obj1 -> Const_max obj1
-    | Proj_const_min obj1 -> Const_min obj1
+    | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
+    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
   let compose_simple_proj_meet_const_core : type a c p l.
       c obj ->
@@ -3310,8 +3364,8 @@ module Lattices_mono = struct
         (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
     | Proj_id (ax1, obj1) ->
       Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
-    | Proj_const_max obj1 -> Const_max obj1
-    | Proj_const_min obj1 -> Const_min obj1
+    | Proj_const_max obj1 -> Const (obj1, Simple_morph.apply dst m0 c1)
+    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
   let compose_simple_proj_core_imply_const : type a c p r.
       c obj ->
@@ -3328,8 +3382,8 @@ module Lattices_mono = struct
     | Proj_id (ax1, obj1) ->
       let c1 = Axis.proj ax1 c1 in
       Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
-    | Proj_const_max obj1 -> Const_max obj1
-    | Proj_const_min obj1 -> Const_min obj1
+    | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
+    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
   let compose_simple_proj_with_simple : type a b c p d.
       c obj ->
@@ -3487,7 +3541,7 @@ module Lattices_mono = struct
       | Misc.Is_not_eq ->
         let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
         let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
-        Const_max a_obj
+        const_max_or_apply dst m0 a_obj
       end
     | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
       begin match Axis.equal ax0 ax1 with
@@ -3495,7 +3549,7 @@ module Lattices_mono = struct
       | Misc.Is_not_eq ->
         let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
         let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
-        Const_min a_obj
+        const_min_or_apply dst m0 a_obj
       end
     | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
       ->
@@ -3519,22 +3573,12 @@ module Lattices_mono = struct
         allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
       | Not_allowed_left -> Compose (m0', m1')
       end
-    | Simple m0, Const_max a_obj ->
-      begin match Simple_morph.maybe_allowed_right m0 with
-      | Allowed_right _ -> Const_max a_obj
-      | Not_allowed_right ->
-        let b_obj = Simple_morph.src dst m0 in
-        Const (a_obj, Simple_morph.apply dst m0 (max b_obj))
-      end
-    | Simple m0, Const_min a_obj ->
-      begin match Simple_morph.maybe_allowed_left m0 with
-      | Allowed_left _ -> Const_min a_obj
-      | Not_allowed_left ->
-        let b_obj = Simple_morph.src dst m0 in
-        Const (a_obj, Simple_morph.apply dst m0 (min b_obj))
-      end
-    | Simple_proj (_m0, _ax0, _obj0), Const_max obj1 -> Const_max obj1
-    | Simple_proj (_m0, _ax0, _obj0), Const_min obj1 -> Const_min obj1
+    | Simple m0, Const_max a_obj -> const_max_or_apply dst m0 a_obj
+    | Simple m0, Const_min a_obj -> const_min_or_apply dst m0 a_obj
+    | Simple_proj (m0, _ax0, _obj0), Const_max obj1 ->
+      const_max_or_apply dst m0 obj1
+    | Simple_proj (m0, _ax0, _obj0), Const_min obj1 ->
+      const_min_or_apply dst m0 obj1
     | Min_with_simple (ax0, m0), Const_max obj1 ->
       let q_obj = proj_obj ax0 dst in
       let b_obj = Simple_morph.src q_obj m0 in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1565,6 +1565,26 @@ module Lattices_mono = struct
       | Contention_op -> [Pb (Monadic_op, Contention)]
       | Visibility_op -> [Pb (Monadic_op, Visibility)]
       | Staticity_op -> [Pb (Monadic_op, Staticity)]
+
+    type ('a, 'p) owner =
+      | Monadic : (Monadic_op.t, 'p) t -> (Monadic_op.t, 'p) owner
+      | Comonadic :
+          'ar comonadic_with obj * ('ar comonadic_with, 'p) t
+          -> ('ar comonadic_with, 'p) owner
+
+    let owner : type a p. a obj -> (a, p) t -> (a, p) owner =
+     fun obj ax ->
+      match ax with
+      | Areality -> Comonadic (obj, ax)
+      | Forkable -> Comonadic (obj, ax)
+      | Yielding -> Comonadic (obj, ax)
+      | Linearity -> Comonadic (obj, ax)
+      | Statefulness -> Comonadic (obj, ax)
+      | Portability -> Comonadic (obj, ax)
+      | Uniqueness -> Monadic ax
+      | Visibility -> Monadic ax
+      | Contention -> Monadic ax
+      | Staticity -> Monadic ax
   end
 
   type packed_obj = Obj : 'a obj -> packed_obj
@@ -1888,6 +1908,36 @@ module Lattices_mono = struct
       | Regional_to_global_regionality, Local_to_regional -> Disallowed
       | Regional_to_global_regionality, Local_to_regional_regionality ->
         Disallowed
+
+    let id_with_regional_to_locality : type a b l r.
+        (Regionality.t, Locality.t, l * r) t ->
+        a comonadic_with obj ->
+        b comonadic_with obj ->
+        (a, b, l * r) compose_result =
+     fun regional_to_locality src dst ->
+      match src, dst with
+      | Comonadic_with_regionality, Comonadic_with_locality ->
+        Morph regional_to_locality
+      | Comonadic_with_locality, Comonadic_with_regionality ->
+        Morph Locality_as_regionality
+      | Comonadic_with_regionality, Comonadic_with_regionality -> Id
+      | Comonadic_with_locality, Comonadic_with_locality -> Id
+
+    (** Closest-to-identity morphism between comonadic_with axes, using r2g for
+        regionality-to-locality. *)
+    let id_r2g : type a b.
+        a comonadic_with obj ->
+        b comonadic_with obj ->
+        (a, b, disallowed * allowed) compose_result =
+     fun src dst -> id_with_regional_to_locality Regional_to_global src dst
+
+    (** Closest-to-identity morphism between comonadic_with axes, using r2l for
+        regionality-to-locality. *)
+    let id_r2l : type a b.
+        a comonadic_with obj ->
+        b comonadic_with obj ->
+        (a, b, allowed * disallowed) compose_result =
+     fun src dst -> id_with_regional_to_locality Regional_to_local src dst
   end
 
   module Core_morph = struct
@@ -2543,6 +2593,108 @@ module Lattices_mono = struct
       | _, _ -> .
     [@@warning "-4"]
 
+    type ('a, 'b, 'd) compose_result =
+      | Id : ('a, 'a, 'd) compose_result
+      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) compose_result
+      | Disallowed : ('a, 'b, neither) compose_result
+
+    let lift_locality_compose_result : type a b l r.
+        (a, b, l * r) Locality_morph.compose_result ->
+        (a comonadic_with, b comonadic_with, l * r) compose_result = function
+      | Locality_morph.Id -> Id
+      | Locality_morph.Morph lm -> Morph (Locality_full lm)
+      | Locality_morph.Disallowed -> Disallowed
+
+    (** Closest-to-identity morphism between full product objects, as enforced
+        by the [Axis.t] arguments. Uses r2g for comonadic areality and plain
+        identity for monadic axes. *)
+    let id_r2g : type a b p.
+        a obj ->
+        b obj ->
+        (a, p) Axis.t ->
+        (b, p) Axis.t ->
+        (a, b, disallowed * allowed) compose_result =
+     fun src dst ax0 ax1 ->
+      match Axis.owner src ax0, Axis.owner dst ax1 with
+      | Axis.Monadic _, Axis.Monadic _ -> Id
+      | Axis.Comonadic (src, _), Axis.Comonadic (dst, _) ->
+        Locality_morph.id_r2g src dst |> lift_locality_compose_result
+      | Axis.Monadic _, Axis.Comonadic _ -> .
+      | Axis.Comonadic _, Axis.Monadic _ -> .
+
+    (** Closest-to-identity morphism between full product objects, as enforced
+        by the [Axis.t] arguments. Uses r2l for comonadic areality and plain
+        identity for monadic axes. *)
+    let id_r2l : type a b p.
+        a obj ->
+        b obj ->
+        (a, p) Axis.t ->
+        (b, p) Axis.t ->
+        (a, b, allowed * disallowed) compose_result =
+     fun src dst ax0 ax1 ->
+      match Axis.owner src ax0, Axis.owner dst ax1 with
+      | Axis.Monadic _, Axis.Monadic _ -> Id
+      | Axis.Comonadic (src, _), Axis.Comonadic (dst, _) ->
+        Locality_morph.id_r2l src dst |> lift_locality_compose_result
+      | Axis.Monadic _, Axis.Comonadic _ -> .
+      | Axis.Comonadic _, Axis.Monadic _ -> .
+
+    (** Lift a core morphism between projected axes to a core morphism between
+        the enclosing objects. Goes to max for axes with no dual. *)
+    let lift_max : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, disallowed * allowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, disallowed * allowed) compose_result =
+     fun src dst m ax0 ax1 ->
+      match m, ax0, ax1, src, dst with
+      | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+        Morph Monadic_to_comonadic_max
+      | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+        Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Contention_op_to_portability, Contention, Portability, _, _ ->
+        Morph Monadic_to_comonadic_max
+      | Portability_to_contention_op, Portability, Contention, _, _ ->
+        Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+        Morph Monadic_to_comonadic_max
+      | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+        Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Locality_restricted lm, Areality, Areality, _, _ ->
+        Morph (Locality_full lm)
+      | _, _, _, _, _ -> .
+    [@@warning "-4"]
+
+    (** Lift a core morphism between projected axes to a core morphism between
+        the enclosing objects. Goes to min for axes with no dual. *)
+    let lift_min : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, allowed * disallowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, allowed * disallowed) compose_result =
+     fun src dst m ax0 ax1 ->
+      match m, ax0, ax1, src, dst with
+      | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+        Morph Monadic_to_comonadic_min
+      | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+        Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Contention_op_to_portability, Contention, Portability, _, _ ->
+        Morph Monadic_to_comonadic_min
+      | Portability_to_contention_op, Portability, Contention, _, _ ->
+        Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+        Morph Monadic_to_comonadic_min
+      | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+        Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Locality_restricted lm, Areality, Areality, _, _ ->
+        Morph (Locality_full lm)
+      | _, _, _, _, _ -> .
+    [@@warning "-4"]
+
     type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
     [@@unboxed]
 
@@ -3116,6 +3268,18 @@ module Lattices_mono = struct
       | (Compose _ as m1), m2 -> Compose (m1, m2)
       | _, Compose _ -> .
 
+    let lift_core_compose_result_r : type a b l.
+        (a, b, l * allowed) Core_morph.compose_result -> (a, b, l * allowed) t =
+      function
+      | Core_morph.Id -> Id
+      | Core_morph.Morph m -> Core m
+
+    let lift_core_compose_result_l : type a b r.
+        (a, b, allowed * r) Core_morph.compose_result -> (a, b, allowed * r) t =
+      function
+      | Core_morph.Id -> Id
+      | Core_morph.Morph m -> Core m
+
     let rec lift_max : type a b p q.
         a obj ->
         b obj ->
@@ -3126,51 +3290,15 @@ module Lattices_mono = struct
      fun src dst m ax0 ax1 ->
       let m : (a, b, disallowed * allowed) t =
         match m with
-        | Id ->
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            Core (Locality_full Regional_to_global)
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            Core (Locality_full Locality_as_regionality)
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
-          | Monadic_op, Monadic_op, _, _ -> Id
-          | _, _, _, _ -> .
-          end
+        | Id -> Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
         | Core m ->
-          begin match m, ax0, ax1, src, dst with
-          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
-            Core Monadic_to_comonadic_max
-          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
-            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
-          | Contention_op_to_portability, Contention, Portability, _, _ ->
-            Core Monadic_to_comonadic_max
-          | Portability_to_contention_op, Portability, Contention, _, _ ->
-            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
-          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
-            Core Monadic_to_comonadic_max
-          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
-            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
-          | Locality_restricted lm, Areality, Areality, _, _ ->
-            Core (Locality_full lm)
-          | _, _, _, _, _ -> .
-          end
+          Core_morph.lift_max src dst m ax0 ax1 |> lift_core_compose_result_r
         | Imply_const c ->
           let c = Axis.set ax1 c (max dst) in
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            compose dst (Imply_const c)
-              (Core (Locality_full Regional_to_global))
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            compose dst (Imply_const c)
-              (Core (Locality_full Locality_as_regionality))
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
-            Imply_const c
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
-            Imply_const c
-          | Monadic_op, Monadic_op, _, _ -> Imply_const c
-          | _, _, _, _ -> .
-          end
+          let m =
+            Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
+          in
+          compose dst (Imply_const c) m
         | Core_imply_const (m, c) ->
           let m = lift_max src dst (Core m) ax0 ax1 in
           let c = Axis.set ax0 c (max src) in
@@ -3191,50 +3319,15 @@ module Lattices_mono = struct
      fun src dst m ax0 ax1 ->
       let m : (a, b, allowed * disallowed) t =
         match m with
-        | Id ->
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            Core (Locality_full Regional_to_local)
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            Core (Locality_full Locality_as_regionality)
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
-          | Monadic_op, Monadic_op, _, _ -> Id
-          | _, _, _, _ -> .
-          end
+        | Id -> Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
         | Core m ->
-          begin match m, ax0, ax1, src, dst with
-          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
-            Core Monadic_to_comonadic_min
-          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
-            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
-          | Contention_op_to_portability, Contention, Portability, _, _ ->
-            Core Monadic_to_comonadic_min
-          | Portability_to_contention_op, Portability, Contention, _, _ ->
-            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
-          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
-            Core Monadic_to_comonadic_min
-          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
-            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
-          | Locality_restricted lm, Areality, Areality, _, _ ->
-            Core (Locality_full lm)
-          | _, _, _, _, _ -> .
-          end
+          Core_morph.lift_min src dst m ax0 ax1 |> lift_core_compose_result_l
         | Meet_const c ->
           let c = Axis.set ax1 c (min dst) in
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            compose dst (Meet_const c) (Core (Locality_full Regional_to_local))
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            compose dst (Meet_const c)
-              (Core (Locality_full Locality_as_regionality))
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
-            Meet_const c
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
-            Meet_const c
-          | Monadic_op, Monadic_op, _, _ -> Meet_const c
-          | _, _, _, _ -> .
-          end
+          let m =
+            Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
+          in
+          compose dst (Meet_const c) m
         | Meet_const_core (c, m) ->
           let m = lift_min src dst (Core m) ax0 ax1 in
           let c = Axis.set ax1 c (min dst) in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5284,7 +5284,7 @@ module Comonadic_gen (Obj : Obj) = struct
   let allow_right m = S.allow_right m
 
   let choose_level level =
-    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+    if Language_extension.(is_at_least_mode_poly Beta) then level else 0
 
   let newvar level =
     let level = choose_level level in
@@ -5322,12 +5322,12 @@ module Comonadic_gen (Obj : Obj) = struct
   let update_level i a = with_log (S.update_level i obj a)
 
   let generalize ~current_level a =
-    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    if Language_extension.(is_at_least_mode_poly Alpha)
     then S.generalize ~log:None ~current_level obj a
     else S.generalize_structure ~log:None ~current_level obj a
 
   let generalize_structure ~current_level a =
-    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    if Language_extension.(is_at_least_mode_poly Beta)
     then S.generalize_structure ~log:None ~current_level obj a
 
   let instantiate ~copy_scope ~current_level a =
@@ -5455,7 +5455,7 @@ module Monadic_gen (Obj : Obj) = struct
   let allow_right m = S.allow_left m
 
   let choose_level level =
-    if Language_extension.(is_at_least Mode_polymorphism Beta) then level else 0
+    if Language_extension.(is_at_least_mode_poly Beta) then level else 0
 
   let newvar level =
     let level = choose_level level in
@@ -5491,12 +5491,12 @@ module Monadic_gen (Obj : Obj) = struct
   let update_level i a = S.update_level ~log:None i obj a
 
   let generalize ~current_level a =
-    if Language_extension.(is_at_least Mode_polymorphism Alpha)
+    if Language_extension.(is_at_least_mode_poly Alpha)
     then S.generalize ~log:None ~current_level obj a
     else S.generalize_structure ~log:None ~current_level obj a
 
   let generalize_structure ~current_level a =
-    if Language_extension.(is_at_least Mode_polymorphism Beta)
+    if Language_extension.(is_at_least_mode_poly Beta)
     then S.generalize_structure ~log:None ~current_level obj a
 
   let instantiate ~copy_scope ~current_level a =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1635,13 +1635,7 @@ module Lattices_mono = struct
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
-       further, but we never need the missing operation).
-
-      INVARIANT: each locality morphism below must preserve binary meets:
-        lm(x meet y) == lm(x) meet lm(y). If the invariant is broken,
-        [commute_meet_const_from_right] may no longer be correct (or implementable), and
-        we may need to change [Simple_morph.compose] and add the missing case in
-        [Simple_morph.t] *)
+       further, but we never need the missing operation). *)
     type ('a, 'b, 'd) t =
       | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
           (** Maps local to regional, global to global *)
@@ -1948,11 +1942,6 @@ module Lattices_mono = struct
   end
 
   module Core_morph = struct
-    (* INVARIANT: each core morphism below must preserve binary meets:
-        cm(x meet y) == cm(x) meet cm(y). If the invariant is broken,
-        [commute_meet_const_from_right] may no longer be correct (or implementable), and
-        we may need to change [Simple_morph.compose] and add the missing case in
-        [Simple_morph.t] *)
     type ('a, 'b, 'd) t =
       | Locality_restricted :
           ('a, 'b, 'l * 'r) Locality_morph.t
@@ -2370,20 +2359,49 @@ module Lattices_mono = struct
     (* Commutes a meet through a morphism from the right, such that:
        [apply dst m (meet_const c x)] is equivalent to
        [meet_const (commute_meet_const_from_right dst m c) (apply dst m x)]
+
+       PRECONDITION: All [Core_morph.t] preserves binary meets:
+        m(x meet y) == m(x) meet m(y). Without this precondition,
+        [commute_meet_const_from_right] may no longer be implementable, and
+        we will need to change the implementation of [Simple_morph.compose], as well as
+        add the missing cases in [Simple_morph.t].
     *)
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
      fun dst m c ->
-      (* All morphisms preserve binary meets. The correctness argument
-         thus goes as follows:
+      match m with
+      | Locality_restricted Local_to_regional
+      | Locality_restricted Regional_to_local
+      | Locality_restricted Locality_as_regionality
+      | Locality_restricted Regional_to_global
+      | Locality_restricted Local_to_regional_regionality
+      | Locality_restricted Regional_to_local_regionality
+      | Locality_restricted Regional_to_global_regionality
+      | Locality_full Local_to_regional
+      | Locality_full Regional_to_local
+      | Locality_full Locality_as_regionality
+      | Locality_full Regional_to_global
+      | Locality_full Local_to_regional_regionality
+      | Locality_full Regional_to_local_regionality
+      | Locality_full Regional_to_global_regionality
+      | Uniqueness_op_to_linearity | Linearity_to_uniqueness_op
+      | Contention_op_to_portability | Portability_to_contention_op
+      | Visibility_op_to_statefulness | Statefulness_to_visibility_op
+      | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
+      | Monadic_to_comonadic_max | Comonadic_to_monadic_max _ ->
+        (* If all morphisms preserve binary meets, the correctness argument
+           goes as follows:
 
-         Consider [apply dst m (meet_const c x)].
-         [apply dst m (meet_const c x)]
-         == meet (apply dst m c) (apply dst m x) ;; [m] preserves binary meets
-         == meet_const (apply dst m c) (apply dst m x) ;; by definition of meet_const
+           Consider [apply dst m (meet_const c x)].
+           [apply dst m (meet_const c x)]
+           == meet (apply dst m c) (apply dst m x) ;; [m] preserves binary
+           meets
+           == meet_const (apply dst m c) (apply dst m x) ;; by definition of
+           meet_const
 
-         The correct result for [commute_meet_const_from_right] is thus [apply dst m c] *)
-      apply dst m c
+           The correct result for [commute_meet_const_from_right] is thus
+           [apply dst m c]. *)
+        apply dst m c
 
     (* Commutes an implication through a morphism from the left, such that:
        [imply_const c (apply dst m x)] is equivalent to

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2558,69 +2558,66 @@ module Lattices_mono = struct
       | _, _ -> .
     [@@warning "-4"]
 
-    type ('b, 'd) packed_to =
-      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
-
-    let to_ : type a b d. (a, b, d) t -> (b, d) packed_to =
-     fun m -> To (src m, m)
+    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
+    [@@unboxed]
 
     let left_to : type b. b obj -> (b, left_only) packed_to list = function
-      | Locality -> [to_ (Locality_restricted Regional_to_local)]
+      | Locality -> [To (Locality_restricted Regional_to_local)]
       | Regionality ->
-        [ to_ (Locality_restricted Local_to_regional);
-          to_ (Locality_restricted Locality_as_regionality);
-          to_ (Locality_restricted Local_to_regional_regionality);
-          to_ (Locality_restricted Regional_to_local_regionality) ]
-      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
-      | Linearity -> [to_ Uniqueness_op_to_linearity]
-      | Portability -> [to_ Contention_op_to_portability]
+        [ To (Locality_restricted Local_to_regional);
+          To (Locality_restricted Locality_as_regionality);
+          To (Locality_restricted Local_to_regional_regionality);
+          To (Locality_restricted Regional_to_local_regionality) ]
+      | Uniqueness_op -> [To Linearity_to_uniqueness_op]
+      | Linearity -> [To Uniqueness_op_to_linearity]
+      | Portability -> [To Contention_op_to_portability]
       | Forkable -> []
       | Yielding -> []
-      | Statefulness -> [to_ Visibility_op_to_statefulness]
-      | Contention_op -> [to_ Portability_to_contention_op]
-      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Statefulness -> [To Visibility_op_to_statefulness]
+      | Contention_op -> [To Portability_to_contention_op]
+      | Visibility_op -> [To Statefulness_to_visibility_op]
       | Staticity_op -> []
       | Monadic_op ->
-        [ to_ (Comonadic_to_monadic_min Locality);
-          to_ (Comonadic_to_monadic_min Regionality) ]
+        [ To (Comonadic_to_monadic_min Locality);
+          To (Comonadic_to_monadic_min Regionality) ]
       | Comonadic_with_locality ->
-        [to_ (Locality_full Regional_to_local); to_ Monadic_to_comonadic_min]
+        [To (Locality_full Regional_to_local); To Monadic_to_comonadic_min]
       | Comonadic_with_regionality ->
-        [ to_ (Locality_full Local_to_regional);
-          to_ (Locality_full Locality_as_regionality);
-          to_ (Locality_full Local_to_regional_regionality);
-          to_ (Locality_full Regional_to_local_regionality);
-          to_ Monadic_to_comonadic_min ]
+        [ To (Locality_full Local_to_regional);
+          To (Locality_full Locality_as_regionality);
+          To (Locality_full Local_to_regional_regionality);
+          To (Locality_full Regional_to_local_regionality);
+          To Monadic_to_comonadic_min ]
 
     let right_to : type b. b obj -> (b, right_only) packed_to list = function
       | Locality ->
-        [ to_ (Locality_restricted Regional_to_local);
-          to_ (Locality_restricted Regional_to_global) ]
+        [ To (Locality_restricted Regional_to_local);
+          To (Locality_restricted Regional_to_global) ]
       | Regionality ->
-        [ to_ (Locality_restricted Locality_as_regionality);
-          to_ (Locality_restricted Regional_to_local_regionality);
-          to_ (Locality_restricted Regional_to_global_regionality) ]
-      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
-      | Linearity -> [to_ Uniqueness_op_to_linearity]
-      | Portability -> [to_ Contention_op_to_portability]
+        [ To (Locality_restricted Locality_as_regionality);
+          To (Locality_restricted Regional_to_local_regionality);
+          To (Locality_restricted Regional_to_global_regionality) ]
+      | Uniqueness_op -> [To Linearity_to_uniqueness_op]
+      | Linearity -> [To Uniqueness_op_to_linearity]
+      | Portability -> [To Contention_op_to_portability]
       | Forkable -> []
       | Yielding -> []
-      | Statefulness -> [to_ Visibility_op_to_statefulness]
-      | Contention_op -> [to_ Portability_to_contention_op]
-      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Statefulness -> [To Visibility_op_to_statefulness]
+      | Contention_op -> [To Portability_to_contention_op]
+      | Visibility_op -> [To Statefulness_to_visibility_op]
       | Staticity_op -> []
       | Monadic_op ->
-        [ to_ (Comonadic_to_monadic_max Locality);
-          to_ (Comonadic_to_monadic_max Regionality) ]
+        [ To (Comonadic_to_monadic_max Locality);
+          To (Comonadic_to_monadic_max Regionality) ]
       | Comonadic_with_locality ->
-        [ to_ (Locality_full Regional_to_local);
-          to_ (Locality_full Regional_to_global);
-          to_ Monadic_to_comonadic_max ]
+        [ To (Locality_full Regional_to_local);
+          To (Locality_full Regional_to_global);
+          To Monadic_to_comonadic_max ]
       | Comonadic_with_regionality ->
-        [ to_ (Locality_full Locality_as_regionality);
-          to_ (Locality_full Regional_to_local_regionality);
-          to_ (Locality_full Regional_to_global_regionality);
-          to_ Monadic_to_comonadic_max ]
+        [ To (Locality_full Locality_as_regionality);
+          To (Locality_full Regional_to_local_regionality);
+          To (Locality_full Regional_to_global_regionality);
+          To Monadic_to_comonadic_max ]
   end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
@@ -3275,44 +3272,38 @@ module Lattices_mono = struct
 
     let ( let+ ) xs f = List.map f xs
 
-    type ('b, 'd) packed_to =
-      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
-
-    let to_ : type a b d. b obj -> (a, b, d) t -> (b, d) packed_to =
-     fun dst m -> To (src dst m, m)
+    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
+    [@@unboxed]
 
     let left_to : type b. full:bool -> b obj -> (b, left_only) packed_to list =
      fun ~full dst ->
       let constants =
-        List.map (fun c -> to_ dst (Meet_const c)) (get_elements ~full dst)
+        List.map (fun c -> To (Meet_const c)) (get_elements ~full dst)
       in
       let cores = Core_morph.left_to dst in
-      let core_morphs =
-        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
-      in
+      let core_morphs = List.map (fun (Core_morph.To m) -> To (Core m)) cores in
       let meet_const_cores =
         let* c = get_elements ~full dst in
-        let+ (Core_morph.To (_, m)) = cores in
-        to_ dst (Meet_const_core (c, m))
+        let+ (Core_morph.To m) = cores in
+        To (Meet_const_core (c, m))
       in
-      (to_ dst Id :: core_morphs) @ constants @ meet_const_cores
+      (To Id :: core_morphs) @ constants @ meet_const_cores
 
     let right_to : type b. full:bool -> b obj -> (b, right_only) packed_to list
         =
      fun ~full dst ->
       let constants =
-        List.map (fun c -> to_ dst (Imply_const c)) (get_elements ~full dst)
+        List.map (fun c -> To (Imply_const c)) (get_elements ~full dst)
       in
       let cores = Core_morph.right_to dst in
-      let core_morphs =
-        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
-      in
+      let core_morphs = List.map (fun (Core_morph.To m) -> To (Core m)) cores in
       let core_imply_consts =
-        let* (Core_morph.To (src, m)) = cores in
+        let* (Core_morph.To m) = cores in
+        let src = Core_morph.src m in
         let+ c = get_elements ~full src in
-        to_ dst (Core_imply_const (m, c))
+        To (Core_imply_const (m, c))
       in
-      (to_ dst Id :: core_morphs) @ constants @ core_imply_consts
+      (To Id :: core_morphs) @ constants @ core_imply_consts
   end
 
   type ('a, 'b, 'd) morph =
@@ -3916,130 +3907,105 @@ module Lattices_mono = struct
 
   let ( let+ ) xs f = List.map f xs
 
-  type 'b packed_morph_to =
-    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
+  type 'b packed_to = To : ('a, 'b, neither) morph -> 'b packed_to [@@unboxed]
 
-  let left_morph_to : type a b.
-      a obj -> (a, b, left_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_left morph)
-
-  let right_morph_to : type a b.
-      a obj -> (a, b, right_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_right morph)
-
-  let generate_left_morphs_to : type b.
-      full:bool -> b obj -> b packed_morph_to list =
+  let generate_left_morphs_to : type b. full:bool -> b obj -> b packed_to list =
    fun ~full dst ->
     let simple_morphs = Simple_morph.left_to ~full dst in
     let simple =
       List.map
-        (fun (Simple_morph.To (src, m)) -> left_morph_to src (Simple m))
+        (fun (Simple_morph.To m) -> To (disallow_left (Simple m)))
         simple_morphs
     in
     let projections =
-      let* (Simple_morph.To (projected, m)) = simple_morphs in
-      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
-      left_morph_to src (Simple_proj (m, ax, src))
+      let* (Simple_morph.To m) = simple_morphs in
+      let src = Simple_morph.src dst m in
+      let+ (Axis.Pb (src, ax)) = Axis.axis_to src in
+      To (disallow_left (Simple_proj (m, ax, src)))
     in
     let min_with =
       let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
-      let+ (Simple_morph.To (src, m)) = Simple_morph.left_to ~full projected in
-      left_morph_to src (Min_with_simple (ax, m))
+      let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
+      To (disallow_left (Min_with_simple (ax, m)))
     in
     let const_min =
-      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+      List.map (fun (Obj src) -> To (disallow_left (Const_min src))) all_objs
     in
     simple @ projections @ min_with @ const_min
 
-  let generate_right_morphs_to : type b.
-      full:bool -> b obj -> b packed_morph_to list =
+  let generate_right_morphs_to : type b. full:bool -> b obj -> b packed_to list
+      =
    fun ~full dst ->
     let simple_morphs = Simple_morph.right_to ~full dst in
     let simple =
       List.map
-        (fun (Simple_morph.To (src, m)) -> right_morph_to src (Simple m))
+        (fun (Simple_morph.To m) -> To (disallow_right (Simple m)))
         simple_morphs
     in
     let projections =
-      let* (Simple_morph.To (projected, m)) = simple_morphs in
+      let* (Simple_morph.To m) = simple_morphs in
+      let projected = Simple_morph.src dst m in
       let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
-      right_morph_to src (Simple_proj (m, ax, src))
+      To (disallow_right (Simple_proj (m, ax, src)))
     in
     let max_with =
       let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
-      let+ (Simple_morph.To (src, m)) = Simple_morph.right_to ~full projected in
-      right_morph_to src (Max_with_simple (ax, m))
+      let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
+      To (disallow_right (Max_with_simple (ax, m)))
     in
     let const_max =
-      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+      List.map (fun (Obj src) -> To (disallow_right (Const_max src))) all_objs
     in
     simple @ projections @ max_with @ const_max
 
   let generate_morphs_to ~full dst =
     generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
 
-  let force_by_coverage ~full (full_list, partial_list) =
-    Lazy.force (if full then full_list else partial_list)
+  type 'a covered =
+    { full_coverage : 'a;
+      partial_coverage : 'a
+    }
 
-  let morphs_to_locality =
-    ( lazy (generate_morphs_to ~full:true Locality),
-      lazy (generate_morphs_to ~full:false Locality) )
+  let force_by_coverage ~full { full_coverage; partial_coverage } =
+    Lazy.force (if full then full_coverage else partial_coverage)
 
-  let morphs_to_regionality =
-    ( lazy (generate_morphs_to ~full:true Regionality),
-      lazy (generate_morphs_to ~full:false Regionality) )
+  let morphs_to_obj obj =
+    let full_coverage = lazy (generate_morphs_to ~full:true obj) in
+    let partial_coverage = lazy (generate_morphs_to ~full:false obj) in
+    { full_coverage; partial_coverage }
 
-  let morphs_to_uniqueness_op =
-    ( lazy (generate_morphs_to ~full:true Uniqueness_op),
-      lazy (generate_morphs_to ~full:false Uniqueness_op) )
+  let morphs_to_locality = morphs_to_obj Locality
 
-  let morphs_to_linearity =
-    ( lazy (generate_morphs_to ~full:true Linearity),
-      lazy (generate_morphs_to ~full:false Linearity) )
+  let morphs_to_regionality = morphs_to_obj Regionality
 
-  let morphs_to_portability =
-    ( lazy (generate_morphs_to ~full:true Portability),
-      lazy (generate_morphs_to ~full:false Portability) )
+  let morphs_to_uniqueness_op = morphs_to_obj Uniqueness_op
 
-  let morphs_to_forkable =
-    ( lazy (generate_morphs_to ~full:true Forkable),
-      lazy (generate_morphs_to ~full:false Forkable) )
+  let morphs_to_linearity = morphs_to_obj Linearity
 
-  let morphs_to_yielding =
-    ( lazy (generate_morphs_to ~full:true Yielding),
-      lazy (generate_morphs_to ~full:false Yielding) )
+  let morphs_to_portability = morphs_to_obj Portability
 
-  let morphs_to_statefulness =
-    ( lazy (generate_morphs_to ~full:true Statefulness),
-      lazy (generate_morphs_to ~full:false Statefulness) )
+  let morphs_to_forkable = morphs_to_obj Forkable
 
-  let morphs_to_contention_op =
-    ( lazy (generate_morphs_to ~full:true Contention_op),
-      lazy (generate_morphs_to ~full:false Contention_op) )
+  let morphs_to_yielding = morphs_to_obj Yielding
 
-  let morphs_to_visibility_op =
-    ( lazy (generate_morphs_to ~full:true Visibility_op),
-      lazy (generate_morphs_to ~full:false Visibility_op) )
+  let morphs_to_statefulness = morphs_to_obj Statefulness
 
-  let morphs_to_staticity_op =
-    ( lazy (generate_morphs_to ~full:true Staticity_op),
-      lazy (generate_morphs_to ~full:false Staticity_op) )
+  let morphs_to_contention_op = morphs_to_obj Contention_op
 
-  let morphs_to_monadic_op =
-    ( lazy (generate_morphs_to ~full:true Monadic_op),
-      lazy (generate_morphs_to ~full:false Monadic_op) )
+  let morphs_to_visibility_op = morphs_to_obj Visibility_op
 
-  let morphs_to_comonadic_with_locality =
-    ( lazy (generate_morphs_to ~full:true Comonadic_with_locality),
-      lazy (generate_morphs_to ~full:false Comonadic_with_locality) )
+  let morphs_to_staticity_op = morphs_to_obj Staticity_op
+
+  let morphs_to_monadic_op = morphs_to_obj Monadic_op
+
+  let morphs_to_comonadic_with_locality = morphs_to_obj Comonadic_with_locality
 
   let morphs_to_comonadic_with_regionality =
-    ( lazy (generate_morphs_to ~full:true Comonadic_with_regionality),
-      lazy (generate_morphs_to ~full:false Comonadic_with_regionality) )
+    morphs_to_obj Comonadic_with_regionality
 
-  let morphs_to : type b. full:bool -> b obj -> b packed_morph_to list =
+  let morphs_to : type b. full:bool -> b obj -> b packed_to list =
    fun ~full -> function
     | Locality -> force_by_coverage ~full morphs_to_locality
     | Regionality -> force_by_coverage ~full morphs_to_regionality
@@ -4224,11 +4190,14 @@ module For_testing = struct
 
   let check_jobs ~full () =
     let* (Obj dst) = all_objs in
-    let+ (Morph_to (mid, f)) = morphs_to ~full dst in
+    let+ (To f) = morphs_to ~full dst in
+    let mid = src dst f in
     let morphs_to_mid = morphs_to ~full mid in
     fun () ->
       List.iter
-        (fun (Morph_to (src, g)) -> check_compose ~full src mid dst f g)
+        (fun (To g) ->
+          let src = src mid g in
+          check_compose ~full src mid dst f g)
         morphs_to_mid
 end
 

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -74,6 +74,30 @@ type ('d0, 'd1) polarity =
   constraint 'd0 = _ * _ constraint 'd1 = _ * _
 [@@warning "-62"]
 
+(* CR-someday zqian: Put [Modality.Const.t] here, once the dependency circle is
+   resolved. To fix that, we can move [Modality.Const] to in front of [Hint],
+   while [Modality] stays in place. *)
+type modality = Modality
+
+type containing =
+  | Tuple
+  | Record of string * modality
+  | Array of modality
+  | Constructor of string * modality
+  | Structure of structure_item * modality
+(* Some structure items (such as classes) don't have modalities. We gloss over
+     for simplicity. *)
+
+type contains =
+  { containing : containing;
+    contained : pinpoint
+  }
+
+type is_contained_by =
+  { containing : containing;
+    container : pinpoint
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -103,36 +127,13 @@ type 'd const =
   | Escape_region : region -> (disallowed * 'r) const
   | Quoted_computation : ('l * disallowed) pos const
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
+  | Contained_by : is_contained_by -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 
 type closure_details =
   { closure : pinpoint;
     closed : pinpoint
-  }
-
-(* CR-someday zqian: Put [Modality.Const.t] here, once the dependency circle is
-   resolved. To fix that, we can move [Modality.Const] to in front of [Hint],
-   while [Modality] stays in place. *)
-type modality = Modality
-
-type containing =
-  | Tuple
-  | Record of string * modality
-  | Array of modality
-  | Constructor of string * modality
-  | Structure of structure_item * modality
-(* Some structure items (such as classes) don't have modalities. We gloss over
-     for simplicity. *)
-
-type contains =
-  { containing : containing;
-    contained : pinpoint
-  }
-
-type is_contained_by =
-  { containing : containing;
-    container : pinpoint
   }
 
 type allocation_desc =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -879,15 +879,16 @@ module type S = sig
     *)
     val partial_apply : (allowed * 'r) t -> l
 
-    (** Copies a mode variable and its submodes from generic level to the
+    (** Copies a mode variable and its children from generic level to the
         current level *)
     val instantiate :
       copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
 
-    (** Copies a mode variable and its submodes from generic level to max int *)
+    (** Copies a mode variable and its children from generic level to generic
+        level *)
     val copy_generic : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
 
-    (** Fully duplicates a mode and its submodes to max int *)
+    (** Fully duplicates a mode and its children to max int *)
     val duplicate : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
 
     module Guts : sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -284,6 +284,10 @@ module type S = sig
     end
   end
 
+  module For_testing : sig
+    val check_all_allowed_compositions : unit -> unit
+  end
+
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref
 
   (* CR-someday zqian: find a better stroy to erase bounds (and hints) that incorporates

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -286,8 +286,26 @@ module type S = sig
     end
   end
 
+  (** Module for tests that validate internal mode lattice invariants. *)
   module For_testing : sig
-    val check_jobs : full:bool -> unit -> (unit -> unit) list
+    (** A failed internal invariant check. *)
+    type error
+
+    (** Print a detailed description of a failed check. *)
+    val print_error : Fmt.formatter -> error -> unit
+
+    (** Validates that morphism composition is sound.
+
+        For a selected subset of generated pair of morphisms [f : b -> c] and
+        [g : a -> b], this checks that [compose f g] and [fun x -> f (g x)]
+        agree on every selected element of [a].
+
+        The selected elements are either every possible lattice element (when
+        [full] is [true]) or a smaller spanning set where each axis value is
+        covered at least once, but every combination is not (when [full] is
+        [false]). *)
+    val check_composition_jobs :
+      full:bool -> unit -> (unit -> (unit, error) result) list
   end
 
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -749,9 +749,15 @@ module type S = sig
 
     val proj_monadic : 'a Monadic.Axis.t -> ('l * 'r) t -> ('a, 'r * 'l) mode
 
-    val meet_const : Comonadic.Const.t -> ('l * 'r) t -> ('l * 'r) t
+    val meet_const : Comonadic.Const.t -> ('l * 'r) t -> ('l * disallowed) t
 
-    val join_const : Monadic.Const.t -> ('l * 'r) t -> ('l * 'r) t
+    val join_const : Monadic.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
+
+    val meet_const_with :
+      'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * disallowed) t
+
+    val join_const_with :
+      'a Monadic.Axis.t -> 'a -> ('l * 'r) t -> (disallowed * 'r) t
 
     (** [max_with ax elt] returns [max] but with the axis [ax] set to [elt]. *)
     val max_with_comonadic :
@@ -764,11 +770,6 @@ module type S = sig
     (* [min_with_monadic ax elt] returns [min] but with the monadic axis [ax] set to [elt]. *)
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
-
-    val meet_const_with :
-      'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * 'r) t
-
-    val join_const_with : 'a Monadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * 'r) t
 
     val zap_to_legacy : lr -> Const.t
 
@@ -817,30 +818,31 @@ module type S = sig
     val locality_as_regionality : Locality.Const.t -> Regionality.Const.t
   end
 
-  (** Converts regional to local, identity otherwise *)
-  val regional_to_local : ('l * 'r) Regionality.t -> ('l * 'r) Locality.t
-
   (** Inject locality into regionality *)
-  val locality_as_regionality : ('l * 'r) Locality.t -> ('l * 'r) Regionality.t
-
-  (** Converts regional to global, identity otherwise *)
-  val regional_to_global : ('l * 'r) Regionality.t -> ('l * 'r) Locality.t
+  val locality_as_regionality : Locality.l -> Regionality.l
 
   (** Similar to [locality_as_regionality], behaves as identity on other axes *)
-  val alloc_as_value : ('l * 'r) Alloc.t -> ('l * 'r) Value.t
+  val alloc_as_value :
+    ?hint:('l * 'r) Hint.morph -> ('l * 'r) Alloc.t -> ('l * 'r) Value.t
 
   (** Similar to [local_to_regional], behaves as identity in other axes *)
   val alloc_to_value_l2r : ('l * 'r) Alloc.t -> ('l * disallowed) Value.t
 
   (** Similar to [regional_to_local], behaves as identity on other axes *)
-  val value_to_alloc_r2l : ('l * 'r) Value.t -> ('l * 'r) Alloc.t
+  val value_to_alloc_r2l :
+    ?hint:('l * 'r) Hint.morph -> ('l * 'r) Value.t -> ('l * 'r) Alloc.t
 
   (** Similar to [regional_to_global], behaves as identity on other axes *)
-  val value_to_alloc_r2g : ('l * 'r) Value.t -> ('l * 'r) Alloc.t
+  val value_to_alloc_r2g :
+    ?hint:(disallowed * 'r) Hint.morph ->
+    ('l * 'r) Value.t ->
+    (disallowed * 'r) Alloc.t
 
   (** Similar to [value_to_alloc_r2g], but followed by [alloc_as_value]. *)
   val value_r2g :
-    ?hint:('l * 'r) Hint.morph -> ('l * 'r) Value.t -> ('l * 'r) Value.t
+    ?hint:(disallowed * 'r) Hint.morph ->
+    ('l * 'r) Value.t ->
+    (disallowed * 'r) Value.t
 
   module Modality : sig
     module Comonadic : sig
@@ -918,13 +920,19 @@ module type S = sig
 
       (* CR-soon zqian: make the [hint] below mandatory *)
 
-      (** Apply a modality on mode. *)
-      val apply :
-        ?hint:
-          (('l * 'r) neg Hint.morph, ('l * 'r) pos Hint.morph) monadic_comonadic ->
+      (** Apply a modality on left mode. *)
+      val apply_left :
+        ?is_contained_by:Hint.is_contained_by ->
         t ->
-        ('l * 'r) Value.t ->
-        ('l * 'r) Value.t
+        (allowed * 'r) Value.t ->
+        Value.l
+
+      (** Apply a modality on right mode. *)
+      val apply_right :
+        ?is_contained_by:Hint.is_contained_by ->
+        t ->
+        ('l * allowed) Value.t ->
+        Value.r
 
       (** [concat ~then t] returns the modality that is [then_] after [t]. *)
       val concat : then_:t -> t -> t
@@ -967,11 +975,8 @@ module type S = sig
     (** Apply a modality on a left mode. The calller should ensure that
         [apply t m] is only called for [m >= md_mode] for inferred modalities.
     *)
-    val apply :
-      ?hint:
-        ( (allowed * 'r) neg Hint.morph,
-          (allowed * 'r) pos Hint.morph )
-        monadic_comonadic ->
+    val apply_left :
+      ?is_contained_by:Hint.is_contained_by ->
       t ->
       (allowed * 'r) Value.t ->
       Value.l
@@ -1168,10 +1173,10 @@ module type S = sig
     val to_modality : t -> Modality.Const.t
 
     (** Apply mode crossing on a left mode, making it stronger. *)
-    val apply_left : t -> ('l * 'r) Value.t -> ('l * disallowed) Value.t
+    val apply_left : t -> (allowed * 'r) Value.t -> Value.l
 
     (** Apply mode crossing on a right mode, making it more permissive. *)
-    val apply_right : t -> ('l * 'r) Value.t -> (disallowed * 'r) Value.t
+    val apply_right : t -> ('l * allowed) Value.t -> Value.r
 
     (* We extend mode crossing on [Value] to [Alloc] via [alloc_as_value].
        Concretely, two [Alloc] modes are indistinguishable if their images under

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -285,7 +285,7 @@ module type S = sig
   end
 
   module For_testing : sig
-    val check_all_allowed_compositions : unit -> unit
+    val check_all_allowed_compositions : full:bool -> unit -> unit
   end
 
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -42,6 +42,8 @@ module type Const = sig
   include Lattice
 
   val legacy : t
+
+  val all : t list lazy_t
 end
 
 module type Const_product = sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -203,14 +203,6 @@ module type Common = sig
   (** Returns true iff the mode is a variable at the given level *)
   val check_level_var : ('l * 'r) t -> int -> bool
 
-  (** zaps all variables to ceil (including generic variables): use with caution
-  *)
-  val zap_to_ceil_force : ('l * allowed) t -> Const.t
-
-  (** zaps all variables to floor (including generic variables): use with
-      caution *)
-  val zap_to_floor_force : (allowed * 'r) t -> Const.t
-
   (** zaps non-generic variables to ceil, raises a [Cannot_zap_generic] excetion
       if variable is generic *)
   val zap_to_ceil_exn : ('l * allowed) t -> Const.t
@@ -794,6 +786,108 @@ module type S = sig
 
     val with_zap_scope : (zap_scope:zap_scope -> 'a) -> 'a
 
+    (** Exposed subset of the monotone Lattices interface *)
+    module C : sig
+      type ('a, 'b, 'd) morph
+
+      type 'a obj
+
+      val le : 'a obj -> 'a -> 'a -> bool
+
+      val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.is_eq
+
+      val src : 'b obj -> ('a, 'b, 'd) morph -> 'a obj
+
+      val id : ('a, 'a, 'd) morph
+
+      val compose :
+        'c obj -> ('b, 'c, 'd) morph -> ('a, 'b, 'd) morph -> ('a, 'c, 'd) morph
+
+      val equal_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        ('a0, 'a1) Misc.is_eq
+
+      val left_adjoint :
+        'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
+
+      val disallow_right :
+        ('a, 'b, 'l * 'r) morph -> ('a, 'b, 'l * disallowed) morph
+
+      val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
+
+      val print_morph : 'b obj -> Fmt.formatter -> ('a, 'b, 'd) morph -> unit
+    end
+
+    (** The exposed description of modes *)
+    module Desc : sig
+      module Var : sig
+        type 'a t
+
+        type ('b, 'd) t_with_morph =
+          | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+        module Head : sig
+          type 'a t =
+            { desc_id : int;
+              desc_upper : 'a;
+              desc_lower : 'a;
+              desc_vlower : ('a, left_only) t_with_morph list;
+              desc_level : int
+            }
+
+          val equal : 'a t -> 'b t -> bool
+
+          val hash : 'a t -> int
+        end
+
+        val force : 'a C.obj -> 'a t -> 'a Head.t
+      end
+
+      type ('b, 'd) morphvar =
+        | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+      type ('a, 'd) t =
+        | Amode : 'a -> ('a, 'l * 'r) t
+        | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+        | Amodejoin :
+            'a * ('a, 'l * disallowed) morphvar list
+            -> ('a, 'l * disallowed) t
+        | Amodemeet :
+            'a * ('a, disallowed * 'r) morphvar list
+            -> ('a, disallowed * 'r) t
+
+      val equal : 'a C.obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+      val print : 'a C.obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+    end
+
+    val obj_monadic : Monadic.Const.t C.obj
+
+    val obj_comonadic : Comonadic.Const.t C.obj
+
+    val get_comonadic_desc : 'd Comonadic.t -> (Comonadic.Const.t, 'd) Desc.t
+
+    val get_monadic_desc :
+      ('l * 'r) Monadic.t -> (Monadic.Const.t, 'r * 'l) Desc.t
+
+    val meet_const_morph : 'a -> ('a, 'a, allowed * disallowed) C.morph
+
+    val pretty_print_monadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Monadic.Const.t, 'f) C.morph ->
+      unit
+
+    val pretty_print_comonadic_morph :
+      (Fmt.formatter -> 'a -> unit) ->
+      'a ->
+      Fmt.formatter ->
+      ('d, Comonadic.Const.t, 'f) C.morph ->
+      unit
+
     include
       Common
         with module Const := Const
@@ -848,15 +942,11 @@ module type S = sig
 
     val zap_to_legacy : lr -> Const.t option
 
-    val zap_to_legacy_force : lr -> Const.t
+    val zap_to_legacy_force : ?commit:bool -> lr -> Const.t
 
     val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     val zap_to_floor_exn : (allowed * 'r) t -> Const.t
-
-    val zap_to_ceil_force : ('l * allowed) t -> Const.t
-
-    val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->
@@ -895,6 +985,18 @@ module type S = sig
       (** Returns [Some c] if the given mode has been constrained to constant
           [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
       val check_const : (allowed * allowed) t -> Const.t option
+
+      (** Returns the precise bounds of a mode, as close to legacy as possible.
+          see notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val get_legacy : (allowed * allowed) t -> Const.t
+
+      (** Returns the precise ceiling of a mode. see notes on [get_ceil] in
+          [solver_intf.mli] for cautions. *)
+      val get_ceil : ('l * allowed) t -> Const.t
+
+      (** Checks that a constant is within the precise bounds of a mode. see
+          notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val in_bounds : Const.t -> (allowed * allowed) t -> bool
     end
   end
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -730,6 +730,8 @@ module type S = sig
       (** Similar to [comonadic_to_monadic_min] but for constants *)
       val comonadic_to_monadic_min : Comonadic.Const.t -> Monadic.Const.t
 
+      val monadic_to_comonadic_min : Monadic.Const.t -> Comonadic.Const.t
+
       (** Prints a constant on any axis. *)
       val print_axis : 'a Axis.t -> Fmt.formatter -> 'a -> unit
     end
@@ -1106,6 +1108,11 @@ module type S = sig
         visibility:Visibility.Const.t Atom.t ->
         staticity:Staticity.Const.t Atom.t ->
         t
+
+      val apply_right :
+        t ->
+        (disallowed * 'r) Alloc.Monadic.t ->
+        (disallowed * 'r) Alloc.Monadic.t
     end
 
     module Comonadic : sig
@@ -1138,6 +1145,11 @@ module type S = sig
       (** Create the mode crossing for a type whose values are always
           constructed at the given mode. *)
       val always_constructed_at : Value.Comonadic.Const.t -> t
+
+      val apply_left :
+        t ->
+        ('l * disallowed) Alloc.Comonadic.t ->
+        ('l * disallowed) Alloc.Comonadic.t
     end
 
     (** The mode crossing capability on all axes, split into monadic and

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -128,7 +128,9 @@ module type Common = sig
 
   val legacy : lr
 
-  val newvar : unit -> ('l * 'r) t
+  val generic_level : int
+
+  val newvar : int -> ('l * 'r) t
 
   (* How to submode
 
@@ -170,6 +172,12 @@ module type Common = sig
   val submode_err :
     Mode_hint.pinpoint -> (allowed * 'r) t -> ('l * allowed) t -> unit
 
+  val update_level : int -> ('l * 'r) t -> unit
+
+  val generalize : current_level:int -> ('l * 'r) t -> unit
+
+  val generalize_structure : current_level:int -> ('l * 'r) t -> unit
+
   val equate : lr -> lr -> (unit, equate_error) result
 
   (** Similiar to [submode], but crashes the compiler if errors. Use this
@@ -183,15 +191,41 @@ module type Common = sig
 
   val meet : ('l * allowed) t list -> right_only t
 
-  val newvar_above : (allowed * 'r) t -> ('l * 'r_) t * bool
+  val newvar_above : int -> (allowed * 'r) t -> ('l * 'r_) t * bool
 
-  val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
+  val newvar_below : int -> ('l * allowed) t -> ('l_ * 'r) t * bool
 
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
-  val zap_to_ceil : ('l * allowed) t -> Const.t
+  (** If a mode is a variable, returns true iff it has the given level *)
+  val check_level : ('l * 'r) t -> int -> bool
 
-  val zap_to_floor : (allowed * 'r) t -> Const.t
+  (** Returns true iff the mode is a variable at the given level *)
+  val check_level_var : ('l * 'r) t -> int -> bool
+
+  (** zaps all variables to ceil (including generic variables): use with caution
+  *)
+  val zap_to_ceil_force : ('l * allowed) t -> Const.t
+
+  (** zaps all variables to floor (including generic variables): use with
+      caution *)
+  val zap_to_floor_force : (allowed * 'r) t -> Const.t
+
+  (** zaps non-generic variables to ceil, raises a [Cannot_zap_generic] excetion
+      if variable is generic *)
+  val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+  (** zaps non-generic variables to floor, raises a [Cannot_zap_generic]
+      excetion if variable is generic *)
+  val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+  (** zaps non-generic variables to ceil, returns [None] if variable is generic.
+  *)
+  val zap_to_ceil : ('l * allowed) t -> Const.t option
+
+  (** zaps non-generic variables to floor, returns [None] if variable is
+      generic. *)
+  val zap_to_floor : (allowed * 'r) t -> Const.t option
 end
 
 module type Common_axis = sig
@@ -332,6 +366,10 @@ module type S = sig
   val undo_changes : changes -> unit
 
   val set_append_changes : (changes ref -> unit) -> unit
+
+  type copy_scope
+
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
 
   type nonrec allowed = allowed
 
@@ -707,6 +745,8 @@ module type S = sig
         val proj : 'a Axis.t -> t -> 'a option
 
         val set : 'a Axis.t -> 'a option -> t -> t
+
+        val partial_print : Fmt.formatter -> t -> unit
       end
 
       val is_max : 'a Axis.t -> 'a -> bool
@@ -748,6 +788,11 @@ module type S = sig
     type simple_error = Error : 'a Axis.t * 'a simple_axerror -> simple_error
 
     type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
+
+    (** Scope containing pending zap jobs *)
+    type zap_scope
+
+    val with_zap_scope : (zap_scope:zap_scope -> 'a) -> 'a
 
     include
       Common
@@ -797,7 +842,21 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    val zap_to_legacy : lr -> Const.t
+    val add_mode_to_zap_scope : (allowed * allowed) t -> zap_scope -> unit
+
+    val zap_to_legacy_exn : lr -> Const.t
+
+    val zap_to_legacy : lr -> Const.t option
+
+    val zap_to_legacy_force : lr -> Const.t
+
+    val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+    val zap_to_ceil_force : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->
@@ -819,6 +878,23 @@ module type S = sig
     (** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C]
     *)
     val partial_apply : (allowed * 'r) t -> l
+
+    (** Copies a mode variable and its submodes from generic level to the
+        current level *)
+    val instantiate :
+      copy_scope:copy_scope -> current_level:int -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Copies a mode variable and its submodes from generic level to max int *)
+    val copy_generic : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    (** Fully duplicates a mode and its submodes to max int *)
+    val duplicate : copy_scope:copy_scope -> ('l * 'r) t -> ('l * 'r) t
+
+    module Guts : sig
+      (** Returns [Some c] if the given mode has been constrained to constant
+          [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val check_const : (allowed * allowed) t -> Const.t option
+    end
   end
 
   (** The most general mode. Used in most type checking, including in value
@@ -1014,6 +1090,9 @@ module type S = sig
         is the axis on which the modalities disagree. [left] is the projection
         of [t0] on [ax], and [right] is the projection of [t1] on [ax]. *)
     val sub : t -> t -> (unit, error) Result.t
+
+    (** [update_level n t] updates the level of mode variables in [t] to [n] *)
+    val update_level : int -> t -> unit
 
     (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
         [t0 <= t1] and [t1 <= t0]. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -285,7 +285,7 @@ module type S = sig
   end
 
   module For_testing : sig
-    val check_all_allowed_compositions : full:bool -> unit -> unit
+    val check_jobs : full:bool -> unit -> (unit -> unit) list
   end
 
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -929,6 +929,8 @@ let lower_nongen nglev mty =
       | _ ->
           super.it_do_type_expr it ty
     in
-    let it = {super with it_do_type_expr} in
+  let it_mode_expr m = Mode.Alloc.update_level nglev m in
+  let it_modality m = Mode.Modality.update_level nglev m in
+    let it = {super with it_do_type_expr; it_mode_expr; it_modality} in
     it.it_module_type it mty
   end

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -92,7 +92,7 @@ module General = struct
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -76,7 +76,7 @@ module General : sig
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc * Uid.t
                 * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1044,7 +1044,7 @@ let nameable_row row =
 (* This specialized version of [Btype.iter_type_expr] normalizes and
    short-circuits the traversal of the [type_expr], so that it covers only the
    subterms that would be printed by the type printer. *)
-let printer_iter_type_expr f ty =
+let printer_iter_type_expr f fm  ty =
   match get_desc ty with
   | Tconstr(p, tyl, _) ->
       let (_p', s) = best_type_path p in
@@ -1073,7 +1073,7 @@ let printer_iter_type_expr f ty =
         f ty1;
       f ty2
   | _ ->
-      Btype.iter_type_expr f ty
+      Btype.iter_type_expr f fm ty
 
 let quoted_ident ppf x =
   Style.as_inline_code !Oprint.out_ident ppf x
@@ -1199,7 +1199,7 @@ end = struct
       | Tvar _ | Tunivar _ ->
           add_named_var tty
       | _ ->
-          printer_iter_type_expr add_named_vars ty
+          printer_iter_type_expr add_named_vars (Fun.const ()) ty
     end
 
   let substitute ty =
@@ -1353,13 +1353,13 @@ let rec mark_loops_rec visited ty =
         if List.memq px !visited_objects then add_alias_proxy px else begin
           if should_visit_object ty then
             visited_objects := px :: !visited_objects;
-          printer_iter_type_expr (mark_loops_rec visited) ty
+          printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
         end
     | Tpoly(ty, tyl) ->
         List.iter add_alias tyl;
         mark_loops_rec visited ty
     | _ ->
-        printer_iter_type_expr (mark_loops_rec visited) ty
+        printer_iter_type_expr (mark_loops_rec visited) (Fun.const ()) ty
 
 let mark_loops ty =
   mark_loops_rec [] ty
@@ -1550,7 +1550,7 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy mode in
+        let mode = Alloc.zap_to_legacy_force mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
     | Other _ -> tree
   in
@@ -1579,7 +1579,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy marg in
+        let arg_mode = Alloc.zap_to_legacy_force marg in
         let t1 =
           if is_optional l then
             match
@@ -1592,7 +1592,7 @@ let rec tree_of_modal_typexp mode modal ty =
           else
             tree_of_typexp mode arg_mode ty1
         in
-        let acc_mode = curry_mode alloc_mode arg_mode in
+        let acc_mode = curry_mode_const alloc_mode arg_mode in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
         Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
@@ -1832,6 +1832,7 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 and tree_of_ret_typ_mutating acc_mode m ty=
   match get_desc ty with
   | Tarrow _ -> begin
+      let c = Alloc.zap_to_legacy_force m in
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
       match Alloc.equate (Alloc.of_const acc_mode) m with
@@ -1840,11 +1841,10 @@ and tree_of_ret_typ_mutating acc_mode m ty=
       | Error _ ->
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let m = Alloc.zap_to_legacy m in
-        (Orm_parens (tree_of_modes m), m)
+        (Orm_parens (tree_of_modes c), c)
       end
   | _ ->
-    let m = Alloc.zap_to_legacy m in
+    let m = Alloc.zap_to_legacy_force m in
     (Orm_any (tree_of_modes m), m)
 
 and tree_of_typobject_repr fi =
@@ -2832,7 +2832,7 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-      let mres = m_res |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let mres = m_res |> Mode.Alloc.zap_to_legacy_force |> tree_of_modes in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       Omty_alias (tree_of_path (Some Module) p)
@@ -2859,7 +2859,7 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-      let marg = m_arg |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let marg = m_arg |> Mode.Alloc.zap_to_legacy_force |> tree_of_modes in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1078,6 +1078,13 @@ let printer_iter_type_expr f fm  ty =
 let quoted_ident ppf x =
   Style.as_inline_code !Oprint.out_ident ppf x
 
+(* Mode variables for mode polymorphism should only be printed if
+  the following two flags are enabled *)
+let mode_polymorphism_printing_enabled () =
+  Language_extension.(
+    is_at_least Mode_polymorphism Alpha
+    && is_enabled Mode_polymorphism_printing)
+
 module Internal_names : sig
 
   val reset : unit -> unit
@@ -1142,16 +1149,40 @@ end = struct
 
 end
 
+let zap_to_legacy : Alloc.lr -> Alloc.Const.t =
+  fun m ->
+    Option.value (Alloc.zap_to_legacy m) ~default:(Alloc.Guts.get_legacy m)
+
+let curry_mode_const : Alloc.Const.t -> Alloc.lr -> Alloc.Const.t =
+  fun alloc_mode marg ->
+    let arg_mode =
+      Option.value (Alloc.zap_to_legacy marg)
+      ~default:(Alloc.Guts.get_ceil marg) in
+    curry_mode_const alloc_mode arg_mode
+
+let equate_with_const : Alloc.lr -> Alloc.Const.t -> bool =
+  fun m c ->
+    if not (Alloc.check_level_var m generic_level)
+       || not (mode_polymorphism_printing_enabled ())
+    then
+      Result.is_ok (Alloc.equate m (Alloc.of_const c))
+    else
+      Alloc.Guts.in_bounds c m
+
 module Names : sig
   val reset_names : unit -> unit
 
   val add_named_vars : type_expr -> unit
+  val add_named_modevars : type_expr -> unit
+  val zap_non_generic_modes : type_expr -> unit
+  val add_visible_paths : unit -> unit
   val add_subst : (type_expr * type_expr) list -> unit
 
   val new_name : unit -> string
   val new_var_name : non_gen:bool -> type_expr -> unit -> string
 
   val name_of_type : (unit -> string) -> transient_expr -> string
+  val name_of_mode : Alloc.lr -> string
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
   val remove_names : transient_expr list -> unit
@@ -1162,6 +1193,13 @@ module Names : sig
      itself for the toplevel *)
   val refresh_weak : unit -> unit
 end = struct
+  type monadic_description =
+    (Alloc.Monadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type comonadic_description =
+    (Alloc.Comonadic.Const.t, (allowed * allowed)) Alloc.Desc.t
+  type visible_pair =
+    (monadic_description, comonadic_description) monadic_comonadic
+
   (* We map from types to names, but not directly; we also store a substitution,
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
@@ -1171,6 +1209,90 @@ end = struct
   let name_counter = ref 0
   let named_vars = ref ([] : string list)
   let visited_for_named_vars = ref ([] : transient_expr list)
+  let visited_for_modes = ref ([] : transient_expr list)
+  let visited_for_named_modevars = ref ([] : transient_expr list)
+
+  module Desc = Alloc.Desc
+  module C = Alloc.C
+
+  (** Boxed var and morphisms (paths) to use in hashtables *)
+  type boxedvar =
+  | K : 'a C.obj * 'a Desc.Var.Head.t -> boxedvar
+  type boxedpath =
+  | P : 'b C.obj
+        * 'a Desc.Var.Head.t
+        * ('a, 'b, (allowed * disallowed)) C.morph
+      -> boxedpath
+
+  (** The name of polymorphic mode variables will be
+  determined by two variables and morphism pair. The object
+  types are irrelevant, and are thus forgotten. See [edge]
+  for more explanation *)
+  type boxedname =
+  | N : 'c Desc.Var.Head.t
+        * 'd Desc.Var.Head.t
+        * 'a C.obj
+        * 'b C.obj
+        * ('a, 'b, ('l * 'r)) C.morph
+      -> boxedname
+
+  module VarTbl = Hashtbl.Make (struct
+    type t = boxedvar
+    let equal (K (_, v1)) (K (_, v2)) = Desc.Var.Head.equal v1 v2
+    let hash (K (_, v)) = Desc.Var.Head.hash v
+  end)
+
+  module VarPairTbl = Hashtbl.Make (struct
+    type t = boxedvar * boxedvar
+    let equal (K (_, v1), K (_, v1')) (K (_, v2), K (_, v2')) =
+      Desc.Var.Head.equal v1 v2 && Desc.Var.Head.equal v1' v2'
+    let hash (K (_, v), K (_, v')) =
+      Hashtbl.hash (Desc.Var.Head.hash v, Desc.Var.Head.hash v')
+  end)
+
+  (** Tracks the mapping of monadic and comonadic mode
+  descriptions visible in the type *)
+  let visible_pairs = ref ([] : visible_pair list)
+  let aliased_visible_pairs = ref ([] : visible_pair list)
+  let printed_aliased_visible_pairs = ref ([] : (visible_pair * string) list)
+
+  (** Tracks all mode variables that may occur in the above
+  list (for fast visibility checking) *)
+  let visible_vars = VarTbl.create 17
+
+  (** Tracks all paths from a visible monadic mode
+  variable to another. A path is defined as follows:
+    let [(v, f)] and [(u, h)] be two visible monadic
+    morphvars, such that [v] can reach [u] by following
+    vlowers. Let [g] be one such composition of vlower
+    functions. By
+    transitivity, we know the following to be true: [g u <= v].
+
+    A path from [(v, f)] to [(u, h)] is defined as: [f ∘ g ∘ h'],
+    where [h'] is the left adjoint of [h]
+  *)
+  let visible_monadic_paths_tbl = VarPairTbl.create 17
+
+  (** Tracks all paths from a visible comonadic mode
+  variable to another. See description of
+  [visible_monadic_paths_tbl] for a definition of a
+  path *)
+  let visible_comonadic_paths_tbl = VarPairTbl.create 17
+
+  (** Tracks all paths from a visible comonadic mode
+  variable to visible monadic mode variable. Since
+  the path goes from a comonadic to a monadic mode,
+  it will have to go through a "monadic to comonadic"
+  morphism. These paths will correspond to a closing
+  over relation between two mode variables
+
+  See description of [visible_monadic_paths_tbl] for
+  a definition of a path *)
+  let visible_closing_over_paths_tbl = VarPairTbl.create 17
+
+  (** counter used to generate names for polymorphic mode variables *)
+  let modename_counter = ref 0
+  let modenames = ref ([] : (boxedname * string) list)
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
@@ -1181,7 +1303,18 @@ end = struct
     name_subst := [];
     name_counter := 0;
     named_vars := [];
-    visited_for_named_vars := []
+    visited_for_named_vars := [];
+    visited_for_modes := [];
+    visited_for_named_modevars := [];
+    visible_pairs := [];
+    aliased_visible_pairs := [];
+    printed_aliased_visible_pairs := [];
+    modenames := [];
+    VarPairTbl.reset visible_monadic_paths_tbl;
+    VarPairTbl.reset visible_comonadic_paths_tbl;
+    VarPairTbl.reset visible_closing_over_paths_tbl;
+    VarTbl.reset visible_vars;
+    modename_counter := 0
 
   let add_named_var tty =
     match tty.desc with
@@ -1201,6 +1334,849 @@ end = struct
       | _ ->
           printer_iter_type_expr add_named_vars (Fun.const ()) ty
     end
+
+  (* The following preprocessing step zaps non-generic
+    modes to legacy, while equating a derived curry mode
+    with the inferred non-generic return modes. This step
+    should exactly mirror the behavior of
+    [tree_of_typexp]. It is needed so we get the correct
+    precise bounds of mode descriptions
+  *)
+  let rec zap_non_generic_modes : Alloc.Const.t -> type_expr -> unit =
+    fun alloc_mode ty ->
+    let px = proxy ty in
+    if List.memq px !visited_for_modes then () else begin
+      visited_for_modes := px :: !visited_for_modes;
+      let tty = Transient_expr.repr ty in
+      match tty.desc with
+      | Tarrow ((_l, marg, mret), _ty1, ty2, _) ->
+        let _ = zap_to_legacy marg in
+        let acc_mode = curry_mode_const alloc_mode marg in
+        equate_curry acc_mode mret ty2
+      | _ ->
+        printer_iter_type_expr (zap_non_generic_modes Alloc.Const.legacy)
+          (Fun.const ()) ty
+    end
+
+  and equate_curry : Alloc.Const.t -> Alloc.lr -> type_expr -> unit =
+    fun acc_mode mret ty ->
+      match get_desc ty with
+      | Tarrow _ ->
+          if equate_with_const mret acc_mode then
+            zap_non_generic_modes acc_mode ty
+          else begin
+            let mret = zap_to_legacy mret in
+            zap_non_generic_modes mret ty
+          end
+      | _ ->
+        let mret = zap_to_legacy mret in
+        zap_non_generic_modes mret ty
+
+  let zap_non_generic_modes ty =
+    zap_non_generic_modes Alloc.Const.legacy ty
+
+  let eq_pair :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun { monadic = mon0; comonadic = com0 }
+        { monadic = mon1; comonadic = com1 } ->
+    Desc.equal Alloc.obj_monadic mon0 mon1
+    && Desc.equal Alloc.obj_comonadic com0 com1
+
+  (* The following preprocessing step registers all the
+    modes pointed to by a type. Recall that a [Alloc.lr]
+    has two parts: { monadic; comonadic }. We need to
+    register each individual mode variable, as well as
+    the association between the monadic and comonadic
+    parts.
+
+    The former are registered in a VarTbl, the latter
+    in a list of mode descriptions
+    We also use this step to register mode aliases
+  *)
+  let add_visible : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> unit =
+    fun dst desc ->
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let src = C.src dst f in
+        let v = K (src, v) in
+        VarTbl.add visible_vars v ()
+
+  let add_named_modevar : Alloc.lr -> unit =
+    fun ({ monadic; comonadic } as mode) ->
+      if Alloc.check_level_var mode generic_level then begin
+        let monadic_desc = Alloc.get_monadic_desc monadic in
+        let comonadic_desc = Alloc.get_comonadic_desc comonadic in
+        let pair = { monadic = monadic_desc; comonadic = comonadic_desc } in
+        add_visible Alloc.obj_monadic monadic_desc;
+        add_visible Alloc.obj_comonadic comonadic_desc;
+        if List.exists (eq_pair pair) !visible_pairs then
+          aliased_visible_pairs := pair :: !aliased_visible_pairs
+        else
+          visible_pairs := pair :: !visible_pairs
+      end
+
+  let rec add_named_modevars ty =
+    let px = proxy ty in
+    if not (List.memq px !visited_for_named_modevars) then begin
+      visited_for_named_modevars := px :: !visited_for_named_modevars;
+      printer_iter_type_expr add_named_modevars add_named_modevar ty
+    end
+
+  (* The next preprocessing step registers all direct
+    paths from one visible mode variable to another.
+  *)
+
+  type memoized = (boxedpath list) VarTbl.t
+  type visited = unit VarTbl.t
+
+  exception Cannot_unwrap
+
+  (* Find the [b -> Monadic] morphism associated with
+    some visible variable [v] of object type [b] *)
+  let find_monadic_morph_opt : type b. b C.obj -> b Desc.Var.Head.t
+      -> ((b, Alloc.Monadic.Const.t, (allowed * allowed)) C.morph) option =
+    fun obj v ->
+      let find_match { monadic } =
+        match monadic with
+        | Desc.Amodevar (Amorphvar (u, f)) ->
+            if not (Desc.Var.Head.equal v u) then None else begin
+              let obj' = C.src Alloc.obj_monadic f in
+                match C.equal_obj obj obj' with
+                | Is_eq ->
+                  let (f : ((b, Alloc.Monadic.Const.t,
+                    (allowed * allowed)) C.morph)) = f in
+                  if Desc.Var.Head.equal v u then Some f else None
+                | Is_not_eq -> raise Cannot_unwrap
+            end
+        | Desc.Amode _ -> None
+      in
+      List.find_map find_match !visible_pairs
+
+  (* Find the [b -> Comonadic] morphism associated with
+    some visible variable [v] of object type [b] *)
+  let find_comonadic_morph_opt : type b. b C.obj -> b Desc.Var.Head.t
+      -> ((b, Alloc.Comonadic.Const.t, (allowed * allowed)) C.morph) option =
+    fun obj v ->
+      let find_match { comonadic } =
+        match comonadic with
+        | Desc.Amodevar (Amorphvar (u, f)) ->
+            if not (Desc.Var.Head.equal v u) then None else begin
+              let obj' = C.src Alloc.obj_comonadic f in
+                match C.equal_obj obj obj' with
+                | Is_eq ->
+                  let (f : ((b, Alloc.Comonadic.Const.t,
+                    (allowed * allowed)) C.morph)) = f in
+                  if Desc.Var.Head.equal v u then Some f else None
+                | Is_not_eq -> raise Cannot_unwrap
+            end
+        | Desc.Amode _ -> None
+      in
+      List.find_map find_match !visible_pairs
+
+  let visible : type b. b C.obj -> b Desc.Var.Head.t -> bool =
+    fun obj v ->
+      VarTbl.mem visible_vars (K (obj, v))
+
+  let remove_duplicate_paths : boxedpath list -> boxedpath list =
+    fun paths ->
+      let sort (P (fdst, v, f)) (P (gdst, u, g)) =
+        match C.equal_obj fdst gdst with
+        | Is_not_eq -> 1
+        | Is_eq ->
+          match C.equal_morph fdst f g with
+          | Is_not_eq -> 1
+          | Is_eq -> Int.compare v.desc_id u.desc_id
+      in
+      List.sort_uniq sort paths
+
+  (* Find all direct paths (via vlowers) from some
+    variable [v] to all other reachable visible variables
+    at generic level. *)
+  (* CR ageorges: WARNING: cycles are *not* registered
+      as a separate morphism:
+      e.g.: let [w] be a visible generic variable with
+            the following (vlower) edges:
+            v -f> u1 -g> u2 -g'> u1 -h> w
+            [find_paths v] will return only the direct
+            path [(f ∘ h)]
+      In the future, we might want to register all
+      paths. This will require a lattice of morphisms,
+      so we can calculate the fixed point of cycle *)
+  let rec find_paths :
+      type b. memoized:memoized -> visited:visited
+      -> bool -> b C.obj -> b Desc.Var.Head.t
+      -> boxedpath list =
+    fun ~memoized ~visited first dst v ->
+      if visible dst v && not first then [P (dst, v, C.id)] else begin
+        if VarTbl.mem visited (K (dst, v)) then [] else begin
+          VarTbl.add visited (K (dst, v)) ();
+          match VarTbl.find_opt memoized (K (dst, v)) with
+          | Some paths -> paths
+          | None ->
+            let paths =
+              List.filter_map (fun (Desc.Var.Amorphvar (w, f)) ->
+                let fsrc = C.src dst f in
+                let w = Desc.Var.force fsrc w in
+                if w.desc_level <> generic_level then None else begin
+                let wpaths = find_paths ~memoized ~visited false fsrc w in
+                Some (List.map (fun (P (gdst, u, g)) ->
+                  match C.equal_obj fsrc gdst with
+                  | Is_eq ->
+                    let fg = C.compose dst f g in
+                    P (dst, u, fg)
+                  | Is_not_eq -> raise Cannot_unwrap) wpaths)
+              end) v.desc_vlower
+            in
+            (* TODO: we might want to remove duplicates here *)
+            let paths = List.flatten paths in
+            let paths = remove_duplicate_paths paths in
+            VarTbl.add memoized (K (dst,v)) paths;
+            paths
+          end
+      end
+
+  let find_paths :
+      memoized:memoized -> visited:visited
+      -> boxedvar -> boxedpath list =
+    fun ~memoized ~visited (K (dst, v)) ->
+      find_paths ~memoized ~visited true dst v
+
+  (** [find_path_from_description] constructs all morphisms
+    from one visible mode variable to another, and applies
+    an iterator [iter] on them.
+    The [find_morph_opt] parameter takes a variable as
+    input, and returns its associated morphism. The final
+    morphism is constructed as follows:
+      - let the parameter [desc] be a morphvar
+        description [(v, f)]
+      - let g be vlower path from [v] to some [u].
+        (recall g : [u.obj] -> [v.obj])
+      - let [find_morph_opt u] = Some [h]
+    [find_path_from_description] runs [iter] on
+    ([v], [u]) and [fgh'] where [h'] is the left
+    adjoint of [h].
+
+    See [visible_monadic_paths_tbl] for an explanation
+    why this is the morphism we want *)
+  type 'b find_morph_opt =
+    { f : 'a. 'a C.obj
+          -> 'a Desc.Var.Head.t
+          -> (('a, 'b, (allowed * allowed)) C.morph) option; } [@@unboxed]
+  let find_path_from_description :
+      type a b. memoized:memoized
+      -> a C.obj
+      -> b C.obj
+      -> (a, (allowed * allowed)) Desc.t
+      -> b find_morph_opt
+      -> (boxedvar * boxedvar -> (b, a, (allowed * disallowed)) C.morph -> unit)
+      -> unit =
+    fun ~memoized dst bobj desc find_morph_opt iter ->
+      match desc with
+      | Amode _ -> ()
+      | Amodevar (Amorphvar (v, f)) ->
+        let fsrc = C.src dst f in
+        let v = K (fsrc, v) in
+        let visited = VarTbl.create 17 in
+        let paths = find_paths ~memoized ~visited v in
+        List.iter (fun (P (gdst, u, g)) ->
+          match C.equal_obj fsrc gdst with
+            | Is_eq ->
+              let gsrc = C.src gdst g in
+              Option.iter (fun h ->
+                let h' = C.left_adjoint bobj h in
+                let fg = C.compose dst (C.disallow_right f) g in
+                let fgh' = C.compose dst fg h' in
+                iter (v, (K (gsrc, u))) fgh'
+              ) (find_morph_opt.f gsrc u)
+            | Is_not_eq -> raise Cannot_unwrap
+          ) paths
+
+
+  (* The following function is expensive and should be
+  called once during preprocessing. It constructs all
+  morphisms from a visible monadic/comonadic variable to
+  another visible monadic/comonadic variable, and records
+  them in their respective tables *)
+  let add_visible_paths () =
+    let memoized = VarTbl.create 17 in
+    List.iter
+      (fun { monadic; comonadic } ->
+        find_path_from_description ~memoized
+          Alloc.obj_monadic Alloc.obj_monadic monadic
+          { f = find_monadic_morph_opt }
+          (VarPairTbl.add visible_monadic_paths_tbl);
+        find_path_from_description ~memoized
+          Alloc.obj_comonadic Alloc.obj_comonadic
+          comonadic
+          { f = find_comonadic_morph_opt }
+          (VarPairTbl.add visible_comonadic_paths_tbl);
+        find_path_from_description ~memoized
+          Alloc.obj_comonadic Alloc.obj_monadic
+          comonadic
+          { f = find_monadic_morph_opt }
+          (VarPairTbl.add visible_closing_over_paths_tbl)
+      ) !visible_pairs
+
+  type ('a,'b) morphl = ('a, 'b, (allowed * disallowed)) C.morph
+  type monadic_morph =
+    (Alloc.Monadic.Const.t, Alloc.Monadic.Const.t) morphl
+  type comonadic_morph =
+    (Alloc.Comonadic.Const.t, Alloc.Comonadic.Const.t)
+      morphl
+  type closing_over_morph =
+    (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) morphl
+
+  type simple_edge =
+    { via :
+        (monadic_morph, comonadic_morph)
+          monadic_comonadic;
+        (** The pair of morphisms between the two modes.
+        The monadic morphism gives a path from the
+        monadic part of [src] to the monadic part of
+        [target], the comonadic morphism gives a path
+        from the comonadic part of [target] to the
+        comonadic part of [src] *)
+      name : boxedname;
+        (** When printing, we name edges rather than
+        nodes, such that we can print monadic and
+        comonadic constraints in different bounds, thus
+        only printing left_only morphisms. By default,
+        the name is determined by the comonadic
+        morphism, but if this morphism is trivial (i.e.
+        the bounds can determine it), we use the
+        monadic morphism instead. *)
+    }
+
+  type comonadic_edge =
+    { c_via : comonadic_morph;
+        (** The comonadic morphism between two modes
+        when there is no path between their monadic
+        counterparts. This edge represents a partial
+        constraint between two modes. The morphism
+        gives a path from [target] to [src] *)
+      c_name : boxedname;
+        (** The boxed name of [c_via] *)
+    }
+
+  (** [closing_over_edge] describes a specific pattern
+  that may arise between an argument, a return and a
+  curry-mode.
+
+  Consider the following function (the K-combinator)
+  let k x y = x
+
+  The mode of the argument [x] describes a lower bound on
+  the inner return. But when [k] is partially applied, this
+  mode also describes an upper bound on the closure [k x].
+
+  We want to print such a pattern as follows:
+
+  [k : x @ [< 'm] -> (y @ 'n -> x @ [> 'm]) @ [> close('m)]]
+
+  Where [close('m)] denotes a relation to the comonadic
+  parts of the argument, and the monadic part of the return *)
+
+  (** A [closing_over_edge] describes a relationship between
+  three visible mode variables: [src], [target] and [curry]*)
+  type closing_over_edge =
+    { cls_target : closing_over_morph;
+        (** A path from [curry] to monadic
+        part of [target] *)
+      cls_src : comonadic_morph;
+        (** A path from [curry] to comonadic
+        part of [src] *)
+      cls_edge : simple_edge
+        (** the edge from [src] to [target].
+        The name of a [closing_over_edge]
+        corresponds to the name of [cls_edge]. *)
+    }
+
+  type edge =
+  | Simple of simple_edge
+      (** a constraint between two alloc modes *)
+  | Comonadic of comonadic_edge
+      (** a constraint between the comonadic parts
+      of two alloc modes *)
+  | ClosingOver of closing_over_edge
+      (** a constraint between the monadic part
+      of one mode and the comonadic part of another *)
+
+   let dupper_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_upper
+
+  let dlower_lr : type a. a C.obj -> (a, (allowed * allowed)) Desc.t -> a =
+    fun dst descr ->
+      match descr with
+      | Amode l -> l
+      | Amodevar (Amorphvar (v, f)) ->
+        C.apply dst f v.desc_lower
+
+  let construct_morphs :
+      type a. a C.obj
+        -> (a, (allowed * allowed)) Desc.t
+        -> (a, (allowed * allowed)) Desc.t
+        -> (boxedvar * boxedvar -> ((a, a) morphl) list)
+        -> ((a, a) morphl) list =
+    fun dst src_descr target_descr get_descr_from_vars ->
+      match src_descr, target_descr with
+      | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+        let vobj = C.src dst f in
+        let uobj = C.src dst g in
+        let l = C.apply dst f v.desc_upper in
+        let r = C.apply dst g u.desc_lower in
+        if C.le dst l r
+        then [C.id]
+        else get_descr_from_vars (K (vobj, v), K (uobj, u))
+      | _, _ ->
+        let l = dupper_lr dst src_descr in
+        let r = dlower_lr dst target_descr in
+        if C.le dst l r
+        then [C.id]
+        else [Alloc.meet_const_morph r]
+
+  let construct_closing_over_morphs :
+      (Alloc.Comonadic.Const.t, allowed * allowed) Desc.t
+      -> (Alloc.Monadic.Const.t, allowed * allowed) Desc.t
+      -> closing_over_morph list =
+    fun src_descr target_descr ->
+    match src_descr, target_descr with
+    | Amodevar (Amorphvar (v, f)), Amodevar (Amorphvar (u, g)) ->
+      let vobj = C.src Alloc.obj_comonadic f in
+      let uobj = C.src Alloc.obj_monadic g in
+        VarPairTbl.find_all visible_closing_over_paths_tbl
+        (K (vobj, v), K (uobj, u))
+    | _, _ -> []
+
+  let construct_monadic_morphs src_descr target_descr =
+    construct_morphs Alloc.obj_monadic src_descr target_descr
+      (VarPairTbl.find_all visible_monadic_paths_tbl)
+
+  let construct_comonadic_morphs src_descr target_descr =
+    construct_morphs Alloc.obj_comonadic src_descr target_descr
+      (VarPairTbl.find_all visible_comonadic_paths_tbl)
+
+  (* Tests whether the relation between two descriptions can be decided by
+  their bounds. If the following is true for two parts of a mode variable pair,
+  then no constraint needs to be printed *)
+  let descr_compare_dec :
+      type a. a C.obj
+      -> (a, (allowed * allowed)) Desc.t
+      -> (a, (allowed * allowed)) Desc.t
+      -> bool =
+    fun dst a0 a1 ->
+      let upper0 = dupper_lr dst a0 in
+      let lower0 = dlower_lr dst a0 in
+      let upper1 = dupper_lr dst a1 in
+      let lower1 = dlower_lr dst a1 in
+      C.le dst upper0 lower1 ||
+      C.le dst upper1 lower0
+
+  let descr_is_var : type a. (a, (allowed * allowed)) Desc.t -> bool =
+    fun v ->
+      match v with
+      | Amode _ -> false
+      | Amodevar _ -> true
+
+  (** We only want to print a constraint (and thus
+  construct an edge) between [(mon0, com0)] and
+  [(mon1, com1)] if the following is true:
+
+  1) Either [compare mon0 mon1], or
+     [compare com0 com1] can't be decided via bounds
+  2) Either [mon0] and [mon1] are both variables,
+     or [com0] and [com1] are both variables
+  3) [(mon0, com0)] and [(mon1, com1)] are not equal
+  *)
+  let construct_edge_condition :
+      visible_pair
+      -> visible_pair
+      -> bool =
+    fun ({ monadic = mon0; comonadic = com0 } as pair0)
+        ({ monadic = mon1; comonadic = com1 } as pair1) ->
+      let compare_dec =
+        not (descr_compare_dec
+               Alloc.obj_monadic mon0 mon1)
+        || not (descr_compare_dec
+                  Alloc.obj_comonadic com0 com1)
+      in
+      let check_signature =
+        (descr_is_var mon0 && descr_is_var mon1)
+        || (descr_is_var com0 && descr_is_var com1)
+      in
+      let pairs_ne = not (eq_pair pair0 pair1) in
+      compare_dec && check_signature && pairs_ne
+
+  exception Invalid_edge
+  let construct_name_exn :
+      visible_pair
+      -> (monadic_morph, comonadic_morph) monadic_comonadic
+      -> visible_pair
+      -> boxedname =
+    fun { monadic = mon0; comonadic = com0 }
+        { monadic = mon_morph; comonadic = com_morph }
+        { monadic = mon1; comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        N (u, v, Alloc.obj_comonadic, Alloc.obj_comonadic, com_morph)
+      | _, _ ->
+        match mon0, mon1 with
+        | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+          N (u, v, Alloc.obj_monadic, Alloc.obj_monadic, mon_morph)
+        | _, _ -> raise Invalid_edge
+                  (* edges are only created when one of the morphism
+                  goes from a variable to a variable*)
+
+  let construct_comonadic_name_exn :
+      visible_pair
+      -> comonadic_morph
+      -> visible_pair
+      -> boxedname =
+    fun { comonadic = com0 }
+        com_morph
+        { comonadic = com1 } ->
+      match com0, com1 with
+      | Amodevar (Amorphvar (v, _)), Amodevar (Amorphvar (u, _)) ->
+        N (u, v, Alloc.obj_comonadic, Alloc.obj_comonadic, com_morph)
+      | _, _ -> raise Invalid_edge
+          (* comonadic edges are only created when one of the morphism
+          goes from a variable to a variable*)
+
+  let construct_simple_between =
+    fun pair0 pair1 ->
+
+      let mon_morphs =
+        construct_monadic_morphs
+          pair0.monadic pair1.monadic
+      in
+      let com_morphs =
+        construct_comonadic_morphs
+          pair1.comonadic pair0.comonadic
+      in
+      let edges =
+        List.fold_left (fun acc com_morph ->
+          List.fold_left (fun acc mon_morph ->
+          let via =
+            { monadic = mon_morph;
+              comonadic = com_morph }
+          in
+          let name =
+            construct_name_exn pair0 via pair1
+          in
+          let edge = { via; name } in
+          edge :: acc )
+          acc mon_morphs)
+        [] com_morphs
+      in
+      edges
+
+  let check_closing_over_candidate pair0 pair1 =
+    List.exists
+      (fun pair2 ->
+        let closing_over_morphs =
+          construct_closing_over_morphs
+            pair1.comonadic pair2.monadic
+        in
+        let edges =
+          if construct_edge_condition pair0 pair2
+          then construct_simple_between pair0 pair2
+          else [] in
+        edges <> [] && closing_over_morphs <> []
+      ) !visible_pairs
+
+  let construct_comonadic_between =
+    fun pair0 pair1 ->
+      let mon_morphs =
+        construct_monadic_morphs
+          pair0.monadic pair1.monadic
+      in
+      let com_morphs =
+        construct_comonadic_morphs
+          pair1.comonadic pair0.comonadic
+      in
+      if not (check_closing_over_candidate pair0 pair1) && mon_morphs = [] then
+        List.map (fun com_morph ->
+          let c_name = construct_comonadic_name_exn pair0 com_morph pair1 in
+          Comonadic { c_via = com_morph; c_name }) com_morphs
+      else []
+
+  let construct_closing_over_to =
+    fun pair1 ->
+      List.fold_left (fun acc pair0 ->
+        List.fold_left (fun acc pair2 ->
+            let com_morphs =
+              construct_comonadic_morphs
+                pair1.comonadic pair0.comonadic
+            in
+            let closing_over_morphs =
+              construct_closing_over_morphs
+                pair1.comonadic pair2.monadic
+            in
+            let simple_edges =
+              if (construct_edge_condition pair0 pair2)
+              then construct_simple_between pair0 pair2
+              else []
+            in
+            List.fold_left (fun acc edge ->
+              List.fold_left (fun acc cls_morph ->
+                List.fold_left (fun acc com_morph ->
+                  ClosingOver {
+                    cls_target = cls_morph;
+                    cls_src = com_morph;
+                    cls_edge = edge
+                  } :: acc
+                ) acc com_morphs
+              ) acc closing_over_morphs
+            ) acc simple_edges
+          )
+        acc !visible_pairs)
+      [] !visible_pairs
+
+  let construct_edges_to :
+      visible_pair -> edge list =
+    fun pair1 ->
+      let find_edges pair0 =
+        if not (construct_edge_condition pair0 pair1)
+        then []
+        else begin
+          let edges = construct_simple_between pair0 pair1 in
+          let com_morphs = construct_comonadic_between pair0 pair1 in
+          let edges = List.map (fun edge -> Simple edge) edges in
+          edges @ com_morphs
+        end
+      in
+      let edges =
+        List.map find_edges !visible_pairs
+      in
+      let close_over = construct_closing_over_to pair1 in
+      close_over @ List.flatten edges
+
+  let construct_edges_from :
+      visible_pair -> edge list =
+    fun pair0 ->
+      let find_edges pair1 =
+        if not (construct_edge_condition pair0 pair1)
+        then []
+        else begin
+          let edges = construct_simple_between pair0 pair1 in
+          let com_morphs = construct_comonadic_between pair0 pair1 in
+          let edges = List.map (fun edge -> Simple edge) edges in
+          edges @ com_morphs
+        end
+      in
+      let edges =
+        List.map find_edges !visible_pairs
+      in
+      List.flatten edges
+
+  let eq_boxedname
+      (N (v, v', _, dstf, f)) (N (u, u', _, dstg, g)) =
+    match C.equal_obj dstf dstg with
+    | Is_eq ->
+      Desc.Var.Head.equal v u
+      && Desc.Var.Head.equal v' u'
+      && (match C.equal_morph dstf f g with
+      | Is_eq -> true
+      | Is_not_eq -> false)
+    | Is_not_eq -> false
+
+  let pick_name : int -> string = fun i ->
+    match i with
+    | 0 -> "'m"
+    | 1 -> "'n"
+    | 2 -> "'o"
+    | 3 -> "'p"
+    | 4 -> "'q"
+    | _ -> Fmt.asprintf "'mm%d" (i - 5)
+
+  let add_named_modevar name =
+    let mopt =
+      List.find_opt
+        (fun (name', _) -> eq_boxedname name name')
+        !modenames
+    in
+    match mopt with
+    | Some (_, m) -> m
+    | None ->
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      modenames := (name, m) :: !modenames;
+      m
+
+  type 'a interval = { lo: 'a; hi: 'a }
+  let construct_raw_bounds { monadic; comonadic } :
+      string interval =
+    let mupper = dupper_lr Alloc.obj_monadic monadic in
+    let mlower = dlower_lr Alloc.obj_monadic monadic in
+    let cupper = dupper_lr Alloc.obj_comonadic comonadic in
+    let clower = dlower_lr Alloc.obj_comonadic comonadic in
+    let lower =
+      Alloc.Const.merge
+        { monadic = mupper; comonadic = clower }
+    in
+    let upper =
+      Alloc.Const.merge
+        { monadic = mlower; comonadic = cupper }
+    in
+    let lower =
+      Alloc.Const.diff lower Alloc.Const.min
+    in
+    let upper =
+      Alloc.Const.diff upper Alloc.Const.max
+    in
+    { lo = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print lower;
+      hi = Fmt.asprintf "%a"
+             Alloc.Const.Option.partial_print upper}
+
+  type edge_as_lower =
+  | Lower_simple : simple_edge -> edge_as_lower
+  | Lower_comonadic : comonadic_edge -> edge_as_lower
+  | Lower_closing_over_to : closing_over_edge -> edge_as_lower
+
+  type edge_as_upper =
+  | Upper_simple : simple_edge -> edge_as_upper
+  | Upper_comonadic : comonadic_edge -> edge_as_upper
+
+  let print_raw_upper_bound ppf edge =
+    match edge with
+    | Upper_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_monadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.monadic
+    | Upper_comonadic { c_name } ->
+      let m = add_named_modevar c_name in
+      Fmt.fprintf ppf "%s @@@@ past" m
+
+  let print_raw_lower_bound ppf edge =
+    match edge with
+    | Lower_simple { via; name } ->
+      let m = add_named_modevar name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf via.comonadic
+    | Lower_comonadic { c_via; c_name } ->
+      let m = add_named_modevar c_name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf s -> Fmt.fprintf ppf "%s" s)
+        m ppf c_via
+    | Lower_closing_over_to { cls_target; cls_src; cls_edge } ->
+      let m = add_named_modevar cls_edge.name in
+      Alloc.pretty_print_comonadic_morph
+        (fun ppf cls ->
+          Alloc.pretty_print_comonadic_morph
+            (fun ppf s -> Fmt.fprintf ppf "%s" s)
+            m ppf cls)
+        cls_target ppf cls_src
+
+  let partition_edges_into_bounds :
+      edges_from:edge list ->
+      edges_to:edge list ->
+      edge_as_lower list * edge_as_upper list =
+    fun ~edges_from ~edges_to ->
+    let into_lower_from = function
+      | ClosingOver _ -> assert false
+      | Simple e -> Upper_simple e
+      | Comonadic e -> Upper_comonadic e
+    in
+    let into_lower_to = function
+      | ClosingOver e -> Lower_closing_over_to e
+      | Simple e -> Lower_simple e
+      | Comonadic e -> Lower_comonadic e
+    in
+    let upper = List.map into_lower_from edges_from in
+    let lower = List.map into_lower_to edges_to in
+    lower, upper
+
+  let print_raw_constraints { lo; hi } ppf pair =
+    let edges_to = construct_edges_to pair in
+    let edges_from = construct_edges_from pair in
+    let edges_lower, edges_upper =
+      partition_edges_into_bounds ~edges_from ~edges_to
+    in
+    if edges_lower = [] && edges_upper = []
+       && lo = "" && hi = ""
+    then begin
+      let name =
+        construct_name_exn pair
+          { monadic = C.id; comonadic = C.id }
+          pair
+      in
+      Fmt.fprintf ppf "%s" (add_named_modevar name)
+    end
+    else begin
+      let pp_sep sep ppf () =
+        Fmt.fprintf ppf "%s" sep
+      in
+      let pp_bounds pp sep extra ppf items =
+        match items, extra with
+        | [], "" -> ()
+        | [], s -> Fmt.fprintf ppf "%s" s
+        | l, "" ->
+          Fmt.pp_print_list
+            ~pp_sep:(pp_sep sep) pp ppf l
+        | l, s ->
+          Fmt.fprintf ppf "%a%s%s"
+            (Fmt.pp_print_list
+               ~pp_sep:(pp_sep sep) pp)
+            l sep s
+      in
+      let has_upper =
+        edges_upper <> [] || hi <> ""
+      in
+      let has_lower =
+        edges_lower <> [] || lo <> ""
+      in
+      Fmt.fprintf ppf "[%s%a%s%s%a]"
+        (if has_upper then "< " else "")
+        (pp_bounds print_raw_upper_bound
+           " & " hi)
+        edges_upper
+        (if has_upper && has_lower
+         then " " else "")
+        (if has_lower then "> " else "")
+        (pp_bounds print_raw_lower_bound
+           " | " lo)
+        edges_lower
+    end
+
+  let find_mode_already_printed pair =
+    let find (pair_alias, m) =
+      if eq_pair pair pair_alias then Some m else None
+    in
+    List.find_map find !printed_aliased_visible_pairs
+
+  let mode_print_alias ppf pair =
+    if List.exists (eq_pair pair)
+         !aliased_visible_pairs
+    then begin
+      let cnt = !modename_counter in
+      modename_counter := cnt + 1;
+      let m = pick_name cnt in
+      printed_aliased_visible_pairs :=
+        (pair,m) :: !printed_aliased_visible_pairs;
+      Fmt.fprintf ppf "as %s" m
+    end
+
+  let name_of_mode (modes : Alloc.lr) =
+    let monadic = Alloc.get_monadic_desc modes.monadic in
+    let comonadic = Alloc.get_comonadic_desc modes.comonadic in
+    let pair = { monadic; comonadic } in
+    match find_mode_already_printed pair with
+    | Some m -> Fmt.asprintf "%s" m
+    | None ->
+        let bounds = construct_raw_bounds pair in
+        Fmt.asprintf "%a%a"
+          (print_raw_constraints bounds) pair
+          mode_print_alias pair
 
   let substitute ty =
     match List.assq ty !name_subst with
@@ -1302,7 +2278,14 @@ end
 
 let reserve_names ty =
   normalize_type ty;
-  Names.add_named_vars ty
+  Names.add_named_vars ty;
+  if mode_polymorphism_printing_enabled () then begin
+    let snap = Btype.snapshot () in
+    Names.zap_non_generic_modes ty;
+    Names.add_named_modevars ty;
+    Names.add_visible_paths ();
+    Btype.backtrack snap
+  end
 
 let visited_objects = ref ([] : transient_expr list)
 let aliased = ref ([] : transient_expr list)
@@ -1453,7 +2436,7 @@ let tree_of_modalities mut t =
   |> List.map (fun (Atom (ax, m) : Modality.atom) ->
       Fmt.asprintf "%a" (Modality.Per_axis.print ax) m)
 
-let tree_of_modes (modes : Mode.Alloc.Const.t) =
+let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)
   let diff =
 
@@ -1509,6 +2492,15 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
   in
   List.filter_map (fun x -> x) modes
 
+let tree_of_modes : Alloc.lr -> zapped:Alloc.Const.t -> string list =
+  fun modes ~zapped ->
+    if Alloc.check_level_var modes generic_level &&
+      mode_polymorphism_printing_enabled () then
+      [ (Fmt.asprintf "%s"
+            (Names.name_of_mode modes))]
+    else
+      tree_of_modes_const zapped
+
 (** The modal context on a type when printing it. This is to reproduce the mode
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
@@ -1550,8 +2542,8 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy_force mode in
-        Otyp_ret (Orm_any (tree_of_modes mode), tree)
+        let mode = zap_to_legacy mode in
+        Otyp_ret (Orm_any (tree_of_modes_const mode), tree)
     | Other _ -> tree
   in
   let ty =
@@ -1579,7 +2571,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy_force marg in
+        let arg_mode = zap_to_legacy marg in
         let t1 =
           if is_optional l then
             match
@@ -1592,10 +2584,10 @@ let rec tree_of_modal_typexp mode modal ty =
           else
             tree_of_typexp mode arg_mode ty1
         in
-        let acc_mode = curry_mode_const alloc_mode arg_mode in
+        let acc_mode = curry_mode_const alloc_mode marg in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
-        Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
+        Otyp_arrow (lab, tree_of_modes marg ~zapped:arg_mode, t1, t2)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->
@@ -1829,23 +2821,23 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating acc_mode m ty=
+and tree_of_ret_typ_mutating (acc_mode : Alloc.Const.t) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
-      let c = Alloc.zap_to_legacy_force m in
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
-      match Alloc.equate (Alloc.of_const acc_mode) m with
-      | Ok () ->
+      if equate_with_const m acc_mode then begin
         (Orm_no_parens, acc_mode)
-      | Error _ ->
+      end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        (Orm_parens (tree_of_modes c), c)
+        let zapped = zap_to_legacy m in
+        (Orm_parens (tree_of_modes m ~zapped), zapped)
       end
+    end
   | _ ->
-    let m = Alloc.zap_to_legacy_force m in
-    (Orm_any (tree_of_modes m), m)
+    let acc = zap_to_legacy m in
+    (Orm_any (tree_of_modes m ~zapped:acc), acc)
 
 and tree_of_typobject_repr fi =
   let (fields, rest) = flatten_fields fi in
@@ -2832,7 +3824,7 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-      let mres = m_res |> Mode.Alloc.zap_to_legacy_force |> tree_of_modes in
+      let mres = m_res |> zap_to_legacy |> tree_of_modes_const in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       Omty_alias (tree_of_path (Some Module) p)
@@ -2859,7 +3851,7 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-      let marg = m_arg |> Mode.Alloc.zap_to_legacy_force |> tree_of_modes in
+      let marg = m_arg |> zap_to_legacy |> tree_of_modes_const in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -313,7 +313,7 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Alloc.print ())) m
+    line i ppf "%a\n" (Format_doc.compat (Mode.Locality.print ())) m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
 
@@ -591,7 +591,7 @@ and function_body i ppf (body : function_body) =
       line i ppf "Tfunction_cases%a %a\n"
         fmt_partiality fc_partial
         fmt_location fc_loc;
-      alloc_mode_raw i ppf fc_arg_mode;
+      locality_mode i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes (i+1) ppf fc_attributes;
       List.iter (fun e -> expression_extra (i+1) ppf e []) fc_exp_extra;
@@ -632,15 +632,15 @@ and expression_extra i ppf x attrs =
       attributes i ppf attrs;
       type_inspection (i+1) ppf ti
 
-and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m ->
-    line i ppf "alloc_mode %a\n" (Format_doc.compat (Mode.Alloc.print ())) m
-
-and alloc_mode i ppf (m : alloc_mode) = alloc_mode_raw i ppf m
+and alloc_mode i ppf (m : alloc_mode_r) =
+  line i ppf "alloc_mode %a\n"
+    (Format_doc.compat (Mode.Locality.print ()))
+    m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
-and locality_mode i ppf m =
+and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
+ fun i ppf m ->
   line i ppf "locality_mode %a\n"
     (Format_doc.compat (Mode.Locality.print ())) m
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1298,7 +1298,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
     (* If bounds are already tight, there is no need to create a copy *)
-    if not (C.le dst u.upper u.lower)
+    if (not (C.le dst u.upper u.lower)) && u.level = generic_level
     then begin
       let copy = fresh ~upper:u.upper ~lower:u.lower ~level:current_level dst in
       let ok1 =
@@ -1312,6 +1312,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
       in
       assert (Result.is_ok ok1 && Result.is_ok ok2);
+      set_gencopy ~log copy u.gencopy;
       set_gencopy ~log u (Some copy)
     end
 
@@ -1347,9 +1348,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       update_level_v ~log dst current_level u
     else begin
       (* the bounds are non-trivial *)
+      let old_level = u.level in
       generalize_topology ~log dst ~current_level u;
       update_level_v ~log dst generic_level u;
-      create_gencopy ~log dst ~current_level u
+      if old_level > current_level && old_level < generic_level
+      then begin
+        create_gencopy ~log dst ~current_level u
+      end
     end
 
   let generalize (type a l r) ~current_level (obj : a C.obj)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -2135,5 +2135,127 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
           mvs;
         allow_left (Amodevar mu), true
+
+  (** Exposed description of mode variables, used for printing generic mode
+      variables *)
+  module Desc = struct
+    module Var = struct
+      type 'a t = 'a var
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+      module Head = struct
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        let equal v1 v2 = v1.desc_id = v2.desc_id
+
+        let hash v = Hashtbl.hash v.desc_id
+      end
+
+      let force : 'a C.obj -> 'a var -> 'a Head.t =
+       fun obj v ->
+        let desc_id = v.id in
+        let desc_lower =
+          get_floor obj
+            (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        let desc_upper =
+          get_ceil obj (Amodevar (Amorphvar (v, C.id, Comp_hint.Morph_hint.Id)))
+        in
+        (* let desc_lower = v.lower in
+          let desc_upper = v.upper in *)
+        let desc_vlower =
+          let f (Amorphvar (a, f, _) : _ morphvar) = Amorphvar (a, f) in
+          let vlower = VarMap.map f v.vlower in
+          var_map_to_list vlower
+        in
+        let desc_level = v.level in
+        { desc_id; desc_lower; desc_upper; desc_vlower; desc_level }
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    let equal_morphvar : type a l r.
+        a C.obj -> (a, l * r) morphvar -> (a, l * r) morphvar -> bool =
+     fun obj (Amorphvar (v1, m1)) (Amorphvar (v2, m2)) ->
+      let c = C.compare_morph obj m1 m2 in
+      c = 0 && Var.Head.equal v1 v2
+
+    let equal : type a l r. a C.obj -> (a, l * r) t -> (a, l * r) t -> bool =
+     fun obj m1 m2 ->
+      match m1, m2 with
+      | Amode a1, Amode a2 -> C.equal obj a1 a2
+      | Amodevar mv1, Amodevar mv2 -> equal_morphvar obj mv1 mv2
+      | Amodejoin (a1, mv1), Amodejoin (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | Amodemeet (a1, mv1), Amodejoin (a2, mv2) ->
+        C.equal obj a1 a2 && List.for_all2 (equal_morphvar obj) mv1 mv2
+      | _, _ -> false
+
+    let print_var : type a. a C.obj -> Fmt.formatter -> a Var.Head.t -> unit =
+     fun obj ppf { desc_id; desc_upper; desc_lower; desc_level } ->
+      Fmt.fprintf ppf "%x<%d>[%a--%a]" desc_id desc_level (C.print obj)
+        desc_lower (C.print obj) desc_upper
+
+    let print_morphvar : type a l r.
+        a C.obj -> Fmt.formatter -> (a, l * r) morphvar -> unit =
+     fun dst ppf mv ->
+      let (Amorphvar (v, f)) = mv in
+      let src = C.src dst f in
+      Fmt.fprintf ppf "%a(%a)" (C.print_morph dst) f (print_var src) v
+
+    let print : type a l r. a C.obj -> Fmt.formatter -> (a, l * r) t -> unit =
+     fun obj ppf m ->
+      match m with
+      | Amode a -> C.print obj ppf a
+      | Amodevar mv -> print_morphvar obj ppf mv
+      | Amodejoin (a, mvs) ->
+        Fmt.fprintf ppf "join(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+      | Amodemeet (a, mvs) ->
+        Fmt.fprintf ppf "meet(%a,%a)" (C.print obj) a
+          (Fmt.pp_print_list
+             ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",")
+             (print_morphvar obj))
+          mvs
+  end
+
+  let desc_morphvar : type a l r.
+      a C.obj -> (a, l * r) morphvar -> (a, l * r) Desc.morphvar =
+   fun dst (Amorphvar (v, f, _)) ->
+    let src = C.src dst f in
+    let v = Desc.Var.force src v in
+    Desc.Amorphvar (v, f)
+
+  let desc : type a l r. a C.obj -> (a, l * r) mode -> (a, l * r) Desc.t =
+   fun dst m ->
+    match m with
+    | Amode (a, _, _) -> Desc.Amode a
+    | Amodevar mv -> Desc.Amodevar (desc_morphvar dst mv)
+    | Amodejoin (a, _, mvs) ->
+      Desc.Amodejoin (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
+    | Amodemeet (a, _, mvs) ->
+      Desc.Amodemeet (a, var_map_to_list (VarMap.map (desc_morphvar dst) mvs))
 end
 [@@inline always]

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1322,10 +1322,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     generalize_topology ~log dst ~current_level u;
     update_level_v ~log dst generic_level u
 
-  (* generalize_structure has three cases:
-    (1) if bounds are tight, the var is moved to generic_level
-    (2) if bounds are fully open, do nothing --- we consider only the case where bounds
-        are precise by virtue of having no vupper/vlower
+  (* generalize_structure first moves a variable generic_level.
+     It then has three cases:
+    (1) if bounds are tight, leave it as is
+    (2) if bounds are fully open --- by virtue of having no
+        vupper/vlower at or above the current level, and fully open
+        conservative bounds --- we move it to current level
     (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
         original var to generic_level, and mark the two variables as equivalent by adding
         constraint arrows via [add_vlower] and [add_vupper]
@@ -1333,28 +1335,39 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_structure_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
+    (* we optimize away vlower and vuppers if bounds are tight *)
     if C.le dst u.upper u.lower
     then begin
-      (* the bounds are tight *)
-      generalize_topology ~log dst ~current_level u;
-      update_level_v ~log dst generic_level u
-    end
+      set_vlower ~log u VarMap.empty;
+      set_vupper ~log u VarMap.empty
+    end;
+    let old_level = u.level in
+    generalize_topology ~log dst ~current_level u;
+    update_level_v ~log dst generic_level u;
+    let vlower_above_current =
+      VarMap.filter
+        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+        u.vlower
+    in
+    let vupper_above_current =
+      VarMap.filter
+        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+        u.vupper
+    in
+    if C.le dst u.upper u.lower
+    then ()
     else if
       C.le dst (C.max dst) u.upper
       && C.le dst u.lower (C.min dst)
-      && VarMap.is_empty u.vlower && VarMap.is_empty u.vupper
+      && VarMap.is_empty vlower_above_current
+      && VarMap.is_empty vupper_above_current
     then
       (* the bounds are fully open *)
       update_level_v ~log dst current_level u
-    else begin
-      (* the bounds are non-trivial *)
-      let old_level = u.level in
-      generalize_topology ~log dst ~current_level u;
-      update_level_v ~log dst generic_level u;
-      if old_level > current_level && old_level < generic_level
-      then begin
-        create_gencopy ~log dst ~current_level u
-      end
+    else if old_level <> generic_level && u.level = generic_level
+    then begin
+      (* we only create a copy if the variable was generalized *)
+      create_gencopy ~log dst ~current_level u
     end
 
   let generalize (type a l r) ~current_level (obj : a C.obj)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1470,6 +1470,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       ~finally:(fun () -> cleanup_mode_copy_scope scope)
       (fun () -> f scope)
 
+  let rec trace_gencopy ~copy_to_level v =
+    match v.gencopy with
+    | None -> None
+    | Some v' when v'.level = copy_to_level -> Some v'
+    | Some v' -> trace_gencopy ~copy_to_level v'
+
   let rec copy_v : type a.
       copy_scope:_ ->
       copy_from_level:int ->
@@ -1483,7 +1489,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     else
       (* generalize_structure might have already created a copy, cached in [gencopy].
          If such a copy exist, we return it *)
-      begin match v.gencopy with
+      begin match trace_gencopy ~copy_to_level v with
       | Some v' -> v'
       | None -> (
         match v.subst with

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -602,16 +602,21 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let mode_iter : type a l r. a C.obj -> (a, l * r) mode -> var_iterator -> unit
       =
    fun dst m { iter } ->
-    match m with
-    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+    let iter_morphvar : type l' r'. (a, l' * r') morphvar -> unit =
+     fun (Amorphvar (v, f, _f_hint)) ->
       let src = C.src dst f in
       iter src (Amodevar (Amorphvar (v, C.id, Id)))
-    | _ -> ()
+    in
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv -> iter_morphvar mv
+    | Amodejoin (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
+    | Amodemeet (_, _, mvs) -> VarMap.iter (fun _ mv -> iter_morphvar mv) mvs
 
   let rec iter_covariant_morphvar : type a r.
       visited:(int, unit) Hashtbl.t ->
       a C.obj ->
-      (int -> (a, allowed * disallowed) mode -> unit) ->
+      (id:int -> level:int -> (a, allowed * disallowed) mode -> unit) ->
       (a, allowed * r) morphvar ->
       unit =
    fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
@@ -627,7 +632,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
           in
           let mu = Amorphvar (u, fg, fg_hint) in
-          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter ~id:u.id ~level:u.level (Amodevar mu);
           iter_covariant_morphvar ~visited dst iter mu)
         v.vlower
     end
@@ -635,7 +640,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let iter_covariant : type a r.
       a C.obj ->
       (a, allowed * r) mode ->
-      (int -> (a, allowed * disallowed) mode -> unit) ->
+      (id:int -> level:int -> (a, allowed * disallowed) mode -> unit) ->
       unit =
    fun dst m iter ->
     match m with
@@ -650,7 +655,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let rec iter_contravariant_morphvar : type a l.
       visited:(int, unit) Hashtbl.t ->
       a C.obj ->
-      (int -> (a, disallowed * allowed) mode -> unit) ->
+      (id:int -> level:int -> (a, disallowed * allowed) mode -> unit) ->
       (a, l * allowed) morphvar ->
       unit =
    fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
@@ -666,7 +671,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
           in
           let mu = Amorphvar (u, fg, fg_hint) in
-          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter ~id:u.id ~level:u.level (Amodevar mu);
           iter_contravariant_morphvar ~visited dst iter mu)
         v.vupper
     end
@@ -674,7 +679,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let iter_contravariant : type a l.
       a C.obj ->
       (a, l * allowed) mode ->
-      (int -> (a, disallowed * allowed) mode -> unit) ->
+      (id:int -> level:int -> (a, disallowed * allowed) mode -> unit) ->
       unit =
    fun dst m iter ->
     match m with

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1263,8 +1263,16 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           update_level_v ~log obj level v)
         mvs
 
+  let cnt = ref 0
+
   let submode (type a r l) (pp : H.Pinpoint.t) (obj : a C.obj)
       (a : (a, allowed * r) mode) (b : (a, l * allowed) mode) ~log =
+    if !debug_modes
+    then begin
+      if !cnt mod 10 = 0 then update_level (!cnt mod 3) obj a ~log;
+      if !cnt mod 15 = 0 then update_level (!cnt mod 5) obj b ~log;
+      cnt := !cnt + 1
+    end;
     let submode_cc ~log:_ _pp obj left left_hint right right_hint =
       if C.le obj left right
       then Ok ()

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1300,23 +1300,19 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     (* If bounds are already tight, there is no need to create a copy *)
     if not (C.le dst u.upper u.lower)
     then begin
-      match u.gencopy with
-      | Some _ -> ()
-      | None ->
-        let copy = fresh ~upper:u.upper ~lower:u.lower ~level:u.level dst in
-        let ok1 =
-          submode_mvmv ~log H.Pinpoint.unknown dst
-            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
-            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
-        in
-        let ok2 =
-          submode_mvmv ~log H.Pinpoint.unknown dst
-            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
-            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
-        in
-        assert (Result.is_ok ok1 && Result.is_ok ok2);
-        update_level_v ~log dst current_level copy;
-        set_gencopy ~log u (Some copy)
+      let copy = fresh ~upper:u.upper ~lower:u.lower ~level:current_level dst in
+      let ok1 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+      in
+      let ok2 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+      in
+      assert (Result.is_ok ok1 && Result.is_ok ok2);
+      set_gencopy ~log u (Some copy)
     end
 
   let generalize_v : type a.

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1274,18 +1274,23 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
 
   (* Moves every reachable variable from [u] such that
   [current_level] < [u.level] < [generic_level] to
-  [generic_level + (u.level - current_level)], preserving the exact topology *)
+  [generic_level + (u.level - current_level)], preserving the exact topology
+
+  PRECONDITIONS: None
+  POSTCONDITIONS:
+    current_level < u.level < generic_level ==>
+      Forall v in the reachable set of variables from u:
+        v.level = generic_level + (v.level - current_level) *)
   let rec generalize_topology : type a.
-      log:_ -> a C.obj -> current_level:int -> a var -> unit =
-   fun ~log dst ~current_level u ->
+      log:_ -> current_level:int -> a var -> unit =
+   fun ~log ~current_level u ->
     if u.level <= current_level || u.level >= generic_level
     then ()
     else begin
       let new_level = generic_level + (u.level - current_level) in
       set_level ~log u new_level;
-      let do_gen _ (Amorphvar (v, f, _f_hint)) =
-        let src = C.src dst f in
-        generalize_topology ~log src ~current_level v
+      let do_gen _ (Amorphvar (v, _f, _f_hint)) =
+        generalize_topology ~log ~current_level v
       in
       VarMap.iter do_gen u.vupper;
       VarMap.iter do_gen u.vlower
@@ -1319,55 +1324,75 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    generalize_topology ~log dst ~current_level u;
+    generalize_topology ~log ~current_level u;
     update_level_v ~log dst generic_level u
 
-  (* generalize_structure first moves a variable generic_level.
+  (* generalize_structure first moves a variable to generic_level (like generalize does).
      It then has three cases:
     (1) if bounds are tight, leave it as is
     (2) if bounds are fully open --- by virtue of having no
         vupper/vlower at or above the current level, and fully open
         conservative bounds --- we move it to current level
-    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
-        original var to generic_level, and mark the two variables as equivalent by adding
+    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, keep the
+        original var at generic_level, and mark the two variables as equivalent by adding
         constraint arrows via [add_vlower] and [add_vupper]
-  *)
+
+    PRECONDITIONS: None
+    POSTCONDITIONS:
+      u.level <= current_level ==> no changes to u
+      current_level < u.level ==>
+        ( (u.upper <= u.lower
+              ==> u.vlower = Ø && u.vupper = Ø && u.level = generic_level)
+          && (u.lower = min && u.upper = max
+              && u does not have children at or above current_level
+              ==> u.level = current_level)
+          && (u.lower < u.upper
+              && (u.lower != min || u.upper != max
+                  || u has children at or above current_level)
+              ==> u.level = generic_level && u.gencopy = v where v is a copy of u
+                  where v.level = current_level && v <= u && u <= v)
+        ) *)
   let generalize_structure_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    (* we optimize away vlower and vuppers if bounds are tight *)
-    if C.le dst u.upper u.lower
-    then begin
-      set_vlower ~log u VarMap.empty;
-      set_vupper ~log u VarMap.empty
-    end;
-    let old_level = u.level in
-    generalize_topology ~log dst ~current_level u;
-    update_level_v ~log dst generic_level u;
-    let vlower_above_current =
-      VarMap.filter
-        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
-        u.vlower
-    in
-    let vupper_above_current =
-      VarMap.filter
-        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
-        u.vupper
-    in
-    if C.le dst u.upper u.lower
+    (* if the following does not hold: current_level < u.level
+      [generalize_topology] and [update_level] do nothing. We check it here to optimize
+      away the subsequent checks *)
+    if u.level <= current_level
     then ()
-    else if
-      C.le dst (C.max dst) u.upper
-      && C.le dst u.lower (C.min dst)
-      && VarMap.is_empty vlower_above_current
-      && VarMap.is_empty vupper_above_current
-    then
-      (* the bounds are fully open *)
-      update_level_v ~log dst current_level u
-    else if old_level <> generic_level && u.level = generic_level
-    then begin
-      (* we only create a copy if the variable was generalized *)
-      create_gencopy ~log dst ~current_level u
+    else begin
+      (* we optimize away vlower and vuppers if bounds are tight *)
+      if C.le dst u.upper u.lower
+      then begin
+        set_vlower ~log u VarMap.empty;
+        set_vupper ~log u VarMap.empty
+      end;
+      generalize_topology ~log ~current_level u;
+      update_level_v ~log dst generic_level u;
+      let vlower_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vlower
+      in
+      let vupper_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vupper
+      in
+      if C.le dst u.upper u.lower
+      then ()
+      else if
+        C.le dst (C.max dst) u.upper
+        && C.le dst u.lower (C.min dst)
+        && VarMap.is_empty vlower_above_current
+        && VarMap.is_empty vupper_above_current
+      then
+        (* the bounds are fully open *)
+        update_level_v ~log dst current_level u
+      else begin
+        (* we create a copy of the now generalized variable at [current_level] *)
+        create_gencopy ~log dst ~current_level u
+      end
     end
 
   let generalize (type a l r) ~current_level (obj : a C.obj)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -278,7 +278,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let var_map_to_list t = VarMap.fold (fun _ a xs -> a :: xs) t []
 
   type 'a var =
-    { level : int;
+    { mutable level : int;
           (** The level of the variable. This has the same meaning as the level
               field of a [type_expr]. *)
       mutable vlower : 'a lmorphvar VarMap.t;
@@ -344,6 +344,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Clower : 'a var * 'a * ('a, left_only) Comp_hint.t -> change
     | Cvlower : 'a var * 'a lmorphvar VarMap.t -> change
     | Cvupper : 'a var * 'a rmorphvar VarMap.t -> change
+    | Clevel : 'a var * int -> change
 
   type changes = change list
 
@@ -356,6 +357,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       v.lower_hint <- lower_hint
     | Cvlower (v, vlower) -> v.vlower <- vlower
     | Cvupper (v, vupper) -> v.vupper <- vupper
+    | Clevel (v, level) -> v.level <- level
 
   let empty_changes = []
 
@@ -697,6 +699,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
 
+  (** When called, graph must be fixed so maintain INVARIANT *)
+  let set_level ~log v level =
+    (match log with
+    | None -> ()
+    | Some log -> log := Clevel (v, v.level) :: !log);
+    v.level <- level
+
   (** Returns [Ok ()] if success; [Error x] if failed, and [x] is the next best
       (read: strictly lower) guess to replace the constant argument that MIGHT
       succeed. *)
@@ -975,6 +984,214 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         v.vlower
     end
 
+  (* Tighten the lower bound of [u] based on the lower bound of [f' v].
+  No recursion into [u.vuppers] *)
+  let push_lower_bound : type a b r.
+      log:_ ->
+      b C.obj ->
+      a var ->
+      (a, b, allowed * r) C.morph ->
+      (a, b, allowed * r) Comp_hint.Morph_hint.t ->
+      b var ->
+      unit =
+   fun ~log dst v f' f'_hint u ->
+    let mv = Amorphvar (v, f', f'_hint) in
+    let mlower = mlower dst mv in
+    let mlower_hint = mlower_hint mv in
+    update_lower ~log dst u mlower mlower_hint
+
+  (* Tighten the upper bound of [u] based on the upper bound of [f' v].
+  No recursion into [u.vlowers] *)
+  let push_upper_bound : type a b l.
+      log:_ ->
+      b C.obj ->
+      a var ->
+      (a, b, l * allowed) C.morph ->
+      (a, b, l * allowed) Comp_hint.Morph_hint.t ->
+      b var ->
+      unit =
+   fun ~log dst v f' f'_hint u ->
+    let mv = Amorphvar (v, f', f'_hint) in
+    let mupper = mupper dst mv in
+    let mupper_hint = mupper_hint mv in
+    update_upper ~log dst u mupper mupper_hint
+
+  let add_vlower_nocheck : type a b r.
+      log:_ ->
+      a C.obj ->
+      a var ->
+      b var ->
+      (b, a, allowed * r) C.morph ->
+      (b, a, allowed * r) Comp_hint.Morph_hint.t ->
+      unit =
+   fun ~log dst v u f f_hint ->
+    let x =
+      Amorphvar
+        (u, C.disallow_right f, Comp_hint.Morph_hint.disallow_right f_hint)
+    in
+    let key = get_key dst x in
+    if VarMap.mem key v.vupper
+    then ()
+    else set_vlower ~log v (VarMap.add key x v.vlower)
+
+  let add_vupper_nocheck : type a b l.
+      log:_ ->
+      a C.obj ->
+      a var ->
+      b var ->
+      (b, a, l * allowed) C.morph ->
+      (b, a, l * allowed) Comp_hint.Morph_hint.t ->
+      unit =
+   fun ~log dst v u f f_hint ->
+    let x =
+      Amorphvar (u, C.disallow_left f, Comp_hint.Morph_hint.disallow_left f_hint)
+    in
+    let key = get_key dst x in
+    if VarMap.mem key v.vupper
+    then ()
+    else set_vupper ~log v (VarMap.add key x v.vupper)
+
+  (* Add a vlower entry for the relation [f u <= v], tighten the upper bound of [u],
+  and recursively add relations to maintain invariant.
+  The lower and upper bounds of [u] and [v] are not checked, upper bound is not pushed
+  down [u.vlower] *)
+  let rec add_vlower_reversed : type a b r.
+      log:_ ->
+      H.Pinpoint.t ->
+      a C.obj ->
+      a var ->
+      b var ->
+      (b, a, allowed * r) C.morph ->
+      (b, a, allowed * r) Comp_hint.Morph_hint.t ->
+      unit =
+   fun ~log pp dst v u f f_hint ->
+    let x =
+      Amorphvar
+        (u, C.disallow_right f, Comp_hint.Morph_hint.disallow_right f_hint)
+    in
+    let key = get_key dst x in
+    if VarMap.mem key v.vlower
+    then ()
+    else begin
+      let f' = C.right_adjoint dst f in
+      let _, src, f'_hint = Comp_hint.Morph_hint.right_adjoint pp dst f_hint in
+      push_upper_bound ~log src v f' f'_hint u;
+      set_vlower ~log v (VarMap.add key x v.vlower);
+      VarMap.iter
+        (fun _ (Amorphvar (w, h, h_hint)) ->
+          if w.level < u.level
+          then begin
+            let f'h = C.compose src f' h in
+            let f'h_hint = Comp_hint.Morph_hint.Compose (f'_hint, h_hint) in
+            add_vupper_nocheck ~log src u w f'h f'h_hint
+          end
+          else begin
+            let h' = C.left_adjoint dst h in
+            let _, src, h'_hint =
+              Comp_hint.Morph_hint.left_adjoint pp dst h_hint
+            in
+            let h'f = C.compose src h' (C.disallow_right f) in
+            let h'f_hint =
+              Comp_hint.Morph_hint.Compose
+                (h'_hint, Comp_hint.Morph_hint.disallow_right f_hint)
+            in
+            add_vlower_reversed ~log pp src w u h'f h'f_hint
+          end)
+        v.vupper
+    end
+
+  (* Add a vupper entry for the relation [v <= f u], tighten the lower bound of [u],
+    and recursively add relations to maintain invariant.
+    The lower and upper bounds of [u] and [v] are not checked, lower bound is not pushed
+    down [u.vupper] *)
+  let rec add_vupper_reversed : type a b l.
+      log:_ ->
+      H.Pinpoint.t ->
+      a C.obj ->
+      a var ->
+      b var ->
+      (b, a, l * allowed) C.morph ->
+      (b, a, l * allowed) Comp_hint.Morph_hint.t ->
+      unit =
+   fun ~log pp dst v u f f_hint ->
+    let x =
+      Amorphvar (u, C.disallow_left f, Comp_hint.Morph_hint.disallow_left f_hint)
+    in
+    let key = get_key dst x in
+    if VarMap.mem key v.vupper
+    then ()
+    else begin
+      let f' = C.left_adjoint dst f in
+      let _, src, f'_hint = Comp_hint.Morph_hint.left_adjoint pp dst f_hint in
+      push_lower_bound ~log src v f' f'_hint u;
+      set_vupper ~log v (VarMap.add key x v.vupper);
+      VarMap.iter
+        (fun _ (Amorphvar (w, h, h_hint)) ->
+          if u.level < w.level
+          then begin
+            let h' = C.right_adjoint dst h in
+            let _, src, h'_hint =
+              Comp_hint.Morph_hint.right_adjoint pp dst h_hint
+            in
+            let h'f = C.compose src h' (C.disallow_left f) in
+            let h'f_hint =
+              Comp_hint.Morph_hint.Compose
+                (h'_hint, Comp_hint.Morph_hint.disallow_left f_hint)
+            in
+            add_vupper_reversed ~log pp src w u h'f h'f_hint
+          end
+          else begin
+            let f'h = C.compose src f' h in
+            let f'h_hint = Comp_hint.Morph_hint.Compose (f'_hint, h_hint) in
+            add_vlower_nocheck ~log src u w f'h f'h_hint
+          end)
+        v.vlower
+    end
+
+  let update_level_finalize : type a. log:_ -> a C.obj -> int -> a var -> unit =
+   fun ~log dst level u ->
+    let vupper_lt, vupper_ge =
+      VarMap.partition (fun _ (Amorphvar (v, _, _)) -> v.level < level) u.vupper
+    in
+    let vlower_le, vlower_gt =
+      VarMap.partition
+        (fun _ (Amorphvar (v, _, _)) -> v.level <= level)
+        u.vlower
+    in
+    set_vlower ~log u vlower_le;
+    set_vupper ~log u vupper_lt;
+    VarMap.iter
+      (fun _ (Amorphvar (v, f, f_hint)) ->
+        let f' = C.right_adjoint dst f in
+        let _, src, f'_hint =
+          Comp_hint.Morph_hint.right_adjoint H.Pinpoint.unknown dst f_hint
+        in
+        add_vupper_reversed ~log H.Pinpoint.unknown src v u f' f'_hint)
+      vlower_gt;
+    VarMap.iter
+      (fun _ (Amorphvar (v, f, f_hint)) ->
+        let f' = C.left_adjoint dst f in
+        let _, src, f'_hint =
+          Comp_hint.Morph_hint.left_adjoint H.Pinpoint.unknown dst f_hint
+        in
+        add_vlower_reversed ~log H.Pinpoint.unknown src v u f' f'_hint)
+      vupper_ge;
+    (* optimization: if lower = upper, we can remove vuppers and vlowers since the
+      information is as precise as it can get *)
+    if C.le dst u.upper u.lower
+    then begin
+      set_vlower ~log u VarMap.empty;
+      set_vupper ~log u VarMap.empty
+    end
+
+  let update_level_v : type a. log:_ -> a C.obj -> int -> a var -> unit =
+   fun ~log dst level u ->
+    if u.level > level
+    then begin
+      set_level ~log u level;
+      update_level_finalize ~log dst level u
+    end
+
   let vars = ref (0, [])
 
   let debug_modes = ref true
@@ -1025,6 +1242,26 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       right : 'a;
       right_hint : ('a, right_only) hint_raw
     }
+
+  let update_level (type a l r) (level : int) (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _)) ->
+      let obj = C.src obj f in
+      update_level_v ~log obj level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _)) ->
+          let obj = C.src obj f in
+          update_level_v ~log obj level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _)) ->
+          let obj = C.src obj f in
+          update_level_v ~log obj level v)
+        mvs
 
   let submode (type a r l) (pp : H.Pinpoint.t) (obj : a C.obj)
       (a : (a, allowed * r) mode) (b : (a, l * allowed) mode) ~log =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -998,7 +998,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let mv = Amorphvar (v, f', f'_hint) in
     let mlower = mlower dst mv in
     let mlower_hint = mlower_hint mv in
-    update_lower ~log dst u mlower mlower_hint
+    if not (C.le dst mlower u.lower)
+    then update_lower ~log dst u mlower mlower_hint
 
   (* Tighten the upper bound of [u] based on the upper bound of [f' v].
   No recursion into [u.vlowers] *)
@@ -1014,7 +1015,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let mv = Amorphvar (v, f', f'_hint) in
     let mupper = mupper dst mv in
     let mupper_hint = mupper_hint mv in
-    update_upper ~log dst u mupper mupper_hint
+    if not (C.le dst u.upper mupper)
+    then update_upper ~log dst u mupper mupper_hint
 
   let add_vlower_nocheck : type a b r.
       log:_ ->
@@ -1030,7 +1032,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         (u, C.disallow_right f, Comp_hint.Morph_hint.disallow_right f_hint)
     in
     let key = get_key dst x in
-    if VarMap.mem key v.vupper
+    if VarMap.mem key v.vlower
     then ()
     else set_vlower ~log v (VarMap.add key x v.vlower)
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1426,6 +1426,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       if !cnt mod 15 = 0 then update_level (!cnt mod 5) obj b ~log;
       cnt := !cnt + 1
     end;
+    if !debug_modes && !cnt mod 29 = 0
+    then begin
+      let current_level = !cnt mod 13 in
+      generalize ~current_level ~log obj a
+    end;
     let submode_cc ~log:_ _pp obj left left_hint right right_hint =
       if C.le obj left right
       then Ok ()

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -319,7 +319,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
            but not necessarily [v.upper <= f u.upper].
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
-      id : int  (** For identification/printing *)
+      id : int;  (** For identification/printing *)
+      mutable gencopy : 'a var option
+          (** Calls to [generalize_structure] creates additional copies to make
+              sure the bounds of a generalize structure is rigid: [gencopy]
+              caches such copies *)
     }
 
   and 'b lmorphvar = ('b, left_only) morphvar
@@ -345,6 +349,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower : 'a var * 'a lmorphvar VarMap.t -> change
     | Cvupper : 'a var * 'a rmorphvar VarMap.t -> change
     | Clevel : 'a var * int -> change
+    | Cgencopy : 'a var * 'a var option -> change
 
   type changes = change list
 
@@ -358,6 +363,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower (v, vlower) -> v.vlower <- vlower
     | Cvupper (v, vupper) -> v.vupper <- vupper
     | Clevel (v, level) -> v.level <- level
+    | Cgencopy (v, copy) -> v.gencopy <- copy
 
   let empty_changes = []
 
@@ -390,6 +396,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             morphvars have their own hints). *)
     constraint 'd = _ * _
   [@@ocaml.warning "-62"]
+
+  (** Levels *)
+  let generic_level = Ident.highest_scope
 
   (** Prints a mode variable, including the set of variables related to it
       (recursively). To handle cycles, [traversed] is the set of variables that
@@ -698,6 +707,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by generalize_structure to cache newly created
+      copies *)
+  let set_gencopy ~log v copy =
+    (match log with
+    | None -> ()
+    | Some log -> log := Cgencopy (v, v.gencopy) :: !log);
+    v.gencopy <- copy
 
   (** When called, graph must be fixed so maintain INVARIANT *)
   let set_level ~log v level =
@@ -1217,8 +1234,18 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
     let level = if !debug_modes then id mod 5 else level in
+    let gencopy = None in
     let var =
-      { level; upper; upper_hint; lower; lower_hint; vlower; vupper; id }
+      { level;
+        upper;
+        upper_hint;
+        lower;
+        lower_hint;
+        vlower;
+        vupper;
+        id;
+        gencopy
+      }
     in
     vars := id + 1, Var var :: l;
     var
@@ -1244,6 +1271,130 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       right : 'a;
       right_hint : ('a, right_only) hint_raw
     }
+
+  (* Moves every reachable variable from [u] such that
+  [current_level] < [u.level] < [generic_level] to
+  [generic_level + (u.level - current_level)], preserving the exact topology *)
+  let rec generalize_topology : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    if u.level <= current_level || u.level >= generic_level
+    then ()
+    else begin
+      let new_level = generic_level + (u.level - current_level) in
+      set_level ~log u new_level;
+      let do_gen _ (Amorphvar (v, f, _f_hint)) =
+        let src = C.src dst f in
+        generalize_topology ~log src ~current_level v
+      in
+      VarMap.iter do_gen u.vupper;
+      VarMap.iter do_gen u.vlower
+    end
+
+  (* creates a copy of the variable [u] such that [u] < [copy] and [copy] < [u] via
+  submode, and lowers the [copy] to [current_level].
+  The [copy] is cached in the [gencopy] of [u] *)
+  let create_gencopy : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    (* If bounds are already tight, there is no need to create a copy *)
+    if not (C.le dst u.upper u.lower)
+    then begin
+      match u.gencopy with
+      | Some _ -> ()
+      | None ->
+        let copy = fresh ~upper:u.upper ~lower:u.lower ~level:u.level dst in
+        let ok1 =
+          submode_mvmv ~log H.Pinpoint.unknown dst
+            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+        in
+        let ok2 =
+          submode_mvmv ~log H.Pinpoint.unknown dst
+            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+        in
+        assert (Result.is_ok ok1 && Result.is_ok ok2);
+        update_level_v ~log dst current_level copy;
+        set_gencopy ~log u (Some copy)
+    end
+
+  let generalize_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    generalize_topology ~log dst ~current_level u;
+    update_level_v ~log dst generic_level u
+
+  (* generalize_structure has three cases:
+    (1) if bounds are tight, the var is moved to generic_level
+    (2) if bounds are fully open, do nothing --- we consider only the case where bounds
+        are precise by virtue of having no vupper/vlower
+    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
+        original var to generic_level, and mark the two variables as equivalent by adding
+        constraint arrows via [add_vlower] and [add_vupper]
+  *)
+  let generalize_structure_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    if C.le dst u.upper u.lower
+    then begin
+      (* the bounds are tight *)
+      generalize_topology ~log dst ~current_level u;
+      update_level_v ~log dst generic_level u
+    end
+    else if
+      C.le dst (C.max dst) u.upper
+      && C.le dst u.lower (C.min dst)
+      && VarMap.is_empty u.vlower && VarMap.is_empty u.vupper
+    then
+      (* the bounds are fully open *)
+      update_level_v ~log dst current_level u
+    else begin
+      (* the bounds are non-trivial *)
+      generalize_topology ~log dst ~current_level u;
+      update_level_v ~log dst generic_level u;
+      create_gencopy ~log dst ~current_level u
+    end
+
+  let generalize (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+
+  let generalize_structure (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_structure_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -595,6 +595,99 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         mvs
         (not (VarMap.is_empty mvs))
 
+  type var_iterator =
+    { iter : 'a. 'a C.obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  let mode_iter : type a l r. a C.obj -> (a, l * r) mode -> var_iterator -> unit
+      =
+   fun dst m { iter } ->
+    match m with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let src = C.src dst f in
+      iter src (Amodevar (Amorphvar (v, C.id, Id)))
+    | _ -> ()
+
+  let rec iter_covariant_morphvar : type a r.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (int -> (a, allowed * disallowed) mode -> unit) ->
+      (a, allowed * r) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_right f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_right f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter_covariant_morphvar ~visited dst iter mu)
+        v.vlower
+    end
+
+  let iter_covariant : type a r.
+      a C.obj ->
+      (a, allowed * r) mode ->
+      (int -> (a, allowed * disallowed) mode -> unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_covariant_morphvar ~visited dst iter mv
+    | Amodejoin (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter (fun _ mv -> iter_covariant_morphvar ~visited dst iter mv) mvs
+
+  let rec iter_contravariant_morphvar : type a l.
+      visited:(int, unit) Hashtbl.t ->
+      a C.obj ->
+      (int -> (a, disallowed * allowed) mode -> unit) ->
+      (a, l * allowed) morphvar ->
+      unit =
+   fun ~visited dst iter (Amorphvar (v, f, f_hint)) ->
+    if Hashtbl.mem visited v.id
+    then ()
+    else begin
+      Hashtbl.add visited v.id ();
+      VarMap.iter
+        (fun _ (Amorphvar (u, g, g_hint)) ->
+          let fg = C.compose dst (C.disallow_left f) g in
+          let fg_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_left f_hint, g_hint)
+          in
+          let mu = Amorphvar (u, fg, fg_hint) in
+          if u.level <> generic_level then iter u.id (Amodevar mu);
+          iter_contravariant_morphvar ~visited dst iter mu)
+        v.vupper
+    end
+
+  let iter_contravariant : type a l.
+      a C.obj ->
+      (a, l * allowed) mode ->
+      (int -> (a, disallowed * allowed) mode -> unit) ->
+      unit =
+   fun dst m iter ->
+    match m with
+    | Amode _ -> ()
+    | Amodevar mv ->
+      let visited = Hashtbl.create 17 in
+      iter_contravariant_morphvar ~visited dst iter mv
+    | Amodemeet (_, _, mvs) ->
+      let visited = Hashtbl.create 17 in
+      VarMap.iter
+        (fun _ mv -> iter_contravariant_morphvar ~visited dst iter mv)
+        mvs
+
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
     Amorphvar
@@ -1229,8 +1322,6 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
 
   let vars = ref (0, [])
 
-  let debug_modes = ref true
-
   let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper ~level obj =
     let id, l = !vars in
     let upper, upper_hint =
@@ -1249,7 +1340,6 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
-    let level = if !debug_modes then id mod 5 else level in
     let gencopy = None in
     let subst = None in
     let var =
@@ -1576,21 +1666,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           update_level_v ~log obj level v)
         mvs
 
-  let cnt = ref 0
-
   let submode (type a r l) (pp : H.Pinpoint.t) (obj : a C.obj)
       (a : (a, allowed * r) mode) (b : (a, l * allowed) mode) ~log =
-    if !debug_modes
-    then begin
-      if !cnt mod 10 = 0 then update_level (!cnt mod 3) obj a ~log;
-      if !cnt mod 15 = 0 then update_level (!cnt mod 5) obj b ~log;
-      cnt := !cnt + 1
-    end;
-    if !debug_modes && !cnt mod 29 = 0
-    then begin
-      let current_level = !cnt mod 13 in
-      generalize ~current_level ~log obj a
-    end;
     let submode_cc ~log:_ _pp obj left left_hint right right_hint =
       if C.le obj left right
       then Ok ()

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -977,6 +977,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
 
   let vars = ref (0, [])
 
+  let debug_modes = ref true
+
   let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper ~level obj =
     let id, l = !vars in
     let upper, upper_hint =
@@ -995,6 +997,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
+    let level = if !debug_modes then id mod 5 else level in
     let var =
       { level; upper; upper_hint; lower; lower_hint; vlower; vupper; id }
     in

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -278,41 +278,53 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let var_map_to_list t = VarMap.fold (fun _ a xs -> a :: xs) t []
 
   type 'a var =
-    { mutable vlower : 'a lmorphvar VarMap.t;
+    { level : int;
+          (** The level of the variable. This has the same meaning as the level
+              field of a [type_expr]. *)
+      mutable vlower : 'a lmorphvar VarMap.t;
           (** A list of variables directly under the current variable. Each is a
               pair [f] [v], and we have [f v <= u] where [u] is the current
               variable. *)
-      mutable upper : 'a;  (** The precise upper bound of the variable *)
-      mutable upper_hint : ('a, right_only) Comp_hint.t;
-          (** Hints for [upper] *)
+      mutable vupper : 'a rmorphvar VarMap.t;
+          (** A list of variables directly above the current variable. Each is a
+              pair [f] [v], and we have [u <= f v] where [u] is the current
+              variable. *)
       mutable lower : 'a;
           (** The *conservative* lower bound of the variable. Why conservative:
               if a user calls [submode c u] where [c] is some constant and [u]
               some variable, we can modify [u.lower] of course. Idealy we should
               also modify all [v.lower] where [v] is variable above [u].
-              However, we only have [vlower] not [vupper]. Therefore, the
-              [lower] of higher variables are not updated immediately, hence
-              conservative. Those [lower] of higher variables can be made
-              precise later on demand, see [zap_to_floor_var_aux].
-
-              One might argue for an additional [vupper] field, so that [lower]
-              are always precise. While this might be doable, we note that the
-              "hotspot" of the mode solver is to detect conflict, which is
-              already achieved without precise [lower]. Adding [vupper] and
-              keeping [lower] precise will come at extra cost. *)
+              However, variables at a higher [level] are not reachable from [u].
+              Therefore, the [lower] of higher variables are not updated
+              immediately, hence conservative. Those [lower] of higher variables
+              can be made precise later on demand, see [zap_to_floor_var_aux].
+          *)
+      mutable lower_hint : ('a, left_only) Comp_hint.t;
+          (** Hints for [lower] *)
+      mutable upper : 'a;
+          (** The conservative upper bound of the variable. See [lower] to
+              understand why the bound is conservative *)
+      mutable upper_hint : ('a, right_only) Comp_hint.t;
+          (** Hints for [upper] *)
       (* To summarize, INVARIANT:
          - For any variable [v], we have [v.lower <= v.upper].
          - Variables that have been fully constrained will have
          [v.lower = v.upper]. Note that adding a boolean field indicating that
          won't help much.
-         - For any [v] and [f u \in v.vlower], we have [f u.upper <= v.upper], but not
-         necessarily [f u.lower <= v.lower]. *)
-      mutable lower_hint : ('a, left_only) Comp_hint.t;
-          (** Hints for [lower] *)
+         - For any [v] and [f u \in v.vlower], [u.level <= v.level]
+         - For any [v] and [f u \in v.vupper], [u.level < v.level]
+         - For any [v] and [f u \in v.vlower], we have [f u.upper <= v.upper],
+           but not necessarily [f u.lower <= v.lower].
+         - For any [v] and [f u \in v.vupper], we have [v.lower <= f u.lower],
+           but not necessarily [v.upper <= f u.upper].
+         - for all [f u \in v.vlower] and [g w \in v.vupper] we
+           have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
       id : int  (** For identification/printing *)
     }
 
   and 'b lmorphvar = ('b, left_only) morphvar
+
+  and 'b rmorphvar = ('b, right_only) morphvar
 
   and ('b, 'd) morphvar =
     | Amorphvar :
@@ -331,6 +343,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cupper : 'a var * 'a * ('a, right_only) Comp_hint.t -> change
     | Clower : 'a var * 'a * ('a, left_only) Comp_hint.t -> change
     | Cvlower : 'a var * 'a lmorphvar VarMap.t -> change
+    | Cvupper : 'a var * 'a rmorphvar VarMap.t -> change
 
   type changes = change list
 
@@ -342,6 +355,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       v.lower <- lower;
       v.lower_hint <- lower_hint
     | Cvlower (v, vlower) -> v.vlower <- vlower
+    | Cvupper (v, vupper) -> v.vupper <- vupper
 
   let empty_changes = []
 
@@ -375,7 +389,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     constraint 'd = _ * _
   [@@ocaml.warning "-62"]
 
-  (** Prints a mode variable, including the set of variables below it
+  (** Prints a mode variable, including the set of variables related to it
       (recursively). To handle cycles, [traversed] is the set of variables that
       we have already printed and will be skipped. An example of cycle:
 
@@ -388,24 +402,29 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       f 2 = 2
       v}
 
-      Note that f has a left right, which allows us to write f on the LHS of
+      Note that f has a left adjoint, which allows us to write f on the LHS of
       submode. Say we create a unconstrained variable [x], and invoke submode:
       [f x <= x] this would result in adding (f, x) into the [vlower] of [x].
       That is, there will be a self-loop on [x]. *)
   let rec print_var : type a. ?traversed:VarSet.t -> a C.obj -> _ -> a var -> _
       =
    fun ?traversed obj ppf v ->
-    Fmt.fprintf ppf "modevar#%x[%a .. %a]" v.id (C.print obj) v.lower
-      (C.print obj) v.upper;
+    Fmt.fprintf ppf "modevar#%x<%x>[%a .. %a]" v.id v.level (C.print obj)
+      v.lower (C.print obj) v.upper;
     match traversed with
     | None -> ()
     | Some traversed ->
       if VarSet.mem v.id traversed
       then ()
-      else
+      else if (not (VarMap.is_empty v.vlower)) || not (VarMap.is_empty v.vupper)
+      then begin
         let traversed = VarSet.add v.id traversed in
-        let p = print_morphvar ~traversed obj in
-        Fmt.fprintf ppf "{%a}" (Fmt.pp_print_list p) (var_map_to_list v.vlower)
+        Fmt.fprintf ppf "{%a--%a}"
+          (Fmt.pp_print_list (print_morphvar ~traversed obj))
+          (var_map_to_list v.vlower)
+          (Fmt.pp_print_list (print_morphvar ~traversed obj))
+          (var_map_to_list v.vupper)
+      end
 
   and print_morphvar : type a l r.
       ?traversed:VarSet.t -> a C.obj -> _ -> (a, l * r) morphvar -> _ =
@@ -528,6 +547,35 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     Amode (a, hint, hint)
 
+  let check_level_morphvar : type a l r. (a, l * r) morphvar -> int -> bool =
+   fun (Amorphvar (v, _, _)) i -> v.level = i
+
+  let check_level : type a l r. (a, l * r) mode -> int -> bool =
+   fun m i ->
+    match m with
+    | Amode _ -> true
+    | Amodevar mv -> check_level_morphvar mv i
+    | Amodemeet (_, _, mvs) ->
+      VarMap.fold (fun _ mv acc -> acc && check_level_morphvar mv i) mvs true
+    | Amodejoin (_, _, mvs) ->
+      VarMap.fold (fun _ mv acc -> acc && check_level_morphvar mv i) mvs true
+
+  let check_level_var : type a l r. (a, l * r) mode -> int -> bool =
+   fun m i ->
+    match m with
+    | Amode _ -> false
+    | Amodevar mv -> check_level_morphvar mv i
+    | Amodemeet (_, _, mvs) ->
+      VarMap.fold
+        (fun _ mv acc -> acc && check_level_morphvar mv i)
+        mvs
+        (not (VarMap.is_empty mvs))
+    | Amodejoin (_, _, mvs) ->
+      VarMap.fold
+        (fun _ mv acc -> acc && check_level_morphvar mv i)
+        mvs
+        (not (VarMap.is_empty mvs))
+
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
     Amorphvar
@@ -641,7 +689,18 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Some log -> log := Cvlower (v, v.vlower) :: !log);
     v.vlower <- vlower
 
-  let submode_cv : type a.
+  (** Arguments are not checked and used directly. They must satisfy the
+      INVARIANT listed above. *)
+  let set_vupper ~log v vupper =
+    (match log with
+    | None -> ()
+    | Some log -> log := Cvupper (v, v.vupper) :: !log);
+    v.vupper <- vupper
+
+  (** Returns [Ok ()] if success; [Error x] if failed, and [x] is the next best
+      (read: strictly lower) guess to replace the constant argument that MIGHT
+      succeed. *)
+  let rec submode_cv : type a.
       log:_ ->
       H.Pinpoint.t ->
       a C.obj ->
@@ -649,17 +708,33 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       (a, left_only) Comp_hint.t ->
       a var ->
       (unit, a * (a, right_only) Comp_hint.t) Result.t =
-   fun (type a) ~log _pp (obj : a C.obj) a' a'_hint v ->
+   fun (type a) ~log pp (obj : a C.obj) a' a'_hint v ->
     if C.le obj a' v.lower
     then Ok ()
     else if not (C.le obj a' v.upper)
     then Error (v.upper, v.upper_hint)
     else (
       update_lower ~log obj v a' a'_hint;
-      if C.le obj v.upper v.lower then set_vlower ~log v VarMap.empty;
-      Ok ())
+      let r =
+        v.vupper
+        |> find_error (fun mu ->
+            let r = submode_cmv ~log pp obj a' a'_hint mu in
+            (if Result.is_ok r && VarMap.is_empty v.vlower
+             then
+               (* Optimization: update [v.upper] based on [mupper u].*)
+               let mu_upper = mupper obj mu in
+               if not (C.le obj mu_upper v.upper)
+               then update_upper ~log obj v mu_upper (mupper_hint mu));
+            r)
+      in
+      if C.le obj v.upper v.lower
+      then begin
+        set_vlower ~log v VarMap.empty;
+        set_vupper ~log v VarMap.empty
+      end;
+      r)
 
-  let submode_cmv : type a l.
+  and submode_cmv : type a l.
       log:_ ->
       H.Pinpoint.t ->
       a C.obj ->
@@ -685,8 +760,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       in
       let a' = C.apply src f' a in
       let a'_hint = Comp_hint.Apply (f'_hint, a_hint) in
-      submode_cv ~log src_pp src a' a'_hint v |> Result.get_ok;
-      Ok ()
+      match submode_cv ~log src_pp src a' a'_hint v with
+      | Ok () -> Ok ()
+      | Error (e, e_hint) ->
+        Error
+          ( C.apply obj f e,
+            Comp_hint.Apply (Comp_hint.Morph_hint.disallow_left f_hint, e_hint)
+          )
 
   (** Returns [Ok ()] if success; [Error x] if failed, and [x] is the next best
       (read: strictly higher) guess to replace the constant argument that MIGHT
@@ -710,7 +790,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         v.vlower
         |> find_error (fun mu ->
             let r = submode_mvc ~log pp obj mu a' a'_hint in
-            (if Result.is_ok r
+            (if Result.is_ok r && VarMap.is_empty v.vupper
              then
                (* Optimization: update [v.lower] based on [mlower u].*)
                let mu_lower = mlower obj mu in
@@ -719,7 +799,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
                then update_lower ~log obj v mu_lower mu_lower_hint);
             r)
       in
-      if C.le obj v.upper v.lower then set_vlower ~log v VarMap.empty;
+      if C.le obj v.upper v.lower
+      then begin
+        set_vlower ~log v VarMap.empty;
+        set_vupper ~log v VarMap.empty
+      end;
       r)
 
   and submode_mvc :
@@ -776,8 +860,15 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       | Misc.Is_not_eq -> false
       | Misc.Is_eq -> true
 
-  let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
-      (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =
+  let rec submode_mvmv : type a l r.
+      log:_ ->
+      H.Pinpoint.t ->
+      a C.obj ->
+      (a, allowed * r) morphvar ->
+      (a, l * allowed) morphvar ->
+      (_, a * (a, _) Comp_hint.t * a * (a, _) Comp_hint.t) result =
+   fun ~log pp dst (Amorphvar (v, f, f_hint) as mv)
+       (Amorphvar (u, g, g_hint) as mu) ->
     if C.le dst (mupper dst mv) (mlower dst mu)
     then Ok ()
     else if eq_morphvar dst mv mu
@@ -785,10 +876,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     else
       let muupper = mupper dst mu in
       let muupper_hint = mupper_hint mu in
-      (* The call f v <= g u translates to three steps:
+      (* The call f v <= g u translates to the following step:
          1. f v <= g u.upper
          2. f v.lower <= g u
-         3. adding g' (f v) to the u.vlower, where g' is the left adjoint of g.
+         3. If v.level <= u.level, for all (h w) in u.vupper, g' (f v) <= h w
+         4. If v.level <= u.level adding g' (f v) to u.vlower, where g' is the left adjoint of g
+         5. If v.level > u.level, for all (h w) in v.vlower, h w <= f' (g u)
+         6. If v.level > u.level adding f' (g u) to v.vupper, where f' is the right adjoint of f
+         Steps 3 and 4 are implemented by [add_vlower], steps 5 and 6 by [add_vupper].
       *)
       match submode_mvc ~log pp dst mv muupper muupper_hint with
       | Error (a, a_hint) -> Error (a, a_hint, muupper, muupper_hint)
@@ -798,27 +893,91 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         match submode_cmv ~log pp dst mvlower mvlower_hint mu with
         | Error (a, a_hint) -> Error (mvlower, mvlower_hint, a, a_hint)
         | Ok () ->
-          (* At this point, we know that [f v <= g u.upper], which means [f v]
-             lies within the downward closure of [g]'s image. Therefore, asking [f
-             v <= g u] is equivalent to asking [g' f v <= u] *)
-          let g' = C.left_adjoint dst g in
-          let _, src, g'_hint =
-            Comp_hint.Morph_hint.left_adjoint pp dst g_hint
-          in
-          let g'f = C.compose src g' (C.disallow_right f) in
-          let g'f_hint =
+          if v.level <= u.level
+          then add_vlower ~log pp dst v f f_hint mv u g g_hint
+          else add_vupper ~log pp dst v f f_hint u g g_hint mu)
+
+  (* Add a vlower entry for the relationship [f v <= g u] if necessary. *)
+  and add_vlower : type a b c l r.
+      log:_ ->
+      H.Pinpoint.t ->
+      b C.obj ->
+      a var ->
+      (a, b, allowed * r) C.morph ->
+      (a, b, allowed * r) Comp_hint.Morph_hint.t ->
+      (b, allowed * r) morphvar ->
+      c var ->
+      (c, b, l * allowed) C.morph ->
+      (c, b, l * allowed) Comp_hint.Morph_hint.t ->
+      (_, b * (b, _) Comp_hint.t * b * (b, _) Comp_hint.t) result =
+   fun ~log pp dst v f f_hint mv u g g_hint ->
+    let g' = C.left_adjoint dst g in
+    let _, src, g'_hint = Comp_hint.Morph_hint.left_adjoint pp dst g_hint in
+    let g'f = C.compose src g' (C.disallow_right f) in
+    let g'f_hint =
+      Comp_hint.Morph_hint.Compose
+        (g'_hint, Comp_hint.Morph_hint.disallow_right f_hint)
+    in
+    let x = Amorphvar (v, g'f, g'f_hint) in
+    let key = get_key src x in
+    if VarMap.mem key u.vlower
+    then Ok ()
+    else begin
+      set_vlower ~log u (VarMap.add key x u.vlower);
+      find_error
+        (fun (Amorphvar (w, h, h_hint)) ->
+          let gh = C.compose dst (C.disallow_left g) h in
+          let gh_hint =
             Comp_hint.Morph_hint.Compose
-              (g'_hint, Comp_hint.Morph_hint.disallow_right f_hint)
+              (Comp_hint.Morph_hint.disallow_left g_hint, h_hint)
           in
-          let x = Amorphvar (v, g'f, g'f_hint) in
-          let key = get_key src x in
-          if not (VarMap.mem key u.vlower)
-          then set_vlower ~log u (VarMap.add key x u.vlower);
-          Ok ())
+          let y = Amorphvar (w, gh, gh_hint) in
+          submode_mvmv ~log pp dst mv y)
+        u.vupper
+    end
+
+  (* Add a vupper entry for the relationship [f v <= g u] if necessary. *)
+  and add_vupper : type a b c l r.
+      log:_ ->
+      H.Pinpoint.t ->
+      b C.obj ->
+      a var ->
+      (a, b, allowed * r) C.morph ->
+      (a, b, allowed * r) Comp_hint.Morph_hint.t ->
+      c var ->
+      (c, b, l * allowed) C.morph ->
+      (c, b, l * allowed) Comp_hint.Morph_hint.t ->
+      (b, l * allowed) morphvar ->
+      (_, b * (b, _) Comp_hint.t * b * (b, _) Comp_hint.t) result =
+   fun ~log pp dst v f f_hint u g g_hint mu ->
+    let f' = C.right_adjoint dst f in
+    let _, src, f'_hint = Comp_hint.Morph_hint.right_adjoint pp dst f_hint in
+    let f'g = C.compose src f' (C.disallow_left g) in
+    let f'g_hint =
+      Comp_hint.Morph_hint.Compose
+        (f'_hint, Comp_hint.Morph_hint.disallow_left g_hint)
+    in
+    let x = Amorphvar (u, f'g, f'g_hint) in
+    let key = get_key src x in
+    if VarMap.mem key v.vupper
+    then Ok ()
+    else begin
+      set_vupper ~log v (VarMap.add key x v.vupper);
+      find_error
+        (fun (Amorphvar (w, h, h_hint)) ->
+          let fh = C.compose dst (C.disallow_right f) h in
+          let fh_hint =
+            Comp_hint.Morph_hint.Compose
+              (Comp_hint.Morph_hint.disallow_right f_hint, h_hint)
+          in
+          let y = Amorphvar (w, fh, fh_hint) in
+          submode_mvmv ~log pp dst y mu)
+        v.vlower
+    end
 
   let vars = ref (0, [])
 
-  let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower obj =
+  let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper ~level obj =
     let id, l = !vars in
     let upper, upper_hint =
       match upper, upper_hint with
@@ -835,7 +994,10 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       | Some lower, Some lower_hint -> lower, lower_hint
     in
     let vlower = Option.value vlower ~default:VarMap.empty in
-    let var = { upper; upper_hint; lower; lower_hint; vlower; id } in
+    let vupper = Option.value vupper ~default:VarMap.empty in
+    let var =
+      { level; upper; upper_hint; lower; lower_hint; vlower; vupper; id }
+    in
     vars := id + 1, Var var :: l;
     var
 
@@ -1045,20 +1207,6 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Amodemeet (a, _a_hint, mvs) ->
       VarMap.fold (fun _ mv acc -> C.meet obj acc (mlower obj mv)) mvs a
 
-  (* Due to our biased implementation, the ceil is precise. *)
-  let get_ceil = get_loose_ceil
-
-  let zap_to_ceil : type a l. a C.obj -> (a, l * allowed) mode -> log:_ -> a =
-   fun obj m ~log ->
-    let ceil = get_ceil obj m in
-    (* We want a hint to explain why [ceil] is high. However, we only have hint
-       for why [ceil] is low. There is no good hint to use. *)
-    submode H.Pinpoint.unknown obj
-      (Amode (ceil, Unknown ceil, Unknown ceil))
-      m ~log
-    |> Result.get_ok;
-    ceil
-
   (** Zap [mv] to its lower bound. Returns the [log] of the zapping, in case the
       caller are only interested in the lower bound and wants to reverse the
       zapping.
@@ -1089,6 +1237,34 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         loop (C.join obj a lower)
     in
     loop (mlower obj mv)
+
+  (** Zap [mv] to its upper bound. Returns the [log] of the zapping, in case the
+      caller are only interested in the lower bound and wants to reverse the
+      zapping.
+
+      [mupper mv] is not precise; to get the precise upper bound of [mv], we
+      call [submode (mupper mv) mv ]. This will propagate to all its children,
+      which might fail because some children's upper bound [a] is more
+      up-to-date than [mv]. In that case, we call [submode a mv]. We repeat this
+      process until no failure, and we will get the precise lower bound.
+
+      The loop is guaranteed to terminate, because for each iteration our
+      guessed lower bound is strictly higher; and all lattices are finite. *)
+  let zap_to_ceil_morphvar_aux (type a l) (obj : a C.obj)
+      (mv : (a, l * allowed) morphvar) =
+    let rec loop upper =
+      let log = ref empty_changes in
+      let r =
+        submode_cmv ~log:(Some log) H.Pinpoint.unknown obj upper (Unknown upper)
+          mv
+      in
+      match r with
+      | Ok () -> !log, upper
+      | Error (a, _) ->
+        undo_changes !log;
+        loop (C.meet obj a upper)
+    in
+    loop (mupper obj mv)
 
   (** Zaps a morphvar to its floor and returns the floor. [commit] could be
       [Some log], in which case the zapping is appended to [log]; it could also
@@ -1122,6 +1298,38 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         mvs;
       floor
 
+  (** Zaps a morphvar to its ceiling and returns the ceiling. [commit] could be
+      [Some log], in which case the zapping is appended to [log]; it could also
+      be [None], in which case the zapping is reverted. The latter is useful
+      when the caller only wants to know the ceiling without zapping. *)
+  let zap_to_ceil_morphvar obj mv ~commit =
+    let log_, upper = zap_to_ceil_morphvar_aux obj mv in
+    (match commit with
+    | None -> undo_changes log_
+    | Some log -> log := append_changes !log log_);
+    upper
+
+  let zap_to_ceil : type a l. a C.obj -> (a, l * allowed) mode -> log:_ -> a =
+   fun obj m ~log ->
+    match m with
+    | Amode (a, _a_hint_lower, _a_hint_upper) -> a
+    | Amodevar mv -> zap_to_ceil_morphvar obj mv ~commit:log
+    | Amodemeet (a, _a_hint, mvs) ->
+      let ceil =
+        VarMap.fold
+          (fun _ mv acc ->
+            C.meet obj acc (zap_to_ceil_morphvar obj mv ~commit:None))
+          mvs a
+      in
+      VarMap.iter
+        (fun _ mv ->
+          let ok =
+            submode_cmv H.Pinpoint.unknown obj ceil (Unknown ceil) mv ~log
+          in
+          assert (Result.is_ok ok))
+        mvs;
+      ceil
+
   let get_floor : type a r. a C.obj -> (a, allowed * r) mode -> a =
    fun obj m ->
     match m with
@@ -1131,6 +1339,17 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       VarMap.fold
         (fun _ mv acc ->
           C.join obj acc (zap_to_floor_morphvar obj mv ~commit:None))
+        mvs a
+
+  let get_ceil : type a l. a C.obj -> (a, l * allowed) mode -> a =
+   fun obj m ->
+    match m with
+    | Amode (a, _a_hint_lower, _a_hint_upper) -> a
+    | Amodevar mv -> zap_to_ceil_morphvar obj mv ~commit:None
+    | Amodemeet (a, _a_hint, mvs) ->
+      VarMap.fold
+        (fun _ mv acc ->
+          C.meet obj acc (zap_to_ceil_morphvar obj mv ~commit:None))
         mvs a
 
   let to_const_exn obj m =
@@ -1154,9 +1373,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     then C.print obj ppf ceil
     else print_raw ?verbose obj ppf m
 
-  let newvar obj = Amodevar (Amorphvar (fresh obj, C.id, Id))
+  let newvar obj level =
+    let u = fresh ~level obj in
+    Amodevar (Amorphvar (u, C.id, Id))
 
-  let newvar_above (type a r) (obj : a C.obj) (m : (a, allowed * r) mode) =
+  let newvar_above (type a r) (obj : a C.obj) (level : int)
+      (m : (a, allowed * r) mode) =
     match disallow_right m with
     | Amode (a, a_hint_lower, _a_hint_upper) ->
       if C.le obj (C.max obj) a
@@ -1166,29 +1388,53 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             (Amorphvar
                ( fresh ~lower:a
                    ~lower_hint:(Comp_hint.disallow_right a_hint_lower)
-                   obj,
+                   ~level obj,
                  C.id,
                  Id )),
           true )
-    | Amodevar mv ->
-      (* [~lower] is not precise (because [mlower mv] is not precise), but
+    | Amodevar (Amorphvar (v, _, _) as mv) ->
+      if v.level <= level
+      then
+        (* [~lower] is not precise (because [mlower mv] is not precise), but
          it doesn't need to be *)
-      ( Amodevar
-          (Amorphvar
-             ( fresh ~lower:(mlower obj mv) ~lower_hint:(mlower_hint mv)
-                 ~vlower:(VarMap.singleton (get_key obj mv) mv)
-                 obj,
-               C.id,
-               Id )),
-        true )
+        ( Amodevar
+            (Amorphvar
+               ( fresh ~lower:(mlower obj mv) ~lower_hint:(mlower_hint mv)
+                   ~vlower:(VarMap.singleton (get_key obj mv) mv)
+                   ~level obj,
+                 C.id,
+                 Id )),
+          true )
+      else
+        let u = fresh ~level obj in
+        let mu = Amorphvar (u, C.id, Id) in
+        let ok = submode_mvmv ~log:None H.Pinpoint.unknown obj mv mu in
+        assert (Result.is_ok ok);
+        allow_right (Amodevar mu), true
     | Amodejoin (a, a_hint, mvs) ->
-      (* [~lower] is not precise here, but it doesn't need to be *)
-      ( Amodevar
-          (Amorphvar
-             (fresh ~lower:a ~lower_hint:a_hint ~vlower:mvs obj, C.id, Id)),
-        true )
+      if VarMap.for_all (fun _ (Amorphvar (v, _, _)) -> v.level <= level) mvs
+      then
+        (* [~lower] is not precise here, but it doesn't need to be *)
+        ( Amodevar
+            (Amorphvar
+               ( fresh ~lower:a ~lower_hint:a_hint ~vlower:mvs ~level obj,
+                 C.id,
+                 Id )),
+          true )
+      else
+        let u = fresh ~level obj in
+        let mu = Amorphvar (u, C.id, Id) in
+        submode_cmv H.Pinpoint.unknown obj ~log:None a a_hint mu
+        |> Result.get_ok;
+        VarMap.iter
+          (fun _ mv ->
+            let ok = submode_mvmv ~log:None H.Pinpoint.unknown obj mv mu in
+            assert (Result.is_ok ok))
+          mvs;
+        allow_right (Amodevar mu), true
 
-  let newvar_below (type a l) (obj : a C.obj) (m : (a, l * allowed) mode) =
+  let newvar_below (type a l) (obj : a C.obj) (level : int)
+      (m : (a, l * allowed) mode) =
     match disallow_left m with
     | Amode (a, _a_hint_lower, a_hint_upper) ->
       if C.le obj a (C.min obj)
@@ -1198,23 +1444,47 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             (Amorphvar
                ( fresh ~upper:a
                    ~upper_hint:(Comp_hint.disallow_left a_hint_upper)
-                   obj,
+                   ~level obj,
                  C.id,
                  Id )),
           true )
-    | Amodevar mv ->
-      let u = fresh obj in
-      let mu = Amorphvar (u, C.id, Id) in
-      submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok;
-      allow_left (Amodevar mu), true
+    | Amodevar (Amorphvar (v, _, _) as mv) ->
+      if v.level < level
+      then
+        (* [~upper] is not precise (because [mupper mv] is not precise), but
+         it doesn't need to be *)
+        ( Amodevar
+            (Amorphvar
+               ( fresh ~upper:(mupper obj mv) ~upper_hint:(mupper_hint mv)
+                   ~vupper:(VarMap.singleton (get_key obj mv) mv)
+                   ~level obj,
+                 C.id,
+                 Id )),
+          true )
+      else
+        let u = fresh ~level obj in
+        let mu = Amorphvar (u, C.id, Id) in
+        submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok;
+        allow_left (Amodevar mu), true
     | Amodemeet (a, a_hint, mvs) ->
-      let u = fresh obj in
-      let mu = Amorphvar (u, C.id, Id) in
-      submode_mvc H.Pinpoint.unknown obj ~log:None mu a a_hint |> Result.get_ok;
-      VarMap.iter
-        (fun _ mv ->
-          submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
-        mvs;
-      allow_left (Amodevar mu), true
+      if VarMap.for_all (fun _ (Amorphvar (v, _, _)) -> v.level < level) mvs
+      then
+        (* [~upper] is not precise here, but it doesn't need to be *)
+        ( Amodevar
+            (Amorphvar
+               ( fresh ~upper:a ~upper_hint:a_hint ~vupper:mvs ~level obj,
+                 C.id,
+                 Id )),
+          true )
+      else
+        let u = fresh ~level obj in
+        let mu = Amorphvar (u, C.id, Id) in
+        submode_mvc H.Pinpoint.unknown obj ~log:None mu a a_hint
+        |> Result.get_ok;
+        VarMap.iter
+          (fun _ mv ->
+            submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
+          mvs;
+        allow_left (Amodevar mu), true
 end
 [@@inline always]

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -320,6 +320,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
       id : int;  (** For identification/printing *)
+      mutable subst : 'a var option;
+          (** Similar to Tsubst in a type, the [subst] field holds an optional
+              copy used during instantiation *)
       mutable gencopy : 'a var option
           (** Calls to [generalize_structure] creates additional copies to make
               sure the bounds of a generalize structure is rigid: [gencopy]
@@ -372,6 +375,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   (** [append_changes l0 l1] returns a log that's equivalent to [l0] followed by
       [l1]. *)
   let append_changes l0 l1 = l1 @ l0
+
+  type copy_change =
+    | Coptcopy : 'a C.obj * int * 'a var * 'a var option -> copy_change
+
+  type copy_scope = { mutable saved_copies : copy_change list }
 
   type ('a, 'd) mode =
     | Amode :
@@ -707,6 +715,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by copy, where [changes] maintains the cleanup
+      once the copy is done. Unlike other setters, the [changes] is here
+      mandatory *)
+  let set_optcopy ~changes obj ~copy_to_level v copy =
+    changes.saved_copies
+      <- Coptcopy (obj, copy_to_level, v, v.subst) :: changes.saved_copies;
+    v.subst <- copy
 
   (** Function used internally by generalize_structure to cache newly created
       copies *)
@@ -1235,6 +1251,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let vupper = Option.value vupper ~default:VarMap.empty in
     let level = if !debug_modes then id mod 5 else level in
     let gencopy = None in
+    let subst = None in
     let var =
       { level;
         upper;
@@ -1244,7 +1261,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         vlower;
         vupper;
         id;
-        gencopy
+        gencopy;
+        subst
       }
     in
     vars := id + 1, Var var :: l;
@@ -1434,6 +1452,103 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           let obj = C.src obj f in
           generalize_structure_v ~log obj ~current_level v)
         mvs
+
+  let fresh_mode_copy_scope () = { saved_copies = [] }
+
+  let undo_copy_change = function
+    | Coptcopy (dst, update_to_level, v, copy) ->
+      Option.iter
+        (fun u -> update_level_finalize ~log:None dst update_to_level u)
+        v.subst;
+      v.subst <- copy
+
+  let cleanup_mode_copy_scope l = List.iter undo_copy_change l.saved_copies
+
+  let with_copy_scope f =
+    let scope = fresh_mode_copy_scope () in
+    Fun.protect
+      ~finally:(fun () -> cleanup_mode_copy_scope scope)
+      (fun () -> f scope)
+
+  let rec copy_v : type a.
+      copy_scope:_ ->
+      copy_from_level:int ->
+      copy_to_level:int ->
+      a C.obj ->
+      a var ->
+      a var =
+   fun ~copy_scope ~copy_from_level ~copy_to_level obj v ->
+    if v.level < copy_from_level
+    then v
+    else
+      (* generalize_structure might have already created a copy, cached in [gencopy].
+         If such a copy exist, we return it *)
+      begin match v.gencopy with
+      | Some v' -> v'
+      | None -> (
+        match v.subst with
+        | Some v' -> v'
+        | None ->
+          let copy = fresh ~upper:v.upper ~lower:v.lower ~level:v.level obj in
+          set_optcopy ~changes:copy_scope obj ~copy_to_level v (Some copy);
+          let vupper =
+            VarMap.map
+              (fun (Amorphvar (u, f, f_hint)) ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
+                in
+                Amorphvar (ucopy, f, f_hint))
+              v.vupper
+          in
+          let vlower =
+            VarMap.map
+              (fun (Amorphvar (u, f, f_hint)) ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
+                in
+                Amorphvar (ucopy, f, f_hint))
+              v.vlower
+          in
+          copy.vupper <- vupper;
+          copy.vlower <- vlower;
+          set_level ~log:None copy copy_to_level;
+          copy)
+      end
+
+  let copy (type a l r) ~copy_scope ~copy_from_level ~copy_to_level
+      (obj : a C.obj) (a : (a, l * r) mode) : (a, l * r) mode =
+    match a with
+    | Amodevar (Amorphvar (v, f, f_hint)) ->
+      let obj = C.src obj f in
+      let vcopy = copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v in
+      if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
+    | Amode _ -> a
+    | Amodejoin (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.map
+          (fun (Amorphvar (v, f, f_hint)) ->
+            let obj = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v
+            in
+            Amorphvar (vcopy, f, f_hint))
+          mvs
+      in
+      Amodejoin (a, a_hint, mvscopy)
+    | Amodemeet (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.map
+          (fun (Amorphvar (v, f, f_hint)) ->
+            let obj = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v
+            in
+            Amorphvar (vcopy, f, f_hint))
+          mvs
+      in
+      Amodemeet (a, a_hint, mvscopy)
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1010,7 +1010,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let unhint_var v =
     v.upper_hint <- Comp_hint.Unknown v.upper;
     v.lower_hint <- Comp_hint.Unknown v.lower;
-    v.vlower <- VarMap.map unhint_morphvar v.vlower
+    v.vlower <- VarMap.map unhint_morphvar v.vlower;
+    v.vupper <- VarMap.map unhint_morphvar v.vupper
 
   let erase_hints () =
     let _, l = !vars in

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -250,8 +250,8 @@ module type Solver_mono = sig
   val zap_to_ceil :
     'a obj -> ('a, 'l * allowed) mode -> log:changes ref option -> 'a
 
-  (** Create a new mode variable of the full range. *)
-  val newvar : 'a obj -> ('a, 'l * 'r) mode
+  (** Create a new mode variable of the full range at given level. *)
+  val newvar : 'a obj -> int -> ('a, 'l * 'r) mode
 
   (** Remove hints from all vars that have been created. This doesn't affect
       hints that were applied on top of vars. For example:
@@ -294,13 +294,13 @@ module type Solver_mono = sig
       the speical case where the given mode is top, returns the constant top and
       [false]. *)
   val newvar_above :
-    'a obj -> ('a, allowed * 'r_) mode -> ('a, 'l * 'r) mode * bool
+    'a obj -> int -> ('a, allowed * 'r_) mode -> ('a, 'l * 'r) mode * bool
 
   (** Creates a new mode variable below the given mode and returns [true]. In
       the speical case where the given mode is bottom, returns the constant
       bottom and [false]. *)
   val newvar_below :
-    'a obj -> ('a, 'l_ * allowed) mode -> ('a, 'l * 'r) mode * bool
+    'a obj -> int -> ('a, 'l_ * allowed) mode -> ('a, 'l * 'r) mode * bool
 
   (** Returns the join of the list of modes. *)
   val join : 'a obj -> ('a, allowed * 'r) mode list -> ('a, left_only) mode
@@ -330,6 +330,12 @@ module type Solver_mono = sig
   (** Printing a mode for debugging. *)
   val print :
     ?verbose:bool -> 'a obj -> Fmt.formatter -> ('a, 'l * 'r) mode -> unit
+
+  (** Returns true iff the mode has the given level or is a constant *)
+  val check_level : ('a, 'l * 'r) mode -> int -> bool
+
+  (** Returns true iff the mode is a variable at the given level *)
+  val check_level_var : ('a, 'l * 'r) mode -> int -> bool
 
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -400,7 +400,7 @@ module type Solver_mono = sig
   val iter_covariant :
     'a obj ->
     ('a, allowed * 'r) mode ->
-    (int -> ('a, allowed * disallowed) mode -> unit) ->
+    (id:int -> level:int -> ('a, allowed * disallowed) mode -> unit) ->
     unit
 
   (** Applies an iterator over every reachable contravariant (right-) constraint
@@ -411,7 +411,7 @@ module type Solver_mono = sig
   val iter_contravariant :
     'a obj ->
     ('a, 'l * allowed) mode ->
-    (int -> ('a, disallowed * allowed) mode -> unit) ->
+    (id:int -> level:int -> ('a, disallowed * allowed) mode -> unit) ->
     unit
 
   (** Apply a monotone morphism explained by an optional hint *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -194,6 +194,15 @@ module type Solver_mono = sig
 
   type pinpoint
 
+  (** Represents a sequence of local changes to the copying scope of a mode
+      variable. Copying a mode takes a [copy_scope], and it is up to the caller
+      to create a new copy scope, and reset it once all copies have been made *)
+  type copy_scope
+
+  (** Runs a function [f] in a fresh mode copy scope, which gets cleaned up once
+      [f] is finished *)
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
+
   type 'd hint_morph constraint 'd = 'l * 'r
 
   type 'd hint_const constraint 'd = 'l * 'r
@@ -316,6 +325,17 @@ module type Solver_mono = sig
     ('a, 'l * 'r) mode ->
     log:changes ref option ->
     unit
+
+  (** Copies all reachable variables whose level is at or above
+      [copy_from_level], and enforces that the copy is below [copy_to_level].
+      Returns the copied mode *)
+  val copy :
+    copy_scope:copy_scope ->
+    copy_from_level:int ->
+    copy_to_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    ('a, 'l * 'r) mode
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -290,6 +290,10 @@ module type Solver_mono = sig
     log:changes ref option ->
     (unit, 'a error_raw) result
 
+  (** Lowers a level of a variable. *)
+  val update_level :
+    int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and
       [false]. *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -326,9 +326,11 @@ module type Solver_mono = sig
     log:changes ref option ->
     unit
 
-  (** Copies all reachable variables whose level is at or above
+  (** If the variable has not yet been copied within the same [copy_scope],
+      [copy] copies all reachable variables whose level is at or above
       [copy_from_level], and enforces that the copy is below [copy_to_level].
-      Returns the copied mode *)
+      Returns either the freshly copied mode, or the copy cached in
+      [copy_scope]. *)
   val copy :
     copy_scope:copy_scope ->
     copy_from_level:int ->

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -386,6 +386,34 @@ module type Solver_mono = sig
   (** Returns true iff the mode is a variable at the given level *)
   val check_level_var : ('a, 'l * 'r) mode -> int -> bool
 
+  type var_iterator =
+    { iter : 'a. 'a obj -> ('a, allowed * allowed) mode -> unit }
+  [@@unboxed]
+
+  val mode_iter : 'a obj -> ('a, 'l * 'r) mode -> var_iterator -> unit
+
+  (** Applies an iterator over every reachable covariant (left-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_covariant :
+    'a obj ->
+    ('a, allowed * 'r) mode ->
+    (int -> ('a, allowed * disallowed) mode -> unit) ->
+    unit
+
+  (** Applies an iterator over every reachable contravariant (right-) constraint
+      variable. The iterator is only applied to constraint variables at level 0,
+      and exposes the int identifier of the constraint variable. WARNING: the
+      iterator is only applied once per constraint, even when it appears as a
+      constraint multiple times via different morphisms *)
+  val iter_contravariant :
+    'a obj ->
+    ('a, 'l * allowed) mode ->
+    (int -> ('a, disallowed * allowed) mode -> unit) ->
+    unit
+
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
     'b obj ->

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -229,8 +229,7 @@ module type Solver_mono = sig
   (* CR-soon zqian: [to_const_exn] should return hints as well. *)
 
   (** Given a mode whose lower and upper bounds are equal, returns that bound.
-      Raises exception if the condition does not hold, or if the variable is
-      generic *)
+      Raises exception if the condition does not hold. *)
   val to_const_exn : 'a obj -> ('a, allowed * allowed) mode -> 'a
 
   (** The minimum mode in the lattice *)
@@ -298,8 +297,9 @@ module type Solver_mono = sig
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
 
-  (** Generalizes all reachable variables whose level is above [current_level],
-      by putting their level to [generic_level]. *)
+  (** Generalizes a variable whose level is above [current_level], by putting
+      its level to [generic_level], and all its children above [current_level]
+      to [generic_level + i] for some nonzero [i]. *)
   val generalize :
     current_level:int ->
     'a obj ->

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -229,7 +229,8 @@ module type Solver_mono = sig
   (* CR-soon zqian: [to_const_exn] should return hints as well. *)
 
   (** Given a mode whose lower and upper bounds are equal, returns that bound.
-      Raises exception if the condition does not hold. *)
+      Raises exception if the condition does not hold, or if the variable is
+      generic *)
   val to_const_exn : 'a obj -> ('a, allowed * allowed) mode -> 'a
 
   (** The minimum mode in the lattice *)
@@ -237,6 +238,9 @@ module type Solver_mono = sig
 
   (** The maximum mode in the lattice *)
   val max : 'a obj -> ('a, 'l * 'r) mode
+
+  (** The level of generic variables *)
+  val generic_level : int
 
   (* CR-someday zqian: [zap_*] should take optional hint, pointing to the location in
      the source code where zapping happens *)
@@ -293,6 +297,25 @@ module type Solver_mono = sig
   (** Lowers a level of a variable. *)
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
+  (** Generalizes all reachable variables whose level is above [current_level],
+      by putting their level to [generic_level]. *)
+  val generalize :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
+
+  (** Generalizes all reachable variables whose level is above [current_level],
+      whose value is fully determined, by putting their level to
+      [generic_level].*)
+  val generalize_structure :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -73,7 +73,7 @@ module type Lattices_mono = sig
         adjoint.
       - [disallowed], meaning the morphism cannot be on the left because it does
         not have right adjoint. Similar for ['r]. *)
-  type ('a, 'b, 'd) morph constraint 'd = 'l * 'r
+  type ('a, 'b, 'd) morph
 
   (* Due to the implementation in [solver.ml], a mode doesn't have sufficient
      information to infer the object it lives in,  whether at compile-time or
@@ -187,7 +187,7 @@ module type Solver_mono = sig
 
   (** The morphism type from the [Lattices_mono] we're working with. See
       comments on [Lattices_mono.morph]. *)
-  type ('a, 'b, 'd) morph constraint 'd = 'l * 'r
+  type ('a, 'b, 'd) morph
 
   (** The object type from the [Lattices_mono] we're working with *)
   type 'a obj

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -480,6 +480,52 @@ module type Solver_mono = sig
     val apply :
       'b obj -> ('a, 'b, 'l * 'r) morph -> ('a, 'l * 'r) t -> ('b, 'l * 'r) t
   end
+
+  (** The exposed description of modes *)
+  module Desc : sig
+    module Var : sig
+      type 'a t
+
+      type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) morph -> ('b, 'd) t_with_morph
+
+      module Head : sig
+        type 'a t =
+          { desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : ('a, left_only) t_with_morph list;
+            desc_level : int
+          }
+
+        val equal : 'a t -> 'b t -> bool
+
+        val hash : 'a t -> int
+      end
+
+      val force : 'a obj -> 'a t -> 'a Head.t
+    end
+
+    type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+          'a * ('a, disallowed * 'r) morphvar list
+          -> ('a, disallowed * 'r) t
+
+    val equal : 'a obj -> ('a, 'l * 'r) t -> ('a, 'l * 'r) t -> bool
+
+    val print : 'a obj -> Fmt.formatter -> ('a, 'l * 'r) t -> unit
+  end
+
+  (** Returns the description of a mode. *)
+  val desc : 'a obj -> ('a, 'd) mode -> ('a, 'd) Desc.t
 end
 
 (** Hint module to be provided by the user of the solver. *)

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -664,16 +664,6 @@ let rec typexp copy_scope s ty =
       if should_duplicate_vars then newpersty (Tvar {name = None; jkind})
       else newgenstub ~scope:(get_scope ty) jkind
     in
-    let copy_mode =
-      if should_duplicate_vars || get_id ty < 0
-      then (fun m -> For_copy.mode_duplicate copy_scope m)
-      else (fun m -> m)
-    in
-    let copy_mode_generic =
-      if should_duplicate_vars || get_id ty < 0
-      then (fun m -> For_copy.mode_copy_generic copy_scope m)
-      else (fun m -> m)
-    in
     For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
     let desc =
       if has_fixed_row then
@@ -753,10 +743,17 @@ let rec typexp copy_scope s ty =
           Tlink (typexp copy_scope s t2)
       | Tarrow ((label, marg, mret), arg, ret, comm) ->
           let marg, mret =
+            if get_id ty < 0 then
+              For_copy.mode_copy_generic copy_scope marg,
+              For_copy.mode_copy_generic copy_scope mret
+            else
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              copy_mode_generic (prepare_mode marg),
-              copy_mode_generic (prepare_mode mret)
+              For_copy.mode_copy_generic copy_scope (prepare_mode marg),
+              For_copy.mode_copy_generic copy_scope (prepare_mode mret)
+            | Duplicate_variables ->
+              For_copy.mode_copy_generic copy_scope marg,
+              For_copy.mode_copy_generic copy_scope mret
             | _ -> marg, mret
           in
           let arg = typexp copy_scope s arg in
@@ -764,7 +761,7 @@ let rec typexp copy_scope s ty =
           let comm = copy_commu comm in
           Tarrow ((label, marg, mret), arg, ret, comm)
       | _ ->
-        copy_type_desc (typexp copy_scope s) copy_mode desc
+        copy_type_desc (typexp copy_scope s) (fun _ -> assert false) desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -301,8 +301,11 @@ let with_additional_action =
         in
         (* CR-someday zqian: preserve the hints *)
         (* modes and modalities should have been zapped already *)
+        (* if a mode is generic variable we leave it as is *)
         let prepare_mode mode =
-          Mode.Alloc.(mode |> to_const_exn |> of_const)
+          if Mode.Alloc.check_level_var mode generic_level
+          then mode
+          else Mode.Alloc.(mode |> to_const_exn |> of_const)
         in
         let prepare_modality modality =
           Mode.Modality.(modality |> to_const_exn|> of_const)
@@ -508,7 +511,8 @@ let apply_type_function params args body =
           let t = newgenstub ~scope:(get_scope ty)
             (Jkind.Builtin.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
-          let desc' = copy_type_desc copy desc in
+          let copy_mode m = For_copy.mode_copy_generic copy_scope m in
+          let desc' = copy_type_desc copy copy_mode desc in
           Transient_expr.set_stub_desc t desc';
           t
     in
@@ -660,6 +664,16 @@ let rec typexp copy_scope s ty =
       if should_duplicate_vars then newpersty (Tvar {name = None; jkind})
       else newgenstub ~scope:(get_scope ty) jkind
     in
+    let copy_mode =
+      if should_duplicate_vars || get_id ty < 0
+      then (fun m -> For_copy.mode_duplicate copy_scope m)
+      else (fun m -> m)
+    in
+    let copy_mode_generic =
+      if should_duplicate_vars || get_id ty < 0
+      then (fun m -> For_copy.mode_copy_generic copy_scope m)
+      else (fun m -> m)
+    in
     For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
     let desc =
       if has_fixed_row then
@@ -741,14 +755,16 @@ let rec typexp copy_scope s ty =
           let marg, mret =
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
-              prepare_mode marg, prepare_mode mret
+              copy_mode_generic (prepare_mode marg),
+              copy_mode_generic (prepare_mode mret)
             | _ -> marg, mret
           in
           let arg = typexp copy_scope s arg in
           let ret = typexp copy_scope s ret in
           let comm = copy_commu comm in
           Tarrow ((label, marg, mret), arg, ret, comm)
-      | _ -> copy_type_desc (typexp copy_scope s) desc
+      | _ ->
+        copy_type_desc (typexp copy_scope s) copy_mode desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'
@@ -787,7 +803,8 @@ let jkind copy_scope s loc jk =
 *)
 let type_expr s ty =
   let loc = Option.value s.loc ~default:Location.none in
-  For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)
+  For_copy.with_scope (fun copy_scope ->
+    typexp copy_scope s loc ty)
 
 let label_declaration copy_scope s l =
   {

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1407,9 +1407,15 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                     else if Btype.is_position l && is_erased () then
                       eliminate_position_arg ()
                     else begin
-                      let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
-                      let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
-                      let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+                      let mode_closure =
+                        Mode.Locality.disallow_left Mode.Locality.legacy
+                      in
+                      let mode_arg =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                      in
+                      let mode_ret =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                      in
                       let sort_arg = Jkind.Sort.scannable in
                       let sort_ret = Jkind.Sort.scannable in
                       Omitted { mode_closure; mode_arg; mode_ret; sort_arg;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1932,7 +1932,7 @@ let final_decl env define_class
     );
 
   begin match
-    Ctype.closed_class clty.cty_params
+    Alloc.with_zap_scope Ctype.closed_class clty.cty_params
       (Btype.signature_of_class_type clty.cty_type)
   with
     None        -> ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -746,17 +746,22 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Alloc.r list ref = Local_store.s_ref []
+let allocations : Typedtree.alloc_mode_r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
 let register_allocation_mode alloc_mode =
-  let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
+
+let create_allocation_mode (mode : Alloc.lr) : Locality.lr =
+  let locality_mode = Alloc.proj_comonadic Areality mode in
+  fst (Locality.newvar_below locality_mode)
 
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode = value_to_alloc_r2g mode in
+  let alloc_mode =
+    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
+  in
   register_allocation_mode alloc_mode;
   let mode =
     value_r2g ~hint:(Allocation_r {loc; txt = desc})
@@ -769,16 +774,18 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+let register_closure_allocation (mode : Value.r) ~loc
+  : Locality.lr * Alloc.lr * Value.r =
   let hint = Hint.Allocation_r {loc; txt = Unknown} in
-  let (alloc_mode : Alloc.lr), _ =
+  let (mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~hint mode)
   in
-  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let alloc_mode = create_allocation_mode mode in
   let closed_over_mode =
-    alloc_as_value ~hint:Skip (Alloc.disallow_left alloc_mode)
+    alloc_as_value ~hint:Skip (Alloc.disallow_left mode)
   in
-  alloc_mode, closed_over_mode
+  register_allocation_mode (Locality.disallow_left alloc_mode);
+  alloc_mode, mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -798,7 +805,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil (Alloc.proj_comonadic Areality mode)
+      Locality.zap_to_ceil mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -4768,21 +4775,30 @@ let type_omitted_parameters expected_mode env loc ty_ret mode_ret args =
              let open_args = [] in
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
-             let mode_closure, _ =
+             let mode_cls, _ =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
+             in
+             let mode_closure =
+               Alloc.proj_comonadic Areality (Alloc.disallow_left mode_cls)
+             in
+             let mode_arg =
+               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_arg)
+             in
+             let mode_ret =
+               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_ret)
              in
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure = Alloc.disallow_left mode_closure;
-                mode_arg = Alloc.disallow_right mode_arg;
-                mode_ret = Alloc.disallow_right mode_ret;
+                mode_closure;
+                mode_arg;
+                mode_ret;
                 sort_arg;
                 sort_ret }
              in
              let args = (lbl, arg, None) :: args in
-             (ty_ret, mode_closure, open_args, closed_args, args))
+             (ty_ret, mode_cls, open_args, closed_args, args))
       (ty_ret, mode_ret, [], [], []) (List.rev args)
   in
   ty_ret, mode_ret, args
@@ -5885,10 +5901,14 @@ type split_function_ty =
       *)
     expected_pat_mode: expected_pat_mode;
     expected_inner_mode: expected_mode;
-    (* [alloc_mode] is the mode of [fun x_i ... x_n -> e].
-       This needs to be a left mode for the construction of the [fp_curry] field
-       of the outer function. *)
-    alloc_mode: Mode.Alloc.lr;
+    (* [closure_mode] is the mode of [fun x_i ... x_n -> e].
+       This needs to be a left mode for making sure that nested
+       closures have a mode greater than outer closures, and it
+       needs to be a right mode for making sure
+       arguments generate a lower bound for subsequent closures.
+       [alloc_mode] tracks the locality component to store in the Typedtree. *)
+    closure_mode: Mode.Alloc.lr;
+    alloc_mode: Locality.lr;
     really_poly: bool
   }
 
@@ -5910,12 +5930,12 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+  let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality alloc_mode);
+      (Alloc.proj_comonadic Areality closure_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -5992,7 +6012,7 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; ty_arg_mono;
+    alloc_mode; closure_mode; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
     really_poly
   }
@@ -6000,6 +6020,11 @@ let split_function_ty
 type type_function_result_param =
   { param : function_param;
     has_poly : bool;
+  }
+
+type fun_alloc_mode =
+  { alloc_mode: Locality.lr;
+    fun_closure_mode: Mode.Alloc.lr;
   }
 
 (* The result of calling [type_function]. For the outer call to
@@ -6020,7 +6045,7 @@ type type_function_result =
        be a left mode for the construction of the [fp_curry] field of the outer
        function.
     *)
-    fun_alloc_mode: Mode.Alloc.lr option;
+    fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for
        recursive calls to [type_function] when there are no parameters
        left.
@@ -8122,11 +8147,9 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          let local =
-            Alloc.(of_const ~hint_comonadic:Stack_expression
-              { Const.min with areality = Local })
-          in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Locality.submode_err (exp.exp_loc, Allocation)
+            (Locality.of_const ~hint:Stack_expression Local)
+            alloc_mode
         end
       | Texp_list_comprehension _ -> unsupported List_comprehension
       | Texp_array_comprehension _ -> unsupported Array_comprehension
@@ -8600,7 +8623,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           let mode = Locality.disallow_left mode in
+           register_allocation_mode mode
        | _ -> ()
        end;
        [], ty, Id_prim (Option.map Locality.disallow_right mode, sort)
@@ -8741,7 +8765,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; really_poly
+            alloc_mode; closure_mode; really_poly
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -8823,7 +8847,7 @@ and type_function
                 | None ->
                   assert(is_final_val_param);
                   Final_arg
-                | Some fun_alloc_mode ->
+                | Some { fun_closure_mode; alloc_mode } ->
                   assert(not is_final_val_param);
                   (* Handle mode crossing of [arg_mode]. Note that [close_over]
                      uses the [arg_mode.comonadic] as a left mode, and
@@ -8831,20 +8855,23 @@ and type_function
                      mode-crossed differently. *)
                   let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
+                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   begin match
-                    Alloc.submode (Alloc.partial_apply alloc_mode) fun_alloc_mode
+                    Alloc.submode
+                      (Alloc.partial_apply closure_mode)
+                      fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
-                  More_args {partial_mode = Alloc.disallow_right fun_alloc_mode}
+                  More_args
+                    { partial_mode = Locality.disallow_right alloc_mode }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt, curry
           end
@@ -8904,6 +8931,9 @@ and type_function
             param,
             param_uid
       in
+      let arg_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      in
       let param =
         { has_poly;
           param =
@@ -8915,7 +8945,7 @@ and type_function
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = Alloc.disallow_right arg_mode };
+                { mode_annots with mode_modes = arg_mode };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -8930,9 +8960,13 @@ and type_function
           in
           Some { ret_sort ; ret_mode }
       in
+      let fun_alloc_mode =
+        { fun_closure_mode = closure_mode;
+          alloc_mode }
+      in
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
-        ret_info; fun_alloc_mode = Some alloc_mode;
+        ret_info; fun_alloc_mode = Some fun_alloc_mode;
       }
   | [] ->
     let exp_type, body, fun_alloc_mode, ret_info =
@@ -9641,6 +9675,12 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
+      let fc_arg_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right marg)
+      in
+      let fc_ret_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+      in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
          cases, look toward the end of
@@ -9652,7 +9692,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
              (texp,
               args @ [Nolabel, Arg (eta_var, arg_sort)],
               Nontail,
-              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
+              fc_ret_mode,
               None)}
         in
         let e = {texp with exp_type = ty_res; exp_desc = Texp_exclave e} in
@@ -9668,11 +9708,11 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                     fc_param_debug_uid = param_uid; fc_env = env;
                     fc_ret_type = ty_res; fc_loc = cases_loc;
                     fc_exp_extra = []; fc_attributes = [];
-                    fc_arg_mode = Alloc.disallow_right marg;
+                    fc_arg_mode;
                     fc_arg_sort = arg_sort;
                   };
               ret_mode =
-                { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
+                { mode_modes = fc_ret_mode; mode_desc = [] };
               ret_sort;
               alloc_mode;
               zero_alloc = Zero_alloc.default
@@ -10645,7 +10685,7 @@ and type_function_cases_expect
   Builtin_attributes.warning_scope attrs begin fun () ->
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
-          arg_sort; ret_sort;
+          arg_sort; ret_sort; closure_mode;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
@@ -10664,6 +10704,9 @@ and type_function_cases_expect
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
+    let fc_arg_mode =
+      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+    in
     let param , param_uid = name_cases "param" cases in
     let cases =
       { fc_cases = cases;
@@ -10675,11 +10718,15 @@ and type_function_cases_expect
         fc_env = env;
         fc_ret_type = ty_ret;
         fc_attributes = [];
-        fc_arg_mode = Alloc.disallow_right arg_mode;
+        fc_arg_mode;
         fc_arg_sort = arg_sort;
       }
     in
-    cases, ty_fun, alloc_mode,
+    let fun_alloc_mode =
+      { fun_closure_mode = closure_mode;
+        alloc_mode }
+    in
+    cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
           {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} }
@@ -11342,12 +11389,17 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
+    let ret_mode_modes =
+      Alloc.proj_comonadic Areality ret_mode.mode_modes
+    in
+    let ret_mode = { ret_mode with mode_modes = ret_mode_modes } in
     re
       { exp_desc =
           Texp_function
             { params; body; ret_sort;
-              alloc_mode; ret_mode;
+              alloc_mode =
+                Locality.disallow_left fun_alloc_mode.alloc_mode;
+              ret_mode;
               zero_alloc
             };
         exp_loc = loc;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -280,7 +280,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
-  | Uncurried_function_escapes of Alloc.error
+  | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -1101,13 +1101,17 @@ let has_poly_constraint spat =
     end
   | _ -> false
 
-(** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
-    fragment is a left mode. *)
-let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
+(** Mode cross a right monadic mode fragment *)
+let alloc_monadic_mode_cross_to_min env ty monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
+  let crossing = crossing_of_ty env ty in
+  Crossing.Monadic.apply_right crossing.monadic monadic
+
+(** Mode cross a left comonadic mode fragment *)
+let alloc_comonadic_mode_cross_to_max env ty comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
   let crossing = crossing_of_ty env ty in
-  Crossing.apply_left_right_alloc crossing { monadic; comonadic }
+  Crossing.Comonadic.apply_left crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
@@ -5907,7 +5911,8 @@ type split_function_ty =
        needs to be a right mode for making sure
        arguments generate a lower bound for subsequent closures.
        [alloc_mode] tracks the locality component to store in the Typedtree. *)
-    closure_mode: Mode.Alloc.lr;
+    closure_mode: Mode.Alloc.Comonadic.lr;
+    env_mode: Mode.Alloc.Monadic.r;
     alloc_mode: Locality.lr;
     really_poly: bool
   }
@@ -6001,7 +6006,8 @@ let split_function_ty
       end
     end
   in
-  let arg_value_mode = alloc_to_value_l2r arg_mode in
+  let env_mode, _ = Alloc.newvar_above arg_mode in
+  let arg_value_mode = alloc_to_value_l2r env_mode in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6012,9 +6018,9 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; closure_mode; ty_arg_mono;
+    alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_mode.monadic)
   }
 
 type type_function_result_param =
@@ -6024,7 +6030,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr;
   }
 
 (* The result of calling [type_function]. For the outer call to
@@ -8765,7 +8771,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; closure_mode; really_poly
+            alloc_mode; closure_mode; really_poly; env_mode
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -8853,22 +8859,40 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
-                  let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
+                  let arg_mode =
+                    alloc_comonadic_mode_cross_to_max env ty_arg
+                      arg_mode.comonadic
+                  in
+                  let env_mode =
+                    alloc_monadic_mode_cross_to_min env ty_arg env_mode
+                  in
+                  let cls_details : Mode.Hint.closure_details =
+                    { closure = (loc, Function);
+                      closed = (pparam_loc, Pattern) }
+                  in
+                  let hint : _ Hint.morph =
+                    Is_closed_by (Monadic, cls_details)
+                  in
+                  Alloc.Monadic.submode_err (pparam_loc, Pattern)
+                    (Alloc.comonadic_to_monadic_min ~hint fun_closure_mode)
+                    env_mode;
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
+                    Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.submode
-                      (Alloc.partial_apply closure_mode)
+                    Alloc.Comonadic.submode
+                      (Alloc.Comonadic.disallow_right closure_mode)
                       fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   More_args
                     { partial_mode = Locality.disallow_right alloc_mode }
@@ -12799,19 +12823,21 @@ let report_error ~loc env =
         but was expected to %s which is %a.@]"
         desc (Style.as_inline_code (Alloc.Const.print_axis ax)) actual
         desc_inf (Style.as_inline_code (Alloc.Const.print_axis ax)) expected
-  | Uncurried_function_escapes e -> begin
-      let Mode.Alloc.Error (ax, {left; right}) = Mode.Alloc.to_simple_error e in
+  | Uncurried_function_escapes_comonadic e -> begin
+      let Mode.Alloc.Comonadic.Error (ax, {left; right}) =
+        Mode.Alloc.Comonadic.to_simple_error e
+      in
       match ax with
-      | Comonadic Areality ->
-          Location.errorf ~loc
+      | Areality ->
+        Location.errorf ~loc
             "This function or one of its parameters escape their region@ \
             when it is partially applied."
       | _ ->
-          Location.errorf ~loc
+        Location.errorf ~loc
             "This function when partially applied returns a value which is %a,@ \
               but expected to be %a."
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) left
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) right
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -757,7 +757,7 @@ let register_allocation_mode alloc_mode =
   allocations := alloc_mode :: !allocations
 
 let newvar_below_if_modepoly level m =
-  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  if Language_extension.(is_at_least_mode_poly Beta)
   then fst (Locality.newvar_below level m)
   else m
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -567,12 +567,12 @@ let mode_morph f expected_mode =
 (** Similiar to [apply_is_contained_by] but for [expected_mode]. *)
 let mode_is_contained_by is_contained_by ?modalities expected_mode =
   as_single_mode expected_mode
-  |> apply_is_contained_by is_contained_by ?modalities
+  |> apply_right_is_contained_by is_contained_by ?modalities
   |> mode_default
 
 let mode_modality modality expected_mode =
   as_single_mode expected_mode
-  |> Modality.Const.apply modality
+  |> Modality.Const.apply_right modality
   |> mode_default
 
 (* used when entering a function;
@@ -763,6 +763,22 @@ let register_allocation_value_mode ~loc
       (Mode.Value.disallow_left mode)
   in
   alloc_mode, mode
+
+(* Unlike most allocations, which can be the highest mode allowed by
+   [expected_mode], functions have more constraints. For example, a two
+   parameter function needs to be made global if its partial application
+   to one argument must be global. As a result, a function gets an
+   [Alloc.lr] allocation mode that can be further constrained. *)
+let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+  let hint = Hint.Allocation_r {loc; txt = Unknown} in
+  let (alloc_mode : Alloc.lr), _ =
+    Alloc.newvar_below (value_to_alloc_r2g ~hint mode)
+  in
+  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let closed_over_mode =
+    alloc_as_value ~hint:Skip (Alloc.disallow_left alloc_mode)
+  in
+  alloc_mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -1839,7 +1855,7 @@ let solve_Ppat_tuple ~refine ~alloc_mode loc env args expected_ty =
         { containing = Tuple;
           container = (loc, Pattern) }
       in
-      let mode = apply_is_contained_by is_contained_by alloc_mode.mode in
+      let mode = apply_left_is_contained_by is_contained_by alloc_mode.mode in
       List.init arity (fun _ -> mode)
   in
   let ann =
@@ -1870,7 +1886,7 @@ let solve_Ppat_unboxed_tuple ~refine ~alloc_mode loc env args expected_ty =
         { containing = Tuple;
           container = (loc, Pattern) }
       in
-      let mode = apply_is_contained_by is_contained_by alloc_mode.mode in
+      let mode = apply_left_is_contained_by is_contained_by alloc_mode.mode in
       List.init arity (fun _ -> mode)
   in
   let ann =
@@ -3066,7 +3082,7 @@ and type_pat_aux
       {containing = Array Modality; container = (loc, Pattern)}
     in
     let alloc_mode =
-      apply_is_contained_by is_contained_by ~modalities alloc_mode.mode
+      apply_left_is_contained_by is_contained_by ~modalities alloc_mode.mode
     in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl =
@@ -3186,8 +3202,8 @@ and type_pat_aux
             container = (loc, Pattern) }
         in
         let mode =
-          apply_is_contained_by is_contained_by ~modalities:label.lbl_modalities
-            alloc_mode.mode
+          apply_left_is_contained_by is_contained_by
+            ~modalities:label.lbl_modalities alloc_mode.mode
         in
         let alloc_mode = simple_pat_mode mode in
         let ty_sort =
@@ -3499,7 +3515,7 @@ and type_pat_aux
         List.map2
           (fun p (arg : Types.constructor_argument) ->
              let alloc_mode =
-              apply_is_contained_by is_contained_by
+              apply_left_is_contained_by is_contained_by
                 ~modalities:arg.ca_modalities alloc_mode.mode
              in
              let alloc_mode =
@@ -5894,15 +5910,8 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, mode =
-      (* Unlike most allocations which can be the highest mode allowed by
-         [expected_mode] and their [alloc_mode] identical to [expected_mode] ,
-         functions have more constraints. For example, an outer function needs
-         to be made global if its inner function is global. As a result, a
-         function deserves a separate allocation mode.
-      *)
-      let mode, _ = Value.newvar_below (as_single_mode expected_mode) in
-      register_allocation_value_mode ~loc mode
+  let alloc_mode, closed_over_mode =
+    register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
@@ -5945,7 +5954,7 @@ let split_function_ty
         let env =
           Env.add_closure_lock
             (loc, Function)
-            mode.comonadic
+            closed_over_mode.comonadic
             env
         in
         Env.add_region_lock env
@@ -6357,7 +6366,7 @@ and type_expect_
           (fun loc ty mode -> (* only change mode here, see type_label_exp *)
              List.map (fun (_, label, _) ->
                let mode =
-                apply_is_contained_by
+                apply_left_is_contained_by
                   { containing = Record (label.lbl_name, Modality);
                     container = (loc, Expression) }
                   ~modalities:label.lbl_modalities mode
@@ -6405,7 +6414,7 @@ and type_expect_
                   container = (extended_expr_loc, Expression) }
               in
               let mode =
-                apply_is_contained_by is_contained_by
+                apply_left_is_contained_by is_contained_by
                   ~modalities:lbl.lbl_modalities mode
               in
               let mode = cross_left env lbl.lbl_arg mode in
@@ -6598,7 +6607,7 @@ and type_expect_
             match path with
             | Path.Pident id ->
               let modalities = Typemode.let_mutable_modalities in
-              let mode = Modality.Const.apply modalities actual_mode in
+              let mode = Modality.Const.apply_left modalities actual_mode in
               submode ~loc ~env mode expected_mode;
               Texp_mutvar {loc = lid.loc; txt = id}
             | _ ->
@@ -7110,8 +7119,8 @@ and type_expect_
           container = (record.exp_loc, Expression) }
       in
       let mode =
-        apply_is_contained_by is_contained_by ~modalities:label.lbl_modalities
-          rmode
+        apply_left_is_contained_by is_contained_by
+          ~modalities:label.lbl_modalities rmode
       in
       let boxing : texp_field_boxing =
         let is_float_boxing =
@@ -7178,8 +7187,8 @@ and type_expect_
           container = (record.exp_loc, Expression) }
       in
       let mode =
-        apply_is_contained_by is_contained_by ~modalities:label.lbl_modalities
-          rmode
+        apply_left_is_contained_by is_contained_by
+          ~modalities:label.lbl_modalities rmode
       in
       let mode = cross_left env ty_arg mode in
       submode ~loc ~env mode expected_mode;
@@ -7238,8 +7247,9 @@ and type_expect_
           record_repres;
           record_sorts;
           modality =
-            Locality.disallow_right (regional_to_local
-              (Value.proj_comonadic Areality rmode));
+            Locality.disallow_right
+              (Alloc.proj_comonadic Areality
+               (value_to_alloc_r2l rmode));
           lid = label_loc;
           label;
           newval;
@@ -9636,16 +9646,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
          cases, look toward the end of
          typing-layouts-missing-cmi/function_arg.ml *)
       let func texp =
-        let ret_mode = alloc_as_value mret in
         let e =
           {texp with exp_type = ty_res; exp_desc =
            Texp_apply
              (texp,
-              args @ [Nolabel, Arg (eta_var, arg_sort)], Nontail,
-              ret_mode
-              |> Value.proj_comonadic Areality
-              |> regional_to_global
-              |> Locality.disallow_right,
+              args @ [Nolabel, Arg (eta_var, arg_sort)],
+              Nontail,
+              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
               None)}
         in
         let e = {texp with exp_type = ty_res; exp_desc = Texp_exclave e} in
@@ -9880,7 +9887,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
   in
   let argument_mode =
     value_mode
-    |> apply_is_contained_by
+    |> apply_right_is_contained_by
       {containing = Tuple; container = (loc, Expression)}
   in
   (* CR layouts v5: non-values in tuples *)
@@ -9949,7 +9956,8 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
     (Misc.repeated_label sexpl);
   let argument_mode =
     expected_mode.mode
-    |> apply_is_contained_by {containing = Tuple; container = (loc, Expression)}
+    |> apply_right_is_contained_by
+      {containing = Tuple; container = (loc, Expression)}
   in
   (* elements must be representable *)
   let labels_types_and_sorts =
@@ -10135,7 +10143,7 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
          let ty_args, _, _ = unify_as_construct ty in
          List.map (fun ty_arg ->
            let mode =
-            apply_is_contained_by
+            apply_left_is_contained_by
               { containing = Constructor (constr.cstr_name, Modality);
                 container = (loc, Expression) }
               ~modalities:ty_arg.Types.ca_modalities mode

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -675,7 +675,10 @@ tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
 let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
-  let vmode , _ = Value.newvar_below (alloc_as_value marg) in
+  let vmode , _ =
+    Value.newvar_below
+      (Ctype.get_current_level ()) (alloc_as_value marg)
+  in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
   | Texp_ident { desc = {val_kind =
@@ -753,15 +756,27 @@ let reset_allocations () = allocations := []
 let register_allocation_mode alloc_mode =
   allocations := alloc_mode :: !allocations
 
-let create_allocation_mode (mode : Alloc.lr) : Locality.lr =
+let newvar_below_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  then fst (Locality.newvar_below level m)
+  else m
+
+let newvar_above_if_modepoly level m =
+  if Language_extension.(is_at_least Mode_polymorphism Beta)
+  then fst (Locality.newvar_above level m)
+  else m
+
+let create_allocation_mode_l mode =
   let locality_mode = Alloc.proj_comonadic Areality mode in
-  fst (Locality.newvar_below locality_mode)
+  newvar_above_if_modepoly 0 locality_mode |> Locality.disallow_right
+
+let create_allocation_mode_r mode =
+  let locality_mode = Alloc.proj_comonadic Areality mode in
+  newvar_below_if_modepoly 0 locality_mode |> Locality.disallow_left
 
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode =
-    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
-  in
+  let alloc_mode = create_allocation_mode_r (value_to_alloc_r2g mode) in
   register_allocation_mode alloc_mode;
   let mode =
     value_r2g ~hint:(Allocation_r {loc; txt = desc})
@@ -778,9 +793,11 @@ let register_closure_allocation (mode : Value.r) ~loc
   : Locality.lr * Alloc.lr * Value.r =
   let hint = Hint.Allocation_r {loc; txt = Unknown} in
   let (mode : Alloc.lr), _ =
-    Alloc.newvar_below (value_to_alloc_r2g ~hint mode)
+    Alloc.newvar_below (Ctype.get_current_level ())
+      (value_to_alloc_r2g ~hint mode)
   in
-  let alloc_mode = create_allocation_mode mode in
+  let locality_mode = Alloc.proj_comonadic Areality mode in
+  let alloc_mode, _ = Locality.newvar_below 0 locality_mode in
   let closed_over_mode =
     alloc_as_value ~hint:Skip (Alloc.disallow_left mode)
   in
@@ -805,7 +822,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil mode
+      Locality.zap_to_ceil_exn mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -1172,8 +1189,8 @@ let check_dynamic pp hint expected_mode =
 (** Take [m0] which is the parameter to mutable, and the mode of the RHS (the
     content expression), returns the strongest mode the mutable variable can be.
 *)
-let mutvar_mode ~loc ~env m0 exp_mode =
-  let m = Value.newvar () in
+let mutvar_mode ~loc ~env level m0 exp_mode =
+  let m = Value.newvar level in
   let mode = mode_default m in
   let modalities = Typemode.let_mutable_modalities in
   submode ~loc ~env exp_mode (mode_modality modalities mode);
@@ -1679,7 +1696,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
       let priv = (cstr.cstr_private = Private) in
       let mode =
         if priv || pl <> [] then mode
-        else Value.newvar ()
+        else Value.newvar (get_current_level ())
       in
       let keep =
         priv ||
@@ -1700,7 +1717,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
   | Tpat_variant(l, p', _) ->
       let ty = Option.map (build_as_type env) p' in
       let mode =
-        if p' = None then Value.newvar ()
+        if p' = None then Value.newvar (get_current_level ())
         else mode
       in
       let ty =
@@ -1729,7 +1746,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
               fields
           in
           let mode =
-            if all_constant then Value.newvar ()
+            if all_constant then Value.newvar (get_current_level ())
             else mode
           in
           let ty =
@@ -3283,8 +3300,11 @@ and type_pat_aux
         match mutable_flag with
         | Immutable -> alloc_mode, Val_reg sort
         | Mutable ->
-            let m0 = Value.Comonadic.newvar () in
-            let mode = mutvar_mode ~loc ~env:!!penv m0 alloc_mode in
+            let m0 = Value.Comonadic.newvar (Ctype.get_current_level ()) in
+            let mode =
+              mutvar_mode ~loc ~env:!!penv
+                (Ctype.get_current_level ()) m0 alloc_mode
+            in
             let kind = Val_mut (m0, sort) in
             mode, kind
       in
@@ -4404,7 +4424,8 @@ let remaining_function_type ty_ret mode_ret rev_args =
                  (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
              in
              let mode_ret, _ =
-               Alloc.newvar_above (Alloc.join (mode_fun :: closed_args))
+               Alloc.newvar_above (Ctype.get_current_level ())
+                 (Alloc.join (mode_fun :: closed_args))
              in
              (ty_ret, mode_ret, closed_args))
       (ty_ret, mode_ret, []) rev_args
@@ -4563,8 +4584,8 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
               then
                 Location.prerr_warning sarg.pexp_loc
                   Warnings.Ignored_extra_argument;
-              let mode_arg = Alloc.newvar () in
-              let mode_ret = Alloc.newvar () in
+              let mode_arg = Alloc.newvar (get_current_level ()) in
+              let mode_ret = Alloc.newvar (get_current_level ()) in
               let kind = (lbl, mode_arg, mode_ret) in
               begin try
                 unify env ty_fun
@@ -4780,17 +4801,17 @@ let type_omitted_parameters expected_mode env loc ty_ret mode_ret args =
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
              let mode_cls, _ =
-               Alloc.newvar_above (Alloc.join
+               Alloc.newvar_above (Ctype.get_current_level ()) (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
                Alloc.proj_comonadic Areality (Alloc.disallow_left mode_cls)
              in
              let mode_arg =
-               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_arg)
+               create_allocation_mode_l mode_arg
              in
              let mode_ret =
-               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_ret)
+               create_allocation_mode_l mode_ret
              in
              register_allocation_mode mode_closure;
              let arg =
@@ -5196,7 +5217,7 @@ let rec approx_type env sty =
         in
         let ret = approx_type env sty in
         let marg = Alloc.of_const arg_mode.mode_modes in
-        let mret = Alloc.newvar () in
+        let mret = Alloc.newvar (get_current_level ()) in
         newty (Tarrow ((p,marg,mret), arg_ty.ctyp_type, ret, commu_ok))
       end
   | Ptyp_arrow (p, arg_sty, sty, arg_mode, _) ->
@@ -5209,7 +5230,7 @@ let rec approx_type env sty =
       in
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
-      let mret = Alloc.newvar () in
+      let mret = Alloc.newvar (get_current_level ()) in
       newty (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (label, t) -> label, approx_type env t) args))
@@ -5572,9 +5593,16 @@ let pattern_needs_partial_application_check p =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   with_type_mark begin fun mark ->
+    let check_const_mode m =
+      if Mode.Alloc.check_level_var m generic_level then
+        Option.is_some (Mode.Alloc.Guts.check_const m)
+      else true
+    in
+    let checkmode m = if not (check_const_mode m) then raise Exit in
     let rec check ty =
       if try_mark_node mark ty then
-        if get_level ty <= level then raise Exit else iter_type_expr check ty
+        if get_level ty <= level then raise Exit
+        else iter_type_expr check checkmode ty
     in
     try check ty; true with Exit -> false
   end
@@ -5597,7 +5625,7 @@ let contains_variant_either ty =
               (row_fields row);
           iter_row loop row
       | _ ->
-          iter_type_expr loop ty
+          iter_type_expr loop (Fun.const ()) ty
       end
   in
   try loop ty; false with Exit -> true
@@ -5986,14 +6014,15 @@ let split_function_ty
   in
   let ret_value_mode = alloc_as_value ret_mode in
   let expected_inner_mode =
-    if not is_final_val_param then
+    if not is_final_val_param then begin
       (* no need to check mode crossing in this case because ty_res always a
       function *)
       mode_default ret_value_mode
-    else
+    end else begin
       let ret_value_mode = mode_return ret_value_mode in
       let ret_value_mode = expect_mode_cross env ty_ret ret_value_mode in
       ret_value_mode
+    end
   in
   let ty_arg_mono =
     if has_poly then ty_arg
@@ -6006,7 +6035,7 @@ let split_function_ty
       end
     end
   in
-  let env_mode, _ = Alloc.newvar_above arg_mode in
+  let env_mode, _ = Alloc.newvar_above (get_current_level ()) arg_mode in
   let arg_value_mode = alloc_to_value_l2r env_mode in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
@@ -6061,7 +6090,7 @@ type type_function_result =
 
 and type_function_ret_info =
   { (* The mode the function returns at. *)
-    ret_mode: Mode.Alloc.l modes;
+    ret_mode: alloc_mode_l modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
   }
@@ -6154,12 +6183,19 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     | None -> begin
         match pat_tuple_arity spat with
         | Not_local_tuple | Maybe_local_tuple ->
-            let mode = Value.newvar () in
+            let mode = Value.newvar (get_current_level ()) in
             simple_pat_mode mode, mode_default mode
         | Local_tuple locs ->
-            let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+            let modes =
+              List.map
+                (fun loc ->
+                   Value.newvar (get_current_level ()), loc)
+                locs
+            in
             let modes_pat = List.map fst modes in
-            let mode = Value.newvar () in
+            let mode =
+              Value.newvar (get_current_level ())
+            in
             tuple_pat_mode mode modes_pat, mode_tuple mode modes
       end
     | Some mode ->
@@ -6274,7 +6310,7 @@ and type_expect_
         | Some sexp ->
             let exp, mode =
               with_local_level_if_principal begin fun () ->
-                let mode = Value.newvar () in
+                let mode = Value.newvar 0 in
                 let exp = type_exp ~recarg env (mode_default mode) sexp in
                 exp, mode
               end ~post:(fun (exp, _) -> generalize_structure_exp exp)
@@ -6904,12 +6940,12 @@ and type_expect_
         match pm.apply_position with
         | Tail ->
           let mode, _ =
-            Value.(newvar_below
+            Value.(newvar_below (get_current_level ())
               (of_const ~hint_comonadic:Tailcall_function
                 { Const.max with areality = Regional }))
           in
           mode
-        | Nontail | Default -> Value.newvar ()
+        | Nontail | Default -> Value.newvar (get_current_level ())
       in
       let funct_expected_mode = mode_default funct_mode in
       (* does the function return a tvar which is too generic? *)
@@ -6977,8 +7013,10 @@ and type_expect_
       let (args, ty_ret, mode_ret, pm) =
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
+      let ap_mode =
+        create_allocation_mode_l mode_ret
+      in
       let mode_ret = Alloc.disallow_right mode_ret in
-      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7015,12 +7053,19 @@ and type_expect_
       let arg_pat_mode, arg_expected_mode =
         match cases_tuple_arity caselist with
         | Not_local_tuple | Maybe_local_tuple ->
-          let mode = Value.newvar () in
+          let mode = Value.newvar (get_current_level ()) in
           simple_pat_mode mode, mode_default mode
         | Local_tuple locs ->
-          let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+          let modes =
+            List.map
+              (fun loc ->
+                 Value.newvar (get_current_level ()), loc)
+              locs
+          in
           let modes_pat = List.map fst modes in
-          let mode = Value.newvar () in
+          let mode =
+            Value.newvar (get_current_level ())
+          in
           tuple_pat_mode mode modes_pat, mode_tuple mode modes
       in
       let arg, sort =
@@ -8195,6 +8240,7 @@ and type_expect_
         (* The overwritten cell has to be unique
            and should have the areality expected here: *)
         Value.newvar_below
+          (get_current_level ())
           (Value.meet [
             Value.of_const {Value.Const.max with uniqueness = Unique};
             Value.max_with_comonadic Areality
@@ -8956,7 +9002,7 @@ and type_function
             param_uid
       in
       let arg_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+        create_allocation_mode_l arg_mode
       in
       let param =
         { has_poly;
@@ -8980,7 +9026,10 @@ and type_function
         | Some _ as x -> x
         | None ->
           let ret_mode =
-            {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
+            create_allocation_mode_l ret_mode
+          in
+          let ret_mode =
+            {ret_mode_annots with mode_modes = ret_mode }
           in
           Some { ret_sort ; ret_mode }
       in
@@ -9106,7 +9155,7 @@ and type_label_access
   : 'rep . 'rep record_form -> _ -> _ -> _ -> _ ->
     _ * _ * _ * 'rep gen_label_description * _ * _
   = fun record_form env srecord usage lid ->
-  let mode = Value.newvar () in
+  let mode = Value.newvar (get_current_level ()) in
   let record_jkind, record_sort =
     Jkind.of_new_sort_var ~why:Record_projection
       ~level:(Ctype.get_current_level ())
@@ -9555,15 +9604,19 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     let lv = get_level expty in
     let lv' = get_level expty' in
     match get_desc expty', get_desc expty with
-    | Tarrow((l, marg, mret), ty_arg', ty_res', _),
+    | Tarrow((l, marg', mret'), ty_arg', ty_res', _),
       Tarrow(_, ty_arg,  ty_res,  _)
       when lv' = generic_level || not !Clflags.principal ->
       let ty_res', ty_res, changed = loosen_arrow_modes ty_res' ty_res in
-      let mret, changed' = Alloc.newvar_below mret in
-      let marg, changed'' = Alloc.newvar_above marg in
-      if changed || changed' || changed'' then
-        newty2 ~level:lv' (Tarrow((l, marg, mret), ty_arg', ty_res', commu_ok)),
-        newty2 ~level:lv  (Tarrow((l, marg, mret), ty_arg,  ty_res,  commu_ok)),
+      let mret', changed1 = Alloc.newvar_below (lv) mret' in
+      let marg', changed2 = Alloc.newvar_above (lv) marg' in
+      if changed || changed1 || changed2 then
+        newty2 ~level:lv'
+          (Tarrow((l, marg', mret'), ty_arg', ty_res',
+                  commu_ok)),
+        newty2 ~level:lv
+          (Tarrow((l, marg', mret'), ty_arg, ty_res,
+                  commu_ok)),
         true
       else
         ty', ty, false
@@ -9603,7 +9656,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     Some (safe_expect, lv) ->
       (* apply omittable arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
-      let exp_mode, _ = Value.newvar_below (as_single_mode mode) in
+      let exp_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (as_single_mode mode)
+      in
       let texp =
         with_local_level_if_principal ~post:generalize_structure_exp
           (fun () ->
@@ -9687,7 +9743,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                       desc; kind = Id_value; unique_use = uu;
                       mode = Value.disallow_right mode }}
       in
-      let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in
+      let eta_mode, _ =
+        Value.newvar_below
+          (get_current_level ()) (alloc_as_value marg)
+      in
       Regionality.submode_exn
         (Value.proj_comonadic Areality eta_mode) Regionality.regional;
       let type_sort ~why ty =
@@ -9700,10 +9759,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       let fc_arg_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right marg)
+        create_allocation_mode_l marg
       in
       let fc_ret_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        create_allocation_mode_l mret
       in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
@@ -10613,7 +10672,7 @@ and type_newtype
         Hashtbl.add seen (get_id t) ();
         match get_desc t with
         | Tconstr (Path.Pident id', _, _) when id == id' -> link_type t ty
-        | _ -> Btype.iter_type_expr replace t
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t
       end
     in
     let ety = Subst.type_expr Subst.identity exp_type in
@@ -10729,7 +10788,7 @@ and type_function_cases_expect
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
     let fc_arg_mode =
-      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      create_allocation_mode_l arg_mode
     in
     let param , param_uid = name_cases "param" cases in
     let cases =
@@ -10753,7 +10812,9 @@ and type_function_cases_expect
     cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} }
+          { mode_modes =
+              create_allocation_mode_l ret_mode;
+            mode_desc = [] } }
   end
 
 (* Typing of let bindings *)
@@ -10787,7 +10848,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let entirely_functions = List.for_all vb_is_fun spat_sexp_list in
   let rec_mode_var =
     match rec_flag with
-    | Recursive when entirely_functions -> Some (Value.newvar ())
+    | Recursive when entirely_functions ->
+      Some (Value.newvar (get_current_level ()))
     | Recursive ->
         (* If the definitions are not purely functions, this involves multiple
            allocations pointing to each other. For this to be safe, they are all
@@ -10796,7 +10858,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let m, _ =
           {Value.Const.max with areality = Global}
           |> Value.of_const
-          |> Value.newvar_below
+          |> Value.newvar_below (get_current_level ())
         in
         Some m
     | Nonrecursive -> None
@@ -11355,7 +11417,9 @@ and type_n_ary_function
                           (Jkind.of_new_sort ~why
                              ~level:(Ctype.get_current_level ()))
                       in
-                      let new_mode_var () = Mode.Alloc.newvar () in
+                      let new_mode_var () =
+                        Mode.Alloc.newvar (get_current_level ())
+                      in
                       (newty
                          (Tarrow
                             ( (arg_label, new_mode_var (), new_mode_var ())
@@ -11413,10 +11477,6 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let ret_mode_modes =
-      Alloc.proj_comonadic Areality ret_mode.mode_modes
-    in
-    let ret_mode = { ret_mode with mode_modes = ret_mode_modes } in
     re
       { exp_desc =
           Texp_function

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -281,6 +281,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -6059,7 +6060,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.Comonadic.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr
   }
 
 (* The result of calling [type_function]. For the outer call to
@@ -7013,10 +7014,11 @@ and type_expect_
       let (args, ty_ret, mode_ret, pm) =
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
-      let ap_mode =
+      let ap_mode_alloc =
         create_allocation_mode_l mode_ret
       in
       let mode_ret = Alloc.disallow_right mode_ret in
+      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
@@ -7035,7 +7037,7 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode,
+        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode_alloc,
                               zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
@@ -7312,6 +7314,9 @@ and type_expect_
           (Texp_inspected_type (Label_disambiguation ambiguity), loc, [])
             :: record.exp_extra }
       in
+      let modality, _ =
+        Mode.Locality.newvar_above 0
+          (Mode.Alloc.proj_comonadic Areality (value_to_alloc_r2l rmode)) in
       unify_exp env record ty_record;
       let record_sorts, record_repres =
         update_labels env Legacy ~representative_label:label ~loc
@@ -7322,10 +7327,7 @@ and type_expect_
           record;
           record_repres;
           record_sorts;
-          modality =
-            Locality.disallow_right
-              (Alloc.proj_comonadic Areality
-               (value_to_alloc_r2l rmode));
+          modality;
           lid = label_loc;
           label;
           newval;
@@ -8925,20 +8927,24 @@ and type_function
                   begin match
                     Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
-                    | Ok () -> ()
+                    | Ok () ->
+                        Locality.submode_exn
+                        (Alloc.Comonadic.proj Areality arg_mode)
+                      alloc_mode
                     | Error e ->
                       raise (Error(loc_fun, env,
                         Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.Comonadic.submode
-                      (Alloc.Comonadic.disallow_right closure_mode)
-                      fun_closure_mode
-                  with
+                      Locality.submode
+                        (Alloc.Comonadic.proj Areality
+                           closure_mode)
+                        alloc_mode
+                    with
                     | Ok () -> ()
-                    | Error e ->
+                    | Error _ ->
                       raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e))
+                        Uncurried_function_escapes_locality));
                   end;
                   More_args
                     { partial_mode = Locality.disallow_right alloc_mode }
@@ -12898,6 +12904,11 @@ let report_error ~loc env =
               but expected to be %a."
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
             (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
+    end
+  | Uncurried_function_escapes_locality -> begin
+      Location.errorf ~loc
+            "This function or one of its parameters escape their region@ \
+            when it is partially applied."
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -329,6 +329,7 @@ type error =
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
   | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
+  | Uncurried_function_escapes_locality
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -328,7 +328,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
-  | Uncurried_function_escapes of Mode.Alloc.error
+  | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1487,7 +1487,8 @@ let rec check_constraints_rec env loc visited ty =
       check_constraints_rec env loc visited ty
   | _ ->
       Ctype.iter_type_expr_with_stages
-        (fun env -> check_constraints_rec env loc visited) env ty
+        (fun env -> check_constraints_rec env loc visited) env
+        (Fun.const ()) ty
   end
 
 let check_constraints_labels env visited l pl =
@@ -2879,7 +2880,8 @@ let check_well_founded ~abs_env env loc path to_check visited ty0 =
               List.iter (check_subtype parents trace ty env) tyl
         end
     | _ ->
-        Ctype.iter_type_expr_with_stages (check_subtype parents trace ty) env ty
+        Ctype.iter_type_expr_with_stages
+          (check_subtype parents trace ty) env (Fun.const ()) ty
   and check_subtype parents trace outer_ty env inner_ty =
       check parents (Contains (outer_ty, inner_ty) :: trace) env inner_ty
   in
@@ -3163,7 +3165,7 @@ let check_regularity ~abs_env env loc path decl to_check =
           check_regular cpath args prev_exp trace env ty
       | _ ->
           Ctype.iter_type_expr_with_stages
-            (check_subtype cpath args prev_exp trace ty) env ty
+            (check_subtype cpath args prev_exp trace ty) env (Fun.const ()) ty
     end
     and check_subtype cpath args prev_exp trace outer_ty env inner_ty =
       let trace = Contains (outer_ty, inner_ty) :: trace in
@@ -3572,7 +3574,7 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
-       match Ctype.closed_type_decl decl with
+       match Mode.Alloc.with_zap_scope Ctype.closed_type_decl decl with
          Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
@@ -3879,7 +3881,10 @@ let transl_type_extension extend env loc styext =
   (* Check that all type variables are closed *)
   List.iter
     (fun (ext, _shape) ->
-       match Ctype.closed_extension_constructor ext.ext_type with
+       match Mode.Alloc.with_zap_scope
+               Ctype.closed_extension_constructor
+               ext.ext_type
+       with
          Some ty ->
            raise(Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
        | None -> ())
@@ -3935,7 +3940,10 @@ let transl_exception env sext =
       end
   in
   (* Check that all type variables are closed *)
-  begin match Ctype.closed_extension_constructor ext.ext_type with
+  begin match
+    Mode.Alloc.with_zap_scope
+      Ctype.closed_extension_constructor ext.ext_type
+  with
     Some ty ->
       raise (Error(ext.ext_loc, Unbound_type_var_ext(ty, ext.ext_type)))
   | None -> ()
@@ -4284,7 +4292,10 @@ let check_unboxable env loc ty =
       | _ -> acc
     with Not_found -> acc
   in
-  let all_unboxable_types = Btype.fold_type_expr check_type Path.Set.empty ty in
+  let all_unboxable_types =
+    Btype.fold_type_expr check_type
+      (fun a _ -> a) Path.Set.empty ty
+  in
   Path.Set.fold
     (fun p () ->
        Location.prerr_warning loc
@@ -4724,7 +4735,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   in
   Option.iter (fun p -> set_private_row env sdecl.ptype_loc p new_sig_decl)
     fixed_row_path;
-  begin match Ctype.closed_type_decl new_sig_decl with None -> ()
+  begin match
+    Mode.Alloc.with_zap_scope
+      Ctype.closed_type_decl new_sig_decl
+  with None -> ()
   | Some ty -> raise(Error(loc, Unbound_type_var(ty, new_sig_decl)))
   end;
   let new_sig_decl = name_recursion sdecl id new_sig_decl in

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -157,13 +157,13 @@ let compute_variance_type env ~check (required, loc) decl tyl =
             | Tconstr _ ->
                 let old = !visited in
                 begin try
-                  Ctype.iter_type_expr_with_stages check env ty
+                  Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
                 with Exit ->
                   visited := old;
                   let ty' = Ctype.expand_head_opt env ty in
                   if eq_type ty ty' then raise Exit else check env ty'
                 end
-            | _ -> Ctype.iter_type_expr_with_stages check env ty
+            | _ -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
           end
         in
         try check env ty; compute_variance env tvl injective ty
@@ -236,7 +236,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                      , Bad_variance ( variance_error
                                     , (c1,n1,false)
                                     , (c2,n2,false))))
-        | None -> Ctype.iter_type_expr_with_stages check env ty
+        | None -> Ctype.iter_type_expr_with_stages check env (Fun.const ()) ty
       end
     in
     List.iter (fun (_,ty) -> check env ty) tyl;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -131,10 +131,12 @@ let print_unique_use ppf (u,l) =
     (Format_doc.compat (Mode.Uniqueness.print ())) u
     (Format_doc.compat (Mode.Linearity.print ())) l
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+type alloc_mode_l = Mode.Locality.l
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   | Non_boxing of unique_use
 
 let aliased_many_use =
@@ -204,7 +206,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       lpoly: Lpoly.t;
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc
@@ -289,31 +291,32 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : alloc_mode_l modes;
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         zero_alloc : Zero_alloc.t;
       }
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
-        Mode.Locality.l * Zero_alloc.assume option
+        alloc_mode_l * Zero_alloc.assume option
   | Texp_match of expression * Jkind.sort * computation case list * partial
   | Texp_try of expression * value case list
   | Texp_unboxed_unit
   | Texp_unboxed_bool of bool
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
   | Texp_unboxed_tuple of (string option * expression * Jkind.sort) list
   | Texp_construct of
       Longident.t loc * constructor_description * constructor_representation *
-      (Jkind.sort * expression) list * alloc_mode option
-  | Texp_variant of label * (expression * alloc_mode) option
+      (Jkind.sort * expression) list
+      * alloc_mode_r option
+  | Texp_variant of label * (expression * alloc_mode_r) option
   | Texp_record of {
       fields :
         ( Types.label_description * Jkind.sort * record_label_definition )
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
   | Texp_record_unboxed_product of {
       fields :
@@ -324,7 +327,7 @@ and expression_desc =
     }
   | Texp_atomic_loc of
       expression * Jkind.sort * Longident.t loc * label_description *
-      alloc_mode
+      alloc_mode_r
   | Texp_field of {
       record : expression;
       record_sort : Jkind.sort;
@@ -352,7 +355,7 @@ and expression_desc =
       label : Types.label_description;
       newval : expression;
     }
-  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of mutability * Jkind.sort * comprehension
@@ -465,7 +468,7 @@ and 'k case =
     }
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and function_param =
@@ -476,7 +479,7 @@ and function_param =
     fp_partial: partial;
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -494,7 +497,7 @@ and function_body =
 and function_cases =
   { fc_cases: value case list;
     fc_env : Env.t;
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -526,9 +529,9 @@ and ('a, 'b) arg_or_omitted =
   | Omitted of 'b
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : alloc_mode_l;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -83,7 +83,7 @@ module Unique_barrier = struct
 
   let enable barrier = match !barrier with
     | Not_computed ->
-      barrier := Enabled (Uniqueness.newvar ())
+      barrier := Enabled (Uniqueness.newvar 0)
     | _ -> Misc.fatal_error "Unique barrier was enabled twice"
 
   (* Due to or-patterns a barrier may have several upper bounds. *)
@@ -95,7 +95,7 @@ module Unique_barrier = struct
   let resolve barrier =
     match !barrier with
     | Enabled uniq ->
-      let zapped = Uniqueness.zap_to_ceil uniq in
+      let zapped = Uniqueness.zap_to_ceil_exn uniq in
       barrier := Resolved zapped;
       zapped
     | Resolved barrier -> barrier

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -109,7 +109,9 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 val print_unique_use : Format.formatter -> unique_use -> unit
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+type alloc_mode_l = Mode.Locality.l
 
 (* CR-someday liam923: We'd like to split this into an arrow_modes and
    value_modes type. *)
@@ -124,7 +126,7 @@ type modalities = Typemode.modalities =
   }
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
@@ -251,7 +253,7 @@ and 'k pattern_desc =
       the allocation mode of the captured environment. [pending] during
       type-checking; guaranteed [determined] of (potentially empty) generic sort
       variables after [type_let] returns. *)
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
       (** The allocation mode of the environment captured by the layout
       function.
 
@@ -482,11 +484,11 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : alloc_mode_l modes;
         (* Mode where the function allocates, ie local for a function of
            type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)
         zero_alloc : Zero_alloc.t;
         (* zero-alloc attributes *)
@@ -502,7 +504,7 @@ and expression_desc =
       *)
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
-        Mode.Locality.l * Zero_alloc.assume option
+        alloc_mode_l * Zero_alloc.assume option
         (** E0 ~l1:E1 ... ~ln:En
 
             The expression can be Omitted if the expression is abstracted over
@@ -535,7 +537,7 @@ and expression_desc =
         (** #() *)
   | Texp_unboxed_bool of bool
         (** #false, #true *)
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
         (** [Texp_tuple(el)] represents
             - [(E1, ..., En)]
                 when [el] is [(None, E1);...;(None, En)],
@@ -556,7 +558,7 @@ and expression_desc =
   | Texp_construct of
       Longident.t loc * Types.constructor_description *
       Types.constructor_representation * (Jkind.sort * expression) list *
-      alloc_mode option
+      alloc_mode_r option
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
@@ -565,7 +567,7 @@ and expression_desc =
             or [None] if the constructor is [Cstr_unboxed] or [Cstr_constant],
             in which case it does not need allocation.
          *)
-  | Texp_variant of label * (expression * alloc_mode) option
+  | Texp_variant of label * (expression * alloc_mode_r) option
         (** [alloc_mode] is the allocation mode of the variant,
             or [None] if the variant has no argument,
             in which case it does not need allocation.
@@ -576,7 +578,7 @@ and expression_desc =
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
             { E0 with l1=P1; ...; ln=Pn }   (extended_expression = Some E0)
@@ -611,7 +613,7 @@ and expression_desc =
           *)
   | Texp_atomic_loc of
       expression * Jkind.sort * Longident.t loc * Types.label_description *
-      alloc_mode
+      alloc_mode_r
   | Texp_field of {
       record : expression;
       record_sort : Jkind.sort;
@@ -644,7 +646,8 @@ and expression_desc =
       newval : expression;
     }
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of
+      Types.mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   (* CR layouts-scannable: The sort here is no longer used. Instead, a layout is
@@ -712,7 +715,7 @@ and expression_desc =
   | Texp_antiquotation of expression
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and function_param =
@@ -731,7 +734,7 @@ and function_param =
     *)
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -772,7 +775,7 @@ and function_cases =
     (** [fc_env] contains entries from all parameters except
         for the last one being matched by the cases.
     *)
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -869,9 +872,9 @@ and ('a, 'b) arg_or_omitted =
   | Omitted of 'b (* an argument not passed due to partial application *)
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : alloc_mode_l;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2804,7 +2804,7 @@ let check_nongen_signature env sg =
 let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
       let zap_mode mode =
-        if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+        if Language_extension.(is_at_least_mode_poly Alpha) then begin
           Alloc.add_mode_to_zap_scope mode zap_scope
          end else begin
           Alloc.zap_to_legacy_force mode |> ignore

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -114,13 +114,23 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
   mode
 
-let register_allocation () =
-  let m, _ =
-    Value.(newvar_below (of_const
+let register_module_allocation () =
+  let upper_bound =
+    Value.of_const
       ~hint_comonadic:Module_allocated_on_heap
-      { Const.max with areality = Global }))
+      { Value.Const.max with areality = Global }
   in
-  value_to_alloc_r2g m, m
+  fst (Value.newvar_below upper_bound)
+
+let register_closure_allocation () : Alloc.lr * Value.lr =
+  let upper_bound =
+    Alloc.of_const
+      ~hint_comonadic:Module_allocated_on_heap
+      { Alloc.Const.max with areality = Global }
+  in
+  let alloc_mode, _ = Alloc.newvar_below upper_bound in
+  let closed_over_mode = alloc_as_value ~hint:Skip alloc_mode in
+  alloc_mode, closed_over_mode
 
 open Typedtree
 
@@ -143,7 +153,7 @@ let apply_is_contained_by ~loc_md item ?modalities mode =
     { containing = Structure (item, Modality);
       container = (loc_md, Structure) }
   in
-  Ctype.apply_is_contained_by is_contained_by ?modalities mode
+  Ctype.apply_right_is_contained_by is_contained_by ?modalities mode
 
 (** Given a value whose location in the source code is described by [pp] and at
 [mode], infer the modalities on the value when it's placed as an [item] in a
@@ -190,11 +200,7 @@ let rebase_modalities ~loc ~loc_md item ~md_mode ~mode modalities =
     { containing = Structure (item, Modality);
       container = (loc, Structure)}
   in
-  let hint =
-    { monadic = Hint.Is_contained_by (Monadic, is_contained_by);
-      comonadic = Hint.Is_contained_by (Comonadic, is_contained_by) }
-  in
-  let mode = Modality.apply ~hint modalities mode in
+  let mode = Modality.apply_left ~is_contained_by modalities mode in
   infer_modalities pp ~loc_md item ~md_mode ~mode
 
 (** Similiar to [rebase_modalities] but lifted to signatures. *)
@@ -3154,9 +3160,13 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       in
       md, shape
   | Pmod_functor(arg_opt, sbody) ->
-      let alloc_mode, mode = register_allocation () in
+      let alloc_mode, closed_over_mode =
+        register_closure_allocation ()
+      in
       let newenv =
-        Env.add_closure_lock (smod.pmod_loc, Functor) mode.comonadic env
+        Env.add_closure_lock
+          (smod.pmod_loc, Functor)
+          closed_over_mode.comonadic env
       in
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
@@ -3209,7 +3219,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
        | _ -> ());
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type, ret_mode);
-        mod_mode = Value.disallow_right mode, None;
+        mod_mode = Value.disallow_right closed_over_mode, None;
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
@@ -3612,7 +3622,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
   (* CR implicit-types: implement implicit variable jkinds in structures. *)
   let env = Env.clear_implicit_jkinds env in
   let names = Signature_names.create () in
-  let _, md_mode = register_allocation () in
+  let md_mode = register_module_allocation () in
   let loc_md = location_of_structure sstr in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
@@ -4272,7 +4282,7 @@ let type_package env m p fl =
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';
-  let _, mode = register_allocation () in
+  let mode = register_module_allocation () in
   let modl =
     wrap_constraint_package env true modl mty mode Tmodtype_implicit
   in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -107,7 +107,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
-  let mode = Mode.Value.newvar () in
+  let mode = Mode.Value.newvar 0 in
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
   Value.submode_exn (min |> Alloc.of_const |> alloc_as_value) mode;
@@ -120,7 +120,7 @@ let register_allocation () : Alloc.lr * Value.lr =
       ~hint_comonadic:Module_allocated_on_heap
       { Alloc.Const.max with areality = Global }
   in
-  let alloc_mode, _ = Alloc.newvar_below upper_bound in
+  let alloc_mode, _ = Alloc.newvar_below 0 upper_bound in
   let closed_over_mode = alloc_as_value ~hint:Skip alloc_mode in
   alloc_mode, closed_over_mode
 
@@ -170,7 +170,7 @@ let infer_modalities pp ~loc_md item ~md_mode ~mode =
       To achieve that, the mode of [foo] to be exposed as [M.foo] should be a
       flexible mode variable weaker than its actual mode.
     *)
-    let mode, _ = Mode.Value.newvar_above mode in
+    let mode, _ = Mode.Value.newvar_above (Ctype.get_current_level ()) mode in
     (* Upon construction, for comonadic (prescriptive) axes, module
     must be weaker than the values therein, for otherwise operations
     would be allowed to performed on the module (and extended to the
@@ -2801,19 +2801,31 @@ let check_nongen_signature_item env sig_item =
 let check_nongen_signature env sg =
   List.iter (check_nongen_signature_item env) sg
 
-let remove_functor_mode_variables = function
+let remove_functor_mode_variables ~zap_scope = function
   | Mty_functor (arg_opt, _, mres) ->
-      Mode.Alloc.zap_to_legacy mres |> ignore;
+      let zap_mode mode =
+        if Language_extension.(is_at_least Mode_polymorphism Alpha) then begin
+          Alloc.add_mode_to_zap_scope mode zap_scope
+         end else begin
+          Alloc.zap_to_legacy_force mode |> ignore
+         end
+      in
+      zap_mode mres;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy marg |> ignore
+      | Named (_, _, marg) -> zap_mode marg
       end
   | _ -> ()
 
 let remove_mode_and_jkind_variables env sg =
-  let rm_ty _env ty = Ctype.remove_mode_and_jkind_variables ty; None in
-  let rm_mty _env mty = remove_functor_mode_variables mty in
-  List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore
+  Mode.Alloc.with_zap_scope(fun ~zap_scope ->
+    let rm_ty _env ty =
+      Ctype.remove_mode_and_jkind_variables
+        ty ~zap_scope;
+      None
+    in
+    let rm_mty _env mty = remove_functor_mode_variables ~zap_scope mty in
+    List.find_map (nongen_signature_item env rm_ty rm_mty) sg |> ignore)
 
 (* Helpers for typing recursive modules *)
 
@@ -3197,7 +3209,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
 
       let body, body_shape = type_module true funct_body None newenv sbody in
       let body_mode = mode_without_locks_exn body.mod_mode in
-      let ret_mode = Alloc.newvar () in
+      let ret_mode = Alloc.newvar 0 in
       Value.submode_exn body_mode (ret_mode |> alloc_as_value);
       (* Apply currying constraints if the body is a functor,
          similar to constraints for functions. *)
@@ -3248,7 +3260,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       },
       final_shape
   | Pmod_unpack sexp ->
-      let mode = Value.newvar () in
+      let mode = Value.newvar 0 in
       let exp =
         Ctype.with_local_level_if_principal
           (fun () -> Typecore.type_exp env sexp
@@ -3258,6 +3270,11 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       let mty =
         match get_desc (Ctype.expand_head env exp.exp_type) with
           Tpackage (p, fl) ->
+            List.iter
+              (fun (_n, t) ->
+                 Mode.Alloc.with_zap_scope
+                   Ctype.remove_mode_and_jkind_variables t)
+              fl;
             if List.exists (fun (_n, t) -> not (Ctype.closed_type_expr t)) fl
             then
               raise (Error (smod.pmod_loc, env,
@@ -4100,7 +4117,8 @@ let remove_mode_and_jkind_variables_for_toplevel str =
                          vb_expr = exp}])) }] ->
      (* These types are printed by the toplevel,
         even though they do not appear in sg *)
-     Ctype.remove_mode_and_jkind_variables exp.exp_type
+     Mode.Alloc.with_zap_scope
+       Ctype.remove_mode_and_jkind_variables exp.exp_type
   | _ -> ()
 
 let type_toplevel_phrase env sig_acc s =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -114,15 +114,7 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
   mode
 
-let register_module_allocation () =
-  let upper_bound =
-    Value.of_const
-      ~hint_comonadic:Module_allocated_on_heap
-      { Value.Const.max with areality = Global }
-  in
-  fst (Value.newvar_below upper_bound)
-
-let register_closure_allocation () : Alloc.lr * Value.lr =
+let register_allocation () : Alloc.lr * Value.lr =
   let upper_bound =
     Alloc.of_const
       ~hint_comonadic:Module_allocated_on_heap
@@ -3161,7 +3153,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       md, shape
   | Pmod_functor(arg_opt, sbody) ->
       let alloc_mode, closed_over_mode =
-        register_closure_allocation ()
+        register_allocation ()
       in
       let newenv =
         Env.add_closure_lock
@@ -3622,7 +3614,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
   (* CR implicit-types: implement implicit variable jkinds in structures. *)
   let env = Env.clear_implicit_jkinds env in
   let names = Signature_names.create () in
-  let md_mode = register_module_allocation () in
+  let _, md_mode = register_allocation () in
   let loc_md = location_of_structure sstr in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
@@ -4282,7 +4274,7 @@ let type_package env m p fl =
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';
-  let mode = register_module_allocation () in
+  let _, mode = register_allocation () in
   let modl =
     wrap_constraint_package env true modl mty mode Tmodtype_implicit
   in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -873,7 +873,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode.mode_modes arg
           in
-          let acc_mode = curry_mode acc_mode arg_mode.mode_modes in
+          let acc_mode = curry_mode_const acc_mode arg_mode.mode_modes in
           let ret_mode =
             match rest with
             | [] -> ret_mode
@@ -1536,7 +1536,7 @@ let rec make_fixed_univars mark ty =
                   ~fixed:(Some (Univar more))));
         Btype.iter_row (make_fixed_univars mark) row
     | _ ->
-        Btype.iter_type_expr (make_fixed_univars mark) ty
+        Btype.iter_type_expr (make_fixed_univars mark) (Fun.const ()) ty
     end
 
 let make_fixed_univars ty =
@@ -1602,7 +1602,7 @@ let transl_type_scheme_mono env styp =
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =
@@ -1626,7 +1626,7 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ~post:(fun (_,_,typ) -> generalize_ctyp typ)
   in
   let _ : _ list = TyVarEnv.instance_poly_univars env loc univars in
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
     ctyp_env = env;
@@ -1683,7 +1683,7 @@ let transl_type_scheme_lpoly env attrs loc vars inner_type =
               Types.set_var_jkind t jkind
             | None -> ())
           | _ -> ())
-        | _ -> Btype.iter_type_expr replace t)
+        | _ -> Btype.iter_type_expr replace (Fun.const ()) t)
       end
     in
     let ety = Subst.type_expr Subst.identity ty in

--- a/utils/language_extension_kernel.ml
+++ b/utils/language_extension_kernel.ml
@@ -9,6 +9,7 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -27,6 +28,7 @@ let to_string : type a. a t -> string = function
   | Mode -> "mode"
   | Unique -> "unique"
   | Overwriting -> "overwriting"
+  | Mode_polymorphism -> "mode_polymorphism"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"

--- a/utils/language_extension_kernel.ml
+++ b/utils/language_extension_kernel.ml
@@ -10,6 +10,7 @@ type _ t =
   | Unique : maturity t
   | Overwriting : unit t
   | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -29,6 +30,7 @@ let to_string : type a. a t -> string = function
   | Unique -> "unique"
   | Overwriting -> "overwriting"
   | Mode_polymorphism -> "mode_polymorphism"
+  | Mode_polymorphism_printing -> "mode_polymorphism_printing"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"

--- a/utils/language_extension_kernel.mli
+++ b/utils/language_extension_kernel.mli
@@ -20,6 +20,7 @@ type _ t =
   | Mode : maturity t
   | Unique : maturity t
   | Overwriting : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/utils/language_extension_kernel.mli
+++ b/utils/language_extension_kernel.mli
@@ -21,6 +21,7 @@ type _ t =
   | Unique : maturity t
   | Overwriting : unit t
   | Mode_polymorphism : maturity t
+  | Mode_polymorphism_printing : unit t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1941,6 +1941,10 @@ type (_, _) is_eq =
   | Is_eq : ('a, 'a) is_eq
   | Is_not_eq : ('a, 'b) is_eq
 
+let get_eq_exn : type a b. (a, b) is_eq -> (a, b) eq = function
+  | Is_eq -> Refl
+  | Is_not_eq -> fatal_error "Propositional equality does not hold"
+
 (*********************************************)
 (* Fancy modules *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -1130,6 +1130,9 @@ type (_, _) is_eq =
   | Is_eq : ('a, 'a) is_eq
   | Is_not_eq : ('a, 'b) is_eq
 
+(** Raises an exception if propositional equality test does not hold *)
+val get_eq_exn : ('a, 'b) is_eq -> ('a, 'b) eq
+
 (** Utilities for module-level programming *)
 module type T = sig
   type t

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -10,8 +10,8 @@ let count_language_extensions typing_input =
     | Comprehensions | Include_functor | Immutable_arrays | Module_strengthening
       ->
       Language_extension_kernel.to_string lang_ext
-    | Mode | Unique | Polymorphic_parameters | Layouts | SIMD | Small_numbers
-    | Instances | Overwriting | Let_mutable | Layout_poly
+    | Mode | Unique | Mode_polymorphism | Polymorphic_parameters | Layouts
+    | SIMD | Small_numbers | Instances | Overwriting | Let_mutable | Layout_poly
     | Runtime_metaprogramming ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -10,9 +10,9 @@ let count_language_extensions typing_input =
     | Comprehensions | Include_functor | Immutable_arrays | Module_strengthening
       ->
       Language_extension_kernel.to_string lang_ext
-    | Mode | Unique | Mode_polymorphism | Polymorphic_parameters | Layouts
-    | SIMD | Small_numbers | Instances | Overwriting | Let_mutable | Layout_poly
-    | Runtime_metaprogramming ->
+    | Mode | Unique | Mode_polymorphism | Mode_polymorphism_printing
+    | Polymorphic_parameters | Layouts | SIMD | Small_numbers | Instances
+    | Overwriting | Let_mutable | Layout_poly | Runtime_metaprogramming ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."
           (Language_extension_kernel.to_string lang_ext)


### PR DESCRIPTION
Prints polymorphic mode variables and their constraints. In general, mode variables is printed in `[...]` containing its lower and upper bounds and constraints as follows: `[< ... & ... > ... | ...]`. Lower and upper bounds refer to the constant bounds on the polymorphic variable, and constraints might refer to other mode variables.

If a mode variable has no bounds or constraints, it is printed as a fresh mode variable name: `'m`, `'n`, `'o`, etc.

Printing mode variables requires an expensive pre-processing step, which is only applied when `-extension mode_polymorphism_alpha` is on.

Below are some examples: 
- `val id : 'a @ [< 'm] -> 'a @ [> 'm]`

- `let fst x y = x` involves currying, and gets printed to `val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]`.

Where `close('m)` refers to the meet between the comonadic parts of `'m` and the monadic part `'m`, taken to its dual comonadic counterpart. Note that `'m` describes an upper bound in the argument, and a lower bound on the inner return. 

If the curry mode does not flow in both directions, we print the following constraint:

- `let snd x y = y : 'a @ [< 'm @@ past] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> 'm]` 

Where `'m @@ past` refers to the comonadic part of `'m` only, and can be read as "mod past", or "modulo past", or "mod monadic".

- `let fst x = fun y -> x` has slightly different constrains: `val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]`. The returned closure is polymorphic, but must be `global` since the allocation of the closure is here decided to be global.

- let `type 'a mytyp = { a : 'a @@ portable }` then `let f x = x.a` is inferred and printed as `val f : 'a mytyp @ [< 'm] -> 'a @ [> 'm @@ portable]`. Here `@@ portable` stands for a meet, and the type expresses the output is lower bounded by `'m`, except for the portability axis, which is lower bounded by `portable`.