### PR TITLE
Split pass: typo in docstring

### DIFF
--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -309,7 +309,7 @@ let make_reload : type a. a make_operation =
     ~id:(InstructionId.get_and_incr instr_id)
     ~copy ~from:stack_reg ~to_:new_reg
 
-(* Inserts the relaods in a block, as late as possible (i.e. immediately before
+(* Inserts the reloads in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. *)
 let insert_reloads_in_block :
     State.t ->


### PR DESCRIPTION
(As per title.)