### PR TITLE
Sort variables have negative IDs in .cmi files

### DIFF
--- a/testsuite/tests/layout_poly/import_layout_poly.ml
+++ b/testsuite/tests/layout_poly/import_layout_poly.ml
@@ -1,0 +1,18 @@
+(* TEST
+   flags = "-extension layout_poly_alpha";
+   readonly_files = "layout_sigs.mli";
+   setup-ocamlc.byte-build-env;
+   module = "layout_sigs.mli";
+   ocamlc.byte;
+   module = "import_layout_poly.ml";
+   ocamlc.byte;
+   check-ocamlc.byte-output;
+*)
+
+(* CR-soon layouts: update these tests as soon as instantiation works. *)
+
+let _ = fun (module M : Layout_sigs.Sig_with_repr) -> M.foo
+
+let _ = fun (module M : Layout_sigs.Sig_with_layout_1) -> ()
+
+let _ = fun (module M : Layout_sigs.Sig_with_layout_2) -> ()

--- a/testsuite/tests/layout_poly/layout_sigs.mli
+++ b/testsuite/tests/layout_poly/layout_sigs.mli
@@ -1,0 +1,21 @@
+(* flags = "-extension layout_poly_alpha";
+*)
+
+(** This purpose of this file is to be used as part of a round-trip test: are
+    CMIs created and read from consistently?
+    The compiler codebase contains several assertions concerning the sign of
+    sort variable IDs.
+    The correct behaviour means that the compiler never asserts false.
+*)
+
+module type Sig_with_repr = sig
+  val foo : (repr_ 'a). 'a -> 'a
+end
+
+module type Sig_with_layout_1 = sig
+  val bar : layout_ l. ('a : l). 'a -> 'a
+end
+
+module type Sig_with_layout_2 = sig
+  val bam : layout_ l1 l2. ('a : l1) ('b : l2). 'a -> 'b -> #('a * 'b)
+end

--- a/testsuite/tests/layout_poly/layout_sigs.mli
+++ b/testsuite/tests/layout_poly/layout_sigs.mli
@@ -19,3 +19,5 @@ end
 module type Sig_with_layout_2 = sig
   val bam : layout_ l1 l2. ('a : l1) ('b : l2). 'a -> 'b -> #('a * 'b)
 end
+
+val f : layout_ l. ('a : l). 'a -> 'a

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3249,7 +3249,7 @@ let persistent_structures_of_dir dir =
 let save_signature_with_transform cmi_transform ~alerts sg modname kind
       cmi_info =
   Btype.cleanup_abbrev ();
-  Subst.reset_additional_action_type_id ();
+  Subst.reset_additional_action_id ();
   let sg = Subst.Lazy.of_signature sg
     |> Subst.Lazy.signature Make_local
         (Subst.with_additional_action Prepare_for_saving Subst.identity)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3249,7 +3249,7 @@ let persistent_structures_of_dir dir =
 let save_signature_with_transform cmi_transform ~alerts sg modname kind
       cmi_info =
   Btype.cleanup_abbrev ();
-  Subst.reset_additional_action_id ();
+  Subst.reset_additional_action_type_id ();
   let sg = Subst.Lazy.of_signature sg
     |> Subst.Lazy.signature Make_local
         (Subst.with_additional_action Prepare_for_saving Subst.identity)

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -242,8 +242,15 @@ module type Sort = sig
   *)
   val new_genvar : unit -> var
 
-  (** Returns [true] iff the variable was created by {!new_genvar}. *)
+  (** Create a polymorphic sort variable (level = [Ident.highest_scope]),
+      intended for saving to a cmi. *)
+  val new_genvar_for_cmi : unit -> var
+
+  (** Returns [true] iff the variable was created by {!new_genvar} or
+      {!new_genvar_for_cmi}. *)
   val is_genvar : var -> bool
+
+  val reset_cmi_sort_id : unit -> unit
 
   (** Get the concrete content of a variable. The returned sort must be
       representable (including rigid sorts). *)
@@ -252,12 +259,6 @@ module type Sort = sig
   (** [subst s t] applies the variable substitution [s] to [t], replacing each
       [Var v] where [(v, t')] is in [subst] with [t']. *)
   val subst : (var * t) list -> t -> t
-
-  (** Create a polymorphic sort variable with given level and id. Since [id] is
-      used to determined sort variable equality, [new_genvar] is the preferred
-      option in almost all cases. Currently, [create_var] is only used in the
-      context of saving signatures, where [id] is a negative number. *)
-  val create_var_with_id : level:int -> id:int -> t option -> var
 
   (** [instance_with ~level vars f] creates a fresh sort var at [level] for each
       var in [vars], calls [f] with {!instance} configured to replace each var

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -257,7 +257,7 @@ module type Sort = sig
       used to determined sort variable equality, [new_genvar] is the preferred
       option in almost all cases. Currently, [create_var] is only used in the
       context of saving signatures, where [id] is a negative number. *)
-  val create_var : level:int -> id:int -> t option -> var
+  val create_var_with_id : level:int -> id:int -> t option -> var
 
   (** [instance_with ~level vars f] creates a fresh sort var at [level] for each
       var in [vars], calls [f] with {!instance} configured to replace each var

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -168,12 +168,16 @@ module type Sort = sig
   end
 
   module Var : sig
-    type id = private int
-    (* the [private int] allows the debugger to print it *)
+    type id = int
 
-    (** Extract the unique id for a [var]; this should be used only for
-        debugging or printing, not for decision making *)
+    (** Extract the unique id for a [var]. *)
     val get_id : var -> id
+
+    (** Extract the variable contents. *)
+    val get_contents : var -> t option
+
+    (** Extract the variable level. *)
+    val get_level : var -> int
 
     (** Get the number of an [id], useful for printing. These numbers get
         allocated only when an [id] gets printed, and so they are less brittle
@@ -248,6 +252,12 @@ module type Sort = sig
   (** [subst s t] applies the variable substitution [s] to [t], replacing each
       [Var v] where [(v, t')] is in [subst] with [t']. *)
   val subst : (var * t) list -> t -> t
+
+  (** Create a polymorphic sort variable with given level and id. Since [id] is
+      used to determined sort variable equality, [new_genvar] is the preferred
+      option in almost all cases. Currently, [create_var] is only used in the
+      context of saving signatures, where [id] is a negative number. *)
+  val create_var : level:int -> id:int -> t option -> var
 
   (** [instance_with ~level vars f] creates a fresh sort var at [level] for each
       var in [vars], calls [f] with {!instance} configured to replace each var

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -168,16 +168,15 @@ module type Sort = sig
   end
 
   module Var : sig
-    type id = int
+    type id = private int
+    (* the [private int] allows the debugger to print it *)
+
+    (** Checks whether a [var] satisfies the properties that hold for variables
+        saved to a cmi. *)
+    val is_cmi_var : var -> bool
 
     (** Extract the unique id for a [var]. *)
     val get_id : var -> id
-
-    (** Extract the variable contents. *)
-    val get_contents : var -> t option
-
-    (** Extract the variable level. *)
-    val get_level : var -> int
 
     (** Get the number of an [id], useful for printing. These numbers get
         allocated only when an [id] gets printed, and so they are less brittle

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -175,7 +175,8 @@ module type Sort = sig
         saved to a cmi. *)
     val is_cmi_var : var -> bool
 
-    (** Extract the unique id for a [var]. *)
+    (** Extract the unique id for a [var]. Outside of a cmi, equal [id]s imply
+        physical equality of [var]s. *)
     val get_id : var -> id
 
     (** Get the number of an [id], useful for printing. These numbers get

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -83,8 +83,6 @@ module Sort = struct
     assert (Option.is_none var.contents);
     var.level = level_generic
 
-  let create_var_with_id ~level ~id contents = { contents; level; id }
-
   let equal_base b1 b2 =
     match b1, b2 with
     | Void, Void
@@ -582,10 +580,14 @@ module Sort = struct
 
   let last_var_id = ref 0
 
+  let last_var_cmi_id = ref 0
+
+  let reset_cmi_sort_id () = last_var_cmi_id := 0
+
   let new_var_unsafe ~level =
     incr last_var_id;
     assert (!last_var_id > 0);
-    { contents = None; id = !last_var_id; level }
+    { contents = None; level; id = !last_var_id }
 
   let new_var ~level =
     (* Guard against accidentally creating a genvar or rigidvar via this path:
@@ -598,6 +600,11 @@ module Sort = struct
     new_var_unsafe ~level
 
   let new_genvar () = new_var_unsafe ~level:level_generic
+
+  let new_genvar_for_cmi () =
+    decr last_var_cmi_id;
+    assert (!last_var_cmi_id < 0);
+    { contents = None; level = level_generic; id = !last_var_cmi_id }
 
   let new_rigidvar () = new_var_unsafe ~level:level_rigid
 

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -71,13 +71,7 @@ module Sort = struct
 
   and var =
     { mutable contents : t option;
-      mutable level : int;
-      (* When [contents = None], [level = Ident.highest_scope] indicates
-        generic sort variables, and [level = Ident.highest_scope - 1] indicates
-        rigid variables. When [contents = Some t], [level] is meaningless and
-        the variable means whatever [t] means. *)
-      (* CR-soon zqian: Add the invariant that, when [contents = Some v], we
-         have [level >= v.level]. This can improve performance. *)
+      mutable level : int; (** See comments on [level_generic] *)
       id : int
     }
 
@@ -89,7 +83,7 @@ module Sort = struct
     assert (Option.is_none var.contents);
     var.level = level_generic
 
-  let create_var ~level ~id contents = { contents; level; id }
+  let create_var_with_id ~level ~id contents = { contents; level; id }
 
   let equal_base b1 b2 =
     match b1, b2 with

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -71,7 +71,7 @@ module Sort = struct
 
   and var =
     { mutable contents : t option;
-      mutable level : int; (** See comments on [level_generic] *)
+      mutable level : int;  (** See comments on [level_generic] *)
       id : int
     }
 

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -71,8 +71,14 @@ module Sort = struct
 
   and var =
     { mutable contents : t option;
-      mutable level : int;  (** See comments on [level_generic] *)
-      uid : int (* For debugging / printing only *)
+      mutable level : int;
+      (* When [contents = None], [level = Ident.highest_scope] indicates
+        generic sort variables, and [level = Ident.highest_scope - 1] indicates
+        rigid variables. When [contents = Some t], [level] is meaningless and
+        the variable means whatever [t] means. *)
+      (* CR-soon zqian: Add the invariant that, when [contents = Some v], we
+         have [level >= v.level]. This can improve performance. *)
+      id : int
     }
 
   let is_rigidvar var =
@@ -82,6 +88,8 @@ module Sort = struct
   let is_genvar var =
     assert (Option.is_none var.contents);
     var.level = level_generic
+
+  let create_var ~level ~id contents = { contents; level; id }
 
   let equal_base b1 b2 =
     match b1, b2 with
@@ -167,7 +175,7 @@ module Sort = struct
       | Base b1, Base b2 -> equal_base b1 b2
       | Product cs1, Product cs2 -> List.equal equal cs1 cs2
       | Univar uv1, Univar uv2 -> equal_univar_univar uv1 uv2
-      | Genvar v1, Genvar v2 -> v1 == v2
+      | Genvar v1, Genvar v2 -> v1.id == v2.id
       | (Base _ | Product _ | Univar _ | Genvar _), _ -> false
 
     let format ppf c =
@@ -245,7 +253,7 @@ module Sort = struct
               cs
           | Univar { name = Some n } -> Format.fprintf ppf "Univar '%s" n
           | Univar { name = None } -> Format.fprintf ppf "Univar '_"
-          | Genvar v -> Format.fprintf ppf "Genvar %d" v.uid
+          | Genvar v -> Format.fprintf ppf "Genvar %d" v.id
         in
         pp_element ~nested:false ppf c
     end
@@ -306,24 +314,28 @@ module Sort = struct
   module Var = struct
     type id = int
 
-    let get_id { uid; _ } = uid
+    let get_id { id; _ } = id
 
-    (* Map var uids to smaller numbers for more consistent printing. *)
+    let get_contents { contents; _ } = contents
+
+    let get_level { level; _ } = level
+
+    (* Map var ids to smaller numbers for more consistent printing. *)
     let next_id = ref 1
 
     let names : (int, int) Hashtbl.t = Hashtbl.create 16
 
-    let get_print_number uid =
-      match Hashtbl.find_opt names uid with
+    let get_print_number id =
+      match Hashtbl.find_opt names id with
       | Some n -> n
       | None ->
-        let id = !next_id in
+        let counter = !next_id in
         incr next_id;
-        Hashtbl.add names uid id;
-        id
+        Hashtbl.add names id counter;
+        counter
 
-    let name { uid; _ } =
-      "'_representable_layout_" ^ Int.to_string (get_print_number uid)
+    let name { id; _ } =
+      "'_representable_layout_" ^ Int.to_string (get_print_number id)
   end
 
   (*** debug printing **)
@@ -362,7 +374,7 @@ module Sort = struct
       | None -> fprintf ppf "None"
 
     and var ppf v =
-      fprintf ppf "{@[@ contents = %a;@ uid = %d@ @]}" opt_t v.contents v.uid
+      fprintf ppf "{@[@ contents = %a;@ id = %d@ @]}" opt_t v.contents v.id
   end
 
   (* To record changes to sorts, for use with `Types.{snapshot, backtrack}` *)
@@ -574,11 +586,12 @@ module Sort = struct
 
   let of_var v = Var v
 
-  let last_var_uid = ref 0
+  let last_var_id = ref 0
 
   let new_var_unsafe ~level =
-    incr last_var_uid;
-    { contents = None; uid = !last_var_uid; level }
+    incr last_var_id;
+    assert (!last_var_id > 0);
+    { contents = None; id = !last_var_id; level }
 
   let new_var ~level =
     (* Guard against accidentally creating a genvar or rigidvar via this path:
@@ -601,7 +614,9 @@ module Sort = struct
       List.map
         (fun v ->
           assert (is_genvar v);
+          assert (v.id > 0);
           let v' = new_var_unsafe ~level in
+          assert (v'.id > 0);
           v, v')
         vars
     in
@@ -821,7 +836,7 @@ module Sort = struct
     | Univar uv2 -> equate_var_univar v1 uv2
 
   and equate_var_var v1 v2 =
-    if v1 == v2
+    if v1.id == v2.id (* equal id means physical equality *)
     then Equal_no_mutation
     else
       match v1.contents, v2.contents with
@@ -967,7 +982,7 @@ module Layout = struct
       | Any sa1, Any sa2 -> Scannable_axes.equal sa1 sa2
       | Product cs1, Product cs2 -> List.equal equal cs1 cs2
       | Univar uv1, Univar uv2 -> Sort.equal_univar_univar uv1 uv2
-      | Genvar v1, Genvar v2 -> v1 == v2
+      | Genvar v1, Genvar v2 -> v1.id == v2.id
       | (Base _ | Any _ | Product _ | Univar _ | Genvar _), _ -> false
 
     let rec get_sort : t -> Sort.Const.t option = function

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -584,7 +584,6 @@ module Sort = struct
 
   let new_var_unsafe ~level =
     incr last_var_id;
-    assert (!last_var_id > 0);
     { contents = None; level; id = !last_var_id }
 
   let new_var ~level =
@@ -601,7 +600,6 @@ module Sort = struct
 
   let new_genvar_for_cmi () =
     decr last_var_cmi_id;
-    assert (!last_var_cmi_id < 0);
     { contents = None; level = level_generic; id = !last_var_cmi_id }
 
   let new_rigidvar () = new_var_unsafe ~level:level_rigid
@@ -613,9 +611,9 @@ module Sort = struct
       List.map
         (fun v ->
           assert (is_genvar v);
+          (* ensure the variable is not a CMI serialised variable *)
           assert (v.id > 0);
           let v' = new_var_unsafe ~level in
-          assert (v'.id > 0);
           v, v')
         vars
     in

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -167,7 +167,7 @@ module Sort = struct
       | Base b1, Base b2 -> equal_base b1 b2
       | Product cs1, Product cs2 -> List.equal equal cs1 cs2
       | Univar uv1, Univar uv2 -> equal_univar_univar uv1 uv2
-      | Genvar v1, Genvar v2 -> v1.id == v2.id
+      | Genvar v1, Genvar v2 -> v1.id = v2.id
       | (Base _ | Product _ | Univar _ | Genvar _), _ -> false
 
     let format ppf c =
@@ -308,9 +308,7 @@ module Sort = struct
 
     let get_id { id; _ } = id
 
-    let get_contents { contents; _ } = contents
-
-    let get_level { level; _ } = level
+    let is_cmi_var { id; _ } = id < 0
 
     (* Map var ids to smaller numbers for more consistent printing. *)
     let next_id = ref 1
@@ -837,7 +835,7 @@ module Sort = struct
     | Univar uv2 -> equate_var_univar v1 uv2
 
   and equate_var_var v1 v2 =
-    if v1.id == v2.id (* equal id means physical equality *)
+    if v1.id = v2.id (* equal id means physical equality *)
     then Equal_no_mutation
     else
       match v1.contents, v2.contents with
@@ -983,7 +981,7 @@ module Layout = struct
       | Any sa1, Any sa2 -> Scannable_axes.equal sa1 sa2
       | Product cs1, Product cs2 -> List.equal equal cs1 cs2
       | Univar uv1, Univar uv2 -> Sort.equal_univar_univar uv1 uv2
-      | Genvar v1, Genvar v2 -> v1.id == v2.id
+      | Genvar v1, Genvar v2 -> v1.id = v2.id
       | (Base _ | Any _ | Product _ | Univar _ | Genvar _), _ -> false
 
     let rec get_sort : t -> Sort.Const.t option = function

--- a/typing/signature_with_global_bindings.ml
+++ b/typing/signature_with_global_bindings.ml
@@ -8,7 +8,7 @@ type t = {
 let read_from_cmi (cmi : Cmi_format.cmi_infos_lazy) =
   let sign =
     (* Freshen identifiers bound by signature *)
-    Subst.Lazy.signature Make_local Subst.identity cmi.cmi_sign in
+    Subst.Lazy.signature Make_local (Subst.for_loading_cmi ()) cmi.cmi_sign in
   let bound_globals = cmi.cmi_globals in
   { sign; bound_globals }
 

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -41,7 +41,7 @@ type additional_action =
   | Prepare_for_saving of
       { prepare_jkind : 'l 'r. Location.t -> ('l * 'r) jkind -> ('l * 'r) jkind;
         prepare_mode : Mode.Alloc.lr -> Mode.Alloc.lr;
-        prepare_modality : Mode.Modality.t -> Mode.Modality.t
+        prepare_modality : Mode.Modality.t -> Mode.Modality.t;
       }
     (* The [prepare_jkind] function should be applied to all jkinds when
        saving; this commons them up, truncates their histories, and runs
@@ -60,6 +60,7 @@ type s =
     jkinds: kind_replacement Path.Map.t;
 
     additional_action: additional_action;
+    sort_var_mapping: (int, Jkind_types.Sort.var) Hashtbl.t;
 
     loc: Location.t option;
     mutable last_compose: (s * s) option  (* Memoized composition *)
@@ -88,6 +89,7 @@ let identity =
     modtypes = Path.Map.empty;
     jkinds = Path.Map.empty;
     additional_action = No_action;
+    sort_var_mapping = Hashtbl.create 0;
     loc = None;
     last_compose = None;
   }
@@ -286,7 +288,11 @@ let with_additional_action =
         in
         Prepare_for_saving { prepare_jkind; prepare_mode; prepare_modality }
   in
-  { s with additional_action; last_compose = None }
+  { s with
+    additional_action;
+    sort_var_mapping = Hashtbl.create 17;
+    last_compose = None;
+  }
 
 let change_locs s loc = { s with loc = Some loc; last_compose = None }
 
@@ -400,15 +406,23 @@ let to_subst_by_type_function s p =
   | Type_function _ -> true
   | exception Not_found -> false
 
-(* Special type ids for saved signatures *)
+(* Special type and sort ids for saved signatures *)
 
-let new_id = s_ref (-1)
-let reset_additional_action_type_id () = new_id := -1
+let new_type_id = s_ref (-1)
+let new_sort_id = s_ref (-1)
+let reset_additional_action_id () =
+  new_type_id := -1;
+  new_sort_id := -1
 
 let newpersty desc =
-  decr new_id;
+  decr new_type_id;
   create_expr
-    desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_id
+    desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_type_id
+
+let newsortvar desc =
+  decr new_sort_id;
+  Jkind_types.Sort.create_var
+    desc ~level:generic_level ~id:!new_sort_id
 
 (* CR layouts: remove this. While we're still developing, though, it might
    be nice to get the location of this kind of error. *)
@@ -485,6 +499,42 @@ let apply_type_function params args body =
     copy body)
 
 
+let rec sort s srt =
+  let open Jkind_types.Sort in
+  match srt with
+  | Base _ | Univar _ -> srt
+  | Product sorts -> Product (List.map (sort s) sorts)
+  | Var var ->
+    let id = Var.get_id var in
+    let var' =
+      match Hashtbl.find_opt s.sort_var_mapping id with
+      | Some var -> var
+      | None ->
+        let desc = Var.get_contents var in
+        let level = Var.get_level var in
+        let var = match s.additional_action with
+          | Prepare_for_saving _ -> newsortvar desc
+          | Duplicate_variables -> new_var ~level
+          | No_action ->
+            if id < 0 then new_var ~level
+            else var
+        in
+        Hashtbl.add s.sort_var_mapping id var;
+        var
+    in
+    if var == var' then srt
+    else Var var'
+
+let rec layout s l =
+  let open Jkind_types.Layout in
+  match l with
+  | Any _ -> l
+  | Product sorts -> Product (List.map (layout s) sorts)
+  | Sort (sort_l, ax) ->
+    let sort_l' = sort s sort_l in
+    if sort_l == sort_l' then l
+    else Sort (sort_l', ax)
+
 let jkind_desc s jkind =
   match jkind.base with
   | Kconstr p ->
@@ -502,7 +552,10 @@ let jkind_desc s jkind =
       in
       Jkind.Base_and_axes.map_layout Jkind_types.Layout.of_const const
     end
-  | Layout _ -> jkind
+  | Layout l ->
+    let l' = layout s l in
+    if l == l' then jkind
+    else { jkind with base = Layout l' }
 
 let jkind_const_desc s
       ({ with_bounds = No_with_bounds } as jkind : jkind_const_desc_lr) =
@@ -1228,6 +1281,7 @@ and compose s1 s2 =
             | (Prepare_for_saving _ as prepare1), Prepare_for_saving _
                 -> prepare1
           end;
+          sort_var_mapping = Hashtbl.create 17;
           loc = keep_latest_loc s1.loc s2.loc;
           last_compose = None
         }

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -431,10 +431,10 @@ let to_subst_by_type_function s p =
   | Type_function _ -> true
   | exception Not_found -> false
 
-(* Special type and sort ids for saved signatures *)
+(* Special type ids for saved signatures *)
 
 let new_type_id = s_ref (-1)
-let reset_additional_action_id () =
+let reset_additional_action_type_id () =
   new_type_id := -1;
   Jkind_types.Sort.reset_cmi_sort_id ()
 
@@ -524,8 +524,8 @@ let apply_type_function params args body =
 let sort_var s srt var =
   let open Jkind_types.Sort in
   let assert_generic var =
-    if Var.get_level var <> generic_level then
-      fatal_errorf "sort_var: not generic, level is %d" (Var.get_level var);
+    if not (is_genvar var) then
+      fatal_errorf "sort_var: not generic"
   in
   let id = Var.get_id var in
   let var' =

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -64,11 +64,6 @@ type sort_map =
   | Nothing
     (* substitution has nothing to do with cmi operations *)
 
-let find_in_sort_map_opt ~id =
-  function
-  | Nothing -> None
-  | Saving m | Loading m -> Hashtbl.find_opt m id
-
 type s =
   { types: type_replacement Path.Map.t;
     modules: Path.t Path.Map.t;
@@ -438,9 +433,6 @@ let newpersty desc =
   create_expr
     desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_type_id
 
-let newsortvar () =
-  Jkind_types.Sort.new_genvar_for_cmi ()
-
 (* CR layouts: remove this. While we're still developing, though, it might
    be nice to get the location of this kind of error. *)
 (* We use a ref instead of passing [loc] as an argument to [typexp]
@@ -516,43 +508,46 @@ let apply_type_function params args body =
     copy body)
 
 
-let sort_var s srt var =
+let sort_var s var =
   let open Jkind_types.Sort in
   let assert_generic var =
     if not (is_genvar var) then
       fatal_errorf "sort_var: not generic"
   in
-  let id = Var.get_id var in
-  let var' =
-    match find_in_sort_map_opt ~id s.sort_var_mapping with
+  let lookup_sort_map_or_create ~post_condition ~create sort_map var =
+    assert (not (post_condition var));
+    let id = Var.get_id var in
+    match Hashtbl.find_opt sort_map id with
     | Some var -> var
     | None ->
-      match s.sort_var_mapping with
-      | Saving m ->
-        assert (not (Var.is_cmi_var var));
-        assert_generic var;
-        let var = newsortvar () in
-        assert (Var.is_cmi_var var);
-        Hashtbl.add m id var;
-        var
-      | Loading m ->
-        assert (Var.is_cmi_var var);
-        assert_generic var;
-        let var = new_genvar () in
-        assert (not (Var.is_cmi_var var));
-        Hashtbl.add m id var;
-        var
-      | Nothing -> var
+      assert_generic var;
+      let var = create () in
+      assert (post_condition var);
+      Hashtbl.add sort_map id var;
+      var
   in
-  if var == var' then srt
-  else Var var'
+  match s.sort_var_mapping with
+  | Nothing -> var
+  | Saving m ->
+    lookup_sort_map_or_create
+      ~post_condition:Var.is_cmi_var
+      ~create:new_genvar_for_cmi
+      m var
+  | Loading m ->
+    lookup_sort_map_or_create
+      ~post_condition:(Fun.negate Var.is_cmi_var)
+      ~create:new_genvar
+      m var
 
 let rec sort s srt =
   let open Jkind_types.Sort in
   match srt with
   | Base _ | Univar _ -> srt
   | Product sorts -> Product (List.map (sort s) sorts)
-  | Var var -> sort_var s srt var
+  | Var var ->
+    let var' = sort_var s var in
+    if var == var' then srt
+    else Var var'
 
 let rec layout s l =
   let open Jkind_types.Layout in
@@ -754,6 +749,7 @@ and jkind : 'l 'r. _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
       prepare_jkind !location_for_jkind_check_errors jkind
     | Duplicate_variables | No_action -> jkind
   in
+  (* CR-soon layouts aivaskovic: get rid of map_type_expr *)
   let jkind = Jkind.map_type_expr (typexp copy_scope s) jkind in
   let jkind_desc = jkind_desc s jkind.jkind in
   if jkind_desc == jkind.jkind then jkind

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -1154,7 +1154,11 @@ let force_type_expr ty = Wrap.force (fun _ s ty ->
   let loc = Option.value s.loc ~default:Location.none in
   For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)) ty
 
-let force_lpoly lpoly = Wrap.force (fun _ _ x -> x) lpoly
+let force_lpoly lpoly = Wrap.force (fun _ s lpoly ->
+  (* CR-someday zqian: maybe subst should work for [pending] as well. *)
+  let vars = Types.Lpoly.get_exn lpoly in
+  let vars = List.map (sort_var s) vars in
+  Types.Lpoly.determined vars) lpoly
 
 let rec subst_lazy_value_description s descr =
   let val_modalities =
@@ -1166,7 +1170,7 @@ let rec subst_lazy_value_description s descr =
   { val_type = Wrap.substitute ~compose Keep s descr.val_type;
     val_modalities;
     val_kind = descr.val_kind;
-    val_lpoly = descr.val_lpoly;
+    val_lpoly = Wrap.substitute ~compose Keep s descr.val_lpoly;
     val_loc = loc s descr.val_loc;
     val_zero_alloc =
       (* When saving a cmi file, we replace zero_alloc variables with constants.

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -542,7 +542,10 @@ let rec sort s srt =
   let open Jkind_types.Sort in
   match srt with
   | Base _ | Univar _ -> srt
-  | Product sorts -> Product (List.map (sort s) sorts)
+  | Product sorts ->
+    let sorts' = Misc.Stdlib.List.map_sharing (sort s) sorts in
+    if sorts == sorts' then srt
+    else Product sorts'
   | Var var ->
     let var' = sort_var s var in
     if var == var' then srt
@@ -552,7 +555,10 @@ let rec layout s l =
   let open Jkind_types.Layout in
   match l with
   | Any _ -> l
-  | Product sorts -> Product (List.map (layout s) sorts)
+  | Product sorts ->
+    let sorts' = Misc.Stdlib.List.map_sharing (layout s) sorts in
+    if sorts == sorts' then l
+    else Product sorts'
   | Sort (sort_l, ax) ->
     let sort_l' = sort s sort_l in
     if sort_l == sort_l' then l

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -53,26 +53,21 @@ type additional_action =
   | Duplicate_variables
   | No_action
 
+(* These represent maps from variable ids to the corresponding sort vars.
+   The reason for their existence is ensuring that the same variable id maps
+   to the same physical variable being saved to a cmi or loaded from a cmi. *)
 type sort_map =
-  | Saving of (int, Jkind_types.Sort.var) Hashtbl.t
-  | Loading of (int, Jkind_types.Sort.var) Hashtbl.t
+  | Saving of (Jkind_types.Sort.Var.id, Jkind_types.Sort.var) Hashtbl.t
+    (* saving to a cmi *)
+  | Loading of (Jkind_types.Sort.Var.id, Jkind_types.Sort.var) Hashtbl.t
+    (* loading from a cmi *)
   | Nothing
+    (* substitution has nothing to do with cmi operations *)
 
 let find_in_sort_map_opt ~id =
   function
   | Nothing -> None
   | Saving m | Loading m -> Hashtbl.find_opt m id
-
-let add_to_sort_map ~id ~data =
-  let open Jkind_types.Sort in
-  function
-  | Nothing -> fatal_error "subst: add_to_sort_map"
-  | Saving m ->
-    assert (Var.get_id data < 0);
-    Hashtbl.add m id data
-  | Loading m ->
-    assert (Var.get_id data > 0);
-    Hashtbl.add m id data
 
 type s =
   { types: type_replacement Path.Map.t;
@@ -533,15 +528,19 @@ let sort_var s srt var =
     | Some var -> var
     | None ->
       match s.sort_var_mapping with
-      | Saving _ ->
+      | Saving m ->
+        assert (not (Var.is_cmi_var var));
         assert_generic var;
         let var = newsortvar () in
-        add_to_sort_map ~id ~data:var s.sort_var_mapping;
+        assert (Var.is_cmi_var var);
+        Hashtbl.add m id var;
         var
-      | Loading _ ->
+      | Loading m ->
+        assert (Var.is_cmi_var var);
         assert_generic var;
         let var = new_genvar () in
-        add_to_sort_map ~id ~data:var s.sort_var_mapping;
+        assert (not (Var.is_cmi_var var));
+        Hashtbl.add m id var;
         var
       | Nothing -> var
   in
@@ -1316,8 +1315,9 @@ and compose s1 s2 =
             | action, Nothing | Nothing, action -> action
             | (Loading _ as s), Loading _ -> s
             | (Saving _ as s), Saving _ -> s
-            | (Saving _ as s), Loading _
-            | Loading _, (Saving _ as s) -> s
+            | Saving _, Loading _
+            | Loading _, Saving _ ->
+              fatal_error "compose: composing Saving and Loading"
           end;
           loc = keep_latest_loc s1.loc s2.loc;
           last_compose = None

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -41,7 +41,7 @@ type additional_action =
   | Prepare_for_saving of
       { prepare_jkind : 'l 'r. Location.t -> ('l * 'r) jkind -> ('l * 'r) jkind;
         prepare_mode : Mode.Alloc.lr -> Mode.Alloc.lr;
-        prepare_modality : Mode.Modality.t -> Mode.Modality.t;
+        prepare_modality : Mode.Modality.t -> Mode.Modality.t
       }
     (* The [prepare_jkind] function should be applied to all jkinds when
        saving; this commons them up, truncates their histories, and runs
@@ -53,6 +53,27 @@ type additional_action =
   | Duplicate_variables
   | No_action
 
+type sort_map =
+  | Saving of (int, Jkind_types.Sort.var) Hashtbl.t
+  | Loading of (int, Jkind_types.Sort.var) Hashtbl.t
+  | Nothing
+
+let find_in_sort_map_opt ~id =
+  function
+  | Nothing -> None
+  | Saving m | Loading m -> Hashtbl.find_opt m id
+
+let add_to_sort_map ~id ~data =
+  let open Jkind_types.Sort in
+  function
+  | Nothing -> fatal_error "subst: add_to_sort_map"
+  | Saving m ->
+    assert (Var.get_id data < 0);
+    Hashtbl.add m id data
+  | Loading m ->
+    assert (Var.get_id data > 0);
+    Hashtbl.add m id data
+
 type s =
   { types: type_replacement Path.Map.t;
     modules: Path.t Path.Map.t;
@@ -60,7 +81,7 @@ type s =
     jkinds: kind_replacement Path.Map.t;
 
     additional_action: additional_action;
-    sort_var_mapping: (int, Jkind_types.Sort.var) Hashtbl.t;
+    sort_var_mapping: sort_map;
 
     loc: Location.t option;
     mutable last_compose: (s * s) option  (* Memoized composition *)
@@ -89,10 +110,13 @@ let identity =
     modtypes = Path.Map.empty;
     jkinds = Path.Map.empty;
     additional_action = No_action;
-    sort_var_mapping = Hashtbl.create 0;
+    sort_var_mapping = Nothing;
     loc = None;
     last_compose = None;
   }
+
+let for_loading_cmi () =
+  { identity with sort_var_mapping = Loading (Hashtbl.create 17) }
 
 (* Add a replacement for both a path and its unboxed version, even if that
    unboxed version doesn't exist (as we can't tell here whether it exists).
@@ -251,9 +275,9 @@ let with_additional_action =
      We'll need to revisit the Note [Preparing_for_saving always the same]
      once we do this tailoring.
   *)
-  let additional_action : additional_action =
+  let (additional_action, sort_var_mapping) : additional_action * sort_map =
     match config with
-    | Duplicate_variables -> Duplicate_variables
+    | Duplicate_variables -> Duplicate_variables, Nothing
     | Prepare_for_saving ->
         let prepare_jkind (type l r) loc (jkind : (l * r) jkind) =
           match Jkind.get_const jkind with
@@ -286,11 +310,12 @@ let with_additional_action =
         let prepare_modality modality =
           Mode.Modality.(modality |> to_const_exn|> of_const)
         in
-        Prepare_for_saving { prepare_jkind; prepare_mode; prepare_modality }
+        Prepare_for_saving { prepare_jkind; prepare_mode; prepare_modality },
+        Saving (Hashtbl.create 17)
   in
   { s with
     additional_action;
-    sort_var_mapping = Hashtbl.create 17;
+    sort_var_mapping;
     last_compose = None;
   }
 
@@ -409,20 +434,17 @@ let to_subst_by_type_function s p =
 (* Special type and sort ids for saved signatures *)
 
 let new_type_id = s_ref (-1)
-let new_sort_id = s_ref (-1)
 let reset_additional_action_id () =
   new_type_id := -1;
-  new_sort_id := -1
+  Jkind_types.Sort.reset_cmi_sort_id ()
 
 let newpersty desc =
   decr new_type_id;
   create_expr
     desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_type_id
 
-let newsortvar desc =
-  decr new_sort_id;
-  Jkind_types.Sort.create_var_with_id
-    desc ~level:generic_level ~id:!new_sort_id
+let newsortvar () =
+  Jkind_types.Sort.new_genvar_for_cmi ()
 
 (* CR layouts: remove this. While we're still developing, though, it might
    be nice to get the location of this kind of error. *)
@@ -499,31 +521,39 @@ let apply_type_function params args body =
     copy body)
 
 
+let sort_var s srt var =
+  let open Jkind_types.Sort in
+  let assert_generic var =
+    if Var.get_level var <> generic_level then
+      fatal_errorf "sort_var: not generic, level is %d" (Var.get_level var);
+  in
+  let id = Var.get_id var in
+  let var' =
+    match find_in_sort_map_opt ~id s.sort_var_mapping with
+    | Some var -> var
+    | None ->
+      match s.sort_var_mapping with
+      | Saving _ ->
+        assert_generic var;
+        let var = newsortvar () in
+        add_to_sort_map ~id ~data:var s.sort_var_mapping;
+        var
+      | Loading _ ->
+        assert_generic var;
+        let var = new_genvar () in
+        add_to_sort_map ~id ~data:var s.sort_var_mapping;
+        var
+      | Nothing -> var
+  in
+  if var == var' then srt
+  else Var var'
+
 let rec sort s srt =
   let open Jkind_types.Sort in
   match srt with
   | Base _ | Univar _ -> srt
   | Product sorts -> Product (List.map (sort s) sorts)
-  | Var var ->
-    let id = Var.get_id var in
-    let var' =
-      match Hashtbl.find_opt s.sort_var_mapping id with
-      | Some var -> var
-      | None ->
-        let desc = Var.get_contents var in
-        let level = Var.get_level var in
-        let var = match s.additional_action with
-          | Prepare_for_saving _ -> newsortvar desc
-          | Duplicate_variables -> new_var ~level
-          | No_action ->
-            if id < 0 then new_var ~level
-            else var
-        in
-        Hashtbl.add s.sort_var_mapping id var;
-        var
-    in
-    if var == var' then srt
-    else Var var'
+  | Var var -> sort_var s srt var
 
 let rec layout s l =
   let open Jkind_types.Layout in
@@ -720,15 +750,15 @@ let rec typexp copy_scope s ty =
 and jkind : 'l 'r. _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
   fun copy_scope s jkind ->
   let jkind =
-    let jkind_desc = jkind_desc s jkind.jkind in
-    if jkind_desc == jkind.jkind then jkind
-    else { jkind with jkind = jkind_desc }
+    match s.additional_action with
+    | Prepare_for_saving { prepare_jkind; _ } ->
+      prepare_jkind !location_for_jkind_check_errors jkind
+    | Duplicate_variables | No_action -> jkind
   in
   let jkind = Jkind.map_type_expr (typexp copy_scope s) jkind in
-  match s.additional_action with
-  | Prepare_for_saving { prepare_jkind; _ } ->
-    prepare_jkind !location_for_jkind_check_errors jkind
-  | Duplicate_variables | No_action -> jkind
+  let jkind_desc = jkind_desc s jkind.jkind in
+  if jkind_desc == jkind.jkind then jkind
+  else { jkind with jkind = jkind_desc }
 
 (* [loc] is different than [s.loc]:
      - [s.loc] is a way for the external client of the module to indicate the
@@ -1281,7 +1311,14 @@ and compose s1 s2 =
             | (Prepare_for_saving _ as prepare1), Prepare_for_saving _
                 -> prepare1
           end;
-          sort_var_mapping = Hashtbl.create 17;
+          sort_var_mapping = begin
+            match s1.sort_var_mapping, s2.sort_var_mapping with
+            | action, Nothing | Nothing, action -> action
+            | (Loading _ as s), Loading _ -> s
+            | (Saving _ as s), Saving _ -> s
+            | (Saving _ as s), Loading _
+            | Loading _, (Saving _ as s) -> s
+          end;
           loc = keep_latest_loc s1.loc s2.loc;
           last_compose = None
         }

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -421,7 +421,7 @@ let newpersty desc =
 
 let newsortvar desc =
   decr new_sort_id;
-  Jkind_types.Sort.create_var
+  Jkind_types.Sort.create_var_with_id
     desc ~level:generic_level ~id:!new_sort_id
 
 (* CR layouts: remove this. While we're still developing, though, it might

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -424,7 +424,7 @@ let to_subst_by_type_function s p =
 (* Special type ids for saved signatures *)
 
 let new_type_id = s_ref (-1)
-let reset_additional_action_type_id () =
+let reset_additional_action_id () =
   new_type_id := -1;
   Jkind_types.Sort.reset_cmi_sort_id ()
 
@@ -514,15 +514,14 @@ let sort_var s var =
     if not (is_genvar var) then
       fatal_errorf "sort_var: not generic"
   in
-  let lookup_sort_map_or_create ~post_condition ~create sort_map var =
-    assert (not (post_condition var));
+  let lookup_sort_map_or_create ~pre_condition ~create sort_map var =
+    assert (pre_condition var);
     let id = Var.get_id var in
     match Hashtbl.find_opt sort_map id with
     | Some var -> var
     | None ->
       assert_generic var;
       let var = create () in
-      assert (post_condition var);
       Hashtbl.add sort_map id var;
       var
   in
@@ -530,12 +529,12 @@ let sort_var s var =
   | Nothing -> var
   | Saving m ->
     lookup_sort_map_or_create
-      ~post_condition:Var.is_cmi_var
+      ~pre_condition:(Fun.negate Var.is_cmi_var)
       ~create:new_genvar_for_cmi
       m var
   | Loading m ->
     lookup_sort_map_or_create
-      ~post_condition:(Fun.negate Var.is_cmi_var)
+      ~pre_condition:Var.is_cmi_var
       ~create:new_genvar
       m var
 
@@ -1313,8 +1312,10 @@ and compose s1 s2 =
           sort_var_mapping = begin
             match s1.sort_var_mapping, s2.sort_var_mapping with
             | action, Nothing | Nothing, action -> action
-            | (Loading _ as s), Loading _ -> s
-            | (Saving _ as s), Saving _ -> s
+            | Loading _, Loading _ ->
+              fatal_error "compose: composing Loading and Loading"
+            | Saving _ , Saving _ ->
+              fatal_error "compose: composing Saving and Saving"
             | Saving _, Loading _
             | Loading _, Saving _ ->
               fatal_error "compose: composing Saving and Loading"

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -70,11 +70,11 @@ type additional_action_config =
 *)
 val with_additional_action: additional_action_config -> t -> t
 
-(* Any of the additional actions involve copying type variables. Calling
-   [reset_additional_action_type_id] resets the id counter used when the copying
-   of type variables needs to mint new type variable ids.
+(* Any of the additional actions involve copying type and sort variables.
+   Calling [reset_additional_action_id] resets the id counters used when saving
+   needs to mint new ids for copied type variables or sort variables.
 *)
-val reset_additional_action_type_id: unit -> unit
+val reset_additional_action_id: unit -> unit
 
 val change_locs: 'k subst -> Location.t -> 'k subst
 

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -72,11 +72,11 @@ type additional_action_config =
 val with_additional_action: additional_action_config -> t -> t
 
 (* Any of the additional actions involve copying type variables. Calling
-   [reset_additional_action_type_id] resets the id counter used when the copying
+   [reset_additional_action_id] resets the id counter used when the copying
    of type variables needs to mint new type variable ids.
    The function additionally reset the counter used for sort ids.
 *)
-val reset_additional_action_type_id: unit -> unit
+val reset_additional_action_id: unit -> unit
 
 val change_locs: 'k subst -> Location.t -> 'k subst
 

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -45,6 +45,7 @@ type t = safe subst
 (** Standard substitution*)
 
 val identity: 'a subst
+val for_loading_cmi : unit -> t
 val unsafe: t -> unsafe subst
 
 val add_type: Ident.t -> Path.t -> 'k subst -> 'k subst

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -71,11 +71,12 @@ type additional_action_config =
 *)
 val with_additional_action: additional_action_config -> t -> t
 
-(* Any of the additional actions involve copying type and sort variables.
-   Calling [reset_additional_action_id] resets the id counters used when saving
-   needs to mint new ids for copied type variables or sort variables.
+(* Any of the additional actions involve copying type variables. Calling
+   [reset_additional_action_type_id] resets the id counter used when the copying
+   of type variables needs to mint new type variable ids.
+   The function additionally reset the counter used for sort ids.
 *)
-val reset_additional_action_id: unit -> unit
+val reset_additional_action_type_id: unit -> unit
 
 val change_locs: 'k subst -> Location.t -> 'k subst
 


### PR DESCRIPTION
Currently, the IDs of sort variables saved in `.cmi` files are equal to the IDs they have during typing. This creates a possibility of sort variable ID collisions when a `.cmi` file is loaded.

This PR adds logic to `subst.ml` so that the saved IDs are negative (similarly to what is done to type variable IDs). Likewise, the IDs are positive when a `.cmi` is loaded.

The testing is simple and minimal: module types with layout-polymorphic functions within a module are referenced from another file, requiring a dependency and loading a `.cmi`.
In addition, assertions about the sign of sort variable IDs are added.