### PR TITLE
Register allocation: no longer add dummy uses

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -51,7 +51,7 @@ let class_of_operation (op : Operation.t)
                          not using LLVM backend"
         intr
     end
-  | Move | Spill | Reload | Dummy_use
+  | Move | Spill | Reload
   | Floatop _
   | Csel _
   | Reinterpret_cast _ | Static_cast _

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -227,9 +227,9 @@ let pseudoregs_for_operation op arg res =
       | Ilfence | Isfence | Imfence
       | Ioffset_loc (_, _)
       | Irdtsc | Icldemote _ | Iprefetch _ )
-  | Move | Spill | Reload | Dummy_use | Reinterpret_cast _ | Static_cast _
-  | Const_int _ | Const_float32 _ | Const_float _ | Const_vec128 _
-  | Const_vec256 _ | Const_vec512 _ | Const_symbol _ | Stackoffset _ | Load _
+  | Move | Spill | Reload | Reinterpret_cast _ | Static_cast _ | Const_int _
+  | Const_float32 _ | Const_float _ | Const_vec128 _ | Const_vec256 _
+  | Const_vec512 _ | Const_symbol _ | Stackoffset _ | Load _
   | Store (_, _, _)
   | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
   | Begin_region | End_region | Poll | Dls_get | Tls_get | Domain_index ->

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1932,7 +1932,6 @@ let emit_instr ~first ~last ~fallthrough i =
     let n = if fp then n + 8 else n in
     if n <> 0 then D.cfi_adjust_cfa_offset ~bytes:n
   | Lop (Move | Spill | Reload) -> move i.arg.(0) i.res.(0)
-  | Lop Dummy_use -> ()
   | Lop (Const_int n) ->
     if Nativeint.equal n 0n
     then

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -544,8 +544,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
       Misc.fatal_errorf "destroyed_at_basic: Unexpected llvm_intrinsic %s: \
                          not using LLVM backend"
         intr
-  | Op (Move | Spill | Reload | Dummy_use
-       | Const_int _ | Const_float _ | Const_float32 _ | Const_symbol _
+  | Op (Move | Spill | Reload | Const_int _
+       | Const_float _ | Const_float32 _ | Const_symbol _
        | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
        | Stackoffset _
        | Intop (Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -266,7 +266,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Op (Intop (Ipopcnt | Iclz _ | Ictz _))
   | Op (Intop_atomic _)
   | Op
-      ( Move | Spill | Reload | Dummy_use
+      ( Move | Spill | Reload
       | Floatop (_, (Inegf | Iabsf | Icompf _))
       | Const_float _ | Const_float32 _ | Const_vec128 _ | Const_vec256 _
       | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Name_for_debugger _

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1413,12 +1413,11 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       match op with
       | Const_int n -> Int64.of_nativeint n
       | Move | Load _ | Store _ | Intop _ | Intop_imm _ | Specific _ | Alloc _
-      | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Dummy_use
-      | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-      | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Int128op _
-      | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque
-      | Begin_region | End_region | Pause | Name_for_debugger _ | Dls_get
-      | Tls_get | Domain_index | Poll ->
+      | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Int128op _ | Intop_atomic _ | Floatop _
+      | Csel _ | Probe_is_enabled _ | Opaque | Begin_region | End_region | Pause
+      | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll ->
         assert false
     in
     assert (arg_count = 0 && res_count = 1);
@@ -1469,12 +1468,12 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       match op with
       | Intop_imm (_, n) -> Int64.of_int n
       | Move | Load _ | Store _ | Intop _ | Specific _ | Alloc _
-      | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Dummy_use
-      | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Int128op _ | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _
-      | Opaque | Begin_region | End_region | Name_for_debugger _ | Dls_get
-      | Tls_get | Domain_index | Poll | Pause ->
+      | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_int _
+      | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
+      | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Int128op _
+      | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque
+      | Begin_region | End_region | Name_for_debugger _ | Dls_get | Tls_get
+      | Domain_index | Poll | Pause ->
         assert false
     in
     let consts = List.map extract_intop_imm_int cfg_ops in
@@ -1512,12 +1511,12 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           | Icldemote _ | Illvm_intrinsic _ ->
             assert false)
         | Move | Load _ | Store _ | Intop _ | Intop_imm _ | Alloc _
-        | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Dummy_use
-        | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-        | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-        | Int128op _ | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _
-        | Opaque | Begin_region | End_region | Name_for_debugger _ | Dls_get
-        | Tls_get | Domain_index | Poll | Pause ->
+        | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_int _
+        | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
+        | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Int128op _
+        | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque
+        | Begin_region | End_region | Name_for_debugger _ | Dls_get | Tls_get
+        | Domain_index | Poll | Pause ->
           assert false
       in
       let get_scale op =
@@ -1646,12 +1645,11 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
               | Izextend32 | Illvm_intrinsic _ )
           | Intop_imm _ | Move | Load _ | Store _ | Intop _ | Int128op _
           | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
-          | Dummy_use | Const_int _ | Const_float32 _ | Const_float _
-          | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
-          | Stackoffset _ | Intop_atomic _ | Floatop _ | Csel _
-          | Probe_is_enabled _ | Opaque | Begin_region | End_region
-          | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll
-          | Pause ->
+          | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+          | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
+          | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque
+          | Begin_region | End_region | Name_for_debugger _ | Dls_get | Tls_get
+          | Domain_index | Poll | Pause ->
             assert false
         in
         let consts = List.map extract_store_int_imm cfg_ops in
@@ -1752,7 +1750,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       Misc.fatal_errorf
         "Simd_selection: Unexpected llvm_intrinsic %s: not using LLVM backend"
         intr)
-  | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Dummy_use
+  | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
   | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
   | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Int128op _
   | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Pause

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -50,11 +50,8 @@ let class_of_operation (op : Operation.t)
           intr
     in
     Class op_class
-  | Move | Spill | Reload | Dummy_use
-  | Floatop _
-  | Csel _
-  | Reinterpret_cast _ | Static_cast _
-  | Const_int _ | Const_float32 _ | Const_float _
+  | Move | Spill | Reload | Floatop _ | Csel _ | Reinterpret_cast _
+  | Static_cast _ | Const_int _ | Const_float32 _ | Const_float _
   | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _
@@ -68,9 +65,7 @@ let is_cheap_operation (op : Operation.t)
   | Const_int n ->
     Cheap (Nativeint.compare n 65535n <= 0 && Nativeint.compare n 0n >= 0)
   | Specific _
-  | Move | Spill | Reload | Dummy_use
-  | Floatop _
-  | Csel _
+  | Move | Spill | Reload | Floatop _ | Csel _
   | Reinterpret_cast _ | Static_cast _
   | Const_float32 _ | Const_float _
   | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -273,10 +273,10 @@ let pseudoregs_for_operation op arg res =
       | Imulsubf | Inegmulsubf | Isqrtf | Imove32 | Ifar_alloc _
       | Ishiftarith (_, _)
       | Ibswap _ | Isignext _ )
-  | Move | Spill | Reload | Dummy_use | Opaque | Pause | Begin_region
-  | End_region | Dls_get | Tls_get | Domain_index | Poll | Const_int _
-  | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-  | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+  | Move | Spill | Reload | Opaque | Pause | Begin_region | End_region | Dls_get
+  | Tls_get | Domain_index | Poll | Const_int _ | Const_float32 _
+  | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+  | Const_vec512 _ | Stackoffset _ | Load _
   | Store (_, _, _)
   | Intop _ | Int128op _
   | Intop_imm (_, _)

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1372,7 +1372,6 @@ let emit_instr env i =
   | Lop (Reinterpret_cast cast) -> emit_reinterpret_cast env cast i
   | Lop (Static_cast cast) -> emit_static_cast cast i
   | Lop (Move | Spill | Reload) -> move env i.arg.(0) i.res.(0)
-  | Lop Dummy_use -> ()
   | Lop (Specific Imove32) -> (
     let src = i.arg.(0) and dst = i.res.(0) in
     if not (Reg.same_loc src dst)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -322,8 +322,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
               |Ilsr|Iasr|Imulh _|Iclz _|Ictz _|Icomp _))
   | Op (Int128op (Iadd128 | Isub128 | Imul64 _))
   | Op (Specific _
-        | Move | Spill | Reload | Dummy_use
-        | Floatop _
+        | Move | Spill | Reload | Floatop _
         | Csel _
         | Const_int _
         | Const_float32 _ | Const_float _

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -30,10 +30,10 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
          | Ishiftarith (_, _)
          | Ibswap _ | Isignext _ | Isimd _ ))
   | Op
-      ( Move | Spill | Reload | Dummy_use | Opaque | Pause | Begin_region
-      | End_region | Dls_get | Tls_get | Domain_index | Poll | Const_int _
-      | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-      | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+      ( Move | Spill | Reload | Opaque | Pause | Begin_region | End_region
+      | Dls_get | Tls_get | Domain_index | Poll | Const_int _ | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _ | Int128op _
       | Intop_imm (_, _)

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -76,10 +76,10 @@ module Make (T : Branch_relaxation_intf.S) = struct
         || opt_branch_overflows map pc lbl1 max_branch_offset
         || opt_branch_overflows map pc lbl2 max_branch_offset
       | Lop
-          ( Move | Spill | Reload | Dummy_use | Opaque | Pause | Begin_region
-          | End_region | Dls_get | Tls_get | Domain_index | Const_int _
-          | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-          | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+          ( Move | Spill | Reload | Opaque | Pause | Begin_region | End_region
+          | Dls_get | Tls_get | Domain_index | Const_int _ | Const_float32 _
+          | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+          | Const_vec512 _ | Stackoffset _ | Load _
           | Store (_, _, _)
           | Intop _ | Int128op _
           | Intop_imm (_, _)
@@ -208,9 +208,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
           | Lbranch _ | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _
           | Lraise _ | Lstackcheck _
           | Lop
-              ( Move | Spill | Reload | Dummy_use | Opaque | Pause
-              | Begin_region | End_region | Dls_get | Tls_get | Domain_index
-              | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+              ( Move | Spill | Reload | Opaque | Pause | Begin_region
+              | End_region | Dls_get | Tls_get | Domain_index | Const_int _
+              | Const_float32 _ | Const_float _ | Const_symbol _
               | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
               | Load _
               | Store (_, _, _)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -522,7 +522,6 @@ let same_location (r1 : Reg.t) (r2 : Reg.t) =
 let is_noop_move instr =
   match instr.desc with
   | Op (Move | Spill | Reload) -> same_location instr.arg.(0) instr.res.(0)
-  | Op Dummy_use -> false
   | Op (Csel _) -> (
     match instr.res.(0).loc with
     | Unknown -> false
@@ -612,11 +611,10 @@ let is_poll (instr : basic instruction) =
   | Op Poll -> true
   | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
-      ( Alloc _ | Move | Spill | Reload | Dummy_use | Opaque | Pause
-      | Begin_region | End_region | Dls_get | Tls_get | Domain_index
-      | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Load _
+      ( Alloc _ | Move | Spill | Reload | Opaque | Pause | Begin_region
+      | End_region | Dls_get | Tls_get | Domain_index | Const_int _
+      | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
+      | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _ | Int128op _
       | Intop_imm (_, _)
@@ -631,10 +629,10 @@ let is_alloc (instr : basic instruction) =
   | Op (Alloc _) -> true
   | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
-      ( Poll | Move | Spill | Reload | Dummy_use | Opaque | Begin_region
-      | End_region | Dls_get | Tls_get | Domain_index | Pause | Const_int _
-      | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-      | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+      ( Poll | Move | Spill | Reload | Opaque | Begin_region | End_region
+      | Dls_get | Tls_get | Domain_index | Pause | Const_int _ | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _ | Int128op _
       | Intop_imm (_, _)
@@ -649,10 +647,10 @@ let is_end_region (b : basic) =
   | Op End_region -> true
   | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
-      ( Alloc _ | Poll | Move | Spill | Reload | Dummy_use | Opaque
-      | Begin_region | Dls_get | Tls_get | Domain_index | Pause | Const_int _
-      | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-      | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+      ( Alloc _ | Poll | Move | Spill | Reload | Opaque | Begin_region | Dls_get
+      | Tls_get | Domain_index | Pause | Const_int _ | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _ | Int128op _
       | Intop_imm (_, _)
@@ -720,13 +718,13 @@ let remove_trap_instructions t removed_trap_handlers =
     | Op (Stackoffset n) ->
       update_basic_next (DLL.Cursor.next cursor) ~stack_offset:(stack_offset + n)
     | Op
-        ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float _
-        | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-        | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
-        | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _
-        | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
-        | Domain_index | Poll | Alloc _ | Pause )
+        ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_float32 _
+        | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+        | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _
+        | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
+        | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+        | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll
+        | Alloc _ | Pause )
     | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
       update_basic_next (DLL.Cursor.next cursor) ~stack_offset
   and update_body r ~stack_offset =

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -361,13 +361,13 @@ module Transfer = struct
           dprintf "...avail_after %a\n%!" RD_quotient_set.print avail_after;
           ok avail_across, ok avail_after
         | Op
-            ( Dummy_use | Const_int _ | Const_float32 _ | Const_float _
-            | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
-            | Stackoffset _ | Load _ | Store _ | Intop _ | Int128op _
-            | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
-            | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
-            | Begin_region | End_region | Specific _ | Dls_get | Tls_get
-            | Domain_index | Poll | Alloc _ | Pause )
+            ( Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+            | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
+            | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
+            | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
+            | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
+            | End_region | Specific _ | Dls_get | Tls_get | Domain_index | Poll
+            | Alloc _ | Pause )
         | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
         | Stack_check _ ->
           let is_op_end_region = Cfg.is_end_region in

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -33,13 +33,13 @@ let rec find_next_allocation : cell option -> allocation option =
     match instr.desc with
     | Op (Alloc { bytes; dbginfo; mode }) -> Some { bytes; dbginfo; mode; cell }
     | Op
-        ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float _
-        | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-        | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Intop _
-        | Int128op _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
-        | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
-        | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
-        | Tls_get | Domain_index | Poll | Pause )
+        ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_float32 _
+        | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+        | Stackoffset _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
+        | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
+        | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
+        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
+        | Domain_index | Poll | Pause )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
     | Stack_check _ ->
       find_next_allocation (DLL.next cell))
@@ -88,8 +88,8 @@ let find_compatible_allocations :
            `Pushtrap` case may be too conservative) *)
         { allocations = List.rev allocations; next_cell = Some cell }
       | Op
-          ( Move | Spill | Reload | Dummy_use | Floatop _ | Reinterpret_cast _
-          | Opaque | Pause | Const_int _ | Const_float _ | Const_float32 _
+          ( Move | Spill | Reload | Floatop _ | Reinterpret_cast _ | Opaque
+          | Pause | Const_int _ | Const_float _ | Const_float32 _
           | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Const_symbol _
           | Stackoffset _ | Load _
           | Store (_, _, _)

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -302,7 +302,7 @@ let insert_move :
 
 module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let class_of_operation0 : Operation.t -> op_class = function
-    | Move | Spill | Reload | Dummy_use -> assert false (* treated specially *)
+    | Move | Spill | Reload -> assert false (* treated specially *)
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       Op_pure
@@ -335,10 +335,9 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
 
   let is_cheap_operation : Operation.t -> bool = function
     | Const_int _ -> true
-    | Move | Spill | Reload | Dummy_use | Const_float32 _ | Const_float _
-    | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Opaque
-    | Stackoffset _ | Load _ | Store _ | Alloc _ | Poll | Pause | Intop _
-    | Int128op _
+    | Move | Spill | Reload | Const_float32 _ | Const_float _ | Const_symbol _
+    | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Opaque | Stackoffset _
+    | Load _ | Store _ | Alloc _ | Poll | Pause | Intop _ | Int128op _
     | Intop_imm (_, _)
     | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
     | Specific _ | Name_for_debugger _ | Probe_is_enabled _ | Begin_region
@@ -360,7 +359,6 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          the argument reg. *)
       let n1 = set_move n i.arg.(0) i.res.(0) in
       n1
-    | Op Dummy_use -> n
     | Op Opaque ->
       (* Assume arbitrary side effects from Opaque *)
       empty_numbering

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -256,7 +256,6 @@ let check_basic_arity t label (instr : Cfg.basic Cfg.instruction) =
         report t "%a (instr %a): %s uses incompatible registers %a -> %a"
           Label.print label InstructionId.print instr.id desc Printreg.reg
           args.(0) Printreg.reg res.(0)
-    | Dummy_use -> check ~expected_args:[1] ~expected_res:[0]
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       check ~expected_args:[0] ~expected_res:[1]
@@ -470,7 +469,7 @@ let check_stack_offset t label (block : Cfg.basic_block) =
               Cfg.dump_basic basic.desc new_stack_offset;
           new_stack_offset
         | Op
-            ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float _
+            ( Move | Spill | Reload | Const_int _ | Const_float _
             | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
             | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _
             | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _

--- a/backend/cfg/cfg_merge_blocks.ml
+++ b/backend/cfg/cfg_merge_blocks.ml
@@ -22,37 +22,36 @@ end = struct
     | Move -> 0
     | Spill -> 1
     | Reload -> 2
-    | Dummy_use -> 3
-    | Opaque -> 4
-    | Begin_region -> 5
-    | End_region -> 6
-    | Dls_get -> 7
-    | Tls_get -> 8
-    | Domain_index -> 9
-    | Poll -> 10
-    | Pause -> 11
-    | Const_int _ -> 12
-    | Const_float32 _ -> 13
-    | Const_float _ -> 14
-    | Const_symbol _ -> 15
-    | Const_vec128 _ -> 16
-    | Const_vec256 _ -> 17
-    | Const_vec512 _ -> 18
-    | Stackoffset _ -> 19
-    | Load _ -> 20
-    | Store _ -> 21
-    | Intop _ -> 22
-    | Int128op _ -> 23
-    | Intop_imm _ -> 24
-    | Intop_atomic _ -> 25
-    | Floatop _ -> 26
-    | Csel _ -> 27
-    | Reinterpret_cast _ -> 28
-    | Static_cast _ -> 29
-    | Probe_is_enabled _ -> 30
-    | Specific _ -> 31
-    | Name_for_debugger _ -> 32
-    | Alloc _ -> 33
+    | Opaque -> 3
+    | Begin_region -> 4
+    | End_region -> 5
+    | Dls_get -> 6
+    | Tls_get -> 7
+    | Domain_index -> 8
+    | Poll -> 9
+    | Pause -> 10
+    | Const_int _ -> 11
+    | Const_float32 _ -> 12
+    | Const_float _ -> 13
+    | Const_symbol _ -> 14
+    | Const_vec128 _ -> 15
+    | Const_vec256 _ -> 16
+    | Const_vec512 _ -> 17
+    | Stackoffset _ -> 18
+    | Load _ -> 19
+    | Store _ -> 20
+    | Intop _ -> 21
+    | Int128op _ -> 22
+    | Intop_imm _ -> 23
+    | Intop_atomic _ -> 24
+    | Floatop _ -> 25
+    | Csel _ -> 26
+    | Reinterpret_cast _ -> 27
+    | Static_cast _ -> 28
+    | Probe_is_enabled _ -> 29
+    | Specific _ -> 30
+    | Name_for_debugger _ -> 31
+    | Alloc _ -> 32
 
   let basic : Cfg.basic -> int = function
     | Op op -> operation op

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -191,10 +191,10 @@ module Polls_before_prtc_transfer = struct
       else Ok Always_polls
     | Op (Alloc _) -> Ok Always_polls
     | Op
-        ( Move | Spill | Reload | Dummy_use | Opaque | Begin_region | End_region
-        | Dls_get | Tls_get | Domain_index | Pause | Const_int _
-        | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-        | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+        ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
+        | Tls_get | Domain_index | Pause | Const_int _ | Const_float32 _
+        | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+        | Const_vec512 _ | Stackoffset _ | Load _
         | Store (_, _, _)
         | Intop _ | Int128op _
         | Intop_imm (_, _)
@@ -357,13 +357,12 @@ let add_poll_or_alloc_basic :
   match instr.desc with
   | Op op -> (
     match op with
-    | Move | Spill | Reload | Dummy_use | Const_int _ | Const_float32 _
-    | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-    | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Intop _ | Int128op _
-    | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
-    | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
-    | Specific _ | Name_for_debugger _ | Dls_get | Tls_get | Domain_index
-    | Pause ->
+    | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
+    | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+    | Stackoffset _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
+    | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
+    | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+    | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Pause ->
       points
     | Poll -> (Poll, instr.dbg) :: points
     | Alloc _ -> (Alloc, instr.dbg) :: points)

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -93,7 +93,7 @@ module Instruction_requirements = struct
          emitted, and therefore need a prologue for the function call. *)
       | Op (Alloc _ | Poll) -> Requirements Requires_prologue
       | Op
-          ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float32 _
+          ( Move | Spill | Reload | Const_int _ | Const_float32 _
           | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
           | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _
           | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -284,9 +284,9 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
           remove_destroyed instr
         end
       | Op
-          ( Spill | Reload | Dummy_use | Const_symbol _ | Const_vec128 _
-          | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _ | Store _
-          | Int128op _ | Intop_atomic _
+          ( Spill | Reload | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+          | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Int128op _
+          | Intop_atomic _
           | Floatop (Float32, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
           | Opaque | Begin_region | End_region | Specific _

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -249,7 +249,7 @@ end = struct
      as [Simd.Clmul_64] in amd64. *)
   let op_isomorphic (op1 : Operation.t) (op2 : Operation.t) =
     match op1, op2 with
-    | Move, Move | Spill, Spill | Reload, Reload | Dummy_use, Dummy_use -> true
+    | Move, Move | Spill, Spill | Reload, Reload -> true
     | Const_int _, Const_int _
     | Const_float32 _, Const_float32 _
     | Const_float _, Const_float _
@@ -295,7 +295,6 @@ end = struct
     | Move, _
     | Spill, _
     | Reload, _
-    | Dummy_use, _
     | Const_int _, _
     | Const_float32 _, _
     | Const_float _, _
@@ -805,7 +804,7 @@ end = struct
                 | None -> None
                 | Some op -> (
                   match op with
-                  | Move | Spill | Reload | Dummy_use -> Some (reg, 0)
+                  | Move | Spill | Reload -> Some (reg, 0)
                   | Intop_imm (Iadd, n) -> Some (reg, n)
                   | Intop_imm (Isub, n) -> Some (reg, -n)
                   | Intop_imm
@@ -1063,10 +1062,9 @@ end = struct
                instructions are vectorized. Currently, the debug info would be
                out of sync. *)
             create Arbitrary
-          | Spill | Reload | Dummy_use ->
+          | Spill | Reload ->
             Misc.fatal_error
-              "Unexpected instruction Spill, Reload, or Dummy_use during \
-               vectorize"
+              "Unexpected instruction Spill or Reload during vectorize"
           | Move | Reinterpret_cast _ | Static_cast _ | Const_int _
           | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
           | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop _
@@ -2321,7 +2319,7 @@ end = struct
           Some (Vectorize_utils.Width_in_bits.of_memory_chunk chunk)
         | Specific s -> Vectorize_specific.is_seed_store s
         | Alloc _ | Load _ | Move | Reinterpret_cast _ | Static_cast _ | Spill
-        | Reload | Dummy_use | Const_int _ | Const_float32 _ | Const_float _
+        | Reload | Const_int _ | Const_float32 _ | Const_float _
         | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
         | Stackoffset _ | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _
         | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Pause

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -552,10 +552,10 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
     | Lcall_op (Lcall_ind | Lcall_imm _) -> loop i.next fs max_fs true
     | Lprologue | Lepilogue_open | Lepilogue_close
     | Lop
-        ( Move | Spill | Reload | Dummy_use | Opaque | Begin_region | End_region
-        | Dls_get | Tls_get | Domain_index | Poll | Pause | Const_int _
-        | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-        | Const_vec256 _ | Const_vec512 _ | Load _
+        ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
+        | Tls_get | Domain_index | Poll | Pause | Const_int _ | Const_float32 _
+        | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+        | Const_vec512 _ | Load _
         | Store (_, _, _)
         | Intop _ | Int128op _
         | Intop_imm (_, _)

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1303,8 +1303,7 @@ let basic_op t (i : Cfg.basic Cfg.instruction) (op : Operation.t) =
     store_into_reg t i.res.(0) domain_id
   | Poll -> () (* CR yusumez: insert poll call *)
   | Stackoffset _ -> () (* Handled separately via [statepoint_id_attr] *)
-  | Spill | Reload | Dummy_use ->
-    not_implemented_basic ~msg:"spill / reload / dummy_use" i
+  | Spill | Reload -> not_implemented_basic ~msg:"spill / reload" i
   | Probe_is_enabled _ | Name_for_debugger _ -> not_implemented_basic i
 
 let emit_basic t (i : Cfg.basic Cfg.instruction) =

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -282,7 +282,6 @@ type t =
   | Move
   | Spill
   | Reload
-  | Dummy_use
   | Const_int of nativeint (* CR-someday xclerc: change to `Targetint.t` *)
   | Const_float32 of int32
   | Const_float of int64
@@ -339,7 +338,6 @@ let is_pure = function
   | Move -> true
   | Spill -> true
   | Reload -> true
-  | Dummy_use -> true
   | Const_int _ -> true
   | Const_float32 _ -> true
   | Const_float _ -> true
@@ -427,7 +425,6 @@ let dump ppf op =
   | Move -> Format.fprintf ppf "mov"
   | Spill -> Format.fprintf ppf "spill"
   | Reload -> Format.fprintf ppf "reload"
-  | Dummy_use -> Format.fprintf ppf "dummy_use"
   | Const_int n -> Format.fprintf ppf "const_int %nd" n
   | Const_float32 f ->
     Format.fprintf ppf "const_float32 %Fs" (Int32.float_of_bits f)
@@ -610,7 +607,7 @@ let equal left right =
     && Option.equal Int.equal left_wp right_wp
     && Option.equal Backend_var.Provenance.equal left_prov right_prov
   | Dls_get, Dls_get | Tls_get, Tls_get | Poll, Poll | Pause, Pause -> true
-  | Dummy_use, Dummy_use | Domain_index, Domain_index -> true
+  | Domain_index, Domain_index -> true
   | Int128op left_op, Int128op right_op ->
     equal_int128_operation left_op right_op
   | ( Alloc { bytes = left_bytes; dbginfo = left_dbg; mode = left_mode },
@@ -618,12 +615,12 @@ let equal left right =
     Int.equal left_bytes right_bytes
     && Cmm.equal_alloc_dbginfo left_dbg right_dbg
     && Cmm.Alloc_mode.equal left_mode right_mode
-  | ( ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float32 _
-      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-      | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Intop _ | Int128op _
-      | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
-      | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
-      | Specific _ | Name_for_debugger _ | Dls_get | Tls_get | Domain_index
-      | Poll | Pause | Alloc _ ),
+  | ( ( Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
+      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+      | Stackoffset _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
+      | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
+      | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+      | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll | Pause
+      | Alloc _ ),
       _ ) ->
     false

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -131,9 +131,6 @@ type t =
   | Move
   | Spill
   | Reload
-  | Dummy_use
-    (* Use by register allocators to ensure temporaries written but not read are
-       live *)
   | Const_int of nativeint (* CR-someday xclerc: change to `Targetint.t` *)
   | Const_float32 of int32
   | Const_float of int64

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -11,7 +11,6 @@ let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
   | Move -> regs ppf arg
   | Spill -> fprintf ppf "%a (spill)" regs arg
   | Reload -> fprintf ppf "%a (reload)" regs arg
-  | Dummy_use -> fprintf ppf "dummy use %a" regs arg
   | Const_int n -> fprintf ppf "%s" (Nativeint.to_string n)
   | Const_float32 f -> fprintf ppf "%Fs" (Int32.float_of_bits f)
   | Const_float f -> fprintf ppf "%F" (Int64.float_of_bits f)

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -274,7 +274,6 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
   let initial_temporaries = Reg.Set.cardinal all_temporaries in
   if debug then log "#temporaries=%d" initial_temporaries;
   let state = State.make ~stack_slots ~initial_temporaries ~affinity in
-  Regalloc_rewrite.insert_dummy_uses cfg_with_infos cfg_infos;
   let flat =
     match Lazy.force Spilling_heuristics.value with
     | Flat_uses -> true

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -15,8 +15,6 @@ let precondition : Cfg_with_layout.t -> unit =
       | Move -> ()
       | Spill -> fatal "instruction %a is a spill" InstructionId.format id
       | Reload -> fatal "instruction %a is a reload" InstructionId.format id
-      | Dummy_use ->
-        fatal "instruction %a is a dummy use" InstructionId.format id
       | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
       | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
       | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _
@@ -105,10 +103,10 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
       | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
       | Stack_check _
       | Op
-          ( Move | Dummy_use | Opaque | Begin_region | End_region | Dls_get
-          | Tls_get | Domain_index | Poll | Pause | Const_int _
-          | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
-          | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+          ( Move | Opaque | Begin_region | End_region | Dls_get | Tls_get
+          | Domain_index | Poll | Pause | Const_int _ | Const_float32 _
+          | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+          | Const_vec512 _ | Stackoffset _ | Load _
           | Store (_, _, _)
           | Intop _ | Int128op _
           | Intop_imm (_, _)

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -539,7 +539,6 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t option =
       ~initial:(Reg.Set.elements all_temporaries)
       ~stack_slots ~affinity ()
   in
-  Regalloc_rewrite.insert_dummy_uses cfg_with_infos cfg_infos;
   match main ~round:1 state cfg_with_infos with
   | exception Function_is_too_complex -> None
   | () ->

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -47,14 +47,14 @@ let build : State.t -> Cfg_with_infos.t -> unit =
         (fun reg1 ->
           if move_src == Reg.dummy || not (Reg.same reg1 move_src)
           then Array.iter def ~f:(fun reg2 -> State.add_edge state reg1 reg2))
-        live.across;
+        live.across
       (* Add interference edges between all pairs of results, since they are all
          defined simultaneously and must be in different registers. *)
-      for i = 0 to Array.length def - 2 do
+      (*= for i = 0 to Array.length def - 2 do
         for j = i + 1 to Array.length def - 1 do
           State.add_edge state def.(i) def.(j)
         done
-      done
+      done *)
     end;
     if Array.length destroyed > 0
     then

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -47,14 +47,14 @@ let build : State.t -> Cfg_with_infos.t -> unit =
         (fun reg1 ->
           if move_src == Reg.dummy || not (Reg.same reg1 move_src)
           then Array.iter def ~f:(fun reg2 -> State.add_edge state reg1 reg2))
-        live.across
+        live.across;
       (* Add interference edges between all pairs of results, since they are all
          defined simultaneously and must be in different registers. *)
-      (*= for i = 0 to Array.length def - 2 do
+      for i = 0 to Array.length def - 2 do
         for j = i + 1 to Array.length def - 1 do
           State.add_edge state def.(i) def.(j)
         done
-      done *)
+      done
     end;
     if Array.length destroyed > 0
     then

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -127,7 +127,6 @@ let is_move_basic : Cfg.basic -> bool =
     | Static_cast _ -> false
     | Spill -> false
     | Reload -> false
-    | Dummy_use -> false
     | Const_int _ -> false
     | Const_float32 _ -> false
     | Const_float _ -> false

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -283,7 +283,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
   if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
-  let cfg_infos, stack_slots, affinity =
+  let (_ : cfg_infos), stack_slots, affinity =
     Regalloc_rewrite.prelude
       (module Utils)
       ~on_fatal_callback:(fun () ->
@@ -302,7 +302,6 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
         save_cfg "ls" cfg_with_layout)
       cfg_with_infos
   in
-  Regalloc_rewrite.insert_dummy_uses cfg_with_infos cfg_infos;
   let state = State.make ~stack_slots ~affinity in
   main ~round:1 state cfg_with_infos;
   Regalloc_rewrite.postlude

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -88,8 +88,8 @@ let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
     | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
     | Stack_check _
     | Op
-        ( Move | Dummy_use | Opaque | Begin_region | End_region | Dls_get
-        | Tls_get | Domain_index | Poll | Pause | Const_int _ | Const_float32 _
+        ( Move | Opaque | Begin_region | End_region | Dls_get | Tls_get
+        | Domain_index | Poll | Pause | Const_int _ | Const_float32 _
         | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
         | Const_vec512 _ | Stackoffset _ | Load _
         | Store (_, _, _)
@@ -459,59 +459,6 @@ let prelude :
     else cfg_infos, Regalloc_stack_slots.make ()
   in
   cfg_infos, stack_slots, Regalloc_affinity.compute cfg_with_infos
-
-let make_dummy_use :
-    Cfg.t -> copy:_ Cfg.instruction -> reg:Reg.t -> Cfg.basic Cfg.instruction =
- fun cfg ~copy ~reg ->
-  Cfg.make_instruction_from_copy copy ~desc:(Cfg.Op Dummy_use)
-    ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-    ~arg:[| reg |] ~res:[||] ()
-
-let insert_dummy_uses : Cfg_with_infos.t -> cfg_infos -> unit =
- fun cfg_with_infos cfg_infos ->
-  let set_but_unused_regs = Reg.Set.diff cfg_infos.res cfg_infos.arg in
-  if not (Reg.Set.is_empty set_but_unused_regs)
-  then begin
-    let cfg = Cfg_with_infos.cfg cfg_with_infos in
-    let block_insertion = ref false in
-    Cfg.iter_blocks cfg ~f:(fun _label block ->
-        (* process body *)
-        DLL.iter_cell block.body ~f:(fun cell ->
-            let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
-            Reg.Set.iter
-              (fun set_but_unused_reg ->
-                if occurs_array instr.res set_but_unused_reg
-                then
-                  let dummy_use =
-                    make_dummy_use cfg ~copy:instr ~reg:set_but_unused_reg
-                  in
-                  DLL.insert_after cell dummy_use)
-              set_but_unused_regs);
-        (* process terminator *)
-        let term = block.terminator in
-        Reg.Set.iter
-          (fun set_but_unused_reg ->
-            if occurs_array term.res set_but_unused_reg
-            then begin
-              let dummy_use =
-                make_dummy_use cfg ~copy:term ~reg:set_but_unused_reg
-              in
-              let new_instrs = DLL.make_single dummy_use in
-              (* CR-soon xclerc for xclerc: now that we preprocess critical
-                 nodes, no block insertion should occur here. *)
-              let (_ : Cfg.basic_block list) =
-                Cfg_with_layout.insert_block
-                  (Cfg_with_infos.cfg_with_layout cfg_with_infos)
-                  new_instrs ~after:block ~before:None
-              in
-              block_insertion := true
-            end)
-          set_but_unused_regs);
-    (* invalidate liveness / structural info as needed *)
-    Cfg_with_infos.invalidate_liveness cfg_with_infos;
-    if !block_insertion
-    then Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos
-  end
 
 let postlude : type s.
     (module State with type t = s) ->

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -49,12 +49,6 @@ val prelude :
   Cfg_with_infos.t ->
   cfg_infos * Regalloc_stack_slots.t * Regalloc_affinity.t
 
-(* Inserts dummy temporary uses, so that temporaries which are written but not
-   read are live. If such temporaries are never live, then they don't "interact"
-   with any other temporary and register allocators may assign any hardware
-   register to them. No instructions will be emitted for dummy uses. *)
-val insert_dummy_uses : Cfg_with_infos.t -> cfg_infos -> unit
-
 (* Runs the last steps common to register allocators, updating the CFG (stack
    slots, live fields, and prologue), running [f], and checking
    postconditions. *)

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -340,7 +340,7 @@ module Description : sig
 
   (** Will return [Some _] for the instructions that existed in the CFG before
       allocation and [None] otherwise. Currently, only instructions that
-      register allocation can add are [Spill], [Reload], and [Dummy_use]. *)
+      register allocation can add are [Spill] and [Reload]. *)
   val find_basic : t -> basic instruction -> basic Instruction.t option
 
   (** Will return [Some _] for the terminators that existed in CFG before
@@ -376,7 +376,7 @@ end = struct
   let reg_fun_args t = t.reg_fun_args
 
   let is_regalloc_specific_basic (desc : Cfg.basic) =
-    match desc with Op (Reload | Spill | Dummy_use) -> true | _ -> false
+    match desc with Op (Reload | Spill) -> true | _ -> false
 
   let add_instr_id ~seen_ids ~context id =
     if Hashtbl.mem seen_ids id
@@ -1212,7 +1212,6 @@ module Transfer (Desc_val : Description_value) :
       match instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
-      | Op Dummy_use -> Result.ok t
       | _ -> assert false)
     | Some instr_before -> (
       match instr.desc with

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -546,13 +546,13 @@ module Stack_offset_and_exn = struct
         stack_offset, traps)
     | Op (Stackoffset n) -> stack_offset + n, traps
     | Op
-        ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float _
-        | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-        | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
-        | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _
-        | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
-        | Domain_index | Poll | Pause | Alloc _ )
+        ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_float32 _
+        | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+        | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _
+        | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
+        | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+        | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll | Pause
+        | Alloc _ )
     | Reloadretaddr | Prologue | Epilogue ->
       stack_offset, traps
     | Stack_check _ ->

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2612,9 +2612,9 @@ end = struct
 
       let operation t ~next (op : Operation.t) dbg =
         match op with
-        | Move | Spill | Dummy_use | Reload | Const_int _ | Const_float32 _
-        | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-        | Const_vec512 _ | Load _ | Floatop _
+        | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
+        | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+        | Load _ | Floatop _
         | Intop_imm
             ( ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
               | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ ),


### PR DESCRIPTION
Remove the `Dummy_use` operation from the compiler backend. `Dummy_use` was intended to keep temporaries that are written but never read "live," preventing the allocator from assigning them arbitrary registers. However, it never actually achieved this goal for two independent reasons:
  1. **Purity defeated liveness**: `Dummy_use` was marked `is_pure = true` and had no results (`res = [||]`). The liveness analysis in `cfg_liveness.ml` skips marking arguments as live for pure instructions whose results are unused — and with an empty result array, results are trivially unused. So `Dummy_use` never actually made its argument register live.
  2. **IRC didn't add edges between co-defined registers**: Even if liveness had been increased, IRC's `build` function only adds interference edges between each defined register and the registers in `live.across`, not between the defined registers themselves. So two outputs of the same instruction still wouldn't interfere with each other.

We should fix the second point by adding interference edges in IRC, to be done in a later PR.
