### PR TITLE
Generalized unboxed reprs

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2193,6 +2193,13 @@ let get_expr_args_constr ~scopes head { arg; mut; sort; layout; _ } rem =
     { arg; binding_kind; mut; sort; layout } :: rem
   else
     match cstr.cstr_repr with
+    | Variant_with_null_boxed _
+      when (match erased_kind_of_constructor cstr with
+            | Some (Erased_immediate | Erased_pointer) -> true
+            | Some (Erased_boxed | Erased_null) | None -> false) ->
+      (* [@repr immediate]/[@repr pointer]: payload-unboxed, so the argument is
+         the scrutinee itself (like the unboxed / [This] cases below). *)
+      { arg; binding_kind; mut; sort; layout } :: rem
     | Variant_boxed _ | Variant_with_null_boxed _ ->
       (* [@repr null] ordinary constructors are represented exactly like
          [Variant_boxed]: read each field out of the block.  (The null
@@ -3606,25 +3613,48 @@ let combine_unboxed_bool value_kind loc arg partial ctx def
   in
   (lambda1, Jumps.union local_jumps total)
 
+(* Splits the constructor cases into buckets used to build the runtime
+   discrimination: constant constructors (immediates at tags 0..k), boxed
+   non-constant constructors (keyed by runtime tag), the null constructor, and
+   the single [@repr immediate] constructor whose payload spans the whole int
+   range.  The immediate bucket is exclusive with the constant bucket (enforced
+   at typedecl time), so it can take the whole isint-true side without a
+   switch. *)
 let split_cases tag_lambda_list =
   let rec split_rec = function
-    | [] -> ([], [], None)
-    | ({cstr_tag; cstr_repr; cstr_constant}, act) :: rem -> (
-        let consts, nonconsts, null = split_rec rem in
-        match cstr_tag, cstr_repr with
+    | [] -> ([], [], None, None, None)
+    | (cstr, act) :: rem -> (
+        let consts, nonconsts, null, immediate, pointer = split_rec rem in
+        match cstr.cstr_tag, cstr.cstr_repr with
         | Ordinary _, (Variant_unboxed | Variant_with_null) ->
           (* [Variant_unboxed] has a single constructor and [Variant_with_null]
              a single (unboxed) non-null constructor, both at tag 0. *)
-          (consts, (0, act) :: nonconsts, null)
-        | Ordinary {runtime_tag}, (Variant_boxed _ | Variant_with_null_boxed _)
-          when cstr_constant ->
-          ((runtime_tag, act) :: consts, nonconsts, null)
-        | Ordinary {runtime_tag}, (Variant_boxed _ | Variant_with_null_boxed _)
-          ->
-          (consts, (runtime_tag, act) :: nonconsts, null)
+          (consts, (0, act) :: nonconsts, null, immediate, pointer)
+        | Ordinary {runtime_tag}, Variant_boxed _ when cstr.cstr_constant ->
+          ((runtime_tag, act) :: consts, nonconsts, null, immediate, pointer)
+        | Ordinary {runtime_tag}, Variant_boxed _ ->
+          (consts, (runtime_tag, act) :: nonconsts, null, immediate, pointer)
+        | Ordinary {runtime_tag}, Variant_with_null_boxed _ ->
+          (match erased_kind_of_constructor cstr with
+           | Some Erased_immediate ->
+             (match immediate with
+              | None -> (consts, nonconsts, null, Some act, pointer)
+              | Some _ -> Misc.fatal_error
+                  "Multiple immediate cases in Matching.split_cases")
+           | Some Erased_pointer ->
+             (match pointer with
+              | None -> (consts, nonconsts, null, immediate, Some act)
+              | Some _ -> Misc.fatal_error
+                  "Multiple pointer cases in Matching.split_cases")
+           | Some (Erased_boxed | Erased_null) | None ->
+             if cstr.cstr_constant
+             then ((runtime_tag, act) :: consts, nonconsts, null, immediate,
+                   pointer)
+             else (consts, (runtime_tag, act) :: nonconsts, null, immediate,
+                   pointer))
         | Null, (Variant_with_null | Variant_with_null_boxed _) ->
           (match null with
-          | None -> (consts, nonconsts, Some act)
+          | None -> (consts, nonconsts, Some act, immediate, pointer)
           | Some _ -> Misc.fatal_error
             "Multiple null cases in Matching.split_cases")
         | Null, (Variant_boxed _ | Variant_unboxed) ->
@@ -3633,8 +3663,9 @@ let split_cases tag_lambda_list =
         | Extension _, _ -> assert false
       )
   in
-  let const, nonconst, null = split_rec tag_lambda_list in
-  (sort_int_lambda_list const, sort_int_lambda_list nonconst, null)
+  let const, nonconst, null, immediate, pointer = split_rec tag_lambda_list in
+  (sort_int_lambda_list const, sort_int_lambda_list nonconst, null, immediate,
+   pointer)
 
 (* The bool tracks whether the constructor is constant, because we don't have a
    constructor_description available for polymorphic variants *)
@@ -3733,7 +3764,9 @@ let combine_regular_constructor value_kind loc arg cstr partial
       mk_failaction_pos partial constrs ctx def
   in
   let descr_lambda_list = fails @ descr_lambda_list in
-  let consts, nonconsts, null = split_cases descr_lambda_list in
+  let consts, nonconsts, null, immediate, pointer =
+    split_cases descr_lambda_list
+  in
   (* Our duty below is to generate code, for matching on a list of
      constructor+action cases, that is good for both bytecode and
      native-code compilation. (Optimizations that only work well
@@ -3758,7 +3791,64 @@ let combine_regular_constructor value_kind loc arg cstr partial
   *)
   (* Build the switch over the (non-null) constant and block constructors,
      given the number of constant/block constructors to switch over. *)
+  (* The blocks-only switch over the boxed non-constant constructors (the
+     isint-false side when a [@repr immediate] constructor is present). *)
+  let boxed_switch num_nonconsts nonconsts =
+    match nonconsts with
+    | [ (_, act) ] when Option.is_none fail_opt ->
+        (* A single boxed constructor: every block value is it, no tag test. *)
+        act
+    | _ ->
+        let sw =
+          { sw_numconsts = 0;
+            sw_consts = [];
+            sw_numblocks = num_nonconsts;
+            sw_blocks = nonconsts;
+            sw_failaction = fail_opt
+          }
+        in
+        let hs, sw = share_actions_sw value_kind sw in
+        let sw = reintroduce_fail sw in
+        hs (Lswitch (arg, sw, loc, value_kind))
+  in
+  (* The isint-false side.  A [@repr pointer] constructor takes the ENTIRE
+     non-immediate side (no ordinary boxed constructor can coexist, so
+     [nonconsts] is empty here); otherwise switch over the boxed blocks. *)
+  let nonimmediate_branch num_nonconsts nonconsts =
+    match pointer with
+    | Some pointer_act -> pointer_act
+    | None -> boxed_switch num_nonconsts nonconsts
+  in
   let combine_non_null num_consts num_nonconsts consts nonconsts =
+    match immediate with
+    | Some immediate_act ->
+        (* [@repr immediate]: no ordinary constant constructor can coexist, so
+           [consts] is empty and the immediate payload takes the whole
+           isint-true side; the isint-false side is the pointer or the boxed
+           constructors (if any).
+
+           When a [@repr pointer] constructor is on the non-immediate side, that
+           value is a BARE non-immediate (e.g. a string), not a variant block,
+           so we must use [variant_only:false]: with [variant_only:true]
+           flambda2 would refine the false branch to "a variant block" and then
+           prove e.g. [String_length] on it invalid, miscompiling the match. *)
+        (match nonconsts, pointer with
+         | [], None -> immediate_act
+         | _ ->
+             let variant_only = Option.is_none pointer in
+             Lifthenelse
+               ( Lprim (Pisint { variant_only }, [ arg ], loc),
+                 immediate_act,
+                 nonimmediate_branch num_nonconsts nonconsts,
+                 value_kind ))
+    | None ->
+    match pointer with
+    | Some pointer_act ->
+        (* [@repr pointer] with no [@repr immediate]: no ordinary constant
+           constructor can coexist either, so every non-null value is the
+           pointer -- no isint test needed. *)
+        pointer_act
+    | None ->
     match (num_consts, num_nonconsts, consts, nonconsts) with
     | 1, 1, [ (0, act1) ], [ (0, act2) ]
       when not (Clflags.is_flambda2 ()) ->

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2193,7 +2193,11 @@ let get_expr_args_constr ~scopes head { arg; mut; sort; layout; _ } rem =
     { arg; binding_kind; mut; sort; layout } :: rem
   else
     match cstr.cstr_repr with
-    | Variant_boxed _ ->
+    | Variant_boxed _ | Variant_with_null_boxed _ ->
+      (* [@repr null] ordinary constructors are represented exactly like
+         [Variant_boxed]: read each field out of the block.  (The null
+         constructor is [cstr_constant] and carries no fields, so its patterns
+         reach here with an empty [arg_sorts].) *)
       List.mapi
       (fun i ca_sort ->
          make_field_access binding_kind ca_sort ~field:i ~pos:i)
@@ -2586,7 +2590,8 @@ let get_expr_args_record ~scopes head { arg; mut; sort; layout; _ } rem =
       let access, sort, layout =
         match lbl_repres with
         | Record_boxed
-        | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
+        | Record_inlined (_, Constructor_uniform_value,
+                          (Variant_boxed _ | Variant_with_null_boxed _)) ->
             Lprim (Pfield (lbl.lbl_pos, ptr, sem), [ arg ], loc),
             lbl_sort, lbl_layout
         | Record_unboxed
@@ -2607,7 +2612,8 @@ let get_expr_args_record ~scopes head { arg; mut; sort; layout; _ } rem =
             (* CR layouts v5.9: support this *)
             fatal_error
               "Mixed inlined records not supported for extensible variants"
-        | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+        | Record_inlined (_, Constructor_mixed shape,
+                          (Variant_boxed _ | Variant_with_null_boxed _))
         | Record_mixed shape ->
             let shape =
               Lambda.transl_mixed_product_shape_for_read
@@ -3607,12 +3613,16 @@ let split_cases tag_lambda_list =
         let consts, nonconsts, null = split_rec rem in
         match cstr_tag, cstr_repr with
         | Ordinary _, (Variant_unboxed | Variant_with_null) ->
+          (* [Variant_unboxed] has a single constructor and [Variant_with_null]
+             a single (unboxed) non-null constructor, both at tag 0. *)
           (consts, (0, act) :: nonconsts, null)
-        | Ordinary {runtime_tag}, Variant_boxed _ when cstr_constant ->
+        | Ordinary {runtime_tag}, (Variant_boxed _ | Variant_with_null_boxed _)
+          when cstr_constant ->
           ((runtime_tag, act) :: consts, nonconsts, null)
-        | Ordinary {runtime_tag}, Variant_boxed _ ->
+        | Ordinary {runtime_tag}, (Variant_boxed _ | Variant_with_null_boxed _)
+          ->
           (consts, (runtime_tag, act) :: nonconsts, null)
-        | Null, Variant_with_null ->
+        | Null, (Variant_with_null | Variant_with_null_boxed _) ->
           (match null with
           | None -> (consts, nonconsts, Some act)
           | Some _ -> Misc.fatal_error
@@ -3746,80 +3756,93 @@ let combine_regular_constructor value_kind loc arg cstr partial
      switcher directly can result in more compact code. This is
      a reason to deviate from the one-instruction policy.
   *)
+  (* Build the switch over the (non-null) constant and block constructors,
+     given the number of constant/block constructors to switch over. *)
+  let combine_non_null num_consts num_nonconsts consts nonconsts =
+    match (num_consts, num_nonconsts, consts, nonconsts) with
+    | 1, 1, [ (0, act1) ], [ (0, act2) ]
+      when not (Clflags.is_flambda2 ()) ->
+        transl_match_on_option value_kind arg loc
+          ~if_none:act1 ~if_some:act2
+    | 0, _, [], [ (_, act) ] when Option.is_none fail_opt ->
+        (* A single non-null block constructor (the or_null / [@repr null]
+           unary case): no immediate to test, so no switch. *)
+        act
+    | n, 0, _, [] ->
+        (* The matched type defines constant constructors only.
+           (typically the constant cases are dense, so
+           call_switcher will generate a Lswitch, still one
+           instruction.) *)
+        call_switcher value_kind loc fail_opt arg
+          ~low:0 ~high:(n - 1) consts
+    | n, _, _, _ -> (
+        let act0 =
+          (* = Some act when all non-const constructors match to act *)
+          match (fail_opt, nonconsts) with
+          | Some a, [] -> Some a
+          | Some _, _ ->
+              if List.length nonconsts = num_nonconsts then
+                same_actions nonconsts
+              else
+                None
+          | None, _ -> same_actions nonconsts
+        in
+        match act0 with
+        | Some act when n > 0 ->
+            (* This case deviates from our policy, by typically
+               generating three bytecode instructions.
+
+               It can save a lot of bytecode space when matching
+               on a type with many non-constant constructors,
+               all sent to the same action. This pattern occurs
+               several times in the compiler codebase
+               (for example), due to code fragments such as the
+               following:
+
+                   match token with SEMISEMI -> true | _ -> false
+
+               (The type of tokens has more than 120 constructors.)
+               *)
+            Lifthenelse
+              ( Lprim (Pisint { variant_only = true }, [ arg ], loc),
+                call_switcher value_kind loc fail_opt arg
+                  ~low:0 ~high:(n - 1) consts,
+                act, value_kind )
+        | Some _ | None ->
+            (* In the general case, emit a switch. *)
+            let sw =
+              { sw_numconsts = num_consts;
+                sw_consts = consts;
+                sw_numblocks = num_nonconsts;
+                sw_blocks = nonconsts;
+                sw_failaction = fail_opt
+              }
+            in
+            let hs, sw = share_actions_sw value_kind sw in
+            let sw = reintroduce_fail sw in
+            hs (Lswitch (arg, sw, loc, value_kind)))
+  in
   let lambda1 =
     match (fail_opt, same_actions descr_lambda_list) with
     | None, Some act ->
         (* Identical actions, no failure: 0 control-flow instructions. *)
         act
     | _ -> (
-        match
-          (cstr.cstr_consts, cstr.cstr_nonconsts, consts, nonconsts, null)
-        with
-        | 1, 1, [ (0, act1) ], [ (0, act2) ], None
-          when not (Clflags.is_flambda2 ()) ->
-            transl_match_on_option value_kind arg loc
-              ~if_none:act1 ~if_some:act2
-        | 1, 1, [], [(_, act2)], Some act1 ->
-            (* The [Variant_with_null] case. *)
-            transl_match_on_or_null value_kind arg loc
-              ~if_null:act1 ~if_this:act2
-        | _, _, _, _, Some _ ->
-            Misc.fatal_error
-              "Matching.combine_regular_constructor: \
-               Unexpected Null case"
-        | n, 0, _, [], None ->
-            (* The matched type defines constant constructors only.
-               (typically the constant cases are dense, so
-               call_switcher will generate a Lswitch, still one
-               instruction.) *)
-            call_switcher value_kind loc fail_opt arg
-              ~low:0 ~high:(n - 1) consts
-        | n, _, _, _, None -> (
-            let act0 =
-              (* = Some act when all non-const constructors match to act *)
-              match (fail_opt, nonconsts) with
-              | Some a, [] -> Some a
-              | Some _, _ ->
-                  if List.length nonconsts = cstr.cstr_nonconsts then
-                    same_actions nonconsts
-                  else
-                    None
-              | None, _ -> same_actions nonconsts
+        match null with
+        | Some null_act ->
+            (* [@@or_null] / [@repr null]: test the null pointer, then switch
+               over the remaining non-null constructors.  The null constructor
+               is counted among [cstr_consts] but is not a real immediate, so
+               drop it from the constant count of the inner switch. *)
+            let if_this =
+              combine_non_null
+                (cstr.cstr_consts - 1) cstr.cstr_nonconsts consts nonconsts
             in
-            match act0 with
-            | Some act ->
-                (* This case deviates from our policy, by typically
-                   generating three bytecode instructions.
-
-                   It can save a lot of bytecode space when matching
-                   on a type with many non-constant constructors,
-                   all sent to the same action. This pattern occurs
-                   several times in the compiler codebase
-                   (for example), due to code fragments such as the
-                   following:
-
-                       match token with SEMISEMI -> true | _ -> false
-
-                   (The type of tokens has more than 120 constructors.)
-                   *)
-                Lifthenelse
-                  ( Lprim (Pisint { variant_only = true }, [ arg ], loc),
-                    call_switcher value_kind loc fail_opt arg
-                      ~low:0 ~high:(n - 1) consts,
-                    act, value_kind )
-            | None ->
-                (* In the general case, emit a switch. *)
-                let sw =
-                  { sw_numconsts = cstr.cstr_consts;
-                    sw_consts = consts;
-                    sw_numblocks = cstr.cstr_nonconsts;
-                    sw_blocks = nonconsts;
-                    sw_failaction = fail_opt
-                  }
-                in
-                let hs, sw = share_actions_sw value_kind sw in
-                let sw = reintroduce_fail sw in
-                hs (Lswitch (arg, sw, loc, value_kind))))
+            transl_match_on_or_null value_kind arg loc
+              ~if_null:null_act ~if_this
+        | None ->
+            combine_non_null
+              cstr.cstr_consts cstr.cstr_nonconsts consts nonconsts)
   in
   (lambda1, Jumps.union local_jumps total1)
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -51,6 +51,7 @@ let field_offset_for_label lbl repres =
   match repres with
   | Record_boxed
   | Record_inlined (_, Constructor_uniform_value, Variant_boxed _)
+  | Record_inlined (_, Constructor_uniform_value, Variant_with_null_boxed _)
   | Record_inlined (_, Constructor_uniform_value, Variant_with_null) ->
       lbl.lbl_pos
   | Record_inlined (_, Constructor_uniform_value, Variant_extensible) ->
@@ -66,6 +67,7 @@ let field_offset_for_label lbl repres =
   | Record_inlined (_, Constructor_mixed _, Variant_extensible) ->
       fatal_error "Mixed inlined records not supported for extensible variants"
   | Record_inlined (_, Constructor_mixed _, Variant_boxed _)
+  | Record_inlined (_, Constructor_mixed _, Variant_with_null_boxed _)
   | Record_inlined (_, Constructor_mixed _, Variant_with_null)
   | Record_mixed _ ->
       lbl.lbl_pos
@@ -574,11 +576,13 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
             transl_exp ~scopes layout e) args_with_sorts
         in
         match cstr.cstr_tag, cstr.cstr_repr with
-      | Null, Variant_with_null -> Lconst Const_null
+      | Null, (Variant_with_null | Variant_with_null_boxed _) ->
+        Lconst Const_null
       | Null, (Variant_boxed _ | Variant_unboxed | Variant_extensible) ->
         assert false
       | Ordinary {runtime_tag},
-        (Variant_boxed _ | Variant_extensible) when cstr.cstr_constant ->
+        (Variant_boxed _ | Variant_with_null_boxed _ | Variant_extensible)
+        when cstr.cstr_constant ->
           assert (
             List.for_all
               (fun (_, s) -> Jkind.Sort.Const.all_void s) args_with_sorts);
@@ -587,8 +591,10 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
             ((tagged_immediate runtime_tag) : lambda)
             ll
       | Ordinary _, (Variant_unboxed | Variant_with_null) ->
+          (* The unboxed variant constructor, or the non-null constructor of an
+             [@@or_null] type: the value is the payload itself. *)
           (match ll with [v] -> v | _ -> assert false)
-      | Ordinary {runtime_tag}, Variant_boxed _ ->
+      | Ordinary {runtime_tag}, (Variant_boxed _ | Variant_with_null_boxed _) ->
           let constant =
             match List.map extract_constant ll with
             | exception Not_constant -> None
@@ -693,7 +699,8 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
                                extensible variant"
             in
             Lprim (makeblock, lam :: ll, of_location ~scopes e.exp_loc)
-      | Extension _, (Variant_boxed _ | Variant_unboxed | Variant_with_null)
+      | Extension _, (Variant_boxed _ | Variant_unboxed | Variant_with_null
+                     | Variant_with_null_boxed _)
       | Ordinary _, Variant_extensible -> assert false
       end
   | Texp_extension_constructor (_, path) ->
@@ -754,7 +761,8 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
       let prim_and_args =
         match record_repres with
           Record_boxed
-        | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
+        | Record_inlined (_, Constructor_uniform_value,
+                          (Variant_boxed _ | Variant_with_null_boxed _)) ->
           let immediate_or_pointer, _ = maybe_pointer e in
           if Types.is_atomic lbl.lbl_mut
           then
@@ -791,7 +799,8 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
             (* CR layouts v5.9: support this *)
             fatal_error
               "Mixed inlined records not supported for extensible variants"
-        | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+        | Record_inlined (_, Constructor_mixed shape,
+                          (Variant_boxed _ | Variant_with_null_boxed _))
           (* CR layouts v5: once all-void records are allowed, handle
              constructors with all-void inline records, which are stored as
              immediates *)
@@ -884,7 +893,8 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
       let prim, args =
         match record_repres with
           Record_boxed
-        | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
+        | Record_inlined (_, Constructor_uniform_value,
+                          (Variant_boxed _ | Variant_with_null_boxed _)) ->
           let immediate_or_pointer, _ = maybe_pointer newval in
           if Types.is_atomic lbl.lbl_mut
           then
@@ -914,7 +924,8 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
             (* CR layouts v5.9: support this *)
             fatal_error
               "Mixed inlined records not supported for extensible variants"
-        | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+        | Record_inlined (_, Constructor_mixed shape,
+                          (Variant_boxed _ | Variant_with_null_boxed _))
           (* CR layouts v5: once all-void records are allowed, handle
              constructors with all-void inline records, which are stored as
              immediates *)
@@ -2215,7 +2226,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
           let upd =
             match repres with
               Record_boxed
-            | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
+            | Record_inlined (_, Constructor_uniform_value,
+                              (Variant_boxed _ | Variant_with_null_boxed _)) ->
                 let ptr, _ = maybe_pointer expr in
                 Psetfield(lbl.lbl_pos, ptr, Assignment modify_heap)
             | Record_unboxed | Record_inlined (_, _, Variant_unboxed) ->
@@ -2232,7 +2244,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                 (* CR layouts v5.9: support this *)
                 fatal_error
                   "Mixed inlined records not supported for extensible variants"
-            | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+            | Record_inlined (_, Constructor_mixed shape,
+                              (Variant_boxed _ | Variant_with_null_boxed _))
                 (* CR layouts v5: once all-void records are allowed, handle
                   constructors with all-void inline records, which are stored as
                   immediates *)
@@ -2293,7 +2306,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                let access =
                  match repres with
                    Record_boxed
-                 | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
+                 | Record_inlined (_, Constructor_uniform_value,
+                                   (Variant_boxed _
+                                   | Variant_with_null_boxed _)) ->
                    let ptr, _ = maybe_pointer_type env typ in
                    Pfield (i, ptr, sem)
                  | Record_unboxed | Record_inlined (_, _, Variant_unboxed) ->
@@ -2310,7 +2325,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                        so it's simpler to leave it Alloc_heap *)
                     Pfloatfield (i, sem, alloc_heap)
                  | Record_ufloat -> Pufloatfield (i, sem)
-                 | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+                 | Record_inlined (_, Constructor_mixed shape,
+                                   (Variant_boxed _
+                                   | Variant_with_null_boxed _))
                    (* CR layouts v5: once all-void records are allowed, handle
                       constructors with all-void inline records, which are
                       stored as immediates *)
@@ -2363,7 +2380,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         match repres with
         | Record_boxed -> Lconst(Const_block(0, cl))
         | Record_inlined (Ordinary {runtime_tag},
-                          Constructor_uniform_value, Variant_boxed _) ->
+                          Constructor_uniform_value,
+                          (Variant_boxed _ | Variant_with_null_boxed _)) ->
             Lconst(Const_block(runtime_tag, cl))
         | Record_unboxed | Record_inlined (_, _, Variant_unboxed) ->
             Lconst(match cl with [v] -> v | _ -> assert false)
@@ -2386,13 +2404,14 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
               raise Not_constant
         | Record_inlined
             (Ordinary { runtime_tag = _; _ }, Constructor_mixed shape,
-             Variant_boxed _)
+             (Variant_boxed _ | Variant_with_null_boxed _))
           when Mixed_product_bytes.types_shape_is_all_value shape ->
             (* Currently unreachable; see Note [Constant all-value
                mixed records]. *)
             (* Lconst(Const_block(runtime_tag, cl)) *)
             raise Not_constant
-        | Record_inlined (_, Constructor_mixed _, Variant_boxed _)
+        | Record_inlined (_, Constructor_mixed _,
+                          (Variant_boxed _ | Variant_with_null_boxed _))
         | Record_ufloat ->
             (* CR layouts v5.1: We should support structured constants for
                blocks containing unboxed float literals.
@@ -2415,7 +2434,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                              Lambda.block_shape_of_value_kinds (Some shape),
                              Option.get mode), ll, loc)
         | Record_inlined (Ordinary {runtime_tag},
-                          Constructor_uniform_value, Variant_boxed _) ->
+                          Constructor_uniform_value,
+                          (Variant_boxed _ | Variant_with_null_boxed _)) ->
             let shape = List.map must_be_value shape in
             Lprim(Pmakeblock(runtime_tag, mut,
                              Lambda.block_shape_of_value_kinds (Some shape),
@@ -2441,14 +2461,17 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                                (Some (Lambda.generic_value :: shape)),
                              Option.get mode),
                   slot :: ll, loc)
-        | Record_inlined (Extension _, _, (Variant_unboxed | Variant_boxed _))
+        | Record_inlined (Extension _, _,
+                          (Variant_unboxed | Variant_boxed _
+                          | Variant_with_null_boxed _))
         | Record_inlined (Ordinary _, _, Variant_extensible) ->
             assert false
         | Record_mixed shape ->
             let shape = Lambda.transl_mixed_product_shape shape in
             Lprim (Pmakeblock (0, mut, Shape shape, Option.get mode), ll, loc)
         | Record_inlined (Ordinary { runtime_tag },
-                          Constructor_mixed shape, Variant_boxed _) ->
+                          Constructor_mixed shape,
+                          (Variant_boxed _ | Variant_with_null_boxed _)) ->
             (* CR layouts v5: once all-void records are allowed, handle
               constructors with all-void inline records, which are stored as
               immediates *)
@@ -2595,6 +2618,7 @@ and transl_atomic_loc ~scopes arg arg_layout lbl repres =
       Misc.fatal_error "Bad lbl_repres for label of atomic_loc"
   | Record_boxed
   | Record_inlined (_, _, ( Variant_boxed _
+                          | Variant_with_null_boxed _
                           | Variant_extensible
                           | Variant_with_null))
     -> ()

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -594,6 +594,13 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
           (* The unboxed variant constructor, or the non-null constructor of an
              [@@or_null] type: the value is the payload itself. *)
           (match ll with [v] -> v | _ -> assert false)
+      | Ordinary _, Variant_with_null_boxed _
+        when (match erased_kind_of_constructor cstr with
+              | Some (Erased_immediate | Erased_pointer) -> true
+              | Some (Erased_boxed | Erased_null) | None -> false) ->
+          (* [@repr immediate]/[@repr pointer]: payload-unboxed, so the value is
+             the payload itself (distinguished at run time by isint). *)
+          (match ll with [v] -> v | _ -> assert false)
       | Ordinary {runtime_tag}, (Variant_boxed _ | Variant_with_null_boxed _) ->
           let constant =
             match List.map extract_constant ll with

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -307,12 +307,14 @@ let compute_static_size lam =
         begin match repres with
         | Record_boxed
         | Record_inlined (_, Constructor_uniform_value,
-                          (Variant_boxed _ | Variant_extensible)) ->
+                          (Variant_boxed _ | Variant_with_null_boxed _
+                          | Variant_extensible)) ->
             Block (Regular_block size)
         | Record_float ->
             Block (Float_record size)
         | Record_inlined (_, Constructor_mixed shape,
-                          (Variant_boxed _ | Variant_extensible))
+                          (Variant_boxed _ | Variant_with_null_boxed _
+                          | Variant_extensible))
         | Record_mixed shape ->
             if Mixed_product_bytes.types_shape_is_all_value shape
             then

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2105,7 +2105,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         Naked_floats
           { length = Target_ocaml_int.of_int machine_width num_fields }
       | Record_inlined
-          (Ordinary { runtime_tag; _ }, Constructor_mixed shape, Variant_boxed _)
+          ( Ordinary { runtime_tag; _ },
+            Constructor_mixed shape,
+            (Variant_boxed _ | Variant_with_null_boxed _) )
         when Mixed_product_bytes.types_shape_is_all_value shape ->
         Values
           { tag = Tag.Scannable.create_exn runtime_tag;
@@ -2121,7 +2123,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Record_inlined
           ( Ordinary { runtime_tag; _ },
             Constructor_uniform_value,
-            Variant_boxed _ ) ->
+            (Variant_boxed _ | Variant_with_null_boxed _) ) ->
         Values
           { tag = Tag.Scannable.create_exn runtime_tag;
             length = Target_ocaml_int.of_int machine_width num_fields

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -145,7 +145,13 @@ let prove_is_int_generic_value ~variant_only env
   | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _ | Boxed_int64 _
   | Boxed_vec128 _ | Boxed_vec256 _ | Boxed_vec512 _ | Boxed_nativeint _
   | Closures _ | String _ | Array _ ->
-    if variant_only then Invalid else Proved false
+    (* [variant_only] means the test comes from variant matching, but with
+       constructor-level erased representations ([@repr pointer]/[@repr
+       immediate]) a variant inhabitant can be represented directly as a bare
+       non-immediate value (e.g. a string). So this is a live test that must
+       simplify to [false], not [Invalid] (which would delete a live branch). *)
+    let _ = variant_only in
+    Proved false
 
 let prove_is_int_generic ~variant_only env t =
   gen_value_to_gen (prove_is_int_generic_value ~variant_only) env t

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -124,6 +124,7 @@ let builtin_attrs =
   ; "layout_poly"
   ; "or_null"
   ; "or_null_reexport"
+  ; "repr"
   ; "no_recursive_modalities"
   ; "jane.non_erasable.instances"
   ; "cold"
@@ -709,6 +710,23 @@ let has_or_null attrs =
 
 let has_or_null_reexport attrs =
   has_attribute "or_null_reexport" attrs
+
+(* [@repr <ident>] constructor-level attribute prototype.  Returns the payload
+   identifier of the first [@repr ...] attribute, if any, e.g. [Some "null"]. *)
+let repr_payload_ident attrs =
+  List.find_map
+    (fun a ->
+       if attr_equals_builtin a "repr"
+       then (mark_used a.attr_name; ident_of_payload a.attr_payload)
+       else None)
+    attrs
+
+(* [@repr null]: a payloadless constructor represented as the null pointer,
+   coexisting with ordinary boxed constructors. *)
+let has_repr_null attrs =
+  match repr_payload_ident attrs with
+  | Some "null" -> true
+  | Some _ | None -> false
 
 let has_magic_staged_modes attrs =
   has_attribute "magic_staged_modes" attrs

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -220,6 +220,8 @@ val has_layout_poly: Parsetree.attributes -> bool
 val has_curry: Parsetree.attributes -> bool
 val has_or_null : Parsetree.attributes -> bool
 val has_or_null_reexport : Parsetree.attributes -> bool
+val has_repr_null : Parsetree.attributes -> bool
+val repr_payload_ident : Parsetree.attributes -> string option
 val has_magic_staged_modes : Parsetree.attributes -> bool
 
 val tailcall : Parsetree.attributes ->

--- a/testsuite/tests/typing-layouts-or-null/repr_erased.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_erased.ml
@@ -1,0 +1,180 @@
+(* TEST
+ flags = "-w -181";
+ expect;
+*)
+
+(* Tranche-2 constructor-level erased representations: [@repr immediate] and
+   [@repr pointer], and their sound coexistence with [@repr null] and ordinary
+   boxed constructors. *)
+
+(* --- [@repr immediate] acceptances --- *)
+
+(* An immediate payload alongside an ordinary boxed constructor. *)
+type bignum = Small of int [@repr immediate] | Big of string
+
+[%%expect{|
+type bignum = Small of int | Big of string
+|}]
+
+(* [@repr immediate] alone. *)
+type only_imm = I of int [@repr immediate]
+
+[%%expect{|
+type only_imm = I of int
+|}]
+
+(* [@repr immediate] coexisting with [@repr null]. *)
+type imm_or_null = N [@repr null] | I of int [@repr immediate]
+
+[%%expect{|
+type imm_or_null = N | I of int
+|}]
+
+(* --- [@repr pointer] acceptances --- *)
+
+(* immediate + pointer: the classic tagged-or-boxed encoding. *)
+type int_or_err = I of int [@repr immediate] | E of string [@repr pointer]
+
+[%%expect{|
+type int_or_err = I of int | E of string
+|}]
+
+(* null + pointer with a boxed-record payload. *)
+type box = { a : int; b : string }
+type boxed_or_null = Null_ptr [@repr null] | Ptr of box [@repr pointer]
+
+[%%expect{|
+type box = { a : int; b : string; }
+type boxed_or_null = Null_ptr | Ptr of box
+|}]
+
+(* null + immediate + pointer, all three erased kinds at once. *)
+type three = N [@repr null] | I of int [@repr immediate] | P of string [@repr pointer]
+
+[%%expect{|
+type three = N | I of int | P of string
+|}]
+
+(* null + immediate + ordinary boxed (the tree shape). *)
+type tree = Empty [@repr null] | Leaf of int [@repr immediate] | Branch of tree * tree
+
+[%%expect{|
+type tree = Empty | Leaf of int | Branch of tree * tree
+|}]
+
+(* --- [@repr immediate] rejections --- *)
+
+(* Immediate collides with ordinary constant constructors. *)
+type imm_const = K | I of int [@repr immediate]
+
+[%%expect{|
+Line 1, characters 0-47:
+1 | type imm_const = K | I of int [@repr immediate]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr immediate] must not coexist with ordinary constant constructors: both occupy the immediate space.
+|}]
+
+(* At most one immediate. *)
+type two_imm = A of int [@repr immediate] | B of int [@repr immediate]
+
+[%%expect{|
+Line 1, characters 0-70:
+1 | type two_imm = A of int [@repr immediate] | B of int [@repr immediate]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       there may be at most one [@repr immediate] constructor.
+|}]
+
+(* The payload must be an immediate. *)
+type imm_str = I of string [@repr immediate]
+
+[%%expect{|
+Line 1, characters 15-44:
+1 | type imm_str = I of string [@repr immediate]
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr immediate] requires an immediate, non-null payload.
+|}]
+
+(* --- [@repr pointer] rejections --- *)
+
+(* Pointer collides with an ordinary boxed (non-constant) constructor. *)
+type ptr_boxed = P of string [@repr pointer] | B of int list
+
+[%%expect{|
+Line 1, characters 0-60:
+1 | type ptr_boxed = P of string [@repr pointer] | B of int list
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] may only coexist with [@repr null] and [@repr immediate] constructors: a raw pointer occupies the whole non-immediate space and would collide with ordinary constructors.
+|}]
+
+(* Pointer collides with an ordinary constant constructor. *)
+type ptr_const = P of string [@repr pointer] | K
+
+[%%expect{|
+Line 1, characters 0-48:
+1 | type ptr_const = P of string [@repr pointer] | K
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] may only coexist with [@repr null] and [@repr immediate] constructors: a raw pointer occupies the whole non-immediate space and would collide with ordinary constructors.
+|}]
+
+(* At most one pointer. *)
+type two_ptr = A of string [@repr pointer] | B of bytes [@repr pointer]
+
+[%%expect{|
+Line 1, characters 0-71:
+1 | type two_ptr = A of string [@repr pointer] | B of bytes [@repr pointer]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       there may be at most one [@repr pointer] constructor.
+|}]
+
+(* The payload must be a pointer, not an immediate. *)
+type ptr_imm = P of int [@repr pointer]
+
+[%%expect{|
+Line 1, characters 15-39:
+1 | type ptr_imm = P of int [@repr pointer]
+                   ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] requires a payload that is definitely a non-null pointer.
+|}]
+
+(* The payload must be DEFINITELY a pointer: an unconstrained type variable
+   could be instantiated with an immediate. *)
+type 'a ptr_tvar = P of 'a [@repr pointer]
+
+[%%expect{|
+Line 1, characters 19-42:
+1 | type 'a ptr_tvar = P of 'a [@repr pointer]
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] requires a payload that is definitely a non-null pointer.
+|}]
+
+(* Float guard: a boxed float shares the flat-float-array representation. *)
+type ptr_float = P of float [@repr pointer]
+
+[%%expect{|
+Line 1, characters 17-43:
+1 | type ptr_float = P of float [@repr pointer]
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] requires a payload that is definitely a non-null pointer.
+|}]
+
+(* Abstract payloads are rejected (cannot confirm pointer-ness). *)
+module M : sig type t_abstract end = struct type t_abstract = int end
+type ptr_abstract = P of M.t_abstract [@repr pointer]
+
+[%%expect{|
+module M : sig type t_abstract end
+Line 2, characters 20-53:
+2 | type ptr_abstract = P of M.t_abstract [@repr pointer]
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] requires a payload that is definitely a non-null pointer.
+|}]

--- a/testsuite/tests/typing-layouts-or-null/repr_erased.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_erased.ml
@@ -178,3 +178,159 @@ Line 2, characters 20-53:
 Error: Invalid [@repr] declaration:
        [@repr pointer] requires a payload that is definitely a non-null pointer.
 |}]
+
+(* --- inline-record payload rejection --- *)
+
+(* [@repr immediate] requires a unary tuple constructor, not an inline record. *)
+type imm_inline = N [@repr null] | A of { x : int } [@repr immediate]
+
+[%%expect{|
+Line 1, characters 0-69:
+1 | type imm_inline = N [@repr null] | A of { x : int } [@repr immediate]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr immediate] requires a unary tuple constructor.
+|}]
+
+(* [@repr pointer] requires a unary tuple constructor, not an inline record. *)
+type ptr_inline = N [@repr null] | A of { x : int } [@repr pointer]
+
+[%%expect{|
+Line 1, characters 0-67:
+1 | type ptr_inline = N [@repr null] | A of { x : int } [@repr pointer]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr pointer] requires a unary tuple constructor.
+|}]
+
+(* --- [@repr] on extensible variants / exceptions is accepted and silently
+   ignored: these never receive an erased representation, so there is no
+   soundness concern.  (Batch compilation additionally emits Warning 53
+   [misplaced-attribute]; the toplevel driving this test does not.) *)
+
+exception Exn_repr of int [@repr immediate]
+
+[%%expect{|
+exception Exn_repr of int
+|}]
+
+type ext = ..
+type ext += Ext_repr of int [@repr immediate]
+
+[%%expect{|
+type ext = ..
+type ext += Ext_repr of int
+|}]
+
+(* --- GADT constructors may carry [@repr] --- *)
+type _ gadt =
+  | Code : int -> int gadt [@repr immediate]
+  | Text : string -> string gadt [@repr pointer]
+
+[%%expect{|
+type _ gadt = Code : int -> int gadt | Text : string -> string gadt
+|}]
+
+(* --- module inclusion: [@repr] is part of the representation, so signature
+   and implementation must agree on it --- *)
+
+(* Exploit (soundness): a [@repr immediate] signature constructor is
+   payload-unboxed, but a plain implementation constructor is a boxed block.
+   Without comparing the erased representations this was accepted and a client
+   read the block pointer as a tagged int. *)
+module M_imm_boxed : sig
+  type t = N [@repr null] | A of int [@repr immediate]
+end = struct
+  type t = N [@repr null] | A of int
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = N [@repr null] | A of int
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = N | A of int end
+       is not included in
+         sig type t = N | A of int end
+       Type declarations do not match:
+         type t = N | A of int
+       is not included in
+         type t = N | A of int
+       Their internal representations differ:
+       constructor A uses the ordinary boxed representation in the first declaration but [@repr immediate] in the second declaration.
+|}]
+
+(* The other direction (signature boxed, implementation [@repr immediate]) is
+   equally rejected. *)
+module M_boxed_imm : sig
+  type t = N [@repr null] | A of int
+end = struct
+  type t = N [@repr null] | A of int [@repr immediate]
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = N [@repr null] | A of int [@repr immediate]
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = N | A of int end
+       is not included in
+         sig type t = N | A of int end
+       Type declarations do not match:
+         type t = N | A of int
+       is not included in
+         type t = N | A of int
+       Their internal representations differ:
+       constructor A uses [@repr immediate] in the first declaration but the ordinary boxed representation in the second declaration.
+|}]
+
+(* [@repr pointer] versus a plain boxed implementation is also rejected. *)
+module M_ptr_boxed : sig
+  type t = N [@repr null] | A of string [@repr pointer]
+end = struct
+  type t = N [@repr null] | A of string
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = N [@repr null] | A of string
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = N | A of string end
+       is not included in
+         sig type t = N | A of string end
+       Type declarations do not match:
+         type t = N | A of string
+       is not included in
+         type t = N | A of string
+       Their internal representations differ:
+       constructor A uses the ordinary boxed representation in the first declaration but [@repr pointer] in the second declaration.
+|}]
+
+(* Positive: identical [@repr immediate] on both sides is accepted. *)
+module M_imm_ok : sig
+  type t = N [@repr null] | A of int [@repr immediate]
+end = struct
+  type t = N [@repr null] | A of int [@repr immediate]
+end
+
+[%%expect{|
+module M_imm_ok : sig type t = N | A of int end
+|}]
+
+(* Positive: identical [@repr pointer] on both sides is accepted. *)
+module M_ptr_ok : sig
+  type t = N [@repr null] | A of string [@repr pointer]
+end = struct
+  type t = N [@repr null] | A of string [@repr pointer]
+end
+
+[%%expect{|
+module M_ptr_ok : sig type t = N | A of string end
+|}]

--- a/testsuite/tests/typing-layouts-or-null/repr_erased_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_erased_runtime.ml
@@ -102,3 +102,35 @@ let () =
    | Im n -> assert (n = 99)
    | N | Pt _ -> assert false)
 ;;
+
+(* Polymorphic [compare] and [Hashtbl] over erased-representation values:
+   the payload-unboxed constructors participate correctly (the runtime
+   distinguishes immediate from pointer payloads by [isint]). *)
+let () =
+  assert (compare (Small 3) (Small 3) = 0);
+  assert (compare (Small 3) (Small 4) < 0);
+  assert (compare (Small 4) (Small 3) > 0);
+  assert (compare (Big "a") (Big "a") = 0);
+  assert (compare (I 1) (E "x") <> 0);
+  let h = Hashtbl.create 8 in
+  Hashtbl.replace h (I 7) "seven";
+  Hashtbl.replace h (E "hi") "greeting";
+  assert (Hashtbl.find h (I 7) = "seven");
+  assert (Hashtbl.find h (E "hi") = "greeting");
+  assert (Hashtbl.hash (I 7) = Hashtbl.hash (I 7));
+  assert (Hashtbl.hash (E "hi") = Hashtbl.hash (E "hi"))
+;;
+
+(* A GADT whose constructors carry [@repr immediate] / [@repr pointer]:
+   construction and matching behave correctly at run time. *)
+type _ gadt =
+  | G_code : int -> int gadt [@repr immediate]
+  | G_text : string -> string gadt [@repr pointer]
+
+let gadt_int : int gadt -> int = function G_code n -> n
+let gadt_str : string gadt -> string = function G_text s -> s
+
+let () =
+  assert (gadt_int (G_code 42) = 42);
+  assert (gadt_str (G_text "hi") = "hi")
+;;

--- a/testsuite/tests/typing-layouts-or-null/repr_erased_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_erased_runtime.ml
@@ -1,0 +1,104 @@
+(* TEST
+ flags = "-w -181";
+ flambda2;
+ {
+   native;
+ } {
+   flags = "-w -181 -O3";
+   native;
+ } {
+   flags = "-w -181 -Oclassic";
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+(* Runtime behaviour of tranche-2 erased representations: construction, match,
+   [Obj] identity of payload-unboxed constructors, and [Marshal] round-trips.
+   Compiled native (default / -O3 / -Oclassic) and bytecode. *)
+
+(* [@repr immediate] alongside an ordinary boxed constructor. *)
+type bignum = Small of int [@repr immediate] | Big of string
+
+let bignum_val = function Small n -> n | Big s -> String.length s
+
+(* immediate + pointer. *)
+type int_or_err = I of int [@repr immediate] | E of string [@repr pointer]
+
+let ioe = function I n -> n | E s -> String.length s
+
+(* null + pointer with a boxed-record payload. *)
+type box = { a : int; b : string }
+type boxed_or_null = Null_ptr [@repr null] | Ptr of box [@repr pointer]
+
+let bon = function Null_ptr -> -1 | Ptr r -> r.a
+
+(* null + immediate + pointer. *)
+type three = N [@repr null] | Im of int [@repr immediate] | Pt of string [@repr pointer]
+
+let three_val = function N -> 0 | Im n -> n | Pt s -> String.length s
+
+(* null + immediate + ordinary boxed (the tree). *)
+type tree = Empty [@repr null] | Leaf of int [@repr immediate] | Branch of tree * tree
+
+let rec tree_sum = function
+  | Empty -> 0
+  | Leaf n -> n
+  | Branch (l, r) -> tree_sum l + tree_sum r
+
+let () =
+  (* immediate construction + match *)
+  assert (bignum_val (Small 3) = 3);
+  assert (bignum_val (Big "abcd") = 4);
+  (* immediate is the raw int: Obj identity with the payload *)
+  assert (Obj.repr (Small 7) == Obj.repr 7);
+  assert (Obj.is_int (Obj.repr (Small 0)));
+  assert (not (Obj.is_int (Obj.repr (Big "x"))));
+
+  (* immediate + pointer *)
+  assert (ioe (I 5) = 5);
+  assert (ioe (E "xy") = 2);
+  let s = "hello" in
+  assert (Obj.repr (E s) == Obj.repr s);   (* pointer is the payload identity *)
+  assert (Obj.is_int (Obj.repr (I 9)));
+  assert (not (Obj.is_int (Obj.repr (E "z"))));
+
+  (* null + pointer, boxed record.  [boxed_or_null] is value_or_null
+     (nullable), so [Obj.repr] cannot apply; check payload identity via the
+     match instead. *)
+  let r = { a = 42; b = "x" } in
+  assert (bon (Ptr r) = 42);
+  assert (bon Null_ptr = -1);
+  assert (match Ptr r with Ptr r' -> r' == r | Null_ptr -> false);
+
+  (* null + immediate + pointer *)
+  assert (three_val N = 0);
+  assert (three_val (Im 11) = 11);
+  assert (three_val (Pt "abcde") = 5);
+
+  (* tree: null + immediate + ordinary boxed *)
+  let t = Branch (Leaf 5, Branch (Empty, Leaf 7)) in
+  assert (tree_sum t = 12);
+  assert (tree_sum Empty = 0);
+
+  (* Marshal round-trips through the erased representations. *)
+  let roundtrip (v : bignum) =
+    (Marshal.from_string (Marshal.to_string v []) 0 : bignum)
+  in
+  (match roundtrip (Small 12345) with
+   | Small n -> assert (n = 12345)
+   | Big _ -> assert false);
+  (match roundtrip (Big "hello") with
+   | Big s -> assert (s = "hello")
+   | Small _ -> assert false);
+  let roundtrip_three (v : three) =
+    (Marshal.from_string (Marshal.to_string v []) 0 : three)
+  in
+  (match roundtrip_three (Pt "ptr") with
+   | Pt s -> assert (s = "ptr")
+   | N | Im _ -> assert false);
+  (match roundtrip_three (Im 99) with
+   | Im n -> assert (n = 99)
+   | N | Pt _ -> assert false)
+;;

--- a/testsuite/tests/typing-layouts-or-null/repr_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_null.ml
@@ -1,0 +1,119 @@
+(* TEST
+ flags = "-w -181";
+ expect;
+*)
+
+(* [@repr null] on a nullary constructor coexisting with an ordinary
+   non-constant (boxed) constructor. *)
+type tree = Empty [@repr null] | Node of int * tree * tree
+
+[%%expect{|
+type tree = Empty | Node of int * tree * tree
+|}]
+
+(* [@repr null] coexisting with ordinary constant constructors. *)
+type t_consts = Null_const [@repr null] | A | B
+
+[%%expect{|
+type t_consts = Null_const | A | B
+|}]
+
+(* [@repr value] + [@repr null]: exactly the [@@or_null] shape.  The payload of
+   the value constructor is stored unboxed. *)
+type ('a : value) t_val : value_or_null = N [@repr null] | V of 'a [@repr value]
+
+let to_option = function N -> None | V x -> Some x
+
+[%%expect{|
+type 'a t_val = N | V of 'a
+val to_option : 'a t_val -> 'a option = <fun>
+|}]
+
+(* [@repr unboxed]: a single unary constructor, whole-variant unboxed. *)
+type u = K of string [@repr unboxed]
+
+[%%expect{|
+type u = K of string [@@unboxed]
+|}]
+
+(* Rejection: [@repr immediate] is not yet supported. *)
+type b_imm = Small of int [@repr immediate]
+
+[%%expect{|
+Line 1, characters 13-43:
+1 | type b_imm = Small of int [@repr immediate]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "[@repr immediate]" is not yet supported;
+       only "[@repr null]", "[@repr value]" and "[@repr unboxed]" are currently implemented.
+|}]
+
+(* Rejection: [@repr pointer] is not yet supported. *)
+type b_ptr = P of int [@repr pointer]
+
+[%%expect{|
+Line 1, characters 13-37:
+1 | type b_ptr = P of int [@repr pointer]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "[@repr pointer]" is not yet supported;
+       only "[@repr null]", "[@repr value]" and "[@repr unboxed]" are currently implemented.
+|}]
+
+(* Rejection: [@repr value] may only coexist with a single [@repr null]. *)
+type 'a bad_val = N [@repr null] | V of 'a [@repr value] | X
+
+[%%expect{|
+Line 1, characters 0-60:
+1 | type 'a bad_val = N [@repr null] | V of 'a [@repr value] | X
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr value] may only coexist with a single [@repr null] constructor.
+|}]
+
+(* Rejection: [@repr unboxed] requires a single unary constructor. *)
+type bad_unboxed = A of int [@repr unboxed] | B of int
+
+[%%expect{|
+Line 1, characters 0-54:
+1 | type bad_unboxed = A of int [@repr unboxed] | B of int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr unboxed] requires a single unary constructor.
+|}]
+
+(* Rejection: [@repr null] requires a nullary constructor. *)
+type bad_null = Bad of int [@repr null] | Other
+
+[%%expect{|
+Line 1, characters 0-47:
+1 | type bad_null = Bad of int [@repr null] | Other
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [@repr] declaration:
+       [@repr null] requires a nullary constructor.
+|}]
+
+(* Module inclusion: the representation is part of the signature, so a
+   [@repr null] implementation does not match a plain-variant signature. *)
+module M : sig
+  type t = Empty | Node of int
+end = struct
+  type t = Empty [@repr null] | Node of int
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Empty [@repr null] | Node of int
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Empty | Node of int end
+       is not included in
+         sig type t = Empty | Node of int end
+       Type declarations do not match:
+         type t = Empty | Node of int
+       is not included in
+         type t = Empty | Node of int
+       Their internal representations differ:
+       the first declaration has a constructor represented as a null pointer.
+       Hint: add [@@or_null] or [@@or_null_reexport].
+|}]

--- a/testsuite/tests/typing-layouts-or-null/repr_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_null.ml
@@ -36,26 +36,24 @@ type u = K of string [@repr unboxed]
 type u = K of string [@@unboxed]
 |}]
 
-(* Rejection: [@repr immediate] is not yet supported. *)
+(* [@repr immediate]: a payload-unboxed immediate constructor (tranche 2). *)
 type b_imm = Small of int [@repr immediate]
 
 [%%expect{|
-Line 1, characters 13-43:
-1 | type b_imm = Small of int [@repr immediate]
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: "[@repr immediate]" is not yet supported;
-       only "[@repr null]", "[@repr value]" and "[@repr unboxed]" are currently implemented.
+type b_imm = Small of int
 |}]
 
-(* Rejection: [@repr pointer] is not yet supported. *)
+(* [@repr pointer] is now supported (tranche 2); an [int] payload is rejected
+   because it is an immediate, not a pointer.  See repr_erased.ml for full
+   pointer coverage. *)
 type b_ptr = P of int [@repr pointer]
 
 [%%expect{|
 Line 1, characters 13-37:
 1 | type b_ptr = P of int [@repr pointer]
                  ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: "[@repr pointer]" is not yet supported;
-       only "[@repr null]", "[@repr value]" and "[@repr unboxed]" are currently implemented.
+Error: Invalid [@repr] declaration:
+       [@repr pointer] requires a payload that is definitely a non-null pointer.
 |}]
 
 (* Rejection: [@repr value] may only coexist with a single [@repr null]. *)

--- a/testsuite/tests/typing-layouts-or-null/repr_null_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/repr_null_runtime.ml
@@ -1,0 +1,59 @@
+(* TEST
+*)
+
+(* [@repr null] coexisting with ordinary constant constructors, including a
+   Marshal round-trip to confirm the runtime representation (null pointer +
+   immediates) survives serialization. *)
+type colour = Null_const [@repr null] | A | B
+
+let classify = function Null_const -> 0 | A -> 1 | B -> 2
+
+let () =
+  assert (classify Null_const = 0);
+  assert (classify A = 1);
+  assert (classify B = 2);
+  List.iter
+    (fun v ->
+       let v' : colour = Marshal.from_string (Marshal.to_string v []) 0 in
+       assert (classify v = classify v'))
+    [ Null_const; A; B ]
+
+(* [@repr null] coexisting with a boxed non-constant constructor: deep tree
+   build and traverse. *)
+type tree = Empty [@repr null] | Node of int * tree * tree
+
+let rec sum = function Empty -> 0 | Node (n, l, r) -> n + sum l + sum r
+let rec depth = function Empty -> 0 | Node (_, l, r) -> 1 + max (depth l) (depth r)
+let rec build n = if n = 0 then Empty else Node (n, build (n - 1), build (n - 1))
+
+let () =
+  let t =
+    Node (5, Node (3, Empty, Empty), Node (7, Empty, Node (9, Empty, Empty)))
+  in
+  assert (sum t = 24);
+  assert (depth t = 3);
+  assert (not (match t with Empty -> true | Node _ -> false));
+  let big = build 12 in
+  assert (depth big = 12);
+  assert (sum big = sum big) (* deterministic, non-crashing traversal *)
+
+(* [@repr value] + [@repr null]: or_null-style, payload stored unboxed. *)
+type ('a : value) opt : value_or_null = N [@repr null] | V of 'a [@repr value]
+
+let to_option = function N -> None | V x -> Some x
+
+let () =
+  assert (to_option N = None);
+  assert (to_option (V 42) = Some 42);
+  assert (to_option (V "hi") = Some "hi");
+  (match V 7 with N -> assert false | V x -> assert (x = 7))
+
+(* [@repr unboxed]: single unary constructor, payload stored directly. *)
+type wrapped = K of string [@repr unboxed]
+
+let unwrap = function K s -> s
+
+let () =
+  assert (unwrap (K "hello") = "hello");
+  let k = K "world" in
+  assert (unwrap k = "world")

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -647,7 +647,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             | Variant_unboxed -> true
             | Variant_with_null when tag = -1 -> false
             | Variant_with_null -> true
-            | Variant_boxed _ | Variant_extensible -> false
+            | Variant_boxed _ | Variant_with_null_boxed _
+            | Variant_extensible -> false
           in
           match cd_args with
           | Cstr_tuple l ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2779,6 +2779,9 @@ let unbox_once env ty =
                                    or_null = None }) lbls)
         | Type_record_unboxed_product ([], _, _) ->
           Misc.fatal_error "Ctype.unboxed_once: fieldless record"
+        (* [@repr null] coexistence ([Variant_with_null_boxed]) types are
+           boxed, not unboxed, so they fall through to the [Final_result]
+           catch-all below. *)
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3559,6 +3559,86 @@ let is_always_gc_ignorable env ty =
     (Jkind_axis.Externality.upper_bound_if_is_always_gc_ignorable ())
   || type_is_gc_ignorable_scannable env ty
 
+(* Conservative allowlist for [@repr pointer] payloads: returns [true] only when
+   the payload's values are DEFINITELY a non-null, non-immediate, non-float
+   boxed pointer, so that the runtime discrimination (isnull / isint) never
+   misclassifies one.  We look only at the expanded head (one [expand_head_opt],
+   which already chases abbreviations/aliases) and do not recurse into type
+   arguments or fuel-bound anything: a payload behind an abstract type or a type
+   variable is rejected.  Rejecting a genuine pointer is acceptable; accepting a
+   non-pointer is not.  Notably rejects [float]/[floatarray] (float guard: a
+   boxed float shares the flat-float-array representation), unboxed records and
+   unboxed products, [@@unboxed]/or_null/[@repr null]-coexistence variants (they
+   are payload-unboxed and may be immediates/floats), and any [Variant_boxed]
+   with an immediate inhabitant (a constant constructor). *)
+let repr_pointer_payload_ok env ty =
+  (* A constructor is "definitely non-constant" (hence a boxed block, never an
+     immediate) iff it has at least one field with a known non-void sort.  An
+     unknown ([None]) sort is treated conservatively as not-definitely-nonconst,
+     so a variant with any unresolved constructor is rejected. *)
+  let definitely_nonconstant (c : constructor_declaration) =
+    let known_nonvoid sort_opt =
+      match sort_opt with
+      | Some s -> not (Jkind_types.Sort.Const.all_void s)
+      | None -> false
+    in
+    match c.cd_args with
+    | Cstr_tuple [] | Cstr_record [] -> false
+    | Cstr_tuple args ->
+      List.exists (fun (ca : constructor_argument) -> known_nonvoid ca.ca_sort)
+        args
+    | Cstr_record lbls ->
+      List.exists (fun (ld : label_declaration) -> known_nonvoid ld.ld_sort)
+        lbls
+  in
+  match get_desc (expand_head_opt env ty) with
+  | Tarrow _ | Tobject _ | Ttuple _ | Tpackage _ -> true
+  | Tconstr (p, _, _) ->
+    if Path.same p Predef.path_string
+       || Path.same p Predef.path_bytes
+       || Path.same p Predef.path_exn
+       || Path.same p Predef.path_lazy_t
+       || Path.same p Predef.path_array
+       || Path.same p Predef.path_iarray
+    then true
+    (* [float]/[floatarray] deliberately rejected: float guard. *)
+    else begin
+      match Env.find_type p env with
+      | exception Not_found -> false
+      | decl ->
+        begin match decl.type_kind with
+        | Type_record (_, Record_boxed, _) -> true
+        | Type_record
+            (_, (Record_unboxed | Record_inlined _ | Record_float
+                | Record_ufloat | Record_mixed _ | Record_dummy _
+                | Record_variable), _) -> false
+        | Type_record_unboxed_product _ -> false
+        | Type_variant (cstrs, Variant_boxed _, _) ->
+          cstrs <> [] && List.for_all definitely_nonconstant cstrs
+        | Type_variant
+            (_, (Variant_unboxed | Variant_with_null | Variant_with_null_boxed _
+                | Variant_extensible), _) -> false
+        | Type_open -> true
+        | Type_abstract _ -> false
+        end
+    end
+  | Tvariant row ->
+    (* Closed polymorphic variant, every field present-with-argument (or a
+       non-empty conjunctive [Reither]) so no constant tag: a boxed block. *)
+    row_closed row
+    && List.for_all
+         (fun (_, field) ->
+            match row_field_repr field with
+            | Rpresent (Some _) -> true
+            | Reither (false, _ :: _, _) -> true
+            | Rpresent None | Reither _ | Rabsent -> false)
+         (row_fields row)
+  (* [Tbox] ([ty box]) is in fact a heap pointer, but we reject it
+     conservatively: this allowlist errs towards rejection. *)
+  | Tvar _ | Tunivar _ | Tnil | Tfield _ | Tlink _ | Tsubst _ | Tpoly _
+  | Tof_kind _ | Tunboxed_tuple _ | Tquote _ | Tsplice _ | Tquote_eval _
+  | Trepr _ | Tbox _ -> false
+
 let check_type_jkind_exn env texn ty jkind =
   match check_type_jkind env ty jkind with
   | Ok _ -> ()

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -762,6 +762,12 @@ val check_type_externality :
    platform. *)
 val is_always_gc_ignorable : Env.t -> type_expr -> bool
 
+(* Conservative allowlist for [@repr pointer] payloads: [true] only when the
+   payload's values are definitely a non-null, non-immediate, non-float boxed
+   pointer.  Looks only at the expanded head; rejects (soundly) anything it
+   cannot confirm.  See the definition for the exact accept/reject list. *)
+val repr_pointer_payload_ok : Env.t -> type_expr -> bool
+
 (* Check whether a type's nullability is less than some target.
    Potentially cheaper than just calling [type_jkind], because this can stop
    expansion once it succeeds. *)

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -55,6 +55,21 @@ let may_equal_constr c1 c2 =
      | tag1, tag2 ->
          equal_tag tag1 tag2)
 
+(* For a [Variant_with_null_boxed] variant, recover how this constructor is
+   represented at run time.  Returns [None] for every other representation
+   (ordinary boxed/unboxed/value/extensible variants), which lets callers keep
+   their existing paths for those. *)
+let erased_kind_of_constructor cstr : erased_kind option =
+  match cstr.cstr_repr, cstr.cstr_tag with
+  | Variant_with_null_boxed erased, Ordinary { src_index; _ } ->
+    Some erased.(src_index).erased
+  | Variant_with_null_boxed _, Null -> Some Erased_null
+  | Variant_with_null_boxed _, Extension _
+  | ( ( Variant_unboxed | Variant_boxed _ | Variant_extensible
+      | Variant_with_null ),
+      (Ordinary _ | Null | Extension _) ) ->
+    None
+
 let cstr_res_type_path cstr =
   match get_desc cstr.cstr_res with
   | Tconstr (p, _, _) -> p

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -50,6 +50,10 @@ val equal_constr :
 val may_equal_constr :
     constructor_description ->  constructor_description -> bool
 
+(* For a [Variant_with_null_boxed] variant, how the constructor is represented
+   at run time.  [None] for all other representations. *)
+val erased_kind_of_constructor : constructor_description -> erased_kind option
+
 (* Type constructor of the constructor's result type. *)
 val cstr_res_type_path : constructor_description -> Path.t
 

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -142,7 +142,9 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
   let cstr_layouts, is_unboxed =
     match rep, cstrs with
     | Variant_extensible, _ -> assert false
-    | (Variant_boxed x | Variant_with_null_boxed x), _ -> x, false
+    | Variant_boxed x, _ -> x, false
+    | Variant_with_null_boxed erased, _ ->
+      Array.map (fun (e : Types.cstr_erased) -> e.layout) erased, false
     | Variant_unboxed, [{ cd_args }] ->
       (* CR layouts: It's tempting just to use [decl.type_jkind] here, instead
          of grabbing the jkind from the argument. However, doing so does not
@@ -231,10 +233,15 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
     in
     let cstr_tag =
       match rep with
-      | Variant_with_null_boxed _ ->
-        if Builtin_attributes.has_repr_null cd_attributes
-        then Null
-        else Ordinary {src_index; runtime_tag}
+      | Variant_with_null_boxed erased ->
+        (* The [erased_kind] array is the source of truth: the null constructor
+           is the null pointer; ordinary/immediate/pointer constructors carry
+           an [Ordinary] tag (immediate/pointer never materialize a block, so
+           their [runtime_tag] slot is unused). *)
+        (match erased.(src_index).erased with
+         | Erased_null -> Null
+         | Erased_boxed | Erased_immediate | Erased_pointer ->
+           Ordinary {src_index; runtime_tag})
       | Variant_with_null ->
         begin match classify_variant_with_null_constructor
           { cd_id; cd_args; cd_res; cd_loc; cd_attributes; cd_uid }

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -142,7 +142,7 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
   let cstr_layouts, is_unboxed =
     match rep, cstrs with
     | Variant_extensible, _ -> assert false
-    | Variant_boxed x, _ -> x, false
+    | (Variant_boxed x | Variant_with_null_boxed x), _ -> x, false
     | Variant_unboxed, [{ cd_args }] ->
       (* CR layouts: It's tempting just to use [decl.type_jkind] here, instead
          of grabbing the jkind from the argument. However, doing so does not
@@ -231,6 +231,10 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
     in
     let cstr_tag =
       match rep with
+      | Variant_with_null_boxed _ ->
+        if Builtin_attributes.has_repr_null cd_attributes
+        then Null
+        else Ordinary {src_index; runtime_tag}
       | Variant_with_null ->
         begin match classify_variant_with_null_constructor
           { cd_id; cd_args; cd_res; cd_loc; cd_attributes; cd_uid }
@@ -238,7 +242,8 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
         | Variant_with_null_nullary -> Null
         | Variant_with_null_payload _ -> Ordinary {src_index; runtime_tag}
         end
-      | _ -> Ordinary {src_index; runtime_tag}
+      | Variant_unboxed | Variant_boxed _ | Variant_extensible ->
+        Ordinary {src_index; runtime_tag}
     in
     let cstr_existentials, cstr_args, cstr_inlined =
       let record_repr = Record_inlined (cstr_tag, cstr_shape, rep) in

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -776,13 +776,17 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
               ~validate_label:validate_immutable_unboxed_label lbls
           in
           Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
-          (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
-             captured by its constructors: nullability/separability and
-             mode-crossing are baked into its representation. We defer to
-             jkinds because ikinds cannot express this today. This deferral
-             can be removed once separability and nullability become layout
-             properties rather than modal axes. *)
+        | Types.Type_variant
+            ( _cstrs,
+              (Types.Variant_with_null | Types.Variant_with_null_boxed _),
+              _umc_opt ) ->
+          (* [Variant_with_null] (i.e. [or_null]) and the [@repr null]
+             coexistence representation [Variant_with_null_boxed] have
+             semantics that are not captured by their constructors:
+             nullability/separability and mode-crossing are baked into the
+             representation. We defer to jkinds because ikinds cannot express
+             this today. This deferral can be removed once separability and
+             nullability become layout properties rather than modal axes. *)
           use_decl_jkind ~treat_as_abstract:false
         | Types.Type_variant (cstrs, rep, _umc_opt) ->
           (* Choose base: immediate for void-only variants; sync if any record

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1312,7 +1312,8 @@ module Variant_diffing = struct
     | None, Variant_unboxed, Variant_unboxed
     | None, Variant_boxed _, Variant_boxed _
     | None, Variant_extensible, Variant_extensible
-    | None, Variant_with_null, Variant_with_null -> None
+    | None, Variant_with_null, Variant_with_null
+    | None, Variant_with_null_boxed _, Variant_with_null_boxed _ -> None
     | Some err, _, _ ->
         Some (Variant_mismatch err)
     | None, Variant_unboxed, Variant_boxed _ ->
@@ -1326,6 +1327,10 @@ module Variant_diffing = struct
     | None, Variant_with_null, _ ->
       Some (With_null_representation First)
     | None, _, Variant_with_null ->
+      Some (With_null_representation Second)
+    | None, Variant_with_null_boxed _, _ ->
+      Some (With_null_representation First)
+    | None, _, Variant_with_null_boxed _ ->
       Some (With_null_representation Second)
 end
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -415,6 +415,11 @@ type type_mismatch =
   | Unboxed_representation of position * attributes
   | Extensible_representation of position
   | With_null_representation of position
+  | Erased_representation of
+      { name : string;
+        first : Types.erased_kind;
+        second : Types.erased_kind;
+      }
   | Fixed_representation of position
   | Jkind of Jkind.Violation.t
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
@@ -835,6 +840,18 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a constructor represented as a null pointer";
       pr "@ Hint: add [%@%@or_null] or [%@%@or_null_reexport]."
+  | Erased_representation { name; first = k1; second = k2 } ->
+      let describe : Types.erased_kind -> string = function
+        | Erased_boxed -> "the ordinary boxed representation"
+        | Erased_null -> "[@repr null]"
+        | Erased_immediate -> "[@repr immediate]"
+        | Erased_pointer -> "[@repr pointer]"
+      in
+      pr "Their internal representations differ:@ \
+          constructor %s uses %s in %s %s but %s in %s %s."
+         name
+         (describe k1) first decl
+         (describe k2) second decl
   | Fixed_representation ord ->
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
@@ -1291,10 +1308,16 @@ module Variant_diffing = struct
       | Variant_boxed cstr_layouts1, Variant_boxed cstr_layouts2 ->
           Array.map shape_of_layout cstr_layouts1 |> Array.to_list,
           Array.map shape_of_layout cstr_layouts2 |> Array.to_list
+      | Variant_with_null_boxed erased1, Variant_with_null_boxed erased2 ->
+          Array.map (fun (e : Types.cstr_erased) -> shape_of_layout e.layout)
+            erased1 |> Array.to_list,
+          Array.map (fun (e : Types.cstr_erased) -> shape_of_layout e.layout)
+            erased2 |> Array.to_list
       | _, _ ->
-          (* Only need to compare shapes in the boxed-versus-boxed case. In
-             other cases, either the comparison is doomed anyway due to
-             different representations or the shapes aren't relevant. *)
+          (* Only need to compare shapes in the boxed-versus-boxed and
+             null-boxed-versus-null-boxed cases. In other cases, either the
+             comparison is doomed anyway due to different representations or the
+             shapes aren't relevant. *)
           List.map (fun _ -> None) cstrs1,
           List.map (fun _ -> None) cstrs2
     in
@@ -1312,8 +1335,36 @@ module Variant_diffing = struct
     | None, Variant_unboxed, Variant_unboxed
     | None, Variant_boxed _, Variant_boxed _
     | None, Variant_extensible, Variant_extensible
-    | None, Variant_with_null, Variant_with_null
-    | None, Variant_with_null_boxed _, Variant_with_null_boxed _ -> None
+    | None, Variant_with_null, Variant_with_null -> None
+    | None, Variant_with_null_boxed erased1, Variant_with_null_boxed erased2 ->
+        (* The [erased_kind] array records the physical representation chosen by
+           the [@repr] attributes, which [compare_constructors] does not compare
+           (it checks constructor types and alerts, not [@repr]).  Two
+           constructor lists can therefore be equal while signature and
+           implementation disagree on layout -- a soundness hole -- so compare
+           the erased kinds element-wise here. *)
+        let names =
+          Array.of_list
+            (List.map
+               (fun (cd : Types.constructor_declaration) -> Ident.name cd.cd_id)
+               cstrs1)
+        in
+        let n =
+          min (Array.length erased1)
+            (min (Array.length erased2) (Array.length names))
+        in
+        let rec find i =
+          if i >= n then None
+          else
+            let k1 = (erased1.(i) : Types.cstr_erased).erased in
+            let k2 = (erased2.(i) : Types.cstr_erased).erased in
+            if Types.equal_erased_kind k1 k2 then find (i + 1)
+            else
+              Some
+                (Erased_representation
+                   { name = names.(i); first = k1; second = k2 })
+        in
+        find 0
     | Some err, _, _ ->
         Some (Variant_mismatch err)
     | None, Variant_unboxed, Variant_boxed _ ->

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -143,6 +143,11 @@ type type_mismatch =
   | Unboxed_representation of position * attributes
   | Extensible_representation of position
   | With_null_representation of position
+  | Erased_representation of
+      { name : string;
+        first : Types.erased_kind;
+        second : Types.erased_kind;
+      }
   | Fixed_representation of position
   | Jkind of Jkind.Violation.t
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1907,7 +1907,7 @@ let tree_of_single_constructor ~all_void cd =
    boxed variant and has at least one argument, all of which are void. *)
 let constructor_is_all_void rep cd =
   match (rep : Types.variant_representation) with
-  | Variant_boxed _ -> begin
+  | Variant_boxed _ | Variant_with_null_boxed _ -> begin
       match cd.cd_args with
       | Cstr_tuple ((_ :: _) as args) ->
           List.for_all
@@ -2059,7 +2059,8 @@ let tree_of_type_decl id decl =
         let unboxed =
           match rep with
           | Variant_unboxed -> true
-          | Variant_boxed _ | Variant_extensible | Variant_with_null -> false
+          | Variant_boxed _ | Variant_extensible | Variant_with_null
+          | Variant_with_null_boxed _ -> false
         in
         let or_null_attribute =
           if Builtin_attributes.has_or_null decl.type_attributes then

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -247,6 +247,15 @@ let variant_representation i ppf = let open Types in function
       layouts
   | Variant_extensible -> line i ppf "Variant_inlined\n"
   | Variant_with_null -> line i ppf "Variant_with_null\n"
+  | Variant_with_null_boxed layouts ->
+    line i ppf "Variant_with_null_boxed %a\n"
+      (array (i+1) (fun _ ppf l ->
+         match (l : Types.cstr_layout) with
+         | Cstr_layout_variable ->
+           line (i+1) ppf "Cstr_layout_variable\n"
+         | Cstr_layout_known { sorts; _ } ->
+           sort_array (i+1) ppf sorts))
+      layouts
 
 let mixed_block_element i ppf mixed_block_element =
   line i ppf "%s\n" (Types.mixed_block_element_to_string mixed_block_element)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -247,15 +247,20 @@ let variant_representation i ppf = let open Types in function
       layouts
   | Variant_extensible -> line i ppf "Variant_inlined\n"
   | Variant_with_null -> line i ppf "Variant_with_null\n"
-  | Variant_with_null_boxed layouts ->
+  | Variant_with_null_boxed erased ->
     line i ppf "Variant_with_null_boxed %a\n"
-      (array (i+1) (fun _ ppf l ->
-         match (l : Types.cstr_layout) with
+      (array (i+1) (fun _ ppf (e : Types.cstr_erased) ->
+         (match e.erased with
+          | Erased_boxed -> line (i+1) ppf "Erased_boxed\n"
+          | Erased_null -> line (i+1) ppf "Erased_null\n"
+          | Erased_immediate -> line (i+1) ppf "Erased_immediate\n"
+          | Erased_pointer -> line (i+1) ppf "Erased_pointer\n");
+         match e.layout with
          | Cstr_layout_variable ->
            line (i+1) ppf "Cstr_layout_variable\n"
          | Cstr_layout_known { sorts; _ } ->
            sort_array (i+1) ppf sorts))
-      layouts
+      erased
 
 let mixed_block_element i ppf mixed_block_element =
   line i ppf "%s\n" (Types.mixed_block_element_to_string mixed_block_element)

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -583,8 +583,10 @@ module Type_decl_shape = struct
         | Type_variant (([] | _ :: _ :: _), Variant_unboxed, _) ->
           Misc.fatal_error "Unboxed variant must have exactly one constructor."
         | Type_variant
-            (_, (Variant_extensible | Variant_with_null), _unsafe_mode_crossing)
-          ->
+            ( _,
+              ( Variant_extensible | Variant_with_null
+              | Variant_with_null_boxed _ ),
+              _unsafe_mode_crossing ) ->
           unknown_shape ()
           (* CR sspies: These variants are not yet supported. *)
         | Type_record (lbl_list, record_repr, _unsafe_mode_crossing) -> (

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6585,7 +6585,8 @@ and type_expect_
           | Record_inlined (_, _, (Variant_unboxed | Variant_with_null))
             -> false
           | Record_boxed | Record_float | Record_ufloat | Record_mixed _
-          | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
+          | Record_inlined (_, _, (Variant_boxed _ | Variant_with_null_boxed _
+                                  | Variant_extensible))
           | Record_variable
             -> true
           | Record_dummy _ ->
@@ -10557,8 +10558,12 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
   let (argument_mode, alloc_mode) =
     match constr.cstr_repr with
     | Variant_unboxed | Variant_with_null -> expected_mode, None
-    | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
-    | Variant_boxed _ | Variant_extensible ->
+    | (Variant_boxed _ | Variant_with_null_boxed _)
+      when constr.cstr_constant ->
+      (* Constant constructors (including the [@repr null] null pointer) are
+         immediates: no allocation. *)
+      expected_mode, None
+    | Variant_boxed _ | Variant_with_null_boxed _ | Variant_extensible ->
        let alloc_mode, argument_mode =
          register_allocation ~loc:sexp.pexp_loc expected_mode
        in
@@ -10604,7 +10609,7 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
     begin match constr.cstr_repr with
     | Variant_extensible ->
         raise(Error(sexp.pexp_loc, env, Private_constructor (constr, ty_res)))
-    | Variant_boxed _ | Variant_unboxed ->
+    | Variant_boxed _ | Variant_unboxed | Variant_with_null_boxed _ ->
         raise (Error(sexp.pexp_loc, env, Private_type ty_res));
     | Variant_with_null -> assert false
       (* [Variant_with_null] can't be made private due to [or_null_reexport]. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -10556,6 +10556,12 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
       Mode.Value.meet [ expected_mode.mode; constructor_mode ] }
   in
   let (argument_mode, alloc_mode) =
+    match erased_kind_of_constructor constr with
+    | Some (Erased_null | Erased_immediate | Erased_pointer) ->
+      (* No allocation: the null pointer, or a payload-unboxed
+         [@repr immediate]/[@repr pointer] value (the payload is the value). *)
+      expected_mode, None
+    | Some Erased_boxed | None ->
     match constr.cstr_repr with
     | Variant_unboxed | Variant_with_null -> expected_mode, None
     | (Variant_boxed _ | Variant_with_null_boxed _)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1141,15 +1141,17 @@ let transl_declaration env sdecl (id, uid) =
         in
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
         (* [@repr <ident>] prototype.  Supported idents: [null], [value],
-           [unboxed].  [immediate] and [pointer] are rejected with a clean
-           "not yet supported" error; any other ident likewise. *)
+           [unboxed], [immediate], [pointer].  Any other ident is rejected with
+           a clean "not yet supported" error. *)
         let repr_of (scstr : Parsetree.constructor_declaration) =
           Builtin_attributes.repr_payload_ident scstr.pcd_attributes
         in
         List.iter
           (fun scstr ->
              match repr_of scstr with
-             | None | Some ("null" | "value" | "unboxed") -> ()
+             | None
+             | Some ("null" | "value" | "unboxed" | "immediate" | "pointer") ->
+               ()
              | Some other ->
                raise (Error (scstr.pcd_loc, Unsupported_repr_attribute other)))
           scstrs;
@@ -1157,16 +1159,19 @@ let transl_declaration env sdecl (id, uid) =
           List.length (List.filter (fun c -> repr_of c = Some ident) scstrs)
         in
         let n_null = count "null" and n_value = count "value"
-        and n_unboxed = count "unboxed" in
+        and n_unboxed = count "unboxed" and n_immediate = count "immediate"
+        and n_pointer = count "pointer" in
         let uses_repr_value = n_value > 0 in
         let uses_repr_unboxed = n_unboxed > 0 in
+        let uses_repr_immediate = n_immediate > 0 in
+        let uses_repr_pointer = n_pointer > 0 in
         let bad msg = raise (Error (sdecl.ptype_loc, Bad_repr_attribute msg)) in
         (* [@repr value]: exactly one [@repr null] (nullary) + one [@repr value]
            (unary), nothing else.  This is precisely the [@@or_null] shape, and
            is mapped onto the [Variant_with_null] representation below. *)
         if uses_repr_value then begin
           if n_value <> 1 || n_null <> 1 || List.length scstrs <> 2
-             || uses_repr_unboxed
+             || uses_repr_unboxed || uses_repr_immediate || uses_repr_pointer
           then bad "[@repr value] may only coexist with a single \
                     [@repr null] constructor";
           (match sdecl.ptype_private with
@@ -1188,7 +1193,8 @@ let transl_declaration env sdecl (id, uid) =
            other [@repr] attribute.  Mapped onto [Variant_unboxed] via the
            [unbox] flag computed above. *)
         if uses_repr_unboxed then begin
-          if n_unboxed > 1 || n_null > 0 || uses_repr_value then
+          if n_unboxed > 1 || n_null > 0 || uses_repr_value
+             || uses_repr_immediate || uses_repr_pointer then
             bad "[@repr unboxed] cannot be combined with other [@repr] \
                  attributes";
           match scstrs with
@@ -1197,9 +1203,90 @@ let transl_declaration env sdecl (id, uid) =
                       | _ -> false) -> ()
           | _ -> bad "[@repr unboxed] requires a single unary constructor"
         end;
+        (* [@repr immediate]: the payload is passed through unchanged as an
+           immediate, distinguished at run time from the boxed constructors by
+           an [isint] test.
+
+           Immediate-space accounting: the [isint]-true bucket holds BOTH the
+           ordinary constant constructors (tags 0..k) AND the [@repr immediate]
+           payload (which spans the whole int range).  They cannot be told
+           apart, so [@repr immediate] must not coexist with any ordinary
+           constant constructor.  It MAY coexist with [@repr null] (the null
+           pointer is caught by an outer [isnull] and consumes no immediate
+           slot) and with ordinary non-constant (boxed) constructors (caught on
+           the [isint]-false side by a tag switch). *)
+        if uses_repr_immediate then begin
+          if n_immediate > 1 then
+            bad "there may be at most one [@repr immediate] constructor";
+          if uses_repr_value then
+            bad "[@repr immediate] may only coexist with [@repr null] and \
+                 ordinary constructors";
+          let has_unannotated_constant =
+            List.exists
+              (fun (scstr : Parsetree.constructor_declaration) ->
+                 repr_of scstr = None
+                 && match scstr.pcd_args with
+                    | Pcstr_tuple [] -> true
+                    | Pcstr_tuple (_ :: _) | Pcstr_record _ -> false)
+              scstrs
+          in
+          if has_unannotated_constant then
+            bad "[@repr immediate] must not coexist with ordinary constant \
+                 constructors: both occupy the immediate space";
+          List.iter
+            (fun (scstr : Parsetree.constructor_declaration) ->
+               match repr_of scstr, scstr.pcd_args with
+               | Some "immediate", Pcstr_tuple [_] -> ()
+               | Some "immediate", _ ->
+                 bad "[@repr immediate] requires a unary tuple constructor"
+               | _ -> ())
+            scstrs
+        end;
+        (* [@repr pointer]: the payload is passed through unchanged as a
+           non-null, non-immediate pointer, caught at run time on the
+           [isint]-false side (after the outer [isnull]).
+
+           Pointer-space accounting: [@repr pointer] takes the ENTIRE
+           non-immediate side -- any block value matches it -- so it cannot
+           share a variant with an ordinary constructor: an ordinary
+           non-constant (boxed block) would be indistinguishable from the raw
+           pointer, and we conservatively forbid ordinary constant constructors
+           too.  [@repr pointer] MAY coexist with [@repr null] (caught by the
+           outer [isnull]) and [@repr immediate] (caught by [isint]). *)
+        if uses_repr_pointer then begin
+          if n_pointer > 1 then
+            bad "there may be at most one [@repr pointer] constructor";
+          if uses_repr_value then
+            bad "[@repr pointer] may only coexist with [@repr null] and \
+                 [@repr immediate]";
+          let has_unannotated =
+            List.exists
+              (fun (scstr : Parsetree.constructor_declaration) ->
+                 repr_of scstr = None)
+              scstrs
+          in
+          if has_unannotated then
+            bad "[@repr pointer] may only coexist with [@repr null] and \
+                 [@repr immediate] constructors: a raw pointer occupies the \
+                 whole non-immediate space and would collide with ordinary \
+                 constructors";
+          List.iter
+            (fun (scstr : Parsetree.constructor_declaration) ->
+               match repr_of scstr, scstr.pcd_args with
+               | Some "pointer", Pcstr_tuple [_] -> ()
+               | Some "pointer", _ ->
+                 bad "[@repr pointer] requires a unary tuple constructor"
+               | _ -> ())
+            scstrs
+        end;
         (* [@repr null] without [@repr value]: the coexistence-with-ordinary
            representation from stage 1. *)
         let uses_repr_null_boxed = n_null > 0 && not uses_repr_value in
+        (* [@repr null]/[@repr immediate]/[@repr pointer] coexisting with
+           ordinary constructors all share [Variant_with_null_boxed]. *)
+        let uses_erased_boxed =
+          uses_repr_null_boxed || uses_repr_immediate || uses_repr_pointer
+        in
         if uses_repr_null_boxed then
           List.iter
             (fun scstr ->
@@ -1225,25 +1312,44 @@ let transl_declaration env sdecl (id, uid) =
            the circular type checks make it safe to check sorts.  Likewise,
            [Constructor_uniform_value] is potentially wrong and will be updated
            later. *)
+        let dummy_layout_of (cstr : Types.constructor_declaration) =
+          let sorts =
+            match cstr.cd_args with
+            | Cstr_tuple args ->
+              Array.make (List.length args) Jkind.Sort.Const.void
+            | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
+          in
+          Cstr_layout_known { shape = Constructor_uniform_value; sorts }
+        in
         let dummy_boxed_layouts () =
-          Array.map
-            (fun cstr ->
-               let sorts =
-                 match Types.(cstr.cd_args) with
-                 | Cstr_tuple args ->
-                   Array.make (List.length args) Jkind.Sort.Const.void
-                 | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
-               in
-               Cstr_layout_known
-                 { shape = Constructor_uniform_value; sorts })
-            (Array.of_list cstrs)
+          Array.map dummy_layout_of (Array.of_list cstrs)
+        in
+        (* Per-constructor [erased_kind] array for [Variant_with_null_boxed].
+           The kind comes from the source [@repr <ident>] annotation; every
+           unannotated constructor is [Erased_boxed]. *)
+        let dummy_erased_layouts () =
+          Array.of_list
+            (List.map2
+               (fun (scstr : Parsetree.constructor_declaration)
+                    (cstr : Types.constructor_declaration) ->
+                  let erased : Types.erased_kind =
+                    match repr_of scstr with
+                    | Some "null" -> Erased_null
+                    | Some "immediate" -> Erased_immediate
+                    | Some "pointer" -> Erased_pointer
+                    | Some _ | None -> Erased_boxed
+                  in
+                  { Types.layout = dummy_layout_of cstr; erased })
+               scstrs cstrs)
         in
         let rep, jkind =
           match or_null_payload_arg with
-          | _ when uses_repr_null_boxed ->
-            (* The type includes the null pointer, so its (placeholder) jkind
-               is nullable; [update_decl_jkind] refines it later. *)
-            Variant_with_null_boxed (dummy_boxed_layouts ()),
+          | _ when uses_erased_boxed ->
+            (* The (placeholder) jkind is nullable when a null pointer is
+               possible, and value-ish otherwise; [update_decl_jkind] refines
+               it later (to immediate / immediate_or_null when [@repr immediate]
+               is present). *)
+            Variant_with_null_boxed (dummy_erased_layouts ()),
             Jkind.Builtin.value_or_null ~why:V1_safety_check
           | Some payload_arg ->
             let payload_ty = payload_arg.Types.ca_type in
@@ -2629,52 +2735,170 @@ let rec update_decl_jkind env dpath decl =
          exactly like [Variant_boxed] (constants as immediates, non-constants
          as boxed blocks), so reuse that machinery to fill the layout array and
          compute the jkind, then mark it nullable because the type includes the
-         null pointer. *)
+         null pointer.
+
+         [@repr immediate] constructors are payload-unboxed: the value is the
+         payload itself, which must be an immediate and non-null.  They do not
+         go through the boxed-representation machinery; instead we check the
+         payload and record its sort. *)
+      let has kind =
+        Array.exists
+          (fun (e : Types.cstr_erased) -> Types.equal_erased_kind e.erased kind)
+          cstr_layouts
+      in
+      let has_immediate = has Erased_immediate in
+      let has_pointer = has Erased_pointer in
+      let has_null = has Erased_null in
+      (* Set when any ordinary ([Erased_boxed]) constructor is non-constant,
+         i.e. represented as a boxed block (a pointer value).  When this holds
+         the type has pointer values and cannot be an [immediate] jkind even if
+         a [@repr immediate] constructor is present. *)
+      let has_block = ref false in
+      (* Shared by the payload-unboxed kinds ([@repr immediate]/[@repr
+         pointer]): record the payload's sort in the layout and keep the
+         payload as the value. *)
+      let record_payload_unboxed idx cstr ca ty =
+        let jk = Ctype.type_jkind env ty in
+        let sort = Jkind.sort_of_jkind env jk in
+        let ca_sort =
+          match Jkind.Sort.default_to_scannable_and_get_some sort with
+          | Some s -> s
+          | None -> Jkind.Sort.Const.scannable
+        in
+        cstr_layouts.(idx) <-
+          { (cstr_layouts.(idx)) with
+            layout =
+              Cstr_layout_known
+                { shape = Constructor_uniform_value; sorts = [| ca_sort |] } };
+        { cstr with
+          Types.cd_args =
+            Cstr_tuple [{ ca with Types.ca_sort = Some ca_sort }] }
+      in
+      let payload_arg (cstr : Types.constructor_declaration) ~what =
+        match cstr.cd_args with
+        | Cstr_tuple [ca] -> ca
+        | _ ->
+          (* shape enforced at [transl_declaration] *)
+          Misc.fatal_error (what ^ " constructor is not a unary tuple")
+      in
       let cstrs =
         List.mapi (fun idx cstr ->
-          let cd_args, ~constant, cstr_repr, arg_sorts =
-            update_constructor_representation_and_arg_sorts env
-              cstr.Types.cd_loc cstr.Types.cd_args
-              ~is_extension_constructor:false
-          in
-          let is_nonempty_all_void =
-            constant
-            && (match cd_args with
-                | Cstr_tuple (_ :: _) -> true
-                | Cstr_tuple [] | Cstr_record _ -> false)
-          in
-          if is_nonempty_all_void
-          && not (Builtin_attributes.has_immediate_all_void_constructor
-                    cstr.Types.cd_attributes)
-          then
-            raise
-              (Error (cstr.Types.cd_loc,
-                      Missing_immediate_all_void_constructor_attribute
-                        (Ident.name cstr.Types.cd_id)));
-          let () =
-            match cstr_repr, arg_sorts with
-            | Ok shape, Some sorts ->
-                cstr_layouts.(idx) <- Cstr_layout_known { shape; sorts }
-            | Ok _, None ->
-                Misc.fatal_error "Representation but no arg sorts?"
-            | _, _ ->
-                assert_any_args_support loc;
-                cstr_layouts.(idx) <- Cstr_layout_variable
-          in
-          { cstr with Types.cd_args }) cstrs
+          match cstr_layouts.(idx).Types.erased with
+          | Erased_immediate ->
+            let ca = payload_arg cstr ~what:"[@repr immediate]" in
+            let ty = ca.Types.ca_type in
+            if not (Ctype.is_always_gc_ignorable env ty
+                    && Ctype.check_type_nullability env ty
+                         Jkind_axis.Nullability.Non_null)
+            then
+              raise
+                (Error (cstr.Types.cd_loc,
+                        Bad_repr_attribute
+                          "[@repr immediate] requires an immediate, non-null \
+                           payload"));
+            record_payload_unboxed idx cstr ca ty
+          | Erased_pointer ->
+            let ca = payload_arg cstr ~what:"[@repr pointer]" in
+            let ty = ca.Types.ca_type in
+            (* No pointer jkind axis on this foundation, so the conservative
+               head-shape allowlist is the sole pointer-definiteness gate. *)
+            if not (Ctype.repr_pointer_payload_ok env ty) then
+              raise
+                (Error (cstr.Types.cd_loc,
+                        Bad_repr_attribute
+                          "[@repr pointer] requires a payload that is \
+                           definitely a non-null pointer"));
+            record_payload_unboxed idx cstr ca ty
+          | Erased_boxed | Erased_null ->
+            let cd_args, ~constant, cstr_repr, arg_sorts =
+              update_constructor_representation_and_arg_sorts env
+                cstr.Types.cd_loc cstr.Types.cd_args
+                ~is_extension_constructor:false
+            in
+            (* A non-constant ordinary constructor is a boxed block. *)
+            if not constant then has_block := true;
+            let is_nonempty_all_void =
+              constant
+              && (match cd_args with
+                  | Cstr_tuple (_ :: _) -> true
+                  | Cstr_tuple [] | Cstr_record _ -> false)
+            in
+            if is_nonempty_all_void
+            && not (Builtin_attributes.has_immediate_all_void_constructor
+                      cstr.Types.cd_attributes)
+            then
+              raise
+                (Error (cstr.Types.cd_loc,
+                        Missing_immediate_all_void_constructor_attribute
+                          (Ident.name cstr.Types.cd_id)));
+            let () =
+              let set_layout layout =
+                cstr_layouts.(idx) <- { (cstr_layouts.(idx)) with layout }
+              in
+              match cstr_repr, arg_sorts with
+              | Ok shape, Some sorts ->
+                  set_layout (Cstr_layout_known { shape; sorts })
+              | Ok _, None ->
+                  Misc.fatal_error "Representation but no arg sorts?"
+              | _, _ ->
+                  assert_any_args_support loc;
+                  set_layout Cstr_layout_variable
+            in
+            { cstr with Types.cd_args }) cstrs
       in
       let jkind =
-        Jkind.for_boxed_variant
-          ~loc
-          ~decl_params:decl.type_params
-          ~type_apply:(Ctype.apply env)
-          ~get_free_vars:(Ctype.free_variable_set_of_list env)
-          (List.rev cstrs)
-      in
-      let jkind =
-        match Jkind.apply_or_null_l env jkind with
-        | Ok jkind -> jkind
-        | Error () -> jkind
+        if has_pointer then
+          (* A [@repr pointer] value is a bare non-immediate pointer; it may
+             coexist with [@repr immediate] (a value) and [@repr null].  We do
+             NOT use [for_non_float] (which would assert [Non_float]); instead
+             use the plain [value]/[value_or_null] builtins, whose separability
+             is [Separable]/[Maybe_separable].  This keeps the flat-float-array
+             optimization sound even though the [repr_pointer_payload_ok] float
+             guard already rejects float payloads.  With no [@repr null]
+             constructor the type is genuinely non-null, so use [value] (which,
+             being [Non_null], also lets clients use e.g. [Obj.repr]); otherwise
+             [value_or_null]. *)
+          if has_null then
+            Jkind.Builtin.value_or_null
+              ~why:(Type_argument
+                      { parent_path = dpath; position = 1; arity = 1 })
+          else
+            Jkind.Builtin.value ~why:Boxed_variant
+        else if has_immediate && not !has_block then
+          (* Immediate-ONLY (no ordinary boxed block coexists): every value is
+             an immediate or (with [@repr null]) null pointer.  [immediate]'s
+             [Non_pointer] separability also makes it a non-float, so the
+             flat-float-array optimization is unaffected.  (When a boxed block
+             DOES coexist -- e.g. [Small of int [@repr immediate] | Big of
+             string] -- the type has pointer values and must fall through to the
+             boxed [value] jkind below.) *)
+          if has_null then
+            Jkind.Builtin.immediate_or_null
+              ~why:(Primitive (Ident.create_local "repr_immediate_or_null"))
+          else
+            Jkind.Builtin.immediate
+              ~why:(Primitive (Ident.create_local "repr_immediate"))
+        else
+          (* Ordinary boxed constructors (possibly mixed with a payload-unboxed
+             [@repr immediate] constructor, which [for_boxed_variant] sees as a
+             constructor with a value payload -- sound, since [value] is a safe
+             over-approximation).  Mark the result nullable ONLY when a
+             [@repr null] constructor is present; otherwise (e.g. [Small of int
+             [@repr immediate] | Big of string]) the type is genuinely non-null
+             and staying [value] lets clients use e.g. [Obj.repr]. *)
+          let jkind =
+            Jkind.for_boxed_variant
+              ~loc
+              ~decl_params:decl.type_params
+              ~type_apply:(Ctype.apply env)
+              ~get_free_vars:(Ctype.free_variable_set_of_list env)
+              (List.rev cstrs)
+          in
+          if has_null then
+            match Jkind.apply_or_null_l env jkind with
+            | Ok jkind -> jkind
+            | Error () -> jkind
+          else jkind
       in
       cstrs, Variant_with_null_boxed cstr_layouts, jkind
     | _, Variant_with_null ->
@@ -6046,12 +6270,13 @@ let report_error ~loc = function
       Location.errorf ~loc "Invalid [@@or_null] declaration:@ %s." msg
   | Unsupported_repr_attribute repr ->
       Location.errorf ~loc
-        "%a is not yet supported;@ only %a, %a and %a are currently \
+        "%a is not yet supported;@ only %a, %a, %a and %a are currently \
          implemented."
         Style.inline_code (Printf.sprintf "[@repr %s]" repr)
         Style.inline_code "[@repr null]"
         Style.inline_code "[@repr value]"
         Style.inline_code "[@repr unboxed]"
+        Style.inline_code "[@repr immediate]"
   | Bad_repr_attribute msg ->
       Location.errorf ~loc "Invalid [@repr] declaration:@ %s." msg
   | Zero_alloc_attr_unsupported ca ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -139,6 +139,8 @@ type error =
   | Unexpected_layout_any_in_primitive of string
   | Useless_layout_poly
   | Bad_or_null_attribute of string
+  | Unsupported_repr_attribute of string
+  | Bad_repr_attribute of string
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity
@@ -980,6 +982,21 @@ let transl_declaration env sdecl (id, uid) =
   let flatten_floats =
     Builtin_attributes.has_flatten_floats sdecl.ptype_attributes
   in
+  (* [@repr unboxed] on a constructor requests the whole-variant unboxed
+     representation, exactly like [@@unboxed].  We reuse the [unbox] flag so it
+     flows through main's existing [Variant_unboxed] machinery; the shape is
+     validated in the [Ptype_variant] branch below. *)
+  let repr_unboxed_ctor =
+    match sdecl.ptype_kind with
+    | Ptype_variant scstrs ->
+      List.exists
+        (fun (c : Parsetree.constructor_declaration) ->
+           Builtin_attributes.repr_payload_ident c.pcd_attributes
+           = Some "unboxed")
+        scstrs
+    | Ptype_abstract | Ptype_record _ | Ptype_record_unboxed_product _
+    | Ptype_open -> false
+  in
   let unbox, unboxed_default =
     (* [unboxed_default] is [true] iff the user did not specify an explicit
        representation attribute ([@@unboxed], [@@represent_as_float_array],
@@ -988,11 +1005,13 @@ let transl_declaration env sdecl (id, uid) =
     | Ptype_variant [{pcd_args = Pcstr_tuple [_]; _}]
     | Ptype_variant [{pcd_args = Pcstr_record [{pld_mutable=Immutable; _}]; _}]
     | Ptype_record [{pld_mutable=Immutable; _}] ->
-      Option.value unboxed_attr
-        ~default:(!Clflags.unboxed_types && not represent_as_float_array),
+      (Option.value unboxed_attr
+        ~default:(!Clflags.unboxed_types && not represent_as_float_array))
+      || repr_unboxed_ctor,
       Option.is_none unboxed_attr
       && not represent_as_float_array
       && not flatten_floats
+      && not repr_unboxed_ctor
     | Ptype_record_unboxed_product _ -> false, false
     | _ -> false, false (* Not unboxable, mark as boxed *)
   in
@@ -1121,8 +1140,79 @@ let transl_declaration env sdecl (id, uid) =
             (fun () -> make_cstr scstr)
         in
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
+        (* [@repr <ident>] prototype.  Supported idents: [null], [value],
+           [unboxed].  [immediate] and [pointer] are rejected with a clean
+           "not yet supported" error; any other ident likewise. *)
+        let repr_of (scstr : Parsetree.constructor_declaration) =
+          Builtin_attributes.repr_payload_ident scstr.pcd_attributes
+        in
+        List.iter
+          (fun scstr ->
+             match repr_of scstr with
+             | None | Some ("null" | "value" | "unboxed") -> ()
+             | Some other ->
+               raise (Error (scstr.pcd_loc, Unsupported_repr_attribute other)))
+          scstrs;
+        let count ident =
+          List.length (List.filter (fun c -> repr_of c = Some ident) scstrs)
+        in
+        let n_null = count "null" and n_value = count "value"
+        and n_unboxed = count "unboxed" in
+        let uses_repr_value = n_value > 0 in
+        let uses_repr_unboxed = n_unboxed > 0 in
+        let bad msg = raise (Error (sdecl.ptype_loc, Bad_repr_attribute msg)) in
+        (* [@repr value]: exactly one [@repr null] (nullary) + one [@repr value]
+           (unary), nothing else.  This is precisely the [@@or_null] shape, and
+           is mapped onto the [Variant_with_null] representation below. *)
+        if uses_repr_value then begin
+          if n_value <> 1 || n_null <> 1 || List.length scstrs <> 2
+             || uses_repr_unboxed
+          then bad "[@repr value] may only coexist with a single \
+                    [@repr null] constructor";
+          (match sdecl.ptype_private with
+           | Private -> bad "[@repr value] is not supported on private types"
+           | Public -> ());
+          List.iter
+            (fun scstr ->
+               match repr_of scstr, scstr.pcd_args with
+               | Some "value", Pcstr_tuple [_] -> ()
+               | Some "value", _ ->
+                 bad "[@repr value] requires a unary constructor"
+               | Some "null", Pcstr_tuple [] -> ()
+               | Some "null", _ ->
+                 bad "[@repr null] requires a nullary constructor"
+               | _ -> bad "[@repr value] may only coexist with [@repr null]")
+            scstrs
+        end;
+        (* [@repr unboxed]: exactly one unary constructor, not combined with any
+           other [@repr] attribute.  Mapped onto [Variant_unboxed] via the
+           [unbox] flag computed above. *)
+        if uses_repr_unboxed then begin
+          if n_unboxed > 1 || n_null > 0 || uses_repr_value then
+            bad "[@repr unboxed] cannot be combined with other [@repr] \
+                 attributes";
+          match scstrs with
+          | [c] when (match c.pcd_args with
+                      | Pcstr_tuple [_] | Pcstr_record [_] -> true
+                      | _ -> false) -> ()
+          | _ -> bad "[@repr unboxed] requires a single unary constructor"
+        end;
+        (* [@repr null] without [@repr value]: the coexistence-with-ordinary
+           representation from stage 1. *)
+        let uses_repr_null_boxed = n_null > 0 && not uses_repr_value in
+        if uses_repr_null_boxed then
+          List.iter
+            (fun scstr ->
+               if Builtin_attributes.has_repr_null scstr.pcd_attributes then
+                 match scstr.pcd_args with
+                 | Pcstr_tuple [] -> ()
+                 | _ ->
+                   bad "[@repr null] requires a nullary constructor")
+            scstrs;
+        (* [@repr value] reuses the [@@or_null] payload machinery wholesale. *)
+        let treat_as_or_null = or_null || uses_repr_value in
         let or_null_payload_arg =
-          if or_null then begin
+          if treat_as_or_null then begin
             let payload_arg = get_or_null_payload_arg cstrs in
             let payload_ty = payload_arg.Types.ca_type in
             let payload_loc = payload_arg.Types.ca_loc in
@@ -1131,8 +1221,30 @@ let transl_declaration env sdecl (id, uid) =
           end else
             None
         in
+        (* We mark all arg sorts "void" here.  They are updated later, after
+           the circular type checks make it safe to check sorts.  Likewise,
+           [Constructor_uniform_value] is potentially wrong and will be updated
+           later. *)
+        let dummy_boxed_layouts () =
+          Array.map
+            (fun cstr ->
+               let sorts =
+                 match Types.(cstr.cd_args) with
+                 | Cstr_tuple args ->
+                   Array.make (List.length args) Jkind.Sort.Const.void
+                 | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
+               in
+               Cstr_layout_known
+                 { shape = Constructor_uniform_value; sorts })
+            (Array.of_list cstrs)
+        in
         let rep, jkind =
           match or_null_payload_arg with
+          | _ when uses_repr_null_boxed ->
+            (* The type includes the null pointer, so its (placeholder) jkind
+               is nullable; [update_decl_jkind] refines it later. *)
+            Variant_with_null_boxed (dummy_boxed_layouts ()),
+            Jkind.Builtin.value_or_null ~why:V1_safety_check
           | Some payload_arg ->
             let payload_ty = payload_arg.Types.ca_type in
             let modality = payload_arg.Types.ca_modalities in
@@ -1143,25 +1255,8 @@ let transl_declaration env sdecl (id, uid) =
               Variant_unboxed,
               Jkind.Builtin.any ~why:Old_style_unboxed_type
             else
-              (* We mark all arg sorts "void" here.  They are updated later,
-                 after the circular type checks make it safe to check sorts.
-                 Likewise, [Constructor_uniform_value] is potentially wrong
-                 and will be updated later.
-              *)
-              Variant_boxed (
-                Array.map
-                  (fun cstr ->
-                     let sorts =
-                       match Types.(cstr.cd_args) with
-                        | Cstr_tuple args ->
-                          Array.make (List.length args) Jkind.Sort.Const.void
-                        | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
-                      in
-                      Cstr_layout_known
-                        { shape = Constructor_uniform_value; sorts })
-                   (Array.of_list cstrs)
-               ),
-               Jkind.for_non_float ~why:Boxed_variant
+              Variant_boxed (dummy_boxed_layouts ()),
+              Jkind.for_non_float ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->
@@ -2405,7 +2500,7 @@ let update_record_inlined_kind env loc lbls jkinds tag vrep : _ Result.t =
     (* The shape of an unboxed constructor is always
        [Constructor_uniform_value], as at declaration time. *)
     Ok (Record_inlined (tag, Constructor_uniform_value, Variant_unboxed))
-  | Variant_boxed _ as vrep ->
+  | (Variant_boxed _ | Variant_with_null_boxed _) as vrep ->
     let lbl_decls =
       List.map (fun (ld, ty) -> { ld with Types.ld_type = ty }) lbls
     in
@@ -2529,6 +2624,59 @@ let rec update_decl_jkind env dpath decl =
   let update_variant_kind loc cstrs rep =
     (* CR layouts: factor out duplication *)
     match cstrs, rep with
+    | cstrs, Variant_with_null_boxed cstr_layouts ->
+      (* [@repr null] coexistence: the ordinary constructors are represented
+         exactly like [Variant_boxed] (constants as immediates, non-constants
+         as boxed blocks), so reuse that machinery to fill the layout array and
+         compute the jkind, then mark it nullable because the type includes the
+         null pointer. *)
+      let cstrs =
+        List.mapi (fun idx cstr ->
+          let cd_args, ~constant, cstr_repr, arg_sorts =
+            update_constructor_representation_and_arg_sorts env
+              cstr.Types.cd_loc cstr.Types.cd_args
+              ~is_extension_constructor:false
+          in
+          let is_nonempty_all_void =
+            constant
+            && (match cd_args with
+                | Cstr_tuple (_ :: _) -> true
+                | Cstr_tuple [] | Cstr_record _ -> false)
+          in
+          if is_nonempty_all_void
+          && not (Builtin_attributes.has_immediate_all_void_constructor
+                    cstr.Types.cd_attributes)
+          then
+            raise
+              (Error (cstr.Types.cd_loc,
+                      Missing_immediate_all_void_constructor_attribute
+                        (Ident.name cstr.Types.cd_id)));
+          let () =
+            match cstr_repr, arg_sorts with
+            | Ok shape, Some sorts ->
+                cstr_layouts.(idx) <- Cstr_layout_known { shape; sorts }
+            | Ok _, None ->
+                Misc.fatal_error "Representation but no arg sorts?"
+            | _, _ ->
+                assert_any_args_support loc;
+                cstr_layouts.(idx) <- Cstr_layout_variable
+          in
+          { cstr with Types.cd_args }) cstrs
+      in
+      let jkind =
+        Jkind.for_boxed_variant
+          ~loc
+          ~decl_params:decl.type_params
+          ~type_apply:(Ctype.apply env)
+          ~get_free_vars:(Ctype.free_variable_set_of_list env)
+          (List.rev cstrs)
+      in
+      let jkind =
+        match Jkind.apply_or_null_l env jkind with
+        | Ok jkind -> jkind
+        | Error () -> jkind
+      in
+      cstrs, Variant_with_null_boxed cstr_layouts, jkind
     | _, Variant_with_null ->
       begin match Datarepr.find_variant_with_null_payload cstrs with
       | Some
@@ -5896,6 +6044,16 @@ let report_error ~loc = function
         Style.inline_code "[@layout_poly]"
   | Bad_or_null_attribute msg ->
       Location.errorf ~loc "Invalid [@@or_null] declaration:@ %s." msg
+  | Unsupported_repr_attribute repr ->
+      Location.errorf ~loc
+        "%a is not yet supported;@ only %a, %a and %a are currently \
+         implemented."
+        Style.inline_code (Printf.sprintf "[@repr %s]" repr)
+        Style.inline_code "[@repr null]"
+        Style.inline_code "[@repr value]"
+        Style.inline_code "[@repr unboxed]"
+  | Bad_repr_attribute msg ->
+      Location.errorf ~loc "Invalid [@repr] declaration:@ %s." msg
   | Zero_alloc_attr_unsupported ca ->
       let variety = match ca with
         | Default_zero_alloc  | Check _ -> assert false

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -237,6 +237,8 @@ type error =
   | Unexpected_layout_any_in_primitive of string
   | Useless_layout_poly
   | Bad_or_null_attribute of string
+  | Unsupported_repr_attribute of string
+  | Bad_repr_attribute of string
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -915,16 +915,33 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       | _ -> assert false
     end
-  | Variant_boxed cstr_layouts | Variant_with_null_boxed cstr_layouts ->
+  | Variant_boxed _ | Variant_with_null_boxed _ ->
     (* [@repr null] coexistence ([Variant_with_null_boxed]) reuses the boxed
        analysis for accurate block shapes, then marks the result nullable
-       because the type includes the null pointer. *)
-    let result_nullable : Lambda.nullable =
+       because the type includes the null pointer.  [@repr immediate]/[@repr
+       pointer] constructors are payload-unboxed and their runtime values are
+       not the blocks the boxed analysis would describe, so if any is present
+       we fall back to the generic [Pgenval] value kind (conservative: it makes
+       no block-shape or immediacy claims). *)
+    let cstr_layouts, result_nullable, erased_unboxed_payload =
       match rep with
-      | Variant_with_null_boxed _ -> Nullable
-      | Variant_unboxed | Variant_boxed _ | Variant_extensible
-      | Variant_with_null -> Non_nullable
+      | Variant_boxed x -> x, (Non_nullable : Lambda.nullable), false
+      | Variant_with_null_boxed erased ->
+        let has_unboxed_payload =
+          Array.exists
+            (fun (e : Types.cstr_erased) ->
+               match e.erased with
+               | Erased_immediate | Erased_pointer -> true
+               | Erased_boxed | Erased_null -> false)
+            erased
+        in
+        Array.map (fun (e : Types.cstr_erased) -> e.layout) erased,
+        Nullable, has_unboxed_payload
+      | Variant_unboxed | Variant_extensible | Variant_with_null -> assert false
     in
+    if erased_unboxed_payload
+    then num_nodes_visited, { raw_kind = Pgenval; nullable = result_nullable }
+    else
     let depth = depth + 1 in
     let substitute_cd_args (cd_args : Types.constructor_arguments) =
       let substitute ty = Ctype.apply env params ty args in

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -915,7 +915,16 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       | _ -> assert false
     end
-  | Variant_boxed cstr_layouts ->
+  | Variant_boxed cstr_layouts | Variant_with_null_boxed cstr_layouts ->
+    (* [@repr null] coexistence ([Variant_with_null_boxed]) reuses the boxed
+       analysis for accurate block shapes, then marks the result nullable
+       because the type includes the null pointer. *)
+    let result_nullable : Lambda.nullable =
+      match rep with
+      | Variant_with_null_boxed _ -> Nullable
+      | Variant_unboxed | Variant_boxed _ | Variant_extensible
+      | Variant_with_null -> Non_nullable
+    in
     let depth = depth + 1 in
     let substitute_cd_args (cd_args : Types.constructor_arguments) =
       let substitute ty = Ctype.apply env params ty args in
@@ -1084,7 +1093,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
           (num_nodes_visited, Pvariant { consts; non_consts })
       end
     in
-    num_nodes_visited, non_nullable raw_kind
+    num_nodes_visited, { raw_kind; nullable = result_nullable }
 
 and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
       (labels : Types.label_declaration list) rep =
@@ -1105,7 +1114,8 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
     Misc.fatal_error
       "Typeopt.value_kind_record: unexpected variable representation"
   | Record_inlined (_, _, Variant_with_null) -> assert false
-  | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
+  | Record_inlined (_, _, (Variant_boxed _ | Variant_with_null_boxed _
+                          | Variant_extensible))
   | Record_boxed | Record_float | Record_ufloat | Record_mixed _ -> begin
       let is_mutable =
         List.exists (fun label -> Types.is_mutable label.Types.ld_mutable)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -537,10 +537,35 @@ and variant_representation =
   (* [@repr null] prototype: a single nullary constructor represented as the
      null pointer, coexisting with ordinary constructors that are represented
      exactly like [Variant_boxed] (constants as immediates, non-constants as
-     boxed blocks -- never payload-unboxed).  The layout array covers every
+     boxed blocks -- never payload-unboxed).  The array covers every
      constructor in source order; the null constructor occupies a (dead)
-     nullary slot. *)
-  | Variant_with_null_boxed of cstr_layout array
+     nullary slot.
+
+     Generalized in tranche 2: each element also records an [erased_kind]
+     saying how that constructor is represented at run time.  [@repr null]
+     alone yields [Erased_null] for the null constructor and [Erased_boxed]
+     for the rest; [@repr immediate]/[@repr pointer] constructors carry
+     [Erased_immediate]/[Erased_pointer] and are payload-unboxed (the value is
+     the payload itself, distinguished at run time by isnull/isint). *)
+  | Variant_with_null_boxed of cstr_erased array
+
+and cstr_erased =
+  { layout : cstr_layout;
+    erased : erased_kind;
+  }
+
+and erased_kind =
+  | Erased_boxed
+  (* Ordinary constructor: constant -> immediate, non-constant -> boxed block,
+     exactly like [Variant_boxed]. *)
+  | Erased_null
+  (* The null pointer ([Const_null]). *)
+  | Erased_immediate
+  (* [@repr immediate]: the payload is passed through unchanged and is an
+     immediate (distinguished at run time by isint). *)
+  | Erased_pointer
+  (* [@repr pointer]: the payload is passed through unchanged and is a non-null
+     pointer (distinguished at run time by not-isint). *)
 
 and cstr_layout =
   | Cstr_layout_known of
@@ -947,6 +972,15 @@ let equal_constructor_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
   | (Constructor_mixed _ | Constructor_uniform_value | Constructor_variable), _
     -> false
 
+let equal_erased_kind (k1 : erased_kind) (k2 : erased_kind) =
+  match k1, k2 with
+  | Erased_boxed, Erased_boxed
+  | Erased_null, Erased_null
+  | Erased_immediate, Erased_immediate
+  | Erased_pointer, Erased_pointer -> true
+  | (Erased_boxed | Erased_null | Erased_immediate | Erased_pointer), _ ->
+    false
+
 let equal_variant_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
   match r1, r2 with
   | Variant_unboxed, Variant_unboxed ->
@@ -965,17 +999,19 @@ let equal_variant_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
   | Variant_extensible, Variant_extensible ->
       true
   | Variant_with_null, Variant_with_null -> true
-  | Variant_with_null_boxed layouts1, Variant_with_null_boxed layouts2 ->
+  | Variant_with_null_boxed erased1, Variant_with_null_boxed erased2 ->
       Misc.Stdlib.Array.equal
-        (fun l1 l2 -> match l1, l2 with
+        (fun e1 e2 ->
+           equal_erased_kind e1.erased e2.erased
+           && match e1.layout, e2.layout with
            | Cstr_layout_variable, Cstr_layout_variable -> true
            | Cstr_layout_known { shape = s1; sorts = ss1 },
              Cstr_layout_known { shape = s2; sorts = ss2 } ->
              equal_constructor_representation_up_to_scannable_axes s1 s2
              && Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal ss1 ss2
            | (Cstr_layout_known _ | Cstr_layout_variable), _ -> false)
-        layouts1
-        layouts2
+        erased1
+        erased2
   | (Variant_unboxed | Variant_boxed _ | Variant_extensible | Variant_with_null
     | Variant_with_null_boxed _), _ ->
       false

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -534,6 +534,13 @@ and variant_representation =
   | Variant_boxed of cstr_layout array
   | Variant_extensible
   | Variant_with_null
+  (* [@repr null] prototype: a single nullary constructor represented as the
+     null pointer, coexisting with ordinary constructors that are represented
+     exactly like [Variant_boxed] (constants as immediates, non-constants as
+     boxed blocks -- never payload-unboxed).  The layout array covers every
+     constructor in source order; the null constructor occupies a (dead)
+     nullary slot. *)
+  | Variant_with_null_boxed of cstr_layout array
 
 and cstr_layout =
   | Cstr_layout_known of
@@ -958,7 +965,19 @@ let equal_variant_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
   | Variant_extensible, Variant_extensible ->
       true
   | Variant_with_null, Variant_with_null -> true
-  | (Variant_unboxed | Variant_boxed _ | Variant_extensible | Variant_with_null), _ ->
+  | Variant_with_null_boxed layouts1, Variant_with_null_boxed layouts2 ->
+      Misc.Stdlib.Array.equal
+        (fun l1 l2 -> match l1, l2 with
+           | Cstr_layout_variable, Cstr_layout_variable -> true
+           | Cstr_layout_known { shape = s1; sorts = ss1 },
+             Cstr_layout_known { shape = s2; sorts = ss2 } ->
+             equal_constructor_representation_up_to_scannable_axes s1 s2
+             && Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal ss1 ss2
+           | (Cstr_layout_known _ | Cstr_layout_variable), _ -> false)
+        layouts1
+        layouts2
+  | (Variant_unboxed | Variant_boxed _ | Variant_extensible | Variant_with_null
+    | Variant_with_null_boxed _), _ ->
       false
 
 let equal_record_representation_up_to_scannable_axes r1 r2 = match r1, r2 with
@@ -1038,7 +1057,8 @@ let find_unboxed_type decl =
   | Type_record_unboxed_product
       (_, (Record_unboxed_product | Record_unboxed_product_variable), _)
   | Type_variant (_, ( Variant_boxed _ | Variant_unboxed
-                     | Variant_extensible | Variant_with_null), _)
+                     | Variant_extensible | Variant_with_null
+                     | Variant_with_null_boxed _), _)
   | Type_abstract _ | Type_open ->
     None
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -978,6 +978,11 @@ and variant_representation =
   *)
   | Variant_extensible
   | Variant_with_null
+  (* [@repr null] prototype: a single nullary constructor represented as the
+     null pointer, coexisting with ordinary constructors represented exactly
+     like [Variant_boxed].  The array has an element for each constructor (the
+     null constructor occupies a dead nullary slot). *)
+  | Variant_with_null_boxed of cstr_layout array
 
 and cstr_layout =
   | Cstr_layout_known of

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -981,8 +981,32 @@ and variant_representation =
   (* [@repr null] prototype: a single nullary constructor represented as the
      null pointer, coexisting with ordinary constructors represented exactly
      like [Variant_boxed].  The array has an element for each constructor (the
-     null constructor occupies a dead nullary slot). *)
-  | Variant_with_null_boxed of cstr_layout array
+     null constructor occupies a dead nullary slot).
+
+     Generalized in tranche 2: each element also records an [erased_kind]
+     saying how that constructor is represented at run time.  [@repr null]
+     alone yields [Erased_null] for the null constructor and [Erased_boxed]
+     for the rest; [@repr immediate]/[@repr pointer] constructors carry
+     [Erased_immediate]/[Erased_pointer] and are payload-unboxed. *)
+  | Variant_with_null_boxed of cstr_erased array
+
+and cstr_erased =
+  { layout : cstr_layout;
+    erased : erased_kind;
+  }
+
+and erased_kind =
+  | Erased_boxed
+  (* Ordinary constructor: constant -> immediate, non-constant -> boxed block,
+     exactly like [Variant_boxed]. *)
+  | Erased_null
+  (* The null pointer ([Const_null]). *)
+  | Erased_immediate
+  (* [@repr immediate]: the payload is passed through unchanged and is an
+     immediate (distinguished at run time by isint). *)
+  | Erased_pointer
+  (* [@repr pointer]: the payload is passed through unchanged and is a non-null
+     pointer (distinguished at run time by not-isint). *)
 
 and cstr_layout =
   | Cstr_layout_known of
@@ -1312,6 +1336,8 @@ val equal_record_unboxed_product_representation_up_to_scannable_axes :
 
 val equal_variant_representation_up_to_scannable_axes :
   variant_representation -> variant_representation -> bool
+
+val equal_erased_kind : erased_kind -> erased_kind -> bool
 
 val mixed_block_element_of_const_sort :
   Jkind_types.Sort.Const.t -> mixed_block_element

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -789,7 +789,7 @@ let rec expression : Typedtree.expression -> term_judg =
       let arg_mode i = match desc.cstr_repr with
         | Variant_unboxed | Variant_with_null ->
           Return
-        | Variant_boxed _ | Variant_extensible ->
+        | Variant_boxed _ | Variant_with_null_boxed _ | Variant_extensible ->
            (match shape with
             | Constructor_uniform_value -> Guard
             | Constructor_mixed mixed_shape ->

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -293,7 +293,8 @@ and value_kind_variant env subst ~visited ~depth
     (cstrs : Types.constructor_declaration list) rep =
   match rep with
   | Variant_extensible -> raise (Vicuna_unsupported Extensible_variants)
-  | Variant_with_null -> raise (Vicuna_unsupported With_null_variants)
+  | Variant_with_null | Variant_with_null_boxed _ ->
+    raise (Vicuna_unsupported With_null_variants)
   | Variant_unboxed -> (
     match cstrs with
     | [{ cd_args = Cstr_tuple [{ ca_type = ty; _ }]; _ }]


### PR DESCRIPTION
**This is an experimental draft PR for myself to test if I can speed up key data structures in the compiler with this mechanism.**

This PR adds constructor-level `[@repr ...]` annotations for variants,
which let users describe allocation-free variant encodings directly on constructors:

- `[@repr null]` -> represent a payloadless constructor as `null`
- `[@repr immediate]` -> unbox a constructor carrying an `immediate`
- `[@repr pointer]`-> unbox a constructor carrying a known `pointer`
- `[@repr value]` -> unbox a constructor carrying a `value`
- `[@repr unboxed]` -> unbox a single constructor carrying anything

## Motivating examples

Small ints in bignums can stay unboxed:

```ocaml
type bignum =
  | Small of int [@repr immediate]
  | Big of big_int
```

And tree nodes can use a compact mixed representation:

```ocaml
type tree =
  | Empty [@repr null]
  | Leaf of int [@repr immediate]
  | Branch2 of tree * tree
  | Branch3 of tree * tree * tree
```

Both `Empty` and `Leaf` stay unboxed.

And a type for a number or error:

```ocaml
type int_or_err =
  | Int of int [@repr immediate]
  | Error of string [@repr pointer]
```

## Key rules

- `[@repr value]` may only coexist with `[@repr null]`
- `[@repr immediate]` may not coexist with ordinary constant constructors
- `[@repr pointer]` may not coexist with ordinary boxed constructors
- erased constructors are restricted to unary payload constructors

## What this PR does

1. generalizes the old null-like internal representation
2. adds constructor-level `[@repr unboxed]`
3. adds the `pointer` scannable axis
4. adds mixed `[@repr null]` / `[@repr immediate]` / `[@repr pointer]`
5. adds `[@repr value]`
6. add pattern matching and codegen support
7. test coverage