### PR TITLE
Tweak bash scripts to accommodate macOS

### DIFF
--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -33,7 +33,7 @@ exit_code=0
 $opam_exec dune build @fmt --auto-promote || exit_code=1
 # Format owee files explicitly (external/ is vendored so dune skips it)
 $opam_exec ocamlformat -i external/owee/owee_archive.ml external/owee/owee_archive.mli || exit_code=1
-if [[ ! -v SKIP_80CH ]]; then
+if [[ -z "${SKIP_80CH+x}" ]]; then # don't use `-v` to accommodate macOS (old bash)
   scripts/80ch.sh || exit_code=1
 fi
 exit $exit_code

--- a/tools/ci/actions/check-fmt.sh
+++ b/tools/ci/actions/check-fmt.sh
@@ -31,7 +31,7 @@ touch dune.runtime_selection duneconf/dirs-to-ignore.inc duneconf/ox-extra.inc
 
 exit_code=0
 $opam_exec dune build @fmt || exit_code=1
-if [[ ! -v SKIP_80CH ]]; then
+if [[ -z "${SKIP_80CH+x}" ]]; then # don't use `-v` to accommodate macOS (old bash)
   scripts/80ch.sh || exit_code=1
 fi
 exit $exit_code


### PR DESCRIPTION
As per title; macOS ships with an old
version of `bash` (3.2), the default
shell being `zsh`.