### PR TITLE
Make `Texp_ident` an inline record

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -45,10 +45,10 @@ let mkTarrow (label, t1, t2, comm) =
 
 type texp_ident_identifier = ident_kind * unique_use
 
-let mkTexp_ident ?id:(ident_kind, uu = Id_value, aliased_many_use)
-    (path, longident, vd) =
-  Texp_ident
-    (path, longident, vd, ident_kind, uu, Mode.Value.(disallow_right legacy))
+let mkTexp_ident ?id:(kind, unique_use = Id_value, aliased_many_use)
+    (path, lid, desc) =
+  let mode = Mode.Value.(disallow_right legacy) in
+  Texp_ident { path; lid; desc; kind; unique_use; mode }
 
 type nonrec apply_arg = apply_arg
 
@@ -245,8 +245,8 @@ let untype_label = function
 
 let view_texp (e : expression_desc) =
   match e with
-  | Texp_ident (path, longident, vd, ident_kind, uu, _mode) ->
-    Texp_ident (path, longident, vd, (ident_kind, uu))
+  | Texp_ident { path; lid; desc; kind; unique_use; _ } ->
+    Texp_ident (path, lid, desc, (kind, unique_use))
   | Texp_apply (exp, args, pos, mode, za) ->
     let args = List.map (fun (label, x) -> untype_label label, x) args in
     Texp_apply (exp, args, (pos, mode, za))

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -221,7 +221,7 @@ let iter_on_occurrences
 
   expr = (fun sub ({ exp_desc; exp_env; _ } as e) ->
       (match exp_desc with
-      | Texp_ident (path, lid, _, _, _, _) ->
+      | Texp_ident { path; lid; _ } ->
           f ~namespace:Value exp_env path lid
       | Texp_construct (lid, constr_desc, _, _) ->
           add_constructor_description exp_env lid constr_desc

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -338,7 +338,7 @@ let zero_alloc_of_application
   | Some assume, _ ->
     (* The user wrote a zero_alloc attribute on the application - keep it. *)
     Builtin_attributes.assume_zero_alloc ~inferred:false assume
-  | None, Texp_ident (_, _, { val_zero_alloc; _ }, _, _, _) ->
+  | None, Texp_ident { desc = { val_zero_alloc; _ }; _ } ->
     (* We assume the call is zero_alloc if the function is known to be
        zero_alloc. If the function is zero_alloc opt, then we need to be sure
        that the opt checks were run to license this assumption. We judge
@@ -386,7 +386,7 @@ and transl_exp1 ~scopes ~in_new_scope sort e =
 
 and transl_exp0 ~in_new_scope ~scopes sort e =
   match e.exp_desc with
-  | Texp_ident(path, _, desc, kind, _, _) ->
+  | Texp_ident { path; desc; kind; _ } ->
       transl_ident (of_location ~scopes e.exp_loc)
         e.exp_env e.exp_type path desc kind
   | Texp_constant cst -> Lconst (Const_base cst)
@@ -403,8 +403,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let ret_sort = Jkind.Sort.default_for_transl_and_get ret_sort in
       transl_function ~in_new_scope ~scopes e params body
         ~alloc_mode ~ret_mode ~ret_sort ~region:true ~zero_alloc
-  | Texp_apply({ exp_desc = Texp_ident(path, _, {val_kind = Val_prim p},
-                                       Id_prim (pmode, psort), _, _);
+  | Texp_apply({ exp_desc = Texp_ident { path;
+                                        desc = {val_kind = Val_prim p};
+                                        kind = Id_prim (pmode, psort); _ };
                  exp_type = prim_type; } as funct,
                oargs, pos, ap_mode, zero_alloc)
     when can_apply_primitive p pmode pos oargs ->

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -3461,8 +3461,8 @@ and quote_expression_desc ~scopes ~transl stage e =
   List.iter (update_env_with_extra ~loc) e.exp_extra;
   let body =
     match e.exp_desc with
-    | Texp_ident (path, _, _, ident_kind, _, _) ->
-      quote_value_ident_path_as_exp loc env path ident_kind
+    | Texp_ident { path; kind; _ } ->
+      quote_value_ident_path_as_exp loc env path kind
     | Texp_constant const ->
       let const = quote_constant loc const in
       Exp_desc.constant loc const

--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -77,7 +77,7 @@ let rec iterator ~scope rebuild_env =
 
   and expr sub exp =
     begin match exp.exp_desc with
-    | Texp_ident (path, _, _, _, _, _) ->
+    | Texp_ident { path; _ } ->
         let full_name = Path.name ~paren:Oprint.parenthesized_ident path in
         let env =
           if rebuild_env then

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -2635,7 +2635,7 @@ let all_rhs_idents exp =
   let open Tast_iterator in
   let expr_iter iter exp =
     match exp.exp_desc with
-    | Texp_ident (path, _lid, _descr, _kind, _mode, _actual_mode) ->
+    | Texp_ident { path; _ } ->
       List.iter (fun id -> ids := Ident.Set.add id !ids) (Path.heads path)
     (* Use default iterator methods for rest of match.*)
     | _ -> Tast_iterator.default_iterator.expr iter exp

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -647,7 +647,7 @@ and expression i ppf x =
     List.iter (fun (x, _, attrs) -> expression_extra (i+1) ppf x attrs) extra;
   end;
   match x.exp_desc with
-  | Texp_ident (li,_,_,_,_,_) -> line i ppf "Texp_ident %a\n" fmt_path li;
+  | Texp_ident { path; _ } -> line i ppf "Texp_ident %a\n" fmt_path path;
   | Texp_instvar (_, li,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;
   | Texp_mutvar id -> line i ppf "Texp_mutvar %a\n" fmt_ident id.txt;
   | Texp_constant (c) -> line i ppf "Texp_constant %a\n" fmt_constant c;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -377,7 +377,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
     | Uaccess_unboxed_field (lid, _) -> iter_loc sub lid
   in
   match exp_desc with
-  | Texp_ident (_, lid, _, _, _, _)  -> iter_loc sub lid
+  | Texp_ident { lid; _ } -> iter_loc sub lid
   | Texp_constant _ -> ()
   | Texp_let (rec_flag, list, exp) ->
       sub.value_bindings sub (rec_flag, list);

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -517,8 +517,8 @@ let expr sub x =
   in
   let exp_desc =
     match x.exp_desc with
-    | Texp_ident (path, lid, vd, idk, uu, mode) ->
-        Texp_ident (path, map_loc sub lid, vd, idk, uu, mode)
+    | Texp_ident r ->
+        Texp_ident { r with lid = map_loc sub r.lid }
     | Texp_constant _ as d -> d
     | Texp_let (rec_flag, list, exp) ->
         let (rec_flag, list) = sub.value_bindings sub (rec_flag, list) in

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1258,9 +1258,11 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
             in
             (id,
              {exp_desc =
-              Texp_ident(path, mknoloc (Longident.Lident (Ident.name id)), vd,
-                         Id_value, aliased_many_use,
-                         Mode.Value.(disallow_right legacy));
+              Texp_ident { path;
+                           lid = mknoloc (Longident.Lident (Ident.name id));
+                           desc = vd; kind = Id_value;
+                           unique_use = aliased_many_use;
+                           mode = Mode.Value.(disallow_right legacy) };
               exp_loc = Location.none; exp_extra = [];
               exp_type = Ctype.instance vd.val_type;
               exp_attributes = []; (* check *)
@@ -1467,9 +1469,11 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              in
              let expr =
                {exp_desc =
-                Texp_ident(path, mknoloc(Longident.Lident (Ident.name id)),vd,
-                           Id_value, aliased_many_use,
-                           Mode.Value.(disallow_right legacy));
+                Texp_ident { path;
+                             lid = mknoloc (Longident.Lident (Ident.name id));
+                             desc = vd; kind = Id_value;
+                             unique_use = aliased_many_use;
+                             mode = Mode.Value.(disallow_right legacy) };
                 exp_loc = Location.none; exp_extra = [];
                 exp_type = ty;
                 exp_attributes = [];

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -664,14 +664,14 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
   let vmode , _ = Value.newvar_below (alloc_as_value marg) in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
-  | Texp_ident (_, _, {val_kind =
-      Val_prim {Primitive.prim_name = ("%sequor"|"%sequand")}},
-                Id_prim _, _, _), 1, Tail ->
+  | Texp_ident { desc = {val_kind =
+      Val_prim {Primitive.prim_name = ("%sequor"|"%sequand")}};
+                kind = Id_prim _; _ }, 1, Tail ->
      (* RHS of (&&) and (||) is at the tail of function region if the
         application is. The argument mode is not constrained otherwise. *)
      mode_with_position vmode (RTail (Option.get position_and_mode.region_mode, FTail)),
      vmode
-  | Texp_ident (_, _, _, Id_prim _, _, _), _, _ ->
+  | Texp_ident { kind = Id_prim _; _ }, _, _ ->
      (* Other primitives cannot be tail-called *)
      mode_default vmode, vmode
   | _, _, (Nontail | Default) ->
@@ -4063,8 +4063,8 @@ let rec final_subexpression exp =
 
 let is_prim ~name funct =
   match funct.exp_desc with
-  | Texp_ident (_, _, {val_kind=Val_prim{Primitive.prim_name; _}}, Id_prim _, _,
-      _) ->
+  | Texp_ident { desc = {val_kind=Val_prim{Primitive.prim_name; _}};
+                 kind = Id_prim _; _ } ->
       prim_name = name
   | _ -> false
 
@@ -4656,7 +4656,7 @@ let rec is_nonexpansive exp =
       is_nonexpansive exp
   | Texp_apply (
       { exp_desc =
-        Texp_ident (_, _, {val_kind = Val_prim prim}, Id_prim _, _, _) },
+        Texp_ident { desc = {val_kind = Val_prim prim}; kind = Id_prim _; _ } },
         args, _, _, _) ->
      is_nonexpansive_prim prim args
   | Texp_array (_, _, _ :: _, _)
@@ -6181,13 +6181,13 @@ and type_expect_
                 (Longident.Lident ("self-" ^ cl_num))
                 env
             in
-            Texp_ident(path, lid, desc, kind,
-              unique_use ~loc ~env actual_mode
-                (as_single_mode expected_mode), actual_mode)
+            Texp_ident { path; lid; desc; kind;
+              unique_use = unique_use ~loc ~env actual_mode
+                (as_single_mode expected_mode); mode = actual_mode }
         | _ ->
-            Texp_ident(path, lid, desc, kind,
-              unique_use ~loc ~env actual_mode
-                (as_single_mode expected_mode), actual_mode)
+            Texp_ident { path; lid; desc; kind;
+              unique_use = unique_use ~loc ~env actual_mode
+                (as_single_mode expected_mode); mode = actual_mode }
       in
       let exp = rue {
         exp_desc; exp_loc = loc; exp_extra = [];
@@ -6484,14 +6484,16 @@ and type_expect_
       let (rt, funct), sargs =
         let rt, funct = type_sfunct sfunct in
         match funct.exp_desc, sargs with
-        | Texp_ident (_, _, {val_kind = Val_prim {prim_name = "%revapply"}; val_type},
-                      Id_prim _, _, _),
+        | Texp_ident { desc = {val_kind = Val_prim {prim_name = "%revapply"};
+                               val_type};
+                       kind = Id_prim _; _ },
           [Nolabel, sarg; Nolabel, actual_sfunct]
           when is_inferred actual_sfunct
             && check_apply_prim_type Revapply val_type ->
             type_sfunct_args actual_sfunct [Nolabel, sarg]
-        | Texp_ident (_, _, {val_kind = Val_prim {prim_name = "%apply"}; val_type},
-                      Id_prim _, _, _),
+        | Texp_ident { desc = {val_kind = Val_prim {prim_name = "%apply"};
+                               val_type};
+                       kind = Id_prim _; _ },
           [Nolabel, actual_sfunct; Nolabel, sarg]
           when check_apply_prim_type Apply val_type ->
             type_sfunct_args actual_sfunct [Nolabel, sarg]
@@ -7716,7 +7718,7 @@ and type_expect_
       | Texp_object _ -> unsupported Object
       | Texp_pack _ -> unsupported Module
       | Texp_apply({ exp_desc =
-          Texp_ident(_, _, {val_kind = Val_prim _}, _, _, _)}, _, _, _, _)
+          Texp_ident { desc = {val_kind = Val_prim _}; _ }}, _, _, _, _)
           (* [stack_ (prim foo)] will be checked by [transl_primitive_application]. *)
           (* CR zqian: Move/Copy [Lambda.primitive_may_allocate] to [typing], then we can
           check primitive allocation here, and also improve the logic in [type_ident]. *)
@@ -7984,7 +7986,7 @@ and expression_constraint pexp =
     is_self =
       (fun expr ->
          match expr.exp_desc with
-         | Texp_ident (_, _, { val_kind = Val_self _ }, _, _, _) -> true
+         | Texp_ident { desc = { val_kind = Val_self _ }; _ } -> true
          | _ -> false);
   }
 
@@ -9139,8 +9141,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
         {exp_type = ty; exp_loc = Location.none; exp_env = exp_env;
          exp_extra = []; exp_attributes = [];
          exp_desc =
-         Texp_ident(Path.Pident id, mknoloc (Longident.Lident name),
-                    desc, Id_value, uu, Value.disallow_right mode)}
+         Texp_ident { path = Path.Pident id;
+                      lid = mknoloc (Longident.Lident name);
+                      desc; kind = Id_value; unique_use = uu;
+                      mode = Value.disallow_right mode }}
       in
       let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in
       Regionality.submode_exn
@@ -11096,7 +11100,7 @@ and type_send env loc explanation e met =
   let obj = type_exp env mode_object e in
   let (meth, typ) =
     match obj.exp_desc with
-    | Texp_ident(_, _, {val_kind = Val_self(sign, meths, _, _)}, _, _, _) ->
+    | Texp_ident { desc = {val_kind = Val_self(sign, meths, _, _)}; _ } ->
         let id, typ =
           match meths with
           | Self_concrete meths ->
@@ -11126,7 +11130,7 @@ and type_send env loc explanation e met =
           end
         in
         Tmeth_val id, typ
-    | Texp_ident(_, _, {val_kind = Val_anc (sign, meths, cl_num)}, _, _, _) ->
+    | Texp_ident { desc = {val_kind = Val_anc (sign, meths, cl_num)}; _ } ->
         let id =
           match Meths.find met meths with
           | id -> id

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -259,8 +259,12 @@ and arg_label = Types.arg_label =
 
 and expression_desc =
     Texp_ident of
-      Path.t * Longident.t loc * Types.value_description * ident_kind *
-        unique_use * Mode.Value.l
+      { path : Path.t;
+        lid : Longident.t loc;
+        desc : Types.value_description;
+        kind : ident_kind;
+        unique_use : unique_use;
+        mode : Mode.Value.l }
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
   | Texp_letmutable of value_binding * expression
@@ -1425,8 +1429,8 @@ let nominal_exp_doc lid t =
   let rec nominal_exp_doc doc exp =
     match exp.exp_desc with
     | _ when exp.exp_attributes <> [] -> None
-    | Texp_ident (_,l,_,_,_,_) ->
-        Some (longident l doc)
+    | Texp_ident { lid; _ } ->
+        Some (longident lid doc)
     | Texp_instvar (_,_,s) ->
         Some (string s.Location.txt doc)
     | Texp_constant _ -> assert false

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -399,8 +399,12 @@ and arg_label = Types.arg_label =
 *)
 and expression_desc =
     Texp_ident of
-      Path.t * Longident.t loc * Types.value_description * ident_kind *
-        unique_use * Mode.Value.l
+      { path : Path.t;
+        lid : Longident.t loc;
+        desc : Types.value_description;
+        kind : ident_kind;
+        unique_use : unique_use;
+        mode : Mode.Value.l }
         (** x
             M.x
          *)

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2235,7 +2235,7 @@ let open_variables ienv f =
       expr =
         (fun self e ->
           (match e.exp_desc with
-          | Texp_ident (path, _, _, _, unique_use, _) -> (
+          | Texp_ident { path; unique_use; _ } -> (
             (* We test if a variable is open by looking it up in the current
                [ienv]: the [ienv] does not contain the internally-bound
                variables in the module. In other words, open variables will be
@@ -2700,10 +2700,10 @@ and check_uniqueness_exp ~borrows ~overwrite (ienv : Ienv.t) exp : UF.t =
     needed *)
 and check_uniqueness_exp_desc_as_value ~borrows ienv ~loc : _ -> Value.t * UF.t
     = function
-  | Texp_ident (p, _, _, _, unique_use, _) ->
+  | Texp_ident { path; unique_use; _ } ->
     let occ = Occurrence.mk loc in
     let value =
-      match value_of_ident ienv unique_use occ p with
+      match value_of_ident ienv unique_use occ path with
       | None ->
         (* cross module access - don't track *)
         Value.untracked unique_use occ

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -527,7 +527,7 @@ let expression sub exp =
   let attrs = sub.attributes sub exp.exp_attributes in
   let desc =
     match exp.exp_desc with
-      Texp_ident (_path, lid, _, _, _, _) -> Pexp_ident (map_loc sub lid)
+      Texp_ident { lid; _ } -> Pexp_ident (map_loc sub lid)
     | Texp_constant cst -> Pexp_constant (constant cst)
     | Texp_let (rec_flag, list, exp) ->
         Pexp_let (Immutable, rec_flag,

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -162,7 +162,7 @@ let classify_expression : Typedtree.expression -> sd =
         let size = classify_module_expression env mexp in
         let env = Ident.add mid size env in
         classify_expression env e
-    | Texp_ident (path, _, _, _, _, _) ->
+    | Texp_ident { path; _ } ->
         classify_path env path
 
     (* non-binding cases *)
@@ -228,7 +228,7 @@ let classify_expression : Typedtree.expression -> sd =
         (* CR vlaviron: Dynamic would probably be a better choice *)
         Static
 
-    | Texp_apply ({exp_desc = Texp_ident (_, _, vd, Id_prim _, _, _)},
+    | Texp_apply ({exp_desc = Texp_ident { desc = vd; kind = Id_prim _; _ }},
         _, _, _, _)
       when is_ref vd ->
         Static
@@ -645,7 +645,7 @@ let array_mode exp elt_sort = match Typeopt.array_kind exp elt_sort with
 *)
 let rec expression : Typedtree.expression -> term_judg =
   fun exp -> match exp.exp_desc with
-    | Texp_ident (pth, _, _, _, _, _) ->
+    | Texp_ident { path = pth; _ } ->
       path pth
     | Texp_let (rec_flag, bindings, body) ->
       (*
@@ -708,8 +708,8 @@ let rec expression : Typedtree.expression -> term_judg =
     | Texp_mutvar id ->
         single id.txt << Dereference
     | Texp_apply
-        ({exp_desc = Texp_ident (_, _, vd, Id_prim _, _, _)}, [_, Arg (arg, _)],
-         _, _, _)
+        ({exp_desc = Texp_ident { desc = vd; kind = Id_prim _; _ }},
+         [_, Arg (arg, _)], _, _, _)
       when is_ref vd ->
       (*
         G |- e: m[Guard]


### PR DESCRIPTION
What the title says - this makes code easier to read and reduces diffs of future PRs that might modify `Texp_ident`.