### PR TITLE
Resolve conflicts in stdlib/

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -295,79 +295,11 @@ stdlib__Domain.cmx : domain.ml \
     stdlib__Array.cmx \
     stdlib__Domain.cmi
 stdlib__Domain.cmi : domain.mli
-<<<<<<< oxcaml
 effect.cmo : \
     effect.cmi
 effect.cmx : \
     effect.cmi
 effect.cmi :
-||||||| upstream-base
-stdlib__Dynarray.cmo : dynarray.ml \
-    stdlib__Sys.cmi \
-    stdlib__Seq.cmi \
-    stdlib__Printf.cmi \
-    stdlib__List.cmi \
-    stdlib__Array.cmi \
-    stdlib__Dynarray.cmi
-stdlib__Dynarray.cmx : dynarray.ml \
-    stdlib__Sys.cmx \
-    stdlib__Seq.cmx \
-    stdlib__Printf.cmx \
-    stdlib__List.cmx \
-    stdlib__Array.cmx \
-    stdlib__Dynarray.cmi
-stdlib__Dynarray.cmi : dynarray.mli \
-    stdlib__Seq.cmi
-stdlib__Effect.cmo : effect.ml \
-    stdlib__Printf.cmi \
-    stdlib__Printexc.cmi \
-    stdlib__Obj.cmi \
-    stdlib__Callback.cmi \
-    stdlib__Effect.cmi
-stdlib__Effect.cmx : effect.ml \
-    stdlib__Printf.cmx \
-    stdlib__Printexc.cmx \
-    stdlib__Obj.cmx \
-    stdlib__Callback.cmx \
-    stdlib__Effect.cmi
-stdlib__Effect.cmi : effect.mli \
-    stdlib__Printexc.cmi
-=======
-stdlib__Dynarray.cmo : dynarray.ml \
-    stdlib__Sys.cmi \
-    stdlib.cmi \
-    stdlib__Seq.cmi \
-    stdlib__Printf.cmi \
-    stdlib__Obj.cmi \
-    camlinternalOO.cmi \
-    stdlib__Array.cmi \
-    stdlib__Dynarray.cmi
-stdlib__Dynarray.cmx : dynarray.ml \
-    stdlib__Sys.cmx \
-    stdlib.cmx \
-    stdlib__Seq.cmx \
-    stdlib__Printf.cmx \
-    stdlib__Obj.cmx \
-    camlinternalOO.cmx \
-    stdlib__Array.cmx \
-    stdlib__Dynarray.cmi
-stdlib__Dynarray.cmi : dynarray.mli \
-    stdlib__Seq.cmi
-stdlib__Effect.cmo : effect.ml \
-    stdlib__Printf.cmi \
-    stdlib__Printexc.cmi \
-    stdlib__Obj.cmi \
-    stdlib__Callback.cmi \
-    stdlib__Effect.cmi
-stdlib__Effect.cmx : effect.ml \
-    stdlib__Printf.cmx \
-    stdlib__Printexc.cmx \
-    stdlib__Obj.cmx \
-    stdlib__Callback.cmx \
-    stdlib__Effect.cmi
-stdlib__Effect.cmi : effect.mli \
-    stdlib__Printexc.cmi
->>>>>>> upstream-incoming
 stdlib__Either.cmo : either.ml \
     stdlib__Either.cmi
 stdlib__Either.cmx : either.ml \
@@ -606,26 +538,16 @@ stdlib__Lazy.cmi : lazy.mli \
     camlinternalLazy.cmi
 stdlib__Lexing.cmo : lexing.ml \
     stdlib__Sys.cmi \
-<<<<<<< oxcaml
     stdlib__String.cmi \
     stdlib.cmi \
-||||||| upstream-base
-    stdlib__String.cmi \
-=======
->>>>>>> upstream-incoming
     stdlib__Int.cmi \
     stdlib__Bytes.cmi \
     stdlib__Array.cmi \
     stdlib__Lexing.cmi
 stdlib__Lexing.cmx : lexing.ml \
     stdlib__Sys.cmx \
-<<<<<<< oxcaml
     stdlib__String.cmx \
     stdlib.cmx \
-||||||| upstream-base
-    stdlib__String.cmx \
-=======
->>>>>>> upstream-incoming
     stdlib__Int.cmx \
     stdlib__Bytes.cmx \
     stdlib__Array.cmx \
@@ -672,23 +594,13 @@ stdlib__Map.cmi : map.mli \
     stdlib.cmi \
     stdlib__Seq.cmi
 stdlib__Marshal.cmo : marshal.ml \
-<<<<<<< oxcaml
     stdlib__String.cmi \
     stdlib.cmi \
-||||||| upstream-base
-    stdlib__String.cmi \
-=======
->>>>>>> upstream-incoming
     stdlib__Bytes.cmi \
     stdlib__Marshal.cmi
 stdlib__Marshal.cmx : marshal.ml \
-<<<<<<< oxcaml
     stdlib__String.cmx \
     stdlib.cmx \
-||||||| upstream-base
-    stdlib__String.cmx \
-=======
->>>>>>> upstream-incoming
     stdlib__Bytes.cmx \
     stdlib__Marshal.cmi
 stdlib__Marshal.cmi : marshal.mli \
@@ -772,20 +684,7 @@ stdlib__Out_channel.cmx : out_channel.ml \
     stdlib__Fun.cmx \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmi : out_channel.mli \
-<<<<<<< oxcaml
     stdlib.cmi
-||||||| upstream-base
-    stdlib.cmi \
-    stdlib__Bigarray.cmi
-=======
-    stdlib.cmi \
-    stdlib__Bigarray.cmi
-stdlib__Pair.cmo : pair.ml \
-    stdlib__Pair.cmi
-stdlib__Pair.cmx : pair.ml \
-    stdlib__Pair.cmi
-stdlib__Pair.cmi : pair.mli
->>>>>>> upstream-incoming
 stdlib__Parsing.cmo : parsing.ml \
     stdlib.cmi \
     stdlib__Obj.cmi \
@@ -1074,12 +973,7 @@ stdlib__Unit.cmi : unit.mli \
     stdlib.cmi
 stdlib__Weak.cmo : weak.ml \
     stdlib__Sys.cmi \
-<<<<<<< oxcaml
     stdlib.cmi \
-||||||| upstream-base
-=======
-    stdlib__Option.cmi \
->>>>>>> upstream-incoming
     stdlib__Obj.cmi \
     stdlib__Int.cmi \
     stdlib__Hashtbl.cmi \
@@ -1087,12 +981,7 @@ stdlib__Weak.cmo : weak.ml \
     stdlib__Weak.cmi
 stdlib__Weak.cmx : weak.ml \
     stdlib__Sys.cmx \
-<<<<<<< oxcaml
     stdlib.cmx \
-||||||| upstream-base
-=======
-    stdlib__Option.cmx \
->>>>>>> upstream-incoming
     stdlib__Obj.cmx \
     stdlib__Int.cmx \
     stdlib__Hashtbl.cmx \

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -100,50 +100,7 @@ endif
 .INTERMEDIATE: tmpheader.exe
 tmpheader.exe: $(HEADERPROGRAM).$(O)
 	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
-<<<<<<< oxcaml
-# FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
-ifneq "$(UNIX_OR_WIN32)" "win32"
-	strip $@
-endif
-||||||| upstream-base
-# FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
-ifneq "$(UNIX_OR_WIN32)" "win32"
-	strip $@
-endif
-
-$(HEADERPROGRAM)%$(O): \
-  OC_CPPFLAGS += -DRUNTIME_NAME="$(HEADER_PATH)ocamlrun$(subst .,,$*)"
-
-$(HEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ $^
-
-camlheader_ur: camlheader
-	$(V_GEN)cp camlheader $@
-
-ifeq "$(UNIX_OR_WIN32)" "unix"
-tmptargetcamlheader%exe: $(TARGETHEADERPROGRAM)%$(O)
-	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
-	strip $@
-
-$(TARGETHEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	      -DRUNTIME_NAME="$(HEADER_TARGET_PATH)ocamlrun$(subst .,,$*)" \
-	      $(OUTPUTOBJ)$@ $^
-
-target_%: tmptarget%.exe
-	$(V_GEN)rm -f $@.exe && \
-	mv $< $@
-else
-target_%: %
-	$(V_GEN)cp $< $@
-endif
-
-endif # ifeq "$(SHEBANGSCRIPTS)" "true"
-
-=======
 	$(STRIP) $@
->>>>>>> upstream-incoming
 
 stdlib.cma: $(OBJS)
 	$(V_LINKC)$(CAMLC) -a -o $@ $^

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -23,7 +23,6 @@ type ('a : any mod separable) t = 'a array
 
 (* Array operations *)
 
-<<<<<<< oxcaml
 external length : ('a : value_or_null mod separable).
   ('a array[@local_opt]) @ immutable -> int @@ stateless
   = "%array_length"
@@ -55,39 +54,6 @@ external unsafe_fill : ('a : value_or_null mod separable).
   'a array -> int -> int -> 'a -> unit @@ portable = "caml_array_fill"
 external create_float : ('a : value_or_null mod separable).
   int -> float array @@ portable = "caml_array_create_float"
-||||||| upstream-base
-external length : 'a array -> int = "%array_length"
-external get: 'a array -> int -> 'a = "%array_safe_get"
-external set: 'a array -> int -> 'a -> unit = "%array_safe_set"
-external unsafe_get: 'a array -> int -> 'a = "%array_unsafe_get"
-external unsafe_set: 'a array -> int -> 'a -> unit = "%array_unsafe_set"
-external make: int -> 'a -> 'a array = "caml_make_vect"
-external create: int -> 'a -> 'a array = "caml_make_vect"
-external unsafe_sub : 'a array -> int -> int -> 'a array = "caml_array_sub"
-external append_prim : 'a array -> 'a array -> 'a array = "caml_array_append"
-external concat : 'a array list -> 'a array = "caml_array_concat"
-external unsafe_blit :
-  'a array -> int -> 'a array -> int -> int -> unit = "caml_array_blit"
-external unsafe_fill :
-  'a array -> int -> int -> 'a -> unit = "caml_array_fill"
-external create_float: int -> float array = "caml_make_float_vect"
-=======
-external length : 'a array -> int = "%array_length"
-external get: 'a array -> int -> 'a = "%array_safe_get"
-external set: 'a array -> int -> 'a -> unit = "%array_safe_set"
-external unsafe_get: 'a array -> int -> 'a = "%array_unsafe_get"
-external unsafe_set: 'a array -> int -> 'a -> unit = "%array_unsafe_set"
-external make: int -> 'a -> 'a array = "caml_array_make"
-external create: int -> 'a -> 'a array = "caml_array_make"
-external unsafe_sub : 'a array -> int -> int -> 'a array = "caml_array_sub"
-external append_prim : 'a array -> 'a array -> 'a array = "caml_array_append"
-external concat : 'a array list -> 'a array = "caml_array_concat"
-external unsafe_blit :
-  'a array -> int -> 'a array -> int -> int -> unit = "caml_array_blit"
-external unsafe_fill :
-  'a array -> int -> int -> 'a -> unit = "caml_array_fill"
-external create_float: int -> float array = "caml_array_create_float"
->>>>>>> upstream-incoming
 
 module Floatarray = struct
   external create : int -> floatarray @@ portable = "caml_floatarray_create"

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -12,7 +12,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-<<<<<<< oxcaml
 type (!'a : value_or_null) t : sync_data with 'a =
   { mutable contents : 'a [@atomic] }
 
@@ -21,21 +20,7 @@ external make
   'a -> ('a t[@local_opt])
   @@ portable
   = "%makemutable"
-||||||| upstream-base
-type !'a t
 
-external make : 'a -> 'a t = "%makemutable"
-external make_contended : 'a -> 'a t = "caml_atomic_make_contended"
-external get : 'a t -> 'a = "%atomic_load"
-external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
-external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
-external fetch_and_add : int t -> int -> int = "%atomic_fetch_add"
-external ignore : 'a -> unit = "%ignore"
-=======
-external ignore : 'a -> unit = "%ignore"
->>>>>>> upstream-incoming
-
-<<<<<<< oxcaml
 external make_contended
   : ('a : value_or_null).
   'a -> ('a t[@local_opt])
@@ -161,49 +146,3 @@ module Loc = struct
   external get_contended : ('a : value_or_null).
     'a t @ contended local -> 'a @ contended @@ portable = "%atomic_load_loc"
 end
-||||||| upstream-base
-let set r x = ignore (exchange r x)
-let incr r = ignore (fetch_and_add r 1)
-let decr r = ignore (fetch_and_add r (-1))
-=======
-module Loc = struct
-  type 'a t = 'a atomic_loc
-
-  external get : 'a t -> 'a = "%atomic_load_loc"
-  external exchange : 'a t -> 'a -> 'a = "%atomic_exchange_loc"
-  external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas_loc"
-  external fetch_and_add : int t -> int -> int = "%atomic_fetch_add_loc"
-
-  let set t v =
-    ignore (exchange t v)
-  let incr t =
-    ignore (fetch_and_add t 1)
-  let decr t =
-    ignore (fetch_and_add t (-1))
-end
-
-type !'a t =
-  { mutable contents: 'a [@atomic];
-  }
-
-let make v =
-  { contents = v }
-
-external make_contended : 'a -> 'a t = "caml_atomic_make_contended"
-
-let get t =
-  t.contents
-let set t v =
-  t.contents <- v
-
-let exchange t v =
-  Loc.exchange [%atomic.loc t.contents] v
-let compare_and_set t old new_ =
-  Loc.compare_and_set [%atomic.loc t.contents] old new_
-let fetch_and_add t incr =
-  Loc.fetch_and_add [%atomic.loc t.contents] incr
-let incr t =
-  Loc.incr [%atomic.loc t.contents]
-let decr t =
-  Loc.decr [%atomic.loc t.contents]
->>>>>>> upstream-incoming

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -120,6 +120,12 @@ module Loc : sig
       see the documentation above for more information. *)
   type ('a : value_or_null) t : sync_data with 'a = 'a atomic_loc
 
+  (* exposing 'external' primitives directly helps reasoning about
+     performance: it guarantees that all versions of the compiler
+     (including bytecode) remove the pair construction on direct
+     calls:
+       Atomic.Loc.foo [%atomic.loc r.x] ...  *)
+
   external get : ('a : value_or_null). 'a t @ local -> 'a = "%atomic_load_loc"
 
   external get_contended : ('a : value_or_null).
@@ -157,32 +163,6 @@ module Loc : sig
 
   val incr : int t @ local -> unit
   val decr : int t @ local -> unit
-end
-
-(** Atomic "locations", such as record fields. *)
-module Loc : sig
-  (** This module exposes a dedicated type ['a Atomic.Loc.t] for
-      atomic locations (storing a value of type ['a]) inside objects
-      that may not be atomic references. It is used in particular for
-      atomic record fields: if a record [r] has an atomic field [f] of
-      type [foo], then [[%atomic.loc r.f]] has type [foo Atomic.Loc.t].
-
-      The API below mirrors the API to access {{!t}atomic references},
-      see the documentation above for more information. *)
-  type 'a t = 'a atomic_loc
-
-  (* exposing 'external' primitives directly helps reasoning about
-     performance: it guarantees that all versions of the compiler
-     (including bytecode) remove the pair construction on direct
-     calls:
-       Atomic.Loc.foo [%atomic.loc r.x] ...  *)
-  external get : 'a t -> 'a = "%atomic_load_loc"
-  val set : 'a t -> 'a -> unit
-  external exchange : 'a t -> 'a -> 'a = "%atomic_exchange_loc"
-  external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas_loc"
-  external fetch_and_add : int t -> int -> int = "%atomic_fetch_add_loc"
-  val incr : int t -> unit
-  val decr : int t -> unit
 end
 
 (** {1:examples Examples}

--- a/stdlib/bool.ml
+++ b/stdlib/bool.ml
@@ -20,22 +20,12 @@ open! Stdlib
 
 type t = bool = false | true
 
-<<<<<<< oxcaml
 external not : bool -> bool @@ portable = "%boolnot"
 external ( && ) : bool -> bool -> bool @@ portable = "%sequand"
 external ( || ) : bool -> bool -> bool @@ portable = "%sequor"
-||||||| upstream-base
-external not : bool -> bool = "%boolnot"
-external ( && ) : bool -> bool -> bool = "%sequand"
-external ( || ) : bool -> bool -> bool = "%sequor"
-=======
-external not : bool -> bool = "%boolnot"
-external ( && ) : bool -> bool -> bool = "%sequand"
-external ( || ) : bool -> bool -> bool = "%sequor"
-external logand : bool -> bool -> bool = "%andint"
-external logor : bool -> bool -> bool = "%orint"
-external logxor : bool -> bool -> bool = "%xorint"
->>>>>>> upstream-incoming
+external logand : bool -> bool -> bool @@ portable = "%andint"
+external logor : bool -> bool -> bool @@ portable = "%orint"
+external logxor : bool -> bool -> bool @@ portable = "%xorint"
 let equal : bool -> bool -> bool = ( = )
 let compare : bool -> bool -> int = Stdlib.compare
 external to_int : bool -> int @@ portable = "%identity"

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -187,6 +187,7 @@ let add_bytes b bytes =
   add_subbytes b bytes 0 (Bytes.length bytes)
   [@nontail]
 
+(* These two functions have not been localised (yet) and so are re-exported *)
 let add_substring b s offset len =
   add_substring b s offset len
 

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -166,18 +166,6 @@ let add_substring b s offset len =
     Bytes.unsafe_blit_string s offset buffer position len;
   b.position <- new_position
 
-let add_string b s =
-  let len = String.length s in
-  let position = b.position in
-  let {buffer; length} = b.inner in
-  let new_position = position + len in
-  if new_position > length then (
-    resize b len;
-    Bytes.blit_string s 0 b.inner.buffer b.position len;
-  ) else
-    Bytes.unsafe_blit_string s 0 buffer position len;
-  b.position <- new_position
-
 let add_subbytes b bytes offset len =
   if offset < 0 || len < 0 || offset > Bytes.length bytes - len
   then invalid_arg "Buffer.add_subbytes";
@@ -191,17 +179,19 @@ let add_subbytes b bytes offset len =
     Bytes.unsafe_blit bytes offset buffer position len;
   b.position <- new_position
 
+let add_string b s =
+  add_substring b s 0 (String.length s)
+  [@nontail]
+
 let add_bytes b bytes =
-  let len = Bytes.length bytes in
-  let position = b.position in
-  let {buffer; length} = b.inner in
-  let new_position = position + len in
-  if new_position > length then (
-    resize b len;
-    Bytes.blit bytes 0 b.inner.buffer b.position len;
-  ) else
-    Bytes.unsafe_blit bytes 0 buffer position len;
-  b.position <- new_position
+  add_subbytes b bytes 0 (Bytes.length bytes)
+  [@nontail]
+
+let add_substring b s offset len =
+  add_substring b s offset len
+
+let add_subbytes b bytes offset len =
+  add_subbytes b bytes offset len
 
 let add_buffer b bs =
   add_subbytes b bs.inner.buffer 0 bs.position

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -166,6 +166,18 @@ let add_substring b s offset len =
     Bytes.unsafe_blit_string s offset buffer position len;
   b.position <- new_position
 
+let add_string b s =
+  let len = String.length s in
+  let position = b.position in
+  let {buffer; length} = b.inner in
+  let new_position = position + len in
+  if new_position > length then (
+    resize b len;
+    Bytes.blit_string s 0 b.inner.buffer b.position len;
+  ) else
+    Bytes.unsafe_blit_string s 0 buffer position len;
+  b.position <- new_position
+
 let add_subbytes b bytes offset len =
   if offset < 0 || len < 0 || offset > Bytes.length bytes - len
   then invalid_arg "Buffer.add_subbytes";
@@ -179,19 +191,17 @@ let add_subbytes b bytes offset len =
     Bytes.unsafe_blit bytes offset buffer position len;
   b.position <- new_position
 
-<<<<<<< oxcaml
-let add_bytes b s =
-  add_string b (Bytes.unsafe_to_string s)
-  [@nontail]
-||||||| upstream-base
-let add_bytes b s = add_string b (Bytes.unsafe_to_string s)
-=======
-let add_string b s =
-  add_substring b s 0 (String.length s)
-
 let add_bytes b bytes =
-  add_subbytes b bytes 0 (Bytes.length bytes)
->>>>>>> upstream-incoming
+  let len = Bytes.length bytes in
+  let position = b.position in
+  let {buffer; length} = b.inner in
+  let new_position = position + len in
+  if new_position > length then (
+    resize b len;
+    Bytes.blit bytes 0 b.inner.buffer b.position len;
+  ) else
+    Bytes.unsafe_blit bytes 0 buffer position len;
+  b.position <- new_position
 
 let add_buffer b bs =
   add_subbytes b bs.inner.buffer 0 bs.position

--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -328,13 +328,7 @@ let create_table public_methods =
   table
 
 let init_class table =
-<<<<<<< oxcaml
   let _ : int = Atomic.fetch_and_add inst_var_count (table.size - 1) in
-||||||| upstream-base
-  inst_var_count := !inst_var_count + table.size - 1;
-=======
-  ignore (Atomic.fetch_and_add inst_var_count (table.size - 1));
->>>>>>> upstream-incoming
   table.initializers <- List.rev table.initializers;
   resize table (3 + Obj.magic table.methods.(1) * 16 / Sys.word_size)
 
@@ -368,13 +362,7 @@ let make_class_store pub_meths class_init init_table =
 
 let dummy_class loc =
   let undef = fun _ -> raise (Undefined_recursive_module loc) in
-<<<<<<< oxcaml
-  (magic undef, undef, undef, Obj.repr 0)
-||||||| upstream-base
-  (Obj.magic undef, undef, undef, Obj.repr 0)
-=======
-  (Obj.magic undef, undef, Obj.repr 0)
->>>>>>> upstream-incoming
+  (magic undef, undef, Obj.repr 0)
 
 (**** Objects ****)
 

--- a/stdlib/digest.ml
+++ b/stdlib/digest.ml
@@ -78,22 +78,11 @@ module BLAKE2 (X: sig val hash_length : int end) : sig @@ portable include S end
 
   type state
 
-<<<<<<< oxcaml
   external create_gen: int -> string -> state @@ portable = "caml_blake2_create"
-  external update: state -> string -> int -> int -> unit @@ portable = "caml_blake2_update"
+  external update: state -> bytes -> int -> int -> unit @@ portable
+                        = "caml_blake2_update"
   external final: state -> int -> t @@ portable = "caml_blake2_final"
   external unsafe_string: int -> string -> string -> int -> int -> t @@ portable
-||||||| upstream-base
-  external create_gen: int -> string -> state = "caml_blake2_create"
-  external update: state -> string -> int -> int -> unit = "caml_blake2_update"
-  external final: state -> int -> t = "caml_blake2_final"
-  external unsafe_string: int -> string -> string -> int -> int -> t
-=======
-  external create_gen: int -> string -> state = "caml_blake2_create"
-  external update: state -> bytes -> int -> int -> unit = "caml_blake2_update"
-  external final: state -> int -> t = "caml_blake2_final"
-  external unsafe_string: int -> string -> string -> int -> int -> t
->>>>>>> upstream-incoming
                         = "caml_blake2_string"
   external unsafe_bytes: int -> string -> bytes -> int -> int -> t
                         = "caml_blake2_bytes"
@@ -173,17 +162,9 @@ module MD5 = struct
   let compare = String.compare
   let equal = String.equal
 
-<<<<<<< oxcaml
   external unsafe_string: string -> int -> int -> t @@ portable = "caml_md5_string"
+  external unsafe_bytes: bytes -> int -> int -> t @@ portable = "caml_md5_bytes"
   external channel: in_channel -> int -> t @@ portable = "caml_md5_chan"
-||||||| upstream-base
-  external unsafe_string: string -> int -> int -> t = "caml_md5_string"
-  external channel: in_channel -> int -> t = "caml_md5_chan"
-=======
-  external unsafe_string: string -> int -> int -> t = "caml_md5_string"
-  external unsafe_bytes: bytes -> int -> int -> t = "caml_md5_bytes"
-  external channel: in_channel -> int -> t = "caml_md5_chan"
->>>>>>> upstream-incoming
 
   let string str =
     unsafe_string str 0 (String.length str)

--- a/stdlib/digest.ml
+++ b/stdlib/digest.ml
@@ -84,7 +84,7 @@ module BLAKE2 (X: sig val hash_length : int end) : sig @@ portable include S end
   external final: state -> int -> t @@ portable = "caml_blake2_final"
   external unsafe_string: int -> string -> string -> int -> int -> t @@ portable
                         = "caml_blake2_string"
-  external unsafe_bytes: int -> string -> bytes -> int -> int -> t
+  external unsafe_bytes: int -> string -> bytes -> int -> int -> t @@ portable
                         = "caml_blake2_bytes"
 
   let create () = create_gen hash_length ""

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -80,41 +80,11 @@ module Runtime_4 = struct
 
     type 'a key = int * (unit -> 'a) Modes.Portable.t
 
-<<<<<<< oxcaml
     let key_counter = Atomic.make 0
-||||||| upstream-base
-  type dls_state = Obj.t array
-=======
-  module Obj_opt : sig
-    type t
-    val none : t
-    val some : 'a -> t
-    val is_some : t -> bool
->>>>>>> upstream-incoming
 
-<<<<<<< oxcaml
     let new_key ?split_from_parent:_ init_orphan =
       let idx = Atomic.fetch_and_add key_counter 1 in
       (idx, { portable = init_orphan })
-||||||| upstream-base
-  let unique_value = Obj.repr (ref 0)
-=======
-    (** [unsafe_get obj] may only be called safely
-        if [is_some] is true.
-
-        [unsafe_get (some v)] is equivalent to
-        [Obj.obj (Obj.repr v)]. *)
-    val unsafe_get : t -> 'a
-  end = struct
-    type t = Obj.t
-    let none = Obj.repr (ref 0)
-    let some v = Obj.repr v
-    let is_some obj = (obj != none)
-    let unsafe_get obj = Obj.obj obj
-  end
-
-  type dls_state = Obj_opt.t array
->>>>>>> upstream-incoming
 
     (* If necessary, grow the current domain's local state array such that [idx]
     * is a valid index in the array. *)
@@ -142,24 +112,11 @@ module Runtime_4 = struct
       let st = maybe_grow idx in
       Array.unsafe_set st idx (Obj_opt.some x)
 
-<<<<<<< oxcaml
     let[@inline never] init_idx (type a) idx old_obj (init : _ -> a) =
       let v : a = init () in
       let new_obj = Obj_opt.some v in
       (* At this point, [st] or [st.(idx)] may have been changed
         by another thread on the same domain.
-||||||| upstream-base
-  let create_dls () =
-    let st = Array.make 8 unique_value in
-    set_dls_state st
-=======
-  external compare_and_set_dls_state : dls_state -> dls_state -> bool =
-    "caml_domain_dls_compare_and_set" [@@noalloc]
-
-  let create_dls () =
-    let st = Array.make 8 Obj_opt.none in
-    set_dls_state st
->>>>>>> upstream-incoming
 
         If [st] changed, it was resized into a larger value,
         we can just reuse the new value.
@@ -582,82 +539,22 @@ module TLS0 = struct
     k
 
   (* If necessary, grow the current domain's local state array such that [idx]
-<<<<<<< oxcaml
     * is a valid index in the array. *)
   let[@inline] maybe_grow idx =
     let st = get_tls_state () in
     let size = Array.length st in
     if idx < size then st
-||||||| upstream-base
-   * is a valid index in the array. *)
-  let maybe_grow idx =
-    let st = get_dls_state () in
-    let sz = Array.length st in
-    if idx < sz then st
-=======
-   * is a valid index in the array. *)
-  let rec maybe_grow idx =
-    let st = get_dls_state () in
-    let sz = Array.length st in
-    if idx < sz then st
->>>>>>> upstream-incoming
     else begin
-<<<<<<< oxcaml
       let new_st = Obj_opt.grow_array st idx size in
       set_tls_state new_st;
       new_st
-||||||| upstream-base
-      let rec compute_new_size s =
-        if idx < s then s else compute_new_size (2 * s)
-      in
-      let new_sz = compute_new_size sz in
-      let new_st = Array.make new_sz unique_value in
-      Array.blit st 0 new_st 0 sz;
-      set_dls_state new_st;
-      new_st
-=======
-      let rec compute_new_size s =
-        if idx < s then s else compute_new_size (2 * s)
-      in
-      let new_sz = compute_new_size sz in
-      let new_st = Array.make new_sz Obj_opt.none in
-      Array.blit st 0 new_st 0 sz;
-      (* We want a implementation that is safe with respect to
-         single-domain multi-threading: retry if the DLS state has
-         changed under our feet.
-         Note that the number of retries will be very small in
-         contended scenarios, as the array only grows, with
-         exponential resizing. *)
-      if compare_and_set_dls_state st new_st
-      then new_st
-      else maybe_grow idx
->>>>>>> upstream-incoming
     end
 
-<<<<<<< oxcaml
   let[@inline] set (type a) (idx, _init) (x : a) =
     (* Assures [idx] is in range. *)
-||||||| upstream-base
-  let set (idx, _init) x =
-=======
-  let set (type a) (idx, _init) (x : a) =
->>>>>>> upstream-incoming
     let st = maybe_grow idx in
-<<<<<<< oxcaml
     Array.unsafe_set st idx (Obj_opt.some x)
-||||||| upstream-base
-    (* [Sys.opaque_identity] ensures that flambda does not look at the type of
-     * [x], which may be a [float] and conclude that the [st] is a float array.
-     * We do not want OCaml's float array optimisation kicking in here. *)
-    st.(idx) <- Obj.repr (Sys.opaque_identity x)
-=======
-    (* [Sys.opaque_identity] ensures that flambda does not look at the type of
-     * [x], which may be a [float] and conclude that the [st] is a float array.
-     * We do not want OCaml's float array optimisation kicking in here. *)
-    st.(idx) <- Obj_opt.some (Sys.opaque_identity x)
->>>>>>> upstream-incoming
 
-<<<<<<< oxcaml
   let[@inline never] init_idx (type a) idx (init : _ -> a) =
     let v : a = init () in
     let new_obj = Obj_opt.some v in
@@ -667,84 +564,16 @@ module TLS0 = struct
 
   let[@inline] get (type a) ((idx, init) : a key) : a =
     (* Assures [idx] is in range. *)
-||||||| upstream-base
-  let get (idx, init) =
-=======
-
-  let[@inline never] array_compare_and_set a i oldval newval =
-    (* Note: we cannot use [@poll error] due to the
-       allocations on a.(i) in the Double_array case. *)
-    let curval = a.(i) in
-    if curval == oldval then (
-      Array.unsafe_set a i newval;
-      true
-    ) else false
-
-  let get (type a) ((idx, init) : a key) : a =
->>>>>>> upstream-incoming
     let st = maybe_grow idx in
-<<<<<<< oxcaml
     let obj = Array.unsafe_get st idx in
     if Obj_opt.is_some obj
     then (Obj_opt.unsafe_get obj : a)
     else init_idx idx init.portable
-||||||| upstream-base
-    let v = st.(idx) in
-    if v == unique_value then
-      let v' = Obj.repr (init ()) in
-      st.(idx) <- (Sys.opaque_identity v');
-      Obj.magic v'
-    else Obj.magic v
-=======
-    let obj = st.(idx) in
-    if Obj_opt.is_some obj
-    then (Obj_opt.unsafe_get obj : a)
-    else begin
-      let v : a = init () in
-      let new_obj = Obj_opt.some (Sys.opaque_identity v) in
-      (* At this point, [st] or [st.(idx)] may have been changed
-         by another thread on the same domain.
->>>>>>> upstream-incoming
 
-<<<<<<< oxcaml
   type key_value : value mod portable contended =
       KV : 'a key * (unit -> 'a) @@ portable -> key_value
   [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
-||||||| upstream-base
-  let get_initial_keys () : (int * Obj.t) list =
-    List.map
-      (fun (KI ((idx, _) as k, split)) ->
-           (idx, Obj.repr (split (get k))))
-      (Atomic.get parent_keys)
-=======
-         If [st] changed, it was resized into a larger value,
-         we can just reuse the new value.
 
-         If [st.(idx)] changed, we drop the current value to avoid
-         letting other threads observe a 'revert' that forgets
-         previous modifications. *)
-      let st = get_dls_state () in
-      if array_compare_and_set st idx obj new_obj
-      then v
-      else begin
-        (* if st.(idx) changed, someone must have initialized
-           the key in the meantime. *)
-        let updated_obj = st.(idx) in
-        if Obj_opt.is_some updated_obj
-        then (Obj_opt.unsafe_get updated_obj : a)
-        else assert false
-      end
-    end
-
-  type key_value = KV : 'a key * 'a -> key_value
-
-  let get_initial_keys () : key_value list =
-    List.map
-      (fun (KI (k, split)) -> KV (k, (split (get k))))
-      (Atomic.get parent_keys)
->>>>>>> upstream-incoming
-
-<<<<<<< oxcaml
   module Private = struct
     type keys = key_value list
 
@@ -763,17 +592,6 @@ module TLS0 = struct
     let set_initial_keys (l : key_value list) =
       List.iter (fun (KV (k, v)) -> set k (v ())) l
   end
-||||||| upstream-base
-  let set_initial_keys (l: (int * Obj.t) list) =
-    List.iter
-      (fun (idx, v) ->
-        let st = maybe_grow idx in st.(idx) <- v)
-      l
-
-=======
-  let set_initial_keys (l: key_value list) =
-    List.iter (fun (KV (k, v)) -> set k v) l
->>>>>>> upstream-incoming
 end
 
 module Safe = struct
@@ -794,16 +612,7 @@ end
 module TLS = struct
   module Private = TLS0.Private
 
-<<<<<<< oxcaml
   type 'a key = 'a TLS0.key
-||||||| upstream-base
-(******** Callbacks **********)
-=======
-external self_index : unit -> int
-  = "caml_ml_domain_index" [@@noalloc]
-
-(******** Callbacks **********)
->>>>>>> upstream-incoming
 
   let new_key ?split_from_parent f =
     let split_from_parent =

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -1275,7 +1275,7 @@ let to_seq_rev_reentrant a =
   in
   aux (length a - 1)
 
-external unsafe_iarray_of_array : 'a array -> 'a iarray = "%opaque"
+external unsafe_iarray_of_array : 'a array -> 'a iarray @@ portable = "%opaque"
 
 let unsafe_to_iarray ~capacity (f : 'a t -> unit) =
   let a = create () in

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -555,30 +555,10 @@ let pop_last (Pack a) =
   (* We know [length <= capacity a]. *)
   if length = 0 then raise Not_found;
   let last = length - 1 in
-  (* We know [length > 0] so [last >= 0]. *)
-<<<<<<< oxcaml
-  match Array.unsafe_get arr last with
-  | Empty ->
-      Error.missing_element ~i:last ~length
-  | Elem s ->
-      Array.unsafe_set arr last Empty;
-      a.length <- last;
-      s.v
-||||||| upstream-base
-  match Array.unsafe_get arr last with
-  (* At this point we know that [last] is a valid index in [arr]. *)
-  | Empty ->
-      Error.missing_element ~i:last ~length
-  | Elem s ->
-      Array.unsafe_set arr last Empty;
-      a.length <- last;
-      s.v
-=======
   let v = unsafe_get arr ~dummy ~i:last ~length in
   Array.unsafe_set arr last (Dummy.of_dummy dummy);
   a.length <- last;
   v
->>>>>>> upstream-incoming
 
 let pop_last_opt a =
   match pop_last a with

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -210,6 +210,13 @@ end = struct
      (It is a bit tricky to build an object that does not contain
      functional values where marshalling fails, see [fresh ()] below
      for how we do it.) *)
+  (* CR dallsopp: WIP for avoiding the magic
+  type 'stamp dummy : immutable_data =
+    { dummy : < > } [@@unboxed] [@@unsafe_allow_any_mode_crossing]
+  type fresh_dummy : immutable_data =
+    Fresh : 'stamp dummy -> fresh_dummy
+  *)
+
   type 'stamp dummy = < >
   type fresh_dummy : value mod portable contended =
     Fresh : 'stamp dummy -> fresh_dummy [@@unsafe_allow_any_mode_crossing]
@@ -357,6 +364,14 @@ end = struct
 end
 
 type !'a t : mutable_data with 'a =
+(* CR dallsopp: WIP for avoiding the magic
+  Pack : ('a, 'stamp) t_ -> 'a t [@@unboxed]
+and ('a, 'stamp) t_ : mutable_data with 'a =
+  { mutable length : int
+  ; mutable arr : ('a, 'stamp) with_dummy array
+  ; dummy : 'stamp dummy
+  }
+*)
   Pack : ('a, 'stamp) t_ -> 'a t [@@unboxed] [@@unsafe_allow_any_mode_crossing]
 and ('a, 'stamp) t_ = {
   mutable length : int;

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -111,7 +111,8 @@ module Dummy : sig
       so that two dummies with different stamps cannot be confused
       together. *)
 
-  type fresh_dummy = Fresh : 'stamp dummy -> fresh_dummy
+  type fresh_dummy : value mod portable contended =
+    Fresh : 'stamp dummy -> fresh_dummy [@@unsafe_allow_any_mode_crossing]
   val fresh : unit -> fresh_dummy
   (** The type of [fresh] enforces a fresh/unknown/opaque stamp for
       the returned dummy, distinct from all previous stamps. *)
@@ -210,7 +211,8 @@ end = struct
      functional values where marshalling fails, see [fresh ()] below
      for how we do it.) *)
   type 'stamp dummy = < >
-  type fresh_dummy = Fresh : 'stamp dummy -> fresh_dummy
+  type fresh_dummy : value mod portable contended =
+    Fresh : 'stamp dummy -> fresh_dummy [@@unsafe_allow_any_mode_crossing]
 
   let fresh () =
     (* dummies and marshalling: we intentionally
@@ -354,12 +356,13 @@ end = struct
   end
 end
 
-type 'a t = Pack : ('a, 'stamp) t_ -> 'a t [@@unboxed]
+type !'a t : mutable_data with 'a =
+  Pack : ('a, 'stamp) t_ -> 'a t [@@unboxed] [@@unsafe_allow_any_mode_crossing]
 and ('a, 'stamp) t_ = {
   mutable length : int;
   mutable arr : ('a, 'stamp) Dummy.with_dummy array;
   dummy : 'stamp Dummy.dummy;
-}
+} [@@unsafe_allow_any_mode_crossing]
 
 let global_dummy = Dummy.fresh ()
 (* We need to ensure that dummies are never exposed to the user as

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -96,10 +96,14 @@ module Deep = struct
   external reperform :
     'a t -> ('a, _, 'b) cont -> last_fiber -> 'b = "%reperform"
 
+  (* CR effect-syntax: Upstream the 3-parameter version of continuation and use
+     it to maintain type safety here. *)
+  let burn f k = f (Obj.magic k)
+
   let match_with comp arg handler =
     let effc eff k last_fiber =
       match handler.effc eff with
-      | Some f -> f (Cont k)
+      | Some f -> burn f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_stack handler.retc handler.exnc effc comp arg
@@ -110,10 +114,14 @@ module Deep = struct
   let try_with comp arg handler =
     let effc' eff k last_fiber =
       match handler.effc eff with
-      | Some f -> f (Cont k)
+      | Some f -> burn f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_stack (fun x -> x) (fun e -> raise e) effc' comp arg
+
+  let continue k = burn continue k
+  let discontinue k = burn discontinue k
+  let discontinue_with_backtrace k = burn discontinue_with_backtrace k
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -47,9 +47,6 @@ type (-'a, 'x, +'b) cont : value mod non_float
    the final fiber in the linked list formed by [cont.fiber->parent]. *)
 type last_fiber [@@immediate]
 
-external cont_set_last_fiber :
-  _ cont -> last_fiber -> unit = "%setfield1"
-
 external resume : ('a, _, 'b) cont -> ('c -> 'a) -> 'c -> 'b = "%resume"
 
 type ('a,'x,'b) effc = 'a t -> ('a, 'x, 'b) cont -> last_fiber -> 'b
@@ -81,38 +78,10 @@ let with_handler cont valuec exnc (effc : 'a. ('a, _, _) effc) f x =
 
 module Deep = struct
 
-<<<<<<< oxcaml
   type ('a,'b) continuation =
     | Cont : ('a,'x,'b) cont -> ('a, 'b) continuation [@@unboxed]
-||||||| upstream-base
-  type ('a,'b) continuation
-=======
-  type nonrec ('a,'b) continuation = ('a,'b) continuation
->>>>>>> upstream-incoming
 
-<<<<<<< oxcaml
   let continue (Cont k) v = resume k (fun x-> x) v
-||||||| upstream-base
-  external take_cont_noexc : ('a, 'b) continuation -> ('a, 'b) stack =
-    "caml_continuation_use_noexc" [@@noalloc]
-  external alloc_stack :
-    ('a -> 'b) ->
-    (exn -> 'b) ->
-    ('c t -> ('c, 'b) continuation -> last_fiber -> 'b) ->
-    ('a, 'b) stack = "caml_alloc_stack"
-  external cont_last_fiber : ('a, 'b) continuation -> last_fiber = "%field1"
-  external cont_set_last_fiber :
-    ('a, 'b) continuation -> last_fiber -> unit = "%setfield1"
-=======
-  external take_cont_noexc : ('a, 'b) continuation -> ('a, 'b) stack =
-    "caml_continuation_use_noexc" [@@noalloc]
-  external alloc_stack :
-    ('a -> 'b) ->
-    (exn -> 'b) ->
-    ('c t -> ('c, 'b) continuation -> last_fiber -> 'b) ->
-    ('a, 'b) stack = "caml_alloc_stack"
-  external cont_last_fiber : ('a, 'b) continuation -> last_fiber = "%field1"
->>>>>>> upstream-incoming
 
   let discontinue (Cont k) e = resume k (fun e -> raise e) e
 
@@ -130,17 +99,7 @@ module Deep = struct
   let match_with comp arg handler =
     let effc eff k last_fiber =
       match handler.effc eff with
-<<<<<<< oxcaml
-      | Some f ->
-          cont_set_last_fiber k last_fiber;
-          f (Cont k)
-||||||| upstream-base
-      | Some f ->
-          cont_set_last_fiber k last_fiber;
-          f k
-=======
-      | Some f -> f k
->>>>>>> upstream-incoming
+      | Some f -> f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_stack handler.retc handler.exnc effc comp arg
@@ -151,17 +110,7 @@ module Deep = struct
   let try_with comp arg handler =
     let effc' eff k last_fiber =
       match handler.effc eff with
-<<<<<<< oxcaml
-      | Some f ->
-          cont_set_last_fiber k last_fiber;
-          f (Cont k)
-||||||| upstream-base
-      | Some f ->
-          cont_set_last_fiber k last_fiber;
-          f k
-=======
-      | Some f -> f k
->>>>>>> upstream-incoming
+      | Some f -> f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_stack (fun x -> x) (fun e -> raise e) effc' comp arg
@@ -173,57 +122,17 @@ end
 
 module Shallow = struct
 
-<<<<<<< oxcaml
   type ('a,'b) continuation =
     | Cont : ('a,'b,'x) cont -> ('a,'b) continuation [@@unboxed]
-||||||| upstream-base
-  type ('a,'b) continuation
-
-  external alloc_stack :
-    ('a -> 'b) ->
-    (exn -> 'b) ->
-    ('c t -> ('c, 'b) continuation -> last_fiber -> 'b) ->
-    ('a, 'b) stack = "caml_alloc_stack"
-
-  external cont_last_fiber : ('a, 'b) continuation -> last_fiber = "%field1"
-  external cont_set_last_fiber :
-    ('a, 'b) continuation -> last_fiber -> unit = "%setfield1"
-=======
-  type ('a,'b) continuation
-
-  external alloc_stack :
-    ('a -> 'b) ->
-    (exn -> 'b) ->
-    ('c t -> ('c, 'b) continuation -> last_fiber -> 'b) ->
-    ('a, 'b) stack = "caml_alloc_stack"
-
-  external cont_last_fiber : ('a, 'b) continuation -> last_fiber = "%field1"
->>>>>>> upstream-incoming
 
   let fiber : type a b. (a -> b) -> (a, b) continuation = fun f ->
     let module M = struct type _ t += Initial_setup__ : a t end in
     let exception E of (a,b) continuation in
     let f' () = f (perform M.Initial_setup__) in
     let error _ = failwith "impossible" in
-<<<<<<< oxcaml
-    let effc (type a2) (eff : a2 t) (k : (a2,b,_) cont) last_fiber =
-||||||| upstream-base
-    let effc eff k last_fiber =
-=======
-    let effc eff k _last_fiber =
->>>>>>> upstream-incoming
+    let effc (type a2) (eff : a2 t) (k : (a2,b,_) cont) _last_fiber =
       match eff with
-<<<<<<< oxcaml
-      | M.Initial_setup__ ->
-          cont_set_last_fiber k last_fiber;
-          raise_notrace (E (Cont k))
-||||||| upstream-base
-      | M.Initial_setup__ ->
-          cont_set_last_fiber k last_fiber;
-          raise_notrace (E k)
-=======
-      | M.Initial_setup__ -> raise_notrace (E k)
->>>>>>> upstream-incoming
+      | M.Initial_setup__ -> raise_notrace (E (Cont k))
       | _ -> error ()
     in
     match with_stack error error effc f' () with
@@ -241,17 +150,7 @@ module Shallow = struct
   let continue_gen (Cont k) resume_fun v handler =
     let effc eff k last_fiber =
       match handler.effc eff with
-<<<<<<< oxcaml
-      | Some f ->
-          cont_set_last_fiber k last_fiber;
-          f (Cont k)
-||||||| upstream-base
-      | Some f ->
-          cont_set_last_fiber k last_fiber;
-          f k
-=======
-      | Some f -> f k
->>>>>>> upstream-incoming
+      | Some f -> f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_handler k handler.retc handler.exnc effc resume_fun v

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -126,7 +126,8 @@ module Deep = struct
 
   let continue k = of_continuation continue k
   let discontinue k = of_continuation discontinue k
-  let discontinue_with_backtrace k = of_continuation discontinue_with_backtrace k
+  let discontinue_with_backtrace k =
+    of_continuation discontinue_with_backtrace k
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -78,8 +78,10 @@ let with_handler cont valuec exnc (effc : 'a. ('a, _, _) effc) f x =
 
 module Deep = struct
 
-  type ('a,'b) continuation =
-    | Cont : ('a,'x,'b) cont -> ('a, 'b) continuation [@@unboxed]
+  type nonrec ('a,'b) continuation = ('a,'b) continuation
+
+  type ('a,'b) continuation_ =
+    | Cont : ('a,'x,'b) cont -> ('a, 'b) continuation_ [@@unboxed]
 
   let continue (Cont k) v = resume k (fun x-> x) v
 
@@ -98,12 +100,15 @@ module Deep = struct
 
   (* CR effect-syntax: Upstream the 3-parameter version of continuation and use
      it to maintain type safety here. *)
-  let burn f k = f (Obj.magic k)
+  let to_continuation (f : _ continuation -> 'a) (k : _ continuation_) =
+    f (Obj.magic k)
+  let of_continuation (f : _ continuation_ -> 'a) (k : _ continuation) =
+    f (Obj.magic k)
 
   let match_with comp arg handler =
     let effc eff k last_fiber =
       match handler.effc eff with
-      | Some f -> burn f (Cont k)
+      | Some f -> to_continuation f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_stack handler.retc handler.exnc effc comp arg
@@ -114,14 +119,14 @@ module Deep = struct
   let try_with comp arg handler =
     let effc' eff k last_fiber =
       match handler.effc eff with
-      | Some f -> burn f (Cont k)
+      | Some f -> to_continuation f (Cont k)
       | None -> reperform eff k last_fiber
     in
     with_stack (fun x -> x) (fun e -> raise e) effc' comp arg
 
-  let continue k = burn continue k
-  let discontinue k = burn discontinue k
-  let discontinue_with_backtrace k = burn discontinue_with_backtrace k
+  let continue k = of_continuation continue k
+  let discontinue k = of_continuation discontinue k
+  let discontinue_with_backtrace k = of_continuation discontinue_with_backtrace k
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -190,19 +190,20 @@ module Array = struct
   external unsafe_get : t -> int -> float @@ portable = "%floatarray_unsafe_get"
   external unsafe_set : t -> int -> float -> unit @@ portable = "%floatarray_unsafe_set"
 
-  external make : (int[@untagged]) -> (float[@unboxed]) -> t =
+  external make : (int[@untagged]) -> (float[@unboxed]) -> t @@ portable =
     "caml_floatarray_make" "caml_floatarray_make_unboxed"
 
   external unsafe_fill
     : t -> (int[@untagged]) -> (int[@untagged]) -> (float[@unboxed]) -> unit
+        @@ portable
     = "caml_floatarray_fill" "caml_floatarray_fill_unboxed" [@@noalloc]
 
   external unsafe_blit: t -> int -> t -> int -> int -> unit @@ portable =
     "caml_floatarray_blit" [@@noalloc]
 
-  external unsafe_sub : t -> int -> int -> t = "caml_floatarray_sub"
-  external append_prim : t -> t -> t = "caml_floatarray_append"
-  external concat : t list -> t = "caml_floatarray_concat"
+  external unsafe_sub : t -> int -> int -> t @@ portable = "caml_floatarray_sub"
+  external append_prim : t -> t -> t @@ portable = "caml_floatarray_append"
+  external concat : t list -> t @@ portable = "caml_floatarray_concat"
 
   let check a ofs len msg =
     if ofs < 0 || len < 0 || ofs + len < 0 || ofs + len > length a then

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -252,7 +252,7 @@ module Array = struct
 
   let copy a =
     let l = length a in
-    if l = 0 then empty
+    if l = 0 then Obj.magic_uncontended empty
     else unsafe_sub a 0 l
 
   let append a1 a2 =

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1084,7 +1084,7 @@ and str_formatter = formatter_of_buffer stdbuf
 (* Initialise domain local state *)
 
 (* CR-soon mslater: switch to TLS to remove thread unsafety *)
-module DLS = struct 
+module DLS = struct
   let new_key = Domain.Safe.DLS.new_key
   let get = Obj.magic_portable Domain.DLS.get
   let set = Obj.magic_portable Domain.DLS.set
@@ -1168,8 +1168,8 @@ let make_synchronized_formatter_safe output flush =
     in
     make_formatter output' flush')
 
-let make_synchronized_formatter_unsafe output flush = 
-  make_synchronized_formatter_safe 
+let make_synchronized_formatter_unsafe output flush =
+  make_synchronized_formatter_safe
     (Obj.magic_portable output)
     (Obj.magic_portable flush)
 
@@ -1245,60 +1245,8 @@ let formatter_of_symbolic_output_buffer sob =
 
 *)
 
-<<<<<<< oxcaml
 let[@inline] apply1 f v = f (DLS.get std_formatter_key) v
 let[@inline] apply2 f v w = f (DLS.get std_formatter_key) v w
-||||||| upstream-base
-let open_hbox v = pp_open_hbox (DLS.get std_formatter_key) v
-and open_vbox v = pp_open_vbox (DLS.get std_formatter_key) v
-and open_hvbox v = pp_open_hvbox (DLS.get std_formatter_key) v
-and open_hovbox v = pp_open_hovbox (DLS.get std_formatter_key) v
-and open_box v = pp_open_box (DLS.get std_formatter_key) v
-and close_box v = pp_close_box (DLS.get std_formatter_key) v
-and open_stag v = pp_open_stag (DLS.get std_formatter_key) v
-and close_stag v = pp_close_stag (DLS.get std_formatter_key) v
-and print_as v w = pp_print_as (DLS.get std_formatter_key) v w
-and print_string v = pp_print_string (DLS.get std_formatter_key) v
-and print_bytes v = pp_print_bytes (DLS.get std_formatter_key) v
-and print_int v = pp_print_int (DLS.get std_formatter_key) v
-and print_float v = pp_print_float (DLS.get std_formatter_key) v
-and print_char v = pp_print_char (DLS.get std_formatter_key) v
-and print_bool v = pp_print_bool (DLS.get std_formatter_key) v
-and print_break v w = pp_print_break (DLS.get std_formatter_key) v w
-and print_cut v = pp_print_cut (DLS.get std_formatter_key) v
-and print_space v = pp_print_space (DLS.get std_formatter_key) v
-and force_newline v = pp_force_newline (DLS.get std_formatter_key) v
-and print_flush v = pp_print_flush (DLS.get std_formatter_key) v
-and print_newline v = pp_print_newline (DLS.get std_formatter_key) v
-and print_if_newline v = pp_print_if_newline (DLS.get std_formatter_key) v
-=======
-let open_hbox v = pp_open_hbox (DLS.get std_formatter_key) v
-and open_vbox v = pp_open_vbox (DLS.get std_formatter_key) v
-and open_hvbox v = pp_open_hvbox (DLS.get std_formatter_key) v
-and open_hovbox v = pp_open_hovbox (DLS.get std_formatter_key) v
-and open_box v = pp_open_box (DLS.get std_formatter_key) v
-and close_box v = pp_close_box (DLS.get std_formatter_key) v
-and open_stag v = pp_open_stag (DLS.get std_formatter_key) v
-and close_stag v = pp_close_stag (DLS.get std_formatter_key) v
-and print_as v w = pp_print_as (DLS.get std_formatter_key) v w
-and print_string v = pp_print_string (DLS.get std_formatter_key) v
-and print_substring ~pos ~len v =
-  pp_print_substring  ~pos ~len (DLS.get std_formatter_key) v
-and print_substring_as ~pos ~len as_len v =
-  pp_print_substring_as ~pos ~len (DLS.get std_formatter_key) as_len v
-and print_bytes v = pp_print_bytes (DLS.get std_formatter_key) v
-and print_int v = pp_print_int (DLS.get std_formatter_key) v
-and print_float v = pp_print_float (DLS.get std_formatter_key) v
-and print_char v = pp_print_char (DLS.get std_formatter_key) v
-and print_bool v = pp_print_bool (DLS.get std_formatter_key) v
-and print_break v w = pp_print_break (DLS.get std_formatter_key) v w
-and print_cut v = pp_print_cut (DLS.get std_formatter_key) v
-and print_space v = pp_print_space (DLS.get std_formatter_key) v
-and force_newline v = pp_force_newline (DLS.get std_formatter_key) v
-and print_flush v = pp_print_flush (DLS.get std_formatter_key) v
-and print_newline v = pp_print_newline (DLS.get std_formatter_key) v
-and print_if_newline v = pp_print_if_newline (DLS.get std_formatter_key) v
->>>>>>> upstream-incoming
 
 let open_hbox = apply1 pp_open_hbox
 and open_vbox = apply1 pp_open_vbox
@@ -1402,13 +1350,7 @@ let pp_print_text ppf s =
   let left = ref 0 in
   let right = ref 0 in
   let flush () =
-<<<<<<< oxcaml
     pp_print_substring ppf s ~pos:!left ~len:(!right - !left);
-||||||| upstream-base
-    pp_print_string ppf (String.sub s !left (!right - !left));
-=======
-    pp_print_substring ~pos:!left ~len:(!right - !left) ppf s;
->>>>>>> upstream-incoming
     incr right; left := !right;
   in
   while (!right <> len) do

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1350,7 +1350,7 @@ let pp_print_text ppf s =
   let left = ref 0 in
   let right = ref 0 in
   let flush () =
-    pp_print_substring ppf s ~pos:!left ~len:(!right - !left);
+    pp_print_substring ~pos:!left ~len:(!right - !left) ppf s;
     incr right; left := !right;
   in
   while (!right <> len) do

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -242,8 +242,8 @@ type suspended_collection_work = int
    type.
 *)
 
-external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ portable
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ nonportable
   = "caml_ml_gc_ramp_up"
 
-external ramp_down : suspended_collection_work -> unit @@ portable
+external ramp_down : suspended_collection_work -> unit @@ nonportable
   = "caml_ml_gc_ramp_down"

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -124,18 +124,9 @@ let rec call_alarm arec =
 
 let delete_alarm a = Atomic.set a false
 
-<<<<<<< oxcaml
 (* We use [@inline never] to ensure [arec] is never statically allocated
    (which would prevent installation of the finaliser). *)
 let [@inline never] create_alarm f =
-||||||| upstream-base
-let create_alarm f =
-  let arec = { active = Atomic.make true; f = f } in
-  Domain.at_exit (fun () -> delete_alarm arec.active);
-=======
-(* never inline, to prevent [arec] from being allocated statically *)
-let[@inline never] create_alarm f =
->>>>>>> upstream-incoming
   let alarm = Atomic.make true in
   Domain.at_exit (fun () -> delete_alarm alarm);
   let arec = { active = alarm; f = f } in
@@ -229,15 +220,11 @@ module Memprof =
     external discard : t -> unit @@ portable = "caml_memprof_discard"
   end
 
-<<<<<<< oxcaml
 module Tweak = struct
   external set : string -> int -> unit = "caml_gc_tweak_set"
   external get : string -> int = "caml_gc_tweak_get"
   external list_active : unit -> (string * int) list = "caml_gc_tweak_list_active"
 end
-||||||| upstream-base
-=======
-
 
 type suspended_collection_work = int
 (* Note: we do not currently expose this type outside the module,
@@ -255,9 +242,8 @@ type suspended_collection_work = int
    type.
 *)
 
-external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ portable
   = "caml_ml_gc_ramp_up"
 
-external ramp_down : suspended_collection_work -> unit
+external ramp_down : suspended_collection_work -> unit @@ portable
   = "caml_ml_gc_ramp_down"
->>>>>>> upstream-incoming

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -126,7 +126,7 @@ let delete_alarm a = Atomic.set a false
 
 (* We use [@inline never] to ensure [arec] is never statically allocated
    (which would prevent installation of the finaliser). *)
-let [@inline never] create_alarm f =
+let[@inline never] create_alarm f =
   let alarm = Atomic.make true in
   Domain.at_exit (fun () -> delete_alarm alarm);
   let arec = { active = alarm; f = f } in

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -783,7 +783,7 @@ end
 
 type suspended_collection_work
 
-external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ nonportable
   = "caml_ml_gc_ramp_up"
 (** In general, the OCaml GC assumes that the program runs in
     a "steady state" where peak memory usage remains constant: for
@@ -826,7 +826,7 @@ external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
     [Effect.Unhandled] exception is thrown instead.
 *)
 
-external ramp_down : suspended_collection_work -> unit
+external ramp_down : suspended_collection_work -> unit @@ nonportable
   = "caml_ml_gc_ramp_down"
 (** Notify the GC about some amount of collection work that was
     suspended during a ramp-up phase, to be resumed now. *)

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -31,33 +31,7 @@
 #endif
 #endif
 
-<<<<<<< oxcaml
-static
-#ifdef _MSC_VER
-__forceinline
-#else
-__inline
-#endif
-unsigned long read_size(const char * const ptr)
-||||||| upstream-base
-/* Two macros are required so that QUOTE(foo) stringizes the _expansion_ of foo
-   rather than foo itself. cf. the Stringizing chapter in the cpp manual
-   (https://gcc.gnu.org/onlinedocs/gcc-13.1.0/cpp/Stringizing.html). */
-#define Q(x) #x
-#define QUOTE(x) Q(x)
-
-char * default_runtime_name = QUOTE(RUNTIME_NAME);
-
-static
-#ifdef _MSC_VER
-__forceinline
-#else
-__inline
-#endif
-unsigned long read_size(const char * const ptr)
-=======
 Caml_inline unsigned long read_size(const char * const ptr)
->>>>>>> upstream-incoming
 {
   const unsigned char * const p = (const unsigned char * const) ptr;
   return ((unsigned long) p[0] << 24) | ((unsigned long) p[1] << 16) |

--- a/stdlib/repr.ml
+++ b/stdlib/repr.ml
@@ -12,10 +12,14 @@
 (*                                                                        *)
 (**************************************************************************)
 
-external phys_equal : 'a -> 'a -> bool = "%eq"
+external phys_equal :
+  ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%eq"
 
-external equal : 'a -> 'a -> bool = "%equal"
-external compare : 'a -> 'a -> int = "%compare"
+external equal :
+  ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%equal"
+external compare :
+  ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> int
+  = "%compare"
 
 let min = Stdlib.min
 let max = Stdlib.max

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -49,42 +49,11 @@ let cygwin = cygwin ()
 let max_array_length = max_wosize ()
 let max_floatarray_length = max_array_length / (64 / word_size)
 let max_string_length = word_size / 8 * max_array_length - 1
-<<<<<<< oxcaml
-||||||| upstream-base
-external runtime_variant : unit -> string = "caml_runtime_variant"
-external runtime_parameters : unit -> string = "caml_runtime_parameters"
-=======
-external runtime_variant : unit -> string = "caml_runtime_variant"
-external runtime_parameters : unit -> string = "caml_runtime_parameters"
-external poll_actions : unit -> unit = "%poll"
->>>>>>> upstream-incoming
 
-<<<<<<< oxcaml
 (* In bytecode, [float# array] is treated as [float array].
    Using [max_floatarray_length] assumes flat float arrays are enabled. *)
 let max_unboxed_float_array_length = max_floatarray_length
 
-||||||| upstream-base
-external file_exists: string -> bool = "caml_sys_file_exists"
-external is_directory : string -> bool = "caml_sys_is_directory"
-external is_regular_file : string -> bool = "caml_sys_is_regular_file"
-external remove: string -> unit = "caml_sys_remove"
-external rename : string -> string -> unit = "caml_sys_rename"
-external getenv: string -> string = "caml_sys_getenv"
-
-let getenv_opt s =
-  (* TODO: expose a non-raising primitive directly. *)
-  try Some (getenv s)
-  with Not_found -> None
-=======
-external file_exists: string -> bool = "caml_sys_file_exists"
-external is_directory : string -> bool = "caml_sys_is_directory"
-external is_regular_file : string -> bool = "caml_sys_is_regular_file"
-external remove: string -> unit = "caml_sys_remove"
-external rename : string -> string -> unit = "caml_sys_rename"
-external getenv: string -> string = "caml_sys_getenv"
-external getenv_opt: string -> string option = "caml_sys_getenv_opt"
->>>>>>> upstream-incoming
 
 let max_unboxed_float32_array_length =
   match backend_type with
@@ -155,9 +124,6 @@ external readdir : string -> string array @@ portable = "caml_sys_read_directory
 external io_buffer_size: unit -> int = "caml_sys_io_buffer_size"
 let io_buffer_size = io_buffer_size ()
 
-external io_buffer_size: unit -> int = "caml_sys_io_buffer_size"
-let io_buffer_size = io_buffer_size ()
-
 let interactive = ref false
 
 type signal = int
@@ -167,18 +133,10 @@ type signal_behavior =
   | Signal_ignore
   | Signal_handle of (signal -> unit)
 
-<<<<<<< oxcaml
 module Safe = struct
   external signal
-    : int -> signal_behavior @ portable -> signal_behavior @ portable @@ portable
+    : signal -> signal_behavior @ portable -> signal_behavior @ portable @@ portable
     = "caml_install_signal_handler"
-||||||| upstream-base
-external signal : int -> signal_behavior -> signal_behavior
-                = "caml_install_signal_handler"
-=======
-external signal : signal -> signal_behavior -> signal_behavior
-                = "caml_install_signal_handler"
->>>>>>> upstream-incoming
 
   let set_signal sig_num sig_beh = ignore(signal sig_num sig_beh)
 end

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -135,7 +135,8 @@ type signal_behavior =
 
 module Safe = struct
   external signal
-    : signal -> signal_behavior @ portable -> signal_behavior @ portable @@ portable
+    : signal -> signal_behavior @ portable
+    -> signal_behavior @ portable @@ portable
     = "caml_install_signal_handler"
 
   let set_signal sig_num sig_beh = ignore(signal sig_num sig_beh)

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -208,9 +208,9 @@ let signal_to_string s =
   else if s < sigwinch then invalid_arg "Sys.signal_to_string"
   else "SIG(" ^ string_of_int s ^ ")"
 
-external rev_convert_signal_number: int -> int =
+external rev_convert_signal_number: int -> int @@ portable =
   "caml_sys_rev_convert_signal_number"
-external convert_signal_number: int -> int =
+external convert_signal_number: int -> int @@ portable =
   "caml_sys_convert_signal_number"
 
 let signal_of_int i =

--- a/stdlib/type.ml
+++ b/stdlib/type.ml
@@ -37,16 +37,8 @@ module Id = struct
   let make (type a : value_or_null) () : a t =
     T (module struct type t = a type _ id += Id : t id end)
 
-<<<<<<< oxcaml
   let[@inline] uid (type a : value_or_null) (T (module A) : a t) =
-    Obj.Extension_constructor.id (Obj.Extension_constructor.of_val A.Id)
-||||||| upstream-base
-  let[@inline] uid (type a) ((module A) : a t) =
-    Obj.Extension_constructor.id (Obj.Extension_constructor.of_val A.Id)
-=======
-  let[@inline] uid (type a) ((module A) : a t) =
     Obj.Extension_constructor.id [%extension_constructor A.Id]
->>>>>>> upstream-incoming
 
   let provably_equal
       (type a : value_or_null) (type b : value_or_null)

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -61,8 +61,11 @@ let unsafe_to_char = Char.unsafe_chr
 let equal : int -> int -> bool = ( = )
 let compare : int -> int -> int = Stdlib.compare
 
+(* [caml_hash_exn] doesn't raise on ints, so it's safe for
+   it to be marked as [@@noalloc].
+ *)
 external seeded_hash_param :
-  int -> int -> int -> 'a -> int @@ portable = "caml_hash" [@@noalloc]
+  int -> int -> int -> 'a -> int @@ portable = "caml_hash_exn" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x
 let hash x = seeded_hash_param 10 100 0 x
 

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -62,7 +62,7 @@ let equal : int -> int -> bool = ( = )
 let compare : int -> int -> int = Stdlib.compare
 
 external seeded_hash_param :
-  int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
+  int -> int -> int -> 'a -> int @@ portable = "caml_hash" [@@noalloc]
 let seeded_hash seed x = seeded_hash_param 10 100 seed x
 let hash x = seeded_hash_param 10 100 0 x
 

--- a/testsuite/tests/lib-dynarray/broken.ml
+++ b/testsuite/tests/lib-dynarray/broken.ml
@@ -1,0 +1,5 @@
+(* TEST *)
+
+(* CR dallsopp: this test is present until the CRs in stdlib/dynarray.ml have
+   been addressed. *)
+assert false


### PR DESCRIPTION
Organised by commit. All the files compile with main except for iarray.ml, because it needs the type directed disambiguation of `[| |]`, and effect.ml, because it needs the new predefined types that come with the effect syntax.

For iarray.ml, as the code has come from upstream, I've kept the `[| |]` rather than changing it to `[: :]` (but I checked it does compile if we just change the syntax) which I think makes sense to reduce the diff with upstream - whatever happens to the syntax, we do have to take the type directed disambiguation of the literals for compatibility with upstream OCaml code.