### PR TITLE
Add `env_alloc_mode` to `Tpat_fun_layout`

### DIFF
--- a/chamelon/lib/minimizer/flatteningmodules.ml
+++ b/chamelon/lib/minimizer/flatteningmodules.ml
@@ -130,14 +130,16 @@ let rec replace_in_pat : type k. _ -> k general_pattern -> k general_pattern =
       | O (Tpat_lazy pat) -> Tpat_lazy (replace_in_pat mod_name pat)
       | O (Tpat_variant (lab, Some p, t)) ->
         Tpat_variant (lab, Some (replace_in_pat mod_name p), t)
-      | O (Tpat_fun_layout { id; name; uid; sort; mode; lpoly }) ->
+      | O (Tpat_fun_layout { id; name; uid; sort; mode; lpoly; env_alloc_mode })
+        ->
         Tpat_fun_layout
           { id = create_local (mod_name ^ "_" ^ Ident.name id);
             name = { name with txt = mod_name ^ "_" ^ name.txt };
             uid;
             sort;
             mode;
-            lpoly
+            lpoly;
+            env_alloc_mode
           }
       | O (Tpat_value _)
       (* p) -> as_computation_pattern (replace_in_pat mod_name p) *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -258,7 +258,7 @@ end = struct
       | `Any -> stop p `Any
       | `Var (id, s, uid, sort, mode) ->
         continue p (`Alias (Patterns.omega, id, s, uid, sort, mode, p.pat_type))
-      | `Fun_layout (_, _, _, _, _, lpoly) -> fatal_var_lpoly lpoly
+      | `Fun_layout (_, _, _, _, _, lpoly, _) -> fatal_var_lpoly lpoly
       | `Alias (p, id, _, duid, sort, _, _) ->
           aux
             ( (General.view p, patl),
@@ -375,7 +375,7 @@ end = struct
             { p with pat_desc =
                 `Alias (Patterns.omega, id, str, uid, sort, mode, p.pat_type) }
             aliases rem
-      | `Fun_layout (_, _, _, _, _, lpoly) -> fatal_var_lpoly lpoly
+      | `Fun_layout (_, _, _, _, _, lpoly, _) -> fatal_var_lpoly lpoly
       | #view as view ->
           (* We are doing two things here:
              - we freshen the variables of the pattern, to
@@ -625,7 +625,7 @@ end = struct
               filter_rec ((left, p1, right) :: (left, p2, right) :: rem)
           | `Alias (p, _, _, _, _, _, _) -> filter_rec ((left, p, right) :: rem)
           | `Var _ -> filter_rec ((left, Patterns.omega, right) :: rem)
-          | `Fun_layout (_, _, _, _, _, lpoly) -> fatal_var_lpoly lpoly
+          | `Fun_layout (_, _, _, _, _, lpoly, _) -> fatal_var_lpoly lpoly
           | #Simple.view as view -> (
               let p = { p with pat_desc = view } in
               match matcher head p right with
@@ -754,7 +754,7 @@ end = struct
           match p.pat_desc with
           | `Alias (p, _, _, _, _, _, _) -> filter_rec ((p, ps) :: rem)
           | `Var _ -> filter_rec ((Patterns.omega, ps) :: rem)
-          | `Fun_layout (_, _, _, _, _, lpoly) -> fatal_var_lpoly lpoly
+          | `Fun_layout (_, _, _, _, _, lpoly, _) -> fatal_var_lpoly lpoly
           | `Or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
           | #Simple.view as view -> (
               let p = { p with pat_desc = view } in

--- a/testsuite/tests/layout_poly/apply_layout.ml
+++ b/testsuite/tests/layout_poly/apply_layout.ml
@@ -172,7 +172,8 @@ end
 Line 6, characters 16-22:
 6 |   let poly_ g = M.f 42
                     ^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 

--- a/testsuite/tests/layout_poly/apply_layout.ml
+++ b/testsuite/tests/layout_poly/apply_layout.ml
@@ -169,26 +169,10 @@ end = struct
   let poly_ g = M.f 42
 end
 [%%expect{|
-Line 6, characters 12-13:
+Line 6, characters 2-22:
 6 |   let poly_ g = M.f 42
-                ^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
-
-Lines 5-7, characters 6-3:
-5 | ......struct
-6 |   let poly_ g = M.f 42
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val g : '_weak2 -> unit end
-       is not included in
-         sig val g : layout_ l. ('b : l). 'b -> unit end
-       Values do not match:
-         val g : '_weak2 -> unit
-       is not included in
-         val g : layout_ l. ('b : l). 'b -> unit
-       The type "'_weak2 -> unit" is not compatible with the type "'a -> unit"
-       Type "'_weak2" is not compatible with type "'a"
+      ^^^^^^^^^^^^^^^^^^^^
+Error: The right-hand side of a "let poly_" binding must be a syntactic value.
 |}]
 
 

--- a/testsuite/tests/layout_poly/apply_layout.ml
+++ b/testsuite/tests/layout_poly/apply_layout.ml
@@ -169,10 +169,10 @@ end = struct
   let poly_ g = M.f 42
 end
 [%%expect{|
-Line 6, characters 2-22:
+Line 6, characters 16-22:
 6 |   let poly_ g = M.f 42
-      ^^^^^^^^^^^^^^^^^^^^
-Error: The right-hand side of a "let poly_" binding must be a syntactic value.
+                    ^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
 |}]
 
 

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -47,11 +47,10 @@ end = struct
     f
 end
 [%%expect{|
-Lines 4-6, characters 2-5:
-4 | ..let poly_ id =
-5 |     let f x = x in
+Lines 5-6, characters 4-5:
+5 | ....let f x = x in
 6 |     f
-Error: The right-hand side of a "let poly_" binding must be a syntactic value.
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
 |}]
 
 module _ : sig
@@ -233,10 +232,136 @@ end = struct
   let poly_ pair = let y = 42 in fun x -> #(x, y)
 end
 [%%expect{|
-Line 4, characters 2-49:
+Line 4, characters 19-49:
 4 |   let poly_ pair = let y = 42 in fun x -> #(x, y)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The right-hand side of a "let poly_" binding must be a syntactic value.
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+|}]
+
+(* constructor: passing when all args are syntactic values *)
+let poly_ f = Some (fun x -> x)
+[%%expect{|
+>> Fatal error: layout: unexpected genvar
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* constructor: failing when an arg is not a syntactic value *)
+let poly_ f = Some (let x = ref 0 in x)
+[%%expect{|
+Line 1, characters 19-39:
+1 | let poly_ f = Some (let x = ref 0 in x)
+                       ^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+|}]
+
+(* variant: passing - no payload *)
+let poly_ f = `A
+[%%expect{|
+Line 1, characters 10-11:
+1 | let poly_ f = `A
+              ^
+Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+>> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* variant: passing - payload is a syntactic value *)
+let poly_ f = `A (fun x -> x)
+[%%expect{|
+>> Fatal error: layout: unexpected genvar
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* variant: failing - payload is not a syntactic value *)
+let poly_ f = `A (let x = ref 0 in x)
+[%%expect{|
+Line 1, characters 17-37:
+1 | let poly_ f = `A (let x = ref 0 in x)
+                     ^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+|}]
+
+(* tuple: passing when all components are syntactic values *)
+let poly_ f = (42, fun x -> x)
+[%%expect{|
+>> Fatal error: layout: unexpected genvar
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* tuple: failing when a component is not a syntactic value *)
+let poly_ f = (let x = ref 0 in x, fun x -> x)
+[%%expect{|
+Line 1, characters 14-46:
+1 | let poly_ f = (let x = ref 0 in x, fun x -> x)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+|}]
+
+(* unboxed tuple: passing when all components are syntactic values *)
+let poly_ f = #(42, fun x -> x)
+[%%expect{|
+>> Fatal error: layout: unexpected genvar
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* unboxed tuple: failing when a component is not a syntactic value *)
+let poly_ f = #((let x = ref 0 in x), fun x -> x)
+[%%expect{|
+Line 1, characters 16-36:
+1 | let poly_ f = #((let x = ref 0 in x), fun x -> x)
+                    ^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+|}]
+
+(* record: passing when all fields are syntactic values *)
+type r = { a : int; b : int -> int }
+let poly_ f = { a = 42; b = fun x -> x }
+[%%expect{|
+type r = { a : int; b : int -> int; }
+Line 2, characters 10-11:
+2 | let poly_ f = { a = 42; b = fun x -> x }
+              ^
+Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+>> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* record: failing when a field is not a syntactic value *)
+let poly_ f = { a = (let x = ref 0 in !x); b = fun x -> x }
+[%%expect{|
+Line 1, characters 20-41:
+1 | let poly_ f = { a = (let x = ref 0 in !x); b = fun x -> x }
+                        ^^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+|}]
+
+(* unboxed product record: passing when all fields are syntactic values *)
+type ur = #{ a : int; b : int }
+let poly_ f = #{ a = 42; b = 0 }
+[%%expect{|
+type ur = #{ a : int; b : int; }
+Line 2, characters 10-11:
+2 | let poly_ f = #{ a = 42; b = 0 }
+              ^
+Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+>> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+(* unboxed product record: failing when a field is not a syntactic value *)
+let poly_ f = #{ a = (let x = ref 0 in !x); b = 0 }
+[%%expect{|
+Line 1, characters 21-42:
+1 | let poly_ f = #{ a = (let x = ref 0 in !x); b = 0 }
+                         ^^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* RHS might constrain a layout and makes it not polymorphic *)

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -47,22 +47,11 @@ end = struct
     f
 end
 [%%expect{|
-Lines 3-7, characters 6-3:
-3 | ......struct
-4 |   let poly_ id =
+Lines 4-6, characters 2-5:
+4 | ..let poly_ id =
 5 |     let f x = x in
 6 |     f
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val id : layout_ l. ('a : l). 'a -> 'a end
-       is not included in
-         sig val id : int end
-       Values do not match:
-         val id : layout_ l. ('a : l). 'a -> 'a
-       is not included in
-         val id : int
-       The type "'a -> 'a" is not compatible with the type "int"
+Error: The right-hand side of a "let poly_" binding must be a syntactic value.
 |}]
 
 module _ : sig
@@ -176,15 +165,13 @@ module _ : sig
   val bar : layout_ p q. ('a : p) ('b : q). 'a -> 'b -> 'a
 end = struct
   let poly_ foo, bar =
-    let poly_ foo x = x in
-    let poly_ bar x _y = x in
-    (foo, bar)
+    (fun x -> x, fun x _ -> x)
 end
 [%%expect{|
->> Fatal error: Translcore: translation of layout-polymorphic instantiation is not yet supported
-(layout args: [<genvar>])
-Uncaught exception: Misc.Fatal_error
-
+Line 6, characters 4-30:
+6 |     (fun x -> x, fun x _ -> x)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression should not be a function, the expected type is "'a * 'b"
 |}]
 
 (* CR-someday zqian: Mixing poly_ and non-poly_ in let ... and ... is a type
@@ -239,27 +226,17 @@ Error: Signature mismatch:
        which is not supported yet.
 |}]
 
-(* Still works when the RHS is not immediately a function *)
+(* The RHS has to be a syntactic value *)
 module M : sig
   val pair : int
 end = struct
   let poly_ pair = let y = 42 in fun x -> #(x, y)
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
+Line 4, characters 2-49:
 4 |   let poly_ pair = let y = 42 in fun x -> #(x, y)
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val pair : layout_ l. ('a : l). 'a -> #('a * int) end
-       is not included in
-         sig val pair : int end
-       Values do not match:
-         val pair : layout_ l. ('a : l). 'a -> #('a * int)
-       is not included in
-         val pair : int
-       The type "'a -> #('a * int)" is not compatible with the type "int"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The right-hand side of a "let poly_" binding must be a syntactic value.
 |}]
 
 (* RHS might constrain a layout and makes it not polymorphic *)
@@ -495,4 +472,52 @@ Line 6, characters 2-15:
 6 |   and g x = f x
       ^^^^^^^^^^^^^
 Error: All bindings in a "let" must be either all "poly_" or all non-"poly_"
+|}]
+
+(* The following fails, because [f] contains a captured environment containing x which is
+   regional, and that makes the captured environment to be local, which makes [f] unable
+   to escape the regiohn. *)
+let _bar (x @ local) =
+  let poly_ f = x in
+  f
+[%%expect{|
+Line 2, characters 12-13:
+2 |   let poly_ f = x in
+                ^
+Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+
+Line 3, characters 2-3:
+3 |   f
+      ^
+Error: This value is "local"
+         because it is defined by a layout-polymorphic expression (at line 2, characters 12-13)
+         which is "local" to the parent region.
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}]
+
+(* multiple poly can be have different captured environment mode *)
+let f (x @ local) =
+  let poly_ f = x
+  and poly_ g = () in
+  g
+[%%expect{|
+Line 3, characters 12-13:
+3 |   and poly_ g = () in
+                ^
+Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+
+Line 2, characters 12-13:
+2 |   let poly_ f = x
+                ^
+Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+
+Line 2, characters 12-13:
+2 |   let poly_ f = x
+                ^
+Warning 26 [unused-var]: unused variable f.
+>> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+Uncaught exception: Misc.Fatal_error
+
 |}]

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -50,7 +50,8 @@ end
 Lines 5-6, characters 4-5:
 5 | ....let f x = x in
 6 |     f
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 module _ : sig
@@ -235,7 +236,8 @@ end
 Line 4, characters 19-49:
 4 |   let poly_ pair = let y = 42 in fun x -> #(x, y)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* constructor: passing when all args are syntactic values *)
@@ -252,7 +254,8 @@ let poly_ f = Some (let x = ref 0 in x)
 Line 1, characters 19-39:
 1 | let poly_ f = Some (let x = ref 0 in x)
                        ^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* variant: passing - no payload *)
@@ -281,7 +284,8 @@ let poly_ f = `A (let x = ref 0 in x)
 Line 1, characters 17-37:
 1 | let poly_ f = `A (let x = ref 0 in x)
                      ^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* tuple: passing when all components are syntactic values *)
@@ -298,7 +302,8 @@ let poly_ f = (let x = ref 0 in x, fun x -> x)
 Line 1, characters 14-46:
 1 | let poly_ f = (let x = ref 0 in x, fun x -> x)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* unboxed tuple: passing when all components are syntactic values *)
@@ -315,7 +320,8 @@ let poly_ f = #((let x = ref 0 in x), fun x -> x)
 Line 1, characters 16-36:
 1 | let poly_ f = #((let x = ref 0 in x), fun x -> x)
                     ^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* record: passing when all fields are syntactic values *)
@@ -338,7 +344,8 @@ let poly_ f = { a = (let x = ref 0 in !x); b = fun x -> x }
 Line 1, characters 20-41:
 1 | let poly_ f = { a = (let x = ref 0 in !x); b = fun x -> x }
                         ^^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* unboxed product record: passing when all fields are syntactic values *)
@@ -361,7 +368,8 @@ let poly_ f = #{ a = (let x = ref 0 in !x); b = 0 }
 Line 1, characters 21-42:
 1 | let poly_ f = #{ a = (let x = ref 0 in !x); b = 0 }
                          ^^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not allowed in a "let poly_" definition; it must be a function, constructor, tuple, record, or constant.
+Error: This expression is not allowed in a "let poly_" definition;
+       it must be a function, constructor, tuple, record, or constant.
 |}]
 
 (* RHS might constrain a layout and makes it not polymorphic *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -301,27 +301,29 @@ module Pattern_env : sig
     { mutable env : Env.t;
       equations_scope : int;
       allow_recursive_equations : bool;
-      is_lpoly : bool; }
-  val make: ?is_lpoly:bool -> Env.t -> equations_scope:int
+      mutable env_alloc_mode : Mode.Alloc.r option; }
+  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
     -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
+  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
       allow_recursive_equations : bool;
-      is_lpoly : bool; }
-  let make ?(is_lpoly=false) env ~equations_scope ~allow_recursive_equations =
+      mutable env_alloc_mode : Mode.Alloc.r option; }
+  let make ?env_alloc_mode env ~equations_scope ~allow_recursive_equations =
     { env;
       equations_scope;
       allow_recursive_equations;
-      is_lpoly; }
+      env_alloc_mode; }
   let copy ?equations_scope penv =
     let equations_scope =
       match equations_scope with None -> penv.equations_scope | Some s -> s in
     { penv with equations_scope }
   let set_env penv env = penv.env <- env
+  let set_env_alloc_mode penv m = penv.env_alloc_mode <- m
 end
 
 (**** unification mode ****)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -198,13 +198,15 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       allow_recursive_equations : bool;
       (* true iff checking counter examples *)
-      is_lpoly : bool;
-      (* true iff the pattern is under let poly_ *)
+      mutable env_alloc_mode : Mode.Alloc.r option;
+      (** [Some m] if the pattern is under [let poly_], where [m] is the
+         allocation mode of the captured environment *)
     }
-  val make: ?is_lpoly:bool -> Env.t -> equations_scope:int
+  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
     -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
+  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
 end
 
 type existential_treatment =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2413,6 +2413,10 @@ module Report = struct
         "is projected (at %a) from a float record (and thus allocated)"
         (Location.Doc.loc ~capitalize_first:false)
         loc
+    | Lpoly_captured_environment ->
+      Fmt.dprintf "is defined by a layout-polymorphic expression (at %a)"
+        (Location.Doc.loc ~capitalize_first:false)
+        loc
 
   let print_allocation_r : allocation -> Fmt.formatter -> unit =
    fun { txt; _ } ->
@@ -2427,6 +2431,9 @@ module Report = struct
          allocation)"
     | Float_projection ->
       Fmt.dprintf "is a float-record projection (and thus an allocation)"
+    | Lpoly_captured_environment ->
+      (* currently not testable *)
+      Fmt.dprintf "is a layout-polymorphic expression"
 
   let modality_if_relevant ~fixpoint pp =
     if

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -140,6 +140,7 @@ type allocation_desc =
   | Optional_argument
   | Function_coercion
   | Float_projection
+  | Lpoly_captured_environment
 
 type allocation = allocation_desc Location.loc
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -2503,7 +2503,7 @@ let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
     match (Patterns.General.view p).pat_desc with
     | `Alias (p,x,_,_,_,_,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
-    | `Var (x, _, _, _, _) | `Fun_layout (x, _, _, _, _, _) ->
+    | `Var (x, _, _, _, _) | `Fun_layout (x, _, _, _, _, _, _) ->
       simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k
     | `Or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -89,6 +89,7 @@ module General = struct
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
+                   * alloc_mode
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]
@@ -99,8 +100,9 @@ module General = struct
        `Any
     | Tpat_var { id; name = str; uid; sort; mode } ->
        `Var (id, str, uid, sort, mode)
-    | Tpat_fun_layout { id; name = str; uid; sort; mode; lpoly } ->
-       `Fun_layout (id, str, uid, sort, mode, lpoly)
+    | Tpat_fun_layout { id; name = str; uid; sort; mode; lpoly;
+                        env_alloc_mode } ->
+       `Fun_layout (id, str, uid, sort, mode, lpoly, env_alloc_mode)
     | Tpat_alias { pattern = p; id; name = str; uid; sort; mode;
                    type_expr = ty } ->
        `Alias (p, id, str, uid, sort, mode, ty)
@@ -133,8 +135,9 @@ module General = struct
     | `Any -> Tpat_any
     | `Var (id, str, uid, sort, mode) ->
        Tpat_var { id; name = str; uid; sort; mode }
-    | `Fun_layout (id, str, uid, sort, mode, lpoly) ->
-       Tpat_fun_layout { id; name = str; uid; sort; mode; lpoly }
+    | `Fun_layout (id, str, uid, sort, mode, lpoly, env_alloc_mode) ->
+       Tpat_fun_layout { id; name = str; uid; sort; mode; lpoly;
+                         env_alloc_mode }
     | `Alias (p, id, str, uid, sort, mode, ty) ->
        Tpat_alias { pattern = p; id; name = str; uid; sort; mode;
                     type_expr = ty }

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -73,6 +73,7 @@ module General : sig
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
+                   * alloc_mode
     | `Alias of pattern * Ident.t * string loc * Uid.t
                 * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -365,8 +365,9 @@ let pat
         Tpat_alias { pattern = sub.pat sub pattern; id;
                      name = map_loc sub name; uid;
                      sort; mode; type_expr }
-    | Tpat_fun_layout { id; name; uid; sort; mode; lpoly } ->
-        Tpat_fun_layout { id; name = map_loc sub name; uid; sort; mode; lpoly }
+    | Tpat_fun_layout { id; name; uid; sort; mode; lpoly; env_alloc_mode } ->
+        Tpat_fun_layout { id; name = map_loc sub name; uid; sort; mode;
+                          lpoly; env_alloc_mode }
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->
        (as_computation_pattern (sub.pat sub (p :> pattern))).pat_desc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4903,25 +4903,34 @@ let rec maybe_computation exp =
 (* Returns true if, for every [Texp_ident x] occurring in the expression,
    the comonadic axes of the expression are weaker (higher) than [x].
    Conservative: may return false when the condition holds. *)
-let rec captures_comonadic (exp : expression) =
+let rec check_captures_comonadic env (exp : expression) =
+  let check e = check_captures_comonadic env e in
+  let fail () =
+    raise (Error (exp.exp_loc, env, Let_poly_not_syntactic_value))
+  in
   match exp.exp_desc with
   | Texp_ident _ | Texp_constant _ | Texp_unboxed_unit | Texp_unboxed_bool _
-  | Texp_function _ -> true
+  | Texp_function _ -> ()
   | Texp_construct (_, _, args, _) ->
-    List.for_all captures_comonadic args
-  | Texp_variant (_, None) -> true
-  | Texp_variant (_, Some (e, _)) -> captures_comonadic e
+    List.iter check args
+  | Texp_variant (_, None) -> ()
+  | Texp_variant (_, Some (e, _)) -> check e
   | Texp_tuple (args, _) ->
-    List.for_all (fun (_, e) -> captures_comonadic e) args
+    List.iter (fun (_, e) -> check e) args
   | Texp_unboxed_tuple args ->
-    List.for_all (fun (_, e, _) -> captures_comonadic e) args
+    List.iter (fun (_, e, _) -> check e) args
   | Texp_record { fields; extended_expression = None; _ } ->
-    Array.for_all (fun (_, def) ->
+    Array.iter (fun (_, def) ->
       match def with
       | Kept _ -> assert false
-      | Overridden (_, e) -> captures_comonadic e) fields
-  | Texp_apply_layout (e, _) | Texp_exclave e -> captures_comonadic e
-  | _ -> false
+      | Overridden (_, e) -> check e) fields
+  | Texp_record_unboxed_product { fields; extended_expression = None; _ } ->
+    Array.iter (fun (_, def) ->
+      match def with
+      | Kept _ -> assert false
+      | Overridden (_, e) -> check e) fields
+  | Texp_apply_layout (e, _) | Texp_exclave e -> check e
+  | _ -> fail ()
 
 let annotate_recursive_bindings env valbinds =
   let ids = let_bound_idents valbinds in
@@ -10558,10 +10567,9 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         mode_pat_typ_list
         (List.map2 (fun (attrs, _, _, _, _) (e, _) -> attrs, e) spatl exp_list);
       if is_lpoly then
-        List.iter2 (fun { pvb_loc; _ } (exp, _) ->
-          if not (captures_comonadic exp) then
-            raise (Error (pvb_loc, env, Let_poly_not_syntactic_value))
-        ) spat_sexp_list exp_list;
+        List.iter (fun (exp, _) ->
+          check_captures_comonadic env exp
+        ) exp_list;
       (mode_pat_typ_list, exp_list, new_env, mvs, sorts,
        List.map (fun pv -> { pv with pv_type = instance pv.pv_type}) pvs)
     end
@@ -12545,7 +12553,8 @@ let report_error ~loc env =
         Style.inline_code "let poly_"
   | Let_poly_not_syntactic_value ->
       Location.errorf ~loc
-        "The right-hand side of a %a binding must be a syntactic value."
+        "This expression is not allowed in a %a definition; \
+         it must be a function, constructor, tuple, record, or constant."
         Style.inline_code "let poly_"
   | Layout_poly_inst_not_yet_supported ctx ->
       let ctx_str = match ctx with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4903,24 +4903,24 @@ let rec maybe_computation exp =
 (* Returns true if, for every [Texp_ident x] occurring in the expression,
    the comonadic axes of the expression are weaker (higher) than [x].
    Conservative: may return false when the condition holds. *)
-let rec is_syntactic_value (exp : expression) =
+let rec captures_comonadic (exp : expression) =
   match exp.exp_desc with
   | Texp_ident _ | Texp_constant _ | Texp_unboxed_unit | Texp_unboxed_bool _
   | Texp_function _ -> true
   | Texp_construct (_, _, args, _) ->
-    List.for_all is_syntactic_value args
+    List.for_all captures_comonadic args
   | Texp_variant (_, None) -> true
-  | Texp_variant (_, Some (e, _)) -> is_syntactic_value e
+  | Texp_variant (_, Some (e, _)) -> captures_comonadic e
   | Texp_tuple (args, _) ->
-    List.for_all (fun (_, e) -> is_syntactic_value e) args
+    List.for_all (fun (_, e) -> captures_comonadic e) args
   | Texp_unboxed_tuple args ->
-    List.for_all (fun (_, e, _) -> is_syntactic_value e) args
+    List.for_all (fun (_, e, _) -> captures_comonadic e) args
   | Texp_record { fields; extended_expression = None; _ } ->
     Array.for_all (fun (_, def) ->
       match def with
       | Kept _ -> assert false
-      | Overridden (_, e) -> is_syntactic_value e) fields
-  | Texp_apply_layout (e, _) | Texp_exclave e -> is_syntactic_value e
+      | Overridden (_, e) -> captures_comonadic e) fields
+  | Texp_apply_layout (e, _) | Texp_exclave e -> captures_comonadic e
   | _ -> false
 
 let annotate_recursive_bindings env valbinds =
@@ -5950,7 +5950,7 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
   in
   let env_alloc_mode, exp_mode =
     if is_lpoly then
-      (* Since we require [is_syntactic_value] for the RHS of [let poly_], we
+      (* Since we require [captures_comonadic] for the RHS of [let poly_], we
          can conservatively use the RHS's comonadic mode as the captured
          environment's mode. *)
       let env_alloc_mode, env_mode =
@@ -10559,7 +10559,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         (List.map2 (fun (attrs, _, _, _, _) (e, _) -> attrs, e) spatl exp_list);
       if is_lpoly then
         List.iter2 (fun { pvb_loc; _ } (exp, _) ->
-          if not (is_syntactic_value exp) then
+          if not (captures_comonadic exp) then
             raise (Error (pvb_loc, env, Let_poly_not_syntactic_value))
         ) spat_sexp_list exp_list;
       (mode_pat_typ_list, exp_list, new_env, mvs, sorts,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -302,6 +302,7 @@ type error =
   | Overwrite_of_invalid_term
   | Unexpected_hole
   | Let_poly_not_yet_implemented
+  | Let_poly_not_syntactic_value
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
 
 and invalid_layout_poly_inst_context =
@@ -3114,18 +3115,23 @@ and type_pat_aux
             let kind = Val_mut (m0, sort) in
             mode, kind
       in
-      let lpoly =
-        if (penv : Pattern_env.t).is_lpoly
-        then Lpoly.pending ~loc
-        else Lpoly.determined []
-      in
-      let id, uid =
-        enter_variable ~lpoly tps loc name mode ~kind ty sp.ppat_attributes sort
-      in
       let pat_desc =
-        if (penv : Pattern_env.t).is_lpoly
-        then Tpat_fun_layout { id; name; uid; sort; mode = alloc_mode; lpoly }
-        else Tpat_var { id; name; uid; sort; mode = alloc_mode }
+        match (penv : Pattern_env.t).env_alloc_mode with
+        | Some env_alloc_mode ->
+          let lpoly = Lpoly.pending ~loc in
+          let id, uid =
+            enter_variable ~lpoly tps loc name mode ~kind ty
+              sp.ppat_attributes sort
+          in
+          Tpat_fun_layout { id; name; uid; sort;
+                            mode = alloc_mode; lpoly; env_alloc_mode }
+        | None ->
+          let lpoly = Lpoly.determined [] in
+          let id, uid =
+            enter_variable ~lpoly tps loc name mode ~kind ty
+              sp.ppat_attributes sort
+          in
+          Tpat_var { id; name; uid; sort; mode = alloc_mode }
       in
       rvp {
         pat_desc;
@@ -3555,13 +3561,14 @@ let type_pattern
 
 let type_pattern_list
     category no_existentials env mutable_flag spatl expected_tys expected_sorts
-    allow_modules ~is_lpoly
+    allow_modules
   =
   let tps = create_type_pat_state allow_modules in
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
-      ~is_lpoly ~equations_scope ~allow_recursive_equations:false in
-  let type_pat (attrs, pat_mode, exp_mode, pat) ty sort =
+      ~equations_scope ~allow_recursive_equations:false in
+  let type_pat (attrs, pat_mode, env_alloc_mode, exp_mode, pat) ty sort =
+    Pattern_env.set_env_alloc_mode new_penv env_alloc_mode;
     Builtin_attributes.warning_scope ~ppwarning:false attrs
       (fun () ->
          exp_mode,
@@ -4893,6 +4900,29 @@ let rec maybe_computation exp =
   | Texp_apply_layout _
     -> true
 
+(* Returns true if, for every [Texp_ident x] occurring in the expression,
+   the comonadic axes of the expression are weaker (higher) than [x].
+   Conservative: may return false when the condition holds. *)
+let rec is_syntactic_value (exp : expression) =
+  match exp.exp_desc with
+  | Texp_ident _ | Texp_constant _ | Texp_unboxed_unit | Texp_unboxed_bool _
+  | Texp_function _ -> true
+  | Texp_construct (_, _, args, _) ->
+    List.for_all is_syntactic_value args
+  | Texp_variant (_, None) -> true
+  | Texp_variant (_, Some (e, _)) -> is_syntactic_value e
+  | Texp_tuple (args, _) ->
+    List.for_all (fun (_, e) -> is_syntactic_value e) args
+  | Texp_unboxed_tuple args ->
+    List.for_all (fun (_, e, _) -> is_syntactic_value e) args
+  | Texp_record { fields; extended_expression = None; _ } ->
+    Array.for_all (fun (_, def) ->
+      match def with
+      | Kept _ -> assert false
+      | Overridden (_, e) -> is_syntactic_value e) fields
+  | Texp_apply_layout (e, _) | Texp_exclave e -> is_syntactic_value e
+  | _ -> false
+
 let annotate_recursive_bindings env valbinds =
   let ids = let_bound_idents valbinds in
   List.map
@@ -5899,7 +5929,7 @@ let vb_pat_constraint
   in
   vb.pvb_attributes, spat
 
-let pat_modes ~force_toplevel rec_mode_var (attrs, spat) =
+let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
   let pat_mode, exp_mode =
     if force_toplevel
     then simple_pat_mode Value.legacy, mode_legacy
@@ -5918,7 +5948,24 @@ let pat_modes ~force_toplevel rec_mode_var (attrs, spat) =
     | Some mode ->
         simple_pat_mode mode, mode_default mode
   in
-  attrs, pat_mode, exp_mode, spat
+  let env_alloc_mode, exp_mode =
+    if is_lpoly then
+      (* Since we require [is_syntactic_value] for the RHS of [let poly_], we
+         can conservatively use the RHS's comonadic mode as the captured
+         environment's mode. *)
+      let env_alloc_mode, env_mode =
+        register_allocation ~loc:spat.ppat_loc
+          ~desc:Lpoly_captured_environment exp_mode
+      in
+      let exp_mode =
+        (* [env_mode] guaranteed to be lower than [exp_mode], but prioritize
+           [exp_mode] for mode error hints. *)
+        Mode.Value.meet (List.map as_single_mode [exp_mode; env_mode])
+      in
+      Some env_alloc_mode, mode_default exp_mode
+    else None, exp_mode
+  in
+  attrs, pat_mode, env_alloc_mode, exp_mode, spat
 
 let add_zero_alloc_attribute expr attributes =
   let open Builtin_attributes in
@@ -10365,8 +10412,10 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     | Nonrecursive -> None
   in
   let spatl = List.map vb_pat_constraint spat_sexp_list in
-  let spatl = List.map (pat_modes ~force_toplevel rec_mode_var) spatl in
-  let attrs_list = List.map (fun (attrs, _, _, _) -> attrs) spatl in
+  let spatl =
+    List.map (pat_modes ~force_toplevel rec_mode_var ~is_lpoly) spatl
+  in
+  let attrs_list = List.map (fun (attrs, _, _, _, _) -> attrs) spatl in
   let is_recursive = (rec_flag = Recursive) in
 
   let (pat_list, exp_list, new_env, mvs, sorts, _pvs) =
@@ -10381,7 +10430,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
           let (pat_list, _new_env, _force, pvs, _mvs as res) =
             with_local_level_if is_recursive (fun () ->
               type_pattern_list Value existential_context env mutable_flag spatl
-                nvs sorts allow_modules ~is_lpoly
+                nvs sorts allow_modules
             ) ~post:(fun (_, _, _, pvs, _) ->
                        iter_pattern_variables_type generalize pvs)
           in
@@ -10507,7 +10556,12 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
             )
         )
         mode_pat_typ_list
-        (List.map2 (fun (attrs, _, _, _) (e, _) -> attrs, e) spatl exp_list);
+        (List.map2 (fun (attrs, _, _, _, _) (e, _) -> attrs, e) spatl exp_list);
+      if is_lpoly then
+        List.iter2 (fun { pvb_loc; _ } (exp, _) ->
+          if not (is_syntactic_value exp) then
+            raise (Error (pvb_loc, env, Let_poly_not_syntactic_value))
+        ) spat_sexp_list exp_list;
       (mode_pat_typ_list, exp_list, new_env, mvs, sorts,
        List.map (fun pv -> { pv with pv_type = instance pv.pv_type}) pvs)
     end
@@ -12488,6 +12542,10 @@ let report_error ~loc env =
   | Let_poly_not_yet_implemented ->
       Location.errorf ~loc
         "The %a annotation is not yet implemented."
+        Style.inline_code "let poly_"
+  | Let_poly_not_syntactic_value ->
+      Location.errorf ~loc
+        "The right-hand side of a %a binding must be a syntactic value."
         Style.inline_code "let poly_"
   | Layout_poly_inst_not_yet_supported ctx ->
       let ctx_str = match ctx with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -12553,7 +12553,7 @@ let report_error ~loc env =
         Style.inline_code "let poly_"
   | Let_poly_not_syntactic_value ->
       Location.errorf ~loc
-        "This expression is not allowed in a %a definition; \
+        "This expression is not allowed in a %a definition;@ \
          it must be a function, constructor, tuple, record, or constant."
         Style.inline_code "let poly_"
   | Layout_poly_inst_not_yet_supported ctx ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -350,6 +350,7 @@ type error =
   | Overwrite_of_invalid_term
   | Unexpected_hole
   | Let_poly_not_yet_implemented
+  | Let_poly_not_syntactic_value
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
 
 and invalid_layout_poly_inst_context =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -200,6 +200,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       lpoly: Lpoly.t;
+      env_alloc_mode: alloc_mode;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -232,14 +232,40 @@ and 'k pattern_desc =
       name: string loc;
       uid: Uid.t;
       sort: Jkind_types.Sort.t;
+      (** the sort of the layout function body *)
       mode: Mode.Value.l;
+      (** the mode of the layout function body *)
       lpoly: Types.Lpoly.t;
+      (** The sort variables abstracted over by this compile-time function, and
+          the allocation mode of the captured environment. [pending] during
+          type-checking; guaranteed [determined] of (potentially empty) generic
+          sort variables after [type_let] returns. *)
+      env_alloc_mode: alloc_mode;
+      (** The allocation mode of the environment captured by the layout
+      function.
+
+      Imagine we defined [let poly_ f = .. x ..] in a structure [M], where [.. x
+      ..] is some expression (not necessarily a function) that refers to [x]. It
+      translates to runtime:
+
+       [let f__float = fun env -> let {x; ..} = env in .. x ..
+        let f_env = {x = x; ..}]
+
+      where [f__float] is the instantiated function and [f_env] is the captured
+      environment (containing the example variable [x]) and is passed to
+      [f__float]. Only [f_env] is stored within the structure [M] - [f__float]
+      will be a top-level symbol.
+
+      Observe the following constraint:
+      - For comonadic axes, [f_env <= M] and [x <= f_env].
+      - The monadic axes of [f_env] doesn't matter. In particular, note that
+        nothing closes over [f_env]. Also note that we don't perform on [f_env]
+        operations warranted by monadic modes such as [unique] or [uncontended].
+        *)
     } -> value pattern_desc
-        (** x with layout polymorphism, used in let poly_ bindings.
-            [lpoly] is [pending] during type-checking and guaranteed
-            [determined] after [type_let] returns. It may be determined with
-            an empty list of sort vars if no layout poly is actually inferred
-            (in which case a [Useless_lpoly] warning is emitted). *)
+        (** [let poly_ f = exp] creates a compile-time function [f] abstracted
+        over the layouts in [lpoly], and returns [exp] at [ret_sort] and
+         [ret_mode]. Note that [exp] is not necessarily a function. *)
   | Tpat_constant : constant -> value pattern_desc
         (** 1, 'a', "true", 1.0, 1l, 1L, 1n *)
   | Tpat_unboxed_unit : value pattern_desc

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -237,9 +237,9 @@ and 'k pattern_desc =
       (** the mode of the layout function body *)
       lpoly: Types.Lpoly.t;
       (** The sort variables abstracted over by this compile-time function, and
-          the allocation mode of the captured environment. [pending] during
-          type-checking; guaranteed [determined] of (potentially empty) generic
-          sort variables after [type_let] returns. *)
+      the allocation mode of the captured environment. [pending] during
+      type-checking; guaranteed [determined] of (potentially empty) generic sort
+      variables after [type_let] returns. *)
       env_alloc_mode: alloc_mode;
       (** The allocation mode of the environment captured by the layout
       function.
@@ -248,24 +248,24 @@ and 'k pattern_desc =
       ..] is some expression (not necessarily a function) that refers to [x]. It
       translates to runtime:
 
-       [let f__float = fun env -> let {x; ..} = env in .. x ..
-        let f_env = {x = x; ..}]
+      [let f__float = fun env -> let {x; ..} = env in .. x ..
+       let f_env = {x = x; ..}]
 
       where [f__float] is the instantiated function and [f_env] is the captured
       environment (containing the example variable [x]) and is passed to
-      [f__float]. Only [f_env] is stored within the structure [M] - [f__float]
-      will be a top-level symbol.
+      [f__float]. Only [f_env] is stored within the structure [M]; [f__float]
+      is a top-level symbol.
 
       Observe the following constraint:
       - For comonadic axes, [f_env <= M] and [x <= f_env].
-      - The monadic axes of [f_env] doesn't matter. In particular, note that
+      - The monadic axes of [f_env] don't matter. In particular, note that
         nothing closes over [f_env]. Also note that we don't perform on [f_env]
         operations warranted by monadic modes such as [unique] or [uncontended].
         *)
     } -> value pattern_desc
         (** [let poly_ f = exp] creates a compile-time function [f] abstracted
         over the layouts in [lpoly], and returns [exp] at [ret_sort] and
-         [ret_mode]. Note that [exp] is not necessarily a function. *)
+        [ret_mode]. Note that [exp] is not necessarily a function. *)
   | Tpat_constant : constant -> value pattern_desc
         (** 1, 'a', "true", 1.0, 1l, 1L, 1n *)
   | Tpat_unboxed_unit : value pattern_desc


### PR DESCRIPTION
Based on #5791 and #5792 

- We require the RHS of `let poly_` to be `is_syntactic_value` - it's defined from the perspective of modes, see the code.
- Based on that, we can conservatively take the comonadic modes of the RHS as the mode of the captured environment.