### PR TITLE
Split pass: strengthen occur check

### DIFF
--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -62,13 +62,14 @@ for_loop_layout:
   cmpq  $1, %rax
   jl    .L120
   subq  $24, %rsp
-  movl  $1, %edi
-.L108:
-  movq  %rdi, 16(%rsp)
-  movq  %rax, (%rsp)
+  movq  %rbx, (%rsp)
+  sarq  $1, %rax
+  movq  %rax, 8(%rsp)
+  xorl  %eax, %eax
+.L109:
+  movq  %rax, 16(%rsp)
   movl  $1, %eax
   movq  (%rbx), %rdi
-  movq  %rbx, 8(%rsp)
   call  *%rdi
 .L124:
   movq  16(%rsp), %rax

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -135,7 +135,6 @@ loop_readonly_use_spilled_var:
   subq  $8, %rsp
   movq  %rax, %rbx
   movq  %rbx, (%rsp)
-  movq  %rbx, %rax
   cmpq  $1, %rax
   jge   .L111
 .L108:
@@ -171,9 +170,9 @@ spill_unspill_loop_movement:
   movq  %rbx, %rax
   cmpq  $3, %rax
   jl    .L135
-  movq  %rax, (%rsp)
   movq  %rdi, 24(%rsp)
   movq  %rax, %rbx
+  movq  %rax, (%rsp)
   sarq  $1, %rbx
   movq  %rbx, 8(%rsp)
   movl  $1, %edi
@@ -352,7 +351,6 @@ double_loop_no_definition_at_beginning:
   movq  %rsi, 40(%rsp)
   xorl  %edx, %edx
 .L113:
-  movq  %rdx, (%rsp)
   movq  64(%r14), %rbx
   movq  %rbx, 8(%rsp)
   movq  64(%r14), %rbx
@@ -368,16 +366,17 @@ double_loop_no_definition_at_beginning:
   movq  %rcx, (%rbx)
   movabsq $108086391056891911, %rcx
   movq  %rcx, 8(%rbx)
-  leaq  1(%rdx,%rdx), %rdx
-  movq  %rdx, 16(%rbx)
+  leaq  1(%rdx,%rdx), %rcx
+  movq  %rdx, (%rsp)
+  movq  %rcx, 16(%rbx)
   movq  %rax, 24(%rbx)
   movq  %rbx, 48(%rsp)
   movq  %rdi, %rdx
   testb $1, %dl
   jne   .L135
 .L128:
-  movq  %rdx, 56(%rsp)
   movq  (%rdx), %rax
+  movq  %rdx, 56(%rsp)
   call  camlTOP15__f_33_37_code@PLT
 .L158:
   movq  56(%rsp), %rdx


### PR DESCRIPTION
As per title; change the occur check
to take any kind of occurrence into
account. The current code, which is
believed to be correct, may lead to
deadcode (as in useless instructions)
which makes the validator fail.

A better fix would be, in due course,
to adapt the validator, but it feels
less risky for now to be slightly more
conservative about the code motion
for spills/reloads.