### PR TITLE
Mode bitfields part 2: Pack constant mode products

### DIFF
--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -91,7 +91,9 @@ let lo_mask =
   Array.mapi
     (fun i offset ->
       if i < Array.length modal_slots
-      then Modal_bit_layout.low_mask modal_slots.(i)
+      then
+        Prefix_ones_bitfield.low_mask
+          ~offset:(Modal_bit_layout.offset modal_slots.(i))
       else Prefix_ones_bitfield.low_mask ~offset)
     offsets
 
@@ -99,7 +101,10 @@ let axis_mask =
   Array.mapi
     (fun i off ->
       if i < Array.length modal_slots
-      then Modal_bit_layout.mask modal_slots.(i)
+      then
+        Prefix_ones_bitfield.mask
+          ~offset:off
+          ~width:(Modal_bit_layout.width modal_slots.(i))
       else Prefix_ones_bitfield.mask ~offset:off ~width:widths.(i))
     offsets
 

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -12,6 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Prefix_ones_bitfield = Misc.Prefix_ones_bitfield
+module Modal_bit_layout = Misc.Modal_bit_layout
+
 (* Axis lattice: efficient bitfield encoding of jkind axes.
 
    This module packs 13 axes into an OCaml immediate-sized integer, where each
@@ -54,59 +57,51 @@
 
 let axis_by_number = Array.of_list Jkind_axis.Axis.all
 
+let modal_slots =
+  Mode.Crossing.Axis.all
+  |> List.map (fun (Mode.Crossing.Axis.P axis) -> Mode.Crossing.Axis.slot axis)
+  |> Array.of_list
+
 let axis_sizes =
-  let open Jkind_axis.Axis in
-  let open Mode.Axis in
-  let open Mode.Crossing.Axis in
-  Array.map
-    (fun (Pack axis) ->
-      match axis with
-      | Modal (Comonadic Areality) -> 3
-      | Modal (Monadic Uniqueness) -> 2
-      | Modal (Comonadic Linearity) -> 2
-      | Modal (Monadic Contention) -> 3
-      | Modal (Comonadic Portability) -> 3
-      | Modal (Comonadic Forkable) -> 2
-      | Modal (Comonadic Yielding) -> 2
-      | Modal (Comonadic Statefulness) -> 3
-      | Modal (Monadic Visibility) -> 3
-      | Modal (Monadic Staticity) -> 2
-      | Nonmodal Externality -> 3
-      | Nonmodal Nullability -> 2
-      | Nonmodal Separability -> 3)
-    axis_by_number
+  let modal_sizes =
+    Array.map (fun slot -> Modal_bit_layout.width slot + 1) modal_slots
+  in
+  Array.append modal_sizes [| 3; 2; 3 |]
 
 let num_axes = Array.length axis_sizes
 
 (* widths[i] = 2 for size-3 axes, 1 for size-2 *)
 let widths =
-  Array.map
-    (function 3 -> 2 | 2 -> 1 | _ -> invalid_arg "bad axis size")
+  Array.mapi
+    (fun i size ->
+      if i < Array.length modal_slots
+      then Modal_bit_layout.width modal_slots.(i)
+      else Prefix_ones_bitfield.width_of_size size)
     axis_sizes
 
-(* consecutive packing offsets *)
 let offsets =
-  let _, offs =
-    Array.fold_left_map (fun acc width -> acc + width, acc) 0 widths
-  in
-  offs
+  Array.append
+    (Array.map Modal_bit_layout.offset modal_slots)
+    [| Modal_bit_layout.modal_width;
+       Modal_bit_layout.modal_width + widths.(10);
+       Modal_bit_layout.modal_width + widths.(10) + widths.(11)
+    |]
 
-(* 1 if axis i has a high bit (i.e. width=2), else 0 *)
-let has_hi =
-  Array.init num_axes (fun i ->
-      match axis_sizes.(i) with
-      | 3 -> 1
-      | 2 -> 0
-      | _ -> invalid_arg "bad axis size")
-
-let lo_mask = Array.map (fun off -> 1 lsl off) offsets
-
-let hi_mask =
+let lo_mask =
   Array.mapi
-    (fun i off -> if has_hi.(i) = 1 then 1 lsl (off + 1) else 0)
+    (fun i offset ->
+      if i < Array.length modal_slots
+      then Modal_bit_layout.low_mask modal_slots.(i)
+      else Prefix_ones_bitfield.low_mask ~offset)
     offsets
 
-let axis_mask = Array.map2 (fun lo hi -> lo lor hi) lo_mask hi_mask
+let axis_mask =
+  Array.mapi
+    (fun i off ->
+      if i < Array.length modal_slots
+      then Modal_bit_layout.mask modal_slots.(i)
+      else Prefix_ones_bitfield.mask ~offset:off ~width:widths.(i))
+    offsets
 
 (* OR of all low bits (for size-2 axes that’s their only bit).
    For this layout: 0x6D75D. *)
@@ -129,25 +124,11 @@ let equal (a : t) (b : t) : bool = a = b
 
 let hash = Hashtbl.hash
 
-(* Branchless get: for 3-ary axes level = lo + hi (00→0, 01→1, 11→2).
-    For 2-ary axes hi=0 (masked by has_hi). *)
 let get_axis (v : t) ~axis:i : int =
-  let off = offsets.(i) in
-  let lo = (v lsr off) land 1 in
-  let hi = (v lsr (off + 1)) land has_hi.(i) in
-  lo + hi
+  Prefix_ones_bitfield.get_level ~offset:offsets.(i) ~width:widths.(i) v
 
-(* Branchless set:
-    low_bit  = (lev | (lev >> 1)) & 1  (0→0, 1→1, 2→1)
-    high_bit = (lev >> 1) & has_hi
-      (0→0, 1→0, 2→1; zeroed for 1-bit axes)
-    No range checks—caller keeps lev in-range. *)
 let set_axis (v : t) ~axis:i ~level:lev : t =
-  let off = offsets.(i) in
-  let cleared = v land lnot axis_mask.(i) in
-  let lo = lev lor (lev lsr 1) land 1 in
-  let hi = (lev lsr 1) land has_hi.(i) in
-  cleared lor (lo lsl off) lor (hi lsl (off + 1))
+  Prefix_ones_bitfield.set_level ~offset:offsets.(i) ~width:widths.(i) lev v
 
 let decode (v : t) : int array =
   Array.init num_axes (fun i -> get_axis v ~axis:i)
@@ -175,11 +156,7 @@ let to_string = pp
     AND with ~ (lows >> 1) kills spillovers from low bits into neighbors;
     OR repairs 10 -> 11. *)
 
-let lnot_lsr_1_lows = lnot (lows lsr 1)
-
-let co_sub (a : t) (b : t) : t =
-  let r = a land lnot b in
-  r lor ((r lsr 1) land lnot_lsr_1_lows)
+let co_sub (a : t) (b : t) : t = Prefix_ones_bitfield.co_sub ~lows a b
 
 (* Build a mask from a set of relevant axes. *)
 let of_axis_set (set : Jkind_axis.Axis_set.t) : t =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1783,12 +1783,13 @@ let with_locality_and_forkable_yielding (locality, fy) m =
   Forkable.equate_exn (Alloc.proj_comonadic Forkable m') forkable;
   Yielding.equate_exn (Alloc.proj_comonadic Yielding m') yielding;
   let c =
-    Alloc.Comonadic.encode
-      { (Alloc.Comonadic.decode Alloc.Comonadic.Const.max) with
-        areality = Locality.Const.min;
-        forkable = Forkable.Const.min;
-        yielding = Yielding.Const.min
-      }
+    Alloc.Comonadic.Const.max
+    |> Alloc.Comonadic.Const.set Areality
+         Locality.Const.min
+    |> Alloc.Comonadic.Const.set Forkable
+         Forkable.Const.min
+    |> Alloc.Comonadic.Const.set Yielding
+         Yielding.Const.min
   in
   Alloc.submode_exn (Alloc.meet_const c m') m;
   Alloc.submode_exn (Alloc.meet_const c m) m';

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -231,20 +231,12 @@ module Axis = struct
   type packed = Pack : 'a t -> packed [@@unboxed]
 
   let all =
-    [ Pack (Modal (Comonadic Areality));
-      Pack (Modal (Monadic Uniqueness));
-      Pack (Modal (Comonadic Linearity));
-      Pack (Modal (Monadic Contention));
-      Pack (Modal (Comonadic Portability));
-      Pack (Modal (Comonadic Forkable));
-      Pack (Modal (Comonadic Yielding));
-      Pack (Modal (Comonadic Statefulness));
-      Pack (Modal (Monadic Visibility));
-      Pack (Modal (Monadic Staticity));
-      (* CR-soon zqian: call [Mode.Crossing.Axis.all] for modal axes *)
-      Pack (Nonmodal Externality);
-      Pack (Nonmodal Nullability);
-      Pack (Nonmodal Separability) ]
+    List.map
+      (fun (Mode.Crossing.Axis.P axis) -> Pack (Modal axis))
+      Mode.Crossing.Axis.all
+    @ [ Pack (Nonmodal Externality);
+        Pack (Nonmodal Nullability);
+        Pack (Nonmodal Separability) ]
 
   let name (type a) : a t -> string = function
     | Modal ax ->
@@ -389,17 +381,7 @@ module Axis_set = struct
   type t = int
 
   let[@inline] axis_index (type a) : a Axis.t -> _ = function
-    | Modal (Comonadic Areality) -> 0
-    | Modal (Monadic Uniqueness) -> 1
-    | Modal (Comonadic Linearity) -> 2
-    | Modal (Monadic Contention) -> 3
-    | Modal (Comonadic Portability) -> 4
-    | Modal (Comonadic Forkable) -> 5
-    | Modal (Comonadic Yielding) -> 6
-    | Modal (Comonadic Statefulness) -> 7
-    | Modal (Monadic Visibility) -> 8
-    | Modal (Monadic Staticity) -> 9
-    (* CR-soon zqian: call [Mode.Crossing.Axis.index] for modal axes *)
+    | Modal axis -> Mode.Crossing.Axis.index axis
     | Nonmodal Externality -> 10
     | Nonmodal Nullability -> 11
     | Nonmodal Separability -> 12
@@ -416,22 +398,15 @@ module Axis_set = struct
   let[@inline] add t axis = set ~axis ~to_:true t
 
   let[@inline] create ~f =
-    (* PERF: this is manually unrolled because flambda2 doesn't unroll for us, and this
-       function is quite hot *)
     let[@inline] set_axis axis t =
       if f ~axis:(Axis.Pack axis) then t lor axis_mask axis else t
     in
-    0
-    |> set_axis (Modal (Comonadic Areality))
-    |> set_axis (Modal (Monadic Uniqueness))
-    |> set_axis (Modal (Comonadic Linearity))
-    |> set_axis (Modal (Monadic Contention))
-    |> set_axis (Modal (Comonadic Portability))
-    |> set_axis (Modal (Comonadic Forkable))
-    |> set_axis (Modal (Comonadic Yielding))
-    |> set_axis (Modal (Comonadic Statefulness))
-    |> set_axis (Modal (Monadic Visibility))
-    |> set_axis (Modal (Monadic Staticity))
+    let t =
+      List.fold_left
+        (fun t (Mode.Crossing.Axis.P axis) -> set_axis (Modal axis) t)
+        0 Mode.Crossing.Axis.all
+    in
+    t
     |> set_axis (Nonmodal Externality)
     |> set_axis (Nonmodal Nullability)
     |> set_axis (Nonmodal Separability)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -21,6 +21,7 @@ open Solver
 open Mode_intf
 module Hint = Mode_hint
 module Fmt = Format_doc
+module Modal_bit_layout = Misc.Modal_bit_layout
 
 module Hint_for_solver (* : Solver_intf.Hint *) = struct
   module Pinpoint = struct
@@ -333,6 +334,10 @@ module Lattices = struct
 
     include Heyting with type t := t
 
+    val encode_raw_level : t -> int
+
+    val decode_raw_level : int -> t
+
     val _is_areality : unit
   end
 
@@ -356,6 +361,13 @@ module Lattices = struct
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
       | Local -> Fmt.fprintf ppf "local"
+
+    let encode_raw_level = function Global -> 0 | Local -> 2
+
+    let decode_raw_level = function
+      | 0 -> Global
+      | 2 -> Local
+      | _ -> Misc.fatal_error "Mode.Locality.decode_raw_level"
 
     let _is_areality = ()
   end
@@ -382,6 +394,14 @@ module Lattices = struct
       | Global -> Fmt.fprintf ppf "global"
       | Regional -> Fmt.fprintf ppf "regional"
       | Local -> Fmt.fprintf ppf "local"
+
+    let encode_raw_level = function Global -> 0 | Regional -> 1 | Local -> 2
+
+    let decode_raw_level = function
+      | 0 -> Global
+      | 1 -> Regional
+      | 2 -> Local
+      | _ -> Misc.fatal_error "Mode.Regionality.decode_raw_level"
 
     let _is_areality = ()
   end
@@ -592,13 +612,6 @@ module Lattices = struct
       | Static -> Fmt.fprintf ppf "static"
   end
 
-  type monadic_repr =
-    { uniqueness : Uniqueness.t;
-      contention : Contention.t;
-      visibility : Visibility.t;
-      staticity : Staticity.t
-    }
-
   type 'areality comonadic_with_repr =
     { areality : 'areality;
       linearity : Linearity.t;
@@ -608,132 +621,260 @@ module Lattices = struct
       statefulness : Statefulness.t
     }
 
-  type monadic = { value : monadic_repr } [@@unboxed]
+  type monadic_repr =
+    { uniqueness : Uniqueness.t;
+      contention : Contention.t;
+      visibility : Visibility.t;
+      staticity : Staticity.t
+    }
 
-  let[@inline] encode_monadic (m : monadic_repr) : monadic = { value = m }
+  module Monadic_bits = struct
+    let max = Modal_bit_layout.monadic_mask
 
-  let[@inline] decode_monadic (m : monadic) : monadic_repr = m.value
+    let[@inline] level_of_uniqueness = function
+      | Uniqueness.Unique -> 0
+      | Uniqueness.Aliased -> 1
+
+    let[@inline] level_of_contention = function
+      | Contention.Uncontended -> 0
+      | Contention.Shared -> 1
+      | Contention.Contended -> 2
+
+    let[@inline] level_of_visibility = function
+      | Visibility.Read_write -> 0
+      | Visibility.Read -> 1
+      | Visibility.Immutable -> 2
+
+    let[@inline] level_of_staticity = function
+      | Staticity.Static -> 0
+      | Staticity.Dynamic -> 1
+
+    let[@inline] uniqueness_of_level = function
+      | 0 -> Uniqueness.Unique
+      | 1 -> Uniqueness.Aliased
+      | _ -> Misc.fatal_error "Mode.Monadic_bits.uniqueness_of_level"
+
+    let[@inline] contention_of_level = function
+      | 0 -> Contention.Uncontended
+      | 1 -> Contention.Shared
+      | 2 -> Contention.Contended
+      | _ -> Misc.fatal_error "Mode.Monadic_bits.contention_of_level"
+
+    let[@inline] visibility_of_level = function
+      | 0 -> Visibility.Read_write
+      | 1 -> Visibility.Read
+      | 2 -> Visibility.Immutable
+      | _ -> Misc.fatal_error "Mode.Monadic_bits.visibility_of_level"
+
+    let[@inline] staticity_of_level = function
+      | 0 -> Staticity.Static
+      | 1 -> Staticity.Dynamic
+      | _ -> Misc.fatal_error "Mode.Monadic_bits.staticity_of_level"
+
+    let[@inline] uniqueness m =
+      uniqueness_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Uniqueness m)
+
+    let[@inline] contention m =
+      contention_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Contention m)
+
+    let[@inline] visibility m =
+      visibility_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Visibility m)
+
+    let[@inline] staticity m =
+      staticity_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Staticity m)
+
+    let[@inline] set_uniqueness u m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Uniqueness
+        (level_of_uniqueness u) m
+
+    let[@inline] set_contention c m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Contention
+        (level_of_contention c) m
+
+    let[@inline] set_visibility v m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Visibility
+        (level_of_visibility v) m
+
+    let[@inline] set_staticity s m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Staticity
+        (level_of_staticity s) m
+
+    let[@inline] co_sub left right = Modal_bit_layout.co_sub left right
+  end
+
+  type monadic = { bits : Modal_bit_layout.t } [@@unboxed]
+
+  let[@inline] encode_monadic
+      ({ uniqueness; contention; visibility; staticity } : monadic_repr) :
+      monadic =
+    { bits =
+        0
+        |> Monadic_bits.set_uniqueness uniqueness
+        |> Monadic_bits.set_contention contention
+        |> Monadic_bits.set_visibility visibility
+        |> Monadic_bits.set_staticity staticity
+    }
+
+  let[@inline] decode_monadic (m : monadic) : monadic_repr =
+    { uniqueness = Monadic_bits.uniqueness m.bits;
+      contention = Monadic_bits.contention m.bits;
+      visibility = Monadic_bits.visibility m.bits;
+      staticity = Monadic_bits.staticity m.bits
+    }
 
   module Monadic = struct
     type t = monadic
 
-    let[@inline] uniqueness (m : t) = (decode_monadic m).uniqueness
+    let[@inline] uniqueness (m : t) = Monadic_bits.uniqueness m.bits
 
-    let[@inline] contention (m : t) = (decode_monadic m).contention
+    let[@inline] contention (m : t) = Monadic_bits.contention m.bits
 
-    let[@inline] visibility (m : t) = (decode_monadic m).visibility
+    let[@inline] visibility (m : t) = Monadic_bits.visibility m.bits
 
-    let[@inline] staticity (m : t) = (decode_monadic m).staticity
+    let[@inline] staticity (m : t) = Monadic_bits.staticity m.bits
 
     let[@inline] set_uniqueness uniqueness m =
-      encode_monadic { (decode_monadic m) with uniqueness }
+      { bits = Monadic_bits.set_uniqueness uniqueness m.bits }
 
     let[@inline] set_contention contention m =
-      encode_monadic { (decode_monadic m) with contention }
+      { bits = Monadic_bits.set_contention contention m.bits }
 
     let[@inline] set_visibility visibility m =
-      encode_monadic { (decode_monadic m) with visibility }
+      { bits = Monadic_bits.set_visibility visibility m.bits }
 
     let[@inline] set_staticity staticity m =
-      encode_monadic { (decode_monadic m) with staticity }
+      { bits = Monadic_bits.set_staticity staticity m.bits }
 
-    let min =
-      let uniqueness = Uniqueness.min in
-      let contention = Contention.min in
-      let visibility = Visibility.min in
-      let staticity = Staticity.min in
-      encode_monadic { uniqueness; contention; visibility; staticity }
+    let min = { bits = 0 }
 
-    let max =
-      let uniqueness = Uniqueness.max in
-      let contention = Contention.max in
-      let visibility = Visibility.max in
-      let staticity = Staticity.max in
-      encode_monadic { uniqueness; contention; visibility; staticity }
+    let max = { bits = Monadic_bits.max }
 
     let legacy =
-      let uniqueness = Uniqueness.legacy in
-      let contention = Contention.legacy in
-      let visibility = Visibility.legacy in
-      let staticity = Staticity.legacy in
-      encode_monadic { uniqueness; contention; visibility; staticity }
+      encode_monadic
+        { uniqueness = Uniqueness.legacy;
+          contention = Contention.legacy;
+          visibility = Visibility.legacy;
+          staticity = Staticity.legacy
+        }
 
-    let le m1 m2 =
-      let m1 = decode_monadic m1 in
-      let m2 = decode_monadic m2 in
-      let { uniqueness = uniqueness1;
-            contention = contention1;
-            visibility = visibility1;
-            staticity = staticity1
-          } =
-        m1
-      in
-      let { uniqueness = uniqueness2;
-            contention = contention2;
-            visibility = visibility2;
-            staticity = staticity2
-          } =
-        m2
-      in
-      Uniqueness.le uniqueness1 uniqueness2
-      && Contention.le contention1 contention2
-      && Visibility.le visibility1 visibility2
-      && Staticity.le staticity1 staticity2
+    let le m1 m2 = m1.bits land m2.bits = m1.bits
 
-    let equal m1 m2 =
-      let m1 = decode_monadic m1 in
-      let m2 = decode_monadic m2 in
-      let { uniqueness = uniqueness1;
-            contention = contention1;
-            visibility = visibility1;
-            staticity = staticity1
-          } =
-        m1
-      in
-      let { uniqueness = uniqueness2;
-            contention = contention2;
-            visibility = visibility2;
-            staticity = staticity2
-          } =
-        m2
-      in
-      Uniqueness.equal uniqueness1 uniqueness2
-      && Contention.equal contention1 contention2
-      && Visibility.equal visibility1 visibility2
-      && Staticity.equal staticity1 staticity2
+    let equal (m1 : t) m2 = m1.bits = m2.bits
 
-    let join m1 m2 =
-      let m1 = decode_monadic m1 in
-      let m2 = decode_monadic m2 in
-      let uniqueness = Uniqueness.join m1.uniqueness m2.uniqueness in
-      let contention = Contention.join m1.contention m2.contention in
-      let visibility = Visibility.join m1.visibility m2.visibility in
-      let staticity = Staticity.join m1.staticity m2.staticity in
-      encode_monadic { uniqueness; contention; visibility; staticity }
+    let join (m1 : t) m2 = { bits = m1.bits lor m2.bits }
 
-    let meet m1 m2 =
-      let m1 = decode_monadic m1 in
-      let m2 = decode_monadic m2 in
-      let uniqueness = Uniqueness.meet m1.uniqueness m2.uniqueness in
-      let contention = Contention.meet m1.contention m2.contention in
-      let visibility = Visibility.meet m1.visibility m2.visibility in
-      let staticity = Staticity.meet m1.staticity m2.staticity in
-      encode_monadic { uniqueness; contention; visibility; staticity }
+    let meet (m1 : t) m2 = { bits = m1.bits land m2.bits }
 
-    let subtract m1 m2 =
-      let m1 = decode_monadic m1 in
-      let m2 = decode_monadic m2 in
-      let uniqueness = Uniqueness.subtract m1.uniqueness m2.uniqueness in
-      let contention = Contention.subtract m1.contention m2.contention in
-      let visibility = Visibility.subtract m1.visibility m2.visibility in
-      let staticity = Staticity.subtract m1.staticity m2.staticity in
-      encode_monadic { uniqueness; contention; visibility; staticity }
+    let subtract (m1 : t) m2 = { bits = Monadic_bits.co_sub m1.bits m2.bits }
 
     let print ppf m =
-      let m = decode_monadic m in
-      Fmt.fprintf ppf "%a,%a,%a,%a" Uniqueness.print m.uniqueness
-        Contention.print m.contention Visibility.print m.visibility
-        Staticity.print m.staticity
+      let { uniqueness; contention; visibility; staticity } =
+        decode_monadic m
+      in
+      Fmt.fprintf ppf "%a,%a,%a,%a" Uniqueness.print uniqueness Contention.print
+        contention Visibility.print visibility Staticity.print staticity
+  end
+
+  module Comonadic_bits (Areality : Areality) = struct
+    let[@inline] level_of_linearity = function
+      | Linearity.Many -> 0
+      | Linearity.Once -> 1
+
+    let[@inline] level_of_portability = function
+      | Portability.Portable -> 0
+      | Portability.Shareable -> 1
+      | Portability.Nonportable -> 2
+
+    let[@inline] level_of_forkable = function
+      | Forkable.Forkable -> 0
+      | Forkable.Unforkable -> 1
+
+    let[@inline] level_of_yielding = function
+      | Yielding.Unyielding -> 0
+      | Yielding.Yielding -> 1
+
+    let[@inline] level_of_statefulness = function
+      | Statefulness.Stateless -> 0
+      | Statefulness.Observing -> 1
+      | Statefulness.Stateful -> 2
+
+    let[@inline] linearity_of_level = function
+      | 0 -> Linearity.Many
+      | 1 -> Linearity.Once
+      | _ -> Misc.fatal_error "Mode.Comonadic_bits.linearity_of_level"
+
+    let[@inline] portability_of_level = function
+      | 0 -> Portability.Portable
+      | 1 -> Portability.Shareable
+      | 2 -> Portability.Nonportable
+      | _ -> Misc.fatal_error "Mode.Comonadic_bits.portability_of_level"
+
+    let[@inline] forkable_of_level = function
+      | 0 -> Forkable.Forkable
+      | 1 -> Forkable.Unforkable
+      | _ -> Misc.fatal_error "Mode.Comonadic_bits.forkable_of_level"
+
+    let[@inline] yielding_of_level = function
+      | 0 -> Yielding.Unyielding
+      | 1 -> Yielding.Yielding
+      | _ -> Misc.fatal_error "Mode.Comonadic_bits.yielding_of_level"
+
+    let[@inline] statefulness_of_level = function
+      | 0 -> Statefulness.Stateless
+      | 1 -> Statefulness.Observing
+      | 2 -> Statefulness.Stateful
+      | _ -> Misc.fatal_error "Mode.Comonadic_bits.statefulness_of_level"
+
+    let[@inline] areality m =
+      Areality.decode_raw_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Areality m)
+
+    let[@inline] linearity m =
+      linearity_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Linearity m)
+
+    let[@inline] portability m =
+      portability_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Portability m)
+
+    let[@inline] forkable m =
+      forkable_of_level (Modal_bit_layout.get_level Modal_bit_layout.Forkable m)
+
+    let[@inline] yielding m =
+      yielding_of_level (Modal_bit_layout.get_level Modal_bit_layout.Yielding m)
+
+    let[@inline] statefulness m =
+      statefulness_of_level
+        (Modal_bit_layout.get_level Modal_bit_layout.Statefulness m)
+
+    let[@inline] set_areality a m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Areality
+        (Areality.encode_raw_level a)
+        m
+
+    let[@inline] set_linearity l m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Linearity
+        (level_of_linearity l) m
+
+    let[@inline] set_portability p m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Portability
+        (level_of_portability p) m
+
+    let[@inline] set_forkable f m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Forkable
+        (level_of_forkable f) m
+
+    let[@inline] set_yielding y m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Yielding
+        (level_of_yielding y) m
+
+    let[@inline] set_statefulness s m =
+      Modal_bit_layout.set_level_unsafe Modal_bit_layout.Statefulness
+        (level_of_statefulness s) m
   end
 
   type 'areality comonadic_with = { value : 'areality comonadic_with_repr }
@@ -781,34 +922,34 @@ module Lattices = struct
     let[@inline] decode (m : t) : repr = m.value
 
     let min =
-      let areality = Areality.min in
-      let linearity = Linearity.min in
-      let portability = Portability.min in
-      let forkable = Forkable.min in
-      let yielding = Yielding.min in
-      let statefulness = Statefulness.min in
       encode
-        { areality; linearity; portability; forkable; yielding; statefulness }
+        { areality = Areality.min;
+          linearity = Linearity.min;
+          portability = Portability.min;
+          forkable = Forkable.min;
+          yielding = Yielding.min;
+          statefulness = Statefulness.min
+        }
 
     let max =
-      let areality = Areality.max in
-      let linearity = Linearity.max in
-      let portability = Portability.max in
-      let forkable = Forkable.max in
-      let yielding = Yielding.max in
-      let statefulness = Statefulness.max in
       encode
-        { areality; linearity; portability; forkable; yielding; statefulness }
+        { areality = Areality.max;
+          linearity = Linearity.max;
+          portability = Portability.max;
+          forkable = Forkable.max;
+          yielding = Yielding.max;
+          statefulness = Statefulness.max
+        }
 
     let legacy =
-      let areality = Areality.legacy in
-      let linearity = Linearity.legacy in
-      let portability = Portability.legacy in
-      let forkable = Forkable.legacy in
-      let yielding = Yielding.legacy in
-      let statefulness = Statefulness.legacy in
       encode
-        { areality; linearity; portability; forkable; yielding; statefulness }
+        { areality = Areality.legacy;
+          linearity = Linearity.legacy;
+          portability = Portability.legacy;
+          forkable = Forkable.legacy;
+          yielding = Yielding.legacy;
+          statefulness = Statefulness.legacy
+        }
 
     let le m1 m2 =
       let m1 = decode m1 in
@@ -893,14 +1034,14 @@ module Lattices = struct
     let imply m1 m2 =
       let m1 = decode m1 in
       let m2 = decode m2 in
-      let areality = Areality.imply m1.areality m2.areality in
-      let linearity = Linearity.imply m1.linearity m2.linearity in
-      let portability = Portability.imply m1.portability m2.portability in
-      let forkable = Forkable.imply m1.forkable m2.forkable in
-      let yielding = Yielding.imply m1.yielding m2.yielding in
-      let statefulness = Statefulness.imply m1.statefulness m2.statefulness in
       encode
-        { areality; linearity; portability; forkable; yielding; statefulness }
+        { areality = Areality.imply m1.areality m2.areality;
+          linearity = Linearity.imply m1.linearity m2.linearity;
+          portability = Portability.imply m1.portability m2.portability;
+          forkable = Forkable.imply m1.forkable m2.forkable;
+          yielding = Yielding.imply m1.yielding m2.yielding;
+          statefulness = Statefulness.imply m1.statefulness m2.statefulness
+        }
 
     let print ppf m =
       let { areality; linearity; portability; forkable; yielding; statefulness }
@@ -1381,6 +1522,8 @@ module Lattices_mono = struct
     constraint 'd = _ * _
   [@@ocaml.warning "-62"]
 
+  let[@inline] map_comonadic _src _dst f = Map_comonadic f
+
   include Magic_allow_disallow (struct
     type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph constraint 'd = 'l * 'r
 
@@ -1583,9 +1726,8 @@ module Lattices_mono = struct
         | None -> None
         | Some Refl -> Some Refl))
     | Map_comonadic f, Map_comonadic g -> (
-      match equal_morph (proj_obj Areality _dst) f g with
-      | Some Refl -> Some Refl
-      | None -> None)
+      let dst0 = proj_obj Areality _dst in
+      match equal_morph dst0 f g with Some Refl -> Some Refl | None -> None)
     | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_const _
         | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
         | Monadic_to_comonadic_max | Comonadic_to_monadic_max _
@@ -1774,17 +1916,16 @@ module Lattices_mono = struct
   let monadic_to_comonadic_min : type a.
       a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
    fun obj m ->
-    let m = decode_monadic m in
     let areality : a =
       match obj with
       | Comonadic_with_locality -> Locality.min
       | Comonadic_with_regionality -> Regionality.min
     in
-    let linearity = unique_to_linear m.uniqueness in
-    let portability = contended_to_portable m.contention in
+    let linearity = unique_to_linear (Monadic.uniqueness m) in
+    let portability = contended_to_portable (Monadic.contention m) in
     let forkable = Forkable.min in
     let yielding = Yielding.min in
-    let statefulness = visibility_to_statefulness m.visibility in
+    let statefulness = visibility_to_statefulness (Monadic.visibility m) in
     match obj with
     | Comonadic_with_locality ->
       let module M = Comonadic_with (Locality) in
@@ -1834,17 +1975,16 @@ module Lattices_mono = struct
   let monadic_to_comonadic_max : type a.
       a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
    fun obj m ->
-    let m = decode_monadic m in
     let areality : a =
       match obj with
       | Comonadic_with_locality -> Locality.max
       | Comonadic_with_regionality -> Regionality.max
     in
-    let linearity = unique_to_linear m.uniqueness in
-    let portability = contended_to_portable m.contention in
+    let linearity = unique_to_linear (Monadic.uniqueness m) in
+    let portability = contended_to_portable (Monadic.contention m) in
     let forkable = Forkable.max in
     let yielding = Yielding.max in
-    let statefulness = visibility_to_statefulness m.visibility in
+    let statefulness = visibility_to_statefulness (Monadic.visibility m) in
     match obj with
     | Comonadic_with_locality ->
       let module M = Comonadic_with (Locality) in
@@ -1879,8 +2019,8 @@ module Lattices_mono = struct
     | Regional_to_global -> regional_to_global a
     | Global_to_regional -> global_to_regional a
     | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
       let a0 = Axis.proj Areality a in
+      let dst0 = proj_obj Areality dst in
       set_areality (apply dst0 f a0) a
 
   module For_hint = struct
@@ -2063,18 +2203,20 @@ module Lattices_mono = struct
            Locality_as_regionality)
     | Map_comonadic f, Meet_const c ->
       let dst0 = proj_obj Areality dst in
+      let src0 = src dst0 f in
       let areality = Axis.proj Areality c in
       Some
         (compose dst
            (Meet_const (set_areality (max dst0) c))
-           (Map_comonadic (compose dst0 f (Meet_const areality))))
+           (map_comonadic src0 dst0 (compose dst0 f (Meet_const areality))))
     | Map_comonadic f, Imply_const c ->
       let dst0 = proj_obj Areality dst in
+      let src0 = src dst0 f in
       let areality = Axis.proj Areality c in
       Some
         (compose dst
            (Imply_const (set_areality (max dst0) c))
-           (Map_comonadic (compose dst0 f (Imply_const areality))))
+           (map_comonadic src0 dst0 (compose dst0 f (Imply_const areality))))
     | Regional_to_global, Locality_as_regionality -> Some Id
     | Regional_to_global, Local_to_regional -> Some (Meet_const Locality.Global)
     | Local_to_regional, Regional_to_local -> None
@@ -2140,8 +2282,9 @@ module Lattices_mono = struct
     | Regional_to_local -> Local_to_regional
     | Map_comonadic f ->
       let dst0 = proj_obj Areality dst in
+      let src0 = src dst0 f in
       let f' = left_adjoint dst0 f in
-      Map_comonadic f'
+      map_comonadic dst0 src0 f'
 
   and right_adjoint : type a b r.
       b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
@@ -2164,8 +2307,9 @@ module Lattices_mono = struct
     | Regional_to_global -> Global_to_regional
     | Map_comonadic f ->
       let dst0 = proj_obj Areality dst in
+      let src0 = src dst0 f in
       let f' = right_adjoint dst0 f in
-      Map_comonadic f'
+      map_comonadic dst0 src0 f'
 end
 
 module C = Lattices_mono
@@ -2180,7 +2324,7 @@ type monadic_repr = C.monadic_repr =
     staticity : C.Staticity.t
   }
 
-type monadic = C.monadic = { value : monadic_repr } [@@unboxed]
+type monadic = C.monadic = { bits : Misc.Modal_bit_layout.t } [@@unboxed]
 
 let encode_monadic = C.encode_monadic
 
@@ -3396,6 +3540,8 @@ end
 module Lattice_Product (L : Lattice) = struct
   open L
 
+  let set = Axis.set
+
   let min_with ax c = Axis.set ax c min
 
   let max_with ax c = Axis.set ax c max
@@ -3763,45 +3909,76 @@ module Value_with (Areality : Areality) = struct
       staticity : 'j
     }
 
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
-    ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes_repr
+  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes = int
 
-  let encode (m : ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes_repr) :
-      ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
-    m
+  module Packed_comonadic = C.Comonadic_bits (Areality.Const)
 
-  let decode (m : ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes) :
-      ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes_repr =
-    m
+  let encode_comonadic
+      ({ areality; linearity; portability; forkable; yielding; statefulness } :
+        Areality.Const.t comonadic_with_repr) =
+    0
+    |> Packed_comonadic.set_areality areality
+    |> Packed_comonadic.set_linearity linearity
+    |> Packed_comonadic.set_portability portability
+    |> Packed_comonadic.set_forkable forkable
+    |> Packed_comonadic.set_yielding yielding
+    |> Packed_comonadic.set_statefulness statefulness
 
-  let split
-      { areality;
-        linearity;
-        portability;
-        forkable;
-        yielding;
-        statefulness;
-        uniqueness;
-        contention;
-        visibility;
-        staticity
-      } =
-    let monadic : Monadic.Const.t =
-      encode_monadic { uniqueness; contention; visibility; staticity }
-    in
-    let comonadic : Comonadic.Const.t =
-      Comonadic.encode
-        { areality; linearity; portability; forkable; yielding; statefulness }
-    in
-    { comonadic; monadic }
+  let decode_comonadic_bits bits : Areality.Const.t comonadic_with_repr =
+    { areality = Packed_comonadic.areality bits;
+      linearity = Packed_comonadic.linearity bits;
+      portability = Packed_comonadic.portability bits;
+      forkable = Packed_comonadic.forkable bits;
+      yielding = Packed_comonadic.yielding bits;
+      statefulness = Packed_comonadic.statefulness bits
+    }
 
-  let merge { comonadic; monadic } =
+  let encode
+      ({ areality;
+         linearity;
+         portability;
+         forkable;
+         yielding;
+         statefulness;
+         uniqueness;
+         contention;
+         visibility;
+         staticity
+       } :
+        ( Areality.Const.t,
+          Linearity.Const.t,
+          Uniqueness.Const.t,
+          Portability.Const.t,
+          Contention.Const.t,
+          Forkable.Const.t,
+          Yielding.Const.t,
+          Statefulness.Const.t,
+          Visibility.Const.t,
+          Staticity.Const.t )
+        modes_repr) =
+    encode_comonadic
+      { areality; linearity; portability; forkable; yielding; statefulness }
+    lor (encode_monadic { uniqueness; contention; visibility; staticity }).bits
+
+  let decode
+      (m :
+        ( Areality.Const.t,
+          Linearity.Const.t,
+          Uniqueness.Const.t,
+          Portability.Const.t,
+          Contention.Const.t,
+          Forkable.Const.t,
+          Yielding.Const.t,
+          Statefulness.Const.t,
+          Visibility.Const.t,
+          Staticity.Const.t )
+        modes) =
     let ({ areality; linearity; portability; forkable; yielding; statefulness }
-          : Comonadic.repr) =
-      Comonadic.decode comonadic
+          : Areality.Const.t comonadic_with_repr) =
+      decode_comonadic_bits m
     in
     let ({ uniqueness; contention; visibility; staticity } : monadic_repr) =
-      decode_monadic monadic
+      decode_monadic { bits = m land Modal_bit_layout.monadic_mask }
     in
     { areality;
       linearity;
@@ -3814,6 +3991,16 @@ module Value_with (Areality : Areality) = struct
       visibility;
       staticity
     }
+
+  let split m =
+    { comonadic =
+        m land Modal_bit_layout.comonadic_mask
+        |> decode_comonadic_bits |> Comonadic.Const.encode;
+      monadic = { bits = m land Modal_bit_layout.monadic_mask }
+    }
+
+  let merge { comonadic; monadic } =
+    encode_comonadic (Comonadic.Const.decode comonadic) lor monadic.bits
 
   let print ?verbose () ppf { monadic; comonadic } =
     Fmt.fprintf ppf "%a;%a"
@@ -3853,8 +4040,6 @@ module Value_with (Areality : Areality) = struct
     module Monadic = Monadic.Const
     module Comonadic = Comonadic.Const
 
-    (* CR-soon zqian: make a functor [Mode.Value.Const.Make] to generalize over any type
-       operator applied on each mode constants. *)
     type repr =
       ( Areality.Const.t,
         Linearity.Const.t,
@@ -3889,16 +4074,9 @@ module Value_with (Areality : Areality) = struct
 
     let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
 
-    let le m1 m2 =
-      let m1 = split m1 in
-      let m2 = split m2 in
-      Comonadic.le m1.comonadic m2.comonadic && Monadic.le m1.monadic m2.monadic
+    let le m1 m2 = m1 land m2 = m1
 
-    let equal m1 m2 =
-      let m1 = split m1 in
-      let m2 = split m2 in
-      Comonadic.equal m1.comonadic m2.comonadic
-      && Monadic.equal m1.monadic m2.monadic
+    let equal (m1 : t) m2 = m1 = m2
 
     let print ppf m =
       let { monadic; comonadic } = split m in
@@ -3907,19 +4085,27 @@ module Value_with (Areality : Areality) = struct
     let legacy =
       merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
 
-    let meet m1 m2 =
-      let m1 = split m1 in
-      let m2 = split m2 in
-      let monadic = Monadic.meet m1.monadic m2.monadic in
-      let comonadic = Comonadic.meet m1.comonadic m2.comonadic in
-      merge { monadic; comonadic }
+    let meet (m1 : t) m2 = m1 land m2
 
-    let join m1 m2 =
-      let m1 = split m1 in
-      let m2 = split m2 in
-      let monadic = Monadic.join m1.monadic m2.monadic in
-      let comonadic = Comonadic.join m1.comonadic m2.comonadic in
-      merge { monadic; comonadic }
+    let join (m1 : t) m2 = m1 lor m2
+
+    let proj (type a) (ax : a Axis.t) (m : t) : a =
+      match ax with
+      | Monadic ax ->
+        let { monadic; _ } = split m in
+        Monadic.proj ax monadic
+      | Comonadic ax ->
+        let { comonadic; _ } = split m in
+        Comonadic.proj ax comonadic
+
+    let set (type a) (ax : a Axis.t) (a : a) (m : t) : t =
+      match ax with
+      | Monadic ax ->
+        let { comonadic; monadic } = split m in
+        merge { comonadic; monadic = Monadic.set ax a monadic }
+      | Comonadic ax ->
+        let { comonadic; monadic } = split m in
+        merge { monadic; comonadic = Comonadic.set ax a comonadic }
 
     module Option = struct
       type some = t
@@ -3951,6 +4137,7 @@ module Value_with (Areality : Areality) = struct
         }
 
       let value opt ~default =
+        let default = decode default in
         let areality = Option.value opt.areality ~default:default.areality in
         let uniqueness =
           Option.value opt.uniqueness ~default:default.uniqueness
@@ -3971,17 +4158,18 @@ module Value_with (Areality : Areality) = struct
           Option.value opt.visibility ~default:default.visibility
         in
         let staticity = Option.value opt.staticity ~default:default.staticity in
-        { areality;
-          uniqueness;
-          linearity;
-          portability;
-          contention;
-          forkable;
-          yielding;
-          statefulness;
-          visibility;
-          staticity
-        }
+        encode
+          { areality;
+            uniqueness;
+            linearity;
+            portability;
+            contention;
+            forkable;
+            yielding;
+            statefulness;
+            visibility;
+            staticity
+          }
 
       let proj (type a) (ax : a Axis.t) (t : t) : a option =
         match ax with
@@ -4057,6 +4245,8 @@ module Value_with (Areality : Areality) = struct
     end
 
     let diff m1 m2 =
+      let m1 = decode m1 in
+      let m2 = decode m2 in
       let diff le a1 a2 = if le a1 a2 && le a2 a1 then None else Some a1 in
       let areality = diff Areality.Const.le m1.areality m2.areality in
       let linearity = diff Linearity.Const.le m1.linearity m2.linearity in
@@ -4356,31 +4546,34 @@ module Value = Value_with (Regionality)
 module Alloc = Value_with (Locality)
 
 module Const = struct
-  let alloc_as_value
-      ({ areality;
-         linearity;
-         portability;
-         uniqueness;
-         contention;
-         forkable;
-         yielding;
-         statefulness;
-         visibility;
-         staticity
-       } :
-        Alloc.Const.t) : Value.Const.t =
+  let alloc_as_value (c : Alloc.Const.t) : Value.Const.t =
+    let ({ areality;
+           linearity;
+           portability;
+           uniqueness;
+           contention;
+           forkable;
+           yielding;
+           statefulness;
+           visibility;
+           staticity
+         }
+          : Alloc.Const.repr) =
+      Alloc.Const.decode c
+    in
     let areality = C.locality_as_regionality areality in
-    { areality;
-      linearity;
-      portability;
-      uniqueness;
-      contention;
-      forkable;
-      yielding;
-      statefulness;
-      visibility;
-      staticity
-    }
+    Value.Const.encode
+      { areality;
+        linearity;
+        portability;
+        uniqueness;
+        contention;
+        forkable;
+        yielding;
+        statefulness;
+        visibility;
+        staticity
+      }
 
   module Axis = struct
     let is_areality (type a) :
@@ -4411,11 +4604,13 @@ end
    operate on [Unhint] so they can be composed and assigned hint as a whole. *)
 
 let comonadic_locality_as_regionality comonadic =
-  S.Unhint.apply Value.Comonadic.Obj.obj (Map_comonadic Locality_as_regionality)
+  S.Unhint.apply Value.Comonadic.Obj.obj
+    (C.map_comonadic C.Locality C.Regionality C.Locality_as_regionality)
     comonadic
 
 let comonadic_regional_to_local comonadic =
-  S.Unhint.apply Alloc.Comonadic.Obj.obj (Map_comonadic Regional_to_local)
+  S.Unhint.apply Alloc.Comonadic.Obj.obj
+    (C.map_comonadic C.Regionality C.Locality C.Regional_to_local)
     comonadic
 
 let alloc_as_value_unhint m =
@@ -4429,7 +4624,8 @@ let alloc_as_value m =
 let alloc_to_value_l2r_unhint m =
   let { comonadic; monadic } = m in
   let comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj (Map_comonadic Local_to_regional)
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (C.map_comonadic C.Locality C.Regionality C.Local_to_regional)
       comonadic
   in
   { comonadic; monadic }
@@ -4441,7 +4637,8 @@ let alloc_to_value_l2r m =
 let value_to_alloc_r2g_unhint m =
   let { comonadic; monadic } = m in
   let comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj (Map_comonadic Regional_to_global)
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (C.map_comonadic C.Regionality C.Locality C.Regional_to_global)
       comonadic
   in
   { comonadic; monadic }
@@ -5186,7 +5383,7 @@ module Crossing = struct
         ~statefulness:(Atom.Modality (Meet_const statefulness)) =
       Modality
         (Meet_const
-           (Mode.encode
+           (Mode.Const.encode
               { areality;
                 linearity;
                 portability;
@@ -5241,6 +5438,22 @@ module Crossing = struct
 
     type packed = P : 'a t -> packed
 
+    type with_slot = A : 'a t * Misc.Modal_bit_layout.slot -> with_slot
+
+    let all_with_slots =
+      [ A (Comonadic Areality, Areality);
+        A (Monadic Uniqueness, Uniqueness);
+        A (Comonadic Linearity, Linearity);
+        A (Monadic Contention, Contention);
+        A (Comonadic Portability, Portability);
+        A (Comonadic Forkable, Forkable);
+        A (Comonadic Yielding, Yielding);
+        A (Comonadic Statefulness, Statefulness);
+        A (Monadic Visibility, Visibility);
+        A (Monadic Staticity, Staticity) ]
+
+    let all = List.map (fun (A (ax, _)) -> P ax) all_with_slots
+
     let of_modality : Modality.Axis.packed -> packed = function
       | P (Monadic ax) -> P (Monadic ax)
       | P (Comonadic ax) -> P (Comonadic ax)
@@ -5280,6 +5493,31 @@ module Crossing = struct
      fun ppf -> function
       | Monadic ax -> Axis.print ppf ax
       | Comonadic ax -> Axis.print ppf ax
+
+    let slot : type a. a t -> Misc.Modal_bit_layout.slot =
+     fun ax ->
+      let rec loop : type b. b t -> with_slot list -> Misc.Modal_bit_layout.slot
+          =
+       fun ax all_with_slots ->
+        match all_with_slots with
+        | [] -> invalid_arg "Mode.Crossing.Axis.slot"
+        | A (ax', slot) :: rest -> (
+          match equal ax ax' with Some Refl -> slot | None -> loop ax rest)
+      in
+      loop ax all_with_slots
+
+    let index : type a. a t -> int =
+     fun ax ->
+      let rec loop : type b. int -> b t -> with_slot list -> int =
+       fun i ax all_with_slots ->
+        match all_with_slots with
+        | [] -> invalid_arg "Mode.Crossing.Axis.index"
+        | A (ax', _) :: rest -> (
+          match equal ax ax' with
+          | Some Refl -> i
+          | None -> loop (i + 1) ax rest)
+      in
+      loop 0 ax all_with_slots
   end
 
   module Per_axis = struct
@@ -5447,7 +5685,7 @@ module Crossing = struct
       Comonadic.create ~regionality ~linearity ~portability ~yielding ~forkable
         ~statefulness
     in
-    pack ~monadic ~comonadic
+    { monadic; comonadic }
 
   let print ppf t =
     let l =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -712,7 +712,7 @@ module Lattices = struct
       ({ uniqueness; contention; visibility; staticity } : monadic_repr) :
       monadic =
     { bits =
-        0
+        Modal_bit_layout.empty
         |> Monadic_bits.set_uniqueness uniqueness
         |> Monadic_bits.set_contention contention
         |> Monadic_bits.set_visibility visibility
@@ -749,7 +749,7 @@ module Lattices = struct
     let[@inline] set_staticity staticity m =
       { bits = Monadic_bits.set_staticity staticity m.bits }
 
-    let min = { bits = 0 }
+    let min = { bits = Modal_bit_layout.empty }
 
     let max = { bits = Monadic_bits.max }
 
@@ -761,13 +761,13 @@ module Lattices = struct
           staticity = Staticity.legacy
         }
 
-    let le m1 m2 = m1.bits land m2.bits = m1.bits
+    let le m1 m2 = Modal_bit_layout.le m1.bits m2.bits
 
-    let equal (m1 : t) m2 = m1.bits = m2.bits
+    let equal (m1 : t) m2 = Modal_bit_layout.equal m1.bits m2.bits
 
-    let join (m1 : t) m2 = { bits = m1.bits lor m2.bits }
+    let join (m1 : t) m2 = { bits = Modal_bit_layout.union m1.bits m2.bits }
 
-    let meet (m1 : t) m2 = { bits = m1.bits land m2.bits }
+    let meet (m1 : t) m2 = { bits = Modal_bit_layout.inter m1.bits m2.bits }
 
     let subtract (m1 : t) m2 = { bits = Monadic_bits.co_sub m1.bits m2.bits }
 
@@ -3909,14 +3909,14 @@ module Value_with (Areality : Areality) = struct
       staticity : 'j
     }
 
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes = int
+  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes = Modal_bit_layout.t
 
   module Packed_comonadic = C.Comonadic_bits (Areality.Const)
 
   let encode_comonadic
       ({ areality; linearity; portability; forkable; yielding; statefulness } :
         Areality.Const.t comonadic_with_repr) =
-    0
+    Modal_bit_layout.empty
     |> Packed_comonadic.set_areality areality
     |> Packed_comonadic.set_linearity linearity
     |> Packed_comonadic.set_portability portability
@@ -3956,9 +3956,10 @@ module Value_with (Areality : Areality) = struct
           Visibility.Const.t,
           Staticity.Const.t )
         modes_repr) =
-    encode_comonadic
-      { areality; linearity; portability; forkable; yielding; statefulness }
-    lor (encode_monadic { uniqueness; contention; visibility; staticity }).bits
+    Modal_bit_layout.union
+      (encode_comonadic
+         { areality; linearity; portability; forkable; yielding; statefulness })
+      (encode_monadic { uniqueness; contention; visibility; staticity }).bits
 
   let decode
       (m :
@@ -3978,7 +3979,8 @@ module Value_with (Areality : Areality) = struct
       decode_comonadic_bits m
     in
     let ({ uniqueness; contention; visibility; staticity } : monadic_repr) =
-      decode_monadic { bits = m land Modal_bit_layout.monadic_mask }
+      decode_monadic
+        { bits = Modal_bit_layout.inter m Modal_bit_layout.monadic_mask }
     in
     { areality;
       linearity;
@@ -3994,13 +3996,16 @@ module Value_with (Areality : Areality) = struct
 
   let split m =
     { comonadic =
-        m land Modal_bit_layout.comonadic_mask
+        Modal_bit_layout.inter m Modal_bit_layout.comonadic_mask
         |> decode_comonadic_bits |> Comonadic.Const.encode;
-      monadic = { bits = m land Modal_bit_layout.monadic_mask }
+      monadic =
+        { bits = Modal_bit_layout.inter m Modal_bit_layout.monadic_mask }
     }
 
   let merge { comonadic; monadic } =
-    encode_comonadic (Comonadic.Const.decode comonadic) lor monadic.bits
+    Modal_bit_layout.union
+      (encode_comonadic (Comonadic.Const.decode comonadic))
+      monadic.bits
 
   let print ?verbose () ppf { monadic; comonadic } =
     Fmt.fprintf ppf "%a;%a"
@@ -4074,9 +4079,9 @@ module Value_with (Areality : Areality) = struct
 
     let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
 
-    let le m1 m2 = m1 land m2 = m1
+    let le m1 m2 = Modal_bit_layout.le m1 m2
 
-    let equal (m1 : t) m2 = m1 = m2
+    let equal (m1 : t) m2 = Modal_bit_layout.equal m1 m2
 
     let print ppf m =
       let { monadic; comonadic } = split m in
@@ -4085,9 +4090,9 @@ module Value_with (Areality : Areality) = struct
     let legacy =
       merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
 
-    let meet (m1 : t) m2 = m1 land m2
+    let meet (m1 : t) m2 = Modal_bit_layout.inter m1 m2
 
-    let join (m1 : t) m2 = m1 lor m2
+    let join (m1 : t) m2 = Modal_bit_layout.union m1 m2
 
     let proj (type a) (ax : a Axis.t) (m : t) : a =
       match ax with

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -49,6 +49,10 @@ module type Const_product = sig
 
   type 'a axis
 
+  val proj : 'a axis -> t -> 'a
+
+  val set : 'a axis -> 'a -> t -> t
+
   (** [min_with ax elt] returns [min] but with the axis [ax] set to [elt]. *)
   val min_with : 'a axis -> 'a -> t
 
@@ -522,7 +526,7 @@ module type S = sig
      type. Callers should treat this as abstract and prefer
      [encode_monadic]/[decode_monadic] rather than inspecting the wrapper
      directly. *)
-  type monadic = private { value : monadic_repr } [@@unboxed]
+  type monadic = private { bits : Misc.Modal_bit_layout.t } [@@unboxed]
 
   val encode_monadic : monadic_repr -> monadic
 
@@ -656,6 +660,10 @@ module type S = sig
       val encode : repr -> t
 
       val decode : t -> repr
+
+      val proj : 'a Axis.t -> t -> 'a
+
+      val set : 'a Axis.t -> 'a -> t -> t
 
       module Option : sig
         type some = t
@@ -1123,6 +1131,14 @@ module type S = sig
 
       type packed = P : 'a t -> packed
 
+      (** All modal axes in the shared packed-layout order. *)
+      val all : packed list
+
+      (** Index in the shared packed-layout order. *)
+      val index : 'a t -> int
+
+      val slot : 'a t -> Misc.Modal_bit_layout.slot
+
       val of_modality : Modality.Axis.packed -> packed
 
       val to_modality : packed -> Modality.Axis.packed
@@ -1134,10 +1150,8 @@ module type S = sig
 
     (** Convenience for creating a mode crossing capability on all axes, using a
         boolean for each axis where [true] means full crossing and [false] means
-        no crossing. Alternatively, call [Monadic.create] and [Comonadic.create]
-        and pack the results using [pack]. *)
-    val pack : monadic:Monadic.t -> comonadic:Comonadic.t -> t
-
+        no crossing. Alternatively, call [Monadic.create] and
+        [Comonadic.create], then [pack] the results. *)
     val create :
       regionality:bool ->
       linearity:bool ->
@@ -1150,6 +1164,8 @@ module type S = sig
       visibility:bool ->
       staticity:bool ->
       t
+
+    val pack : monadic:Monadic.t -> comonadic:Comonadic.t -> t
 
     (** Project a mode crossing (of all axes) onto the specified axis. *)
     val proj : 'a Axis.t -> t -> 'a

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -494,13 +494,13 @@ let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
 
 let meet_regional ?hint:h mode =
   let mode = Value.disallow_left mode in
+  let areality_ax : Regionality.Const.t Value.Axis.t =
+    Value.Axis.Comonadic Areality
+  in
   Value.meet
     [ Value.(
         of_const ?hint_comonadic:h
-          (Const.encode
-             { (Const.decode Const.max) with
-               areality = Regionality.Const.Regional
-             }));
+          (Const.set areality_ax Regionality.Const.Regional Const.max));
       mode
     ]
 
@@ -624,13 +624,20 @@ let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
 
 let mode_lazy expected_mode =
+  let areality_ax : Regionality.Const.t Value.Axis.t =
+    Value.Axis.Comonadic Areality
+  in
+  let forkable_ax : Forkable.Const.t Value.Axis.t =
+    Value.Axis.Comonadic Forkable
+  in
+  let yielding_ax : Yielding.Const.t Value.Axis.t =
+    Value.Axis.Comonadic Yielding
+  in
   let mode =
-    Value.Const.encode
-      { (Value.Const.decode Value.Const.max) with
-        areality = Regionality.Const.Global;
-        forkable = Forkable.Const.Forkable;
-        yielding = Yielding.Const.Unyielding
-      }
+    Value.Const.max
+    |> Value.Const.set areality_ax Regionality.Const.Global
+    |> Value.Const.set forkable_ax Forkable.Const.Forkable
+    |> Value.Const.set yielding_ax Yielding.Const.Unyielding
   in
   let expected_mode =
     mode_coerce (Value.of_const ~hint_comonadic:Lazy_allocated_on_heap mode)
@@ -683,11 +690,13 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
   | _, _, (Nontail | Default) ->
      mode_default vmode, vmode
   | _, _, Tail -> begin
-    Value.submode_exn vmode Value.(of_const ~hint_comonadic:Tailcall_argument
-      (Const.encode
-         { (Const.decode Const.max) with
-           areality = Regionality.Const.Regional
-         }));
+    let areality_ax : Regionality.Const.t Value.Axis.t =
+      Value.Axis.Comonadic Areality
+    in
+    Value.submode_exn vmode
+      Value.(
+        of_const ~hint_comonadic:Tailcall_argument
+          (Const.set areality_ax Regionality.Const.Regional Const.max));
     mode_default vmode, vmode
   end
 
@@ -1149,34 +1158,41 @@ let mutvar_mode ~loc ~env m0 exp_mode =
 (** The [expected_mode] of the record when projecting a mutable field. *)
 let mode_project_mutable mut_name =
   let mode =
-    Value.Const.encode
-      { (Value.Const.decode Value.Const.max) with
-        visibility = Visibility.Const.Read;
-        contention = Contention.Const.Shared
-      }
+    Value.Const.max
+    |> Value.Const.set
+         (Value.Axis.Monadic Visibility)
+         Visibility.Const.Read
+    |> Value.Const.set
+         (Value.Axis.Monadic Contention)
+         Contention.Const.Shared
     |> Value.of_const ~hint_monadic:(Mutable_read mut_name)
   in
   mode_default mode
 
 (** The [expected_mode] of the record when mutating a mutable field. *)
 let mode_mutate_mutable mut_name =
+  let visibility_ax : Visibility.Const.t Value.Axis.t =
+    Value.Axis.Monadic Visibility
+  in
+  let contention_ax : Contention.Const.t Value.Axis.t =
+    Value.Axis.Monadic Contention
+  in
   let mode =
-    Value.Const.encode
-      { (Value.Const.decode Value.Const.max) with
-        visibility = Visibility.Const.Read_write;
-        contention = Contention.Const.Uncontended
-      }
+    Value.Const.max
+    |> Value.Const.set visibility_ax Visibility.Const.Read_write
+    |> Value.Const.set contention_ax Contention.Const.Uncontended
     |> Value.of_const ~hint_monadic:(Mutable_write mut_name)
   in
   mode_default mode
 
 (** The [expected_mode] of the lazy expression when forcing it. *)
 let mode_force_lazy =
+  let contention_ax : Contention.Const.t Value.Axis.t =
+    Value.Axis.Monadic Contention
+  in
   let mode =
-    Value.Const.encode
-      { (Value.Const.decode Value.Const.max) with
-        contention = Contention.Const.Uncontended
-      }
+    Value.Const.max
+    |> Value.Const.set contention_ax Contention.Const.Uncontended
     |> Value.of_const ~hint_monadic:Lazy_forced
   in
   mode_default mode
@@ -5451,22 +5467,22 @@ let with_explanation explanation f =
 let unique_use ~loc ~env mode_l mode_r  =
   if not (Language_extension.is_at_least Unique
             Language_extension.maturity_of_unique_for_drf) then begin
+    let uniqueness_ax : Uniqueness.Const.t Value.Axis.t =
+      Value.Axis.Monadic Uniqueness
+    in
+    let linearity_ax : Linearity.Const.t Value.Axis.t =
+      Value.Axis.Comonadic Linearity
+    in
     (* if unique extension is not enabled, we will not run uniqueness analysis;
        instead, we force all uses to be aliased and many. This is equivalent to
        running a UA which forces everything *)
     submode ~loc ~env
-      Value.(of_const
-        (Const.encode
-           { (Const.decode Const.min) with
-             uniqueness = Uniqueness.Const.Aliased
-           }))
+      Value.(
+        of_const
+          (Const.set uniqueness_ax Uniqueness.Const.Aliased Const.min))
       (mode_default mode_r);
-    submode ~loc ~env mode_l
-      (mode_default Value.(of_const
-         (Const.encode
-            { (Const.decode Const.max) with
-              linearity = Linearity.Const.Many
-            })));
+    submode ~loc ~env mode_l (mode_default Value.(of_const
+      (Const.set linearity_ax Linearity.Const.Many Const.max)));
     (Uniqueness.disallow_left Uniqueness.aliased,
      Linearity.disallow_right Linearity.many)
   end
@@ -6408,11 +6424,12 @@ and type_expect_
       end
   | Pexp_borrow body ->
     let hint_comonadic = Hint.Borrowed (loc, Comonadic) in
+    let areality_ax : Regionality.Const.t Mode.Value.Axis.t =
+      Mode.Value.Axis.Comonadic Areality
+    in
     let mode =
-      Mode.Value.Const.encode
-        { (Mode.Value.Const.decode Mode.Value.Const.min) with
-          areality = Regionality.Const.Local
-        }
+      Mode.Value.Const.set areality_ax Regionality.Const.Local
+        Mode.Value.Const.min
       |> Value.of_const ~hint_comonadic
     in
     submode ~loc ~env mode expected_mode;
@@ -6444,13 +6461,13 @@ and type_expect_
       let funct_mode =
         match pm.apply_position with
         | Tail ->
+          let areality_ax : Regionality.Const.t Value.Axis.t =
+            Value.Axis.Comonadic Areality
+          in
           let mode, _ =
             Value.(newvar_below
               (of_const ~hint_comonadic:Tailcall_function
-                (Const.encode
-                   { (Const.decode Const.max) with
-                     areality = Regionality.Const.Regional
-                   })))
+                (Const.set areality_ax Regionality.Const.Regional Const.max)))
           in
           mode
         | Nontail | Default -> Value.newvar ()
@@ -7000,13 +7017,12 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_while(scond, sbody) ->
-    let env =
-      Env.add_const_closure_lock ~ghost:true (loc, Loop)
-        (Value.Comonadic.encode
-           { (Value.Comonadic.decode Value.Comonadic.Const.max) with
-             linearity = Linearity.Const.Many
-           })
-        env
+      let linearity_ax : Linearity.Const.t Value.Comonadic.Axis.t = Linearity in
+      let env =
+        Env.add_const_closure_lock ~ghost:true (loc, Loop)
+          (Value.Comonadic.Const.set linearity_ax Linearity.Const.Many
+             Value.Comonadic.Const.max)
+          env
       in
       let cond_env = Env.add_region_lock env in
       let mode = mode_region Value.max in
@@ -7033,6 +7049,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
+      let linearity_ax : Linearity.Const.t Value.Comonadic.Axis.t = Linearity in
       let for_from =
         type_expect env (mode_region Value.max) slow
           (mk_expected ~explanation:For_loop_start_index Predef.type_int)
@@ -7043,10 +7060,8 @@ and type_expect_
       in
       let env =
         Env.add_const_closure_lock ~ghost:true (loc, Loop)
-          (Value.Comonadic.encode
-             { (Value.Comonadic.decode Value.Comonadic.Const.max) with
-               linearity = Linearity.Const.Many
-             })
+          (Value.Comonadic.Const.set linearity_ax Linearity.Const.Many
+             Value.Comonadic.Const.max)
           env
       in
       let (for_id, for_uid), new_env =
@@ -7726,19 +7741,19 @@ and type_expect_
       | Texp_array (_, _, _, alloc_mode)
       | Texp_field (_, _, _, _, Boxing (alloc_mode, _), _) ->
         begin
+          let value_areality_ax : Regionality.Const.t Value.Axis.t =
+            Value.Axis.Comonadic Areality
+          in
+          let alloc_areality_ax : Locality.Const.t Alloc.Axis.t =
+            Alloc.Axis.Comonadic Areality
+          in
           submode ~loc ~env
             Value.(of_const ~hint_comonadic:Stack_expression
-              (Const.encode
-                 { (Const.decode Const.min) with
-                   areality = Regionality.Const.Local
-                 }))
+              (Const.set value_areality_ax Regionality.Const.Local Const.min))
             expected_mode;
           let local =
             Alloc.(of_const ~hint_comonadic:Stack_expression
-              (Const.encode
-                 { (Const.decode Const.min) with
-                   areality = Locality.Const.Local
-                 }))
+              (Const.set alloc_areality_ax Locality.Const.Local Const.min))
           in
           Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
         end
@@ -7779,13 +7794,14 @@ and type_expect_
       let cell_mode, _ =
         (* The overwritten cell has to be unique
            and should have the areality expected here: *)
+        let uniqueness_ax : Uniqueness.Const.t Value.Axis.t =
+          Value.Axis.Monadic Uniqueness
+        in
         Value.newvar_below
           (Value.meet [
             Value.of_const
-              (Value.Const.encode
-                 { (Value.Const.decode Value.Const.max) with
-                   uniqueness = Uniqueness.Const.Unique
-                 });
+              (Value.Const.set uniqueness_ax Uniqueness.Const.Unique
+                 Value.Const.max);
             Value.max_with_comonadic Areality
               (Value.proj_comonadic Areality expected_mode.mode)])
       in
@@ -7799,12 +7815,13 @@ and type_expect_
            We enforce that here, by asking the allocation to be global.
            This makes the block alloc_heap, but we ignore that information anyway. *)
         (* CR uniqueness: this shouldn't mention yielding *)
-        Value.Comonadic.encode
-          { (Value.Comonadic.decode Value.Comonadic.Const.max) with
-            areality = Regionality.Const.Global;
-            forkable = Forkable.Const.Forkable;
-            yielding = Yielding.Const.Unyielding
-          }
+        Value.Comonadic.Const.max
+        |> Value.Comonadic.Const.set Areality
+             Regionality.Const.Global
+        |> Value.Comonadic.Const.set Forkable
+             Forkable.Const.Forkable
+        |> Value.Comonadic.Const.set Yielding
+             Yielding.Const.Unyielding
       in
       let exp2 =
         let exp2_mode =
@@ -10219,11 +10236,11 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
            allocations pointing to each other. For this to be safe, they are all
            heap-allocated. *)
         (* CR zqian: the multiple allocations should enjoy their own modes. *)
+        let areality_ax : Regionality.Const.t Value.Axis.t =
+          Value.Axis.Comonadic Areality
+        in
         let m, _ =
-          Value.Const.encode
-            { (Value.Const.decode Value.Const.max) with
-              areality = Regionality.Const.Global
-            }
+          Value.Const.set areality_ax Regionality.Const.Global Value.Const.max
           |> Value.of_const
           |> Value.newvar_below
         in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4024,13 +4024,13 @@ let transl_value_decl env loc ~modal ~why valdecl =
         let modes = List.map modality_to_mode valdecl.pval_modalities in
         let modes = Typemode.transl_mode_annots modes in
         let mode =
+          let staticity_ax : Mode.Staticity.Const.t Mode.Alloc.Axis.t =
+            Mode.Alloc.Axis.Monadic Staticity
+          in
           modes.mode_modes
-          |> Mode.Alloc.Const.Option.value
-               ~default:
-                 (Mode.Alloc.Const.encode
-                    { (Mode.Alloc.Const.decode Mode.Alloc.Const.legacy) with
-                      staticity = Mode.Staticity.Static
-                    })
+          |> Mode.Alloc.Const.(
+              Option.value
+                ~default:(set staticity_ax Mode.Staticity.Static legacy))
           |> Mode.Alloc.of_const
           |> Mode.alloc_as_value
         in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -115,13 +115,13 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   mode
 
 let register_allocation () =
+  let areality_ax : Mode.Regionality.Const.t Value.Axis.t =
+    Value.Axis.Comonadic Areality
+  in
   let m, _ =
     Value.(newvar_below (of_const
       ~hint_comonadic:Module_allocated_on_heap
-      (Const.encode
-         { (Const.decode Const.max) with
-           areality = Mode.Regionality.Const.Global
-         })))
+      (Const.set areality_ax Mode.Regionality.Const.Global Const.max)))
   in
   value_to_alloc_r2g m, m
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -112,6 +112,135 @@ let rec last = function
   | [x] -> Some x
   | _ :: tl -> last tl
 
+module Prefix_ones_bitfield = struct
+  let width_of_size = function
+    | 2 -> 1
+    | 3 -> 2
+    | _ -> invalid_arg "Prefix_ones_bitfield.width_of_size"
+
+  let[@inline] low_mask ~offset = 1 lsl offset
+
+  let[@inline] mask ~offset ~width = ((1 lsl width) - 1) lsl offset
+
+  let[@inline] encode_level level = level lor (level lsr 1)
+
+  let[@inline] decode_level ~width bits =
+    match width with
+    | 1 -> bits land 0b1
+    | 2 ->
+      let bits = bits land 0b11 in
+      (bits land 0b1) + ((bits lsr 1) land 0b1)
+    | _ -> invalid_arg "Prefix_ones_bitfield.decode_level"
+
+  let[@inline] get_level ~offset ~width t =
+    decode_level ~width (t lsr offset)
+
+  let max_level ~width =
+    match width with
+    | 1 -> 1
+    | 2 -> 2
+    | _ -> invalid_arg "Prefix_ones_bitfield.max_level"
+
+  let[@inline] set_level_unsafe ~offset ~width level t =
+    let cleared = t land lnot (mask ~offset ~width) in
+    cleared lor (encode_level level lsl offset)
+
+  let[@inline] set_level ~offset ~width level t =
+    if level < 0 || level > max_level ~width
+    then invalid_arg "Prefix_ones_bitfield.set_level"
+    else set_level_unsafe ~offset ~width level t
+
+  let[@inline] co_sub ~lows left right =
+    let diff = left land lnot right in
+    diff lor ((diff lsr 1) land lnot (lows lsr 1))
+end
+
+module Modal_bit_layout = struct
+  type t = int
+
+  type slot =
+    | Areality
+    | Uniqueness
+    | Linearity
+    | Contention
+    | Portability
+    | Forkable
+    | Yielding
+    | Statefulness
+    | Visibility
+    | Staticity
+
+  let size = function
+    | Areality -> 3
+    | Uniqueness -> 2
+    | Linearity -> 2
+    | Contention -> 3
+    | Portability -> 3
+    | Forkable -> 2
+    | Yielding -> 2
+    | Statefulness -> 3
+    | Visibility -> 3
+    | Staticity -> 2
+
+  let width slot = Prefix_ones_bitfield.width_of_size (size slot)
+
+  let offset = function
+    | Areality -> 0
+    | Uniqueness -> 2
+    | Linearity -> 3
+    | Contention -> 4
+    | Portability -> 6
+    | Forkable -> 8
+    | Yielding -> 9
+    | Statefulness -> 10
+    | Visibility -> 12
+    | Staticity -> 14
+
+  let modal_width = 15
+
+  let low_mask slot = Prefix_ones_bitfield.low_mask ~offset:(offset slot)
+
+  let mask slot =
+    Prefix_ones_bitfield.mask ~offset:(offset slot) ~width:(width slot)
+
+  let lows =
+    low_mask Areality lor low_mask Uniqueness lor low_mask Linearity
+    lor low_mask Contention lor low_mask Portability lor low_mask Forkable
+    lor low_mask Yielding lor low_mask Statefulness lor low_mask Visibility
+    lor low_mask Staticity
+
+  let monadic_mask =
+    mask Uniqueness lor mask Contention lor mask Visibility lor mask Staticity
+
+  let comonadic_mask =
+    mask Areality lor mask Linearity lor mask Portability lor mask Forkable
+    lor mask Yielding lor mask Statefulness
+
+  let modal_mask = monadic_mask lor comonadic_mask
+
+  let[@inline] get_level slot t =
+    Prefix_ones_bitfield.get_level
+      ~offset:(offset slot)
+      ~width:(width slot)
+      t
+
+  let[@inline] set_level slot level t =
+    Prefix_ones_bitfield.set_level
+      ~offset:(offset slot)
+      ~width:(width slot)
+      level
+      t
+
+  let[@inline] set_level_unsafe slot level t =
+    Prefix_ones_bitfield.set_level_unsafe
+      ~offset:(offset slot)
+      ~width:(width slot)
+      level
+      t
+
+  let[@inline] co_sub left right = Prefix_ones_bitfield.co_sub ~lows left right
+end
+
 module Stdlib = struct
   module List = struct
     include List

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -198,6 +198,8 @@ module Modal_bit_layout = struct
 
   let modal_width = 15
 
+  let empty = 0
+
   let low_mask slot = Prefix_ones_bitfield.low_mask ~offset:(offset slot)
 
   let mask slot =
@@ -217,6 +219,14 @@ module Modal_bit_layout = struct
     lor mask Yielding lor mask Statefulness
 
   let modal_mask = monadic_mask lor comonadic_mask
+
+  let[@inline] equal (left : t) right = left = right
+
+  let[@inline] inter (left : t) right = left land right
+
+  let[@inline] le left right = equal (inter left right) left
+
+  let[@inline] union (left : t) right = left lor right
 
   let[@inline] get_level slot t =
     Prefix_ones_bitfield.get_level

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -124,7 +124,7 @@ module Prefix_ones_bitfield : sig
 end
 
 module Modal_bit_layout : sig
-  type t = int
+  type t
 
   type slot =
     | Areality
@@ -141,11 +141,16 @@ module Modal_bit_layout : sig
   val width : slot -> int
   val offset : slot -> int
   val modal_width : int
+  val empty : t
   val low_mask : slot -> t
   val mask : slot -> t
   val monadic_mask : t
   val comonadic_mask : t
   val modal_mask : t
+  val equal : t -> t -> bool
+  val le : t -> t -> bool
+  val union : t -> t -> t
+  val inter : t -> t -> t
   val get_level : slot -> t -> int
   val set_level : slot -> int -> t -> t
   val set_level_unsafe : slot -> int -> t -> t

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -111,6 +111,47 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
        (** Create a hashtable with the given initial size and fills it
            with the given bindings. *)
 
+(** {1 Bitfield helpers} *)
+
+module Prefix_ones_bitfield : sig
+  val width_of_size : int -> int
+  val low_mask : offset:int -> int
+  val mask : offset:int -> width:int -> int
+  val get_level : offset:int -> width:int -> int -> int
+  val set_level : offset:int -> width:int -> int -> int -> int
+  val set_level_unsafe : offset:int -> width:int -> int -> int -> int
+  val co_sub : lows:int -> int -> int -> int
+end
+
+module Modal_bit_layout : sig
+  type t = int
+
+  type slot =
+    | Areality
+    | Uniqueness
+    | Linearity
+    | Contention
+    | Portability
+    | Forkable
+    | Yielding
+    | Statefulness
+    | Visibility
+    | Staticity
+
+  val width : slot -> int
+  val offset : slot -> int
+  val modal_width : int
+  val low_mask : slot -> t
+  val mask : slot -> t
+  val monadic_mask : t
+  val comonadic_mask : t
+  val modal_mask : t
+  val get_level : slot -> t -> int
+  val set_level : slot -> int -> t -> t
+  val set_level_unsafe : slot -> int -> t -> t
+  val co_sub : t -> t -> t
+end
+
 (** {1 Extensions to the standard library} *)
 
 module Stdlib : sig


### PR DESCRIPTION
This PR packs the constant mode products onto a shared modal bitfield layout.

In particular:

* `monadic` becomes a packed modal word
* the full constant modal product becomes a packed modal word
* `mode.ml` and `axis_lattice.ml` share the same low-level bitfield/layout machinery

The layout is chosen so whole constant modal values line up with the modal prefix of axis_lattice, which makes splitting, merging, and later conversions straightforward.