### PR TITLE
Add -O4 optimization level meaning -O3+reaper

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -407,6 +407,7 @@ let read_one_param ppf position name v =
   | "Oclassic" -> if check_bool ppf "Oclassic" v then Clflags.set_oclassic ()
   | "O2" -> if check_bool ppf "O2" v then Clflags.set_o2 ()
   | "O3" -> if check_bool ppf "O3" v then Clflags.set_o3 ()
+  | "O4" -> if check_bool ppf "O4" v then Clflags.set_o4 ()
   | "unbox-closures" ->
       set "unbox-closures" [ unbox_closures ] v
   | "unbox-closures-factor" ->

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -240,6 +240,10 @@ let mk_o3 f =
   "-O3", Arg.Unit f, " Apply aggressive optimization for speed (may \
     significantly increase code size and compilation time)"
 
+let mk_o4 f =
+  "-O4", Arg.Unit f, " Like -O3, but also enable the reaper pass \
+    (Flambda 2 only)"
+
 let mk_rounds f =
   "-rounds", Arg.Int f,
     Printf.sprintf "<n>  Repeat tree optimization and inlining phases this \
@@ -1289,6 +1293,7 @@ module type Optcommon_options = sig
   val _no_unbox_specialised_args : unit -> unit
   val _o2 : unit -> unit
   val _o3 : unit -> unit
+  val _o4 : unit -> unit
   val _insn_sched : unit -> unit
   val _no_insn_sched : unit -> unit
   val _linscan : unit -> unit
@@ -1371,6 +1376,7 @@ module type Jscomp_options = sig
   val _classic_inlining : unit -> unit
   val _o2 : unit -> unit
   val _o3 : unit -> unit
+  val _o4 : unit -> unit
 end
 
 module type Opttop_options = sig
@@ -1735,6 +1741,7 @@ struct
     mk_o F._o;
     mk_o2 F._o2;
     mk_o3 F._o3;
+    mk_o4 F._o4;
     mk_opaque F._opaque;
     mk_open F._open;
     mk_output_obj F._output_obj;
@@ -1904,6 +1911,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_no_unbox_specialised_args F._no_unbox_specialised_args;
     mk_o2 F._o2;
     mk_o3 F._o3;
+    mk_o4 F._o4;
     mk_open F._open;
     mk_ppx F._ppx;
     mk_principal F._principal;
@@ -2037,6 +2045,7 @@ struct
     mk_o F._o;
     mk_o2 F._o2;
     mk_o3 F._o3;
+    mk_o4 F._o4;
     mk_opaque F._opaque;
     mk_open F._open;
     mk_output_obj F._output_obj;
@@ -2415,6 +2424,7 @@ module Default = struct
     *)
     let _o2 () = Clflags.set_o2 ()
     let _o3 () = Clflags.set_o3 ()
+    let _o4 () = Clflags.set_o4 ()
     let _remove_unused_arguments = set remove_unused_arguments
     let _rounds n = simplify_rounds := (Some n)
     let _unbox_closures = set unbox_closures
@@ -2747,5 +2757,6 @@ third-party libraries such as Lwt, but with a different API."
     let _classic_inlining () = set_oclassic ()
     let _o2 () = Clflags.set_o2 ()
     let _o3 () = Clflags.set_o3 ()
+    let _o4 () = Clflags.set_o4 ()
   end
 end

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -229,6 +229,7 @@ module type Optcommon_options = sig
   val _no_unbox_specialised_args : unit -> unit
   val _o2 : unit -> unit
   val _o3 : unit -> unit
+  val _o4 : unit -> unit
   val _insn_sched : unit -> unit
   val _no_insn_sched : unit -> unit
   val _linscan : unit -> unit
@@ -318,6 +319,7 @@ module type Jscomp_options = sig
   val _classic_inlining : unit -> unit
   val _o2 : unit -> unit
   val _o3 : unit -> unit
+  val _o4 : unit -> unit
 end
 
 module type Ocamldoc_options = sig

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -113,7 +113,7 @@ let caml_apply_inline_fast_path = ref false  (* -caml-apply-inline-fast-path *)
 type function_result_types = Never | Functors_only | All_functions
 type join_algorithm = Binary | N_way | Checked
 type reaper_preserve_direct_calls = Never | Always | Zero_alloc | Auto
-type opt_level = Oclassic | O2 | O3
+type opt_level = Oclassic | O2 | O3 | O4
 type 'a or_default = Set of 'a | Default
 
 
@@ -131,12 +131,13 @@ let gc_timings = ref false
 
 let symbol_visibility_protected = ref false (* -symbol-visibility-protected*)
 
-let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 =
+let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 ~o4 =
   match opt_level with
   | Default -> default
   | Set Oclassic -> oclassic
   | Set O2 -> o2
   | Set O3 -> o3
+  | Set O4 -> o4
 
   (* -llvm-backend is at [Clflags.llvm_backend] *)
 
@@ -226,7 +227,13 @@ module Flambda2 = struct
     function_result_types = Functors_only
   }
 
-  let default_for_opt_level opt_level = flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3
+  let o4 = {
+    o3 with
+    enable_reaper = true
+  }
+
+  let default_for_opt_level opt_level =
+    flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 ~o4
 
   let classic_mode = ref Default
   let join_points = ref Default
@@ -317,8 +324,10 @@ module Flambda2 = struct
 
     let o3 = default
 
+    let o4 = default
+
     let default_for_opt_level opt_level =
-      flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3
+      flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 ~o4
 
     let fallback_inlining_heuristic = ref Default
     let inline_effects_in_cmm = ref Default
@@ -489,8 +498,16 @@ let set_o3 () =
     Clflags.Opt_flag_handler.default.set_o3 ();
   end
 
+let set_o4 () =
+  if Clflags.is_flambda2 () then begin
+    Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o3_arguments;
+    opt_level := Set O4
+  end else begin
+    Clflags.Opt_flag_handler.default.set_o3 ();
+  end
+
 let opt_flag_handler : Clflags.Opt_flag_handler.t =
-  { set_oclassic; set_o2; set_o3 }
+  { set_oclassic; set_o2; set_o3; set_o4 }
 
 let use_cached_generic_functions = ref false
 let cached_generic_functions_path =

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -98,7 +98,7 @@ val caml_apply_inline_fast_path : bool ref
 type function_result_types = Never | Functors_only | All_functions
 type reaper_preserve_direct_calls = Never | Always | Zero_alloc | Auto
 type join_algorithm = Binary | N_way | Checked
-type opt_level = Oclassic | O2 | O3
+type opt_level = Oclassic | O2 | O3 | O4
 type 'a or_default = Set of 'a | Default
 
 val dump_inlining_paths : bool ref

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -191,7 +191,7 @@ module Inlining = struct
     match opt_level with
     | Oclassic -> I.oclassic_arguments
     | O2 -> I.o2_arguments
-    | O3 -> I.o3_arguments
+    | O3 | O4 -> I.o3_arguments
 
   let max_depth round_or_default =
     let depth =

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -99,6 +99,7 @@ let builtin_attrs =
   ; "nolabels"
   ; "flambda_oclassic"
   ; "flambda_o3"
+  ; "flambda_o4"
   ; "afl_inst_ratio"
   ; "local_opt"
   ; "curry"; "extension.curry"
@@ -581,6 +582,11 @@ let flambda_o3_attribute attr =
     ~name:"flambda_o3"
     ~f:(fun () -> if Config.flambda || Config.flambda2 then Clflags.set_o3 ())
 
+let flambda_o4_attribute attr =
+  clflags_attribute_without_payload' attr
+    ~name:"flambda_o4"
+    ~f:(fun () -> if Config.flambda || Config.flambda2 then Clflags.set_o4 ())
+
 let llvm_backend_attribute attr =
   clflags_attribute_without_payload' attr
     ~name:"llvm_backend"
@@ -661,6 +667,7 @@ let parse_standard_implementation_attributes attr =
   inline_attribute attr;
   afl_inst_ratio_attribute attr;
   flambda_o3_attribute attr;
+  flambda_o4_attribute attr;
   flambda_oclassic_attribute attr;
   zero_alloc_attribute ~in_signature:false attr;
   unsafe_allow_any_mode_crossing_attribute attr;

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -22,6 +22,7 @@
     - ocaml.deprecated_mutable
     - ocaml.explicit_arity
     - ocaml.flambda_o3
+    - ocaml.flambda_o4
     - ocaml.flambda_oclassic
     - ocaml.immediate
     - ocaml.immediate64

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -654,6 +654,7 @@ module Opt_flag_handler = struct
     set_oclassic : unit -> unit;
     set_o2 : unit -> unit;
     set_o3 : unit -> unit;
+    set_o4 : unit -> unit;
   }
 
   let default =
@@ -675,7 +676,8 @@ module Opt_flag_handler = struct
       use_inlining_arguments_set ~round:1 o2_arguments;
       use_inlining_arguments_set ~round:0 o1_arguments
     in
-    { set_oclassic; set_o2; set_o3 }
+    let set_o4 () = set_o3 () in
+    { set_oclassic; set_o2; set_o3; set_o4 }
 
   let current = ref default
 
@@ -685,6 +687,7 @@ end
 let set_oclassic () = (!Opt_flag_handler.current).set_oclassic ()
 let set_o2 () = (!Opt_flag_handler.current).set_o2 ()
 let set_o3 () = (!Opt_flag_handler.current).set_o3 ()
+let set_o4 () = (!Opt_flag_handler.current).set_o4 ()
 
 (* This is used by the -stop-after option. *)
 module Compiler_pass = struct

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -289,6 +289,7 @@ module Opt_flag_handler : sig
     set_oclassic : unit -> unit;
     set_o2 : unit -> unit;
     set_o3 : unit -> unit;
+    set_o4 : unit -> unit;
   }
 
   val default : t
@@ -299,6 +300,7 @@ end
 val set_oclassic : unit -> unit
 val set_o2 : unit -> unit
 val set_o3 : unit -> unit
+val set_o4 : unit -> unit
 
 module Compiler_ir : sig
   type t = Linear | Cfg | Llvmir


### PR DESCRIPTION
To make the transition to using the reaper easier for people, this adds `-O4`, which is the same as `-O3` plus `-flambda2-reaper`.  There is also a new attribute `[@@@ocaml.flambda_o4]`.

In due course we're likely to rearrange the optimization levels to make things easier and remove some unusual cases that aren't used.