### PR TITLE
Resolve conflicts in tools/

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -208,26 +208,16 @@ case "${OCAML_ARCH}" in
     host='--host=i686-pc-windows'
     instdir='C:/ocamlms'
     cleanup=true
-<<<<<<< oxcaml
-    init_submodule=true
-||||||| upstream-base
-=======
     init_submodule_flexdll=true
     init_submodule_winpthreads=true
->>>>>>> upstream-incoming
   ;;
   msvc64)
     build='--build=x86_64-pc-cygwin'
     host='--host=x86_64-pc-windows'
     instdir='C:/ocamlms64'
     cleanup=true
-<<<<<<< oxcaml
-    init_submodule=true
-||||||| upstream-base
-=======
     init_submodule_flexdll=true
     init_submodule_winpthreads=true
->>>>>>> upstream-incoming
   ;;
   *) arch_error;;
 esac

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -173,12 +173,7 @@ git clean -q -f -d -x
 ./configure \
   CC="$CC" \
   --enable-tsan \
-<<<<<<< oxcaml
-  CFLAGS="-DTSAN_INSTRUMENT_ALL" \
-||||||| upstream-base
-=======
   CPPFLAGS="-DTSAN_INSTRUMENT_ALL" \
->>>>>>> upstream-incoming
   --disable-stdlib-manpages --enable-dependency-generation
 
 # Build the system

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -511,20 +511,12 @@ let dump_obj ic =
     List.iter print_reloc cu.cu_reloc;
   if cu.cu_debug > 0 then begin
     seek_in ic cu.cu_debug;
-<<<<<<< oxcaml
     (* CR ocaml 5 compressed-marshal:
     let evl = (Compression.input_value ic : debug_event list) in
     ignore (Compression.input_value ic);
     *)
     let evl = (Marshal.from_channel ic : debug_event list) in
     ignore (Marshal.from_channel ic);
-||||||| upstream-base
-    let evl = (input_value ic : debug_event list) in
-    ignore (input_value ic); (* Skip the list of absolute directory names *)
-=======
-    let evl = (Compression.input_value ic : debug_event list) in
-    ignore (Compression.input_value ic);
->>>>>>> upstream-incoming
                 (* Skip the list of absolute directory names *)
     record_events 0 evl
   end;
@@ -552,24 +544,14 @@ let dump_exe ic =
         let num_eventlists = input_binary_int ic in
         for _i = 1 to num_eventlists do
           let orig = input_binary_int ic in
-<<<<<<< oxcaml
           (* CR ocaml 5 compressed-marshal:
-||||||| upstream-base
-          let evl = (input_value ic : debug_event list) in
-=======
->>>>>>> upstream-incoming
           let evl = (Compression.input_value ic : debug_event list) in
           (* Skip the list of absolute directory names *)
           ignore (Compression.input_value ic);
-<<<<<<< oxcaml
           *)
           let evl = (Marshal.from_channel ic : debug_event list) in
           (* Skip the list of absolute directory names *)
           ignore (Marshal.from_channel ic);
-||||||| upstream-base
-          ignore (input_value ic);
-=======
->>>>>>> upstream-incoming
           record_events orig evl
         done
   end;

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -302,7 +302,11 @@ let print_general_infos print_name name crc defines arg_descr mbf
 
 let print_global_table table =
   printf "Globals defined:\n";
-  Symtable.iter_global_map (fun id _ -> print_line (Symtable.Global.name id))
+  Symtable.iter_global_map
+    (fun global _ ->
+       let desc = Format_doc.compat Symtable.Global.description in
+       print_line (Format.asprintf "%a" desc global)
+    )
     table
 
 open Cmx_format

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -154,7 +154,6 @@ let print_cma_infos (lib : Cmo_format.library) =
   printf "\n";
   List.iter print_cmo_infos lib.lib_units
 
-<<<<<<< oxcaml
 let print_cmi_infos name crcs kind params global_name_bindings =
   if not !quiet then begin
     let open Cmi_format in
@@ -179,49 +178,14 @@ let print_cmi_infos name crcs kind params global_name_bindings =
     Array.iter print_intf_import crcs;
     printf "Globals in scope:\n";
     Array.iter print_global_name_binding global_name_bindings
-||||||| upstream-base
-let print_cmi_infos name crcs =
-  printf "Unit name: %s\n" name;
-  printf "Interfaces imported:\n";
-  List.iter print_name_crc crcs
-=======
-let print_cmi_infos name crcs =
-  if not !quiet then begin
-    printf "Unit name: %s\n" name;
-    printf "Interfaces imported:\n";
-    List.iter print_name_crc crcs
->>>>>>> upstream-incoming
   end
 
 let print_cmt_infos cmt =
   let open Cmt_format in
   if not !quiet then begin
-<<<<<<< oxcaml
     printf "Cmt unit name: %a\n" Compilation_unit.output cmt.cmt_modname;
     print_string "Cmt interfaces imported:\n";
     Array.iter print_intf_import cmt.cmt_imports;
-||||||| upstream-base
-  printf "Cmt unit name: %s\n" cmt.cmt_modname;
-  print_string "Cmt interfaces imported:\n";
-  List.iter print_name_crc cmt.cmt_imports;
-  printf "Source file: %s\n"
-         (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
-  printf "Compilation flags:";
-  Array.iter print_spaced_string cmt.cmt_args;
-  printf "\nLoad path:\n  Visible:";
-  List.iter print_spaced_string cmt.cmt_loadpath.visible;
-  printf "\n  Hidden:";
-  List.iter print_spaced_string cmt.cmt_loadpath.hidden;
-  printf "\n";
-  printf "cmt interface digest: %s\n"
-    (match cmt.cmt_interface_digest with
-     | None -> ""
-     | Some crc -> string_of_crc crc);
-=======
-    printf "Cmt unit name: %s\n" cmt.cmt_modname;
-    print_string "Cmt interfaces imported:\n";
-    List.iter print_name_crc cmt.cmt_imports;
->>>>>>> upstream-incoming
     printf "Source file: %s\n"
           (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
     printf "Compilation flags:";
@@ -244,7 +208,6 @@ let print_cmt_infos cmt =
   end;
   if !index then begin
     printf "Indexed shapes:\n";
-<<<<<<< oxcaml
     Array.iter (fun (loc, item) ->
       let pp_loc fmt { Location.txt; loc } =
         Format.fprintf fmt "%a (%a)"
@@ -285,49 +248,6 @@ let print_cmt_infos cmt =
         | Value vd -> vd.val_name
         | Value_binding vb ->
           let (_, name, _, _, _) =
-||||||| upstream-base
-=======
-    List.iter (fun (loc, item) ->
-      let pp_loc fmt { Location.txt; loc } =
-        Format.fprintf fmt "%a (%a)"
-          Pprintast.longident txt Location.print_loc loc
-      in
-      Format.printf "@[<hov 2>%a:@ %a@]@;"
-        Shape_reduce.print_result item pp_loc loc)
-      cmt.cmt_ident_occurrences;
-    Format.print_flush ()
-  end;
-  if !uid_deps then begin
-    printf "\nUid dependencies:\n";
-    let arr = Array.of_list cmt.cmt_declaration_dependencies in
-    let () =
-      Array.sort (fun (_tr, u1, u2) (_tr', u1', u2') ->
-                    match Shape.Uid.compare u1 u1' with
-                    | 0 -> Shape.Uid.compare u2 u2'
-                    | n -> n) arr
-    in
-    Format.printf "@[<v>";
-    Array.iter (fun (rk, u1, u2) ->
-      let rk = match rk with
-        | Definition_to_declaration -> "<-"
-        | Declaration_to_declaration -> "<->"
-      in
-      Format.printf "@[<h>%a %s %a@]@;"
-        Shape.Uid.print u1
-        rk
-        Shape.Uid.print u2) arr;
-    Format.printf "@]";
-  end;
-  if !decls then begin
-    printf "\nUid of decls:\n";
-    let decls = Array.of_list (Shape.Uid.Tbl.to_list cmt.cmt_uid_to_decl) in
-    Array.sort (fun (uid, _) (uid', _) -> Shape.Uid.compare uid uid') decls;
-    Array.iter (fun (uid, item) ->
-      let loc = match (item : Typedtree.item_declaration) with
-        | Value vd -> vd.val_name
-        | Value_binding vb ->
-          let (_, name, _, _) =
->>>>>>> upstream-incoming
             List.hd (Typedtree.let_bound_idents_full [vb])
           in
           name
@@ -382,21 +302,7 @@ let print_general_infos print_name name crc defines arg_descr mbf
 
 let print_global_table table =
   printf "Globals defined:\n";
-<<<<<<< oxcaml
   Symtable.iter_global_map (fun id _ -> print_line (Symtable.Global.name id))
-||||||| upstream-base
-  Symtable.iter_global_map
-    (fun global _ ->
-       print_line
-         (Format.asprintf "%a" Symtable.Global.description global)
-    )
-=======
-  Symtable.iter_global_map
-    (fun global _ ->
-       let desc = Format_doc.compat Symtable.Global.description in
-       print_line (Format.asprintf "%a" desc global)
-    )
->>>>>>> upstream-incoming
     table
 
 open Cmx_format
@@ -696,12 +602,7 @@ let print_version_num () =
 
 let arg_list = [
   "-quiet", Arg.Set quiet,
-<<<<<<< oxcaml
-    " Only print explicitely required information";
-||||||| upstream-base
-=======
     " Only print explicitly required information";
->>>>>>> upstream-incoming
   "-no-approx", Arg.Set no_approx,
     " Do not print module approximation information";
   "-no-code", Arg.Set no_code,


### PR DESCRIPTION
Straightforward - we already have `ocamlobjinfo -quiet` and the dumpobj conflict with just because of compressed marshalling.