### PR TITLE
Replace CFG dump with `Printcfg` module

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -48,7 +48,9 @@ let cmm_invariants ppf fd_cmm =
 let cfg_invariants ppf cfg =
   let print_fundecl ppf c =
     if !Oxcaml_flags.dump_cfg
-    then Cfg_with_layout.dump ppf c ~msg:"*** Cfg invariant check failed"
+    then
+      Format.fprintf ppf "*** Cfg invariant check failed\n%a"
+        Printcfg.cfg_with_layout c
     else Format.fprintf ppf "%s" (Cfg_with_layout.cfg c).fun_name
   in
   if !Oxcaml_flags.cfg_invariants && Cfg_invariants.run ppf cfg
@@ -62,8 +64,7 @@ let pass_dump_linear_if ppf flag message phrase =
   phrase
 
 let pass_dump_cfg_if ppf flag message c =
-  if !flag
-  then fprintf ppf "*** %s@.%a@." message (Cfg_with_layout.dump ~msg:"") c;
+  if !flag then fprintf ppf "*** %s@.%a@." message Printcfg.cfg_with_layout c;
   c
 
 let should_vectorize () =

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -290,15 +290,15 @@ let dump_basic ppf (basic : basic) =
   let open Format in
   match basic with
   | Op op -> Operation.dump ppf op
-  | Reloadretaddr -> fprintf ppf "Reloadretaddr"
+  | Reloadretaddr -> fprintf ppf "reloadretaddr"
   | Pushtrap { lbl_handler } ->
-    fprintf ppf "Pushtrap handler=%a" Label.format lbl_handler
+    fprintf ppf "pushtrap handler=%a" Label.format lbl_handler
   | Poptrap { lbl_handler } ->
-    fprintf ppf "Poptrap handler=%a" Label.format lbl_handler
-  | Prologue -> fprintf ppf "Prologue"
-  | Epilogue -> fprintf ppf "Epilogue"
+    fprintf ppf "poptrap handler=%a" Label.format lbl_handler
+  | Prologue -> fprintf ppf "prologue"
+  | Epilogue -> fprintf ppf "epilogue"
   | Stack_check { max_frame_size_bytes } ->
-    fprintf ppf "Stack_check size=%d" max_frame_size_bytes
+    fprintf ppf "stack_check size=%d" max_frame_size_bytes
 
 let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
     ?(sep = "\n") ppf (terminator : terminator) =
@@ -359,9 +359,9 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
       let i = label_count - 1 in
       fprintf ppf "case %d: goto %a" i Label.format labels.(i))
   | Call_no_return { func_symbol; _ } ->
-    fprintf ppf "Call_no_return %s%a" func_symbol print_args args
-  | Return -> fprintf ppf "Return%a" print_args args
-  | Raise _ -> fprintf ppf "Raise%a" print_args args
+    fprintf ppf "call_no_return %s%a" func_symbol print_args args
+  | Return -> fprintf ppf "return%a" print_args args
+  | Raise _ -> fprintf ppf "raise%a" print_args args
   | Tailcall_self { destination } ->
     dump_linear_call_op ppf
       (Linear.Ltailcall_imm
@@ -383,7 +383,7 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
       (match call with
       | Indirect _callees -> Linear.Lcall_ind
       | Direct func -> Linear.Lcall_imm { func });
-    Format.fprintf ppf "%sgoto %a" sep Label.format label_after
+    Format.fprintf ppf "%s\n           goto %a" sep Label.format label_after
   | Prim { op = prim; label_after } ->
     Format.fprintf ppf "%t%a" print_res dump_linear_call_op
       (match prim with
@@ -433,7 +433,9 @@ let print_basic' ?print_reg ppf (instruction : basic instruction) =
 let print_basic ppf i = print_basic' ppf i
 
 let print_terminator' ?print_reg ppf (ti : terminator instruction) =
-  dump_terminator' ?print_reg ~res:ti.res ~args:ti.arg ~sep:"\n" ppf ti.desc
+  Format.fprintf ppf "%t%a%t" Cfg_colours.terminator
+    (dump_terminator' ?print_reg ~res:ti.res ~args:ti.arg ~sep:"")
+    ti.desc Cfg_colours.pop
 
 let print_terminator ppf ti = print_terminator' ppf ti
 

--- a/backend/cfg/cfg_colours.ml
+++ b/backend/cfg/cfg_colours.ml
@@ -1,0 +1,111 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* CR mshinwell: share some of this with Flambda_colours *)
+
+(* Whether to output an up arrow on push and a down arrow on pop. Handy for
+   hunting down mismatched pushes and pops. *)
+let debug_push_and_pop = false
+
+type directive = Format.formatter -> unit
+
+let disable_colours = ref false
+
+let is_colour_enabled =
+  let colour_enabled =
+    lazy
+      ((* This avoids having to alter misc.ml *)
+       let buf = Buffer.create 10 in
+       let ppf = Format.formatter_of_buffer buf in
+       Misc.Style.set_tag_handling ppf;
+       Format.fprintf ppf "@{<error>@}%!";
+       String.length (Buffer.contents buf) > 0)
+  in
+  fun () -> Lazy.force colour_enabled && not !disable_colours
+
+let without_colours ~f =
+  let tmp = !disable_colours in
+  disable_colours := true;
+  let res = f () in
+  disable_colours := tmp;
+  res
+
+type state =
+  { fg : int option;
+    bg : int option
+  }
+
+let initial_state = { fg = None; bg = None }
+
+let state_stack =
+  (* Instead of an actual empty stack, we start with the initial state on top,
+     since this makes [push] and [pop] simpler. *)
+  ref [initial_state]
+
+let output ppf str =
+  if is_colour_enabled () then Format.fprintf ppf "@<0>%s" str
+
+let sequence command_code arg =
+  Printf.sprintf "\x1b[%d;5;%d;1m" command_code arg
+
+let fg_256 n ppf = output ppf (sequence 38 n)
+
+let bg_256 n ppf = output ppf (sequence 48 n)
+
+let reset_out ppf = output ppf "\x1b[0m"
+
+let render_state state ppf =
+  reset_out ppf;
+  Option.iter (fun fg -> fg_256 fg ppf) state.fg;
+  Option.iter (fun bg -> bg_256 bg ppf) state.bg
+
+let pop ppf =
+  match !state_stack with
+  | [] | [_] -> Misc.fatal_error "Cfg_colours.pop: too many pops"
+  | _ :: (top_state :: _ as states) ->
+    state_stack := states;
+    render_state top_state ppf;
+    if debug_push_and_pop then output ppf "\u{2193}"
+
+let push ?fg ?bg ppf =
+  let current_state =
+    match !state_stack with
+    | [] -> Misc.fatal_error "Cfg_colours.push_modified: empty stack"
+    | state :: _ -> state
+  in
+  let update new_value old_value =
+    match new_value with None -> old_value | Some _ -> new_value
+  in
+  let new_state =
+    { fg = update fg current_state.fg; bg = update bg current_state.bg }
+  in
+  state_stack := new_state :: !state_stack;
+  render_state new_state ppf;
+  if debug_push_and_pop then output ppf "\u{2191}"
+
+let none ppf = push ppf
+
+let terminator ppf = push ~fg:111 ppf
+
+let block_label ppf = push ~fg:198 ppf
+
+let block_label_exn ppf = push ~fg:198 ~bg:197 ppf
+
+let instr_id ppf = push ~fg:43 ppf
+
+let pred_succ ppf = push ~fg:243 ppf
+
+let function_name ppf = push ~fg:1 ~bg:169 ppf
+
+let basic ppf = push ~fg:65 ppf

--- a/backend/cfg/cfg_colours.ml
+++ b/backend/cfg/cfg_colours.ml
@@ -25,7 +25,7 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(* CR mshinwell: share some of this with Flambda_colours *)
+(* CR-someday mshinwell/xclerc: share some of this with Flambda_colours *)
 
 (* Whether to output an up arrow on push and a down arrow on pop. Handy for
    hunting down mismatched pushes and pops. *)

--- a/backend/cfg/cfg_colours.ml
+++ b/backend/cfg/cfg_colours.ml
@@ -1,16 +1,29 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*                   Mark Shinwell, Jane Street Europe                    *)
-(*                                                                        *)
-(*   Copyright 2019 Jane Street Group LLC                                 *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
 
 (* CR mshinwell: share some of this with Flambda_colours *)
 
@@ -34,12 +47,7 @@ let is_colour_enabled =
   in
   fun () -> Lazy.force colour_enabled && not !disable_colours
 
-let without_colours ~f =
-  let tmp = !disable_colours in
-  disable_colours := true;
-  let res = f () in
-  disable_colours := tmp;
-  res
+let without_colours ~f = Misc.protect_refs [Misc.R (disable_colours, true)] f
 
 type state =
   { fg : int option;
@@ -105,6 +113,8 @@ let block_label_exn ppf = push ~fg:198 ~bg:197 ppf
 let instr_id ppf = push ~fg:43 ppf
 
 let pred_succ ppf = push ~fg:243 ppf
+
+let liveness ppf = push ~fg:243 ppf
 
 let function_name ppf = push ~fg:1 ~bg:169 ppf
 

--- a/backend/cfg/cfg_colours.mli
+++ b/backend/cfg/cfg_colours.mli
@@ -1,16 +1,29 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*                   Mark Shinwell, Jane Street Europe                    *)
-(*                                                                        *)
-(*   Copyright 2019 Jane Street Group LLC                                 *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
 
 (** A colour directive. Can be passed as an argument to [Format.printf] and
     frients using the "%t" specifier. Each directive (besides [pop]) acts by
@@ -35,6 +48,8 @@ val block_label_exn : directive
 val instr_id : directive
 
 val pred_succ : directive
+
+val liveness : directive
 
 val function_name : directive
 

--- a/backend/cfg/cfg_colours.mli
+++ b/backend/cfg/cfg_colours.mli
@@ -1,0 +1,43 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** A colour directive. Can be passed as an argument to [Format.printf] and
+    frients using the "%t" specifier. Each directive (besides [pop]) acts by
+    pushing a new state onto a stack, allowing the previous state to be restored
+    using [pop]. *)
+type directive = Format.formatter -> unit
+
+(** Undo the most recent colour directive, restoring the previous state. Raises
+    a fatal error if the stack is empty. *)
+val pop : directive
+
+(** Push a copy of the current state onto the stack. Useful when setting a
+    colour conditionally so that a following [pop] will always be matched. *)
+val none : directive
+
+val terminator : directive
+
+val block_label : directive
+
+val block_label_exn : directive
+
+val instr_id : directive
+
+val pred_succ : directive
+
+val function_name : directive
+
+val basic : directive
+
+val without_colours : f:(unit -> 'a) -> 'a

--- a/backend/cfg/cfg_with_infos.ml
+++ b/backend/cfg/cfg_with_infos.ml
@@ -53,6 +53,8 @@ let liveness t =
   compute_if_necessary t.liveness ~f:(fun () ->
       liveness_analysis t.cfg_with_layout)
 
+let liveness_if_available t = !(t.liveness)
+
 let liveness_find t id = InstructionId.Tbl.find (liveness t) id
 
 let liveness_find_opt t id = InstructionId.Tbl.find_opt (liveness t) id

--- a/backend/cfg/cfg_with_infos.mli
+++ b/backend/cfg/cfg_with_infos.mli
@@ -32,6 +32,8 @@ val get_block_exn : t -> Label.t -> Cfg.basic_block
 
 val liveness : t -> liveness
 
+val liveness_if_available : t -> liveness option
+
 val liveness_find : t -> InstructionId.t -> Cfg_liveness.Liveness.domain
 
 val liveness_find_opt :

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -113,54 +113,6 @@ let is_trap_handler t label =
 
 (* Printing utilities for debug *)
 
-let dump ppf t ~msg =
-  let open Format in
-  fprintf ppf "\ncfg for %s\n" msg;
-  fprintf ppf "%s\n" t.cfg.fun_name;
-  let regalloc =
-    List.find_map
-      (function[@ocaml.warning "-4"]
-        | Cfg.Use_regalloc regalloc -> Some regalloc | _ -> None)
-      t.cfg.fun_codegen_options
-  in
-  (match regalloc with
-  | None -> ()
-  | Some regalloc ->
-    fprintf ppf "use_regalloc=%a\n" Clflags.Register_allocator.format regalloc);
-  let regalloc_params =
-    List.find_map
-      (function[@ocaml.warning "-4"]
-        | Cfg.Use_regalloc_param params -> Some params | _ -> None)
-      t.cfg.fun_codegen_options
-  in
-  (match regalloc_params with
-  | None -> ()
-  | Some regalloc_params ->
-    fprintf ppf "regalloc_params=%s\n" (String.concat ", " regalloc_params));
-  fprintf ppf "layout.length=%d\n" (DLL.length t.layout);
-  fprintf ppf "blocks.length=%d\n" (Label.Tbl.length t.cfg.blocks);
-  let print_block label =
-    let block = Label.Tbl.find t.cfg.blocks label in
-    fprintf ppf "\n%a:\n" Label.format label;
-    let pp_with_id ppf ~pp (instr : _ Cfg.instruction) =
-      fprintf ppf "(id:%a) %a\n" InstructionId.format instr.id pp instr
-    in
-    DLL.iter ~f:(pp_with_id ppf ~pp:Cfg.print_basic) block.body;
-    pp_with_id ppf ~pp:Cfg.print_terminator block.terminator;
-    fprintf ppf "\npredecessors:";
-    Label.Set.iter (fprintf ppf " %a" Label.format) block.predecessors;
-    fprintf ppf "\nsuccessors:";
-    Label.Set.iter
-      (fprintf ppf " %a" Label.format)
-      (Cfg.successor_labels ~normal:true ~exn:false block);
-    fprintf ppf "\nexn-successors:";
-    Label.Set.iter
-      (fprintf ppf " %a" Label.format)
-      (Cfg.successor_labels ~normal:false ~exn:true block);
-    fprintf ppf "\n"
-  in
-  DLL.iter ~f:print_block t.layout
-
 let print_row r ppf = Format.dprintf "@,@[<v 1><tr>%t@]@,</tr>" r ppf
 
 type align =

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -82,8 +82,6 @@ val print_dot :
   t ->
   unit
 
-val dump : Format.formatter -> t -> msg:string -> unit
-
 (** Change layout: randomly reorder the blocks, keeping the entry block first.
     This function is intended for testing and enabled by compiler flag
     "-reorder-blocks-random".

--- a/backend/cfg/instructionId.ml
+++ b/backend/cfg/instructionId.ml
@@ -11,9 +11,11 @@ let max = Int.max
 
 let to_string = Int.to_string
 
-let to_string_padded t = Printf.sprintf "#%04d" t
+let to_string_padded t = Printf.sprintf "#%08d" t
 
 let format fmt t = Format.fprintf fmt "%d" t
+
+let format_padded fmt t = Format.fprintf fmt "%8d" t
 
 type sequence = { mutable next : t }
 

--- a/backend/cfg/instructionId.ml
+++ b/backend/cfg/instructionId.ml
@@ -11,7 +11,7 @@ let max = Int.max
 
 let to_string = Int.to_string
 
-let to_string_padded t = Printf.sprintf "#%08d" t
+let to_string_padded t = Printf.sprintf "#%04d" t
 
 let format fmt t = Format.fprintf fmt "%d" t
 

--- a/backend/cfg/instructionId.mli
+++ b/backend/cfg/instructionId.mli
@@ -16,6 +16,8 @@ val to_string_padded : t -> string
 
 val format : Format.formatter -> t -> unit
 
+val format_padded : Format.formatter -> t -> unit
+
 type sequence
 
 val make_sequence : ?last_used:t -> unit -> sequence

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -41,27 +41,25 @@ let block :
     Cfg_with_infos.liveness option ->
     unit =
  fun fmt block liveness ->
-  Format.fprintf fmt "block %t%a%t:"
+  Format.fprintf fmt "block %t%a%t%s -"
     (if block.is_trap_handler
      then Cfg_colours.block_label_exn
      else Cfg_colours.block_label)
-    Label.format block.start Cfg_colours.pop;
-  (match block.is_trap_handler with
-  | false -> ()
-  | true -> Format.fprintf fmt " [handler]");
+    Label.format block.start Cfg_colours.pop
+    (match block.is_trap_handler with false -> "" | true -> " [handler]");
   (match block.cold with false -> () | true -> Format.fprintf fmt " [cold]");
-  Format.fprintf fmt "\n";
-  Format.fprintf fmt "  %tpredecessors: %a%t\n" Cfg_colours.pred_succ label_set
+  Format.fprintf fmt " %tpredecessors: %a%t" Cfg_colours.pred_succ label_set
     block.predecessors Cfg_colours.pop;
-  Format.fprintf fmt "  %tnormal successors: %a%t\n" Cfg_colours.pred_succ
+  Format.fprintf fmt " %tnormal successors: %a%t" Cfg_colours.pred_succ
     label_set
     (Cfg.successor_labels block ~normal:true ~exn:false)
     Cfg_colours.pop;
   (match block.exn with
   | None -> ()
   | Some exn_label ->
-    Format.fprintf fmt "  %texceptional successor: %a%t\n" Cfg_colours.pred_succ
+    Format.fprintf fmt " %texceptional successor: %a%t" Cfg_colours.pred_succ
       Label.format exn_label Cfg_colours.pop);
+  Format.fprintf fmt "\n";
   DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
       Format.fprintf fmt "%a%t%a%t%a\n" instr_prefix instr Cfg_colours.basic
         Cfg.dump_basic instr.desc Cfg_colours.pop instr_suffix (instr, liveness));

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -8,7 +8,9 @@ module List = ListLabels
 let instr_prefix : type a. Format.formatter -> a Cfg.instruction -> unit =
  fun fmt instr ->
   Format.fprintf fmt "%t%a%t " Cfg_colours.instr_id InstructionId.format_padded
-    instr.id Cfg_colours.pop
+    instr.id Cfg_colours.pop;
+  if Array.length instr.res > 0
+  then Format.fprintf fmt "%a := " Printreg.regs instr.res
 
 let instr_suffix : type a.
     Format.formatter ->
@@ -16,9 +18,7 @@ let instr_suffix : type a.
     unit =
  fun fmt (instr, liveness) ->
   if Array.length instr.arg > 0
-  then Format.fprintf fmt " arg:[|%a|]" Printreg.regs instr.arg;
-  if Array.length instr.res > 0
-  then Format.fprintf fmt " res:[|%a|]" Printreg.regs instr.res;
+  then Format.fprintf fmt " %a" Printreg.regs instr.arg;
   match liveness with
   | None -> ()
   | Some liveness -> (
@@ -69,7 +69,7 @@ let block :
         Cfg.dump_basic instr.desc Cfg_colours.pop instr_suffix (instr, liveness));
   Format.fprintf fmt "%a%t%a%t%a\n\n" instr_prefix block.terminator
     Cfg_colours.terminator
-    (Cfg.dump_terminator ~sep:", ")
+    (Cfg.dump_terminator ~sep:"\n         ")
     block.terminator.desc Cfg_colours.pop instr_suffix
     (block.terminator, liveness)
 

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -7,7 +7,8 @@ module List = ListLabels
 
 let instr_prefix : type a. Format.formatter -> a Cfg.instruction -> unit =
  fun fmt instr ->
-  Format.fprintf fmt "  %s " (InstructionId.to_string_padded instr.id)
+  Format.fprintf fmt "%t%a%t " Cfg_colours.instr_id InstructionId.format_padded
+    instr.id Cfg_colours.pop
 
 let instr_suffix : type a.
     Format.formatter ->
@@ -28,27 +29,46 @@ let instr_suffix : type a.
       | true -> ()
       | false -> Format.fprintf fmt " live:[|%a|]" Printreg.regset live))
 
+let label_set : Format.formatter -> Label.Set.t -> unit =
+ fun fmt set ->
+  Format.fprintf fmt "{";
+  Label.Set.iter (fun label -> Format.fprintf fmt " %a" Label.print label) set;
+  Format.fprintf fmt " }"
+
 let block :
     Format.formatter ->
     Cfg.basic_block ->
     Cfg_with_infos.liveness option ->
     unit =
  fun fmt block liveness ->
-  Format.fprintf fmt "block %a:" Label.format block.start;
-  (match block.exn with
-  | None -> ()
-  | Some exn_label -> Format.fprintf fmt " [exn: %a]" Label.format exn_label);
+  Format.fprintf fmt "block %t%a%t:"
+    (if block.is_trap_handler
+     then Cfg_colours.block_label_exn
+     else Cfg_colours.block_label)
+    Label.format block.start Cfg_colours.pop;
   (match block.is_trap_handler with
   | false -> ()
   | true -> Format.fprintf fmt " [handler]");
   (match block.cold with false -> () | true -> Format.fprintf fmt " [cold]");
   Format.fprintf fmt "\n";
+  Format.fprintf fmt "  %tpredecessors: %a%t\n" Cfg_colours.pred_succ label_set
+    block.predecessors Cfg_colours.pop;
+  Format.fprintf fmt "  %tnormal successors: %a%t\n" Cfg_colours.pred_succ
+    label_set
+    (Cfg.successor_labels block ~normal:true ~exn:false)
+    Cfg_colours.pop;
+  (match block.exn with
+  | None -> ()
+  | Some exn_label ->
+    Format.fprintf fmt "  %texceptional successor: %a%t\n" Cfg_colours.pred_succ
+      Label.format exn_label Cfg_colours.pop);
   DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
-      Format.fprintf fmt "%a%a%a\n" instr_prefix instr Cfg.dump_basic instr.desc
-        instr_suffix (instr, liveness));
-  Format.fprintf fmt "%a%a%a\n\n" instr_prefix block.terminator
+      Format.fprintf fmt "%a%t%a%t%a\n" instr_prefix instr Cfg_colours.basic
+        Cfg.dump_basic instr.desc Cfg_colours.pop instr_suffix (instr, liveness));
+  Format.fprintf fmt "%a%t%a%t%a\n\n" instr_prefix block.terminator
+    Cfg_colours.terminator
     (Cfg.dump_terminator ~sep:", ")
-    block.terminator.desc instr_suffix
+    block.terminator.desc Cfg_colours.pop instr_suffix
     (block.terminator, liveness)
 
 let format :
@@ -58,7 +78,8 @@ let format :
     Cfg_with_infos.liveness option ->
     unit =
  fun fmt cfg labels liveness ->
-  Format.fprintf fmt "cfg for %s\n" cfg.fun_name;
+  Format.fprintf fmt "cfg for %t%s%t\n" Cfg_colours.function_name cfg.fun_name
+    Cfg_colours.pop;
   Format.fprintf fmt "  args: %a\n" Printreg.regs cfg.fun_args;
   Format.fprintf fmt "  ret_type: %a\n" Printcmm.machtype cfg.fun_ret_type;
   Format.fprintf fmt "  entry_label: %a\n" Label.format cfg.entry_label;

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -1,0 +1,108 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+module Array = ArrayLabels
+module DLL = Oxcaml_utils.Doubly_linked_list
+module List = ListLabels
+
+let instr_prefix : type a. Format.formatter -> a Cfg.instruction -> unit =
+ fun fmt instr ->
+  Format.fprintf fmt "  %s " (InstructionId.to_string_padded instr.id)
+
+let instr_suffix : type a.
+    Format.formatter ->
+    a Cfg.instruction * Cfg_with_infos.liveness option ->
+    unit =
+ fun fmt (instr, liveness) ->
+  if Array.length instr.arg > 0
+  then Format.fprintf fmt " arg:[|%a|]" Printreg.regs instr.arg;
+  if Array.length instr.res > 0
+  then Format.fprintf fmt " res:[|%a|]" Printreg.regs instr.res;
+  match liveness with
+  | None -> ()
+  | Some liveness -> (
+    match InstructionId.Tbl.find_opt liveness instr.id with
+    | None -> Format.fprintf fmt " (no liveness found)"
+    | Some { before = _; across = live } -> (
+      match Reg.Set.is_empty live with
+      | true -> ()
+      | false -> Format.fprintf fmt " live:[|%a|]" Printreg.regset live))
+
+let block :
+    Format.formatter ->
+    Cfg.basic_block ->
+    Cfg_with_infos.liveness option ->
+    unit =
+ fun fmt block liveness ->
+  Format.fprintf fmt "block %a:" Label.format block.start;
+  (match block.exn with
+  | None -> ()
+  | Some exn_label -> Format.fprintf fmt " [exn: %a]" Label.format exn_label);
+  (match block.is_trap_handler with
+  | false -> ()
+  | true -> Format.fprintf fmt " [handler]");
+  (match block.cold with false -> () | true -> Format.fprintf fmt " [cold]");
+  Format.fprintf fmt "\n";
+  DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+      Format.fprintf fmt "%a%a%a\n" instr_prefix instr Cfg.dump_basic instr.desc
+        instr_suffix (instr, liveness));
+  Format.fprintf fmt "%a%a%a\n\n" instr_prefix block.terminator
+    (Cfg.dump_terminator ~sep:", ")
+    block.terminator.desc instr_suffix
+    (block.terminator, liveness)
+
+let format :
+    Format.formatter ->
+    Cfg.t ->
+    Label.t array ->
+    Cfg_with_infos.liveness option ->
+    unit =
+ fun fmt cfg labels liveness ->
+  Format.fprintf fmt "cfg for %s\n" cfg.fun_name;
+  Format.fprintf fmt "  args: %a\n" Printreg.regs cfg.fun_args;
+  Format.fprintf fmt "  ret_type: %a\n" Printcmm.machtype cfg.fun_ret_type;
+  Format.fprintf fmt "  entry_label: %a\n" Label.format cfg.entry_label;
+  let regalloc =
+    List.find_map cfg.fun_codegen_options ~f:(function[@ocaml.warning "-4"]
+      | Cfg.Use_regalloc regalloc -> Some regalloc
+      | _ -> None)
+  in
+  (match regalloc with
+  | None -> ()
+  | Some regalloc ->
+    Format.fprintf fmt "  use_regalloc: %a\n" Clflags.Register_allocator.format
+      regalloc);
+  let regalloc_params =
+    List.find_map cfg.fun_codegen_options ~f:(function[@ocaml.warning "-4"]
+      | Cfg.Use_regalloc_param params -> Some params
+      | _ -> None)
+  in
+  (match regalloc_params with
+  | None -> ()
+  | Some regalloc_params ->
+    Format.fprintf fmt "  regalloc_params: %s\n"
+      (String.concat ", " regalloc_params));
+  Format.fprintf fmt "\n";
+  Array.iter labels ~f:(fun label ->
+      block fmt (Cfg.get_block_exn cfg label) liveness);
+  Format.fprintf fmt "%!"
+
+let cfg : Format.formatter -> Cfg.t -> unit =
+ fun fmt cfg ->
+  let labels = cfg.blocks |> Label.Tbl.to_seq_keys |> Array.of_seq in
+  Array.sort ~cmp:Label.compare labels;
+  format fmt cfg labels None
+
+let cfg_with_layout : Format.formatter -> Cfg_with_layout.t -> unit =
+ fun fmt cfg_with_layout ->
+  let labels = cfg_with_layout |> Cfg_with_layout.layout |> DLL.to_array in
+  format fmt (Cfg_with_layout.cfg cfg_with_layout) labels None
+
+let cfg_with_infos : Format.formatter -> Cfg_with_infos.t -> unit =
+ fun fmt cfg_with_infos ->
+  let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
+  let labels = cfg_with_layout |> Cfg_with_layout.layout |> DLL.to_array in
+  format fmt
+    (Cfg_with_layout.cfg cfg_with_layout)
+    labels
+    (Cfg_with_infos.liveness_if_available cfg_with_infos)

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -69,7 +69,7 @@ let block :
         Cfg.dump_basic instr.desc Cfg_colours.pop instr_suffix (instr, liveness));
   Format.fprintf fmt "%a%t%a%t%a\n\n" instr_prefix block.terminator
     Cfg_colours.terminator
-    (Cfg.dump_terminator ~sep:"\n         ")
+    (Cfg.dump_terminator ~sep:", ")
     block.terminator.desc Cfg_colours.pop instr_suffix
     (block.terminator, liveness)
 

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -23,11 +23,15 @@ let instr_suffix : type a.
   | None -> ()
   | Some liveness -> (
     match InstructionId.Tbl.find_opt liveness instr.id with
-    | None -> Format.fprintf fmt " (no liveness found)"
+    | None ->
+      Format.fprintf fmt " %t(no liveness found)%t" Cfg_colours.liveness
+        Cfg_colours.pop
     | Some { before = _; across = live } -> (
       match Reg.Set.is_empty live with
       | true -> ()
-      | false -> Format.fprintf fmt " live:[|%a|]" Printreg.regset live))
+      | false ->
+        Format.fprintf fmt " %tlive:[|%a|]%t" Cfg_colours.liveness
+          Printreg.regset live Cfg_colours.pop))
 
 let label_set : Format.formatter -> Label.Set.t -> unit =
  fun fmt set ->
@@ -41,13 +45,13 @@ let block :
     Cfg_with_infos.liveness option ->
     unit =
  fun fmt block liveness ->
-  Format.fprintf fmt "block %t%a%t%s -"
+  Format.fprintf fmt "block %t%a%t%s%s -"
     (if block.is_trap_handler
      then Cfg_colours.block_label_exn
      else Cfg_colours.block_label)
     Label.format block.start Cfg_colours.pop
-    (match block.is_trap_handler with false -> "" | true -> " [handler]");
-  (match block.cold with false -> () | true -> Format.fprintf fmt " [cold]");
+    (match block.is_trap_handler with false -> "" | true -> " [handler]")
+    (match block.cold with false -> "" | true -> " [cold]");
   Format.fprintf fmt " %tpredecessors: %a%t" Cfg_colours.pred_succ label_set
     block.predecessors Cfg_colours.pop;
   Format.fprintf fmt " %tnormal successors: %a%t" Cfg_colours.pred_succ

--- a/backend/cfg/printcfg.mli
+++ b/backend/cfg/printcfg.mli
@@ -1,0 +1,7 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+val cfg : Format.formatter -> Cfg.t -> unit
+
+val cfg_with_layout : Format.formatter -> Cfg_with_layout.t -> unit
+
+val cfg_with_infos : Format.formatter -> Cfg_with_infos.t -> unit

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -445,9 +445,9 @@ let dump ppf op =
   | Stackoffset n -> Format.fprintf ppf "stackoffset %d" n
   | Load _ -> Format.fprintf ppf "load"
   | Store _ -> Format.fprintf ppf "store"
-  | Intop op -> Format.fprintf ppf "intop %s" (intop op)
-  | Int128op op -> Format.fprintf ppf "int128op %s" (int128op op)
-  | Intop_imm (op, n) -> Format.fprintf ppf "intop %s %d" (intop op) n
+  | Intop op -> Format.fprintf ppf "intop%s" (intop op)
+  | Int128op op -> Format.fprintf ppf "int128op%s" (int128op op)
+  | Intop_imm (op, n) -> Format.fprintf ppf "intop%s%d" (intop op) n
   | Intop_atomic { op; size = _; addr = _ } ->
     Format.fprintf ppf "intop atomic %s" (Printcmm.atomic_op op)
   | Floatop (Float64, op) -> Format.fprintf ppf "floatop %a" floatop op

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -214,6 +214,7 @@ let make_log_body_and_terminator :
   then Cfg.dump_terminator ~sep:", " Format.err_formatter term.Cfg.desc;
   if enabled then log_instruction_suffix term liveness
 
+(* CR-soon xclerc for xclerc: factor out with `Printcfg`. *)
 let make_log_cfg_with_infos :
     log_function ->
     instr_prefix:(Cfg.basic Cfg.instruction -> string) ->

--- a/dune
+++ b/dune
@@ -622,6 +622,7 @@
   ;; backend/cfg
   cfg
   cfg_available_regs
+  cfg_colours
   cfg_edge
   cfg_intf
   cfg_reducibility

--- a/dune
+++ b/dune
@@ -643,6 +643,7 @@
   cfg_prologue
   extra_debug
   label
+  printcfg
   linear_utils
   simplify_terminator
   vectorize

--- a/oxcaml/tests/backend/attributes/backend_attributes.output
+++ b/oxcaml/tests/backend/attributes/backend_attributes.output
@@ -1,10 +1,10 @@
 Backend_attributes__with_irc
-use_regalloc=irc
+  use_regalloc: irc
 Backend_attributes__with_irc
-use_regalloc=irc
+  use_regalloc: irc
 Backend_attributes__with_irc_and_param
-use_regalloc=irc
-regalloc_params=IRC_SPILLING_HEURISTICS=flat
+  use_regalloc: irc
+  regalloc_params: IRC_SPILLING_HEURISTICS=flat
 Backend_attributes__with_irc_and_param
-use_regalloc=irc
-regalloc_params=IRC_SPILLING_HEURISTICS=flat
+  use_regalloc: irc
+  regalloc_params: IRC_SPILLING_HEURISTICS=flat

--- a/oxcaml/tests/backend/attributes/dune
+++ b/oxcaml/tests/backend/attributes/dune
@@ -10,7 +10,7 @@
   (progn
    (with-outputs-to
     backend_attributes.output.raw
-    (run %{bin:ocamlopt.opt} -c -dcfg -w +A-70 backend_attributes.ml))
+    (run %{bin:ocamlopt.opt} -c -dcfg -color never -w +A-70 backend_attributes.ml))
    (with-outputs-to
     backend_attributes.output.corrected
     (run ./grep_dump.exe backend_attributes.output.raw)))))

--- a/oxcaml/tests/backend/attributes/grep_dump.ml
+++ b/oxcaml/tests/backend/attributes/grep_dump.ml
@@ -1,9 +1,10 @@
 let is_interesting_line line =
   List.exists
     (fun prefix -> String.starts_with ~prefix line)
-    ["use_regalloc="; "regalloc_params="]
+    ["  use_regalloc:"; "  regalloc_params:"; "cfg for "]
+  && not (String.ends_with ~suffix:"__entry" line)
 
-let function_name = Str.regexp "caml\\(.*\\)_[0-9]+_[0-9]+\\(_code\\)?"
+let function_name = Str.regexp "cfg for caml\\(.*\\)_[0-9]+_[0-9]+\\(_code\\)?"
 
 let remove_suffix line =
   match Str.string_match function_name line 0 with
@@ -13,15 +14,8 @@ let remove_suffix line =
 let () =
   let chan = open_in Sys.argv.(1) in
   try
-    let prev_line = ref "" in
     while true do
       let line = input_line chan in
-      if is_interesting_line line
-      then begin
-        if not (is_interesting_line !prev_line)
-        then print_endline (remove_suffix !prev_line);
-        print_endline line
-      end;
-      prev_line := line
+      if is_interesting_line line then print_endline (remove_suffix line)
     done
   with End_of_file -> close_in_noerr chan

--- a/oxcaml/tests/backend/validators/check_prologue_validation.ml
+++ b/oxcaml/tests/backend/validators/check_prologue_validation.ml
@@ -1,6 +1,8 @@
 open Cfg_intf.S
 open Utils
 
+let () = Clflags.color := Some Misc.Color.Never
+
 let check =
   check
     ~validate:(fun cfg ->

--- a/oxcaml/tests/backend/validators/check_prologue_validation.ml
+++ b/oxcaml/tests/backend/validators/check_prologue_validation.ml
@@ -1,8 +1,6 @@
 open Cfg_intf.S
 open Utils
 
-let () = Clflags.color := Some Misc.Color.Never
-
 let check =
   check
     ~validate:(fun cfg ->

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -533,7 +533,7 @@ let () =
     ~exp_std:"fatal exception raised when validating description"
     ~exp_err:
       ">> Fatal error: Register allocation added a terminator no. 26 but \
-       that's not allowed for this type of terminator: Return"
+       that's not allowed for this type of terminator: return"
 
 let () =
   check "Regalloc reordered instructions between blocks"
@@ -621,7 +621,7 @@ let () =
     ~exp_std:"fatal exception raised when validating description"
     ~exp_err:
       ">> Fatal error: The desc of terminator with id 3 changed, before: \
-       Return, after: Raise."
+       return, after: raise."
 
 let () =
   check "Deleted instruction"

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -1,6 +1,8 @@
 open Cfg_intf.S
 open Utils
 
+let () = Clflags.color := Some Misc.Color.Never
+
 (*= CR xclerc for xclerc: that test relies on the use of the polymorphic
         comparison over CFG values, but that can no longer be used since instruction
         lists now contain circular values.

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -1,8 +1,6 @@
 open Cfg_intf.S
 open Utils
 
-let () = Clflags.color := Some Misc.Color.Never
-
 (*= CR xclerc for xclerc: that test relies on the use of the polymorphic
         comparison over CFG values, but that can no longer be used since instruction
         lists now contain circular values.

--- a/oxcaml/tests/backend/validators/utils.ml
+++ b/oxcaml/tests/backend/validators/utils.ml
@@ -170,16 +170,17 @@ let int = Array.init 8 (fun _ -> Reg.create Int)
 let check name f ~validate ~save ~exp_std ~exp_err =
   let cfg = f () in
   let with_wrap_ppf ppf f =
-    Format.pp_print_flush ppf ();
-    let buf = Buffer.create 0 in
-    let ppf_buf = Format.formatter_of_buffer buf in
-    let old_out_func = Format.pp_get_formatter_out_functions ppf () in
-    Format.pp_set_formatter_out_functions ppf
-      (Format.pp_get_formatter_out_functions ppf_buf ());
-    let res = f () in
-    Format.pp_print_flush ppf ();
-    Format.pp_set_formatter_out_functions ppf old_out_func;
-    res, buf |> Buffer.to_bytes |> Bytes.to_string |> String.trim
+    Cfg_colours.without_colours ~f:(fun () ->
+        Format.pp_print_flush ppf ();
+        let buf = Buffer.create 0 in
+        let ppf_buf = Format.formatter_of_buffer buf in
+        let old_out_func = Format.pp_get_formatter_out_functions ppf () in
+        Format.pp_set_formatter_out_functions ppf
+          (Format.pp_get_formatter_out_functions ppf_buf ());
+        let res = f () in
+        Format.pp_print_flush ppf ();
+        Format.pp_set_formatter_out_functions ppf old_out_func;
+        res, buf |> Buffer.to_bytes |> Bytes.to_string |> String.trim)
   in
   let ((), err_out), std_out =
     with_wrap_ppf Format.std_formatter (fun () ->


### PR DESCRIPTION
As per title. This pull request also changes
the format, for a more compact one, that
should be easier to use (by both human
and AI operators).