### PR TITLE
Types before the pattern's stage are not instantiable

### DIFF
--- a/testsuite/tests/quotation/typing/quotes_splices/gadt.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/gadt.ml
@@ -297,108 +297,125 @@ let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
 (* Evidence stays in the same *wrong* stage -- should always fail:
    [S_proof = S_min] and [T_proof =/= T_subj] *)
 
-(* CR metaprogramming jbachurski: Tests succeed until constraints are staged. *)
-
 (* 0 ~~> 0  @  1 <=> 0 *)
 let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
             (x : M.t) -> x + 1
 [%%expect{|
-- : (<[M.t]> expr, <[int]> expr) Type.eq -> M.t -> int = <fun>
+Line 2, characters 25-26:
+2 |             (x : M.t) -> x + 1
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 
 (* 1 ~~> 2 ~~> 1  @  1 <=> 0 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) (x : M.t) ->
     <[ $(Quote.Expr.int (x + 1)) * 2 ]> ]>
 [%%expect {|
-- : <[(<[M.t]> expr, <[int]> expr) Type.eq -> M.t -> <[int]> expr]> expr =
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
-    (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) (x : M.t) ->
-    <[($(Stdlib.Quote.Expr.int (x + 1))) * 2]>
-]>
+Line 2, characters 25-26:
+2 |     <[ $(Quote.Expr.int (x + 1)) * 2 ]> ]>
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 1 ~~> 2 ~~> 1  @  0 <=> 1 *)
 let _ = <[ fun (Equal : (M.t, int) Type.eq) (x : <[M.t]> expr) ->
     <[ $x + 1 ]> ]>
 [%%expect {|
-- : <[(M.t, int) Type.eq -> <[M.t]> expr -> <[int]> expr]> expr =
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) : (M.t, int)
-    Stdlib.Type.eq) (x : <[M.t]> expr) -> <[($x) + 1]>
-]>
+Line 2, characters 8-9:
+2 |     <[ $x + 1 ]> ]>
+            ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" = "int" is not compatible with type "int"
 |}]
 
 (* 0 ~~> 0  @  1 <=> 0 *)
 let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
             (x : M.t) -> x + 1
 [%%expect {|
-- : (<[M.t]> expr, <[int]> expr) Type.eq -> M.t -> int = <fun>
+Line 2, characters 25-26:
+2 |             (x : M.t) -> x + 1
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 0 ~~> 0  @  1 <=> 2 *)
 let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
             (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]>
 [%%expect {|
-- : (<[M.t]> expr, <[int]> expr) Type.eq ->
-    <[<[M.t]> expr]> expr -> <[<[int]> expr]> expr
-= <fun>
+Line 2, characters 50-51:
+2 |             (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]>
+                                                      ^
+Error: This expression has type "<[<[M.t]> expr]> expr"
+       but an expression was expected of type "<[<[int]> expr]> expr"
+       Type "<[M.t]>" = "<[int]>" is not compatible with type "<[int]>"
+       Type "M.t" is not compatible with type "int"
 |}]
 (* 1 ~~> 1  @  1 <=> 2 *)
 let _ = <[ fun (Equal : (M.t, int) Type.eq)
                (x : <[M.t]> expr) -> <[$x + 1]> ]>
 [%%expect {|
-- : <[(M.t, int) Type.eq -> <[M.t]> expr -> <[int]> expr]> expr =
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) : (M.t, int)
-    Stdlib.Type.eq) (x : <[M.t]> expr) -> <[($x) + 1]>
-]>
+Line 2, characters 40-41:
+2 |                (x : <[M.t]> expr) -> <[$x + 1]> ]>
+                                            ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" = "int" is not compatible with type "int"
 |}]
 (* 0 ~~> 0  @  2 <=> 0 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
             (x : M.t) -> x + 1
 [%%expect {|
-- : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq -> M.t -> int =
-<fun>
+Line 2, characters 25-26:
+2 |             (x : M.t) -> x + 1
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 0 ~~> 0  @  2 <=> 1 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
             (x : <[M.t]> expr) -> <[$x + 1]>
 [%%expect {|
-- : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq ->
-    <[M.t]> expr -> <[int]> expr
-= <fun>
+Line 2, characters 37-38:
+2 |             (x : <[M.t]> expr) -> <[$x + 1]>
+                                         ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" is not compatible with type "int"
 |}]
 (* 0 ~~> 0  @  2 <=> 3 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
             (x : <[<[<[M.t]> expr]> expr]> expr) -> <[<[<[$($($x)) + 1]>]>]>
 [%%expect {|
-- : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq ->
-    <[<[<[M.t]> expr]> expr]> expr -> <[<[<[int]> expr]> expr]> expr
-= <fun>
+Line 2, characters 63-64:
+2 |             (x : <[<[<[M.t]> expr]> expr]> expr) -> <[<[<[$($($x)) + 1]>]>]>
+                                                                   ^
+Error: This expression has type "<[<[<[M.t]> expr]> expr]> expr"
+       but an expression was expected of type "<[<[<[int]> expr]> expr]> expr"
+       Type "M.t" is not compatible with type "int"
 |}]
 (* 1 ~~> 1  @  2 <=> 1 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
                (x : M.t) -> x + 1 ]>
 [%%expect {|
-- : <[(<[M.t]> expr, <[int]> expr) Type.eq -> M.t -> int]> expr =
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
-    (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) (x : M.t) -> x + 1
-]>
+Line 2, characters 28-29:
+2 |                (x : M.t) -> x + 1 ]>
+                                ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 1 ~~> 1  @  2 <=> 3 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
                (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]> ]>
 [%%expect {|
-- : <[
-     (<[M.t]> expr, <[int]> expr) Type.eq ->
-     <[<[M.t]> expr]> expr -> <[<[int]> expr]> expr]>
-    expr
-=
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
-    (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) (x : <[<[M.t]> expr]> expr)
-    -> <[<[($($x)) + 1]>]>
-]>
+Line 2, characters 53-54:
+2 |                (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]> ]>
+                                                         ^
+Error: This expression has type "<[<[M.t]> expr]> expr"
+       but an expression was expected of type "<[<[int]> expr]> expr"
+       Type "<[M.t]>" = "<[int]>" is not compatible with type "<[int]>"
+       Type "M.t" is not compatible with type "int"
 |}]
 
 (* Evidence travels to the right stage in the future -- should always succeed:
@@ -484,93 +501,101 @@ let _ = <[ <[
 (* Evidence travels to the wrong stage in the future -- should always fail:
    [S_proof < S_min] and [T_proof =/= T_subj] *)
 
-(* CR metaprogramming jbachurski: Tests succeed until constraints are staged. *)
-
 (* 0 ~~> 1  @  1 <=> 2 *)
 let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
      <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]>
 [%%expect {|
-- : (<[M.t]> expr, <[int]> expr) Type.eq ->
-    <[<[M.t]> expr -> <[int]> expr]> expr
-= <fun>
+Line 2, characters 37-38:
+2 |      <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]>
+                                         ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" = "int" is not compatible with type "int"
 |}]
 (* 0 ~~> 2  @  1 <=> 2 *)
 let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
   <[ <[ fun (x : M.t) -> x + 1 ]> ]>
 [%%expect {|
-- : (<[M.t]> expr, <[int]> expr) Type.eq -> <[<[M.t -> int]> expr]> expr =
-<fun>
+Line 2, characters 25-26:
+2 |   <[ <[ fun (x : M.t) -> x + 1 ]> ]>
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 1 ~~> 2  @  1 <=> 2 *)
 let _ = <[ fun (Equal : (M.t, int) Type.eq) ->
         <[ fun (x : M.t) -> x + 1 ]> ]>
 [%%expect {|
-- : <[(M.t, int) Type.eq -> <[M.t -> int]> expr]> expr =
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) : (M.t, int)
-    Stdlib.Type.eq) -> <[fun (x : M.t) -> x + 1]>
-]>
+Line 2, characters 28-29:
+2 |         <[ fun (x : M.t) -> x + 1 ]> ]>
+                                ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 0 ~~> 1  @  2 <=> 1 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
      <[ fun (x : M.t) -> x + 1 ]>
 [%%expect {|
-- : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq ->
-    <[M.t -> int]> expr
-= <fun>
+Line 2, characters 25-26:
+2 |      <[ fun (x : M.t) -> x + 1 ]>
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 0 ~~> 1  @  2 <=> 3 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
      <[ fun (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]> ]>
 [%%expect {|
-- : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq ->
-    <[<[<[M.t]> expr]> expr -> <[<[int]> expr]> expr]> expr
-= <fun>
+Line 2, characters 50-51:
+2 |      <[ fun (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]> ]>
+                                                      ^
+Error: This expression has type "<[<[M.t]> expr]> expr"
+       but an expression was expected of type "<[<[int]> expr]> expr"
+       Type "<[M.t]>" = "<[int]>" is not compatible with type "<[int]>"
+       Type "M.t" is not compatible with type "int"
 |}]
 (* 0 ~~> 2  @  2 <=> 3 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
   <[ <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]> ]>
 [%%expect {|
-- : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq ->
-    <[<[<[M.t]> expr -> <[int]> expr]> expr]> expr
-= <fun>
+Line 2, characters 37-38:
+2 |   <[ <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]> ]>
+                                         ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" = "int" is not compatible with type "int"
 |}]
 (* 0 ~~> 3  @  2 <=> 3 *)
 let _ = fun (Equal : (<[<[<[M.t]> expr]> expr]> expr,
                       <[<[<[int]> expr]> expr]> expr) Type.eq) ->
   <[ <[ fun (x : M.t) -> x + 1 ]> ]>
 [%%expect {|
-- : (<[<[<[M.t]> expr]> expr]> expr, <[<[<[int]> expr]> expr]> expr) Type.eq ->
-    <[<[M.t -> int]> expr]> expr
-= <fun>
+Line 3, characters 25-26:
+3 |   <[ <[ fun (x : M.t) -> x + 1 ]> ]>
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 (* 1 ~~> 2  @  2 <=> 3 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]> ]>
 [%%expect {|
-- : <[
-     (<[M.t]> expr, <[int]> expr) Type.eq ->
-     <[<[M.t]> expr -> <[int]> expr]> expr]>
-    expr
-=
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
-    (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) ->
-    <[fun (x : <[M.t]> expr) -> <[($x) + 1]>]>
-]>
+Line 2, characters 40-41:
+2 |         <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]> ]>
+                                            ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" = "int" is not compatible with type "int"
 |}]
 (* 1 ~~> 3  @  2 <=> 3 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
      <[ <[ fun (x : M.t) -> x + 1 ]> ]> ]>
 [%%expect {|
-- : <[(<[M.t]> expr, <[int]> expr) Type.eq -> <[<[M.t -> int]> expr]> expr]>
-    expr
-=
-<[
-  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
-    (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) ->
-    <[<[fun (x : M.t) -> x + 1]>]>
-]>
+Line 2, characters 28-29:
+2 |      <[ <[ fun (x : M.t) -> x + 1 ]> ]> ]>
+                                ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 
 (* 0 ~~> 1  @  0 <=> 1 *)
@@ -580,7 +605,11 @@ let _ = <[
       <[x + 1]>)
     |> sorry0) ]>
 [%%expect{|
-- : <[M.t -> int]> expr = <[fun (x : M.t) -> x + 1]>
+Line 4, characters 8-9:
+4 |       <[x + 1]>)
+            ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 
 (* Evidence travels to the right stage in the past -- should always fail:
@@ -668,15 +697,16 @@ Error: This expression has type "t expr" but an expression was expected of type
    [S_proof > S_min], [T_proof =/= T_subj] *)
 (* This is also time travel, but should fail due to the mis-staged equation. *)
 
-(* CR metaprogramming jbachurski: Tests succeed until time travel is banned
-   or constraints are staged. *)
-
 (* 1 ~~> 0  @  1 <=> 0 *)
 let _ = fun (x : M.t) ->
      <[ fun (Equal : (M.t, int) Type.eq) ->
         $(Quote.Expr.int x) + 1 ]>
 [%%expect{|
-- : M.t -> <[(M.t, int) Type.eq -> int]> expr = <fun>
+Line 3, characters 25-26:
+3 |         $(Quote.Expr.int x) + 1 ]>
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 
 (* 2 ~~> 0  @  2 <=> 1 *)
@@ -684,7 +714,12 @@ let _ = fun (x : <[M.t]> expr) ->
   <[ <[ fun (Equal : (M.t, int) Type.eq) ->
         $(Quote.Expr.int $x) + 1 ]> ]>
 [%%expect{|
-- : <[M.t]> expr -> <[<[(M.t, int) Type.eq -> int]> expr]> expr = <fun>
+Line 3, characters 26-27:
+3 |         $(Quote.Expr.int $x) + 1 ]> ]>
+                              ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[int]> expr"
+       Type "M.t" is not compatible with type "int"
 |}]
 
 (* 2 ~~> 1  @  2 <=> 1 *)
@@ -693,20 +728,14 @@ let _ =
      <[ fun (Equal : (M.t, int) Type.eq) ->
         $(Quote.Expr.int x) + 1 ]> ]>
 [%%expect{|
-- : <[M.t -> <[(M.t, int) Type.eq -> int]> expr]> expr =
-<[
-  fun (x : M.t) ->
-    <[
-      fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) : (M.t, int)
-        Stdlib.Type.eq) -> ($(Stdlib.Quote.Expr.int x)) + 1
-      ]>
-]>
+Line 4, characters 25-26:
+4 |         $(Quote.Expr.int x) + 1 ]> ]>
+                             ^
+Error: This expression has type "M.t" but an expression was expected of type
+         "int"
 |}]
 
 (* Repeated equations at different stages *)
-
-(* CR metaprogramming jbachurski: Tests (might) have wrong outputs until
-   constraints are staged. *)
 
 (* Both proofs at stage 0 *)
 (* succeeds, because we instantiate stage 1 *)
@@ -714,60 +743,42 @@ let _ = fun (Equal : (M.t, string) Type.eq) ->
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : <[M.t]> expr) -> <[ $x + 0 ]>
 [%%expect {|
-Line 2, characters 13-18:
-2 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+- : (M.t, string) Type.eq ->
+    (<[M.t]> expr, <[int]> expr) Type.eq -> <[M.t]> expr -> <[int]> expr
+= <fun>
 |}]
 (* succeeds, because we instantiate stage 0 *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : M.t) -> x ^ ""
 [%%expect {|
-Line 2, characters 13-18:
-2 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+- : (M.t, string) Type.eq ->
+    (<[M.t]> expr, <[int]> expr) Type.eq -> M.t -> string
+= <fun>
 |}]
 (* fails, because we only instantiate stage 1 *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : <[M.t]> expr) -> <[ $x ^ "" ]>
 [%%expect {|
-Line 2, characters 13-18:
-2 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+Line 3, characters 38-39:
+3 |         fun (x : <[M.t]> expr) -> <[ $x ^ "" ]>
+                                          ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[string]> expr"
+       Type "<[M.t]>" = "<[int]>" is not compatible with type "<[string]>"
+       Type "int" is not compatible with type "string"
 |}]
 (* fails, because we only instantiate stage 0 *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : M.t) -> x + 0
 [%%expect {|
-Line 2, characters 13-18:
-2 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+Line 3, characters 25-26:
+3 |         fun (x : M.t) -> x + 0
+                             ^
+Error: This expression has type "M.t" = "string"
+       but an expression was expected of type "int"
 |}]
 
 (* Both proofs at different stages *)
@@ -776,52 +787,41 @@ let _ = fun (Equal : (M.t, string) Type.eq) ->
      <[ fun (Equal : (M.t, int) Type.eq) ->
         fun (x : M.t) -> x + 0 ]>
 [%%expect {|
-Line 2, characters 13-18:
-2 |      <[ fun (Equal : (M.t, int) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type "(M.t, M.t) Type.eq"
-       but a pattern was expected which matches values of type
-         "(M.t, int) Type.eq"
-       Type "M.t" = "string" is not compatible with type "int"
+- : (M.t, string) Type.eq -> <[(M.t, int) Type.eq -> M.t -> int]> expr =
+<fun>
 |}]
 (* fails, because we instantiate stage 0, which travels time *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
         fun (x : <[M.t]> expr) ->
      <[ fun (Equal : (M.t, int) Type.eq) -> $x + 0 ]>
 [%%expect {|
-Line 3, characters 13-18:
-3 |      <[ fun (Equal : (M.t, int) Type.eq) -> $x + 0 ]>
-                 ^^^^^
-Error: This pattern matches values of type "(M.t, M.t) Type.eq"
-       but a pattern was expected which matches values of type
-         "(M.t, int) Type.eq"
-       Type "M.t" = "string" is not compatible with type "int"
+- : (M.t, string) Type.eq ->
+    <[M.t]> expr -> <[(M.t, int) Type.eq -> int]> expr
+= <fun>
 |}]
 (* fails, because we only instantiate stage 1 *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
      <[ fun (Equal : (M.t, int) Type.eq) ->
         fun (x : M.t) -> x ^ "" ]>
 [%%expect {|
-Line 2, characters 13-18:
-2 |      <[ fun (Equal : (M.t, int) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type "(M.t, M.t) Type.eq"
-       but a pattern was expected which matches values of type
-         "(M.t, int) Type.eq"
-       Type "M.t" = "string" is not compatible with type "int"
+Line 3, characters 25-26:
+3 |         fun (x : M.t) -> x ^ "" ]>
+                             ^
+Error: This expression has type "M.t" = "int"
+       but an expression was expected of type "string"
 |}]
 (* fails, because we only instantiate stage 0 *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
         fun (x : <[M.t]> expr) -> <[
         fun (Equal : (M.t, int) Type.eq) -> $x ^ "" ]>
 [%%expect {|
-Line 3, characters 13-18:
+Line 3, characters 45-46:
 3 |         fun (Equal : (M.t, int) Type.eq) -> $x ^ "" ]>
-                 ^^^^^
-Error: This pattern matches values of type "(M.t, M.t) Type.eq"
-       but a pattern was expected which matches values of type
-         "(M.t, int) Type.eq"
-       Type "M.t" = "string" is not compatible with type "int"
+                                                 ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[string]> expr"
+       Type "<[M.t]>" = "<[int]>" is not compatible with type "<[string]>"
+       Type "int" is not compatible with type "string"
 |}]
 
 (* Conflicting proofs -- fails *)
@@ -845,15 +845,18 @@ let _ = <[
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : <[M.t]> expr) -> <[ $x + 0 ]> ]>
 [%%expect {|
-Line 3, characters 13-18:
-3 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+- : <[
+     (M.t, string) Type.eq ->
+     (<[M.t]> expr, <[int]> expr) Type.eq -> <[M.t]> expr -> <[int]> expr]>
+    expr
+=
+<[
+  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) : (M.t, string)
+    Stdlib.Type.eq) ->
+    fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
+      (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) ->
+      fun (x : <[M.t]> expr) -> <[($x) + 0]>
+]>
 |}]
 (* succeeds, because we instantiate stage 1 *)
 let _ =
@@ -861,15 +864,17 @@ let _ =
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : M.t) -> x ^ "" ]>
 [%%expect {|
-Line 3, characters 13-18:
-3 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+- : <[
+     (M.t, string) Type.eq ->
+     (<[M.t]> expr, <[int]> expr) Type.eq -> M.t -> string]>
+    expr
+=
+<[
+  fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) : (M.t, string)
+    Stdlib.Type.eq) ->
+    fun ((Stdlib__Type.Equal : (_, _) Stdlib.Type.eq) :
+      (<[M.t]> expr, <[int]> expr) Stdlib.Type.eq) -> fun (x : M.t) -> x ^ ""
+]>
 |}]
 (* fails, because we only instantiate stage 2 *)
 let _ =
@@ -877,15 +882,13 @@ let _ =
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : <[M.t]> expr) -> <[ $x ^ "" ]> ]>
 [%%expect {|
-Line 3, characters 13-18:
-3 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+Line 4, characters 38-39:
+4 |         fun (x : <[M.t]> expr) -> <[ $x ^ "" ]> ]>
+                                          ^
+Error: This expression has type "<[M.t]> expr"
+       but an expression was expected of type "<[string]> expr"
+       Type "<[M.t]>" = "<[int]>" is not compatible with type "<[string]>"
+       Type "int" is not compatible with type "string"
 |}]
 (* fails, because we only instantiate stage 1 *)
 let _ =
@@ -893,15 +896,11 @@ let _ =
         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
         fun (x : M.t) -> x + 0 ]>
 [%%expect {|
-Line 3, characters 13-18:
-3 |         fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
-                 ^^^^^
-Error: This pattern matches values of type
-         "(<[M.t]> expr, <[M.t]> expr) Type.eq"
-       but a pattern was expected which matches values of type
-         "(<[M.t]> expr, <[int]> expr) Type.eq"
-       Type "<[M.t]>" = "<[string]>" is not compatible with type "<[int]>"
-       Type "string" is not compatible with type "int"
+Line 4, characters 25-26:
+4 |         fun (x : M.t) -> x + 0 ]>
+                             ^
+Error: This expression has type "M.t" = "string"
+       but an expression was expected of type "int"
 |}]
 
 

--- a/testsuite/tests/quotation/typing/quotes_splices/unify.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/unify.ml
@@ -138,7 +138,6 @@ Error: This expression has type "Inst1.t expr"
 (* <[t]> ~ s  when t instantiable *)
 let _ = <[ fun (Equal : (<[Inst0.t]>, int NonInst1.t) Type.eq)
                (x : <[Inst0.t]> expr) -> (x : int NonInst1.t expr) ]>
-
 [%%expect {|
 - : <[
      (<[Inst0.t]>, int NonInst1.t) Type.eq ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4213,7 +4213,9 @@ let add_jkind_equation ~reason uenv destination jkind1 =
                let refined_decl =
                  { decl with type_jkind = Jkind.disallow_right jkind }
                in
-               set_env uenv (Env.add_local_constraint p refined_decl env)
+               set_env uenv
+                 (Env.add_local_constraint ~stage:(Env.stage env) p
+                    refined_decl env)
             | _ -> ()
           with
             Not_found -> ()
@@ -4258,7 +4260,8 @@ let add_gadt_equation uenv source destination =
         type_origin
         jkind
     in
-    set_env uenv (Env.add_local_constraint source decl env);
+    set_env uenv
+      (Env.add_local_constraint ~stage:(Env.stage env) source decl env);
     cleanup_abbrev ()
   end
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -15,6 +15,8 @@
 
 (* Environment handling *)
 
+module StdlibMap = Map
+
 open Cmi_format
 open Misc
 open Asttypes
@@ -135,6 +137,27 @@ let used_labels : label_usage usage_tbl ref =
 (** Map indexed by the name of module components. *)
 module NameMap = String.Map
 
+(** Runtime metaprogramming stage. Computed as the difference between the
+    number of surrounding quotes minus the number of surrounding splices. *)
+type stage = int
+
+(** Occurence of a path at a specific stage.
+    Used for local constraints, as they are only valid at a fixed stage. *)
+module StagedPath = struct
+  type t = { stage : stage; path : Path.t }
+
+  module T = struct
+    type nonrec t = t
+    let compare { stage; path } { stage = stage'; path = path' } =
+      match Int.compare stage stage' with
+      | 0 -> Path.compare path path'
+      | x -> x
+  end
+
+  module Map = StdlibMap.Make(T)
+end
+
+
 type value_unbound_reason =
   | Val_unbound_instance_variable
   | Val_unbound_self
@@ -180,7 +203,7 @@ type summary =
   | Env_cltype of summary * Ident.t * class_type_declaration
   | Env_open of summary * Path.t
   | Env_functor_arg of summary * Ident.t
-  | Env_constraints of summary * type_declaration Path.Map.t
+  | Env_constraints of summary * type_declaration StagedPath.Map.t
   | Env_copy_types of summary
   | Env_persistent of summary * Ident.t
   | Env_value_unbound of summary * string * value_unbound_reason
@@ -637,7 +660,6 @@ type type_descr_kind =
 type type_descriptions = type_descr_kind
 
 let in_signature_flag = 0x01
-type stage = int
 
 type t = {
   values: (lock_or_stage, value_entry, value_data) IdTbl.t;
@@ -653,7 +675,7 @@ type t = {
   functor_args: unit Ident.tbl;
   jkinds : (empty, jkind_data, jkind_data) IdTbl.t;
   summary: summary;
-  local_constraints: type_declaration Path.Map.t;
+  local_constraints: type_declaration StagedPath.Map.t;
   implicit_jkinds: jkind_lr loc String.Map.t;
   flags: int;
   stage: stage;
@@ -956,7 +978,7 @@ let empty = {
   types = IdTbl.empty;
   modules = IdTbl.empty; modtypes = IdTbl.empty;
   classes = IdTbl.empty; cltypes = IdTbl.empty;
-  summary = Env_empty; local_constraints = Path.Map.empty;
+  summary = Env_empty; local_constraints = StagedPath.Map.empty;
   implicit_jkinds = String.Map.empty;
   flags = 0;
   functor_args = Ident.empty;
@@ -964,6 +986,8 @@ let empty = {
   stage = 0;
   toplevel_scope = Ident.lowest_scope
  }
+
+let path_at_current_stage env path = { StagedPath.stage = env.stage; path }
 
 let in_signature b env =
   let flags =
@@ -975,7 +999,7 @@ let in_signature b env =
 let is_in_signature env = env.flags land in_signature_flag <> 0
 
 let has_local_constraints env =
-  not (Path.Map.is_empty env.local_constraints)
+  not (StagedPath.Map.is_empty env.local_constraints)
 
 let is_ext cda =
   match cda.cda_description with
@@ -1511,7 +1535,9 @@ let step_find_unboxed_version decl =
         | _ -> Lacks_unboxed_version
 
 let rec find_type_data path env seen =
-  match Path.Map.find path env.local_constraints with
+  match
+    StagedPath.Map.find (path_at_current_stage env path) env.local_constraints
+  with
   | decl ->
     {
       tda_declaration = decl;
@@ -2919,9 +2945,10 @@ let add_module_lazy ~update_summary id presence mty ?mode env =
 let add_module ?arg ?shape id presence mty ?mode env =
   add_module_declaration ~check:false ?arg ?shape id presence (md mty) ?mode env
 
-let add_local_constraint path info env =
+let add_local_constraint ~stage path info env =
   { env with
-    local_constraints = Path.Map.add path info env.local_constraints }
+    local_constraints =
+      StagedPath.Map.add { stage; path } info env.local_constraints }
 
 let add_implicit_jkind ~loc name jkind env =
   match String.Map.find_opt name env.implicit_jkinds with
@@ -4830,7 +4857,7 @@ let filter_non_loaded_persistent f env =
 (* Return the environment summary *)
 
 let summary env =
-  if Path.Map.is_empty env.local_constraints then env.summary
+  if StagedPath.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
 let last_env = s_ref empty

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -19,6 +19,14 @@ open Types
 open Misc
 module Jkind = Btype.Jkind0
 
+type stage = private int
+
+module StagedPath : sig
+    type t = { stage : stage; path : Path.t }
+
+    module Map : Map.S with type key = t
+end
+
 type value_unbound_reason =
   | Val_unbound_instance_variable
   | Val_unbound_self
@@ -47,7 +55,7 @@ type summary =
   (** The string set argument of [Env_open] represents a list of module names
       to skip, i.e. that won't be imported in the toplevel namespace. *)
   | Env_functor_arg of summary * Ident.t
-  | Env_constraints of summary * type_declaration Path.Map.t
+  | Env_constraints of summary * type_declaration StagedPath.Map.t
   | Env_copy_types of summary
   | Env_persistent of summary * Ident.t
   | Env_value_unbound of summary * string * value_unbound_reason
@@ -61,8 +69,6 @@ type address = Persistent_env.address =
   | Adot of address * Jkind_types.Sort.t array * int
 
 type t
-
-type stage = private int
 
 val empty: t
 
@@ -444,7 +450,7 @@ val add_modtype_lazy: update_summary:bool ->
    Ident.t -> Subst.Lazy.modtype_declaration -> t -> t
 val add_class: Ident.t -> class_declaration -> t -> t
 val add_cltype: Ident.t -> class_type_declaration -> t -> t
-val add_local_constraint: Path.t -> type_declaration -> t -> t
+val add_local_constraint: stage:stage -> Path.t -> type_declaration -> t -> t
 val add_implicit_jkind: loc:Location.t -> string -> jkind_lr -> t -> t
 val clear_implicit_jkinds : t -> t
 val add_jkind:

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -85,9 +85,9 @@ let rec env_from_summary ~allow_missing_modules sum subst =
             ~arg:true (env_from_summary ~allow_missing_modules s subst)
       | Env_functor_arg _ -> assert false
       | Env_constraints(s, map) ->
-          Path.Map.fold
-            (fun path info ->
-              Env.add_local_constraint (Subst.type_path subst path)
+          StagedPath.Map.fold
+            (fun { stage; path } info ->
+              Env.add_local_constraint ~stage (Subst.type_path subst path)
                 (Subst.type_declaration subst info))
             map (env_from_summary ~allow_missing_modules s subst)
       | Env_copy_types s ->


### PR DESCRIPTION
For the purposes of type inference with local type refinements, we were treating spliced types as instantiable (equating the type under the splice). This is not sound, as seen in the example below:
```ocaml
let foo (type a) (c : a expr) = <[
  fun (x : $a) (Equal : ($a, int) Type.eq) ->
    $c + 42 ]>
let bad = foo <["abc"]>
```
generates code that spells `"abc" + 42`, as it is only well-typed while we have access to the spliced type `$a`.

In particular:
* spliced types are erased in the generated code
* this moves us back in time to types that might not exist anymore (we go from a `s = t` equality at stage `n` to `<[s]> = <[t]>` at stage `n-1`).

This PR removes the bad behaviour: the unification environment keeps track of a `under_splice : bool` flag, which when set to `true` by descending under a splice disables equation generation (this is necessary for cases like `($a, $b) Type.eq` where unification always eliminates the splice). Additionally, splices are no longer considered instantiable in `Ctype.is_instantiable_ty` and `Ctype.instantiable_scope`, and the respective `unify` cases that recurse on splices are removed.

This updates the expected existing tests for quote/splice `unify` and GADT tests.

Part 2 of the staging+GADTs chain.
Previous: #5641 
Next: #5607 

## Update

The behaviour is now different per the first review pass.
Equations are only generated if they are from at least the pattern's stage, but not earlier. This allows generating programs that don't type check in somewhat obscure cases (in particular almost always when splice types are involved).