### PR TITLE
First parameter of indices is `value_or_null`

### DIFF
--- a/otherlibs/stdlib_stable/idx_imm.ml
+++ b/otherlibs/stdlib_stable/idx_imm.ml
@@ -14,10 +14,10 @@
 
 [@@@ocaml.flambda_o3]
 
-type ('a, 'b : any) t : bits64 mod everything = ('a, 'b) idx_imm
+type ('a : value_or_null, 'b : any) t : bits64 mod everything = ('a, 'b) idx_imm
 
 external get
-  : 'a ('b : any).
+  : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_imm -> ('b[@local_opt])
   = "%get_idx_imm"
 [@@layout_poly]

--- a/otherlibs/stdlib_stable/idx_imm.mli
+++ b/otherlibs/stdlib_stable/idx_imm.mli
@@ -15,11 +15,11 @@
 (** Immutable indices into blocks. *)
 
 (** An alias for the type of immutable indices into blocks. *)
-type ('a, 'b : any) t : bits64 mod everything = ('a, 'b) idx_imm
+type ('a : value_or_null, 'b : any) t : bits64 mod everything = ('a, 'b) idx_imm
 
 (** [get a i] uses the index [i] to access [a]. *)
 external get
-  : 'a ('b : any).
+  : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_imm -> ('b[@local_opt])
   = "%get_idx_imm"
 [@@layout_poly]

--- a/otherlibs/stdlib_stable/idx_mut.ml
+++ b/otherlibs/stdlib_stable/idx_mut.ml
@@ -14,16 +14,16 @@
 
 [@@@ocaml.flambda_o3]
 
-type ('a, 'b : any) t : bits64 mod everything = ('a, 'b) idx_mut
+type ('a : value_or_null, 'b : any) t : bits64 mod everything = ('a, 'b) idx_mut
 
 external get
-  : 'a ('b : any).
+  : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_mut -> ('b[@local_opt])
   = "%get_idx"
 [@@layout_poly]
 
 external set
-  : 'a ('b : any).
+  : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_mut -> 'b -> unit
   = "%set_idx"
 [@@layout_poly]

--- a/otherlibs/stdlib_stable/idx_mut.mli
+++ b/otherlibs/stdlib_stable/idx_mut.mli
@@ -15,11 +15,11 @@
 (** Mutable indices into blocks. *)
 
 (** An alias for the type of mutable indices into blocks. *)
-type ('a, 'b : any) t : bits64 mod everything = ('a, 'b) idx_mut
+type ('a : value_or_null, 'b : any) t : bits64 mod everything = ('a, 'b) idx_mut
 
 (** [get a i] uses the index [i] to access [a]. *)
 external get
-  : 'a ('b : any).
+  : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_mut -> ('b[@local_opt])
   = "%get_idx"
 [@@layout_poly]
@@ -30,7 +30,7 @@ external get
     array elements or mutable record fields) can only be created to elements
     with the [global] modality. *)
 external set
-  : 'a ('b : any).
+  : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_mut -> 'b -> unit
   = "%set_idx"
 [@@layout_poly]

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -637,7 +637,7 @@ let build_initial_env add_type add_extension add_jkind empty_env =
            ~type_expr:param)
   |> add_type2 ident_idx_imm
        ~param1_jkind:(
-         Jkind.Builtin.value ~why:(Type_argument {
+         Jkind.Builtin.value_or_null ~why:(Type_argument {
            parent_path = Path.Pident ident_idx_imm;
            position = 1;
            arity = 2;
@@ -655,7 +655,7 @@ let build_initial_env add_type add_extension add_jkind empty_env =
        ~type_separability:[Separability.Ind; Separability.Ind]
   |> add_type2 ident_idx_mut
        ~param1_jkind:(
-         Jkind.Builtin.value ~why:(Type_argument {
+         Jkind.Builtin.value_or_null ~why:(Type_argument {
            parent_path = Path.Pident ident_idx_mut;
            position = 1;
            arity = 2;


### PR DESCRIPTION
This is a safe change because there is no way to create indices with a null base, but can be used for:
1. Abstracting over types as `value_or_null`
2. Creating indices into arbitrary memory using magic.

Example of (1):
```ocaml
open Stdlib_stable

module M : sig
  type t : value_or_null
  val t : t
  val i : (t, int) idx_mut
  val j : (t, int) idx_imm
end = struct
  type t = { mutable i : int; j : int }
  let t = { i = 1; j = 2 }
  let i = (.i)
  let j = (.j)
end

let () =
  let i = Idx_mut.get M.t M.i in
  let j = Idx_imm.get M.t M.j in
  Idx_mut.set M.t M.i 3;
  let i' = Idx_mut.get M.t M.i in
  Printf.printf "i = %d, j = %d, i' = %d\n" i j i'
```
```
i = 1, j = 2, i' = 3
```
