### PR TITLE
Hoist generated primitive repr tables out of prim_has_valid_reprs

### DIFF
--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -587,99 +587,104 @@ end
    with [@layout_poly] (see [make_native_repr] and the note above
    [error_if_containing_unexpected_jkind]).  Here we have more speicific checks
    for individual primitives. *)
-let prim_has_valid_reprs ~loc prim =
-  let open Repr_check in
+module Primitive_reprs = struct
+  module C = Jkind_types.Sort.Const
 
-  let module C = Jkind_types.Sort.Const in
-
-  let check =
-    (* Corresponds to [indexing_primitives] in [translprim.ml]. *)
-    let stringlike_indexing_primitives =
-      let widths : (_ * _ * Jkind_types.Sort.Const.t) list =
-        [
-          ("8", "", C.scannable);
-          ("i8", "", C.scannable);
-          ("16", "", C.scannable);
-          ("i16", "", C.scannable);
-          ("32", "", C.scannable);
-          ("f32", "", C.scannable);
-          ("64", "", C.scannable);
-          ("a128", "", C.scannable);
-          ("u128", "", C.scannable);
-          ("a256", "", C.scannable);
-          ("u256", "", C.scannable);
-          ("a512", "", C.scannable);
-          ("u512", "", C.scannable);
-          ("8", "#", C.bits8);
-          ("i8", "#", C.bits8);
-          ("16", "#", C.bits16);
-          ("i16", "#", C.bits16);
-          ("32", "#", C.bits32);
-          ("f32", "#", C.float32);
-          ("64", "#", C.bits64);
-          ("a128", "#", C.vec128);
-          ("u128", "#", C.vec128);
-          ("a256", "#", C.vec256);
-          ("u256", "#", C.vec256);
-          ("a512", "#", C.vec512);
-          ("u512", "#", C.vec512);
-        ]
-      in
-      let indices : (_ * Jkind_types.Sort.Const.t) list =
-        [
-          ("", C.scannable);
-          ("_indexed_by_nativeint#", C.word);
-          ("_indexed_by_int8#", C.bits8);
-          ("_indexed_by_int16#", C.bits16);
-          ("_indexed_by_int32#", C.bits32);
-          ("_indexed_by_int64#", C.bits64);
-        ]
-      in
-      let combiners =
-        [
-          ( Printf.sprintf "%%caml_%s_get%s%s%s%s",
-            fun index_kind width_kind ->
-              [
-                Same_as_ocaml_repr C.scannable;
-                Same_as_ocaml_repr index_kind;
-                Same_as_ocaml_repr width_kind;
-              ] );
-          ( Printf.sprintf "%%caml_%s_set%s%s%s%s",
-            fun index_kind width_kind ->
-              [
-                Same_as_ocaml_repr C.scannable;
-                Same_as_ocaml_repr index_kind;
-                Same_as_ocaml_repr width_kind;
-                Same_as_ocaml_repr C.scannable;
-              ] );
-        ]
-      in
-      (let ( let* ) x f = List.concat_map f x in
-       let* container = [ "bigstring"; "bytes"; "string" ] in
-       let* safe_sigil = [ ""; "u" ] in
-       let* index_sigil, index_kind = indices in
-       let* width_sigil, unboxed_sigil, width_kind = widths in
-       let* combine_string, combine_repr = combiners in
-       let string =
-         combine_string container width_sigil safe_sigil unboxed_sigil
-           index_sigil
-       in
-       let reprs = combine_repr index_kind width_kind in
-       [ (string, reprs) ])
-      |> List.to_seq
-      |> fun seq -> String.Map.add_seq seq String.Map.empty
+  (* Corresponds to [indexing_primitives] in [translprim.ml]. *)
+  let stringlike_indexing_primitives =
+    lazy
+      (
+    let widths : (_ * _ * Jkind_types.Sort.Const.t) list =
+      [
+        ("8", "", C.scannable);
+        ("i8", "", C.scannable);
+        ("16", "", C.scannable);
+        ("i16", "", C.scannable);
+        ("32", "", C.scannable);
+        ("f32", "", C.scannable);
+        ("64", "", C.scannable);
+        ("a128", "", C.scannable);
+        ("u128", "", C.scannable);
+        ("a256", "", C.scannable);
+        ("u256", "", C.scannable);
+        ("a512", "", C.scannable);
+        ("u512", "", C.scannable);
+        ("8", "#", C.bits8);
+        ("i8", "#", C.bits8);
+        ("16", "#", C.bits16);
+        ("i16", "#", C.bits16);
+        ("32", "#", C.bits32);
+        ("f32", "#", C.float32);
+        ("64", "#", C.bits64);
+        ("a128", "#", C.vec128);
+        ("u128", "#", C.vec128);
+        ("a256", "#", C.vec256);
+        ("u256", "#", C.vec256);
+        ("a512", "#", C.vec512);
+        ("u512", "#", C.vec512);
+      ]
     in
-    (* Corresponds to [array_vec_primitives] in [translprim.ml]. *)
-    let vector_array_indexing_primitives =
-      let vector_sizes = [
+    let indices : (_ * Jkind_types.Sort.Const.t) list =
+      [
+        ("", C.scannable);
+        ("_indexed_by_nativeint#", C.word);
+        ("_indexed_by_int8#", C.bits8);
+        ("_indexed_by_int16#", C.bits16);
+        ("_indexed_by_int32#", C.bits32);
+        ("_indexed_by_int64#", C.bits64);
+      ]
+    in
+    let combiners =
+      [
+        ( Printf.sprintf "%%caml_%s_get%s%s%s%s",
+          fun index_kind width_kind ->
+            [
+              Same_as_ocaml_repr C.scannable;
+              Same_as_ocaml_repr index_kind;
+              Same_as_ocaml_repr width_kind;
+            ] );
+        ( Printf.sprintf "%%caml_%s_set%s%s%s%s",
+          fun index_kind width_kind ->
+            [
+              Same_as_ocaml_repr C.scannable;
+              Same_as_ocaml_repr index_kind;
+              Same_as_ocaml_repr width_kind;
+              Same_as_ocaml_repr C.scannable;
+            ] );
+      ]
+    in
+    (let ( let* ) x f = List.concat_map f x in
+     let* container = [ "bigstring"; "bytes"; "string" ] in
+     let* safe_sigil = [ ""; "u" ] in
+     let* index_sigil, index_kind = indices in
+     let* width_sigil, unboxed_sigil, width_kind = widths in
+     let* combine_string, combine_repr = combiners in
+     let string =
+       combine_string container width_sigil safe_sigil unboxed_sigil
+         index_sigil
+     in
+     let reprs = combine_repr index_kind width_kind in
+     [ string, reprs ])
+    |> List.to_seq
+    |> fun seq -> String.Map.add_seq seq String.Map.empty)
+
+  (* Corresponds to [array_vec_primitives] in [translprim.ml]. *)
+  let vector_array_indexing_primitives =
+    lazy
+      (
+    let vector_sizes =
+      [
         ("128", "", C.scannable);
         ("128", "#", C.vec128);
         ("256", "", C.scannable);
         ("256", "#", C.vec256);
         ("512", "", C.scannable);
         ("512", "#", C.vec512);
-      ] in
-      let array_types = [
+      ]
+    in
+    let array_types =
+      [
+        "float_array";
         "floatarray";
         "unboxed_float_array";
         "unboxed_float32_array";
@@ -689,49 +694,65 @@ let prim_has_valid_reprs ~loc prim =
         "untagged_int16_array";
         "untagged_int8_array";
         "unboxed_nativeint_array";
-      ] in
-      let safe_sigils = [""; "u"] in
-      let indices = [
+      ]
+    in
+    let safe_sigils = [ ""; "u" ] in
+    let indices =
+      [
         ("", C.scannable);
         ("_indexed_by_nativeint#", C.word);
         ("_indexed_by_int8#", C.bits8);
         ("_indexed_by_int16#", C.bits16);
         ("_indexed_by_int32#", C.bits32);
         ("_indexed_by_int64#", C.bits64);
-      ] in
-      let combiners =
-        [
-          ( Printf.sprintf "%%caml_%s_get%s%s%s%s",
-            fun index_kind vector_kind ->
-              [
-                Same_as_ocaml_repr C.scannable;
-                Same_as_ocaml_repr index_kind;
-                Same_as_ocaml_repr vector_kind;
-              ] );
-          ( Printf.sprintf "%%caml_%s_set%s%s%s%s",
-            fun index_kind vector_kind ->
-              [
-                Same_as_ocaml_repr C.scannable;
-                Same_as_ocaml_repr index_kind;
-                Same_as_ocaml_repr vector_kind;
-                Same_as_ocaml_repr C.scannable;
-              ] );
-        ]
-      in
-      (let ( let* ) x f = List.concat_map f x in
-       let* array_type = array_types in
-       let* safe_sigil = safe_sigils in
-       let* size_str, unboxed_sigil, vector_kind = vector_sizes in
-       let* index_suffix, index_kind = indices in
-       let* combine_string, combine_repr = combiners in
-       let string =
-         combine_string array_type size_str safe_sigil unboxed_sigil
-           index_suffix
-       in
-       let reprs = combine_repr index_kind vector_kind in
-       [ (string, reprs) ])
-      |> List.to_seq
-      |> fun seq -> String.Map.add_seq seq String.Map.empty
+      ]
+    in
+    let combiners =
+      [
+        ( Printf.sprintf "%%caml_%s_get%s%s%s%s",
+          fun index_kind vector_kind ->
+            [
+              Same_as_ocaml_repr C.scannable;
+              Same_as_ocaml_repr index_kind;
+              Same_as_ocaml_repr vector_kind;
+            ] );
+        ( Printf.sprintf "%%caml_%s_set%s%s%s%s",
+          fun index_kind vector_kind ->
+            [
+              Same_as_ocaml_repr C.scannable;
+              Same_as_ocaml_repr index_kind;
+              Same_as_ocaml_repr vector_kind;
+              Same_as_ocaml_repr C.scannable;
+            ] );
+      ]
+    in
+    (let ( let* ) x f = List.concat_map f x in
+     let* array_type = array_types in
+     let* safe_sigil = safe_sigils in
+     let* size_str, unboxed_sigil, vector_kind = vector_sizes in
+     let* index_suffix, index_kind = indices in
+     let* combine_string, combine_repr = combiners in
+     let string =
+       combine_string array_type size_str safe_sigil unboxed_sigil
+         index_suffix
+     in
+     let reprs = combine_repr index_kind vector_kind in
+     [ string, reprs ])
+    |> List.to_seq
+    |> fun seq -> String.Map.add_seq seq String.Map.empty)
+end
+
+let prim_has_valid_reprs ~loc prim =
+  let open Repr_check in
+
+  let module C = Jkind_types.Sort.Const in
+
+  let check =
+    let stringlike_indexing_primitives =
+      Lazy.force Primitive_reprs.stringlike_indexing_primitives
+    in
+    let vector_array_indexing_primitives =
+      Lazy.force Primitive_reprs.vector_array_indexing_primitives
     in
     match prim.prim_name with
     | "%identity"

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -684,7 +684,6 @@ module Primitive_reprs = struct
     in
     let array_types =
       [
-        "float_array";
         "floatarray";
         "unboxed_float_array";
         "unboxed_float32_array";


### PR DESCRIPTION
`Primitive.prim_has_valid_reprs` was rebuilding two large generated `String.Map`s on every call. This hoists them into shared lazy values so that work is done at most once per compiler process.

## Effect

This reduces allocations and improves compile times of modules with many primitive `external` declarations:

- `otherlibs/unix/unix_unix.ml`
  - time: `334.3 ms -> 192.9 ms` (`1.73x` faster)
  - allocation: `1.1 GB -> 0.4 GB`

- `stdlib/sys.ml`
  - time: `85.0 ms -> 47.5 ms` (`1.79x` faster)
  - allocation: `0.2 GB -> 35.4 MB`

- `stdlib/bytes.ml`
  - time: `237.5 ms -> 209.9 ms` (`1.13x` faster)
  - allocation: `0.6 GB -> 0.4 GB`

Files without many `external` declarations are unaffected, since this only changes the primitive repr checking path.
