### PR TITLE
Cancel the tick thread

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -62,6 +62,12 @@ static void st_thread_join(st_thread_id thr)
   /* best effort: ignore errors */
 }
 
+static void st_thread_cancel(st_thread_id thr)
+{
+  pthread_cancel(thr);
+  /* best effort: ignore errors */
+}
+
 /* The master lock.  This is a mutex that is held most of the time,
    so we implement it in a slightly convoluted way to avoid
    all risks of busy-waiting.  Also, we count the number of waiting

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -752,6 +752,7 @@ static void stop_tick_thread(void)
 {
   if (Tick_thread_running){
     atomic_store_release(&Tick_thread_stop, 1);
+    st_thread_cancel(Tick_thread_id);
     st_thread_join(Tick_thread_id);
     atomic_store_release(&Tick_thread_stop, 0);
     Tick_thread_running = 0;


### PR DESCRIPTION
Currently, terminating a domain joins its tick thread, which can take up to 50ms. Now we attempt to wake it up early with `pthread_cancel`.