### PR TITLE
Metrics workflow: retry if push fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,7 +521,7 @@ jobs:
 
           git add raw-data/
           git commit -m "Add metrics for commit ${COMMIT_HASH}"
-          git push
+          git push || (git pull --rebase && git push)
 
       - name: Upload core dumps
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
With quite a bit of time between the
clone and the eventual push, the
workflow is subject to a race condition
(even though we are using a queue,
because of direct merges to main).
So, if the push fails, we now immediately
retry after a pull. This is not a very
good solution, but should be enough
in practice.