### PR TITLE
Refine recursive unboxed product dummy layouts

### DIFF
--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -548,6 +548,27 @@ Line 4, characters 4-33:
 Error: Atomic record fields are not permitted in mixed blocks.
 |}]
 
+module Mixed_blocks_rec_alias = struct
+  type t = {
+    padding : u;
+    mutable field : int [@atomic]
+  }
+
+  and u = v
+
+  and v = #{
+    x : int#;
+    y : float#
+  }
+end
+
+[%%expect{|
+Line 4, characters 4-33:
+4 |     mutable field : int [@atomic]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields are not permitted in mixed blocks.
+|}]
+
 (* Test atomic record fields with non-value layouts *)
 
 module Non_value_atomic = struct

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -105,6 +105,20 @@ Error: The layout of type "t2_wrong" is value & (float64 & value)
          because of the annotation on the declaration of the type t2_wrong.
 |}]
 
+type t2_wrong_group : value & float64 & value =
+  #{ so : string option; t1 : t1 }
+and t2_wrong_group_boxed = Box of t2_wrong_group
+[%%expect{|
+Lines 1-2, characters 0-34:
+1 | type t2_wrong_group : value & float64 & value =
+2 |   #{ so : string option; t1 : t1 }
+Error: The layout of type "t2_wrong_group" is value & (float64 & value)
+         because it is an unboxed record.
+       But the layout of type "t2_wrong_group" must be a sublayout of
+           value & float64 & value
+         because of the annotation on the declaration of the type t2_wrong_group.
+|}]
+
 type ('a : value & bits64) t3 = 'a
 type t4 = #(int * int64#) t3
 type t5 = t4 t3

--- a/testsuite/tests/typing-layouts-products/recursive.ml
+++ b/testsuite/tests/typing-layouts-products/recursive.ml
@@ -96,13 +96,8 @@ and b = a * a
 type t = { u : u }
 and u = #{ x : #(unit * unit); y : unit }
 [%%expect{|
-Line 2, characters 0-41:
-2 | and u = #{ x : #(unit * unit); y : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "u" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "u" must be a sublayout of value & value
-         because it is an unboxed record.
+type t = { u : u; }
+and u = #{ x : #(unit * unit); y : unit; }
 |}]
 
 (* Boxing one edge can make a mutually recursive product finite *)
@@ -116,26 +111,17 @@ and u = #{ t1 : t; t2 : t; }
 type t = #{ u : u }
 and u = #{ x : #(unit * unit); y : unit }
 [%%expect{|
-Line 2, characters 0-41:
-2 | and u = #{ x : #(unit * unit); y : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "u" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "u" must be a sublayout of value & value
-         because it is an unboxed record.
+type t = #{ u : u; }
+and u = #{ x : #(unit * unit); y : unit; }
 |}]
 
 type 'a operation = Resume of 'a resumable
 and 'a suspended = #{ run : 'a -> unit; ctx : string }
 and 'a resumable = #{ suspended : 'a suspended; x : 'a }
 [%%expect{|
-Line 3, characters 0-56:
-3 | and 'a resumable = #{ suspended : 'a suspended; x : 'a }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "resumable" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "resumable" must be a sublayout of value & value
-         because it is an unboxed record.
+type 'a operation = Resume of 'a resumable
+and 'a suspended = #{ run : 'a -> unit; ctx : string; }
+and 'a resumable = #{ suspended : 'a suspended; x : 'a; }
 |}]
 
 module Kinds = struct
@@ -156,26 +142,16 @@ and ('a : Kinds.single) suspended_k = #{ run_k : 'a -> unit; ctx_k : string }
 and ('a : Kinds.single) resumable_k =
   #{ suspended_k : 'a suspended_k; x_k : 'a }
 [%%expect{|
-Lines 3-4, characters 0-45:
-3 | and ('a : Kinds.single) resumable_k =
-4 |   #{ suspended_k : 'a suspended_k; x_k : 'a }
-Error: The layout of type "resumable_k" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "resumable_k" must be a sublayout of
-           value & value
-         because it is an unboxed record.
+type 'a operation_k = Resume_k of 'a resumable_k
+and 'a suspended_k = #{ run_k : 'a -> unit; ctx_k : string; }
+and 'a resumable_k = #{ suspended_k : 'a suspended_k; x_k : 'a; }
 |}]
 
 type t_kind = #{ u_kind : u_kind }
 and u_kind = #{ x_kind : pairish; y_kind : unit }
 [%%expect{|
-Line 2, characters 0-49:
-2 | and u_kind = #{ x_kind : pairish; y_kind : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "u_kind" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "u_kind" must be a sublayout of value & value
-         because it is an unboxed record.
+type t_kind = #{ u_kind : u_kind; }
+and u_kind = #{ x_kind : pairish; y_kind : unit; }
 |}]
 
 type t_bad_kind = #{ u_bad_kind : u_bad_kind }
@@ -194,13 +170,9 @@ type a_chain = #{ b_chain : b_chain }
 and b_chain = #{ c_chain : c_chain; z_chain : unit }
 and c_chain = #{ x_chain : #(unit * unit); y_chain : unit }
 [%%expect{|
-Line 2, characters 0-52:
-2 | and b_chain = #{ c_chain : c_chain; z_chain : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "b_chain" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "b_chain" must be a sublayout of value & value
-         because it is an unboxed record.
+type a_chain = #{ b_chain : b_chain; }
+and b_chain = #{ c_chain : c_chain; z_chain : unit; }
+and c_chain = #{ x_chain : #(unit * unit); y_chain : unit; }
 |}]
 
 (* Guarded by a function *)

--- a/testsuite/tests/typing-layouts-products/recursive.ml
+++ b/testsuite/tests/typing-layouts-products/recursive.ml
@@ -78,12 +78,129 @@ type t = #{ f1 : t -> t ; f2 : t -> t }
 type t = #{ f1 : t -> t; f2 : t -> t; }
 |}]
 
+(* A single recursive declaration can also flatten nested products. *)
+type t = #{ next : unit -> t; pair : #(unit * unit) }
+[%%expect{|
+type t = #{ next : unit -> t; pair : #(unit * unit); }
+|}]
+
 (* Guarded by a tuple *)
 type a = #{ b : b }
 and b = a * a
 [%%expect{|
 type a = #{ b : b; }
 and b = a * a
+|}]
+
+(* Guarded by a boxed record *)
+type t = { u : u }
+and u = #{ x : #(unit * unit); y : unit }
+[%%expect{|
+Line 2, characters 0-41:
+2 | and u = #{ x : #(unit * unit); y : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "u" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+(* Boxing one edge can make a mutually recursive product finite *)
+type t = { u : u }
+and u = #{ t1 : t; t2 : t }
+[%%expect{|
+type t = { u : u; }
+and u = #{ t1 : t; t2 : t; }
+|}]
+
+type t = #{ u : u }
+and u = #{ x : #(unit * unit); y : unit }
+[%%expect{|
+Line 2, characters 0-41:
+2 | and u = #{ x : #(unit * unit); y : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "u" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+type 'a operation = Resume of 'a resumable
+and 'a suspended = #{ run : 'a -> unit; ctx : string }
+and 'a resumable = #{ suspended : 'a suspended; x : 'a }
+[%%expect{|
+Line 3, characters 0-56:
+3 | and 'a resumable = #{ suspended : 'a suspended; x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "resumable" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "resumable" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+module Kinds = struct
+  kind_ single = value
+  kind_ pair = value & value
+end
+[%%expect{|
+module Kinds : sig kind_ single = value kind_ pair = value & value end
+|}]
+
+type pairish : Kinds.pair = #(unit * unit)
+[%%expect{|
+type pairish = #(unit * unit)
+|}]
+
+type ('a : Kinds.single) operation_k = Resume_k of 'a resumable_k
+and ('a : Kinds.single) suspended_k = #{ run_k : 'a -> unit; ctx_k : string }
+and ('a : Kinds.single) resumable_k =
+  #{ suspended_k : 'a suspended_k; x_k : 'a }
+[%%expect{|
+Lines 3-4, characters 0-45:
+3 | and ('a : Kinds.single) resumable_k =
+4 |   #{ suspended_k : 'a suspended_k; x_k : 'a }
+Error: The layout of type "resumable_k" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "resumable_k" must be a sublayout of
+           value & value
+         because it is an unboxed record.
+|}]
+
+type t_kind = #{ u_kind : u_kind }
+and u_kind = #{ x_kind : pairish; y_kind : unit }
+[%%expect{|
+Line 2, characters 0-49:
+2 | and u_kind = #{ x_kind : pairish; y_kind : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "u_kind" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u_kind" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+type t_bad_kind = #{ u_bad_kind : u_bad_kind }
+and u_bad_kind : Kinds.pair = #{ x_bad_kind : #(unit * unit); y_bad_kind : unit }
+[%%expect{|
+Line 2, characters 0-81:
+2 | and u_bad_kind : Kinds.pair = #{ x_bad_kind : #(unit * unit); y_bad_kind : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "u_bad_kind" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u_bad_kind" must be a sublayout of value & value
+         because of the annotation on the declaration of the type u_bad_kind.
+|}]
+
+type a_chain = #{ b_chain : b_chain }
+and b_chain = #{ c_chain : c_chain; z_chain : unit }
+and c_chain = #{ x_chain : #(unit * unit); y_chain : unit }
+[%%expect{|
+Line 2, characters 0-52:
+2 | and b_chain = #{ c_chain : c_chain; z_chain : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "b_chain" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "b_chain" must be a sublayout of value & value
+         because it is an unboxed record.
 |}]
 
 (* Guarded by a function *)
@@ -133,6 +250,46 @@ Line 1, characters 0-31:
 Error: The definition of "a_bad" is recursive without boxing:
          "a_bad" contains "b_bad",
          "b_bad" contains "a_bad"
+|}]
+
+type t = #{ u1 : u; u2 : u }
+and u = #{ t1 : t; t2 : t }
+[%%expect{|
+Line 1, characters 0-28:
+1 | type t = #{ u1 : u; u2 : u }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" is recursive without boxing:
+         "t" contains "u",
+         "u" contains "t"
+|}]
+
+type t = #{ u : pair_u }
+and pair_u = #{ t1 : t; t2 : t }
+[%%expect{|
+Line 1, characters 0-24:
+1 | type t = #{ u : pair_u }
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" is recursive without boxing:
+         "t" contains "pair_u",
+         "pair_u" contains "t"
+|}]
+
+type t = { u : pair_u }
+and pair_u = #{ t1 : t; t2 : t }
+[%%expect{|
+type t = { u : pair_u; }
+and pair_u = #{ t1 : t; t2 : t; }
+|}]
+
+type 'a t = #{ u1 : 'a u; u2 : 'a u }
+and 'a u = #{ t1 : 'a t; t2 : 'a t }
+[%%expect{|
+Line 1, characters 0-37:
+1 | type 'a t = #{ u1 : 'a u; u2 : 'a u }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" is recursive without boxing:
+         "'a t" contains "'a u",
+         "'a u" contains "'a t"
 |}]
 
 type bad : any = #{ bad : bad }

--- a/testsuite/tests/typing-layouts-products/recursive_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/recursive_implicit_unboxed_records.ml
@@ -103,26 +103,17 @@ and u = { t1 : t; t2 : t; }
 type t = { u : u# }
 and u = { x : #(unit * unit); y : unit }
 [%%expect{|
-Line 2, characters 0-40:
-2 | and u = { x : #(unit * unit); y : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "u#" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "u#" must be a sublayout of value & value
-         because it is an unboxed record.
+type t = { u : u#; }
+and u = { x : #(unit * unit); y : unit; }
 |}]
 
 type 'a operation = Resume of 'a resumable#
 and 'a suspended = { run : 'a -> unit; ctx : string }
 and 'a resumable = { suspended : 'a suspended#; x : 'a }
 [%%expect{|
-Line 3, characters 0-56:
-3 | and 'a resumable = { suspended : 'a suspended#; x : 'a }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "resumable#" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "resumable#" must be a sublayout of value & value
-         because it is an unboxed record.
+type 'a operation = Resume of 'a resumable#
+and 'a suspended = { run : 'a -> unit; ctx : string; }
+and 'a resumable = { suspended : 'a suspended#; x : 'a; }
 |}]
 
 module Kinds = struct
@@ -143,26 +134,16 @@ and ('a : Kinds.single) suspended_k = { run_k : 'a -> unit; ctx_k : string }
 and ('a : Kinds.single) resumable_k =
   { suspended_k : 'a suspended_k#; x_k : 'a }
 [%%expect{|
-Lines 3-4, characters 0-45:
-3 | and ('a : Kinds.single) resumable_k =
-4 |   { suspended_k : 'a suspended_k#; x_k : 'a }
-Error: The layout of type "resumable_k#" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "resumable_k#" must be a sublayout of
-           value & value
-         because it is an unboxed record.
+type 'a operation_k = Resume_k of 'a resumable_k#
+and 'a suspended_k = { run_k : 'a -> unit; ctx_k : string; }
+and 'a resumable_k = { suspended_k : 'a suspended_k#; x_k : 'a; }
 |}]
 
 type t_kind = { u_kind : u_kind# }
 and u_kind = { x_kind : pairish; y_kind : unit }
 [%%expect{|
-Line 2, characters 0-48:
-2 | and u_kind = { x_kind : pairish; y_kind : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "u_kind#" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "u_kind#" must be a sublayout of value & value
-         because it is an unboxed record.
+type t_kind = { u_kind : u_kind#; }
+and u_kind = { x_kind : pairish; y_kind : unit; }
 |}]
 
 type t_bad_kind = { u_bad_kind : u_bad_kind# }
@@ -172,24 +153,19 @@ and u_bad_kind : Kinds.pair =
 Lines 2-3, characters 0-52:
 2 | and u_bad_kind : Kinds.pair =
 3 |   { x_bad_kind : #(unit * unit); y_bad_kind : unit }
-Error: The layout of type "u_bad_kind#" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "u_bad_kind#" must be a sublayout of
-           value & value
-         because it is an unboxed record.
+Error: The layout of type "u_bad_kind" is value
+         because it's a boxed record type.
+       But the layout of type "u_bad_kind" must be a sublayout of value & value
+         because of the annotation on the declaration of the type u_bad_kind.
 |}]
 
 type a_chain = { b_chain : b_chain# }
 and b_chain = { c_chain : c_chain#; z_chain : unit }
 and c_chain = { x_chain : #(unit * unit); y_chain : unit }
 [%%expect{|
-Line 2, characters 0-52:
-2 | and b_chain = { c_chain : c_chain#; z_chain : unit }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "b_chain#" is (value & value) & value
-         because it is an unboxed record.
-       But the layout of type "b_chain#" must be a sublayout of value & value
-         because it is an unboxed record.
+type a_chain = { b_chain : b_chain#; }
+and b_chain = { c_chain : c_chain#; z_chain : unit; }
+and c_chain = { x_chain : #(unit * unit); y_chain : unit; }
 |}]
 
 (* Guarded by a function *)

--- a/testsuite/tests/typing-layouts-products/recursive_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/recursive_implicit_unboxed_records.ml
@@ -78,12 +78,118 @@ type t = { f1 : t# -> t# ; f2 : t# -> t# }
 type t = { f1 : t# -> t#; f2 : t# -> t#; }
 |}]
 
+(* A single recursive declaration can also flatten nested products. *)
+type t = { next : unit -> t#; pair : #(unit * unit) }
+[%%expect{|
+type t = { next : unit -> t#; pair : #(unit * unit); }
+|}]
+
 (* Guarded by a tuple *)
 type a = { b : b }
 and b = a# * a#
 [%%expect{|
 type a = { b : b; }
 and b = a# * a#
+|}]
+
+(* Boxing one edge can make a mutually recursive product finite *)
+type t = { u : u# }
+and u = { t1 : t; t2 : t }
+[%%expect{|
+type t = { u : u#; }
+and u = { t1 : t; t2 : t; }
+|}]
+
+type t = { u : u# }
+and u = { x : #(unit * unit); y : unit }
+[%%expect{|
+Line 2, characters 0-40:
+2 | and u = { x : #(unit * unit); y : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "u#" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u#" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+type 'a operation = Resume of 'a resumable#
+and 'a suspended = { run : 'a -> unit; ctx : string }
+and 'a resumable = { suspended : 'a suspended#; x : 'a }
+[%%expect{|
+Line 3, characters 0-56:
+3 | and 'a resumable = { suspended : 'a suspended#; x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "resumable#" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "resumable#" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+module Kinds = struct
+  kind_ single = value
+  kind_ pair = value & value
+end
+[%%expect{|
+module Kinds : sig kind_ single = value kind_ pair = value & value end
+|}]
+
+type pairish : Kinds.pair = #(unit * unit)
+[%%expect{|
+type pairish = #(unit * unit)
+|}]
+
+type ('a : Kinds.single) operation_k = Resume_k of 'a resumable_k#
+and ('a : Kinds.single) suspended_k = { run_k : 'a -> unit; ctx_k : string }
+and ('a : Kinds.single) resumable_k =
+  { suspended_k : 'a suspended_k#; x_k : 'a }
+[%%expect{|
+Lines 3-4, characters 0-45:
+3 | and ('a : Kinds.single) resumable_k =
+4 |   { suspended_k : 'a suspended_k#; x_k : 'a }
+Error: The layout of type "resumable_k#" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "resumable_k#" must be a sublayout of
+           value & value
+         because it is an unboxed record.
+|}]
+
+type t_kind = { u_kind : u_kind# }
+and u_kind = { x_kind : pairish; y_kind : unit }
+[%%expect{|
+Line 2, characters 0-48:
+2 | and u_kind = { x_kind : pairish; y_kind : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "u_kind#" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u_kind#" must be a sublayout of value & value
+         because it is an unboxed record.
+|}]
+
+type t_bad_kind = { u_bad_kind : u_bad_kind# }
+and u_bad_kind : Kinds.pair =
+  { x_bad_kind : #(unit * unit); y_bad_kind : unit }
+[%%expect{|
+Lines 2-3, characters 0-52:
+2 | and u_bad_kind : Kinds.pair =
+3 |   { x_bad_kind : #(unit * unit); y_bad_kind : unit }
+Error: The layout of type "u_bad_kind#" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "u_bad_kind#" must be a sublayout of
+           value & value
+         because it is an unboxed record.
+|}]
+
+type a_chain = { b_chain : b_chain# }
+and b_chain = { c_chain : c_chain#; z_chain : unit }
+and c_chain = { x_chain : #(unit * unit); y_chain : unit }
+[%%expect{|
+Line 2, characters 0-52:
+2 | and b_chain = { c_chain : c_chain#; z_chain : unit }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "b_chain#" is (value & value) & value
+         because it is an unboxed record.
+       But the layout of type "b_chain#" must be a sublayout of value & value
+         because it is an unboxed record.
 |}]
 
 (* Guarded by a function *)
@@ -133,6 +239,46 @@ Line 1, characters 0-31:
 Error: The definition of "a_bad#" is recursive without boxing:
          "a_bad#" contains "b_bad#",
          "b_bad#" contains "a_bad#"
+|}]
+
+type t = { u1 : u#; u2 : u# }
+and u = { t1 : t#; t2 : t# }
+[%%expect{|
+Line 1, characters 0-29:
+1 | type t = { u1 : u#; u2 : u# }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t#" is recursive without boxing:
+         "t#" contains "u#",
+         "u#" contains "t#"
+|}]
+
+type t = { u : pair_u# }
+and pair_u = { t1 : t#; t2 : t# }
+[%%expect{|
+Line 1, characters 0-24:
+1 | type t = { u : pair_u# }
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t#" is recursive without boxing:
+         "t#" contains "pair_u#",
+         "pair_u#" contains "t#"
+|}]
+
+type t = { u : pair_u# }
+and pair_u = { t1 : t; t2 : t }
+[%%expect{|
+type t = { u : pair_u#; }
+and pair_u = { t1 : t; t2 : t; }
+|}]
+
+type 'a t = { u1 : 'a u#; u2 : 'a u# }
+and 'a u = { t1 : 'a t#; t2 : 'a t# }
+[%%expect{|
+Line 1, characters 0-38:
+1 | type 'a t = { u1 : 'a u#; u2 : 'a u# }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t#" is recursive without boxing:
+         "'a t#" contains "'a u#",
+         "'a u#" contains "'a t#"
 |}]
 
 type bad : any = { bad : bad# }

--- a/testsuite/tests/typing-layouts-products/separability.ml
+++ b/testsuite/tests/typing-layouts-products/separability.ml
@@ -116,7 +116,11 @@ type t_void : void
 and 'a r : value & any = #{ a : 'a ; v : t_void }
 and bad = F : { x : 'a r } -> bad [@@unboxed]
 [%%expect{|
->> Fatal error: Jkind.sort_of_jkind: layout is any
-Uncaught exception: Misc.Fatal_error
-
+Line 3, characters 0-45:
+3 | and bad = F : { x : 'a r } -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "bad" is value & any
+         because of the annotation on the declaration of the type r.
+       But the layout of type "bad" must be representable
+         because it's an [@@unboxed] type.
 |}]

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -81,6 +81,15 @@ type u = string uu#
 and 'a uu = unit
 |}]
 
+(* And through a longer chain in the same recursive group. *)
+type g : float64 = unit gg#
+and 'a gg = 'a hh
+and 'a hh = float
+[%%expect{|
+type g = unit gg#
+and 'a gg = 'a hh
+and 'a hh = float
+|}]
 (* If a type with an unboxed version is shadowed by another, [#]
    also points to the new type. *)
 type float = int32
@@ -1239,6 +1248,18 @@ Line 5, characters 13-23:
                  ^^^^^^^^^^
 Error: In the signature of this functor application:
        The type "s" has no unboxed version.
+|}]
+
+(* Mutually recursive aliases with an unboxed version should stay accepted. *)
+module Good(M : sig type t = float end) = struct
+  type u = unit s#
+  and 'a s = 'a inner
+  and 'a inner = M.t
+end
+[%%expect{|
+module Good :
+  functor (M : sig type t = float end) ->
+    sig type u = unit s# and 'a s = 'a inner and 'a inner = M.t end
 |}]
 
 (* Make sure our check isn't too restrictive. We allow a module with a

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2780,6 +2780,7 @@ module Format_history = struct
          representable at call sites)"
     | Peek_or_poke ->
       fprintf ppf "it's the type being used for a peek or poke primitive"
+    | Unboxed_record_type -> fprintf ppf "it is an unboxed record"
     | Old_style_unboxed_type -> fprintf ppf "it's an [@@@@unboxed] type"
     | Array_element -> fprintf ppf "it's the type of an array element"
     | Idx_element ->
@@ -3713,6 +3714,7 @@ module Debug_printers = struct
     | Layout_poly_in_external -> fprintf ppf "Layout_poly_in_external"
     | Unboxed_tuple_element -> fprintf ppf "Unboxed_tuple_element"
     | Peek_or_poke -> fprintf ppf "Peek_or_poke"
+    | Unboxed_record_type -> fprintf ppf "Unboxed_record_type"
     | Old_style_unboxed_type -> fprintf ppf "Old_style_unboxed_type"
     | Array_element -> fprintf ppf "Array_element"
     | Idx_element -> fprintf ppf "Idx_element"

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -304,6 +304,7 @@ module History = struct
     | Layout_poly_in_external
     | Unboxed_tuple_element
     | Peek_or_poke
+    | Unboxed_record_type
     | Old_style_unboxed_type
     | Array_element
     | Idx_element

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -220,6 +220,55 @@ let enter_type ?abstract_abbrevs rec_flag env sdecl (id, uid) =
   let arity = List.length sdecl.ptype_params in
   let path = Path.Pident id in
   let any = Jkind.Builtin.any ~why:Initial_typedecl_env in
+  let unbox = Builtin_attributes.has_unboxed sdecl.ptype_attributes in
+  let recursive_unknown_reason =
+    match sdecl.ptype_kind with
+    | Ptype_record_unboxed_product _ ->
+      Some Jkind.History.Unboxed_record_type
+    | Ptype_record _ | Ptype_variant _ ->
+      Some Jkind.History.Old_style_unboxed_type
+    | Ptype_abstract | Ptype_open -> None
+  in
+  let needs_recursive_unknown =
+    match sdecl.ptype_kind with
+    | Ptype_record_unboxed_product _ -> true
+    | Ptype_record _ | Ptype_variant _ -> unbox
+    | Ptype_abstract | Ptype_open -> false
+  in
+  let has_derived_unboxed_version =
+    match sdecl.ptype_kind with
+    | Ptype_record _ -> not unbox
+    | Ptype_abstract | Ptype_variant _ | Ptype_record_unboxed_product _
+    | Ptype_open -> false
+  in
+  let recursive_unknown =
+    if rec_flag = Asttypes.Recursive
+       && Option.is_none sdecl.ptype_jkind_annotation
+       && Option.is_none sdecl.ptype_manifest
+       && needs_recursive_unknown
+    then
+      Some
+        (Jkind.of_new_sort
+           ~why:
+             (match recursive_unknown_reason with
+              | Some reason -> reason
+              | None -> assert false)
+           ~level:(Ctype.get_current_level ()))
+    else
+      None
+  in
+  let recursive_unknown_unboxed =
+    if rec_flag = Asttypes.Recursive
+       && Option.is_none sdecl.ptype_jkind_annotation
+       && Option.is_none sdecl.ptype_manifest
+       && has_derived_unboxed_version
+    then
+      Some
+        (Jkind.of_new_sort ~why:Jkind.History.Old_style_unboxed_type
+           ~level:(Ctype.get_current_level ()))
+    else
+      None
+  in
 
   (* There is some trickiness going on here with the jkind.  It expands on an
      old trick used in the manifest of [decl] below.
@@ -275,11 +324,14 @@ let enter_type ?abstract_abbrevs rec_flag env sdecl (id, uid) =
      are checked and then unified with the real manifest and checked against the
      kind. *)
   let type_jkind =
-    Jkind.of_type_decl_overapproximate_unknown
-      env
-      ~context:(Type_declaration path)
-      sdecl
-    |> Option.value ~default:(Jkind.disallow_right any)
+    match recursive_unknown with
+    | Some jkind -> Jkind.disallow_right jkind
+    | None ->
+      Jkind.of_type_decl_overapproximate_unknown
+        env
+        ~context:(Type_declaration path)
+        sdecl
+      |> Option.value ~default:(Jkind.disallow_right any)
   in
   let abstract_source, type_manifest, unboxed_type_manifest =
     match sdecl.ptype_manifest, abstract_abbrevs with
@@ -289,7 +341,14 @@ let enter_type ?abstract_abbrevs rec_flag env sdecl (id, uid) =
        an annotation here, and doing so with separated left- and right-jkinds
        is hard to do. *)
     | None, _ | Some _, None ->
-      Definition, Some (Ctype.newvar any), Some (Ctype.newvar any)
+      let manifest_jkind =
+        Option.value recursive_unknown ~default:any
+      in
+      ( Definition,
+        Some (Ctype.newvar manifest_jkind),
+        Some
+          (Ctype.newvar
+             (Option.value recursive_unknown_unboxed ~default:any)) )
     | Some _, Some reason -> reason, None, None
 in
   let type_params =
@@ -302,10 +361,15 @@ in
   (* In the temporary environment, all types get an unboxed version.
      See Note [Typechecking unboxed versions of types]. *)
   let type_unboxed_version =
+    let type_unboxed_version_jkind =
+      match recursive_unknown_unboxed with
+      | Some jkind -> Jkind.disallow_right jkind
+      | None -> type_jkind
+    in
     Some { type_params;
       type_arity = arity;
       type_kind = Type_abstract abstract_source;
-      type_jkind;
+      type_jkind = type_unboxed_version_jkind;
       type_ikind = Types.ikinds_todo "transl_declaration initial unboxed";
       type_private = sdecl.ptype_private;
       type_manifest = unboxed_type_manifest;
@@ -894,6 +958,26 @@ let transl_declaration env sdecl (id, uid) =
       let cty = transl_simple_type ~new_var_jkind:Any env ~closed:no_row Mode.Alloc.Const.legacy sty in
       Some cty, Some cty.ctyp_type
   in
+  let recursive_default_jkind =
+    match Env.find_type path env with
+    | decl -> begin
+        match decl.type_manifest with
+        | Some ty -> begin
+            match get_desc ty with
+            | Tvar { jkind } | Tunivar { jkind } -> begin
+                match jkind.Types.history with
+                | Creation (Concrete_creation Jkind.History.Unboxed_record_type)
+                | Creation
+                    (Concrete_creation Jkind.History.Old_style_unboxed_type) ->
+                  Some (Jkind.disallow_right jkind)
+                | _ -> None
+              end
+            | _ -> None
+          end
+        | None -> None
+      end
+    | exception Not_found -> None
+  in
   (* jkind_default is the jkind to use for now as the type_jkind when there
      is no annotation and no manifest.
      See Note [Default jkinds in transl_declaration].
@@ -982,7 +1066,7 @@ let transl_declaration env sdecl (id, uid) =
         let rep, jkind =
           if unbox then
             Variant_unboxed,
-            Jkind.of_new_sort ~why:Old_style_unboxed_type
+            Jkind.of_new_sort ~why:Jkind.History.Old_style_unboxed_type
               ~level:(Ctype.get_current_level ())
           else
             (* We mark all arg sorts "void" here.  They are updated later,
@@ -1013,7 +1097,7 @@ let transl_declaration env sdecl (id, uid) =
           let rep, jkind =
             if unbox then
               Record_unboxed,
-              Jkind.of_new_sort ~why:Old_style_unboxed_type
+              Jkind.of_new_sort ~why:Jkind.History.Old_style_unboxed_type
                 ~level:(Ctype.get_current_level ())
             else
             (* Note this is inaccurate, using `Record_boxed` in cases where the
@@ -1060,7 +1144,7 @@ let transl_declaration env sdecl (id, uid) =
       match jkind_from_annotation, man with
       | Some annot, _ -> annot
       | None, Some _ -> Jkind.Builtin.any ~why:Initial_typedecl_env
-      | None, None -> jkind_default
+      | None, None -> Option.value recursive_default_jkind ~default:jkind_default
     in
     let jkind =
       (* Hack: unboxed records are given a product-of-[any]s layout
@@ -1234,7 +1318,8 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
     (* CR layouts v11: update type_jkind once we have [layout_of] layouts *)
     let jkind =
       Jkind.Builtin.product_of_sorts ~why:Unboxed_record
-        ~level:(Ctype.get_current_level ()) (List.length lbls) in
+        ~level:(Ctype.get_current_level ()) (List.length lbls)
+    in
     let kind =
       Type_record_unboxed_product(lbls_unboxed, Record_unboxed_product, umc)
     in
@@ -1639,6 +1724,15 @@ let check_abbrev env sdecl (id, decl) =
    including which fields of a record are void.  This would be hard to do during
    [transl_declaration] due to mutually recursive types.
 *)
+let metadata_sort_of_jkind env jkind =
+  match Jkind.get_layout env jkind with
+  | Some layout -> begin
+      match Jkind.Layout.Const.get_sort layout with
+      | Some sort -> sort
+      | None -> Jkind.Sort.Const.value
+    end
+  | None -> Jkind.Sort.Const.value
+
 (* [update_label_sorts] additionally returns whether all the jkinds
    were void, and the jkinds of the labels *)
 (* CR reisenberg: remove all_void return *)
@@ -1655,9 +1749,7 @@ let update_label_sorts env loc lbls named =
   let lbls_and_jkinds =
     List.mapi (fun idx (Types.{ld_type} as lbl) ->
       let jkind = Ctype.type_jkind env ld_type in
-      (* Next line guaranteed to be safe because of [check_representable] *)
-      let sort = Jkind.sort_of_jkind env jkind in
-      let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+      let ld_sort = metadata_sort_of_jkind env jkind in
       update idx ld_sort;
       {lbl with ld_sort}, jkind
     ) lbls
@@ -1682,9 +1774,7 @@ let update_constructor_arguments_sorts env loc cd_args sorts =
     let args_and_jkinds =
       List.mapi (fun idx ({Types.ca_type; _} as arg) ->
           let jkind = Ctype.type_jkind env ca_type in
-          (* Next line guaranteed to be safe because of [check_representable] *)
-          let sort = Jkind.sort_of_jkind env jkind in
-          let ca_sort = Jkind.Sort.default_to_value_and_get sort in
+          let ca_sort = metadata_sort_of_jkind env jkind in
           update idx ca_sort;
           {arg with ca_sort}, jkind)
         args
@@ -1778,17 +1868,27 @@ module Element_repr = struct
     in
     of_t t
 
-  let classify env ty jkind =
+  (* During recursive typedecl solving, field jkinds may still be unresolved
+     placeholders. For mixed-block classification we must not default those
+     placeholders to [value], so fall back to structural unboxing information
+     instead. *)
+  let rec classify_unresolved_recursive_field env ty =
+    let ty = Ctype.expand_head_opt env ty in
+    match Ctype.contained_without_boxing env ty with
+    | [] -> Value_element
+    | [ty] -> classify env ty (Ctype.type_jkind env ty)
+    | tys ->
+      Unboxed_element
+        (Product
+           (tys
+            |> List.map (fun ty -> classify env ty (Ctype.type_jkind env ty))
+            |> Array.of_list))
+
+  and classify : type l r. Env.t -> Types.type_expr -> (l * r) Types.jkind -> t =
+    fun env ty jkind ->
     if is_float env ty
     then Float_element
     else
-      let layout = Jkind.get_layout_defaulting_to_value env jkind in
-      let sort =
-        match Option.bind layout Jkind.Layout.Const.get_sort with
-        | None ->
-          Misc.fatal_error "Element_repr.classify: unexpected abstract layout"
-        | Some s -> s
-      in
       let rec sort_to_t : Jkind_types.Sort.Const.t -> t = function
       | Base Value -> Value_element
       | Base Float64 -> Unboxed_element Float64
@@ -1808,7 +1908,13 @@ module Element_repr = struct
       | Univar _ -> Misc.fatal_error "sort_to_t: unexpected univar"
       | Genvar _ -> Misc.fatal_error "sort_to_t: unexpected genvar"
       in
-      sort_to_t sort
+      match Jkind.get_layout env jkind with
+      | Some layout -> begin
+          match Jkind.Layout.Const.get_sort layout with
+          | Some sort -> sort_to_t sort
+          | None -> classify_unresolved_recursive_field env ty
+        end
+      | None -> classify_unresolved_recursive_field env ty
 
   let mixed_product_shape loc ts kind =
     let boxed_elements =
@@ -1942,10 +2048,7 @@ let rec update_decl_jkind env dpath decl =
         Ctype.type_jkind env ld_type |>
         Jkind.apply_modality_l lbl.ld_modalities
       in
-      (* This next line is guaranteed to be OK because of a call to
-         [check_representable] *)
-      let sort = Jkind.sort_of_jkind env jkind in
-      let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+      let ld_sort = metadata_sort_of_jkind env jkind in
       [{lbl with ld_sort}], Record_unboxed, jkind
     | _, Record_boxed sorts ->
       let lbls, _all_void, jkinds =
@@ -2121,16 +2224,14 @@ let rec update_decl_jkind env dpath decl =
         match cd_args with
         | Cstr_tuple [{ca_type=ty; _} as arg] -> begin
             let jkind = Ctype.type_jkind env ty in
-            let sort = Jkind.sort_of_jkind env jkind in
-            let ca_sort = Jkind.Sort.default_to_value_and_get sort in
+            let ca_sort = metadata_sort_of_jkind env jkind in
             [{ cstr with Types.cd_args =
                            Cstr_tuple [{ arg with ca_sort }] }],
             Variant_unboxed, jkind
           end
         | Cstr_record [{ld_type} as lbl] -> begin
             let jkind = Ctype.type_jkind env ld_type in
-            let sort = Jkind.sort_of_jkind env jkind in
-            let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+            let ld_sort = metadata_sort_of_jkind env jkind in
             [{ cstr with Types.cd_args =
                            Cstr_record [{ lbl with ld_sort }] }],
             Variant_unboxed, jkind
@@ -2226,10 +2327,7 @@ let rec update_decl_jkind env dpath decl =
           let (lbls, layouts) =
             List.map (fun (Types.{ld_type} as lbl) ->
               let jkind = Ctype.type_jkind env ld_type in
-              (* This next line is guaranteed to be OK because of a call to
-                 [check_representable] *)
-              let sort = Jkind.sort_of_jkind env jkind in
-              let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+              let ld_sort = metadata_sort_of_jkind env jkind in
               let layout =
                 match Jkind.extract_layout env jkind with
                 | Ok l -> l

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1144,7 +1144,8 @@ let transl_declaration env sdecl (id, uid) =
       match jkind_from_annotation, man with
       | Some annot, _ -> annot
       | None, Some _ -> Jkind.Builtin.any ~why:Initial_typedecl_env
-      | None, None -> Option.value recursive_default_jkind ~default:jkind_default
+      | None, None ->
+        Option.value recursive_default_jkind ~default:jkind_default
     in
     let jkind =
       (* Hack: unboxed records are given a product-of-[any]s layout
@@ -1884,7 +1885,9 @@ module Element_repr = struct
             |> List.map (fun ty -> classify env ty (Ctype.type_jkind env ty))
             |> Array.of_list))
 
-  and classify : type l r. Env.t -> Types.type_expr -> (l * r) Types.jkind -> t =
+  and classify
+      : type l r. Env.t -> Types.type_expr -> (l * r) Types.jkind -> t
+    =
     fun env ty jkind ->
     if is_float env ty
     then Float_element


### PR DESCRIPTION
This PR fixes recursive unboxed-product typing for cases where the initial
dummy jkind uses one component per field, but the real flattened layout has a
different product shape.

The motivating examples are recursive groups like:

```ocaml
type t = #{ u : u }
and u = #{ x : #(unit * unit); y : unit }
```

and the parameterized variant:

```ocaml
type 'a operation = Resume of 'a resumable#
and 'a suspended = { run : 'a -> unit; ctx : string }
and 'a resumable = { suspended : 'a suspended#; x : 'a }
```

Previously these could fail during recursive typechecking because the temporary
dummy jkind for the unboxed record was based on the number of fields, while the
later refined jkind used the flattened product layout of those fields.

## Commit structure

This branch is split into two commits:

1. Tests:
   - adds regression coverage first
   - promotes the tests to the current baseline behavior

2. Implementation:
   - computes a better placeholder product shape for recursive unboxed records using sort variables
   - promotes the affected tests to the new behavior