### PR TITLE
Use information about leaf functions to determine which registers are clobbered

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -295,13 +295,106 @@ let cfg_block_counters (block : Cfg.basic_block) =
   |> Profile.Counters.set "block" 1
   |> Profile.Counters.set "move" moves
 
+(* Estimate the reduction in register saves at a direct call to [callee_name],
+   computed from pre-allocation liveness.
+
+   For each register class c: R_c = available registers in class c K_c =
+   available registers in class c actually clobbered by the callee L_c = values
+   of class c live across this call (from pre-allocation liveness)
+
+   With the current calling convention, an optimizing allocator must save all
+   L_c live values (it must assume any register in the class might be
+   clobbered). With an improved convention using the callee's actual clobber
+   set, it can keep up to (R_c - K_c) values in safe (non-clobbered) registers,
+   and must only spill max(0, L_c - (R_c - K_c)) values.
+
+   Savings per class = L_c - max(0, L_c - (R_c - K_c)) = min(L_c, R_c - K_c).
+   Total savings = sum over all classes of min(L_c, max(0, R_c - K_c)). *)
+let callee_regs_savings_at_call (liveness : Cfg_with_infos.liveness)
+    (term : Cfg.terminator Cfg.instruction) callee_name =
+  let current_unit_info =
+    (Compilenv.current_unit_infos ()).ui_callee_regs_info
+  in
+  let callee_info =
+    match Callee_regs_info.get_value current_unit_info callee_name with
+    | Some _ as v -> v
+    | None ->
+      Callee_regs_info.get_value Compilenv.cached_callee_regs_info callee_name
+  in
+  match callee_info with
+  | None -> 0, 0
+  | Some callee_clobbers ->
+    let live_across =
+      match InstructionId.Tbl.find_opt liveness term.id with
+      | None -> Reg.Set.empty
+      | Some { Cfg_liveness.across; _ } -> across
+    in
+    let num_classes = List.length Regs.Reg_class.all in
+    let live_counts = Array.make num_classes 0 in
+    (* Only count virtual (unassigned) registers; pinned physical registers are
+       not subject to the allocator's placement choices. *)
+    Reg.Set.iter
+      (fun (reg : Reg.t) ->
+        match reg.loc with
+        | Reg.Unknown ->
+          let cls = Regs.Reg_class.of_machtype reg.typ in
+          let cls_idx = Regs.Reg_class.hash cls in
+          live_counts.(cls_idx) <- live_counts.(cls_idx) + 1
+        | Reg.Reg _ | Reg.Stack _ -> ())
+      live_across;
+    let savings =
+      List.fold_left
+        (fun acc cls ->
+          let cls_idx = Regs.Reg_class.hash cls in
+          let available = Regs.available_registers cls in
+          let k_c =
+            Array.fold_left
+              (fun n phys_reg ->
+                let bit = Regs.index_in_class phys_reg in
+                if callee_clobbers.(cls_idx) land (1 lsl bit) <> 0
+                then n + 1
+                else n)
+              0 available
+          in
+          let r_c = Array.length available in
+          let l_c = live_counts.(cls_idx) in
+          acc + Int.min l_c (Int.max 0 (r_c - k_c)))
+        0 Regs.Reg_class.all
+    in
+    let live = Array.fold_left ( + ) 0 live_counts in
+    savings, live
+
+let count_callee_regs_savings (cfg_with_infos : Cfg_with_infos.t) =
+  let cfg = Cfg_with_infos.cfg cfg_with_infos in
+  let liveness = Cfg_with_infos.liveness cfg_with_infos in
+  Cfg.fold_blocks cfg ~init:(0, 0)
+    ~f:(fun _label block (acc_savings, acc_live) ->
+      match block.Cfg.terminator.desc with
+      | Call { op = Direct sym; _ } ->
+        let savings, live =
+          callee_regs_savings_at_call liveness block.Cfg.terminator sym.sym_name
+        in
+        acc_savings + savings, acc_live + live
+      | _ -> acc_savings, acc_live)
+
+(* Hold the savings and live-set estimates for the function currently being
+   compiled. Set just before the register allocator (while [Cfg_with_infos.t] is
+   in scope and pre-allocation liveness is available), then read back by
+   [whole_cfg_counters] for every subsequent profiled pass. *)
+let callee_regs_savings_estimate = ref 0
+
+let callee_regs_live_estimate = ref 0
+
 (** Returns all CFG counters that require the whole CFG to produce a count. *)
 let whole_cfg_counters (cfg : Cfg.t) =
   let stack_slots =
     Stack_class.Tbl.fold cfg.fun_num_stack_slots ~init:0
       ~f:(fun _stack_class num acc -> num + acc)
   in
-  Profile.Counters.create () |> Profile.Counters.set "stack_slot" stack_slots
+  Profile.Counters.create ()
+  |> Profile.Counters.set "stack_slot" stack_slots
+  |> Profile.Counters.set "callee_regs_savings" !callee_regs_savings_estimate
+  |> Profile.Counters.set "callee_regs_live" !callee_regs_live_estimate
 
 let cfg_profile to_cfg =
   let total_counters = ref (Profile.Counters.create ()) in
@@ -416,6 +509,11 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg_cse
   ++ Cfg_with_infos.make
   ++ cfg_with_infos_profile ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
+  ++ (fun (cfg_with_infos : Cfg_with_infos.t) ->
+  let savings, live = count_callee_regs_savings cfg_with_infos in
+  callee_regs_savings_estimate := savings;
+  callee_regs_live_estimate := live;
+  cfg_with_infos)
   ++ save_cfg_before_regalloc
   ++ Profile.record ~accumulate:true "regalloc" (fun cfg_with_infos ->
       let cfg_description =

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -425,9 +425,6 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
       cfg_with_infos ++ register_allocator fd_cmm
       ++ cfg_with_infos_profile ~accumulate:true "cfg_validate_description"
            (Regalloc_validate.run cfg_description))
-  ++ (fun cfg_with_infos ->
-  Callee_regs_collector.cfg cfg_with_infos;
-  cfg_with_infos)
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue_validate"
        Cfg_prologue.validate
@@ -461,6 +458,9 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
     (Cfg_with_layout.cfg cfg_with_layout).allowed_to_be_irreducible <- true;
     cfg_with_layout_profile ~accumulate:true "cfg_simplify"
       Regalloc_utils.simplify_cfg cfg_with_layout)
+  ++ (fun cfg_with_layout ->
+  Callee_regs_collector.cfg cfg_with_layout;
+  cfg_with_layout)
   ++ cfg_with_layout_profile ~accumulate:true "save_cfg" save_cfg
   ++ cfg_with_layout_profile ~accumulate:true "cfg_reorder_blocks"
        (reorder_blocks_random ppf_dump)

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -425,6 +425,9 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
       cfg_with_infos ++ register_allocator fd_cmm
       ++ cfg_with_infos_profile ~accumulate:true "cfg_validate_description"
            (Regalloc_validate.run cfg_description))
+  ++ (fun cfg_with_infos ->
+  Callee_regs_collector.cfg cfg_with_infos;
+  cfg_with_infos)
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue_validate"
        Cfg_prologue.validate

--- a/asmcomp/cm_bundle.ml
+++ b/asmcomp/cm_bundle.ml
@@ -111,6 +111,8 @@ let cmx_bundle ~quoted_globals =
           uir_generic_fns = info.ui_generic_fns;
           uir_export_info = raw_export_info;
           uir_zero_alloc_info = Zero_alloc_info.to_raw info.ui_zero_alloc_info;
+          uir_callee_regs_info =
+            Callee_regs_info.to_raw info.ui_callee_regs_info;
           uir_force_link = info.ui_force_link;
           uir_section_toc = toc;
           uir_sections_length = total_length;

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -38,6 +38,8 @@ asm_targets/**/*.ml
 asm_targets/**/*.mli
 branch_relaxation.ml
 branch_relaxation.mli
+callee_regs_collector.ml
+callee_regs_collector.mli
 cfg/**/*.ml
 cfg/**/*.mli
 cfg/vectorize.ml

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -574,6 +574,38 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        be clobbered in the middle. *)
     destroyed_r10
 
+let get_callee_regs_info
+  : Cmm.symbol -> Callee_regs_info.value option
+  = fun symb ->
+  match !Oxcaml_flags.regalloc_leaf_functions with
+  | false -> None
+  | true ->
+    let callee_name = symb.sym_name in
+    let current_unit_info =
+      (Compilenv.current_unit_infos ()).ui_callee_regs_info
+    in
+    match Callee_regs_info.get_value current_unit_info callee_name with
+    | Some _ as v -> v
+    | None ->
+      Callee_regs_info.get_value Compilenv.cached_callee_regs_info callee_name
+
+(* CR xclerc for xclerc: copied for the time being, because of circular dependencies *)
+let value_to_phys_regs (value : Callee_regs_info.value) :
+    (Regs.Reg_class.t * Regs.Phys_reg.t list) list =
+  List.filter_map
+    (fun cls ->
+      let cls_idx = Regs.Reg_class.hash cls in
+      let bitmask = value.(cls_idx) in
+      let regs =
+        Array.fold_left
+          (fun acc phys_reg ->
+            let bit = Regs.index_in_class phys_reg in
+            if bitmask land (1 lsl bit) <> 0 then phys_reg :: acc else acc)
+          [] (Regs.available_registers cls)
+      in
+      if List.is_empty regs then None else Some (cls, regs))
+    Regs.Reg_class.all
+
 (* note: keep this function in sync with `is_destruction_point` below. *)
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with
@@ -594,7 +626,38 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   | Invalid { message = _; stack_ofs; stack_align = _; label_after = _ } ->
     assert (stack_ofs >= 0);
     if stack_ofs > 0 then all_phys_regs else destroyed_at_c_call
-  | Call {op = Indirect _ | Direct _; _} -> all_phys_regs
+  | Call {op = Indirect _; _} -> all_phys_regs
+  | Call {op = Direct callee; _} ->
+    let callee_regs_info =
+      get_callee_regs_info callee
+    in
+    match callee_regs_info with
+    | None -> all_phys_regs
+    | Some callee_regs ->
+      let clobbered_regs : (Regs.reg_class * Regs.phys_reg list) list =
+        value_to_phys_regs callee_regs
+      in
+      let gpr =
+        let regs =
+        match List.assoc_opt Regs.GPR clobbered_regs with
+        | None -> []
+        | Some (regs : Regs.phys_reg list) -> regs
+         in
+         let regs = (Regs.P Regs.R11) :: regs in
+          (* CR xclerc for xclerc: probably wrong when !Clflags.llvm_backend (See `phys_reg` above) *)
+          List.map (fun reg -> phys_reg Val reg) regs
+      in
+      let simd =
+        match List.assoc_opt Regs.SIMD clobbered_regs with
+        | None -> []
+        | Some (regs : Regs.phys_reg list) ->
+        List.concat_map (fun reg ->
+          [phys_reg Float reg; phys_reg Float32 reg; phys_reg Vec128 reg]
+          @ (if Arch.Extension.enabled_vec256 () then [phys_reg Vec256 reg] else [])
+          @ (if Arch.Extension.enabled_vec512 () then [phys_reg Vec512 reg] else [])
+        ) regs
+      in
+      Array.of_list (gpr @ simd)
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
    We current return `true` when `destroyed_at_terminator` returns
@@ -620,8 +683,11 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
     else
       if alloc || stack_ofs > 0 then true else false
   | Invalid _ -> more_destruction_points
-  | Call {op = Indirect _ | Direct _; _} ->
+  | Call {op = Indirect _ ; _} ->
     true
+  | Call {op =  Direct callee; _} ->
+    Option.is_none (get_callee_regs_info callee)
+
 
 (* Layout of the stack frame *)
 

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -56,10 +56,10 @@ let is_leaf_function (cfg : Cfg.t) =
 
 let cfg (cfg_with_layout : Cfg_with_layout.t) =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  (* CR xclerc for xclerc: we (temporarily?) disable the feature if in
-    "opaque" mode, to please the CI (there is test ensuring that two
-    different implementations sharing the same interface result in
-    equivalent cmx files). *)
+  (* CR xclerc for xclerc: we (temporarily?) disable the feature if in "opaque"
+     mode, to please the CI (there is test ensuring that two different
+     implementations sharing the same interface result in equivalent cmx
+     files). *)
   if (not !Clflags.opaque) && is_leaf_function cfg
   then begin
     let num_classes = List.length Regs.Reg_class.all in

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -2,6 +2,18 @@
 
 module DLL = Oxcaml_utils.Doubly_linked_list
 
+let value_to_phys_regs (value : Callee_regs_info.value) : Regs.Phys_reg.t list =
+  List.concat_map
+    (fun cls ->
+      let cls_idx = Regs.Reg_class.hash cls in
+      let bitmask = value.(cls_idx) in
+      Array.fold_left
+        (fun acc phys_reg ->
+          let bit = Regs.index_in_class phys_reg in
+          if bitmask land (1 lsl bit) <> 0 then phys_reg :: acc else acc)
+        [] (Regs.available_registers cls))
+    Regs.Reg_class.all
+
 let add_phys_reg value phys_reg =
   let cls = Regs.Phys_reg.reg_class phys_reg in
   let cls_idx = Regs.Reg_class.hash cls in

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -50,7 +50,11 @@ let is_leaf_function (cfg : Cfg.t) =
 
 let cfg (cfg_with_layout : Cfg_with_layout.t) =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  if is_leaf_function cfg
+  (* CR xclerc for xclerc: we (temporarily?) disable the feature if in
+    "opaque" mode, to please the CI (there is test ensuring that two
+    different implementations sharing the same interface result in
+    equivalent cmx files). *)
+  if (not !Clflags.opaque) && is_leaf_function cfg
   then begin
     let num_classes = List.length Regs.Reg_class.all in
     let value = Array.make num_classes 0 in

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -13,7 +13,8 @@ let value_to_phys_regs (value : Callee_regs_info.value) :
           (fun acc phys_reg ->
             let bit = Regs.index_in_class phys_reg in
             if bitmask land (1 lsl bit) <> 0 then phys_reg :: acc else acc)
-          [] (Regs.available_registers cls)
+          []
+          (Regs.available_registers cls)
       in
       if regs = [] then None else Some (cls, regs))
     Regs.Reg_class.all
@@ -31,6 +32,8 @@ let add_reg value (reg : Reg.t) =
 
 let add_regs value regs = Array.iter (add_reg value) regs
 
+(* CR xclerc for xclerc: consider renaming, given it is use for `Raise` in
+   `is_leaf_function` below *)
 exception Has_ocaml_call
 
 (* A "leaf function" for our purposes is one that contains no [Call] or
@@ -41,9 +44,12 @@ exception Has_ocaml_call
 let is_leaf_function (cfg : Cfg.t) =
   match
     Cfg.iter_blocks cfg ~f:(fun _label block ->
-      (match[@ocaml.warning "-4"] block.Cfg.terminator.desc with
-      | Cfg.Call _ | Cfg.Tailcall_func _ -> raise Has_ocaml_call
-      | _ -> ()))
+        match[@ocaml.warning "-4"] block.Cfg.terminator.desc with
+        | Cfg.Call _ | Cfg.Tailcall_func _
+        | Cfg.Raise (Raise_regular | Raise_reraise) ->
+          (* CR xclerc for xclerc: double check `Raise_notrace` is ok *)
+          raise Has_ocaml_call
+        | _ -> ())
   with
   | () -> true
   | exception Has_ocaml_call -> false
@@ -59,12 +65,12 @@ let cfg (cfg_with_layout : Cfg_with_layout.t) =
     let num_classes = List.length Regs.Reg_class.all in
     let value = Array.make num_classes 0 in
     Cfg.iter_blocks cfg ~f:(fun _label block ->
-      DLL.iter block.Cfg.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
-        add_regs value instr.res;
-        add_regs value (Proc.destroyed_at_basic instr.desc));
-      let term = block.Cfg.terminator in
-      add_regs value term.res;
-      add_regs value (Proc.destroyed_at_terminator term.desc));
+        DLL.iter block.Cfg.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+            add_regs value instr.res;
+            add_regs value (Proc.destroyed_at_basic instr.desc));
+        let term = block.Cfg.terminator in
+        add_regs value term.res;
+        add_regs value (Proc.destroyed_at_terminator term.desc));
     let info = (Compilenv.current_unit_infos ()).ui_callee_regs_info in
     Callee_regs_info.set_value info cfg.Cfg.fun_name value
   end

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -15,12 +15,26 @@ let add_reg value (reg : Reg.t) =
 
 let add_regs value regs = Array.iter (add_reg value) regs
 
+exception Has_ocaml_call
+
+(* A "leaf function" for our purposes is one that contains no [Call] or
+   [Tailcall_func] terminators — i.e. it never transfers control to another
+   OCaml function. Allocations, polls, external C calls, and probes are all
+   fine: their register effects are captured by [Proc.destroyed_at_basic] /
+   [Proc.destroyed_at_terminator]. *)
+let is_leaf_function (cfg : Cfg.t) =
+  match
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+      (match[@ocaml.warning "-4"] block.Cfg.terminator.desc with
+      | Cfg.Call _ | Cfg.Tailcall_func _ -> raise Has_ocaml_call
+      | _ -> ()))
+  with
+  | () -> true
+  | exception Has_ocaml_call -> false
+
 let cfg (cfg_with_layout : Cfg_with_layout.t) =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  (* CR xclerc: we use [fun_contains_calls] as a proxy for "leaf function",
-     but we should perhaps reconsider this choice, e.g. by directly checking
-     for the absence of [Call]/[Tailcall_func] terminators in the CFG. *)
-  if not cfg.Cfg.fun_contains_calls
+  if is_leaf_function cfg
   then begin
     let num_classes = List.length Regs.Reg_class.all in
     let value = Array.make num_classes 0 in

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -1,0 +1,36 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+let add_phys_reg value phys_reg =
+  let cls = Regs.Phys_reg.reg_class phys_reg in
+  let cls_idx = Regs.Reg_class.hash cls in
+  let bit = Regs.index_in_class phys_reg in
+  value.(cls_idx) <- value.(cls_idx) lor (1 lsl bit)
+
+let add_reg value (reg : Reg.t) =
+  match reg.loc with
+  | Reg.Reg phys_reg -> add_phys_reg value phys_reg
+  | Reg.Unknown | Reg.Stack _ -> ()
+
+let add_regs value regs = Array.iter (add_reg value) regs
+
+let cfg (cfg_with_infos : Cfg_with_infos.t) =
+  let cfg = Cfg_with_infos.cfg cfg_with_infos in
+  (* CR xclerc: we use [fun_contains_calls] as a proxy for "leaf function",
+     but we should perhaps reconsider this choice, e.g. by directly checking
+     for the absence of [Call]/[Tailcall_func] terminators in the CFG. *)
+  if not cfg.Cfg.fun_contains_calls
+  then begin
+    let num_classes = List.length Regs.Reg_class.all in
+    let value = Array.make num_classes 0 in
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+      DLL.iter block.Cfg.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+        add_regs value instr.res;
+        add_regs value (Proc.destroyed_at_basic instr.desc));
+      let term = block.Cfg.terminator in
+      add_regs value term.res;
+      add_regs value (Proc.destroyed_at_terminator term.desc));
+    let info = (Compilenv.current_unit_infos ()).ui_callee_regs_info in
+    Callee_regs_info.set_value info cfg.Cfg.fun_name value
+  end

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -2,16 +2,20 @@
 
 module DLL = Oxcaml_utils.Doubly_linked_list
 
-let value_to_phys_regs (value : Callee_regs_info.value) : Regs.Phys_reg.t list =
-  List.concat_map
+let value_to_phys_regs (value : Callee_regs_info.value) :
+    (Regs.Reg_class.t * Regs.Phys_reg.t list) list =
+  List.filter_map
     (fun cls ->
       let cls_idx = Regs.Reg_class.hash cls in
       let bitmask = value.(cls_idx) in
-      Array.fold_left
-        (fun acc phys_reg ->
-          let bit = Regs.index_in_class phys_reg in
-          if bitmask land (1 lsl bit) <> 0 then phys_reg :: acc else acc)
-        [] (Regs.available_registers cls))
+      let regs =
+        Array.fold_left
+          (fun acc phys_reg ->
+            let bit = Regs.index_in_class phys_reg in
+            if bitmask land (1 lsl bit) <> 0 then phys_reg :: acc else acc)
+          [] (Regs.available_registers cls)
+      in
+      if regs = [] then None else Some (cls, regs))
     Regs.Reg_class.all
 
 let add_phys_reg value phys_reg =

--- a/backend/callee_regs_collector.ml
+++ b/backend/callee_regs_collector.ml
@@ -15,8 +15,8 @@ let add_reg value (reg : Reg.t) =
 
 let add_regs value regs = Array.iter (add_reg value) regs
 
-let cfg (cfg_with_infos : Cfg_with_infos.t) =
-  let cfg = Cfg_with_infos.cfg cfg_with_infos in
+let cfg (cfg_with_layout : Cfg_with_layout.t) =
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
   (* CR xclerc: we use [fun_contains_calls] as a proxy for "leaf function",
      but we should perhaps reconsider this choice, e.g. by directly checking
      for the absence of [Call]/[Tailcall_func] terminators in the CFG. *)

--- a/backend/callee_regs_collector.mli
+++ b/backend/callee_regs_collector.mli
@@ -5,9 +5,14 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 (** [cfg cfg_with_layout] computes the set of registers clobbered by the
-    function described by [cfg_with_layout] — if it is a leaf function
-    (i.e. [fun_contains_calls = false]) — and records the result in
-    [Compilenv].
+    function described by [cfg_with_layout] — if it is a leaf function —
+    and records the result in [Compilenv].
+
+    A leaf function is one that contains no [Call] or [Tailcall_func]
+    terminators (i.e. it never transfers control to another OCaml function).
+    Functions that allocate, poll, make external C calls, or contain probes
+    are still considered leaf functions; their register effects are captured
+    via [Proc.destroyed_at_basic] and [Proc.destroyed_at_terminator].
 
     Clobbered registers include registers appearing in the [res] arrays of
     all instructions, as well as registers implicitly destroyed by

--- a/backend/callee_regs_collector.mli
+++ b/backend/callee_regs_collector.mli
@@ -1,27 +1,26 @@
 (** Collects the set of registers clobbered by leaf functions after register
-    allocation and records the result in [Compilenv] for storage in .cmx
-    files. *)
+    allocation and records the result in [Compilenv] for storage in .cmx files.
+*)
 
 [@@@ocaml.warning "+a-40-41-42"]
 
 (** [cfg cfg_with_layout] computes the set of registers clobbered by the
-    function described by [cfg_with_layout] — if it is a leaf function —
-    and records the result in [Compilenv].
+    function described by [cfg_with_layout] — if it is a leaf function — and
+    records the result in [Compilenv].
 
     A leaf function is one that contains no [Call] or [Tailcall_func]
     terminators (i.e. it never transfers control to another OCaml function).
-    Functions that allocate, poll, make external C calls, or contain probes
-    are still considered leaf functions; their register effects are captured
-    via [Proc.destroyed_at_basic] and [Proc.destroyed_at_terminator].
+    Functions that allocate, poll, make external C calls, or contain probes are
+    still considered leaf functions; their register effects are captured via
+    [Proc.destroyed_at_basic] and [Proc.destroyed_at_terminator].
 
-    Clobbered registers include registers appearing in the [res] arrays of
-    all instructions, as well as registers implicitly destroyed by
-    instructions (as reported by [Proc.destroyed_at_basic] and
-    [Proc.destroyed_at_terminator]).
+    Clobbered registers include registers appearing in the [res] arrays of all
+    instructions, as well as registers implicitly destroyed by instructions (as
+    reported by [Proc.destroyed_at_basic] and [Proc.destroyed_at_terminator]).
 
-    This pass must run after all CFG rewrites (in particular after all calls
-    to [simplify_cfg]) so that the collected set reflects what is actually
-    emitted in the assembly output.
+    This pass must run after all CFG rewrites (in particular after all calls to
+    [simplify_cfg]) so that the collected set reflects what is actually emitted
+    in the assembly output.
 
     If the function is not a leaf function, no information is recorded. *)
 val cfg : Cfg_with_layout.t -> unit

--- a/backend/callee_regs_collector.mli
+++ b/backend/callee_regs_collector.mli
@@ -4,8 +4,8 @@
 
 [@@@ocaml.warning "+a-40-41-42"]
 
-(** [cfg cfg_with_infos] computes the set of registers clobbered by the
-    function described by [cfg_with_infos] — if it is a leaf function
+(** [cfg cfg_with_layout] computes the set of registers clobbered by the
+    function described by [cfg_with_layout] — if it is a leaf function
     (i.e. [fun_contains_calls = false]) — and records the result in
     [Compilenv].
 
@@ -14,5 +14,9 @@
     instructions (as reported by [Proc.destroyed_at_basic] and
     [Proc.destroyed_at_terminator]).
 
+    This pass must run after all CFG rewrites (in particular after all calls
+    to [simplify_cfg]) so that the collected set reflects what is actually
+    emitted in the assembly output.
+
     If the function is not a leaf function, no information is recorded. *)
-val cfg : Cfg_with_infos.t -> unit
+val cfg : Cfg_with_layout.t -> unit

--- a/backend/callee_regs_collector.mli
+++ b/backend/callee_regs_collector.mli
@@ -25,3 +25,7 @@
 
     If the function is not a leaf function, no information is recorded. *)
 val cfg : Cfg_with_layout.t -> unit
+
+(** [value_to_phys_regs value] returns the list of physical registers encoded
+    in [value]. *)
+val value_to_phys_regs : Callee_regs_info.value -> Regs.Phys_reg.t list

--- a/backend/callee_regs_collector.mli
+++ b/backend/callee_regs_collector.mli
@@ -26,6 +26,8 @@
     If the function is not a leaf function, no information is recorded. *)
 val cfg : Cfg_with_layout.t -> unit
 
-(** [value_to_phys_regs value] returns the list of physical registers encoded
-    in [value]. *)
-val value_to_phys_regs : Callee_regs_info.value -> Regs.Phys_reg.t list
+(** [value_to_phys_regs value] returns, for each register class, the list of
+    physical registers encoded in [value]. Classes with no clobbered registers
+    are omitted from the result. *)
+val value_to_phys_regs :
+  Callee_regs_info.value -> (Regs.Reg_class.t * Regs.Phys_reg.t list) list

--- a/backend/callee_regs_collector.mli
+++ b/backend/callee_regs_collector.mli
@@ -1,0 +1,18 @@
+(** Collects the set of registers clobbered by leaf functions after register
+    allocation and records the result in [Compilenv] for storage in .cmx
+    files. *)
+
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** [cfg cfg_with_infos] computes the set of registers clobbered by the
+    function described by [cfg_with_infos] — if it is a leaf function
+    (i.e. [fun_contains_calls = false]) — and records the result in
+    [Compilenv].
+
+    Clobbered registers include registers appearing in the [res] arrays of
+    all instructions, as well as registers implicitly destroyed by
+    instructions (as reported by [Proc.destroyed_at_basic] and
+    [Proc.destroyed_at_terminator]).
+
+    If the function is not a leaf function, no information is recorded. *)
+val cfg : Cfg_with_infos.t -> unit

--- a/backend/callee_regs_info.ml
+++ b/backend/callee_regs_info.ml
@@ -1,0 +1,90 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@warning "-66"]
+module String = Misc.Stdlib.String
+
+type value = int array
+
+type t = { mutable callee_regs : value String.Map.t }
+
+let create () = { callee_regs = String.Map.empty }
+
+let reset t = t.callee_regs <- String.Map.empty
+
+let merge src ~into:dst =
+  let join key _v1 _v2 =
+    Misc.fatal_errorf "Unexpected merge for %s" key
+  in
+  dst.callee_regs <- String.Map.union join dst.callee_regs src.callee_regs
+
+let get_value (t : t) s = String.Map.find_opt s t.callee_regs
+
+let set_value (t : t) s (v : value) =
+  let f new_ old =
+    if not (Option.is_none old)
+    then Misc.fatal_errorf "Value of %s is already set" s;
+    Some new_
+  in
+  t.callee_regs <- String.Map.update s (f v) t.callee_regs
+
+module Raw = struct
+  type entries = (string * int array) list
+
+  type t = entries option
+
+  let entries_to_map (e : entries) =
+    List.fold_left (fun acc (k, v) -> String.Map.add k v acc) String.Map.empty e
+
+  let print t =
+    let print (name, v) =
+      Printf.printf "\t\t%s = [%s]\n" name
+        (String.concat "; "
+           (List.init (Array.length v) (fun i -> string_of_int v.(i))))
+    in
+    Printf.printf "Callee register usage for leaf functions:\n";
+    List.iter print t
+
+  let print = function None -> () | Some t -> print t
+
+  let decode_bitmask ~class_idx ~reg_name bitmask =
+    let regs = ref [] in
+    let b = ref bitmask in
+    let bit_idx = ref 0 in
+    while !b <> 0 do
+      if !b land 1 <> 0
+      then regs := reg_name ~class_idx ~bit_idx:!bit_idx :: !regs;
+      b := !b lsr 1;
+      incr bit_idx
+    done;
+    List.rev !regs
+
+  let print_with_names ~class_name ~reg_name t =
+    let print (fun_name, v) =
+      Printf.printf "\t\t%s:\n" fun_name;
+      Array.iteri
+        (fun class_idx bitmask ->
+          if bitmask <> 0
+          then begin
+            let reg_names = decode_bitmask ~class_idx ~reg_name bitmask in
+            Printf.printf "\t\t\t%s: %s\n" (class_name class_idx)
+              (String.concat " " reg_names)
+          end)
+        v
+    in
+    Printf.printf "Callee register usage for leaf functions:\n";
+    List.iter print t
+
+  let print_with_names ~class_name ~reg_name = function
+    | None -> ()
+    | Some t -> print_with_names ~class_name ~reg_name t
+end
+
+let to_raw (t : t) : Raw.t =
+  if String.Map.is_empty t.callee_regs
+  then None
+  else Some (String.Map.bindings t.callee_regs)
+
+let of_raw (t : Raw.t) : t =
+  match t with
+  | None -> create ()
+  | Some t -> { callee_regs = Raw.entries_to_map t }

--- a/backend/callee_regs_info.mli
+++ b/backend/callee_regs_info.mli
@@ -1,0 +1,46 @@
+(** Per-function register usage information for leaf functions,
+    encoded per register class for storage in .cmx files. *)
+
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** A register set for one function: an array indexed by register class
+    (using the class's [hash] function as the index), where each element
+    is a bitmask of used registers within that class (bit [j] is set iff
+    the register with [Regs.index_in_class = j] is clobbered). *)
+type value = int array
+
+type t
+
+val create : unit -> t
+
+val reset : t -> unit
+
+(** [merge src ~into:dst] modifies [dst] by adding information from [src]. *)
+val merge : t -> into:t -> unit
+
+(** [get_value t fun_name] returns [None] if [fun_name] is not associated
+    with any value. *)
+val get_value : t -> string -> value option
+
+val set_value : t -> string -> value -> unit
+
+module Raw : sig
+  type t
+
+  (** Simple integer dump. *)
+  val print : t -> unit
+
+  (** [print_with_names ~class_name ~reg_name t] prints the register set in a
+      human-readable form, using [class_name class_idx] for the name of class
+      [class_idx] and [reg_name ~class_idx ~bit_idx] for the name of the
+      register at bit position [bit_idx] within class [class_idx]. *)
+  val print_with_names :
+    class_name:(int -> string) ->
+    reg_name:(class_idx:int -> bit_idx:int -> string) ->
+    t ->
+    unit
+end
+
+val to_raw : t -> Raw.t
+
+val of_raw : Raw.t -> t

--- a/backend/regs_utils.ml
+++ b/backend/regs_utils.ml
@@ -23,6 +23,10 @@ module type T = sig
     include Identifiable.S with type t := t
 
     val reg_class : t -> Reg_class.t
+
+    (** A stable integer index for the register, unique within all registers
+        across all classes (i.e. a flat global index). *)
+    val to_int : t -> int
   end
 
   val index_in_class : Phys_reg.t -> int

--- a/backend/regs_utils.mli
+++ b/backend/regs_utils.mli
@@ -24,6 +24,10 @@ module type T = sig
     include Identifiable.S with type t := t
 
     val reg_class : t -> Reg_class.t
+
+    (** A stable integer index for the register, unique within all registers
+        across all classes (i.e. a flat global index). *)
+    val to_int : t -> int
   end
 
   val index_in_class : Phys_reg.t -> int

--- a/callee-regs-savings.md
+++ b/callee-regs-savings.md
@@ -1,0 +1,100 @@
+# Callee-Register Savings Estimate
+
+## Background
+
+OCaml's current calling convention treats every register as caller-saved: before
+a direct call, the allocator must assume that the callee clobbers every register
+in each class, so any value that is live across the call must be spilled.  In
+reality, leaf functions (those that never call another OCaml function) often
+clobber only a small subset of registers.
+
+The work recorded here adds infrastructure to measure how much register-save
+traffic could be eliminated if the allocator knew — and exploited — the actual
+clobber set of each leaf callee.
+
+## Infrastructure Added
+
+### Callee clobber sets in `.cmx` files (`backend/callee_regs_collector.ml`)
+
+After register allocation, `Callee_regs_collector.cfg` computes the set of
+physical registers written by a function and stores it in `Compilenv` under the
+function's name, from where it is serialised into the `.cmx` file.  The
+information is stored as a per-register-class bitmask.
+
+A function qualifies as a *leaf* if its CFG contains no `Call` or
+`Tailcall_func` terminators (i.e. it never transfers control to another OCaml
+function).  Functions that allocate, poll, make external C calls, or contain
+probes still qualify; their register effects are captured by
+`Proc.destroyed_at_basic` / `Proc.destroyed_at_terminator` and therefore appear
+in the bitmask.
+
+### Profile counters (`asmcomp/asmgen.ml`)
+
+Two new `whole_cfg` counters are recorded for every compilation unit:
+
+- **`callee_regs_live`** — total number of virtual (pre-allocation) registers
+  live across all direct call sites that target a leaf callee with known clobber
+  information.  Only registers with `loc = Unknown` are counted; pinned physical
+  registers are not subject to the allocator's placement choices.
+
+- **`callee_regs_savings`** — estimated number of those live registers that the
+  allocator could keep in non-clobbered physical registers (and therefore avoid
+  spilling), given the callee's actual clobber set.
+
+Both counters are computed **before register allocation**, using the pre-allocation
+liveness information from `Cfg_with_infos.liveness`.  Using post-allocation
+liveness would undercount, because spilled values are already absent from
+post-allocation live sets.
+
+### Estimation formula
+
+For each direct call site targeting a leaf callee with known clobber set, and
+for each register class `c`:
+
+| Symbol | Meaning |
+|--------|---------|
+| `L_c`  | number of virtual registers of class `c` live across this call |
+| `R_c`  | number of registers available to the allocator in class `c` |
+| `K_c`  | number of those registers actually clobbered by the callee |
+
+With the **current** convention the allocator must treat all `R_c` registers as
+clobbered, so any of the `L_c` live values may need saving.  With the callee's
+actual clobber set, up to `R_c - K_c` registers are safe havens; the allocator
+need only spill `max(0, L_c - (R_c - K_c))` values.
+
+```
+savings_c = L_c - max(0, L_c - (R_c - K_c))
+          = min(L_c, max(0, R_c - K_c))
+```
+
+The per-call-site contribution to `callee_regs_savings` is the sum of
+`savings_c` over all classes; `callee_regs_live` accumulates the corresponding
+sum of `L_c`.
+
+### Extraction script (`extract_callee_regs_counters.py`)
+
+A Python 3 script at the repository root reads all `*.csv` profile files in a
+directory and prints, for each file and in total, the accumulated values of both
+counters together with their ratio.  It filters to rows whose pass name ends
+with `/save_cfg` (emitted exactly once per function) to avoid double-counting
+across passes.
+
+## Results on the OxCaml Compiler Distribution
+
+Running the compiler with profiling enabled on its own sources (1,234
+compilation units) and aggregating the output with `extract_callee_regs_counters.py`
+yields:
+
+| Metric | Value |
+|--------|-------|
+| Compilation units | 1,234 |
+| `callee_regs_live` (total) | 49,539 |
+| `callee_regs_savings` (total) | 34,801 |
+| Savings ratio | **70.2 %** |
+
+In other words, roughly 70 % of the registers that are live across direct calls
+to leaf functions could, in principle, be kept in non-clobbered registers rather
+than being spilled — provided the allocator were given and exploited the callee's
+actual clobber set.  This is a conservative lower bound on the potential benefit,
+since it counts only calls to leaf callees for which clobber information is
+available.

--- a/callee-regs-savings.md
+++ b/callee-regs-savings.md
@@ -98,3 +98,29 @@ than being spilled — provided the allocator were given and exploited the calle
 actual clobber set.  This is a conservative lower bound on the potential benefit,
 since it counts only calls to leaf callees for which clobber information is
 available.
+
+## Effect of Higher Optimisation (`O3`)
+
+The same experiment was repeated with `OCAMLPARAM=_,O3=1` and
+`BUILD_OCAMLPARAM=_,O3=1` (still 1,234 compilation units):
+
+| Metric | Default | O3 |
+|--------|---------|----|
+| `callee_regs_live` (total) | 49,539 | 38,914 |
+| `callee_regs_savings` (total) | 34,801 | 15,585 |
+| Savings ratio | **70.2 %** | **40.0 %** |
+
+Two effects combine here.  First, `callee_regs_live` falls from 49,539 to
+38,914: O3 inlines more aggressively, eliminating a significant number of direct
+call sites altogether and therefore reducing the pool of live-across-call
+registers that the measurement even considers.  Second, and more striking, the
+savings ratio drops from 70 % to 40 %: the call sites that survive inlining tend
+to be the harder cases — callees that clobber a larger fraction of the available
+registers, leaving fewer safe havens for live values.
+
+The combined result is that the absolute savings estimate falls from 34,801 to
+15,585, a reduction of roughly 55 %.  This suggests that a meaningful share of
+the potential benefit identified at the default optimisation level is already
+addressed implicitly by inlining at O3, but a substantial residual opportunity
+(~15,000 register saves per compiler self-build) remains even at the higher
+level.

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -75,6 +75,16 @@ let mk_regalloc_validate f =
 let mk_no_regalloc_validate f =
   ("-no-regalloc-validate", Arg.Unit f, " Do not validate register allocation")
 
+let mk_regalloc_leaf_functions f =
+  ( "-regalloc-leaf-functions",
+    Arg.Unit f,
+    " Use the information about leaf functions" )
+
+let mk_no_regalloc_leaf_functions f =
+  ( "-no-regalloc-leaf-functions",
+    Arg.Unit f,
+    " Do not use the information about leaf functions" )
+
 let mk_vectorize f =
   ("-vectorize", Arg.Unit f, " Enable vectorizer (EXPERIMENTAL)")
 
@@ -1179,6 +1189,8 @@ module type Oxcaml_options = sig
   val regalloc_param : string -> unit
   val regalloc_validate : unit -> unit
   val no_regalloc_validate : unit -> unit
+  val regalloc_leaf_functions : unit -> unit
+  val no_regalloc_leaf_functions : unit -> unit
   val vectorize : unit -> unit
   val no_vectorize : unit -> unit
   val vectorize_max_block_size : int -> unit
@@ -1346,6 +1358,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_regalloc_param F.regalloc_param;
       mk_regalloc_validate F.regalloc_validate;
       mk_no_regalloc_validate F.no_regalloc_validate;
+      mk_regalloc_leaf_functions F.regalloc_leaf_functions;
+      mk_no_regalloc_leaf_functions F.no_regalloc_leaf_functions;
       mk_vectorize F.vectorize;
       mk_no_vectorize F.no_vectorize;
       mk_vectorize_max_block_size F.vectorize_max_block_size;
@@ -1549,6 +1563,8 @@ module Oxcaml_options_impl = struct
 
   let regalloc_validate = set' Oxcaml_flags.regalloc_validate
   let no_regalloc_validate = clear' Oxcaml_flags.regalloc_validate
+  let regalloc_leaf_functions = set' Oxcaml_flags.regalloc_leaf_functions
+  let no_regalloc_leaf_functions = clear' Oxcaml_flags.regalloc_leaf_functions
   let vectorize = set' Oxcaml_flags.vectorize
   let no_vectorize = clear' Oxcaml_flags.vectorize
   let vectorize_max_block_size n = Oxcaml_flags.vectorize_max_block_size := n
@@ -2095,6 +2111,7 @@ module Extra_params = struct
         set_int' Oxcaml_flags.regalloc_linscan_threshold
     | "regalloc-param" -> add_string Oxcaml_flags.regalloc_params
     | "regalloc-validate" -> set' Oxcaml_flags.regalloc_validate
+    | "regalloc-leaf-functions" -> set' Oxcaml_flags.regalloc_leaf_functions
     | "vectorize" -> set' Oxcaml_flags.vectorize
     | "dump-vectorize" -> set' Oxcaml_flags.dump_vectorize
     | "vectorize-max-block-size" ->

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -37,6 +37,8 @@ module type Oxcaml_options = sig
   val regalloc_param : string -> unit
   val regalloc_validate : unit -> unit
   val no_regalloc_validate : unit -> unit
+  val regalloc_leaf_functions : unit -> unit
+  val no_regalloc_leaf_functions : unit -> unit
   val vectorize : unit -> unit
   val no_vectorize : unit -> unit
   val vectorize_max_block_size : int -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -20,6 +20,7 @@ let default_regalloc_linscan_threshold = 100_000
 let regalloc_linscan_threshold = ref max_int (* -regalloc-linscan-threshold *)
 let regalloc_params = ref ([] : string list)  (* -regalloc-param *)
 let regalloc_validate = ref true        (* -[no-]regalloc-validate *)
+let regalloc_leaf_functions = ref false (* -[no-]regalloc-leaf-functions *)
 
 let vectorize = ref false                (* -[no-]vectorize *)
 let dump_vectorize = ref false          (* -dvectorize *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -23,6 +23,7 @@ val default_regalloc_linscan_threshold : int
 val regalloc_linscan_threshold : int ref
 val regalloc_params : string list ref
 val regalloc_validate : bool ref
+val regalloc_leaf_functions : bool ref
 
 val vectorize : bool ref
 val dump_vectorize : bool ref

--- a/dune
+++ b/dune
@@ -617,6 +617,8 @@
   x86_masm
   x86_proc
   jit_backend
+  callee_regs_collector
+  callee_regs_info
   zero_alloc_checker
   zero_alloc_info
   ;; backend/cfg

--- a/extract_callee_regs_counters.py
+++ b/extract_callee_regs_counters.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Extract callee_regs_savings and callee_regs_live counters from profile CSVs.
+
+Usage: python3 extract_callee_regs_counters.py <directory>
+
+Scans all *.csv files in the given directory.  For each file, reads the row
+whose pass name ends with "/save_cfg" (accumulated once per function, so
+there is no double-counting) and sums the two counters of interest.
+"""
+
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+def parse_counters(cell: str) -> Dict[str, int]:
+    """Parse '[k1 = v1; k2 = v2; ...]' into {k1: v1, k2: v2, ...}."""
+    cell = cell.strip()
+    if not cell or cell == "[]":
+        return {}
+    # Strip surrounding brackets
+    if cell.startswith("["):
+        cell = cell[1:]
+    if cell.endswith("]"):
+        cell = cell[:-1]
+    result = {}
+    for entry in cell.split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        m = re.fullmatch(r"(\S+)\s*=\s*(-?\d+)", entry)
+        if m:
+            result[m.group(1)] = int(m.group(2))
+    return result
+
+
+def process_file(path: Path) -> Tuple[int, int]:
+    """Return (callee_regs_live, callee_regs_savings) summed over save_cfg rows."""
+    live = 0
+    savings = 0
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            pass_name = row.get("pass name", "")
+            if not pass_name.endswith("/save_cfg"):
+                continue
+            counters = parse_counters(row.get("counters", ""))
+            live += counters.get("callee_regs_live", 0)
+            savings += counters.get("callee_regs_savings", 0)
+    return live, savings
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: {} <directory>".format(sys.argv[0]), file=sys.stderr)
+        sys.exit(1)
+
+    directory = Path(sys.argv[1])
+    if not directory.is_dir():
+        print("Error: '{}' is not a directory".format(directory), file=sys.stderr)
+        sys.exit(1)
+
+    csv_files = sorted(directory.glob("*.csv"))
+    if not csv_files:
+        print("No CSV files found in '{}'".format(directory), file=sys.stderr)
+        sys.exit(1)
+
+    total_live = 0
+    total_savings = 0
+
+    for path in csv_files:
+        live, savings = process_file(path)
+        ratio = savings / live if live > 0 else float("nan")
+        print("{}: live={}, savings={}, ratio={:.3f}".format(
+            path.name, live, savings, ratio))
+        total_live += live
+        total_savings += savings
+
+    total_ratio = total_savings / total_live if total_live > 0 else float("nan")
+    print()
+    print("Total ({} file(s)): live={}, savings={}, ratio={:.3f}".format(
+        len(csv_files), total_live, total_savings, total_ratio))
+
+
+if __name__ == "__main__":
+    main()

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -71,6 +71,7 @@ type 'format unit_infos_gen =
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: Flambda2_cmx.Flambda_cmx_format.t option;
     mutable ui_zero_alloc_info: Zero_alloc_info.t;
+    mutable ui_callee_regs_info: Callee_regs_info.t;
     mutable ui_force_link: bool;          (* Always linked *)
     mutable ui_external_symbols: string list; (* Set of external symbols *)
   }
@@ -88,6 +89,7 @@ type unit_infos_raw =
     uir_generic_fns: generic_fns;
     uir_export_info: Flambda2_cmx.Flambda_cmx_format.raw option;
     uir_zero_alloc_info: Zero_alloc_info.Raw.t;
+    uir_callee_regs_info: Callee_regs_info.Raw.t;
     uir_force_link: bool;
     uir_section_toc: int array;    (* Byte offsets of sections in .cmx
                                       relative to byte immediately after

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -51,6 +51,11 @@ let cached_zero_alloc_info = Zero_alloc_info.create ()
 
 let cache_zero_alloc_info c = Zero_alloc_info.merge c ~into:cached_zero_alloc_info
 
+let cached_callee_regs_info = Callee_regs_info.create ()
+
+let cache_callee_regs_info c =
+  Callee_regs_info.merge c ~into:cached_callee_regs_info
+
 let current_unit =
   { ui_unit = CU.dummy;
     ui_defines = [];
@@ -62,6 +67,7 @@ let current_unit =
     ui_generic_fns = { curry_fun = []; apply_fun = []; send_fun = [] };
     ui_force_link = false;
     ui_zero_alloc_info = Zero_alloc_info.create ();
+    ui_callee_regs_info = Callee_regs_info.create ();
     ui_export_info = None;
     ui_external_symbols = [];
   }
@@ -70,6 +76,7 @@ let reset unit_info =
   let compilation_unit = Unit_info.modname unit_info in
   Infos_table.clear global_infos_table;
   Zero_alloc_info.reset cached_zero_alloc_info;
+  Callee_regs_info.reset cached_callee_regs_info;
   Env.set_unit_name (Some unit_info);
   current_unit.ui_unit <- compilation_unit;
   current_unit.ui_defines <- [compilation_unit];
@@ -82,6 +89,7 @@ let reset unit_info =
     { curry_fun = []; apply_fun = []; send_fun = [] };
   current_unit.ui_force_link <- !Clflags.link_everything;
   Zero_alloc_info.reset current_unit.ui_zero_alloc_info;
+  Callee_regs_info.reset current_unit.ui_callee_regs_info;
   Hashtbl.clear exported_constants;
   current_unit.ui_export_info <- None;
   current_unit.ui_external_symbols <- []
@@ -124,6 +132,7 @@ let read_unit_info filename =
       ui_generic_fns = uir.uir_generic_fns;
       ui_export_info = export_info;
       ui_zero_alloc_info = Zero_alloc_info.of_raw uir.uir_zero_alloc_info;
+      ui_callee_regs_info = Callee_regs_info.of_raw uir.uir_callee_regs_info;
       ui_force_link = uir.uir_force_link;
       ui_external_symbols = uir.uir_external_symbols |> Array.to_list;
     }
@@ -186,6 +195,7 @@ let get_unit_export_info comp_unit =
             if not (CU.equal ui.ui_unit comp_unit) then
               raise(Error(Illegal_renaming(comp_unit, ui.ui_unit, filename)));
             cache_zero_alloc_info ui.ui_zero_alloc_info;
+            cache_callee_regs_info ui.ui_callee_regs_info;
             (Some ui, Some crc)
           with Not_found ->
             let warn =
@@ -211,6 +221,7 @@ let get_global_export_info comp_unit =
 
 let cache_unit_info ui =
   cache_zero_alloc_info ui.ui_zero_alloc_info;
+  cache_callee_regs_info ui.ui_callee_regs_info;
   Infos_table.add global_infos_table
     (ui.ui_unit |> CU.to_global_name_without_prefix) (Some ui)
 
@@ -284,6 +295,7 @@ let write_unit_info info filename =
     uir_generic_fns = info.ui_generic_fns;
     uir_export_info = raw_export_info;
     uir_zero_alloc_info = Zero_alloc_info.to_raw info.ui_zero_alloc_info;
+    uir_callee_regs_info = Callee_regs_info.to_raw info.ui_callee_regs_info;
     uir_force_link = info.ui_force_link;
     uir_section_toc = toc;
     uir_sections_length = total_length;

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -57,6 +57,13 @@ val cached_zero_alloc_info : Zero_alloc_info.t
 val cache_zero_alloc_info : Zero_alloc_info.t -> unit
         (* [cache_zero_alloc_info c] adds [c] to [cached_zero_alloc_info] *)
 
+val cached_callee_regs_info : Callee_regs_info.t
+        (* Return cached information about registers clobbered by leaf
+           functions (from other compilation units). *)
+
+val cache_callee_regs_info : Callee_regs_info.t -> unit
+        (* [cache_callee_regs_info c] adds [c] to [cached_callee_regs_info] *)
+
 val new_const_symbol : unit -> string
 
 val read_unit_info: string -> unit_infos * Digest.t

--- a/optcomp/optpackager.ml
+++ b/optcomp/optpackager.ml
@@ -194,6 +194,12 @@ end) : S = struct
       (fun info ->
         Zero_alloc_info.merge info.ui_zero_alloc_info ~into:ui_zero_alloc_info)
       units;
+    let ui_callee_regs_info = Callee_regs_info.create () in
+    List.iter
+      (fun info ->
+        Callee_regs_info.merge info.ui_callee_regs_info
+          ~into:ui_callee_regs_info)
+      units;
     let modname = Compilation_unit.name ui.ui_unit in
     let format : Lambda.main_module_block_format =
       (* Open modules not supported with packs, so always just a record *)
@@ -224,6 +230,7 @@ end) : S = struct
         ui_force_link = List.exists (fun info -> info.ui_force_link) units;
         ui_export_info;
         ui_zero_alloc_info;
+        ui_callee_regs_info;
         ui_external_symbols =
           union (List.map (fun info -> info.ui_external_symbols) units)
       }

--- a/otherlibs/camlinternaleval/camlinternaleval.ml
+++ b/otherlibs/camlinternaleval/camlinternaleval.ml
@@ -124,6 +124,8 @@ let read_bundles ~marshalled_cmi_bundle ~marshalled_cmx_bundle =
             ui_generic_fns = uir.uir_generic_fns;
             ui_export_info = export_info;
             ui_zero_alloc_info = Zero_alloc_info.of_raw uir.uir_zero_alloc_info;
+            ui_callee_regs_info =
+              Callee_regs_info.of_raw uir.uir_callee_regs_info;
             ui_force_link = uir.uir_force_link;
             ui_external_symbols = uir.uir_external_symbols |> Array.to_list
           }

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -367,7 +367,23 @@ let print_cmx_infos (uir, sections, crc) =
   print_generic_fns uir.uir_generic_fns;
   printf "Force link: %s\n" (if uir.uir_force_link then "YES" else "no");
   if not (!no_code || !no_approx) then begin
-    Zero_alloc_info.Raw.print uir.uir_zero_alloc_info
+    Zero_alloc_info.Raw.print uir.uir_zero_alloc_info;
+    let class_name class_idx =
+      match List.nth_opt Regs.Reg_class.all class_idx with
+      | None -> Printf.sprintf "class_%d" class_idx
+      | Some cls -> Format.asprintf "%a" Regs.Reg_class.print cls
+    in
+    let reg_name ~class_idx ~bit_idx =
+      match List.nth_opt Regs.Reg_class.all class_idx with
+      | None -> Printf.sprintf "reg_%d_%d" class_idx bit_idx
+      | Some cls ->
+        let regs = Regs.registers cls in
+        if bit_idx < Array.length regs
+        then Format.asprintf "%a" Regs.Phys_reg.print regs.(bit_idx)
+        else Printf.sprintf "reg_%d_%d" class_idx bit_idx
+    in
+    Callee_regs_info.Raw.print_with_names ~class_name ~reg_name
+      uir.uir_callee_regs_info
   end
 
 let print_cmxa_infos (lib : Cmx_format.library_infos) =


### PR DESCRIPTION
This is an early draft, based on the experiment in #5613.
Among other things, as of 570ca49, only amd64 is supported.

The pull request add a command-line parameter (namely
`-regalloc-leaf-functions`) to ask the backend to use
the information about registers clobbered by leaf
functions. Indeed, instead of assuming all registers
can be clobbered, `Proc.destroyed_at_terminator` will
return only the set of registers actually clobbered by
the called. If the information is not available, the
function is assumed to clobber all registers.

Here are the results on the compiler distribution:

|              |  disabled |   enabled | ratio (%) |
| ------------ | --------- | --------- | --------- |
| blocks	     |   714,752 |   715,010 |    100.04 |
| instructions | 3,780,305 | 3,773,074 |     99.81 |
| moves	       |   311,439 |   319,729 |    102.66 |
| reloads	     |   350,150 |   340,412 |     97.22 |
| spills	     |   247,243 |   241,202 |     97.56 |
| stack slots	 |   143,070 |   139,158 |     97.27 |

The benefits appear to be very limited, especially
when compared to the [estimate](https://github.com/oxcaml/oxcaml/blob/9f3cd45a929eef6df7e008c2b9ad4ad5a83ab602/callee-regs-savings.md#results-on-the-oxcaml-compiler-distribution), but the estimate
was based only on live sets, and did not take into
acccount the optimizations performed by the split
preprocessing pass. Another element to consider is
that this pull request leaves the split preprocessing
pass untouched. It should probably be changed to
split not only all registers at destruction point,
but split the registers destroyed by a call.

note: the fact that a function is a leaf function is
likely not the best criterion. A leaf function
destroying all registers should still be viewed as a
destruction point by the split preprocessing pass.
A better criterion might be about the number / percentage
of registers clobbered by a function (and its callees).

note: the validator is not as helpful as it is on
other pull requests touching the register allocators,
because it will use the same source to determine
which registers are clobbered. In other words, that
pull request is significantly riskier than other pull
requests in this area.
