### PR TITLE
Renaming of env operations in middle_end

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -82,16 +82,16 @@ let all_predefined_exception_symbols () =
   Predef.all_predef_exns |> List.map symbol_for_global |> Symbol.Set.of_list
 
 let predefined_exception_typing_env () =
-  let unit_info = Env.get_unit_name () in
+  let unit_info = Env.get_current_unit () in
   let predef_unit_info =
     Unit_info.make_dummy ~input_name:"<predefined exceptions>"
       Compilation_unit.predef_exn
   in
-  Env.set_unit_name (Some predef_unit_info);
+  Env.set_current_unit (Some predef_unit_info);
   let typing_env =
     TE.Serializable.predefined_exceptions (all_predefined_exception_symbols ())
   in
-  Env.set_unit_name unit_info;
+  Env.set_current_unit unit_info;
   typing_env
 
 let create_loader ~get_module_info =

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -217,7 +217,7 @@ let print0 ~sections ~print_typing_env ~print_code ~print_offsets ppf t =
   let unit_info =
     Unit_info.make_dummy ~input_name:"<none>" t.original_compilation_unit
   in
-  Env.set_unit_name (Some unit_info);
+  Env.set_current_unit (Some unit_info);
   let typing_env, code = import_typing_env_and_code0 ~sections t in
   if print_typing_env
   then

--- a/middle_end/flambda2/parser/parse_flambda.ml
+++ b/middle_end/flambda2/parser/parse_flambda.ml
@@ -154,8 +154,8 @@ let parse filename =
   |> Result.map (fun fexpr ->
       let comp_unit = make_compilation_unit ~extension:".fl" ~filename () in
       let unit_info = Unit_info.make_dummy ~input_name:filename comp_unit in
-      let old_unit_info = Env.get_unit_name () in
-      Env.set_unit_name (Some unit_info);
+      let old_unit_info = Env.get_current_unit () in
+      Env.set_current_unit (Some unit_info);
       let flambda = Fexpr_to_flambda.conv comp_unit fexpr in
-      Env.set_unit_name old_unit_info;
+      Env.set_current_unit old_unit_info;
       flambda)


### PR DESCRIPTION
A few `env.ml` operations got renamed upstream in 5.2 -> 5.4, and we need to pull these renamings into middle end. 