### PR TITLE
Add missing mode-crossing to functional record update

### DIFF
--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -504,3 +504,16 @@ let foo (local_ x : int) =
 [%%expect{|
 val foo : int @ local -> (int -> int) ref = <fun>
 |}]
+
+(* Functional record update allows mode-crossing on kept fields *)
+type r = { foo: int ref; bar: int; mutable baz: int; qux : int ref @@ global }
+let f (orig @ local) = { orig with foo = ref 42; baz = 42 }
+[%%expect{|
+type r = {
+  foo : int ref;
+  bar : int;
+  mutable baz : int;
+  qux : int ref @@ global;
+}
+val f : r @ local -> r = <fun>
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5877,7 +5877,7 @@ and type_expect_
                 exp, mode
               end ~post:(fun (exp, _) -> generalize_structure_exp exp)
             in
-            Some (exp, mode)
+            Some (exp, Mode.Value.disallow_right mode)
       in
       let ty_record, expected_type =
         let extract_record loc ty other_form_error not_a_record_error =
@@ -6042,6 +6042,7 @@ and type_expect_
                 apply_is_contained_by is_contained_by
                   ~modalities:lbl.lbl_modalities mode
               in
+              let mode = cross_left env lbl.lbl_arg mode in
               check_construct_mutability ~loc:record_loc ~env lbl.lbl_mut
                 ~ty:lbl.lbl_arg ~modalities:lbl.lbl_modalities record_mode;
               let is_contained_by : Mode.Hint.is_contained_by =


### PR DESCRIPTION
Previously, `{ x with ...; foo = x.foo }` had better mode-crossing than `{ x with ... }`, since there was an extra crossing in normal field projection that was missing in functional record update.

cc @riaqn 