### PR TITLE
Add Compression module

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -222,17 +222,9 @@ let link_compunit output_fun currpos_fun inchan file_name compunit =
   if !Clflags.debug && compunit.cu_debug > 0 then begin
     seek_in inchan compunit.cu_debug;
     let debug_event_list : Instruct.debug_event list =
-      (* CR ocaml 5 compressed-marshal:
-      Compression.input_value inchan
-      *)
-      Marshal.from_channel inchan
-    in
+      Compression.input_value inchan in
     let debug_dirs : string list =
-      (* CR ocaml 5 compressed-marshal:
-      Compression.input_value inchan
-      *)
-      Marshal.from_channel inchan
-    in
+      Compression.input_value inchan in
     let file_path = Filename.dirname (Location.absolute_path file_name) in
     let debug_dirs =
       if List.mem file_path debug_dirs

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -156,20 +156,14 @@ let process_append_bytecode oc state objfile compunit =
     let events, debug_dirs =
       if !Clflags.debug && compunit.cu_debug > 0 then begin
         seek_in ic compunit.cu_debug;
-        (* CR ocaml 5 compressed-marshal:
         let unit_events = (Compression.input_value ic : debug_event list) in
-        *)
-        let unit_events = (Marshal.from_channel ic : debug_event list) in
         let events =
           rev_append_map
             (relocate_debug state.offset state.subst)
             unit_events
             state.events in
         let unit_debug_dirs =
-          (* CR ocaml 5 compressed-marshal:
           (Compression.input_value ic : string list)
-          *)
-          (Marshal.from_channel ic : string list)
         in
         let debug_dirs =
           String.Set.union

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -442,16 +442,8 @@ let to_file outchan cu artifact_info ~required_globals ~main_module_block_format
           (Filename.dirname (Location.absolute_path filename))
         !debug_dirs;
       let p = pos_out outchan in
-      (* CR ocaml 5 compressed-marshal mshinwell:
-         Compression not supported in the OCaml 4 runtime
       Compression.output_value outchan !events;
       Compression.output_value outchan (String.Set.elements !debug_dirs);
-      *)
-(* BACKPORT BEGIN *)
-      Marshal.(to_channel outchan !events []);
-      Marshal.(to_channel outchan (String.Set.elements !debug_dirs)
-                          []);
-(* BACKPORT END *)
       (p, pos_out outchan - p)
     end else
       (0, 0) in

--- a/configure.ac
+++ b/configure.ac
@@ -2806,7 +2806,8 @@ zstd_libs=""
 
 AS_IF([test x"$with_zstd" != "xno"],
   # Try pkg-config first, as it gives the most reliable results
-  [AS_IF([${PKG_CONFIG} libzstd 2>/dev/null],
+  [AC_MSG_ERROR([OxCaml doesn't support compressed marshalling yet])
+    AS_IF([${PKG_CONFIG} libzstd 2>/dev/null],
     # Now check the version
     [AS_IF([${PKG_CONFIG} --atleast-version 1.4 libzstd],
       [zstd_libs=`${PKG_CONFIG} --libs libzstd`

--- a/dune
+++ b/dune
@@ -135,7 +135,7 @@
       (echo "module MenhirLib = CamlinternalMenhirLib")
       (run cat %{input-file})))
     parser)))
- (library_flags -linkall)
+ (library_flags -linkall (:include comprmarsh_flags.sexp))
  (libraries flambda2_floats)
  (modules_without_implementation
   annot
@@ -150,6 +150,7 @@
   mode_intf)
  (modules
   ;; UTILS
+  compression
   arrayset
   config
   build_path_prefix_map
@@ -466,6 +467,22 @@
    (= %{context_name} "runtime_stdlib")))
  (action
   (copy %{project_root}/ocamlopt_oxcaml_flags.sexp %{targets})))
+
+; C libraries needed to resolve [caml_zstd_initialize] when linking
+; ocamlcommon.cmxa. -lcomprmarsh is always needed, along with the context's
+; compression libraries. Note that ocamlcommon.cmxa built with the system
+; compiler needs this even though OxCaml doesn't at present use compression
+; because the executable links with the _system_'s libcomprmarsh.a which will
+; need -lzstd if the system compiler was configured with compressed marshalling.
+(rule
+ (targets comprmarsh_flags.sexp)
+ (action
+  (with-stdout-to
+   %{targets}
+   (bash
+    "printf '(-cclib -lcomprmarsh'; \
+     for l in $(ocamlopt -config-var compression_c_libraries); do \
+       printf ' -cclib %s' \"$l\"; done; printf ')'"))))
 
 (install
  (files ocamlyacc)

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -172,10 +172,9 @@ let input_cmi_lazy ic =
       header_globals = globals;
       header_sign = (sign, staticity);
       header_params = params;
-    } = (input_value ic : header) in
+    } = (Compression.input_value ic : header) in
   let crcs = (input_value ic : crcs) in
   let flags = (input_value ic : flags) in
-  (* CR ocaml 5 compressed-marshal mshinwell: upstream uses [Compression] *)
   {
       cmi_name = name;
       cmi_kind = kind;
@@ -235,7 +234,7 @@ let output_cmi filename oc cmi =
   let len = Int64.sub val_pos data_pos in
   output_int64 oc len;
   Out_channel.seek oc val_pos;
-  output_value oc
+  Compression.output_value oc
     {
       header_name = cmi.cmi_name;
       header_kind = cmi.cmi_kind;

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -443,21 +443,11 @@ let index_occurrences binary_annots =
 
 exception Error of error
 
-let input_cmt ic : cmt_infos =
-  (* CR ocaml 5 compressed-marshal mshinwell:
-     (Compression.input_value ic : cmt_infos)
-  *)
-  Marshal.from_channel ic
+let input_cmt ic = (Compression.input_value ic : cmt_infos)
 
 let output_cmt oc cmt =
   output_string oc Config.cmt_magic_number;
-  (* BACKPORT BEGIN *)
-  (* CR ocaml 5 compressed-marshal mshinwell:
-     upstream uses [Compression] here:
-     Compression.output_value oc (cmt : cmt_infos)
-  *)
-  Marshal.(to_channel oc (cmt : cmt_infos) [])
-  (* BACKPORT END *)
+  Compression.output_value oc (cmt : cmt_infos)
 
 let read filename =
 (*  Printf.fprintf stderr "Cmt_format.read %s\n%!" filename; *)

--- a/otherlibs/dynlink/compression.ml
+++ b/otherlibs/dynlink/compression.ml
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*        Xavier Leroy, Collège de France and Inria project Cambium       *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* This is a copy of [utils/compression.ml] without the reference to the
+   primitive, so that dynlink.cmxa doesn't need to link with -lcomprmarsh.
+   This disappears when dynlink_compilerlibs is removed, which is a prereq
+   for having actual marshalled compression. *)
+
+let compression_supported = false
+
+let output_value = Stdlib.output_value
+
+let input_value = Stdlib.input_value

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -77,6 +77,7 @@
   binutils
   local_store
   config
+  compression
   build_path_prefix_map
   misc
   format_doc
@@ -221,6 +222,11 @@
 (copy_files ../../utils/local_store.ml)
 
 (copy_files ../../utils/config.ml)
+
+; NOTE: only the .mli is copied; compression.ml is a dynlink-specific stub
+; (see the comment in that file) that avoids the caml_zstd_initialize
+; primitive, so that dynlink.cmxa does not need -lcomprmarsh.
+(copy_files ../../utils/compression.mli)
 
 (copy_files ../../utils/build_path_prefix_map.ml)
 
@@ -695,6 +701,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Local_store.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Build_path_prefix_map.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Config.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Compression.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Format_doc.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Misc.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Target_system.cmo
@@ -820,6 +827,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Local_store.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Build_path_prefix_map.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Config.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Compression.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Format_doc.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Misc.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Target_system.cmx

--- a/runtime/dune
+++ b/runtime/dune
@@ -54,6 +54,7 @@
    dynlink.c backtrace_byt.c backtrace.c afl.c bigarray.c prng.c float32.c
    simd.c
    blake2.c
+   zstd.c
    misc.c
    build_config.h sync_posix.h caml/jumptbl.h caml/domain_state.tbl)
  (action
@@ -64,7 +65,7 @@
 (rule
  (targets libasmrun.a libasmrund.a libasmruni.a libasmrun_pic.a
     libasmrun_shared.so libcamlrun.a libcamlrund.a libcamlruni.a libcamlrun_pic.a
-    libcamlrun_shared.so ocamlrun ocamlrund ocamlruni ld.conf)
+    libcamlrun_shared.so libcomprmarsh.a ocamlrun ocamlrund ocamlruni ld.conf)
  (mode    fallback)
  (deps
    ../Makefile.config
@@ -90,7 +91,7 @@
      (bash "rm -f sak build_config.h")
      (bash "cd .. && make V=1 -j8 -f Makefile.upstream runtime/libasmrun.a runtime/libasmrund.a runtime/libasmruni.a runtime/libasmrun_pic.a \
     runtime/libasmrun_shared.so runtime/libcamlrun.a runtime/libcamlrund.a runtime/libcamlruni.a runtime/libcamlrun_pic.a \
-    runtime/libcamlrun_shared.so runtime/ocamlrun runtime/ocamlrund runtime/ocamlruni runtime/ld.conf COMPUTE_DEPS=false")))))
+    runtime/libcamlrun_shared.so runtime/libcomprmarsh.a runtime/ocamlrun runtime/ocamlrund runtime/ocamlruni runtime/ld.conf COMPUTE_DEPS=false")))))
 
 (install
   (files
@@ -121,6 +122,7 @@
     libasmruni.a
     libasmrun_pic.a
     libasmrun_shared.so
+    libcomprmarsh.a
   )
   (section lib)
   (package ocaml_runtime_stdlib))
@@ -140,4 +142,5 @@
     libasmrund.a
     libasmruni.a
     libasmrun_pic.a
-    libasmrun_shared.so))
+    libasmrun_shared.so
+    libcomprmarsh.a))

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -511,12 +511,8 @@ let dump_obj ic =
     List.iter print_reloc cu.cu_reloc;
   if cu.cu_debug > 0 then begin
     seek_in ic cu.cu_debug;
-    (* CR ocaml 5 compressed-marshal:
     let evl = (Compression.input_value ic : debug_event list) in
     ignore (Compression.input_value ic);
-    *)
-    let evl = (Marshal.from_channel ic : debug_event list) in
-    ignore (Marshal.from_channel ic);
                 (* Skip the list of absolute directory names *)
     record_events 0 evl
   end;
@@ -544,13 +540,9 @@ let dump_exe ic =
         let num_eventlists = input_binary_int ic in
         for _i = 1 to num_eventlists do
           let orig = input_binary_int ic in
-          (* CR ocaml 5 compressed-marshal:
           let evl = (Compression.input_value ic : debug_event list) in
           (* Skip the list of absolute directory names *)
           ignore (Compression.input_value ic);
-          *)
-          let evl = (Marshal.from_channel ic : debug_event list) in
-          (* Skip the list of absolute directory names *)
           ignore (Marshal.from_channel ic);
           record_events orig evl
         done

--- a/utils/compression.ml
+++ b/utils/compression.ml
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*        Xavier Leroy, Collège de France and Inria project Cambium       *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+external zstd_initialize: unit -> bool = "caml_zstd_initialize"
+
+let compression_supported = zstd_initialize ()
+
+type [@warning "-unused-constructor"] extern_flags =
+    No_sharing                          (** Don't preserve sharing *)
+  | Closures                            (** Send function closures *)
+  | Compat_32                           (** Ensure 32-bit compatibility *)
+  | Compression                         (** Optional compression *)
+
+external to_channel: out_channel -> 'a -> extern_flags list -> unit
+                   = "caml_output_value"
+
+(* CR compressed-marshal: the Compression flag must not be passed to an upstream
+   runtime, because that could result in artefacts which runtime4 can't read. *)
+let output_value ch v = to_channel ch v [(*Compression*)]
+
+let input_value = Stdlib.input_value

--- a/utils/compression.mli
+++ b/utils/compression.mli
@@ -1,0 +1,34 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*        Xavier Leroy, Collège de France and Inria project Cambium       *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val output_value : out_channel -> 'a -> unit
+(** [Compression.output_value chan v] writes the representation
+    of [v] on channel [chan].
+    If compression is supported, the marshaled data
+    representing value [v] is compressed before being written to
+    channel [chan].
+    If compression is not supported, this function behaves like
+    {!Stdlib.output_value}. *)
+
+val input_value : in_channel -> 'a
+(** [Compression.input_value chan] reads from channel [chan] the
+    byte representation of a structured value, as produced by
+    [Compression.output_value], and reconstructs and
+    returns the corresponding value.
+    If compression is not supported, this function behaves like
+    {!Stdlib.input_value}. *)
+
+val compression_supported : bool
+(** Reports whether compression is supported. *)


### PR DESCRIPTION
Implement compressed marshalling, but forcing it to remain disabled. This takes utils/compression.ml{,i} from e019d19f173d5fed82f2820b0d7e536165406166 and removes the various CRs related to it.

This is a draft for now, because there are too many other moving parts - once 5.4 is building and #5420 integrated, I'll come back and finish this off (there's some subtlety still to get right with libcomprmarsh which provides the `caml_zstd_initialize` primitive - there was some complexity which was circumvented upstream by deviating the bytecode and native-code versions of dynlink\_compilerlibs)