### PR TITLE
Ability to make arguments of a higher-order functions have zero-alloc expectations

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2802,7 +2802,7 @@ let type_for_annotation ~env ~loc typ =
               Typemode.transl_alloc_mode [],
               go ty',
               Typemode.transl_alloc_mode [] )
-        | Tpoly (ty, tyl) -> (
+        | Tpoly (ty, tyl, _za) -> (
           let cty = go ty in
           match List.filter_map unwrap_univar tyl with
           | [] -> cty.ctyp_desc

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -66,7 +66,7 @@ let parameter_list_from_arrows typ =
       Types.Tarrow ((l,_,_), t1, t2, _) ->
         (l, t1) :: (iter t2)
     | Types.Tlink texp
-    | Types.Tpoly (texp, _) | Types.Trepr (texp, _) -> iter texp
+    | Types.Tpoly (texp, _, _) | Types.Trepr (texp, _) -> iter texp
     | Types.Tvar _
     | Types.Ttuple _
     | Types.Tunboxed_tuple _

--- a/oxcaml/tests/backend/zero_alloc_checker/fail20.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail20.ml
@@ -14,8 +14,8 @@ let[@zero_alloc strict] foo1 x =
   then List.nth (div (x + 2)) x
   else nor x
 
-(* zero_alloc properties are used when type-checking within a module;
-   this previously failed, the test is kept here to prevent regressions *)
+(* zero_alloc properties are used when type-checking within a module; this
+   previously failed, the test is kept here to prevent regressions *)
 let[@zero_alloc] [@inline never] [@local never] foo x =
   let[@opaque] bar x y = Sys.opaque_identity (x + y), x in
   fst (bar x (x * x))

--- a/oxcaml/tests/backend/zero_alloc_checker/fail20.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail20.ml
@@ -14,6 +14,8 @@ let[@zero_alloc strict] foo1 x =
   then List.nth (div (x + 2)) x
   else nor x
 
+(* zero_alloc properties are used when type-checking within a module;
+   this previously failed, the test is kept here to prevent regressions *)
 let[@zero_alloc] [@inline never] [@local never] foo x =
   let[@opaque] bar x y = Sys.opaque_identity (x + y), x in
   fst (bar x (x * x))

--- a/oxcaml/tests/backend/zero_alloc_checker/fail20.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail20.output
@@ -11,9 +11,3 @@ Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20
 
 File "fail20.ml", line 19, characters 6-21:
 Error: called function may allocate (direct call camlFail20.bar_HIDE_STAMP)
-
-File "fail20.ml", line 21, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20.zee_HIDE_STAMP).
-
-File "fail20.ml", line 21, characters 27-58:
-Error: called function may allocate (direct tailcall camlFail20.foo_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/fail20.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail20.output
@@ -6,8 +6,8 @@ Error: allocation of 32 bytes on a path to exceptional return
 inlined from
 fail20.ml:12,7--18[Fail20.foo1]
 
-File "fail20.ml", line 17, characters 5-15:
+File "fail20.ml", line 19, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP).
 
-File "fail20.ml", line 19, characters 6-21:
+File "fail20.ml", line 21, characters 6-21:
 Error: called function may allocate (direct call camlFail20.bar_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/fail25.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail25.ml
@@ -52,8 +52,8 @@ let[@zero_alloc] rec f1 x = if x > Sys.opaque_identity 10 then x else f2 (x + 1)
 and[@zero_alloc] f2 x = f1 (x + 1)
 
 (* Previously, this failed the check when -disable-precise-zero-alloc-checker
-   was passed and -function-layout source.
-   Adding zero_alloc information on pattern variables fixed this. *)
+   was passed and -function-layout source. Adding zero_alloc information on
+   pattern variables changed this behaviour. *)
 let[@zero_alloc] outer x =
   let[@zero_alloc] [@inline never] [@local never] inner x =
     if x > Sys.opaque_identity 10 then x else x + 1

--- a/oxcaml/tests/backend/zero_alloc_checker/fail25.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail25.ml
@@ -51,8 +51,9 @@ let[@zero_alloc] rec f1 x = if x > Sys.opaque_identity 10 then x else f2 (x + 1)
 
 and[@zero_alloc] f2 x = f1 (x + 1)
 
-(* Fail the check when -disable-precise-zero-alloc-checker is passed and
-   -function-layout source *)
+(* Previously, this failed the check when -disable-precise-zero-alloc-checker
+   was passed and -function-layout source.
+   Adding zero_alloc information on pattern variables fixed this. *)
 let[@zero_alloc] outer x =
   let[@zero_alloc] [@inline never] [@local never] inner x =
     if x > Sys.opaque_identity 10 then x else x + 1

--- a/oxcaml/tests/backend/zero_alloc_checker/fail25.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail25.output
@@ -33,11 +33,3 @@ Error: Annotation check for zero_alloc failed on function Fail25.f2 (camlFail25.
 
 File "fail25.ml", line 52, characters 24-34:
 Error: called function may allocate (direct tailcall camlFail25.f1_HIDE_STAMP)
-
-File "fail25.ml", line 56, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.outer (camlFail25.outer_HIDE_STAMP).
-
-File "fail25.ml", line 60, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail25.inner_HIDE_STAMP)
-Hint: Recompile without -disable-precise-zero-alloc-checker for more precise results.
-

--- a/oxcaml/tests/backend/zero_alloc_checker/fail26.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail26.output
@@ -16,8 +16,8 @@ Error: Annotation check for zero_alloc failed on function Fail26.f1 (camlFail26.
 File "fail26.ml", line 52, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail26.f2 (camlFail26.f2_HIDE_STAMP).
 
-File "fail26.ml", line 56, characters 5-15:
+File "fail26.ml", line 57, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail26.outer (camlFail26.outer_HIDE_STAMP).
 
-File "fail26.ml", line 57, characters 7-17:
+File "fail26.ml", line 58, characters 7-17:
 Error: Annotation check for zero_alloc failed on function Fail26.outer.inner (camlFail26.inner_HIDE_STAMP).

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -17,6 +17,11 @@ open Asttypes
 open Parsetree
 open Ast_helper
 
+type error =
+  | Must_provide_zero_alloc_arity
+  | Zero_alloc_attr_non_function
+
+exception Error_builtin of Location.t * error
 
 module Attribute_table = Hashtbl.Make (struct
   type t = string with_loc
@@ -1033,7 +1038,17 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
     in
     match get_optional_payload get_ids_and_constants_from_exp payload with
     | Error () -> warn (); Default_zero_alloc
-    | Ok None -> empty default_arity None
+    | Ok None ->
+      let default_arity = begin
+        match default_arity with
+        | None ->
+          if on_function_argument then
+            raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
+          else
+            raise (Error_builtin (loc, Zero_alloc_attr_non_function))
+        | Some arity -> arity
+      end in
+      empty default_arity None
     | Ok (Some payload) ->
       let custom_error_message, payload =
         match filter_custom_error_message payload with
@@ -1050,9 +1065,22 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
           else
             Some custom_error_message, payload
       in
+      if List.filter_map
+           (function (Ident, s) -> Some s | _ -> None) payload
+         = ["ignore"] then Ignore_assert_all
+      else
+      let default_arity () = begin
+        match default_arity with
+        | None ->
+          if on_function_argument then
+            raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
+          else
+            raise (Error_builtin (loc, Zero_alloc_attr_non_function))
+        | Some arity -> arity
+      end in
       let arity, payload =
         match filter_arity payload with
-        | None -> default_arity, payload
+        | None -> default_arity (), payload
         | Some (user_arity, payload) ->
           if in_signature || on_function_argument then
             user_arity, payload
@@ -1060,7 +1088,7 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
             (warn_payload loc txt
                "The \"arity\" field is only supported on \"zero_alloc\" in \
                 signatures or on function arguments";
-             default_arity, payload)
+             default_arity (), payload)
       in
       let _, payload = List.split payload in
       let parse p =
@@ -1189,3 +1217,23 @@ let get_tracing_probe_payload (payload : Parsetree.payload) =
   Ok { name; name_loc; enabled_at_init; arg }
 
 let has_atomic attrs = has_attribute "atomic" attrs
+
+let report_error ~loc =
+  function
+  | Must_provide_zero_alloc_arity ->
+      Location.errorf ~loc
+        "Zero-alloc annotations on function arguments must specify arity."
+  | Zero_alloc_attr_non_function ->
+      Location.errorf ~loc
+        "%a attributes on function arguments require the argument@ \
+         to be a function type."
+        Style.inline_code "zero_alloc"
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Error_builtin (loc, err) ->
+        Some (report_error ~loc err)
+      | _ ->
+        None
+    )

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -23,6 +23,13 @@ type error =
 
 exception Error_builtin of Location.t * error
 
+type zero_alloc_attribute_use =
+  | Value_decl of int
+  | Function_param
+  | Arrow_lhs of int
+  | Function_definition of int
+  | Application of int
+
 module Attribute_table = Hashtbl.Make (struct
   type t = string with_loc
 
@@ -1011,8 +1018,15 @@ let parse_zero_alloc_payload ~loc ~arity ~custom_error_message
     | None -> warn ();  Default_zero_alloc
     | Some ca -> ca arity loc custom_error_message
 
-let parse_zero_alloc_attribute ~in_signature ~on_application
-      ~on_function_argument ~default_arity attr =
+let parse_zero_alloc_attribute usage attr =
+  let in_signature, on_function_argument, on_application =
+    match usage with
+    | Value_decl _ -> true, false, false
+    | Function_param -> false, true, false
+    | Arrow_lhs _ -> false, true, false
+    | Function_definition _ -> false, false, false
+    | Application _ -> false, false, true
+  in
   match attr with
   | None -> Default_zero_alloc
   | Some {Parsetree.attr_name = {txt; loc}; attr_payload = payload} ->
@@ -1037,13 +1051,11 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
       Check { strict = false; opt = false; arity; loc; custom_error_msg; }
     in
     let default_arity () = begin
-      match default_arity with
-      | None ->
-        if on_function_argument then
-          raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
-        else
-          raise (Error_builtin (loc, Zero_alloc_attr_non_function))
-      | Some arity -> arity
+      match usage with
+      | Function_param ->
+        raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
+      | Value_decl arity | Arrow_lhs arity
+      | Function_definition arity | Application arity -> arity
     end in
     match get_optional_payload get_ids_and_constants_from_exp payload with
     | Error () -> warn (); Default_zero_alloc
@@ -1118,22 +1130,20 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
             Default_zero_alloc)
 
 
-let get_zero_alloc_attribute ~in_signature ~on_application ~on_function_argument
-      ~default_arity l =
+let get_zero_alloc_attribute usage l =
   let attr = select_attribute is_zero_alloc_attribute l in
-  let res =
-      parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity
-        ~on_function_argument attr
-  in
-  (match attr, res with
-   | None, Default_zero_alloc -> ()
-   | _, Default_zero_alloc -> ()
-   | None, (Check _ | Assume _ | Ignore_assert_all) -> assert false
-   | Some _, Ignore_assert_all -> ()
-   | Some _, Assume _ -> ()
-   | Some attr, Check { opt; _ } ->
-     if not on_function_argument && not in_signature &&
-        is_zero_alloc_check_enabled ~opt && !Clflags.native_code then
+  let res = parse_zero_alloc_attribute usage attr in
+  (match attr, res, usage with
+   | None, Default_zero_alloc, _ -> ()
+   | _, Default_zero_alloc, _ -> ()
+   | None, (Check _ | Assume _ | Ignore_assert_all), _ -> assert false
+   | Some _, Ignore_assert_all, _ -> ()
+   | Some _, Assume _, _ -> ()
+   | Some _, Check _,
+     (Value_decl _ | Function_param | Application _ | Arrow_lhs _) ->
+     ()
+   | Some attr, Check { opt; _ }, Function_definition _ ->
+     if is_zero_alloc_check_enabled ~opt && !Clflags.native_code then
        (* The warning for unchecked functions will not trigger if the check is
           requested through the [@@@zero_alloc all] top-level annotation rather
           than through the function annotation [@zero_alloc]. *)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -1006,7 +1006,8 @@ let parse_zero_alloc_payload ~loc ~arity ~custom_error_message
     | None -> warn ();  Default_zero_alloc
     | Some ca -> ca arity loc custom_error_message
 
-let parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity attr =
+let parse_zero_alloc_attribute ~in_signature ~on_application
+      ~on_function_argument ~default_arity attr =
   match attr with
   | None -> Default_zero_alloc
   | Some {Parsetree.attr_name = {txt; loc}; attr_payload = payload} ->
@@ -1053,12 +1054,12 @@ let parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity attr
         match filter_arity payload with
         | None -> default_arity, payload
         | Some (user_arity, payload) ->
-          if in_signature then
+          if in_signature || on_function_argument then
             user_arity, payload
           else
             (warn_payload loc txt
                "The \"arity\" field is only supported on \"zero_alloc\" in \
-                signatures";
+                signatures or on function arguments";
              default_arity, payload)
       in
       let _, payload = List.split payload in
@@ -1099,11 +1100,12 @@ let parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity attr
             Default_zero_alloc)
 
 
-let get_zero_alloc_attribute ~in_signature ~on_application ~default_arity l =
+let get_zero_alloc_attribute ~in_signature ~on_application ~on_function_argument
+      ~default_arity l =
   let attr = select_attribute is_zero_alloc_attribute l in
   let res =
       parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity
-        attr
+        ~on_function_argument attr
   in
   (match attr, res with
    | None, Default_zero_alloc -> ()
@@ -1112,7 +1114,7 @@ let get_zero_alloc_attribute ~in_signature ~on_application ~default_arity l =
    | Some _, Ignore_assert_all -> ()
    | Some _, Assume _ -> ()
    | Some attr, Check { opt; _ } ->
-     if not in_signature && is_zero_alloc_check_enabled ~opt && !Clflags.native_code then
+     if not on_function_argument && not in_signature && is_zero_alloc_check_enabled ~opt && !Clflags.native_code then
        (* The warning for unchecked functions will not trigger if the check is
           requested through the [@@@zero_alloc all] top-level annotation rather
           than through the function annotation [@zero_alloc]. *)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -1036,19 +1036,18 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
     let empty arity custom_error_msg =
       Check { strict = false; opt = false; arity; loc; custom_error_msg; }
     in
+    let default_arity () = begin
+      match default_arity with
+      | None ->
+        if on_function_argument then
+          raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
+        else
+          raise (Error_builtin (loc, Zero_alloc_attr_non_function))
+      | Some arity -> arity
+    end in
     match get_optional_payload get_ids_and_constants_from_exp payload with
     | Error () -> warn (); Default_zero_alloc
-    | Ok None ->
-      let default_arity = begin
-        match default_arity with
-        | None ->
-          if on_function_argument then
-            raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
-          else
-            raise (Error_builtin (loc, Zero_alloc_attr_non_function))
-        | Some arity -> arity
-      end in
-      empty default_arity None
+    | Ok None -> empty (default_arity ()) None
     | Ok (Some payload) ->
       let custom_error_message, payload =
         match filter_custom_error_message payload with
@@ -1069,15 +1068,6 @@ let parse_zero_alloc_attribute ~in_signature ~on_application
            (function (Ident, s) -> Some s | _ -> None) payload
          = ["ignore"] then Ignore_assert_all
       else
-      let default_arity () = begin
-        match default_arity with
-        | None ->
-          if on_function_argument then
-            raise (Error_builtin (loc, Must_provide_zero_alloc_arity))
-          else
-            raise (Error_builtin (loc, Zero_alloc_attr_non_function))
-        | Some arity -> arity
-      end in
       let arity, payload =
         match filter_arity payload with
         | None -> default_arity (), payload

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -1114,7 +1114,8 @@ let get_zero_alloc_attribute ~in_signature ~on_application ~on_function_argument
    | Some _, Ignore_assert_all -> ()
    | Some _, Assume _ -> ()
    | Some attr, Check { opt; _ } ->
-     if not on_function_argument && not in_signature && is_zero_alloc_check_enabled ~opt && !Clflags.native_code then
+     if not on_function_argument && not in_signature &&
+        is_zero_alloc_check_enabled ~opt && !Clflags.native_code then
        (* The warning for unchecked functions will not trigger if the check is
           requested through the [@@@zero_alloc all] top-level annotation rather
           than through the function annotation [@zero_alloc]. *)

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -324,8 +324,8 @@ val is_zero_alloc_check_enabled : opt:bool -> bool
    "arity n" field is allowed, and whether we track this attribute for
    warning 199. *)
 val get_zero_alloc_attribute :
-  in_signature:bool -> on_application:bool-> default_arity:int -> Parsetree.attributes ->
-  zero_alloc_attribute
+  in_signature:bool -> on_application:bool-> on_function_argument:bool ->
+  default_arity:int -> Parsetree.attributes -> zero_alloc_attribute
 
 (* This returns the [zero_alloc_assume] if the input is an assume.  Otherwise,
    it returns None. If the input attribute is [Check], this issues a warning. *)

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -75,6 +75,14 @@ type error =
 
 exception Error_builtin of Location.t * error
 
+type zero_alloc_attribute_use =
+  (* any int payload is the default arity from the usage location *)
+  | Value_decl of int
+  | Function_param
+  | Arrow_lhs of int
+  | Function_definition of int
+  | Application of int
+
 type current_phase = Parser | Invariant_check
 val register_attr : current_phase -> string Location.loc -> unit
 
@@ -326,12 +334,12 @@ type zero_alloc_attribute =
 
 val is_zero_alloc_check_enabled : opt:bool -> bool
 
-(* Gets a zero_alloc attribute.  [~in_signature] controls both whether the
-   "arity n" field is allowed, and whether we track this attribute for
-   warning 199. *)
+(* Gets a zero_alloc attribute.  The [zero_alloc_attribute_use]-typed argument
+   tells us about the context in which this attribute is used, which as the
+   effect on deciding whether the "arity n" field is allowed, and whether we
+   track this attribute for warning 199. *)
 val get_zero_alloc_attribute :
-  in_signature:bool -> on_application:bool-> on_function_argument:bool ->
-  default_arity:int option -> Parsetree.attributes -> zero_alloc_attribute
+  zero_alloc_attribute_use -> Parsetree.attributes -> zero_alloc_attribute
 
 (* This returns the [zero_alloc_assume] if the input is an assume.  Otherwise,
    it returns None. If the input attribute is [Check], this issues a warning. *)

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -69,6 +69,12 @@
     marshalled ast files if no ppx is being used, ensuring we don't miss
     attributes in that case.
 *)
+type error =
+  | Must_provide_zero_alloc_arity
+  | Zero_alloc_attr_non_function
+
+exception Error_builtin of Location.t * error
+
 type current_phase = Parser | Invariant_check
 val register_attr : current_phase -> string Location.loc -> unit
 
@@ -325,7 +331,7 @@ val is_zero_alloc_check_enabled : opt:bool -> bool
    warning 199. *)
 val get_zero_alloc_attribute :
   in_signature:bool -> on_application:bool-> on_function_argument:bool ->
-  default_arity:int -> Parsetree.attributes -> zero_alloc_attribute
+  default_arity:int option -> Parsetree.attributes -> zero_alloc_attribute
 
 (* This returns the [zero_alloc_assume] if the input is an assume.  Otherwise,
    it returns None. If the input attribute is [Check], this issues a warning. *)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4745,7 +4745,7 @@ optional_atat_modalities_expr:
   | expr { $1 }
   | stack(expr) { $1 }
 
-%inline param_type:
+poly_param_type:
   | mktyp(
     LPAREN bound_vars = typevar_list DOT inner_type = core_type RPAREN
       { Ptyp_poly (bound_vars, inner_type) }
@@ -4761,8 +4761,13 @@ optional_atat_modalities_expr:
       { Ptyp_newlayout (bound_vars, inner_type) }
     )
     { $1 }
-  | ty = tuple_type
-    { ty }
+  | ty = poly_param_type attr = attribute
+    { Typ.attr ty attr }
+;
+
+%inline param_type:
+  | poly_param_type { $1 }
+  | ty = tuple_type { ty }
 ;
 
 (* Tuple types include:

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1351,10 +1351,10 @@ and class_field ctxt f x =
         (override ovf)
         private_flag pf
         (fun f -> function
-           | {pexp_desc=Pexp_poly (e, Some ct); pexp_attributes=[]; _} ->
+           | {pexp_desc=Pexp_poly (e, Some ct); _} ->
                pp f "%a :@;%a=@;%a"
                  ident_of_name s.txt (core_type ctxt) ct (expression ctxt) e
-           | {pexp_desc=Pexp_poly (e, None); pexp_attributes=[]; _} ->
+           | {pexp_desc=Pexp_poly (e, None); _} ->
                bind e
            | _ -> bind e) e
         (item_attributes ctxt) x.pcf_attributes

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -558,8 +558,9 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int -> int [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 1 and the latter is 2.
 |}]
 
@@ -607,8 +608,9 @@ Error: Signature mismatch:
        is not included in
          val f : t_two_args [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 1 and the latter is 2.
 |}]
 
@@ -636,8 +638,9 @@ Error: Signature mismatch:
        is not included in
          val f : t_two_args [@@zero_alloc arity 1]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
@@ -693,8 +696,9 @@ Error: Signature mismatch:
        is not included in
          val f : int -> t [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
@@ -737,8 +741,9 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int -> int -> int * int [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 3 and the latter is 2.
 |}]
 
@@ -795,7 +800,7 @@ Line 2, characters 7-17:
 2 |   let[@zero_alloc arity 2] f x y = x + y
            ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The "arity" field is only supported on "zero_alloc" in signatures
+The "arity" field is only supported on "zero_alloc" in signatures or on function arguments
 
 module M_struct_arity_let_1 :
   sig val f : int -> int -> int [@@zero_alloc] end
@@ -809,7 +814,7 @@ Line 2, characters 7-17:
 2 |   let[@zero_alloc arity 2] f = fun x y -> x + y
            ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The "arity" field is only supported on "zero_alloc" in signatures
+The "arity" field is only supported on "zero_alloc" in signatures or on function arguments
 
 module M_struct_arity_let_2 :
   sig val f : int -> int -> int [@@zero_alloc] end
@@ -823,7 +828,7 @@ Line 2, characters 15-25:
 2 |   let f = fun[@zero_alloc arity 2]  x y -> x + y
                    ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The "arity" field is only supported on "zero_alloc" in signatures
+The "arity" field is only supported on "zero_alloc" in signatures or on function arguments
 
 module M_struct_arity_let_fun_1 :
   sig val f : int -> int -> int [@@zero_alloc] end
@@ -841,7 +846,7 @@ Line 4, characters 11-21:
 4 |       fun[@zero_alloc arity 1] y -> y
                ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The "arity" field is only supported on "zero_alloc" in signatures
+The "arity" field is only supported on "zero_alloc" in signatures or on function arguments
 
 module M_struct_arity_let_fun_2 : sig val f : int -> int -> int end
 |}]
@@ -1084,8 +1089,9 @@ Error: Signature mismatch:
        is not included in
          val f : int -> t [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
@@ -1111,8 +1117,9 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int -> int [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
+       When using "zero_alloc" in a signature, the
+       syntactic arity of the implementation must match the function type in
+       the interface.
        Here the former is 1 and the latter is 2.
 |}]
 

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -614,6 +614,11 @@ Error: Signature mismatch:
        Here the former is 1 and the latter is 2.
 |}]
 
+module type S_with_newtype = sig
+  type 'a t
+  val[@zero_alloc] f : 'a. 'a t -> int -> 'a
+end
+
 module type S_alias_explicit_arity_1 = sig
   val[@zero_alloc arity 1] f : t_two_args
 end
@@ -622,12 +627,14 @@ module M_bad_explicit_arity_1 : S_alias_explicit_arity_1 = struct
   let[@zero_alloc] f x y = x + y
 end
 [%%expect{|
+module type S_with_newtype =
+  sig type 'a t val f : 'a t -> int -> 'a [@@zero_alloc] end
 module type S_alias_explicit_arity_1 =
   sig val f : t_two_args [@@zero_alloc arity 1] end
-Lines 5-7, characters 59-3:
-5 | ...........................................................struct
-6 |   let[@zero_alloc] f x y = x + y
-7 | end
+Lines 10-12, characters 59-3:
+10 | ...........................................................struct
+11 |   let[@zero_alloc] f x y = x + y
+12 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int -> int [@@zero_alloc] end
@@ -642,6 +649,14 @@ Error: Signature mismatch:
        syntactic arity of the implementation must match the function type in
        the interface.
        Here the former is 2 and the latter is 1.
+|}]
+
+module M : S_with_newtype = struct
+  type 'a t = 'a list
+  let[@zero_alloc] f (type a) l n : a = List.nth l n
+end
+[%%expect {|
+module M : S_with_newtype
 |}]
 
 module M_good_explicit_arity_1 : S_alias_explicit_arity_1 = struct

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -558,9 +558,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int -> int [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 1 and the latter is 2.
 |}]
 
@@ -608,9 +607,8 @@ Error: Signature mismatch:
        is not included in
          val f : t_two_args [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 1 and the latter is 2.
 |}]
 
@@ -645,9 +643,8 @@ Error: Signature mismatch:
        is not included in
          val f : t_two_args [@@zero_alloc arity 1]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
@@ -711,9 +708,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> t [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
@@ -756,9 +752,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int -> int -> int * int [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 3 and the latter is 2.
 |}]
 
@@ -1104,9 +1099,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> t [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
@@ -1132,9 +1126,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int -> int [@@zero_alloc]
        zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the
-       syntactic arity of the implementation must match the function type in
-       the interface.
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
        Here the former is 1 and the latter is 2.
 |}]
 
@@ -1831,4 +1824,40 @@ module T3 :
     module M' : S1
     module M'' : S2
   end
+|}]
+
+(*****************************************)
+(* Test 19: Interaction of value aliases *)
+
+module T1 : sig
+  val[@zero_alloc] f : 'a -> 'a
+  val[@zero_alloc] g : 'a -> 'a
+end = struct
+  let (f as g) = fun x -> x
+end
+[%%expect{|
+module T1 :
+  sig val f : 'a -> 'a [@@zero_alloc] val g : 'a -> 'a [@@zero_alloc] end
+|}]
+
+module T1' : sig
+  val[@zero_alloc] f : 'a -> 'a
+  val[@zero_alloc] g : int -> int
+end = struct
+  let (f as g) = fun x -> x
+end
+[%%expect{|
+module T1' :
+  sig val f : 'a -> 'a [@@zero_alloc] val g : int -> int [@@zero_alloc] end
+|}]
+
+module T2 : sig
+  val[@zero_alloc] f : 'a -> 'a
+  val[@zero_alloc] g : int -> int
+end = struct
+  let[@zero_alloc] (f as g) = fun x -> x
+end
+[%%expect{|
+module T2 :
+  sig val f : 'a -> 'a [@@zero_alloc] val g : int -> int [@@zero_alloc] end
 |}]

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -1,0 +1,898 @@
+(* TEST
+   flags = "-w +198";
+   expect.opt;
+*)
+
+(** This tests the typing behavior of `[@zero_alloc]` attributes on function arguments.
+
+    These tests show what is permitted and what is prohibited by the type system.
+    Some tests pass type checking, but end up erroring in the compiler backend;
+    these are almost exclusively those where the zero_alloc attributes do not match
+    the higher-order function semantics.
+*)
+
+(** Module typing: zero_alloc information on a parameter should be printed only
+    when the attribute is present. *)
+
+module M1 = struct
+  let f (g [@zero_alloc arity 1]) x = g (x + 1)
+end;;
+[%%expect {|
+module M1 : sig val f : ((int -> 'a) [@zero_alloc arity 1]) -> int -> 'a end
+|}];;
+
+module M2 = struct
+  let f g x = g (x + 1)
+end;;
+[%%expect {|
+module M2 : sig val f : (int -> 'a) -> int -> 'a end
+|}];;
+
+module M3 = struct
+  let f (g [@zero_alloc arity 2]) x = g (x + 1) (x - 1)
+end;;
+[%%expect {|
+module M3 :
+  sig val f : ((int -> int -> 'a) [@zero_alloc arity 2]) -> int -> 'a end
+|}];;
+
+module M4 = struct
+  let f (g [@zero_alloc arity 1]) x = g (x + 1) (x - 1)
+end;;
+[%%expect {|
+Line 2, characters 8-33:
+2 |   let f (g [@zero_alloc arity 1]) x = g (x + 1) (x - 1)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (1) does not match the
+       number of parameters in the argument type (2).
+|}];;
+
+(** Examples of zero_alloc in function arguments, with further frontend and
+    backend checks. *)
+
+let[@zero_alloc] require_za_arity_1 (f [@zero_alloc arity 1]) =
+  f 42;; (* should succeed *)
+[%%expect {|
+val require_za_arity_1 : ((int -> 'a) [@zero_alloc arity 1]) -> 'a
+  [@@zero_alloc] = <fun>
+|}];;
+
+let _ =
+  let[@zero_alloc] f x = x in
+  require_za_arity_1 f;; (* should succeed *)
+[%%expect {|
+- : int = 42
+|}];;
+
+let _ =
+  let f x = x in
+  require_za_arity_1 f;; (* should fail *)
+[%%expect {|
+Line 3, characters 21-22:
+3 |   require_za_arity_1 f;; (* should fail *)
+                         ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  fun (g [@zero_alloc arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
+|}];;
+
+let[@zero_alloc] f : ((int -> int -> int) [@zero_alloc]) -> int =
+  fun (g [@zero_alloc arity 1]) -> g 42 123;; (* should fail *)
+[%%expect {|
+Line 2, characters 6-31:
+2 |   fun (g [@zero_alloc arity 1]) -> g 42 123;; (* should fail *)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute on this function parameter conflicts
+       with the one on its type.
+       When using "zero_alloc" on function parameters, the arities in the
+       type of the function and the parameter term mus match exactly.
+       Here the arity in the actual parameter term is 1 and the arity in
+       the type of the function is 2.
+|}];;
+
+let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
+[%%expect {|
+Line 1, characters 19-44:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (2) does not match the
+       number of parameters in the argument type (1).
+|}];;
+
+let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
+[%%expect {|
+Line 1, characters 19-44:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (2) does not match the
+       number of parameters in the argument type (1).
+|}];;
+
+let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail *)
+[%%expect {|
+Line 1, characters 19-44:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail *)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (2) does not match the
+       number of parameters in the argument type (3).
+|}];;
+
+(* checks with strict *)
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc strict]) -> int =
+  fun (g [@zero_alloc strict arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc strict arity 1]) -> int [@@zero_alloc] =
+  <fun>
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc strict]) -> int =
+  fun (g [@zero_alloc arity 1]) -> g 42;; (* should fail *)
+[%%expect {|
+Line 2, characters 6-31:
+2 |   fun (g [@zero_alloc arity 1]) -> g 42;; (* should fail *)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute on this function parameter conflicts
+       with the one on its type.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  fun (g [@zero_alloc strict arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
+|}];;
+
+let[@zero_alloc] test_f_strict : ((int -> int) [@zero_alloc strict]) -> int =
+  fun (g [@zero_alloc strict arity 1]) -> g 123;; (* should succeed *)
+[%%expect {|
+val test_f_strict : ((int -> int) [@zero_alloc strict arity 1]) -> int
+  [@@zero_alloc] = <fun>
+|}];;
+
+let _ =
+  let[@zero_alloc] f x = x + 555 in
+  test_f_strict f;;  (* should fail *)
+[%%expect {|
+Line 3, characters 16-17:
+3 |   test_f_strict f;;  (* should fail *)
+                    ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}];;
+
+(* checks with opt *)
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
+  fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
+[%%expect {|
+Line 1, characters 5-15:
+1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
+         ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP21.f (camlTOP21__f_18_19_code).
+Line 2, characters 39-43:
+2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
+                                           ^^^^
+Error: called function may allocate (indirect tailcall)
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
+  fun (g [@zero_alloc arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc opt arity 1]) -> int [@@zero_alloc] =
+  <fun>
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
+[%%expect {|
+Line 2, characters 6-35:
+2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute on this function parameter conflicts
+       with the one on its type.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}];;
+
+(* assume not supported on function parameters *)
+let[@zero_alloc] f : ((int -> int) [@zero_alloc assume]) -> int =
+  fun (g [@zero_alloc assume arity 1]) -> g 42;; (* should fail *)
+[%%expect {|
+Line 1, characters 21-63:
+1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc assume]) -> int =
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "assume" is not permitted in "zero_alloc" attributes on function arguments.
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  fun (g [@zero_alloc arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
+|}];;
+
+(* partial application *)
+let _ =
+  let[@zero_alloc] f x y = x + y in
+  let f' = f 123 in
+  require_za_arity_1 f';; (* should fail; f' zero_alloc information is not available *)
+[%%expect {|
+Line 4, characters 21-23:
+4 |   require_za_arity_1 f';; (* should fail; f' zero_alloc information is not available *)
+                         ^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(* partial application with specified zero_alloc *)
+let _ =
+  let[@zero_alloc] f x y = x + y in
+  let[@zero_alloc] f' = f 123 in
+  require_za_arity_1 f';; (* should fail *)
+[%%expect {|
+Line 4, characters 21-23:
+4 |   require_za_arity_1 f';; (* should fail *)
+                         ^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let _ = require_za_arity_1 (fun[@zero_alloc] x -> 42);; (* should succeed *)
+[%%expect {|
+- : int = 42
+|}];;
+
+let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
+[%%expect {|
+Line 1, characters 33-43:
+1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
+                                     ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP29._$.(fun) (camlTOP29__fn[:1,27--59]_26_27_code).
+Line 1, characters 50-58:
+1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
+                                                      ^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+(* Function abstraction argument that is not marked zero_alloc. *)
+let _ = require_za_arity_1 (fun x -> 1);; (* should succeed, inferred *)
+[%%expect {|
+- : int = 1
+|}];;
+
+let _ = require_za_arity_1 (fun x -> x + 111);; (* should succeed *)
+[%%expect {|
+- : int = 153
+|}]
+
+let _ = require_za_arity_1 (fun x -> x);; (* should succeed *)
+[%%expect {|
+- : int = 42
+|}];;
+
+let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
+[%%expect {|
+Line 1, characters 27-41:
+1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
+                               ^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP33._$.(fun) (camlTOP33__fn[:1,27--41]_34_35_code).
+Line 1, characters 37-40:
+1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
+                                         ^^^
+Error: allocation of 24 bytes
+|}];;
+
+let _ =
+  let[@zero_alloc] id x = x in
+  let[@zero_alloc] id' = id id in
+  require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
+[%%expect {|
+Line 4, characters 21-24:
+4 |   require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
+                         ^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let _ =
+  let[@zero_alloc] id x = x in
+  let id' = id id in
+  require_za_arity_1 id';; (* should fail, as above *)
+[%%expect {|
+Line 4, characters 21-24:
+4 |   require_za_arity_1 id';; (* should fail, as above *)
+                         ^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(* eta expansion helps *)
+let _ =
+  let[@zero_alloc] id x = x in
+  let[@zero_alloc] id' x = id id x in
+  require_za_arity_1 id';; (* should succeed *)
+[%%expect {|
+- : int = 42
+|}];;
+
+let _ =
+  let[@zero_alloc] id x = x in
+  let id' x = id id x in
+  require_za_arity_1 id';; (* should fail; zero-allocness not inferred *)
+[%%expect {|
+Line 4, characters 21-24:
+4 |   require_za_arity_1 id';; (* should fail; zero-allocness not inferred *)
+                         ^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let _ =
+  let id x = x in
+  let id' = id id in
+  require_za_arity_1 id';; (* should fail *)
+[%%expect {|
+Line 4, characters 21-24:
+4 |   require_za_arity_1 id';; (* should fail *)
+                         ^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let _ =
+  let[@zero_alloc] require_za_arity (f [@zero_alloc arity 1]) x = f x in
+  let id x = x in
+  let[@zero_alloc] id' x = (id x, x) in
+  require_za_arity id' 42;; (* should fail in the backend *)
+[%%expect {|
+Line 4, characters 7-17:
+4 |   let[@zero_alloc] id' x = (id x, x) in
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP39._$.id' (camlTOP39__id'_41_43_code).
+Line 4, characters 27-36:
+4 |   let[@zero_alloc] id' x = (id x, x) in
+                               ^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+(** Frontend analysis fails when the arguments is neither an identifier nor a
+    function abstraction. *)
+
+let _ =
+  let[@zero_alloc] f x y = x + y in
+  require_za_arity_1 (f 1);; (* should fail in the frontend *)
+[%%expect {|
+Line 6, characters 21-26:
+6 |   require_za_arity_1 (f 1);; (* should fail in the frontend *)
+                         ^^^^^
+Error: This function application expects an argument that does not allocate.
+       Only identifiers and anonymous functions may be passed as arguments
+       to functions with "zero_alloc" parameters.
+|}];;
+
+let _ = require_za_arity_1 ((fun x -> x) (fun x -> x));; (* should fail in the frontend *)
+[%%expect {|
+Line 1, characters 27-54:
+1 | let _ = require_za_arity_1 ((fun x -> x) (fun x -> x));; (* should fail in the frontend *)
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This function application expects an argument that does not allocate.
+       Only identifiers and anonymous functions may be passed as arguments
+       to functions with "zero_alloc" parameters.
+|}];;
+
+(* CR-soon zero_alloc aivaskovic: add support for zero_alloc records *)
+type rcd = {x : int -> int};;
+let _ = fun t -> require_za_arity_1 t.x;; (* should fail in the frontend *)
+[%%expect {|
+type rcd = { x : int -> int; }
+Line 2, characters 36-39:
+2 | let _ = fun t -> require_za_arity_1 t.x;; (* should fail in the frontend *)
+                                        ^^^
+Error: This function application expects an argument that does not allocate.
+       Only identifiers and anonymous functions may be passed as arguments
+       to functions with "zero_alloc" parameters.
+|}];;
+
+(** Modules and module types.
+    These tests check that modules and module types have expected behaviour. *)
+
+module Needs_arity_on_argument = struct
+  let[@zero_alloc] f' (g' [@zero_alloc]) = g' 123 456 (* should fail *)
+end;;
+[%%expect {|
+Line 5, characters 22-40:
+5 |   let[@zero_alloc] f' (g' [@zero_alloc]) = g' 123 456 (* should fail *)
+                          ^^^^^^^^^^^^^^^^^^
+Error: Zero-alloc annotations on function arguments must specify arity.
+|}];;
+
+module Needs_arity_on_argument' : sig
+  val f': ((int -> 'b) [@zero_alloc]) -> 'b [@@zero_alloc]
+end = struct
+  let[@zero_alloc] f' (g' [@zero_alloc]) = g' 123 (* should fail *)
+end;;
+[%%expect {|
+Line 4, characters 22-40:
+4 |   let[@zero_alloc] f' (g' [@zero_alloc]) = g' 123 (* should fail *)
+                          ^^^^^^^^^^^^^^^^^^
+Error: Zero-alloc annotations on function arguments must specify arity.
+|}];;
+
+module Zero_alloc_on_arg : sig
+  val f': ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b [@@zero_alloc]
+end = struct
+  let[@zero_alloc] f' (g' [@zero_alloc arity 2]) = g' 123 456 (* should succeed *)
+end;;
+[%%expect {|
+module Zero_alloc_on_arg :
+  sig
+    val f' : ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b [@@zero_alloc]
+  end
+|}];;
+
+module Inferred_on_value_description : sig
+  val f': ((int -> int -> 'b) [@zero_alloc]) -> 'b [@@zero_alloc]
+end = struct
+  let[@zero_alloc] f' (g' [@zero_alloc arity 2]) = g' 123 456 (* should succeed *)
+end;;
+[%%expect {|
+module Inferred_on_value_description :
+  sig
+    val f' : ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b [@@zero_alloc]
+  end
+|}];;
+
+module Mismatched_zero_alloc_arities : sig
+  val f': ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b [@@zero_alloc]
+end = struct
+  let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
+end;;
+[%%expect {|
+Line 4, characters 22-48:
+4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (1) does not match the
+       number of parameters in the argument type (2).
+|}];;
+
+module Nonsense_matching_arity : sig
+  val f': ((int -> int -> 'b) [@zero_alloc arity 1]) -> 'b [@@zero_alloc]
+end = struct
+  let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
+end;;
+[%%expect {|
+Line 4, characters 22-48:
+4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (1) does not match the
+       number of parameters in the argument type (2).
+|}];;
+
+module Zero_alloc_arity_is_2 : sig
+  val f': ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b [@@zero_alloc]
+end = struct
+  let[@zero_alloc] f' g' = g' 123 456 (* fails now, will succeed later *)
+end;;
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let[@zero_alloc] f' g' = g' 123 456 (* fails now, will succeed later *)
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f' : (int -> int -> 'a) -> 'a [@@zero_alloc] end
+       is not included in
+         sig
+           val f' : ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b
+             [@@zero_alloc]
+         end
+       Values do not match:
+         val f' : (int -> int -> 'a) -> 'a [@@zero_alloc]
+       is not included in
+         val f' : ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b
+           [@@zero_alloc]
+       The type "(int -> int -> 'a) -> 'a" is not compatible with the type
+         "((int -> int -> 'a) [@zero_alloc arity 2]) -> 'a"
+       The two types must agree on "zero_alloc": either both carry the annotation or neither does.
+|}];;
+
+(* Interaction between the two meanings of Tpoly. *)
+let w2 : ('a. (('a -> int) [@zero_alloc])) -> int =
+  fun (f [@zero_alloc arity 1]) -> f 123;;
+[%%expect {|
+val w2 : (('a. 'a -> int) [@zero_alloc arity 1]) -> int = <fun>
+|}];;
+
+(* zero_alloc on the Ptyp_poly node; arity inferred. *)
+let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
+  fun (f [@zero_alloc arity 1]) -> f 123;;
+[%%expect {|
+val w3 : (('a. 'a -> int) [@zero_alloc arity 1]) -> int = <fun>
+|}];;
+
+(* zero_alloc on the Ptyp_poly node with explicit arity. *)
+let w4 : ('a. 'a -> int) [@zero_alloc arity 1] -> int =
+  fun (f [@zero_alloc arity 1]) -> f 123;;
+[%%expect {|
+val w4 : (('a. 'a -> int) [@zero_alloc arity 1]) -> int = <fun>
+|}];;
+
+(* Wrong explicit arity should fail. *)
+let w5 : ('a. 'a -> int) [@zero_alloc arity 2] -> int =
+  fun (f [@zero_alloc arity 1]) -> f 123;;
+[%%expect {|
+Line 1, characters 9-24:
+1 | let w5 : ('a. 'a -> int) [@zero_alloc arity 2] -> int =
+             ^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (2) does not match the
+       number of parameters in the argument type (1).
+|}];;
+
+(* Non-function inner type should fail. *)
+let w6 : ('a. 'a) [@zero_alloc] -> int =
+  fun _ -> 1;;
+[%%expect {|
+Line 1, characters 9-17:
+1 | let w6 : ('a. 'a) [@zero_alloc] -> int =
+             ^^^^^^^^
+Error: "zero_alloc" attributes on function arguments require the argument
+       to be a function type.
+|}];;
+
+(* Does zero-alloc information propagate across aliases?
+   Strictly speaking, this has nothing to do with zero-alloc on
+   function parameters, but it is related to where values in the
+   environment get their zero-alloc information from. *)
+module M : sig
+  val[@zero_alloc] g : int -> int
+end = struct
+  let[@zero_alloc] f x = x + 1
+  let g = f
+end
+[%%expect {|
+Lines 3-6, characters 6-3:
+3 | ......struct
+4 |   let[@zero_alloc] f x = x + 1
+5 |   let g = f
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int [@@zero_alloc] val g : int -> int end
+       is not included in
+         sig val g : int -> int [@@zero_alloc] end
+       Values do not match:
+         val g : int -> int
+       is not included in
+         val g : int -> int [@@zero_alloc]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(** First-class modules and reading zero_alloc from module types. *)
+
+module type S1 = sig
+  val baz : (int -> int) [@@zero_alloc strict]
+end;;
+module type S2 = sig
+  val bam : int -> int [@@zero_alloc]
+end;;
+module type S3 = sig
+  val bal : int -> int
+end;;
+[%%expect {|
+module type S1 = sig val baz : int -> int [@@zero_alloc strict] end
+module type S2 = sig val bam : int -> int [@@zero_alloc] end
+module type S3 = sig val bal : int -> int end
+|}];;
+
+let[@zero_alloc] test_with_fc_module_1 (module M : S1) x =
+  test_f_strict M.baz;;
+[%%expect {|
+val test_with_fc_module_1 : (module S1) -> 'a -> int [@@zero_alloc] = <fun>
+|}];;
+
+let[@zero_alloc] test_with_fc_module_2 (module M : S2) x =
+  test_f_strict M.bam;;
+[%%expect {|
+Line 2, characters 16-21:
+2 |   test_f_strict M.bam;;
+                    ^^^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}];;
+
+let[@zero_alloc] test_with_fc_module_3 (module M : S3) x =
+  test_f_strict M.bal;;
+[%%expect {|
+Line 2, characters 16-21:
+2 |   test_f_strict M.bal;;
+                    ^^^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(** Dealing with inference: what happens when there are multiple competing
+    zero_alloc constraints?
+    The tests should succeed when arities can match exactly, but otherwise
+    fail. *)
+
+let g1 (f [@zero_alloc arity 1]) = f 500;;
+let g2 (f [@zero_alloc strict arity 1]) = f 99;;
+let g3 (f [@zero_alloc strict arity 2]) = f 111;;
+[%%expect {|
+val g1 : ((int -> 'a) [@zero_alloc arity 1]) -> 'a = <fun>
+val g2 : ((int -> 'a) [@zero_alloc strict arity 1]) -> 'a = <fun>
+Line 8, characters 7-39:
+8 | let g3 (f [@zero_alloc strict arity 2]) = f 111;;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The arity in the "zero_alloc" attribute (2) does not match the
+       number of parameters in the argument type (1).
+|}];;
+
+let _ =
+  let f x = x + 123 in
+  let _ = g1 f in
+  let _ = g2 f in
+  f;;
+[%%expect {|
+Line 3, characters 13-14:
+3 |   let _ = g1 f in
+                 ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let _ =
+  let f x = x + 123 in
+  let _ = g1 f in
+  let _ = g2 f in
+  let _ = g3 f in
+  f;;
+[%%expect {|
+Line 3, characters 13-14:
+3 |   let _ = g1 f in
+                 ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let _ =
+  let f x = x + 123 in
+  let _ = g2 f in
+  let _ = g1 f in
+  f;;
+[%%expect {|
+Line 3, characters 13-14:
+3 |   let _ = g2 f in
+                 ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+let f_inferred x = x + 123;;
+let _ = g1 f_inferred;;
+let _ = g2 f_inferred;;
+let _ = g3 f_inferred;;
+[%%expect {|
+val f_inferred : int -> int = <fun>
+Line 2, characters 11-21:
+2 | let _ = g1 f_inferred;;
+               ^^^^^^^^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(* custom error messages can be placed on zero_alloc parameters *)
+
+module type S = sig
+  val f : (int -> int [@zero_alloc custom_error_message "my specific error"]) -> int
+end;;
+
+module F(X : S) = struct
+  let g () = X.f (fun x -> Format.printf "foo"; x)
+end;;
+[%%expect {|
+module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
+Line 6, characters 17-50:
+6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP76.F.g.(fun) (camlTOP76__fn[:6,17--50]_64_67_code).
+my specific error
+
+File "format.ml", lines 1498-1500, characters 2-18:
+Error: called function may allocate (direct call camlCamlinternalFormat__make_printf_120_401_code) (:6,27--46)
+|}];;
+
+(* zero_alloc requirements work on labeled parameters *)
+
+module type S_labeled = sig
+  val f : foo:((int -> int) [@zero_alloc]) -> int
+end;;
+[%%expect {|
+module type S_labeled =
+  sig val f : foo:((int -> int) [@zero_alloc arity 1]) -> int end
+|}];;
+
+let[@zero_alloc] f' x = x + 1;;
+
+let[@zero_alloc] apply_labeled ~foo:(foo[@zero_alloc arity 1]) () = foo 0;;
+
+let[@zero_alloc] use_labeled () = apply_labeled ~foo:f' ();;
+[%%expect {|
+val f' : int -> int [@@zero_alloc] = <fun>
+val apply_labeled : foo:((int -> 'a) [@zero_alloc arity 1]) -> unit -> 'a
+  [@@zero_alloc] = <fun>
+val use_labeled : unit -> int [@@zero_alloc] = <fun>
+|}];;
+
+(* zero_alloc requirements cannot be placed on optional parameters *)
+
+module type S = sig
+  val f : ?foo:((int -> int) [@zero_alloc]) -> int
+end;;
+
+let[@zero_alloc] f' x = x + 1;;
+
+module F(X : S) = struct
+  let g () = X.f ~foo:f'
+end;;
+[%%expect {|
+Line 2, characters 17-27:
+2 |   val f : ?foo:((int -> int) [@zero_alloc]) -> int
+                     ^^^^^^^^^^
+Error: "zero_alloc" attributes are not supported on optional parameters.
+|}];;
+
+(* how zero_alloc propagates down a pattern *)
+
+let needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
+let (f | f) = fun x -> (x, x) in
+ignore (needs_za_1 f);;
+[%%expect {|
+Line 3, characters 19-20:
+3 | ignore (needs_za_1 f);;
+                       ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(** Aliases and zero_alloc parameters.
+    Type aliases (type t = int -> int) work because the compiler expands them
+    before checking.
+    Value aliases (let g = f) are not yet supported. *)
+
+(* Type alias for a single-arrow function used as the annotation on a
+   zero_alloc parameter. *)
+type arrow_alias = int -> int
+
+let[@zero_alloc] use_arrow_alias (g [@zero_alloc arity 1] : arrow_alias) = g 42
+[%%expect {|
+type arrow_alias = int -> int
+val use_arrow_alias : (arrow_alias [@zero_alloc arity 1]) -> int
+  [@@zero_alloc] = <fun>
+|}];;
+
+(* Same, but for a two-arrow alias. *)
+type arrow_alias_2 = int -> int -> int
+
+let[@zero_alloc] use_arrow_alias_2
+    (g [@zero_alloc arity 2] : arrow_alias_2) = g 42 43
+[%%expect {|
+type arrow_alias_2 = int -> int -> int
+val use_arrow_alias_2 : (arrow_alias_2 [@zero_alloc arity 2]) -> int
+  [@@zero_alloc] = <fun>
+|}];;
+
+(* A global value alias of a zero_alloc function does not carry zero_alloc
+   information.
+   CR-soon zero-alloc aivaskovic: add support for value aliases. *)
+let[@zero_alloc] fn_for_alias x = x + 1
+let fn_alias = fn_for_alias
+let _ = require_za_arity_1 fn_alias
+[%%expect {|
+val fn_for_alias : int -> int [@@zero_alloc] = <fun>
+val fn_alias : int -> int = <fun>
+Line 3, characters 27-35:
+3 | let _ = require_za_arity_1 fn_alias
+                               ^^^^^^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(* A local alias of a zero_alloc parameter also loses the guarantee.
+   CR-soon zero-alloc aivaskovic: add support for local aliases of zero_alloc
+   parameters. *)
+let[@zero_alloc] use_local_alias (f[@zero_alloc arity 1]) =
+  let g = f in
+  require_za_arity_1 g
+[%%expect {|
+Line 3, characters 21-22:
+3 |   require_za_arity_1 g
+                         ^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(** Pattern aliases and zero_alloc parameters.
+    Tests for `(pat as x)` pattern aliases in zero_alloc contexts.
+    The zero_alloc annotation propagates to both the annotated binding and the
+    alias, so both can be used in zero_alloc contexts. *)
+
+(* Calling the alias of a zero_alloc-annotated pattern binding. *)
+let[@zero_alloc] call_alias_of_za_param ((f [@zero_alloc arity 1]) as g) x = g x
+[%%expect {|
+val call_alias_of_za_param : (('a -> 'b) [@zero_alloc arity 1]) -> 'a -> 'b
+  [@@zero_alloc] = <fun>
+|}];;
+
+(* The alias carries the zero_alloc annotation and can be passed to a
+   function expecting a zero_alloc argument. *)
+let[@zero_alloc] pass_alias_to_za_consumer ((f [@zero_alloc arity 1]) as g) x =
+  let _ = require_za_arity_1 g in
+  f x
+[%%expect {|
+val pass_alias_to_za_consumer :
+  ((int -> 'a) [@zero_alloc arity 1]) -> int -> 'a [@@zero_alloc] = <fun>
+|}];;
+
+(* Only the annotated binding is used; alias is ignored. *)
+let[@zero_alloc] use_annotated_ignore_alias ((f [@zero_alloc arity 1]) as _g) x = f x
+[%%expect {|
+val use_annotated_ignore_alias :
+  (('a -> 'b) [@zero_alloc arity 1]) -> 'a -> 'b [@@zero_alloc] = <fun>
+|}];;
+
+(** `external` declarations and zero_alloc parameters.
+    Zero_alloc attributes on parameters of `external` declarations behave
+    the same as on `val` declarations in signatures. *)
+
+(* external in a module type with a zero_alloc param *)
+module type S_ext = sig
+  external f : ((int -> int) [@zero_alloc arity 1]) -> int = "f"
+end;;
+[%%expect {|
+module type S_ext =
+  sig external f : ((int -> int) [@zero_alloc arity 1]) -> int = "f" end
+|}];;
+
+(* strict variant *)
+module type S_ext_strict = sig
+  external f : ((int -> int) [@zero_alloc strict arity 1]) -> int = "f"
+end;;
+[%%expect {|
+module type S_ext_strict =
+  sig
+    external f : ((int -> int) [@zero_alloc strict arity 1]) -> int = "f"
+  end
+|}];;
+
+(* error: zero_alloc on a non-function param *)
+module type S_ext_bad_nonfun = sig
+  external f : (int [@zero_alloc]) -> int = "f"
+end;;
+[%%expect {|
+Line 2, characters 15-41:
+2 |   external f : (int [@zero_alloc]) -> int = "f"
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "zero_alloc" attributes on function arguments require the argument
+       to be a function type.
+|}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -40,11 +40,8 @@ module M4 = struct
   let f (g [@zero_alloc arity 1]) x = g (x + 1) (x - 1)
 end;;
 [%%expect {|
-Line 2, characters 8-33:
-2 |   let f (g [@zero_alloc arity 1]) x = g (x + 1) (x - 1)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (1) does not match the
-       number of parameters in the argument type (2).
+module M4 :
+  sig val f : ((int -> int -> 'a) [@zero_alloc arity 1]) -> int -> 'a end
 |}];;
 
 (** Examples of zero_alloc in function arguments, with further frontend and
@@ -91,22 +88,33 @@ Error: The "zero_alloc" attribute on this function parameter conflicts
        the type of the function is 2.
 |}];;
 
-let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
+let f (g [@zero_alloc arity 2]) x = g x;; (* should succeed *)
 [%%expect {|
-Line 1, characters 19-44:
-1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (2) does not match the
-       number of parameters in the argument type (1).
+val f : (('a -> 'b) [@zero_alloc arity 2]) -> 'a -> 'b = <fun>
 |}];;
 
-let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail *)
+let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
 [%%expect {|
-Line 1, characters 19-44:
-1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail *)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (2) does not match the
-       number of parameters in the argument type (3).
+Line 1, characters 5-15:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
+         ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP14.f (camlTOP14__f_18_19_code).
+Line 1, characters 49-52:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
+                                                     ^^^
+Error: called function may allocate (indirect tailcall)
+|}];;
+
+let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
+[%%expect {|
+Line 1, characters 5-15:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
+         ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP15.f (camlTOP15__f_20_21_code).
+Line 1, characters 53-60:
+1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
+                                                         ^^^^^^^
+Error: called function may allocate (direct tailcall caml_apply3)
 |}];;
 
 (* checks with strict *)
@@ -163,7 +171,7 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP20.f (camlTOP20__f_20_21_code).
+Error: Annotation check for zero_alloc failed on function TOP21.f (camlTOP21__f_28_29_code).
 Line 2, characters 39-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
                                            ^^^^
@@ -219,13 +227,13 @@ let _ =
   let[@zero_alloc] f' = f 123 in
   require_za_arity_1 f';; (* should fail *)
 [%%expect {|
-Line 4, characters 21-23:
-4 |   require_za_arity_1 f';; (* should fail *)
-                         ^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+Line 3, characters 2-29:
+3 |   let[@zero_alloc] f' = f 123 in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute placed on a "let"-binding can only be
+       used for function definitions.
+       If this defines a function, rewrite it so that its arguments are
+       present in the definition.
 |}];;
 
 let _ = require_za_arity_1 (fun[@zero_alloc] x -> 42);; (* should succeed *)
@@ -238,7 +246,7 @@ let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in 
 Line 1, characters 33-43:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                      ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP27._$.(fun) (camlTOP27__fn[:1,27--59]_26_27_code).
+Error: Annotation check for zero_alloc failed on function TOP28._$.(fun) (camlTOP28__fn[:1,27--59]_34_35_code).
 Line 1, characters 50-58:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                                       ^^^^^^^^
@@ -266,7 +274,7 @@ let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
 Line 1, characters 27-41:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP31._$.(fun) (camlTOP31__fn[:1,27--41]_34_35_code).
+Error: Annotation check for zero_alloc failed on function TOP32._$.(fun) (camlTOP32__fn[:1,27--41]_42_43_code).
 Line 1, characters 37-40:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                          ^^^
@@ -278,13 +286,13 @@ let _ =
   let[@zero_alloc] id' = id id in
   require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
 [%%expect {|
-Line 4, characters 21-24:
-4 |   require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
-                         ^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+Line 3, characters 2-30:
+3 |   let[@zero_alloc] id' = id id in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute placed on a "let"-binding can only be
+       used for function definitions.
+       If this defines a function, rewrite it so that its arguments are
+       present in the definition.
 |}];;
 
 let _ =
@@ -341,7 +349,7 @@ let _ =
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] id' x = (id x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP37._$.id' (camlTOP37__id'_45_47_code).
+Error: Annotation check for zero_alloc failed on function TOP38._$.id' (camlTOP38__id'_53_55_code).
 Line 4, characters 27-36:
 4 |   let[@zero_alloc] id' x = (id x, x) in
                                ^^^^^^^^^
@@ -441,24 +449,48 @@ end = struct
   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
 end;;
 [%%expect {|
-Line 4, characters 22-48:
+Lines 3-5, characters 6-3:
+3 | ......struct
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (1) does not match the
-       number of parameters in the argument type (2).
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val f' : ((int -> int -> 'a) [@zero_alloc arity 1]) -> 'a
+             [@@zero_alloc]
+         end
+       is not included in
+         sig
+           val f' : ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b
+             [@@zero_alloc]
+         end
+       Values do not match:
+         val f' : ((int -> int -> 'a) [@zero_alloc arity 1]) -> 'a
+           [@@zero_alloc]
+       is not included in
+         val f' : ((int -> int -> 'b) [@zero_alloc arity 2]) -> 'b
+           [@@zero_alloc]
+       The type "((int -> int -> 'a) [@zero_alloc arity 1]) -> 'a"
+       is not compatible with the type
+         "((int -> int -> 'a) [@zero_alloc arity 2]) -> 'a"
+       Inconsistent "zero_alloc" arity payload for a function parameter:
+       the implementation specifies 1, but it is constrained to be 2.
 |}];;
 
 module Nonsense_matching_arity : sig
   val f': ((int -> int -> 'b) [@zero_alloc arity 1]) -> 'b [@@zero_alloc]
 end = struct
-  let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
+  let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
 end;;
 [%%expect {|
-Line 4, characters 22-48:
-4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail *)
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (1) does not match the
-       number of parameters in the argument type (2).
+Line 4, characters 7-17:
+4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP50.Nonsense_matching_arity.f' (camlTOP50__f'_60_61_code).
+Line 4, characters 51-61:
+4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
+                                                       ^^^^^^^^^^
+Error: called function may allocate (direct tailcall caml_apply2)
 |}];;
 
 module Zero_alloc_arity_is_2 : sig
@@ -503,9 +535,9 @@ val w2 :
 let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
   fun (f [@zero_alloc arity 1]) -> f 123;;
 [%%expect {|
-Line 1, characters 27-37:
+Line 1, characters 9-45:
 1 | let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
-                               ^^^^^^^^^^
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
 |}];;
@@ -523,20 +555,20 @@ val w4 :
 let w5 : ('a. 'a -> int) [@zero_alloc arity 2] -> int =
   fun (f [@zero_alloc arity 1]) -> f 123;;
 [%%expect {|
-Line 1, characters 9-24:
+Line 1, characters 9-53:
 1 | let w5 : ('a. 'a -> int) [@zero_alloc arity 2] -> int =
-             ^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (2) does not match the
-       number of parameters in the argument type (1).
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "zero_alloc" attributes on function arguments require the argument
+       to be a function type.
 |}];;
 
 (* Non-function inner type should fail. *)
 let w6 : ('a. 'a) [@zero_alloc] -> int =
   fun _ -> 1;;
 [%%expect {|
-Line 1, characters 20-30:
+Line 1, characters 9-17:
 1 | let w6 : ('a. 'a) [@zero_alloc] -> int =
-                        ^^^^^^^^^^
+             ^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
 |}];;
@@ -657,11 +689,7 @@ let g3 (f [@zero_alloc strict arity 2]) = f 111;;
 [%%expect {|
 val g1 : ((int -> 'a) [@zero_alloc arity 1]) -> 'a = <fun>
 val g2 : ((int -> 'a) [@zero_alloc strict arity 1]) -> 'a = <fun>
-Line 8, characters 7-39:
-8 | let g3 (f [@zero_alloc strict arity 2]) = f 111;;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (2) does not match the
-       number of parameters in the argument type (1).
+val g3 : ((int -> 'a) [@zero_alloc strict arity 2]) -> 'a = <fun>
 |}];;
 
 let _ =
@@ -707,7 +735,7 @@ let _ =
 Line 3, characters 2-72:
 3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP73._$.f_nonstrict (camlTOP73__f_nonstrict_66_67_code).
+Error: Annotation check for zero_alloc strict failed on function TOP74._$.f_nonstrict (camlTOP74__f_nonstrict_78_79_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:3,47--64)
 Line 3, characters 42-65:
@@ -731,7 +759,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP75.F.g.(fun) (camlTOP75__fn[:6,17--50]_70_73_code).
+Error: Annotation check for zero_alloc failed on function TOP76.F.g.(fun) (camlTOP76__fn[:6,17--50]_82_85_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -787,7 +815,7 @@ let _ =
 Line 3, characters 7-17:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP81._$.f (camlTOP81__*match*_79_81_code).
+Error: Annotation check for zero_alloc failed on function TOP82._$.f (camlTOP82__*match*_91_93_code).
 Line 3, characters 38-44:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
                                           ^^^^^^
@@ -802,7 +830,7 @@ let _ =
 Line 3, characters 2-31:
 3 |   let (f | f) = fun x -> (x, x) in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP82._$.f (camlTOP82__*match*_81_83_code).
+Error: Annotation check for zero_alloc failed on function TOP83._$.f (camlTOP83__*match*_93_95_code).
 Line 3, characters 25-31:
 3 |   let (f | f) = fun x -> (x, x) in
                              ^^^^^^
@@ -918,6 +946,22 @@ let _ =
 - : unit = ()
 |}];;
 
+let _ =
+  let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
+  let _ = require_za_arity_1 f in
+  let _ = require_za_arity_1 g in
+  () (* fails in the backend *)
+[%%expect {|
+Line 2, characters 7-17:
+2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP99._$.f (camlTOP99__g_111_113_code).
+Line 2, characters 39-52:
+2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
+                                           ^^^^^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
 (** `external` declarations and zero_alloc parameters.
     Zero_alloc attributes on parameters of `external` declarations behave
     the same as on `val` declarations in signatures. *)
@@ -947,9 +991,9 @@ module type S_ext_bad_nonfun = sig
   external f : (int [@zero_alloc]) -> int = "f"
 end;;
 [%%expect {|
-Line 2, characters 22-32:
+Line 2, characters 15-41:
 2 |   external f : (int [@zero_alloc]) -> int = "f"
-                          ^^^^^^^^^^
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
 |}];;
@@ -966,7 +1010,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP102._$.(fun) (camlTOP102__fn[:7,6--67]_101_105_code).
+Error: Annotation check for zero_alloc strict failed on function TOP104._$.(fun) (camlTOP104__fn[:7,6--67]_115_119_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:
@@ -984,4 +1028,24 @@ let _ =
       (fun x -> if x < 0 then 123 else x) a;;
 [%%expect {|
 - : int -> int = <fun>
+|}];;
+
+(* Non-principal inference. Emits warning. *)
+let with_id (f : (('a -> 'a)[@zero_alloc arity 1]) -> 'b) = f (fun x -> x);;
+
+let _ = with_id (fun id -> id 4, id 17);;
+
+let non_principal p f =
+  if p then with_id f
+  else f (fun x -> x);;
+[%%expect {|
+val with_id : ((('a -> 'a) [@zero_alloc arity 1]) -> 'b) -> 'b = <fun>
+- : int * int = (4, 17)
+Line 7, characters 7-21:
+7 |   else f (fun x -> x);;
+           ^^^^^^^^^^^^^^
+Warning 18 [not-principal]: applying a function with zero_alloc requirements here is not principal.
+
+val non_principal : bool -> ((('a -> 'a) [@zero_alloc arity 1]) -> 'b) -> 'b =
+  <fun>
 |}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -249,7 +249,7 @@ let _ =
 Line 3, characters 2-29:
 3 |   let[@zero_alloc] f' = f 123 in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 182 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
 rewrite the binding with explicit parameters or remove the attribute.
 
 Line 4, characters 21-23:
@@ -314,7 +314,7 @@ let _ =
 Line 3, characters 2-30:
 3 |   let[@zero_alloc] id' = id id in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 182 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
 rewrite the binding with explicit parameters or remove the attribute.
 
 Line 4, characters 21-24:
@@ -843,14 +843,11 @@ let _ =
   let[@zero_alloc] (f | f) = fun x -> (x, x) in
   needs_za_1 f;;
 [%%expect {|
-Line 3, characters 7-17:
+Line 3, characters 19-26:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
-           ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP84._$.f (camlTOP84__*match*_95_97_code).
-Line 3, characters 38-44:
-3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
-                                          ^^^^^^
-Error: allocation of 24 bytes
+                       ^^^^^^^
+Error: The "zero_alloc" attribute is only supported on patterns that bind
+       a variable.
 |}];;
 
 let _ =
@@ -861,7 +858,7 @@ let _ =
 Line 3, characters 2-31:
 3 |   let (f | f) = fun x -> (x, x) in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP85._$.f (camlTOP85__*match*_97_99_code).
+Error: Annotation check for zero_alloc failed on function TOP85._$.f (camlTOP85__*match*_95_97_code).
 Line 3, characters 25-31:
 3 |   let (f | f) = fun x -> (x, x) in
                              ^^^^^^
@@ -873,7 +870,11 @@ let _ =
   let[@zero_alloc] (f | f) = fun x -> x - 1 in
   needs_za_1 f;;
 [%%expect {|
-- : int = 41
+Line 3, characters 19-26:
+3 |   let[@zero_alloc] (f | f) = fun x -> x - 1 in
+                       ^^^^^^^
+Error: The "zero_alloc" attribute is only supported on patterns that bind
+       a variable.
 |}];;
 
 
@@ -986,7 +987,7 @@ let _ =
 Line 2, characters 7-17:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP101._$.f (camlTOP101__g_115_117_code).
+Error: Annotation check for zero_alloc failed on function TOP101._$.f (camlTOP101__g_111_113_code).
 Line 2, characters 39-52:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
                                            ^^^^^^^^^^^^^
@@ -1052,7 +1053,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP107._$.(fun) (camlTOP107__fn[:7,6--67]_121_125_code).
+Error: Annotation check for zero_alloc strict failed on function TOP107._$.(fun) (camlTOP107__fn[:7,6--67]_117_121_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:
@@ -1101,7 +1102,7 @@ let _ =
 Line 3, characters 2-16:
 3 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP112._$.g (camlTOP112__g_142_145_code).
+Error: Annotation check for zero_alloc failed on function TOP112._$.g (camlTOP112__g_138_141_code).
 Line 3, characters 12-16:
 3 |   and g x = x, x in
                 ^^^^
@@ -1118,9 +1119,44 @@ let _ =
 Line 5, characters 2-16:
 5 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP113._$.g (camlTOP113__g_146_150_code).
+Error: Annotation check for zero_alloc strict failed on function TOP113._$.g (camlTOP113__g_142_146_code).
 Line 5, characters 12-16:
 5 |   and g x = x, x in
                 ^^^^
 Error: allocation of 24 bytes
+|}];;
+
+(* Error if zero_alloc is placed on a function parameter that is . *)
+type a = A
+let _ = fun (A [@zero_alloc arity 1]) -> A;;
+[%%expect {|
+type a = A
+Line 2, characters 12-37:
+2 | let _ = fun (A [@zero_alloc arity 1]) -> A;;
+                ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute is only supported on patterns that bind
+       a variable.
+|}];;
+
+type b = X | Y
+let _ = function
+  | (X [@zero_alloc arity 1]) -> 1
+  | (Y [@zero_alloc arity 1]) -> 2;;
+[%%expect {|
+type b = X | Y
+Line 3, characters 4-29:
+3 |   | (X [@zero_alloc arity 1]) -> 1
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute is only supported on patterns that bind
+       a variable.
+|}];;
+
+let _ = function
+  | ((X | Y) as g) [@zero_alloc arity 1] -> g
+[%%expect {|
+Line 2, characters 4-18:
+2 |   | ((X | Y) as g) [@zero_alloc arity 1] -> g
+        ^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute is only supported on patterns that bind
+       a variable.
 |}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -230,10 +230,16 @@ let _ =
 Line 3, characters 2-29:
 3 |   let[@zero_alloc] f' = f 123 in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The "zero_alloc" attribute placed on a "let"-binding can only be
-       used for function definitions.
-       If this defines a function, rewrite it so that its arguments are
-       present in the definition.
+Warning 182 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+Line 4, characters 21-23:
+4 |   require_za_arity_1 f';; (* should fail *)
+                         ^^
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let _ = require_za_arity_1 (fun[@zero_alloc] x -> 42);; (* should succeed *)
@@ -289,10 +295,16 @@ let _ =
 Line 3, characters 2-30:
 3 |   let[@zero_alloc] id' = id id in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The "zero_alloc" attribute placed on a "let"-binding can only be
-       used for function definitions.
-       If this defines a function, rewrite it so that its arguments are
-       present in the definition.
+Warning 182 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+Line 4, characters 21-24:
+4 |   require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
+                         ^^^
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let _ =

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -68,6 +68,13 @@ let _ =
 - : int = 42
 |}];;
 
+module _ = struct
+  let f x = x
+  let _ = require_za_arity_1 f
+end;;
+[%%expect {|
+|}];;
+
 let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
   fun (g [@zero_alloc arity 1]) -> g 42;; (* should succeed *)
 [%%expect {|
@@ -114,7 +121,7 @@ let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the bac
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP16.f (camlTOP16__f_20_21_code).
+Error: Annotation check for zero_alloc failed on function TOP17.f (camlTOP17__f_22_23_code).
 Line 1, characters 49-52:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
                                                      ^^^
@@ -126,7 +133,7 @@ let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP17.f (camlTOP17__f_22_23_code).
+Error: Annotation check for zero_alloc failed on function TOP18.f (camlTOP18__f_24_25_code).
 Line 1, characters 53-60:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
                                                          ^^^^^^^
@@ -179,6 +186,20 @@ Error: Mismatch between this argument and the "zero_alloc" requirement
        but this function is not.
 |}];;
 
+module _ = struct
+  let[@zero_alloc] f x = x + 555
+  let _ = test_f_strict f
+end;;
+[%%expect {|
+Line 3, characters 24-25:
+3 |   let _ = test_f_strict f
+                            ^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The argument's "zero_alloc" property is required to be "strict",
+       but this function is not.
+|}];;
+
 (* checks with opt *)
 
 let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
@@ -187,7 +208,7 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP23.f (camlTOP23__f_30_31_code).
+Error: Annotation check for zero_alloc failed on function TOP25.f (camlTOP25__f_32_33_code).
 Line 2, characters 39-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
                                            ^^^^
@@ -212,6 +233,30 @@ Error: The "zero_alloc" attribute on this function parameter conflicts
        The former provides a weaker "zero_alloc" guarantee than the latter.
 |}];;
 
+let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
+  fun g -> g 42;; (* should succeed *)
+[%%expect {|
+Line 2, characters 2-15:
+2 |   fun g -> g 42;; (* should succeed *)
+      ^^^^^^^^^^^^^
+Error: The parameter type declares a "zero_alloc" requirement of arity 1,
+       but the binding pattern does not. Hint: annotate the pattern.
+|}];;
+
+let[@zero_alloc] f : (int -> int) -> int =
+  fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+Line 1, characters 5-15:
+1 | let[@zero_alloc] f : (int -> int) -> int =
+         ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP29.f (camlTOP29__f_36_37_code).
+Line 2, characters 39-43:
+2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should succeed *)
+                                           ^^^^
+Error: called function may allocate (indirect tailcall)
+|}];;
+
+
 (* assume not supported on function parameters *)
 let[@zero_alloc] f : ((int -> int) [@zero_alloc assume]) -> int =
   fun (g [@zero_alloc assume arity 1]) -> g 42;; (* should fail *)
@@ -231,6 +276,21 @@ let _ =
 Line 4, characters 21-23:
 4 |   require_za_arity_1 f';; (* should fail; f' zero_alloc information is not available *)
                          ^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
+|}];;
+
+module _ = struct
+  let[@zero_alloc] f x y = x + y
+  let f' = f 123
+  let _ = require_za_arity_1 f'
+end;;
+[%%expect {|
+Line 4, characters 29-31:
+4 |   let _ = require_za_arity_1 f'
+                                 ^^
 Error: Mismatch between this argument and the "zero_alloc" requirement
        of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
@@ -258,6 +318,27 @@ Error: Mismatch between this argument and the "zero_alloc" requirement
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
+module _ = struct
+  let[@zero_alloc] f x y = x + y
+  let[@zero_alloc] f' = f 123
+  let _ = require_za_arity_1 f'
+end;;
+[%%expect {|
+Line 3, characters 2-29:
+3 |   let[@zero_alloc] f' = f 123
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+Line 4, characters 29-31:
+4 |   let _ = require_za_arity_1 f'
+                                 ^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
+|}];;
+
 let _ = require_za_arity_1 (fun[@zero_alloc] x -> 42);; (* should succeed *)
 [%%expect {|
 - : int = 42
@@ -268,7 +349,7 @@ let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in 
 Line 1, characters 33-43:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                      ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP30._$.(fun) (camlTOP30__fn[:1,27--59]_36_37_code).
+Error: Annotation check for zero_alloc failed on function TOP36._$.(fun) (camlTOP36__fn[:1,27--59]_40_41_code).
 Line 1, characters 50-58:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                                       ^^^^^^^^
@@ -296,7 +377,7 @@ let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
 Line 1, characters 27-41:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP34._$.(fun) (camlTOP34__fn[:1,27--41]_44_45_code).
+Error: Annotation check for zero_alloc failed on function TOP40._$.(fun) (camlTOP40__fn[:1,27--41]_48_49_code).
 Line 1, characters 37-40:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                          ^^^
@@ -323,6 +404,27 @@ Error: Mismatch between this argument and the "zero_alloc" requirement
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
+module _ = struct
+  let[@zero_alloc] id x = x
+  let[@zero_alloc] id' = id id
+  let _ = require_za_arity_1 id'
+end;;
+[%%expect {|
+Line 3, characters 2-30:
+3 |   let[@zero_alloc] id' = id id
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+Line 4, characters 29-32:
+4 |   let _ = require_za_arity_1 id'
+                                 ^^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
+|}];;
+
 let _ =
   let[@zero_alloc] id x = x in
   let id' = id id in
@@ -331,6 +433,21 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail, as above *)
                          ^^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
+|}];;
+
+module _ = struct
+  let[@zero_alloc] id x = x
+  let id' = id id
+  let _ = require_za_arity_1 id'
+end;;
+[%%expect {|
+Line 4, characters 29-32:
+4 |   let _ = require_za_arity_1 id'
+                                 ^^^
 Error: Mismatch between this argument and the "zero_alloc" requirement
        of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
@@ -346,12 +463,28 @@ let _ =
 - : int = 42
 |}];;
 
+module _ = struct
+  let[@zero_alloc] id x = x
+  let[@zero_alloc] id' x = id id x
+  let _ = require_za_arity_1 id'
+end;;
+[%%expect {|
+|}];;
+
 let _ =
   let[@zero_alloc] id x = x in
   let id' x = id id x in
   require_za_arity_1 id';; (* should succeed; zero-alloc of id' is a var *)
 [%%expect {|
 - : int = 42
+|}];;
+
+module _ = struct
+  let[@zero_alloc] id x = x
+  let id' x = id id x
+  let _ = require_za_arity_1 id'
+end;;
+[%%expect {|
 |}];;
 
 let _ =
@@ -368,6 +501,21 @@ Error: Mismatch between this argument and the "zero_alloc" requirement
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
+module _ = struct
+  let id x = x
+  let id' = id id
+  let _ = require_za_arity_1 id'
+end;;
+[%%expect {|
+Line 4, characters 29-32:
+4 |   let _ = require_za_arity_1 id'
+                                 ^^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
+|}];;
+
 let _ =
   let[@zero_alloc] require_za_arity (f [@zero_alloc arity 1]) x = f x in
   let id x = x in
@@ -377,9 +525,26 @@ let _ =
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] id' x = (id x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP40._$.id' (camlTOP40__id'_55_57_code).
+Error: Annotation check for zero_alloc failed on function TOP51._$.id' (camlTOP51__id'_67_69_code).
 Line 4, characters 27-36:
 4 |   let[@zero_alloc] id' x = (id x, x) in
+                               ^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  let[@zero_alloc] require_za_arity (f [@zero_alloc arity 1]) x = f x
+  let id x = x
+  let[@zero_alloc] id' x = (id x, x)
+  let _ = require_za_arity id' 42
+end;;
+[%%expect {|
+Line 4, characters 7-17:
+4 |   let[@zero_alloc] id' x = (id x, x)
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP52.id' (camlTOP52__id'_72_75_code).
+Line 4, characters 27-36:
+4 |   let[@zero_alloc] id' x = (id x, x)
                                ^^^^^^^^^
 Error: allocation of 24 bytes
 |}];;
@@ -394,6 +559,19 @@ let _ =
 Line 6, characters 21-26:
 6 |   require_za_arity_1 (f 1);; (* should fail in the frontend *)
                          ^^^^^
+Error: This function application expects an argument that does not allocate.
+       Only identifiers and anonymous functions may be passed as arguments
+       to functions with "zero_alloc" parameters.
+|}];;
+
+module _ = struct
+  let[@zero_alloc] f x y = x + y
+  let _ = require_za_arity_1 (f 1)
+end;;
+[%%expect {|
+Line 3, characters 29-34:
+3 |   let _ = require_za_arity_1 (f 1)
+                                 ^^^^^
 Error: This function application expects an argument that does not allocate.
        Only identifiers and anonymous functions may be passed as arguments
        to functions with "zero_alloc" parameters.
@@ -514,7 +692,7 @@ end;;
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP52.Nonsense_matching_arity.f' (camlTOP52__f'_62_63_code).
+Error: Annotation check for zero_alloc failed on function TOP65.Nonsense_matching_arity.f' (camlTOP65__f'_80_81_code).
 Line 4, characters 51-61:
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
                                                        ^^^^^^^^^^
@@ -732,6 +910,21 @@ Error: Mismatch between this argument and the "zero_alloc" requirement
        but this function is not.
 |}];;
 
+module _ = struct
+  let[@zero_alloc] f x = x + 123
+  let _ = g1 f
+  let _ = g2 f
+end;;
+[%%expect {|
+Line 4, characters 13-14:
+4 |   let _ = g2 f
+                 ^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The argument's "zero_alloc" property is required to be "strict",
+       but this function is not.
+|}];;
+
 let _ =
   let[@zero_alloc strict] f_strict x = x + 123 in
   let _ = g1 f_strict in
@@ -739,6 +932,14 @@ let _ =
   f_strict;;
 [%%expect {|
 - : int -> int = <fun>
+|}];;
+
+module _ = struct
+  let[@zero_alloc strict] f_strict x = x + 123
+  let _ = g1 f_strict
+  let _ = g2 f_strict
+end;;
+[%%expect {|
 |}];;
 
 let _ =
@@ -750,6 +951,14 @@ let _ =
 - : int -> int = <fun>
 |}];;
 
+module _ = struct
+  let f_unannotated x = x + 123
+  let _ = g1 f_unannotated
+  let _ = g2 f_unannotated
+end;;
+[%%expect {|
+|}];;
+
 let _ =
   let exception Err of string in
   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
@@ -757,15 +966,35 @@ let _ =
   let _ = g2 f_nonstrict in
   f_nonstrict
 [%%expect {|
-Line 3, characters 2-72:
+Line 3, characters 18-72:
 3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP76._$.f_nonstrict (camlTOP76__f_nonstrict_80_81_code).
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc strict failed on function TOP92._$.f_nonstrict (camlTOP92__f_nonstrict_102_103_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:3,47--64)
 Line 3, characters 42-65:
 3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  exception Err_nonstrict of string
+  let f_nonstrict x =
+    if x < 0 then raise (Err_nonstrict (string_of_int x)) else x
+  let _ = g1 f_nonstrict
+  let _ = g2 f_nonstrict
+end;;
+[%%expect {|
+Lines 3-4, characters 18-64:
+3 | ..................x =
+4 |     if x < 0 then raise (Err_nonstrict (string_of_int x)) else x
+Error: Annotation check for zero_alloc strict failed on function TOP93.f_nonstrict (camlTOP93__f_nonstrict_104_105_code).
+File "stdlib.ml", line 280, characters 2-19:
+Error: called function may allocate (external call to caml_format_int) (:4,39--56)
+Line 4, characters 24-57:
+4 |     if x < 0 then raise (Err_nonstrict (string_of_int x)) else x
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: allocation of 24 bytes
 |}];;
 
@@ -784,7 +1013,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP78.F.g.(fun) (camlTOP78__fn[:6,17--50]_84_87_code).
+Error: Annotation check for zero_alloc failed on function TOP95.F.g.(fun) (camlTOP95__fn[:6,17--50]_108_111_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -840,9 +1069,25 @@ let _ =
 Line 3, characters 7-17:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP84._$.f (camlTOP84__*match*_93_95_code).
+Error: Annotation check for zero_alloc failed on function TOP101._$.f (camlTOP101__*match*_117_119_code).
 Line 3, characters 38-44:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
+                                          ^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42
+  let[@zero_alloc] (f | f) = fun x -> (x, x)
+  let _ = needs_za_1 f
+end;;
+[%%expect {|
+Line 3, characters 7-17:
+3 |   let[@zero_alloc] (f | f) = fun x -> (x, x)
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP102.f (camlTOP102__*match*_120_123_code).
+Line 3, characters 38-44:
+3 |   let[@zero_alloc] (f | f) = fun x -> (x, x)
                                           ^^^^^^
 Error: allocation of 24 bytes
 |}];;
@@ -852,12 +1097,28 @@ let _ =
   let (f | f) = fun x -> (x, x) in
   needs_za_1 f;;
 [%%expect {|
-Line 3, characters 2-31:
+Line 3, characters 16-31:
 3 |   let (f | f) = fun x -> (x, x) in
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP85._$.f (camlTOP85__*match*_95_97_code).
+                    ^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP103._$.f (camlTOP103__*match*_123_125_code).
 Line 3, characters 25-31:
 3 |   let (f | f) = fun x -> (x, x) in
+                             ^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42
+  let (f | f) = fun x -> (x, x)
+  let _ = needs_za_1 f
+end;;
+[%%expect {|
+Line 3, characters 16-31:
+3 |   let (f | f) = fun x -> (x, x)
+                    ^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP104.f (camlTOP104__*match*_126_129_code).
+Line 3, characters 25-31:
+3 |   let (f | f) = fun x -> (x, x)
                              ^^^^^^
 Error: allocation of 24 bytes
 |}];;
@@ -870,12 +1131,28 @@ let _ =
 - : int = 41
 |}];;
 
+module _ = struct
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42
+  let[@zero_alloc] (f | f) = fun x -> x - 1
+  let _ = needs_za_1 f
+end;;
+[%%expect {|
+|}];;
+
 let _ =
   let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
   let (f | f) = fun x -> x - 1 in
   needs_za_1 f;;
 [%%expect {|
 - : int = 41
+|}];;
+
+module _ = struct
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42
+  let (f | f) = fun x -> x - 1
+  let _ = needs_za_1 f
+end;;
+[%%expect {|
 |}];;
 
 
@@ -979,6 +1256,14 @@ let _ =
 - : unit = ()
 |}];;
 
+module _ = struct
+  let[@zero_alloc] (f as g) = fun x -> x + 123
+  let _ = require_za_arity_1 f
+  let _ = require_za_arity_1 g
+end;;
+[%%expect {|
+|}];;
+
 let _ =
   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
   let _ = require_za_arity_1 f in
@@ -988,9 +1273,25 @@ let _ =
 Line 2, characters 7-17:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP102._$.f (camlTOP102__g_115_117_code).
+Error: Annotation check for zero_alloc failed on function TOP124._$.f (camlTOP124__g_157_159_code).
 Line 2, characters 39-52:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
+                                           ^^^^^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  let[@zero_alloc] (f as g) = fun x -> (x + 123, 42)
+  let _ = require_za_arity_1 f
+  let _ = require_za_arity_1 g
+end;;
+[%%expect {|
+Line 2, characters 7-17:
+2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42)
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP125.f (camlTOP125__g_159_161_code).
+Line 2, characters 39-52:
+2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42)
                                            ^^^^^^^^^^^^^
 Error: allocation of 24 bytes
 |}];;
@@ -1004,6 +1305,15 @@ let _ =
   ()
 [%%expect {|
 - : unit = ()
+|}];;
+
+module _ = struct
+  let[@zero_alloc] ((f as g) as h) = fun x -> x + 123
+  let _ = require_za_arity_1 f
+  let _ = require_za_arity_1 g
+  let _ = require_za_arity_1 h
+end;;
+[%%expect {|
 |}];;
 
 (** `external` declarations and zero_alloc parameters.
@@ -1054,12 +1364,33 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP108._$.(fun) (camlTOP108__fn[:7,6--67]_121_125_code).
+Error: Annotation check for zero_alloc strict failed on function TOP132._$.(fun) (camlTOP132__fn[:7,6--67]_167_171_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
                                         ^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  exception Err_apply_strict of string
+  let[@zero_alloc] apply_strict (f [@zero_alloc strict arity 1]) a = f a
+  let _ = fun a ->
+    apply_strict
+      (fun x ->
+         if x < 0 then raise (Err_apply_strict (string_of_int x)) else x) a
+end;;
+[%%expect {|
+Lines 6-7, characters 6-73:
+6 | ......(fun x ->
+7 |          if x < 0 then raise (Err_apply_strict (string_of_int x)) else x)..
+Error: Annotation check for zero_alloc strict failed on function TOP133.(fun) (camlTOP133__fn[:6,6--89]_173_177_code).
+File "stdlib.ml", line 280, characters 2-19:
+Error: called function may allocate (external call to caml_format_int) (:7,47--64)
+Line 7, characters 29-65:
+7 |          if x < 0 then raise (Err_apply_strict (string_of_int x)) else x) a
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: allocation of 24 bytes
 |}];;
 
@@ -1072,6 +1403,14 @@ let _ =
       (fun x -> if x < 0 then 123 else x) a;;
 [%%expect {|
 - : int -> int = <fun>
+|}];;
+
+module _ = struct
+  let[@zero_alloc] apply_strict (f [@zero_alloc strict arity 1]) a = f a
+  let _ = fun a ->
+    apply_strict (fun x -> if x < 0 then 123 else x) a
+end;;
+[%%expect {|
 |}];;
 
 (* Inference is non-principal because of zero-alloc.
@@ -1101,13 +1440,29 @@ let _ =
   and g x = x, x in
   f g;;  (* fails in the backend *)
 [%%expect {|
-Line 3, characters 2-16:
+Line 3, characters 8-16:
 3 |   and g x = x, x in
-      ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP113._$.g (camlTOP113__g_142_145_code).
+            ^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP139._$.g (camlTOP139__g_200_203_code).
 Line 3, characters 12-16:
 3 |   and g x = x, x in
                 ^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  let rec f_rec (g[@zero_alloc arity 1]) = g 42
+  and g_rec x = x, x
+  let _ = f_rec g_rec
+end;;
+[%%expect {|
+Line 3, characters 12-20:
+3 |   and g_rec x = x, x
+                ^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP140.g_rec (camlTOP140__g_rec_204_207_code).
+Line 3, characters 16-20:
+3 |   and g_rec x = x, x
+                    ^^^^
 Error: allocation of 24 bytes
 |}];;
 
@@ -1118,13 +1473,31 @@ let _ =
   and g x = x, x in
   fun r x -> f g r x;;  (* fails in the backend *)
 [%%expect {|
-Line 5, characters 2-16:
+Line 5, characters 8-16:
 5 |   and g x = x, x in
-      ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP114._$.g (camlTOP114__g_146_150_code).
+            ^^^^^^^^
+Error: Annotation check for zero_alloc strict failed on function TOP141._$.g (camlTOP141__g_208_212_code).
 Line 5, characters 12-16:
 5 |   and g x = x, x in
                 ^^^^
+Error: allocation of 24 bytes
+|}];;
+
+module _ = struct
+  exception Err_rec of string
+  let rec f_rec2 (g[@zero_alloc strict arity 1]) p x =
+    if p then g x else raise (Err_rec (string_of_int x))
+  and g_rec2 x = x, x
+  let _ = fun r x -> f_rec2 g_rec2 r x
+end;;
+[%%expect {|
+Line 5, characters 13-21:
+5 |   and g_rec2 x = x, x
+                 ^^^^^^^^
+Error: Annotation check for zero_alloc strict failed on function TOP142.g_rec2 (camlTOP142__g_rec2_214_218_code).
+Line 5, characters 17-21:
+5 |   and g_rec2 x = x, x
+                     ^^^^
 Error: allocation of 24 bytes
 |}];;
 
@@ -1165,27 +1538,94 @@ Error: The "zero_alloc" attribute is only supported on patterns that bind
        a variable.
 |}];;
 
-(* Side-effects / impure example *)
-(* Here we cannot place [%%expect {|...|}] after a separately-defined print_num,
-   because inserting [%%expect] forces the compilation of print_num to native code
-   and completes backend analysis.
-   This means that backend analysis of print_num does not occur once it appears as
-   an argument of an application of a function with zero_alloc requirements.
-   This behaviour does not occur in any meaningful way outside of expect tests. *)
-(* CR-soon aivaskovic: see if the semantics can be changed *)
 let _ =
+  let foo = fun[@zero_alloc] x -> x in
+  require_za_arity_1 foo;;
+[%%expect {|
+- : int = 42
+|}];;
+
+let _ =
+  let[@zero_alloc] foo = fun[@zero_alloc] x -> x in
+  require_za_arity_1 foo;;
+[%%expect {|
+Line 2, characters 2-48:
+2 |   let[@zero_alloc] foo = fun[@zero_alloc] x -> x in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 54 [duplicated-attribute]: the "assert_zero_alloc" attribute is used more than once on this expression
+
+- : int = 42
+|}];;
+
+let _ =
+  let[@zero_alloc] foo = fun x -> x in
+  require_za_arity_1 foo;;
+[%%expect {|
+- : int = 42
+|}];;
+
+let _ =
+  let[@zero_alloc opt] foo = fun[@zero_alloc strict] x -> x in
+  require_za_arity_1 foo;;
+[%%expect {|
+Line 2, characters 2-59:
+2 |   let[@zero_alloc opt] foo = fun[@zero_alloc strict] x -> x in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 54 [duplicated-attribute]: the "assert_zero_alloc" attribute is used more than once on this expression
+
+Line 3, characters 21-24:
+3 |   require_za_arity_1 foo;;
+                         ^^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The argument's "zero_alloc" check is "opt", but the parameter
+       requires a non-"opt" check.
+|}];;
+
+let _ =
+  let[@zero_alloc assume] foo = fun[@zero_alloc strict] x -> x in
+  test_f_strict foo;;
+[%%expect {|
+Line 2, characters 2-62:
+2 |   let[@zero_alloc assume] foo = fun[@zero_alloc strict] x -> x in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 54 [duplicated-attribute]: the "assume_zero_alloc" attribute is used more than once on this expression
+
+Line 3, characters 16-19:
+3 |   test_f_strict foo;;
+                    ^^^
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
+       The argument's "zero_alloc" property is required to be "strict",
+       but this function is not.
+|}];;
+
+let _ =
+  let[@zero_alloc strict] foo = fun[@zero_alloc assume] x -> x in
+  test_f_strict foo;;
+[%%expect {|
+Line 2, characters 2-62:
+2 |   let[@zero_alloc strict] foo = fun[@zero_alloc assume] x -> x in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 54 [duplicated-attribute]: the "assert_zero_alloc strict" attribute is used more than once on this expression
+
+- : int = 123
+|}];;
+
+(* Side-effects / impure example *)
+module _ = struct
   let print_num n =
     Format.printf "allocates str %d" n;
     n
-  in
-  let attempt_to_apply (f [@zero_alloc arity 1]) = f 42 in
-  attempt_to_apply print_num;;
+  let attempt_to_apply (f [@zero_alloc arity 1]) = f 42
+  let _ = attempt_to_apply print_num
+end;;
 [%%expect {|
-Lines 2-4, characters 2-5:
-2 | ..let print_num n =
+Lines 2-4, characters 16-5:
+2 | ................n =
 3 |     Format.printf "allocates str %d" n;
 4 |     n
-Error: Annotation check for zero_alloc failed on function TOP120._$.print_num (camlTOP120__print_num_151_153_code).
+Error: Annotation check for zero_alloc failed on function TOP154.print_num (camlTOP154__print_num_227_230_code).
 Line 3, characters 4-38:
 3 |     Format.printf "allocates str %d" n;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -86,9 +86,9 @@ val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
 let[@zero_alloc] f : ((int -> int -> int) [@zero_alloc]) -> int =
   fun (g [@zero_alloc arity 1]) -> g 42 123;; (* should fail *)
 [%%expect {|
-Line 2, characters 6-31:
+Line 2, characters 2-43:
 2 |   fun (g [@zero_alloc arity 1]) -> g 42 123;; (* should fail *)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The "zero_alloc" attribute on this function parameter conflicts
        with the one on its type.
        When using "zero_alloc" on function parameters, the arities in the
@@ -127,9 +127,9 @@ val f : ((int -> int) [@zero_alloc strict arity 1]) -> int [@@zero_alloc] =
 let[@zero_alloc] f : ((int -> int) [@zero_alloc strict]) -> int =
   fun (g [@zero_alloc arity 1]) -> g 42;; (* should fail *)
 [%%expect {|
-Line 2, characters 6-31:
+Line 2, characters 2-39:
 2 |   fun (g [@zero_alloc arity 1]) -> g 42;; (* should fail *)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The "zero_alloc" attribute on this function parameter conflicts
        with the one on its type.
        The former provides a weaker "zero_alloc" guarantee than the latter.
@@ -186,9 +186,9 @@ val f : ((int -> int) [@zero_alloc opt arity 1]) -> int [@@zero_alloc] =
 let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
 [%%expect {|
-Line 2, characters 6-35:
+Line 2, characters 2-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The "zero_alloc" attribute on this function parameter conflicts
        with the one on its type.
        The former provides a weaker "zero_alloc" guarantee than the latter.
@@ -515,9 +515,9 @@ val w2 :
 let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
   fun (f [@zero_alloc arity 1]) -> f 123;;
 [%%expect {|
-Line 1, characters 9-45:
+Line 1, characters 27-37:
 1 | let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                               ^^^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
 |}];;
@@ -546,9 +546,9 @@ Error: The arity in the "zero_alloc" attribute (2) does not match the
 let w6 : ('a. 'a) [@zero_alloc] -> int =
   fun _ -> 1;;
 [%%expect {|
-Line 1, characters 9-17:
+Line 1, characters 20-30:
 1 | let w6 : ('a. 'a) [@zero_alloc] -> int =
-             ^^^^^^^^
+                        ^^^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
 |}];;
@@ -920,9 +920,9 @@ module type S_ext_bad_nonfun = sig
   external f : (int [@zero_alloc]) -> int = "f"
 end;;
 [%%expect {|
-Line 2, characters 15-41:
+Line 2, characters 22-32:
 2 |   external f : (int [@zero_alloc]) -> int = "f"
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                          ^^^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
 |}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -66,15 +66,9 @@ let _ =
 
 let _ =
   let f x = x in
-  require_za_arity_1 f;; (* should fail *)
+  require_za_arity_1 f;; (* should succeed *)
 [%%expect {|
-Line 3, characters 21-22:
-3 |   require_za_arity_1 f;; (* should fail *)
-                         ^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+- : int = 42
 |}];;
 
 let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
@@ -169,7 +163,7 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP20.f (camlTOP20__f_18_19_code).
+Error: Annotation check for zero_alloc failed on function TOP20.f (camlTOP20__f_20_21_code).
 Line 2, characters 39-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
                                            ^^^^
@@ -244,7 +238,7 @@ let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in 
 Line 1, characters 33-43:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                      ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP27._$.(fun) (camlTOP27__fn[:1,27--59]_24_25_code).
+Error: Annotation check for zero_alloc failed on function TOP27._$.(fun) (camlTOP27__fn[:1,27--59]_26_27_code).
 Line 1, characters 50-58:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                                       ^^^^^^^^
@@ -272,7 +266,7 @@ let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
 Line 1, characters 27-41:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP31._$.(fun) (camlTOP31__fn[:1,27--41]_32_33_code).
+Error: Annotation check for zero_alloc failed on function TOP31._$.(fun) (camlTOP31__fn[:1,27--41]_34_35_code).
 Line 1, characters 37-40:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                          ^^^
@@ -319,15 +313,9 @@ let _ =
 let _ =
   let[@zero_alloc] id x = x in
   let id' x = id id x in
-  require_za_arity_1 id';; (* should fail; zero-allocness not inferred *)
+  require_za_arity_1 id';; (* should succeed; zero-alloc of id' is a var *)
 [%%expect {|
-Line 4, characters 21-24:
-4 |   require_za_arity_1 id';; (* should fail; zero-allocness not inferred *)
-                         ^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+- : int = 42
 |}];;
 
 let _ =
@@ -353,7 +341,7 @@ let _ =
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] id' x = (id x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP37._$.id' (camlTOP37__id'_39_41_code).
+Error: Annotation check for zero_alloc failed on function TOP37._$.id' (camlTOP37__id'_45_47_code).
 Line 4, characters 27-36:
 4 |   let[@zero_alloc] id' x = (id x, x) in
                                ^^^^^^^^^
@@ -706,14 +694,28 @@ let _ =
   let _ = g2 f_unannotated in
   f_unannotated
 [%%expect {|
-Line 3, characters 13-26:
-3 |   let _ = g1 f_unannotated in
-                 ^^^^^^^^^^^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+- : int -> int = <fun>
 |}];;
+
+let _ =
+  let exception Err of string in
+  let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
+  let _ = g1 f_nonstrict in
+  let _ = g2 f_nonstrict in
+  f_nonstrict
+[%%expect {|
+Line 3, characters 2-72:
+3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc strict failed on function TOP73._$.f_nonstrict (camlTOP73__f_nonstrict_66_67_code).
+File "stdlib.ml", line 280, characters 2-19:
+Error: called function may allocate (external call to caml_format_int) (:3,47--64)
+Line 3, characters 42-65:
+3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
+                                              ^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
 
 (* custom error messages can be placed on zero_alloc parameters *)
 
@@ -729,7 +731,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP74.F.g.(fun) (camlTOP74__fn[:6,17--50]_60_63_code).
+Error: Annotation check for zero_alloc failed on function TOP75.F.g.(fun) (camlTOP75__fn[:6,17--50]_70_73_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -777,19 +779,44 @@ Error: "zero_alloc" attributes are not supported on optional parameters.
 |}];;
 
 (* how zero_alloc propagates down a pattern *)
-
-let needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
-let (f | f) = fun x -> (x, x) in
-ignore (needs_za_1 f);;
+let _ =
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
+  let[@zero_alloc] (f | f) = fun x -> (x, x) in
+  needs_za_1 f;;
 [%%expect {|
-Line 3, characters 19-20:
-3 | ignore (needs_za_1 f);;
-                       ^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+Line 3, characters 7-17:
+3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP81._$.f (camlTOP81__*match*_79_81_code).
+Line 3, characters 38-44:
+3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
+                                          ^^^^^^
+Error: allocation of 24 bytes
 |}];;
+
+let _ =
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
+  let (f | f) = fun x -> (x, x) in
+  needs_za_1 f;;
+[%%expect {|
+Line 3, characters 2-31:
+3 |   let (f | f) = fun x -> (x, x) in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP82._$.f (camlTOP82__*match*_81_83_code).
+Line 3, characters 25-31:
+3 |   let (f | f) = fun x -> (x, x) in
+                             ^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+let _ =
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
+  let[@zero_alloc] (f | f) = fun x -> x - 1 in
+  needs_za_1 f;;
+[%%expect {|
+- : int = 41
+|}];;
+
 
 (** Aliases and zero_alloc parameters.
     Type aliases (type t = int -> int) work because the compiler expands them
@@ -939,7 +966,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP99._$.(fun) (camlTOP99__fn[:7,6--67]_85_89_code).
+Error: Annotation check for zero_alloc strict failed on function TOP102._$.(fun) (camlTOP102__fn[:7,6--67]_101_105_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -74,6 +74,25 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
 val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
 |}];;
 
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  function (g [@zero_alloc arity 1]) -> g 42;; (* should succeed *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  function g -> g 42;; (* should fail in the backend *)
+[%%expect {|
+Line 1, characters 5-15:
+1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+         ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP13.f (camlTOP13__f_18_19_code).
+Line 2, characters 16-20:
+2 |   function g -> g 42;; (* should fail in the backend *)
+                    ^^^^
+Error: called function may allocate (indirect tailcall)
+|}];;
+
 let[@zero_alloc] f : ((int -> int -> int) [@zero_alloc]) -> int =
   fun (g [@zero_alloc arity 1]) -> g 42 123;; (* should fail *)
 [%%expect {|
@@ -98,7 +117,7 @@ let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the bac
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP14.f (camlTOP14__f_18_19_code).
+Error: Annotation check for zero_alloc failed on function TOP16.f (camlTOP16__f_22_23_code).
 Line 1, characters 49-52:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
                                                      ^^^
@@ -110,7 +129,7 @@ let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP15.f (camlTOP15__f_20_21_code).
+Error: Annotation check for zero_alloc failed on function TOP17.f (camlTOP17__f_24_25_code).
 Line 1, characters 53-60:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
                                                          ^^^^^^^
@@ -171,7 +190,7 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP21.f (camlTOP21__f_28_29_code).
+Error: Annotation check for zero_alloc failed on function TOP23.f (camlTOP23__f_32_33_code).
 Line 2, characters 39-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
                                            ^^^^
@@ -252,7 +271,7 @@ let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in 
 Line 1, characters 33-43:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                      ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP28._$.(fun) (camlTOP28__fn[:1,27--59]_34_35_code).
+Error: Annotation check for zero_alloc failed on function TOP30._$.(fun) (camlTOP30__fn[:1,27--59]_38_39_code).
 Line 1, characters 50-58:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                                       ^^^^^^^^
@@ -280,7 +299,7 @@ let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
 Line 1, characters 27-41:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP32._$.(fun) (camlTOP32__fn[:1,27--41]_42_43_code).
+Error: Annotation check for zero_alloc failed on function TOP34._$.(fun) (camlTOP34__fn[:1,27--41]_46_47_code).
 Line 1, characters 37-40:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                          ^^^
@@ -361,7 +380,7 @@ let _ =
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] id' x = (id x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP38._$.id' (camlTOP38__id'_53_55_code).
+Error: Annotation check for zero_alloc failed on function TOP40._$.id' (camlTOP40__id'_57_59_code).
 Line 4, characters 27-36:
 4 |   let[@zero_alloc] id' x = (id x, x) in
                                ^^^^^^^^^
@@ -498,7 +517,7 @@ end;;
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP50.Nonsense_matching_arity.f' (camlTOP50__f'_60_61_code).
+Error: Annotation check for zero_alloc failed on function TOP52.Nonsense_matching_arity.f' (camlTOP52__f'_64_65_code).
 Line 4, characters 51-61:
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
                                                        ^^^^^^^^^^
@@ -747,7 +766,7 @@ let _ =
 Line 3, characters 2-72:
 3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP74._$.f_nonstrict (camlTOP74__f_nonstrict_78_79_code).
+Error: Annotation check for zero_alloc strict failed on function TOP76._$.f_nonstrict (camlTOP76__f_nonstrict_82_83_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:3,47--64)
 Line 3, characters 42-65:
@@ -771,7 +790,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP76.F.g.(fun) (camlTOP76__fn[:6,17--50]_82_85_code).
+Error: Annotation check for zero_alloc failed on function TOP78.F.g.(fun) (camlTOP78__fn[:6,17--50]_86_89_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -827,7 +846,7 @@ let _ =
 Line 3, characters 7-17:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP82._$.f (camlTOP82__*match*_91_93_code).
+Error: Annotation check for zero_alloc failed on function TOP84._$.f (camlTOP84__*match*_95_97_code).
 Line 3, characters 38-44:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
                                           ^^^^^^
@@ -842,7 +861,7 @@ let _ =
 Line 3, characters 2-31:
 3 |   let (f | f) = fun x -> (x, x) in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP83._$.f (camlTOP83__*match*_93_95_code).
+Error: Annotation check for zero_alloc failed on function TOP85._$.f (camlTOP85__*match*_97_99_code).
 Line 3, characters 25-31:
 3 |   let (f | f) = fun x -> (x, x) in
                              ^^^^^^
@@ -967,7 +986,7 @@ let _ =
 Line 2, characters 7-17:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP99._$.f (camlTOP99__g_111_113_code).
+Error: Annotation check for zero_alloc failed on function TOP101._$.f (camlTOP101__g_115_117_code).
 Line 2, characters 39-52:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
                                            ^^^^^^^^^^^^^
@@ -1033,7 +1052,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP105._$.(fun) (camlTOP105__fn[:7,6--67]_117_121_code).
+Error: Annotation check for zero_alloc strict failed on function TOP107._$.(fun) (camlTOP107__fn[:7,6--67]_121_125_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:
@@ -1082,7 +1101,7 @@ let _ =
 Line 3, characters 2-16:
 3 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP110._$.g (camlTOP110__g_138_141_code).
+Error: Annotation check for zero_alloc failed on function TOP112._$.g (camlTOP112__g_142_145_code).
 Line 3, characters 12-16:
 3 |   and g x = x, x in
                 ^^^^
@@ -1099,7 +1118,7 @@ let _ =
 Line 5, characters 2-16:
 5 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP111._$.g (camlTOP111__g_142_146_code).
+Error: Annotation check for zero_alloc strict failed on function TOP113._$.g (camlTOP113__g_146_150_code).
 Line 5, characters 12-16:
 5 |   and g x = x, x in
                 ^^^^

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -1049,3 +1049,36 @@ Warning 18 [not-principal]: applying a function with zero_alloc requirements her
 val non_principal : bool -> ((('a -> 'a) [@zero_alloc arity 1]) -> 'b) -> 'b =
   <fun>
 |}];;
+
+(* Recursion with zero_alloc on parameters *)
+let _ =
+  let rec f (g[@zero_alloc arity 1]) = g 42
+  and g x = x, x in
+  f g;;  (* fails in the backend *)
+[%%expect {|
+Line 3, characters 2-16:
+3 |   and g x = x, x in
+      ^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP109._$.g (camlTOP109__g_136_139_code).
+Line 3, characters 12-16:
+3 |   and g x = x, x in
+                ^^^^
+Error: allocation of 24 bytes
+|}];;
+
+let _ =
+  let exception Err of string in
+  let rec f (g[@zero_alloc strict arity 1]) p x =
+    if p then g x else raise (Err (string_of_int x))
+  and g x = x, x in
+  fun r x -> f g r x;;  (* fails in the backend *)
+[%%expect {|
+Line 5, characters 2-16:
+5 |   and g x = x, x in
+      ^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc strict failed on function TOP110._$.g (camlTOP110__g_140_144_code).
+Line 5, characters 12-16:
+5 |   and g x = x, x in
+                ^^^^
+Error: allocation of 24 bytes
+|}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -81,16 +81,13 @@ val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
 |}];;
 
 let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
-  function g -> g 42;; (* should fail in the backend *)
+  function g -> g 42;; (* should fail in the frontend *)
 [%%expect {|
-Line 1, characters 5-15:
-1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
-         ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP13.f (camlTOP13__f_18_19_code).
-Line 2, characters 16-20:
-2 |   function g -> g 42;; (* should fail in the backend *)
-                    ^^^^
-Error: called function may allocate (indirect tailcall)
+Line 2, characters 2-20:
+2 |   function g -> g 42;; (* should fail in the frontend *)
+      ^^^^^^^^^^^^^^^^^^
+Error: The parameter type declares a "zero_alloc" requirement of arity 1,
+       but the binding pattern does not. Hint: annotate the pattern.
 |}];;
 
 let[@zero_alloc] f : ((int -> int -> int) [@zero_alloc]) -> int =
@@ -117,7 +114,7 @@ let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the bac
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP16.f (camlTOP16__f_22_23_code).
+Error: Annotation check for zero_alloc failed on function TOP16.f (camlTOP16__f_20_21_code).
 Line 1, characters 49-52:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail in the backend *)
                                                      ^^^
@@ -129,7 +126,7 @@ let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP17.f (camlTOP17__f_24_25_code).
+Error: Annotation check for zero_alloc failed on function TOP17.f (camlTOP17__f_22_23_code).
 Line 1, characters 53-60:
 1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x y z = g x y z;; (* should fail in the backend *)
                                                          ^^^^^^^
@@ -176,8 +173,8 @@ let _ =
 Line 3, characters 16-17:
 3 |   test_f_strict f;;  (* should fail *)
                     ^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The argument's "zero_alloc" property is required to be "strict",
        but this function is not.
 |}];;
@@ -190,7 +187,7 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP23.f (camlTOP23__f_32_33_code).
+Error: Annotation check for zero_alloc failed on function TOP23.f (camlTOP23__f_30_31_code).
 Line 2, characters 39-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
                                            ^^^^
@@ -234,8 +231,8 @@ let _ =
 Line 4, characters 21-23:
 4 |   require_za_arity_1 f';; (* should fail; f' zero_alloc information is not available *)
                          ^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -255,8 +252,8 @@ rewrite the binding with explicit parameters or remove the attribute.
 Line 4, characters 21-23:
 4 |   require_za_arity_1 f';; (* should fail *)
                          ^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -271,7 +268,7 @@ let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in 
 Line 1, characters 33-43:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                      ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP30._$.(fun) (camlTOP30__fn[:1,27--59]_38_39_code).
+Error: Annotation check for zero_alloc failed on function TOP30._$.(fun) (camlTOP30__fn[:1,27--59]_36_37_code).
 Line 1, characters 50-58:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                                       ^^^^^^^^
@@ -299,7 +296,7 @@ let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
 Line 1, characters 27-41:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP34._$.(fun) (camlTOP34__fn[:1,27--41]_46_47_code).
+Error: Annotation check for zero_alloc failed on function TOP34._$.(fun) (camlTOP34__fn[:1,27--41]_44_45_code).
 Line 1, characters 37-40:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                          ^^^
@@ -320,8 +317,8 @@ rewrite the binding with explicit parameters or remove the attribute.
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
                          ^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -334,8 +331,8 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail, as above *)
                          ^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -365,8 +362,8 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail *)
                          ^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -380,14 +377,14 @@ let _ =
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] id' x = (id x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP40._$.id' (camlTOP40__id'_57_59_code).
+Error: Annotation check for zero_alloc failed on function TOP40._$.id' (camlTOP40__id'_55_57_code).
 Line 4, characters 27-36:
 4 |   let[@zero_alloc] id' x = (id x, x) in
                                ^^^^^^^^^
 Error: allocation of 24 bytes
 |}];;
 
-(** Frontend analysis fails when the arguments is neither an identifier nor a
+(** Frontend analysis fails when the argument is neither an identifier nor a
     function abstraction. *)
 
 let _ =
@@ -517,7 +514,7 @@ end;;
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP52.Nonsense_matching_arity.f' (camlTOP52__f'_64_65_code).
+Error: Annotation check for zero_alloc failed on function TOP52.Nonsense_matching_arity.f' (camlTOP52__f'_62_63_code).
 Line 4, characters 51-61:
 4 |   let[@zero_alloc] f' (g' [@zero_alloc arity 1]) = g' 123 456 (* should fail in the backend *)
                                                        ^^^^^^^^^^
@@ -608,14 +605,11 @@ Error: "zero_alloc" attributes on function arguments require the argument
 let w7 : ('a. (('a -> 'a) [@zero_alloc])) -> int =
   fun (f : 'a. 'a -> 'a) -> f 123;;
 [%%expect {|
-Line 2, characters 7-23:
+Line 2, characters 2-33:
 2 |   fun (f : 'a. 'a -> 'a) -> f 123;;
-           ^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type "'a. 'a -> 'a"
-       but a pattern was expected which matches values of type
-         "('a. (('a -> 'a) [@zero_alloc arity 1]))"
-       The two types must agree on "zero_alloc":
-       either both carry the annotation or neither does.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The parameter type declares a "zero_alloc" requirement of arity 1,
+       but the binding pattern does not. Hint: annotate the pattern.
 |}];;
 
 (* Polymorphic type annotation on the argument pattern, no "zero_alloc"
@@ -691,8 +685,8 @@ let[@zero_alloc] test_with_fc_module_2 (module M : S2) x =
 Line 2, characters 16-21:
 2 |   test_f_strict M.bam;;
                     ^^^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The argument's "zero_alloc" property is required to be "strict",
        but this function is not.
 |}];;
@@ -703,8 +697,8 @@ let[@zero_alloc] test_with_fc_module_3 (module M : S3) x =
 Line 2, characters 16-21:
 2 |   test_f_strict M.bal;;
                     ^^^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -732,8 +726,8 @@ let _ =
 Line 4, characters 13-14:
 4 |   let _ = g2 f in
                  ^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The argument's "zero_alloc" property is required to be "strict",
        but this function is not.
 |}];;
@@ -766,7 +760,7 @@ let _ =
 Line 3, characters 2-72:
 3 |   let f_nonstrict x = if x < 0 then raise (Err (string_of_int x)) else x in
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP76._$.f_nonstrict (camlTOP76__f_nonstrict_82_83_code).
+Error: Annotation check for zero_alloc strict failed on function TOP76._$.f_nonstrict (camlTOP76__f_nonstrict_80_81_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:3,47--64)
 Line 3, characters 42-65:
@@ -790,7 +784,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP78.F.g.(fun) (camlTOP78__fn[:6,17--50]_86_89_code).
+Error: Annotation check for zero_alloc failed on function TOP78.F.g.(fun) (camlTOP78__fn[:6,17--50]_84_87_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -843,11 +837,14 @@ let _ =
   let[@zero_alloc] (f | f) = fun x -> (x, x) in
   needs_za_1 f;;
 [%%expect {|
-Line 3, characters 19-26:
+Line 3, characters 7-17:
 3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
-                       ^^^^^^^
-Error: The "zero_alloc" attribute is only supported on patterns that bind
-       a variable.
+           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP84._$.f (camlTOP84__*match*_93_95_code).
+Line 3, characters 38-44:
+3 |   let[@zero_alloc] (f | f) = fun x -> (x, x) in
+                                          ^^^^^^
+Error: allocation of 24 bytes
 |}];;
 
 let _ =
@@ -870,11 +867,15 @@ let _ =
   let[@zero_alloc] (f | f) = fun x -> x - 1 in
   needs_za_1 f;;
 [%%expect {|
-Line 3, characters 19-26:
-3 |   let[@zero_alloc] (f | f) = fun x -> x - 1 in
-                       ^^^^^^^
-Error: The "zero_alloc" attribute is only supported on patterns that bind
-       a variable.
+- : int = 41
+|}];;
+
+let _ =
+  let[@zero_alloc] needs_za_1 (f[@zero_alloc arity 1]) = f 42 in
+  let (f | f) = fun x -> x - 1 in
+  needs_za_1 f;;
+[%%expect {|
+- : int = 41
 |}];;
 
 
@@ -917,8 +918,8 @@ val fn_alias : int -> int = <fun>
 Line 3, characters 27-35:
 3 | let _ = require_za_arity_1 fn_alias
                                ^^^^^^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -933,8 +934,8 @@ let[@zero_alloc] use_local_alias (f[@zero_alloc arity 1]) =
 Line 3, characters 21-22:
 3 |   require_za_arity_1 g
                          ^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
+Error: Mismatch between this argument and the "zero_alloc" requirement
+       of the function being applied.
        The former provides a weaker "zero_alloc" guarantee than the latter.
        Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
@@ -987,7 +988,7 @@ let _ =
 Line 2, characters 7-17:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP101._$.f (camlTOP101__g_111_113_code).
+Error: Annotation check for zero_alloc failed on function TOP102._$.f (camlTOP102__g_115_117_code).
 Line 2, characters 39-52:
 2 |   let[@zero_alloc] (f as g) = fun x -> (x + 123, 42) in
                                            ^^^^^^^^^^^^^
@@ -1053,7 +1054,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP107._$.(fun) (camlTOP107__fn[:7,6--67]_117_121_code).
+Error: Annotation check for zero_alloc strict failed on function TOP108._$.(fun) (camlTOP108__fn[:7,6--67]_121_125_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:
@@ -1073,10 +1074,11 @@ let _ =
 - : int -> int = <fun>
 |}];;
 
-(* Non-principal inference. Emits warning. *)
+(* Inference is non-principal because of zero-alloc.
+   Emit a warning when non-principal (if-then-else). *)
 let with_id (f : (('a -> 'a)[@zero_alloc arity 1]) -> 'b) = f (fun x -> x);;
 
-let _ = with_id (fun id -> id 4, id 17);;
+let _ = with_id (fun (id [@zero_alloc arity 1]) -> id 4, id 17);;
 
 let non_principal p f =
   if p then with_id f
@@ -1102,7 +1104,7 @@ let _ =
 Line 3, characters 2-16:
 3 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP112._$.g (camlTOP112__g_138_141_code).
+Error: Annotation check for zero_alloc failed on function TOP113._$.g (camlTOP113__g_142_145_code).
 Line 3, characters 12-16:
 3 |   and g x = x, x in
                 ^^^^
@@ -1119,14 +1121,16 @@ let _ =
 Line 5, characters 2-16:
 5 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP113._$.g (camlTOP113__g_142_146_code).
+Error: Annotation check for zero_alloc strict failed on function TOP114._$.g (camlTOP114__g_146_150_code).
 Line 5, characters 12-16:
 5 |   and g x = x, x in
                 ^^^^
 Error: allocation of 24 bytes
 |}];;
 
-(* Error if zero_alloc is placed on a function parameter that is . *)
+(* Error if [@zero_alloc] is placed on a pattern that does not bind a single
+   variable. Covers function parameters and match cases; constructor patterns
+   and aliased or-patterns alike. *)
 type a = A
 let _ = fun (A [@zero_alloc arity 1]) -> A;;
 [%%expect {|
@@ -1159,4 +1163,33 @@ Line 2, characters 4-18:
         ^^^^^^^^^^^^^^
 Error: The "zero_alloc" attribute is only supported on patterns that bind
        a variable.
+|}];;
+
+(* Side-effects / impure example *)
+(* Here we cannot place [%%expect {|...|}] after a separately-defined print_num,
+   because inserting [%%expect] forces the compilation of print_num to native code
+   and completes backend analysis.
+   This means that backend analysis of print_num does not occur once it appears as
+   an argument of an application of a function with zero_alloc requirements.
+   This behaviour does not occur in any meaningful way outside of expect tests. *)
+(* CR-soon aivaskovic: see if the semantics can be changed *)
+let _ =
+  let print_num n =
+    Format.printf "allocates str %d" n;
+    n
+  in
+  let attempt_to_apply (f [@zero_alloc arity 1]) = f 42 in
+  attempt_to_apply print_num;;
+[%%expect {|
+Lines 2-4, characters 2-5:
+2 | ..let print_num n =
+3 |     Format.printf "allocates str %d" n;
+4 |     n
+Error: Annotation check for zero_alloc failed on function TOP120._$.print_num (camlTOP120__print_num_151_153_code).
+Line 3, characters 4-38:
+3 |     Format.printf "allocates str %d" n;
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: called function may allocate (indirect call)
+File "format.ml", lines 1498-1500, characters 2-18:
+Error: called function may allocate (direct call camlCamlinternalFormat__make_printf_120_401_code) (:3,4--38)
 |}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -881,6 +881,16 @@ val use_annotated_ignore_alias :
   (('a -> 'b) [@zero_alloc arity 1]) -> 'a -> 'b [@@zero_alloc] = <fun>
 |}];;
 
+(* Do aliases have the same zero_alloc properties? *)
+let _ =
+  let[@zero_alloc] (f as g) = fun x -> x + 123 in
+  let _ = require_za_arity_1 f in
+  let _ = require_za_arity_1 g in
+  ()
+[%%expect {|
+- : unit = ()
+|}];;
+
 (** `external` declarations and zero_alloc parameters.
     Zero_alloc attributes on parameters of `external` declarations behave
     the same as on `val` declarations in signatures. *)
@@ -929,7 +939,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP98._$.(fun) (camlTOP98__fn[:7,6--67]_83_87_code).
+Error: Annotation check for zero_alloc strict failed on function TOP99._$.(fun) (camlTOP99__fn[:7,6--67]_85_89_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -71,9 +71,10 @@ let _ =
 Line 3, characters 21-22:
 3 |   require_za_arity_1 f;; (* should fail *)
                          ^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
@@ -91,18 +92,9 @@ Line 2, characters 6-31:
 Error: The "zero_alloc" attribute on this function parameter conflicts
        with the one on its type.
        When using "zero_alloc" on function parameters, the arities in the
-       type of the function and the parameter term mus match exactly.
+       type of the function and the parameter term must match exactly.
        Here the arity in the actual parameter term is 1 and the arity in
        the type of the function is 2.
-|}];;
-
-let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
-[%%expect {|
-Line 1, characters 19-44:
-1 | let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The arity in the "zero_alloc" attribute (2) does not match the
-       number of parameters in the argument type (1).
 |}];;
 
 let[@zero_alloc] f (g [@zero_alloc arity 2]) x = g x;; (* should fail *)
@@ -163,8 +155,10 @@ let _ =
 Line 3, characters 16-17:
 3 |   test_f_strict f;;  (* should fail *)
                     ^
-Error: Function argument zero alloc assumption violated.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
+       The argument's "zero_alloc" property is required to be "strict",
+       but this function is not.
 |}];;
 
 (* checks with opt *)
@@ -175,7 +169,7 @@ let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
 Line 1, characters 5-15:
 1 | let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
          ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP21.f (camlTOP21__f_18_19_code).
+Error: Annotation check for zero_alloc failed on function TOP20.f (camlTOP20__f_18_19_code).
 Line 2, characters 39-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;; (* should fail *)
                                            ^^^^
@@ -210,12 +204,6 @@ Line 1, characters 21-63:
 Error: "assume" is not permitted in "zero_alloc" attributes on function arguments.
 |}];;
 
-let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
-  fun (g [@zero_alloc arity 1]) -> g 42;; (* should succeed *)
-[%%expect {|
-val f : ((int -> int) [@zero_alloc arity 1]) -> int [@@zero_alloc] = <fun>
-|}];;
-
 (* partial application *)
 let _ =
   let[@zero_alloc] f x y = x + y in
@@ -225,9 +213,10 @@ let _ =
 Line 4, characters 21-23:
 4 |   require_za_arity_1 f';; (* should fail; f' zero_alloc information is not available *)
                          ^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (* partial application with specified zero_alloc *)
@@ -239,9 +228,10 @@ let _ =
 Line 4, characters 21-23:
 4 |   require_za_arity_1 f';; (* should fail *)
                          ^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let _ = require_za_arity_1 (fun[@zero_alloc] x -> 42);; (* should succeed *)
@@ -254,7 +244,7 @@ let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in 
 Line 1, characters 33-43:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                      ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP29._$.(fun) (camlTOP29__fn[:1,27--59]_26_27_code).
+Error: Annotation check for zero_alloc failed on function TOP27._$.(fun) (camlTOP27__fn[:1,27--59]_24_25_code).
 Line 1, characters 50-58:
 1 | let _ = require_za_arity_1 (fun[@zero_alloc] x -> (x, 123));; (* should fail in the backend *)
                                                       ^^^^^^^^
@@ -282,7 +272,7 @@ let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
 Line 1, characters 27-41:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP33._$.(fun) (camlTOP33__fn[:1,27--41]_34_35_code).
+Error: Annotation check for zero_alloc failed on function TOP31._$.(fun) (camlTOP31__fn[:1,27--41]_32_33_code).
 Line 1, characters 37-40:
 1 | let _ = require_za_arity_1 (fun x -> [x]);; (* should fail in the backend *)
                                          ^^^
@@ -297,9 +287,10 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail; id' is not "syntactically" a function in the let-binding; there is a warning emitted *)
                          ^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let _ =
@@ -310,9 +301,10 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail, as above *)
                          ^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (* eta expansion helps *)
@@ -332,9 +324,10 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail; zero-allocness not inferred *)
                          ^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let _ =
@@ -345,9 +338,10 @@ let _ =
 Line 4, characters 21-24:
 4 |   require_za_arity_1 id';; (* should fail *)
                          ^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 let _ =
@@ -359,7 +353,7 @@ let _ =
 Line 4, characters 7-17:
 4 |   let[@zero_alloc] id' x = (id x, x) in
            ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP39._$.id' (camlTOP39__id'_41_43_code).
+Error: Annotation check for zero_alloc failed on function TOP37._$.id' (camlTOP37__id'_39_41_code).
 Line 4, characters 27-36:
 4 |   let[@zero_alloc] id' x = (id x, x) in
                                ^^^^^^^^^
@@ -504,28 +498,37 @@ Error: Signature mismatch:
            [@@zero_alloc]
        The type "(int -> int -> 'a) -> 'a" is not compatible with the type
          "((int -> int -> 'a) [@zero_alloc arity 2]) -> 'a"
-       The two types must agree on "zero_alloc": either both carry the annotation or neither does.
+       The two types must agree on "zero_alloc":
+       either both carry the annotation or neither does.
 |}];;
 
 (* Interaction between the two meanings of Tpoly. *)
 let w2 : ('a. (('a -> int) [@zero_alloc])) -> int =
   fun (f [@zero_alloc arity 1]) -> f 123;;
 [%%expect {|
-val w2 : (('a. 'a -> int) [@zero_alloc arity 1]) -> int = <fun>
+val w2 :
+  ((('a. (('a -> int) [@zero_alloc arity 1]))) [@zero_alloc arity 1]) -> int =
+  <fun>
 |}];;
 
 (* zero_alloc on the Ptyp_poly node; arity inferred. *)
 let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
   fun (f [@zero_alloc arity 1]) -> f 123;;
 [%%expect {|
-val w3 : (('a. 'a -> int) [@zero_alloc arity 1]) -> int = <fun>
+Line 1, characters 9-45:
+1 | let w3 : ('a. 'a -> int) [@zero_alloc] -> int =
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "zero_alloc" attributes on function arguments require the argument
+       to be a function type.
 |}];;
 
 (* zero_alloc on the Ptyp_poly node with explicit arity. *)
-let w4 : ('a. 'a -> int) [@zero_alloc arity 1] -> int =
+let w4 : ('a. (('a -> int) [@zero_alloc arity 1])) -> int =
   fun (f [@zero_alloc arity 1]) -> f 123;;
 [%%expect {|
-val w4 : (('a. 'a -> int) [@zero_alloc arity 1]) -> int = <fun>
+val w4 :
+  ((('a. (('a -> int) [@zero_alloc arity 1]))) [@zero_alloc arity 1]) -> int =
+  <fun>
 |}];;
 
 (* Wrong explicit arity should fail. *)
@@ -548,6 +551,35 @@ Line 1, characters 9-17:
              ^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
+|}];;
+
+(* Polymorphic type annotation on the argument pattern, no "zero_alloc". *)
+let w7 : ('a. (('a -> 'a) [@zero_alloc])) -> int =
+  fun (f : 'a. 'a -> 'a) -> f 123;;
+[%%expect {|
+Line 2, characters 7-23:
+2 |   fun (f : 'a. 'a -> 'a) -> f 123;;
+           ^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type "'a. 'a -> 'a"
+       but a pattern was expected which matches values of type
+         "('a. (('a -> 'a) [@zero_alloc arity 1]))"
+       The two types must agree on "zero_alloc":
+       either both carry the annotation or neither does.
+|}];;
+
+(* Polymorphic type annotation on the argument pattern, no "zero_alloc"
+   on constraining type. *)
+let w8 : ('a. 'a -> 'a) -> int =
+  fun (f : 'a. (('a -> 'a) [@zero_alloc])) -> f 123;;
+[%%expect {|
+Line 2, characters 7-41:
+2 |   fun (f : 'a. (('a -> 'a) [@zero_alloc])) -> f 123;;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type
+         "('a. (('a -> 'a) [@zero_alloc arity 1]))"
+       but a pattern was expected which matches values of type "'a. 'a -> 'a"
+       The two types must agree on "zero_alloc":
+       either both carry the annotation or neither does.
 |}];;
 
 (* Does zero-alloc information propagate across aliases?
@@ -608,8 +640,10 @@ let[@zero_alloc] test_with_fc_module_2 (module M : S2) x =
 Line 2, characters 16-21:
 2 |   test_f_strict M.bam;;
                     ^^^^^
-Error: Function argument zero alloc assumption violated.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
+       The argument's "zero_alloc" property is required to be "strict",
+       but this function is not.
 |}];;
 
 let[@zero_alloc] test_with_fc_module_3 (module M : S3) x =
@@ -618,9 +652,10 @@ let[@zero_alloc] test_with_fc_module_3 (module M : S3) x =
 Line 2, characters 16-21:
 2 |   test_f_strict M.bal;;
                     ^^^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (** Dealing with inference: what happens when there are multiple competing
@@ -642,60 +677,48 @@ Error: The arity in the "zero_alloc" attribute (2) does not match the
 |}];;
 
 let _ =
-  let f x = x + 123 in
-  let _ = g1 f in
-  let _ = g2 f in
-  f;;
-[%%expect {|
-Line 3, characters 13-14:
-3 |   let _ = g1 f in
-                 ^
-Error: Function argument zero alloc assumption violated.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
-|}];;
-
-let _ =
-  let f x = x + 123 in
+  let[@zero_alloc] f x = x + 123 in
   let _ = g1 f in
   let _ = g2 f in
   let _ = g3 f in
   f;;
 [%%expect {|
-Line 3, characters 13-14:
-3 |   let _ = g1 f in
+Line 4, characters 13-14:
+4 |   let _ = g2 f in
                  ^
-Error: Function argument zero alloc assumption violated.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
+       The argument's "zero_alloc" property is required to be "strict",
+       but this function is not.
 |}];;
 
 let _ =
-  let f x = x + 123 in
-  let _ = g2 f in
-  let _ = g1 f in
+  let[@zero_alloc strict] f_strict x = x + 123 in
+  let _ = g1 f_strict in
+  let _ = g2 f_strict in
+  let _ = g3 f_strict in
   f;;
 [%%expect {|
-Line 3, characters 13-14:
-3 |   let _ = g2 f in
-                 ^
-Error: Function argument zero alloc assumption violated.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+Line 5, characters 10-12:
+5 |   let _ = g3 f_strict in
+              ^^
+Error: Unbound value "g3"
 |}];;
 
-let f_inferred x = x + 123;;
-let _ = g1 f_inferred;;
-let _ = g2 f_inferred;;
-let _ = g3 f_inferred;;
+let _ =
+  let f_unannotated x = x + 123 in
+  let _ = g1 f_unannotated in
+  let _ = g2 f_unannotated in
+  let _ = g3 f_unannotated in
+  f_unannotated
 [%%expect {|
-val f_inferred : int -> int = <fun>
-Line 2, characters 11-21:
-2 | let _ = g1 f_inferred;;
-               ^^^^^^^^^^
-Error: Function argument zero alloc assumption violated.
+Line 3, characters 13-26:
+3 |   let _ = g1 f_unannotated in
+                 ^^^^^^^^^^^^^
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (* custom error messages can be placed on zero_alloc parameters *)
@@ -712,7 +735,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP76.F.g.(fun) (camlTOP76__fn[:6,17--50]_64_67_code).
+Error: Annotation check for zero_alloc failed on function TOP74.F.g.(fun) (camlTOP74__fn[:6,17--50]_58_61_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -768,9 +791,10 @@ ignore (needs_za_1 f);;
 Line 3, characters 19-20:
 3 | ignore (needs_za_1 f);;
                        ^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (** Aliases and zero_alloc parameters.
@@ -812,9 +836,10 @@ val fn_alias : int -> int = <fun>
 Line 3, characters 27-35:
 3 | let _ = require_za_arity_1 fn_alias
                                ^^^^^^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (* A local alias of a zero_alloc parameter also loses the guarantee.
@@ -827,9 +852,10 @@ let[@zero_alloc] use_local_alias (f[@zero_alloc arity 1]) =
 Line 3, characters 21-22:
 3 |   require_za_arity_1 g
                          ^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (** Pattern aliases and zero_alloc parameters.
@@ -895,4 +921,36 @@ Line 2, characters 15-41:
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: "zero_alloc" attributes on function arguments require the argument
        to be a function type.
+|}];;
+
+(* zero_alloc: strict requirement, not strict function; fails in backend *)
+let _ =
+  let exception Err of string in
+  let[@zero_alloc] apply_strict (f [@zero_alloc strict arity 1]) a = f a in
+  fun a ->
+    apply_strict
+      (* use string_of_int to ensure allocation of argument to Err *)
+      (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
+[%%expect {|
+Line 7, characters 6-67:
+7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc strict failed on function TOP98._$.(fun) (camlTOP98__fn[:7,6--67]_81_85_code).
+File "stdlib.ml", line 280, characters 2-19:
+Error: called function may allocate (external call to caml_format_int) (:7,41--58)
+Line 7, characters 36-59:
+7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
+                                        ^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+(* zero_alloc: strict requirement, inferred strict function; succeeds *)
+let _ =
+  let[@zero_alloc] apply_strict (f [@zero_alloc strict arity 1]) a = f a in
+  fun a ->
+    apply_strict
+      (* use string_of_int to ensure allocation of argument to Err *)
+      (fun x -> if x < 0 then 123 else x) a;;
+[%%expect {|
+- : int -> int = <fun>
 |}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -680,7 +680,6 @@ let _ =
   let[@zero_alloc] f x = x + 123 in
   let _ = g1 f in
   let _ = g2 f in
-  let _ = g3 f in
   f;;
 [%%expect {|
 Line 4, characters 13-14:
@@ -696,20 +695,15 @@ let _ =
   let[@zero_alloc strict] f_strict x = x + 123 in
   let _ = g1 f_strict in
   let _ = g2 f_strict in
-  let _ = g3 f_strict in
-  f;;
+  f_strict;;
 [%%expect {|
-Line 5, characters 10-12:
-5 |   let _ = g3 f_strict in
-              ^^
-Error: Unbound value "g3"
+- : int -> int = <fun>
 |}];;
 
 let _ =
   let f_unannotated x = x + 123 in
   let _ = g1 f_unannotated in
   let _ = g2 f_unannotated in
-  let _ = g3 f_unannotated in
   f_unannotated
 [%%expect {|
 Line 3, characters 13-26:
@@ -735,7 +729,7 @@ module type S = sig val f : ((int -> int) [@zero_alloc arity 1]) -> int end
 Line 6, characters 17-50:
 6 |   let g () = X.f (fun x -> Format.printf "foo"; x)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP74.F.g.(fun) (camlTOP74__fn[:6,17--50]_58_61_code).
+Error: Annotation check for zero_alloc failed on function TOP74.F.g.(fun) (camlTOP74__fn[:6,17--50]_60_63_code).
 my specific error
 
 File "format.ml", lines 1498-1500, characters 2-18:
@@ -935,7 +929,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP98._$.(fun) (camlTOP98__fn[:7,6--67]_81_85_code).
+Error: Annotation check for zero_alloc strict failed on function TOP98._$.(fun) (camlTOP98__fn[:7,6--67]_83_87_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param.ml
@@ -974,6 +974,17 @@ Line 2, characters 39-52:
 Error: allocation of 24 bytes
 |}];;
 
+(* Chained aliases: all three names should carry the zero_alloc property. *)
+let _ =
+  let[@zero_alloc] ((f as g) as h) = fun x -> x + 123 in
+  let _ = require_za_arity_1 f in
+  let _ = require_za_arity_1 g in
+  let _ = require_za_arity_1 h in
+  ()
+[%%expect {|
+- : unit = ()
+|}];;
+
 (** `external` declarations and zero_alloc parameters.
     Zero_alloc attributes on parameters of `external` declarations behave
     the same as on `val` declarations in signatures. *)
@@ -1022,7 +1033,7 @@ let _ =
 Line 7, characters 6-67:
 7 |       (fun x -> if x < 0 then raise (Err (string_of_int x)) else x) a;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP104._$.(fun) (camlTOP104__fn[:7,6--67]_115_119_code).
+Error: Annotation check for zero_alloc strict failed on function TOP105._$.(fun) (camlTOP105__fn[:7,6--67]_117_121_code).
 File "stdlib.ml", line 280, characters 2-19:
 Error: called function may allocate (external call to caml_format_int) (:7,41--58)
 Line 7, characters 36-59:
@@ -1071,7 +1082,7 @@ let _ =
 Line 3, characters 2-16:
 3 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP109._$.g (camlTOP109__g_136_139_code).
+Error: Annotation check for zero_alloc failed on function TOP110._$.g (camlTOP110__g_138_141_code).
 Line 3, characters 12-16:
 3 |   and g x = x, x in
                 ^^^^
@@ -1088,7 +1099,7 @@ let _ =
 Line 5, characters 2-16:
 5 |   and g x = x, x in
       ^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc strict failed on function TOP110._$.g (camlTOP110__g_140_144_code).
+Error: Annotation check for zero_alloc strict failed on function TOP111._$.g (camlTOP111__g_142_146_code).
 Line 5, characters 12-16:
 5 |   and g x = x, x in
                 ^^^^

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param_all.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param_all.ml
@@ -1,0 +1,53 @@
+(* TEST
+   flags = "-w +198";
+   expect.opt;
+*)
+
+[@@@zero_alloc all];;
+[%%expect {|
+|}];;
+
+(* Higher-order function: argument must be zero_alloc. *)
+let apply (f [@zero_alloc arity 1]) x = f x;;
+[%%expect {|
+val apply : (('a -> 'b) [@zero_alloc arity 1]) -> 'a -> 'b [@@zero_alloc] =
+  <fun>
+|}];;
+
+(* Higher-order function: no zero_alloc requirement on the argument. *)
+let apply_any f x = f x;;
+[%%expect {|
+Line 1, characters 14-23:
+1 | let apply_any f x = f x;;
+                  ^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP3.apply_any (camlTOP3__apply_any_2_3_code).
+Line 1, characters 20-23:
+1 | let apply_any f x = f x;;
+                        ^^^
+Error: called function may allocate (indirect tailcall)
+|}];;
+
+(* Opted out of zero_alloc all. *)
+let[@zero_alloc ignore] apply_ignore f x = f x;;
+[%%expect {|
+val apply_ignore : ('a -> 'b) -> 'a -> 'b = <fun>
+|}];;
+
+(* Argument explicitly ignored: zero_alloc all does not apply to f at the call site. *)
+let apply_ignore_arg (f [@zero_alloc ignore]) x = f x;;
+[%%expect {|
+Line 1, characters 21-53:
+1 | let apply_ignore_arg (f [@zero_alloc ignore]) x = f x;;
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP5.apply_ignore_arg (camlTOP5__apply_ignore_arg_6_7_code).
+Line 1, characters 50-53:
+1 | let apply_ignore_arg (f [@zero_alloc ignore]) x = f x;;
+                                                      ^^^
+Error: called function may allocate (indirect tailcall)
+|}];;
+
+(* Both the function and its argument are ignored. *)
+let[@zero_alloc ignore] apply_both_ignore (f [@zero_alloc ignore]) x = f x;;
+[%%expect {|
+val apply_both_ignore : ('a -> 'b) -> 'a -> 'b = <fun>
+|}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
@@ -1,0 +1,93 @@
+(* TEST
+   flags = "-w +198 -zero-alloc-check opt";
+   expect.opt;
+*)
+
+(** Tests for `[@zero_alloc opt]` on function arguments, run under
+    `-zero-alloc-check opt`. Under this mode, `opt` annotations are active;
+    compare with the analogous tests in zero_alloc_param.ml
+    which run under the default mode where `opt` is inactive. *)
+
+let[@zero_alloc] require_za_arity_1 (f [@zero_alloc arity 1]) =
+  f 42;;
+[%%expect {|
+val require_za_arity_1 : ((int -> 'a) [@zero_alloc arity 1]) -> 'a
+  [@@zero_alloc] = <fun>
+|}];;
+
+let f_requires_opt (g [@zero_alloc opt arity 1]) = g 0;;
+[%%expect {|
+val f_requires_opt : ((int -> 'a) [@zero_alloc opt arity 1]) -> 'a = <fun>
+|}];;
+
+let[@zero_alloc] za_fn x = x + 1;;
+let non_za_fn x = x + 1;;
+[%%expect {|
+val za_fn : int -> int [@@zero_alloc] = <fun>
+val non_za_fn : int -> int = <fun>
+|}];;
+
+(* Passing a [@zero_alloc] function to an opt parameter: succeeds. *)
+let _ = f_requires_opt za_fn;;
+[%%expect {|
+- : int = 1
+|}];;
+
+(* Passing a function with no zero_alloc to an opt parameter: fails under opt
+   mode. Under the default mode this would succeed because opt is inactive. *)
+let _ = f_requires_opt non_za_fn;;
+[%%expect {|
+Line 1, characters 23-32:
+1 | let _ = f_requires_opt non_za_fn;;
+                           ^^^^^^^^^
+Error: Function argument zero alloc assumption violated.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}];;
+
+(* Under opt mode, [@zero_alloc opt] on a function definition is checked. *)
+let[@zero_alloc opt] allocating_fn x = (x, x);; (* should fail in the backend *)
+[%%expect {|
+Line 1, characters 5-15:
+1 | let[@zero_alloc opt] allocating_fn x = (x, x);; (* should fail in the backend *)
+         ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP8.allocating_fn (camlTOP8__allocating_fn_8_9_code).
+Line 1, characters 39-45:
+1 | let[@zero_alloc opt] allocating_fn x = (x, x);; (* should fail in the backend *)
+                                           ^^^^^^
+Error: allocation of 24 bytes
+|}];;
+
+let[@zero_alloc opt] non_allocating_fn x = x + 1;;
+[%%expect {|
+val non_allocating_fn : int -> int [@@zero_alloc opt] = <fun>
+|}];;
+
+(** The same opt vs. non-opt conflict tests as in zero_alloc_param.ml.
+    Under opt mode, [@zero_alloc opt] is a real guarantee, so calling an opt
+    function in a [@zero_alloc] body succeeds (unlike under default mode). *)
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
+  fun (g [@zero_alloc opt arity 1]) -> g 42;;  (* succeeds under opt mode *)
+[%%expect {|
+val f : ((int -> int) [@zero_alloc opt arity 1]) -> int [@@zero_alloc] =
+  <fun>
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc opt]) -> int =
+  fun (g [@zero_alloc arity 1]) -> g 42;;
+[%%expect {|
+val f : ((int -> int) [@zero_alloc opt arity 1]) -> int [@@zero_alloc] =
+  <fun>
+|}];;
+
+let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
+  fun (g [@zero_alloc opt arity 1]) -> g 42;;  (* should fail in the frontend *)
+[%%expect {|
+Line 2, characters 6-35:
+2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;;  (* should fail in the frontend *)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc" attribute on this function parameter conflicts
+       with the one on its type.
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}];;

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
@@ -33,8 +33,10 @@ let _ = f_requires_opt za_fn;;
 - : int = 1
 |}];;
 
-(* Passing a function with no zero_alloc to an opt parameter: fails under opt
-   mode. Under the default mode this would succeed because opt is inactive. *)
+(* Passing an unannotated function to an opt parameter succeeds in both modes.
+   The function's zero_alloc is a unification Var that absorbs the constraint
+   at the call site; the backend then verifies it; here non_za_fn is
+   non-allocating, so the check passes. *)
 let _ = f_requires_opt non_za_fn;;
 [%%expect {|
 - : int = 1

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
@@ -37,13 +37,7 @@ let _ = f_requires_opt za_fn;;
    mode. Under the default mode this would succeed because opt is inactive. *)
 let _ = f_requires_opt non_za_fn;;
 [%%expect {|
-Line 1, characters 23-32:
-1 | let _ = f_requires_opt non_za_fn;;
-                           ^^^^^^^^^
-Error: Mismatch between the "zero_alloc" requirement of the function
-       being applied and this argument.
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the argument's definition.
+- : int = 1
 |}];;
 
 (* Under opt mode, [@zero_alloc opt] on a function definition is checked. *)

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
@@ -40,9 +40,10 @@ let _ = f_requires_opt non_za_fn;;
 Line 1, characters 23-32:
 1 | let _ = f_requires_opt non_za_fn;;
                            ^^^^^^^^^
-Error: Function argument zero alloc assumption violated.
+Error: Mismatch between the "zero_alloc" requirement of the function
+       being applied and this argument.
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute to the argument's definition.
 |}];;
 
 (* Under opt mode, [@zero_alloc opt] on a function definition is checked. *)

--- a/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
+++ b/testsuite/tests/typing-zero-alloc/zero_alloc_param_opt.ml
@@ -85,9 +85,9 @@ val f : ((int -> int) [@zero_alloc opt arity 1]) -> int [@@zero_alloc] =
 let[@zero_alloc] f : ((int -> int) [@zero_alloc]) -> int =
   fun (g [@zero_alloc opt arity 1]) -> g 42;;  (* should fail in the frontend *)
 [%%expect {|
-Line 2, characters 6-35:
+Line 2, characters 2-43:
 2 |   fun (g [@zero_alloc opt arity 1]) -> g 42;;  (* should fail in the frontend *)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The "zero_alloc" attribute on this function parameter conflicts
        with the one on its type.
        The former provides a weaker "zero_alloc" guarantee than the latter.

--- a/testsuite/tests/warnings/w181.compilers.reference
+++ b/testsuite/tests/warnings/w181.compilers.reference
@@ -1,0 +1,25 @@
+File "w181.ml", line 9, characters 0-23:
+9 | let[@zero_alloc] w = 42
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+File "w181.ml", line 11, characters 0-31:
+11 | let x : int = 42 [@@zero_alloc]
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+File "w181.ml", lines 13-15, characters 0-16:
+13 | let[@zero_alloc assume] foo =
+14 |   let y = 42 in
+15 |   fun z -> z + y
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+File "w181.ml", lines 17-19, characters 0-16:
+17 | let[@zero_alloc] bar =
+18 |   let y = 42 in
+19 |   fun z -> z + y
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.

--- a/testsuite/tests/warnings/w181.compilers.reference
+++ b/testsuite/tests/warnings/w181.compilers.reference
@@ -23,3 +23,14 @@ File "w181.ml", lines 17-19, characters 0-16:
 19 |   fun z -> z + y
 Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
 rewrite the binding with explicit parameters or remove the attribute.
+
+File "w181.ml", line 21, characters 0-30:
+21 | let[@zero_alloc] (x as y) = 42
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 181 [zero-alloc-on-nonfunction]: The [@zero_alloc] attribute has no effect on a non-function binding;
+rewrite the binding with explicit parameters or remove the attribute.
+
+File "w181.ml", line 11, characters 4-5:
+11 | let x : int = 42 [@@zero_alloc]
+         ^
+Warning 32 [unused-value-declaration]: unused value x.

--- a/testsuite/tests/warnings/w181.ml
+++ b/testsuite/tests/warnings/w181.ml
@@ -1,0 +1,19 @@
+(* TEST
+ flags = "-w +A-70";
+ setup-ocamlc.byte-build-env;
+ compile_only = "true";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+let[@zero_alloc] w = 42
+
+let x : int = 42 [@@zero_alloc]
+
+let[@zero_alloc assume] foo =
+  let y = 42 in
+  fun z -> z + y
+
+let[@zero_alloc] bar =
+  let y = 42 in
+  fun z -> z + y

--- a/testsuite/tests/warnings/w181.ml
+++ b/testsuite/tests/warnings/w181.ml
@@ -17,3 +17,5 @@ let[@zero_alloc assume] foo =
 let[@zero_alloc] bar =
   let y = 42 in
   fun z -> z + y
+
+let[@zero_alloc] (x as y) = 42

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -808,1007 +808,987 @@ File "w53.ml", line 360, characters 19-29:
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 363, characters 22-32:
-363 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 363, characters 45-55:
-363 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                                                   ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 364, characters 39-49:
-364 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 363, characters 39-49:
+363 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 365, characters 12-22:
-365 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 364, characters 12-22:
+364 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 367, characters 9-19:
-367 |   class[@zero_alloc] c : (* rejected *)
+File "w53.ml", line 366, characters 9-19:
+366 |   class[@zero_alloc] c : (* rejected *)
                ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53.ml", line 368, characters 11-21:
+368 |       val[@zero_alloc] foo : int * int (* rejected *)
+                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53.ml", line 369, characters 11-21:
-369 |       val[@zero_alloc] foo : int * int (* rejected *)
+369 |       val[@zero_alloc] bar : int -> int (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 370, characters 11-21:
-370 |       val[@zero_alloc] bar : int -> int (* rejected *)
-                 ^^^^^^^^^^
+File "w53.ml", line 370, characters 14-24:
+370 |       method[@zero_alloc] baz : int * int (* rejected *)
+                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53.ml", line 371, characters 14-24:
-371 |       method[@zero_alloc] baz : int * int (* rejected *)
+371 |       method[@zero_alloc] boz : int -> int (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 372, characters 14-24:
-372 |       method[@zero_alloc] boz : int -> int (* rejected *)
-                    ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 377, characters 21-31:
-377 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53.ml", line 376, characters 21-31:
+376 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 378, characters 19-29:
-378 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53.ml", line 377, characters 19-29:
+377 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 379, characters 22-32:
-379 |   let x : int = 42 [@@zero_alloc] (* rejected *)
+File "w53.ml", line 378, characters 22-32:
+378 |   let x : int = 42 [@@zero_alloc] (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 381, characters 7-17:
-381 |   let[@zero_alloc] w = 42 (* rejected *)
+File "w53.ml", line 380, characters 7-17:
+380 |   let[@zero_alloc] w = 42 (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 385, characters 22-32:
-385 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 385, characters 45-55:
-385 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                                                   ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 386, characters 39-49:
-386 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 384, characters 39-49:
+384 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 387, characters 12-22:
-387 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 385, characters 12-22:
+385 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 389, characters 9-19:
-389 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53.ml", line 387, characters 9-19:
+387 |   class[@zero_alloc] foo _y = (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 391, characters 10-20:
-391 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53.ml", line 389, characters 10-20:
+389 |     (fun[@zero_alloc] z -> (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 393, characters 11-21:
-393 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53.ml", line 391, characters 11-21:
+391 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 395, characters 14-24:
-395 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
+File "w53.ml", line 393, characters 14-24:
+393 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 407, characters 14-24:
-407 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+File "w53.ml", line 405, characters 14-24:
+405 |     ((boz x)[@zero_alloc assume]) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 412, characters 7-17:
-412 |   let[@zero_alloc assume] foo = (* rejected *)
+File "w53.ml", line 410, characters 7-17:
+410 |   let[@zero_alloc assume] foo = (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 416, characters 7-17:
-416 |   let[@zero_alloc] bar = (* rejected *)
+File "w53.ml", line 414, characters 7-17:
+414 |   let[@zero_alloc] bar = (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 422, characters 24-29:
-422 |   type t1 = { x : int [@boxed] } (* rejected *)
+File "w53.ml", line 420, characters 24-29:
+420 |   type t1 = { x : int [@boxed] } (* rejected *)
                               ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 424, characters 16-21:
-424 |   val x : int [@boxed] (* rejected *)
+File "w53.ml", line 422, characters 16-21:
+422 |   val x : int [@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 428, characters 17-22:
-428 |   val y : int [@@boxed] (* rejected *)
+File "w53.ml", line 426, characters 17-22:
+426 |   val y : int [@@boxed] (* rejected *)
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 430, characters 6-11:
-430 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 428, characters 6-11:
+428 |   [@@@boxed] (* rejected *)
             ^^^^^
+Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+
+File "w53.ml", line 432, characters 16-21:
+432 |   let x = (42 [@boxed], 84) (* rejected *)
+                      ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
 File "w53.ml", line 434, characters 16-21:
-434 |   let x = (42 [@boxed], 84) (* rejected *)
+434 |   let y = 10 [@@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 436, characters 16-21:
-436 |   let y = 10 [@@boxed] (* rejected *)
-                      ^^^^^
-Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
-
-File "w53.ml", line 438, characters 6-11:
-438 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 436, characters 6-11:
+436 |   [@@@boxed] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 445, characters 16-26:
-445 |   val x : int [@deprecated] (* rejected *)
+File "w53.ml", line 443, characters 16-26:
+443 |   val x : int [@deprecated] (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 451, characters 6-16:
-451 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 449, characters 6-16:
+449 |   [@@@deprecated] (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 455, characters 14-24:
-455 |   let x = 5 [@deprecated] (* rejected *)
+File "w53.ml", line 453, characters 14-24:
+453 |   let x = 5 [@deprecated] (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 457, characters 16-26:
-457 |   let y = 10 [@@deprecated] (* rejected *)
+File "w53.ml", line 455, characters 16-26:
+455 |   let y = 10 [@@deprecated] (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 459, characters 6-16:
-459 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 457, characters 6-16:
+457 |   [@@@deprecated] (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 464, characters 19-37:
-464 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 462, characters 19-37:
+462 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
                          ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 466, characters 16-34:
-466 |   val x : int [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 464, characters 16-34:
+464 |   val x : int [@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 468, characters 21-39:
-468 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 466, characters 21-39:
+466 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 472, characters 24-42:
-472 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
+File "w53.ml", line 470, characters 24-42:
+470 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
                               ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 474, characters 17-35:
-474 |   val y : int [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 472, characters 17-35:
+472 |   val y : int [@@deprecated_mutable] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 476, characters 6-24:
-476 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 474, characters 6-24:
+474 |   [@@@deprecated_mutable] (* rejected *)
             ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 480, characters 14-32:
-480 |   let x = 5 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 478, characters 14-32:
+478 |   let x = 5 [@deprecated_mutable] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 482, characters 16-34:
-482 |   let y = 10 [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 480, characters 16-34:
+480 |   let y = 10 [@@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 484, characters 6-24:
-484 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 482, characters 6-24:
+482 |   [@@@deprecated_mutable] (* rejected *)
             ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 489, characters 32-46:
-489 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
+File "w53.ml", line 487, characters 32-46:
+487 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
                                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 491, characters 16-30:
-491 |   val x : int [@explicit_arity] (* rejected *)
+File "w53.ml", line 489, characters 16-30:
+489 |   val x : int [@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 493, characters 20-34:
-493 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
+File "w53.ml", line 491, characters 20-34:
+491 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
                           ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 495, characters 17-31:
-495 |   val y : int [@@explicit_arity] (* rejected *)
+File "w53.ml", line 493, characters 17-31:
+493 |   val y : int [@@explicit_arity] (* rejected *)
                        ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 497, characters 6-20:
-497 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 495, characters 6-20:
+495 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 501, characters 14-28:
-501 |   let x = 5 [@explicit_arity] (* rejected *)
+File "w53.ml", line 499, characters 14-28:
+499 |   let x = 5 [@explicit_arity] (* rejected *)
                     ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 503, characters 16-30:
-503 |   let y = 10 [@@explicit_arity] (* rejected *)
+File "w53.ml", line 501, characters 16-30:
+501 |   let y = 10 [@@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 505, characters 6-20:
-505 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 503, characters 6-20:
+503 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 510, characters 18-27:
-510 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 508, characters 18-27:
+508 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 514, characters 16-25:
-514 |   val x : int [@immediate] (* rejected *)
+File "w53.ml", line 512, characters 16-25:
+512 |   val x : int [@immediate] (* rejected *)
                       ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 515, characters 17-26:
-515 |   val x : int [@@immediate] (* rejected *)
+File "w53.ml", line 513, characters 17-26:
+513 |   val x : int [@@immediate] (* rejected *)
                        ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 517, characters 6-15:
-517 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 515, characters 6-15:
+515 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 518, characters 6-17:
-518 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 516, characters 6-17:
+516 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 522, characters 15-24:
-522 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 520, characters 15-24:
+520 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                      ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 522, characters 32-43:
-522 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 520, characters 32-43:
+520 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                                       ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 523, characters 21-30:
-523 |   let y = (4, 42) [@@immediate] (* rejected *)
+File "w53.ml", line 521, characters 21-30:
+521 |   let y = (4, 42) [@@immediate] (* rejected *)
                            ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 524, characters 21-32:
-524 |   let z = (4, 42) [@@immediate64] (* rejected *)
+File "w53.ml", line 522, characters 21-32:
+522 |   let z = (4, 42) [@@immediate64] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 526, characters 18-27:
-526 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 524, characters 18-27:
+524 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 530, characters 6-15:
-530 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 528, characters 6-15:
+528 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 531, characters 6-17:
-531 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 529, characters 6-17:
+529 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 536, characters 25-31:
-536 |   type t1 = int -> int [@inline] (* rejected *)
+File "w53.ml", line 534, characters 25-31:
+534 |   type t1 = int -> int [@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 537, characters 26-32:
-537 |   type t2 = int -> int [@@inline] (* rejected *)
+File "w53.ml", line 535, characters 26-32:
+535 |   type t2 = int -> int [@@inline] (* rejected *)
                                 ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 538, characters 25-32:
-538 |   type t3 = int -> int [@inlined] (* rejected *)
+File "w53.ml", line 536, characters 25-32:
+536 |   type t3 = int -> int [@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 539, characters 26-33:
-539 |   type t4 = int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 537, characters 26-33:
+537 |   type t4 = int -> int [@@inlined] (* rejected *)
                                 ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 541, characters 24-30:
-541 |   val f1 : int -> int [@inline] (* rejected *)
+File "w53.ml", line 539, characters 24-30:
+539 |   val f1 : int -> int [@inline] (* rejected *)
                               ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 542, characters 25-31:
-542 |   val f2 : int -> int [@@inline] (* rejected *)
+File "w53.ml", line 540, characters 25-31:
+540 |   val f2 : int -> int [@@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 543, characters 24-31:
-543 |   val f3 : int -> int [@inlined] (* rejected *)
+File "w53.ml", line 541, characters 24-31:
+541 |   val f3 : int -> int [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 544, characters 25-32:
-544 |   val f4 : int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 542, characters 25-32:
+542 |   val f4 : int -> int [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 546, characters 53-59:
-546 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
+File "w53.ml", line 544, characters 53-59:
+544 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
                                                            ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 547, characters 54-60:
-547 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
+File "w53.ml", line 545, characters 54-60:
+545 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
                                                             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 549, characters 6-12:
-549 |   [@@@inline] (* rejected *)
+File "w53.ml", line 547, characters 6-12:
+547 |   [@@@inline] (* rejected *)
             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 550, characters 6-13:
-550 |   [@@@inlined] (* rejected *)
+File "w53.ml", line 548, characters 6-13:
+548 |   [@@@inlined] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 554, characters 16-22:
-554 |   let h x = x [@inline] (* rejected *)
+File "w53.ml", line 552, characters 16-22:
+552 |   let h x = x [@inline] (* rejected *)
                       ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 555, characters 16-28:
-555 |   let h x = x [@ocaml.inline] (* rejected *)
+File "w53.ml", line 553, characters 16-28:
+553 |   let h x = x [@ocaml.inline] (* rejected *)
                       ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 557, characters 16-23:
-557 |   let i x = x [@inlined] (* rejected *)
+File "w53.ml", line 555, characters 16-23:
+555 |   let i x = x [@inlined] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 558, characters 16-29:
-558 |   let j x = x [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 556, characters 16-29:
+556 |   let j x = x [@ocaml.inlined] (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 561, characters 18-25:
-561 |   let l x = h x [@inlined] (* rejected *)
+File "w53.ml", line 559, characters 18-25:
+559 |   let l x = h x [@inlined] (* rejected *)
                         ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 569, characters 27-33:
-569 |   module C = struct end [@@inline] (* rejected *)
+File "w53.ml", line 567, characters 27-33:
+567 |   module C = struct end [@@inline] (* rejected *)
                                  ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 570, characters 28-40:
-570 |   module C' = struct end [@@ocaml.inline] (* rejected *)
+File "w53.ml", line 568, characters 28-40:
+568 |   module C' = struct end [@@ocaml.inline] (* rejected *)
                                   ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 571, characters 27-34:
-571 |   module D = struct end [@@inlined] (* rejected *)
+File "w53.ml", line 569, characters 27-34:
+569 |   module D = struct end [@@inlined] (* rejected *)
                                  ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 572, characters 28-41:
-572 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 570, characters 28-41:
+570 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
                                   ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 576, characters 18-24:
-576 |   module G = (A [@inline])(struct end) (* rejected *)
+File "w53.ml", line 574, characters 18-24:
+574 |   module G = (A [@inline])(struct end) (* rejected *)
                         ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 577, characters 19-31:
-577 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
+File "w53.ml", line 575, characters 19-31:
+575 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
                          ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 581, characters 24-31:
-581 |   module I = Set.Make [@inlined] (* rejected *)
+File "w53.ml", line 579, characters 24-31:
+579 |   module I = Set.Make [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 582, characters 25-38:
-582 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 580, characters 25-38:
+580 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 584, characters 25-32:
-584 |   module J = Set.Make [@@inlined] (* rejected *)
+File "w53.ml", line 582, characters 25-32:
+582 |   module J = Set.Make [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 585, characters 26-39:
-585 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 583, characters 26-39:
+583 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
                                 ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 590, characters 21-28:
-590 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 588, characters 21-28:
+588 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 591, characters 19-26:
-591 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 589, characters 19-26:
+589 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 592, characters 19-26:
-592 |   val x : int64 [@@noalloc] (* rejected *)
+File "w53.ml", line 590, characters 19-26:
+590 |   val x : int64 [@@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 594, characters 24-31:
-594 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 592, characters 24-31:
+592 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 594, characters 46-53:
-594 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 592, characters 46-53:
+592 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 599, characters 21-28:
-599 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 597, characters 21-28:
+597 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 600, characters 19-26:
-600 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 598, characters 19-26:
+598 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 601, characters 25-32:
-601 |   let x : int64 = 42L [@@noalloc] (* rejected *)
+File "w53.ml", line 599, characters 25-32:
+599 |   let x : int64 = 42L [@@noalloc] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 603, characters 24-31:
-603 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 601, characters 24-31:
+601 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 603, characters 46-53:
-603 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 601, characters 46-53:
+601 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 632, characters 21-29:
-632 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 630, characters 21-29:
+630 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 633, characters 19-27:
-633 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 631, characters 19-27:
+631 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 634, characters 16-24:
-634 |   val x : int [@tailcall] (* rejected *)
+File "w53.ml", line 632, characters 16-24:
+632 |   val x : int [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 636, characters 35-43:
-636 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 634, characters 35-43:
+634 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 638, characters 6-14:
-638 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 636, characters 6-14:
+636 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 642, characters 21-29:
-642 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 640, characters 21-29:
+640 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 643, characters 19-27:
-643 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 641, characters 19-27:
+641 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 645, characters 16-24:
-645 |   let m x = x [@tailcall] (* rejected *)
+File "w53.ml", line 643, characters 16-24:
+643 |   let m x = x [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 646, characters 16-30:
-646 |   let n x = x [@ocaml.tailcall] (* rejected *)
+File "w53.ml", line 644, characters 16-30:
+644 |   let n x = x [@ocaml.tailcall] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 649, characters 18-26:
-649 |   let q x = m x [@tailcall] (* rejected *)
+File "w53.ml", line 647, characters 18-26:
+647 |   let q x = m x [@tailcall] (* rejected *)
                         ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 651, characters 35-43:
-651 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 649, characters 35-43:
+649 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 653, characters 6-14:
-653 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 651, characters 6-14:
+651 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 658, characters 24-31:
-658 |   type t1 = { x : int [@unboxed] } (* rejected *)
+File "w53.ml", line 656, characters 24-31:
+656 |   type t1 = { x : int [@unboxed] } (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 660, characters 16-23:
-660 |   val x : int [@unboxed] (* rejected *)
+File "w53.ml", line 658, characters 16-23:
+658 |   val x : int [@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 664, characters 17-24:
-664 |   val y : int [@@unboxed] (* rejected *)
+File "w53.ml", line 662, characters 17-24:
+662 |   val y : int [@@unboxed] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 668, characters 6-13:
-668 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 666, characters 6-13:
+666 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
+Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
+
+File "w53.ml", line 670, characters 16-23:
+670 |   let x = (42 [@unboxed], 84) (* rejected *)
+                      ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
 File "w53.ml", line 672, characters 16-23:
-672 |   let x = (42 [@unboxed], 84) (* rejected *)
+672 |   let y = 10 [@@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 674, characters 16-23:
-674 |   let y = 10 [@@unboxed] (* rejected *)
-                      ^^^^^^^
-Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
-
-File "w53.ml", line 678, characters 6-13:
-678 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 676, characters 6-13:
+676 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 683, characters 21-29:
-683 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 681, characters 21-29:
+681 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 684, characters 19-27:
-684 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 682, characters 19-27:
+682 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 685, characters 17-25:
-685 |   val x : int [@@untagged] (* rejected *)
+File "w53.ml", line 683, characters 17-25:
+683 |   val x : int [@@untagged] (* rejected *)
                        ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 692, characters 21-29:
-692 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 690, characters 21-29:
+690 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 693, characters 19-27:
-693 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 691, characters 19-27:
+691 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 694, characters 22-30:
-694 |   let x : int = 42 [@@untagged] (* rejected *)
+File "w53.ml", line 692, characters 22-30:
+692 |   let x : int = 42 [@@untagged] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 702, characters 24-32:
-702 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 700, characters 24-32:
+700 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 703, characters 27-35:
-703 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 701, characters 27-35:
+701 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 705, characters 23-31:
-705 |   val f : int -> int [@unrolled 42] (* rejected *)
+File "w53.ml", line 703, characters 23-31:
+703 |   val f : int -> int [@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 706, characters 24-32:
-706 |   val g : int -> int [@@unrolled 42] (* rejected *)
+File "w53.ml", line 704, characters 24-32:
+704 |   val g : int -> int [@@unrolled 42] (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 708, characters 39-47:
-708 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 706, characters 39-47:
+706 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 710, characters 6-14:
-710 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 708, characters 6-14:
+708 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 714, characters 8-16:
-714 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
+File "w53.ml", line 712, characters 8-16:
+712 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 721, characters 24-32:
-721 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 719, characters 24-32:
+719 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 722, characters 27-35:
-722 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 720, characters 27-35:
+720 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 724, characters 22-30:
-724 |   let rec f x = f x [@unrolled 42] (* rejected *)
+File "w53.ml", line 722, characters 22-30:
+722 |   let rec f x = f x [@unrolled 42] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 725, characters 23-31:
-725 |   let rec f x = f x [@@unrolled 42] (* rejected *)
+File "w53.ml", line 723, characters 23-31:
+723 |   let rec f x = f x [@@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 727, characters 39-47:
-727 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 725, characters 39-47:
+725 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 729, characters 6-14:
-729 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 727, characters 6-14:
+727 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 778, characters 25-48:
-778 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 776, characters 25-48:
+776 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 782, characters 16-39:
-782 |   val x : int [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 780, characters 16-39:
+780 |   val x : int [@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 784, characters 21-44:
-784 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 782, characters 21-44:
+782 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 786, characters 17-40:
-786 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 784, characters 17-40:
+784 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 788, characters 6-29:
-788 |   [@@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 786, characters 6-29:
+786 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 794, characters 25-48:
-794 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 792, characters 25-48:
+792 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 796, characters 14-37:
-796 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 794, characters 14-37:
+794 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 798, characters 16-39:
-798 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 796, characters 16-39:
+796 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 800, characters 6-29:
-800 |   [@@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 798, characters 6-29:
+798 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 809, characters 21-25:
-809 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 807, characters 21-25:
+807 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 810, characters 19-23:
-810 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 808, characters 19-23:
+808 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 811, characters 19-23:
-811 |   val x : int64 [@@poll error] (* rejected *)
+File "w53.ml", line 809, characters 19-23:
+809 |   val x : int64 [@@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 813, characters 24-28:
-813 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+File "w53.ml", line 811, characters 24-28:
+811 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 813, characters 49-53:
-813 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+File "w53.ml", line 811, characters 49-53:
+811 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 815, characters 39-43:
-815 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+File "w53.ml", line 813, characters 39-43:
+813 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 819, characters 21-25:
-819 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 817, characters 21-25:
+817 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 820, characters 19-23:
-820 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 818, characters 19-23:
+818 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 821, characters 25-29:
-821 |   let x : int64 = 42L [@@poll error] (* rejected *)
+File "w53.ml", line 819, characters 25-29:
+819 |   let x : int64 = 42L [@@poll error] (* rejected *)
                                ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 824, characters 24-28:
-824 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+File "w53.ml", line 822, characters 24-28:
+822 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 824, characters 49-53:
-824 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+File "w53.ml", line 822, characters 49-53:
+822 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 826, characters 39-43:
-826 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+File "w53.ml", line 824, characters 39-43:
+824 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 831, characters 21-31:
-831 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 829, characters 21-31:
+829 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 832, characters 19-29:
-832 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 830, characters 19-29:
+830 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 833, characters 19-29:
-833 |   val x : int64 [@@specialise] (* rejected *)
+File "w53.ml", line 831, characters 19-29:
+831 |   val x : int64 [@@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 835, characters 24-34:
-835 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 833, characters 24-34:
+833 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 835, characters 49-59:
-835 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 833, characters 49-59:
+833 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 837, characters 39-49:
-837 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+File "w53.ml", line 835, characters 39-49:
+835 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 841, characters 21-31:
-841 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 839, characters 21-31:
+839 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 842, characters 19-29:
-842 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 840, characters 19-29:
+840 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 843, characters 25-35:
-843 |   let x : int64 = 42L [@@specialise] (* rejected *)
+File "w53.ml", line 841, characters 25-35:
+841 |   let x : int64 = 42L [@@specialise] (* rejected *)
                                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 845, characters 16-26:
-845 |   let g x = (f[@specialise]) x (* rejected *)
+File "w53.ml", line 843, characters 16-26:
+843 |   let g x = (f[@specialise]) x (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 847, characters 24-34:
-847 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 845, characters 24-34:
+845 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 847, characters 49-59:
-847 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 845, characters 49-59:
+845 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 849, characters 39-49:
-849 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+File "w53.ml", line 847, characters 39-49:
+847 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 854, characters 21-32:
-854 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 852, characters 21-32:
+852 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 855, characters 19-30:
-855 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 853, characters 19-30:
+853 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 856, characters 19-30:
-856 |   val x : int64 [@@specialised] (* rejected *)
+File "w53.ml", line 854, characters 19-30:
+854 |   val x : int64 [@@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 858, characters 24-35:
-858 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 856, characters 24-35:
+856 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 858, characters 50-61:
-858 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 856, characters 50-61:
+856 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 860, characters 39-50:
-860 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+File "w53.ml", line 858, characters 39-50:
+858 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 864, characters 21-32:
-864 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 862, characters 21-32:
+862 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 865, characters 19-30:
-865 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 863, characters 19-30:
+863 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 866, characters 25-36:
-866 |   let x : int64 = 42L [@@specialised] (* rejected *)
+File "w53.ml", line 864, characters 25-36:
+864 |   let x : int64 = 42L [@@specialised] (* rejected *)
                                ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 867, characters 8-19:
-867 |   let [@specialised] f x = x (* rejected *)
+File "w53.ml", line 865, characters 8-19:
+865 |   let [@specialised] f x = x (* rejected *)
               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 870, characters 24-35:
-870 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 868, characters 24-35:
+868 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 870, characters 50-61:
-870 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 868, characters 50-61:
+868 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 872, characters 39-50:
-872 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+File "w53.ml", line 870, characters 39-50:
+870 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 877, characters 21-34:
-877 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 875, characters 21-34:
+875 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 878, characters 19-32:
-878 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+File "w53.ml", line 876, characters 19-32:
+876 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 879, characters 19-32:
-879 |   val x : int64 [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 877, characters 19-32:
+877 |   val x : int64 [@@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 881, characters 24-37:
-881 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 879, characters 24-37:
+879 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 881, characters 52-65:
-881 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 879, characters 52-65:
+879 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 884, characters 39-52:
-884 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 882, characters 39-52:
+882 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 888, characters 21-34:
-888 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 886, characters 21-34:
+886 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 889, characters 19-32:
-889 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+File "w53.ml", line 887, characters 19-32:
+887 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 890, characters 25-38:
-890 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 888, characters 25-38:
+888 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 892, characters 16-29:
-892 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
+File "w53.ml", line 890, characters 16-29:
+890 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 894, characters 24-37:
-894 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 892, characters 24-37:
+892 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 894, characters 52-65:
-894 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 892, characters 52-65:
+892 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 897, characters 39-52:
-897 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 895, characters 39-52:
+895 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 903, characters 10-15:
-903 |       [@@@alert foo "foo"] (* rejected *)
+File "w53.ml", line 901, characters 10-15:
+901 |       [@@@alert foo "foo"] (* rejected *)
                 ^^^^^
 Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -808,753 +808,768 @@ File "w53.ml", line 360, characters 19-29:
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 363, characters 39-49:
-363 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 363, characters 29-39:
+363 |   external y : int -> (int [@zero_alloc]) = "x" (* rejected *)
+                                   ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53.ml", line 364, characters 39-49:
+364 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 364, characters 12-22:
-364 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 365, characters 12-22:
+365 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 366, characters 9-19:
-366 |   class[@zero_alloc] c : (* rejected *)
+File "w53.ml", line 367, characters 9-19:
+367 |   class[@zero_alloc] c : (* rejected *)
                ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 368, characters 11-21:
-368 |       val[@zero_alloc] foo : int * int (* rejected *)
-                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53.ml", line 369, characters 11-21:
-369 |       val[@zero_alloc] bar : int -> int (* rejected *)
+369 |       val[@zero_alloc] foo : int * int (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 370, characters 14-24:
-370 |       method[@zero_alloc] baz : int * int (* rejected *)
-                    ^^^^^^^^^^
+File "w53.ml", line 370, characters 11-21:
+370 |       val[@zero_alloc] bar : int -> int (* rejected *)
+                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53.ml", line 371, characters 14-24:
-371 |       method[@zero_alloc] boz : int -> int (* rejected *)
+371 |       method[@zero_alloc] baz : int * int (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 376, characters 21-31:
-376 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53.ml", line 372, characters 14-24:
+372 |       method[@zero_alloc] boz : int -> int (* rejected *)
+                    ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53.ml", line 377, characters 21-31:
+377 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 377, characters 19-29:
-377 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53.ml", line 378, characters 19-29:
+378 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 378, characters 22-32:
-378 |   let x : int = 42 [@@zero_alloc] (* rejected *)
-                            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 380, characters 7-17:
-380 |   let[@zero_alloc] w = 42 (* rejected *)
-             ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 384, characters 39-49:
-384 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 382, characters 39-49:
+382 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 385, characters 12-22:
-385 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 383, characters 12-22:
+383 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 387, characters 9-19:
-387 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53.ml", line 385, characters 9-19:
+385 |   class[@zero_alloc] foo _y = (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 389, characters 10-20:
-389 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53.ml", line 387, characters 10-20:
+387 |     (fun[@zero_alloc] z -> (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 391, characters 11-21:
-391 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53.ml", line 389, characters 11-21:
+389 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 393, characters 14-24:
-393 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
+File "w53.ml", line 391, characters 14-24:
+391 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 405, characters 14-24:
-405 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+File "w53.ml", line 403, characters 14-24:
+403 |     ((boz x)[@zero_alloc assume]) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 410, characters 7-17:
-410 |   let[@zero_alloc assume] foo = (* rejected *)
-             ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 414, characters 7-17:
-414 |   let[@zero_alloc] bar = (* rejected *)
-             ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 420, characters 24-29:
-420 |   type t1 = { x : int [@boxed] } (* rejected *)
+File "w53.ml", line 409, characters 24-29:
+409 |   type t1 = { x : int [@boxed] } (* rejected *)
                               ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 422, characters 16-21:
-422 |   val x : int [@boxed] (* rejected *)
+File "w53.ml", line 411, characters 16-21:
+411 |   val x : int [@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 426, characters 17-22:
-426 |   val y : int [@@boxed] (* rejected *)
+File "w53.ml", line 415, characters 17-22:
+415 |   val y : int [@@boxed] (* rejected *)
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 428, characters 6-11:
-428 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 417, characters 6-11:
+417 |   [@@@boxed] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 432, characters 16-21:
-432 |   let x = (42 [@boxed], 84) (* rejected *)
+File "w53.ml", line 421, characters 16-21:
+421 |   let x = (42 [@boxed], 84) (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 434, characters 16-21:
-434 |   let y = 10 [@@boxed] (* rejected *)
+File "w53.ml", line 423, characters 16-21:
+423 |   let y = 10 [@@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 436, characters 6-11:
-436 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 425, characters 6-11:
+425 |   [@@@boxed] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 443, characters 16-26:
-443 |   val x : int [@deprecated] (* rejected *)
+File "w53.ml", line 432, characters 16-26:
+432 |   val x : int [@deprecated] (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 449, characters 6-16:
-449 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 438, characters 6-16:
+438 |   [@@@deprecated] (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 453, characters 14-24:
-453 |   let x = 5 [@deprecated] (* rejected *)
+File "w53.ml", line 442, characters 14-24:
+442 |   let x = 5 [@deprecated] (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 455, characters 16-26:
-455 |   let y = 10 [@@deprecated] (* rejected *)
+File "w53.ml", line 444, characters 16-26:
+444 |   let y = 10 [@@deprecated] (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 457, characters 6-16:
-457 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 446, characters 6-16:
+446 |   [@@@deprecated] (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 462, characters 19-37:
-462 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 451, characters 19-37:
+451 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
                          ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 464, characters 16-34:
-464 |   val x : int [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 453, characters 16-34:
+453 |   val x : int [@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 466, characters 21-39:
-466 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 455, characters 21-39:
+455 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 470, characters 24-42:
-470 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
+File "w53.ml", line 459, characters 24-42:
+459 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
                               ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 472, characters 17-35:
-472 |   val y : int [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 461, characters 17-35:
+461 |   val y : int [@@deprecated_mutable] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 474, characters 6-24:
-474 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 463, characters 6-24:
+463 |   [@@@deprecated_mutable] (* rejected *)
             ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 478, characters 14-32:
-478 |   let x = 5 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 467, characters 14-32:
+467 |   let x = 5 [@deprecated_mutable] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 480, characters 16-34:
-480 |   let y = 10 [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 469, characters 16-34:
+469 |   let y = 10 [@@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 482, characters 6-24:
-482 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 471, characters 6-24:
+471 |   [@@@deprecated_mutable] (* rejected *)
             ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 487, characters 32-46:
-487 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
+File "w53.ml", line 476, characters 32-46:
+476 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
                                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 489, characters 16-30:
-489 |   val x : int [@explicit_arity] (* rejected *)
+File "w53.ml", line 478, characters 16-30:
+478 |   val x : int [@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 491, characters 20-34:
-491 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
+File "w53.ml", line 480, characters 20-34:
+480 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
                           ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 493, characters 17-31:
-493 |   val y : int [@@explicit_arity] (* rejected *)
+File "w53.ml", line 482, characters 17-31:
+482 |   val y : int [@@explicit_arity] (* rejected *)
                        ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 495, characters 6-20:
-495 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 484, characters 6-20:
+484 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 499, characters 14-28:
-499 |   let x = 5 [@explicit_arity] (* rejected *)
+File "w53.ml", line 488, characters 14-28:
+488 |   let x = 5 [@explicit_arity] (* rejected *)
                     ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 501, characters 16-30:
-501 |   let y = 10 [@@explicit_arity] (* rejected *)
+File "w53.ml", line 490, characters 16-30:
+490 |   let y = 10 [@@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 503, characters 6-20:
-503 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 492, characters 6-20:
+492 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 508, characters 18-27:
-508 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 497, characters 18-27:
+497 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 512, characters 16-25:
-512 |   val x : int [@immediate] (* rejected *)
+File "w53.ml", line 501, characters 16-25:
+501 |   val x : int [@immediate] (* rejected *)
                       ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 513, characters 17-26:
-513 |   val x : int [@@immediate] (* rejected *)
+File "w53.ml", line 502, characters 17-26:
+502 |   val x : int [@@immediate] (* rejected *)
                        ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 515, characters 6-15:
-515 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 504, characters 6-15:
+504 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 516, characters 6-17:
-516 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 505, characters 6-17:
+505 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 520, characters 15-24:
-520 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 509, characters 15-24:
+509 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                      ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 520, characters 32-43:
-520 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 509, characters 32-43:
+509 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                                       ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 521, characters 21-30:
-521 |   let y = (4, 42) [@@immediate] (* rejected *)
+File "w53.ml", line 510, characters 21-30:
+510 |   let y = (4, 42) [@@immediate] (* rejected *)
                            ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 522, characters 21-32:
-522 |   let z = (4, 42) [@@immediate64] (* rejected *)
+File "w53.ml", line 511, characters 21-32:
+511 |   let z = (4, 42) [@@immediate64] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 524, characters 18-27:
-524 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 513, characters 18-27:
+513 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 528, characters 6-15:
-528 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 517, characters 6-15:
+517 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 529, characters 6-17:
-529 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 518, characters 6-17:
+518 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 534, characters 25-31:
-534 |   type t1 = int -> int [@inline] (* rejected *)
+File "w53.ml", line 523, characters 25-31:
+523 |   type t1 = int -> int [@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 535, characters 26-32:
-535 |   type t2 = int -> int [@@inline] (* rejected *)
+File "w53.ml", line 524, characters 26-32:
+524 |   type t2 = int -> int [@@inline] (* rejected *)
                                 ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 536, characters 25-32:
-536 |   type t3 = int -> int [@inlined] (* rejected *)
+File "w53.ml", line 525, characters 25-32:
+525 |   type t3 = int -> int [@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 537, characters 26-33:
-537 |   type t4 = int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 526, characters 26-33:
+526 |   type t4 = int -> int [@@inlined] (* rejected *)
                                 ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 539, characters 24-30:
-539 |   val f1 : int -> int [@inline] (* rejected *)
+File "w53.ml", line 528, characters 24-30:
+528 |   val f1 : int -> int [@inline] (* rejected *)
                               ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 540, characters 25-31:
-540 |   val f2 : int -> int [@@inline] (* rejected *)
+File "w53.ml", line 529, characters 25-31:
+529 |   val f2 : int -> int [@@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 541, characters 24-31:
-541 |   val f3 : int -> int [@inlined] (* rejected *)
+File "w53.ml", line 530, characters 24-31:
+530 |   val f3 : int -> int [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 542, characters 25-32:
-542 |   val f4 : int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 531, characters 25-32:
+531 |   val f4 : int -> int [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 544, characters 53-59:
-544 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
+File "w53.ml", line 533, characters 53-59:
+533 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
                                                            ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 545, characters 54-60:
-545 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
+File "w53.ml", line 534, characters 54-60:
+534 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
                                                             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 547, characters 6-12:
-547 |   [@@@inline] (* rejected *)
+File "w53.ml", line 536, characters 6-12:
+536 |   [@@@inline] (* rejected *)
             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 548, characters 6-13:
-548 |   [@@@inlined] (* rejected *)
+File "w53.ml", line 537, characters 6-13:
+537 |   [@@@inlined] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 552, characters 16-22:
-552 |   let h x = x [@inline] (* rejected *)
+File "w53.ml", line 541, characters 16-22:
+541 |   let h x = x [@inline] (* rejected *)
                       ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 553, characters 16-28:
-553 |   let h x = x [@ocaml.inline] (* rejected *)
+File "w53.ml", line 542, characters 16-28:
+542 |   let h x = x [@ocaml.inline] (* rejected *)
                       ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 555, characters 16-23:
-555 |   let i x = x [@inlined] (* rejected *)
+File "w53.ml", line 544, characters 16-23:
+544 |   let i x = x [@inlined] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 556, characters 16-29:
-556 |   let j x = x [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 545, characters 16-29:
+545 |   let j x = x [@ocaml.inlined] (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 559, characters 18-25:
-559 |   let l x = h x [@inlined] (* rejected *)
+File "w53.ml", line 548, characters 18-25:
+548 |   let l x = h x [@inlined] (* rejected *)
                         ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 567, characters 27-33:
-567 |   module C = struct end [@@inline] (* rejected *)
+File "w53.ml", line 556, characters 27-33:
+556 |   module C = struct end [@@inline] (* rejected *)
                                  ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 568, characters 28-40:
-568 |   module C' = struct end [@@ocaml.inline] (* rejected *)
+File "w53.ml", line 557, characters 28-40:
+557 |   module C' = struct end [@@ocaml.inline] (* rejected *)
                                   ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 569, characters 27-34:
-569 |   module D = struct end [@@inlined] (* rejected *)
+File "w53.ml", line 558, characters 27-34:
+558 |   module D = struct end [@@inlined] (* rejected *)
                                  ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 570, characters 28-41:
-570 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 559, characters 28-41:
+559 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
                                   ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 574, characters 18-24:
-574 |   module G = (A [@inline])(struct end) (* rejected *)
+File "w53.ml", line 563, characters 18-24:
+563 |   module G = (A [@inline])(struct end) (* rejected *)
                         ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 575, characters 19-31:
-575 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
+File "w53.ml", line 564, characters 19-31:
+564 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
                          ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 579, characters 24-31:
-579 |   module I = Set.Make [@inlined] (* rejected *)
+File "w53.ml", line 568, characters 24-31:
+568 |   module I = Set.Make [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 580, characters 25-38:
-580 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 569, characters 25-38:
+569 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 582, characters 25-32:
-582 |   module J = Set.Make [@@inlined] (* rejected *)
+File "w53.ml", line 571, characters 25-32:
+571 |   module J = Set.Make [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 583, characters 26-39:
-583 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 572, characters 26-39:
+572 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
                                 ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 588, characters 21-28:
-588 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 577, characters 21-28:
+577 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 589, characters 19-26:
-589 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 578, characters 19-26:
+578 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 590, characters 19-26:
-590 |   val x : int64 [@@noalloc] (* rejected *)
+File "w53.ml", line 579, characters 19-26:
+579 |   val x : int64 [@@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 592, characters 24-31:
-592 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 581, characters 24-31:
+581 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 592, characters 46-53:
-592 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 581, characters 46-53:
+581 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 597, characters 21-28:
-597 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 586, characters 21-28:
+586 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 598, characters 19-26:
-598 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 587, characters 19-26:
+587 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 599, characters 25-32:
-599 |   let x : int64 = 42L [@@noalloc] (* rejected *)
+File "w53.ml", line 588, characters 25-32:
+588 |   let x : int64 = 42L [@@noalloc] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 601, characters 24-31:
-601 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 590, characters 24-31:
+590 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 601, characters 46-53:
-601 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 590, characters 46-53:
+590 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 630, characters 21-29:
-630 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 619, characters 21-29:
+619 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 631, characters 19-27:
-631 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 620, characters 19-27:
+620 |   type s1 = Foo1 [@tailcall] (* rejected *)
+                         ^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
+File "w53.ml", line 621, characters 16-24:
+621 |   val x : int [@tailcall] (* rejected *)
+                      ^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
+File "w53.ml", line 623, characters 35-43:
+623 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+                                         ^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
+File "w53.ml", line 625, characters 6-14:
+625 |   [@@@tailcall] (* rejected *)
+            ^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
+File "w53.ml", line 629, characters 21-29:
+629 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+                           ^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
+File "w53.ml", line 630, characters 19-27:
+630 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
 File "w53.ml", line 632, characters 16-24:
-632 |   val x : int [@tailcall] (* rejected *)
+632 |   let m x = x [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 634, characters 35-43:
-634 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
-                                         ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
-
-File "w53.ml", line 636, characters 6-14:
-636 |   [@@@tailcall] (* rejected *)
-            ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
-
-File "w53.ml", line 640, characters 21-29:
-640 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
-                           ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
-
-File "w53.ml", line 641, characters 19-27:
-641 |   type s1 = Foo1 [@tailcall] (* rejected *)
-                         ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
-
-File "w53.ml", line 643, characters 16-24:
-643 |   let m x = x [@tailcall] (* rejected *)
-                      ^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
-
-File "w53.ml", line 644, characters 16-30:
-644 |   let n x = x [@ocaml.tailcall] (* rejected *)
+File "w53.ml", line 633, characters 16-30:
+633 |   let n x = x [@ocaml.tailcall] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 647, characters 18-26:
-647 |   let q x = m x [@tailcall] (* rejected *)
+File "w53.ml", line 636, characters 18-26:
+636 |   let q x = m x [@tailcall] (* rejected *)
                         ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 649, characters 35-43:
-649 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 638, characters 35-43:
+638 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 651, characters 6-14:
-651 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 640, characters 6-14:
+640 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 656, characters 24-31:
-656 |   type t1 = { x : int [@unboxed] } (* rejected *)
+File "w53.ml", line 645, characters 24-31:
+645 |   type t1 = { x : int [@unboxed] } (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 658, characters 16-23:
-658 |   val x : int [@unboxed] (* rejected *)
+File "w53.ml", line 647, characters 16-23:
+647 |   val x : int [@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 662, characters 17-24:
-662 |   val y : int [@@unboxed] (* rejected *)
+File "w53.ml", line 651, characters 17-24:
+651 |   val y : int [@@unboxed] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 666, characters 6-13:
-666 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 655, characters 6-13:
+655 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 670, characters 16-23:
-670 |   let x = (42 [@unboxed], 84) (* rejected *)
+File "w53.ml", line 659, characters 16-23:
+659 |   let x = (42 [@unboxed], 84) (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 672, characters 16-23:
-672 |   let y = 10 [@@unboxed] (* rejected *)
+File "w53.ml", line 661, characters 16-23:
+661 |   let y = 10 [@@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 676, characters 6-13:
-676 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 665, characters 6-13:
+665 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 681, characters 21-29:
-681 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 670, characters 21-29:
+670 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 682, characters 19-27:
-682 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 671, characters 19-27:
+671 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 683, characters 17-25:
-683 |   val x : int [@@untagged] (* rejected *)
+File "w53.ml", line 672, characters 17-25:
+672 |   val x : int [@@untagged] (* rejected *)
                        ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 690, characters 21-29:
-690 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 679, characters 21-29:
+679 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 691, characters 19-27:
-691 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 680, characters 19-27:
+680 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 692, characters 22-30:
-692 |   let x : int = 42 [@@untagged] (* rejected *)
+File "w53.ml", line 681, characters 22-30:
+681 |   let x : int = 42 [@@untagged] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 700, characters 24-32:
-700 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 689, characters 24-32:
+689 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 701, characters 27-35:
-701 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 690, characters 27-35:
+690 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 703, characters 23-31:
-703 |   val f : int -> int [@unrolled 42] (* rejected *)
+File "w53.ml", line 692, characters 23-31:
+692 |   val f : int -> int [@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 704, characters 24-32:
-704 |   val g : int -> int [@@unrolled 42] (* rejected *)
+File "w53.ml", line 693, characters 24-32:
+693 |   val g : int -> int [@@unrolled 42] (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 706, characters 39-47:
-706 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 695, characters 39-47:
+695 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 708, characters 6-14:
-708 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 697, characters 6-14:
+697 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 712, characters 8-16:
-712 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
+File "w53.ml", line 701, characters 8-16:
+701 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 719, characters 24-32:
-719 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 708, characters 24-32:
+708 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 720, characters 27-35:
-720 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 709, characters 27-35:
+709 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 722, characters 22-30:
-722 |   let rec f x = f x [@unrolled 42] (* rejected *)
+File "w53.ml", line 711, characters 22-30:
+711 |   let rec f x = f x [@unrolled 42] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 723, characters 23-31:
-723 |   let rec f x = f x [@@unrolled 42] (* rejected *)
+File "w53.ml", line 712, characters 23-31:
+712 |   let rec f x = f x [@@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 725, characters 39-47:
-725 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 714, characters 39-47:
+714 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 727, characters 6-14:
-727 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 716, characters 6-14:
+716 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 776, characters 25-48:
-776 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 765, characters 25-48:
+765 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 780, characters 16-39:
-780 |   val x : int [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 769, characters 16-39:
+769 |   val x : int [@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 782, characters 21-44:
-782 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 771, characters 21-44:
+771 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 784, characters 17-40:
-784 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 773, characters 17-40:
+773 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 786, characters 6-29:
-786 |   [@@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 775, characters 6-29:
+775 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 792, characters 25-48:
-792 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 781, characters 25-48:
+781 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 794, characters 14-37:
-794 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 783, characters 14-37:
+783 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 796, characters 16-39:
-796 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 785, characters 16-39:
+785 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 798, characters 6-29:
-798 |   [@@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 787, characters 6-29:
+787 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 807, characters 21-25:
-807 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 796, characters 21-25:
+796 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 808, characters 19-23:
-808 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 797, characters 19-23:
+797 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 809, characters 19-23:
-809 |   val x : int64 [@@poll error] (* rejected *)
+File "w53.ml", line 798, characters 19-23:
+798 |   val x : int64 [@@poll error] (* rejected *)
                          ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+
+File "w53.ml", line 800, characters 24-28:
+800 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+                              ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+
+File "w53.ml", line 800, characters 49-53:
+800 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+                                                       ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+
+File "w53.ml", line 802, characters 39-43:
+802 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+                                             ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+
+File "w53.ml", line 806, characters 21-25:
+806 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+                           ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+
+File "w53.ml", line 807, characters 19-23:
+807 |   type s1 = Foo1 [@poll error] (* rejected *)
+                         ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+
+File "w53.ml", line 808, characters 25-29:
+808 |   let x : int64 = 42L [@@poll error] (* rejected *)
+                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
 File "w53.ml", line 811, characters 24-28:
-811 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+811 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
 File "w53.ml", line 811, characters 49-53:
-811 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+811 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
@@ -1563,165 +1578,165 @@ File "w53.ml", line 813, characters 39-43:
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 817, characters 21-25:
-817 |   type 'a t1 = 'a [@@poll error] (* rejected *)
-                           ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
-
-File "w53.ml", line 818, characters 19-23:
-818 |   type s1 = Foo1 [@poll error] (* rejected *)
-                         ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
-
-File "w53.ml", line 819, characters 25-29:
-819 |   let x : int64 = 42L [@@poll error] (* rejected *)
-                               ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
-
-File "w53.ml", line 822, characters 24-28:
-822 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
-                              ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
-
-File "w53.ml", line 822, characters 49-53:
-822 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
-                                                       ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
-
-File "w53.ml", line 824, characters 39-43:
-824 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
-                                             ^^^^
-Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
-
-File "w53.ml", line 829, characters 21-31:
-829 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 818, characters 21-31:
+818 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 830, characters 19-29:
-830 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 819, characters 19-29:
+819 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 831, characters 19-29:
-831 |   val x : int64 [@@specialise] (* rejected *)
+File "w53.ml", line 820, characters 19-29:
+820 |   val x : int64 [@@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 833, characters 24-34:
-833 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 822, characters 24-34:
+822 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 833, characters 49-59:
-833 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 822, characters 49-59:
+822 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 835, characters 39-49:
-835 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+File "w53.ml", line 824, characters 39-49:
+824 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 839, characters 21-31:
-839 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 828, characters 21-31:
+828 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 840, characters 19-29:
-840 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 829, characters 19-29:
+829 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 841, characters 25-35:
-841 |   let x : int64 = 42L [@@specialise] (* rejected *)
+File "w53.ml", line 830, characters 25-35:
+830 |   let x : int64 = 42L [@@specialise] (* rejected *)
                                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 843, characters 16-26:
-843 |   let g x = (f[@specialise]) x (* rejected *)
+File "w53.ml", line 832, characters 16-26:
+832 |   let g x = (f[@specialise]) x (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 845, characters 24-34:
-845 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 834, characters 24-34:
+834 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 845, characters 49-59:
-845 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 834, characters 49-59:
+834 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 847, characters 39-49:
-847 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+File "w53.ml", line 836, characters 39-49:
+836 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 852, characters 21-32:
-852 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 841, characters 21-32:
+841 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 853, characters 19-30:
-853 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 842, characters 19-30:
+842 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 854, characters 19-30:
-854 |   val x : int64 [@@specialised] (* rejected *)
+File "w53.ml", line 843, characters 19-30:
+843 |   val x : int64 [@@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 856, characters 24-35:
-856 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 845, characters 24-35:
+845 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 856, characters 50-61:
-856 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 845, characters 50-61:
+845 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 858, characters 39-50:
-858 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+File "w53.ml", line 847, characters 39-50:
+847 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 862, characters 21-32:
-862 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 851, characters 21-32:
+851 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 863, characters 19-30:
-863 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 852, characters 19-30:
+852 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 864, characters 25-36:
-864 |   let x : int64 = 42L [@@specialised] (* rejected *)
+File "w53.ml", line 853, characters 25-36:
+853 |   let x : int64 = 42L [@@specialised] (* rejected *)
                                ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 865, characters 8-19:
-865 |   let [@specialised] f x = x (* rejected *)
+File "w53.ml", line 854, characters 8-19:
+854 |   let [@specialised] f x = x (* rejected *)
               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 868, characters 24-35:
-868 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 857, characters 24-35:
+857 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 868, characters 50-61:
-868 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 857, characters 50-61:
+857 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 870, characters 39-50:
-870 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+File "w53.ml", line 859, characters 39-50:
+859 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 864, characters 21-34:
+864 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+
+File "w53.ml", line 865, characters 19-32:
+865 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+
+File "w53.ml", line 866, characters 19-32:
+866 |   val x : int64 [@@tail_mod_cons] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+
+File "w53.ml", line 868, characters 24-37:
+868 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+                              ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+
+File "w53.ml", line 868, characters 52-65:
+868 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+                                                          ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+
+File "w53.ml", line 871, characters 39-52:
+871 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
 File "w53.ml", line 875, characters 21-34:
 875 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
@@ -1733,62 +1748,32 @@ File "w53.ml", line 876, characters 19-32:
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 877, characters 19-32:
-877 |   val x : int64 [@@tail_mod_cons] (* rejected *)
-                         ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
-
-File "w53.ml", line 879, characters 24-37:
-879 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
-                              ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
-
-File "w53.ml", line 879, characters 52-65:
-879 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
-                                                          ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
-
-File "w53.ml", line 882, characters 39-52:
-882 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
-                                             ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
-
-File "w53.ml", line 886, characters 21-34:
-886 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
-                           ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
-
-File "w53.ml", line 887, characters 19-32:
-887 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
-                         ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
-
-File "w53.ml", line 888, characters 25-38:
-888 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 877, characters 25-38:
+877 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 890, characters 16-29:
-890 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
+File "w53.ml", line 879, characters 16-29:
+879 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 892, characters 24-37:
-892 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 881, characters 24-37:
+881 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 892, characters 52-65:
-892 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 881, characters 52-65:
+881 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 895, characters 39-52:
-895 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 884, characters 39-52:
+884 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 901, characters 10-15:
-901 |       [@@@alert foo "foo"] (* rejected *)
+File "w53.ml", line 890, characters 10-15:
+890 |       [@@@alert foo "foo"] (* rejected *)
                 ^^^^^
 Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -360,7 +360,6 @@ module type TestZeroAllocSig = sig
   type s1 = Foo1 [@zero_alloc] (* rejected *)
   val f : int -> int [@@zero_alloc] (* accepted *)
 
-  external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
 
@@ -382,7 +381,6 @@ module TestZeroAllocStruct = struct
 
   let[@zero_alloc] f x = x (* accepted *)
 
-  external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
 

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -360,6 +360,7 @@ module type TestZeroAllocSig = sig
   type s1 = Foo1 [@zero_alloc] (* rejected *)
   val f : int -> int [@@zero_alloc] (* accepted *)
 
+  external y : int -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
 
@@ -375,9 +376,6 @@ end
 module TestZeroAllocStruct = struct
   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
   type s1 = Foo1 [@zero_alloc] (* rejected *)
-  let x : int = 42 [@@zero_alloc] (* rejected *)
-
-  let[@zero_alloc] w = 42 (* rejected *)
 
   let[@zero_alloc] f x = x (* accepted *)
 
@@ -405,15 +403,6 @@ module TestZeroAllocStruct = struct
     ((boz x)[@zero_alloc assume]) (* rejected *)
   let[@zero_alloc] fuz x =
     ((boz[@zero_alloc assume]) x) (* accepted *)
-
-  (* Triggers w53 on non-function lets *)
-  let[@zero_alloc assume] foo = (* rejected *)
-    let x = 42 in
-    fun z -> z + x
-
-  let[@zero_alloc] bar = (* rejected *)
-    let x = 42 in
-    fun z -> z + x
 end
 
 module type TestBoxedSig = sig

--- a/testsuite/tests/warnings/w53_zero_alloc_all.compilers.reference
+++ b/testsuite/tests/warnings/w53_zero_alloc_all.compilers.reference
@@ -8,122 +8,102 @@ File "w53_zero_alloc_all.ml", line 20, characters 19-29:
                         ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 23, characters 22-32:
-23 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                           ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 23, characters 45-55:
-23 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                                                  ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 24, characters 39-49:
-24 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 23, characters 39-49:
+23 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 25, characters 12-22:
-25 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53_zero_alloc_all.ml", line 24, characters 12-22:
+24 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 27, characters 9-19:
-27 |   class[@zero_alloc] c : (* rejected *)
+File "w53_zero_alloc_all.ml", line 26, characters 9-19:
+26 |   class[@zero_alloc] c : (* rejected *)
               ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53_zero_alloc_all.ml", line 28, characters 11-21:
+28 |       val[@zero_alloc] foo : int * int (* rejected *)
+                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53_zero_alloc_all.ml", line 29, characters 11-21:
-29 |       val[@zero_alloc] foo : int * int (* rejected *)
+29 |       val[@zero_alloc] bar : int -> int (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 30, characters 11-21:
-30 |       val[@zero_alloc] bar : int -> int (* rejected *)
-                ^^^^^^^^^^
+File "w53_zero_alloc_all.ml", line 30, characters 14-24:
+30 |       method[@zero_alloc] baz : int * int (* rejected *)
+                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53_zero_alloc_all.ml", line 31, characters 14-24:
-31 |       method[@zero_alloc] baz : int * int (* rejected *)
+31 |       method[@zero_alloc] boz : int -> int (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 32, characters 14-24:
-32 |       method[@zero_alloc] boz : int -> int (* rejected *)
-                   ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 37, characters 21-31:
-37 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 36, characters 21-31:
+36 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                           ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 38, characters 19-29:
-38 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 37, characters 19-29:
+37 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                         ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 39, characters 22-32:
-39 |   let x : int = 42 [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 38, characters 22-32:
+38 |   let x : int = 42 [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 41, characters 7-17:
-41 |   let[@zero_alloc] w = 42 (* rejected *)
+File "w53_zero_alloc_all.ml", line 40, characters 7-17:
+40 |   let[@zero_alloc] w = 42 (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 45, characters 22-32:
-45 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                           ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 45, characters 45-55:
-45 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
-                                                  ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 46, characters 39-49:
-46 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 44, characters 39-49:
+44 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 47, characters 12-22:
-47 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53_zero_alloc_all.ml", line 45, characters 12-22:
+45 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 49, characters 9-19:
-49 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53_zero_alloc_all.ml", line 47, characters 9-19:
+47 |   class[@zero_alloc] foo _y = (* rejected *)
               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 51, characters 10-20:
-51 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53_zero_alloc_all.ml", line 49, characters 10-20:
+49 |     (fun[@zero_alloc] z -> (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 53, characters 11-21:
-53 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53_zero_alloc_all.ml", line 51, characters 11-21:
+51 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 55, characters 14-24:
-55 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
+File "w53_zero_alloc_all.ml", line 53, characters 14-24:
+53 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 67, characters 14-24:
-67 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+File "w53_zero_alloc_all.ml", line 65, characters 14-24:
+65 |     ((boz x)[@zero_alloc assume]) (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 72, characters 7-17:
-72 |   let[@zero_alloc assume] foo = (* rejected *)
+File "w53_zero_alloc_all.ml", line 70, characters 7-17:
+70 |   let[@zero_alloc assume] foo = (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 76, characters 7-17:
-76 |   let[@zero_alloc] bar = (* rejected *)
+File "w53_zero_alloc_all.ml", line 74, characters 7-17:
+74 |   let[@zero_alloc] bar = (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53_zero_alloc_all.compilers.reference
+++ b/testsuite/tests/warnings/w53_zero_alloc_all.compilers.reference
@@ -53,57 +53,37 @@ File "w53_zero_alloc_all.ml", line 37, characters 19-29:
                         ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 38, characters 22-32:
-38 |   let x : int = 42 [@@zero_alloc] (* rejected *)
-                           ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 40, characters 7-17:
-40 |   let[@zero_alloc] w = 42 (* rejected *)
-            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 44, characters 39-49:
-44 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 41, characters 39-49:
+41 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 45, characters 12-22:
-45 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53_zero_alloc_all.ml", line 42, characters 12-22:
+42 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 47, characters 9-19:
-47 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53_zero_alloc_all.ml", line 44, characters 9-19:
+44 |   class[@zero_alloc] foo _y = (* rejected *)
               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 49, characters 10-20:
-49 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53_zero_alloc_all.ml", line 46, characters 10-20:
+46 |     (fun[@zero_alloc] z -> (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 51, characters 11-21:
-51 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53_zero_alloc_all.ml", line 48, characters 11-21:
+48 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 53, characters 14-24:
-53 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
+File "w53_zero_alloc_all.ml", line 50, characters 14-24:
+50 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 65, characters 14-24:
-65 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+File "w53_zero_alloc_all.ml", line 62, characters 14-24:
+62 |     ((boz x)[@zero_alloc assume]) (* rejected *)
                    ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 70, characters 7-17:
-70 |   let[@zero_alloc assume] foo = (* rejected *)
-            ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 74, characters 7-17:
-74 |   let[@zero_alloc] bar = (* rejected *)
-            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53_zero_alloc_all.ml
+++ b/testsuite/tests/warnings/w53_zero_alloc_all.ml
@@ -20,7 +20,6 @@ module type TestZeroAllocSig = sig
   type s1 = Foo1 [@zero_alloc] (* rejected *)
   val f : int -> int [@@zero_alloc] (* accepted *)
 
-  external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
 
@@ -42,7 +41,6 @@ module TestZeroAllocStruct = struct
 
   let[@zero_alloc] f x = x (* accepted *)
 
-  external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
 

--- a/testsuite/tests/warnings/w53_zero_alloc_all.ml
+++ b/testsuite/tests/warnings/w53_zero_alloc_all.ml
@@ -35,9 +35,6 @@ end
 module TestZeroAllocStruct = struct
   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
   type s1 = Foo1 [@zero_alloc] (* rejected *)
-  let x : int = 42 [@@zero_alloc] (* rejected *)
-
-  let[@zero_alloc] w = 42 (* rejected *)
 
   let[@zero_alloc] f x = x (* accepted *)
 
@@ -65,15 +62,6 @@ module TestZeroAllocStruct = struct
     ((boz x)[@zero_alloc assume]) (* rejected *)
   let[@zero_alloc] fuz x =
     ((boz[@zero_alloc assume]) x) (* accepted *)
-
-  (* Triggers w53 on non-function lets *)
-  let[@zero_alloc assume] foo = (* rejected *)
-    let x = 42 in
-    fun z -> z + x
-
-  let[@zero_alloc] bar = (* rejected *)
-    let x = 42 in
-    fun z -> z + x
 end
 
 (* TEST

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -692,7 +692,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               end
           | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ | Tof_kind _ ->
               fatal_error "Printval.outval_of_value"
-          | Tpoly (ty, _) ->
+          | Tpoly (ty, _, _) ->
               tree_of_val (depth - 1) obj ty
           | Trepr (ty, _) ->
               tree_of_val (depth - 1) obj ty

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -22,7 +22,7 @@ let type_arrow ta tb =
     Types.Nolabel,Mode.Alloc.legacy,Mode.Alloc.legacy
   in
   Ctype.newty
-    (Tarrow (arrow_desc, Ctype.newmono ta, tb, Types.commu_var ()))
+    (Tarrow (arrow_desc, Ctype.newmono ~zero_alloc:None ta, tb, Types.commu_var ()))
 
 let type_formatter () =
   let format = Path.Pident (Ident.create_persistent "Stdlib__Format") in

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -22,7 +22,8 @@ let type_arrow ta tb =
     Types.Nolabel,Mode.Alloc.legacy,Mode.Alloc.legacy
   in
   Ctype.newty
-    (Tarrow (arrow_desc, Ctype.newmono ~zero_alloc:None ta, tb, Types.commu_var ()))
+    (Tarrow
+       (arrow_desc, Ctype.newmono ~zero_alloc:None ta, tb, Types.commu_var ()))
 
 let type_formatter () =
   let format = Path.Pident (Ident.create_persistent "Stdlib__Format") in

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -23,7 +23,7 @@ let type_arrow ta tb =
   in
   Ctype.newty
     (Tarrow
-       (arrow_desc, Ctype.newmono ~zero_alloc:None ta, tb, Types.commu_var ()))
+       (arrow_desc, Ctype.newmono ta, tb, Types.commu_var ()))
 
 let type_formatter () =
   let format = Path.Pident (Ident.create_persistent "Stdlib__Format") in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -313,7 +313,7 @@ let fold_type_expr f init ty =
   | Tlink _             -> assert false
   | Tsubst (ty, _)      -> f init ty
   | Tunivar _           -> init
-  | Tpoly (ty, tyl)     ->
+  | Tpoly (ty, tyl, _)     ->
     let result = f init ty in
     List.fold_left f result tyl
   | Trepr (ty, _sort_vars) ->
@@ -553,9 +553,9 @@ let rec copy_type_desc ?(keep_names=false) f = function
   | Tlink ty            -> copy_type_desc f (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
-  | Tpoly (ty, tyl)     ->
+  | Tpoly (ty, tyl, za) ->
       let tyl = List.map f tyl in
-      Tpoly (f ty, tyl)
+      Tpoly (f ty, tyl, za)
   | Trepr (ty, sort_vars) ->
       Trepr (f ty, sort_vars)
   | Tpackage (p, fl)  -> Tpackage (p, List.map (fun (n, ty) -> (n, f ty)) fl)
@@ -822,18 +822,18 @@ let instance_variable_type label sign =
 
 let tpoly_is_mono ty =
   match get_desc ty with
-  | Tpoly(_, []) -> true
-  | Tpoly(_, _ :: _) -> false
+  | Tpoly(_, [], _) -> true
+  | Tpoly(_, _ :: _, _) -> false
   | _ -> assert false
 
 let tpoly_get_poly ty =
   match get_desc ty with
-  | Tpoly(ty, vars) -> (ty, vars)
+  | Tpoly(ty, vars, za) -> (ty, vars, za)
   | _ -> assert false
 
 let tpoly_get_mono ty =
   match get_desc ty with
-  | Tpoly(ty, []) -> ty
+  | Tpoly(ty, [], _) -> ty
   | _ -> assert false
 
                   (**********)

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -822,7 +822,8 @@ let instance_variable_type label sign =
 
 let tpoly_is_mono ty =
   match get_desc ty with
-  | Tpoly(_, [], _) -> true
+  | Tpoly(_, [], None) -> true
+  | Tpoly(_, [], Some _) -> false
   | Tpoly(_, _ :: _, _) -> false
   | _ -> assert false
 
@@ -832,6 +833,12 @@ let tpoly_get_poly ty =
   | _ -> assert false
 
 let tpoly_get_mono ty =
+  match get_desc ty with
+  | Tpoly(ty, [], None) -> ty
+  | _ -> assert false
+
+(* Like [tpoly_get_mono] but also works for [Tpoly(ty, [], Some _)] types. *)
+let tpoly_get_inner ty =
   match get_desc ty with
   | Tpoly(ty, [], _) -> ty
   | _ -> assert false
@@ -846,6 +853,18 @@ let cstr_type_path cstr =
   match get_desc cstr.cstr_res with
   | Tconstr (p, _, _) -> p
   | _ -> assert false
+
+                  (****************)
+                  (*  zero_alloc  *)
+                  (****************)
+
+type explicit_poly =
+  | Mono
+  | Poly of Zero_alloc.check option
+
+let is_explicitly_poly = function
+  | Mono -> false
+  | Poly _ -> true
 
                   (************)
                   (*  Jkinds  *)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -125,7 +125,8 @@ val proxy: type_expr -> type_expr
 (* These three functions can only be called on [Tpoly] nodes. *)
 val tpoly_is_mono : type_expr -> bool
 val tpoly_get_mono : type_expr -> type_expr
-val tpoly_get_poly : type_expr -> type_expr * type_expr list
+val tpoly_get_poly :
+  type_expr -> type_expr * type_expr list * Zero_alloc.check option
 
 (**** Utilities for private abbreviations with fixed rows ****)
 val row_of_type: type_expr -> type_expr

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -122,11 +122,19 @@ val proxy: type_expr -> type_expr
 
 (* Poly types. *)
 
-(* These three functions can only be called on [Tpoly] nodes. *)
+(* These four functions can only be called on [Tpoly] nodes. *)
 val tpoly_is_mono : type_expr -> bool
 val tpoly_get_mono : type_expr -> type_expr
+val tpoly_get_inner : type_expr -> type_expr
 val tpoly_get_poly :
   type_expr -> type_expr * type_expr list * Zero_alloc.check option
+
+(* zero_alloc. *)
+
+type explicit_poly =
+  | Mono
+  | Poly of Zero_alloc.check option
+val is_explicitly_poly : explicit_poly -> bool
 
 (**** Utilities for private abbreviations with fixed rows ****)
 val row_of_type: type_expr -> type_expr

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -276,7 +276,7 @@ let newobj fields      = newty (Tobject (fields, ref None))
 
 let newconstr path tyl = newty (Tconstr (path, tyl, ref Mnil))
 
-let newmono ~zero_alloc ty = newty (Tpoly(ty, [], zero_alloc))
+let newmono ty = newty (Tpoly(ty, [], None))
 
 let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 
@@ -4110,14 +4110,9 @@ let equivalent_with_nolabels l1 l2 =
   | _ -> false)
 
 let verify_zero_alloc_equal context_za context_tr za1 za2 =
-  match za1, za2 with
-  | None, None -> ()
-  | Some _, None | None, Some _ ->
-    raise_for context_tr (Incompatible_zero_alloc Zero_alloc.one_missing)
-  | Some check1, Some check2 ->
-    match Zero_alloc.assert_equal_checks ~context:context_za check1 check2 with
-    | Ok () -> ()
-    | Error e -> raise_for context_tr (Incompatible_zero_alloc e)
+  match Zero_alloc.check_option_equal ~context:context_za za1 za2 with
+  | Ok () -> ()
+  | Error e -> raise_for context_tr (Incompatible_zero_alloc e)
 
 (* the [tk] means we're comparing a type against a jkind; axes do
    not matter, so a jkind extracted from a type_declaration does
@@ -5498,15 +5493,16 @@ type filtered_arrow =
     ret_mode : Mode.Alloc.lr
   }
 
-let filter_arrow env t l ~force_tpoly ~zero_alloc =
+let filter_arrow env t l ~has_poly =
   let function_type level =
     let k_arg = Jkind.Builtin.any ~why:Inside_of_Tarrow in
     let k_res = Jkind.Builtin.any ~why:Inside_of_Tarrow in
     let ty_arg =
-      if not force_tpoly then begin
+      begin match has_poly with
+      | Mono ->
         assert (not (is_optional l));
         newvar2 level k_arg
-      end else begin
+      | Poly zero_alloc ->
         let t1 =
           if is_optional l then
             newty2 ~level
@@ -5570,14 +5566,14 @@ exception Filter_mono_failed
 
 let filter_mono ty =
   match get_desc ty with
-  | Tpoly(ty, [], _) -> ty
+  | Tpoly(ty, [], None) -> ty
   | Tpoly _ -> raise Filter_mono_failed
   | _ -> assert false
 
 exception Filter_arrow_mono_failed
 
 let filter_arrow_mono env t l =
-  match filter_arrow env t l ~force_tpoly:true ~zero_alloc:None with
+  match filter_arrow env t l ~has_poly:(Poly None) with
   | exception Filter_arrow_failed _ -> raise Filter_arrow_mono_failed
   | {ty_arg; _} as farr ->
       match filter_mono ty_arg with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -276,7 +276,7 @@ let newobj fields      = newty (Tobject (fields, ref None))
 
 let newconstr path tyl = newty (Tconstr (path, tyl, ref Mnil))
 
-let newmono ty = newty (Tpoly(ty, []))
+let newmono ~zero_alloc ty = newty (Tpoly(ty, [], zero_alloc))
 
 let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 
@@ -989,7 +989,7 @@ let rec generalize_spine ty =
       set_level ty generic_level;
       generalize_spine ty1;
       generalize_spine ty2;
-  | Tpoly (ty', _) ->
+  | Tpoly (ty', _, _) ->
       set_level ty generic_level;
       generalize_spine ty'
   | Ttuple tyl ->
@@ -1308,7 +1308,7 @@ let compute_univars ty =
   let node_univars = TypeHash.create 17 in
   let rec add_univar univ inv =
     match get_desc inv.inv_type with
-      Tpoly (_ty, tl) when List.memq (get_id univ) (List.map get_id tl) -> ()
+      Tpoly (_ty, tl, _) when List.memq (get_id univ) (List.map get_id tl) -> ()
     | _ ->
         try
           let univs = TypeHash.find node_univars inv.inv_type in
@@ -1741,7 +1741,7 @@ let copy_sep ~copy_scope ~fixed ~partial ~bound_univars
   let rec copy_rec ~bound_univars ~may_share (ty : type_expr) =
     let bound_univars =
       match get_desc ty with
-      | Tpoly (_, tl) -> List.fold_right TypeSet.add tl bound_univars
+      | Tpoly (_, tl, _) -> List.fold_right TypeSet.add tl bound_univars
       | _ -> bound_univars
     in
     let copy_rec = copy_rec ~bound_univars in
@@ -1873,7 +1873,7 @@ let () = Ikind.instance_poly_for_jkind' := instance_poly_for_jkind
 
 let instance_label_type' copy_scope ~fixed lbl_arg =
   match get_desc lbl_arg with
-    Tpoly (ty, tl) ->
+    Tpoly (ty, tl, _) ->
       instance_poly' copy_scope
         ~keep_names:false ~copy_var:None ~fixed ~partial:false tl ty
   | _ ->
@@ -2417,7 +2417,7 @@ let rec try_reduce_once env t =
       Tvariant (copy_row new_quote_eval_ty true row false more)
     (* [<['a. t]> eval] ==> ['b. (<[{$'b/'a} t]> eval)],
         where {t/x} is a substitution of t for x. *)
-    | Tpoly (t, tl) ->
+    | Tpoly (t, tl, zero_alloc) ->
       (* We quantify again, but with the univars [tl'] at an outer stage.
           This means all instances of univars [tl] have to be replaced
           by a corresponding instance in [tl'] spliced. *)
@@ -2435,7 +2435,7 @@ let rec try_reduce_once env t =
           (fun t -> match get_desc t with Tsplice uv -> uv | _ -> assert false)
           tl'
       in
-      Tpoly (new_quote_eval_ty t', tl')
+      Tpoly (new_quote_eval_ty t', tl', zero_alloc)
     (* [<[(sort 'a). t]> eval] ==> [(sort 'a). <[t]> eval] *)
     | Trepr (t, sl) ->
       Trepr (new_quote_eval_ty t, sl)
@@ -2551,7 +2551,7 @@ let rec extract_concrete_typedecl env ty =
                 | May_have_typedecl -> May_have_typedecl
           end
       end
-  | Tpoly(ty, _) -> extract_concrete_typedecl env ty
+  | Tpoly(ty, _, _) -> extract_concrete_typedecl env ty
   | Trepr _ -> Has_no_typedecl
   | Tquote ty -> extract_concrete_typedecl (incr_stage env) ty
   | Tsplice ty -> extract_concrete_typedecl (decr_stage env) ty
@@ -2687,7 +2687,7 @@ let unbox_once env ty =
         end
       end
     end
-  | Tpoly (ty, univars) ->
+  | Tpoly (ty, univars, _) ->
     Stepped
       { ty = instance_poly_for_jkind univars ty
       ; modality = Mode.Modality.Const.id
@@ -2705,7 +2705,7 @@ let contained_without_boxing env ty =
     end
   | Tunboxed_tuple labeled_tys ->
     List.map snd labeled_tys
-  | Tpoly (ty, _) -> [ty]
+  | Tpoly (ty, _, _) -> [ty]
   | Trepr (_, _) ->  Misc.fatal_error "Ctype.contained_without_boxing: repr"
   | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil | Tlink _
   | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ | Tof_kind _
@@ -2942,7 +2942,7 @@ and estimate_type_jkind ~expand_components ~ignore_mod_bounds env ty =
   | Tvariant row ->
      Jkind.for_boxed_row row
   | Tunivar { jkind } -> Jkind.disallow_right jkind
-  | Tpoly (ty, univars) ->
+  | Tpoly (ty, univars, _) ->
     (* The jkind of [ty] might mention the variables bound in this [Tpoly]
        node, and so just returning it here would be wrong. Instead, we need
        to eliminate these variables. We do this by replacing them with
@@ -3092,7 +3092,7 @@ let constrain_type_jkind ~fixed env ty jkind =
 
     (* Handle the [Tpoly] case out here so [Tvar]s wrapped in [Tpoly]s can get
        the treatment above. *)
-    | Tpoly (t, _) ->
+    | Tpoly (t, _, _) ->
       (* [t] probably contains variables that will escapes their scope here. But
          comparing these variables in jkinds is fine, and they can't escape from
          this function (except harmlessly in error messages), so we don't do
@@ -3449,7 +3449,7 @@ let constrain_type_jkind_exn env texn ty jkind =
 *)
 let rec intersect_type_jkind ~reason env ty1 jkind2 =
   match get_desc ty1 with
-  | Tpoly (ty, _) -> intersect_type_jkind ~reason env ty jkind2
+  | Tpoly (ty, _, _) -> intersect_type_jkind ~reason env ty jkind2
   | _ ->
     (* [intersect_type_jkind] is called rarely, so we don't bother with trying
        to avoid this call as in [constrain_type_jkind] *)
@@ -3740,7 +3740,7 @@ let occur_univar ?(inj_only=false) env ty =
         Tunivar _ ->
           if not (TypeSet.mem ty bound) then
             raise_escape_exn (Univ ty)
-      | Tpoly (ty, tyl) ->
+      | Tpoly (ty, tyl, _) ->
           let bound = List.fold_right TypeSet.add tyl bound in
           occur_rec env bound ty
       | Trepr (ty, _sort_vars) ->
@@ -3804,7 +3804,7 @@ let univars_escape env univar_pairs vl ty =
   let rec occur env t =
     if try_mark_node mark t then begin
       match get_desc t with
-        Tpoly (t, tl) ->
+        Tpoly (t, tl, _) ->
           if List.exists (fun t -> TypeSet.mem t family) tl then ()
           else occur env t
       | Tunivar _ -> if TypeSet.mem t family then raise_escape_exn (Univ t)
@@ -3834,9 +3834,11 @@ let enter_poly env univar_pairs t1 tl1 t2 tl2 f =
       TypeSet.empty old_univars
   in
   if List.exists (fun t -> TypeSet.mem t known_univars) tl1 then
-     univars_escape env old_univars tl1 (newty(Tpoly(t2,tl2)));
+    univars_escape env old_univars tl1
+      (newty(Tpoly(t2,tl2,None)));
   if List.exists (fun t -> TypeSet.mem t known_univars) tl2 then
-    univars_escape env old_univars tl2 (newty(Tpoly(t1,tl1)));
+    univars_escape env old_univars tl2
+      (newty(Tpoly(t1,tl1,None)));
   let cl1 = List.map (fun t -> t, ref None) tl1
   and cl2 = List.map (fun t -> t, ref None) tl2 in
   univar_pairs := (cl1,cl2) :: (cl2,cl1) :: old_univars;
@@ -3867,7 +3869,7 @@ let polyfy env ty vars =
   For_copy.with_scope (fun copy_scope ->
     let vars' = List.filter_map (subst_univar copy_scope) vars in
     let ty = copy copy_scope ty in
-    let ty = newty2 ~level:(get_level ty) (Tpoly(ty, vars')) in
+    let ty = newty2 ~level:(get_level ty) (Tpoly(ty, vars', None)) in
     let complete = List.length vars = List.length vars' in
     ty, complete
   )
@@ -4107,6 +4109,16 @@ let equivalent_with_nolabels l1 l2 =
   | (Nolabel | Labelled _), (Nolabel | Labelled _) -> true
   | _ -> false)
 
+let verify_zero_alloc_equal context_za context_tr za1 za2 =
+  match za1, za2 with
+  | None, None -> ()
+  | Some _, None | None, Some _ ->
+    raise_for context_tr (Incompatible_zero_alloc Zero_alloc.one_missing)
+  | Some check1, Some check2 ->
+    match Zero_alloc.assert_equal_checks ~context:context_za check1 check2 with
+    | Ok () -> ()
+    | Error e -> raise_for context_tr (Incompatible_zero_alloc e)
+
 (* the [tk] means we're comparing a type against a jkind; axes do
    not matter, so a jkind extracted from a type_declaration does
    not need to be substed *)
@@ -4217,13 +4229,15 @@ let rec mcomp type_pairs env t1 t2 =
             mcomp type_pairs (incr_stage env) t1 t2
         | (Tnil, Tnil, _, _) ->
             ()
-        | (Tpoly (t1, []), Tpoly (t2, []), _, _) ->
-            mcomp type_pairs env t1 t2
-        | (Tpoly (t1, tl1), Tpoly (t2, tl2), _, _) ->
+        | (Tpoly (t1, [], za1), Tpoly (t2, [], za2), _, _) ->
+            mcomp type_pairs env t1 t2;
+            verify_zero_alloc_equal Fun_param Unify za1 za2
+        | (Tpoly (t1, tl1, za1), Tpoly (t2, tl2, za2), _, _) ->
             (try
                enter_poly env univar_pairs
                  t1 tl1 t2 tl2 (mcomp type_pairs env)
-             with Escape _ -> raise Incompatible)
+             with Escape _ -> raise Incompatible);
+            verify_zero_alloc_equal Fun_param Unify za1 za2
         | (Trepr (t1, sort_vars1), Trepr (t2, sort_vars2), _, _) ->
             (* For layout-polymorphic types, establish correspondence between
                sort variables positionally, then compare the bodies. *)
@@ -5040,11 +5054,13 @@ and unify3 uenv t1 t1' t2 t2' =
           end
       | (Tnil, Tnil) ->
           ()
-      | (Tpoly (t1, []), Tpoly (t2, [])) ->
-          unify uenv t1 t2
-      | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
+      | (Tpoly (t1, [], za1), Tpoly (t2, [], za2)) ->
+          unify uenv t1 t2;
+          verify_zero_alloc_equal Fun_param Unify za1 za2
+      | (Tpoly (t1, tl1, za1), Tpoly (t2, tl2, za2)) ->
           enter_poly_for Unify (get_env uenv) univar_pairs t1 tl1 t2 tl2
-            (unify uenv)
+            (unify uenv);
+          verify_zero_alloc_equal Fun_param Unify za1 za2
       | (Trepr (t1, sort_vars1), Trepr (t2, sort_vars2)) ->
           (* For layout-polymorphic types, establish correspondence between
              sort variables positionally, then unify the bodies. *)
@@ -5482,7 +5498,7 @@ type filtered_arrow =
     ret_mode : Mode.Alloc.lr
   }
 
-let filter_arrow env t l ~force_tpoly =
+let filter_arrow env t l ~force_tpoly ~zero_alloc =
   let function_type level =
     let k_arg = Jkind.Builtin.any ~why:Inside_of_Tarrow in
     let k_res = Jkind.Builtin.any ~why:Inside_of_Tarrow in
@@ -5504,7 +5520,7 @@ let filter_arrow env t l ~force_tpoly =
           else
             newvar2 level k_arg
         in
-        newty2 ~level (Tpoly(t1, []))
+        newty2 ~level (Tpoly(t1, [], zero_alloc))
       end
     in
     let ty_ret = newvar2 level k_res in
@@ -5554,14 +5570,14 @@ exception Filter_mono_failed
 
 let filter_mono ty =
   match get_desc ty with
-  | Tpoly(ty, []) -> ty
+  | Tpoly(ty, [], _) -> ty
   | Tpoly _ -> raise Filter_mono_failed
   | _ -> assert false
 
 exception Filter_arrow_mono_failed
 
 let filter_arrow_mono env t l =
-  match filter_arrow env t l ~force_tpoly:true with
+  match filter_arrow env t l ~force_tpoly:true ~zero_alloc:None with
   | exception Filter_arrow_failed _ -> raise Filter_arrow_mono_failed
   | {ty_arg; _} as farr ->
       match filter_mono ty_arg with
@@ -6217,11 +6233,13 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
                 t1' t2'
           | (Tnil, Tnil) ->
               ()
-          | (Tpoly (t1, []), Tpoly (t2, [])) ->
-              moregen inst_nongen variance type_pairs env t1 t2
-          | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
+          | (Tpoly (t1, [], za1), Tpoly (t2, [], za2)) ->
+              moregen inst_nongen variance type_pairs env t1 t2;
+              verify_zero_alloc_equal Fun_param Moregen za1 za2
+          | (Tpoly (t1, tl1, za1), Tpoly (t2, tl2, za2)) ->
               enter_poly_for Moregen env univar_pairs t1 tl1 t2 tl2
-                (moregen inst_nongen variance type_pairs env)
+                (moregen inst_nongen variance type_pairs env);
+              verify_zero_alloc_equal Fun_param Moregen za1 za2
           | (Trepr (t1, sort_vars1), Trepr (t2, sort_vars2)) ->
               (* For layout-polymorphic types, establish correspondence
                  between sort variables positionally, then check moregen on
@@ -6713,11 +6731,13 @@ let rec eqtype rename type_pairs subst env ~do_jkind_check t1 t2 =
                 t1' t2'
           | (Tnil, Tnil) ->
               ()
-          | (Tpoly (t1, []), Tpoly (t2, [])) ->
-              eqtype rename type_pairs subst env t1 t2 ~do_jkind_check
-          | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
+          | (Tpoly (t1, [], za1), Tpoly (t2, [], za2)) ->
+              eqtype rename type_pairs subst env t1 t2 ~do_jkind_check;
+              verify_zero_alloc_equal Fun_param Equality za1 za2
+          | (Tpoly (t1, tl1, za1), Tpoly (t2, tl2, za2)) ->
               enter_poly_for Equality env univar_pairs t1 tl1 t2 tl2
-                (eqtype rename type_pairs subst env ~do_jkind_check)
+                (eqtype rename type_pairs subst env ~do_jkind_check);
+              verify_zero_alloc_equal Fun_param Equality za1 za2
           | (Trepr (t1, sort_vars1), Trepr (t2, sort_vars2)) ->
               (* For layout-polymorphic types, establish correspondence
                  between sort variables positionally, then check equality on
@@ -7469,9 +7489,9 @@ let rec build_subtype env (visited : transient_expr list)
       end
   | Tsubst _ | Tlink _ ->
       assert false
-  | Tpoly(t1, tl) ->
+  | Tpoly(t1, tl, za) ->
       let (t1', c) = build_subtype env visited loops posi level t1 in
-      if c > Unchanged then (newty (Tpoly(t1', tl)), c)
+      if c > Unchanged then (newty (Tpoly(t1', tl, za)), c)
       else (t, Unchanged)
   | Trepr(t1, tl) ->
       let (t1', c) = build_subtype env visited loops posi level t1 in
@@ -7617,18 +7637,24 @@ let rec subtype_rec env trace t1 t2 cstrs =
         with Exit ->
           (trace, t1, t2, !univar_pairs)::cstrs
         end
-    | (Tpoly (u1, []), Tpoly (u2, [])) ->
-        subtype_rec env trace u1 u2 cstrs
-    | (Tpoly (u1, tl1), Tpoly (u2, [])) ->
+    | (Tpoly (u1, [], za1), Tpoly (u2, [], za2)) ->
+        let r = subtype_rec env trace u1 u2 cstrs in
+        verify_zero_alloc_equal Fun_param Unify za1 za2;
+        r
+    | (Tpoly (u1, tl1, za1), Tpoly (u2, [], za2)) ->
         let u1' = instance_poly tl1 u1 in
-        subtype_rec env trace u1' u2 cstrs
-    | (Tpoly (u1, tl1), Tpoly (u2,tl2)) ->
-        begin try
+        let r = subtype_rec env trace u1' u2 cstrs in
+        verify_zero_alloc_equal Fun_param Unify za1 za2;
+        r
+    | (Tpoly (u1, tl1, za1), Tpoly (u2, tl2, za2)) ->
+        let r = begin try
           enter_poly env univar_pairs u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 cstrs)
         with Escape _ ->
           (trace, t1, t2, !univar_pairs)::cstrs
-        end
+        end in
+        verify_zero_alloc_equal Fun_param Unify za1 za2;
+        r
     | (Trepr (u1, sort_vars1), Trepr (u2, sort_vars2)) ->
         (* For layout-polymorphic types, establish correspondence between
            sort variables positionally, then check subtype on the bodies. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -93,7 +93,7 @@ val new_global_var: ?name:string -> jkind_lr -> type_expr
            (as type variables ['a] in type constraints). *)
 val newobj: type_expr -> type_expr
 val newconstr: Path.t -> type_expr list -> type_expr
-val newmono : zero_alloc:Zero_alloc.check option -> type_expr -> type_expr
+val newmono : type_expr -> type_expr
 val none: type_expr
         (* A dummy type expression *)
 
@@ -348,14 +348,13 @@ type filtered_arrow =
   }
 
 val filter_arrow: Env.t -> type_expr -> arg_label ->
-                  force_tpoly:bool -> zero_alloc:Zero_alloc.check option ->
-                  filtered_arrow
+                  has_poly:Btype.explicit_poly -> filtered_arrow
         (* A special case of unification (with l:'a -> 'b). If
-           [force_poly] is false then the usual invariant that the
+           [has_poly] is [Mono] then the usual invariant that the
            argument type be a [Tpoly] node is not enforced. Raises
            [Filter_arrow_failed] instead of [Unify].  *)
 val filter_mono: type_expr -> type_expr
-        (* A special case of unification (with Tpoly('a, [])). Can
+        (* A special case of unification (with Tpoly('a, [], None)). Can
            only be called on [Tpoly] nodes. Raises [Filter_mono_failed]
            instead of [Unify] *)
 val filter_arrow_mono: Env.t -> type_expr -> arg_label -> filtered_arrow

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -93,7 +93,7 @@ val new_global_var: ?name:string -> jkind_lr -> type_expr
            (as type variables ['a] in type constraints). *)
 val newobj: type_expr -> type_expr
 val newconstr: Path.t -> type_expr list -> type_expr
-val newmono : type_expr -> type_expr
+val newmono : zero_alloc:Zero_alloc.check option -> type_expr -> type_expr
 val none: type_expr
         (* A dummy type expression *)
 
@@ -347,7 +347,8 @@ type filtered_arrow =
     ret_mode : Mode.Alloc.lr
   }
 
-val filter_arrow: Env.t -> type_expr -> arg_label -> force_tpoly:bool ->
+val filter_arrow: Env.t -> type_expr -> arg_label ->
+                  force_tpoly:bool -> zero_alloc:Zero_alloc.check option ->
                   filtered_arrow
         (* A special case of unification (with l:'a -> 'b). If
            [force_poly] is false then the usual invariant that the

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -113,6 +113,7 @@ type ('a, 'variety) elt =
   | Unequal_var_jkinds :
       type_expr * jkind_lr * type_expr * jkind_lr -> ('a, _) elt
   | Unequal_tof_kind_jkinds : jkind_lr * jkind_lr -> ('a, _) elt
+  | Incompatible_zero_alloc : Zero_alloc.error -> ('a, 'variety) elt
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 
@@ -130,6 +131,7 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Bad_jkind_sort _ as x -> x
   | Unequal_var_jkinds _ as x -> x
   | Unequal_tof_kind_jkinds _ as x -> x
+  | Incompatible_zero_alloc _ as x -> x
 
 let map f t = List.map (map_elt f) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -98,6 +98,7 @@ type ('a, 'variety) elt =
   | Unequal_var_jkinds :
       type_expr * jkind_lr * type_expr * jkind_lr -> ('a, _) elt
   | Unequal_tof_kind_jkinds : jkind_lr * jkind_lr -> ('a, _) elt
+  | Incompatible_zero_alloc : Zero_alloc.error -> ('a, 'variety) elt
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -441,7 +441,7 @@ module Solver = struct
       | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
       | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
       | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
-      | Types.Tpoly (ty, univars) ->
+      | Types.Tpoly (ty, univars, _zero_alloc) ->
         (* CR ikinds: this is sound but not fully precise.
           Internal ticket 5746. *)
         let ty = !instance_poly_for_jkind' univars ty in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -196,7 +196,7 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  begin match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
+  begin match Zero_alloc.sub ~context:Signature vd1.val_zero_alloc vd2.val_zero_alloc with
   | Ok () -> ()
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -196,9 +196,11 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  begin match Zero_alloc.sub ~context:Signature vd1.val_zero_alloc vd2.val_zero_alloc with
-  | Ok () -> ()
-  | Error e -> raise (Dont_match (Zero_alloc e))
+  begin
+    match Zero_alloc.sub ~context:Signature
+            vd1.val_zero_alloc vd2.val_zero_alloc with
+    | Ok () -> ()
+    | Error e -> raise (Dont_match (Zero_alloc e))
   end;
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1080,7 +1080,7 @@ module Base_and_axes = struct
             ({ tuple_fuel; seen_constrs; seen_row_vars; fuel_status = _ } as t)
             ty =
           match Types.get_desc ty with
-          | Tpoly (ty, _) | Trepr (ty, _) -> check ~relevant_axes t ty
+          | Tpoly (ty, _, _) | Trepr (ty, _) -> check ~relevant_axes t ty
           | Ttuple _ ->
             if tuple_fuel > 0
             then

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -389,24 +389,26 @@ let print_arg_label_and_out_type ppf (lbl : arg_label) ty ~print_type =
   | Position l -> fprintf ppf "%a:[%%call_pos]" print_lident l
   | Optional l -> fprintf ppf "?%a:%a" print_lident l print_type ty
 
+let pp_arg_zero_alloc ppf (zero_alloc : Zero_alloc.check option) =
+  match zero_alloc with
+  | None -> ()
+  | Some check ->
+    fprintf ppf "@ [@zero_alloc%s]" (Zero_alloc.check_payload_to_string check)
+
 let rec print_out_type_0 ppf =
   function
   | Otyp_alias {non_gen; aliased; alias } ->
     fprintf ppf "@[%a@ as %a@]"
       print_out_type_0 aliased
       (ty_var ~non_gen) alias
-  | Otyp_poly ([], ty) ->
-      print_out_type_0 ppf ty  (* no "." if there are no vars *)
   | Otyp_newlayout ([], ty) ->
       print_out_type_0 ppf ty  (* no "." if there are no vars *)
-  | Otyp_poly (sl, ty) ->
-      fprintf ppf "@[<hov 2>%a.@ %a@]"
-        pr_var_jkinds sl
-        print_out_type_0 ty
   | Otyp_newlayout (sl, ty) ->
       fprintf ppf "@[<hov 2>layout_ %a.@ %a@]"
         pr_sort_univars sl
         print_out_type_0 ty
+  | Otyp_poly _ as ty ->
+      print_poly_body ppf ty
   | Otyp_repr ([], ty) ->
       print_out_type_0 ppf ty  (* no "." if there are no vars *)
   | Otyp_repr (sl, ty) ->
@@ -420,13 +422,33 @@ let rec print_out_type_0 ppf =
    - It is an argument to a function ([~arg])
    - Or, there is at least one mode to print.
  *)
+and print_poly_body ppf = function
+  | Otyp_poly ([], ty, _) -> print_out_type_0 ppf ty
+  | Otyp_poly (sl, ty, _) ->
+      fprintf ppf "@[<hov 2>%a.@ %a@]"
+        pr_var_jkinds sl
+        print_out_type_0 ty
+  | _ -> assert false
+
 and print_out_type_mode ~arg mode ppf ty =
-  let parens =
-    is_initially_labeled_tuple ty && arg
+  let zero_alloc = match ty with
+    | Otyp_poly (_, _, za) -> za
+    | _ -> None
   in
+  let has_zero_alloc = Option.is_some zero_alloc in
+  let parens = (is_initially_labeled_tuple ty || has_zero_alloc) && arg in
   if parens then
     pp_print_char ppf '(';
-  print_out_type_2 ppf ty;
+  (match ty with
+   | Otyp_poly ([], inner, _) ->
+     (* Peel the empty-vars Otyp_poly so that print_out_type_2 can decide
+        whether the inner type needs its own parens (e.g. arrows get them,
+        simple constrs do not), rather than unconditionally wrapping
+        the whole Otyp_poly node in parens. *)
+     print_out_type_2 ppf inner
+   | _ -> print_out_type_2 ppf ty);
+  if has_zero_alloc then
+    pp_arg_zero_alloc ppf zero_alloc;
   if parens then
     pp_print_char ppf ')';
   print_out_modes ppf mode
@@ -435,7 +457,8 @@ and print_out_type_1 ppf =
   function
   | Otyp_arrow (lab, am, ty1, ty2) ->
       pp_open_box ppf 0;
-      print_arg_label_and_out_type ppf lab ty1 ~print_type:(print_out_arg am);
+      print_arg_label_and_out_type ppf lab ty1
+        ~print_type:(print_out_arg am);
       pp_print_string ppf " ->";
       pp_print_space ppf ();
       print_out_ret ppf ty2;
@@ -457,7 +480,8 @@ and print_out_ret ppf =
       pp_print_char ppf ')';
       print_out_modes ppf rm
     end
-  | Otyp_ret (Orm_any rm, ty) -> print_out_type_mode ~arg:false rm ppf ty
+  | Otyp_ret (Orm_any rm, ty) ->
+    print_out_type_mode ~arg:false rm ppf ty
   | _ -> assert false
 
 and print_out_type_2 ppf =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -423,11 +423,19 @@ let rec print_out_type_0 ppf =
    - Or, there is at least one mode to print.
  *)
 and print_poly_body ppf = function
-  | Otyp_poly ([], ty, _) -> print_out_type_0 ppf ty
-  | Otyp_poly (sl, ty, _) ->
+  | Otyp_poly ([], ty, None) ->
+      print_out_type_0 ppf ty
+  | Otyp_poly ([], ty, (Some _ as za)) ->
+      fprintf ppf "(%a%a)" print_simple_out_type ty pp_arg_zero_alloc za
+  | Otyp_poly (sl, ty, None) ->
       fprintf ppf "@[<hov 2>%a.@ %a@]"
         pr_var_jkinds sl
         print_out_type_0 ty
+  | Otyp_poly (sl, ty, (Some _ as za)) ->
+      fprintf ppf "@[<hov 2>(%a.@ (%a%a))@]"
+        pr_var_jkinds sl
+        print_simple_out_type ty
+        pp_arg_zero_alloc za
   | _ -> assert false
 
 and print_out_type_mode ~arg mode ppf ty =

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -83,6 +83,8 @@ type arg_label =
   | Optional of string
   | Position of string
 
+type arg_zero_alloc = Zero_alloc.check option
+
 type out_mode = string
 
 type out_arg_mode = out_mode list
@@ -128,7 +130,8 @@ and out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
-  | Otyp_arrow of arg_label * out_arg_mode * out_type * out_type
+  | Otyp_arrow of
+      arg_label * out_arg_mode * out_type * out_type
   (** INVARIANT: the [out_type] for the return must be [Otyp_ret]. *)
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
@@ -147,7 +150,7 @@ and out_type =
   | Otyp_variant of out_variant * bool * (string list) option
   | Otyp_quote of out_type
   | Otyp_splice of out_type
-  | Otyp_poly of out_vars_jkinds * out_type
+  | Otyp_poly of out_vars_jkinds * out_type * arg_zero_alloc
   | Otyp_repr of string list * out_type
   | Otyp_newlayout of out_sort_genvar list * out_type
   | Otyp_module of out_ident * (string * out_type) list

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -242,7 +242,8 @@ let rec add_native_repr_attributes ty attrs =
   match ty, attrs with
     (* Otyp_poly and Otyp_newlayout case might have been added in e.g.
        tree_of_value_description *)
-  | Otyp_poly (vars, ty), _ -> Otyp_poly (vars, add_native_repr_attributes ty attrs)
+  | Otyp_poly (vars, ty, zero_alloc), _ ->
+    Otyp_poly (vars, add_native_repr_attributes ty attrs, zero_alloc)
   | Otyp_newlayout (vars, ty), _ ->
     Otyp_newlayout (vars, add_native_repr_attributes ty attrs)
   | Otyp_arrow (label, am, a, Otyp_ret (rm, r)), attr_l :: rest ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1528,7 +1528,7 @@ type modal =
     treated as NOT an arrow type, to align with the currying logic in
     [typetexp.ml].
 
-    If [r] is [Tpoly (Tarrow_, [])], it will be treated as NOT an arrow type.
+    If [r] is [Tpoly (Tarrow_, [], _)], it will be treated as NOT an arrow type.
     This gives tedious (but still correct) printing. *)
 
   | Other of Mode.Alloc.Const.t

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -734,7 +734,7 @@ and raw_type_desc ppf = function
   | Tunivar { name; jkind } ->
       fprintf ppf "Tunivar (@,%a,@,%a)"
         print_name name (Jkind.format !printing_env) jkind
-  | Tpoly (t, tl) ->
+  | Tpoly (t, tl, _za) ->
       fprintf ppf "@[<hov1>Tpoly(@,%a,@,%a)@]"
         raw_type t
         raw_type_list tl
@@ -1355,7 +1355,7 @@ let rec mark_loops_rec visited ty =
             visited_objects := px :: !visited_objects;
           printer_iter_type_expr (mark_loops_rec visited) ty
         end
-    | Tpoly(ty, tyl) ->
+    | Tpoly(ty, tyl, _) ->
         List.iter add_alias tyl;
         mark_loops_rec visited ty
     | _ ->
@@ -1662,9 +1662,11 @@ let rec tree_of_modal_typexp mode modal ty =
         Otyp_stuff "<Tsubst>"
     | Tlink _ ->
         fatal_error "Printtyp.tree_of_typexp"
-    | Tpoly (ty, []) | Trepr (ty, []) ->
+    | Tpoly (ty, [], None) ->
         tree_of_typexp mode alloc_mode ty
-    | Tpoly (ty, tyl) ->
+    | Tpoly (ty, [], za) ->
+        Otyp_poly ([], tree_of_typexp mode alloc_mode ty, za)
+    | Tpoly (ty, tyl, za) ->
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
           prerr_string "; " in *)
@@ -1674,15 +1676,19 @@ let rec tree_of_modal_typexp mode modal ty =
            printed once when used as proxy *)
         List.iter add_delayed tyl;
         let tl = tree_of_qtvs tyl in
-        let tr = Otyp_poly (tl, tree_of_typexp mode alloc_mode ty) in
+        let tr =
+          Otyp_poly (tl, tree_of_typexp mode alloc_mode ty, za)
+        in
         (* Forget names when we leave scope *)
         Names.remove_names tyl;
         delayed := old_delayed; tr
+    | Trepr (ty, []) ->
+        tree_of_typexp mode alloc_mode ty
     | Trepr (ty, sort_vars) ->
         (* Trepr wraps a Tpoly that contains the type variables
            corresponding to the sort variables. Extract them and print. *)
         (match get_desc ty with
-         | Tpoly (inner_ty, (_ :: _ as tyl))  ->
+         | Tpoly (inner_ty, (_ :: _ as tyl), _za)  ->
              (* Check that the sort_vars match the jkinds of tyl *)
              let sorts_match =
                match
@@ -2416,8 +2422,32 @@ let extension_only_constructor id ppf ext =
       ocstr_return_type = ret;
     }
 
-(* Print a value declaration *)
+(* Print zero alloc information, if any *)
+let tree_of_zero_alloc zero_alloc apparent_arity =
+  let open Zero_alloc in
+  match zero_alloc with
+  | Default_zero_alloc | Ignore_assert_all -> None
+  | Check ({ custom_error_msg; _ } as check) ->
+    Some { oattr_name =
+         String.concat ""
+           ["zero_alloc";
+            Zero_alloc.check_payload_to_string ~apparent_arity check;
+            match custom_error_msg with
+            | None -> ""
+            | Some msg -> Printf.sprintf " custom_error_message %S" msg
+           ] }
+  | Assume { strict; never_returns_normally; arity; _ } ->
+    Some { oattr_name =
+         String.concat ""
+           ["zero_alloc assume";
+            if strict then " strict" else "";
+            if never_returns_normally then " never_returns_normally" else "";
+            if arity = apparent_arity then "" else
+              Printf.sprintf " arity %d" arity;
+           ]
+     }
 
+(* Print a value declaration *)
 let tree_of_value_description id decl =
   (* Format.eprintf "@[%a@]@." raw_type_expr decl.val_type; *)
   let id = Ident.name id in
@@ -2448,34 +2478,12 @@ let tree_of_value_description id decl =
     count 0 decl.val_type
   in
   let attrs =
-    match Zero_alloc.get decl.val_zero_alloc with
-    | Default_zero_alloc | Ignore_assert_all -> []
-    | Check { strict; opt; arity; custom_error_msg; loc = _; } ->
-      [{ oattr_name =
-           String.concat ""
-             ["zero_alloc";
-              if strict then " strict" else "";
-              if opt then " opt" else "";
-              if arity = apparent_arity then "" else
-                Printf.sprintf " arity %d" arity;
-              match custom_error_msg with
-              | None -> ""
-              | Some msg -> Printf.sprintf " custom_error_message %S" msg
-             ] }]
-    | Assume { strict; never_returns_normally; arity; _ } ->
-      [{ oattr_name =
-           String.concat ""
-             ["zero_alloc assume";
-              if strict then " strict" else "";
-              if never_returns_normally then " never_returns_normally" else "";
-              if arity = apparent_arity then "" else
-                Printf.sprintf " arity %d" arity;
-             ]
-       }]
+    Option.to_list
+      (tree_of_zero_alloc (Zero_alloc.get decl.val_zero_alloc) apparent_arity)
   in
   let vd =
     { oval_name = id;
-      oval_type = Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty));
+      oval_type = Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty, None));
       oval_modalities = tree_of_modalities Immutable moda;
       oval_prims = [];
       oval_attributes = attrs
@@ -2495,7 +2503,7 @@ let value_description id ppf decl =
 
 let method_type priv ty =
   match priv, get_desc ty with
-  | Mpublic, Tpoly(ty, tyl) -> (ty, tyl)
+  | Mpublic, Tpoly(ty, tyl, _) -> (ty, tyl)
   | _ , _ -> (ty, [])
 
 let prepare_method _lab (priv, _virt, ty) =
@@ -2511,7 +2519,7 @@ let tree_of_method mode (lab, priv, virt, ty) =
   Names.remove_names tyl;
   let priv = priv <> Mpublic in
   let virt = virt = Virtual in
-  Ocsg_method (lab, priv, virt, Otyp_poly(qtvs, tty))
+  Ocsg_method (lab, priv, virt, Otyp_poly(qtvs, tty, None))
 
 let rec prepare_class_type params = function
   | Cty_constr (_p, tyl, cty) ->
@@ -3223,7 +3231,7 @@ let print_tags ppf tags  =
   Fmt.(pp_print_list ~pp_sep:comma) print_tag ppf tags
 
 let is_unit_arg env ty =
-  let ty, vars = tpoly_get_poly ty in
+  let ty, vars, _ = tpoly_get_poly ty in
   if vars <> [] then false
   else begin
     (* CR metaprogramming jbachurski: Remove [contains_toplevel_splice] and
@@ -3454,6 +3462,8 @@ let explanation (type variety) intro prev env
       Some (doc_printf "@ because their kinds are different.\
                      @ @[<v>%t@;%t@]"
               (fmt_history "the first" k1) (fmt_history "the second" k2))
+  | Errortrace.Incompatible_zero_alloc e ->
+      Some(doc_printf "@,@[%a@]" Zero_alloc.print_error e)
 
 let mismatch intro env trace =
   Errortrace.explain trace (fun ~prev h -> explanation intro prev env h)
@@ -3516,7 +3526,7 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
            | Unequal_tof_kind_jkinds _) ->
         true
     | Some (Diff _ | Escape _ | Variant _ | Obj _ | Incompatible_fields _
-           | Rec_occur _)
+           | Rec_occur _ | Incompatible_zero_alloc _)
     | None ->
         false
   in

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -293,7 +293,7 @@ module Type_shape = struct
                information about the type. *)
           | Ttuple exprs -> Shape.tuple (of_expr_list (List.map snd exprs))
           | Tvar { name = _; jkind } -> unknown_shape_from_jkind jkind
-          | Tpoly (type_expr, _type_vars) ->
+          | Tpoly (type_expr, _type_vars, _zero_alloc) ->
             (* CR sspies: At the moment, we simply ignore the polymorphic
                variables.
                This code used to only work for [_type_vars = []]. Consider
@@ -322,7 +322,7 @@ module Type_shape = struct
                 | Tobject (_, _)
                 | Tfield (_, _, _, _)
                 | Tvariant _ | Tunivar _
-                | Tpoly (_, _)
+                | Tpoly (_, _, _)
                 | Trepr (_, _)
                 | Tpackage (_, _)
                 | Tquote _ | Tsplice _ | Tquote_eval _ | Tof_kind _ ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -197,7 +197,7 @@ let rec constructor_type constr cty =
       constr
   | Cty_arrow (l, ty, cty) ->
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
-      let ty = Ctype.newmono ty in
+      let ty = Ctype.newmono ~zero_alloc:None ty in
       Ctype.newty
         (Tarrow (arrow_desc, ty, constructor_type constr cty, commu_ok))
 
@@ -830,9 +830,9 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                    let ty' =
                      Ctype.newvar (Jkind.Builtin.value ~why:Object_field)
                    in
-                   Ctype.unify val_env (Ctype.newmono ty') ty;
+                   Ctype.unify val_env (Ctype.newmono ~zero_alloc:None ty') ty;
                    Typecore.type_approx val_env sbody ty'
-               | Tpoly (ty1, tl) ->
+               | Tpoly (ty1, tl, _) ->
                    let ty1' = Ctype.instance_poly tl ty1 in
                    Typecore.type_approx val_env sbody ty1'
                | _ -> assert false
@@ -965,7 +965,7 @@ and class_field_second_pass cl_num sign met_env field =
            let ty = Btype.method_type label.txt sign in
            let self_type = sign.Types.csig_self in
            let arrow_desc = Nolabel, Mode.Alloc.legacy, Mode.Alloc.legacy in
-           let self_param_type = Btype.newgenty (Tpoly(self_type, [])) in
+           let self_param_type = Btype.newgenty (Tpoly(self_type, [], None)) in
            let meth_type =
              Typecore.mk_expected (Btype.newgenty
                 (Tarrow(arrow_desc, self_param_type, ty, commu_ok)))
@@ -983,7 +983,9 @@ and class_field_second_pass cl_num sign met_env field =
       Warnings.with_state warning_state
         (fun () ->
            let unit_type = Ctype.instance Predef.type_unit in
-           let self_param_type = Ctype.newmono sign.Types.csig_self in
+           let self_param_type =
+             Ctype.newmono ~zero_alloc:None sign.Types.csig_self
+           in
            let arrow_desc = Nolabel, Mode.Alloc.legacy, Mode.Alloc.legacy in
            let meth_type =
              Typecore.mk_expected (Ctype.newty
@@ -1489,7 +1491,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                 val_kind = Val_ivar (Immutable, cl_num);
                 val_lpoly = Lpoly.determined [];
                 val_attributes = [];
-                val_zero_alloc = Zero_alloc.default;
+                val_zero_alloc = vd.val_zero_alloc;
                 Types.val_loc = vd.val_loc;
                 val_uid = vd.val_uid;
                }
@@ -1589,7 +1591,7 @@ let rec approx_declaration cl =
           (* CR layouts: use of value here may be relaxed when we update
            classes to work with jkinds *)
       in
-      let arg = Ctype.newmono arg in
+      let arg = Ctype.newmono ~zero_alloc:None arg in
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_declaration cl, commu_ok))
@@ -1609,7 +1611,7 @@ let rec approx_description ct =
         (* CR layouts: use of value here may be relaxed when we
            relax jkinds in classes *)
       in
-      let arg = Ctype.newmono arg in
+      let arg = Ctype.newmono ~zero_alloc:None arg in
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_description ct, commu_ok))

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -197,7 +197,7 @@ let rec constructor_type constr cty =
       constr
   | Cty_arrow (l, ty, cty) ->
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
-      let ty = Ctype.newmono ~zero_alloc:None ty in
+      let ty = Ctype.newmono ty in
       Ctype.newty
         (Tarrow (arrow_desc, ty, constructor_type constr cty, commu_ok))
 
@@ -830,7 +830,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                    let ty' =
                      Ctype.newvar (Jkind.Builtin.value ~why:Object_field)
                    in
-                   Ctype.unify val_env (Ctype.newmono ~zero_alloc:None ty') ty;
+                   Ctype.unify val_env (Ctype.newmono ty') ty;
                    Typecore.type_approx val_env sbody ty'
                | Tpoly (ty1, tl, _) ->
                    let ty1' = Ctype.instance_poly tl ty1 in
@@ -984,7 +984,7 @@ and class_field_second_pass cl_num sign met_env field =
         (fun () ->
            let unit_type = Ctype.instance Predef.type_unit in
            let self_param_type =
-             Ctype.newmono ~zero_alloc:None sign.Types.csig_self
+             Ctype.newmono sign.Types.csig_self
            in
            let arrow_desc = Nolabel, Mode.Alloc.legacy, Mode.Alloc.legacy in
            let meth_type =
@@ -1202,7 +1202,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
           cl_attributes = scl.pcl_attributes;
          }
   | Pcl_fun (l, Some default, spat, sbody) ->
-      if Typecore.has_poly_constraint spat then
+      if Btype.is_explicitly_poly (Typecore.has_poly_constraint spat) then
         raise(Error(spat.ppat_loc, val_env, Polymorphic_class_parameter));
       let loc = default.pexp_loc in
       let open Ast_helper in
@@ -1242,7 +1242,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       class_expr cl_num val_env met_env virt self_scope sfun
   | Pcl_fun (l, None, spat, scl') ->
       let l, spat = Typetexp.transl_label_from_pat l spat in
-      if Typecore.has_poly_constraint spat then
+      if Btype.is_explicitly_poly (Typecore.has_poly_constraint spat) then
         raise(Error(spat.ppat_loc, val_env, Polymorphic_class_parameter));
       let (pat, pv, val_env', met_env) =
         Ctype.with_local_level_if_principal
@@ -1591,7 +1591,7 @@ let rec approx_declaration cl =
           (* CR layouts: use of value here may be relaxed when we update
            classes to work with jkinds *)
       in
-      let arg = Ctype.newmono ~zero_alloc:None arg in
+      let arg = Ctype.newmono arg in
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_declaration cl, commu_ok))
@@ -1611,7 +1611,7 @@ let rec approx_description ct =
         (* CR layouts: use of value here may be relaxed when we
            relax jkinds in classes *)
       in
-      let arg = Ctype.newmono ~zero_alloc:None arg in
+      let arg = Ctype.newmono arg in
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_description ct, commu_ok))

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -454,6 +454,11 @@ type expected_mode =
 
         Each location points to the corresponding sub-pattern of [Ppat_tuple].
     *)
+
+    zero_alloc : Zero_alloc.t;
+    (** Incoming [zero_alloc] information. Not strictly a mode, but there are
+        ways in this zero_alloc is mode-like (in particular, how it is
+        type-checked). *)
   }
 
 type position_and_mode = {
@@ -523,7 +528,8 @@ let mode_default mode =
   { position = RNontail;
     mode = Value.disallow_left mode;
     strictly_local = false;
-    tuple_modes = None }
+    tuple_modes = None;
+    zero_alloc = Zero_alloc.default }
 
 let mode_legacy = mode_default Value.legacy
 
@@ -627,7 +633,8 @@ let mode_exclave expected_mode =
      |> alloc_as_value
   in
   { (mode_default mode)
-    with strictly_local = true
+    with strictly_local = true;
+         zero_alloc = expected_mode.zero_alloc;
   }
 
 let mode_strictly_local expected_mode =
@@ -6251,39 +6258,8 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, zero_alloc, spat) =
       Some env_alloc_mode, mode_default exp_mode
     else None, exp_mode
   in
+  let exp_mode = { exp_mode with zero_alloc } in
   attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, spat
-
-let add_zero_alloc_attribute expr zero_alloc_attribute =
-  let open Builtin_attributes in
-  let to_string : zero_alloc_attribute -> string = function
-    | Check { strict; loc = _} ->
-      Printf.sprintf "assert_zero_alloc%s"
-        (if strict then " strict" else "")
-    | Assume { strict; loc = _} ->
-      Printf.sprintf "assume_zero_alloc%s"
-        (if strict then " strict" else "")
-    | Ignore_assert_all ->
-      "ignore_zero_alloc"
-    | Default_zero_alloc -> assert false
-  in
-  match expr.exp_desc with
-  | Texp_function fn ->
-    begin match zero_alloc_attribute with
-    | Default_zero_alloc -> expr
-    | za ->
-      begin match Zero_alloc.get fn.zero_alloc with
-      | Default_zero_alloc -> ()
-      | Ignore_assert_all | Assume _ | Check _ ->
-        Location.prerr_warning expr.exp_loc
-          (Warnings.Duplicated_attribute (to_string za));
-      end;
-      (* Here, we may be throwing away a zero_alloc variable. There's no need
-         to set it, because it can't have gotten anywhere else yet. *)
-      let zero_alloc = Zero_alloc.create_const za in
-      let exp_desc = Texp_function { fn with zero_alloc } in
-      { expr with exp_desc }
-    end
-  | _ -> expr
 
 let check_arg_compatible ~loc ~zero_alloc_expected env zero_alloc =
   match Zero_alloc.sub ~context:Fun_param zero_alloc zero_alloc_expected with
@@ -6293,16 +6269,37 @@ let check_arg_compatible ~loc ~zero_alloc_expected env zero_alloc =
     then raise (Error (loc, env, Incompatible_param_zero_alloc e))
     else raise (Error (loc, env, Wrong_arg_zero_alloc e))
 
-let add_parsed_zero_alloc_attribute ~default_arity vb =
+let add_parsed_zero_alloc_attribute ~default_arity other_zero_alloc vb =
+  let open Zero_alloc in
   let val_attr =
     Builtin_attributes.get_zero_alloc_attribute
       (Function_definition default_arity)
       vb.pvb_attributes
   in
+  let to_string :
+    Builtin_attributes.zero_alloc_attribute -> string = function
+    | Check { strict } ->
+      Printf.sprintf "assert_zero_alloc%s"
+        (if strict then " strict" else "")
+    | Assume { strict } ->
+      Printf.sprintf "assume_zero_alloc%s"
+        (if strict then " strict" else "")
+    | Ignore_assert_all -> "ignore_zero_alloc"
+    | Default_zero_alloc -> assert false
+  in
   let zero_alloc =
-    match val_attr with
-    | Default_zero_alloc -> Zero_alloc.create_var vb.pvb_loc default_arity
-    | Ignore_assert_all | Assume _ | Check _ -> Zero_alloc.create_const val_attr
+    match val_attr, other_zero_alloc with
+    | Default_zero_alloc, Default_zero_alloc ->
+      create_var vb.pvb_expr.pexp_loc default_arity
+    | _, Default_zero_alloc -> create_const val_attr
+    | Default_zero_alloc, _ -> create_const other_zero_alloc
+    | _, _ ->
+      (* The binding and the lambda each carry their own [@zero_alloc]
+         attribute. Warn about the duplicate and keep the one from the
+         binding. *)
+      Location.prerr_warning vb.pvb_loc
+        (Warnings.Duplicated_attribute (to_string val_attr));
+      create_const val_attr
   in
   vb, zero_alloc
 
@@ -9839,7 +9836,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                 { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
               ret_sort;
               alloc_mode;
-              zero_alloc = Zero_alloc.default
+              zero_alloc = mode.zero_alloc
             }
         }
       in
@@ -10919,7 +10916,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     | Pexp_newtype (_, _, e) -> sexp_is_fun e
     | _ -> false
   in
-  let rec arity_of_fun sexp =
+  let rec arity_and_seen_za_of_fun sexp =
     match sexp.pexp_desc with
     | Pexp_function (params, _, body) ->
       let n_value_params =
@@ -10930,17 +10927,26 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                | Pparam_newtype _ -> false)
              params)
       in
-      (match body with | Pfunction_body _ -> 0 | Pfunction_cases _ -> 1) +
-      n_value_params
+      let n_value_params =
+        (match body with | Pfunction_body _ -> 0 | Pfunction_cases _ -> 1) +
+        n_value_params
+      in
+      let zero_alloc =
+        Builtin_attributes.get_zero_alloc_attribute
+          (Function_definition n_value_params)
+          sexp.pexp_attributes
+      in
+      Some (n_value_params, zero_alloc)
     | Pexp_stack e
     | Pexp_borrow e
     | Pexp_constraint (e, _, _)
-    | Pexp_newtype (_, _, e) -> arity_of_fun e
-    (* function is only ever invoked if sexp_is_fun is true *)
-    | _ -> assert false
+    | Pexp_newtype (_, _, e) -> arity_and_seen_za_of_fun e
+    | _ -> None
   in
   let vb_is_fun { pvb_expr = sexp; _ } = sexp_is_fun sexp in
-  let vb_fun_arity { pvb_expr = sexp; _ } = arity_of_fun sexp in
+  let vb_fun_arity_and_za { pvb_expr = sexp; _ } =
+    arity_and_seen_za_of_fun sexp
+  in
   let entirely_functions = List.for_all vb_is_fun spat_sexp_list in
   let rec_mode_var =
     match rec_flag with
@@ -10961,16 +10967,16 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let spat_sexp_list =
     List.map
       (fun vb ->
-         if vb_is_fun vb then
-           let default_arity = vb_fun_arity vb in
-           add_parsed_zero_alloc_attribute ~default_arity vb
-         else begin
+         match vb_fun_arity_and_za vb with
+         | Some (default_arity, other_zero_alloc) ->
+           add_parsed_zero_alloc_attribute ~default_arity other_zero_alloc vb
+         | None ->
            if Builtin_attributes.has_attribute "zero_alloc" vb.pvb_attributes
            then
              Location.prerr_warning vb.pvb_loc
                Warnings.Zero_alloc_on_nonfunction;
            (vb, Zero_alloc.default)
-         end)
+      )
       spat_sexp_list
   in
   let spatl = List.map vb_pat_constraint spat_sexp_list in
@@ -11197,25 +11203,9 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let l = List.combine sorts l in
   let l =
     List.map2
-      (fun (s, ((_,p,_), (e, _))) (pvb, zero_alloc) ->
+      (fun (s, ((_,p,_), (e, _))) (pvb, _) ->
         (* We check for [zero_alloc] attributes written on the [let] and move
            them to the function. *)
-        let e =
-          let za = Zero_alloc.get zero_alloc in
-          match za, e.exp_desc with
-          | Default_zero_alloc, Texp_function fn ->
-            (match Zero_alloc.get fn.zero_alloc with
-             | Default_zero_alloc ->
-               (* For local lets, link fn.zero_alloc to the binding's Var so
-                  that mutations from body type-checking (sub_var_const_exn at
-                  call sites) are visible to the backend.  Module-level
-                  inference uses the signature-comparison path instead, which
-                  correctly constrains the Var created by the function
-                  expression itself. *)
-               { e with exp_desc = Texp_function { fn with zero_alloc } }
-             | _ -> e)
-          | _ -> add_zero_alloc_attribute e za
-        in
         (* vb_rec_kind will be computed later for recursive bindings *)
         {vb_pat=p; vb_expr=e; vb_sort = s; vb_attributes=pvb.pvb_attributes;
          vb_loc=pvb.pvb_loc; vb_rec_kind = Dynamic;
@@ -11606,15 +11596,25 @@ and type_n_ary_function
               (filter_ty_ret_exn ret_ty Nolabel ~force_tpoly:true : type_expr)
     end;
     let zero_alloc =
-      Builtin_attributes.get_zero_alloc_attribute
-        (Function_definition syntactic_arity)
-        attributes
-    in
-    let zero_alloc =
-      match zero_alloc with
-      | Default_zero_alloc -> Zero_alloc.create_var loc syntactic_arity
-      | Ignore_assert_all | Check _ | Assume _ ->
-        Zero_alloc.create_const zero_alloc
+      if Zero_alloc.is_default_const expected_mode.zero_alloc then
+        (* No incoming zero_alloc information, so this is the only place we'll
+           see the [@zero_alloc] attribute on the function.
+           Create a fresh Var if absent so call sites can constrain it later. *)
+        let za =
+          Builtin_attributes.get_zero_alloc_attribute
+            (Function_definition syntactic_arity)
+            attributes
+        in
+        match za with
+        | Default_zero_alloc -> Zero_alloc.create_var loc syntactic_arity
+        | Ignore_assert_all | Check _ | Assume _ -> Zero_alloc.create_const za
+      else
+        (* Incoming zero_alloc information is used.
+           This typically means that the function is the body of a let binding;
+           then, the [@zero_alloc] attribute has already been read on both the
+           let and on the function.
+           We should not read the attribute twice. *)
+        expected_mode.zero_alloc
     in
     let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
     re

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3256,11 +3256,13 @@ and type_pat_aux
       let lbl_a_list = List.map (type_label_pat sorts) lbl_a_list in
       rvp @@ solve_expected (make_record_pat sorts rep lbl_a_list ambiguity)
   in
-  (* begin match sp.ppat_desc, zero_alloc with
-   * | Ppat_var _, _ -> ()
-   * | _, None -> ()
-   * | _, Some _ -> fatal_error "type_pat_aux: zero_alloc"
-   * end; *)
+  begin match sp.ppat_desc, zero_alloc with
+  | Ppat_var _, _ -> ()
+  | Ppat_alias _, _ -> ()
+  | Ppat_constraint _, _ -> ()
+  | _, None -> ()
+  | _, Some _ -> fatal_error "type_pat_aux: zero_alloc"
+  end;
   match sp.ppat_desc with
     Ppat_any ->
       rvp {
@@ -11739,7 +11741,7 @@ and type_comprehension_clause ~loc ~comprehension_type ~container_type env
         List.map
           (type_comprehension_binding
              ~loc ~comprehension_type ~container_type ~env tps)
-         bindings
+          bindings
       in
       let env =
         let check s = Warnings.Unused_var { name = s; mutated = false } in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -10883,8 +10883,16 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let rec arity_of_fun sexp =
     match sexp.pexp_desc with
     | Pexp_function (params, _, body) ->
-      ((match body with | Pfunction_body _ -> 0 | Pfunction_cases _ -> 1) +
-       List.length params)
+      let n_value_params =
+        List.length
+          (List.filter
+             (fun p -> match p.pparam_desc with
+               | Pparam_val _ -> true
+               | Pparam_newtype _ -> false)
+             params)
+      in
+      (match body with | Pfunction_body _ -> 0 | Pfunction_cases _ -> 1) +
+      n_value_params
     | Pexp_constraint (e, _, _)
     | Pexp_newtype (_, _, e) -> arity_of_fun e
     (* function is only ever invoked if sexp_is_fun is true *)
@@ -11030,7 +11038,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let exp_env =
           if is_recursive then
             let pvs_no_za =
-              List.map (fun pv -> { pv with pv_zero_alloc = Zero_alloc.default }) pvs
+              List.map
+                (fun pv -> { pv with pv_zero_alloc = Zero_alloc.default }) pvs
             in
             add_module_variables
               (add_pattern_variables env_before_pvs pvs_no_za)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3254,15 +3254,19 @@ and type_pat_aux
       let lbl_a_list = List.map (type_label_pat sorts) lbl_a_list in
       rvp @@ solve_expected (make_record_pat sorts rep lbl_a_list ambiguity)
   in
-  begin match sp.ppat_desc with
-  | Ppat_var _ -> ()
-  | Ppat_alias _ -> ()
-  | Ppat_constraint _ -> ()
-  | _ ->
-    (match Zero_alloc.sub ~context:Default zero_alloc Zero_alloc.default with
-    | Ok () -> ()
-    | Error _ -> fatal_error "type_pat_aux: zero_alloc")
-  end;
+  let verify_zero_alloc desc zero_alloc =
+    match desc with
+    | Ppat_var _ | Ppat_alias _ | Ppat_constraint _ -> ()
+    | Ppat_any | Ppat_constant _ | Ppat_interval _ | Ppat_unboxed_unit
+    | Ppat_unboxed_bool _ | Ppat_unboxed_tuple _ | Ppat_variant _
+    | Ppat_construct _ | Ppat_type _ | Ppat_unpack _ | Ppat_extension _
+    | Ppat_exception _ | Ppat_lazy _ | Ppat_open _ | Ppat_tuple _ | Ppat_array _
+    | Ppat_record _ | Ppat_record_unboxed_product _ | Ppat_or _ ->
+      (match Zero_alloc.sub ~context:Default zero_alloc Zero_alloc.default with
+       | Ok () -> ()
+       | Error _ -> fatal_error "type_pat_aux: zero_alloc")
+  in
+  verify_zero_alloc sp.ppat_desc zero_alloc;
   match sp.ppat_desc with
     Ppat_any ->
       rvp {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3085,7 +3085,9 @@ and type_pat_aux
     in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl =
-      List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt arg_sort ~zero_alloc) spl
+      List.map
+        (fun p -> type_pat ~alloc_mode tps Value p ty_elt arg_sort ~zero_alloc)
+        spl
     in
     rvp {
       pat_desc = Tpat_array (mutability, arg_sort, pl);
@@ -3606,7 +3608,8 @@ and type_pat_aux
         with_local_level begin fun () ->
           let type_pat_rec tps penv sp =
             let alloc_mode = dynamic_pat_mode alloc_mode in
-            type_pat ~alloc_mode tps category sp expected_ty sort ~penv ~zero_alloc:None
+            type_pat ~alloc_mode tps category sp expected_ty sort ~penv
+              ~zero_alloc:None
           in
           let penv1 =
             Pattern_env.copy ~equations_scope:(get_current_level ()) penv in
@@ -3676,7 +3679,8 @@ and type_pat_aux
             expected_ty
         in
         let p =
-          type_pat ~alloc_mode tps category sp_constrained expected_ty' sort ~zero_alloc
+          type_pat ~alloc_mode tps category sp_constrained expected_ty' sort
+            ~zero_alloc
         in
         let extra =
           Tpat_constraint (cty, type_modes),
@@ -3685,7 +3689,8 @@ and type_pat_aux
         in
         { p with pat_type = ty; pat_extra = extra::p.pat_extra }
       | None ->
-        type_pat ~alloc_mode tps category sp_constrained expected_ty sort ~zero_alloc
+        type_pat ~alloc_mode tps category sp_constrained expected_ty sort
+          ~zero_alloc
       end
   | Ppat_type lid ->
       Env.check_no_open_quotations sp.ppat_loc !!penv
@@ -3728,9 +3733,8 @@ and type_pat_aux
 let type_pat tps category ?no_existentials ~mutable_flag penv ~zero_alloc =
   type_pat tps category ~no_existentials ~mutable_flag ~penv ~zero_alloc
 
-let type_pattern
-    category ~lev ~alloc_mode env spat expected_ty sort allow_modules ~zero_alloc
-  =
+let type_pattern category ~lev ~alloc_mode env spat expected_ty sort
+    allow_modules ~zero_alloc =
   let tps = create_type_pat_state allow_modules in
   let new_penv = Pattern_env.make env
       ~equations_scope:lev ~allow_recursive_equations:false in
@@ -3809,8 +3813,9 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
   in
   let (pv, val_env, met_env) =
     List.fold_right
-      (fun {pv_id; pv_uid; pv_type; pv_loc; pv_as_var; pv_attributes; pv_sort; pv_zero_alloc}
-        (pv, val_env, met_env) ->
+      (fun {pv_id; pv_uid; pv_type; pv_loc; pv_as_var; pv_attributes; pv_sort;
+            pv_zero_alloc}
+           (pv, val_env, met_env) ->
          let check s =
            if pv_as_var then Warnings.Unused_var { name = s; mutated = false }
            else Warnings.Unused_var_strict { name = s; mutated = false } in
@@ -5211,7 +5216,8 @@ let rec approx_type env sty =
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
       let mret = Alloc.newvar () in
-      newty (Tarrow ((p,marg,mret), newmono ~zero_alloc:None arg, ret, commu_ok))
+      newty
+        (Tarrow ((p,marg,mret), newmono ~zero_alloc:None arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (label, t) -> label, approx_type env t) args))
   | Ptyp_constr (lid, ctl) ->
@@ -5957,7 +5963,9 @@ let split_function_ty
            be a [Tpoly] node *)
         not has_poly
       in
-      try filter_arrow env (instance ty_expected) arg_label ~force_tpoly ~zero_alloc
+      try
+        filter_arrow env (instance ty_expected) arg_label
+          ~force_tpoly ~zero_alloc
       with Filter_arrow_failed err ->
         let err =
           error_of_filter_arrow_failure ~explanation ~first:is_first_val_param
@@ -6256,14 +6264,16 @@ let check_zero_alloc env exp ~zero_alloc_expected =
   | Texp_ident { desc = {val_zero_alloc = zero_alloc; _}; _ } ->
     check_arg_compatible ~loc ~zero_alloc_expected env zero_alloc
   | _ ->
-    match Zero_alloc.sub ~context:Fun_param Zero_alloc.default zero_alloc_expected with
+    match
+      Zero_alloc.sub ~context:Fun_param Zero_alloc.default zero_alloc_expected
+    with
     | Ok () -> ()
     | Error _ -> raise (Error (loc, env, Unsupported_arg_zero_alloc))
 
 let rec type_exp ?recarg ?(overwrite=No_overwrite) env expected_mode sexp =
   (* We now delegate everything to type_expect *)
-  type_expect ?recarg ~overwrite ~on_function_argument:false env expected_mode sexp
-    (mk_expected (newvar (Jkind.Builtin.any ~why:Dummy_jkind)))
+  type_expect ?recarg ~overwrite ~on_function_argument:false env expected_mode
+    sexp (mk_expected (newvar (Jkind.Builtin.any ~why:Dummy_jkind)))
 
 (* Typing of an expression with an expected type.
    This provide better error messages, and allows controlled
@@ -6896,7 +6906,8 @@ and type_expect_
           let mode' = mode_exclave expected_mode in
           let new_env = Env.add_exclave_lock env in
           let exp =
-            type_expect ~recarg ~on_function_argument:false new_env mode' sbody ty_expected_explained
+            type_expect ~recarg ~on_function_argument:false new_env mode' sbody
+              ty_expected_explained
           in
           submode ~loc ~env ~reason:Other
             (Value.min_with_comonadic Areality Regionality.regional)
@@ -7091,7 +7102,8 @@ and type_expect_
         with_local_level begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect ~on_function_argument:false env arg_expected_mode sarg (mk_expected expected_ty)
+            type_expect ~on_function_argument:false env arg_expected_mode sarg
+              (mk_expected expected_ty)
           in
           arg, sort
         end ~post:(fun (arg, _) ->
@@ -7177,7 +7189,8 @@ and type_expect_
               register_allocation ~loc expected_mode
             in
             let arg =
-              type_expect ~on_function_argument:false env argument_mode sarg (mk_expected ty_expected)
+              type_expect ~on_function_argument:false env argument_mode sarg
+                (mk_expected ty_expected)
             in
             Some (arg, alloc_mode)
         in
@@ -7479,10 +7492,12 @@ and type_expect_
             exp_env = env }
       | Some sifnot ->
           let ifso =
-            type_expect ~on_function_argument:false env expected_mode sifso ty_expected_explained
+            type_expect ~on_function_argument:false env expected_mode sifso
+              ty_expected_explained
           in
           let ifnot =
-            type_expect ~on_function_argument:false env expected_mode sifnot ty_expected_explained
+            type_expect ~on_function_argument:false env expected_mode sifnot
+              ty_expected_explained
           in
           (* Keep sharing *)
           unify_exp env ifnot ifso.exp_type;
@@ -7497,7 +7512,10 @@ and type_expect_
       let exp1, sort1 =
         type_statement ~explanation:Sequence_left_hand_side env sexp1
       in
-      let exp2 = type_expect ~on_function_argument:false env expected_mode sexp2 ty_expected_explained in
+      let exp2 =
+        type_expect ~on_function_argument:false env expected_mode sexp2
+          ty_expected_explained
+      in
       re {
         exp_desc = Texp_sequence(exp1, sort1, exp2);
         exp_loc = loc; exp_extra = [];
@@ -7535,12 +7553,12 @@ and type_expect_
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
       let for_from =
-        type_expect ~on_function_argument:false env (mode_region Value.max) slow
-          (mk_expected ~explanation:For_loop_start_index Predef.type_int)
+        type_expect ~on_function_argument:false env (mode_region Value.max)
+          slow (mk_expected ~explanation:For_loop_start_index Predef.type_int)
       in
       let for_to =
-        type_expect ~on_function_argument:false env (mode_region Value.max) shigh
-          (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
+        type_expect ~on_function_argument:false env (mode_region Value.max)
+          shigh (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
       in
       let env =
         Env.add_const_closure_lock ~ghost:true (loc, Loop)
@@ -7709,7 +7727,8 @@ and type_expect_
         match Env.lookup_settable_variable ~loc lab.txt env with
         | Instance_variable (path, Mutable, cl_num,ty) ->
             let newval =
-              type_expect ~on_function_argument:false env mode_legacy snewval (mk_expected (instance ty))
+              type_expect ~on_function_argument:false env mode_legacy snewval
+                (mk_expected (instance ty))
             in
             let (path_self, _) =
               Env.find_value_by_name_lazy
@@ -7757,7 +7776,9 @@ and type_expect_
             begin try
               let id = Vars.find lab.txt vars in
               let ty = Btype.instance_variable_type lab.txt sign in
-              (id, lab, type_expect ~on_function_argument:false env mode_legacy snewval (mk_expected (instance ty)))
+              (id, lab,
+               type_expect ~on_function_argument:false env mode_legacy snewval
+                 (mk_expected (instance ty)))
             with
               Not_found ->
                 let vars = Vars.fold (fun var _ li -> var::li) vars [] in
@@ -7817,7 +7838,10 @@ and type_expect_
              from the local module and refine them into
              Scoping_let_module errors
            *)
-          let body = type_expect ~on_function_argument:false new_env expected_mode sbody ty_expected_explained in
+          let body =
+            type_expect ~on_function_argument:false new_env expected_mode sbody
+              ty_expected_explained
+          in
           (id, pres, modl, new_env, body)
         end
         ~post: begin fun (_id, _pres, _modl, new_env, body) ->
@@ -7835,7 +7859,8 @@ and type_expect_
   | Pexp_letexception(cd, sbody) ->
       let (cd, newenv, _shape) = Typedecl.transl_exception env cd in
       let body =
-        type_expect ~on_function_argument:false newenv expected_mode sbody ty_expected_explained
+        type_expect ~on_function_argument:false newenv expected_mode sbody
+          ty_expected_explained
       in
       re {
         exp_desc = Texp_letexception(cd, body);
@@ -7876,7 +7901,10 @@ and type_expect_
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
       let env = Env.add_closure_lock (loc, Lazy) closure_mode.comonadic env in
-      let arg = type_expect ~on_function_argument:false env expected_mode e (mk_expected ty) in
+      let arg =
+        type_expect ~on_function_argument:false env expected_mode e
+          (mk_expected ty)
+      in
       re {
         exp_desc = Texp_lazy arg;
         exp_loc = loc; exp_extra = [];
@@ -7916,7 +7944,10 @@ and type_expect_
       let exp =
         match get_desc (expand_head env ty) with
           Tpoly (ty', [], _za) ->
-            let exp = type_expect ~on_function_argument:false env expected_mode sbody (mk_expected ty') in
+            let exp =
+              type_expect ~on_function_argument:false env expected_mode sbody
+                (mk_expected ty')
+            in
             { exp with exp_type = instance ty }
         | Tpoly (ty', tl, _za) ->
             (* One more level to generalize locally *)
@@ -7927,7 +7958,10 @@ and type_expect_
                     (fun () -> instance_poly_fixed tl ty')
                     ~post:(fun (_,ty'') -> generalize_structure ty'')
                 in
-                let exp = type_expect ~on_function_argument:false env expected_mode sbody (mk_expected ty'') in
+                let exp =
+                  type_expect ~on_function_argument:false env expected_mode
+                    sbody (mk_expected ty'')
+                in
                 (exp, vars)
               end
               ~post: begin fun (exp,vars) ->
@@ -7982,7 +8016,10 @@ and type_expect_
       end;
       let tv = newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
       let (od, newenv) = !type_open_decl env od in
-      let exp = type_expect ~on_function_argument:false newenv expected_mode e ty_expected_explained in
+      let exp =
+        type_expect ~on_function_argument:false newenv expected_mode e
+          ty_expected_explained
+      in
       (* Force the return type to be well-formed in the original
          environment. *)
       unify_var newenv tv exp.exp_type;
@@ -8036,8 +8073,9 @@ and type_expect_
           let ty_andops, sort_andops = new_rep_var ~why:Function_argument () in
           let ty_op =
             newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_andops,
-              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_func, ty_result, commu_ok)),
-                     commu_ok))
+              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_func,
+                            ty_result, commu_ok)),
+              commu_ok))
           in
           begin try
             unify env op_type ty_op
@@ -8205,7 +8243,10 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
   | Pexp_stack e ->
-      let exp = type_expect ~on_function_argument:false env expected_mode e ty_expected_explained in
+      let exp =
+        type_expect ~on_function_argument:false env expected_mode e
+          ty_expected_explained
+      in
       let unsupported category =
         raise (Error (exp.exp_loc, env, Unsupported_stack_allocation category))
       in
@@ -8274,7 +8315,10 @@ and type_expect_
         (* CR uniqueness: this could be the jkind of exp2 *)
         mk_expected (newvar (Jkind.for_non_float ~why:Boxed_record))
       in
-      let exp1 = type_expect ~recarg ~on_function_argument:false env (mode_default cell_mode) exp1 cell_type in
+      let exp1 =
+        type_expect ~recarg ~on_function_argument:false env
+          (mode_default cell_mode) exp1 cell_type
+      in
       let new_fields_mode =
         (* The newly-written fields have to be global to avoid heap-to-stack pointers.
            We enforce that here, by asking the allocation to be global.
@@ -8309,7 +8353,8 @@ and type_expect_
         let overwrite =
           Overwriting (exp1.exp_loc, exp1.exp_type, fields_mode)
         in
-        type_expect ~recarg ~overwrite ~on_function_argument:false env exp2_mode exp2 ty_expected_explained
+        type_expect ~recarg ~overwrite ~on_function_argument:false env
+          exp2_mode exp2 ty_expected_explained
       in
       re { exp_desc = Texp_overwrite(exp1, exp2);
             exp_loc = loc; exp_extra = [];
@@ -8453,7 +8498,9 @@ and type_block_access env expected_base_ty principal
       | Mutable -> Predef.type_idx_mut base_ty el_ty
     in
     let idx =
-      type_expect ~on_function_argument:false env mode_legacy idx (mk_expected idx_type_expected) in
+      type_expect ~on_function_argument:false env mode_legacy idx
+        (mk_expected idx_type_expected)
+    in
     let ba = Baccess_block (mut, idx) in
     let mut = match mut with Immutable -> false | Mutable -> true in
     let modality = Typemode.idx_expected_modalities ~mut in
@@ -8891,8 +8938,12 @@ and type_function
           match zero_alloc with
           | None -> ()
           | Some check_attr ->
-            let check1 = Zero_alloc.create_const (Zero_alloc.Check check_attr) in
-            let check2 = Zero_alloc.create_const (Zero_alloc.Check check_poly) in
+            let check1 =
+              Zero_alloc.create_const (Zero_alloc.Check check_attr)
+            in
+            let check2 =
+              Zero_alloc.create_const (Zero_alloc.Check check_poly)
+            in
             match Zero_alloc.sub ~context:Fun_param check1 check2 with
             | Ok () -> ()
             | Error e ->
@@ -8937,7 +8988,8 @@ and type_function
             (* Defaults are always global. They can be moved out of the
                function's region by Simplf.split_default_wrapper. *)
             let default_arg =
-              type_expect ~on_function_argument:true env mode_legacy default (mk_expected ty_default_arg)
+              type_expect ~on_function_argument:true env mode_legacy default
+                (mk_expected ty_default_arg)
             in
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
@@ -9005,8 +9057,9 @@ and type_function
         | [ result ], partial -> result, partial
         | ([] | _ :: _ :: _), _ -> assert false
       in
-      (* Check that the annotation arity matches the inferred type's arrow count.
-         We do this after the body is typed so that ty_arg_mono is unified. *)
+      (* Check that the annotation arity matches the inferred type's arrow
+         count. We do this after the body is typed so that ty_arg_mono is
+         unified. *)
       begin match zero_alloc with
       | Some { arity; _ } ->
         let type_arity = Ctype.arity ty_arg_mono in
@@ -9118,7 +9171,9 @@ and type_function
       | Pfunction_body body ->
           let body =
             match ret_type_constraint with
-            | None -> type_expect ~on_function_argument:false env expected_mode body (mk_expected ty_expected)
+            | None ->
+                type_expect ~on_function_argument:false env expected_mode body
+                  (mk_expected ty_expected)
             | Some constraint_ ->
             let body_loc = body.pexp_loc in
             let body, exp_type, exp_extra =
@@ -9217,8 +9272,8 @@ and type_label_access
   let record =
     with_local_level_if_principal ~post:generalize_structure_exp
       (fun () ->
-         type_expect ~recarg:Allowed ~on_function_argument:false env (mode_default mode) srecord
-           (mk_expected (newvar record_jkind)))
+         type_expect ~recarg:Allowed ~on_function_argument:false env
+           (mode_default mode) srecord (mk_expected (newvar record_jkind)))
   in
   let ty_exp = record.exp_type in
   let expected_type =
@@ -9870,8 +9925,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       end
   | None ->
       let mode = expect_mode_cross env ty_expected' mode in
-      let texp = type_expect ?recarg ~overwrite ~on_function_argument:false env mode sarg
-        (mk_expected ?explanation ty_expected') in
+      let texp =
+        type_expect ?recarg ~overwrite ~on_function_argument:false env mode sarg
+          (mk_expected ?explanation ty_expected')
+      in
       unify_exp env texp ty_expected;
       texp
 
@@ -9882,7 +9939,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       let expected_mode, mode_arg =
         mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
       let arg =
-        type_expect ~on_function_argument:false env expected_mode sarg (mk_expected ty_arg_mono)
+        type_expect ~on_function_argument:false env expected_mode sarg
+          (mk_expected ty_arg_mono)
       in
       (match lbl with
        | Labelled _ | Nolabel -> ()
@@ -9990,7 +10048,10 @@ and type_application env app_loc expected_mode position_and_mode
         mode_argument ~funct ~index:0 ~position_and_mode
           ~partial_app:false arg_mode
       in
-      let exp = type_expect ~on_function_argument:false env arg_mode sarg (mk_expected ty_arg) in
+      let exp =
+        type_expect ~on_function_argument:false env arg_mode sarg
+          (mk_expected ty_arg)
+      in
       check_partial_application ~statement:false exp;
       ([Nolabel, Arg (exp, arg_sort), None],
        ty_ret, ret_mode, position_and_mode)
@@ -10105,7 +10166,9 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       (fun (label, body) ((_, ty), argument_mode) overwrite ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-          (label, type_expect ~overwrite ~on_function_argument:false env argument_mode body (mk_expected ty)))
+        (label,
+         type_expect ~overwrite ~on_function_argument:false env argument_mode
+           body (mk_expected ty)))
       sexpl types_and_modes overwrites
   in
   re {
@@ -10169,7 +10232,10 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
       (fun (label, body) ((_, ty, sort), argument_mode) ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-          (label, type_expect ~on_function_argument:false env argument_mode body (mk_expected ty), sort))
+        (label,
+         type_expect ~on_function_argument:false env argument_mode body
+           (mk_expected ty),
+         sort))
       sexpl types_sorts_and_modes
   in
   re {
@@ -10794,7 +10860,8 @@ and type_cases
                 (mk_expected ~explanation:When_guard Predef.type_bool))
         in
         let exp =
-          type_expect ~on_function_argument:false ext_env expr_mode pc_rhs (mk_expected ?explanation ty_expected)
+          type_expect ~on_function_argument:false ext_env expr_mode pc_rhs
+            (mk_expected ?explanation ty_expected)
         in
         {
           c_lhs = pat;
@@ -11054,13 +11121,15 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 in
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect ~on_function_argument:false exp_env mode sexp (mk_expected ty'))
+                    type_expect ~on_function_argument:false exp_env mode sexp
+                      (mk_expected ty'))
                 in
                 exp, Some vars
             | _ ->
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect ~on_function_argument:false exp_env mode sexp (mk_expected expected_ty))
+                    type_expect ~on_function_argument:false exp_env mode sexp
+                      (mk_expected expected_ty))
                 in
                 exp, None)
       in
@@ -11147,8 +11216,10 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
       (fun (s, ((_,p,_), (e, _))) (pvb, zero_alloc) ->
         (* We check for [zero_alloc] attributes written on the [let] and move
            them to the function. *)
-        let e = add_typed_zero_alloc_attribute e
-          (Option.value ~default:Builtin_attributes.Default_zero_alloc zero_alloc)
+         let e =
+           add_typed_zero_alloc_attribute e
+             (Option.value ~default:Builtin_attributes.Default_zero_alloc
+                zero_alloc)
         in
         (* vb_rec_kind will be computed later for recursive bindings *)
         {vb_pat=p; vb_expr=e; vb_sort = s; vb_attributes=pvb.pvb_attributes;
@@ -11338,9 +11409,12 @@ and type_andops env sarg sands expected_sort expected_ty =
             in
             let arrow_desc = (Nolabel, Alloc.legacy, Alloc.legacy) in
             let ty_rest_fun =
-              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_arg, ty_result, commu_ok)) in
+              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_arg,
+                            ty_result, commu_ok)) in
             let ty_op =
-              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_rest, ty_rest_fun, commu_ok)) in
+              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_rest,
+                            ty_rest_fun, commu_ok))
+            in
             begin try
               unify env op_type ty_op
             with Unify err ->
@@ -11355,7 +11429,10 @@ and type_andops env sarg sands expected_sort expected_ty =
         let let_arg, sort_let_arg, rest =
           loop env let_sarg rest sort_rest ty_rest
         in
-        let exp = type_expect ~on_function_argument:false env mode_legacy sexp (mk_expected ty_arg) in
+        let exp =
+          type_expect ~on_function_argument:false env mode_legacy sexp
+            (mk_expected ty_arg)
+        in
         begin try
           unify env (instance ty_result) (instance expected_ty)
         with Unify err ->
@@ -11412,7 +11489,8 @@ and type_generic_array
   let argument_mode = expect_mode_cross env ty argument_mode in
   let argl =
     List.map
-      (fun sarg -> type_expect ~on_function_argument:false env argument_mode sarg (mk_expected ty))
+      (fun sarg -> type_expect ~on_function_argument:false env argument_mode
+                     sarg (mk_expected ty))
       sargl
   in
   re {
@@ -11712,7 +11790,8 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
   let comp_body =
     (* To understand why comprehension bodies are checked at [mode_global], see
        "What modes should comprehensions use?", above *)
-    type_expect ~on_function_argument:false new_env mode_legacy sbody (mk_expected element_ty)
+    type_expect ~on_function_argument:false new_env mode_legacy sbody
+      (mk_expected element_ty)
   in
   re { exp_desc       = make_texp { comp_body ; comp_clauses }
      ; exp_loc        = loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5231,6 +5231,14 @@ let rec approx_type env sty =
       end
   | _ -> approx_type_default ()
 
+let rec get_pat_attrs p =
+  match p.ppat_desc with
+  | Ppat_constraint (inner, _, _) when p.ppat_attributes = [] ->
+    get_pat_attrs inner
+  | Ppat_alias (inner, _) when p.ppat_attributes = [] ->
+    get_pat_attrs inner
+  | _ -> p.ppat_attributes
+
 let type_pattern_approx env spat ty_expected =
   match spat.ppat_desc with
   | Ppat_constraint(_, Some sty, arg_type_mode) ->
@@ -5284,11 +5292,28 @@ let type_approx_fun_one_param
           raise(Error(spat.ppat_loc, env, Optional_poly_param));
         Some mode_annots, has_poly
   in
+  let zero_alloc =
+    match spato with
+    | None -> None
+    | Some spat ->
+      (* If the zero_alloc attribute is malformed, we should only warn once.
+      The `without_warnings` mutes a potential duplicate warning. *)
+      match
+        Warnings.without_warnings (fun () ->
+          Builtin_attributes.get_zero_alloc_attribute
+            Function_param
+            (get_pat_attrs spat))
+      with
+      | Check c -> Some c
+      | Default_zero_alloc | Assume _ | Ignore_assert_all -> None
+  in
   let loc_fun, ty_fun = in_function in
   let { ty_arg; arg_mode; ty_ret; _ } =
     try
       filter_arrow env ty_expected label
-        ~has_poly:(match has_poly with Mono -> Poly None | Poly _ -> Mono)
+        ~has_poly:(match has_poly with
+                   | Mono -> Poly zero_alloc
+                   | Poly _ -> Mono)
     with Filter_arrow_failed err ->
       let err =
         error_of_filter_arrow_failure ~explanation:None ty_fun err ~first
@@ -8849,14 +8874,6 @@ and type_function
            Ppat_constraint (e.g. [(f[@zero_alloc arity 1] : t)]) or
            Ppat_alias (e.g. [(f[@zero_alloc arity 1]) as g]), so look
            through those wrappers when the outer pattern has no attrs. *)
-        let rec get_pat_attrs p =
-          match p.ppat_desc with
-          | Ppat_constraint (inner, _, _) when p.ppat_attributes = [] ->
-            get_pat_attrs inner
-          | Ppat_alias (inner, _) when p.ppat_attributes = [] ->
-            get_pat_attrs inner
-          | _ -> p.ppat_attributes
-        in
         (try
            Builtin_attributes.get_zero_alloc_attribute
              Function_param

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3257,6 +3257,11 @@ and type_pat_aux
       let lbl_a_list = List.map (type_label_pat sorts) lbl_a_list in
       rvp @@ solve_expected (make_record_pat sorts rep lbl_a_list ambiguity)
   in
+  (* begin match sp.ppat_desc, zero_alloc with
+   * | Ppat_var _, _ -> ()
+   * | _, None -> ()
+   * | _, Some _ -> fatal_error "type_pat_aux: zero_alloc"
+   * end; *)
   match sp.ppat_desc with
     Ppat_any ->
       rvp {
@@ -3756,7 +3761,8 @@ let type_pattern_list
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
       ~equations_scope ~allow_recursive_equations:false in
-  let type_pat (attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, pat) ty sort =
+  let type_pat (attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, pat) ty
+        sort =
     let zero_alloc : Zero_alloc.check option =
       match zero_alloc with
       | None
@@ -6015,8 +6021,8 @@ let split_function_ty
   let ty_arg_mono =
     if is_explicitly_poly has_poly then ty_arg
     else begin
-      let ty, vars, _za = tpoly_get_poly ty_arg in
-      if vars = [] then ty
+      let ty, vars, za = tpoly_get_poly ty_arg in
+      if vars = [] && Option.is_none za then ty
       else begin
         with_level ~level:generic_level
           (fun () -> instance_poly ~keep_names:true vars ty)
@@ -6032,6 +6038,27 @@ let split_function_ty
   in
   let arg_sort = type_sort ~why:Function_argument ty_arg in
   let ret_sort = type_sort ~why:Function_result ty_ret in
+  (* Check that the zero_alloc attribute on the pattern is compatible
+     with the one on the parameter type (from a type annotation). *)
+  begin match get_desc ty_arg with
+  | Tpoly (_, _, Some check_poly) ->
+    begin
+      match has_poly with
+      | Mono | Poly None -> ()
+      | Poly (Some check_attr) ->
+        let check1 =
+          Zero_alloc.create_const (Zero_alloc.Check check_attr)
+        in
+        let check2 =
+          Zero_alloc.create_const (Zero_alloc.Check check_poly)
+        in
+        match Zero_alloc.sub ~context:Type_constraint check1 check2 with
+        | Ok () -> ()
+        | Error e ->
+          raise (Error (loc, env, Incompatible_param_zero_alloc e))
+    end
+  | _ -> ()
+  end;
   env,
   { filtered_arrow; arg_sort; ret_sort;
     alloc_mode; ty_arg_mono;
@@ -6274,7 +6301,7 @@ let check_zero_alloc env exp ~zero_alloc_expected =
 
 let rec type_exp ?recarg ?(overwrite=No_overwrite) env expected_mode sexp =
   (* We now delegate everything to type_expect *)
-  type_expect ?recarg ~overwrite ~on_function_argument:false env expected_mode
+  type_expect ?recarg ~overwrite env expected_mode
     sexp (mk_expected (newvar (Jkind.Builtin.any ~why:Dummy_jkind)))
 
 (* Typing of an expression with an expected type.
@@ -6288,14 +6315,13 @@ and check_layout_args_empty ~loc ~env layout_args ctx =
   if not (List.is_empty layout_args) then
     raise (Error (loc, env, Layout_poly_inst_not_yet_supported ctx))
 
-and type_expect ?recarg ?(overwrite=No_overwrite) ~on_function_argument env
+and type_expect ?recarg ?(overwrite=No_overwrite) env
       (expected_mode : expected_mode) sexp ty_expected_explained =
   let previous_saved_types = Cmt_format.get_saved_types () in
   let exp =
     Builtin_attributes.warning_scope sexp.pexp_attributes
       (fun () ->
-         type_expect_ ?recarg ~overwrite ~on_function_argument env expected_mode
-           sexp ty_expected_explained
+         type_expect_ ?recarg ~overwrite env expected_mode sexp ty_expected_explained
       )
   in
   Cmt_format.set_saved_types
@@ -6303,7 +6329,7 @@ and type_expect ?recarg ?(overwrite=No_overwrite) ~on_function_argument env
   exp
 
 and type_expect_
-    ?(recarg=Rejected) ?(overwrite=No_overwrite) ~on_function_argument
+    ?(recarg=Rejected) ?(overwrite=No_overwrite)
     env (expected_mode : expected_mode) sexp ty_expected_explained =
   let { ty = ty_expected; explanation } = ty_expected_explained in
   let loc = sexp.pexp_loc in
@@ -6741,7 +6767,7 @@ and type_expect_
       if is_format then
         let format_parsetree =
           { (type_format loc str env) with pexp_loc = sexp.pexp_loc }  in
-        type_expect ~on_function_argument:false env expected_mode
+        type_expect env expected_mode
           format_parsetree ty_expected_explained
       else
         rue {
@@ -6781,7 +6807,7 @@ and type_expect_
     when turn_let_into_match spat ->
       (* TODO: allow non-empty attributes? *)
       let sval = vb_exp_constraint vb in
-      type_expect ~on_function_argument:false env expected_mode
+      type_expect env expected_mode
         {sexp with
          pexp_desc = Pexp_match (sval, [Ast_helper.Exp.case spat sbody])}
         ty_expected_explained
@@ -6828,7 +6854,7 @@ and type_expect_
               spat_sexp_list allow_modules
           in
           let body =
-            type_expect ~on_function_argument:false
+            type_expect
               new_env expected_mode sbody ty_expected_explained
           in
           let pat_exp_list = match rec_flag with
@@ -6885,8 +6911,7 @@ and type_expect_
         exp_env = env }
   | Pexp_function (params, body_constraint, body) ->
       type_n_ary_function ~loc ~env ~expected_mode ~ty_expected ~explanation
-        ~attributes:sexp.pexp_attributes ~on_function_argument
-        (params, body_constraint, body)
+        ~attributes:sexp.pexp_attributes (params, body_constraint, body)
   | Pexp_apply
       ({ pexp_desc = Pexp_extension({ txt }, PStr []) },
        [Nolabel, sbody]) when is_exclave_extension_node txt ->
@@ -6908,8 +6933,7 @@ and type_expect_
           let mode' = mode_exclave expected_mode in
           let new_env = Env.add_exclave_lock env in
           let exp =
-            type_expect ~recarg ~on_function_argument:false new_env mode' sbody
-              ty_expected_explained
+            type_expect ~recarg new_env mode' sbody ty_expected_explained
           in
           submode ~loc ~env ~reason:Other
             (Value.min_with_comonadic Areality Regionality.regional)
@@ -6930,8 +6954,7 @@ and type_expect_
     in
     submode ~loc ~env mode expected_mode;
     let exp =
-      type_expect ~recarg ~on_function_argument:false env
-        expected_mode body ty_expected_explained
+      type_expect ~recarg env expected_mode body ty_expected_explained
     in
     { exp with
       exp_loc = loc;
@@ -7085,8 +7108,7 @@ and type_expect_
         with_local_level begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect ~on_function_argument:false env arg_expected_mode sarg
-              (mk_expected expected_ty)
+            type_expect env arg_expected_mode sarg (mk_expected expected_ty)
           in
           arg, sort
         end ~post:(fun (arg, _) ->
@@ -7109,7 +7131,7 @@ and type_expect_
   | Pexp_try(sbody, caselist) ->
       check_dynamic (loc, Expression) (Always_dynamic Try_with) expected_mode;
       let body =
-        type_expect ~on_function_argument:false env (mode_trywith expected_mode)
+        type_expect env (mode_trywith expected_mode)
           sbody ty_expected_explained
       in
       let arg_mode = simple_pat_mode Value.legacy in
@@ -7172,8 +7194,7 @@ and type_expect_
               register_allocation ~loc expected_mode
             in
             let arg =
-              type_expect ~on_function_argument:false env argument_mode sarg
-                (mk_expected ty_expected)
+              type_expect env argument_mode sarg (mk_expected ty_expected)
             in
             Some (arg, alloc_mode)
         in
@@ -7459,13 +7480,13 @@ and type_expect_
   | Pexp_ifthenelse(scond, sifso, sifnot) ->
       check_dynamic (loc, Expression) Branching expected_mode;
       let cond =
-        type_expect ~on_function_argument:false env mode_max scond
+        type_expect env mode_max scond
           (mk_expected ~explanation:If_conditional Predef.type_bool)
       in
       begin match sifnot with
         None ->
           let ifso =
-            type_expect ~on_function_argument:false env expected_mode sifso
+            type_expect env expected_mode sifso
               (mk_expected ~explanation:If_no_else_branch Predef.type_unit) in
           rue {
             exp_desc = Texp_ifthenelse(cond, ifso, None);
@@ -7475,12 +7496,10 @@ and type_expect_
             exp_env = env }
       | Some sifnot ->
           let ifso =
-            type_expect ~on_function_argument:false env expected_mode sifso
-              ty_expected_explained
+            type_expect env expected_mode sifso ty_expected_explained
           in
           let ifnot =
-            type_expect ~on_function_argument:false env expected_mode sifnot
-              ty_expected_explained
+            type_expect env expected_mode sifnot ty_expected_explained
           in
           (* Keep sharing *)
           unify_exp env ifnot ifso.exp_type;
@@ -7496,8 +7515,7 @@ and type_expect_
         type_statement ~explanation:Sequence_left_hand_side env sexp1
       in
       let exp2 =
-        type_expect ~on_function_argument:false env expected_mode sexp2
-          ty_expected_explained
+        type_expect env expected_mode sexp2 ty_expected_explained
       in
       re {
         exp_desc = Texp_sequence(exp1, sort1, exp2);
@@ -7513,7 +7531,7 @@ and type_expect_
       let cond_env = Env.add_region_lock env in
       let mode = mode_region Value.max in
       let wh_cond =
-        type_expect ~on_function_argument:false cond_env mode scond
+        type_expect cond_env mode scond
           (mk_expected ~explanation:While_loop_conditional Predef.type_bool)
       in
       let body_env = Env.add_region_lock env in
@@ -7536,12 +7554,12 @@ and type_expect_
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
       let for_from =
-        type_expect ~on_function_argument:false env (mode_region Value.max)
-          slow (mk_expected ~explanation:For_loop_start_index Predef.type_int)
+        type_expect env (mode_region Value.max) slow
+          (mk_expected ~explanation:For_loop_start_index Predef.type_int)
       in
       let for_to =
-        type_expect ~on_function_argument:false env (mode_region Value.max)
-          shigh (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
+        type_expect env (mode_region Value.max) shigh
+          (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
       in
       let env =
         Env.add_const_closure_lock ~ghost:true (loc, Loop)
@@ -7568,10 +7586,7 @@ and type_expect_
       let expected_mode =
         type_expect_mode ~loc ~env ~modes:modes.mode_modes expected_mode
       in
-      let exp =
-        type_expect ~on_function_argument env expected_mode sarg
-          (mk_expected ty_expected ?explanation)
-      in
+      let exp = type_expect env expected_mode sarg (mk_expected ty_expected ?explanation) in
       { exp with exp_loc = loc
       ; exp_extra = (Texp_mode modes, loc, []) :: exp.exp_extra
       }
@@ -7710,8 +7725,7 @@ and type_expect_
         match Env.lookup_settable_variable ~loc lab.txt env with
         | Instance_variable (path, Mutable, cl_num,ty) ->
             let newval =
-              type_expect ~on_function_argument:false env mode_legacy snewval
-                (mk_expected (instance ty))
+              type_expect env mode_legacy snewval (mk_expected (instance ty))
             in
             let (path_self, _) =
               Env.find_value_by_name_lazy
@@ -7723,7 +7737,7 @@ and type_expect_
             raise(Error(loc, env, Instance_variable_not_mutable lab.txt))
         | Mutable_variable (id, mode, ty, sort) ->
             let newval =
-              type_expect ~on_function_argument:false env (mode_default mode)
+              type_expect env (mode_default mode)
                 snewval (mk_expected (instance ty))
             in
             let lid = {txt = id; loc} in
@@ -7759,9 +7773,7 @@ and type_expect_
             begin try
               let id = Vars.find lab.txt vars in
               let ty = Btype.instance_variable_type lab.txt sign in
-              (id, lab,
-               type_expect ~on_function_argument:false env mode_legacy snewval
-                 (mk_expected (instance ty)))
+              (id, lab, type_expect env mode_legacy snewval (mk_expected (instance ty)))
             with
               Not_found ->
                 let vars = Vars.fold (fun var _ li -> var::li) vars [] in
@@ -7822,8 +7834,7 @@ and type_expect_
              Scoping_let_module errors
            *)
           let body =
-            type_expect ~on_function_argument:false new_env expected_mode sbody
-              ty_expected_explained
+            type_expect new_env expected_mode sbody ty_expected_explained
           in
           (id, pres, modl, new_env, body)
         end
@@ -7842,8 +7853,7 @@ and type_expect_
   | Pexp_letexception(cd, sbody) ->
       let (cd, newenv, _shape) = Typedecl.transl_exception env cd in
       let body =
-        type_expect ~on_function_argument:false newenv expected_mode sbody
-          ty_expected_explained
+        type_expect newenv expected_mode sbody ty_expected_explained
       in
       re {
         exp_desc = Texp_letexception(cd, body);
@@ -7854,7 +7864,7 @@ and type_expect_
 
   | Pexp_assert (e) ->
       let cond =
-        type_expect ~on_function_argument:false env mode_max e
+        type_expect env mode_max e
           (mk_expected ~explanation:Assert_condition Predef.type_bool)
       in
       let exp_type =
@@ -7884,10 +7894,7 @@ and type_expect_
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
       let env = Env.add_closure_lock (loc, Lazy) closure_mode.comonadic env in
-      let arg =
-        type_expect ~on_function_argument:false env expected_mode e
-          (mk_expected ty)
-      in
+      let arg = type_expect env expected_mode e (mk_expected ty) in
       re {
         exp_desc = Texp_lazy arg;
         exp_loc = loc; exp_extra = [];
@@ -7927,10 +7934,7 @@ and type_expect_
       let exp =
         match get_desc (expand_head env ty) with
           Tpoly (ty', [], _za) ->
-            let exp =
-              type_expect ~on_function_argument:false env expected_mode sbody
-                (mk_expected ty')
-            in
+            let exp = type_expect env expected_mode sbody (mk_expected ty') in
             { exp with exp_type = instance ty }
         | Tpoly (ty', tl, _za) ->
             (* One more level to generalize locally *)
@@ -7941,10 +7945,7 @@ and type_expect_
                     (fun () -> instance_poly_fixed tl ty')
                     ~post:(fun (_,ty'') -> generalize_structure ty'')
                 in
-                let exp =
-                  type_expect ~on_function_argument:false env expected_mode
-                    sbody (mk_expected ty'')
-                in
+                let exp = type_expect env expected_mode sbody (mk_expected ty'') in
                 (exp, vars)
               end
               ~post: begin fun (exp,vars) ->
@@ -7999,10 +8000,7 @@ and type_expect_
       end;
       let tv = newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
       let (od, newenv) = !type_open_decl env od in
-      let exp =
-        type_expect ~on_function_argument:false newenv expected_mode e
-          ty_expected_explained
-      in
+      let exp = type_expect newenv expected_mode e ty_expected_explained in
       (* Force the return type to be well-formed in the original
          environment. *)
       unify_var newenv tv exp.exp_type;
@@ -8144,7 +8142,7 @@ and type_expect_
     | Ok { name; name_loc; enabled_at_init; arg; } ->
         check_probe_name name name_loc env;
         Env.add_probe name;
-        let exp = type_expect ~on_function_argument:false env mode_legacy arg
+        let exp = type_expect env mode_legacy arg
                     (mk_expected Predef.type_unit) in
         rue {
           exp_desc = Texp_probe {name; handler=exp; enabled_at_init};
@@ -8226,10 +8224,7 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
   | Pexp_stack e ->
-      let exp =
-        type_expect ~on_function_argument:false env expected_mode e
-          ty_expected_explained
-      in
+      let exp = type_expect env expected_mode e ty_expected_explained in
       let unsupported category =
         raise (Error (exp.exp_loc, env, Unsupported_stack_allocation category))
       in
@@ -8298,10 +8293,7 @@ and type_expect_
         (* CR uniqueness: this could be the jkind of exp2 *)
         mk_expected (newvar (Jkind.for_non_float ~why:Boxed_record))
       in
-      let exp1 =
-        type_expect ~recarg ~on_function_argument:false env
-          (mode_default cell_mode) exp1 cell_type
-      in
+      let exp1 = type_expect ~recarg env (mode_default cell_mode) exp1 cell_type in
       let new_fields_mode =
         (* The newly-written fields have to be global to avoid heap-to-stack pointers.
            We enforce that here, by asking the allocation to be global.
@@ -8336,8 +8328,7 @@ and type_expect_
         let overwrite =
           Overwriting (exp1.exp_loc, exp1.exp_type, fields_mode)
         in
-        type_expect ~recarg ~overwrite ~on_function_argument:false env
-          exp2_mode exp2 ty_expected_explained
+        type_expect ~recarg ~overwrite env exp2_mode exp2 ty_expected_explained
       in
       re { exp_desc = Texp_overwrite(exp1, exp2);
             exp_loc = loc; exp_extra = [];
@@ -8367,10 +8358,7 @@ and type_expect_
         then mode_default Value.max
         else mode_quoted
       in
-      let arg =
-        type_expect ~on_function_argument:false new_env mode_quoted exp
-          (mk_expected ty)
-      in
+      let arg = type_expect new_env mode_quoted exp (mk_expected ty) in
       if maybe_computation arg then
         submode ~loc ~env ~reason:Other mode_computation_quoted expected_mode;
       re {
@@ -8394,10 +8382,7 @@ and type_expect_
         submode ~loc ~env ~reason:Other mode_splice expected_mode;
       let new_env = Env.enter_splice ~loc env in
       let ty = Predef.type_code (newgenty (Tquote ty_expected)) in
-      let arg =
-        type_expect ~on_function_argument:false new_env mode_spliced exp
-          (mk_expected ty)
-      in
+      let arg = type_expect new_env mode_spliced exp (mk_expected ty) in
       re {
         exp_desc = Texp_antiquotation arg;
         exp_loc = loc; exp_extra = [];
@@ -8481,9 +8466,7 @@ and type_block_access env expected_base_ty principal
       | Mutable -> Predef.type_idx_mut base_ty el_ty
     in
     let idx =
-      type_expect ~on_function_argument:false env mode_legacy idx
-        (mk_expected idx_type_expected)
-    in
+      type_expect env mode_legacy idx (mk_expected idx_type_expected) in
     let ba = Baccess_block (mut, idx) in
     let mut = match mut with Immutable -> false | Mutable -> true in
     let modality = Typemode.idx_expected_modalities ~mut in
@@ -8914,27 +8897,6 @@ and type_function
           ~mode_annots:mode_annots.mode_modes
           ~ret_mode_annots:ret_mode_annots.mode_modes
       in
-      (* Check that the zero_alloc attribute on the pattern is compatible
-         with the one on the parameter type (from a type annotation). *)
-      begin match get_desc ty_arg with
-      | Tpoly (_, _, Some check_poly) ->
-        begin
-          match zero_alloc with
-          | None -> ()
-          | Some check_attr ->
-            let check1 =
-              Zero_alloc.create_const (Zero_alloc.Check check_attr)
-            in
-            let check2 =
-              Zero_alloc.create_const (Zero_alloc.Check check_poly)
-            in
-            match Zero_alloc.sub ~context:Type_constraint check1 check2 with
-            | Ok () -> ()
-            | Error e ->
-              raise (Error (pparam_loc, env, Incompatible_param_zero_alloc e))
-        end
-      | _ -> ()
-      end;
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
          optional arguments with defaults, where the external [ty_arg_mono]
@@ -8972,16 +8934,16 @@ and type_function
             (* Defaults are always global. They can be moved out of the
                function's region by Simplf.split_default_wrapper. *)
             let default_arg =
-              type_expect ~on_function_argument:true env mode_legacy default
-                (mk_expected ty_default_arg)
+              type_expect env mode_legacy default (mk_expected ty_default_arg)
             in
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
       in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry), partial =
         (* Check everything else in the scope of the parameter. *)
-        map_half_typed_cases ~zero_alloc Value env expected_pat_mode
+        map_half_typed_cases Value env expected_pat_mode
           ty_arg_internal sort_arg_internal ty_ret pat.ppat_loc
+          ~zero_alloc
           ~check_if_total:true
           (* We don't make use of [case_data] here so we pass unit. *)
           [ { pattern = pat; has_guard = false; needs_refute = false }, () ]
@@ -9155,9 +9117,7 @@ and type_function
       | Pfunction_body body ->
           let body =
             match ret_type_constraint with
-            | None ->
-                type_expect ~on_function_argument:false env expected_mode body
-                  (mk_expected ty_expected)
+            | None -> type_expect env expected_mode body (mk_expected ty_expected)
             | Some constraint_ ->
             let body_loc = body.pexp_loc in
             let body, exp_type, exp_extra =
@@ -9256,8 +9216,8 @@ and type_label_access
   let record =
     with_local_level_if_principal ~post:generalize_structure_exp
       (fun () ->
-         type_expect ~recarg:Allowed ~on_function_argument:false env
-           (mode_default mode) srecord (mk_expected (newvar record_jkind)))
+         type_expect ~recarg:Allowed env (mode_default mode) srecord
+           (mk_expected (newvar record_jkind)))
   in
   let ty_exp = record.exp_type in
   let expected_type =
@@ -9878,7 +9838,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                 { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
               ret_sort;
               alloc_mode;
-              zero_alloc = Zero_alloc.default;
+              zero_alloc = Zero_alloc.default
             }
         }
       in
@@ -9910,7 +9870,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
   | None ->
       let mode = expect_mode_cross env ty_expected' mode in
       let texp =
-        type_expect ?recarg ~overwrite ~on_function_argument:false env mode sarg
+        type_expect ?recarg ~overwrite env mode sarg
           (mk_expected ?explanation ty_expected')
       in
       unify_exp env texp ty_expected;
@@ -9923,8 +9883,7 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       let expected_mode, mode_arg =
         mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
       let arg =
-        type_expect ~on_function_argument:false env expected_mode sarg
-          (mk_expected ty_arg_mono)
+        type_expect env expected_mode sarg (mk_expected ty_arg_mono)
       in
       (match lbl with
        | Labelled _ | Nolabel -> ()
@@ -9940,15 +9899,15 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       let expected_mode, mode_arg =
         mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
       let ty_arg', vars, zero_alloc = tpoly_get_poly ty_arg in
-      let arg, sch, zero_alloc =
+      let arg, sch =
         if vars = [] then begin
           let ty_arg0' = tpoly_get_inner ty_arg0 in
           if wrapped_in_some then begin
             type_option_some
-              env expected_mode sarg ty_arg' ty_arg0', None, zero_alloc
+              env expected_mode sarg ty_arg' ty_arg0', None
           end else begin
             type_argument ~overwrite:No_overwrite
-              env expected_mode sarg ty_arg' ty_arg0', None, zero_alloc
+              env expected_mode sarg ty_arg' ty_arg0', None
           end
         end else begin
           let sch =
@@ -9965,28 +9924,28 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
           let separate =
             !Clflags.principal || Env.has_local_constraints env
           in
-          let arg, _, _, zero_alloc =
+          let arg, _, _ =
             with_local_level begin fun () ->
               let vars, ty_arg' =
                 with_local_level_if separate begin fun () ->
                   instance_poly_fixed vars ty_arg'
                 end ~post:(fun (_, ty_arg') -> generalize_structure ty_arg')
               in
-              let (ty_arg0', vars0, za0) = tpoly_get_poly ty_arg0 in
+              let (ty_arg0', vars0, _za0) = tpoly_get_poly ty_arg0 in
               let vars0, ty_arg0' = instance_poly_fixed vars0 ty_arg0' in
               List.iter2 (fun ty ty' -> unify_var env ty ty') vars vars0;
               let arg =
                 type_argument ~overwrite:No_overwrite
                   env expected_mode sarg ty_arg' ty_arg0'
               in
-              arg, ty_arg, vars, za0
+              arg, ty_arg, vars
             end
-            ~post:(fun (arg, ty_arg, vars, _) ->
+            ~post:(fun (arg, ty_arg, vars) ->
               if maybe_expansive arg then
                 lower_contravariant env arg.exp_type;
               generalize_and_check_univars env "argument" arg ty_arg vars);
           in
-          {arg with exp_type = instance arg.exp_type}, sch, zero_alloc
+          {arg with exp_type = instance arg.exp_type}, sch
         end
       in
       begin
@@ -10032,10 +9991,7 @@ and type_application env app_loc expected_mode position_and_mode
         mode_argument ~funct ~index:0 ~position_and_mode
           ~partial_app:false arg_mode
       in
-      let exp =
-        type_expect ~on_function_argument:false env arg_mode sarg
-          (mk_expected ty_arg)
-      in
+      let exp = type_expect env arg_mode sarg (mk_expected ty_arg) in
       check_partial_application ~statement:false exp;
       ([Nolabel, Arg (exp, arg_sort), None],
        ty_ret, ret_mode, position_and_mode)
@@ -10150,9 +10106,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       (fun (label, body) ((_, ty), argument_mode) overwrite ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-        (label,
-         type_expect ~overwrite ~on_function_argument:false env argument_mode
-           body (mk_expected ty)))
+        (label, type_expect ~overwrite env argument_mode body (mk_expected ty)))
       sexpl types_and_modes overwrites
   in
   re {
@@ -10216,10 +10170,7 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
       (fun (label, body) ((_, ty, sort), argument_mode) ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-        (label,
-         type_expect ~on_function_argument:false env argument_mode body
-           (mk_expected ty),
-         sort))
+        (label, type_expect env argument_mode body (mk_expected ty), sort))
       sexpl types_sorts_and_modes
   in
   re {
@@ -10478,7 +10429,7 @@ and type_statement ?explanation ?(position=RNontail) env sexp =
 and map_half_typed_cases
   : type k ret case_data.
     ?additional_checks_for_split_cases:((_ * ret) list -> unit)
-    -> ?zero_alloc:Zero_alloc.check option
+    -> zero_alloc:Zero_alloc.check option
     -> k pattern_category -> _ -> _ -> _ -> _ -> _ -> _
     -> (untyped_case * case_data) list
     -> type_body:(
@@ -10491,7 +10442,7 @@ and map_half_typed_cases
         -> ret)
     -> check_if_total:bool (* if false, assume Partial right away *)
     -> ret list * partial
-  = fun ?additional_checks_for_split_cases ?zero_alloc
+  = fun ?additional_checks_for_split_cases ~zero_alloc
     category env pat_mode
     ty_arg sort_arg ty_res loc caselist ~type_body ~check_if_total ->
   (* ty_arg is _fully_ generalized *)
@@ -10548,14 +10499,6 @@ and map_half_typed_cases
                 (* propagation of pattern *)
                 with_local_level ~post:generalize_structure
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
-              in
-              let zero_alloc =
-                match zero_alloc with
-                | Some za -> za
-                | None ->
-                  if is_Tpoly ty_arg
-                  then thd3 (tpoly_get_poly ty_arg)
-                  else None
               in
               let (pat, ext_env, force, pvs, mvs) =
                 type_pattern category ~lev ~alloc_mode:pat_mode env pattern
@@ -10840,12 +10783,11 @@ and type_cases
           | None -> None
           | Some scond ->
             Some
-              (type_expect ~on_function_argument:false ext_env mode_max scond
+              (type_expect ext_env mode_max scond
                 (mk_expected ~explanation:When_guard Predef.type_bool))
         in
         let exp =
-          type_expect ~on_function_argument:false ext_env expr_mode pc_rhs
-            (mk_expected ?explanation ty_expected)
+          type_expect ext_env expr_mode pc_rhs (mk_expected ?explanation ty_expected)
         in
         {
           c_lhs = pat;
@@ -10853,6 +10795,7 @@ and type_cases
           c_rhs = {exp with exp_type = ty_infer}
         }
     end
+    ~zero_alloc:None
     ~additional_checks_for_split_cases:(fun cases ->
       let cases =
         List.map
@@ -11113,15 +11056,13 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 in
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect ~on_function_argument:false exp_env mode sexp
-                      (mk_expected ty'))
+                    type_expect exp_env mode sexp (mk_expected ty'))
                 in
                 exp, Some vars
             | _ ->
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect ~on_function_argument:false exp_env mode sexp
-                      (mk_expected expected_ty))
+                    type_expect exp_env mode sexp (mk_expected expected_ty))
                 in
                 exp, None)
       in
@@ -11380,8 +11321,7 @@ and type_andops env sarg sands expected_sort expected_ty =
   let rec loop env let_sarg rev_sands expected_sort expected_ty =
     match rev_sands with
     | [] ->
-        type_expect ~on_function_argument:false env mode_legacy let_sarg
-          (mk_expected expected_ty),
+        type_expect env mode_legacy let_sarg (mk_expected expected_ty),
         expected_sort,
         []
     | { pbop_op = sop; pbop_exp = sexp; pbop_loc = loc; _ } :: rest ->
@@ -11417,10 +11357,7 @@ and type_andops env sarg sands expected_sort expected_ty =
         let let_arg, sort_let_arg, rest =
           loop env let_sarg rest sort_rest ty_rest
         in
-        let exp =
-          type_expect ~on_function_argument:false env mode_legacy sexp
-            (mk_expected ty_arg)
-        in
+        let exp = type_expect env mode_legacy sexp (mk_expected ty_arg) in
         begin try
           unify env (instance ty_result) (instance expected_ty)
         with Unify err ->
@@ -11477,8 +11414,7 @@ and type_generic_array
   let argument_mode = expect_mode_cross env ty argument_mode in
   let argl =
     List.map
-      (fun sarg -> type_expect ~on_function_argument:false env argument_mode
-                     sarg (mk_expected ty))
+      (fun sarg -> type_expect env argument_mode sarg (mk_expected ty))
       sargl
   in
   re {
@@ -11502,9 +11438,8 @@ and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
 
 and type_n_ary_function
       ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
-      ~explanation ~attributes ~on_function_argument
-      (params, constraint_, body)
-  =
+      ~explanation ~attributes (params, constraint_, body)
+    =
     let in_function = mk_expected (instance ty_expected) ?explanation, loc in
     let { function_ = exp_type, result_params, body;
           newtypes; params_contain_gadt = contains_gadt;
@@ -11534,34 +11469,15 @@ and type_n_ary_function
         GADT, as this is the only opportunity for arrows to be hidden from the
         resulting type.
     *)
-    let zero_alloc =
-      Builtin_attributes.get_zero_alloc_attribute
-        ~in_signature:false
-        ~on_application:false
-        ~on_function_argument
-        ~default_arity:syntactic_arity
-        attributes
-    in
-    let zero_alloc =
-      match zero_alloc with
-      | Default_zero_alloc -> Zero_alloc.create_var loc syntactic_arity
-      | Ignore_assert_all | Check _ | Assume _ ->
-        Zero_alloc.create_const zero_alloc
-    in
     begin match contains_gadt with
     | No_gadt -> ()
     | Contains_gadt ->
         (* Assert that [ty] is a function, and return its return type. *)
         let filter_ty_ret_exn ty arg_label ~force_tpoly =
-          let zero_alloc =
-            match Zero_alloc.get zero_alloc with
-            | Check c -> Some c
-            | _ -> None
-          in
           let has_poly =
-            match force_tpoly, zero_alloc with
-            | false, None -> Mono
-            | _ -> Poly zero_alloc
+            match force_tpoly with
+            | false -> Mono
+            | _ -> Poly None
           in
           match filter_arrow env ty arg_label ~has_poly with
           | { ty_ret; _ } -> ty_ret
@@ -11623,6 +11539,20 @@ and type_n_ary_function
             ignore
               (filter_ty_ret_exn ret_ty Nolabel ~force_tpoly:true : type_expr)
     end;
+    let zero_alloc =
+      Builtin_attributes.get_zero_alloc_attribute
+        ~in_signature:false
+        ~on_application:false
+        ~on_function_argument:false
+        ~default_arity:syntactic_arity
+        attributes
+    in
+    let zero_alloc =
+      match zero_alloc with
+      | Default_zero_alloc -> Zero_alloc.create_var loc syntactic_arity
+      | Ignore_assert_all | Check _ | Assume _ ->
+        Zero_alloc.create_const zero_alloc
+    in
     let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
     re
       { exp_desc =
@@ -11783,8 +11713,7 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
   let comp_body =
     (* To understand why comprehension bodies are checked at [mode_global], see
        "What modes should comprehensions use?", above *)
-    type_expect ~on_function_argument:false new_env mode_legacy sbody
-      (mk_expected element_ty)
+    type_expect new_env mode_legacy sbody (mk_expected element_ty)
   in
   re { exp_desc       = make_texp { comp_body ; comp_clauses }
      ; exp_loc        = loc
@@ -11824,7 +11753,6 @@ and type_comprehension_clause ~loc ~comprehension_type ~container_type env
            mode, see "What modes should comprehensions use?" in
            [type_comprehension_expr]*)
         type_expect
-          ~on_function_argument:false
           env
           mode_max
           cond
@@ -11857,7 +11785,6 @@ and type_comprehension_iterator
            checked at an arbitrary mode, see "What modes should comprehensions
            use?" in [type_comprehension_expr]*)
         type_expect
-          ~on_function_argument:false
           env
           mode_max
           bound
@@ -11891,7 +11818,6 @@ and type_comprehension_iterator
            (and not local) sequences, see "What modes should comprehensions
            use?" in [type_comprehension_expr]*)
         type_expect
-          ~on_function_argument:false
           env
           mode_legacy
           seq
@@ -12047,8 +11973,7 @@ let type_expression env jkind sexp =
     with_local_level begin fun () ->
       Typetexp.TyVarEnv.reset ();
       let expected = mk_expected (newvar jkind) in
-      type_expect ~on_function_argument:false
-        env mode_toplevel_expression sexp expected
+      type_expect env mode_toplevel_expression sexp expected
     end
     ~post:(may_lower_contravariant_then_generalize env)
   in
@@ -13249,7 +13174,7 @@ let check_partial ?lev a b c cases =
    and check for uniqueness *)
 let type_expect env ?mode e ty =
   let expected_mode = mode_default_opt mode in
-  let exp = type_expect ~on_function_argument:false env expected_mode e ty in
+  let exp = type_expect env expected_mode e ty in
   maybe_check_uniqueness_exp exp; exp
 
 let type_exp env ?mode e =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7129,7 +7129,7 @@ and type_expect_
       let cases, partial =
         type_cases Computation env arg_pat_mode expected_mode
           arg.exp_type sort ty_expected_explained
-          ~check_if_total:true loc caselist in
+          ~check_if_total:true ~zero_alloc:None loc caselist in
       if
         List.for_all (fun c -> pattern_needs_partial_application_check c.c_lhs)
           cases
@@ -7151,7 +7151,7 @@ and type_expect_
         type_cases Value env arg_mode expected_mode
           Predef.type_exn Jkind.Sort.(of_const Const.for_exception)
           ty_expected_explained
-          ~check_if_total:false loc caselist in
+          ~check_if_total:false ~zero_alloc:None loc caselist in
       re {
         exp_desc = Texp_try(body, cases);
         exp_loc = loc; exp_extra = [];
@@ -8093,7 +8093,7 @@ and type_expect_
         type_cases Value body_env
           (simple_pat_mode Value.legacy) (mode_return Value.legacy)
           ty_params param_sort (mk_expected ty_func_result)
-          ~check_if_total:true loc [scase]
+          ~check_if_total:true ~zero_alloc:None loc [scase]
       in
       let body =
         match cases with
@@ -10748,10 +10748,12 @@ and type_newtype_expr
 (* Typing of match cases *)
 and type_cases
     : type k . k pattern_category ->
-           _ -> _ -> _ -> _ -> _ -> _ -> check_if_total:bool -> _ ->
+           _ -> _ -> _ -> _ -> _ -> _ -> check_if_total:bool ->
+           zero_alloc:Zero_alloc.check option -> _ ->
            Parsetree.case list -> k case list * partial
   = fun category env pat_mode expr_mode
-        ty_arg sort_arg ty_res_explained ~check_if_total loc caselist ->
+        ty_arg sort_arg ty_res_explained ~check_if_total ~zero_alloc loc
+        caselist ->
   let { ty = ty_res; explanation } = ty_res_explained in
   let caselist =
     List.map (fun case -> Parmatch.untyped_case case, case) caselist
@@ -10796,7 +10798,7 @@ and type_cases
           c_rhs = {exp with exp_type = ty_infer}
         }
     end
-    ~zero_alloc:None
+    ~zero_alloc
     ~additional_checks_for_split_cases:(fun cases ->
       let cases =
         List.map
@@ -10816,13 +10818,32 @@ and type_cases
 and type_function_cases_expect
     env expected_mode ty_expected loc cases attrs ~first ~in_function =
   Builtin_attributes.warning_scope attrs begin fun () ->
+    let zero_alloc =
+      match cases with
+      | [] -> None
+      | first_case :: _ ->
+        let pat = first_case.pc_lhs in
+        let attr_result =
+          try
+            Builtin_attributes.get_zero_alloc_attribute
+              Function_param
+              (get_pat_attrs pat)
+          with Builtin_attributes.Error_builtin (_, err) ->
+            raise (Builtin_attributes.Error_builtin (pat.ppat_loc, err))
+        in
+        match attr_result with
+        | Default_zero_alloc | Ignore_assert_all -> None
+        | Assume _ ->
+          raise (Error (pat.ppat_loc, env, Invalid_payload_arg_zero_alloc))
+        | Check check -> Some check
+    in
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
           arg_sort; ret_sort;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
-        ~in_function ~has_poly:Mono ~zero_alloc:None
+        ~in_function ~has_poly:Mono ~zero_alloc
         ~mode_annots:Mode.Alloc.Const.Option.none
         ~ret_mode_annots:Mode.Alloc.Const.Option.none
         ~is_first_val_param:first ~is_final_val_param:true
@@ -10830,7 +10851,7 @@ and type_function_cases_expect
     let cases, partial =
       type_cases Value env
         expected_pat_mode expected_inner_mode ty_arg_mono arg_sort
-        (mk_expected ty_ret) ~check_if_total:true loc cases
+        (mk_expected ty_ret) ~check_if_total:true ~zero_alloc loc cases
     in
     let ty_fun =
       instance

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -309,6 +309,12 @@ type error =
   | Let_poly_not_yet_implemented
   | Let_poly_not_syntactic_value
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
+  | Wrong_arg_zero_alloc of Zero_alloc.error
+  | Unsupported_arg_zero_alloc
+  | Must_provide_zero_alloc_arity
+  | Invalid_payload_arg_zero_alloc
+  | Incompatible_param_zero_alloc of Zero_alloc.error
+  | Zero_alloc_arity_mismatch of int * int
 
 and invalid_layout_poly_inst_context =
   | Binding_op
@@ -1336,6 +1342,7 @@ type pattern_variable =
     pv_attributes: attributes;
     pv_sort: Jkind_types.Sort.t;
     pv_lpoly: Lpoly.t;
+    pv_zero_alloc: Zero_alloc.check option;
   }
 
 type module_variable =
@@ -1437,13 +1444,15 @@ let iter_pattern_variables_type_mut ~f_immut ~f_mut pvs =
 let add_pattern_variables ?check ?check_as env pv =
   List.fold_right
     (fun {pv_id; pv_mode; pv_kind; pv_type; pv_loc; pv_as_var;
-          pv_attributes; pv_uid; pv_lpoly} env ->
+          pv_attributes; pv_uid; pv_lpoly; pv_zero_alloc} env ->
        let check = if pv_as_var then check_as else check in
        Env.add_value ?check ~mode:pv_mode pv_id
          {val_type = pv_type; val_kind = pv_kind; val_lpoly = pv_lpoly;
           Types.val_loc = pv_loc;
           val_attributes = pv_attributes; val_modalities = Modality.undefined;
-          val_zero_alloc = Zero_alloc.default;
+          val_zero_alloc = (match pv_zero_alloc with
+            | None -> Zero_alloc.default
+            | Some c -> Zero_alloc.create_const (Zero_alloc.Check c));
           val_uid = pv_uid
          } env
     )
@@ -1491,7 +1500,7 @@ let add_module_variables env module_variables =
 
 let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name mode
     ?(lpoly=Lpoly.determined [])
-    ~kind ty attrs sort =
+    ~kind ty attrs zero_alloc sort =
   if List.exists (fun {pv_id; _} -> Ident.name pv_id = name.txt)
       tps.tps_pattern_variables
   then raise(Error(loc, Env.empty, Multiply_bound_variable name.txt));
@@ -1531,7 +1540,8 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name mode
      pv_attributes = attrs;
      pv_uid;
      pv_sort = sort;
-     pv_lpoly = lpoly} :: tps.tps_pattern_variables;
+     pv_lpoly = lpoly;
+     pv_zero_alloc = zero_alloc} :: tps.tps_pattern_variables;
   id, pv_uid
 
 let sort_pattern_variables vs =
@@ -2111,7 +2121,7 @@ let solve_Ppat_constraint tps loc env mode sty expected_ty =
   unify_pat_types loc env ty (instance expected_ty);
   let expected_ty' =
     match get_desc expected_ty' with
-    | Tpoly (expected_ty', tl) ->
+    | Tpoly (expected_ty', tl, _za) ->
         instance_poly ~keep_names:true tl expected_ty'
     | _ -> expected_ty'
   in
@@ -2224,6 +2234,7 @@ let type_for_loop_like_index ~error ~loc ~env ~param ~any ~var =
           ~pv_loc:loc
           ~pv_as_var:false
           ~pv_attributes:[]
+          ~pv_zero_alloc:None
   | _ ->
       raise (Error (param.ppat_loc, env, error))
 
@@ -2242,6 +2253,7 @@ let type_for_loop_index ~loc ~env ~param =
               ~pv_loc
               ~pv_as_var
               ~pv_attributes
+              ~pv_zero_alloc
           ->
             let check s = Warnings.Unused_for_index s in
             let pv_id = Ident.create_local txt in
@@ -2249,7 +2261,7 @@ let type_for_loop_index ~loc ~env ~param =
             let pv =
               { pv_id; pv_uid; pv_mode;
                 pv_kind = Val_reg Jkind.Sort.(of_const Const.for_loop_index);
-                pv_type; pv_loc; pv_as_var;
+                pv_type; pv_loc; pv_as_var; pv_zero_alloc;
                 pv_attributes;
                 pv_sort = Jkind.Sort.(of_const Const.for_loop_index);
                 pv_lpoly = Lpoly.determined [];
@@ -2267,7 +2279,8 @@ let type_comprehension_for_range_iterator_index ~loc ~env ~param tps =
        because it can't have been referenced later so we don't need to track it
        for duplicates or anything else. *)
     ~any:Fun.id
-    ~var:(fun ~name ~pv_mode ~pv_type ~pv_loc ~pv_as_var ~pv_attributes ->
+    ~var:(fun ~name ~pv_mode ~pv_type ~pv_loc ~pv_as_var ~pv_attributes
+           ~pv_zero_alloc ->
           enter_variable
             ~is_as_variable:pv_as_var
             ~kind:(Val_reg Jkind.Sort.(of_const Const.for_loop_index))
@@ -2277,6 +2290,7 @@ let type_comprehension_for_range_iterator_index ~loc ~env ~param tps =
             pv_mode
             pv_type
             pv_attributes
+            pv_zero_alloc
             Jkind.Sort.(of_const Const.for_loop_index))
 
 let check_let_mutable (mf : mutable_flag) env ?restriction vbs =
@@ -3018,24 +3032,25 @@ let rec type_pat
   : type k . type_pat_state -> k pattern_category ->
       no_existentials: existential_restriction option ->
       alloc_mode:expected_pat_mode -> mutable_flag:_ ->
-      penv: Pattern_env.t -> Parsetree.pattern -> type_expr ->
-      Jkind.Sort.t -> k general_pattern
-  = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv sp
-      expected_ty sort ->
+      penv: Pattern_env.t -> zero_alloc:Zero_alloc.check option ->
+      Parsetree.pattern -> type_expr -> Jkind.Sort.t -> k general_pattern
+  = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv
+      ~zero_alloc sp expected_ty sort ->
   Builtin_attributes.warning_scope sp.ppat_attributes
     (fun () ->
        type_pat_aux tps category ~no_existentials
-         ~alloc_mode ~mutable_flag ~penv sp expected_ty sort
+         ~alloc_mode ~mutable_flag ~penv ~zero_alloc sp expected_ty sort
     )
 
 and type_pat_aux
   : type k . type_pat_state -> k pattern_category -> no_existentials:_ ->
          alloc_mode:expected_pat_mode -> mutable_flag:mutable_flag -> penv:_ ->
-         _ -> _ -> _ -> k general_pattern
-  = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv sp
-        expected_ty sort ->
-  let type_pat tps category ?(alloc_mode=alloc_mode) ?(penv=penv) =
+         zero_alloc:Zero_alloc.check option -> _ -> _ -> _ -> k general_pattern
+  = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv
+        ~zero_alloc sp expected_ty sort ->
+  let type_pat tps category ?(alloc_mode=alloc_mode) ?(penv=penv) ~zero_alloc =
     type_pat tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv
+      ~zero_alloc
   in
   let loc = sp.ppat_loc in
   let solve_expected (x : pattern) : pattern =
@@ -3070,7 +3085,7 @@ and type_pat_aux
     in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl =
-      List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt arg_sort) spl
+      List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt arg_sort ~zero_alloc) spl
     in
     rvp {
       pat_desc = Tpat_array (mutability, arg_sort, pl);
@@ -3104,7 +3119,8 @@ and type_pat_aux
       List.map (fun (lbl, p, t, alloc_mode) ->
         lbl,
         type_pat tps Value ~alloc_mode p t
-          Jkind.Sort.(of_const Const.for_tuple_element))
+          Jkind.Sort.(of_const Const.for_tuple_element)
+          ~zero_alloc:None)
         spl_ann
     in
     rvp {
@@ -3138,7 +3154,7 @@ and type_pat_aux
     in
     let pl =
       List.map (fun (lbl, p, t, alloc_mode, sort) ->
-        lbl, type_pat tps Value ~alloc_mode p t sort, sort)
+        lbl, type_pat tps Value ~alloc_mode ~zero_alloc p t sort, sort)
         spl_ann
     in
     let ty =
@@ -3195,7 +3211,8 @@ and type_pat_aux
           | `Sort s -> Jkind.Sort.of_const s
           | `Same_as_record_sort -> record_sort
         in
-        (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg ty_sort)
+        (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg ty_sort
+                             ~zero_alloc:None)
       in
       let make_record_pat
             sorts (rep : rep)
@@ -3267,7 +3284,7 @@ and type_pat_aux
           let lpoly = Lpoly.pending ~loc in
           let id, uid =
             enter_variable ~lpoly tps loc name mode ~kind ty
-              sp.ppat_attributes sort
+              sp.ppat_attributes zero_alloc sort
           in
           Tpat_fun_layout { id; name; uid; sort;
                             mode = alloc_mode; lpoly; env_alloc_mode }
@@ -3275,7 +3292,7 @@ and type_pat_aux
           let lpoly = Lpoly.determined [] in
           let id, uid =
             enter_variable ~lpoly tps loc name mode ~kind ty
-              sp.ppat_attributes sort
+              sp.ppat_attributes zero_alloc sort
           in
           Tpat_var { id; name; uid; sort; mode = alloc_mode }
       in
@@ -3306,7 +3323,7 @@ and type_pat_aux
           let sort = Jkind.Sort.(of_const Const.for_module) in
           let id, uid =
             enter_variable tps loc v alloc_mode.mode t ~is_module:true
-              ~kind:(Val_reg sort) sp.ppat_attributes sort
+              ~kind:(Val_reg sort) sp.ppat_attributes None sort
           in
           rvp {
             pat_desc = Tpat_var { id; name = v; uid; sort;
@@ -3319,13 +3336,13 @@ and type_pat_aux
             pat_unique_barrier = Unique_barrier.not_computed () }
       end
   | Ppat_alias(sq, name) ->
-      let q = type_pat tps Value sq expected_ty sort in
+      let q = type_pat tps Value sq expected_ty sort ~zero_alloc in
       let ty_var, mode = solve_Ppat_alias ~mode:alloc_mode.mode !!penv q in
       let mode = cross_left !!penv expected_ty mode in
       let id, uid =
         enter_variable ~is_as_variable:true
           ~kind:(Val_reg sort) tps name.loc name mode
-          ty_var sp.ppat_attributes sort
+          ty_var sp.ppat_attributes zero_alloc sort
       in
       rvp { pat_desc = Tpat_alias { pattern = q; id; name; uid;
                                     sort; mode; type_expr = ty_var };
@@ -3376,6 +3393,7 @@ and type_pat_aux
         let p = {p with ppat_loc=loc} in
         type_pat tps category p expected_ty
           Jkind.Sort.(of_const Const.for_predef_scannable)
+          ~zero_alloc:None
         (* TODO: record 'extra' to remember about interval *)
       in
       begin match
@@ -3513,7 +3531,7 @@ and type_pat_aux
                    Jkind.Sort.new_var ~level:(get_current_level ())
                    |> Jkind.Sort.of_var
              in
-             type_pat ~alloc_mode tps Value p arg.ca_type sort)
+             type_pat ~alloc_mode tps Value p arg.ca_type sort ~zero_alloc:None)
           sargs args
       in
       let repr, sorts =
@@ -3548,7 +3566,8 @@ and type_pat_aux
           Some sp, [ty] ->
           Some
             (type_pat tps Value sp ty
-              Jkind.Sort.(of_const Const.for_variant_arg))
+               Jkind.Sort.(of_const Const.for_variant_arg)
+               ~zero_alloc:None)
         | _ -> None
       in
       rvp {
@@ -3587,7 +3606,7 @@ and type_pat_aux
         with_local_level begin fun () ->
           let type_pat_rec tps penv sp =
             let alloc_mode = dynamic_pat_mode alloc_mode in
-            type_pat ~alloc_mode tps category sp expected_ty sort ~penv
+            type_pat ~alloc_mode tps category sp expected_ty sort ~penv ~zero_alloc:None
           in
           let penv1 =
             Pattern_env.copy ~equations_scope:(get_current_level ()) penv in
@@ -3638,6 +3657,7 @@ and type_pat_aux
       let p1 =
         type_pat ~alloc_mode tps Value sp1 nv
           Jkind.Sort.(of_const Const.for_lazy_body)
+          ~zero_alloc:None
       in
       rvp {
         pat_desc = Tpat_lazy p1;
@@ -3656,7 +3676,7 @@ and type_pat_aux
             expected_ty
         in
         let p =
-          type_pat ~alloc_mode tps category sp_constrained expected_ty' sort
+          type_pat ~alloc_mode tps category sp_constrained expected_ty' sort ~zero_alloc
         in
         let extra =
           Tpat_constraint (cty, type_modes),
@@ -3665,7 +3685,7 @@ and type_pat_aux
         in
         { p with pat_type = ty; pat_extra = extra::p.pat_extra }
       | None ->
-        type_pat ~alloc_mode tps category sp_constrained expected_ty sort
+        type_pat ~alloc_mode tps category sp_constrained expected_ty sort ~zero_alloc
       end
   | Ppat_type lid ->
       Env.check_no_open_quotations sp.ppat_loc !!penv
@@ -3678,7 +3698,7 @@ and type_pat_aux
       let path, new_env =
         !type_open Asttypes.Fresh !!penv sp.ppat_loc lid in
       Pattern_env.set_env penv new_env;
-      let p = type_pat tps category ~penv p expected_ty sort in
+      let p = type_pat tps category ~penv p expected_ty sort ~zero_alloc:None in
       let new_env = !!penv in
       begin match Env.remove_last_open path new_env with
       | None -> assert false
@@ -3691,6 +3711,7 @@ and type_pat_aux
       let p_exn =
         type_pat tps Value ~alloc_mode p Predef.type_exn
           Jkind.Sort.(of_const Const.for_exception)
+          ~zero_alloc:None
       in
       rcp {
         pat_desc = Tpat_exception p_exn;
@@ -3704,18 +3725,18 @@ and type_pat_aux
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-let type_pat tps category ?no_existentials ~mutable_flag penv =
-  type_pat tps category ~no_existentials ~mutable_flag ~penv
+let type_pat tps category ?no_existentials ~mutable_flag penv ~zero_alloc =
+  type_pat tps category ~no_existentials ~mutable_flag ~penv ~zero_alloc
 
 let type_pattern
-    category ~lev ~alloc_mode env spat expected_ty sort allow_modules
+    category ~lev ~alloc_mode env spat expected_ty sort allow_modules ~zero_alloc
   =
   let tps = create_type_pat_state allow_modules in
   let new_penv = Pattern_env.make env
       ~equations_scope:lev ~allow_recursive_equations:false in
   let pat =
       type_pat tps category ~alloc_mode ~mutable_flag:Immutable new_penv spat
-        expected_ty sort
+        expected_ty sort ~zero_alloc
   in
   let { tps_pattern_variables = pvs;
         tps_module_variables = mvs;
@@ -3731,14 +3752,23 @@ let type_pattern_list
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
       ~equations_scope ~allow_recursive_equations:false in
-  let type_pat (attrs, pat_mode, env_alloc_mode, exp_mode, pat) ty sort =
+  let type_pat (attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, pat) ty sort =
+    let zero_alloc : Zero_alloc.check option =
+      match zero_alloc with
+      | None
+      | Some (Builtin_attributes.Ignore_assert_all
+             | Builtin_attributes.Default_zero_alloc
+             | Builtin_attributes.Assume _)
+        -> None
+      | Some (Builtin_attributes.Check c) -> Some c
+    in
     Pattern_env.set_env_alloc_mode new_penv env_alloc_mode;
     Builtin_attributes.warning_scope ~ppwarning:false attrs
       (fun () ->
          exp_mode,
          type_pat tps category
            ~no_existentials ~alloc_mode:pat_mode ~mutable_flag
-           new_penv pat ty sort
+           new_penv pat ty sort ~zero_alloc
       )
   in
   let patl = Misc.Stdlib.List.map3 type_pat spatl expected_tys expected_sorts in
@@ -3761,6 +3791,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
         type_pat tps Value ~no_existentials:In_class_args ~alloc_mode
           ~mutable_flag:Immutable new_penv spat nv
           Jkind.Sort.(of_const Const.for_class_arg)
+          ~zero_alloc:None
       in
       if has_variants pat then begin
         Parmatch.pressure_variants val_env [pat];
@@ -3778,7 +3809,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
   in
   let (pv, val_env, met_env) =
     List.fold_right
-      (fun {pv_id; pv_uid; pv_type; pv_loc; pv_as_var; pv_attributes; pv_sort}
+      (fun {pv_id; pv_uid; pv_type; pv_loc; pv_as_var; pv_attributes; pv_sort; pv_zero_alloc}
         (pv, val_env, met_env) ->
          let check s =
            if pv_as_var then Warnings.Unused_var { name = s; mutated = false }
@@ -3790,7 +3821,9 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_kind = Val_reg pv_sort
             ; val_lpoly = Lpoly.determined []
             ; val_attributes = pv_attributes
-            ; val_zero_alloc = Zero_alloc.default
+            ; val_zero_alloc = (match pv_zero_alloc with
+                | None -> Zero_alloc.default
+                | Some c -> Zero_alloc.create_const (Zero_alloc.Check c))
             ; val_modalities = Modality.undefined
             ; val_loc = pv_loc
             ; val_uid = pv_uid
@@ -3803,7 +3836,9 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_kind = Val_ivar (Immutable, cl_num)
             ; val_lpoly = Lpoly.determined []
             ; val_attributes = pv_attributes
-            ; val_zero_alloc = Zero_alloc.default
+            ; val_zero_alloc = (match pv_zero_alloc with
+                | None -> Zero_alloc.default
+                | Some c -> Zero_alloc.create_const (Zero_alloc.Check c))
             ; val_modalities = Modality.undefined
             ; val_loc = pv_loc
             ; val_uid = pv_uid
@@ -3824,10 +3859,12 @@ let type_self_pattern env spat =
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
       ~equations_scope ~allow_recursive_equations:false in
+  let zero_alloc = None in
   let pat =
     type_pat tps Value ~no_existentials:In_self_pattern ~alloc_mode
       ~mutable_flag:Immutable new_penv spat nv
       Jkind.Sort.(of_const Const.for_object)
+      ~zero_alloc
   in
   List.iter (fun f -> f()) tps.tps_pattern_force;
   pat, tps.tps_pattern_variables
@@ -4525,7 +4562,7 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
           match get_desc ty_fun with
           | Tvar { jkind; _ } ->
               let ty_arg_mono, sort_arg = new_rep_var ~why:Function_argument () in
-              let ty_arg = newmono ty_arg_mono in
+              let ty_arg = newmono ~zero_alloc:None ty_arg_mono in
               let ty_res =
                 newvar (Jkind.of_new_sort ~why:Function_result
                           ~level:(Ctype.get_current_level ()))
@@ -5174,7 +5211,7 @@ let rec approx_type env sty =
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
       let mret = Alloc.newvar () in
-      newty (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
+      newty (Tarrow ((p,marg,mret), newmono ~zero_alloc:None arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (label, t) -> label, approx_type env t) args))
   | Ptyp_constr (lid, ctl) ->
@@ -5242,7 +5279,9 @@ let type_approx_fun_one_param
   in
   let loc_fun, ty_fun = in_function in
   let { ty_arg; arg_mode; ty_ret; _ } =
-    try filter_arrow env ty_expected label ~force_tpoly:(not has_poly)
+    try
+      filter_arrow env ty_expected label
+        ~force_tpoly:(not has_poly) ~zero_alloc:None
     with Filter_arrow_failed err ->
       let err =
         error_of_filter_arrow_failure ~explanation:None ty_fun err ~first
@@ -5348,7 +5387,7 @@ let check_univars env kind exp ty_expected vars =
   let exp_ty, vars =
     with_local_level_iter ~post:generalize begin fun () ->
       match get_desc pty with
-        Tpoly (body, tl) ->
+        Tpoly (body, tl, _za) ->
           (* Enforce scoping for type_let:
              since body is not generic,  instance_poly_fixed only makes
              copies of nodes that have a Tunivar as descendant *)
@@ -5815,11 +5854,11 @@ let unique_use ~loc ~env mode_l mode_r  =
     in
     (uniqueness, linearity)
 
-let is_really_poly ~env ty =
+let is_really_poly ~env ~zero_alloc ty =
   let snap = Btype.snapshot () in
   let any = Jkind.Builtin.any ~why:Dummy_jkind in
   let really_poly =
-    try unify env (newmono (newvar any)) ty; false
+    try unify env (newmono ~zero_alloc (newvar any)) ty; false
     with Unify _ -> true
   in
   Btype.backtrack snap;
@@ -5893,6 +5932,7 @@ type split_function_ty =
 let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
+    ~zero_alloc
   =
   let alloc_mode, mode =
       (* Unlike most allocations which can be the highest mode allowed by
@@ -5917,7 +5957,7 @@ let split_function_ty
            be a [Tpoly] node *)
         not has_poly
       in
-      try filter_arrow env (instance ty_expected) arg_label ~force_tpoly
+      try filter_arrow env (instance ty_expected) arg_label ~force_tpoly ~zero_alloc
       with Filter_arrow_failed err ->
         let err =
           error_of_filter_arrow_failure ~explanation ~first:is_first_val_param
@@ -5932,7 +5972,8 @@ let split_function_ty
   apply_mode_annots ~loc:loc_fun ~env Parameter mode_annots arg_mode;
   apply_mode_annots ~loc:loc_fun ~env Return ret_mode_annots ret_mode;
   let really_poly =
-    not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
+    not has_poly && not (tpoly_is_mono ty_arg)
+      && is_really_poly ~env ~zero_alloc ty_arg
   in
   if really_poly &&
      !Clflags.principal && get_level ty_arg < Btype.generic_level then
@@ -5964,7 +6005,7 @@ let split_function_ty
   let ty_arg_mono =
     if has_poly then ty_arg
     else begin
-      let ty, vars = tpoly_get_poly ty_arg in
+      let ty, vars, _za = tpoly_get_poly ty_arg in
       if vars = [] then ty
       else begin
         with_level ~level:generic_level
@@ -6074,7 +6115,8 @@ let vb_exp_constraint {pvb_expr=expr; pvb_pat=pat; pvb_constraint=ct; pvb_modes=
       List.fold_right mk_newtype locally_abstract_univars expr
 
 let vb_pat_constraint
-      ({pvb_pat=pat; pvb_expr = exp; pvb_modes = modes; _ } as vb) =
+      ({pvb_pat=pat; pvb_expr = exp; pvb_modes = modes; _ } as vb,
+       zero_alloc) =
   let spat =
     let open Ast_helper in
     let loc =
@@ -6104,9 +6146,9 @@ let vb_pat_constraint
         Pat.constraint_ ~loc pat (Some sty) modes
     | _ -> maybe_add_modes_constraint pat
   in
-  vb.pvb_attributes, spat
+  vb.pvb_attributes, zero_alloc, spat
 
-let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
+let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, zero_alloc, spat) =
   let pat_mode, exp_mode =
     if force_toplevel
     then simple_pat_mode Value.legacy, mode_legacy
@@ -6142,9 +6184,9 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
       Some env_alloc_mode, mode_default exp_mode
     else None, exp_mode
   in
-  attrs, pat_mode, env_alloc_mode, exp_mode, spat
+  attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, spat
 
-let add_zero_alloc_attribute expr attributes =
+let add_typed_zero_alloc_attribute expr zero_alloc_attribute =
   let open Builtin_attributes in
   let to_string : zero_alloc_attribute -> string = function
     | Check { strict; loc = _} ->
@@ -6159,31 +6201,68 @@ let add_zero_alloc_attribute expr attributes =
   in
   match expr.exp_desc with
   | Texp_function fn ->
-    let default_arity = function_arity fn.params fn.body in
-    let za =
-      get_zero_alloc_attribute ~in_signature:false ~default_arity attributes
-        ~on_application:false
-    in
-    begin match za with
+    begin match zero_alloc_attribute with
     | Default_zero_alloc -> expr
     | Ignore_assert_all | Check _ | Assume _ ->
       begin match Zero_alloc.get fn.zero_alloc with
       | Default_zero_alloc -> ()
       | Ignore_assert_all | Assume _ | Check _ ->
         Location.prerr_warning expr.exp_loc
-          (Warnings.Duplicated_attribute (to_string za));
+          (Warnings.Duplicated_attribute (to_string zero_alloc_attribute));
       end;
       (* Here, we may be throwing away a zero_alloc variable. There's no need
          to set it, because it can't have gotten anywhere else yet. *)
-      let zero_alloc = Zero_alloc.create_const za in
+      let zero_alloc = Zero_alloc.create_const zero_alloc_attribute in
       let exp_desc = Texp_function { fn with zero_alloc } in
       { expr with exp_desc }
     end
   | _ -> expr
 
+let check_arg_compatible ~loc ~zero_alloc_expected env zero_alloc =
+  match Zero_alloc.sub ~context:Fun_param zero_alloc zero_alloc_expected with
+  | Ok () -> ()
+  | Error e ->
+    if Zero_alloc.error_is_arity_mismatch e
+    then raise (Error (loc, env, Incompatible_param_zero_alloc e))
+    else raise (Error (loc, env, Wrong_arg_zero_alloc e))
+
+let add_parsed_zero_alloc_attribute ~default_arity vb =
+  let val_attr =
+    Builtin_attributes.get_zero_alloc_attribute
+      ~in_signature:false
+      ~on_application:false
+      ~on_function_argument:false
+      ~default_arity
+      vb.pvb_attributes
+  in
+  let zero_alloc : Zero_alloc.const option =
+    match val_attr with
+    | Default_zero_alloc -> None
+    | Ignore_assert_all -> Some Ignore_assert_all
+    | Assume a -> Some (Assume a)
+    | Check c -> Some (Check c)
+  in
+  vb, zero_alloc
+
+let check_zero_alloc env exp ~zero_alloc_expected =
+  let loc = exp.exp_loc in
+  let zero_alloc_expected =
+    match zero_alloc_expected with
+    | Some check -> Zero_alloc.create_const (Zero_alloc.Check check)
+    | None -> Zero_alloc.default
+  in
+  match exp.exp_desc with
+  | Texp_function { zero_alloc; _ }
+  | Texp_ident { desc = {val_zero_alloc = zero_alloc; _}; _ } ->
+    check_arg_compatible ~loc ~zero_alloc_expected env zero_alloc
+  | _ ->
+    match Zero_alloc.sub ~context:Fun_param Zero_alloc.default zero_alloc_expected with
+    | Ok () -> ()
+    | Error _ -> raise (Error (loc, env, Unsupported_arg_zero_alloc))
+
 let rec type_exp ?recarg ?(overwrite=No_overwrite) env expected_mode sexp =
   (* We now delegate everything to type_expect *)
-  type_expect ?recarg ~overwrite env expected_mode sexp
+  type_expect ?recarg ~overwrite ~on_function_argument:false env expected_mode sexp
     (mk_expected (newvar (Jkind.Builtin.any ~why:Dummy_jkind)))
 
 (* Typing of an expression with an expected type.
@@ -6197,13 +6276,14 @@ and check_layout_args_empty ~loc ~env layout_args ctx =
   if not (List.is_empty layout_args) then
     raise (Error (loc, env, Layout_poly_inst_not_yet_supported ctx))
 
-and type_expect ?recarg ?(overwrite=No_overwrite) env
+and type_expect ?recarg ?(overwrite=No_overwrite) ~on_function_argument env
       (expected_mode : expected_mode) sexp ty_expected_explained =
   let previous_saved_types = Cmt_format.get_saved_types () in
   let exp =
     Builtin_attributes.warning_scope sexp.pexp_attributes
       (fun () ->
-         type_expect_ ?recarg ~overwrite env expected_mode sexp ty_expected_explained
+         type_expect_ ?recarg ~overwrite ~on_function_argument env expected_mode
+           sexp ty_expected_explained
       )
   in
   Cmt_format.set_saved_types
@@ -6211,7 +6291,7 @@ and type_expect ?recarg ?(overwrite=No_overwrite) env
   exp
 
 and type_expect_
-    ?(recarg=Rejected) ?(overwrite=No_overwrite)
+    ?(recarg=Rejected) ?(overwrite=No_overwrite) ~on_function_argument
     env (expected_mode : expected_mode) sexp ty_expected_explained =
   let { ty = ty_expected; explanation } = ty_expected_explained in
   let loc = sexp.pexp_loc in
@@ -6649,7 +6729,7 @@ and type_expect_
       if is_format then
         let format_parsetree =
           { (type_format loc str env) with pexp_loc = sexp.pexp_loc }  in
-        type_expect env expected_mode
+        type_expect ~on_function_argument:false env expected_mode
           format_parsetree ty_expected_explained
       else
         rue {
@@ -6689,7 +6769,7 @@ and type_expect_
     when turn_let_into_match spat ->
       (* TODO: allow non-empty attributes? *)
       let sval = vb_exp_constraint vb in
-      type_expect env expected_mode
+      type_expect ~on_function_argument:false env expected_mode
         {sexp with
          pexp_desc = Pexp_match (sval, [Ast_helper.Exp.case spat sbody])}
         ty_expected_explained
@@ -6736,7 +6816,7 @@ and type_expect_
               spat_sexp_list allow_modules
           in
           let body =
-            type_expect
+            type_expect ~on_function_argument:false
               new_env expected_mode sbody ty_expected_explained
           in
           let pat_exp_list = match rec_flag with
@@ -6793,7 +6873,8 @@ and type_expect_
         exp_env = env }
   | Pexp_function (params, body_constraint, body) ->
       type_n_ary_function ~loc ~env ~expected_mode ~ty_expected ~explanation
-        ~attributes:sexp.pexp_attributes (params, body_constraint, body)
+        ~attributes:sexp.pexp_attributes ~on_function_argument
+        (params, body_constraint, body)
   | Pexp_apply
       ({ pexp_desc = Pexp_extension({ txt }, PStr []) },
        [Nolabel, sbody]) when is_exclave_extension_node txt ->
@@ -6815,7 +6896,7 @@ and type_expect_
           let mode' = mode_exclave expected_mode in
           let new_env = Env.add_exclave_lock env in
           let exp =
-            type_expect ~recarg new_env mode' sbody ty_expected_explained
+            type_expect ~recarg ~on_function_argument:false new_env mode' sbody ty_expected_explained
           in
           submode ~loc ~env ~reason:Other
             (Value.min_with_comonadic Areality Regionality.regional)
@@ -6836,7 +6917,8 @@ and type_expect_
     in
     submode ~loc ~env mode expected_mode;
     let exp =
-      type_expect ~recarg env expected_mode body ty_expected_explained
+      type_expect ~recarg ~on_function_argument:false env
+        expected_mode body ty_expected_explained
     in
     { exp with
       exp_loc = loc;
@@ -6940,12 +7022,6 @@ and type_expect_
       let mode_ret = Alloc.disallow_right mode_ret in
       let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
-      let zero_alloc =
-        Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
-          ~on_application:true
-          ~default_arity:(List.length args) sfunct.pexp_attributes
-        |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
-      in
       let funct =
         match List.exists (fun (_, _, sch) -> Option.is_some sch) args with
         | true ->
@@ -6954,6 +7030,34 @@ and type_expect_
           { funct with
             exp_extra = (Texp_inspected_type ti, loc, []) :: funct.exp_extra }
         | false -> funct
+      in
+      let extract_zero_alloc_attr () =
+        Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
+          ~on_application:true
+          ~on_function_argument:false
+          ~default_arity:(List.length args)
+          sfunct.pexp_attributes
+      in
+      let zero_alloc =
+        begin
+          match funct.exp_desc with
+          | Texp_ident { desc; _ } ->
+            begin
+              let use_opt =
+                match !Clflags.zero_alloc_check with
+                | Check_default | No_check -> false
+                | Check_all | Check_opt_only -> true
+              in
+              match Zero_alloc.get desc.val_zero_alloc with
+              | Check {strict; arity; loc; opt} when use_opt || not opt ->
+                Assume {strict; arity; loc;
+                        never_returns_normally = false;
+                        never_raises = false}
+              | _ -> extract_zero_alloc_attr ()
+            end
+          | _ -> extract_zero_alloc_attr ()
+        end
+        |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
@@ -6987,7 +7091,7 @@ and type_expect_
         with_local_level begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect env arg_expected_mode sarg (mk_expected expected_ty)
+            type_expect ~on_function_argument:false env arg_expected_mode sarg (mk_expected expected_ty)
           in
           arg, sort
         end ~post:(fun (arg, _) ->
@@ -7010,7 +7114,7 @@ and type_expect_
   | Pexp_try(sbody, caselist) ->
       check_dynamic (loc, Expression) (Always_dynamic Try_with) expected_mode;
       let body =
-        type_expect env (mode_trywith expected_mode)
+        type_expect ~on_function_argument:false env (mode_trywith expected_mode)
           sbody ty_expected_explained
       in
       let arg_mode = simple_pat_mode Value.legacy in
@@ -7073,7 +7177,7 @@ and type_expect_
               register_allocation ~loc expected_mode
             in
             let arg =
-              type_expect env argument_mode sarg (mk_expected ty_expected)
+              type_expect ~on_function_argument:false env argument_mode sarg (mk_expected ty_expected)
             in
             Some (arg, alloc_mode)
         in
@@ -7359,13 +7463,13 @@ and type_expect_
   | Pexp_ifthenelse(scond, sifso, sifnot) ->
       check_dynamic (loc, Expression) Branching expected_mode;
       let cond =
-        type_expect env mode_max scond
+        type_expect ~on_function_argument:false env mode_max scond
           (mk_expected ~explanation:If_conditional Predef.type_bool)
       in
       begin match sifnot with
         None ->
           let ifso =
-            type_expect env expected_mode sifso
+            type_expect ~on_function_argument:false env expected_mode sifso
               (mk_expected ~explanation:If_no_else_branch Predef.type_unit) in
           rue {
             exp_desc = Texp_ifthenelse(cond, ifso, None);
@@ -7375,10 +7479,10 @@ and type_expect_
             exp_env = env }
       | Some sifnot ->
           let ifso =
-            type_expect env expected_mode sifso ty_expected_explained
+            type_expect ~on_function_argument:false env expected_mode sifso ty_expected_explained
           in
           let ifnot =
-            type_expect env expected_mode sifnot ty_expected_explained
+            type_expect ~on_function_argument:false env expected_mode sifnot ty_expected_explained
           in
           (* Keep sharing *)
           unify_exp env ifnot ifso.exp_type;
@@ -7393,7 +7497,7 @@ and type_expect_
       let exp1, sort1 =
         type_statement ~explanation:Sequence_left_hand_side env sexp1
       in
-      let exp2 = type_expect env expected_mode sexp2 ty_expected_explained in
+      let exp2 = type_expect ~on_function_argument:false env expected_mode sexp2 ty_expected_explained in
       re {
         exp_desc = Texp_sequence(exp1, sort1, exp2);
         exp_loc = loc; exp_extra = [];
@@ -7408,7 +7512,7 @@ and type_expect_
       let cond_env = Env.add_region_lock env in
       let mode = mode_region Value.max in
       let wh_cond =
-        type_expect cond_env mode scond
+        type_expect ~on_function_argument:false cond_env mode scond
           (mk_expected ~explanation:While_loop_conditional Predef.type_bool)
       in
       let body_env = Env.add_region_lock env in
@@ -7431,11 +7535,11 @@ and type_expect_
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
       let for_from =
-        type_expect env (mode_region Value.max) slow
+        type_expect ~on_function_argument:false env (mode_region Value.max) slow
           (mk_expected ~explanation:For_loop_start_index Predef.type_int)
       in
       let for_to =
-        type_expect env (mode_region Value.max) shigh
+        type_expect ~on_function_argument:false env (mode_region Value.max) shigh
           (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
       in
       let env =
@@ -7463,7 +7567,10 @@ and type_expect_
       let expected_mode =
         type_expect_mode ~loc ~env ~modes:modes.mode_modes expected_mode
       in
-      let exp = type_expect env expected_mode sarg (mk_expected ty_expected ?explanation) in
+      let exp =
+        type_expect ~on_function_argument env expected_mode sarg
+          (mk_expected ty_expected ?explanation)
+      in
       { exp with exp_loc = loc
       ; exp_extra = (Texp_mode modes, loc, []) :: exp.exp_extra
       }
@@ -7548,9 +7655,9 @@ and type_expect_
       in
       let typ, obj_extra =
         match get_desc typ with
-        | Tpoly (ty, []) ->
+        | Tpoly (ty, [], _za) ->
             instance ty, None
-        | Tpoly (ty, tl) ->
+        | Tpoly (ty, tl, _za) ->
             if !Clflags.principal && get_level typ <> generic_level then
               Location.prerr_warning loc
                 (not_principal "this use of a polymorphic method");
@@ -7561,7 +7668,7 @@ and type_expect_
               loc, [])
         | Tvar _ ->
             let ty' = newvar (Jkind.Builtin.value ~why:Object_field) in
-            unify env (instance typ) (newty(Tpoly(ty',[])));
+            unify env (instance typ) (newty(Tpoly(ty',[],None)));
             (* if not !Clflags.nolabels then
                Location.prerr_warning loc (Warnings.Unknown_method met); *)
             ty', None
@@ -7602,7 +7709,7 @@ and type_expect_
         match Env.lookup_settable_variable ~loc lab.txt env with
         | Instance_variable (path, Mutable, cl_num,ty) ->
             let newval =
-              type_expect env mode_legacy snewval (mk_expected (instance ty))
+              type_expect ~on_function_argument:false env mode_legacy snewval (mk_expected (instance ty))
             in
             let (path_self, _) =
               Env.find_value_by_name_lazy
@@ -7614,7 +7721,7 @@ and type_expect_
             raise(Error(loc, env, Instance_variable_not_mutable lab.txt))
         | Mutable_variable (id, mode, ty, sort) ->
             let newval =
-              type_expect env (mode_default mode)
+              type_expect ~on_function_argument:false env (mode_default mode)
                 snewval (mk_expected (instance ty))
             in
             let lid = {txt = id; loc} in
@@ -7650,7 +7757,7 @@ and type_expect_
             begin try
               let id = Vars.find lab.txt vars in
               let ty = Btype.instance_variable_type lab.txt sign in
-              (id, lab, type_expect env mode_legacy snewval (mk_expected (instance ty)))
+              (id, lab, type_expect ~on_function_argument:false env mode_legacy snewval (mk_expected (instance ty)))
             with
               Not_found ->
                 let vars = Vars.fold (fun var _ li -> var::li) vars [] in
@@ -7710,7 +7817,7 @@ and type_expect_
              from the local module and refine them into
              Scoping_let_module errors
            *)
-          let body = type_expect new_env expected_mode sbody ty_expected_explained in
+          let body = type_expect ~on_function_argument:false new_env expected_mode sbody ty_expected_explained in
           (id, pres, modl, new_env, body)
         end
         ~post: begin fun (_id, _pres, _modl, new_env, body) ->
@@ -7728,7 +7835,7 @@ and type_expect_
   | Pexp_letexception(cd, sbody) ->
       let (cd, newenv, _shape) = Typedecl.transl_exception env cd in
       let body =
-        type_expect newenv expected_mode sbody ty_expected_explained
+        type_expect ~on_function_argument:false newenv expected_mode sbody ty_expected_explained
       in
       re {
         exp_desc = Texp_letexception(cd, body);
@@ -7739,7 +7846,7 @@ and type_expect_
 
   | Pexp_assert (e) ->
       let cond =
-        type_expect env mode_max e
+        type_expect ~on_function_argument:false env mode_max e
           (mk_expected ~explanation:Assert_condition Predef.type_bool)
       in
       let exp_type =
@@ -7769,7 +7876,7 @@ and type_expect_
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
       let env = Env.add_closure_lock (loc, Lazy) closure_mode.comonadic env in
-      let arg = type_expect env expected_mode e (mk_expected ty) in
+      let arg = type_expect ~on_function_argument:false env expected_mode e (mk_expected ty) in
       re {
         exp_desc = Texp_lazy arg;
         exp_loc = loc; exp_extra = [];
@@ -7808,10 +7915,10 @@ and type_expect_
           unify_exp_types loc env (instance ty) (instance ty_expected));
       let exp =
         match get_desc (expand_head env ty) with
-          Tpoly (ty', []) ->
-            let exp = type_expect env expected_mode sbody (mk_expected ty') in
+          Tpoly (ty', [], _za) ->
+            let exp = type_expect ~on_function_argument:false env expected_mode sbody (mk_expected ty') in
             { exp with exp_type = instance ty }
-        | Tpoly (ty', tl) ->
+        | Tpoly (ty', tl, _za) ->
             (* One more level to generalize locally *)
             let (exp,_) =
               with_local_level begin fun () ->
@@ -7820,7 +7927,7 @@ and type_expect_
                     (fun () -> instance_poly_fixed tl ty')
                     ~post:(fun (_,ty'') -> generalize_structure ty'')
                 in
-                let exp = type_expect env expected_mode sbody (mk_expected ty'') in
+                let exp = type_expect ~on_function_argument:false env expected_mode sbody (mk_expected ty'') in
                 (exp, vars)
               end
               ~post: begin fun (exp,vars) ->
@@ -7830,7 +7937,9 @@ and type_expect_
             { exp with exp_type = instance ty }
         | Tvar _ ->
             let exp = type_exp env expected_mode sbody in
-            let exp = {exp with exp_type = newmono exp.exp_type} in
+            let exp =
+              {exp with exp_type = newmono ~zero_alloc:None exp.exp_type}
+            in
             unify_exp env exp ty;
             exp
         | _ -> assert false
@@ -7873,7 +7982,7 @@ and type_expect_
       end;
       let tv = newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
       let (od, newenv) = !type_open_decl env od in
-      let exp = type_expect newenv expected_mode e ty_expected_explained in
+      let exp = type_expect ~on_function_argument:false newenv expected_mode e ty_expected_explained in
       (* Force the return type to be well-formed in the original
          environment. *)
       unify_var newenv tv exp.exp_type;
@@ -7920,14 +8029,14 @@ and type_expect_
           let ty_func_result, body_sort = new_rep_var ~why:Function_result () in
           let arrow_desc = Nolabel, Alloc.legacy, Alloc.legacy in
           let ty_func =
-            newty (Tarrow(arrow_desc, newmono ty_params, ty_func_result,
-                          commu_ok))
+            newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_params,
+                          ty_func_result, commu_ok))
           in
           let ty_result, op_result_sort = new_rep_var ~why:Function_result () in
           let ty_andops, sort_andops = new_rep_var ~why:Function_argument () in
           let ty_op =
-            newty (Tarrow(arrow_desc, newmono ty_andops,
-              newty (Tarrow(arrow_desc, newmono ty_func, ty_result, commu_ok)),
+            newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_andops,
+              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_func, ty_result, commu_ok)),
                      commu_ok))
           in
           begin try
@@ -8014,7 +8123,7 @@ and type_expect_
     | Ok { name; name_loc; enabled_at_init; arg; } ->
         check_probe_name name name_loc env;
         Env.add_probe name;
-        let exp = type_expect env mode_legacy arg
+        let exp = type_expect ~on_function_argument:false env mode_legacy arg
                     (mk_expected Predef.type_unit) in
         rue {
           exp_desc = Texp_probe {name; handler=exp; enabled_at_init};
@@ -8096,7 +8205,7 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
   | Pexp_stack e ->
-      let exp = type_expect env expected_mode e ty_expected_explained in
+      let exp = type_expect ~on_function_argument:false env expected_mode e ty_expected_explained in
       let unsupported category =
         raise (Error (exp.exp_loc, env, Unsupported_stack_allocation category))
       in
@@ -8165,7 +8274,7 @@ and type_expect_
         (* CR uniqueness: this could be the jkind of exp2 *)
         mk_expected (newvar (Jkind.for_non_float ~why:Boxed_record))
       in
-      let exp1 = type_expect ~recarg env (mode_default cell_mode) exp1 cell_type in
+      let exp1 = type_expect ~recarg ~on_function_argument:false env (mode_default cell_mode) exp1 cell_type in
       let new_fields_mode =
         (* The newly-written fields have to be global to avoid heap-to-stack pointers.
            We enforce that here, by asking the allocation to be global.
@@ -8200,7 +8309,7 @@ and type_expect_
         let overwrite =
           Overwriting (exp1.exp_loc, exp1.exp_type, fields_mode)
         in
-        type_expect ~recarg ~overwrite env exp2_mode exp2 ty_expected_explained
+        type_expect ~recarg ~overwrite ~on_function_argument:false env exp2_mode exp2 ty_expected_explained
       in
       re { exp_desc = Texp_overwrite(exp1, exp2);
             exp_loc = loc; exp_extra = [];
@@ -8230,7 +8339,10 @@ and type_expect_
         then mode_default Value.max
         else mode_quoted
       in
-      let arg = type_expect new_env mode_quoted exp (mk_expected ty) in
+      let arg =
+        type_expect ~on_function_argument:false new_env mode_quoted exp
+          (mk_expected ty)
+      in
       if maybe_computation arg then
         submode ~loc ~env ~reason:Other mode_computation_quoted expected_mode;
       re {
@@ -8254,7 +8366,10 @@ and type_expect_
         submode ~loc ~env ~reason:Other mode_splice expected_mode;
       let new_env = Env.enter_splice ~loc env in
       let ty = Predef.type_code (newgenty (Tquote ty_expected)) in
-      let arg = type_expect new_env mode_spliced exp (mk_expected ty) in
+      let arg =
+        type_expect ~on_function_argument:false new_env mode_spliced exp
+          (mk_expected ty)
+      in
       re {
         exp_desc = Texp_antiquotation arg;
         exp_loc = loc; exp_extra = [];
@@ -8338,7 +8453,7 @@ and type_block_access env expected_base_ty principal
       | Mutable -> Predef.type_idx_mut base_ty el_ty
     in
     let idx =
-      type_expect env mode_legacy idx (mk_expected idx_type_expected) in
+      type_expect ~on_function_argument:false env mode_legacy idx (mk_expected idx_type_expected) in
     let ba = Baccess_block (mut, idx) in
     let mut = match mut with Immutable -> false | Mutable -> true in
     let modality = Typemode.idx_expected_modalities ~mut in
@@ -8727,6 +8842,35 @@ and type_function
         | _ :: _ ->
           { mode_modes = Alloc.Const.Option.none; mode_desc = [] }
       in
+      let zero_alloc =
+        (* The [@zero_alloc] attribute may be on the inner pattern of a
+           Ppat_constraint (e.g. [(f[@zero_alloc arity 1] : t)]) or
+           Ppat_alias (e.g. [(f[@zero_alloc arity 1]) as g]), so look
+           through those wrappers when the outer pattern has no attrs. *)
+        let rec get_pat_attrs p =
+          match p.ppat_desc with
+          | Ppat_constraint (inner, _, _) when p.ppat_attributes = [] ->
+            get_pat_attrs inner
+          | Ppat_alias (inner, _) when p.ppat_attributes = [] ->
+            get_pat_attrs inner
+          | _ -> p.ppat_attributes
+        in
+        Builtin_attributes.get_zero_alloc_attribute
+          ~in_signature:false
+          ~on_application:false
+          ~on_function_argument:true
+          ~default_arity:0
+          (get_pat_attrs pat)
+      in
+      let zero_alloc =
+        match zero_alloc with
+        | Default_zero_alloc | Ignore_assert_all -> None
+        | Assume _ ->
+          raise (Error (pparam_loc, env, Invalid_payload_arg_zero_alloc))
+        | Check { arity; _ } when arity = 0 ->
+          raise (Error (pparam_loc, env, Must_provide_zero_alloc_arity))
+        | Check check -> Some check
+      in
       let env,
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
@@ -8735,10 +8879,27 @@ and type_function
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
-          ~arg_label:typed_arg_label ~in_function ~has_poly
+          ~arg_label:typed_arg_label ~in_function ~has_poly ~zero_alloc
           ~mode_annots:mode_annots.mode_modes
           ~ret_mode_annots:ret_mode_annots.mode_modes
       in
+      (* Check that the zero_alloc attribute on the pattern is compatible
+         with the one on the parameter type (from a type annotation). *)
+      begin match get_desc ty_arg with
+      | Tpoly (_, _, Some check_poly) ->
+        begin
+          match zero_alloc with
+          | None -> ()
+          | Some check_attr ->
+            let check1 = Zero_alloc.create_const (Zero_alloc.Check check_attr) in
+            let check2 = Zero_alloc.create_const (Zero_alloc.Check check_poly) in
+            match Zero_alloc.sub ~context:Fun_param check1 check2 with
+            | Ok () -> ()
+            | Error e ->
+              raise (Error (pparam_loc, env, Incompatible_param_zero_alloc e))
+        end
+      | _ -> ()
+      end;
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
          optional arguments with defaults, where the external [ty_arg_mono]
@@ -8776,14 +8937,14 @@ and type_function
             (* Defaults are always global. They can be moved out of the
                function's region by Simplf.split_default_wrapper. *)
             let default_arg =
-              type_expect env mode_legacy default (mk_expected ty_default_arg)
+              type_expect ~on_function_argument:true env mode_legacy default (mk_expected ty_default_arg)
             in
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
       in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry), partial =
         (* Check everything else in the scope of the parameter. *)
-        map_half_typed_cases Value env expected_pat_mode
+        map_half_typed_cases ~zero_alloc Value env expected_pat_mode
           ty_arg_internal sort_arg_internal ty_ret pat.ppat_loc
           ~check_if_total:true
           (* We don't make use of [case_data] here so we pass unit. *)
@@ -8844,6 +9005,16 @@ and type_function
         | [ result ], partial -> result, partial
         | ([] | _ :: _ :: _), _ -> assert false
       in
+      (* Check that the annotation arity matches the inferred type's arrow count.
+         We do this after the body is typed so that ty_arg_mono is unified. *)
+      begin match zero_alloc with
+      | Some { arity; _ } ->
+        let type_arity = Ctype.arity ty_arg_mono in
+        if type_arity > 0 && arity <> type_arity then
+          raise (Error (pparam_loc, env,
+                        Zero_alloc_arity_mismatch (arity, type_arity)))
+      | None -> ()
+      end;
       let exp_type =
         instance
           (newgenty
@@ -8947,7 +9118,7 @@ and type_function
       | Pfunction_body body ->
           let body =
             match ret_type_constraint with
-            | None -> type_expect env expected_mode body (mk_expected ty_expected)
+            | None -> type_expect ~on_function_argument:false env expected_mode body (mk_expected ty_expected)
             | Some constraint_ ->
             let body_loc = body.pexp_loc in
             let body, exp_type, exp_extra =
@@ -9046,7 +9217,7 @@ and type_label_access
   let record =
     with_local_level_if_principal ~post:generalize_structure_exp
       (fun () ->
-         type_expect ~recarg:Allowed env (mode_default mode) srecord
+         type_expect ~recarg:Allowed ~on_function_argument:false env (mode_default mode) srecord
            (mk_expected (newvar record_jkind)))
   in
   let ty_exp = record.exp_type in
@@ -9668,7 +9839,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                 { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
               ret_sort;
               alloc_mode;
-              zero_alloc = Zero_alloc.default
+              zero_alloc = Zero_alloc.default;
             }
         }
       in
@@ -9699,7 +9870,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       end
   | None ->
       let mode = expect_mode_cross env ty_expected' mode in
-      let texp = type_expect ?recarg ~overwrite env mode sarg
+      let texp = type_expect ?recarg ~overwrite ~on_function_argument:false env mode sarg
         (mk_expected ?explanation ty_expected') in
       unify_exp env texp ty_expected;
       texp
@@ -9711,7 +9882,7 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       let expected_mode, mode_arg =
         mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
       let arg =
-        type_expect env expected_mode sarg (mk_expected ty_arg_mono)
+        type_expect ~on_function_argument:false env expected_mode sarg (mk_expected ty_arg_mono)
       in
       (match lbl with
        | Labelled _ | Nolabel -> ()
@@ -9726,20 +9897,20 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
                      mode_arg; wrapped_in_some; sort_arg }) ->
       let expected_mode, mode_arg =
         mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
-      let ty_arg', vars = tpoly_get_poly ty_arg in
-      let arg, sch =
+      let ty_arg', vars, zero_alloc = tpoly_get_poly ty_arg in
+      let arg, sch, zero_alloc =
         if vars = [] then begin
           let ty_arg0' = tpoly_get_mono ty_arg0 in
           if wrapped_in_some then begin
             type_option_some
-              env expected_mode sarg ty_arg' ty_arg0', None
+              env expected_mode sarg ty_arg' ty_arg0', None, zero_alloc
           end else begin
             type_argument ~overwrite:No_overwrite
-              env expected_mode sarg ty_arg' ty_arg0', None
+              env expected_mode sarg ty_arg' ty_arg0', None, zero_alloc
           end
         end else begin
           let sch =
-            let really_poly = is_really_poly ~env ty_arg in
+            let really_poly = is_really_poly ~env ~zero_alloc ty_arg in
             if really_poly &&
                !Clflags.principal && get_level ty_arg < Btype.generic_level
             then
@@ -9752,30 +9923,36 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
           let separate =
             !Clflags.principal || Env.has_local_constraints env
           in
-          let arg, _, _ =
+          let arg, _, _, zero_alloc =
             with_local_level begin fun () ->
               let vars, ty_arg' =
                 with_local_level_if separate begin fun () ->
                   instance_poly_fixed vars ty_arg'
                 end ~post:(fun (_, ty_arg') -> generalize_structure ty_arg')
               in
-              let (ty_arg0', vars0) = tpoly_get_poly ty_arg0 in
+              let (ty_arg0', vars0, za0) = tpoly_get_poly ty_arg0 in
               let vars0, ty_arg0' = instance_poly_fixed vars0 ty_arg0' in
               List.iter2 (fun ty ty' -> unify_var env ty ty') vars vars0;
               let arg =
                 type_argument ~overwrite:No_overwrite
                   env expected_mode sarg ty_arg' ty_arg0'
               in
-              arg, ty_arg, vars
+              arg, ty_arg, vars, za0
             end
-            ~post:(fun (arg, ty_arg, vars) ->
+            ~post:(fun (arg, ty_arg, vars, _) ->
               if maybe_expansive arg then
                 lower_contravariant env arg.exp_type;
               generalize_and_check_univars env "argument" arg ty_arg vars);
           in
-          {arg with exp_type = instance arg.exp_type}, sch
+          {arg with exp_type = instance arg.exp_type}, sch, zero_alloc
         end
       in
+      begin
+        match zero_alloc with
+        | Some _ ->
+          check_zero_alloc env arg ~zero_alloc_expected:zero_alloc
+        | None -> ()
+      end;
       (lbl, Arg (arg, mode_arg, sort_arg), sch)
   | Arg (Eliminated_optional_arg { ty_arg; sort_arg; expected_label; _ }) ->
       (match expected_label with
@@ -9813,7 +9990,7 @@ and type_application env app_loc expected_mode position_and_mode
         mode_argument ~funct ~index:0 ~position_and_mode
           ~partial_app:false arg_mode
       in
-      let exp = type_expect env arg_mode sarg (mk_expected ty_arg) in
+      let exp = type_expect ~on_function_argument:false env arg_mode sarg (mk_expected ty_arg) in
       check_partial_application ~statement:false exp;
       ([Nolabel, Arg (exp, arg_sort), None],
        ty_ret, ret_mode, position_and_mode)
@@ -9928,7 +10105,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       (fun (label, body) ((_, ty), argument_mode) overwrite ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-          (label, type_expect ~overwrite env argument_mode body (mk_expected ty)))
+          (label, type_expect ~overwrite ~on_function_argument:false env argument_mode body (mk_expected ty)))
       sexpl types_and_modes overwrites
   in
   re {
@@ -9992,7 +10169,7 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
       (fun (label, body) ((_, ty, sort), argument_mode) ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-          (label, type_expect env argument_mode body (mk_expected ty), sort))
+          (label, type_expect ~on_function_argument:false env argument_mode body (mk_expected ty), sort))
       sexpl types_sorts_and_modes
   in
   re {
@@ -10251,6 +10428,7 @@ and type_statement ?explanation ?(position=RNontail) env sexp =
 and map_half_typed_cases
   : type k ret case_data.
     ?additional_checks_for_split_cases:((_ * ret) list -> unit)
+    -> ?zero_alloc:Zero_alloc.check option
     -> k pattern_category -> _ -> _ -> _ -> _ -> _ -> _
     -> (untyped_case * case_data) list
     -> type_body:(
@@ -10263,7 +10441,7 @@ and map_half_typed_cases
         -> ret)
     -> check_if_total:bool (* if false, assume Partial right away *)
     -> ret list * partial
-  = fun ?additional_checks_for_split_cases
+  = fun ?additional_checks_for_split_cases ?zero_alloc
     category env pat_mode
     ty_arg sort_arg ty_res loc caselist ~type_body ~check_if_total ->
   (* ty_arg is _fully_ generalized *)
@@ -10321,9 +10499,17 @@ and map_half_typed_cases
                 with_local_level ~post:generalize_structure
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
+              let zero_alloc =
+                match zero_alloc with
+                | Some za -> za
+                | None ->
+                  if is_Tpoly ty_arg
+                  then thd3 (tpoly_get_poly ty_arg)
+                  else None
+              in
               let (pat, ext_env, force, pvs, mvs) =
                 type_pattern category ~lev ~alloc_mode:pat_mode env pattern
-                  ty_arg sort_arg allow_modules
+                  ty_arg sort_arg allow_modules ~zero_alloc
               in
               pattern_force := force @ !pattern_force;
               { typed_pat = pat;
@@ -10604,11 +10790,11 @@ and type_cases
           | None -> None
           | Some scond ->
             Some
-              (type_expect ext_env mode_max scond
+              (type_expect ~on_function_argument:false ext_env mode_max scond
                 (mk_expected ~explanation:When_guard Predef.type_bool))
         in
         let exp =
-          type_expect ext_env expr_mode pc_rhs (mk_expected ?explanation ty_expected)
+          type_expect ~on_function_argument:false ext_env expr_mode pc_rhs (mk_expected ?explanation ty_expected)
         in
         {
           c_lhs = pat;
@@ -10644,6 +10830,7 @@ and type_function_cases_expect
         ~in_function ~has_poly:false ~mode_annots:Mode.Alloc.Const.Option.none
         ~ret_mode_annots:Mode.Alloc.Const.Option.none
         ~is_first_val_param:first ~is_final_val_param:true
+        ~zero_alloc:None
     in
     let cases, partial =
       type_cases Value env
@@ -10704,7 +10891,18 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     | Pexp_newtype (_, _, e) -> sexp_is_fun e
     | _ -> false
   in
+  let rec arity_of_fun sexp =
+    match sexp.pexp_desc with
+    | Pexp_function (params, _, body) ->
+      ((match body with | Pfunction_body _ -> 0 | Pfunction_cases _ -> 1) +
+       List.length params)
+    | Pexp_constraint (e, _, _)
+    | Pexp_newtype (_, _, e) -> arity_of_fun e
+    (* function is only ever invoked if sexp_is_fun is true *)
+    | _ -> assert false
+  in
   let vb_is_fun { pvb_expr = sexp; _ } = sexp_is_fun sexp in
+  let vb_fun_arity { pvb_expr = sexp; _ } = arity_of_fun sexp in
   let entirely_functions = List.for_all vb_is_fun spat_sexp_list in
   let rec_mode_var =
     match rec_flag with
@@ -10722,11 +10920,20 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         Some m
     | Nonrecursive -> None
   in
+  let spat_sexp_list =
+    List.map
+      (fun vb ->
+         if vb_is_fun vb then
+           let default_arity = vb_fun_arity vb in
+           add_parsed_zero_alloc_attribute ~default_arity vb
+         else (vb, None))
+      spat_sexp_list
+  in
   let spatl = List.map vb_pat_constraint spat_sexp_list in
   let spatl =
     List.map (pat_modes ~force_toplevel rec_mode_var ~is_lpoly) spatl
   in
-  let attrs_list = List.map (fun (attrs, _, _, _, _) -> attrs) spatl in
+  let attrs_list = List.map (fun (attrs, _, _, _, _, _) -> attrs) spatl in
   let is_recursive = (rec_flag = Recursive) in
 
   let (pat_list, exp_list, new_env, mvs, sorts, _pvs) =
@@ -10749,10 +10956,10 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
              expression *)
           if is_recursive then
             List.iter2
-              (fun (_, pat) binding ->
+              (fun (_, pat) (binding, _) ->
                 let pat =
                   match get_desc pat.pat_type with
-                  | Tpoly (ty, tl) ->
+                  | Tpoly (ty, tl, _za) ->
                       {pat with pat_type =
                          instance_poly ~keep_names:true tl ty}
                   | _ -> pat
@@ -10839,7 +11046,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
           (fun exp_env ({pvb_attributes; _} as vb) mode expected_ty ->
             let sexp = vb_exp_constraint vb in
             match get_desc expected_ty with
-            | Tpoly (ty, tl) ->
+            | Tpoly (ty, tl, _za) ->
                 let vars, ty' =
                   with_local_level_if_principal
                     ~post:(fun (_,ty') -> generalize_structure ty')
@@ -10847,13 +11054,13 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 in
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect exp_env mode sexp (mk_expected ty'))
+                    type_expect ~on_function_argument:false exp_env mode sexp (mk_expected ty'))
                 in
                 exp, Some vars
             | _ ->
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                    type_expect exp_env mode sexp (mk_expected expected_ty))
+                    type_expect ~on_function_argument:false exp_env mode sexp (mk_expected expected_ty))
                 in
                 exp, None)
       in
@@ -10867,7 +11074,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
             )
         )
         mode_pat_typ_list
-        (List.map2 (fun (attrs, _, _, _, _) (e, _) -> attrs, e) spatl exp_list);
+        (List.map2 (fun (attrs, _, _, _, _, _) (e, _) -> attrs, e)
+           spatl exp_list);
       if is_lpoly then
         List.iter (fun (exp, _) ->
           check_captures_comonadic env exp
@@ -10936,10 +11144,12 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let l = List.combine sorts l in
   let l =
     List.map2
-      (fun (s, ((_,p,_), (e, _))) pvb ->
+      (fun (s, ((_,p,_), (e, _))) (pvb, zero_alloc) ->
         (* We check for [zero_alloc] attributes written on the [let] and move
            them to the function. *)
-        let e = add_zero_alloc_attribute e pvb.pvb_attributes in
+        let e = add_typed_zero_alloc_attribute e
+          (Option.value ~default:Builtin_attributes.Default_zero_alloc zero_alloc)
+        in
         (* vb_rec_kind will be computed later for recursive bindings *)
         {vb_pat=p; vb_expr=e; vb_sort = s; vb_attributes=pvb.pvb_attributes;
          vb_loc=pvb.pvb_loc; vb_rec_kind = Dynamic;
@@ -10971,7 +11181,7 @@ and type_let_def_wrap_warnings
   let is_fake_let =
     match spat_sexp_list with
     | [{pvb_expr={pexp_desc=Pexp_match(
-           {pexp_desc=Pexp_ident({ txt = Longident.Lident name})},_)}}]
+           {pexp_desc=Pexp_ident({ txt = Longident.Lident name})},_)}}, _]
       when String.starts_with ~prefix:"*opt" name ->
         true (* the fake let-declaration introduced by fun ?(x = e) -> ... *)
     | _ ->
@@ -11001,7 +11211,7 @@ and type_let_def_wrap_warnings
          a let .. and ..), and is where the missing "rec" hint suggests to add a
          "rec" keyword. *)
       match spat_sexp_list with
-      | {pvb_loc; _} :: _ ->
+      | ({pvb_loc; _}, _) :: _ ->
           maybe_add_pattern_variables_ghost pvb_loc exp_env pvs
       | _ -> assert false
     end
@@ -11089,14 +11299,14 @@ and type_let_def_wrap_warnings
   in
   let exp_list =
     List.map2
-      (fun case (mode, expected_ty, slot) ->
+      (fun (case, _) (mode, expected_ty, slot) ->
         if is_recursive then current_slot := slot;
         type_def exp_env case mode expected_ty)
       spat_sexp_list mode_typ_slot_list
   in
   current_slot := None;
   if is_recursive && not !rec_needed then begin
-    let {pvb_pat; pvb_attributes} = List.hd spat_sexp_list in
+    let ({pvb_pat; pvb_attributes}, _) = List.hd spat_sexp_list in
     (* See PR#6677 *)
     Builtin_attributes.warning_scope ~ppwarning:false pvb_attributes
       (fun () ->
@@ -11111,7 +11321,7 @@ and type_andops env sarg sands expected_sort expected_ty =
   let rec loop env let_sarg rev_sands expected_sort expected_ty =
     match rev_sands with
     | [] ->
-        type_expect env mode_legacy let_sarg
+        type_expect ~on_function_argument:false env mode_legacy let_sarg
           (mk_expected expected_ty),
         expected_sort,
         []
@@ -11128,9 +11338,9 @@ and type_andops env sarg sands expected_sort expected_ty =
             in
             let arrow_desc = (Nolabel, Alloc.legacy, Alloc.legacy) in
             let ty_rest_fun =
-              newty (Tarrow(arrow_desc, newmono ty_arg, ty_result, commu_ok)) in
+              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_arg, ty_result, commu_ok)) in
             let ty_op =
-              newty (Tarrow(arrow_desc, newmono ty_rest, ty_rest_fun, commu_ok)) in
+              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_rest, ty_rest_fun, commu_ok)) in
             begin try
               unify env op_type ty_op
             with Unify err ->
@@ -11145,7 +11355,7 @@ and type_andops env sarg sands expected_sort expected_ty =
         let let_arg, sort_let_arg, rest =
           loop env let_sarg rest sort_rest ty_rest
         in
-        let exp = type_expect env mode_legacy sexp (mk_expected ty_arg) in
+        let exp = type_expect ~on_function_argument:false env mode_legacy sexp (mk_expected ty_arg) in
         begin try
           unify env (instance ty_result) (instance expected_ty)
         with Unify err ->
@@ -11202,7 +11412,7 @@ and type_generic_array
   let argument_mode = expect_mode_cross env ty argument_mode in
   let argl =
     List.map
-      (fun sarg -> type_expect env argument_mode sarg (mk_expected ty))
+      (fun sarg -> type_expect ~on_function_argument:false env argument_mode sarg (mk_expected ty))
       sargl
   in
   re {
@@ -11226,9 +11436,9 @@ and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
 
 and type_n_ary_function
       ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
-      ~explanation ~attributes
+      ~explanation ~attributes ~on_function_argument
       (params, constraint_, body)
-    =
+  =
     let in_function = mk_expected (instance ty_expected) ?explanation, loc in
     let { function_ = exp_type, result_params, body;
           newtypes; params_contain_gadt = contains_gadt;
@@ -11258,12 +11468,31 @@ and type_n_ary_function
         GADT, as this is the only opportunity for arrows to be hidden from the
         resulting type.
     *)
+    let zero_alloc =
+      Builtin_attributes.get_zero_alloc_attribute
+        ~in_signature:false
+        ~on_application:false
+        ~on_function_argument
+        ~default_arity:syntactic_arity
+        attributes
+    in
+    let zero_alloc =
+      match zero_alloc with
+      | Default_zero_alloc -> Zero_alloc.create_var loc syntactic_arity
+      | Ignore_assert_all | Check _ | Assume _ ->
+        Zero_alloc.create_const zero_alloc
+    in
     begin match contains_gadt with
     | No_gadt -> ()
     | Contains_gadt ->
         (* Assert that [ty] is a function, and return its return type. *)
         let filter_ty_ret_exn ty arg_label ~force_tpoly =
-          match filter_arrow env ty arg_label ~force_tpoly with
+          let zero_alloc =
+            match Zero_alloc.get zero_alloc with
+            | Check c -> Some c
+            | _ -> None
+          in
+          match filter_arrow env ty arg_label ~force_tpoly ~zero_alloc with
           | { ty_ret; _ } -> ty_ret
           | exception (Filter_arrow_failed error) ->
               let trace =
@@ -11323,17 +11552,6 @@ and type_n_ary_function
             ignore
               (filter_ty_ret_exn ret_ty Nolabel ~force_tpoly:true : type_expr)
     end;
-    let zero_alloc =
-      Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
-        ~on_application:false
-        ~default_arity:syntactic_arity attributes
-    in
-    let zero_alloc =
-      match zero_alloc with
-      | Default_zero_alloc -> Zero_alloc.create_var loc syntactic_arity
-      | (Check _ | Assume _ | Ignore_assert_all) ->
-        Zero_alloc.create_const zero_alloc
-    in
     let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
     re
       { exp_desc =
@@ -11494,7 +11712,7 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
   let comp_body =
     (* To understand why comprehension bodies are checked at [mode_global], see
        "What modes should comprehensions use?", above *)
-    type_expect new_env mode_legacy sbody (mk_expected element_ty)
+    type_expect ~on_function_argument:false new_env mode_legacy sbody (mk_expected element_ty)
   in
   re { exp_desc       = make_texp { comp_body ; comp_clauses }
      ; exp_loc        = loc
@@ -11520,7 +11738,7 @@ and type_comprehension_clause ~loc ~comprehension_type ~container_type env
         List.map
           (type_comprehension_binding
              ~loc ~comprehension_type ~container_type ~env tps)
-          bindings
+         bindings
       in
       let env =
         let check s = Warnings.Unused_var { name = s; mutated = false } in
@@ -11534,6 +11752,7 @@ and type_comprehension_clause ~loc ~comprehension_type ~container_type env
            mode, see "What modes should comprehensions use?" in
            [type_comprehension_expr]*)
         type_expect
+          ~on_function_argument:false
           env
           mode_max
           cond
@@ -11566,6 +11785,7 @@ and type_comprehension_iterator
            checked at an arbitrary mode, see "What modes should comprehensions
            use?" in [type_comprehension_expr]*)
         type_expect
+          ~on_function_argument:false
           env
           mode_max
           bound
@@ -11599,6 +11819,7 @@ and type_comprehension_iterator
            (and not local) sequences, see "What modes should comprehensions
            use?" in [type_comprehension_expr]*)
         type_expect
+          ~on_function_argument:false
           env
           mode_legacy
           seq
@@ -11625,6 +11846,7 @@ and type_comprehension_iterator
           pattern
           item_ty
           Jkind.Sort.(of_const Const.for_loop_index)
+          ~zero_alloc:None
       in
       Texp_comp_in { pattern; sequence }
 
@@ -11753,7 +11975,8 @@ let type_expression env jkind sexp =
     with_local_level begin fun () ->
       Typetexp.TyVarEnv.reset ();
       let expected = mk_expected (newvar jkind) in
-      type_expect env mode_toplevel_expression sexp expected
+      type_expect ~on_function_argument:false
+        env mode_toplevel_expression sexp expected
     end
     ~post:(may_lower_contravariant_then_generalize env)
   in
@@ -12897,6 +13120,33 @@ let report_error ~loc env =
       Location.errorf ~loc
         "Instantiation of layout-polymorphic values is not yet supported \
          for %s." ctx_str
+  | Wrong_arg_zero_alloc err ->
+      Location.errorf ~loc
+        "@[Function argument zero alloc assumption violated.@]@ %a"
+        Zero_alloc.print_error err
+  | Unsupported_arg_zero_alloc ->
+      Location.errorf ~loc
+        "@[This function application expects an argument that does not@ \
+         allocate.@ \
+         Only identifiers and anonymous functions may be passed as arguments@ \
+         to functions with %a parameters.@]"
+        Style.inline_code "zero_alloc"
+  | Must_provide_zero_alloc_arity ->
+      Location.errorf ~loc
+        "Zero-alloc annotations on function arguments must specify arity."
+  | Invalid_payload_arg_zero_alloc ->
+      Location.errorf ~loc
+        "Invalid zero-alloc payload for a higher-order function argument."
+  | Incompatible_param_zero_alloc err ->
+      Location.errorf ~loc
+        "@[The \"zero_alloc\" attribute on this function parameter conflicts@ \
+         with the one on its type.@ %a@]"
+        Zero_alloc.print_error err
+  | Zero_alloc_arity_mismatch (annotation_arity, type_arity) ->
+      Location.errorf ~loc
+        "The arity in the \"zero_alloc\" attribute (%d) does not match the@ \
+         number of parameters in the argument type (%d)."
+        annotation_arity type_arity
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env
@@ -12926,7 +13176,7 @@ let check_partial ?lev a b c cases =
    and check for uniqueness *)
 let type_expect env ?mode e ty =
   let expected_mode = mode_default_opt mode in
-  let exp = type_expect env expected_mode e ty in
+  let exp = type_expect ~on_function_argument:false env expected_mode e ty in
   maybe_check_uniqueness_exp exp; exp
 
 let type_exp env ?mode e =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1341,7 +1341,7 @@ type pattern_variable =
     pv_attributes: attributes;
     pv_sort: Jkind_types.Sort.t;
     pv_lpoly: Lpoly.t;
-    pv_zero_alloc: Zero_alloc.check option;
+    pv_zero_alloc: Zero_alloc.t;
   }
 
 type module_variable =
@@ -1449,9 +1449,7 @@ let add_pattern_variables ?check ?check_as env pv =
          {val_type = pv_type; val_kind = pv_kind; val_lpoly = pv_lpoly;
           Types.val_loc = pv_loc;
           val_attributes = pv_attributes; val_modalities = Modality.undefined;
-          val_zero_alloc = (match pv_zero_alloc with
-            | None -> Zero_alloc.default
-            | Some c -> Zero_alloc.create_const (Zero_alloc.Check c));
+          val_zero_alloc = pv_zero_alloc;
           val_uid = pv_uid
          } env
     )
@@ -2233,7 +2231,7 @@ let type_for_loop_like_index ~error ~loc ~env ~param ~any ~var =
           ~pv_loc:loc
           ~pv_as_var:false
           ~pv_attributes:[]
-          ~pv_zero_alloc:None
+          ~pv_zero_alloc:Zero_alloc.default
   | _ ->
       raise (Error (param.ppat_loc, env, error))
 
@@ -3031,7 +3029,7 @@ let rec type_pat
   : type k . type_pat_state -> k pattern_category ->
       no_existentials: existential_restriction option ->
       alloc_mode:expected_pat_mode -> mutable_flag:_ ->
-      penv: Pattern_env.t -> zero_alloc:Zero_alloc.check option ->
+      penv: Pattern_env.t -> zero_alloc:Zero_alloc.t ->
       Parsetree.pattern -> type_expr -> Jkind.Sort.t -> k general_pattern
   = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv
       ~zero_alloc sp expected_ty sort ->
@@ -3044,7 +3042,7 @@ let rec type_pat
 and type_pat_aux
   : type k . type_pat_state -> k pattern_category -> no_existentials:_ ->
          alloc_mode:expected_pat_mode -> mutable_flag:mutable_flag -> penv:_ ->
-         zero_alloc:Zero_alloc.check option -> _ -> _ -> _ -> k general_pattern
+         zero_alloc:Zero_alloc.t -> _ -> _ -> _ -> k general_pattern
   = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv
         ~zero_alloc sp expected_ty sort ->
   let type_pat tps category ?(alloc_mode=alloc_mode) ?(penv=penv) ~zero_alloc =
@@ -3121,7 +3119,7 @@ and type_pat_aux
         lbl,
         type_pat tps Value ~alloc_mode p t
           Jkind.Sort.(of_const Const.for_tuple_element)
-          ~zero_alloc:None)
+          ~zero_alloc:Zero_alloc.default)
         spl_ann
     in
     rvp {
@@ -3213,7 +3211,7 @@ and type_pat_aux
           | `Same_as_record_sort -> record_sort
         in
         (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg ty_sort
-                             ~zero_alloc:None)
+                             ~zero_alloc:Zero_alloc.default)
       in
       let make_record_pat
             sorts (rep : rep)
@@ -3256,12 +3254,14 @@ and type_pat_aux
       let lbl_a_list = List.map (type_label_pat sorts) lbl_a_list in
       rvp @@ solve_expected (make_record_pat sorts rep lbl_a_list ambiguity)
   in
-  begin match sp.ppat_desc, zero_alloc with
-  | Ppat_var _, _ -> ()
-  | Ppat_alias _, _ -> ()
-  | Ppat_constraint _, _ -> ()
-  | _, None -> ()
-  | _, Some _ -> fatal_error "type_pat_aux: zero_alloc"
+  begin match sp.ppat_desc with
+  | Ppat_var _ -> ()
+  | Ppat_alias _ -> ()
+  | Ppat_constraint _ -> ()
+  | _ ->
+    (match Zero_alloc.sub ~context:Default zero_alloc Zero_alloc.default with
+    | Ok () -> ()
+    | Error _ -> fatal_error "type_pat_aux: zero_alloc")
   end;
   match sp.ppat_desc with
     Ppat_any ->
@@ -3331,7 +3331,8 @@ and type_pat_aux
           let sort = Jkind.Sort.(of_const Const.for_module) in
           let id, uid =
             enter_variable tps loc v alloc_mode.mode t ~is_module:true
-              ~kind:(Val_reg sort) sp.ppat_attributes None sort
+              ~kind:(Val_reg sort) sp.ppat_attributes
+              Zero_alloc.default sort
           in
           rvp {
             pat_desc = Tpat_var { id; name = v; uid; sort;
@@ -3401,7 +3402,7 @@ and type_pat_aux
         let p = {p with ppat_loc=loc} in
         type_pat tps category p expected_ty
           Jkind.Sort.(of_const Const.for_predef_scannable)
-          ~zero_alloc:None
+          ~zero_alloc:Zero_alloc.default
         (* TODO: record 'extra' to remember about interval *)
       in
       begin match
@@ -3539,7 +3540,8 @@ and type_pat_aux
                    Jkind.Sort.new_var ~level:(get_current_level ())
                    |> Jkind.Sort.of_var
              in
-             type_pat ~alloc_mode tps Value p arg.ca_type sort ~zero_alloc:None)
+             type_pat ~alloc_mode tps Value p arg.ca_type sort
+               ~zero_alloc:Zero_alloc.default)
           sargs args
       in
       let repr, sorts =
@@ -3575,7 +3577,7 @@ and type_pat_aux
           Some
             (type_pat tps Value sp ty
                Jkind.Sort.(of_const Const.for_variant_arg)
-               ~zero_alloc:None)
+               ~zero_alloc:Zero_alloc.default)
         | _ -> None
       in
       rvp {
@@ -3615,7 +3617,7 @@ and type_pat_aux
           let type_pat_rec tps penv sp =
             let alloc_mode = dynamic_pat_mode alloc_mode in
             type_pat ~alloc_mode tps category sp expected_ty sort ~penv
-              ~zero_alloc:None
+              ~zero_alloc
           in
           let penv1 =
             Pattern_env.copy ~equations_scope:(get_current_level ()) penv in
@@ -3666,7 +3668,7 @@ and type_pat_aux
       let p1 =
         type_pat ~alloc_mode tps Value sp1 nv
           Jkind.Sort.(of_const Const.for_lazy_body)
-          ~zero_alloc:None
+          ~zero_alloc:Zero_alloc.default
       in
       rvp {
         pat_desc = Tpat_lazy p1;
@@ -3709,7 +3711,8 @@ and type_pat_aux
       let path, new_env =
         !type_open Asttypes.Fresh !!penv sp.ppat_loc lid in
       Pattern_env.set_env penv new_env;
-      let p = type_pat tps category ~penv p expected_ty sort ~zero_alloc:None in
+      let p = type_pat tps category ~penv p expected_ty sort
+                ~zero_alloc:Zero_alloc.default in
       let new_env = !!penv in
       begin match Env.remove_last_open path new_env with
       | None -> assert false
@@ -3722,7 +3725,7 @@ and type_pat_aux
       let p_exn =
         type_pat tps Value ~alloc_mode p Predef.type_exn
           Jkind.Sort.(of_const Const.for_exception)
-          ~zero_alloc:None
+          ~zero_alloc:Zero_alloc.default
       in
       rcp {
         pat_desc = Tpat_exception p_exn;
@@ -3764,15 +3767,6 @@ let type_pattern_list
       ~equations_scope ~allow_recursive_equations:false in
   let type_pat (attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, pat) ty
         sort =
-    let zero_alloc : Zero_alloc.check option =
-      match zero_alloc with
-      | None
-      | Some (Builtin_attributes.Ignore_assert_all
-             | Builtin_attributes.Default_zero_alloc
-             | Builtin_attributes.Assume _)
-        -> None
-      | Some (Builtin_attributes.Check c) -> Some c
-    in
     Pattern_env.set_env_alloc_mode new_penv env_alloc_mode;
     Builtin_attributes.warning_scope ~ppwarning:false attrs
       (fun () ->
@@ -3802,7 +3796,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
         type_pat tps Value ~no_existentials:In_class_args ~alloc_mode
           ~mutable_flag:Immutable new_penv spat nv
           Jkind.Sort.(of_const Const.for_class_arg)
-          ~zero_alloc:None
+          ~zero_alloc:Zero_alloc.default
       in
       if has_variants pat then begin
         Parmatch.pressure_variants val_env [pat];
@@ -3833,9 +3827,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_kind = Val_reg pv_sort
             ; val_lpoly = Lpoly.determined []
             ; val_attributes = pv_attributes
-            ; val_zero_alloc = (match pv_zero_alloc with
-                | None -> Zero_alloc.default
-                | Some c -> Zero_alloc.create_const (Zero_alloc.Check c))
+            ; val_zero_alloc = pv_zero_alloc
             ; val_modalities = Modality.undefined
             ; val_loc = pv_loc
             ; val_uid = pv_uid
@@ -3848,9 +3840,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_kind = Val_ivar (Immutable, cl_num)
             ; val_lpoly = Lpoly.determined []
             ; val_attributes = pv_attributes
-            ; val_zero_alloc = (match pv_zero_alloc with
-                | None -> Zero_alloc.default
-                | Some c -> Zero_alloc.create_const (Zero_alloc.Check c))
+            ; val_zero_alloc = pv_zero_alloc
             ; val_modalities = Modality.undefined
             ; val_loc = pv_loc
             ; val_uid = pv_uid
@@ -3871,7 +3861,7 @@ let type_self_pattern env spat =
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
       ~equations_scope ~allow_recursive_equations:false in
-  let zero_alloc = None in
+  let zero_alloc = Zero_alloc.default in
   let pat =
     type_pat tps Value ~no_existentials:In_self_pattern ~alloc_mode
       ~mutable_flag:Immutable new_penv spat nv
@@ -6240,8 +6230,8 @@ let add_zero_alloc_attribute expr zero_alloc_attribute =
   match expr.exp_desc with
   | Texp_function fn ->
     begin match zero_alloc_attribute with
-    | None | Some Default_zero_alloc -> expr
-    | Some za ->
+    | Default_zero_alloc -> expr
+    | za ->
       begin match Zero_alloc.get fn.zero_alloc with
       | Default_zero_alloc -> ()
       | Ignore_assert_all | Assume _ | Check _ ->
@@ -6270,15 +6260,13 @@ let add_parsed_zero_alloc_attribute ~default_arity vb =
       ~in_signature:false
       ~on_application:false
       ~on_function_argument:false
-      ~default_arity
+      ~default_arity:(Some default_arity)
       vb.pvb_attributes
   in
-  let zero_alloc : Zero_alloc.const option =
+  let zero_alloc =
     match val_attr with
-    | Default_zero_alloc -> None
-    | Ignore_assert_all -> Some Ignore_assert_all
-    | Assume a -> Some (Assume a)
-    | Check c -> Some (Check c)
+    | Default_zero_alloc -> Zero_alloc.create_var vb.pvb_loc default_arity
+    | Ignore_assert_all | Assume _ | Check _ -> Zero_alloc.create_const val_attr
   in
   vb, zero_alloc
 
@@ -10502,6 +10490,11 @@ and map_half_typed_cases
                 with_local_level ~post:generalize_structure
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
+              let zero_alloc =
+                match zero_alloc with
+                | None -> Zero_alloc.default
+                | Some c -> Zero_alloc.create_const (Check c)
+              in
               let (pat, ext_env, force, pvs, mvs) =
                 type_pattern category ~lev ~alloc_mode:pat_mode env pattern
                   ty_arg sort_arg allow_modules ~zero_alloc
@@ -10920,9 +10913,9 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     List.map
       (fun vb ->
          if vb_is_fun vb then
-           let default_arity = Some (vb_fun_arity vb) in
+           let default_arity = vb_fun_arity vb in
            add_parsed_zero_alloc_attribute ~default_arity vb
-         else (vb, None))
+         else (vb, Zero_alloc.default))
       spat_sexp_list
   in
   let spatl = List.map vb_pat_constraint spat_sexp_list in
@@ -11037,7 +11030,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let exp_env =
           if is_recursive then
             let pvs_no_za =
-              List.map (fun pv -> { pv with pv_zero_alloc = None }) pvs
+              List.map (fun pv -> { pv with pv_zero_alloc = Zero_alloc.default }) pvs
             in
             add_module_variables
               (add_pattern_variables env_before_pvs pvs_no_za)
@@ -11151,7 +11144,23 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
       (fun (s, ((_,p,_), (e, _))) (pvb, zero_alloc) ->
         (* We check for [zero_alloc] attributes written on the [let] and move
            them to the function. *)
-        let e = add_zero_alloc_attribute e zero_alloc in
+        let e =
+          let za = Zero_alloc.get zero_alloc in
+          match za, e.exp_desc with
+          | Default_zero_alloc, Texp_function fn
+            when existential_context <> At_toplevel ->
+            (match Zero_alloc.get fn.zero_alloc with
+             | Default_zero_alloc ->
+               (* For local lets, link fn.zero_alloc to the binding's Var so
+                  that mutations from body type-checking (sub_var_const_exn at
+                  call sites) are visible to the backend.  Module-level
+                  inference uses the signature-comparison path instead, which
+                  correctly constrains the Var created by the function
+                  expression itself. *)
+               { e with exp_desc = Texp_function { fn with zero_alloc } }
+             | _ -> e)
+          | _ -> add_zero_alloc_attribute e za
+        in
         (* vb_rec_kind will be computed later for recursive bindings *)
         {vb_pat=p; vb_expr=e; vb_sort = s; vb_attributes=pvb.pvb_attributes;
          vb_loc=pvb.pvb_loc; vb_rec_kind = Dynamic;
@@ -11846,7 +11855,7 @@ and type_comprehension_iterator
           pattern
           item_ty
           Jkind.Sort.(of_const Const.for_loop_index)
-          ~zero_alloc:None
+          ~zero_alloc:Zero_alloc.default
       in
       Texp_comp_in { pattern; sequence }
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -313,7 +313,6 @@ type error =
   | Unsupported_arg_zero_alloc
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
-  | Zero_alloc_on_nonfunction
 
 and invalid_layout_poly_inst_context =
   | Binding_op
@@ -10930,10 +10929,13 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
          if vb_is_fun vb then
            let default_arity = vb_fun_arity vb in
            add_parsed_zero_alloc_attribute ~default_arity vb
-         else
-         if Builtin_attributes.has_attribute "zero_alloc" vb.pvb_attributes
-         then raise (Error (vb.pvb_loc, env, Zero_alloc_on_nonfunction))
-         else (vb, Zero_alloc.default))
+         else begin
+           if Builtin_attributes.has_attribute "zero_alloc" vb.pvb_attributes
+           then
+             Location.prerr_warning vb.pvb_loc
+               Warnings.Zero_alloc_on_nonfunction;
+           (vb, Zero_alloc.default)
+         end)
       spat_sexp_list
   in
   let spatl = List.map vb_pat_constraint spat_sexp_list in
@@ -13167,14 +13169,6 @@ let report_error ~loc env =
          with the one on its type.@ %a@]"
         Style.inline_code "zero_alloc"
         Zero_alloc.print_error err
-  | Zero_alloc_on_nonfunction ->
-      Location.errorf ~loc
-        "@[The %a attribute placed on a %a-binding can only be@ \
-         used for function definitions.@ \
-         If this defines a function, rewrite it so that its arguments are@ \
-         present in the definition.@]"
-        Style.inline_code "zero_alloc"
-        Style.inline_code "let"
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -311,7 +311,6 @@ type error =
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
   | Wrong_arg_zero_alloc of Zero_alloc.error
   | Unsupported_arg_zero_alloc
-  | Must_provide_zero_alloc_arity
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
   | Zero_alloc_arity_mismatch of int * int
@@ -6043,9 +6042,9 @@ let split_function_ty
   begin match get_desc ty_arg with
   | Tpoly (_, _, Some check_poly) ->
     begin
-      match has_poly with
-      | Mono | Poly None -> ()
-      | Poly (Some check_attr) ->
+      match zero_alloc with
+      | None -> ()
+      | Some check_attr ->
         let check1 =
           Zero_alloc.create_const (Zero_alloc.Check check_attr)
         in
@@ -7072,7 +7071,7 @@ and type_expect_
           ~in_signature:false
           ~on_application:true
           ~on_function_argument:false
-          ~default_arity:(List.length args)
+          ~default_arity:(Some (List.length args))
           sfunct.pexp_attributes
         |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
       in
@@ -8869,20 +8868,21 @@ and type_function
             get_pat_attrs inner
           | _ -> p.ppat_attributes
         in
-        Builtin_attributes.get_zero_alloc_attribute
-          ~in_signature:false
-          ~on_application:false
-          ~on_function_argument:true
-          ~default_arity:0
-          (get_pat_attrs pat)
+        (try
+          Builtin_attributes.get_zero_alloc_attribute
+            ~in_signature:false
+            ~on_application:false
+            ~on_function_argument:true
+            ~default_arity:None
+            (get_pat_attrs pat)
+        with Builtin_attributes.Error_builtin (_, err) ->
+          raise (Builtin_attributes.Error_builtin (pparam_loc, err)))
       in
       let zero_alloc =
         match zero_alloc with
         | Default_zero_alloc | Ignore_assert_all -> None
         | Assume _ ->
           raise (Error (pparam_loc, env, Invalid_payload_arg_zero_alloc))
-        | Check { arity; _ } when arity = 0 ->
-          raise (Error (pparam_loc, env, Must_provide_zero_alloc_arity))
         | Check check -> Some check
       in
       let env,
@@ -10918,7 +10918,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     List.map
       (fun vb ->
          if vb_is_fun vb then
-           let default_arity = vb_fun_arity vb in
+           let default_arity = Some (vb_fun_arity vb) in
            add_parsed_zero_alloc_attribute ~default_arity vb
          else (vb, None))
       spat_sexp_list
@@ -11544,7 +11544,7 @@ and type_n_ary_function
         ~in_signature:false
         ~on_application:false
         ~on_function_argument:false
-        ~default_arity:syntactic_arity
+        ~default_arity:(Some syntactic_arity)
         attributes
     in
     let zero_alloc =
@@ -13129,9 +13129,6 @@ let report_error ~loc env =
          Only identifiers and anonymous functions may be passed as arguments@ \
          to functions with %a parameters.@]"
         Style.inline_code "zero_alloc"
-  | Must_provide_zero_alloc_arity ->
-      Location.errorf ~loc
-        "Zero-alloc annotations on function arguments must specify arity."
   | Invalid_payload_arg_zero_alloc ->
       Location.errorf ~loc
         "Invalid zero-alloc payload for a higher-order function argument."

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -313,6 +313,7 @@ type error =
   | Unsupported_arg_zero_alloc
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
+  | Zero_alloc_on_non_var_pattern
 
 and invalid_layout_poly_inst_context =
   | Binding_op
@@ -3253,17 +3254,20 @@ and type_pat_aux
       let lbl_a_list = List.map (type_label_pat sorts) lbl_a_list in
       rvp @@ solve_expected (make_record_pat sorts rep lbl_a_list ambiguity)
   in
-  let verify_zero_alloc desc zero_alloc =
+  let rec verify_zero_alloc desc zero_alloc =
     match desc with
-    | Ppat_var _ | Ppat_alias _ | Ppat_constraint _ -> ()
+    | Ppat_var _ -> ()
+    | Ppat_alias (p, _) | Ppat_constraint (p, _, _) ->
+      verify_zero_alloc p.ppat_desc zero_alloc
     | Ppat_any | Ppat_constant _ | Ppat_interval _ | Ppat_unboxed_unit
     | Ppat_unboxed_bool _ | Ppat_unboxed_tuple _ | Ppat_variant _
     | Ppat_construct _ | Ppat_type _ | Ppat_unpack _ | Ppat_extension _
     | Ppat_exception _ | Ppat_lazy _ | Ppat_open _ | Ppat_tuple _ | Ppat_array _
     | Ppat_record _ | Ppat_record_unboxed_product _ | Ppat_or _ ->
-      (match Zero_alloc.sub ~context:Default zero_alloc Zero_alloc.default with
-       | Ok () -> ()
-       | Error _ -> fatal_error "type_pat_aux: zero_alloc")
+      (match Zero_alloc.get zero_alloc with
+       | Default_zero_alloc -> ()
+       | Check _ | Assume _ | Ignore_assert_all ->
+         raise (Error (sp.ppat_loc, !!penv, Zero_alloc_on_non_var_pattern)))
   in
   verify_zero_alloc sp.ppat_desc zero_alloc;
   match sp.ppat_desc with
@@ -13190,6 +13194,11 @@ let report_error ~loc env =
          with the one on its type.@ %a@]"
         Style.inline_code "zero_alloc"
         Zero_alloc.print_error err
+  | Zero_alloc_on_non_var_pattern ->
+      Location.errorf ~loc
+        "@[The %a attribute is only supported on patterns that bind@ \
+         a variable.@]"
+        Style.inline_code "zero_alloc"
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -314,6 +314,7 @@ type error =
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
   | Zero_alloc_on_non_var_pattern
+  | Missing_pattern_zero_alloc_for_type of Zero_alloc.check
 
 and invalid_layout_poly_inst_context =
   | Binding_op
@@ -3259,11 +3260,14 @@ and type_pat_aux
     | Ppat_var _ -> ()
     | Ppat_alias (p, _) | Ppat_constraint (p, _, _) ->
       verify_zero_alloc p.ppat_desc zero_alloc
+    | Ppat_or (p1, p2) ->
+      verify_zero_alloc p1.ppat_desc zero_alloc;
+      verify_zero_alloc p2.ppat_desc zero_alloc
     | Ppat_any | Ppat_constant _ | Ppat_interval _ | Ppat_unboxed_unit
     | Ppat_unboxed_bool _ | Ppat_unboxed_tuple _ | Ppat_variant _
     | Ppat_construct _ | Ppat_type _ | Ppat_unpack _ | Ppat_extension _
     | Ppat_exception _ | Ppat_lazy _ | Ppat_open _ | Ppat_tuple _ | Ppat_array _
-    | Ppat_record _ | Ppat_record_unboxed_product _ | Ppat_or _ ->
+    | Ppat_record _ | Ppat_record_unboxed_product _ ->
       (match Zero_alloc.get zero_alloc with
        | Default_zero_alloc -> ()
        | Check _ | Assume _ | Ignore_assert_all ->
@@ -6067,7 +6071,9 @@ let split_function_ty
   | Tpoly (_, _, Some check_poly) ->
     begin
       match zero_alloc with
-      | None -> ()
+      | None ->
+        raise
+          (Error (loc, env, Missing_pattern_zero_alloc_for_type check_poly))
       | Some check_attr ->
         let check1 =
           Zero_alloc.create_const (Zero_alloc.Check check_attr)
@@ -10907,6 +10913,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let rec sexp_is_fun sexp =
     match sexp.pexp_desc with
     | Pexp_function _ -> true
+    | Pexp_stack e
+    | Pexp_borrow e
     | Pexp_constraint (e, _, _)
     | Pexp_newtype (_, _, e) -> sexp_is_fun e
     | _ -> false
@@ -10924,6 +10932,8 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
       in
       (match body with | Pfunction_body _ -> 0 | Pfunction_cases _ -> 1) +
       n_value_params
+    | Pexp_stack e
+    | Pexp_borrow e
     | Pexp_constraint (e, _, _)
     | Pexp_newtype (_, _, e) -> arity_of_fun e
     (* function is only ever invoked if sexp_is_fun is true *)
@@ -11193,8 +11203,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let e =
           let za = Zero_alloc.get zero_alloc in
           match za, e.exp_desc with
-          | Default_zero_alloc, Texp_function fn
-            when existential_context <> At_toplevel ->
+          | Default_zero_alloc, Texp_function fn ->
             (match Zero_alloc.get fn.zero_alloc with
              | Default_zero_alloc ->
                (* For local lets, link fn.zero_alloc to the binding's Var so
@@ -13173,8 +13182,8 @@ let report_error ~loc env =
          for %s." ctx_str
   | Wrong_arg_zero_alloc err ->
       Location.errorf ~loc
-        "@[Mismatch between the %a requirement of the function@ \
-         being applied and this argument.@]@ %a"
+        "@[Mismatch between this argument and the %a requirement@ \
+         of the function being applied.@]@ %a"
         Style.inline_code "zero_alloc"
         Zero_alloc.print_error err
   | Unsupported_arg_zero_alloc ->
@@ -13199,6 +13208,13 @@ let report_error ~loc env =
         "@[The %a attribute is only supported on patterns that bind@ \
          a variable.@]"
         Style.inline_code "zero_alloc"
+  | Missing_pattern_zero_alloc_for_type check ->
+      Location.errorf ~loc
+        "@[The parameter type declares a %a requirement of arity %d,@ \
+         but the binding pattern does not.@ \
+         Hint: annotate the pattern.@]"
+        Style.inline_code "zero_alloc"
+        check.arity
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -313,7 +313,7 @@ type error =
   | Unsupported_arg_zero_alloc
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
-  | Zero_alloc_arity_mismatch of int * int
+  | Zero_alloc_on_nonfunction
 
 and invalid_layout_poly_inst_context =
   | Binding_op
@@ -6052,7 +6052,8 @@ let split_function_ty
         | Error e ->
           raise (Error (loc, env, Incompatible_param_zero_alloc e))
     end
-  | _ -> ()
+  | Tvar _ | Tpoly (_, _, None) -> ()
+  | _ -> fatal_error "split_function_ty: zero_alloc"
   end;
   env,
   { filtered_arrow; arg_sort; ret_sort;
@@ -6261,10 +6262,7 @@ let check_arg_compatible ~loc ~zero_alloc_expected env zero_alloc =
 let add_parsed_zero_alloc_attribute ~default_arity vb =
   let val_attr =
     Builtin_attributes.get_zero_alloc_attribute
-      ~in_signature:false
-      ~on_application:false
-      ~on_function_argument:false
-      ~default_arity:(Some default_arity)
+      (Function_definition default_arity)
       vb.pvb_attributes
   in
   let zero_alloc =
@@ -7051,6 +7049,12 @@ and type_expect_
       let mode_ret = Alloc.disallow_right mode_ret in
       let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
+      let zero_alloc =
+        Builtin_attributes.get_zero_alloc_attribute
+          (Builtin_attributes.Application (List.length args))
+          sfunct.pexp_attributes
+        |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
+      in
       let funct =
         match List.exists (fun (_, _, sch) -> Option.is_some sch) args with
         | true ->
@@ -7059,15 +7063,6 @@ and type_expect_
           { funct with
             exp_extra = (Texp_inspected_type ti, loc, []) :: funct.exp_extra }
         | false -> funct
-      in
-      let zero_alloc =
-        Builtin_attributes.get_zero_alloc_attribute
-          ~in_signature:false
-          ~on_application:true
-          ~on_function_argument:false
-          ~default_arity:(Some (List.length args))
-          sfunct.pexp_attributes
-        |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
@@ -8863,12 +8858,9 @@ and type_function
           | _ -> p.ppat_attributes
         in
         (try
-          Builtin_attributes.get_zero_alloc_attribute
-            ~in_signature:false
-            ~on_application:false
-            ~on_function_argument:true
-            ~default_arity:None
-            (get_pat_attrs pat)
+           Builtin_attributes.get_zero_alloc_attribute
+             Function_param
+             (get_pat_attrs pat)
         with Builtin_attributes.Error_builtin (_, err) ->
           raise (Builtin_attributes.Error_builtin (pparam_loc, err)))
       in
@@ -8997,17 +8989,6 @@ and type_function
         | [ result ], partial -> result, partial
         | ([] | _ :: _ :: _), _ -> assert false
       in
-      (* Check that the annotation arity matches the inferred type's arrow
-         count. We do this after the body is typed so that ty_arg_mono is
-         unified. *)
-      begin match zero_alloc with
-      | Some { arity; _ } ->
-        let type_arity = Ctype.arity ty_arg_mono in
-        if type_arity > 0 && arity <> type_arity then
-          raise (Error (pparam_loc, env,
-                        Zero_alloc_arity_mismatch (arity, type_arity)))
-      | None -> ()
-      end;
       let exp_type =
         instance
           (newgenty
@@ -9894,7 +9875,7 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
         mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
       let ty_arg', vars, zero_alloc = tpoly_get_poly ty_arg in
       let arg, sch =
-        if vars = [] then begin
+        if vars = [] && Option.is_none zero_alloc then begin
           let ty_arg0' = tpoly_get_inner ty_arg0 in
           if wrapped_in_some then begin
             type_option_some
@@ -9915,6 +9896,11 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
             then Some (Ctype.instance ~partial:true ty_arg)
             else None
           in
+          if !Clflags.principal && Option.is_some zero_alloc &&
+             get_level ty_arg < Btype.generic_level then
+              Location.prerr_warning app_loc
+                (not_principal
+                   "applying a function with zero_alloc requirements here");
           let separate =
             !Clflags.principal || Env.has_local_constraints env
           in
@@ -10100,7 +10086,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       (fun (label, body) ((_, ty), argument_mode) overwrite ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-        (label, type_expect ~overwrite env argument_mode body (mk_expected ty)))
+          (label, type_expect ~overwrite env argument_mode body (mk_expected ty)))
       sexpl types_and_modes overwrites
   in
   re {
@@ -10164,7 +10150,7 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
       (fun (label, body) ((_, ty, sort), argument_mode) ->
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
-        (label, type_expect env argument_mode body (mk_expected ty), sort))
+          (label, type_expect env argument_mode body (mk_expected ty), sort))
       sexpl types_sorts_and_modes
   in
   re {
@@ -10927,6 +10913,9 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
          if vb_is_fun vb then
            let default_arity = vb_fun_arity vb in
            add_parsed_zero_alloc_attribute ~default_arity vb
+         else
+         if Builtin_attributes.has_attribute "zero_alloc" vb.pvb_attributes
+         then raise (Error (vb.pvb_loc, env, Zero_alloc_on_nonfunction))
          else (vb, Zero_alloc.default))
       spat_sexp_list
   in
@@ -11565,10 +11554,7 @@ and type_n_ary_function
     end;
     let zero_alloc =
       Builtin_attributes.get_zero_alloc_attribute
-        ~in_signature:false
-        ~on_application:false
-        ~on_function_argument:false
-        ~default_arity:(Some syntactic_arity)
+        (Function_definition syntactic_arity)
         attributes
     in
     let zero_alloc =
@@ -13143,8 +13129,9 @@ let report_error ~loc env =
          for %s." ctx_str
   | Wrong_arg_zero_alloc err ->
       Location.errorf ~loc
-        "@[Mismatch between the \"zero_alloc\" requirement of the function@ \
+        "@[Mismatch between the %a requirement of the function@ \
          being applied and this argument.@]@ %a"
+        Style.inline_code "zero_alloc"
         Zero_alloc.print_error err
   | Unsupported_arg_zero_alloc ->
       Location.errorf ~loc
@@ -13155,17 +13142,22 @@ let report_error ~loc env =
         Style.inline_code "zero_alloc"
   | Invalid_payload_arg_zero_alloc ->
       Location.errorf ~loc
-        "Invalid zero-alloc payload for a higher-order function argument."
+        "Invalid %a payload for a higher-order function argument."
+        Style.inline_code "zero_alloc"
   | Incompatible_param_zero_alloc err ->
       Location.errorf ~loc
-        "@[The \"zero_alloc\" attribute on this function parameter conflicts@ \
+        "@[The %a attribute on this function parameter conflicts@ \
          with the one on its type.@ %a@]"
+        Style.inline_code "zero_alloc"
         Zero_alloc.print_error err
-  | Zero_alloc_arity_mismatch (annotation_arity, type_arity) ->
+  | Zero_alloc_on_nonfunction ->
       Location.errorf ~loc
-        "The arity in the \"zero_alloc\" attribute (%d) does not match the@ \
-         number of parameters in the argument type (%d)."
-        annotation_arity type_arity
+        "@[The %a attribute placed on a %a-binding can only be@ \
+         used for function definitions.@ \
+         If this defines a function, rewrite it so that its arguments are@ \
+         present in the definition.@]"
+        Style.inline_code "zero_alloc"
+        Style.inline_code "let"
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1079,10 +1079,10 @@ let has_poly_constraint spat =
   match spat.ppat_desc with
   | Ppat_constraint(_, Some styp, _) -> begin
       match styp.ptyp_desc with
-      | Ptyp_poly _ -> true
-      | _ -> false
+      | Ptyp_poly _ -> Poly None
+      | _ -> Mono
     end
-  | _ -> false
+  | _ -> Mono
 
 (** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
     fragment is a left mode. *)
@@ -4567,7 +4567,7 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
           match get_desc ty_fun with
           | Tvar { jkind; _ } ->
               let ty_arg_mono, sort_arg = new_rep_var ~why:Function_argument () in
-              let ty_arg = newmono ~zero_alloc:None ty_arg_mono in
+              let ty_arg = newmono ty_arg_mono in
               let ty_res =
                 newvar (Jkind.of_new_sort ~why:Function_result
                           ~level:(Ctype.get_current_level ()))
@@ -4609,7 +4609,7 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
               | Error err -> raise(Error(funct.exp_loc, env,
                                          Function_type_not_rep (ty_arg,err)))
             in
-            (sort_arg, mode_arg, tpoly_get_mono ty_arg, mode_ret, ty_res)
+            (sort_arg, mode_arg, tpoly_get_inner ty_arg, mode_ret, ty_res)
         | td ->
             let ty_fun = match td with Tarrow _ -> newty td | _ -> ty_fun in
             let ty_res = remaining_function_type ty_fun mode_fun rev_args in
@@ -5217,7 +5217,7 @@ let rec approx_type env sty =
       let marg = Alloc.of_const arg_mode.mode_modes in
       let mret = Alloc.newvar () in
       newty
-        (Tarrow ((p,marg,mret), newmono ~zero_alloc:None arg, ret, commu_ok))
+        (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (label, t) -> label, approx_type env t) args))
   | Ptyp_constr (lid, ctl) ->
@@ -5275,11 +5275,11 @@ let type_approx_fun_one_param
   =
   let mode_annots, has_poly =
     match spato with
-    | None -> None, false
+    | None -> None, Mono
     | Some spat ->
         let mode_annots = mode_annots_from_pat spat in
         let has_poly = has_poly_constraint spat in
-        if has_poly && is_optional label then
+        if is_explicitly_poly has_poly && is_optional label then
           raise(Error(spat.ppat_loc, env, Optional_poly_param));
         Some mode_annots, has_poly
   in
@@ -5287,7 +5287,7 @@ let type_approx_fun_one_param
   let { ty_arg; arg_mode; ty_ret; _ } =
     try
       filter_arrow env ty_expected label
-        ~force_tpoly:(not has_poly) ~zero_alloc:None
+        ~has_poly:(match has_poly with Mono -> Poly None | Poly _ -> Mono)
     with Filter_arrow_failed err ->
       let err =
         error_of_filter_arrow_failure ~explanation:None ty_fun err ~first
@@ -5298,7 +5298,7 @@ let type_approx_fun_one_param
     (fun mode_annots ->
       apply_mode_annots ~loc ~env Parameter mode_annots.mode_modes arg_mode)
     mode_annots;
-  if has_poly then begin
+  if is_explicitly_poly has_poly then begin
     match spato with
     | None -> ()
     | Some spat -> type_pattern_approx env spat ty_arg
@@ -5860,11 +5860,14 @@ let unique_use ~loc ~env mode_l mode_r  =
     in
     (uniqueness, linearity)
 
-let is_really_poly ~env ~zero_alloc ty =
+let is_really_poly ~env ty =
   let snap = Btype.snapshot () in
   let any = Jkind.Builtin.any ~why:Dummy_jkind in
   let really_poly =
-    try unify env (newmono ~zero_alloc (newvar any)) ty; false
+    let zero_alloc =
+      match get_desc ty with Tpoly(_, _, za) -> za | _ -> None
+    in
+    try unify env (newty (Tpoly(newvar any, [], zero_alloc))) ty; false
     with Unify _ -> true
   in
   Btype.backtrack snap;
@@ -5937,8 +5940,8 @@ type split_function_ty =
 *)
 let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
-    ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
-    ~zero_alloc
+    ~zero_alloc ~mode_annots ~ret_mode_annots ~in_function
+    ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, mode =
       (* Unlike most allocations which can be the highest mode allowed by
@@ -5957,15 +5960,11 @@ let split_function_ty
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
     with_local_level_if separate begin fun () ->
-      let force_tpoly =
-        (* If [has_poly] is true then we rely on the later call to
-           type_pat to enforce the invariant that the parameter type
-           be a [Tpoly] node *)
-        not has_poly
-      in
       try
-        filter_arrow env (instance ty_expected) arg_label
-          ~force_tpoly ~zero_alloc
+        let has_poly =
+          match has_poly with Mono -> Poly zero_alloc | Poly _ -> Mono
+        in
+        filter_arrow env (instance ty_expected) arg_label ~has_poly
       with Filter_arrow_failed err ->
         let err =
           error_of_filter_arrow_failure ~explanation ~first:is_first_val_param
@@ -5980,8 +5979,11 @@ let split_function_ty
   apply_mode_annots ~loc:loc_fun ~env Parameter mode_annots arg_mode;
   apply_mode_annots ~loc:loc_fun ~env Return ret_mode_annots ret_mode;
   let really_poly =
-    not has_poly && not (tpoly_is_mono ty_arg)
-      && is_really_poly ~env ~zero_alloc ty_arg
+    not (is_explicitly_poly has_poly)
+    && (match get_desc ty_arg with
+        | Tpoly _ -> not (tpoly_is_mono ty_arg)
+        | _ -> false)
+    && is_really_poly ~env ty_arg
   in
   if really_poly &&
      !Clflags.principal && get_level ty_arg < Btype.generic_level then
@@ -6011,7 +6013,7 @@ let split_function_ty
       ret_value_mode
   in
   let ty_arg_mono =
-    if has_poly then ty_arg
+    if is_explicitly_poly has_poly then ty_arg
     else begin
       let ty, vars, _za = tpoly_get_poly ty_arg in
       if vars = [] then ty
@@ -6194,7 +6196,7 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, zero_alloc, spat) =
   in
   attrs, zero_alloc, pat_mode, env_alloc_mode, exp_mode, spat
 
-let add_typed_zero_alloc_attribute expr zero_alloc_attribute =
+let add_zero_alloc_attribute expr zero_alloc_attribute =
   let open Builtin_attributes in
   let to_string : zero_alloc_attribute -> string = function
     | Check { strict; loc = _} ->
@@ -6210,17 +6212,17 @@ let add_typed_zero_alloc_attribute expr zero_alloc_attribute =
   match expr.exp_desc with
   | Texp_function fn ->
     begin match zero_alloc_attribute with
-    | Default_zero_alloc -> expr
-    | Ignore_assert_all | Check _ | Assume _ ->
+    | None | Some Default_zero_alloc -> expr
+    | Some za ->
       begin match Zero_alloc.get fn.zero_alloc with
       | Default_zero_alloc -> ()
       | Ignore_assert_all | Assume _ | Check _ ->
         Location.prerr_warning expr.exp_loc
-          (Warnings.Duplicated_attribute (to_string zero_alloc_attribute));
+          (Warnings.Duplicated_attribute (to_string za));
       end;
       (* Here, we may be throwing away a zero_alloc variable. There's no need
          to set it, because it can't have gotten anywhere else yet. *)
-      let zero_alloc = Zero_alloc.create_const zero_alloc_attribute in
+      let zero_alloc = Zero_alloc.create_const za in
       let exp_desc = Texp_function { fn with zero_alloc } in
       { expr with exp_desc }
     end
@@ -7042,32 +7044,13 @@ and type_expect_
             exp_extra = (Texp_inspected_type ti, loc, []) :: funct.exp_extra }
         | false -> funct
       in
-      let extract_zero_alloc_attr () =
-        Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
+      let zero_alloc =
+        Builtin_attributes.get_zero_alloc_attribute
+          ~in_signature:false
           ~on_application:true
           ~on_function_argument:false
           ~default_arity:(List.length args)
           sfunct.pexp_attributes
-      in
-      let zero_alloc =
-        begin
-          match funct.exp_desc with
-          | Texp_ident { desc; _ } ->
-            begin
-              let use_opt =
-                match !Clflags.zero_alloc_check with
-                | Check_default | No_check -> false
-                | Check_all | Check_opt_only -> true
-              in
-              match Zero_alloc.get desc.val_zero_alloc with
-              | Check {strict; arity; loc; opt} when use_opt || not opt ->
-                Assume {strict; arity; loc;
-                        never_returns_normally = false;
-                        never_raises = false}
-              | _ -> extract_zero_alloc_attr ()
-            end
-          | _ -> extract_zero_alloc_attr ()
-        end
         |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
@@ -7972,7 +7955,7 @@ and type_expect_
         | Tvar _ ->
             let exp = type_exp env expected_mode sbody in
             let exp =
-              {exp with exp_type = newmono ~zero_alloc:None exp.exp_type}
+              {exp with exp_type = newmono exp.exp_type}
             in
             unify_exp env exp ty;
             exp
@@ -8066,14 +8049,14 @@ and type_expect_
           let ty_func_result, body_sort = new_rep_var ~why:Function_result () in
           let arrow_desc = Nolabel, Alloc.legacy, Alloc.legacy in
           let ty_func =
-            newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_params,
+            newty (Tarrow(arrow_desc, newmono ty_params,
                           ty_func_result, commu_ok))
           in
           let ty_result, op_result_sort = new_rep_var ~why:Function_result () in
           let ty_andops, sort_andops = new_rep_var ~why:Function_argument () in
           let ty_op =
-            newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_andops,
-              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_func,
+            newty (Tarrow(arrow_desc, newmono ty_andops,
+              newty (Tarrow(arrow_desc, newmono ty_func,
                             ty_result, commu_ok)),
               commu_ok))
           in
@@ -8857,9 +8840,10 @@ and type_function
       in
       let mode_annots = mode_annots_from_pat pat in
       let has_poly = has_poly_constraint pat in
-      if has_poly && is_optional_parsetree arg_label then
+      let has_explicit_poly = is_explicitly_poly has_poly in
+      if has_explicit_poly && is_optional_parsetree arg_label then
         raise(Error(pat.ppat_loc, env, Optional_poly_param));
-      if has_poly
+      if has_explicit_poly
       && not (Language_extension.is_enabled Polymorphic_parameters) then
         raise (Typetexp.Error (loc, env,
                                Unsupported_extension Polymorphic_parameters));
@@ -8944,7 +8928,7 @@ and type_function
             let check2 =
               Zero_alloc.create_const (Zero_alloc.Check check_poly)
             in
-            match Zero_alloc.sub ~context:Fun_param check1 check2 with
+            match Zero_alloc.sub ~context:Type_constraint check1 check2 with
             | Ok () -> ()
             | Error e ->
               raise (Error (pparam_loc, env, Incompatible_param_zero_alloc e))
@@ -9119,7 +9103,7 @@ and type_function
             param_uid
       in
       let param =
-        { has_poly;
+        { has_poly = is_explicitly_poly has_poly;
           param =
             { fp_kind;
               fp_arg_label = typed_arg_label;
@@ -9777,7 +9761,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
         match get_desc (expand_head env ty_fun) with
         | Tarrow ((l,_marg,_mret),ty_arg,ty_fun,_) when is_optional l ->
             let ty =
-              type_option_none env (instance (tpoly_get_mono ty_arg))
+              type_option_none env (instance (tpoly_get_inner ty_arg))
                 sarg.pexp_loc
             in
             (* CR layouts v5: change value assumption below when we allow
@@ -9958,7 +9942,7 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       let ty_arg', vars, zero_alloc = tpoly_get_poly ty_arg in
       let arg, sch, zero_alloc =
         if vars = [] then begin
-          let ty_arg0' = tpoly_get_mono ty_arg0 in
+          let ty_arg0' = tpoly_get_inner ty_arg0 in
           if wrapped_in_some then begin
             type_option_some
               env expected_mode sarg ty_arg' ty_arg0', None, zero_alloc
@@ -9968,7 +9952,7 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
           end
         end else begin
           let sch =
-            let really_poly = is_really_poly ~env ~zero_alloc ty_arg in
+            let really_poly = is_really_poly ~env ty_arg in
             if really_poly &&
                !Clflags.principal && get_level ty_arg < Btype.generic_level
             then
@@ -10894,10 +10878,10 @@ and type_function_cases_expect
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
-        ~in_function ~has_poly:false ~mode_annots:Mode.Alloc.Const.Option.none
+        ~in_function ~has_poly:Mono ~zero_alloc:None
+        ~mode_annots:Mode.Alloc.Const.Option.none
         ~ret_mode_annots:Mode.Alloc.Const.Option.none
         ~is_first_val_param:first ~is_final_val_param:true
-        ~zero_alloc:None
     in
     let cases, partial =
       type_cases Value env
@@ -11087,6 +11071,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
          we type-checked expressions before patterns, then we could call
          [add_module_variables] here.
       *)
+      let env_before_pvs = new_env in
       let new_env = add_pattern_variables new_env pvs in
       let mode_pat_typ_list =
         List.map
@@ -11105,7 +11090,14 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
            fail, even if the type of [m] is known.
         *)
         let exp_env =
-          if is_recursive then add_module_variables new_env mvs else env
+          if is_recursive then
+            let pvs_no_za =
+              List.map (fun pv -> { pv with pv_zero_alloc = None }) pvs
+            in
+            add_module_variables
+              (add_pattern_variables env_before_pvs pvs_no_za)
+              mvs
+          else env
         in
         type_let_def_wrap_warnings ?check ?check_strict ~is_recursive
           ~entirely_functions
@@ -11216,11 +11208,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
       (fun (s, ((_,p,_), (e, _))) (pvb, zero_alloc) ->
         (* We check for [zero_alloc] attributes written on the [let] and move
            them to the function. *)
-         let e =
-           add_typed_zero_alloc_attribute e
-             (Option.value ~default:Builtin_attributes.Default_zero_alloc
-                zero_alloc)
-        in
+        let e = add_zero_alloc_attribute e zero_alloc in
         (* vb_rec_kind will be computed later for recursive bindings *)
         {vb_pat=p; vb_expr=e; vb_sort = s; vb_attributes=pvb.pvb_attributes;
          vb_loc=pvb.pvb_loc; vb_rec_kind = Dynamic;
@@ -11409,10 +11397,10 @@ and type_andops env sarg sands expected_sort expected_ty =
             in
             let arrow_desc = (Nolabel, Alloc.legacy, Alloc.legacy) in
             let ty_rest_fun =
-              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_arg,
+              newty (Tarrow(arrow_desc, newmono ty_arg,
                             ty_result, commu_ok)) in
             let ty_op =
-              newty (Tarrow(arrow_desc, newmono ~zero_alloc:None ty_rest,
+              newty (Tarrow(arrow_desc, newmono ty_rest,
                             ty_rest_fun, commu_ok))
             in
             begin try
@@ -11570,7 +11558,12 @@ and type_n_ary_function
             | Check c -> Some c
             | _ -> None
           in
-          match filter_arrow env ty arg_label ~force_tpoly ~zero_alloc with
+          let has_poly =
+            match force_tpoly, zero_alloc with
+            | false, None -> Mono
+            | _ -> Poly zero_alloc
+          in
+          match filter_arrow env ty arg_label ~has_poly with
           | { ty_ret; _ } -> ty_ret
           | exception (Filter_arrow_failed error) ->
               let trace =
@@ -13201,7 +13194,8 @@ let report_error ~loc env =
          for %s." ctx_str
   | Wrong_arg_zero_alloc err ->
       Location.errorf ~loc
-        "@[Function argument zero alloc assumption violated.@]@ %a"
+        "@[Mismatch between the \"zero_alloc\" requirement of the function@ \
+         being applied and this argument.@]@ %a"
         Zero_alloc.print_error err
   | Unsupported_arg_zero_alloc ->
       Location.errorf ~loc

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -74,7 +74,7 @@ type pattern_variable =
     pv_lpoly: Types.Lpoly.t;
     (** Not yet determined; gets determined during generalization in
         [type_let]. *)
-    pv_zero_alloc: Zero_alloc.check option;
+    pv_zero_alloc: Zero_alloc.t;
   }
 
 val mk_expected:

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -362,7 +362,6 @@ type error =
   | Unsupported_arg_zero_alloc
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
-  | Zero_alloc_on_nonfunction
 
 and invalid_layout_poly_inst_context =
   | Binding_op

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -362,7 +362,7 @@ type error =
   | Unsupported_arg_zero_alloc
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
-  | Zero_alloc_arity_mismatch of int * int
+  | Zero_alloc_on_nonfunction
 
 and invalid_layout_poly_inst_context =
   | Binding_op

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -362,6 +362,7 @@ type error =
   | Unsupported_arg_zero_alloc
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
+  | Zero_alloc_on_non_var_pattern
 
 and invalid_layout_poly_inst_context =
   | Binding_op

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -360,7 +360,6 @@ type error =
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
   | Wrong_arg_zero_alloc of Zero_alloc.error
   | Unsupported_arg_zero_alloc
-  | Must_provide_zero_alloc_arity
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
   | Zero_alloc_arity_mismatch of int * int

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -177,7 +177,7 @@ val force_delayed_checks: unit -> unit
 val reset_allocations: unit -> unit
 val optimise_allocations: unit -> unit
 
-val has_poly_constraint : Parsetree.pattern -> bool
+val has_poly_constraint : Parsetree.pattern -> Btype.explicit_poly
 
 
 val name_pattern : string -> Typedtree.pattern list -> Ident.t * Uid.t

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -74,6 +74,7 @@ type pattern_variable =
     pv_lpoly: Types.Lpoly.t;
     (** Not yet determined; gets determined during generalization in
         [type_let]. *)
+    pv_zero_alloc: Zero_alloc.check option;
   }
 
 val mk_expected:
@@ -357,6 +358,12 @@ type error =
   | Let_poly_not_yet_implemented
   | Let_poly_not_syntactic_value
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
+  | Wrong_arg_zero_alloc of Zero_alloc.error
+  | Unsupported_arg_zero_alloc
+  | Must_provide_zero_alloc_arity
+  | Invalid_payload_arg_zero_alloc
+  | Incompatible_param_zero_alloc of Zero_alloc.error
+  | Zero_alloc_arity_mismatch of int * int
 
 and invalid_layout_poly_inst_context =
   | Binding_op

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -363,6 +363,7 @@ type error =
   | Invalid_payload_arg_zero_alloc
   | Incompatible_param_zero_alloc of Zero_alloc.error
   | Zero_alloc_on_non_var_pattern
+  | Missing_pattern_zero_alloc_for_type of Zero_alloc.check
 
 and invalid_layout_poly_inst_context =
   | Binding_op

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -592,7 +592,12 @@ let transl_labels (type rep) ~(record_form : rep record_form) ~new_var_jkind
     List.map
       (fun ld ->
          let ty = ld.ld_type.ctyp_type in
-         let ty = match get_desc ty with Tpoly(t,[]) -> t | _ -> ty in
+         let ty =
+           match get_desc ty with
+           | Tpoly(t,[],None) -> t
+           | Tpoly(_,[],Some _) -> fatal_error "transl_labels (zero_alloc)"
+           |  _ -> ty
+         in
          if extension then begin
            check_representable ~why:(Extension_label_declaration ld.ld_id)
              env ld.ld_loc kloc ty
@@ -1491,7 +1496,7 @@ let rec check_constraints_rec env loc visited ty =
         | All_good -> ()
       end;
       List.iter (check_constraints_rec env loc visited) args
-  | Tpoly (ty, tl) ->
+  | Tpoly (ty, tl, _za) ->
       let ty = Ctype.instance_poly tl ty in
       check_constraints_rec env loc visited ty
   | _ ->
@@ -3167,7 +3172,7 @@ let check_regularity ~abs_env env loc path decl to_check =
             with Not_found -> ()
           end;
           List.iter (check_subtype cpath args prev_exp trace ty env) args'
-      | Tpoly (ty, tl) ->
+      | Tpoly (ty, tl, _) ->
           let ty = Ctype.instance_poly ~keep_names:true tl ty in
           check_regular cpath args prev_exp trace env ty
       | _ ->
@@ -4248,7 +4253,7 @@ let rec parse_native_repr_attributes env core_type ty rmode
     raise (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type kind))
   | Ptyp_arrow (_, ct1, ct2, _, _), Tarrow ((_,marg,mret), t1, t2, _), _
     when not (Builtin_attributes.has_curry core_type.ptyp_attributes) ->
-    let t1, _ = Btype.tpoly_get_poly t1 in
+    let t1, _, _ = Btype.tpoly_get_poly t1 in
     let repr_arg =
       make_native_repr
         env ct1 t1 ~global_repr
@@ -4289,7 +4294,7 @@ let check_unboxable env loc ty =
         if tydecl.type_unboxed_default then
           Path.Set.add p acc
         else acc
-      | Tpoly (ty, []) -> check_type acc ty
+      | Tpoly (ty, [], _za) -> check_type acc ty
       | _ -> acc
     with Not_found -> acc
   in
@@ -4464,9 +4469,12 @@ let transl_value_decl env loc ~modal ~why valdecl =
         count_arrows 0 ty
       in
       let zero_alloc =
-        Builtin_attributes.get_zero_alloc_attribute ~in_signature:true
+        Builtin_attributes.get_zero_alloc_attribute
+          ~in_signature:true
           ~on_application:false
-          ~default_arity valdecl.pval_attributes
+          ~on_function_argument:false
+          ~default_arity
+          valdecl.pval_attributes
       in
       let zero_alloc =
         match zero_alloc with
@@ -4490,10 +4498,10 @@ let transl_value_decl env loc ~modal ~why valdecl =
              | Assert_all -> create_const ~opt:false
              | Assert_all_opt -> create_const ~opt:true)
         | Ignore_assert_all -> Zero_alloc.ignore_assert_all
-        | Check za ->
-          if default_arity = 0 && za.arity <= 0 then
+        | Check {arity; _} ->
+          if default_arity = 0 && arity <= 0 then
             raise (Error(valdecl.pval_loc, Zero_alloc_attr_non_function));
-          if za.arity <= 0 then
+          if arity <= 0 then
             raise (Error(valdecl.pval_loc, Zero_alloc_attr_bad_user_arity));
           Zero_alloc.create_const zero_alloc
         | Assume _ ->
@@ -5192,7 +5200,8 @@ let report_error_doc ppf = function
       | Bad_jkind (ty, violation) | Bad_jkind_sort (ty, violation) ->
         Some (ty, violation)
       | Unequal_var_jkinds _ | Unequal_tof_kind_jkinds _ | Diff _ | Variant _
-      | Obj _ | Escape _ | Incompatible_fields _ | Rec_occur _ -> None
+      | Obj _ | Escape _ | Incompatible_fields _ | Rec_occur _
+      | Incompatible_zero_alloc _ -> None
       in
       begin match List.find_map get_jkind_error err.trace with
       | Some (ty, violation) ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4460,7 +4460,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
   let v =
   match valdecl.pval_prim with
     [] when Env.is_in_signature env ->
-      let default_arity =
+      let fun_arity =
         let rec count_arrows n ty =
           match get_desc ty with
           | Tarrow (_, _, t2, _) -> count_arrows (n+1) t2
@@ -4468,27 +4468,35 @@ let transl_value_decl env loc ~modal ~why valdecl =
         in
         count_arrows 0 ty
       in
+      let default_arity =
+        if fun_arity = 0 then None else Some fun_arity
+      in
       let zero_alloc =
-        Builtin_attributes.get_zero_alloc_attribute
-          ~in_signature:true
-          ~on_application:false
-          ~on_function_argument:false
-          ~default_arity
-          valdecl.pval_attributes
+        (try
+          Builtin_attributes.get_zero_alloc_attribute
+            ~in_signature:true
+            ~on_application:false
+            ~on_function_argument:false
+            ~default_arity
+            valdecl.pval_attributes
+        with
+        | Builtin_attributes.Error_builtin
+            (_, Builtin_attributes.Zero_alloc_attr_non_function) ->
+          raise (Error (valdecl.pval_loc, Zero_alloc_attr_non_function)))
       in
       let zero_alloc =
         match zero_alloc with
         | Default_zero_alloc ->
           (* We fabricate a "Check" attribute if a top-level annotation
              specifies that all functions should be checked for zero alloc. *)
-          if default_arity = 0 then begin
+          if fun_arity = 0 then begin
             check_for_hidden_arrow env loc ty;
             Zero_alloc.default
           end else
             let create_const ~opt =
               Zero_alloc.create_const
                 (Check { strict = false;
-                         arity = default_arity;
+                         arity = fun_arity;
                          custom_error_msg = None;
                          loc;
                          opt })
@@ -4499,7 +4507,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
              | Assert_all_opt -> create_const ~opt:true)
         | Ignore_assert_all -> Zero_alloc.ignore_assert_all
         | Check {arity; _} ->
-          if default_arity = 0 && arity <= 0 then
+          if fun_arity = 0 && arity <= 0 then
             raise (Error(valdecl.pval_loc, Zero_alloc_attr_non_function));
           if arity <= 0 then
             raise (Error(valdecl.pval_loc, Zero_alloc_attr_bad_user_arity));

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4468,21 +4468,15 @@ let transl_value_decl env loc ~modal ~why valdecl =
         in
         count_arrows 0 ty
       in
-      let default_arity =
-        if fun_arity = 0 then None else Some fun_arity
-      in
+      let usage = Builtin_attributes.Value_decl fun_arity in
       let zero_alloc =
         (try
-          Builtin_attributes.get_zero_alloc_attribute
-            ~in_signature:true
-            ~on_application:false
-            ~on_function_argument:false
-            ~default_arity
-            valdecl.pval_attributes
-        with
-        | Builtin_attributes.Error_builtin
-            (_, Builtin_attributes.Zero_alloc_attr_non_function) ->
-          raise (Error (valdecl.pval_loc, Zero_alloc_attr_non_function)))
+           Builtin_attributes.get_zero_alloc_attribute usage
+             valdecl.pval_attributes
+         with
+         | Builtin_attributes.Error_builtin
+             (_, Builtin_attributes.Zero_alloc_attr_non_function) ->
+           raise (Error (valdecl.pval_loc, Zero_alloc_attr_non_function)))
       in
       let zero_alloc =
         match zero_alloc with

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -151,7 +151,7 @@ let rec immediate_subtypes : type_expr -> type_expr list = fun ty ->
   | Tlink _ | Tsubst _ -> assert false (* impossible due to Ctype.repr *)
   | Tvar _ | Tunivar _ -> []
   | Tof_kind _ -> []
-  | Tpoly (pty, _) -> [pty]
+  | Tpoly (pty, _, _) -> [pty]
   | Trepr (_, _) -> Misc.fatal_error "immediate_subtypes: Trepr"
   | Tconstr (_path, tys, _) -> tys
 
@@ -464,7 +464,7 @@ let check_type
        variable cannot be extracted by constraints (this would be
        a scope violation), so they could be ignored if they occur
        under a separating type constructor. *)
-    | (Tpoly(pty,_)       , m      ) ->
+    | (Tpoly(pty,_,_)     , m      ) ->
         check_type hyps pty m
     | (Trepr(_pty,_)       , _m    ) ->
         assert false

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -108,7 +108,7 @@ let compute_variance env visited vari ty =
             | _ -> ())
           (row_fields row);
         compute_same (row_more row)
-    | Tpoly (ty, _) | Trepr (ty, _) ->
+    | Tpoly (ty, _, _) | Trepr (ty, _) ->
         compute_same ty
     | Tvar _ | Tnil | Tlink _ | Tunivar _ | Tof_kind _ -> ()
     | Tpackage (_, fl) ->

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -1349,13 +1349,20 @@ let let_bound_idents_with_modes_sorts_and_checks bindings =
   let f id sloc _ _uid mode sort =
     Ident.Tbl.add modes_and_sorts id (sloc.loc, mode, sort)
   in
+  let rec idents_of_pat pat =
+    match pat.pat_desc with
+    | Tpat_var { id; _ } -> [id]
+    | Tpat_alias { pattern; id; _ } -> id :: idents_of_pat pattern
+    | Tpat_or (p1, _, _) -> idents_of_pat p1
+    | _ -> []
+  in
   let checks =
     List.fold_left (fun checks vb ->
       for_typing iter_pattern_full
         ~both_sides_of_or:true
         f vb.vb_pat;
-       match vb.vb_pat.pat_desc, vb.vb_expr.exp_desc with
-       | Tpat_var { id; _ }, Texp_function fn ->
+       match idents_of_pat vb.vb_pat, vb.vb_expr.exp_desc with
+       | (_ :: _ as ids), Texp_function fn ->
          let zero_alloc =
            match Zero_alloc.get fn.zero_alloc with
            | Default_zero_alloc ->
@@ -1382,7 +1389,9 @@ let let_bound_idents_with_modes_sorts_and_checks bindings =
                 | Assert_all_opt -> create_const ~opt:true)
            | Ignore_assert_all | Check _ | Assume _ -> fn.zero_alloc
          in
-         Ident.Map.add id zero_alloc checks
+         List.fold_left
+           (fun checks id -> Ident.Map.add id zero_alloc checks)
+           checks ids
          (* CR ccasinghino: To keep the zero-alloc annotation info aliases, it
             may be enough to copy it if the vb_expr is an ident. *)
        | _ -> checks

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -54,7 +54,7 @@ exception Error of Location.t * error
 let scrape_ty env ty =
   let ty =
     match get_desc ty with
-    | Tpoly(ty, _) -> ty
+    | Tpoly(ty, _, _) -> ty
     | _ -> ty
   in
   match get_desc ty with
@@ -85,7 +85,7 @@ let scrape env ty =
 let scrape_poly env ty =
   let ty = scrape_ty env ty in
   match get_desc ty with
-  | Tpoly (ty, _) -> get_desc ty
+  | Tpoly (ty, _, _) -> get_desc ty
   | d -> d
 
 let is_function_type env ty =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -160,7 +160,7 @@ and type_desc =
   | Tsubst of type_expr * type_expr option
   | Tvariant of row_desc
   | Tunivar of { name : string option; jkind : jkind_lr }
-  | Tpoly of type_expr * type_expr list
+  | Tpoly of type_expr * type_expr list * Zero_alloc.check option
   | Trepr of type_expr * Jkind_types.Sort.univar list
   | Tpackage of Path.t * (Longident.t * type_expr) list
   | Tof_kind of jkind_lr
@@ -1434,7 +1434,7 @@ let best_effort_compare_type_expr te1 te2 =
         | Ttuple _ -> 2
         | Tunboxed_tuple _ -> 3
         | Tconstr (_, _, _) -> 5
-        | Tpoly (_, _) -> 6
+        | Tpoly (_, _, _) -> 6
         | Tof_kind _ -> 7
         | Trepr (_, _) -> 8
         (* Types we should never see *)
@@ -1455,10 +1455,21 @@ let best_effort_compare_type_expr te1 te2 =
         if p = 0
         then List.compare (aux (depth + 1)) args1 args2
         else p
-      | Tpoly (t1, ts1), Tpoly (t2, ts2) ->
+      | Tpoly (t1, ts1, za1), Tpoly (t2, ts2, za2) ->
         (* NOTE: this is mostly broken according to the semantics of type_expr, but probably
-           fine for the particular "best-effort" comparison we want. *)
-        List.compare (aux (depth + 1)) (t1 :: ts1) (t2 :: ts2)
+           fine for the particular "best-effort" comparison we want.
+           It likewise does not correctly account for zero_alloc information. *)
+        let cmp =
+          List.compare (aux (depth + 1)) (t1 :: ts1) (t2 :: ts2)
+        in
+        if cmp <> 0
+        then cmp
+        else
+          (match za1, za2 with
+           | None, None -> 0
+           | None, Some _ -> -1
+           | Some _, None -> 1
+           | Some _, Some _ -> 0)
       | Trepr (t1, sort_vars1), Trepr (t2, sort_vars2) ->
         (* Compare by establishing correspondence between univars and comparing
            the inner types with that correspondence. *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -242,10 +242,13 @@ and type_desc =
   (** Occurrence of a type variable introduced by a
       forall quantifier / [Tpoly]. *)
 
-  | Tpoly of type_expr * type_expr list
-  (** [Tpoly (ty,tyl)] ==> ['a1... 'an. ty],
+  | Tpoly of type_expr * type_expr list * Zero_alloc.check option
+  (** [Tpoly (ty,tyl,za)] ==> ['a1... 'an. ty],
       where 'a1 ... 'an are names given to types in tyl
-      and occurrences of those types in ty. *)
+      and occurrences of those types in ty;
+      za is relevant when placed on a function parameter, where it states
+      zero_alloc assumption when used in the function body and expectations
+      on the actual parameter *)
 
   | Trepr of type_expr * Jkind_types.Sort.univar list
   (** [Trepr (ty, sl)] represents layout polymorphism (from [repr_] syntax).

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -262,8 +262,9 @@ and type_desc =
       the same sort univars in different orders represent incompatible types.
 
       Example: [(repr_ 'a) (repr_ 'b). 'a -> 'b] translates to
-      [Trepr (Tpoly ('a -> 'b, ['a; 'b]), [s1; s2])] where [s1] and [s2] are
-      sort univars that appear in the jkinds of ['a] and ['b] respectively. *)
+      [Trepr (Tpoly ('a -> 'b, ['a; 'b], None), [s1; s2])] where [s1] and [s2]
+      are sort univars that appear in the jkinds of ['a] and ['b] respectively.
+  *)
 
 
   | Tpackage of Path.t * (Longident.t * type_expr) list

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -885,26 +885,40 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             | _ :: _ ->
               { mode_modes = acc_mode; mode_desc = [] }
           in
-          let default_arity = Ctype.arity arg_cty.ctyp_type in
-          let za =
-            Builtin_attributes.get_zero_alloc_attribute
-              ~in_signature:false
-              ~on_application:false
-              ~on_function_argument:true
-              ~default_arity
-              arg_cty.ctyp_attributes
-          in
+          let fun_arity = Ctype.arity arg_cty.ctyp_type in
           let zero_alloc =
-            match za with
-            | Check {arity; _} when arity = 0 || default_arity = 0 ->
-              raise (Error (loc, env, Zero_alloc_attr_non_function))
-            | Check {arity; _} when arity <> default_arity ->
-              raise (Error (loc, env,
-                            Zero_alloc_arity_mismatch (arity, default_arity)))
-            | Check za -> Some za
-            | Assume _ ->
-              raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
-            | Ignore_assert_all | Default_zero_alloc -> None
+            if fun_arity = 0 then
+              let za =
+                Builtin_attributes.get_zero_alloc_attribute
+                  ~in_signature:false
+                  ~on_application:false
+                  ~on_function_argument:false
+                  ~default_arity:None
+                  arg_cty.ctyp_attributes
+              in
+              (match za with
+              | Check _ ->
+                raise (Error (loc, env, Zero_alloc_attr_non_function))
+              | Assume _ ->
+                raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+              | Ignore_assert_all | Default_zero_alloc -> None)
+            else
+              let za =
+                Builtin_attributes.get_zero_alloc_attribute
+                  ~in_signature:false
+                  ~on_application:false
+                  ~on_function_argument:true
+                  ~default_arity:(Some fun_arity)
+                  arg_cty.ctyp_attributes
+              in
+              (match za with
+              | Check {arity; _} when fun_arity <> arity ->
+                raise (Error (loc, env,
+                              Zero_alloc_arity_mismatch (arity, fun_arity)))
+              | Check za -> Some za
+              | Assume _ ->
+                raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+              | Ignore_assert_all | Default_zero_alloc -> None)
           in
           let ret_cty = loop acc_mode rest in
           let arg_ty = arg_cty.ctyp_type in
@@ -1187,12 +1201,22 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         | Ptyp_arrow _ -> true
         | _ -> false
       in
+      let default_arity =
+        if on_function_argument then
+          let rec count_arrows = function
+            | Ptyp_arrow (_, _, st, _, _) -> 1 + count_arrows st.ptyp_desc
+            | _ -> 0
+          in
+          Some (count_arrows st.ptyp_desc)
+        else
+          None
+      in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute
           ~in_signature:false
           ~on_application:false
           ~on_function_argument
-          ~default_arity:0
+          ~default_arity
           styp.ptyp_attributes
       in
       let zero_alloc =
@@ -1202,8 +1226,6 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
           | Assume _ ->
             raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
           | Default_zero_alloc | Ignore_assert_all -> None
-          (* arity=0 means no explicit arity; will be inferred in
-             transl_type_poly *)
           | Check check -> Some check
         end
       in
@@ -1341,40 +1363,47 @@ and transl_type_poly env ~policy ~row_context ~zero_alloc mode loc vars st =
       ~post:(fun (_,_,cty) -> generalize_ctyp cty)
   in
   let ty = cty.ctyp_type in
-  let default_arity = Ctype.arity ty in
-  (* Validate and resolve a zero_alloc check against the inner type.
-     arity=0 in the check means "no explicit arity was given"; we infer it
-     from the inner type.  A non-zero arity must match exactly. *)
+  let fun_arity = Ctype.arity ty in
   let resolve_check err_loc (check : Zero_alloc.check) =
-    let arity =
-      if check.arity = 0 then default_arity
-      else check.arity
-    in
-    if arity = 0 then
-      raise (Error (err_loc, env, Zero_alloc_attr_non_function))
-    else if arity <> default_arity then
+    if check.arity <> fun_arity then
       raise (Error (err_loc, env,
-        Zero_alloc_arity_mismatch (arity, default_arity)))
+        Zero_alloc_arity_mismatch (check.arity, fun_arity)))
     else
-      Some { check with arity }
+      Some check
   in
   let zero_alloc =
     match zero_alloc with
     | Some check -> resolve_check loc check
     | None ->
-      let za =
-        Builtin_attributes.get_zero_alloc_attribute
-          ~in_signature:false
-          ~on_application:false
-          ~on_function_argument:true
-          ~default_arity
-          st.ptyp_attributes
-      in
-      match za with
-      | Check check -> resolve_check st.ptyp_loc check
-      | Assume _ ->
-        raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
-      | Ignore_assert_all | Default_zero_alloc -> None
+      if fun_arity = 0 then
+        let za =
+          Builtin_attributes.get_zero_alloc_attribute
+            ~in_signature:false
+            ~on_application:false
+            ~on_function_argument:false
+            ~default_arity:None
+            st.ptyp_attributes
+        in
+        (match za with
+        | Check _ ->
+          raise (Error (st.ptyp_loc, env, Zero_alloc_attr_non_function))
+        | Assume _ ->
+          raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
+        | Ignore_assert_all | Default_zero_alloc -> None)
+      else
+        let za =
+          Builtin_attributes.get_zero_alloc_attribute
+            ~in_signature:false
+            ~on_application:false
+            ~on_function_argument:true
+            ~default_arity:(Some fun_arity)
+            st.ptyp_attributes
+        in
+        (match za with
+        | Check check -> resolve_check st.ptyp_loc check
+        | Assume _ ->
+          raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
+        | Ignore_assert_all | Default_zero_alloc -> None)
   in
   let ty_list = TyVarEnv.check_poly_univars env loc new_univars in
   let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -885,34 +885,32 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             | _ :: _ ->
               { mode_modes = acc_mode; mode_desc = [] }
           in
+          let default_arity = Ctype.arity arg_cty.ctyp_type in
+          let za =
+            Builtin_attributes.get_zero_alloc_attribute
+              ~in_signature:false
+              ~on_application:false
+              ~on_function_argument:true
+              ~default_arity
+              arg_cty.ctyp_attributes
+          in
           let zero_alloc =
-            match Types.get_desc arg_cty.ctyp_type with
-            | Tpoly (_, _, zero_alloc) -> zero_alloc
-            | _ ->
-              let default_arity = Ctype.arity arg_cty.ctyp_type in
-              let za =
-                Builtin_attributes.get_zero_alloc_attribute
-                  ~in_signature:false
-                  ~on_application:false
-                  ~on_function_argument:true
-                  ~default_arity
-                  arg_cty.ctyp_attributes
-              in
-              match za with
-              | Check {arity; _} when arity = 0 || default_arity = 0 ->
-                raise (Error (loc, env, Zero_alloc_attr_non_function))
-              | Check {arity; _} when arity <> default_arity ->
-                raise (Error (loc, env,
-                  Zero_alloc_arity_mismatch (arity, default_arity)))
-              | Check za -> Some za
-              | Assume _ ->
-                raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
-              | Ignore_assert_all | Default_zero_alloc -> None
+            match za with
+            | Check {arity; _} when arity = 0 || default_arity = 0 ->
+              raise (Error (loc, env, Zero_alloc_attr_non_function))
+            | Check {arity; _} when arity <> default_arity ->
+              raise (Error (loc, env,
+                            Zero_alloc_arity_mismatch (arity, default_arity)))
+            | Check za -> Some za
+            | Assume _ ->
+              raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+            | Ignore_assert_all | Default_zero_alloc -> None
           in
           let ret_cty = loop acc_mode rest in
           let arg_ty = arg_cty.ctyp_type in
           let arg_ty =
-            if Btype.is_Tpoly arg_ty then arg_ty else newmono ~zero_alloc arg_ty
+            if Btype.is_Tpoly arg_ty then arg_ty
+            else newty (Tpoly(arg_ty, [], zero_alloc))
           in
           let arg_ty =
             if not (Btype.is_optional l) then arg_ty
@@ -921,7 +919,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 raise (Error (arg.ptyp_loc, env, Zero_alloc_on_optional_param));
               if not (Btype.tpoly_is_mono arg_ty) then
                 raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
-              newmono ~zero_alloc:None
+              newmono
                 (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
             end
           in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -106,6 +106,11 @@ type error =
   | Mismatched_jkind_annotation of
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
+  | Must_provide_zero_alloc_arity
+  | Invalid_payload_arg_zero_alloc
+  | Zero_alloc_on_optional_param
+  | Zero_alloc_attr_non_function
+  | Zero_alloc_arity_mismatch of int * int
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -880,17 +885,41 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             | _ :: _ ->
               { mode_modes = acc_mode; mode_desc = [] }
           in
+          let zero_alloc =
+            match Types.get_desc arg_cty.ctyp_type with
+            | Tpoly (_, _, zero_alloc) -> zero_alloc
+            | _ ->
+              let default_arity = Ctype.arity arg_cty.ctyp_type in
+              let za =
+                Builtin_attributes.get_zero_alloc_attribute
+                  ~in_signature:false
+                  ~on_application:false
+                  ~on_function_argument:true
+                  ~default_arity
+                  arg_cty.ctyp_attributes
+              in
+              match za with
+              | Check {arity; _} when arity = 0 || default_arity = 0 ->
+                raise (Error (loc, env, Zero_alloc_attr_non_function))
+              | Check {arity; _} when arity <> default_arity ->
+                raise (Error (loc, env, Zero_alloc_arity_mismatch (arity, default_arity)))
+              | Check za -> Some za
+              | Assume _ -> raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+              | Ignore_assert_all | Default_zero_alloc -> None
+          in
           let ret_cty = loop acc_mode rest in
           let arg_ty = arg_cty.ctyp_type in
           let arg_ty =
-            if Btype.is_Tpoly arg_ty then arg_ty else newmono arg_ty
+            if Btype.is_Tpoly arg_ty then arg_ty else newmono ~zero_alloc arg_ty
           in
           let arg_ty =
             if not (Btype.is_optional l) then arg_ty
             else begin
+              if Option.is_some zero_alloc then
+                raise (Error (arg.ptyp_loc, env, Zero_alloc_on_optional_param));
               if not (Btype.tpoly_is_mono arg_ty) then
                 raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
-              newmono
+              newmono ~zero_alloc:None
                 (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
             end
           in
@@ -1153,8 +1182,31 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let ty = newty (Tvariant (make_row more)) in
       ctyp (Ttyp_variant (tfields, closed, present)) ty
   | Ptyp_poly(vars, st) ->
+      let on_function_argument =
+        match st.ptyp_desc with
+        | Ptyp_arrow _ -> true
+        | _ -> false
+      in
+      let zero_alloc =
+        Builtin_attributes.get_zero_alloc_attribute
+          ~in_signature:false
+          ~on_application:false
+          ~on_function_argument
+          ~default_arity:0
+          styp.ptyp_attributes
+      in
+      let zero_alloc =
+        begin
+          let open Builtin_attributes in
+          match zero_alloc with
+          | Assume _ ->  raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+          | Default_zero_alloc | Ignore_assert_all -> None
+          (* arity=0 means no explicit arity; will be inferred in transl_type_poly *)
+          | Check check -> Some check
+        end
+      in
       let desc, typ =
-        transl_type_poly env ~policy ~row_context mode styp.ptyp_loc
+        transl_type_poly env ~policy ~row_context ~zero_alloc mode styp.ptyp_loc
           vars st
       in
       ctyp desc typ
@@ -1163,7 +1215,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         Language_extension.Alpha;
       Env.check_no_open_quotations loc env Layout_polymorphism_qt;
       let desc, typ =
-        transl_type_repr env ~policy ~row_context mode styp.ptyp_loc
+        transl_type_repr env ~policy ~row_context ~zero_alloc:None mode styp.ptyp_loc
           vars st
       in
       ctyp desc typ
@@ -1273,7 +1325,7 @@ and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
   in
   Ttyp_var (Some name, jkind_annot), ty
 
-and transl_type_poly env ~policy ~row_context mode loc vars st =
+and transl_type_poly env ~policy ~row_context ~zero_alloc mode loc vars st =
   let typed_vars, new_univars, cty =
     with_local_level begin fun () ->
       let vars = List.map (fun (n, v) -> (n, v, Env.stage env)) vars in
@@ -1287,13 +1339,47 @@ and transl_type_poly env ~policy ~row_context mode loc vars st =
       ~post:(fun (_,_,cty) -> generalize_ctyp cty)
   in
   let ty = cty.ctyp_type in
+  let default_arity = Ctype.arity ty in
+  (* Validate and resolve a zero_alloc check against the inner type.
+     arity=0 in the check means "no explicit arity was given"; we infer it
+     from the inner type.  A non-zero arity must match exactly. *)
+  let resolve_check err_loc (check : Zero_alloc.check) =
+    let arity =
+      if check.arity = 0 then default_arity
+      else check.arity
+    in
+    if arity = 0 then
+      raise (Error (err_loc, env, Zero_alloc_attr_non_function))
+    else if arity <> default_arity then
+      raise (Error (err_loc, env, Zero_alloc_arity_mismatch (arity, default_arity)))
+    else
+      Some { check with arity }
+  in
+  let zero_alloc =
+    match zero_alloc with
+    | Some check -> resolve_check loc check
+    | None ->
+      let za =
+        Builtin_attributes.get_zero_alloc_attribute
+          ~in_signature:false
+          ~on_application:false
+          ~on_function_argument:true
+          ~default_arity
+          st.ptyp_attributes
+      in
+      match za with
+      | Check check -> resolve_check st.ptyp_loc check
+      | Assume _ ->
+        raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
+      | Ignore_assert_all | Default_zero_alloc -> None
+  in
   let ty_list = TyVarEnv.check_poly_univars env loc new_univars in
   let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
-  let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
+  let ty' = Btype.newgenty (Tpoly(ty, ty_list, zero_alloc)) in
   unify_var env (newvar (Jkind.Builtin.any ~why:Dummy_jkind)) ty';
   Ttyp_poly (typed_vars, cty), ty'
 
-and transl_type_repr env ~policy ~row_context mode loc vars st =
+and transl_type_repr env ~policy ~row_context ~zero_alloc mode loc vars st =
   let sort_vars, new_univars, cty =
     with_local_level begin fun () ->
       let vars_with_stage = List.map (fun var -> var, Env.stage env) vars in
@@ -1308,7 +1394,7 @@ and transl_type_repr env ~policy ~row_context mode loc vars st =
   let ty = cty.ctyp_type in
   let ty_list = TyVarEnv.check_poly_univars env loc new_univars in
   let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
-  let ty_poly = Btype.newgenty (Tpoly(ty, ty_list)) in
+  let ty_poly = Btype.newgenty (Tpoly(ty, ty_list, zero_alloc)) in
   let ty' = Btype.newgenty (Trepr(ty_poly, sort_vars)) in
   unify_var env (newvar (Jkind.Builtin.any ~why:Dummy_jkind)) ty';
   Ttyp_repr (List.map (fun v -> v.txt) vars, cty), ty'
@@ -1570,7 +1656,7 @@ let transl_simple_type_univars env styp =
   end in
   make_fixed_univars typ.ctyp_type;
     { typ with ctyp_type =
-        instance (Btype.newgenty (Tpoly (typ.ctyp_type, univs))) }
+        instance (Btype.newgenty (Tpoly (typ.ctyp_type, univs, None))) }
 
 let transl_simple_type_delayed env mode styp =
   TyVarEnv.reset_locals ();
@@ -1922,6 +2008,29 @@ let report_error_doc env ppf =
       fprintf ppf
         "@[Layout polymorphism is not supported in term-level type \
          annotations@]"
+  | Must_provide_zero_alloc_arity ->
+    fprintf ppf
+      "Zero-alloc annotations on function arguments must specify arity."
+  | Invalid_payload_arg_zero_alloc ->
+    fprintf ppf
+      "%a is not permitted in %a attributes on function arguments."
+      Style.inline_code "assume"
+      Style.inline_code "zero_alloc"
+  | Zero_alloc_on_optional_param ->
+    fprintf ppf
+      "%a attributes are not supported on optional parameters."
+      Style.inline_code "zero_alloc"
+  | Zero_alloc_attr_non_function ->
+    fprintf ppf
+      "%a attributes on function arguments require the argument@ \
+       to be a function type."
+      Style.inline_code "zero_alloc"
+  | Zero_alloc_arity_mismatch (annotation_arity, type_arity) ->
+    fprintf ppf
+      "The arity in the %a attribute (%d) does not match the@ \
+       number of parameters in the argument type (%d)."
+      Style.inline_code "zero_alloc"
+      annotation_arity type_arity
 
 let () =
   Location.register_error_of_exn

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -106,11 +106,9 @@ type error =
   | Mismatched_jkind_annotation of
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
-  | Must_provide_zero_alloc_arity
   | Invalid_payload_arg_zero_alloc
   | Zero_alloc_on_optional_param
   | Zero_alloc_attr_non_function
-  | Zero_alloc_arity_mismatch of int * int
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -887,38 +885,18 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
           in
           let fun_arity = Ctype.arity arg_cty.ctyp_type in
           let zero_alloc =
-            if fun_arity = 0 then
-              let za =
-                Builtin_attributes.get_zero_alloc_attribute
-                  ~in_signature:false
-                  ~on_application:false
-                  ~on_function_argument:false
-                  ~default_arity:None
-                  arg_cty.ctyp_attributes
-              in
-              (match za with
-              | Check _ ->
-                raise (Error (loc, env, Zero_alloc_attr_non_function))
-              | Assume _ ->
-                raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
-              | Ignore_assert_all | Default_zero_alloc -> None)
-            else
-              let za =
-                Builtin_attributes.get_zero_alloc_attribute
-                  ~in_signature:false
-                  ~on_application:false
-                  ~on_function_argument:true
-                  ~default_arity:(Some fun_arity)
-                  arg_cty.ctyp_attributes
-              in
-              (match za with
-              | Check {arity; _} when fun_arity <> arity ->
-                raise (Error (loc, env,
-                              Zero_alloc_arity_mismatch (arity, fun_arity)))
-              | Check za -> Some za
-              | Assume _ ->
-                raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
-              | Ignore_assert_all | Default_zero_alloc -> None)
+            let za =
+              Builtin_attributes.get_zero_alloc_attribute
+                (Arrow_lhs fun_arity)
+                arg_cty.ctyp_attributes
+            in
+            (match za with
+             | Check _ when fun_arity = 0 ->
+               raise (Error (loc, env, Zero_alloc_attr_non_function))
+             | Check za -> Some za
+             | Assume _ ->
+               raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+             | Ignore_assert_all | Default_zero_alloc -> None)
           in
           let ret_cty = loop acc_mode rest in
           let arg_ty = arg_cty.ctyp_type in
@@ -1196,28 +1174,13 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let ty = newty (Tvariant (make_row more)) in
       ctyp (Ttyp_variant (tfields, closed, present)) ty
   | Ptyp_poly(vars, st) ->
-      let on_function_argument =
-        match st.ptyp_desc with
-        | Ptyp_arrow _ -> true
-        | _ -> false
-      in
-      let default_arity =
-        if on_function_argument then
-          let rec count_arrows = function
-            | Ptyp_arrow (_, _, st, _, _) -> 1 + count_arrows st.ptyp_desc
-            | _ -> 0
-          in
-          Some (count_arrows st.ptyp_desc)
-        else
-          None
+      let rec count_arrows = function
+        | Ptyp_arrow (_, _, st, _, _) -> 1 + count_arrows st.ptyp_desc
+        | _ -> 0
       in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute
-          ~in_signature:false
-          ~on_application:false
-          ~on_function_argument
-          ~default_arity
-          styp.ptyp_attributes
+          (Arrow_lhs (count_arrows st.ptyp_desc)) styp.ptyp_attributes
       in
       let zero_alloc =
         begin
@@ -1365,9 +1328,8 @@ and transl_type_poly env ~policy ~row_context ~zero_alloc mode loc vars st =
   let ty = cty.ctyp_type in
   let fun_arity = Ctype.arity ty in
   let resolve_check err_loc (check : Zero_alloc.check) =
-    if check.arity <> fun_arity then
-      raise (Error (err_loc, env,
-        Zero_alloc_arity_mismatch (check.arity, fun_arity)))
+    if fun_arity = 0 then
+      raise (Error (err_loc, env, Zero_alloc_attr_non_function))
     else
       Some check
   in
@@ -1375,35 +1337,16 @@ and transl_type_poly env ~policy ~row_context ~zero_alloc mode loc vars st =
     match zero_alloc with
     | Some check -> resolve_check loc check
     | None ->
-      if fun_arity = 0 then
-        let za =
-          Builtin_attributes.get_zero_alloc_attribute
-            ~in_signature:false
-            ~on_application:false
-            ~on_function_argument:false
-            ~default_arity:None
-            st.ptyp_attributes
-        in
-        (match za with
-        | Check _ ->
-          raise (Error (st.ptyp_loc, env, Zero_alloc_attr_non_function))
-        | Assume _ ->
-          raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
-        | Ignore_assert_all | Default_zero_alloc -> None)
-      else
-        let za =
-          Builtin_attributes.get_zero_alloc_attribute
-            ~in_signature:false
-            ~on_application:false
-            ~on_function_argument:true
-            ~default_arity:(Some fun_arity)
-            st.ptyp_attributes
-        in
-        (match za with
-        | Check check -> resolve_check st.ptyp_loc check
-        | Assume _ ->
-          raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
-        | Ignore_assert_all | Default_zero_alloc -> None)
+      let za =
+        Builtin_attributes.get_zero_alloc_attribute
+          (Arrow_lhs fun_arity)
+          st.ptyp_attributes
+      in
+      (match za with
+       | Check check -> resolve_check st.ptyp_loc check
+       | Assume _ ->
+         raise (Error (st.ptyp_loc, env, Invalid_payload_arg_zero_alloc))
+       | Ignore_assert_all | Default_zero_alloc -> None)
   in
   let ty_list = TyVarEnv.check_poly_univars env loc new_univars in
   let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
@@ -2040,9 +1983,6 @@ let report_error_doc env ppf =
       fprintf ppf
         "@[Layout polymorphism is not supported in term-level type \
          annotations@]"
-  | Must_provide_zero_alloc_arity ->
-    fprintf ppf
-      "Zero-alloc annotations on function arguments must specify arity."
   | Invalid_payload_arg_zero_alloc ->
     fprintf ppf
       "%a is not permitted in %a attributes on function arguments."
@@ -2057,12 +1997,6 @@ let report_error_doc env ppf =
       "%a attributes on function arguments require the argument@ \
        to be a function type."
       Style.inline_code "zero_alloc"
-  | Zero_alloc_arity_mismatch (annotation_arity, type_arity) ->
-    fprintf ppf
-      "The arity in the %a attribute (%d) does not match the@ \
-       number of parameters in the argument type (%d)."
-      Style.inline_code "zero_alloc"
-      annotation_arity type_arity
 
 let () =
   Location.register_error_of_exn

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -902,9 +902,11 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               | Check {arity; _} when arity = 0 || default_arity = 0 ->
                 raise (Error (loc, env, Zero_alloc_attr_non_function))
               | Check {arity; _} when arity <> default_arity ->
-                raise (Error (loc, env, Zero_alloc_arity_mismatch (arity, default_arity)))
+                raise (Error (loc, env,
+                  Zero_alloc_arity_mismatch (arity, default_arity)))
               | Check za -> Some za
-              | Assume _ -> raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+              | Assume _ ->
+                raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
               | Ignore_assert_all | Default_zero_alloc -> None
           in
           let ret_cty = loop acc_mode rest in
@@ -1199,9 +1201,11 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         begin
           let open Builtin_attributes in
           match zero_alloc with
-          | Assume _ ->  raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
+          | Assume _ ->
+            raise (Error (loc, env, Invalid_payload_arg_zero_alloc))
           | Default_zero_alloc | Ignore_assert_all -> None
-          (* arity=0 means no explicit arity; will be inferred in transl_type_poly *)
+          (* arity=0 means no explicit arity; will be inferred in
+             transl_type_poly *)
           | Check check -> Some check
         end
       in
@@ -1215,8 +1219,8 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         Language_extension.Alpha;
       Env.check_no_open_quotations loc env Layout_polymorphism_qt;
       let desc, typ =
-        transl_type_repr env ~policy ~row_context ~zero_alloc:None mode styp.ptyp_loc
-          vars st
+        transl_type_repr env ~policy ~row_context ~zero_alloc:None
+          mode styp.ptyp_loc vars st
       in
       ctyp desc typ
   | Ptyp_newlayout _ ->
@@ -1351,7 +1355,8 @@ and transl_type_poly env ~policy ~row_context ~zero_alloc mode loc vars st =
     if arity = 0 then
       raise (Error (err_loc, env, Zero_alloc_attr_non_function))
     else if arity <> default_arity then
-      raise (Error (err_loc, env, Zero_alloc_arity_mismatch (arity, default_arity)))
+      raise (Error (err_loc, env,
+        Zero_alloc_arity_mismatch (arity, default_arity)))
     else
       Some { check with arity }
   in

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -196,6 +196,11 @@ type error =
   | Mismatched_jkind_annotation of
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
+  | Must_provide_zero_alloc_arity
+  | Invalid_payload_arg_zero_alloc
+  | Zero_alloc_on_optional_param
+  | Zero_alloc_attr_non_function
+  | Zero_alloc_arity_mismatch of int * int
 
 exception Error of Location.t * Env.t * error
 

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -196,11 +196,9 @@ type error =
   | Mismatched_jkind_annotation of
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
-  | Must_provide_zero_alloc_arity
   | Invalid_payload_arg_zero_alloc
   | Zero_alloc_on_optional_param
   | Zero_alloc_attr_non_function
-  | Zero_alloc_arity_mismatch of int * int
 
 exception Error of Location.t * Env.t * error
 

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -70,7 +70,7 @@ let rec batch_add_subst args vals subst =
    links, and [@@unboxed] types. The returned type will therefore be none
    of these cases (except in case of missing cmis). *)
 let scrape_ty env ty =
-  let ty = match get_desc ty with Tpoly (ty, _) -> ty | _ -> ty in
+  let ty = match get_desc ty with Tpoly (ty, _, _) -> ty | _ -> ty in
   match get_desc ty with
   | Tconstr _ -> (
     let ty = Ctype.correct_levels ty in
@@ -86,7 +86,7 @@ let scrape_ty env ty =
 
 let scrape_poly env ty =
   let ty = scrape_ty env ty in
-  match get_desc ty with Tpoly (ty, _) -> get_desc ty | d -> d
+  match get_desc ty with Tpoly (ty, _, _) -> get_desc ty | d -> d
 
 type classification =
   | Int (* any immediate type *)

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -83,9 +83,26 @@ let get (t : t) =
     | Some { strict; opt; custom_error_msg; } ->
       Check { loc; arity; strict; opt; custom_error_msg }
 
+type check_context =
+  | Signature
+  | Fun_param
+  | Default
+
+type incompatible_check =
+  | Strict
+  | Opt
+
 type error =
   | Less_general of { missing_entirely : bool }
-  | Arity_mismatch of int * int
+  | Arity_mismatch of int * int * check_context
+  | Incompatible of incompatible_check
+  | One_missing
+
+let one_missing = One_missing
+
+let error_is_arity_mismatch = function
+  | Less_general _ | Incompatible _ | One_missing -> false
+  | Arity_mismatch _ -> true
 
 exception Error of error
 
@@ -96,14 +113,35 @@ let print_error ppf error =
     pr "The former provides a weaker \"zero_alloc\" guarantee than the latter.";
     if missing_entirely then
       pr "@ Hint: Add a \"zero_alloc\" attribute to the implementation."
-  | Arity_mismatch (n1, n2) ->
+  | Incompatible check_type ->
+    pr "There is a mismatch between the two \"zero_alloc\" assumptions:@ \
+        the \"%s\" payloads need to match exactly."
+      (match check_type with
+       | Strict -> "strict"
+       | Opt -> "opt")
+  | Arity_mismatch (n1, n2, Signature) ->
     pr "zero_alloc arity mismatch:@ \
-        When using \"zero_alloc\" in a signature, the syntactic arity of@ \
-        the implementation must match the function type in the interface.@ \
+        When using \"zero_alloc\" in a signature, the@ \
+        syntactic arity of the implementation must match the function type in@ \
+        the interface.@ \
         Here the former is %d and the latter is %d."
       n1 n2
+  | Arity_mismatch (n1, n2, Fun_param) ->
+    pr "When using \"zero_alloc\" on function parameters, the arities in the@ \
+        type of the function and the parameter term mus match exactly.@ \
+        Here the arity in the actual parameter term is %d and the arity in@ \
+        the type of the function is %d."
+      n1 n2
+  | Arity_mismatch (n1, n2, Default) ->
+    pr "Inconsistent \"zero_alloc\" arity properties: seen both %d and %d.@ \
+        This error should never be reported in this context.@ \
+        Contact the OxCaml development team and report a bug."
+      n1 n2
+  | One_missing ->
+    pr "The two types must agree on \"zero_alloc\": \
+        either both carry the annotation or neither does."
 
-let sub_const_const_exn za1 za2 =
+let sub_const_const_exn ~context za1 za2 =
   (* The core of the check here is that we translate both attributes into the
      abstract domain and use the existing inclusion check from there, ensuring
      what we do in the typechecker matches the backend.
@@ -160,7 +198,7 @@ let sub_const_const_exn za1 za2 =
   | Some arity1, Some arity2 ->
     (* Check *)
     if not (arity1 = arity2) then
-      raise (Error (Arity_mismatch (arity1, arity2)))
+      raise (Error (Arity_mismatch (arity1, arity2, context)))
   | Some _, None -> ()
     (* Forgetting zero_alloc info is fine *)
   | None, Some _ ->
@@ -168,14 +206,14 @@ let sub_const_const_exn za1 za2 =
     Misc.fatal_error "Zero_alloc: sub_const_exn"
   | None, None -> ()
 
-let sub_var_const_exn v c =
+let sub_var_const_exn ~context v c =
   (* This can only fail due to an arity mismatch. We have a linear order and can
      always constrain the var lower to make the sub succeed. *)
   match v, c with
   | _, (Default_zero_alloc | Ignore_assert_all | Assume _) -> assert false
   | { arity = arity1; _ }, Check { arity = arity2; _ }
     when arity1 <> arity2 ->
-    raise (Error (Arity_mismatch (arity1, arity2)))
+    raise (Error (Arity_mismatch (arity1, arity2, context)))
   | { desc = None; _ }, Check { strict; opt; custom_error_msg;  } ->
     !log_change (None, v);
     v.desc <- Some { strict; opt; custom_error_msg }
@@ -200,7 +238,7 @@ let sub_var_const_exn v c =
       v.desc <- Some { strict; opt; custom_error_msg; }
     end
 
-let sub_exn za1 za2 =
+let sub_exn ~context za1 za2 =
   match za1, za2 with
   | _, Var _ ->
     (* A fully inferred signature will never have a variable in it, so we almost
@@ -216,16 +254,38 @@ let sub_exn za1 za2 =
        event).
     *)
     if not (za1 == za2) then
-      Misc.fatal_error "zero_alloc: variable constraint"
+      Misc.fatal_error "zero_alloc sub: variable constraint"
   | _, Const (Assume _) ->
-    Misc.fatal_error "zero_alloc: invalid constraint"
+    Misc.fatal_error "zero_alloc sub: invalid constraint"
   | _, (Const (Default_zero_alloc | Ignore_assert_all)) -> ()
-  | Var v, Const c -> sub_var_const_exn v c
-  | Const c1, Const c2 -> sub_const_const_exn c1 c2
+  | Var v, Const c -> sub_var_const_exn ~context v c
+  | Const c1, Const c2 -> sub_const_const_exn ~context c1 c2
 
-let sub za1 za2 =
+let sub ~context za1 za2 =
   try
-    sub_exn za1 za2;
+    sub_exn ~context za1 za2;
+    Ok ()
+  with
+  | Error e -> Result.Error e
+
+let check_payload_to_string ?(apparent_arity = -1) ({strict; opt; arity; _} : check) =
+  String.concat ""
+    [ if strict then " strict" else "";
+      if opt then " opt" else "";
+      if arity = apparent_arity then "" else Printf.sprintf " arity %d" arity;
+    ]
+
+let assert_equal_checks
+      ~context
+      {arity = arity1; opt = opt1; strict = strict1; _}
+      {arity = arity2; opt = opt2; strict = strict2; _} =
+  try
+    if arity1 <> arity2 then
+      raise (Error (Arity_mismatch (arity1, arity2, context)));
+    if strict1 <> strict2 then
+      raise (Error (Incompatible Strict));
+    if opt1 <> opt2 then
+      raise (Error (Incompatible Opt));
     Ok ()
   with
   | Error e -> Result.Error e

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -268,7 +268,8 @@ let sub ~context za1 za2 =
   with
   | Error e -> Result.Error e
 
-let check_payload_to_string ?(apparent_arity = -1) ({strict; opt; arity; _} : check) =
+let check_payload_to_string ?(apparent_arity = -1)
+    ({strict; opt; arity; _} : check) =
   String.concat ""
     [ if strict then " strict" else "";
       if opt then " opt" else "";

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -83,6 +83,10 @@ let get (t : t) =
     | Some { strict; opt; custom_error_msg; } ->
       Check { loc; arity; strict; opt; custom_error_msg }
 
+let is_default_const = function
+  | Const Default_zero_alloc -> true
+  | Const (Ignore_assert_all | Check _ | Assume _) | Var _ -> false
+
 type check_context =
   | Signature
   | Fun_param
@@ -110,6 +114,8 @@ let error_is_arity_mismatch = function
 
 exception Error of error
 
+let one_missing = One_missing
+
 let print_error ppf error =
   let pr fmt = Format_doc.fprintf ppf fmt in
   match error with
@@ -123,12 +129,12 @@ let print_error ppf error =
      | Fun_param ->
        pr "@ Hint: Add a \"zero_alloc\" attribute to the argument's definition."
      | Type_constraint | Default -> ())
-  | Less_general (Parameter_requirement check_type) ->
-    pr "The argument's \"zero_alloc\" property is required to be \"%s\",@ \
+  | Less_general (Parameter_requirement Strict) ->
+    pr "The argument's \"zero_alloc\" property is required to be \"strict\",@ \
         but this function is not."
-      (match check_type with
-       | Strict -> "strict"
-       | Opt -> "opt")
+  | Less_general (Parameter_requirement Opt) ->
+    pr "The argument's \"zero_alloc\" check is \"opt\", but the parameter@ \
+        requires a non-\"opt\" check."
   | Incompatible check_type ->
     pr "There is a mismatch between the two \"zero_alloc\" assumptions:@ \
         the \"%s\" payloads need to match exactly."

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -137,9 +137,8 @@ let print_error ppf error =
        | Opt -> "opt")
   | Arity_mismatch (n1, n2, Signature) ->
     pr "zero_alloc arity mismatch:@ \
-        When using \"zero_alloc\" in a signature, the@ \
-        syntactic arity of the implementation must match the function type in@ \
-        the interface.@ \
+        When using \"zero_alloc\" in a signature, the syntactic arity of@ \
+        the implementation must match the function type in the interface.@ \
         Here the former is %d and the latter is %d."
       n1 n2
   | Arity_mismatch (n1, n2, Type_constraint) ->
@@ -148,7 +147,10 @@ let print_error ppf error =
         Here the arity in the actual parameter term is %d and the arity in@ \
         the type of the function is %d."
       n1 n2
-  | Arity_mismatch (n1, n2, Fun_param)
+  | Arity_mismatch (n1, n2, Fun_param) ->
+    pr "Inconsistent \"zero_alloc\" arity payload for a function parameter:@ \
+        the implementation specifies %d, but it is constrained to be %d."
+      n1 n2
   | Arity_mismatch (n1, n2, Default) ->
     pr "Inconsistent \"zero_alloc\" arity properties: seen both %d and %d.@ \
         This error should never be reported in this context.@ \

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -86,19 +86,23 @@ let get (t : t) =
 type check_context =
   | Signature
   | Fun_param
+  | Type_constraint
   | Default
 
 type incompatible_check =
   | Strict
   | Opt
 
+type less_general =
+  | Missing_entirely of check_context
+  | Parameter_requirement of incompatible_check
+  | Other
+
 type error =
-  | Less_general of { missing_entirely : bool }
+  | Less_general of less_general
   | Arity_mismatch of int * int * check_context
   | Incompatible of incompatible_check
   | One_missing
-
-let one_missing = One_missing
 
 let error_is_arity_mismatch = function
   | Less_general _ | Incompatible _ | One_missing -> false
@@ -109,10 +113,22 @@ exception Error of error
 let print_error ppf error =
   let pr fmt = Format_doc.fprintf ppf fmt in
   match error with
-  | Less_general { missing_entirely } ->
+  | Less_general Other ->
+    pr "The former provides a weaker \"zero_alloc\" guarantee than the latter."
+  | Less_general (Missing_entirely context) ->
     pr "The former provides a weaker \"zero_alloc\" guarantee than the latter.";
-    if missing_entirely then
-      pr "@ Hint: Add a \"zero_alloc\" attribute to the implementation."
+    (match context with
+     | Signature ->
+       pr "@ Hint: Add a \"zero_alloc\" attribute to the implementation."
+     | Fun_param ->
+       pr "@ Hint: Add a \"zero_alloc\" attribute to the argument's definition."
+     | Type_constraint | Default -> ())
+  | Less_general (Parameter_requirement check_type) ->
+    pr "The argument's \"zero_alloc\" property is required to be \"%s\",@ \
+        but this function is not."
+      (match check_type with
+       | Strict -> "strict"
+       | Opt -> "opt")
   | Incompatible check_type ->
     pr "There is a mismatch between the two \"zero_alloc\" assumptions:@ \
         the \"%s\" payloads need to match exactly."
@@ -126,19 +142,20 @@ let print_error ppf error =
         the interface.@ \
         Here the former is %d and the latter is %d."
       n1 n2
-  | Arity_mismatch (n1, n2, Fun_param) ->
+  | Arity_mismatch (n1, n2, Type_constraint) ->
     pr "When using \"zero_alloc\" on function parameters, the arities in the@ \
-        type of the function and the parameter term mus match exactly.@ \
+        type of the function and the parameter term must match exactly.@ \
         Here the arity in the actual parameter term is %d and the arity in@ \
         the type of the function is %d."
       n1 n2
+  | Arity_mismatch (n1, n2, Fun_param)
   | Arity_mismatch (n1, n2, Default) ->
     pr "Inconsistent \"zero_alloc\" arity properties: seen both %d and %d.@ \
         This error should never be reported in this context.@ \
         Contact the OxCaml development team and report a bug."
       n1 n2
   | One_missing ->
-    pr "The two types must agree on \"zero_alloc\": \
+    pr "The two types must agree on \"zero_alloc\":@ \
         either both carry the annotation or neither does."
 
 let sub_const_const_exn ~context za1 za2 =
@@ -154,9 +171,9 @@ let sub_const_const_exn ~context za1 za2 =
        be fully separate.
      - [arity] is also not captured by the abstract domain - it exists only for
        use here, in typechecking.  If the arities do not match, we issue an
-       error. It's essential for the soundness of the way we (will, in the next
-       PR) use zero_alloc in signatures that the apparent arity of the type in
-       the signature matches the syntactic arity of the function.
+       error. It's essential for the soundness of how zero_alloc is used in
+       signatures that the apparent arity of the type in the signature matches
+       the syntactic arity of the function.
      - [ignore] is erased from structure items when computing their signature.
        On signatures, [ignore] is interpreted as "top" for the inclusion check.
        This interpretation is the same as erasing [ignore]. *)
@@ -180,13 +197,21 @@ let sub_const_const_exn ~context za1 za2 =
         | Default_zero_alloc -> true
         | Ignore_assert_all | Check _ | Assume _ -> false
       in
-      raise (Error (Less_general {missing_entirely}))
+      if missing_entirely then
+        raise (Error (Less_general (Missing_entirely context)))
+      else if context = Fun_param then
+        raise (Error (Less_general (Parameter_requirement Strict)))
+      else
+        raise (Error (Less_general Other))
     end;
   (* opt check *)
   begin match za1, za2 with
   | Check { opt = opt1; _ }, Check { opt = opt2; _ } ->
     if opt1 && not opt2 then
-      raise (Error (Less_general {missing_entirely = false}))
+      if context = Fun_param then
+        raise (Error (Less_general (Parameter_requirement Opt)))
+      else
+        raise (Error (Less_general Other))
   | (Check _ | Default_zero_alloc | Assume _ | Ignore_assert_all), _ -> ()
   end;
   (* arity check *)
@@ -276,7 +301,7 @@ let check_payload_to_string ?(apparent_arity = -1)
       if arity = apparent_arity then "" else Printf.sprintf " arity %d" arity;
     ]
 
-let assert_equal_checks
+let check_equal
       ~context
       {arity = arity1; opt = opt1; strict = strict1; _}
       {arity = arity2; opt = opt2; strict = strict2; _} =
@@ -290,3 +315,9 @@ let assert_equal_checks
     Ok ()
   with
   | Error e -> Result.Error e
+
+let check_option_equal ~context za1 za2 =
+  match za1, za2 with
+  | None, None -> Ok ()
+  | Some _, None | None, Some _ -> Result.Error One_missing
+  | Some c1, Some c2 -> check_equal ~context c1 c2

--- a/typing/zero_alloc.mli
+++ b/typing/zero_alloc.mli
@@ -20,6 +20,11 @@ type const = Builtin_attributes.zero_alloc_attribute =
   | Check of check
   | Assume of assume
 
+type check_context =
+  | Signature
+  | Fun_param
+  | Default
+
 (* This type represents whether or not a function will be checked for
    zero-alloc-ness, and with what configuration (strict, opt, etc). It can be a
    variable which will be filled in when the module the function is in is
@@ -52,11 +57,24 @@ val undo_change : change -> unit
 
 (* These are the errors that may be raised by [sub_exn] below. *)
 type error
+val one_missing : error
+val error_is_arity_mismatch : error -> bool
 val print_error : Format_doc.formatter -> error -> unit
 
-(* [sub t1 t2] checks whether the zero_alloc check t1 is stronger than the
-   zero_alloc check t2. It returns [Ok ()] if so, and [Error e] if not.  If [t1]
-   is a variable, it may be set to make the relation hold. *)
-val sub : t -> t -> (unit, error) Result.t
+(* [sub ~context t1 t2] checks whether the zero_alloc check t1 is stronger than
+   the zero_alloc check t2. It returns [Ok ()] if so, and [Error e] if not.
+   The exact error being reported depends on the context. If [t1] is a variable,
+   it may be set to make the relation hold. *)
+val sub : context:check_context -> t -> t -> (unit, error) Result.t
+
+(* [check_payload_to_string ?apparent_arity c] returns the keyword portion of a
+   zero_alloc check attribute, e.g. [" strict opt arity 2"]. If
+   [~apparent_arity] equals the check's arity, the arity suffix is omitted. *)
+val check_payload_to_string : ?apparent_arity:int -> check -> string
+
+(* [assert_equal_checks ~context t1 t2] checks whether two [check] values are
+   identical. If they are not, an error is reported. *)
+val assert_equal_checks :
+  context:check_context -> check -> check -> (unit, error) Result.t
 
 val debug_printer : Format.formatter -> t -> unit

--- a/typing/zero_alloc.mli
+++ b/typing/zero_alloc.mli
@@ -57,6 +57,12 @@ val create_var : Location.t -> int -> t
    [const] and has no effect. *)
 val get : t -> const
 
+(* True iff [t] is structurally [Const Default_zero_alloc].
+   Unlike [get t = Default_zero_alloc], this returns [false] for a [Var] whose
+   [desc] happens to be [None]; the [Var] still carries information that's worth
+   preserving for later mutation. *)
+val is_default_const : t -> bool
+
 (* For types.ml's backtracking mechanism. *)
 type change
 val set_change_log : (change -> unit) -> unit
@@ -66,6 +72,10 @@ val undo_change : change -> unit
 type error
 val error_is_arity_mismatch : error -> bool
 val print_error : Format_doc.formatter -> error -> unit
+
+(* An [error] indicating that two zero_alloc views should agree but don't:
+   one carries an annotation while the other does not. *)
+val one_missing : error
 
 (* [sub ~context t1 t2] checks whether the zero_alloc check t1 is stronger than
    the zero_alloc check t2. It returns [Ok ()] if so, and [Error e] if not.

--- a/typing/zero_alloc.mli
+++ b/typing/zero_alloc.mli
@@ -22,8 +22,15 @@ type const = Builtin_attributes.zero_alloc_attribute =
 
 type check_context =
   | Signature
+  (* zero_alloc requirements come from a module signature *)
   | Fun_param
+  (* mainly used when type-checking applications;
+     zero_alloc requirements come from a higher-order function being applied to
+     another function *)
+  | Type_constraint
+  (* zero_alloc requirements compared against a type constraint *)
   | Default
+  (* all other contexts *)
 
 (* This type represents whether or not a function will be checked for
    zero-alloc-ness, and with what configuration (strict, opt, etc). It can be a
@@ -57,7 +64,6 @@ val undo_change : change -> unit
 
 (* These are the errors that may be raised by [sub_exn] below. *)
 type error
-val one_missing : error
 val error_is_arity_mismatch : error -> bool
 val print_error : Format_doc.formatter -> error -> unit
 
@@ -72,9 +78,11 @@ val sub : context:check_context -> t -> t -> (unit, error) Result.t
    [~apparent_arity] equals the check's arity, the arity suffix is omitted. *)
 val check_payload_to_string : ?apparent_arity:int -> check -> string
 
-(* [assert_equal_checks ~context t1 t2] checks whether two [check] values are
-   identical. If they are not, an error is reported. *)
-val assert_equal_checks :
-  context:check_context -> check -> check -> (unit, error) Result.t
+(* [check_option_equal ~context c1 c2] checks whether two optional [check]
+   values are identical. Returns an error if one is present and the other is
+   absent, or if both are present but differ. *)
+val check_option_equal :
+  context:check_context -> check option -> check option ->
+  (unit, error) Result.t
 
 val debug_printer : Format.formatter -> t -> unit

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -130,6 +130,7 @@ type t =
   | Tmc_breaks_tailcall                     (* 72 *)
   | Generative_application_expects_unit     (* 73 *)
   (* Oxcaml specific warnings: numbers should go down from 199 *)
+  | Zero_alloc_on_nonfunction               (* 181 *)
   | Untagged_external_small_int_return      (* 182 *)
   | Redundant_kind_modifier of string       (* 183 *)
   | Ignored_kind_modifier of string * string list (* 184 *)
@@ -234,6 +235,7 @@ let number = function
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
   | Generative_application_expects_unit -> 73
+  | Zero_alloc_on_nonfunction -> 181
   | Untagged_external_small_int_return -> 182
   | Redundant_kind_modifier _ -> 183
   | Ignored_kind_modifier _ -> 184
@@ -598,6 +600,11 @@ let descriptions = [
     description = "A generative functor is applied to an empty structure \
                    (struct end) rather than to ().";
     since = since 5 1 };
+  { number = 181;
+    names = ["zero-alloc-on-nonfunction"];
+    description = "A @zero_alloc attribute is placed on a let-binding \
+                   that does not define a function.";
+    since = since 5 2 };
   { number = 182;
     names = ["untagged-external-small-int-return"];
     description = "An external declaration returns an (int8[@untagged]) or \
@@ -1291,6 +1298,9 @@ let message = function
   | Generative_application_expects_unit ->
       "A generative functor\n\
        should be applied to '()'; using '(struct end)' is deprecated."
+  | Zero_alloc_on_nonfunction ->
+      "The [@zero_alloc] attribute has no effect on a non-function binding;\n\
+       rewrite the binding with explicit parameters or remove the attribute."
   | Untagged_external_small_int_return ->
       "Using (int8[@untagged]) or (int16[@untagged]) on C stub returns is not\n\
        recommended since [@untagged] does not perform a sign-extension. Use\n\

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -134,6 +134,7 @@ type t =
   | Tmc_breaks_tailcall                     (* 72 *)
   | Generative_application_expects_unit     (* 73 *)
 (* Oxcaml specific warnings: numbers should go down from 199 *)
+  | Zero_alloc_on_nonfunction               (* 181 *)
   | Untagged_external_small_int_return      (* 182 *)
   | Redundant_kind_modifier of string       (* 183 *)
   | Ignored_kind_modifier of string * string list (* 184 *)


### PR DESCRIPTION
The `zero_alloc` attribute, along with all of the options it supports, is currently only possible to place on a limited number of syntactic categories e.g. value descriptions and function definitions. This pull request adds the ability to place them on arguments of higher-order functions; for example:
```
let[@zero_alloc] f (g [@zero_alloc arity 2]) = g 123 456
```
Function arguments in this case require arities to be stated explicitly. When applying a function that expects a zero-alloc argument, this argument must be either an identifier or a function abstraction; otherwise, a type error is reported. The checks are done in the front-end; no changes are made to the back-end verification of `zero_alloc` properties of functions.

There are several key additions to the type system:
- `Tpoly` nodes in the type algebra now have a `Zero_alloc.t` parameter, which represents `zero_alloc` properties of a function argument when `Tpoly` is placed on a function argument
- pattern variables carry `zero_alloc `information (`pv_zero_alloc` record field)

Type checking now has several extra error cases, all having to do with `zero_alloc` checks done in the compiler front-end.

Warning 53 is no longer triggered when the `zero_alloc` attribute is placed on a function parameter. Relevant tests are updated in this PR.

A new test file (`typing-zero-alloc/zero_alloc_param.ml`) is added and it covers the typing behaviour: valid annotations, arity requirements, signature matching, error cases for unsupported arguments.