### PR TITLE
reaper: proper ordering of cannot_unbox0 rules

### DIFF
--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1724,6 +1724,18 @@ let datalog_rules =
          (Known_arity_code_pointer, _) -> false) [relation] ] ==> cannot_unbox0
          allocation_id); *)
       (* CR ncourant: I'm not sure this is useful? *)
+      (* CR-someday ncourant: allowing a symbol to be unboxed is difficult, due
+         to symbols being always values; thus we prevent it. *)
+      (let$ [x; _source] = ["x"; "_source"] in
+       [ sources x _source;
+         when1
+           (fun x ->
+             Code_id_or_name.pattern_match x
+               ~symbol:(fun _ -> true)
+               ~var:(fun _ -> false)
+               ~code_id:(fun _ -> false))
+           x ]
+       ==> cannot_unbox0 x);
       (* An allocation that is stored in another can only be unboxed if either
          the representation of the other allocation can be changed, of it the
          field it is stored in is never read, as in that case a poison value
@@ -1738,18 +1750,6 @@ let datalog_rules =
          when1 real_field relation;
          cannot_unbox0 to_ ]
        ==> cannot_unbox0 allocation_id);
-      (* CR-someday ncourant: allowing a symbol to be unboxed is difficult, due
-         to symbols being always values; thus we prevent it. *)
-      (let$ [x; _source] = ["x"; "_source"] in
-       [ sources x _source;
-         when1
-           (fun x ->
-             Code_id_or_name.pattern_match x
-               ~symbol:(fun _ -> true)
-               ~var:(fun _ -> false)
-               ~code_id:(fun _ -> false))
-           x ]
-       ==> cannot_unbox0 x);
       (* As previously: if any closure of a set of closures cannot be unboxed,
          then every closure in the set cannot be unboxed. *)
       (let$ [x] = ["x"] in


### PR DESCRIPTION
This is a quick fix for the error observed by @mshinwell. A better fix will come later, ensuring we don't come across similar errors in the future.