### PR TITLE
ocamltest: Add fexpr_reference_suffix variable

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -716,6 +716,11 @@ let run_fexpr_check log env =
   let passes_sfx =
     Actions_helpers.words_of_variable env Ocaml_variables.fexpr_dump_files
   in
+  let reference_suffix =
+    match Environments.lookup Ocaml_variables.fexpr_reference_suffix env with
+    | None -> "reference"
+    | Some reference_suffix -> reference_suffix
+  in
   let test_build_dir = Actions_helpers.test_build_directory env in
   let test_source_dir = Actions_helpers.test_source_directory env in
   let test_name = Filename.chop_extension (Actions_helpers.testfile env) in
@@ -724,7 +729,7 @@ let run_fexpr_check log env =
       let pass_ref_file =
         Filename.(make_filename
                     (chop_extension pass_dump_file)
-                    "reference")
+                    reference_suffix)
       in
       let dump_file =
         Filename.make_path [test_build_dir; pass_dump_file]
@@ -733,10 +738,19 @@ let run_fexpr_check log env =
         Filename.make_path [test_source_dir; pass_ref_file]
       in
       let nr =
-        if Sys.file_exists dump_file && Sys.file_exists ref_file then
-          Actions_helpers.compare_files "fexpr" dump_file ref_file log env
+        if Sys.file_exists ref_file then
+          if Sys.file_exists dump_file then
+            Actions_helpers.compare_files "fexpr" dump_file ref_file log env
+          else
+            let dump_sfx = Filename.basename dump_file in
+            (Result.fail_with_reason
+              ("Expected a pass output: " ^ dump_sfx)
+            , env)
         else
-          (Result.fail_with_reason ("Expected a pass output "^pass_sfx), env)
+          let ref_sfx = Filename.basename ref_file in
+          (Result.fail_with_reason
+            ("Missing reference file: " ^ ref_sfx)
+          , env)
       in
       if Result.is_pass res then nr else (res, env))
     (Result.pass, env)

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -251,6 +251,10 @@ let fexpr_dump_files =
   Variables.make ("fexpr_dump_file",
     "Flambda passes dump files suffixes")
 
+let fexpr_reference_suffix =
+  Variables.make ("fexpr_reference_suffix",
+    "Suffix to add to the fexpr reference files")
+
 let init () =
   List.iter register_variable
   [
@@ -318,4 +322,5 @@ let init () =
     sharedobjext;
     use_runtime;
     fexpr_dump_files;
+    fexpr_reference_suffix;
   ]

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -143,4 +143,6 @@ val use_runtime : Variables.t
 
 val fexpr_dump_files : Variables.t
 
+val fexpr_reference_suffix : Variables.t
+
 val init : unit -> unit


### PR DESCRIPTION
This allows writing tests with that check the output of the same file with different flags.