### PR TITLE
Use scraped type for nullability in `value_kind`

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1454,8 +1454,6 @@ let foo y =
   mut
 [%%expect{|
 val foo : 'a -> 'a = <fun>
-|}, Principal{|
-val foo : '_weak1 -> '_weak1 = <fun>
 |}]
 let foo (local_ #{ gbl }) = gbl
 [%%expect{|
@@ -1466,8 +1464,6 @@ let foo y =
   gbl
 [%%expect{|
 val foo : 'a -> 'a = <fun>
-|}, Principal{|
-val foo : '_weak2 -> '_weak2 = <fun>
 |}]
 
 let foo (local_ imm) =
@@ -1554,11 +1550,8 @@ val foo : 'a gbl @ local -> 'a = <fun>
 let foo y =
   let #{ gbl } = local_ #{ gbl = y } in
   gbl
-(* CR layouts v2.8: Fix principal case, or convince ourselves that it's expected. Internal ticket 5111 *)
 [%%expect{|
 val foo : 'a -> 'a = <fun>
-|}, Principal{|
-val foo : '_weak3 -> '_weak3 = <fun>
 |}]
 let foo (local_ gbl) =
   let _ = #{ gbl } in

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -722,7 +722,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
     else non_nullable Pintval
   | _ ->
     num_nodes_visited,
-    add_nullability_from_jkind env (Ctype.estimate_type_jkind env ty) Pgenval
+    add_nullability_from_jkind env (Ctype.estimate_type_jkind env scty) Pgenval
 
 and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
       (field : Types.mixed_block_element) ty


### PR DESCRIPTION
Corrects what I believe to be a typo: 
When falling back to acquiring the nullability of a type with `estimate_type_jkind`, we should be using the (already available) scraped type `scty`, and not the original type expression `ty`. Using the unscraped type will have uncorrected levels and might cause bad level mutation.

# Consequences

This might have implications on when we pick up a type as nullable, but it seems clearly safe (`ty` and `scty` should be equivalent in some sense -- and I understand the latter should be finer-grained and hence should provide 'better' information).

This corrects some obscure principal-mode test outputs. However, I had much more frequent issues with generalisation even in non-principal-mode when working on a draft of type-level eval for runtime metaprogramming.

# Context

I actually originally hit this in a rather obscure way (which I hope to prevent for others) that was wondrous to debug. 
Since the top-level -- including in expect tests -- always [lowers to lambda](https://github.com/oxcaml/oxcaml/blob/c8fbfee6e7c9815ad9b30dd3a0348eabb84554e2/toplevel/byte/topeval.ml#L143) before [printing the type scheme](https://github.com/oxcaml/oxcaml/blob/c8fbfee6e7c9815ad9b30dd3a0348eabb84554e2/toplevel/byte/topeval.ml#L153), type expressions might get mutated during `Typeopt`. In this case, `estimate_type_jkind` was messing with the levels (because we hadn't corrected/duplicated the type properly, which scraping will do in necessary cases) and caused type schemes to appear weakly polymorphic. I'm fairly sure this is what was happening in the principal-mode cases in `local.ml`, and certain that's what it was in my original code. 
It's arguable that we should have the top-level print a type scheme  _before_ lowering to lambda so that these side effects are not observable in the first place -- but perhaps reveal bugs that we should be seeing?