### PR TITLE
X86: Use push/pop for spilling around calls to save code size

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -430,10 +430,10 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
           (Cfg_with_infos.cfg_with_layout cfg_with_infos)
       in
       cfg_with_infos ++ register_allocator fd_cmm
-      ++ cfg_with_infos_profile ~accumulate:true "cfg_validate_description"
-           (Regalloc_validate.run cfg_description)
       ++ cfg_with_infos_profile ~accumulate:true "push_pop_around_calls"
-           Push_pop_around_calls.run)
+           Push_pop_around_calls.run
+      ++ cfg_with_infos_profile ~accumulate:true "cfg_validate_description"
+           (Regalloc_validate.run cfg_description))
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue_validate"
        Cfg_prologue.validate

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -274,7 +274,9 @@ let count_duplicate_spills_reloads_in_block (block : Cfg.basic_block) =
 type spills_reloads_moves =
   { spills : int;
     reloads : int;
-    moves : int
+    moves : int;
+    pushes : int;
+    pops : int
   }
 
 let count_spills_reloads_moves (block : Cfg.basic_block) =
@@ -283,15 +285,23 @@ let count_spills_reloads_moves (block : Cfg.basic_block) =
     | Op Spill -> { acc with spills = acc.spills + 1 }
     | Op Reload -> { acc with reloads = acc.reloads + 1 }
     | Op Move -> { acc with moves = acc.moves + 1 }
+    | _ when Proc.is_push_to_stack instr.desc ->
+      { acc with pushes = acc.pushes + 1 }
+    | _ when Proc.is_pop_from_stack instr.desc ->
+      { acc with pops = acc.pops + 1 }
     | _ -> acc
   in
-  DLL.fold_left ~f ~init:{ spills = 0; reloads = 0; moves = 0 } block.body
+  DLL.fold_left ~f
+    ~init:{ spills = 0; reloads = 0; moves = 0; pushes = 0; pops = 0 }
+    block.body
 
 (** Returns all CFG counters that work on a single block and are summative over
     the blocks. *)
 let cfg_block_counters (block : Cfg.basic_block) =
   let dup_spills, dup_reloads = count_duplicate_spills_reloads_in_block block in
-  let { spills; reloads; moves } = count_spills_reloads_moves block in
+  let { spills; reloads; moves; pushes; pops } =
+    count_spills_reloads_moves block
+  in
   let instructions = DLL.length block.body + 1 in
   Profile.Counters.create ()
   |> Profile.Counters.set "block_duplicate_spill" dup_spills
@@ -301,6 +311,8 @@ let cfg_block_counters (block : Cfg.basic_block) =
   |> Profile.Counters.set "instruction" instructions
   |> Profile.Counters.set "block" 1
   |> Profile.Counters.set "move" moves
+  |> Profile.Counters.set "push_to_stack" pushes
+  |> Profile.Counters.set "pop_from_stack" pops
 
 (** Returns all CFG counters that require the whole CFG to produce a count. *)
 let whole_cfg_counters (cfg : Cfg.t) =

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -229,7 +229,13 @@ let emit_fundecl f =
   then Misc.fatal_error "Linear IR not supported with llvm backend";
   if_emit_do
     (fun (fundecl : Linear.fundecl) ->
-      try Profile.record ~accumulate:true "emit" Emit.fundecl fundecl
+      try
+        Profile.record_with_counters ~accumulate:true
+          ~counter_f:Emitaux.get_frame_counters "emit"
+          (fun fundecl ->
+            Emitaux.reset_frame_counters ();
+            Emit.fundecl fundecl)
+          fundecl
       with Emitaux.Error e ->
         raise (Error (Asm_generation (fundecl.Linear.fun_name, e))))
     f
@@ -430,8 +436,6 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
           (Cfg_with_infos.cfg_with_layout cfg_with_infos)
       in
       cfg_with_infos ++ register_allocator fd_cmm
-      ++ cfg_with_infos_profile ~accumulate:true "push_pop_around_calls"
-           Push_pop_around_calls.run
       ++ cfg_with_infos_profile ~accumulate:true "cfg_validate_description"
            (Regalloc_validate.run cfg_description))
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -431,7 +431,9 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
       in
       cfg_with_infos ++ register_allocator fd_cmm
       ++ cfg_with_infos_profile ~accumulate:true "cfg_validate_description"
-           (Regalloc_validate.run cfg_description))
+           (Regalloc_validate.run cfg_description)
+      ++ cfg_with_infos_profile ~accumulate:true "push_pop_around_calls"
+           Push_pop_around_calls.run)
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue_validate"
        Cfg_prologue.validate

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -1,6 +1,8 @@
 ; CR-soon gyorsh: format all files under arm64/amd64
 amd64/cfg_selection.ml
 amd64/emit.ml
+amd64/push_pop_around_calls.ml
+amd64/push_pop_around_calls.mli
 amd64/regs.ml
 amd64/regs.mli
 amd64/selection.ml
@@ -16,6 +18,8 @@ arm64/cfg_selection.ml
 arm64/dsl_helpers.ml
 arm64/dsl_helpers.mli
 arm64/emit.ml
+arm64/push_pop_around_calls.ml
+arm64/push_pop_around_calls.mli
 arm64/regs.ml
 arm64/regs.mli
 arm64/selection.ml

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -45,7 +45,8 @@ let class_of_operation (op : Operation.t)
     | Isimd_mem (op,_addr) ->
       Class (of_simd_class (Simd.Mem.class_of_operation op))
     | Icldemote _
-    | Iprefetch _ -> Class Op_other
+    | Iprefetch _
+    | Ipush_to_stack | Ipop_from_stack -> Class Op_other
     | Illvm_intrinsic intr ->
       Misc.fatal_errorf "CSE.class_of_operation: Unexpected llvm_intrinsic %s: \
                          not using LLVM backend"

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -45,8 +45,10 @@ let class_of_operation (op : Operation.t)
     | Isimd_mem (op,_addr) ->
       Class (of_simd_class (Simd.Mem.class_of_operation op))
     | Icldemote _
-    | Iprefetch _
-    | Ipush_to_stack | Ipop_from_stack -> Class Op_other
+    | Iprefetch _  -> Class Op_other
+    | Ipush_to_stack | Ipop_from_stack ->
+      Misc.fatal_errorf "unexpected push/pop, should only be introduced during \
+                         regalloc"
     | Illvm_intrinsic intr ->
       Misc.fatal_errorf "CSE.class_of_operation: Unexpected llvm_intrinsic %s: \
                          not using LLVM backend"

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -282,6 +282,8 @@ type specific_operation =
         addr: addressing_mode;
       }
   | Illvm_intrinsic of string
+  | Ipush_to_stack
+  | Ipop_from_stack
 
 (* CR yusumez: [Illvm_intrinsic] exists to pass extcalls with builtin = true to
    the LLVM backend. Ideally, we'd want this variant to contain the LLVM
@@ -441,6 +443,10 @@ let print_specific_operation printreg op ppf arg =
         printreg arg.(0)
   | Illvm_intrinsic name ->
       fprintf ppf "llvm_intrinsic %s" name
+  | Ipush_to_stack ->
+      fprintf ppf "push_to_stack %a" printreg arg.(0)
+  | Ipop_from_stack ->
+      fprintf ppf "pop_from_stack"
 
 let specific_operation_name : specific_operation -> string = fun op ->
   match op with
@@ -463,6 +469,8 @@ let specific_operation_name : specific_operation -> string = fun op ->
   | Icldemote _ -> "cldemote"
   | Iprefetch _ -> "prefetch"
   | Illvm_intrinsic _ -> "llvm_intrinsic"
+  | Ipush_to_stack -> "push_to_stack"
+  | Ipop_from_stack -> "pop_from_stack"
 
 (* Are we using the Windows 64-bit ABI? *)
 let win64 =
@@ -479,7 +487,8 @@ let operation_is_pure = function
   | Irdtsc | Irdpmc
   | Ilfence | Isfence | Imfence
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
-  | Icldemote _ | Iprefetch _ -> false
+  | Icldemote _ | Iprefetch _
+  | Ipush_to_stack | Ipop_from_stack -> false
   | Ipackf32 -> true
   | Isimd op -> Simd.is_pure_operation op
   | Isimd_mem (op, _addr) -> Simd.Mem.is_pure_operation op
@@ -496,7 +505,8 @@ let operation_allocates = function
   | Isimd _ | Isimd_mem _
   | Ilfence | Isfence | Imfence
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
-  | Icldemote _ | Iprefetch _ -> false
+  | Icldemote _ | Iprefetch _
+  | Ipush_to_stack | Ipop_from_stack -> false
   | Illvm_intrinsic _intr ->
       (* Used by the zero_alloc checker that runs before the Llvmize. *)
       false
@@ -592,13 +602,25 @@ let equal_specific_operation left right =
   | Isimd_mem (l,al), Isimd_mem (r,ar) ->
     Simd.Mem.equal_operation l r && equal_addressing_mode al ar
   | Illvm_intrinsic l, Illvm_intrinsic r -> String.equal l r
+  | Ipush_to_stack, Ipush_to_stack -> true
+  | Ipop_from_stack, Ipop_from_stack -> true
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
      Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
      Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ |
-     Illvm_intrinsic _), _ ->
+     Illvm_intrinsic _ | Ipush_to_stack | Ipop_from_stack), _ ->
     false
 
 (* addressing mode functions *)
+
+let specific_operation_stack_offset_delta = function
+  | Ipush_to_stack -> size_addr
+  | Ipop_from_stack -> -size_addr
+  | Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+  | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence
+  | Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _
+  | Illvm_intrinsic _ -> 0
+
+let call_stack_alignment = 16
 
 let equal_addressing_mode_without_displ (addressing_mode_1: addressing_mode) (addressing_mode_2 : addressing_mode) =
   (* Ignores [displ] when comparing to show that it is possible to calculate the offset,
@@ -704,8 +726,10 @@ let isomorphic_specific_operation op1 op2 =
   | Isimd_mem (l,al), Isimd_mem (r,ar) ->
     Simd.Mem.equal_operation l r && equal_addressing_mode_without_displ al ar
   | Illvm_intrinsic l, Illvm_intrinsic r -> String.equal l r
+  | Ipush_to_stack, Ipush_to_stack -> true
+  | Ipop_from_stack, Ipop_from_stack -> true
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
      Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
      Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ |
-     Illvm_intrinsic _), _ ->
+     Illvm_intrinsic _ | Ipush_to_stack | Ipop_from_stack), _ ->
     false

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -107,6 +107,8 @@ type specific_operation =
         addr: addressing_mode;
       }
   | Illvm_intrinsic of string
+  | Ipush_to_stack
+  | Ipop_from_stack
 
 and float_operation =
   | Ifloatadd
@@ -169,6 +171,10 @@ val isomorphic_specific_operation : specific_operation -> specific_operation -> 
 (* addressing mode functions *)
 
 val equal_addressing_mode_without_displ : addressing_mode -> addressing_mode -> bool
+
+val specific_operation_stack_offset_delta : specific_operation -> int
+
+val call_stack_alignment : int
 
 val addressing_offset_in_bytes
   : addressing_mode

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -225,7 +225,7 @@ let pseudoregs_for_operation op arg res =
       | Istore_int (_, _, _)
       | Ilfence | Isfence | Imfence
       | Ioffset_loc (_, _)
-      | Irdtsc | Icldemote _ | Iprefetch _ )
+      | Irdtsc | Icldemote _ | Iprefetch _ | Ipush_to_stack | Ipop_from_stack )
   | Move | Spill | Reload | Reinterpret_cast _ | Static_cast _ | Const_int _
   | Const_float32 _ | Const_float _ | Const_vec128 _ | Const_vec256 _
   | Const_vec512 _ | Const_symbol _ | Stackoffset _ | Load _

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -240,6 +240,10 @@ let frame_required = ref false
 
 let contains_calls = ref false
 
+(* Track values pushed to the stack around calls for GC frame descriptors.
+   Stored in reverse push order (most recent push first). *)
+let pushed_stack_slots : Cmm.machtype_component list ref = ref []
+
 let frame_size () =
   Proc.frame_size ~stack_offset:!stack_offset ~num_stack_slots
     ~contains_calls:!contains_calls
@@ -616,6 +620,12 @@ let record_frame_label live dbg =
         Misc.fatal_errorf "Unknown location %a" Printreg.reg r
       | { typ = Int | Float | Float32 | Vec128 | Vec256 | Vec512; _ } -> ())
     live;
+  List.iteri
+    (fun i (slot_type : Cmm.machtype_component) ->
+      match slot_type with
+      | Val -> live_offset := (i * Arch.size_addr) :: !live_offset
+      | Int | Float | Float32 | Vec128 | Vec256 | Vec512 | Addr | Valx2 -> ())
+    !pushed_stack_slots;
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of Linear labels. *)
   record_frame_descr ~label:lbl ~frame_size:(frame_size ())
@@ -2460,6 +2470,12 @@ let emit_instr ~first ~last ~fallthrough i =
   | Lop (Specific (Illvm_intrinsic intr)) ->
     Misc.fatal_errorf
       "Emit: Unexpected llvm_intrinsic %s: not using LLVM backend" intr
+  | Lop (Specific Ipush_to_stack) ->
+    push (arg i 0);
+    pushed_stack_slots := i.arg.(0).typ :: !pushed_stack_slots
+  | Lop (Specific Ipop_from_stack) ->
+    pop (res i 0);
+    pushed_stack_slots := List.tl !pushed_stack_slots
   | Lop (Static_cast cast) -> emit_static_cast cast i
   | Lop (Reinterpret_cast cast) -> emit_reinterpret_cast cast i
   | Lop (Specific (Icldemote addr)) ->
@@ -2667,6 +2683,7 @@ let fundecl fundecl =
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   contains_calls := fundecl.fun_contains_calls;
   stack_offset := 0;
+  pushed_stack_slots := [];
   call_gc_sites := [];
   local_realloc_sites := [];
   clear_safety_checks ();

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2591,9 +2591,10 @@ let emit_instr ~first ~last ~fallthrough i =
         (* retaddr + rbp *)
       in
       I.lea (mem64 NONE delta (Scalar RSP)) rbp
-  | Ladjust_stack_offset { delta_bytes } ->
+  | Ladjust_stack_offset { delta_bytes; pushed_slots } ->
     D.cfi_adjust_cfa_offset ~bytes:delta_bytes;
-    stack_offset := !stack_offset + delta_bytes
+    stack_offset := !stack_offset + delta_bytes;
+    pushed_stack_slots := pushed_slots
   | Lpushtrap { lbl_handler } ->
     let lbl_handler = label_to_asm_label ~section:Text lbl_handler in
     emit_push_trap_label lbl_handler;

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2958,6 +2958,7 @@ let emit_probe_handler_wrapper (p : Probe_emission.probe) =
   Stack_class.Tbl.copy_values ~from:p.num_stack_slots ~to_:num_stack_slots;
   (* Account for the return address that is now pushed on the stack. *)
   stack_offset := !stack_offset + 8;
+  pushed_stack_slots := [];
   (* Emit function entry code *)
   D.comment (Printf.sprintf "probe %s %s" probe_name handler_code_sym);
   emit_named_text_section (S.encode wrap_label);

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -558,7 +558,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | End_region
        | Specific (Ilea _ | Ioffset_loc _ | Ibswap _
                   | Isextend32 | Izextend32
-                  | Ilfence | Isfence | Imfence)
+                  | Ilfence | Isfence | Imfence
+                  | Ipush_to_stack | Ipop_from_stack)
        | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Pause)
   | Poptrap _ | Prologue | Epilogue ->
     if fp then destroyed_rbp else [||]

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -569,6 +569,16 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        be clobbered in the middle. *)
     destroyed_r10
 
+let[@ocaml.warning "-4"] is_push_to_stack (basic : Cfg_intf.S.basic) =
+  match basic with
+  | Op (Specific Ipush_to_stack) -> true
+  | _ -> false
+
+let[@ocaml.warning "-4"] is_pop_from_stack (basic : Cfg_intf.S.basic) =
+  match basic with
+  | Op (Specific Ipop_from_stack) -> true
+  | _ -> false
+
 (* note: keep this function in sync with `is_destruction_point` below. *)
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -1,0 +1,315 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@warning "-66"]
+module DLL = Oxcaml_utils.Doubly_linked_list
+module Int_set = Stdlib.Set.Make (Stdlib.Int)
+module Int_map = Stdlib.Map.Make (Stdlib.Int)
+
+let is_gp_register (reg : Reg.t) =
+  match reg.typ with
+  | Int | Val | Addr -> true
+  | Float | Float32 | Vec128 | Vec256 | Vec512 | Valx2 -> false
+
+let reg_on_stack (reg : Reg.t) =
+  match reg.loc with Stack _ -> true | Reg _ | Unknown -> false
+
+let is_spill (instr : Cfg.basic Cfg.instruction) =
+  match[@ocaml.warning "-4"] instr.desc with Op Spill -> true | _ -> false
+
+let is_reload (instr : Cfg.basic Cfg.instruction) =
+  match[@ocaml.warning "-4"] instr.desc with Op Reload -> true | _ -> false
+
+let unsupported_after_push (instr : Cfg.basic Cfg.instruction) =
+  if is_spill instr || is_reload instr
+  then false
+  else
+    Array.exists reg_on_stack instr.arg
+    || Array.exists reg_on_stack instr.res
+    ||
+    match instr.desc with
+    | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
+    | Op (Stackoffset _)
+    | Reloadretaddr
+    (* GC or other hidden calls are not supported in the middle of using push to
+       spill. *)
+    | Op (Alloc _ | Poll | Specific _) ->
+      true
+    | Op
+        ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float _
+        | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+        | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
+        | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
+        | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
+        | End_region | Name_for_debugger _ | Dls_get | Tls_get | Domain_index
+        | Pause ) ->
+      false
+
+(* Collect consecutive reload instructions from the start of a block body, as
+   long as no destination register is repeated. Returns a map from spill slot to
+   reload instruction. *)
+let collect_leading_reloads (body : Cfg.basic_instruction_list) =
+  let reloads = ref Reg.Map.empty in
+  let seen_regs = ref Reg.Set.empty in
+  let rec loop (cell : Cfg.basic Cfg.instruction DLL.cell) =
+    let instr = DLL.value cell in
+    if is_reload instr
+    then begin
+      let spill_slot = instr.arg.(0) in
+      let r = instr.res.(0) in
+      if
+        (not (Reg.Set.mem spill_slot instr.live))
+        && not (Reg.Set.mem r !seen_regs)
+      then reloads := Reg.Map.add spill_slot instr !reloads;
+      seen_regs := Reg.Set.add r !seen_regs;
+      Option.iter loop (DLL.next cell)
+    end
+  in
+  Option.iter loop (DLL.hd_cell body);
+  !reloads
+
+(* Collect spills from the end of a block body, walking backwards. Stops at any
+   incompatible instruction. Filters out spills whose slot is read by a later
+   instruction (between the spill and the call). *)
+let collect_spills_backwards (cfg : Cfg.t) (block : Cfg.basic_block) =
+  let exn_entry_live =
+    match block.exn with
+    | None -> Reg.Set.empty
+    | Some exn_label -> (
+      let exn_block = Cfg.get_block_exn cfg exn_label in
+      match DLL.hd_cell exn_block.body with
+      | Some cell -> (DLL.value cell).live
+      | None -> exn_block.terminator.live)
+  in
+  let body = block.body in
+  let spills = ref [] in
+  let used_after = ref exn_entry_live in
+  let add_args args =
+    Array.iter (fun r -> used_after := Reg.Set.add r !used_after) args
+  in
+  let rec loop cell =
+    let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+    if unsupported_after_push instr
+    then ()
+    else begin
+      if
+        is_spill instr
+        && (not (Reg.Set.mem instr.res.(0) !used_after))
+        && is_gp_register instr.arg.(0)
+      then begin
+        spills := instr :: !spills;
+        (* Also mark the spill slot as used, to avoid collecting two spills to
+           the same slot. *)
+        used_after := Reg.Set.add instr.res.(0) !used_after
+      end
+      else add_args instr.arg;
+      match DLL.prev cell with Some prev -> loop prev | None -> ()
+    end
+  in
+  (match DLL.last_cell body with Some cell -> loop cell | None -> ());
+  !spills
+
+let process_call (cfg : Cfg.t) (block : Cfg.basic_block) =
+  let label_after =
+    match block.terminator.desc with
+    | Call { label_after; _ } -> Some label_after
+    | Prim _ | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+    | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
+    | Tailcall_func _ | Call_no_return _ | Invalid _ ->
+      None
+  in
+  match label_after with
+  | None -> ()
+  | Some label_after -> (
+    (* Follow chain of empty Always blocks to find the block with the reloads
+       (the rewrite pass may insert intermediate blocks for call result spills).
+       Returns the reload block and intermediate blocks whose stack_offsets need
+       updating. *)
+    let rec find_reload_block label =
+      let blk = Cfg.get_block_exn cfg label in
+      if Label.Set.cardinal blk.predecessors <> 1
+      then None
+      else if DLL.is_empty blk.body
+      then
+        match[@ocaml.warning "-4"] blk.terminator.desc with
+        | Always next -> find_reload_block next
+        | _ -> Some blk
+      else Some blk
+    in
+    match find_reload_block label_after with
+    | None -> ()
+    | Some after_block ->
+      let reloads = collect_leading_reloads after_block.body in
+      let spills =
+        collect_spills_backwards cfg block
+        |> List.filter (fun (instr : Cfg.basic Cfg.instruction) ->
+            Reg.Map.mem instr.res.(0) reloads)
+      in
+      let n_to_push = List.length spills in
+      let n_to_push =
+        n_to_push - (n_to_push mod (Arch.call_stack_alignment / Arch.size_addr))
+      in
+      let spills = List.filteri (fun i _ -> i < n_to_push) spills in
+      let reloads =
+        spills
+        |> List.map (fun (spill : Cfg.basic Cfg.instruction) ->
+            Reg.Map.find spill.res.(0) reloads)
+      in
+      if n_to_push > 0
+      then begin
+        let now_unused_spill_slots =
+          List.fold_left
+            (fun acc (spill : Cfg.basic Cfg.instruction) ->
+              Reg.Set.add spill.res.(0) acc)
+            Reg.Set.empty spills
+        in
+        let selected_spill_ids =
+          List.fold_left
+            (fun acc (spill : Cfg.basic Cfg.instruction) ->
+              InstructionId.Set.add spill.id acc)
+            InstructionId.Set.empty spills
+        in
+        let selected_reload_ids =
+          List.fold_left
+            (fun acc (reload : Cfg.basic Cfg.instruction) ->
+              InstructionId.Set.add reload.id acc)
+            InstructionId.Set.empty reloads
+        in
+        let base_stack_offset = block.terminator.stack_offset in
+        (* Replace spills with pushes in-place, adjusting stack offsets of
+           intervening instructions. *)
+        let unprocessed_stack_regs = ref now_unused_spill_slots in
+        let stack_offset =
+          ref (base_stack_offset + (List.length spills * Arch.size_addr))
+        in
+        let rewrite_spills_instr (type a) (instr : a Cfg.instruction) cell =
+          assert (instr.stack_offset = base_stack_offset);
+          instr.stack_offset <- !stack_offset;
+          instr.live <- Reg.Set.diff instr.live !unprocessed_stack_regs;
+          if InstructionId.Set.mem instr.id selected_spill_ids
+          then begin
+            unprocessed_stack_regs
+              := Reg.Set.remove instr.res.(0) !unprocessed_stack_regs;
+            stack_offset := !stack_offset - Arch.size_addr;
+            let push =
+              Cfg.make_instruction ~desc:(Cfg.Op (Specific Arch.Ipush_to_stack))
+                ~arg:[| instr.arg.(0) |]
+                ~res:[||] ~dbg:instr.dbg ~fdo:instr.fdo ~live:instr.live
+                ~stack_offset:!stack_offset
+                ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+                ()
+            in
+            DLL.set_value (Option.get cell) push
+          end
+        in
+        let rec rewrite_spills_block (after_block : Cfg.basic_block) =
+          let rec rewrite_spills_cell cell =
+            rewrite_spills_instr (DLL.value cell) (Some cell);
+            if not (Reg.Set.is_empty !unprocessed_stack_regs)
+            then rewrite_spills_cell (DLL.prev cell |> Option.get)
+          in
+          if not (Reg.Set.is_empty !unprocessed_stack_regs)
+          then begin
+            assert (after_block.stack_offset = base_stack_offset);
+            after_block.stack_offset <- !stack_offset;
+            let predecessors = after_block.predecessors in
+            assert (Label.Set.cardinal after_block.predecessors = 1);
+            let block = Cfg.get_block_exn cfg (Label.Set.choose predecessors) in
+            rewrite_spills_instr block.terminator None;
+            Option.iter rewrite_spills_cell (DLL.last_cell block.body);
+            rewrite_spills_block block
+          end
+        in
+        rewrite_spills_block after_block;
+        assert (Reg.Set.is_empty !unprocessed_stack_regs);
+        (* Delete selected reloads from their original positions *)
+        let rec remove_unspills remaining_reloads cell =
+          let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+          assert (is_reload instr);
+          let next = DLL.next cell in
+          let remaining_reloads =
+            if InstructionId.Set.mem instr.id selected_reload_ids
+            then (
+              DLL.delete_curr cell;
+              remaining_reloads - 1)
+            else remaining_reloads
+          in
+          instr.live <- Reg.Set.diff instr.live now_unused_spill_slots;
+          if remaining_reloads > 0
+          then remove_unspills remaining_reloads (Option.get next)
+        in
+        remove_unspills n_to_push (DLL.hd_cell after_block.body |> Option.get);
+        (* Insert pops at the beginning in LIFO order. *)
+        assert (!stack_offset = base_stack_offset);
+        List.iter
+          (fun (reload : Cfg.basic Cfg.instruction) ->
+            stack_offset := !stack_offset + Arch.size_addr;
+            (* CR ttebbi: This live set would have been accurate for the old
+               reload position, but not for the permutation. Since live sets are
+               not used later except for call positions, this is likely fine.
+               Ideally, we should recompute live sets properly or clear them
+               completely. *)
+            let pop =
+              Cfg.make_instruction
+                ~desc:(Cfg.Op (Specific Arch.Ipop_from_stack)) ~arg:[||]
+                ~res:[| reload.res.(0) |]
+                ~dbg:reload.dbg ~fdo:reload.fdo ~live:reload.live
+                ~stack_offset:!stack_offset
+                ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+                ()
+            in
+            DLL.add_begin after_block.body pop)
+          reloads
+      end)
+
+(* Compact stack slots: remove gaps left by converted spills/reloads and
+   renumber remaining slots. *)
+let compact_stack_slots (cfg : Cfg.t) =
+  let used = Stack_class.Tbl.make Int_set.empty in
+  let registers = ref Reg.Set.empty in
+  let record_reg (r : Reg.t) =
+    registers := Reg.Set.add r !registers;
+    match r.loc with
+    | Stack (Local slot) ->
+      let sc = Stack_class.of_machtype r.typ in
+      Stack_class.Tbl.replace used sc
+        (Int_set.add slot (Stack_class.Tbl.find used sc))
+    | Stack (Incoming _ | Outgoing _ | Domainstate _) | Reg _ | Unknown -> ()
+  in
+  let record_arr a = Array.iter record_reg a in
+  Cfg.iter_blocks cfg ~f:(fun _label block ->
+      DLL.iter block.body ~f:(fun (i : Cfg.basic Cfg.instruction) ->
+          record_arr i.arg;
+          record_arr i.res);
+      record_arr block.terminator.arg;
+      record_arr block.terminator.res);
+  let renamings = Stack_class.Tbl.make Int_map.empty in
+  Stack_class.Tbl.iter used ~f:(fun sc slots ->
+      let num_slots, renaming =
+        Int_set.fold
+          (fun old (next, m) -> next + 1, Int_map.add old next m)
+          slots (0, Int_map.empty)
+      in
+      Stack_class.Tbl.replace renamings sc renaming;
+      Stack_class.Tbl.replace cfg.fun_num_stack_slots sc num_slots);
+  let rename_reg (r : Reg.t) : unit =
+    match r.loc with
+    | Stack (Local slot) ->
+      let new_slot =
+        Stack_class.of_machtype r.typ
+        |> Stack_class.Tbl.find renamings
+        |> Int_map.find slot
+      in
+      Reg.set_loc r (Stack (Local new_slot))
+    | Reg _ | Unknown | Stack (Domainstate _ | Incoming _ | Outgoing _) -> ()
+  in
+  Reg.Set.iter rename_reg !registers
+
+let run (cfg_with_infos : Cfg_with_infos.t) =
+  if !Oxcaml_flags.cfg_push_pop_around_calls
+  then begin
+    let cfg = Cfg_with_infos.cfg cfg_with_infos in
+    Cfg.iter_blocks cfg ~f:(fun _label block -> process_call cfg block);
+    compact_stack_slots cfg;
+    cfg_with_infos
+  end
+  else cfg_with_infos

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -74,11 +74,16 @@ let collect_spills_backwards (cfg : Cfg.t) (block : Cfg.basic_block) =
   let exn_entry_live =
     match block.exn with
     | None -> Reg.Set.empty
-    | Some exn_label -> (
+    | Some exn_label ->
       let exn_block = Cfg.get_block_exn cfg exn_label in
-      match DLL.hd_cell exn_block.body with
-      | Some cell -> (DLL.value cell).live
-      | None -> exn_block.terminator.live)
+      let live_across, args =
+        match DLL.hd_cell exn_block.body with
+        | Some cell ->
+          let instr = DLL.value cell in
+          instr.live, instr.arg
+        | None -> exn_block.terminator.live, exn_block.terminator.arg
+      in
+      Array.fold_left (fun live reg -> Reg.Set.add reg live) live_across args
   in
   let body = block.body in
   let spills = ref [] in

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -27,12 +27,21 @@ let unsupported_after_push (instr : Cfg.basic Cfg.instruction) =
       | Domain_index | Pause ) ->
     Array.exists Reg.is_stack instr.arg || Array.exists Reg.is_stack instr.res
 
-(* Collect consecutive reload instructions from the start of a block body, as
-   long as no destination register is repeated. Returns a map from spill slot to
-   reload instruction. *)
-let collect_leading_reloads cfg_with_infos (body : Cfg.basic_instruction_list) =
+(* Collect reload instructions following a call that can be moved and reordered
+   to right after the call. We walk past non-reload instructions, but a reload
+   is collectible only if its source and destination have not been accessed by
+   any prior instruction in this walk so that all the reloads can both be moved
+   to the front and reordered realtive to each other. *)
+let collect_reloads cfg_with_infos (body : Cfg.basic_instruction_list) =
   let reloads = ref Reg.Map.empty in
-  let seen_regs = ref Reg.Set.empty in
+  (* Reg.UsingLocEquality means this is effectively a set of machine registers
+     and stack slots. *)
+  let module Loc_tbl = Reg.UsingLocEquality.Tbl in
+  let disallowed_locations = Loc_tbl.create 8 in
+  let is_disallowed r = Loc_tbl.mem disallowed_locations r in
+  let disallow arr =
+    arr |> Array.iter (fun r -> Loc_tbl.replace disallowed_locations r ())
+  in
   let rec loop (cell : Cfg.basic Cfg.instruction DLL.cell) =
     let instr = DLL.value cell in
     if Cfg.is_reload instr
@@ -42,13 +51,17 @@ let collect_leading_reloads cfg_with_infos (body : Cfg.basic_instruction_list) =
       let live_across =
         (Cfg_with_infos.liveness_find cfg_with_infos instr.id).across
       in
-      if
-        (not (Reg.Set.mem spill_slot live_across))
-        && not (Reg.Set.mem r !seen_regs)
-      then reloads := Reg.Map.add spill_slot instr !reloads;
-      seen_regs := Reg.Set.add r !seen_regs;
-      Option.iter loop (DLL.next cell)
-    end
+      let slot_unused_afterwards = not (Reg.Set.mem spill_slot live_across) in
+      let can_be_moved = not (is_disallowed r || is_disallowed spill_slot) in
+      if slot_unused_afterwards && can_be_moved
+      then reloads := Reg.Map.add spill_slot instr !reloads
+    end;
+    (* Track every reg the instruction reads or writes, regardless of whether it
+       is a reload. *)
+    disallow instr.arg;
+    disallow instr.res;
+    disallow (Proc.destroyed_at_basic instr.desc);
+    Option.iter loop (DLL.next cell)
   in
   Option.iter loop (DLL.hd_cell body);
   !reloads
@@ -76,9 +89,8 @@ let collect_spills_backwards cfg_with_infos (block : Cfg.basic_block) =
   let add_args args = used_after := Reg.add_set_array !used_after args in
   let rec loop cell =
     let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
-    if unsupported_after_push instr
-    then ()
-    else begin
+    if not (unsupported_after_push instr)
+    then begin
       if
         Cfg.is_spill instr
         && (not (Reg.Set.mem instr.res.(0) !used_after))
@@ -217,7 +229,6 @@ let replace_reloads_with_pops (cfg : Cfg.t)
   let n_to_remove = List.length reloads in
   let rec remove_reloads remaining cell =
     let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
-    assert (Cfg.is_reload instr);
     let next = DLL.next cell in
     let remaining =
       if InstructionId.Set.mem instr.id selected_reload_ids
@@ -230,8 +241,8 @@ let replace_reloads_with_pops (cfg : Cfg.t)
   in
   remove_reloads n_to_remove (DLL.hd_cell after_block.body |> Option.get);
   let stack_offset = ref base_stack_offset in
-  List.iter
-    (fun (reload : Cfg.basic Cfg.instruction) ->
+  reloads
+  |> List.iter (fun (reload : Cfg.basic Cfg.instruction) ->
       stack_offset := !stack_offset + Arch.size_addr;
       let pop =
         Cfg.make_instruction ~desc:(Cfg.Op (Specific Arch.Ipop_from_stack))
@@ -242,30 +253,27 @@ let replace_reloads_with_pops (cfg : Cfg.t)
           ()
       in
       DLL.add_begin after_block.body pop)
-    reloads
 
 let process_call cfg_with_infos (block : Cfg.basic_block) =
   let cfg = Cfg_with_infos.cfg cfg_with_infos in
-  match label_after_call block with
-  | None -> ()
-  | Some label_after -> (
-    match find_reload_block cfg label_after with
-    | None -> ()
-    | Some after_block -> (
-      let reloads_map =
-        collect_leading_reloads cfg_with_infos after_block.body
-      in
-      let spills, reloads =
-        match_spills_to_reloads
-          (collect_spills_backwards cfg_with_infos block)
-          reloads_map
-      in
-      match spills with
-      | [] -> ()
-      | _ :: _ ->
-        let base_stack_offset = block.terminator.stack_offset in
-        replace_spills_with_pushes cfg ~spills ~base_stack_offset after_block;
-        replace_reloads_with_pops cfg ~reloads ~base_stack_offset after_block))
+  label_after_call block
+  |> Option.iter (fun label_after ->
+      find_reload_block cfg label_after
+      |> Option.iter (fun (after_block : Cfg.basic_block) ->
+          let reloads_map = collect_reloads cfg_with_infos after_block.body in
+          let spills, reloads =
+            match_spills_to_reloads
+              (collect_spills_backwards cfg_with_infos block)
+              reloads_map
+          in
+          match spills with
+          | [] -> ()
+          | _ :: _ ->
+            let base_stack_offset = block.terminator.stack_offset in
+            replace_spills_with_pushes cfg ~spills ~base_stack_offset
+              after_block;
+            replace_reloads_with_pops cfg ~reloads ~base_stack_offset
+              after_block))
 
 let run (cfg_with_infos : Cfg_with_infos.t) =
   if !Oxcaml_flags.cfg_push_pop_around_calls

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -119,6 +119,12 @@ let rec find_reload_block (cfg : Cfg.t) label =
     | _ -> Some blk
   else Some blk
 
+let instr_id_set (instrs : Cfg.basic Cfg.instruction list) =
+  List.fold_left
+    (fun acc (instr : Cfg.basic Cfg.instruction) ->
+      InstructionId.Set.add instr.id acc)
+    InstructionId.Set.empty instrs
+
 (* From the candidate spills and the per-slot reload map, keep only spills with
    a matching reload, trim to a multiple of the call stack alignment, and pair
    each remaining spill with its reload. Returned lists have the same length and
@@ -156,12 +162,7 @@ let replace_spills_with_pushes (cfg : Cfg.t)
         Reg.Set.add spill.res.(0) acc)
       Reg.Set.empty spills
   in
-  let selected_spill_ids =
-    List.fold_left
-      (fun acc (spill : Cfg.basic Cfg.instruction) ->
-        InstructionId.Set.add spill.id acc)
-      InstructionId.Set.empty spills
-  in
+  let selected_spill_ids = instr_id_set spills in
   let unprocessed_stack_regs = ref now_unused_spill_slots in
   let stack_offset =
     ref (base_stack_offset + (List.length spills * Arch.size_addr))
@@ -212,12 +213,7 @@ let replace_spills_with_pushes (cfg : Cfg.t)
 let replace_reloads_with_pops (cfg : Cfg.t)
     ~(reloads : Cfg.basic Cfg.instruction list) ~base_stack_offset
     (after_block : Cfg.basic_block) =
-  let selected_reload_ids =
-    List.fold_left
-      (fun acc (reload : Cfg.basic Cfg.instruction) ->
-        InstructionId.Set.add reload.id acc)
-      InstructionId.Set.empty reloads
-  in
+  let selected_reload_ids = instr_id_set reloads in
   let n_to_remove = List.length reloads in
   let rec remove_reloads remaining cell =
     let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -279,7 +279,17 @@ let run (cfg_with_infos : Cfg_with_infos.t) =
   if !Oxcaml_flags.cfg_push_pop_around_calls
   then begin
     let cfg = Cfg_with_infos.cfg cfg_with_infos in
+    if !Oxcaml_flags.dump_cfg
+    then
+      Format.eprintf "*** Before push_pop_around_calls@.%a@."
+        (fun fmt -> Printcfg.cfg_with_liveness fmt cfg)
+        (Cfg_with_infos.liveness cfg_with_infos);
     Cfg.iter_blocks cfg ~f:(fun _label block ->
         process_call cfg_with_infos block);
-    Cfg_with_infos.invalidate_liveness cfg_with_infos
+    Cfg_with_infos.invalidate_liveness cfg_with_infos;
+    if !Oxcaml_flags.dump_cfg
+    then
+      Format.eprintf "*** After push_pop_around_calls@.%a@."
+        (fun fmt -> Printcfg.cfg_with_liveness fmt cfg)
+        (Cfg_with_infos.liveness cfg_with_infos)
   end

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -276,5 +276,6 @@ let run (cfg_with_infos : Cfg_with_infos.t) =
   then begin
     let cfg = Cfg_with_infos.cfg cfg_with_infos in
     Cfg.iter_blocks cfg ~f:(fun _label block ->
-        process_call cfg_with_infos block)
+        process_call cfg_with_infos block);
+    Cfg_with_infos.invalidate_liveness cfg_with_infos
   end

--- a/backend/amd64/push_pop_around_calls.ml
+++ b/backend/amd64/push_pop_around_calls.ml
@@ -2,62 +2,48 @@
 
 open! Int_replace_polymorphic_compare [@@warning "-66"]
 module DLL = Oxcaml_utils.Doubly_linked_list
-module Int_set = Stdlib.Set.Make (Stdlib.Int)
-module Int_map = Stdlib.Map.Make (Stdlib.Int)
 
 let is_gp_register (reg : Reg.t) =
-  match reg.typ with
-  | Int | Val | Addr -> true
-  | Float | Float32 | Vec128 | Vec256 | Vec512 | Valx2 -> false
-
-let reg_on_stack (reg : Reg.t) =
-  match reg.loc with Stack _ -> true | Reg _ | Unknown -> false
-
-let is_spill (instr : Cfg.basic Cfg.instruction) =
-  match[@ocaml.warning "-4"] instr.desc with Op Spill -> true | _ -> false
-
-let is_reload (instr : Cfg.basic Cfg.instruction) =
-  match[@ocaml.warning "-4"] instr.desc with Op Reload -> true | _ -> false
+  match Regs.Reg_class.of_machtype reg.typ with
+  | Regs.GPR -> true
+  | Regs.SIMD -> false
 
 let unsupported_after_push (instr : Cfg.basic Cfg.instruction) =
-  if is_spill instr || is_reload instr
-  then false
-  else
-    Array.exists reg_on_stack instr.arg
-    || Array.exists reg_on_stack instr.res
-    ||
-    match instr.desc with
-    | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
-    | Op (Stackoffset _)
-    | Reloadretaddr
-    (* GC or other hidden calls are not supported in the middle of using push to
-       spill. *)
-    | Op (Alloc _ | Poll | Specific _) ->
-      true
-    | Op
-        ( Move | Spill | Reload | Dummy_use | Const_int _ | Const_float _
-        | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-        | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _
-        | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
-        | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Name_for_debugger _ | Dls_get | Tls_get | Domain_index
-        | Pause ) ->
-      false
+  match instr.desc with
+  | Op (Spill | Reload) -> false
+  | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
+  | Op (Stackoffset _)
+  | Reloadretaddr
+  (* GC or other hidden calls are not supported in the middle of using push to
+     spill. *)
+  | Op (Alloc _ | Poll | Specific _) ->
+    true
+  | Op
+      ( Move | Const_int _ | Const_float _ | Const_float32 _ | Const_symbol _
+      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Load _ | Store _
+      | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
+      | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
+      | Begin_region | End_region | Name_for_debugger _ | Dls_get | Tls_get
+      | Domain_index | Pause ) ->
+    Array.exists Reg.is_stack instr.arg || Array.exists Reg.is_stack instr.res
 
 (* Collect consecutive reload instructions from the start of a block body, as
    long as no destination register is repeated. Returns a map from spill slot to
    reload instruction. *)
-let collect_leading_reloads (body : Cfg.basic_instruction_list) =
+let collect_leading_reloads cfg_with_infos (body : Cfg.basic_instruction_list) =
   let reloads = ref Reg.Map.empty in
   let seen_regs = ref Reg.Set.empty in
   let rec loop (cell : Cfg.basic Cfg.instruction DLL.cell) =
     let instr = DLL.value cell in
-    if is_reload instr
+    if Cfg.is_reload instr
     then begin
       let spill_slot = instr.arg.(0) in
       let r = instr.res.(0) in
+      let live_across =
+        (Cfg_with_infos.liveness_find cfg_with_infos instr.id).across
+      in
       if
-        (not (Reg.Set.mem spill_slot instr.live))
+        (not (Reg.Set.mem spill_slot live_across))
         && not (Reg.Set.mem r !seen_regs)
       then reloads := Reg.Map.add spill_slot instr !reloads;
       seen_regs := Reg.Set.add r !seen_regs;
@@ -69,35 +55,32 @@ let collect_leading_reloads (body : Cfg.basic_instruction_list) =
 
 (* Collect spills from the end of a block body, walking backwards. Stops at any
    incompatible instruction. Filters out spills whose slot is read by a later
-   instruction (between the spill and the call). *)
-let collect_spills_backwards (cfg : Cfg.t) (block : Cfg.basic_block) =
+   instruction in the block (between the spill and the call) or by the exception
+   handler. Reads in the after-block (via the matching reloads) are
+   intentionally not considered: we are about to replace those reloads with
+   pop. *)
+let collect_spills_backwards cfg_with_infos (block : Cfg.basic_block) =
+  let cfg = Cfg_with_infos.cfg cfg_with_infos in
   let exn_entry_live =
     match block.exn with
     | None -> Reg.Set.empty
     | Some exn_label ->
-      let exn_block = Cfg.get_block_exn cfg exn_label in
-      let live_across, args =
-        match DLL.hd_cell exn_block.body with
-        | Some cell ->
-          let instr = DLL.value cell in
-          instr.live, instr.arg
-        | None -> exn_block.terminator.live, exn_block.terminator.arg
+      let exn_first_id =
+        Cfg.first_instruction_id (Cfg.get_block_exn cfg exn_label)
       in
-      Array.fold_left (fun live reg -> Reg.Set.add reg live) live_across args
+      (Cfg_with_infos.liveness_find cfg_with_infos exn_first_id).before
   in
   let body = block.body in
   let spills = ref [] in
   let used_after = ref exn_entry_live in
-  let add_args args =
-    Array.iter (fun r -> used_after := Reg.Set.add r !used_after) args
-  in
+  let add_args args = used_after := Reg.add_set_array !used_after args in
   let rec loop cell =
     let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
     if unsupported_after_push instr
     then ()
     else begin
       if
-        is_spill instr
+        Cfg.is_spill instr
         && (not (Reg.Set.mem instr.res.(0) !used_after))
         && is_gp_register instr.arg.(0)
       then begin
@@ -107,214 +90,191 @@ let collect_spills_backwards (cfg : Cfg.t) (block : Cfg.basic_block) =
         used_after := Reg.Set.add instr.res.(0) !used_after
       end
       else add_args instr.arg;
-      match DLL.prev cell with Some prev -> loop prev | None -> ()
+      Option.iter loop (DLL.prev cell)
     end
   in
   (match DLL.last_cell body with Some cell -> loop cell | None -> ());
   !spills
 
-let process_call (cfg : Cfg.t) (block : Cfg.basic_block) =
-  let label_after =
-    match block.terminator.desc with
-    | Call { label_after; _ } -> Some label_after
-    | Prim _ | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
-    | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-    | Tailcall_func _ | Call_no_return _ | Invalid _ ->
-      None
+let label_after_call (block : Cfg.basic_block) =
+  match block.terminator.desc with
+  | Call { label_after; _ } -> Some label_after
+  | Prim _ | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+  | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
+  | Call_no_return _ | Invalid _ ->
+    None
+
+(* Follow a chain of empty [Always] blocks from [label] to find the block
+   holding the post-call reloads. The regalloc rewrite pass may insert
+   intermediate blocks for call result spills; their stack_offsets will be
+   updated alongside the reloads block. *)
+let rec find_reload_block (cfg : Cfg.t) label =
+  let blk = Cfg.get_block_exn cfg label in
+  if Label.Set.cardinal blk.predecessors <> 1
+  then None
+  else if DLL.is_empty blk.body
+  then
+    match[@ocaml.warning "-4"] blk.terminator.desc with
+    | Always next -> find_reload_block cfg next
+    | _ -> Some blk
+  else Some blk
+
+(* From the candidate spills and the per-slot reload map, keep only spills with
+   a matching reload, trim to a multiple of the call stack alignment, and pair
+   each remaining spill with its reload. Returned lists have the same length and
+   are aligned by index. *)
+let match_spills_to_reloads (spills : Cfg.basic Cfg.instruction list)
+    (reloads_map : Cfg.basic Cfg.instruction Reg.Map.t) =
+  let spills =
+    List.filter
+      (fun (instr : Cfg.basic Cfg.instruction) ->
+        Reg.Map.mem instr.res.(0) reloads_map)
+      spills
   in
-  match label_after with
+  let n = List.length spills in
+  let n = n - (n mod (Arch.call_stack_alignment / Arch.size_addr)) in
+  let spills = List.filteri (fun i _ -> i < n) spills in
+  let reloads =
+    List.map
+      (fun (spill : Cfg.basic Cfg.instruction) ->
+        Reg.Map.find spill.res.(0) reloads_map)
+      spills
+  in
+  spills, reloads
+
+(* Replace each selected spill with a [push] instruction. Stack offsets of all
+   instructions and blocks between (and including) the first push and the first
+   post-call reload block are bumped to reflect the additional pushed slots. On
+   entry [stack_offset] starts at [base_stack_offset + n * size_addr] and ends
+   at [base_stack_offset]. *)
+let replace_spills_with_pushes (cfg : Cfg.t)
+    ~(spills : Cfg.basic Cfg.instruction list) ~base_stack_offset
+    (after_block : Cfg.basic_block) =
+  let now_unused_spill_slots =
+    List.fold_left
+      (fun acc (spill : Cfg.basic Cfg.instruction) ->
+        Reg.Set.add spill.res.(0) acc)
+      Reg.Set.empty spills
+  in
+  let selected_spill_ids =
+    List.fold_left
+      (fun acc (spill : Cfg.basic Cfg.instruction) ->
+        InstructionId.Set.add spill.id acc)
+      InstructionId.Set.empty spills
+  in
+  let unprocessed_stack_regs = ref now_unused_spill_slots in
+  let stack_offset =
+    ref (base_stack_offset + (List.length spills * Arch.size_addr))
+  in
+  let rewrite_instr (type a) (instr : a Cfg.instruction) cell =
+    assert (instr.stack_offset = base_stack_offset);
+    instr.stack_offset <- !stack_offset;
+    if InstructionId.Set.mem instr.id selected_spill_ids
+    then begin
+      unprocessed_stack_regs
+        := Reg.Set.remove instr.res.(0) !unprocessed_stack_regs;
+      stack_offset := !stack_offset - Arch.size_addr;
+      let push =
+        Cfg.make_instruction ~desc:(Cfg.Op (Specific Arch.Ipush_to_stack))
+          ~arg:[| instr.arg.(0) |]
+          ~res:[||] ~dbg:instr.dbg ~fdo:instr.fdo ~stack_offset:!stack_offset
+          ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+          ()
+      in
+      DLL.set_value (Option.get cell) push
+    end
+  in
+  let rec rewrite_block (block : Cfg.basic_block) =
+    let rec rewrite_cell cell =
+      rewrite_instr (DLL.value cell) (Some cell);
+      if not (Reg.Set.is_empty !unprocessed_stack_regs)
+      then rewrite_cell (DLL.prev cell |> Option.get)
+    in
+    if not (Reg.Set.is_empty !unprocessed_stack_regs)
+    then begin
+      assert (block.stack_offset = base_stack_offset);
+      block.stack_offset <- !stack_offset;
+      assert (Label.Set.cardinal block.predecessors = 1);
+      let pred = Cfg.get_block_exn cfg (Label.Set.choose block.predecessors) in
+      rewrite_instr pred.terminator None;
+      Option.iter rewrite_cell (DLL.last_cell pred.body);
+      rewrite_block pred
+    end
+  in
+  rewrite_block after_block;
+  assert (Reg.Set.is_empty !unprocessed_stack_regs);
+  assert (!stack_offset = base_stack_offset)
+
+(* Delete the [reloads] from the start of [after_block.body] and prepend the
+   matching [pop] instructions in LIFO order (so the topmost pushed value pops
+   first). Stack offsets on the new pops match the depth at which the pop
+   executes. *)
+let replace_reloads_with_pops (cfg : Cfg.t)
+    ~(reloads : Cfg.basic Cfg.instruction list) ~base_stack_offset
+    (after_block : Cfg.basic_block) =
+  let selected_reload_ids =
+    List.fold_left
+      (fun acc (reload : Cfg.basic Cfg.instruction) ->
+        InstructionId.Set.add reload.id acc)
+      InstructionId.Set.empty reloads
+  in
+  let n_to_remove = List.length reloads in
+  let rec remove_reloads remaining cell =
+    let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+    assert (Cfg.is_reload instr);
+    let next = DLL.next cell in
+    let remaining =
+      if InstructionId.Set.mem instr.id selected_reload_ids
+      then (
+        DLL.delete_curr cell;
+        remaining - 1)
+      else remaining
+    in
+    if remaining > 0 then remove_reloads remaining (Option.get next)
+  in
+  remove_reloads n_to_remove (DLL.hd_cell after_block.body |> Option.get);
+  let stack_offset = ref base_stack_offset in
+  List.iter
+    (fun (reload : Cfg.basic Cfg.instruction) ->
+      stack_offset := !stack_offset + Arch.size_addr;
+      let pop =
+        Cfg.make_instruction ~desc:(Cfg.Op (Specific Arch.Ipop_from_stack))
+          ~arg:[||]
+          ~res:[| reload.res.(0) |]
+          ~dbg:reload.dbg ~fdo:reload.fdo ~stack_offset:!stack_offset
+          ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+          ()
+      in
+      DLL.add_begin after_block.body pop)
+    reloads
+
+let process_call cfg_with_infos (block : Cfg.basic_block) =
+  let cfg = Cfg_with_infos.cfg cfg_with_infos in
+  match label_after_call block with
   | None -> ()
   | Some label_after -> (
-    (* Follow chain of empty Always blocks to find the block with the reloads
-       (the rewrite pass may insert intermediate blocks for call result spills).
-       Returns the reload block and intermediate blocks whose stack_offsets need
-       updating. *)
-    let rec find_reload_block label =
-      let blk = Cfg.get_block_exn cfg label in
-      if Label.Set.cardinal blk.predecessors <> 1
-      then None
-      else if DLL.is_empty blk.body
-      then
-        match[@ocaml.warning "-4"] blk.terminator.desc with
-        | Always next -> find_reload_block next
-        | _ -> Some blk
-      else Some blk
-    in
-    match find_reload_block label_after with
+    match find_reload_block cfg label_after with
     | None -> ()
-    | Some after_block ->
-      let reloads = collect_leading_reloads after_block.body in
-      let spills =
-        collect_spills_backwards cfg block
-        |> List.filter (fun (instr : Cfg.basic Cfg.instruction) ->
-            Reg.Map.mem instr.res.(0) reloads)
+    | Some after_block -> (
+      let reloads_map =
+        collect_leading_reloads cfg_with_infos after_block.body
       in
-      let n_to_push = List.length spills in
-      let n_to_push =
-        n_to_push - (n_to_push mod (Arch.call_stack_alignment / Arch.size_addr))
+      let spills, reloads =
+        match_spills_to_reloads
+          (collect_spills_backwards cfg_with_infos block)
+          reloads_map
       in
-      let spills = List.filteri (fun i _ -> i < n_to_push) spills in
-      let reloads =
-        spills
-        |> List.map (fun (spill : Cfg.basic Cfg.instruction) ->
-            Reg.Map.find spill.res.(0) reloads)
-      in
-      if n_to_push > 0
-      then begin
-        let now_unused_spill_slots =
-          List.fold_left
-            (fun acc (spill : Cfg.basic Cfg.instruction) ->
-              Reg.Set.add spill.res.(0) acc)
-            Reg.Set.empty spills
-        in
-        let selected_spill_ids =
-          List.fold_left
-            (fun acc (spill : Cfg.basic Cfg.instruction) ->
-              InstructionId.Set.add spill.id acc)
-            InstructionId.Set.empty spills
-        in
-        let selected_reload_ids =
-          List.fold_left
-            (fun acc (reload : Cfg.basic Cfg.instruction) ->
-              InstructionId.Set.add reload.id acc)
-            InstructionId.Set.empty reloads
-        in
+      match spills with
+      | [] -> ()
+      | _ :: _ ->
         let base_stack_offset = block.terminator.stack_offset in
-        (* Replace spills with pushes in-place, adjusting stack offsets of
-           intervening instructions. *)
-        let unprocessed_stack_regs = ref now_unused_spill_slots in
-        let stack_offset =
-          ref (base_stack_offset + (List.length spills * Arch.size_addr))
-        in
-        let rewrite_spills_instr (type a) (instr : a Cfg.instruction) cell =
-          assert (instr.stack_offset = base_stack_offset);
-          instr.stack_offset <- !stack_offset;
-          instr.live <- Reg.Set.diff instr.live !unprocessed_stack_regs;
-          if InstructionId.Set.mem instr.id selected_spill_ids
-          then begin
-            unprocessed_stack_regs
-              := Reg.Set.remove instr.res.(0) !unprocessed_stack_regs;
-            stack_offset := !stack_offset - Arch.size_addr;
-            let push =
-              Cfg.make_instruction ~desc:(Cfg.Op (Specific Arch.Ipush_to_stack))
-                ~arg:[| instr.arg.(0) |]
-                ~res:[||] ~dbg:instr.dbg ~fdo:instr.fdo ~live:instr.live
-                ~stack_offset:!stack_offset
-                ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-                ()
-            in
-            DLL.set_value (Option.get cell) push
-          end
-        in
-        let rec rewrite_spills_block (after_block : Cfg.basic_block) =
-          let rec rewrite_spills_cell cell =
-            rewrite_spills_instr (DLL.value cell) (Some cell);
-            if not (Reg.Set.is_empty !unprocessed_stack_regs)
-            then rewrite_spills_cell (DLL.prev cell |> Option.get)
-          in
-          if not (Reg.Set.is_empty !unprocessed_stack_regs)
-          then begin
-            assert (after_block.stack_offset = base_stack_offset);
-            after_block.stack_offset <- !stack_offset;
-            let predecessors = after_block.predecessors in
-            assert (Label.Set.cardinal after_block.predecessors = 1);
-            let block = Cfg.get_block_exn cfg (Label.Set.choose predecessors) in
-            rewrite_spills_instr block.terminator None;
-            Option.iter rewrite_spills_cell (DLL.last_cell block.body);
-            rewrite_spills_block block
-          end
-        in
-        rewrite_spills_block after_block;
-        assert (Reg.Set.is_empty !unprocessed_stack_regs);
-        (* Delete selected reloads from their original positions *)
-        let rec remove_unspills remaining_reloads cell =
-          let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
-          assert (is_reload instr);
-          let next = DLL.next cell in
-          let remaining_reloads =
-            if InstructionId.Set.mem instr.id selected_reload_ids
-            then (
-              DLL.delete_curr cell;
-              remaining_reloads - 1)
-            else remaining_reloads
-          in
-          instr.live <- Reg.Set.diff instr.live now_unused_spill_slots;
-          if remaining_reloads > 0
-          then remove_unspills remaining_reloads (Option.get next)
-        in
-        remove_unspills n_to_push (DLL.hd_cell after_block.body |> Option.get);
-        (* Insert pops at the beginning in LIFO order. *)
-        assert (!stack_offset = base_stack_offset);
-        List.iter
-          (fun (reload : Cfg.basic Cfg.instruction) ->
-            stack_offset := !stack_offset + Arch.size_addr;
-            (* CR ttebbi: This live set would have been accurate for the old
-               reload position, but not for the permutation. Since live sets are
-               not used later except for call positions, this is likely fine.
-               Ideally, we should recompute live sets properly or clear them
-               completely. *)
-            let pop =
-              Cfg.make_instruction
-                ~desc:(Cfg.Op (Specific Arch.Ipop_from_stack)) ~arg:[||]
-                ~res:[| reload.res.(0) |]
-                ~dbg:reload.dbg ~fdo:reload.fdo ~live:reload.live
-                ~stack_offset:!stack_offset
-                ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-                ()
-            in
-            DLL.add_begin after_block.body pop)
-          reloads
-      end)
-
-(* Compact stack slots: remove gaps left by converted spills/reloads and
-   renumber remaining slots. *)
-let compact_stack_slots (cfg : Cfg.t) =
-  let used = Stack_class.Tbl.make Int_set.empty in
-  let registers = ref Reg.Set.empty in
-  let record_reg (r : Reg.t) =
-    registers := Reg.Set.add r !registers;
-    match r.loc with
-    | Stack (Local slot) ->
-      let sc = Stack_class.of_machtype r.typ in
-      Stack_class.Tbl.replace used sc
-        (Int_set.add slot (Stack_class.Tbl.find used sc))
-    | Stack (Incoming _ | Outgoing _ | Domainstate _) | Reg _ | Unknown -> ()
-  in
-  let record_arr a = Array.iter record_reg a in
-  Cfg.iter_blocks cfg ~f:(fun _label block ->
-      DLL.iter block.body ~f:(fun (i : Cfg.basic Cfg.instruction) ->
-          record_arr i.arg;
-          record_arr i.res);
-      record_arr block.terminator.arg;
-      record_arr block.terminator.res);
-  let renamings = Stack_class.Tbl.make Int_map.empty in
-  Stack_class.Tbl.iter used ~f:(fun sc slots ->
-      let num_slots, renaming =
-        Int_set.fold
-          (fun old (next, m) -> next + 1, Int_map.add old next m)
-          slots (0, Int_map.empty)
-      in
-      Stack_class.Tbl.replace renamings sc renaming;
-      Stack_class.Tbl.replace cfg.fun_num_stack_slots sc num_slots);
-  let rename_reg (r : Reg.t) : unit =
-    match r.loc with
-    | Stack (Local slot) ->
-      let new_slot =
-        Stack_class.of_machtype r.typ
-        |> Stack_class.Tbl.find renamings
-        |> Int_map.find slot
-      in
-      Reg.set_loc r (Stack (Local new_slot))
-    | Reg _ | Unknown | Stack (Domainstate _ | Incoming _ | Outgoing _) -> ()
-  in
-  Reg.Set.iter rename_reg !registers
+        replace_spills_with_pushes cfg ~spills ~base_stack_offset after_block;
+        replace_reloads_with_pops cfg ~reloads ~base_stack_offset after_block))
 
 let run (cfg_with_infos : Cfg_with_infos.t) =
   if !Oxcaml_flags.cfg_push_pop_around_calls
   then begin
     let cfg = Cfg_with_infos.cfg cfg_with_infos in
-    Cfg.iter_blocks cfg ~f:(fun _label block -> process_call cfg block);
-    compact_stack_slots cfg;
-    cfg_with_infos
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+        process_call cfg_with_infos block)
   end
-  else cfg_with_infos

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -279,7 +279,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
          | Istore_int (_, _, _)
          | Ioffset_loc (_, _)
          | Ifloatarithmem (_, _, _)
-         | Icldemote _ | Iprefetch _ | Ibswap _ ))
+         | Icldemote _ | Iprefetch _ | Ibswap _ | Ipush_to_stack
+         | Ipop_from_stack ))
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue ->
     (* no rewrite *)
     May_still_have_spilled_registers

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -279,14 +279,13 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
          | Istore_int (_, _, _)
          | Ioffset_loc (_, _)
          | Ifloatarithmem (_, _, _)
-         | Icldemote _ | Iprefetch _ | Ibswap _ | Ipush_to_stack
-         | Ipop_from_stack ))
+         | Icldemote _ | Iprefetch _ | Ibswap _ ))
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue ->
     (* no rewrite *)
     May_still_have_spilled_registers
   | Op (Intop_imm ((Ipopcnt | Iclz | Ictz), _))
   | Stack_check _
-  | Op (Specific (Illvm_intrinsic _)) ->
+  | Op (Specific (Illvm_intrinsic _ | Ipush_to_stack | Ipop_from_stack)) ->
     (* should not happen *)
     fatal "unexpected instruction"
 

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1508,7 +1508,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
           | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence
           | Imfence | Ipackf32 | Isimd _ | Isimd_mem _ | Iprefetch _
-          | Icldemote _ | Illvm_intrinsic _ ->
+          | Icldemote _ | Illvm_intrinsic _ | Ipush_to_stack | Ipop_from_stack
+            ->
             assert false)
         | Move | Load _ | Store _ | Intop _ | Intop_imm _ | Alloc _
         | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_int _
@@ -1642,7 +1643,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
               ( Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _
               | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32
               | Isimd _ | Isimd_mem _ | Ilea _ | Ibswap _ | Isextend32
-              | Izextend32 | Illvm_intrinsic _ )
+              | Izextend32 | Illvm_intrinsic _ | Ipush_to_stack
+              | Ipop_from_stack )
           | Intop_imm _ | Move | Load _ | Store _ | Intop _ | Int128op _
           | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
           | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
@@ -1744,7 +1746,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
     | Isimd_mem _ ->
       Misc.fatal_error "Unexpected simd operation with memory arguments"
     | Ioffset_loc _ | Ibswap _ | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence
-    | Ipackf32 | Isimd _ | Iprefetch _ | Icldemote _ ->
+    | Ipackf32 | Isimd _ | Iprefetch _ | Icldemote _ | Ipush_to_stack
+    | Ipop_from_stack ->
       None
     | Illvm_intrinsic intr ->
       Misc.fatal_errorf

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -63,6 +63,10 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
     Misc.fatal_errorf
       "Vectorize_specific: Unexpected llvm_intrinsic %s: not using LLVM backend"
       intr
+  | Ipush_to_stack | Ipop_from_stack ->
+    Misc.fatal_error
+      "Vectorize_specific: Unexpected push/pop operation, these are only \
+       emitted later."
 
 let is_seed_store :
     Arch.specific_operation -> Vectorize_utils.Width_in_bits.t option =
@@ -78,3 +82,7 @@ let is_seed_store :
       "Vectorize_specific.is_seed_store: Unexpected llvm_intrinsic %s: not \
        using LLVM backend"
       intr
+  | Ipush_to_stack | Ipop_from_stack ->
+    Misc.fatal_error
+      "Vectorize_specific: Unexpected push/pop operation, these are only \
+       emitted later."

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -355,6 +355,10 @@ let operation_allocates = function
       (* Used by the zero_alloc checker that runs before the Llvmize. *)
       false
 
+let specific_operation_stack_offset_delta _op = 0
+
+let call_stack_alignment = 16
+
 (* See `amd64/arch.ml`. *)
 let equal_addressing_mode_without_displ (addressing_mode_1: addressing_mode)
       (addressing_mode_2 : addressing_mode) =

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -130,6 +130,10 @@ val operation_allocates : specific_operation -> bool
 
 val isomorphic_specific_operation : specific_operation -> specific_operation -> bool
 
+val specific_operation_stack_offset_delta : specific_operation -> int
+
+val call_stack_alignment : int
+
 (* See `amd64/arch.mli`. *)
 val equal_addressing_mode_without_displ : addressing_mode -> addressing_mode -> bool
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1874,7 +1874,7 @@ let emit_instr env i =
               femit_label lbltbl
         done *)
   | Lentertrap -> ()
-  | Ladjust_stack_offset { delta_bytes } ->
+  | Ladjust_stack_offset { delta_bytes; pushed_slots = _ } ->
     D.cfi_adjust_cfa_offset ~bytes:delta_bytes;
     Env.set_stack_offset env (Env.stack_offset env + delta_bytes)
   | Lpushtrap { lbl_handler } ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -351,6 +351,10 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
                      V512_of_scalar _ | Scalar_of_v512 _))
     -> Misc.fatal_error "arm64: got 256/512 bit vector"
 
+let is_push_to_stack (_ : Cfg_intf.S.basic) = false
+
+let is_pop_from_stack (_ : Cfg_intf.S.basic) = false
+
 (* note: keep this function in sync with `is_destruction_point` below. *)
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with

--- a/backend/arm64/push_pop_around_calls.ml
+++ b/backend/arm64/push_pop_around_calls.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+let run (cfg_with_infos : Cfg_with_infos.t) = cfg_with_infos

--- a/backend/arm64/push_pop_around_calls.ml
+++ b/backend/arm64/push_pop_around_calls.ml
@@ -1,3 +1,3 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
-let run (cfg_with_infos : Cfg_with_infos.t) = cfg_with_infos
+let run _cfg_with_infos = ()

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -557,12 +557,16 @@ let remove_trap_instructions t removed_trap_handlers =
           ~stack_offset:(stack_offset - Proc.trap_size_in_bytes ())
     | Op (Stackoffset n) ->
       update_basic_next (DLL.Cursor.next cursor) ~stack_offset:(stack_offset + n)
+    | Op (Specific op) ->
+      let delta = Arch.specific_operation_stack_offset_delta op in
+      update_basic_next (DLL.Cursor.next cursor)
+        ~stack_offset:(stack_offset + delta)
     | Op
         ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_float32 _
         | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
         | Load _ | Store _ | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _
         | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
-        | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+        | Probe_is_enabled _ | Opaque | Begin_region | End_region
         | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll
         | Alloc _ | Pause )
     | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -502,6 +502,12 @@ let is_end_region (b : basic) =
 
 let is_alloc_or_poll instr = is_alloc instr || is_poll instr
 
+let is_spill (instr : basic instruction) =
+  match[@ocaml.warning "-4"] instr.desc with Op Spill -> true | _ -> false
+
+let is_reload (instr : basic instruction) =
+  match[@ocaml.warning "-4"] instr.desc with Op Reload -> true | _ -> false
+
 let basic_block_contains_calls block =
   block.is_trap_handler
   || (match block.terminator.desc with

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -211,6 +211,10 @@ val is_alloc : basic instruction -> bool
 
 val is_poll : basic instruction -> bool
 
+val is_reload : basic instruction -> bool
+
+val is_spill : basic instruction -> bool
+
 val is_end_region : basic -> bool
 
 val set_stack_offset : 'a instruction -> int -> unit

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -434,51 +434,44 @@ let check_stack_offset t label (block : Cfg.basic_block) =
              instruction is %d, but expected %d.\n"
             (Label.to_string label) InstructionId.print basic.id
             Printcfg.basic_desc basic.desc basic.stack_offset cur_stack_offset;
-        match basic.desc with
-        | Pushtrap { lbl_handler } ->
-          let handler_block = Cfg.get_block_exn t.cfg lbl_handler in
-          if not (Int.equal cur_stack_offset handler_block.stack_offset)
-          then
-            report t
-              "Wrong stack offset in block %s: the offset of [(id:%a) %a] \
-               instruction is %d, the offset of block %s is %d.\n"
-              (Label.to_string label) InstructionId.print basic.id
-              Printcfg.basic_desc basic.desc cur_stack_offset
-              (Label.to_string lbl_handler)
-              handler_block.stack_offset;
-          cur_stack_offset + Proc.trap_size_in_bytes ()
-        | Poptrap { lbl_handler = _ } ->
-          let new_stack_offset =
+        let new_stack_offset =
+          match basic.desc with
+          | Pushtrap { lbl_handler } ->
+            let handler_block = Cfg.get_block_exn t.cfg lbl_handler in
+            if not (Int.equal cur_stack_offset handler_block.stack_offset)
+            then
+              report t
+                "Wrong stack offset in block %s: the offset of [(id:%a) %a] \
+                 instruction is %d, the offset of block %s is %d.\n"
+                (Label.to_string label) InstructionId.print basic.id
+                Printcfg.basic_desc basic.desc cur_stack_offset
+                (Label.to_string lbl_handler)
+                handler_block.stack_offset;
+            cur_stack_offset + Proc.trap_size_in_bytes ()
+          | Poptrap { lbl_handler = _ } ->
             cur_stack_offset - Proc.trap_size_in_bytes ()
-          in
-          if Int.compare new_stack_offset 0 < 0
-          then
-            report t
-              "Negative stack offset in block %s: the offset after [(id:%a) \
-               %a] instruction is %d\n"
-              (Label.to_string label) InstructionId.print basic.id
-              Printcfg.basic_desc basic.desc new_stack_offset;
-          new_stack_offset
-        | Op (Stackoffset n) ->
-          let new_stack_offset = cur_stack_offset + n in
-          if Int.compare new_stack_offset 0 < 0
-          then
-            report t
-              "Negative stack offset in block %s: the offset after [(id:%a) \
-               %a] instruction is %d\n"
-              (Label.to_string label) InstructionId.print basic.id
-              Printcfg.basic_desc basic.desc new_stack_offset;
-          new_stack_offset
-        | Op
-            ( Move | Spill | Reload | Const_int _ | Const_float _
-            | Const_float32 _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-            | Const_vec512 _ | Load _ | Store _ | Intop _ | Int128op _
-            | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _
-            | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-            | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
-            | Domain_index | Poll | Pause | Alloc _ )
-        | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
-          cur_stack_offset)
+          | Op (Specific op) ->
+            cur_stack_offset + Arch.specific_operation_stack_offset_delta op
+          | Op (Stackoffset n) -> cur_stack_offset + n
+          | Op
+              ( Move | Spill | Reload | Const_int _ | Const_float _
+              | Const_float32 _ | Const_symbol _ | Const_vec128 _
+              | Const_vec256 _ | Const_vec512 _ | Load _ | Store _ | Intop _
+              | Int128op _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
+              | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _ | Opaque
+              | Begin_region | End_region | Name_for_debugger _ | Dls_get
+              | Tls_get | Domain_index | Poll | Pause | Alloc _ )
+          | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
+            cur_stack_offset
+        in
+        if new_stack_offset < 0
+        then
+          report t
+            "Negative stack offset in block %s: the offset after [(id:%a) %a] \
+             instruction is %d\n"
+            (Label.to_string label) InstructionId.print basic.id
+            Printcfg.basic_desc basic.desc new_stack_offset;
+        new_stack_offset)
   in
   if not (Int.equal stack_offset_after_body terminator_stack_offset)
   then

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -473,15 +473,15 @@ let adjust_stack_offset body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) ~pushed_slots_per_block =
   let block_stack_offset = block.stack_offset in
   let prev_stack_offset = prev_block.terminator.stack_offset in
-  if block_stack_offset = prev_stack_offset
+  let pushed_slots =
+    match Label.Tbl.find_opt pushed_slots_per_block block.start with
+    | Some s -> s
+    | None -> []
+  in
+  if block_stack_offset = prev_stack_offset && List.is_empty pushed_slots
   then body
   else
     let delta_bytes = block_stack_offset - prev_stack_offset in
-    let pushed_slots =
-      match Label.Tbl.find_opt pushed_slots_per_block block.start with
-      | Some s -> s
-      | None -> []
-    in
     to_linear_instr
       (Ladjust_stack_offset { delta_bytes; pushed_slots })
       ~next:body

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -397,15 +397,94 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
            terminator %a"
           Printcfg.terminator prev_block.terminator)
 
+(* Compute the [pushed_slots] state (list of pushed slot types, top of stack
+   first) at the entry of each block, by data-flow propagation along normal CFG
+   edges. Push/pop instructions inside a block update the running state; at
+   merges every predecessor must agree. *)
+let compute_pushed_slots_per_block (cfg : Cfg.t) :
+    Cmm.machtype_component list Label.Tbl.t =
+  let pushed_slots_per_block = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
+  let apply_block_body (block : Cfg.basic_block) state =
+    DLL.fold_left block.body ~init:state
+      ~f:(fun acc (instr : Cfg.basic Cfg.instruction) ->
+        match[@ocaml.warning "-4"] instr.desc with
+        | _ when Proc.is_push_to_stack instr.desc ->
+          (instr.arg.(0) : Reg.t).typ :: acc
+        | _ when Proc.is_pop_from_stack instr.desc -> (
+          match acc with
+          | top :: rest ->
+            if not (Cmm.equal_machtype_component top instr.res.(0).typ)
+            then
+              Misc.fatal_errorf
+                "cfg_to_linear: pop type disagrees with the corresponding push \
+                 in block %a at instruction %a"
+                Label.format block.start InstructionId.format instr.id;
+            rest
+          | [] ->
+            Misc.fatal_errorf
+              "cfg_to_linear: pop from empty pushed_slots in block %a at \
+               instruction %a"
+              Label.format block.start InstructionId.format instr.id)
+        (* The trap handler entry state below assumes no [Ipush_to_stack] slots
+           are live when a [Pushtrap] executes; otherwise the handler's actual
+           push state would inherit those slots rather than be empty. *)
+        | Pushtrap _ when not (List.is_empty acc) ->
+          Misc.fatal_errorf
+            "cfg_to_linear: Pushtrap with non-empty pushed_slots in block %a \
+             at instruction %a"
+            Label.format block.start InstructionId.format instr.id
+        | _ -> acc)
+  in
+  let worklist = Queue.create () in
+  let propagate succ state =
+    match Label.Tbl.find_opt pushed_slots_per_block succ with
+    | None ->
+      Label.Tbl.add pushed_slots_per_block succ state;
+      Queue.add succ worklist
+    | Some existing ->
+      if
+        not
+          (List.equal
+             (fun a b -> Cmm.equal_machtype_component a b)
+             existing state)
+      then
+        Misc.fatal_errorf "cfg_to_linear: inconsistent pushed_slots at %a"
+          Label.format succ
+  in
+  propagate cfg.entry_label [];
+  while not (Queue.is_empty worklist) do
+    let label = Queue.pop worklist in
+    let block = Cfg.get_block_exn cfg label in
+    let entry_state = Label.Tbl.find pushed_slots_per_block label in
+    let exit_state = apply_block_body block entry_state in
+    let normal_successors =
+      Cfg.successor_labels block ~normal:true ~exn:false
+    in
+    Label.Set.iter (fun succ -> propagate succ exit_state) normal_successors;
+    (* Exception successors: when raised, the runtime unwinds to the trap
+       handler's saved SP, discarding any [Ipush_to_stack] pushes performed
+       since the matching pushtrap. So trap handlers always enter with an empty
+       push stack. *)
+    Option.iter (fun exn_label -> propagate exn_label []) block.exn
+  done;
+  pushed_slots_per_block
+
 let adjust_stack_offset body (block : Cfg.basic_block)
-    ~(prev_block : Cfg.basic_block) =
+    ~(prev_block : Cfg.basic_block) ~pushed_slots_per_block =
   let block_stack_offset = block.stack_offset in
   let prev_stack_offset = prev_block.terminator.stack_offset in
   if block_stack_offset = prev_stack_offset
   then body
   else
     let delta_bytes = block_stack_offset - prev_stack_offset in
-    to_linear_instr (Ladjust_stack_offset { delta_bytes }) ~next:body
+    let pushed_slots =
+      match Label.Tbl.find_opt pushed_slots_per_block block.start with
+      | Some s -> s
+      | None -> []
+    in
+    to_linear_instr
+      (Ladjust_stack_offset { delta_bytes; pushed_slots })
+      ~next:body
 
 let make_Llabel cfg_with_layout label =
   Linear.Llabel
@@ -420,6 +499,7 @@ let make_Llabel cfg_with_layout label =
    block more than once. *)
 let run cfg_with_layout =
   let cfg = CL.cfg cfg_with_layout in
+  let pushed_slots_per_block = compute_pushed_slots_per_block cfg in
   let layout = CL.layout cfg_with_layout in
   let next = ref Linear_utils.labelled_insn_end in
   let tailrec_label = ref None in
@@ -473,7 +553,7 @@ let run cfg_with_layout =
               }
             else body
           in
-          adjust_stack_offset body block ~prev_block
+          adjust_stack_offset body block ~prev_block ~pushed_slots_per_block
       in
       next := { Linear_utils.label; insn });
   let fun_contains_calls = cfg.fun_contains_calls in

--- a/backend/cfg/printcfg.ml
+++ b/backend/cfg/printcfg.ml
@@ -331,6 +331,16 @@ let cfg : Format.formatter -> Cfg.t -> unit =
   Array.sort ~cmp:Label.compare labels;
   format fmt cfg labels None
 
+let cfg_with_liveness :
+    Format.formatter ->
+    Cfg.t ->
+    Cfg_liveness.Liveness.domain InstructionId.Tbl.t ->
+    unit =
+ fun fmt cfg liveness ->
+  let labels = cfg.blocks |> Label.Tbl.to_seq_keys |> Array.of_seq in
+  Array.sort ~cmp:Label.compare labels;
+  format fmt cfg labels (Some liveness)
+
 let cfg_with_layout : Format.formatter -> Cfg_with_layout.t -> unit =
  fun fmt cfg_with_layout ->
   let labels = cfg_with_layout |> Cfg_with_layout.layout |> DLL.to_array in

--- a/backend/cfg/printcfg.mli
+++ b/backend/cfg/printcfg.mli
@@ -96,5 +96,12 @@ val instruction_with_print_reg :
     Blocks are visited in [Label.compare] order. *)
 val cfg : Format.formatter -> Cfg.t -> unit
 
+(** Like {!cfg}, but interleaves liveness information at each instruction. *)
+val cfg_with_liveness :
+  Format.formatter ->
+  Cfg.t ->
+  Cfg_liveness.Liveness.domain InstructionId.Tbl.t ->
+  unit
+
 (** Like {!cfg}, but visits blocks in the layout's order. *)
 val cfg_with_layout : Format.formatter -> Cfg_with_layout.t -> unit

--- a/backend/cfg/push_pop_around_calls.mli
+++ b/backend/cfg/push_pop_around_calls.mli
@@ -1,0 +1,6 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Replace spill/reload pairs directly adjacent to call instructions with
+    push/pop instructions. This reduces code size on x86 because push/pop
+    encodings are shorter than mov-to/from-stack-slot encodings. *)
+val run : Cfg_with_infos.t -> Cfg_with_infos.t

--- a/backend/cfg/push_pop_around_calls.mli
+++ b/backend/cfg/push_pop_around_calls.mli
@@ -3,4 +3,4 @@
 (** Replace spill/reload pairs directly adjacent to call instructions with
     push/pop instructions. This reduces code size on x86 because push/pop
     encodings are shorter than mov-to/from-stack-slot encodings. *)
-val run : Cfg_with_infos.t -> Cfg_with_infos.t
+val run : Cfg_with_infos.t -> unit

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -68,6 +68,8 @@ module Vars = struct
         | Lpushtrap _ -> t.stack_offset + Proc.trap_frame_size_in_bytes
         | Lpoptrap _ -> t.stack_offset - Proc.trap_frame_size_in_bytes
         | Ladjust_stack_offset { delta_bytes } -> t.stack_offset + delta_bytes
+        | Lop (Specific op) ->
+          t.stack_offset + Arch.specific_operation_stack_offset_delta op
         | Lend | Lprologue | Lepilogue_open | Lepilogue_close | Lop _
         | Lcall_op _ | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _
         | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lraise _

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -67,7 +67,8 @@ module Vars = struct
         | Lop (Stackoffset delta) -> t.stack_offset + delta
         | Lpushtrap _ -> t.stack_offset + Proc.trap_frame_size_in_bytes
         | Lpoptrap _ -> t.stack_offset - Proc.trap_frame_size_in_bytes
-        | Ladjust_stack_offset { delta_bytes } -> t.stack_offset + delta_bytes
+        | Ladjust_stack_offset { delta_bytes; pushed_slots = _ } ->
+          t.stack_offset + delta_bytes
         | Lop (Specific op) ->
           t.stack_offset + Arch.specific_operation_stack_offset_delta op
         | Lend | Lprologue | Lepilogue_open | Lepilogue_close | Lop _

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -542,6 +542,9 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
       let s = fs + trap_size in
       loop i.next s (max s max_fs) nontail_flag
     | Lpoptrap _ -> loop i.next (fs - trap_size) max_fs nontail_flag
+    | Lop (Specific op) ->
+      let fs = fs + Arch.specific_operation_stack_offset_delta op in
+      loop i.next fs (max fs max_fs) nontail_flag
     | Lop (Stackoffset n) ->
       let s = fs + n in
       loop i.next s (max s max_fs) nontail_flag
@@ -558,7 +561,7 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
         | Intop_atomic _
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-        | Specific _ | Name_for_debugger _ | Alloc _ )
+        | Name_for_debugger _ | Alloc _ )
     | Lcall_op (Ltailcall_ind | Ltailcall_imm _ | Lextcall _ | Lprobe _)
     | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _ | Lcondbranch _
     | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lraise _ ->

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -558,7 +558,7 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
   let rec loop (i : Linear.instruction) fs max_fs nontail_flag =
     match i.desc with
     | Lend -> { max_frame_size = max_fs; contains_nontail_calls = nontail_flag }
-    | Ladjust_stack_offset { delta_bytes } ->
+    | Ladjust_stack_offset { delta_bytes; pushed_slots = _ } ->
       let s = fs + delta_bytes in
       loop i.next s (max s max_fs) nontail_flag
     | Lpushtrap _ ->

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -51,6 +51,23 @@ type frame_descr =
 
 let frame_descriptors = ref ([] : frame_descr list)
 
+(* Statistics for frame sizes at GC frame descriptor call sites. Accumulated by
+   [record_frame_descr] and read by [get_frame_counters]. The frame size passed
+   to [record_frame_descr] already includes any slots from push/pop around
+   calls, because the push/pop instructions adjust the stack offset. *)
+let frame_size_sum = ref 0
+
+let frame_descr_count = ref 0
+
+let reset_frame_counters () =
+  frame_size_sum := 0;
+  frame_descr_count := 0
+
+let get_frame_counters () =
+  Profile.Counters.create ()
+  |> Profile.Counters.set "frame_size_sum" !frame_size_sum
+  |> Profile.Counters.set "frame_descr" !frame_descr_count
+
 let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
 
 let get_flags debuginfo =
@@ -74,6 +91,8 @@ let is_long_stack_index n = is_long n
 
 let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
   assert (frame_size land 3 = 0);
+  frame_size_sum := !frame_size_sum + frame_size;
+  incr frame_descr_count;
   let fd_long =
     is_long (frame_size + get_flags debuginfo)
     (* The checks below are redundant (if they fail, then frame size check above
@@ -374,10 +393,14 @@ let with_snapshot ~f =
   let saved_file_pos_nums = !file_pos_nums in
   let saved_file_pos_num_cnt = !file_pos_num_cnt in
   let saved_frame_descriptors = !frame_descriptors in
+  let saved_frame_size_sum = !frame_size_sum in
+  let saved_frame_descr_count = !frame_descr_count in
   let result = f () in
   file_pos_nums := saved_file_pos_nums;
   file_pos_num_cnt := saved_file_pos_num_cnt;
   frame_descriptors := saved_frame_descriptors;
+  frame_size_sum := saved_frame_size_sum;
+  frame_descr_count := saved_frame_descr_count;
   result
 
 let get_file_num ~file_emitter file_name =

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -52,6 +52,14 @@ val record_frame_descr :
   (* Location, if any *)
   unit
 
+(** [reset_frame_counters ()] clears the accumulated frame size statistics that
+    are updated by [record_frame_descr]. *)
+val reset_frame_counters : unit -> unit
+
+(** [get_frame_counters ()] returns counters for the frame descriptors recorded
+    since the last [reset_frame_counters]. *)
+val get_frame_counters : unit -> Profile.Counters.t
+
 (** [with_snapshot f] runs [f] and returns its result, but also ensures that the
     state of this [Emitaux] module is unchanged after [f] returns. *)
 val with_snapshot : f:(unit -> 'a) -> 'a

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -53,7 +53,10 @@ and instruction_desc =
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
   | Lentertrap
-  | Ladjust_stack_offset of { delta_bytes : int }
+  | Ladjust_stack_offset of
+      { delta_bytes : int;
+        pushed_slots : Cmm.machtype_component list
+      }
   | Lpushtrap of { lbl_handler : label }
   | Lpoptrap of { lbl_handler : label }
   | Lraise of Lambda.raise_kind

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -62,7 +62,12 @@ and instruction_desc =
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
   | Lentertrap
-  | Ladjust_stack_offset of { delta_bytes : int }
+  | Ladjust_stack_offset of
+      { delta_bytes : int;
+        (* The [pushed_stack_slots] state that should be in effect after this
+           directive. Stored in reverse push order (top of stack first). *)
+        pushed_slots : Cmm.machtype_component list
+      }
   | Lpushtrap of { lbl_handler : label }
   | Lpoptrap of { lbl_handler : label }
   | Lraise of Lambda.raise_kind

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -111,7 +111,7 @@ let instr' ?(print_reg = Printreg.reg) ppf i =
     done;
     fprintf ppf "@,endswitch"
   | Lentertrap -> fprintf ppf "enter trap"
-  | Ladjust_stack_offset { delta_bytes } ->
+  | Ladjust_stack_offset { delta_bytes; pushed_slots = _ } ->
     fprintf ppf "adjust pseudo stack offset by %d bytes" delta_bytes
   | Lpushtrap { lbl_handler } -> fprintf ppf "push trap %a" label lbl_handler
   | Lpoptrap { lbl_handler } -> fprintf ppf "pop trap %a" label lbl_handler

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -134,5 +134,13 @@ val operation_supported : Cmm.operation -> bool
     supported by this architecture. *)
 val expression_supported : Cmm.expression -> bool
 
+(** Whether this basic instruction is a push to the hardware stack (used by the
+    push/pop around calls optimization). *)
+val is_push_to_stack : Cfg_intf.S.basic -> bool
+
+(** Whether this basic instruction is a pop from the hardware stack (used by the
+    push/pop around calls optimization). *)
+val is_pop_from_stack : Cfg_intf.S.basic -> bool
+
 (** The number of bytes each trap occupies on the stack. *)
 val trap_size_in_bytes : unit -> int

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -470,11 +470,9 @@ let postlude : type s.
  fun (module State : State with type t = s) (module Utils) state ~f
      cfg_with_infos ->
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
-  update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
   Profile.record ~accumulate:true "push_pop_around_calls"
     (fun () -> Push_pop_around_calls.run cfg_with_infos)
     ();
-  Cfg_with_infos.invalidate_liveness cfg_with_infos;
   (* note: slots need to be updated before prologue removal *)
   Profile.record ~accumulate:true "stack_slots_optimize"
     (fun () ->

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -470,16 +470,6 @@ let postlude : type s.
  fun (module State : State with type t = s) (module Utils) state ~f
      cfg_with_infos ->
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
-  Profile.record ~accumulate:true "push_pop_around_calls"
-    (fun () -> Push_pop_around_calls.run cfg_with_infos)
-    ();
-  (* note: slots need to be updated before prologue removal *)
-  Profile.record ~accumulate:true "stack_slots_optimize"
-    (fun () ->
-      Regalloc_stack_slots.optimize (State.stack_slots state) cfg_with_infos)
-    ();
-  Regalloc_stack_slots.update_cfg_with_layout (State.stack_slots state)
-    cfg_with_layout;
   if debug
   then (
     Utils.indent ();
@@ -491,6 +481,17 @@ let postlude : type s.
     Utils.dedent ());
   update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
   f ();
+  Profile.record ~accumulate:true "push_pop_around_calls"
+    (fun () -> Push_pop_around_calls.run cfg_with_infos)
+    ();
+  (* note: slots need to be updated before prologue removal *)
+  Profile.record ~accumulate:true "stack_slots_optimize"
+    (fun () ->
+      Regalloc_stack_slots.optimize (State.stack_slots state) cfg_with_infos)
+    ();
+  Regalloc_stack_slots.update_cfg_with_layout (State.stack_slots state)
+    cfg_with_layout;
+  update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
   (Cfg_with_layout.cfg cfg_with_layout).register_locations_are_set <- true;
   if debug && Lazy.force invariants
   then (

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -470,6 +470,11 @@ let postlude : type s.
  fun (module State : State with type t = s) (module Utils) state ~f
      cfg_with_infos ->
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
+  update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
+  Profile.record ~accumulate:true "push_pop_around_calls"
+    (fun () -> Push_pop_around_calls.run cfg_with_infos)
+    ();
+  Cfg_with_infos.invalidate_liveness cfg_with_infos;
   (* note: slots need to be updated before prologue removal *)
   Profile.record ~accumulate:true "stack_slots_optimize"
     (fun () ->

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -246,16 +246,21 @@ with type slots := t = struct
     in
     Stack_class.Tbl.iter intervals ~f:(fun stack_class intervals ->
         Array.iteri intervals ~f:(fun slot_index interval ->
-            let buckets = Stack_class.Tbl.find buckets stack_class in
-            let bucket_index = ref 0 in
-            while
-              !bucket_index < Array.length buckets
-              && does_not_fit buckets.(!bucket_index) interval
-            do
-              incr bucket_index
-            done;
-            assert (!bucket_index < Array.length buckets);
-            Int.Tbl.replace buckets.(!bucket_index) slot_index interval));
+            (* Skip slots whose interval is empty: they have no uses left and
+               will be dropped by the loop in [optimize] below. *)
+            if interval.Interval.start == Point.dummy
+            then ()
+            else
+              let buckets = Stack_class.Tbl.find buckets stack_class in
+              let bucket_index = ref 0 in
+              while
+                !bucket_index < Array.length buckets
+                && does_not_fit buckets.(!bucket_index) interval
+              do
+                incr bucket_index
+              done;
+              assert (!bucket_index < Array.length buckets);
+              Int.Tbl.replace buckets.(!bucket_index) slot_index interval));
     buckets
 
   let contains_empty t =
@@ -327,8 +332,9 @@ let optimize (t : t) (cfg_with_infos : Cfg_with_infos.t) : unit =
               let stack_class = Stack_class.of_machtype reg.typ in
               match Buckets.find_bucket buckets ~stack_class ~slot_index with
               | None ->
-                fatal "slot %d (stack_class=%a) is not in any of the buckets"
-                  slot_index Stack_class.print stack_class
+                (* The slot has no uses left, so the register is dead. *)
+                Reg.set_loc reg Unknown;
+                Reg.Tbl.remove t.stack_slots reg
               | Some bucket_index ->
                 if debug
                 then

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -26,6 +26,8 @@ module Location : sig
 
   val of_regs_exn : Reg.t array -> t array
 
+  val push_stack : index:int -> t
+
   val to_loc_lossy : t -> Reg.location
 
   val print : Cmm.machtype_component -> Format.formatter -> t -> unit
@@ -133,6 +135,7 @@ end = struct
   type t =
     | Reg of Regs.Phys_reg.t
     | Stack of Stack.t
+    | Push_stack of { index : int }
 
   let of_reg reg =
     match reg.Reg.loc with
@@ -149,20 +152,29 @@ end = struct
 
   let of_regs_exn loc_arr = Array.map of_reg_exn loc_arr
 
+  let push_stack ~index = Push_stack { index }
+
   let to_loc_lossy t =
     match t with
     | Reg idx -> Reg.Reg idx
     | Stack stack -> Reg.Stack (Stack.to_stack_loc_lossy stack)
+    | Push_stack _ -> Reg.Unknown
 
   let print typ ppf t =
-    Printreg.loc ~unknown:(fun _ -> assert false) ppf (to_loc_lossy t) typ
+    match t with
+    | Push_stack { index } -> Format.fprintf ppf "push_stack[%d]" index
+    | _ ->
+      Printreg.loc ~unknown:(fun _ -> assert false) ppf (to_loc_lossy t) typ
 
   let compare (t1 : t) (t2 : t) : int =
     match t1, t2 with
     | Reg r1, Reg r2 -> Regs.Phys_reg.compare r1 r2
     | Stack s1, Stack s2 -> Stack.compare s1 s2
-    | Reg _, Stack _ -> -1
-    | Stack _, Reg _ -> 1
+    | Push_stack { index = i1 }, Push_stack { index = i2 } -> Int.compare i1 i2
+    | Reg _, (Stack _ | Push_stack _) -> -1
+    | (Stack _ | Push_stack _), Reg _ -> 1
+    | Stack _, Push_stack _ -> -1
+    | Push_stack _, Stack _ -> 1
 
   let equal (t1 : t) (t2 : t) : bool = compare t1 t2 = 0
 
@@ -376,7 +388,9 @@ end = struct
   let reg_fun_args t = t.reg_fun_args
 
   let is_regalloc_specific_basic (desc : Cfg.basic) =
-    match desc with Op (Reload | Spill) -> true | _ -> false
+    match desc with
+    | Op (Reload | Spill) -> true
+    | _ -> Proc.is_push_to_stack desc || Proc.is_pop_from_stack desc
 
   let add_instr_id ~seen_ids ~context id =
     if Hashtbl.mem seen_ids id
@@ -1009,6 +1023,8 @@ end
 
 module type Description_value = sig
   val description : Description.t
+
+  val push_pop_slots : int InstructionId.Tbl.t
 end
 
 let print_reg_as_loc ppf reg =
@@ -1209,12 +1225,41 @@ module Transfer (Desc_val : Description_value) :
           ~loc_arg:(Location.of_regs_exn loc_instr.arg)
           equations)
 
+  let push_pop_slots = Desc_val.push_pop_slots
+
+  let rename_push_pop_location equations ~instr =
+    match InstructionId.Tbl.find_opt push_pop_slots instr.id with
+    | None ->
+      Regalloc_utils.fatal "Push/pop instruction no. %a has no assigned slot"
+        InstructionId.format instr.id
+    | Some slot ->
+      let push_loc = Location.push_stack ~index:slot in
+      if Proc.is_push_to_stack instr.desc
+      then begin
+        assert (Array.length instr.arg = 1);
+        assert (Array.length instr.res = 0);
+        Equation_set.rename_loc
+          ~arg:(Location.of_reg_exn instr.arg.(0))
+          ~res:push_loc equations
+      end
+      else begin
+        assert (Array.length instr.arg = 0);
+        assert (Array.length instr.res = 1);
+        Equation_set.rename_loc ~arg:push_loc
+          ~res:(Location.of_reg_exn instr.res.(0))
+          equations
+      end
+
   let basic t instr () : (domain, error) result =
     match Description.find_basic description instr with
     | None -> (
       match instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
+      | _
+        when Proc.is_push_to_stack instr.desc
+             || Proc.is_pop_from_stack instr.desc ->
+        Result.ok @@ rename_push_pop_location t ~instr
       | _ ->
         Regalloc_utils.fatal
           "Regalloc_validate.basic: added instruction no. %a must be Spill, \
@@ -1420,7 +1465,51 @@ let verify_entrypoint (equations : Equation_set.t) (desc : Description.t)
   |> Result.map_error (fun message : Error.At_entrypoint.t ->
       { message; equations; reg_fun_args; loc_fun_args })
 
-let test (desc : Description.t) (cfg : Cfg_with_layout.t) :
+let compute_push_pop_slots (cfg : Cfg.t) : int InstructionId.Tbl.t =
+  let blocks = Label.Tbl.create 8 in
+  let slots = InstructionId.Tbl.create 16 in
+  Label.Tbl.replace blocks (Cfg.entry_label cfg) 0;
+  Cfg.iter_blocks_dfs cfg ~f:(fun label block ->
+      let next_slot =
+        ref
+          (match Label.Tbl.find_opt blocks label with Some s -> s | None -> 0)
+      in
+      DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+          if Proc.is_push_to_stack instr.desc
+          then begin
+            InstructionId.Tbl.replace slots instr.id !next_slot;
+            incr next_slot
+          end
+          else if Proc.is_pop_from_stack instr.desc
+          then begin
+            decr next_slot;
+            if !next_slot < 0
+            then
+              Regalloc_utils.fatal
+                "Push/pop stack underflow at instruction %a in block %a"
+                InstructionId.format instr.id Label.format label;
+            InstructionId.Tbl.replace slots instr.id !next_slot
+          end);
+      let set_successor_slot succ_label slot =
+        match Label.Tbl.find_opt blocks succ_label with
+        | None -> Label.Tbl.replace blocks succ_label slot
+        | Some existing ->
+          if existing <> slot
+          then
+            Regalloc_utils.fatal
+              "Push/pop slot mismatch at block %a: successor %a has slot %d \
+               but expected %d"
+              Label.format label Label.format succ_label existing slot
+      in
+      Label.Set.iter
+        (fun succ -> set_successor_slot succ !next_slot)
+        (Cfg.successor_labels ~normal:true ~exn:false block);
+      Label.Set.iter
+        (fun succ -> set_successor_slot succ 0)
+        (Cfg.successor_labels ~normal:false ~exn:true block));
+  slots
+
+let test (desc : Description.t) ~push_pop_slots (cfg : Cfg_with_layout.t) :
     (Cfg_with_layout.t, Error.t) Result.t =
   if Lazy.force Regalloc_utils.validator_debug
   then
@@ -1436,6 +1525,8 @@ let test (desc : Description.t) (cfg : Cfg_with_layout.t) :
   Description.verify desc cfg;
   let module Check_backwards = Check_backwards (struct
     let description = desc
+
+    let push_pop_slots = push_pop_slots
   end) in
   let res_instr, res_block, result =
     match
@@ -1478,6 +1569,7 @@ let run desc cfg_with_infos =
   match desc with
   | None -> cfg_with_infos
   | Some desc -> (
-    match test desc cfg with
+    let push_pop_slots = compute_push_pop_slots (Cfg_with_layout.cfg cfg) in
+    match test desc ~push_pop_slots cfg with
     | Ok _ -> cfg_with_infos
     | Error error -> Regalloc_utils.fatal "%a%!" Error.dump error)

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -552,10 +552,14 @@ end = struct
          register allocation specific instruction"
         InstructionId.format id
     | None, false -> (
-      match instr.desc with
+      match[@ocaml.warning "-4"] instr.desc with
       | Op Move ->
         (* A move instruction, while no regalloc-specific, can be inserted
            because of phi moves in split/rename. *)
+        successor_id
+      | Op (Specific _) ->
+        (* Specific instructions (including push/pop) may be inserted by the
+           push-pop-around-calls optimization. *)
         successor_id
       | _ ->
         Regalloc_utils.fatal
@@ -1212,9 +1216,13 @@ module Transfer (Desc_val : Description_value) :
   let basic t instr () : (domain, error) result =
     match Description.find_basic description instr with
     | None -> (
-      match instr.desc with
+      match[@ocaml.warning "-4"] instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
+      | Op (Specific _) ->
+        (* Specific instructions (including push/pop) may be inserted by the
+           push-pop-around-calls optimization. *)
+        Result.ok t
       | _ ->
         Regalloc_utils.fatal
           "Regalloc_validate.basic: added instruction no. %a must be Spill, \

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -163,7 +163,7 @@ end = struct
   let print typ ppf t =
     match t with
     | Push_stack { index } -> Format.fprintf ppf "push_stack[%d]" index
-    | _ ->
+    | Reg _ | Stack _ ->
       Printreg.loc ~unknown:(fun _ -> assert false) ppf (to_loc_lossy t) typ
 
   let compare (t1 : t) (t2 : t) : int =
@@ -390,7 +390,27 @@ end = struct
   let is_regalloc_specific_basic (desc : Cfg.basic) =
     match desc with
     | Op (Reload | Spill) -> true
-    | _ -> Proc.is_push_to_stack desc || Proc.is_pop_from_stack desc
+    | Op (Specific _) ->
+      Proc.is_push_to_stack desc || Proc.is_pop_from_stack desc
+    | Op
+        ( Operation.Move | Operation.Const_int _ | Operation.Const_float32 _
+        | Operation.Const_float _ | Operation.Const_symbol _
+        | Operation.Const_vec128 _ | Operation.Const_vec256 _
+        | Operation.Const_vec512 _ | Operation.Stackoffset _ | Operation.Load _
+        | Operation.Store (_, _, _)
+        | Operation.Intop _ | Operation.Int128op _
+        | Operation.Intop_imm (_, _)
+        | Operation.Intop_atomic _
+        | Operation.Floatop (_, _)
+        | Operation.Csel _ | Operation.Reinterpret_cast _
+        | Operation.Static_cast _ | Operation.Probe_is_enabled _
+        | Operation.Opaque | Operation.Begin_region | Operation.End_region
+        | Operation.Name_for_debugger _ | Operation.Dls_get | Operation.Tls_get
+        | Operation.Domain_index | Operation.Poll | Operation.Pause
+        | Operation.Alloc _ )
+    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+    | Stack_check _ ->
+      false
 
   let add_instr_id ~seen_ids ~context id =
     if Hashtbl.mem seen_ids id
@@ -1504,9 +1524,7 @@ let compute_push_pop_slots (cfg : Cfg.t) : int InstructionId.Tbl.t =
       Label.Set.iter
         (fun succ -> set_successor_slot succ !next_slot)
         (Cfg.successor_labels ~normal:true ~exn:false block);
-      Label.Set.iter
-        (fun succ -> set_successor_slot succ 0)
-        (Cfg.successor_labels ~normal:false ~exn:true block));
+      Option.iter (fun succ -> set_successor_slot succ 0) block.exn);
   slots
 
 let test (desc : Description.t) ~push_pop_slots (cfg : Cfg_with_layout.t) :

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -552,14 +552,10 @@ end = struct
          register allocation specific instruction"
         InstructionId.format id
     | None, false -> (
-      match[@ocaml.warning "-4"] instr.desc with
+      match instr.desc with
       | Op Move ->
         (* A move instruction, while no regalloc-specific, can be inserted
            because of phi moves in split/rename. *)
-        successor_id
-      | Op (Specific _) ->
-        (* Specific instructions (including push/pop) may be inserted by the
-           push-pop-around-calls optimization. *)
         successor_id
       | _ ->
         Regalloc_utils.fatal
@@ -1216,13 +1212,9 @@ module Transfer (Desc_val : Description_value) :
   let basic t instr () : (domain, error) result =
     match Description.find_basic description instr with
     | None -> (
-      match[@ocaml.warning "-4"] instr.desc with
+      match instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
-      | Op (Specific _) ->
-        (* Specific instructions (including push/pop) may be inserted by the
-           push-pop-around-calls optimization. *)
-        Result.ok t
       | _ ->
         Regalloc_utils.fatal
           "Regalloc_validate.basic: added instruction no. %a must be Spill, \

--- a/backend/regalloc/regalloc_validate.mli
+++ b/backend/regalloc/regalloc_validate.mli
@@ -13,6 +13,9 @@ module Error : sig
 end
 
 val test :
-  Description.t -> Cfg_with_layout.t -> (Cfg_with_layout.t, Error.t) Result.t
+  Description.t ->
+  push_pop_slots:int InstructionId.Tbl.t ->
+  Cfg_with_layout.t ->
+  (Cfg_with_layout.t, Error.t) Result.t
 
 val run : Description.t option -> Cfg_with_infos.t -> Cfg_with_infos.t

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -128,6 +128,16 @@ let mk_no_x86_peephole_combine_add_rsp f =
     Arg.Unit f,
     " Disable x86 peephole: combine adjacent add rsp" )
 
+let mk_cfg_push_pop_around_calls f =
+  ( "-cfg-push-pop-around-calls",
+    Arg.Unit f,
+    " Use push/pop for spills around calls" )
+
+let mk_no_cfg_push_pop_around_calls f =
+  ( "-no-cfg-push-pop-around-calls",
+    Arg.Unit f,
+    " Do not use push/pop for spills around calls (default)" )
+
 let mk_cfg_cse_optimize f =
   ("-cfg-cse-optimize", Arg.Unit f, " Apply CSE optimizations to CFG")
 
@@ -1288,6 +1298,8 @@ module type Oxcaml_options = sig
   val no_x86_peephole_remove_mov_to_dead_register : unit -> unit
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
+  val cfg_push_pop_around_calls : unit -> unit
+  val no_cfg_push_pop_around_calls : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit
@@ -1474,6 +1486,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_x86_peephole_remove_redundant_cmp
         F.no_x86_peephole_remove_redundant_cmp;
       mk_no_x86_peephole_combine_add_rsp F.no_x86_peephole_combine_add_rsp;
+      mk_cfg_push_pop_around_calls F.cfg_push_pop_around_calls;
+      mk_no_cfg_push_pop_around_calls F.no_cfg_push_pop_around_calls;
       mk_cfg_stack_checks F.cfg_stack_checks;
       mk_no_cfg_stack_checks F.no_cfg_stack_checks;
       mk_cfg_stack_checks_threshold F.cfg_stack_checks_threshold;
@@ -1798,6 +1812,11 @@ module Oxcaml_options_impl = struct
 
   let no_x86_peephole_combine_add_rsp =
     clear' Oxcaml_flags.x86_peephole_combine_add_rsp
+
+  let cfg_push_pop_around_calls = set' Oxcaml_flags.cfg_push_pop_around_calls
+
+  let no_cfg_push_pop_around_calls =
+    clear' Oxcaml_flags.cfg_push_pop_around_calls
 
   let cfg_stack_checks = set' Oxcaml_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Oxcaml_flags.cfg_stack_checks
@@ -2388,6 +2407,7 @@ module Extra_params = struct
         set_int' Oxcaml_flags.vectorize_max_block_size
     | "cfg-peephole-optimize" -> set' Oxcaml_flags.cfg_peephole_optimize
     | "x86-peephole-optimize" -> set' Oxcaml_flags.x86_peephole_optimize
+    | "cfg-push-pop-around-calls" -> set' Oxcaml_flags.cfg_push_pop_around_calls
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -48,6 +48,8 @@ module type Oxcaml_options = sig
   val no_x86_peephole_remove_mov_to_dead_register : unit -> unit
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
+  val cfg_push_pop_around_calls : unit -> unit
+  val no_cfg_push_pop_around_calls : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -35,6 +35,8 @@ let x86_peephole_remove_mov_to_dead_register = ref true
 let x86_peephole_remove_redundant_cmp = ref true
 let x86_peephole_combine_add_rsp = ref true
 
+let cfg_push_pop_around_calls = ref true (* -[no-]cfg-push-pop-around-calls *)
+
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -36,6 +36,8 @@ val x86_peephole_remove_mov_to_dead_register : bool ref
 val x86_peephole_remove_redundant_cmp : bool ref
 val x86_peephole_combine_add_rsp : bool ref
 
+val cfg_push_pop_around_calls : bool ref
+
 val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref
 

--- a/dune
+++ b/dune
@@ -205,7 +205,7 @@
   ast_invariants
   depend
   parser_types ; manual update: mli only files asttypes parsetree
-               ;; TYPING
+  ;; TYPING
   ident
   path
   jkind

--- a/dune
+++ b/dune
@@ -205,7 +205,7 @@
   ast_invariants
   depend
   parser_types ; manual update: mli only files asttypes parsetree
-  ;; TYPING
+               ;; TYPING
   ident
   path
   jkind
@@ -660,6 +660,7 @@
   cfg_simplify
   cfg_prologue
   cfg_merge_blocks
+  push_pop_around_calls
   extra_debug
   label
   printcfg

--- a/oxcaml/tests/backend/attributes/grep_dump.ml
+++ b/oxcaml/tests/backend/attributes/grep_dump.ml
@@ -11,11 +11,26 @@ let remove_suffix line =
   | false -> line
   | true -> Str.matched_group 1 line
 
+(* Each [-dcfg] dump is introduced by a "*** <message>" header. The
+   push_pop_around_calls pass emits extra dumps for debugging; skip their
+   contents so they don't show up in the expected output. *)
+let mentions_push_pop =
+  let re = Str.regexp_string "push_pop_around_calls" in
+  fun line ->
+    try
+      ignore (Str.search_forward re line 0);
+      true
+    with Not_found -> false
+
 let () =
   let chan = open_in Sys.argv.(1) in
+  let skip = ref false in
   try
     while true do
       let line = input_line chan in
-      if is_interesting_line line then print_endline (remove_suffix line)
+      if String.starts_with ~prefix:"*** " line
+      then skip := mentions_push_pop line
+      else if (not !skip) && is_interesting_line line
+      then print_endline (remove_suffix line)
     done
   with End_of_file -> close_in_noerr chan

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -221,7 +221,10 @@ let check =
           | Some desc -> desc
         in
         let res =
-          try Regalloc_validate.test desc after
+          try
+            Regalloc_validate.test desc
+              ~push_pop_slots:(InstructionId.Tbl.create 0)
+              after
           with Misc.Fatal_error ->
             Format.printf "fatal exception raised when validating description";
             raise Break_test

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -184,14 +184,14 @@ spill_unspill_loop_movement:
   movq  8(%rsp), %rbx
   cmpq  $11, %rdx
   jle   .L3
-  movq  %rsi, 32(%rsp)
-  movq  %rdi, 16(%rsp)
+  pushq %rsi
+  pushq %rdi
   call  camlTOP9__f_20_23_code@PLT
 .L2:
+  popq  %rdi
+  popq  %rsi
   movq  (%rsp), %rax
   movq  8(%rsp), %rbx
-  movq  16(%rsp), %rdi
-  movq  32(%rsp), %rsi
 .L3:
   incq  %rdi
   cmpq  %rbx, %rdi
@@ -304,18 +304,18 @@ let spill_one_or_two (a : int) (b : int) f =
 ;;
 [%%expect_asm X86_64{|
 spill_one_or_two:
-  subq  $24, %rsp
-  movq  %rax, (%rsp)
-  movq  %rbx, 8(%rsp)
+  subq  $8, %rsp
+  pushq %rax
+  pushq %rbx
   movq  %rdi, %rbx
   movl  $1, %eax
   movq  (%rbx), %rdi
   call  *%rdi
 .L0:
-  movq  (%rsp), %rax
-  movq  8(%rsp), %rbx
+  popq  %rbx
+  popq  %rax
   leaq  -1(%rax,%rbx), %rax
-  addq  $24, %rsp
+  addq  $8, %rsp
   ret
 |}]
 
@@ -424,13 +424,13 @@ let spilled_phi_merge cond callback f a b c d e =
   f a b c d e
 [%%expect_asm X86_64{|
 spilled_phi_merge:
-  subq  $56, %rsp
+  subq  $40, %rsp
   movq  %rax, 8(%rsp)
-  movq  %rbx, 48(%rsp)
+  movq  %rbx, 24(%rsp)
   movq  %rdi, (%rsp)
   movq  %rsi, %rbp
   movq  %rdx, %rbx
-  movq  %rcx, 24(%rsp)
+  movq  %rcx, 16(%rsp)
   movq  %r8, %r12
   movq  %r9, %r13
   movl  $1, %edi
@@ -438,35 +438,37 @@ spilled_phi_merge:
   movq  8(%rsp), %rax
   cmpq  $1, %rax
   je    .L1
-  movq  %r13, 40(%rsp)
-  movq  %r12, 32(%rsp)
-  movq  24(%rsp), %rax
-  movq  %rbx, 16(%rsp)
-  movq  %rbp, 8(%rsp)
-  movq  (%rsp), %rax
+  pushq %r13
+  pushq %r12
+  movq  32(%rsp), %rax
+  pushq %rax
+  pushq %rbx
+  pushq %rbp
+  movq  40(%rsp), %rax
+  pushq %rax
   movl  $1, %eax
-  movq  48(%rsp), %rbx
+  movq  72(%rsp), %rbx
   movq  (%rbx), %rdi
-  movq  48(%rsp), %rbx
+  movq  72(%rsp), %rbx
   call  *%rdi
 .L0:
-  movq  (%rsp), %rax
-  movq  8(%rsp), %rbp
-  movq  16(%rsp), %rbx
-  movq  24(%rsp), %rdi
-  movq  32(%rsp), %r8
-  movq  40(%rsp), %r9
+  popq  %rax
+  popq  %rbp
+  popq  %rbx
+  popq  %rdi
+  popq  %r8
+  popq  %r9
   movq  %rax, (%rsp)
-  movq  %rdi, 24(%rsp)
+  movq  %rdi, 16(%rsp)
   movq  %r8, %r12
   movq  %r9, %r13
 .L1:
   movq  %rbp, %rax
-  movq  24(%rsp), %rdi
+  movq  16(%rsp), %rdi
   movq  %r12, %rsi
   movq  %r13, %rdx
   movq  (%rsp), %rcx
-  addq  $56, %rsp
+  addq  $40, %rsp
   jmp   caml_apply5@PLT
 |}]
 

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -425,22 +425,22 @@ let spilled_phi_merge cond callback f a b c d e =
 [%%expect_asm X86_64{|
 spilled_phi_merge:
   subq  $40, %rsp
-  movq  %rax, 8(%rsp)
+  movq  %rax, 16(%rsp)
   movq  %rbx, 24(%rsp)
   movq  %rdi, (%rsp)
   movq  %rsi, %rbp
   movq  %rdx, %rbx
-  movq  %rcx, 16(%rsp)
+  movq  %rcx, 8(%rsp)
   movq  %r8, %r12
   movq  %r9, %r13
   movl  $1, %edi
   call  caml_sys_time_unboxed@PLT
-  movq  8(%rsp), %rax
+  movq  16(%rsp), %rax
   cmpq  $1, %rax
   je    .L1
   pushq %r13
   pushq %r12
-  movq  32(%rsp), %rax
+  movq  24(%rsp), %rax
   pushq %rax
   pushq %rbx
   pushq %rbp
@@ -459,12 +459,12 @@ spilled_phi_merge:
   popq  %r8
   popq  %r9
   movq  %rax, (%rsp)
-  movq  %rdi, 16(%rsp)
+  movq  %rdi, 8(%rsp)
   movq  %r8, %r12
   movq  %r9, %r13
 .L1:
   movq  %rbp, %rax
-  movq  16(%rsp), %rdi
+  movq  8(%rsp), %rdi
   movq  %r12, %rsi
   movq  %r13, %rdx
   movq  (%rsp), %rcx


### PR DESCRIPTION
## Push/pop around calls on amd64

### Summary

Replace spill/reload pairs adjacent to function calls with push/pop instructions on amd64. Push/pop encodings are significantly shorter than mov-to/from-stack-slot (1-2 bytes vs 4-5 bytes), reducing code size to improve instruction cache utilization.

The optimization runs as a CFG pass in the regalloc rewrite postlude. For each call site, it identifies spill instructions before the call that have matching reload instructions after the call, and converts them to push/pop pairs. This eliminates the dedicated stack slots for those values; the existing `Regalloc_stack_slots.optimize` then removes or merges stack slots.

### Design

- **Architecture-specific**: Push/pop operations are modeled as `Arch.Ipush_to_stack` / `Arch.Ipop_from_stack` (amd64 `specific_operation` variants). On arm64. the optimization does not apply.
- **Pass placement**: Runs inside the regalloc rewrite postlude (just before stack-slot optimization), so that compaction can reclaim the freed slots and the regalloc validator also covers this new transformation.
- **GC root tracking**: Pushed `Val` values are tracked via `pushed_stack_slots` in the emitter so the GC can find them at call sites.
- **Stack slot compaction**: `Regalloc_stack_slots.optimize` now drops slots whose live interval is empty (i.e., became fully unused after push/pop conversion) and clears the location of any remaining dead `Reg.t`s pointing at those slots.
- **Safety guards**: Stops collecting spills across allocations, polls, and other hidden calls. Values live at exception handler entry are excluded. The number of pushes is rounded down to maintain 16-byte stack alignment at the call.
- **Validation**: The regalloc validator runs after the pass and checks the resulting push/pop placement.

### Status

Disabled by default. Enable with `-cfg-push-pop-around-calls`.

### Test plan

- Updated `testsuite/tests/codegen/register_allocation.ml` expected assembly output to reflect push/pop usage and reduced frame sizes.
- The register allocator verifier always checks the push/pop insertion at runtime.