### PR TITLE
reaper: add limit on the number of unboxed fields

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -638,6 +638,14 @@ let mk_no_reaper_unbox f =
     Printf.sprintf " Disable unboxing in the reaper%s (Flambda2 only)"
       (format_not_default Flambda2.Default.reaper_unbox) )
 
+let mk_reaper_max_unbox_size f =
+  ( "-reaper-max-unbox-size",
+    Arg.Int f,
+    Printf.sprintf
+      " Maximum number of fields unboxed by the reaper for a single block \
+       (default %d) (Flambda2 only)"
+      Flambda2.Default.reaper_max_unbox_size )
+
 let mk_reaper_change_calling_conventions f =
   ( "-reaper-change-calling-conventions",
     Arg.Unit f,
@@ -1249,6 +1257,7 @@ module type Oxcaml_options = sig
   val no_reaper_local_fields : unit -> unit
   val reaper_unbox : unit -> unit
   val no_reaper_unbox : unit -> unit
+  val reaper_max_unbox_size : int -> unit
   val reaper_change_calling_conventions : unit -> unit
   val no_reaper_change_calling_conventions : unit -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit
@@ -1422,6 +1431,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_reaper_local_fields F.no_reaper_local_fields;
       mk_reaper_unbox F.reaper_unbox;
       mk_no_reaper_unbox F.no_reaper_unbox;
+      mk_reaper_max_unbox_size F.reaper_max_unbox_size;
       mk_reaper_change_calling_conventions F.reaper_change_calling_conventions;
       mk_no_reaper_change_calling_conventions
         F.no_reaper_change_calling_conventions;
@@ -1733,6 +1743,9 @@ module Oxcaml_options_impl = struct
   let no_reaper_local_fields = clear Flambda2.reaper_local_fields
   let reaper_unbox = set Flambda2.reaper_unbox
   let no_reaper_unbox = clear Flambda2.reaper_unbox
+
+  let reaper_max_unbox_size size =
+    Flambda2.reaper_max_unbox_size := Oxcaml_flags.Set size
 
   let reaper_change_calling_conventions =
     set Flambda2.reaper_change_calling_conventions

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -125,6 +125,7 @@ module type Oxcaml_options = sig
   val no_reaper_local_fields : unit -> unit
   val reaper_unbox : unit -> unit
   val no_reaper_unbox : unit -> unit
+  val reaper_max_unbox_size : int -> unit
   val reaper_change_calling_conventions : unit -> unit
   val no_reaper_change_calling_conventions : unit -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -165,6 +165,7 @@ module Flambda2 = struct
     let reaper_preserve_direct_calls : reaper_preserve_direct_calls = Auto
     let reaper_local_fields = false
     let reaper_unbox = true
+    let reaper_max_unbox_size = 10
     let reaper_change_calling_conventions = true
     let unicode = true
     let kind_checks = false
@@ -183,6 +184,7 @@ module Flambda2 = struct
     reaper_preserve_direct_calls : reaper_preserve_direct_calls;
     reaper_local_fields : bool;
     reaper_unbox : bool;
+    reaper_max_unbox_size : int;
     reaper_change_calling_conventions : bool;
     unicode : bool;
     kind_checks : bool;
@@ -201,6 +203,7 @@ module Flambda2 = struct
     reaper_preserve_direct_calls = Default.reaper_preserve_direct_calls;
     reaper_local_fields = Default.reaper_local_fields;
     reaper_unbox = Default.reaper_unbox;
+    reaper_max_unbox_size = Default.reaper_max_unbox_size;
     reaper_change_calling_conventions =
       Default.reaper_change_calling_conventions;
     unicode = Default.unicode;
@@ -242,6 +245,7 @@ module Flambda2 = struct
   let reaper_preserve_direct_calls = ref Default
   let reaper_local_fields = ref Default
   let reaper_unbox = ref Default
+  let reaper_max_unbox_size = ref Default
   let reaper_change_calling_conventions = ref Default
 
   module Dump = struct

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -142,6 +142,7 @@ module Flambda2 : sig
     val reaper_preserve_direct_calls : reaper_preserve_direct_calls
     val reaper_local_fields : bool
     val reaper_unbox : bool
+    val reaper_max_unbox_size : int
     val reaper_change_calling_conventions : bool
     val unicode : bool
     val kind_checks : bool
@@ -163,6 +164,7 @@ module Flambda2 : sig
     reaper_preserve_direct_calls : reaper_preserve_direct_calls;
     reaper_local_fields : bool;
     reaper_unbox : bool;
+    reaper_max_unbox_size : int;
     reaper_change_calling_conventions : bool;
     unicode : bool;
     kind_checks : bool;
@@ -183,6 +185,7 @@ module Flambda2 : sig
   val reaper_preserve_direct_calls : reaper_preserve_direct_calls or_default ref
   val reaper_local_fields : bool or_default ref
   val reaper_unbox : bool or_default ref
+  val reaper_max_unbox_size : int or_default ref
   val reaper_change_calling_conventions : bool or_default ref
   val unicode : bool or_default ref
   val kind_checks : bool or_default ref
@@ -190,7 +193,7 @@ module Flambda2 : sig
   module Dump : sig
     type target = Nowhere | Main_dump_stream | File of Misc.filepath
     type pass = Last_pass | This_pass of string
-    
+
     val rawfexpr : target ref
     val fexpr : target ref
     val fexpr_after : pass ref

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1215,8 +1215,11 @@ let get_fields : Datalog.database -> usages -> field_usage Field.Map.t =
          | None, Some m -> Some (Used_as_vars m))
        out1 out2)
 
-let field_of_constructor_is_used =
-  rel2 "field_of_constructor_is_used" Cols.[n; f]
+let field_of_constructor_is_used_tbl =
+  Datalog.create_relation ~name:"field_of_constructor_is_used" Cols.[n; f]
+
+let field_of_constructor_is_used constr field =
+  field_of_constructor_is_used_tbl % [constr; field]
 
 let field_of_constructor_is_used_top =
   rel2 "field_of_constructor_is_used_top" Cols.[n; f]
@@ -1358,7 +1361,9 @@ let cannot_change_representation1 = rel1 "cannot_change_representation1" Cols.[n
 
 let cannot_change_representation = rel1 "cannot_change_representation" Cols.[n]
 
-let cannot_unbox0 = rel1 "cannot_unbox0" Cols.[n]
+let cannot_unbox0_tbl = Datalog.create_relation ~name:"cannot_unbox0" Cols.[n]
+
+let cannot_unbox0 x = cannot_unbox0_tbl % [x]
 
 let cannot_unbox = rel1 "cannot_unbox" Cols.[n]
 
@@ -1373,7 +1378,7 @@ let dominated_by_allocation_point =
 
 let allocation_point_dominator = rel2 "allocation_point_dominator" Cols.[n; n]
 
-let datalog_rules =
+let field_of_constructor_is_used_rules =
   saturate_in_order
     [ (let$ [base; relation; from] = ["base"; "relation"; "from"] in
        [ constructor ~base relation ~from;
@@ -1452,7 +1457,7 @@ let datalog_rules =
          any_usage v ]
        ==> and_
              [ field_of_constructor_is_used base relation;
-               field_of_constructor_is_used_top base relation ]);
+               field_of_constructor_is_used_top base relation ])
       (* CR ncourant: this marks any [Apply] field as
          [field_of_constructor_is_used], as long as the function is called.
          Shouldn't that be gated behind a [cannot_change_calling_convetion]? *)
@@ -1464,7 +1469,11 @@ let datalog_rules =
       (* CR ncourant: should this be reenabled? I think this is no longer
          necessary because we remove unused arguments of continuations,
          including return continuations. *)
-      (* If any usage is possible, do not change the representation. Note that
+    ]
+
+let datalog_rules =
+  saturate_in_order
+    [ (* If any usage is possible, do not change the representation. Note that
          this rule will change in the future, when local value slots are
          properly tracked: a closure will only local value slots that has
          any_use will still be able to have its representation changed. *)
@@ -3337,6 +3346,32 @@ let fixpoint (graph : Global_flow_graph.graph) =
       datalog
   in
   let db = Datalog.Schedule.run ~stats datalog_schedule datalog in
+  let db =
+    List.fold_left
+      (fun db rule -> Datalog.Schedule.run ~stats rule db)
+      db field_of_constructor_is_used_rules
+  in
+  (* We need to do this after [field_of_constructor_is_used] is computed, so
+     that we prevent unboxing based on the number of fields actually used. *)
+  let db =
+    let max_unbox_size = Flambda_features.reaper_max_unbox_size () in
+    Datalog.set_table cannot_unbox0_tbl
+      (Code_id_or_name.Map.filter_map
+         (fun _block fields ->
+           let num_used_fields =
+             Field.Map.fold
+               (fun field () acc ->
+                 if
+                   Field.is_real_field field
+                   && not (Field.is_function_slot field)
+                 then acc + 1
+                 else acc)
+               fields 0
+           in
+           if num_used_fields > max_unbox_size then Some () else None)
+         (Datalog.get_table field_of_constructor_is_used_tbl db))
+      db
+  in
   let db =
     List.fold_left
       (fun db rule -> Datalog.Schedule.run ~stats rule db)

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -92,6 +92,10 @@ let reaper_unbox () =
   !Oxcaml_flags.Flambda2.reaper_unbox
   |> with_default ~f:(fun d -> d.reaper_unbox)
 
+let reaper_max_unbox_size () =
+  !Oxcaml_flags.Flambda2.reaper_max_unbox_size
+  |> with_default ~f:(fun d -> d.reaper_max_unbox_size)
+
 let reaper_change_calling_conventions () =
   !Oxcaml_flags.Flambda2.reaper_change_calling_conventions
   |> with_default ~f:(fun d -> d.reaper_change_calling_conventions)

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -61,6 +61,8 @@ val reaper_local_fields : unit -> bool
 
 val reaper_unbox : unit -> bool
 
+val reaper_max_unbox_size : unit -> int
+
 val reaper_change_calling_conventions : unit -> bool
 
 val kind_checks : unit -> bool

--- a/testsuite/tests/reaper/large_no_unbox.ml
+++ b/testsuite/tests/reaper/large_no_unbox.ml
@@ -1,0 +1,15 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ ocamlopt_flags = "-flambda2-reaper -reaper-max-unbox-size 3";
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte with dump-reaper;
+ check-fexpr-dump;
+*)
+
+let f x =
+  (* [small] is only size 3 for unboxing, as [d] is unused. *)
+  let[@inline never][@local never] small (a, b, c, d) () = a + b + c in
+  (* [large] is size 4, putting it over the max-unbox-size limit. *)
+  let[@inline never][@local never] large (a, b, c, d) () = a + b + c + d in
+  small (x + 1, x + 2, x + 3, x + 4) () + large (x + 5, x + 6, x + 7, x + 8) ()

--- a/testsuite/tests/reaper/large_no_unbox.reaper.reference
+++ b/testsuite/tests/reaper/large_no_unbox.reaper.reference
@@ -1,0 +1,72 @@
+let code small_1 deleted in
+let code large_2 deleted in
+let code f_0 deleted in
+let code inline(never) loopify(never) size(11) newer_version_of(large_2)
+      large_2_1
+        (param : [ 0 of imm tagged * imm tagged * imm tagged * imm tagged ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = %block_load.[`3`] (param) in
+  let Pfield_1 = %block_load.[`2`] (param) in
+  let Pfield_2 = %block_load.[`1`] (param) in
+  let Pfield_3 = %block_load.[`0`] (param) in
+  let int_add = %int_barith.add (Pfield_3, Pfield_2) in
+  let int_add_1 = %int_barith.add (int_add, Pfield_1) in
+  let int_add_2 = %int_barith.add (int_add_1, Pfield) in
+  cont k (int_add_2)
+in
+let $camlLarge_no_unbox__large_5 = closure large_2_1 @large in
+let code inline(never) loopify(never) size(8) newer_version_of(small_1)
+      small_1_1
+        (`Pmakeblock_into_param_field_0_𝕍`,
+         `Pmakeblock_into_param_field_1_𝕍`,
+         `Pmakeblock_into_param_field_2_𝕍`)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = `Pmakeblock_into_param_field_2_𝕍` in
+  let Pfield_1 = `Pmakeblock_into_param_field_1_𝕍` in
+  let Pfield_2 = `Pmakeblock_into_param_field_0_𝕍` in
+  let int_add = %int_barith.add (Pfield_2, Pfield_1) in
+  let int_add_1 = %int_barith.add (int_add, Pfield) in
+  cont k (int_add_1)
+in
+let $camlLarge_no_unbox__small_4 = closure small_1_1 @small in
+let code loopify(never) size(47) newer_version_of(f_0)
+      f_0_1 (x : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `region` = %begin_region () in
+  (let int_add = %int_barith.add (x, 8) in
+   let int_add_1 = %int_barith.add (x, 7) in
+   let int_add_2 = %int_barith.add (x, 6) in
+   let int_add_3 = %int_barith.add (x, 5) in
+   let Pmakeblock =
+     %block.[`0`].`local`[`region`]
+       (int_add_3, int_add_2, int_add_1, int_add)
+   in
+   apply direct(large_2_1)
+     ($camlLarge_no_unbox__large_5 : _ -> imm tagged) (Pmakeblock) -> k2 * k1)
+    where k2 (apply_result : imm tagged) =
+      ((let int_add = %int_barith.add (x, 3) in
+        let int_add_1 = %int_barith.add (x, 2) in
+        let int_add_2 = %int_barith.add (x, 1) in
+        let `Pmakeblock_into_Pmakeblock_field_2_𝕍` = int_add in
+        let `Pmakeblock_into_Pmakeblock_field_1_𝕍` = int_add_1 in
+        let `Pmakeblock_into_Pmakeblock_field_0_𝕍` = int_add_2 in
+        apply direct(small_1_1)
+          ($camlLarge_no_unbox__small_4 : _ -> imm tagged)
+            (`Pmakeblock_into_Pmakeblock_field_0_𝕍`,
+             `Pmakeblock_into_Pmakeblock_field_1_𝕍`,
+             `Pmakeblock_into_Pmakeblock_field_2_𝕍`)
+            -> k2 * k1)
+         where k2 (apply_result_1 : imm tagged) =
+           let int_add = %int_barith.add (apply_result_1, apply_result) in
+           let `unit` = %end_region (`region`) in
+           cont k (int_add))
+in
+let $camlLarge_no_unbox__f_3 = closure f_0_1 @f in
+let $camlLarge_no_unbox = Block 0 ($camlLarge_no_unbox__f_3) in
+cont done ($camlLarge_no_unbox)


### PR DESCRIPTION
Note: the default max size is currently 10, which both seems low when unboxing a single block, and large when considering multiple nested blocks.