### PR TITLE
Optimization fuel to bisect to the optimization step causing a failure

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -799,9 +799,15 @@ let deferred_actions = ref []
 let defer action =
   deferred_actions := action :: !deferred_actions
 
-let anonymous filename = defer (action_of_file filename)
-let impl filename = defer (ProcessImplementation filename)
-let intf filename = defer (ProcessInterface filename)
+let anonymous filename =
+  Opt_fuel.add_arg filename;
+  defer (action_of_file filename)
+let impl filename =
+  Opt_fuel.add_arg filename;
+  defer (ProcessImplementation filename)
+let intf filename =
+  Opt_fuel.add_arg filename;
+  defer (ProcessInterface filename)
 
 let process_deferred_actions env =
   let final_output_name = !output_name in

--- a/dune
+++ b/dune
@@ -327,6 +327,7 @@
   main_args
   compenv
   compmisc
+  opt_fuel
   makedepend
   compile_common
   instantiator

--- a/tools/fuel_bisect.py
+++ b/tools/fuel_bisect.py
@@ -2,8 +2,8 @@
 """Optimization fuel bisect script.
 
 Subcommands:
-  record              Clean build to record step counts
-  bisect <test_cmd>   Binary search for the critical global step
+  bisect <test_cmd>   Record step counts, then binary search for the
+                      critical global step that causes test_cmd to fail.
   fail <threshold>    Rebuild at threshold with OPT_FUEL_FAIL to identify step
 
 The compiler reads OPT_FUEL_RECORD (path to record file),
@@ -11,7 +11,6 @@ OPT_FUEL_THRESHOLD (global step limit), and OPT_FUEL_FAIL (global step
 at which to fail with a diagnostic). All builds are clean.
 
 Example workflow:
-  python3 tools/fuel_bisect.py record
   python3 tools/fuel_bisect.py bisect /tmp/test_cmd
   python3 tools/fuel_bisect.py fail 42
 """
@@ -69,26 +68,6 @@ def find_file_at_threshold(entries, threshold):
     return None, 0, 0
 
 
-def cmd_record():
-    """Record step counts per compiled file."""
-    print("=== Recording optimization steps ===")
-    if os.path.exists(RECORD_FILE):
-        os.remove(RECORD_FILE)
-
-    clean_build(env={"OPT_FUEL_RECORD": RECORD_FILE})
-    if not os.path.exists(RECORD_FILE):
-        print("ERROR: no record file produced")
-        sys.exit(1)
-
-    entries, total = load_record()
-    print(f"Record: {RECORD_FILE}")
-    print(f"  {len(entries)} files, {total} total steps")
-    for path, count in entries[:10]:
-        print(f"  {count:4d} steps: {os.path.basename(path)}")
-    if len(entries) > 10:
-        print(f"  ... ({len(entries) - 10} more)")
-
-
 def test_threshold(threshold, test_cmd):
     """Clean build at threshold, then run test. Returns True if pass."""
     print(f"\n--- threshold={threshold} ---")
@@ -108,23 +87,36 @@ def test_threshold(threshold, test_cmd):
 
 
 def cmd_bisect(test_cmd):
-    """Binary search for the critical threshold."""
+    """Record steps, then binary search for the critical threshold."""
+    # Record step counts with a full build + test command
+    print("=== Recording optimization steps ===")
+    if os.path.exists(RECORD_FILE):
+        os.remove(RECORD_FILE)
+
+    env = {"OPT_FUEL_RECORD": RECORD_FILE}
+    rc = clean_build(env=env)
+    if rc == 0:
+        rc = run(test_cmd, env=env)
+        if rc == 0:
+            print("Test passes with full optimization. Nothing to bisect.")
+            sys.exit(0)
+        else:
+            print("Build FAILS with full optimization. Bisecting...")
+    else:
+        print("Build FAILS with full optimization. Bisecting...")
+
     if not os.path.exists(RECORD_FILE):
-        print("ERROR: record file not found. Run 'record' first.")
+        print("ERROR: no record file produced")
         sys.exit(1)
 
     entries, total = load_record()
     print(f"=== Bisecting {total} steps across {len(entries)} files ===")
     print(f"Test: {test_cmd}")
 
-    # Verify endpoints
+    # Verify threshold=0 passes
     if not test_threshold(0, test_cmd):
         print("ERROR: fails with no optimization. Bug is elsewhere.")
         sys.exit(1)
-
-    if test_threshold(total, test_cmd):
-        print("Passes with full optimization. Nothing to bisect.")
-        sys.exit(0)
 
     # Binary search: lo passes, hi fails
     lo, hi = 0, total
@@ -173,14 +165,11 @@ def main():
         sys.exit(1)
 
     cmd = sys.argv[1]
-    if cmd == "record":
-        cmd_record()
-    elif cmd == "bisect":
-        test_cmd = sys.argv[2] if len(sys.argv) > 2 else None
-        if test_cmd is None:
+    if cmd == "bisect":
+        if len(sys.argv) < 3:
             print("Usage: fuel_bisect.py bisect <test_cmd>")
             sys.exit(1)
-        cmd_bisect(test_cmd)
+        cmd_bisect(sys.argv[2])
     elif cmd == "fail":
         if len(sys.argv) < 3:
             print("Usage: fuel_bisect.py fail <threshold>")

--- a/tools/fuel_bisect.py
+++ b/tools/fuel_bisect.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Optimization fuel bisect script.
+
+Subcommands:
+  record              Clean build to record step counts
+  bisect <test_cmd>   Binary search for the critical global step
+  fail <threshold>    Rebuild at threshold with OPT_FUEL_FAIL to identify step
+
+The compiler reads OPT_FUEL_RECORD (path to record file),
+OPT_FUEL_THRESHOLD (global step limit), and OPT_FUEL_FAIL (global step
+at which to fail with a diagnostic). All builds are clean.
+
+Example workflow:
+  python3 tools/fuel_bisect.py record
+  python3 tools/fuel_bisect.py bisect /tmp/test_cmd
+  python3 tools/fuel_bisect.py fail 42
+"""
+
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RECORD_FILE = os.path.join(REPO, "opt_fuel_record.txt")
+
+
+def run(cmd, env=None, check=True, timeout=None):
+    """Run a shell command in the repo root."""
+    merged = dict(os.environ)
+    if env:
+        merged.update(env)
+    env_prefix = ""
+    if env:
+        env_prefix = " ".join(f"{k}={v}" for k, v in env.items()) + " "
+    print(f"  $ {env_prefix}{cmd}", flush=True)
+    result = subprocess.run(
+        cmd, shell=True, cwd=REPO, env=merged, timeout=timeout,
+    )
+    if check and result.returncode != 0:
+        print(f"  -> exit {result.returncode}")
+    return result.returncode
+
+
+def clean_build(env=None, target="install"):
+    """Clean and rebuild."""
+    run("make -s clean", check=False, env=env)
+    return run(f"make -s {target}", env=env)
+
+
+def load_record():
+    """Load record file. Returns list of (file, count) and total."""
+    entries = []
+    with open(RECORD_FILE) as f:
+        for line in f:
+            parts = line.strip().rsplit(" ", 1)
+            if len(parts) == 2:
+                entries.append((parts[0], int(parts[1])))
+    total = sum(c for _, c in entries)
+    return entries, total
+
+
+def find_file_at_threshold(entries, threshold):
+    """Find which file contains the given global step."""
+    offset = 0
+    for file_path, count in entries:
+        if offset < threshold <= offset + count:
+            return file_path, threshold - offset, count
+        offset += count
+    return None, 0, 0
+
+
+def cmd_record():
+    """Record step counts per compiled file."""
+    print("=== Recording optimization steps ===")
+    if os.path.exists(RECORD_FILE):
+        os.remove(RECORD_FILE)
+
+    rc = clean_build(env={"OPT_FUEL_RECORD": RECORD_FILE})
+    if rc != 0:
+        print("ERROR: build failed during recording")
+        sys.exit(1)
+
+    if not os.path.exists(RECORD_FILE):
+        print("ERROR: no record file produced")
+        sys.exit(1)
+
+    entries, total = load_record()
+    print(f"Record: {RECORD_FILE}")
+    print(f"  {len(entries)} files, {total} total steps")
+    for path, count in entries[:10]:
+        print(f"  {count:4d} steps: {os.path.basename(path)}")
+    if len(entries) > 10:
+        print(f"  ... ({len(entries) - 10} more)")
+
+
+def test_threshold(threshold, test_cmd):
+    """Clean build at threshold, then run test. Returns True if pass."""
+    print(f"\n--- threshold={threshold} ---")
+    env = {
+        "OPT_FUEL_RECORD": RECORD_FILE,
+        "OPT_FUEL_THRESHOLD": str(threshold),
+    }
+    rc = clean_build(env=env)
+    if rc != 0:
+        print(f"  Build FAILED at threshold={threshold}")
+        return False
+
+    rc = run(test_cmd, env=env)
+    passed = rc == 0
+    print(f"  -> {'PASS' if passed else 'FAIL'}")
+    return passed
+
+
+def cmd_bisect(test_cmd):
+    """Binary search for the critical threshold."""
+    if not os.path.exists(RECORD_FILE):
+        print("ERROR: record file not found. Run 'record' first.")
+        sys.exit(1)
+
+    entries, total = load_record()
+    print(f"=== Bisecting {total} steps across {len(entries)} files ===")
+    print(f"Test: {test_cmd}")
+
+    # Verify endpoints
+    if not test_threshold(0, test_cmd):
+        print("ERROR: fails with no optimization. Bug is elsewhere.")
+        sys.exit(1)
+
+    if test_threshold(total, test_cmd):
+        print("Passes with full optimization. Nothing to bisect.")
+        sys.exit(0)
+
+    # Binary search: lo passes, hi fails
+    lo, hi = 0, total
+
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if test_threshold(mid, test_cmd):
+            lo = mid
+        else:
+            hi = mid
+
+    print(f"\n=== RESULT ===")
+    print(f"Critical threshold: {hi}")
+    print(f"  threshold={lo} PASS, threshold={hi} FAIL")
+
+    file_path, local_step, file_total = find_file_at_threshold(
+        entries, hi
+    )
+    if file_path:
+        print(f"  File: {file_path}")
+        print(f"  Local step: {local_step} of {file_total}")
+
+    print(f"\nTo identify: python3 {sys.argv[0]} fail {hi}")
+    return hi
+
+
+def cmd_fail(threshold):
+    """Rebuild with OPT_FUEL_FAIL to get exact location."""
+    print(f"=== Identifying critical step at threshold={threshold} ===")
+    env = {
+        "OPT_FUEL_RECORD": RECORD_FILE,
+        "OPT_FUEL_THRESHOLD": str(threshold),
+        "OPT_FUEL_FAIL": str(threshold - 1),
+    }
+    rc = clean_build(env=env)
+    if rc == 0:
+        print(
+            "Build succeeded. The critical step doesn't cause a build "
+            "failure."
+        )
+        print("Try running the test manually:")
+        print(
+            f"  OPT_FUEL_RECORD={RECORD_FILE} "
+            f"OPT_FUEL_THRESHOLD={threshold} "
+            f"OPT_FUEL_FAIL={threshold - 1} <test>"
+        )
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    if cmd == "record":
+        cmd_record()
+    elif cmd == "bisect":
+        test_cmd = sys.argv[2] if len(sys.argv) > 2 else None
+        if test_cmd is None:
+            print("Usage: fuel_bisect.py bisect <test_cmd>")
+            sys.exit(1)
+        cmd_bisect(test_cmd)
+    elif cmd == "fail":
+        if len(sys.argv) < 3:
+            print("Usage: fuel_bisect.py fail <threshold>")
+            sys.exit(1)
+        cmd_fail(int(sys.argv[2]))
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fuel_bisect.py
+++ b/tools/fuel_bisect.py
@@ -53,8 +53,8 @@ def load_record():
     with open(RECORD_FILE) as f:
         for line in f:
             parts = line.strip().rsplit(" ", 1)
-            if len(parts) == 2:
-                entries.append((parts[0], int(parts[1])))
+            assert len(parts) == 2
+            entries.append((parts[0], int(parts[1])))
     total = sum(c for _, c in entries)
     return entries, total
 
@@ -75,11 +75,7 @@ def cmd_record():
     if os.path.exists(RECORD_FILE):
         os.remove(RECORD_FILE)
 
-    rc = clean_build(env={"OPT_FUEL_RECORD": RECORD_FILE})
-    if rc != 0:
-        print("ERROR: build failed during recording")
-        sys.exit(1)
-
+    clean_build(env={"OPT_FUEL_RECORD": RECORD_FILE})
     if not os.path.exists(RECORD_FILE):
         print("ERROR: no record file produced")
         sys.exit(1)
@@ -134,6 +130,7 @@ def cmd_bisect(test_cmd):
     lo, hi = 0, total
 
     while hi - lo > 1:
+        print(f"=== Bisecting: step range {lo} - {hi} ===")
         mid = (lo + hi) // 2
         if test_threshold(mid, test_cmd):
             lo = mid
@@ -160,20 +157,13 @@ def cmd_fail(threshold):
     print(f"=== Identifying critical step at threshold={threshold} ===")
     env = {
         "OPT_FUEL_RECORD": RECORD_FILE,
-        "OPT_FUEL_THRESHOLD": str(threshold),
-        "OPT_FUEL_FAIL": str(threshold - 1),
+        "OPT_FUEL_FAIL": str(threshold),
     }
     rc = clean_build(env=env)
     if rc == 0:
         print(
             "Build succeeded. The critical step doesn't cause a build "
             "failure."
-        )
-        print("Try running the test manually:")
-        print(
-            f"  OPT_FUEL_RECORD={RECORD_FILE} "
-            f"OPT_FUEL_THRESHOLD={threshold} "
-            f"OPT_FUEL_FAIL={threshold - 1} <test>"
         )
 
 

--- a/tools/fuel_bisect.py
+++ b/tools/fuel_bisect.py
@@ -8,7 +8,7 @@ Subcommands:
 
 The compiler reads OPT_FUEL_RECORD (path to record file),
 OPT_FUEL_THRESHOLD (global step limit), and OPT_FUEL_FAIL (global step
-at which to fail with a diagnostic). All builds are clean.
+at which to fail with a diagnostic).
 
 Example workflow:
   python3 tools/fuel_bisect.py bisect /tmp/test_cmd
@@ -76,6 +76,12 @@ def load_record():
             assert len(parts) == 2
             entries.append((parts[0], int(parts[1])))
     total = sum(c for _, c in entries)
+    seen = set()
+    for file_path, _ in entries:
+        if file_path in seen:
+            print(f"ERROR: duplicate file in record: {file_path}")
+            sys.exit(1)
+        seen.add(file_path)
     return entries, total
 
 

--- a/tools/fuel_bisect.py
+++ b/tools/fuel_bisect.py
@@ -46,6 +46,27 @@ def clean_build(env=None, target="install"):
     return run(f"make -s {target}", env=env)
 
 
+def dedup_record():
+    """Merge duplicate file entries, keeping first occurrence order with max count."""
+    entries = []
+    seen = {}
+    with open(RECORD_FILE) as f:
+        for line in f:
+            parts = line.strip().rsplit(" ", 1)
+            assert len(parts) == 2
+            path, count = parts[0], int(parts[1])
+            if path in seen:
+                idx = seen[path]
+                entries[idx] = (path, max(entries[idx][1], count))
+            else:
+                seen[path] = len(entries)
+                entries.append((path, count))
+    with open(RECORD_FILE, "w") as f:
+        for path, count in entries:
+            f.write(f"{path} {count}\n")
+    return entries
+
+
 def load_record():
     """Load record file. Returns list of (file, count) and total."""
     entries = []
@@ -109,6 +130,7 @@ def cmd_bisect(test_cmd):
         print("ERROR: no record file produced")
         sys.exit(1)
 
+    dedup_record()
     entries, total = load_record()
     print(f"=== Bisecting {total} steps across {len(entries)} files ===")
     print(f"Test: {test_cmd}")

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -18,3 +18,5 @@ priority_queue.ml
 priority_queue.mli
 structured_mangling.ml
 structured_mangling.mli
+opt_fuel.ml
+opt_fuel.mli

--- a/utils/dune
+++ b/utils/dune
@@ -65,7 +65,7 @@
    (:include %{project_root}/ocamlopt_flags.sexp)
    -O3))
  (libraries ocamlcommon)
- (modules doubly_linked_list file_sections lru opt_fuel))
+ (modules doubly_linked_list file_sections lru))
 
 (install
  (files

--- a/utils/dune
+++ b/utils/dune
@@ -65,7 +65,7 @@
    (:include %{project_root}/ocamlopt_flags.sexp)
    -O3))
  (libraries ocamlcommon)
- (modules doubly_linked_list file_sections lru))
+ (modules doubly_linked_list file_sections lru opt_fuel))
 
 (install
  (files

--- a/utils/opt_fuel.ml
+++ b/utils/opt_fuel.ml
@@ -2,13 +2,13 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                    Tobias Tebbi, Jane Street Europe                     *)
+(*                    Tobias Tebbi, Jane Street Europe                    *)
 (*                                                                        *)
 (*   Copyright 2025 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.           *)
+(*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
 
@@ -24,99 +24,103 @@ let fail_thresh =
   | Some s -> ( try Some (int_of_string s) with _ -> None)
   | None -> None
 
-let output_prefix = ref ""
+let recording =
+  match record_path, threshold, fail_thresh with
+  | Some _, None, None -> true
+  | _ -> false
 
-let make_absolute path =
-  if Filename.is_relative path
-  then Filename.concat (Sys.getcwd ()) path
-  else path
+let reading_record = Option.is_some threshold || Option.is_some fail_thresh
 
-let file_id =
-  lazy
-    (if String.length !output_prefix > 0
-     then make_absolute !output_prefix
-     else make_absolute !Location.input_name)
+let file_id = ref (Sys.getcwd ())
 
 let local_step = ref 0
 
+let add_arg arg =
+  assert (!local_step = 0);
+  file_id := !file_id ^ ":" ^ arg
+
+(* --- Recording --- *)
+
 let flush_record () =
+  if recording && !local_step > 0
+  then (
+    let path = Option.get record_path in
+    let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+    Printf.fprintf oc "%s %d\n" !file_id !local_step;
+    close_out oc;
+    local_step := 0)
+
+let _ = at_exit flush_record
+
+(* --- Reading record for bisect/fail --- *)
+
+let compute_step_range file_id =
   match record_path with
-  | None -> ()
-  | Some path ->
-    if !local_step > 0
-    then (
-      let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
-      Printf.fprintf oc "%s %d\n" (Lazy.force file_id) !local_step;
-      close_out oc)
+  | Some path -> (
+    try
+      let ic = open_in path in
+      let global_offset = ref 0 in
+      let result = ref (0, 0) in
+      (try
+         while true do
+           let line = input_line ic in
+           let line = String.trim line in
+           if String.length line > 0
+           then
+             match String.rindex_opt line ' ' with
+             | Some i -> (
+               let f = String.sub line 0 i in
+               let count_s =
+                 String.sub line (i + 1) (String.length line - i - 1)
+               in
+               match int_of_string_opt count_s with
+               | Some count ->
+                 if String.equal f file_id
+                 then result := !global_offset, !global_offset + count;
+                 global_offset := !global_offset + count
+               | None -> ())
+             | None -> ()
+         done
+       with End_of_file -> ());
+      close_in ic;
+      !result
+    with _ -> 0, 0)
+  | _ -> 0, 0
 
-let register_record_flush =
-  let do_register = lazy (at_exit flush_record) in
-  fun () -> Lazy.force do_register
+let step_range =
+  lazy (if reading_record then compute_step_range !file_id else 0, 0)
 
-(* Scan record file once to find this file's global offset *)
-let step_range : (int * int) Lazy.t =
-  lazy
-    (match record_path with
-    | Some path -> (
-      let file = Lazy.force file_id in
-      try
-        let ic = open_in path in
-        let global_offset = ref 0 in
-        let result = ref (0, 0) in
-        (try
-           while true do
-             let line = input_line ic in
-             let line = String.trim line in
-             if String.length line > 0
-             then
-               match String.rindex_opt line ' ' with
-               | Some i -> (
-                 let f = String.sub line 0 i in
-                 let count_s =
-                   String.sub line (i + 1) (String.length line - i - 1)
-                 in
-                 match int_of_string_opt count_s with
-                 | Some count ->
-                   if String.equal f file
-                   then result := !global_offset, !global_offset + count;
-                   global_offset := !global_offset + count
-                 | None -> ())
-               | None -> ()
-           done
-         with End_of_file -> ());
-        close_in ic;
-        !result
-      with _ -> 0, 0)
-    | _ -> 0, 0)
+(* --- Public API --- *)
 
 let format_message = function Some f -> " (" ^ f () ^ ")" | None -> ""
 
 let should_do_opt_step ?message () : bool =
-  let global_from, global_to = Lazy.force step_range in
-  let step = global_from + !local_step in
-  local_step := !local_step + 1;
-  match record_path, threshold, fail_thresh with
-  | None, None, None -> true
-  | Some _, None, None ->
-    register_record_flush ();
+  if recording
+  then (
     local_step := !local_step + 1;
-    true
-  | Some record_path, Some thresh, None ->
+    true)
+  else if reading_record
+  then begin
+    let global_from, global_to = Lazy.force step_range in
+    let step = global_from + !local_step in
+    local_step := !local_step + 1;
     if step >= global_to
     then
       Misc.fatal_errorf
         "OPT_FUEL: step %d exceeds recorded max %d in %s%s; record file %s may \
          be stale or optimization non-deterministic."
-        step global_to (Lazy.force file_id) (format_message message) record_path;
-    step < thresh
-  | Some record_path, None, Some fail_thresh ->
-    if step = fail_thresh - 1
-    then
-      (* We are at the last step that caused failure with this threshold. *)
-      Misc.fatal_errorf "OPT_FUEL: critical step %d in %s%s" step
-        (Lazy.force file_id) (format_message message);
-    true
-  | _ ->
-    Misc.fatal_error
-      "OPT_FUEL: Either provide OPT_FUEL_RECORD+OPT_FUEL_THRESHOLD or \
-       OPT_FUEL_RECORD+OPT_FUEL_FAIL"
+        step global_to !file_id (format_message message)
+        (Option.get record_path);
+    match threshold, fail_thresh with
+    | Some thresh, None -> step < thresh
+    | None, Some fail_thresh ->
+      if step = fail_thresh - 1
+      then
+        Misc.fatal_errorf "OPT_FUEL: critical step %d in %s%s" step !file_id
+          (format_message message);
+      true
+    | _, _ ->
+      Misc.fatal_error
+        "OPT_FUEL: OPT_FUEL_THRESHOLD and OPT_FUEL_FAIL are mutually exclusive"
+  end
+  else true

--- a/utils/opt_fuel.ml
+++ b/utils/opt_fuel.ml
@@ -1,0 +1,122 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                    Tobias Tebbi, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2025 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.           *)
+(*                                                                        *)
+(**************************************************************************)
+
+let record_path = Sys.getenv_opt "OPT_FUEL_RECORD"
+
+let threshold =
+  match Sys.getenv_opt "OPT_FUEL_THRESHOLD" with
+  | Some s -> ( try Some (int_of_string s) with _ -> None)
+  | None -> None
+
+let fail_thresh =
+  match Sys.getenv_opt "OPT_FUEL_FAIL" with
+  | Some s -> ( try Some (int_of_string s) with _ -> None)
+  | None -> None
+
+let output_prefix = ref ""
+
+let make_absolute path =
+  if Filename.is_relative path
+  then Filename.concat (Sys.getcwd ()) path
+  else path
+
+let file_id =
+  lazy
+    (if String.length !output_prefix > 0
+     then make_absolute !output_prefix
+     else make_absolute !Location.input_name)
+
+let local_step = ref 0
+
+let flush_record () =
+  match record_path with
+  | None -> ()
+  | Some path ->
+    if !local_step > 0
+    then (
+      let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+      Printf.fprintf oc "%s %d\n" (Lazy.force file_id) !local_step;
+      close_out oc)
+
+let register_record_flush =
+  let do_register = lazy (at_exit flush_record) in
+  fun () -> Lazy.force do_register
+
+(* Scan record file once to find this file's global offset *)
+let step_range : (int * int) Lazy.t =
+  lazy
+    (match record_path with
+    | Some path -> (
+      let file = Lazy.force file_id in
+      try
+        let ic = open_in path in
+        let global_offset = ref 0 in
+        let result = ref (0, 0) in
+        (try
+           while true do
+             let line = input_line ic in
+             let line = String.trim line in
+             if String.length line > 0
+             then
+               match String.rindex_opt line ' ' with
+               | Some i -> (
+                 let f = String.sub line 0 i in
+                 let count_s =
+                   String.sub line (i + 1) (String.length line - i - 1)
+                 in
+                 match int_of_string_opt count_s with
+                 | Some count ->
+                   if String.equal f file
+                   then result := !global_offset, !global_offset + count;
+                   global_offset := !global_offset + count
+                 | None -> ())
+               | None -> ()
+           done
+         with End_of_file -> ());
+        close_in ic;
+        !result
+      with _ -> 0, 0)
+    | _ -> 0, 0)
+
+let format_message = function Some f -> " (" ^ f () ^ ")" | None -> ""
+
+let should_do_opt_step ?message () : bool =
+  let global_from, global_to = Lazy.force step_range in
+  let step = global_from + !local_step in
+  local_step := !local_step + 1;
+  match record_path, threshold, fail_thresh with
+  | None, None, None -> true
+  | Some _, None, None ->
+    register_record_flush ();
+    local_step := !local_step + 1;
+    true
+  | Some record_path, Some thresh, None ->
+    if step >= global_to
+    then
+      Misc.fatal_errorf
+        "OPT_FUEL: step %d exceeds recorded max %d in %s%s; record file %s may \
+         be stale or optimization non-deterministic."
+        step global_to (Lazy.force file_id) (format_message message) record_path;
+    step < thresh
+  | Some record_path, None, Some fail_thresh ->
+    if step = fail_thresh - 1
+    then
+      (* We are at the last step that caused failure with this threshold. *)
+      Misc.fatal_errorf "OPT_FUEL: critical step %d in %s%s" step
+        (Lazy.force file_id) (format_message message);
+    true
+  | _ ->
+    Misc.fatal_error
+      "OPT_FUEL: Either provide OPT_FUEL_RECORD+OPT_FUEL_THRESHOLD or \
+       OPT_FUEL_RECORD+OPT_FUEL_FAIL"

--- a/utils/opt_fuel.ml
+++ b/utils/opt_fuel.ml
@@ -1,17 +1,3 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*                    Tobias Tebbi, Jane Street Europe                    *)
-(*                                                                        *)
-(*   Copyright 2025 Jane Street Group LLC                                 *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
-
 let record_path = Sys.getenv_opt "OPT_FUEL_RECORD"
 
 let threshold =
@@ -90,9 +76,9 @@ let compute_step_range file_id =
 let step_range =
   lazy (if reading_record then compute_step_range !file_id else 0, 0)
 
-(* --- Public API --- *)
-
 let format_message = function Some f -> " (" ^ f () ^ ")" | None -> ""
+
+(* --- Public API --- *)
 
 let should_do_opt_step ?message () : bool =
   if recording

--- a/utils/opt_fuel.ml
+++ b/utils/opt_fuel.ml
@@ -17,13 +17,16 @@ let recording =
 
 let reading_record = Option.is_some threshold || Option.is_some fail_thresh
 
-let file_id = ref (Sys.getcwd ())
-
 let local_step = ref 0
+
+let args_reverse = ref []
 
 let add_arg arg =
   assert (!local_step = 0);
-  file_id := !file_id ^ ":" ^ arg
+  args_reverse := arg :: !args_reverse
+
+let file_id () =
+  Sys.getcwd () ^ ":" ^ String.concat ":" (List.rev !args_reverse)
 
 (* --- Recording --- *)
 
@@ -32,7 +35,7 @@ let flush_record () =
   then (
     let path = Option.get record_path in
     let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
-    Printf.fprintf oc "%s %d\n" !file_id !local_step;
+    Printf.fprintf oc "%s %d\n" (file_id ()) !local_step;
     close_out oc;
     local_step := 0)
 
@@ -74,7 +77,7 @@ let compute_step_range file_id =
   | _ -> 0, 0
 
 let step_range =
-  lazy (if reading_record then compute_step_range !file_id else 0, 0)
+  lazy (if reading_record then compute_step_range (file_id ()) else 0, 0)
 
 let format_message = function Some f -> " (" ^ f () ^ ")" | None -> ""
 
@@ -95,14 +98,14 @@ let should_do_opt_step ?message () : bool =
       Misc.fatal_errorf
         "OPT_FUEL: step %d exceeds recorded max %d in %s%s; record file %s may \
          be stale or optimization non-deterministic."
-        step global_to !file_id (format_message message)
+        step global_to (file_id ()) (format_message message)
         (Option.get record_path);
     match threshold, fail_thresh with
     | Some thresh, None -> step < thresh
     | None, Some fail_thresh ->
       if step = fail_thresh - 1
       then
-        Misc.fatal_errorf "OPT_FUEL: critical step %d in %s%s" step !file_id
+        Misc.fatal_errorf "OPT_FUEL: critical step %d in %s%s" step (file_id ())
           (format_message message);
       true
     | _, _ ->

--- a/utils/opt_fuel.mli
+++ b/utils/opt_fuel.mli
@@ -20,9 +20,9 @@
       only apply steps whose global index is below the threshold
     - [OPT_FUEL_FAIL=n]: fail compilation when global step [n] is reached *)
 
-(** [add_arg arg] adds a non-flag command-line argument (e.g. a source file)
-    to the identifier used for this compilation run in the fuel record.
-    All arguments have to be added before should_do_opt_step is called. *)
+(** [add_arg arg] adds a non-flag command-line argument (e.g. a source file) to
+    the identifier used for this compilation run in the fuel record. All
+    arguments have to be added before should_do_opt_step is called. *)
 val add_arg : string -> unit
 
 (** [should_do_opt_step ~message:(fun () -> "...") ()] returns [true] if the

--- a/utils/opt_fuel.mli
+++ b/utils/opt_fuel.mli
@@ -2,13 +2,13 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                    Tobias Tebbi, Jane Street Europe                     *)
+(*                    Tobias Tebbi, Jane Street Europe                    *)
 (*                                                                        *)
 (*   Copyright 2025 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.           *)
+(*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
 
@@ -19,6 +19,11 @@
     - [OPT_FUEL_RECORD=path] + [OPT_FUEL_THRESHOLD=n]: read the record file and
       only apply steps whose global index is below the threshold
     - [OPT_FUEL_FAIL=n]: fail compilation when global step [n] is reached *)
+
+(** [add_arg arg] adds a non-flag command-line argument (e.g. a source file)
+    to the identifier used for this compilation run in the fuel record.
+    All arguments have to be added before should_do_opt_step is called. *)
+val add_arg : string -> unit
 
 (** [should_do_opt_step ~message:(fun () -> "...") ()] returns [true] if the
     current optimization step should be applied. In record mode it always

--- a/utils/opt_fuel.mli
+++ b/utils/opt_fuel.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                    Tobias Tebbi, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2025 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.           *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Optimization fuel for debugging.
+
+    Modes (controlled by environment variables):
+    - [OPT_FUEL_RECORD=path]: record step counts per compiled file
+    - [OPT_FUEL_RECORD=path] + [OPT_FUEL_THRESHOLD=n]: read the record file and
+      only apply steps whose global index is below the threshold
+    - [OPT_FUEL_FAIL=n]: fail compilation when global step [n] is reached *)
+
+(** [should_do_opt_step ~message:(fun () -> "...") ()] returns [true] if the
+    current optimization step should be applied. In record mode it always
+    returns [true] and records the step. In bisect mode it returns [true] only
+    for steps below the global threshold. The [message] closure is only called
+    when OPT_FUEL_FAIL is set and the critical step is reached. *)
+val should_do_opt_step : ?message:(unit -> string) -> unit -> bool

--- a/utils/opt_fuel.mli
+++ b/utils/opt_fuel.mli
@@ -1,17 +1,3 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*                    Tobias Tebbi, Jane Street Europe                    *)
-(*                                                                        *)
-(*   Copyright 2025 Jane Street Group LLC                                 *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
-
 (** Optimization fuel for debugging.
 
     Modes (controlled by environment variables):


### PR DESCRIPTION
## Optimization fuel for bisecting miscompilations

Add optimization fuel infrastructure to help identify which specific optimization step causes a miscompilation. The module is placed in `oxcaml_utils` so it can be used from both the middle end and the backend.

### How it works

When suspecting an optimization from causing miscompilation, use `Opt_fuel.should_do_opt_step ()` at every step to ask whether it should apply a given optimization. The behavior is controlled by three environment variables:

- `OPT_FUEL_RECORD=path` — Record mode. Every step is applied, and at exit the compiler appends `<file> <count>` to the record file. A clean build produces a record of all optimization steps across the whole build.
- `OPT_FUEL_RECORD=path OPT_FUEL_THRESHOLD=n` — Bisect mode. The record file is read to compute a global step index per file. Only steps with global index < n are applied. This lets you binary search for the critical step.
- `OPT_FUEL_RECORD=path OPT_FUEL_FAIL=n` — Fail mode. Compilation fails with a diagnostic when global step n is reached, identifying the exact file, function, and optimization being applied.

### Bisect workflow

\```
python3 tools/fuel_bisect.py record
python3 tools/fuel_bisect.py bisect /path/to/test_script
python3 tools/fuel_bisect.py fail <threshold>
\```

The `bisect` subcommand does a binary search over the global step space, doing a clean build at each probe point and running the test script. The `fail` subcommand rebuilds with `OPT_FUEL_FAIL` set to identify the critical step.

### Files

- `utils/opt_fuel.ml{,i}` — The fuel module (in `oxcaml_utils` library)
- `tools/fuel_bisect.py` — Bisect driver script