### PR TITLE
Split pass: bug in loop optimization

### DIFF
--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -138,7 +138,7 @@ end = struct
       in
       (* Add destructions before the loop. *)
       let all_loop_predecessors : Label.Set.t =
-        (Cfg.get_block_exn cfg header).predecessors
+        Label.Set.diff (Cfg.get_block_exn cfg header).predecessors loop
       in
       let destructions_at_end : destructions_at_end =
         Label.Set.fold


### PR DESCRIPTION
This is an "inefficiency" bug, not a
"correctness" bug.

When moving the spills out of loops,
we used to compute the loop
predecessors as the header's
predecessors. That is obvious wrong,
since it will include the source of the
back edge, which is in the loop.

The consequence is that a spill may
still be kept into the loop. The reason
why it was not spotted earlier is that
another optimization (deletion of
dominated spills) will remove the
spill left in the loop in many cases.