### PR TITLE
 Use canonical types for `make_suitable_for_environment`

### DIFF
--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -1291,7 +1291,7 @@ struct
                 TE.add_definition base_env bound_name (TG.kind ty')
               in
               let new_types = Name.Map.add (Name.var var') ty' new_types in
-              Var.Map.add var (var', ty') sbs, base_env, new_types, acc))
+              Var.Map.add var var' sbs, base_env, new_types, acc))
         live_vars
         (Var.Map.empty, base_env, Name.Map.empty, empty)
     in
@@ -1327,20 +1327,20 @@ struct
     in
     let subst var =
       match Var.Map.find_opt var sbs with
-      | Some (v, ty) ->
-        Name.var v, ET.to_type (Expand_head.expand_head final_env ty)
+      | Some v ->
+        Name.var v, TE.find final_env (Name.var v) (Some (Variable.kind v))
       | None -> Misc.fatal_error "Not defined [subst]"
     in
     let to_keep =
       Var.Map.fold
-        (fun _ (var, _) acc -> Variable.Set.add var acc)
+        (fun _ var acc -> Variable.Set.add var acc)
         sbs Variable.Set.empty
     in
     let teev =
       Expand_head.make_suitable_for_environment final_env
         (All_variables_except to_keep) (List.map subst bind_to)
     in
-    Var.Map.map fst sbs, teev
+    sbs, teev
 
   let rewrite env symbol_abstraction =
     (* CR vlaviron for bclement: This should share more code with

--- a/testsuite/tests/reaper/hidden_identity.ml
+++ b/testsuite/tests/reaper/hidden_identity.ml
@@ -1,0 +1,1 @@
+let[@inline never] hidden_identity x = x

--- a/testsuite/tests/reaper/result_types_of_identity.ml
+++ b/testsuite/tests/reaper/result_types_of_identity.ml
@@ -1,0 +1,30 @@
+(* TEST
+ flambda;
+ readonly_files = "hidden_identity.ml";
+ setup-ocamlopt.byte-build-env;
+ {
+   ocamlopt_flags = "-flambda2-reaper -flambda2-result-types-all-functions";
+   all_modules = "hidden_identity.ml";
+   ocamlopt.byte;
+ }{
+   ocamlopt_flags = "hidden_identity.cmx -dfexpr-annot";
+   all_modules = "result_types_of_identity.ml";
+   ocamlopt.byte with dump-simplify;
+   check-fexpr-dump;
+ }
+ {
+   ocamlopt_flags = "-flambda2-reaper -no-flambda2-result-types";
+   all_modules = "hidden_identity.ml";
+   ocamlopt.byte;
+ }{
+   ocamlopt_flags = "hidden_identity.cmx -dfexpr-annot";
+   all_modules = "result_types_of_identity.ml";
+   ocamlopt.byte with dump-simplify;
+   fexpr_reference_suffix = "no-result-types.reference";
+   check-fexpr-dump;
+ }
+*)
+
+let always_0 () =
+  (* The result types should be enough to get rid of the assertion. *)
+  assert ((Hidden_identity.hidden_identity [@inlined never]) 0 = 0)

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
@@ -1,0 +1,36 @@
+let $camlResult_types_of_identity__immstring16 =
+  "result_types_of_identity.ml"
+in
+let $camlResult_types_of_identity__const_block18 =
+  Block 0 ($camlResult_types_of_identity__immstring16, 30, 2)
+in
+let $camlResult_types_of_identity__Pmakeblock21 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure,
+           $camlResult_types_of_identity__const_block18)
+in
+let code always_0_0 deleted in
+let code loopify(never) size(16) newer_version_of(always_0_0)
+      always_0_0_1 (param : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  apply direct(hidden_identity_0) inlined(never)
+    ($Hidden_identity.camlHidden_identity__hidden_identity_1
+     : _ -> imm tagged)
+      (0)
+      -> k2 * k1
+    where k2 (apply_result : imm tagged) =
+      let prim = %phys_eq (apply_result, 0) in
+      switch prim
+        | 0 -> k1
+                 pop(regular k1)
+                 ($camlResult_types_of_identity__Pmakeblock21)
+        | 1 -> k (0)
+in
+let $camlResult_types_of_identity__always_0_1 =
+  closure always_0_0_1 @always_0
+in
+let $camlResult_types_of_identity =
+  Block 0 ($camlResult_types_of_identity__always_0_1)
+in
+cont done ($camlResult_types_of_identity)

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.reference
@@ -1,0 +1,21 @@
+let code always_0_0 deleted in
+let code loopify(never) size(5) newer_version_of(always_0_0)
+      always_0_0_1 (param : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  apply direct(hidden_identity_0) inlined(never)
+    ($Hidden_identity.camlHidden_identity__hidden_identity_1
+     : _ -> imm tagged)
+      (0)
+      -> k2 * k1
+    where k2 (param_1) =
+      cont k (0)
+in
+let $camlResult_types_of_identity__always_0_1 =
+  closure always_0_0_1 @always_0
+in
+let $camlResult_types_of_identity =
+  Block 0 ($camlResult_types_of_identity__always_0_1)
+in
+cont done ($camlResult_types_of_identity)


### PR DESCRIPTION
Using expanded types loses direct relations between arguments and parameters.