### PR TITLE
Enable llvm-mc and avoid stripping debug info

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,7 @@ let
     [
       "--cache-file=/dev/null"
       "--with-objcopy=${pkgs.llvm}/bin/llvm-objcopy"
+      "--enable-assembler-suitable-for-dissector=${pkgs.llvm}/bin/llvm-mc"
       (mkFlag addressSanitizer "address-sanitizer")
       (mkFlag dev "dev")
       (mkFlag flambdaInvariants "flambda-invariants")
@@ -205,7 +206,8 @@ stdenv.mkDerivation {
   OXCAML_CLANG = if oxcamlClang then "${clang}/bin/clang" else null;
 
   enableParallelBuilding = true;
-  separateDebugInfo = !dev;
+  separateDebugInfo = false;
+  dontStrip = true;
 
   # Disable _multioutConfig hook which adds --libdir=$out/lib into
   # configureFlags when separateDebugInfo is enabled, breaking OCaml's configure


### PR DESCRIPTION
This PR combines two changes to the nix config:
- We no longer strip debug information when building, because it removes debug information from the runtime. 
- We enable llvm-mc as the assembler used by the compiler to support the dissector. 

The CI configuration `runtime5 dissector-assembler (x86_64-linux)` already has llvm-mc enabled as the assembler, so I have not changed any of the CI runners. 