### PR TITLE
Fix mistake in Traversals.at_least_this_closure

### DIFF
--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -591,7 +591,7 @@ module Expr = struct
       ~at_least_these_closure_types:closure_types_in_set
       ~at_least_these_value_slots:value_slots_in_set alloc_mode =
     Closure
-      { exact = true;
+      { exact = false;
         function_slot;
         function_slots_in_set;
         closure_types_in_set;


### PR DESCRIPTION
As subject.  This was causing `Invalid`s to be generated from classic mode imports - classic mode always uses `At_least` for exported function types.