### PR TITLE
Remove the leading number from Jekyll links

### DIFF
--- a/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
+++ b/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
@@ -237,7 +237,7 @@ fundamentals of data-race freedom. The [next tutorial] will build on
 the basics by
 covering more primitive operations that exercise more of the system.
 
-[next tutorial]: ../02-intro-to-parallelism-part-2
+[next tutorial]: ../intro-to-parallelism-part-2
 
 ## A trivial example
 
@@ -1253,7 +1253,7 @@ something more sophisticated like a lock over the whole tree, which grants a
 function `uncontended` access while the lock is held (which is safe because of
 course only one domain can hold the lock). See the [capsule API] for details.
 
-[capsule API]: ../../parallelism/02-capsules
+[capsule API]: ../../parallelism/capsules
 
 The good news is that data-race freedom guarantees that even buggy programs can
 be reasoned about intuitively. See [Why are data races bad?].

--- a/jane/doc/extensions/_01-tutorials/02-intro-to-parallelism-part-2.md
+++ b/jane/doc/extensions/_01-tutorials/02-intro-to-parallelism-part-2.md
@@ -27,7 +27,7 @@ title: Introduction to parallelism, Part 2
 
 # Parallelism Tutorial: Part 2
 
-The [first parallelism tutorial](../01-intro-to-parallelism-part-1) introduced the
+The [first parallelism tutorial](../intro-to-parallelism-part-1) introduced the
 contention and portability mode axes, showcasing their use in fork/join
 parallelism and parallel sequences.  However, it only covered one way to share
 mutable data between `portable` functions:
@@ -42,7 +42,7 @@ can be used parallelize programs that operate on more complex mutable data.
 
 _This tutorial uses the ["expert" capsule
 API](https://github.com/janestreet/basement/blob/master/src/capsule.mli), which
-is explained in more detail [here](../../parallelism/02-capsules).  For a brief
+is explained in more detail [here](../../parallelism/capsules).  For a brief
 overview, read on._
 
 Wrapping mutable state in an `Atomic.t` can be a reasonable approach, but
@@ -364,7 +364,7 @@ Since we want to share the input image across multiple parallel tasks, we'll
 need to provide it in a capsule.  For simplicity, we also make use of
 `Capsule.access`, which lets us _unwrap_ the encapsulated image before passing
 it to `blur_at`.  This pattern is explained in more detail in the [capsules
-page](../../parallelism/02-capsules).
+page](../../parallelism/capsules).
 
 ```ocaml
 let filter ~scheduler ~mutex image =
@@ -470,4 +470,4 @@ abstractions alone.
 
 For example, if we needed to preserve the mutability of our input image, we
 could instead protect its capsule with a reader-writer lock.  The [capsules
-page](../../parallelism/02-capsules) discusses several further interfaces.
+page](../../parallelism/capsules) discusses several further interfaces.

--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -179,7 +179,7 @@ Each numeric type has its own library for working with it: `float_u`,
 ## Unboxed options
 
 We now have `type 'a or_null : value_or_null`, the type of unboxed options.
-It has constructors `Null` and `This v`. See the [`or_null` document](../02-or-null)
+It has constructors `Null` and `This v`. See the [`or_null` document](../or-null)
 for more details.
 
 ## Unboxed unit and unboxed bool

--- a/jane/doc/extensions/_03-unboxed-types/02-or-null.md
+++ b/jane/doc/extensions/_03-unboxed-types/02-or-null.md
@@ -8,9 +8,9 @@ title: Or null
 
 This document describes the way we can add a null value to types, thus granting a
 non-allocating version of `option`. This extension builds on the *layouts*
-system described in the [main document for unboxed types](../01-intro). Before
+system described in the [main document for unboxed types](../intro). Before
 reading this document, you may wish to read up through the
-[layouts](../01-intro#layouts) section of the main document.
+[layouts](../intro#layouts) section of the main document.
 
 # Adding null
 

--- a/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
+++ b/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
@@ -8,7 +8,7 @@ title: Block indices
 
 This document describes the language feature and implementation for explicit
 _indices_ into a block. Before reading this document, you may wish to read up
-through the [layouts](../01-intro#layouts) section of the main document.
+through the [layouts](../intro#layouts) section of the main document.
 
 As a quick example:
 ```ocaml
@@ -161,7 +161,7 @@ type c = { mutable b : b; s : string }
 The record `c` presents an interesting problem for block indices: the fields of
 its contained unboxed records `a` and `b` are not actually contiguous at runtime
 when using the native code compiler. This problem is caused by the
-[mixed block representation](../01-intro#the-mixed-block-representation),
+[mixed block representation](../intro#the-mixed-block-representation),
 which mandates that we reorder fields so that values come before unboxed types.
 
 While the layout of `c` has the shape

--- a/jane/doc/extensions/_04-parallelism/01-intro.md
+++ b/jane/doc/extensions/_04-parallelism/01-intro.md
@@ -18,4 +18,4 @@ Based on that, the OCaml Language team developed a collection of compiler featur
 
 This is a stub, with more complete documentation to follow. For now, please see
 our parallelism tutorials, beginning with [part
-1](../../tutorials/01-intro-to-parallelism-part-1).
+1](../../tutorials/intro-to-parallelism-part-1).

--- a/jane/doc/extensions/_05-modes/intro.md
+++ b/jane/doc/extensions/_05-modes/intro.md
@@ -170,7 +170,7 @@ even when they are nonportable.
 {: .table }
 
 Forkable is a future axis that tracks whether a function is permitted to access
-shared values in its parent stack. See [parallelism](../../parallelism/01-intro/).
+shared values in its parent stack. See [parallelism](../../parallelism/intro/).
 
 Forkable has different defaults depending on the locality axis: *global* values are
 defaulted to *forkable*, while *local* values are defaulted to *unforkable*.

--- a/jane/doc/extensions/_06-kinds/01-intro.md
+++ b/jane/doc/extensions/_06-kinds/01-intro.md
@@ -2,7 +2,6 @@
 layout: documentation-page
 collectionName: Kinds
 title: Intro
-slug: intro
 ---
 
 # The kind system
@@ -42,7 +41,7 @@ less precise kind is expected.
 This page describes the kind system at a high level, and contains complete
 details for the non-modal bounds. It does not exhaustively describe the possible
 layouts (which are documented on the [unboxed types
-page](../../unboxed-types/01-intro)) or the modal axes (which are documented on the
+page](../../unboxed-types/intro)) or the modal axes (which are documented on the
 [modes page](../../modes/intro)), but does explain how those components appear in
 kinds, including how the modal bounds are affected by the with-bounds.
 
@@ -84,7 +83,7 @@ floating point numbers that are passed in SIMD registers), `bits64`
 and `bits32` (for types represented by unboxed/untagged integers) and product
 layouts like `float64 & bits32` (an unboxed pair that is passed in two
 registers). More detail on layouts and the unboxed types language feature can be
-found [here](../../unboxed-types/01-intro).
+found [here](../../unboxed-types/intro).
 
 Modal bounds all correspond to modal axes, which are described in more detail in
 the [modes documentation](../../modes/intro). The logic for which types can

--- a/jane/doc/extensions/_06-kinds/02-syntax.md
+++ b/jane/doc/extensions/_06-kinds/02-syntax.md
@@ -2,14 +2,13 @@
 layout: documentation-page
 collectionName: Kinds
 title: Syntax
-slug: syntax
 ---
 
 # Syntax for kind annotations
 
 [overview]: ../intro
 [manual]: https://ocaml.org/manual/language.html
-[unboxed types]: ../../unboxed-types/01-intro
+[unboxed types]: ../../unboxed-types/intro
 [nullability]: ../non-modal#nullability
 [externality]: ../non-modal#externality
 

--- a/jane/doc/extensions/_06-kinds/03-non-modal.md
+++ b/jane/doc/extensions/_06-kinds/03-non-modal.md
@@ -2,7 +2,6 @@
 layout: documentation-page
 collectionName: Kinds
 title: Non-modal bounds
-slug: non-modal
 ---
 
 # Non-modal bounds

--- a/jane/doc/extensions/_06-kinds/04-types.md
+++ b/jane/doc/extensions/_06-kinds/04-types.md
@@ -2,7 +2,6 @@
 layout: documentation-page
 collectionName: Kinds
 title: Kinds of types
-slug: types
 ---
 
 # Kinds of types

--- a/jane/doc/extensions/_06-kinds/05-implicit.md
+++ b/jane/doc/extensions/_06-kinds/05-implicit.md
@@ -2,7 +2,6 @@
 layout: documentation-page
 collectionName: Kinds
 title: Implicit Kind Declarations
-slug: implicit
 ---
 
 # Implicit Kind Declarations

--- a/jane/doc/extensions/_08-comprehensions/01-intro.md
+++ b/jane/doc/extensions/_08-comprehensions/01-intro.md
@@ -8,7 +8,7 @@ title: Intro
 
 This page introduces comprehensions and gives a high-level, user-oriented
 overview.
-For more technical details, see [the detailed documentation](../02-details).
+For more technical details, see [the detailed documentation](../details).
 
 # List and array comprehensions
 
@@ -152,4 +152,4 @@ per surrounding iteration before any of them begin to iterate.
 
 This should be enough to use comprehensions on a day-to-day basis; if you have
 more questions, or are curious about how things work on the inside, see
-the [details page](../02-details).
+the [details page](../details).

--- a/jane/doc/extensions/_08-comprehensions/02-details.md
+++ b/jane/doc/extensions/_08-comprehensions/02-details.md
@@ -8,7 +8,7 @@ title: Details
 
 This file covers how comprehensions work in more detail than is necessary on a
 day-to-day level; for a higher-level view, see the [introduction to
-comprehensions](../01-intro).
+comprehensions](../intro).
 
 ## Syntax
 

--- a/jane/doc/extensions/_09-simd/intro.md
+++ b/jane/doc/extensions/_09-simd/intro.md
@@ -37,7 +37,7 @@ float64x2#      float64x4#
 The types ending with `#` are unboxed: they are passed between functions in
 XMM/YMM registers, stored in structures as flat data, and may be stored in flat
 arrays. The corresponding intrinsics operate on unboxed vectors. For more detail
-on unboxed types, see the [docs](../../unboxed-types/01-intro).
+on unboxed types, see the [docs](../../unboxed-types/intro).
 
 The types without `#` are boxed: when passed to a non-inlined function, they
 will be copied to a heap allocated (abstract) block. Boxed vectors are not


### PR DESCRIPTION
Having the numbers in slugs makes it harder to rearrange pages and easier to create broken links.

Also remove `slug`s from frontmatter since it can be autogenerated from file names. This requires an internal Jekyll configuration change to correctly generate slugs.