### PR TITLE
5.4 merge - towards support for upstream's Stdlib iarray

### DIFF
--- a/otherlibs/stdlib_stable/iarray.ml
+++ b/otherlibs/stdlib_stable/iarray.ml
@@ -67,33 +67,19 @@ external get :
   ('a : any mod separable). ('a iarray[@local_opt]) -> int -> ('a[@local_opt])
   @@ portable = "%array_safe_get"
 [@@layout_poly]
-external ( .:() ) :
-  ('a : any mod separable). ('a iarray[@local_opt]) -> int -> ('a[@local_opt])
-  @@ portable = "%array_safe_get"
-[@@layout_poly]
 external unsafe_get :
   ('a : any mod separable). ('a iarray[@local_opt]) -> int -> ('a[@local_opt])
   @@ portable = "%array_unsafe_get"
 [@@layout_poly]
 external concat : ('a : any mod separable). 'a iarray list -> 'a iarray
   @@ portable = "caml_array_concat"
-external concat_local :
-  ('a : any mod separable). local_ 'a iarray list -> local_ 'a iarray
-  @@ portable = "caml_array_concat_local"
 
 external append_prim :
   ('a : any mod separable). 'a iarray -> 'a iarray -> 'a iarray @@ portable
   = "caml_array_append"
-external append_prim_local :
-  ('a : any mod separable).
-  local_ 'a iarray -> local_ 'a iarray -> local_ 'a iarray @@ portable
-  = "caml_array_append_local"
 external unsafe_sub :
   ('a : any mod separable). 'a iarray -> int -> int -> 'a iarray @@ portable
   = "caml_array_sub"
-external unsafe_sub_local :
-  ('a : any mod separable). local_ 'a iarray -> int -> int -> local_ 'a iarray
-  @@ portable = "caml_array_sub_local"
 external unsafe_of_array : ('a : any mod separable). 'a array -> 'a iarray
   @@ portable = "%array_to_iarray"
 external unsafe_to_array : ('a : any mod separable). 'a iarray -> 'a array
@@ -105,56 +91,9 @@ external unsafe_set_mutable :
   = "%array_unsafe_set"
 [@@layout_poly]
 
-(* VERY UNSAFE: Any of these functions can be used to violate the "no forward
-   pointers" restriction for the local stack if not used carefully.  Each of
-   these can either make a local mutable array or mutate its contents, and if
-   not careful, this can lead to an array's contents pointing forwards.  The
-   latter two functions could be overloaded via [[@local_opt]], but we don't do
-   that in order to isolate the unsafety. *)
-external make_mutable_local :
-  ('a : value_or_null mod separable). int -> local_ 'a -> local_ 'a array
-  @@ portable = "caml_array_make_local"
-external unsafe_of_local_array :
-  ('a : any mod separable). local_ 'a array -> local_ 'a iarray @@ portable
-  = "%array_to_iarray"
-external unsafe_set_local :
-  ('a : any mod separable). local_ 'a array -> int -> local_ 'a -> unit
-  @@ portable = "%array_unsafe_set"
-[@@layout_poly]
-
 (* We can't use immutable array literals in this file, since we don't want to
    require the stdlib to be compiled with extensions, so instead of [[::]] we
    use [unsafe_of_(local_)array [||]] below. *)
-
-(* Really trusting the inliner here; to get maximum performance, it has to
-   inline both [unsafe_init_local] *and* [f]. *)
-(** Precondition: [l >= 0]. *)
-let[@inline always] unsafe_init_local l (local_ f : int -> local_ 'a) =
-  if l = 0 then
-    exclave_ unsafe_of_local_array [||]
-  else
-    (* The design of this function is exceedingly delicate, and is the only way
-       we can correctly allocate a local array on the stack via mutation.  We
-       are subject to the "no forward pointers" constraint on the local stack;
-       we're not allowed to make pointers to later-allocated objects even within
-       the same stack frame.  Thus, in order to get this right, we consume O(n)
-       call-stack space: we allocate the values to put in the array, and only
-       *then* recurse, creating the array as the very last thing of all and
-       *returning* it.  This is why the [f i] call is the first thing in the
-       function, and why it's not tail-recursive; if it were tail-recursive,
-       then we wouldn't have anywhere to put the array elements during the whole
-       process. *)
-    let rec go ~l ~f i = exclave_ begin
-      let x = f i in
-      if i = l - 1 then
-        make_mutable_local l x
-      else begin
-        let res = go ~l ~f (i+1) in
-        unsafe_set_local res i x;
-        res
-      end
-    end in
-    exclave_ unsafe_of_local_array (go ~l ~f 0)
 
 (* The implementation is copied from [Array] so that [f] can be [local_] *)
 let init l (local_ f) =
@@ -169,59 +108,22 @@ let init l (local_ f) =
    done;
    unsafe_of_array res
 
-let init_local l f = exclave_
-  if l < 0 then invalid_arg "Iarray.init_local"
-  (* See #6575. We could also check for maximum array size, but this depends
-     on whether we create a float array or a regular one... *)
-  else unsafe_init_local l f
-
 let append a1 a2 =
   if length a1 = 0 then a2 (* Safe because they're immutable *)
   else if length a2 = 0 then a1
   else append_prim a1 a2
 
-let append_local a1 a2 = exclave_
-  if length a1 = 0 then a2 (* Safe because they're immutable *)
-  else if length a2 = 0 then a1
-  else append_prim_local a1 a2
-
-let sub a ofs len =
-  if ofs < 0 || len < 0 || ofs > length a - len
+let sub a ~pos ~len =
+  if pos < 0 || len < 0 || pos > length a - len
   then invalid_arg "Iarray.sub"
-  else unsafe_sub a ofs len
-
-let sub_local a ofs len = exclave_
-  if ofs < 0 || len < 0 || ofs > length a - len
-  then invalid_arg "Iarray.sub"
-  else unsafe_sub_local a ofs len
+  else unsafe_sub a pos len
 
 let iter f a =
-  for i = 0 to length a - 1 do f(unsafe_get a i) done
-
-let iter_local f a =
   for i = 0 to length a - 1 do f(unsafe_get a i) done
 
 let iter2 f a b =
   if length a <> length b then
     invalid_arg "Iarray.iter2: arrays must have the same length"
-  else
-    for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done
-
-let iter2_local f a b =
-  if length a <> length b then
-    invalid_arg "Iarray.iter2_local: arrays must have the same length"
-  else
-    for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done
-
-let iter2_local_first f a b =
-  if length a <> length b then
-    invalid_arg "Iarray.iter2_local_first: arrays must have the same length"
-  else
-    for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done
-
-let iter2_local_second f a b =
-  if length a <> length b then
-    invalid_arg "Iarray.iter2_local_second: arrays must have the same length"
   else
     for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done
 
@@ -234,22 +136,6 @@ let map f a =
     done;
     unsafe_of_array r
   end
-
-let map_local f a = exclave_
-  unsafe_init_local (length a) (fun i -> exclave_ f (unsafe_get a i))
-
-let map_local_input f a =
-  let l = length a in
-  if l = 0 then unsafe_of_array [||] else begin
-    let r = Array.make l (f(unsafe_get a 0)) in
-    for i = 1 to l - 1 do
-      Array.unsafe_set r i (f(unsafe_get a i))
-    done;
-    unsafe_of_array r
-  end
-
-let map_local_output f a = exclave_
-  unsafe_init_local (length a) (fun i -> exclave_ f (unsafe_get a i))
 
 let map2 f a b =
   let la = length a in
@@ -266,87 +152,7 @@ let map2 f a b =
     end
   end
 
-let map2_local f a b = exclave_
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2_local: arrays must have the same length"
-  else
-    unsafe_init_local la (fun i -> exclave_ f (unsafe_get a i) (unsafe_get b i))
-
-let map2_local_inputs f a b =
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2: arrays must have the same length"
-  else begin
-    if la = 0 then unsafe_of_array [||] else begin
-      let r = Array.make la (f (unsafe_get a 0) (unsafe_get b 0)) in
-      for i = 1 to la - 1 do
-        Array.unsafe_set r i (f (unsafe_get a i) (unsafe_get b i))
-      done;
-      unsafe_of_array r
-    end
-  end
-
-let map2_local_output f a b = exclave_
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2_local: arrays must have the same length"
-  else
-    unsafe_init_local la (fun i -> exclave_ f (unsafe_get a i) (unsafe_get b i))
-
-let map2_local_first_input f a b =
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2: arrays must have the same length"
-  else begin
-    if la = 0 then unsafe_of_array [||] else begin
-      let r = Array.make la (f (unsafe_get a 0) (unsafe_get b 0)) in
-      for i = 1 to la - 1 do
-        Array.unsafe_set r i (f (unsafe_get a i) (unsafe_get b i))
-      done;
-      unsafe_of_array r
-    end
-  end
-
-let map2_local_second_input f a b =
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2: arrays must have the same length"
-  else begin
-    if la = 0 then unsafe_of_array [||] else begin
-      let r = Array.make la (f (unsafe_get a 0) (unsafe_get b 0)) in
-      for i = 1 to la - 1 do
-        Array.unsafe_set r i (f (unsafe_get a i) (unsafe_get b i))
-      done;
-      unsafe_of_array r
-    end
-  end
-
-let map2_local_first_input_and_output f a b = exclave_
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2_local: arrays must have the same length"
-  else
-    unsafe_init_local la (fun i -> exclave_ f (unsafe_get a i) (unsafe_get b i))
-
-let map2_local_second_input_and_output f a b = exclave_
-  let la = length a in
-  let lb = length b in
-  if la <> lb then
-    invalid_arg "Iarray.map2_local: arrays must have the same length"
-  else
-    unsafe_init_local la (fun i -> exclave_ f (unsafe_get a i) (unsafe_get b i))
-
 let iteri f a =
-  for i = 0 to length a - 1 do f i (unsafe_get a i) done
-
-let iteri_local f a =
   for i = 0 to length a - 1 do f i (unsafe_get a i) done
 
 let mapi f a =
@@ -359,50 +165,15 @@ let mapi f a =
     unsafe_of_array r
   end
 
-let mapi_local f a = exclave_
-  unsafe_init_local (length a) (fun i -> exclave_ f i (unsafe_get a i))
-
-let mapi_local_input f a =
-  let l = length a in
-  if l = 0 then unsafe_of_array [||] else begin
-    let r = Array.make l (f 0 (unsafe_get a 0)) in
-    for i = 1 to l - 1 do
-      Array.unsafe_set r i (f i (unsafe_get a i))
-    done;
-    unsafe_of_array r
-  end
-
-let mapi_local_output f a = exclave_
-  unsafe_init_local (length a) (fun i -> exclave_ f i (unsafe_get a i))
-
 let to_list a =
   let rec tolist i res =
     if i < 0 then res else tolist (i - 1) (unsafe_get a i :: res) in
   tolist (length a - 1) []
 
-let to_list_local a = exclave_
-  let rec tolist i res = exclave_
-    if i < 0 then res else tolist (i - 1) (unsafe_get a i :: res) in
-  tolist (length a - 1) []
-
 let of_list l = unsafe_of_array (Array.of_list l)
-
-(* Cannot use List.length here because the List module depends on Array. *)
-let rec list_length accu = function
-  | [] -> accu
-  | _::t -> list_length (succ accu) t
 
 (* This shouldn't violate the forward-pointers restriction because the list
    elements already exist *)
-let of_list_local = function
-  | [] -> exclave_ unsafe_of_array [||]
-  | hd::tl as l -> exclave_
-      let a = make_mutable_local (list_length 0 l) hd in
-      let rec fill i = function
-        | [] -> exclave_ a
-        | hd::tl -> exclave_ unsafe_set_local a i hd; fill (i+1) tl in
-      unsafe_of_local_array (fill 1 tl)
-
 let to_array ia = Array.copy (unsafe_to_array ia)
 
 let of_array ma = unsafe_of_array (Array.copy ma)
@@ -413,31 +184,6 @@ let fold_left f x a =
     r := f !r (unsafe_get a i)
   done;
   !r
-
-let fold_left_local f x a = exclave_
-  let len = length a in
-  let rec go r i = exclave_
-    if i = len
-    then r
-    else go (f r (unsafe_get a i)) (i+1)
-  in
-  go x 0
-
-let fold_left_local_input f x a =
-  let r = ref x in
-  for i = 0 to length a - 1 do
-    r := f !r (unsafe_get a i)
-  done;
-  !r
-
-let fold_left_local_output f x a = exclave_
-  let len = length a in
-  let rec go r i = exclave_
-    if i = len
-    then r
-    else go (f r (unsafe_get a i)) (i+1)
-  in
-  go x 0
 
 let fold_left_map f acc input_array =
   let len = length input_array in
@@ -453,83 +199,12 @@ let fold_left_map f acc input_array =
     !acc, unsafe_of_array output_array
   end
 
-let fold_left_map_local f acc input_array = exclave_
-  let len = length input_array in
-  if len = 0 then (acc, unsafe_of_local_array [||]) else begin
-    let rec go acc i = exclave_
-      let acc, elt = f acc (unsafe_get input_array i) in
-      if i = len - 1 then
-        acc, make_mutable_local len elt
-      else begin
-        let (_, output_array) as res = go acc (i+1) in
-        unsafe_set_local output_array i elt;
-        res
-      end
-    in
-    let acc, output_array = go acc 0 in
-    acc, unsafe_of_local_array output_array
-  end
-
-let fold_left_map_local_input f acc input_array =
-  let len = length input_array in
-  if len = 0 then (acc, unsafe_of_array [||]) else begin
-    let acc, elt = f acc (unsafe_get input_array 0) in
-    let output_array = Array.make len elt in
-    let acc = ref acc in
-    for i = 1 to len - 1 do
-      let acc', elt = f !acc (unsafe_get input_array i) in
-      acc := acc';
-      Array.unsafe_set output_array i elt;
-    done;
-    !acc, unsafe_of_array output_array
-  end
-
-let fold_left_map_local_output f acc input_array = exclave_
-  let len = length input_array in
-  if len = 0 then (acc, unsafe_of_local_array [||]) else begin
-    let rec go acc i = exclave_
-      let acc, elt = f acc (unsafe_get input_array i) in
-      if i = len - 1 then
-        acc, make_mutable_local len elt
-      else begin
-        let (_, output_array) as res = go acc (i+1) in
-        unsafe_set_local output_array i elt;
-        res
-      end
-    in
-    let acc, output_array = go acc 0 in
-    acc, unsafe_of_local_array output_array
-  end
-
 let fold_right f a x =
   let r = ref x in
   for i = length a - 1 downto 0 do
     r := f (unsafe_get a i) !r
   done;
   !r
-
-let fold_right_local f a x = exclave_
-  let rec go r i = exclave_
-    if i = -1
-    then r
-    else go (f (unsafe_get a i) r) (i-1)
-  in
-  go x (length a - 1)
-
-let fold_right_local_input f a x =
-  let r = ref x in
-  for i = length a - 1 downto 0 do
-    r := f (unsafe_get a i) !r
-  done;
-  !r
-
-let fold_right_local_output f a x = exclave_
-  let rec go r i = exclave_
-    if i = -1
-    then r
-    else go (f (unsafe_get a i) r) (i-1)
-  in
-  go x (length a - 1)
 
 (* CR aspectorzabusky: Why do I need this?  Shouldn't mode-crossing handle doing
    this? *)
@@ -543,23 +218,7 @@ let exists p a =
     else loop (succ i) in
   globalize_bool (loop 0)
 
-let exists_local p a =
-  let n = length a in
-  let rec loop i = exclave_
-    if i = n then false
-    else if p (unsafe_get a i) then true
-    else loop (succ i) in
-  globalize_bool (loop 0)
-
 let for_all p a =
-  let n = length a in
-  let rec loop i = exclave_
-    if i = n then true
-    else if p (unsafe_get a i) then loop (succ i)
-    else false in
-  globalize_bool (loop 0)
-
-let for_all_local p a =
   let n = length a in
   let rec loop i = exclave_
     if i = n then true
@@ -577,70 +236,10 @@ let for_all2 p l1 l2 =
     else false in
   globalize_bool (loop 0)
 
-let for_all2_local p l1 l2 =
-  let n1 = length l1
-  and n2 = length l2 in
-  if n1 <> n2 then invalid_arg "Iarray.for_all2_local"
-  else let rec loop i = exclave_
-    if i = n1 then true
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then loop (succ i)
-    else false in
-  globalize_bool (loop 0)
-
-let for_all2_local_first p l1 l2 =
-  let n1 = length l1
-  and n2 = length l2 in
-  if n1 <> n2 then invalid_arg "Iarray.for_all2_local_first"
-  else let rec loop i = exclave_
-    if i = n1 then true
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then loop (succ i)
-    else false in
-  globalize_bool (loop 0)
-
-let for_all2_local_second p l1 l2 =
-  let n1 = length l1
-  and n2 = length l2 in
-  if n1 <> n2 then invalid_arg "Iarray.for_all2_local_second"
-  else let rec loop i = exclave_
-    if i = n1 then true
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then loop (succ i)
-    else false in
-  globalize_bool (loop 0)
-
 let exists2 p l1 l2 =
   let n1 = length l1
   and n2 = length l2 in
   if n1 <> n2 then invalid_arg "Iarray.exists2"
-  else let rec loop i = exclave_
-    if i = n1 then false
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
-    else loop (succ i) in
-  globalize_bool (loop 0)
-
-let exists2_local p l1 l2 =
-  let n1 = length l1
-  and n2 = length l2 in
-  if n1 <> n2 then invalid_arg "Iarray.exists2_local"
-  else let rec loop i = exclave_
-    if i = n1 then false
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
-    else loop (succ i) in
-  globalize_bool (loop 0)
-
-let exists2_local_first p l1 l2 =
-  let n1 = length l1
-  and n2 = length l2 in
-  if n1 <> n2 then invalid_arg "Iarray.exists2_local_first"
-  else let rec loop i = exclave_
-    if i = n1 then false
-    else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
-    else loop (succ i) in
-  globalize_bool (loop 0)
-
-let exists2_local_second p l1 l2 =
-  let n1 = length l1
-  and n2 = length l2 in
-  if n1 <> n2 then invalid_arg "Iarray.exists2_local_second"
   else let rec loop i = exclave_
     if i = n1 then false
     else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
@@ -674,17 +273,6 @@ let find_opt p a =
   in
   loop 0 [@nontail]
 
-let find_opt_local p a = exclave_
-  let n = length a in
-  let rec loop i = exclave_
-    if i = n then None
-    else
-      let x = unsafe_get a i in
-      if p x then Some x
-      else loop (succ i)
-  in
-  loop 0
-
 let find_map f a =
   let n = length a in
   let rec loop i =
@@ -695,39 +283,6 @@ let find_map f a =
       | Some _ as r -> r
   in
   loop 0 [@nontail]
-
-let find_map_local f a = exclave_
-  let n = length a in
-  let rec loop i = exclave_
-    if i = n then None
-    else
-      match f (unsafe_get a i) with
-      | None -> loop (succ i)
-      | Some _ as r -> r
-  in
-  loop 0
-
-let find_map_local_input f a =
-  let n = length a in
-  let rec loop i =
-    if i = n then None
-    else
-      match f (unsafe_get a i) with
-      | None -> loop (succ i)
-      | Some _ as r -> r
-  in
-  loop 0 [@nontail]
-
-let find_map_local_output f a = exclave_
-  let n = length a in
-  let rec loop i = exclave_
-    if i = n then None
-    else
-      match f (unsafe_get a i) with
-      | None -> loop (succ i)
-      | Some _ as r -> r
-  in
-  loop 0
 
 let split x =
   if x = unsafe_of_array [||]
@@ -745,25 +300,6 @@ let split x =
     unsafe_of_array a, unsafe_of_array b
   end
 
-(* This shouldn't violate the forward-pointers restriction because the array
-   elements already exist.  (This doesn't work for [combine], where we need to
-   create the tuples.) *)
-let split_local x = exclave_
-  if x = unsafe_of_array [||]
-  then unsafe_of_array [||], unsafe_of_array [||]
-  else begin
-    let a0, b0 = unsafe_get x 0 in
-    let n = length x in
-    let a = make_mutable_local n a0 in
-    let b = make_mutable_local n b0 in
-    for i = 1 to n - 1 do
-      let ai, bi = unsafe_get x i in
-      unsafe_set_local a i ai;
-      unsafe_set_local b i bi
-    done;
-    unsafe_of_local_array a, unsafe_of_local_array b
-  end
-
 let combine a b =
   let na = length a in
   let nb = length b in
@@ -777,12 +313,6 @@ let combine a b =
     x
   end in
   unsafe_of_array r
-
-let combine_local a b = exclave_
-  let na = length a in
-  let nb = length b in
-  if na <> nb then invalid_arg "Iarray.combine_local";
-  unsafe_init_local na (fun i -> exclave_ unsafe_get a i, unsafe_get b i)
 
 (* Must be fully applied due to the value restriction *)
 let lift_sort sorter cmp iarr =

--- a/otherlibs/stdlib_stable/iarray.mli
+++ b/otherlibs/stdlib_stable/iarray.mli
@@ -19,14 +19,6 @@
 
 open! Stdlib
 
-(* NOTE:
-   If this file is iarrayLabels.mli, run tools/sync_stdlib_docs after editing it
-   to generate iarray.mli.
-
-   If this file is iarray.mli, do not edit it directly -- edit
-   iarrayLabels.mli instead.
- *)
-
 (** Operations on immutable arrays.  This module mirrors the API of [Array], but
     omits functions that assume mutability; in addition to obviously mutating
     functions, it omits [copy] along with the functions [make], [create_float],
@@ -49,16 +41,9 @@ external get :
 (** [get a n] returns the element number [n] of immutable array [a].
    The first element has number 0.
    The last element has number [length a - 1].
-   You can also write [a.:(n)] instead of [get a n].
 
    @raise Invalid_argument
    if [n] is outside the range 0 to [(length a - 1)]. *)
-
-external ( .:() ) :
-  ('a : any mod separable). ('a iarray[@local_opt]) -> int -> ('a[@local_opt])
-  = "%array_safe_get"
-[@@layout_poly]
-(** A synonym for [get]. *)
 
 val init : int -> local_ (int -> 'a) -> 'a iarray
 (** [init n f] returns a fresh immutable array of length [n],
@@ -70,11 +55,6 @@ val init : int -> local_ (int -> 'a) -> 'a iarray
    If the return type of [f] is [float], then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
-val init_local
-  : ('a : value_or_null mod separable).
-  int -> local_ (int -> local_ 'a) -> local_ 'a iarray
-(** The locally-allocating version of [init]. *)
-
 val append
   : ('a : value_or_null mod separable).
   'a iarray -> 'a iarray -> 'a iarray
@@ -83,22 +63,12 @@ val append
    @raise Invalid_argument if
    [length v1 + length v2 > Sys.max_array_length]. *)
 
-val append_local
-  : ('a : value_or_null mod separable).
-  local_ 'a iarray -> local_ 'a iarray -> local_ 'a iarray
-(** The locally-allocating version of [append]. *)
-
 val concat : ('a : value_or_null mod separable). 'a iarray list -> 'a iarray
 (** Same as {!append}, but concatenates a list of immutable arrays. *)
 
-val concat_local
-  : ('a : value_or_null mod separable).
-  local_ 'a iarray list -> local_ 'a iarray
-(** The locally-allocating version of [concat]. *)
-
 val sub
   : ('a : value_or_null mod separable).
-  'a iarray -> int -> int -> 'a iarray
+  'a iarray -> pos:int -> len:int -> 'a iarray
 (** [sub a pos len] returns a fresh immutable array of length [len],
    containing the elements number [pos] to [pos + len - 1]
    of immutable array [a].  This creates a copy of the selected
@@ -108,18 +78,8 @@ val sub
    designate a valid subarray of [a]; that is, if
    [pos < 0], or [len < 0], or [pos + len > length a]. *)
 
-val sub_local
-  : ('a : value_or_null mod separable).
-  local_ 'a iarray -> int -> int -> local_ 'a iarray
-(** The locally-allocating version of [sub]. *)
-
 val to_list : ('a : value_or_null mod separable). 'a iarray -> 'a list
 (** [to_list a] returns the list of all the elements of [a]. *)
-
-val to_list_local
-  : ('a : value_or_null mod separable).
-  local_ 'a iarray -> local_ 'a list
-(** The locally-allocating version of []. *)
 
 val of_list : ('a : value_or_null mod separable). 'a list -> 'a iarray
 (** [of_list l] returns a fresh immutable array containing the elements
@@ -127,11 +87,6 @@ val of_list : ('a : value_or_null mod separable). 'a list -> 'a iarray
 
    @raise Invalid_argument if the length of [l] is greater than
    [Sys.max_array_length]. *)
-
-val of_list_local
-  : ('a : value_or_null mod separable).
-  local_ 'a list -> local_ 'a iarray
-(** The locally-allocating version of [of_list]. *)
 
 (** {1 Converting to and from mutable arrays} *)
 
@@ -150,12 +105,7 @@ val iter
   local_ ('a -> unit) -> 'a iarray -> unit
 (** [iter f a] applies function [f] in turn to all
    the elements of [a].  It is equivalent to
-   [f a.:(0); f a.:(1); ...; f a.:(length a - 1); ()]. *)
-
-val iter_local
-  : ('a : value_or_null mod separable).
-  local_ (local_ 'a -> unit) -> local_ 'a iarray -> unit
-(** The locally-scoped version of [iter]. *)
+   [f (get a 0); f (get a 1); ...; f (get a (length a - 1)); ()]. *)
 
 val iteri
   : ('a : value_or_null mod separable).
@@ -164,32 +114,12 @@ val iteri
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
-val iteri_local
-  : ('a : value_or_null mod separable).
-  local_ (int -> local_ 'a -> unit) -> local_ 'a iarray -> unit
-(** The locally-scoped version of [iteri]. *)
-
 val map
   : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
   local_ ('a -> 'b) -> 'a iarray -> 'b iarray
 (** [map f a] applies function [f] to all the elements of [a],
    and builds an immutable array with the results returned by [f]:
-   [[| f a.:(0); f a.:(1); ...; f a.:(length a - 1) |]]. *)
-
-val map_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b) -> local_ 'a iarray -> local_ 'b iarray
-(** The locally-scoped and locally-allocating version of [map]. *)
-
-val map_local_input
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> 'b) -> local_ 'a iarray -> 'b iarray
-(** The locally-constrained but globally-allocating version of [map]. *)
-
-val map_local_output
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ ('a -> local_ 'b) -> 'a iarray -> local_ 'b iarray
-(** The locally-allocating but global-input version of [map]. *)
+   [[| f (get a 0); f (get a 1); ...; f (get a (length a - 1)) |]]. *)
 
 val mapi
   : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
@@ -198,51 +128,12 @@ val mapi
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
-val mapi_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (int -> local_ 'a -> local_ 'b) -> local_ 'a iarray -> local_ 'b iarray
-(** The locally-scoped and locally-allocating version of [mapi]. *)
-
-val mapi_local_input
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (int -> local_ 'a -> 'b) -> local_ 'a iarray -> 'b iarray
-(** The locally-constrained but globally-allocating version of [mapi]. *)
-
-val mapi_local_output
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (int -> 'a -> local_ 'b) -> 'a iarray -> local_ 'b iarray
-(** The locally-allocating but global-input version of [mapi]. *)
-
 val fold_left
   : ('a : value_or_null) ('b : value_or_null mod separable).
   local_ ('a -> 'b -> 'a) -> 'a -> 'b iarray -> 'a
 (** [fold_left f init a] computes
-   [f (... (f (f init a.:(0)) a.:(1)) ...) a.:(n-1)],
+   [f (... (f (f init (get a 0)) (get a 1)) ...) (get a n-1)],
    where [n] is the length of the immutable array [a]. *)
-
-val fold_left_local
-  : ('a : value_or_null) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> local_ 'a)
-  -> local_ 'a
-  -> local_ 'b iarray
-  -> local_ 'a
-(** The locally-constrained and locally-allocating version of [fold_left].
-
-   WARNING: This function consumes O(n) extra stack space, as every intermediate
-   accumulator will be left on the local stack! *)
-
-val fold_left_local_input
-  : ('a : value_or_null) ('b : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> 'a) -> 'a -> local_ 'b iarray -> 'a
-(** The locally-constrained but globally-allocating version of [fold_left]. *)
-
-val fold_left_local_output
-  : ('a : value_or_null) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> local_ 'a) -> local_ 'a -> 'b iarray -> local_ 'a
-(** The locally-allocating but global-input version of [fold_left].
-
-   WARNING: This function consumes O(n) extra stack space, as every intermediate
-   accumulator will be left on the local stack! *)
 
 val fold_left_map
   : ('a : value_or_null) ('b : value_or_null mod separable)
@@ -251,69 +142,12 @@ val fold_left_map
 (** [fold_left_map] is a combination of {!fold_left} and {!map} that threads an
     accumulator through calls to [f]. *)
 
-val fold_left_map_local
-  : ('a : value_or_null) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> local_ 'a * 'c)
-  -> local_ 'a
-  -> local_ 'b iarray
-  -> local_ 'a * 'c iarray
-(** The locally-constrained and locally-allocating version of [fold_left].
-
-   WARNING: This function consumes O(n) extra stack space, as every intermediate
-   accumulator will be left on the local stack! *)
-
-val fold_left_map_local_input
-  : ('a : value_or_null) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> 'a * 'c)
-  -> 'a
-  -> local_ 'b iarray
-  -> 'a * 'c iarray
-(** The locally-constrained but globally-allocating version of [fold_left]. *)
-
-val fold_left_map_local_output
-  : ('a : value_or_null) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> local_ 'a * 'c)
-  -> local_ 'a
-  -> 'b iarray
-  -> local_ 'a * 'c iarray
-(** The locally-allocating but global-input version of [fold_left].
-
-   WARNING: This function consumes O(n) extra stack space, as every intermediate
-   accumulator will be left on the local stack! *)
-
 val fold_right
   : ('a : value_or_null) ('b : value_or_null mod separable).
   local_ ('b -> 'a -> 'a) -> 'b iarray -> 'a -> 'a
 (** [fold_right f a init] computes
    [f a.:(0) (f a.:(1) ( ... (f a.:(n-1) init) ...))],
    where [n] is the length of the immutable array [a]. *)
-
-val fold_right_local
-  : ('a : value_or_null) ('b : value_or_null mod separable).
-  local_ (local_ 'b -> local_ 'a -> local_ 'a)
-  -> local_ 'b iarray
-  -> local_ 'a
-  -> local_ 'a
-(** The locally-constrained and locally-allocating version of [fold_right].
-
-   WARNING: This function consumes O(n) extra stack space, as every intermediate
-   accumulator will be left on the local stack! *)
-
-val fold_right_local_input
-  : ('a : value_or_null) ('b : value_or_null mod separable).
-  local_ (local_ 'b -> 'a -> 'a) -> local_ 'b iarray -> 'a -> 'a
-(** The locally-constrained but globally-allocating version of [fold_right]. *)
-
-val fold_right_local_output
-  : ('a : value_or_null) ('b : value_or_null mod separable).
-  local_ ('b -> local_ 'a -> local_ 'a) -> 'b iarray -> local_ 'a -> local_ 'a
-(** The locally-allocating but global-input version of [fold_right].
-
-   WARNING: This function consumes O(n) extra stack space, as every intermediate
-   accumulator will be left on the local stack! *)
 
 
 (** {1 Iterators on two arrays} *)
@@ -327,90 +161,16 @@ val iter2
    @raise Invalid_argument if the immutable arrays are not the same size.
    *)
 
-val iter2_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> unit)
-  -> local_ 'a iarray
-  -> local_ 'b iarray
-  -> unit
-(** The locally-scoped version of [iter2]. *)
-
-val iter2_local_first
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> unit) -> local_ 'a iarray -> 'b iarray -> unit
-(** The first-biased partly-locally-scoped version of [iter2]. *)
-
-val iter2_local_second
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> unit) -> 'a iarray -> local_ 'b iarray -> unit
-(** The second-biased partly-locally-scoped version of [iter2]. *)
-
 val map2
   : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
     ('c : value_or_null mod separable).
   local_ ('a -> 'b -> 'c) -> 'a iarray -> 'b iarray -> 'c iarray
 (** [map2 f a b] applies function [f] to all the elements of [a]
    and [b], and builds an immutable array with the results returned by [f]:
-   [[| f a.:(0) b.:(0); ...; f a.:(length a - 1) b.:(length b - 1)|]].
+   [[| f (get a 0) (get b 0);
+       ...;
+       f (get a (length a - 1)) (get b (length b - 1))|]].
    @raise Invalid_argument if the immutable arrays are not the same size. *)
-
-val map2_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> local_ 'c)
-  -> local_ 'a iarray
-  -> local_ 'b iarray
-  -> local_ 'c iarray
-(** The locally-scoped and locally-allocating version of [map2]. *)
-
-val map2_local_inputs
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> 'c)
-  -> local_ 'a iarray
-  -> local_ 'b iarray
-  -> 'c iarray
-(** The locally-scoped but globally-allocating version of [map2]. *)
-
-val map2_local_output
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ ('a -> 'b -> local_ 'c) -> 'a iarray -> 'b iarray -> local_ 'c iarray
-(** The locally-allocating but global-inputs version of [map2]. *)
-
-val map2_local_first_input
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> 'c) -> local_ 'a iarray -> 'b iarray -> 'c iarray
-(** The first-biased partly-locally-scoped but globally-allocating version of
-    [map2]. *)
-
-val map2_local_second_input
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> 'c) -> 'a iarray -> local_ 'b iarray -> 'c iarray
-(** The second-biased partly-locally-scoped but globally-allocating version of
-    [map2]. *)
-
-val map2_local_first_input_and_output
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> local_ 'c)
-  -> local_ 'a iarray
-  -> 'b iarray
-  -> local_ 'c iarray
-(** The locally-allocating and first-biased partly-locally-scoped version of
-    [map2]. *)
-
-val map2_local_second_input_and_output
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable)
-    ('c : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> local_ 'c)
-  -> 'a iarray
-  -> local_ 'b iarray
-  -> local_ 'c iarray
-(** The locally-allocating and second-biased partly-locally-scoped version of
-    [map2]. *)
 
 
 (** {1 Array scanning} *)
@@ -422,22 +182,12 @@ val for_all
    of the immutable array satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)]. *)
 
-val for_all_local
-  : ('a : value_or_null mod separable).
-  local_ (local_ 'a -> bool) -> local_ 'a iarray -> bool
-(** The locally-scoped version of [for_all]. *)
-
 val exists
   : ('a : value_or_null mod separable).
   local_ ('a -> bool) -> 'a iarray -> bool
 (** [exists f [|a1; ...; an|]] checks if at least one element of
     the immutable array satisfies the predicate [f]. That is, it returns
     [(f a1) || (f a2) || ... || (f an)]. *)
-
-val exists_local
-  : ('a : value_or_null mod separable).
-  local_ (local_ 'a -> bool) -> local_ 'a iarray -> bool
-(** The locally-scoped version of [exists]. *)
 
 val for_all2
   : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
@@ -446,48 +196,12 @@ val for_all2
    @raise Invalid_argument if the two immutable arrays have different
    lengths. *)
 
-val for_all2_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> bool)
-  -> local_ 'a iarray
-  -> local_ 'b iarray
-  -> bool
-(** The locally-scoped version of [for_all2]. *)
-
-val for_all2_local_first
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> bool) -> local_ 'a iarray -> 'b iarray -> bool
-(** The first-biased partly-locally-scoped version of [for_all2]. *)
-
-val for_all2_local_second
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> bool) -> 'a iarray -> local_ 'b iarray -> bool
-(** The second-biased partly-locally-scoped version of [for_all2]. *)
-
 val exists2
   : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
   local_ ('a -> 'b -> bool) -> 'a iarray -> 'b iarray -> bool
 (** Same as {!exists}, but for a two-argument predicate.
    @raise Invalid_argument if the two immutable arrays have different
    lengths. *)
-
-val exists2_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> local_ 'b -> bool)
-  -> local_ 'a iarray
-  -> local_ 'b iarray
-  -> bool
-(** The locally-scoped version of [exists2]. *)
-
-val exists2_local_first
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ (local_ 'a -> 'b -> bool) -> local_ 'a iarray -> 'b iarray -> bool
-(** The first-biased partly-locally-scoped version of [exists2]. *)
-
-val exists2_local_second
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ ('a -> local_ 'b -> bool) -> 'a iarray -> local_ 'b iarray -> bool
-(** The second-biased partly-locally-scoped version of [exists2]. *)
 
 val mem
   : ('a : value_or_null mod separable).
@@ -509,31 +223,12 @@ val find_opt
     satisfies the predicate [f], or [None] if there is no value that satisfies
     [f] in the array [a]. *)
 
-val find_opt_local
-  : ('a : value_or_null mod separable).
-  local_ (local_ 'a -> bool) -> local_ 'a iarray -> local_ 'a option
-(** The locally-constrained and locally-allocating version of []. *)
-
 val find_map
   : ('a : value_or_null mod separable) ('b : value_or_null).
   local_ ('a -> 'b option) -> 'a iarray -> 'b option
 (** [find_map ~f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist. *)
 
-val find_map_local
-  : ('a : value_or_null mod separable) ('b : value_or_null).
-  local_ (local_ 'a -> local_ 'b option) -> local_ 'a iarray -> local_ 'b option
-(** The locally-constrained and locally-allocating version of [find_map]. *)
-
-val find_map_local_input
-  : ('a : value_or_null mod separable) ('b : value_or_null).
-  local_ (local_ 'a -> 'b option) -> local_ 'a iarray -> 'b option
-(** The locally-constrained but globally-allocating version of [find_map]. *)
-
-val find_map_local_output
-  : ('a : value_or_null mod separable) ('b : value_or_null).
-  local_ ('a -> local_ 'b option) -> 'a iarray -> local_ 'b option
-(** The locally-allocating but global-input version of [find_map]. *)
 
 (** {1 Arrays of pairs} *)
 
@@ -543,11 +238,6 @@ val split
 (** [split [:(a1,b1); ...; (an,bn):]] is
     [([:a1; ...; an:], [:b1; ...; bn:])]. *)
 
-val split_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ ('a * 'b) iarray -> local_ 'a iarray * 'b iarray
-(** The locally-allocating version of [split]. *)
-
 val combine
   : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
   'a iarray -> 'b iarray -> ('a * 'b) iarray
@@ -555,15 +245,7 @@ val combine
     Raise [Invalid_argument] if the two immutable iarrays have different
     lengths. *)
 
-val combine_local
-  : ('a : value_or_null mod separable) ('b : value_or_null mod separable).
-  local_ 'a iarray -> local_ 'b iarray -> local_ ('a * 'b) iarray
-(** The locally-allocating version of [combine]. *)
-
 (** {1 Sorting} *)
-
-(* CR-someday aspectorzabusky: The comparison functions could be [local_] if we
-   changed [Array] *)
 
 val sort
   : ('a : value_or_null mod separable).
@@ -590,13 +272,7 @@ val sort
    The result of [sort], which we'll call [a'], contains the same elements as
    [a], reordered in such a way that for all i and j valid indices of [a] (or
    equivalently, of [a']):
--   [cmp a'.:(i) a'.:(j)] >= 0 if and only if i >= j
-*)
-
-(* MISSING: Requires rewriting the sorting algorithms
-val sort_local :
-  (local_ 'a -> local_ 'a -> int) -> local_ 'a iarray -> local_ 'a iarray
-(** The locally-constrained and locally-allocating version of [sort]. *)
+-   [cmp (get a' i) (get a' j)] >= 0 if and only if i >= j
 *)
 
 val stable_sort
@@ -611,50 +287,23 @@ val stable_sort
    faster than the current implementation of {!sort}.
 *)
 
-(* MISSING: Requires rewriting the sorting algorithms
-val stable_sort_local :
-  (local_ 'a -> local_ 'a -> int) -> local_ 'a iarray -> local_ 'a iarray
-(** The locally-constrained and locally-allocating version of [stable_sort]. *)
-*)
-
 val fast_sort
   : ('a : value_or_null mod separable).
   ('a -> 'a -> int) -> 'a iarray -> 'a iarray
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input. *)
 
-(* MISSING: Requires rewriting the sorting algorithms
-val fast_sort_local :
-  (local_ 'a -> local_ 'a -> int) -> local_ 'a iarray -> local_ 'a iarray
-(** The locally-constrained and locally-allocating version of [fast_sort]. *)
-*)
-
 (** {1 Iterators} *)
 
 val to_seq : ('a : value_or_null mod separable). 'a iarray -> 'a Seq.t
 (** Iterate on the immutable array, in increasing order. *)
 
-(* MISSING: No meaningful local [Seq.t]s
-val to_seq_local : local_ 'a iarray -> local_ 'a Seq.t
-(** The locally-allocating version of [to_seq]. *)
-*)
-
 val to_seqi : ('a : value_or_null mod separable). 'a iarray -> (int * 'a) Seq.t
 (** Iterate on the immutable array, in increasing order, yielding indices along
     elements. *)
 
-(* MISSING: No meaningful local [Seq.t]s
-val to_seqi_local : local_ 'a iarray -> local_ (int * 'a) Seq.t
-(** The locally-allocating version of [to_seqi]. *)
-*)
-
 val of_seq : ('a : value_or_null mod separable). 'a Seq.t -> 'a iarray
 (** Create an immutable array from the generator *)
-
-(* MISSING: No meaningful local [Seq.t]s
-val of_seq_local : local_ 'a Seq.t -> local_ 'a iarray
-(** The locally-allocating version of [of_seq]. *)
-*)
 
 (**/**)
 

--- a/testsuite/tests/comprehensions/iarray_comprehensions_pure.ml
+++ b/testsuite/tests/comprehensions/iarray_comprehensions_pure.ml
@@ -4,9 +4,9 @@
  expect;
 *)
 
-module Iarray = Stdlib_stable.Iarray;;
+module Iarray = Stdlib_stable.IarrayLabels;;
 [%%expect{|
-module Iarray = Stdlib_stable.Iarray
+module Iarray = Stdlib_stable.IarrayLabels
 |}];;
 
 (******************************************************************************
@@ -90,9 +90,9 @@ pythagorean_triples 10;;
 
 let tails xs =
   let len = Iarray.length xs in
-  Iarray.init (len + 1) (fun i -> Iarray.sub xs i (len - i))
+  Iarray.init (len + 1) ~f:(fun i -> Iarray.sub xs ~pos:i ~len:(len - i))
 in
-let sum = Iarray.fold_left ( + ) 0 in
+let sum = Iarray.fold_left ~f:( + ) ~init:0 in
 [:sum xs for xs in tails [:1; 20; 300; 4_000; 50_000; 600_000; 7_000_000:]:];;
 [%%expect{|
 - : int iarray =

--- a/testsuite/tests/lib-array/test_iarray.ml
+++ b/testsuite/tests/lib-array/test_iarray.ml
@@ -3,17 +3,17 @@
  expect;
 *)
 
-module Iarray = Stdlib_stable.Iarray;;
+module Iarray = Stdlib_stable.IarrayLabels;;
 
 external ( .:() ) : 'a iarray -> int -> 'a = "%array_safe_get";;
 
 (** Create some immutable and mutable arrays *)
 
 let iarray  : int   iarray = [:1;2;3;4;5:];;
-let iarray_local () = exclave_ Iarray.init_local 5 (fun x -> x + 1);;
+let iarray_local () = exclave_ Iarray.init_local 5 ~f:(fun x -> x + 1);;
 let ifarray : float iarray = [:1.5;2.5;3.5;4.5;5.5:];;
 let ifarray_local () =
-  exclave_ Iarray.init_local 5 (fun x -> Int.to_float x +. 1.5);;
+  exclave_ Iarray.init_local 5 ~f:(fun x -> Int.to_float x +. 1.5);;
 
 let marray  : int   array = [|1;2;3;4;5|];;
 let mfarray : float array = [|1.5;2.5;3.5;4.5;5.5|];;
@@ -21,7 +21,7 @@ let mfarray : float array = [|1.5;2.5;3.5;4.5;5.5|];;
 external globalize_float : local_ float -> float = "%obj_dup";;
 external globalize_string : local_ string -> string = "%obj_dup";;
 let globalize_int_iarray (local_ ia) =
-  Iarray.map_local_input (fun x : int -> x) ia;;
+  Iarray.map_local_input ~f:(fun x : int -> x) ia;;
 
 let rec list_map_local_input (local_ f) (local_ list) =
   match list with
@@ -29,7 +29,7 @@ let rec list_map_local_input (local_ f) (local_ list) =
   | x :: xs -> f x :: list_map_local_input f xs;;
 
 [%%expect{|
-module Iarray = Stdlib_stable.Iarray
+module Iarray = Stdlib_stable.IarrayLabels
 external ( .:() ) : 'a iarray -> int -> 'a = "%array_safe_get"
 val iarray : int iarray = [:1; 2; 3; 4; 5:]
 val iarray_local : unit -> int iarray @ local = <fun>
@@ -184,12 +184,12 @@ Iarray.get ifarray 5;;
 Exception: Invalid_argument "index out of bounds".
 |}];;
 
-Iarray.init 10 (fun x -> x * 2);;
+Iarray.init 10 ~f:(fun x -> x * 2);;
 [%%expect{|
 - : int iarray = [:0; 2; 4; 6; 8; 10; 12; 14; 16; 18:]
 |}];;
 
-globalize_int_iarray (Iarray.init_local 10 (fun x -> x * 2));;
+globalize_int_iarray (Iarray.init_local 10 ~f:(fun x -> x * 2));;
 [%%expect{|
 - : int iarray = [:0; 2; 4; 6; 8; 10; 12; 14; 16; 18:]
 |}];;
@@ -200,7 +200,7 @@ Iarray.append iarray iarray;;
 |}];;
 
 globalize_int_iarray (Iarray.append_local
-    (Iarray.init_local 5 (fun x -> x)) (iarray_local ()));;
+    (Iarray.init_local 5 ~f:(fun x -> x)) (iarray_local ()));;
 [%%expect{|
 - : int iarray = [:0; 1; 2; 3; 4; 1; 2; 3; 4; 5:]
 |}];;
@@ -210,62 +210,62 @@ Iarray.concat [];;
 - : 'a iarray = [::]
 |}];;
 
-Iarray.concat [ Iarray.init 1 (fun x ->   1 + x)
-              ; Iarray.init 2 (fun x ->  20 + x)
-              ; Iarray.init 3 (fun x -> 300 + x) ];;
+Iarray.concat [ Iarray.init 1 ~f:(fun x ->   1 + x)
+              ; Iarray.init 2 ~f:(fun x ->  20 + x)
+              ; Iarray.init 3 ~f:(fun x -> 300 + x) ];;
 [%%expect{|
 - : int iarray = [:1; 20; 21; 300; 301; 302:]
 |}];;
 
 globalize_int_iarray
-  (Iarray.concat_local [ Iarray.init_local 1 (fun x ->   1 + x)
-                       ; Iarray.init_local 2 (fun x ->  20 + x)
-                       ; Iarray.init_local 3 (fun x -> 300 + x) ]);;
+  (Iarray.concat_local [ Iarray.init_local 1 ~f:(fun x ->   1 + x)
+                       ; Iarray.init_local 2 ~f:(fun x ->  20 + x)
+                       ; Iarray.init_local 3 ~f:(fun x -> 300 + x) ]);;
 [%%expect{|
 - : int iarray = [:1; 20; 21; 300; 301; 302:]
 |}];;
 
-Iarray.sub iarray 0 2, Iarray.sub iarray 2 3;;
+Iarray.sub iarray ~pos:0 ~len:2, Iarray.sub iarray ~pos:2 ~len:3;;
 [%%expect{|
 - : int iarray * int iarray = ([:1; 2:], [:3; 4; 5:])
 |}];;
 
-Iarray.sub iarray (-1) 3;;
+Iarray.sub iarray ~pos:(-1) ~len:3;;
 [%%expect{|
 Exception: Invalid_argument "Iarray.sub".
 |}];;
 
-Iarray.sub iarray 1 (-3);;
+Iarray.sub iarray ~pos:1 ~len:(-3);;
 [%%expect{|
 Exception: Invalid_argument "Iarray.sub".
 |}];;
 
-Iarray.sub iarray 3 10;;
+Iarray.sub iarray ~pos:3 ~len:10;;
 [%%expect{|
 Exception: Invalid_argument "Iarray.sub".
 |}];;
 
 let iarray = iarray_local () in
-globalize_int_iarray (Iarray.sub_local iarray 0 2),
-globalize_int_iarray (Iarray.sub_local iarray 2 3);;
+globalize_int_iarray (Iarray.sub_local iarray ~pos:0 ~len:2),
+globalize_int_iarray (Iarray.sub_local iarray ~pos:2 ~len:3);;
 [%%expect{|
 - : int iarray * int iarray = ([:1; 2:], [:3; 4; 5:])
 |}];;
 
 let iarray = iarray_local () in
-globalize_int_iarray (Iarray.sub_local iarray (-1) 3);;
+globalize_int_iarray (Iarray.sub_local iarray ~pos:(-1) ~len:3);;
 [%%expect{|
 Exception: Invalid_argument "Iarray.sub".
 |}];;
 
 let iarray = iarray_local () in
-globalize_int_iarray (Iarray.sub_local iarray 1 (-3));;
+globalize_int_iarray (Iarray.sub_local iarray ~pos:1 ~len:(-3));;
 [%%expect{|
 Exception: Invalid_argument "Iarray.sub".
 |}];;
 
 let iarray = iarray_local () in
-globalize_int_iarray (Iarray.sub_local iarray 3 10);;
+globalize_int_iarray (Iarray.sub_local iarray ~pos:3 ~len:10);;
 [%%expect{|
 Exception: Invalid_argument "Iarray.sub".
 |}];;
@@ -320,7 +320,7 @@ Iarray.of_array (Iarray.to_array iarray) == iarray;;
 |}];;
 
 let sum = ref 0. in
-Iarray.iter (fun x -> sum := !sum +. x) ifarray;
+Iarray.iter ~f:(fun x -> sum := !sum +. x) ifarray;
 !sum;;
 [%%expect{|
 - : float = 17.5
@@ -332,7 +332,7 @@ let open struct
     "%addfloat"
 end in
 let sum = ref 0. in
-Iarray.iter_local (fun x -> sum := globalize_float (!sum +. x))
+Iarray.iter_local ~f:(fun x -> sum := globalize_float (!sum +. x))
   [:1.5;2.5;3.5;4.5;5.5:];
 !sum;;
 [%%expect{|
@@ -340,62 +340,62 @@ Iarray.iter_local (fun x -> sum := globalize_float (!sum +. x))
 |}];;
 
 let total = ref 0 in
-Iarray.iteri (fun i x -> total := !total + i*x) iarray;
+Iarray.iteri ~f:(fun i x -> total := !total + i*x) iarray;
 !total;;
 [%%expect{|
 - : int = 40
 |}];;
 
 let total = ref 0 in
-Iarray.iteri_local (fun i x -> total := !total + i*x) [:1;2;3;4;5:];
+Iarray.iteri_local ~f:(fun i x -> total := !total + i*x) [:1;2;3;4;5:];
 !total;;
 [%%expect{|
 - : int = 40
 |}];;
 
-Iarray.map Int.neg iarray;;
+Iarray.map ~f:Int.neg iarray;;
 [%%expect{|
 - : int iarray = [:-1; -2; -3; -4; -5:]
 |}];;
 
-globalize_int_iarray (Iarray.map_local Int.neg
+globalize_int_iarray (Iarray.map_local ~f:Int.neg
                         (iarray_local ()));;
 [%%expect{|
 - : int iarray = [:-1; -2; -3; -4; -5:]
 |}];;
 
-Iarray.map_local_input Int.neg (iarray_local ());;
+Iarray.map_local_input ~f:Int.neg (iarray_local ());;
 [%%expect{|
 - : int iarray = [:-1; -2; -3; -4; -5:]
 |}];;
 
-globalize_int_iarray (Iarray.map_local_output Int.neg iarray);;
+globalize_int_iarray (Iarray.map_local_output ~f:Int.neg iarray);;
 [%%expect{|
 - : int iarray = [:-1; -2; -3; -4; -5:]
 |}];;
 
-Iarray.mapi (fun i x -> i, 10.*.x) ifarray;;
+Iarray.mapi ~f:(fun i x -> i, 10.*.x) ifarray;;
 [%%expect{|
 - : (int * float) iarray =
 [:(0, 15.); (1, 25.); (2, 35.); (3, 45.); (4, 55.):]
 |}];;
 
 let globalize_int_float_iarray (local_ ia) =
-  Iarray.map_local_input (fun ((i : int), f) -> i, globalize_float f) ia;;
+  Iarray.map_local_input ~f:(fun ((i : int), f) -> i, globalize_float f) ia;;
 [%%expect{|
 val globalize_int_float_iarray :
   (int * float) iarray @ local -> (int * float) iarray = <fun>
 |}];;
 
 globalize_int_float_iarray
-  (Iarray.mapi_local (fun i x -> exclave_ i, 10.*.x)
+  (Iarray.mapi_local ~f:(fun i x -> exclave_ i, 10.*.x)
      (ifarray_local ()));;
 [%%expect{|
 - : (int * float) iarray =
 [:(0, 15.); (1, 25.); (2, 35.); (3, 45.); (4, 55.):]
 |}];;
 
-Iarray.mapi_local_input (fun i x -> i, 10. *. globalize_float x)
+Iarray.mapi_local_input ~f:(fun i x -> i, 10. *. globalize_float x)
   (ifarray_local ());;
 [%%expect{|
 - : (int * float) iarray =
@@ -403,91 +403,91 @@ Iarray.mapi_local_input (fun i x -> i, 10. *. globalize_float x)
 |}];;
 
 globalize_int_float_iarray
-  (Iarray.mapi_local_output (fun i x -> exclave_ i, 10.*.x) ifarray);;
+  (Iarray.mapi_local_output ~f:(fun i x -> exclave_ i, 10.*.x) ifarray);;
 [%%expect{|
 - : (int * float) iarray =
 [:(0, 15.); (1, 25.); (2, 35.); (3, 45.); (4, 55.):]
 |}];;
 
-Iarray.fold_left (fun acc x -> -x :: acc) [] iarray;;
+Iarray.fold_left ~f:(fun acc x -> -x :: acc) ~init:[] iarray;;
 [%%expect{|
 - : int list = [-5; -4; -3; -2; -1]
 |}];;
 
 list_map_local_input (fun x : int -> x)
-  (Iarray.fold_left_local (fun acc x -> exclave_ -x :: acc) []
+  (Iarray.fold_left_local ~f:(fun acc x -> exclave_ -x :: acc) ~init:[]
      (iarray_local ()));;
 [%%expect{|
 - : int list = [-5; -4; -3; -2; -1]
 |}];;
 
-Iarray.fold_left_local_input (fun acc x -> -x :: acc) []
+Iarray.fold_left_local_input ~f:(fun acc x -> -x :: acc) ~init:[]
   (iarray_local ());;
 [%%expect{|
 - : int list = [-5; -4; -3; -2; -1]
 |}];;
 
 list_map_local_input (fun x : int -> x)
-  (Iarray.fold_left_local_output (fun acc x -> exclave_ -x :: acc) []
+  (Iarray.fold_left_local_output ~f:(fun acc x -> exclave_ -x :: acc) ~init:[]
      iarray);;
 [%%expect{|
 - : int list = [-5; -4; -3; -2; -1]
 |}];;
 
-Iarray.fold_left_map (fun acc x -> acc + x, string_of_int x) 0 iarray;;
+Iarray.fold_left_map ~f:(fun acc x -> acc + x, string_of_int x) ~init:0 iarray;;
 [%%expect{|
 - : int * string iarray = (15, [:"1"; "2"; "3"; "4"; "5":])
 |}];;
 
 let n, strs =
-  Iarray.fold_left_map_local (fun acc x -> acc + x, string_of_int x) 0 iarray
+  Iarray.fold_left_map_local ~f:(fun acc x -> acc + x, string_of_int x) ~init:0 iarray
 in
-n, Iarray.map_local_input globalize_string strs;;
+n, Iarray.map_local_input ~f:globalize_string strs;;
 [%%expect{|
 - : int * string iarray = (15, [:"1"; "2"; "3"; "4"; "5":])
 |}];;
 
-Iarray.fold_left_map_local_input (fun acc x -> acc + x, string_of_int x) 0 iarray;;
+Iarray.fold_left_map_local_input ~f:(fun acc x -> acc + x, string_of_int x) ~init:0 iarray;;
 [%%expect{|
 - : int * string iarray = (15, [:"1"; "2"; "3"; "4"; "5":])
 |}];;
 
 let n, strs =
   Iarray.fold_left_map_local_output
-     (fun acc x -> acc + x, string_of_int x) 0 iarray
+     ~f:(fun acc x -> acc + x, string_of_int x) ~init:0 iarray
 in
-n, Iarray.map_local_input globalize_string strs;;
+n, Iarray.map_local_input ~f:globalize_string strs;;
 [%%expect{|
 - : int * string iarray = (15, [:"1"; "2"; "3"; "4"; "5":])
 |}];;
 
 (* Confirm the function isn't called on the empty immutable array *)
-Iarray.fold_left_map (fun _ _ -> assert false) 0 [::];;
+Iarray.fold_left_map ~f:(fun _ _ -> assert false) ~init:0 [::];;
 [%%expect{|
 - : int * 'a iarray = (0, [::])
 |}];;
 
-Iarray.fold_right (fun x acc -> -.x :: acc) ifarray [];;
+Iarray.fold_right ~f:(fun x acc -> -.x :: acc) ifarray ~init:[];;
 [%%expect{|
 - : float list = [-1.5; -2.5; -3.5; -4.5; -5.5]
 |}];;
 
 list_map_local_input globalize_float
-  (Iarray.fold_right_local (fun x acc -> exclave_ -.x :: acc)
-     (ifarray_local ()) []);;
+  (Iarray.fold_right_local ~f:(fun x acc -> exclave_ -.x :: acc)
+     (ifarray_local ()) ~init:[]);;
 [%%expect{|
 - : float list = [-1.5; -2.5; -3.5; -4.5; -5.5]
 |}];;
 
-Iarray.fold_right_local_input (fun x acc -> -. (globalize_float x) :: acc)
-  (ifarray_local ()) [];;
+Iarray.fold_right_local_input ~f:(fun x acc -> -. (globalize_float x) :: acc)
+  (ifarray_local ()) ~init:[];;
 [%%expect{|
 - : float list = [-1.5; -2.5; -3.5; -4.5; -5.5]
 |}];;
 
 list_map_local_input globalize_float
-  (Iarray.fold_right_local_output (fun x acc -> exclave_ -.x :: acc)
-     ifarray []);;
+  (Iarray.fold_right_local_output ~f:(fun x acc -> exclave_ -.x :: acc)
+     ifarray ~init:[]);;
 [%%expect{|
 - : float list = [-1.5; -2.5; -3.5; -4.5; -5.5]
 |}];;
@@ -495,7 +495,7 @@ list_map_local_input globalize_float
 let ints   = ref 0  in
 let floats = ref 0. in
 Iarray.iter2
-  (fun i f ->
+  ~f:(fun i f ->
     ints   := i +  !ints;
     floats := f +. !floats)
   iarray
@@ -508,7 +508,7 @@ Iarray.iter2
 let ints   = ref 0  in
 let floats = ref 0. in
 Iarray.iter2_local
-  (fun i f ->
+  ~f:(fun i f ->
      ints   := i +  !ints;
      floats := globalize_float (f +. !floats))
   (iarray_local ()) (ifarray_local ());
@@ -520,7 +520,7 @@ Iarray.iter2_local
 let ints   = ref 0  in
 let floats = ref 0. in
 Iarray.iter2_local_first
-  (fun i f ->
+  ~f:(fun i f ->
      ints   := i +  !ints;
      floats := f +. !floats)
   (iarray_local ()) ifarray;
@@ -532,7 +532,7 @@ Iarray.iter2_local_first
 let ints   = ref 0  in
 let floats = ref 0. in
 Iarray.iter2_local_second
-  (fun i f ->
+  ~f:(fun i f ->
      ints   := i +  !ints;
      floats := globalize_float (f +. !floats))
   iarray (ifarray_local ());
@@ -541,227 +541,227 @@ Iarray.iter2_local_second
 - : int * float = (15, 17.5)
 |}];;
 
-Iarray.map2 (fun i f -> f, i) iarray ifarray;;
+Iarray.map2 ~f:(fun i f -> f, i) iarray ifarray;;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map_local_input (fun (f, (i : int)) -> globalize_float f, i)
-  (Iarray.map2_local (fun i f -> exclave_ f, i)
+Iarray.map_local_input ~f:(fun (f, (i : int)) -> globalize_float f, i)
+  (Iarray.map2_local ~f:(fun i f -> exclave_ f, i)
      (iarray_local ()) (ifarray_local ()));;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map2_local_inputs (fun (i : int) f -> globalize_float f, i)
+Iarray.map2_local_inputs ~f:(fun (i : int) f -> globalize_float f, i)
   (iarray_local ()) (ifarray_local ());;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map_local_input (fun (f, (i : int)) -> globalize_float f, i)
-  (Iarray.map2_local_output (fun i f -> exclave_ f, i)
+Iarray.map_local_input ~f:(fun (f, (i : int)) -> globalize_float f, i)
+  (Iarray.map2_local_output ~f:(fun i f -> exclave_ f, i)
      iarray ifarray);;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map2_local_first_input (fun (i : int) f -> f, i)
+Iarray.map2_local_first_input ~f:(fun (i : int) f -> f, i)
   (iarray_local ()) ifarray;;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map2_local_second_input (fun i f -> globalize_float f, i)
+Iarray.map2_local_second_input ~f:(fun i f -> globalize_float f, i)
   iarray (ifarray_local ());;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map_local_input (fun (f, (i : int)) -> globalize_float f, i)
+Iarray.map_local_input ~f:(fun (f, (i : int)) -> globalize_float f, i)
   (Iarray.map2_local_first_input_and_output
-     (fun i f -> exclave_ f, i)
+     ~f:(fun i f -> exclave_ f, i)
      (iarray_local ()) ifarray);;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.map_local_input (fun (f, (i : int)) -> globalize_float f, i)
+Iarray.map_local_input ~f:(fun (f, (i : int)) -> globalize_float f, i)
   (Iarray.map2_local_second_input_and_output
-     (fun i f -> exclave_ f, i)
+     ~f:(fun i f -> exclave_ f, i)
      iarray (ifarray_local ()));;
 [%%expect{|
 - : (float * int) iarray =
 [:(1.5, 1); (2.5, 2); (3.5, 3); (4.5, 4); (5.5, 5):]
 |}];;
 
-Iarray.for_all (fun i -> i > 0) iarray;;
+Iarray.for_all ~f:(fun i -> i > 0) iarray;;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.for_all (fun f -> f < 5.) ifarray;;
+Iarray.for_all ~f:(fun f -> f < 5.) ifarray;;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.for_all_local (fun i -> i > 0) (iarray_local ());;
+Iarray.for_all_local ~f:(fun i -> i > 0) (iarray_local ());;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.for_all_local (fun f -> f < 5.) (ifarray_local ());;
+Iarray.for_all_local ~f:(fun f -> f < 5.) (ifarray_local ());;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.exists (fun f -> f < 5.) ifarray;;
+Iarray.exists ~f:(fun f -> f < 5.) ifarray;;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.exists (fun i -> i > 10) iarray;;
+Iarray.exists ~f:(fun i -> i > 10) iarray;;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.exists_local (fun f -> f < 5.) (ifarray_local ());;
+Iarray.exists_local ~f:(fun f -> f < 5.) (ifarray_local ());;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.exists_local (fun i -> i > 10) (iarray_local ());;
+Iarray.exists_local ~f:(fun i -> i > 10) (iarray_local ());;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.for_all2 (fun i f -> Float.of_int i < f) iarray ifarray;;
+Iarray.for_all2 ~f:(fun i f -> Float.of_int i < f) iarray ifarray;;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.for_all2 (fun f i -> i = 1 && f = 1.5) ifarray iarray;;
+Iarray.for_all2 ~f:(fun f i -> i = 1 && f = 1.5) ifarray iarray;;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.for_all2_local (fun i f -> Float.of_int i < f)
+Iarray.for_all2_local ~f:(fun i f -> Float.of_int i < f)
   (iarray_local ()) (ifarray_local ());;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.for_all2_local (fun f i -> i = 1 && f = 1.5)
+Iarray.for_all2_local ~f:(fun f i -> i = 1 && f = 1.5)
   (ifarray_local ()) (iarray_local ());;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.for_all2_local_first (fun i f -> Float.of_int i < f)
+Iarray.for_all2_local_first ~f:(fun i f -> Float.of_int i < f)
   (iarray_local ()) ifarray;;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.for_all2_local_first (fun f i -> i = 1 && f = 1.5)
+Iarray.for_all2_local_first ~f:(fun f i -> i = 1 && f = 1.5)
   (ifarray_local ()) iarray;;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.for_all2_local_second (fun i f -> Float.of_int i < f)
+Iarray.for_all2_local_second ~f:(fun i f -> Float.of_int i < f)
   iarray (ifarray_local ());;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.for_all2_local_second (fun f i -> i = 1 && f = 1.5)
+Iarray.for_all2_local_second ~f:(fun f i -> i = 1 && f = 1.5)
   ifarray (iarray_local ());;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.exists2 (fun f i -> Float.of_int i +. f = 8.5) ifarray iarray;;
+Iarray.exists2 ~f:(fun f i -> Float.of_int i +. f = 8.5) ifarray iarray;;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.exists2 (fun i f -> Float.of_int i > f) iarray ifarray;;
+Iarray.exists2 ~f:(fun i f -> Float.of_int i > f) iarray ifarray;;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.exists2_local (fun f i -> Float.of_int i +. f = 8.5)
+Iarray.exists2_local ~f:(fun f i -> Float.of_int i +. f = 8.5)
   (ifarray_local ()) (iarray_local ());;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.exists2_local (fun i f -> Float.of_int i > f)
+Iarray.exists2_local ~f:(fun i f -> Float.of_int i > f)
   (iarray_local ()) (ifarray_local ());;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.exists2_local_first (fun f i -> Float.of_int i +. f = 8.5)
+Iarray.exists2_local_first ~f:(fun f i -> Float.of_int i +. f = 8.5)
   (ifarray_local ()) iarray;;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.exists2_local_first (fun i f -> Float.of_int i > f)
+Iarray.exists2_local_first ~f:(fun i f -> Float.of_int i > f)
   (iarray_local ()) ifarray;;
 [%%expect{|
 - : bool = false
 |}];;
-Iarray.exists2_local_second (fun f i -> Float.of_int i +. f = 8.5)
+Iarray.exists2_local_second ~f:(fun f i -> Float.of_int i +. f = 8.5)
   ifarray (iarray_local ());;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.exists2_local_second (fun i f -> Float.of_int i > f)
+Iarray.exists2_local_second ~f:(fun i f -> Float.of_int i > f)
   iarray (ifarray_local ());;
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.mem 3 iarray, Iarray.mem 3.5 ifarray;;
+Iarray.mem 3 ~set:iarray, Iarray.mem 3.5 ~set:ifarray;;
 [%%expect{|
 - : bool * bool = (true, true)
 |}];;
 
-Iarray.mem 30 iarray, Iarray.mem 35. ifarray;;
+Iarray.mem 30 ~set:iarray, Iarray.mem 35. ~set:ifarray;;
 [%%expect{|
 - : bool * bool = (false, false)
 |}];;
 
 let x = ref 0 in
-Iarray.memq x (Iarray.init 3 (Fun.const x));;
+Iarray.memq x ~set:(Iarray.init 3 ~f:(Fun.const x));;
 [%%expect{|
 - : bool = true
 |}];;
 
-Iarray.memq (ref 0) (Iarray.init 3 (Fun.const (ref 0)))
+Iarray.memq (ref 0) ~set:(Iarray.init 3 ~f:(Fun.const (ref 0)))
 [%%expect{|
 - : bool = false
 |}];;
 
-Iarray.find_opt (fun x -> x*x  > 5)  iarray,
-Iarray.find_opt (fun x -> x*.x > 5.) ifarray;;
+Iarray.find_opt ~f:(fun x -> x*x  > 5)  iarray,
+Iarray.find_opt ~f:(fun x -> x*.x > 5.) ifarray;;
 [%%expect{|
 - : int option * float option = (Some 3, Some 2.5)
 |}];;
 
-Iarray.find_opt (fun x -> x*x  > 50)  iarray,
-Iarray.find_opt (fun x -> x*.x > 50.) ifarray;;
+Iarray.find_opt ~f:(fun x -> x*x  > 50)  iarray,
+Iarray.find_opt ~f:(fun x -> x*.x > 50.) ifarray;;
 [%%expect{|
 - : int option * float option = (None, None)
 |}];;
@@ -779,27 +779,27 @@ val globalize_int_option : int option @ local -> int option = <fun>
 val globalize_float_option : float option @ local -> float option = <fun>
 |}];;
 
-globalize_int_option (Iarray.find_opt_local (fun x -> x*x  > 5)
+globalize_int_option (Iarray.find_opt_local ~f:(fun x -> x*x  > 5)
                         (iarray_local ())),
-globalize_float_option (Iarray.find_opt_local (fun x -> x*.x > 5.)
+globalize_float_option (Iarray.find_opt_local ~f:(fun x -> x*.x > 5.)
                           (ifarray_local ()));;
 [%%expect{|
 - : int option * float option = (Some 3, Some 2.5)
 |}];;
 
-globalize_int_option (Iarray.find_opt_local (fun x -> x*x  > 50)
+globalize_int_option (Iarray.find_opt_local ~f:(fun x -> x*x  > 50)
                         (iarray_local ())),
-globalize_float_option (Iarray.find_opt_local (fun x -> x*.x > 50.)
+globalize_float_option (Iarray.find_opt_local ~f:(fun x -> x*.x > 50.)
                           (ifarray_local ()));;
 [%%expect{|
 - : int option * float option = (None, None)
 |}];;
 
-Iarray.find_map (fun x -> if x mod 2 = 0
+Iarray.find_map ~f:(fun x -> if x mod 2 = 0
                           then Some (x / 2)
                           else None)
                 iarray,
-Iarray.find_map (fun x -> if Float.rem x 2. = 0.5
+Iarray.find_map ~f:(fun x -> if Float.rem x 2. = 0.5
                           then Some ((x -. 0.5) /. 2.)
                           else None)
                 ifarray;;
@@ -807,11 +807,11 @@ Iarray.find_map (fun x -> if Float.rem x 2. = 0.5
 - : int option * float option = (Some 1, Some 1.)
 |}];;
 
-Iarray.find_map (fun x -> if x mod 7 = 0
+Iarray.find_map ~f:(fun x -> if x mod 7 = 0
                           then Some (x / 7)
                           else None)
                 iarray,
-Iarray.find_map (fun x -> if Float.rem x 7. = 0.5
+Iarray.find_map ~f:(fun x -> if Float.rem x 7. = 0.5
                           then Some ((x -. 0.5) /. 7.)
                           else None)
                 ifarray;;
@@ -828,12 +828,12 @@ external rem : (float [@local_opt]) -> (float [@local_opt]) -> float
 |}];;
 
 globalize_int_option
-  (Iarray.find_map_local (fun x -> if x mod 2 = 0
+  (Iarray.find_map_local ~f:(fun x -> if x mod 2 = 0
                           then Some (x / 2)
                           else None)
                 (iarray_local ())),
 globalize_float_option
-  (Iarray.find_map_local (fun x -> if rem x 2. = 0.5
+  (Iarray.find_map_local ~f:(fun x -> if rem x 2. = 0.5
                           then exclave_ Some ((x -. 0.5) /. 2.)
                           else None)
                 (ifarray_local ()));;
@@ -842,12 +842,12 @@ globalize_float_option
 |}];;
 
 globalize_int_option
-  (Iarray.find_map_local (fun x -> if x mod 7 = 0
+  (Iarray.find_map_local ~f:(fun x -> if x mod 7 = 0
                           then Some (x / 7)
                           else None)
                 (iarray_local ())),
 globalize_float_option
-  (Iarray.find_map_local (fun x -> if rem x 7. = 0.5
+  (Iarray.find_map_local ~f:(fun x -> if rem x 7. = 0.5
                           then exclave_ Some ((x -. 0.5) /. 7.)
                           else None)
                 (ifarray_local ()));;
@@ -855,11 +855,11 @@ globalize_float_option
 - : int option * float option = (None, None)
 |}];;
 
-Iarray.find_map_local_input (fun x -> if x mod 2 = 0
+Iarray.find_map_local_input ~f:(fun x -> if x mod 2 = 0
                           then Some (x / 2)
                           else None)
                 (iarray_local ()),
-Iarray.find_map_local_input (fun x -> if rem x 2. = 0.5
+Iarray.find_map_local_input ~f:(fun x -> if rem x 2. = 0.5
                           then Some ((globalize_float x -. 0.5) /. 2.)
                           else None)
                 (ifarray_local ());;
@@ -867,11 +867,11 @@ Iarray.find_map_local_input (fun x -> if rem x 2. = 0.5
 - : int option * float option = (Some 1, Some 1.)
 |}];;
 
-Iarray.find_map_local_input (fun x -> if x mod 7 = 0
+Iarray.find_map_local_input ~f:(fun x -> if x mod 7 = 0
                           then Some (x / 7)
                           else None)
                 (iarray_local ()),
-Iarray.find_map_local_input (fun x -> if rem x 7. = 0.5
+Iarray.find_map_local_input ~f:(fun x -> if rem x 7. = 0.5
                           then Some ((globalize_float x -. 0.5) /. 7.)
                           else None)
                 (ifarray_local ());;
@@ -880,11 +880,11 @@ Iarray.find_map_local_input (fun x -> if rem x 7. = 0.5
 |}];;
 
 globalize_int_option
-  (Iarray.find_map_local_output (fun x -> if x mod 2 = 0
+  (Iarray.find_map_local_output ~f:(fun x -> if x mod 2 = 0
                           then Some (x / 2)
                           else None) iarray),
 globalize_float_option
-  (Iarray.find_map_local_output (fun x -> if rem x 2. = 0.5
+  (Iarray.find_map_local_output ~f:(fun x -> if rem x 2. = 0.5
                           then exclave_ Some ((x -. 0.5) /. 2.)
                           else None) ifarray);;
 [%%expect{|
@@ -892,11 +892,11 @@ globalize_float_option
 |}];;
 
 globalize_int_option
-  (Iarray.find_map_local_output (fun x -> if x mod 7 = 0
+  (Iarray.find_map_local_output ~f:(fun x -> if x mod 7 = 0
                           then Some (x / 7)
                           else None) iarray),
 globalize_float_option
-  (Iarray.find_map_local_output (fun x -> if rem x 7. = 0.5
+  (Iarray.find_map_local_output ~f:(fun x -> if rem x 7. = 0.5
                           then exclave_ Some ((x -. 0.5) /. 7.)
                           else None) ifarray);;
 [%%expect{|
@@ -914,13 +914,13 @@ Iarray.split [::];;
 |}];;
 
 let is, ss = Iarray.split_local (stack_ [: 1, "a"; 2, "b"; 3, "c" :]) in
-globalize_int_iarray is, Iarray.map_local_input globalize_string ss;;
+globalize_int_iarray is, Iarray.map_local_input ~f:globalize_string ss;;
 [%%expect{|
 - : int iarray * string iarray = ([:1; 2; 3:], [:"a"; "b"; "c":])
 |}];;
 
 let is, ss = Iarray.split_local (stack_ [::]) in
-globalize_int_iarray is, Iarray.map_local_input globalize_string ss;;
+globalize_int_iarray is, Iarray.map_local_input ~f:globalize_string ss;;
 [%%expect{|
 - : int iarray * string iarray = ([::], [::])
 |}];;
@@ -958,15 +958,15 @@ globalize_int_float_iarray (Iarray.combine_local iarray [: 1.5 :]);;
 Exception: Invalid_argument "Iarray.combine_local".
 |}];;
 
-Iarray.sort (Fun.flip Int.compare) iarray,
-Iarray.sort (Fun.flip Float.compare) ifarray;;
+Iarray.sort ~cmp:(Fun.flip Int.compare) iarray,
+Iarray.sort ~cmp:(Fun.flip Float.compare) ifarray;;
 [%%expect{|
 - : int iarray * Float.t iarray =
 ([:5; 4; 3; 2; 1:], [:5.5; 4.5; 3.5; 2.5; 1.5:])
 |}];;
 
-Iarray.stable_sort (Fun.flip Int.compare) iarray,
-Iarray.stable_sort (Fun.flip Float.compare) ifarray;;
+Iarray.stable_sort ~cmp:(Fun.flip Int.compare) iarray,
+Iarray.stable_sort ~cmp:(Fun.flip Float.compare) ifarray;;
 [%%expect{|
 - : int iarray * Float.t iarray =
 ([:5; 4; 3; 2; 1:], [:5.5; 4.5; 3.5; 2.5; 1.5:])
@@ -974,7 +974,7 @@ Iarray.stable_sort (Fun.flip Float.compare) ifarray;;
 
 (* Check stability *)
 Iarray.stable_sort
-  (fun s1 s2 -> Int.compare (String.length s1) (String.length s2))
+  ~cmp:(fun s1 s2 -> Int.compare (String.length s1) (String.length s2))
   [: "zero"; "one"; "two"; "three"; "four";
      "five"; "six"; "seven"; "eight"; "nine";
      "ten" :];;
@@ -984,8 +984,8 @@ Iarray.stable_sort
   "seven"; "eight":]
 |}];;
 
-Iarray.fast_sort (Fun.flip Int.compare) iarray,
-Iarray.fast_sort (Fun.flip Float.compare) ifarray;;
+Iarray.fast_sort ~cmp:(Fun.flip Int.compare) iarray,
+Iarray.fast_sort ~cmp:(Fun.flip Float.compare) ifarray;;
 [%%expect{|
 - : int iarray * Float.t iarray =
 ([:5; 4; 3; 2; 1:], [:5.5; 4.5; 3.5; 2.5; 1.5:])

--- a/testsuite/tests/lib-array/test_iarray_typeopt.ml
+++ b/testsuite/tests/lib-array/test_iarray_typeopt.ml
@@ -5,7 +5,7 @@
 *)
 
 module Array = Stdlib.Array
-open Stdlib_stable.Iarray
+open Stdlib_stable.IarrayLabels
 
 [%%expect {|
 0
@@ -101,7 +101,7 @@ val mut_arr : int array = [|1; 2; 3|]
 (let
   (mut_arr/403 =? (apply (field_imm 0 (global Toploop!)) "mut_arr")
    arr/404 =[value<intarray>]
-     (apply (field_imm 13 (global Stdlib_stable__Iarray!)) mut_arr/403))
+     (apply (field_imm 13 (global Stdlib_stable__IarrayLabels!)) mut_arr/403))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/404))
 val arr : int iarray = [:1; 2; 3:]
 |}];;
@@ -167,7 +167,7 @@ val mut_arr : int array = [|1; 2; 3|]
 (let
   (mut_arr/407 =? (apply (field_imm 0 (global Toploop!)) "mut_arr")
    arr/408 =[value<intarray>]
-     (apply (field_imm 13 (global Stdlib_stable__Iarray!)) mut_arr/407))
+     (apply (field_imm 13 (global Stdlib_stable__IarrayLabels!)) mut_arr/407))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/408))
 val arr : int iarray = [:1; 2; 3:]
 |}];;
@@ -233,7 +233,7 @@ val mut_arr : int array = [|1; 2; 3|]
 (let
   (mut_arr/411 =? (apply (field_imm 0 (global Toploop!)) "mut_arr")
    arr/412 =[value<intarray>]
-     (apply (field_imm 13 (global Stdlib_stable__Iarray!)) mut_arr/411))
+     (apply (field_imm 13 (global Stdlib_stable__IarrayLabels!)) mut_arr/411))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/412))
 val arr : int iarray = [:1; 2; 3:]
 |}];;
@@ -329,7 +329,7 @@ val arr : int iarray = [:1; 2; 3:]
 (let
   (arr/466 =? (apply (field_imm 0 (global Toploop!)) "arr")
    mut_arr/467 =[value<intarray>]
-     (apply (field_imm 12 (global Stdlib_stable__Iarray!)) arr/466))
+     (apply (field_imm 12 (global Stdlib_stable__IarrayLabels!)) arr/466))
   (apply (field_imm 1 (global Toploop!)) "mut_arr" mut_arr/467))
 val mut_arr : int array = [|1; 2; 3|]
 |}];;

--- a/testsuite/tests/typing-local/float_iarray.ml
+++ b/testsuite/tests/typing-local/float_iarray.ml
@@ -17,7 +17,7 @@
 (* Testing that local [float iarray]s don't allocate on access.  This is a
    question because for flat float arrays, accesses have to box the float. *)
 
-module Iarray = Stdlib_stable.Iarray
+module Iarray = Stdlib_stable.IarrayLabels
 
 let ( .:() ) = Iarray.( .:() )
 
@@ -63,7 +63,7 @@ let () =
   in
   let local_ r1 = run "access from Iarray.init"
     test_access
-    (Iarray.init_local 10 (fun i -> Float.of_int i))
+    (Iarray.init_local 10 ~f:(fun i -> Float.of_int i))
   in
   (* TODO: Matching currently allocates, but that should be fixed eventually *)
   let local_ r2 = run "match on literal"
@@ -72,7 +72,7 @@ let () =
   in
   let local_ r3 = run "match on Iarray.init"
     test_match
-    (Iarray.init_local 3 (fun i -> Float.of_int i))
+    (Iarray.init_local 3 ~f:(fun i -> Float.of_int i))
   in
   ignore_local (r0, r1, r2, r3);
   ()

--- a/testsuite/tests/typing-local/test_iarray.ml
+++ b/testsuite/tests/typing-local/test_iarray.ml
@@ -22,7 +22,7 @@
    2. Correctness: They actually create arrays on the stack (by testing that no
       GCed allocation happens). *)
 
-module Iarray = Stdlib_stable.Iarray
+module Iarray = Stdlib_stable.IarrayLabels
 
 external opaque_local : local_ 'a -> local_ 'a = "%opaque"
 
@@ -51,13 +51,13 @@ let run name f x = exclave_
 
 (* Testing functions *)
 
-let test_init n = exclave_ Iarray.init_local n local_some
+let test_init n = exclave_ Iarray.init_local n ~f:local_some
 
 let test_append (a1, a2) = exclave_ Iarray.append_local a1 a2
 
 let test_concat = Iarray.concat_local
 
-let test_sub a = exclave_ Iarray.sub_local a 0 3
+let test_sub a = exclave_ Iarray.sub_local a ~pos:0 ~len:3
 
 let test_to_list = Iarray.to_list_local
 
@@ -65,21 +65,21 @@ let test_of_list = Iarray.of_list_local
 
 let test_map a = exclave_
   Iarray.map_local
-    (function Some x -> exclave_ Some (-x) | None -> exclave_ Some 0)
+    ~f:(function Some x -> exclave_ Some (-x) | None -> exclave_ Some 0)
     a
 
-let test_mapi a = exclave_ Iarray.mapi_local (fun i x -> exclave_ i, x) a
+let test_mapi a = exclave_ Iarray.mapi_local ~f:(fun i x -> exclave_ i, x) a
 
 let test_fold_left a = exclave_
-  Iarray.fold_left_local (fun l x -> exclave_ x :: l) [] a
+  Iarray.fold_left_local ~f:(fun l x -> exclave_ x :: l) ~init:[] a
 
 let test_fold_left_map a = exclave_
-  Iarray.fold_left_map_local (fun l x -> exclave_ x :: l, Some x) [] a
+  Iarray.fold_left_map_local ~f:(fun l x -> exclave_ x :: l, Some x) ~init:[] a
 
 let test_fold_right a = exclave_
-  Iarray.fold_right_local (fun x l -> exclave_ x :: l) a []
+  Iarray.fold_right_local ~f:(fun x l -> exclave_ x :: l) a ~init:[]
 
-let test_map2 (a1, a2) = exclave_ Iarray.map2_local (fun x y -> exclave_ x, y) a1 a2
+let test_map2 (a1, a2) = exclave_ Iarray.map2_local ~f:(fun x y -> exclave_ x, y) a1 a2
 
 let test_split = Iarray.split_local
 
@@ -93,53 +93,53 @@ let () =
   in
   let local_ r1 = run "append_local"
     test_append
-    (Iarray.init_local 42 local_some, [:None; Some (-1); Some (-2):])
+    (Iarray.init_local 42 ~f:local_some, [:None; Some (-1); Some (-2):])
   in
   let local_ r2 = run "concat_local"
     test_concat
-    [Iarray.init_local 42 local_some; [:None; Some (-1); Some (-2):]]
+    [Iarray.init_local 42 ~f:local_some; [:None; Some (-1); Some (-2):]]
   in
   let local_ r3 = run "sub_local"
     test_sub
-    (Iarray.init_local 42 local_some)
+    (Iarray.init_local 42 ~f:local_some)
   in
   let local_ r4 = run "to_list_local"
-    test_to_list (Iarray.init_local 42 local_some)
+    test_to_list (Iarray.init_local 42 ~f:local_some)
   in
   let local_ r5 = run "of_list_local"
     test_of_list [Some 0; Some 1; Some 2; Some 3; Some 4; Some 5]
   in
   let local_ r6 = run "map_local"
     test_map
-    (Iarray.init_local 42 local_some)
+    (Iarray.init_local 42 ~f:local_some)
   in
   let local_ r7 = run "mapi_local"
     test_mapi
-    (Iarray.init_local 42 local_some)
+    (Iarray.init_local 42 ~f:local_some)
   in
   let local_ r8 = run "fold_left_local"
     test_fold_left
-    (Iarray.init_local 42 local_some)
+    (Iarray.init_local 42 ~f:local_some)
   in
   let local_ r9 = run "fold_left_map_local"
     test_fold_left_map
-    (Iarray.init_local 42 local_some)
+    (Iarray.init_local 42 ~f:local_some)
   in
   let local_ rA = run "fold_right_local"
     test_fold_right
-    (Iarray.init_local 42 local_some)
+    (Iarray.init_local 42 ~f:local_some)
   in
   let local_ rB = run "map2_local"
     test_map2
-    (Iarray.init_local 3 local_some, [:None; Some (-1); Some (-2):])
+    (Iarray.init_local 3 ~f:local_some, [:None; Some (-1); Some (-2):])
   in
   let local_ rC = run "split_local"
     test_split
-    (Iarray.init_local 42 (fun i -> exclave_ Some i, Some (-i)))
+    (Iarray.init_local 42 ~f:(fun i -> exclave_ Some i, Some (-i)))
   in
   let local_ rD = run "combine_local"
     test_combine
-    (Iarray.init_local 3 local_some, [:None; Some (-1); Some (-2):])
+    (Iarray.init_local 3 ~f:local_some, [:None; Some (-1); Some (-2):])
   in
   (* In debug mode, Gc.minor () checks for backwards local pointers and minor
      heap->local pointers (though we're more concerned about the former) *)


### PR DESCRIPTION
There is now `Stdlib.Iarray` - this PR is a start towards removing the OxCaml-specific parts of otherlibs/stdlib\_stable/iarray.ml with a view to being to make it an alias and then otherlibs/stdlib\_stable/iarrayLabels.ml in terms of it with the 5.4 merge.

~Commit from #5683 presently included (which is how that issue was found).~