### PR TITLE
CFG SSA reconstruction

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -42,6 +42,8 @@ cfg/**/*.ml
 cfg/**/*.mli
 cfg/vectorize.ml
 cfg/vectorize.mli
+cfg/cfg_ssa.ml
+cfg/cfg_ssa.mli
 vectorize_utils.ml
 vectorize_utils.mli
 cfg_selectgen.ml

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -414,7 +414,8 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
 
 let dump_terminator ?sep ppf terminator = dump_terminator' ?sep ppf terminator
 
-let print_basic' ?print_reg ppf (instruction : basic instruction) =
+let print_basic' ?print_reg ?assign_symbol ppf (instruction : basic instruction)
+    =
   let desc = Cfg_to_linear_desc.from_basic instruction.desc in
   let instruction =
     { Linear.desc;
@@ -428,7 +429,7 @@ let print_basic' ?print_reg ppf (instruction : basic instruction) =
       available_across = instruction.available_across
     }
   in
-  Printlinear.instr' ?print_reg ppf instruction
+  Printlinear.instr' ?print_reg ?assign_symbol ppf instruction
 
 let print_basic ppf i = print_basic' ppf i
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -184,6 +184,13 @@ val print_terminator : Format.formatter -> terminator instruction -> unit
 
 val print_basic : Format.formatter -> basic instruction -> unit
 
+val print_basic' :
+  ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  ?assign_symbol:string ->
+  Format.formatter ->
+  basic instruction ->
+  unit
+
 val print_instruction' :
   ?print_reg:(Format.formatter -> Reg.t -> unit) ->
   Format.formatter ->

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -74,13 +74,22 @@ let build (cfg : Cfg.t) : t =
         | Some (Output { label = old_label; instr = old_instr; _ }) ->
           if Label.equal label old_label
           then begin
+            (* Detect 2-operand instructions where the result overwrites an
+               input. Instruction selection emits these as a move-then-operate
+               pair:
+
+               reg := overwritten_input; reg := op(reg, y)
+
+               We require old_instr to be the immediately preceding. As a
+               consequence, we only support a single overwritten output. *)
             match DLL.prev cell with
             | Some prev_cell
               when InstructionId.equal
                      (DLL.value prev_cell : Cfg.basic Cfg.instruction).id
                      old_instr.id -> (
               match[@ocaml.warning "-4"] old_instr.desc, old_instr.arg with
-              | Op Move, [| overwritten_input |] ->
+              | Op Move, [| overwritten_input |]
+                when Array.exists (Reg.same reg) instr.arg ->
                 Reg.Tbl.replace table reg
                   (OverwrittenOutput
                      { label; instr; res_index; overwritten_input });
@@ -90,21 +99,13 @@ let build (cfg : Cfg.t) : t =
           end
           else false
         | Some (OverwrittenOutput _) -> false
-        | Some (Phi { merge_label; regs }) ->
+        | Some (Phi { merge_label; regs }) -> (
           let succ_block = Cfg.get_block_exn cfg merge_label in
-          if not (Label.Set.mem label succ_block.predecessors)
-          then false
-          else begin
-            let i =
-              predecessor_index succ_block.predecessors label |> Option.get
-            in
-            if not (Reg.same regs.(i) Reg.dummy)
-            then false
-            else begin
-              regs.(i) <- reg;
-              true
-            end
-          end
+          match predecessor_index succ_block.predecessors label with
+          | Some i when Reg.same regs.(i) Reg.dummy ->
+            regs.(i) <- reg;
+            true
+          | _ -> false)
       in
       if not success then Reg.Tbl.replace table reg NotSSA
   in

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -23,6 +23,8 @@ type entry =
 
 type t = entry Reg.Tbl.t
 
+let empty : t = Reg.Tbl.create 0
+
 let build (cfg : Cfg.t) : t =
   let table : t = Reg.Tbl.create 64 in
   let predecessor_index preds label =

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -61,17 +61,17 @@ let build (cfg : Cfg.t) : t =
                  _
                })
           when not (Label.equal label old_label) -> begin
-          match find_common_successor old_label label with
-          | None -> false
-          | Some merge_label ->
+          match find_common_successor old_label label, instr with
+          | Some merge_label, { desc = Op Move; arg = [| new_input |]; _ } ->
             let succ_block = Cfg.get_block_exn cfg merge_label in
             let preds = succ_block.predecessors in
             let n = Label.Set.cardinal preds in
             let regs = Array.make n Reg.dummy in
             regs.(predecessor_index preds old_label |> Option.get) <- old_input;
-            regs.(predecessor_index preds label |> Option.get) <- reg;
+            regs.(predecessor_index preds label |> Option.get) <- new_input;
             Reg.Tbl.replace table reg (Phi { merge_label; regs });
             true
+          | _ -> false
         end
         | Some (Output { label = old_label; instr = old_instr; _ }) ->
           if Label.equal label old_label
@@ -103,9 +103,10 @@ let build (cfg : Cfg.t) : t =
         | Some (OverwrittenOutput _) -> false
         | Some (Phi { merge_label; regs }) -> (
           let succ_block = Cfg.get_block_exn cfg merge_label in
-          match predecessor_index succ_block.predecessors label with
-          | Some i when Reg.same regs.(i) Reg.dummy ->
-            regs.(i) <- reg;
+          match predecessor_index succ_block.predecessors label, instr with
+          | Some i, { desc = Op Move; arg = [| input |]; _ }
+            when Reg.same regs.(i) Reg.dummy ->
+            regs.(i) <- input;
             true
           | _ -> false)
       in

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -128,11 +128,6 @@ let find table reg = Reg.Tbl.find_opt table reg
 
 let iter table ~f = Reg.Tbl.iter f table
 
-let is_ssa table reg =
-  match Reg.Tbl.find_opt table reg with
-  | Some (Output _ | OverwrittenOutput _ | Phi _) -> true
-  | Some NotSSA | None -> false
-
 let has_ssa_semantics_at table cfg ~at_block reg =
   match[@ocaml.warning "-4"] Reg.Tbl.find_opt table reg with
   | Some (Output _ | OverwrittenOutput _) -> true

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -1,0 +1,147 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+type entry =
+  | Output of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int
+      }
+  | OverwrittenOutput of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int;
+        overwritten_input : Reg.t
+      }
+  | Phi of
+      { merge_label : Label.t;
+        regs : Reg.t array
+      }
+  | NotSSA
+
+type t = entry Reg.Tbl.t
+
+let build (cfg : Cfg.t) : t =
+  let table : t = Reg.Tbl.create 64 in
+  let predecessor_index preds label =
+    let i =
+      Label.Set.fold
+        (fun l acc -> if Label.equal label l then 0 else acc + 1)
+        preds 0
+    in
+    let n = Label.Set.cardinal preds in
+    if i < n then Some (n - 1 - i) else None
+  in
+  let find_common_successor label1 label2 =
+    let block1 = Cfg.get_block_exn cfg label1 in
+    let block2 = Cfg.get_block_exn cfg label2 in
+    let succs1 = Cfg.successor_labels ~normal:true ~exn:true block1 in
+    let succs2 = Cfg.successor_labels ~normal:true ~exn:true block2 in
+    Label.Set.min_elt_opt (Label.Set.inter succs1 succs2)
+  in
+  let process_body_def label cell res_index reg =
+    if reg.Reg.preassigned
+    then ()
+    else
+      let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+      let success =
+        match[@ocaml.warning "-fragile-match"] Reg.Tbl.find_opt table reg with
+        | None ->
+          Reg.Tbl.replace table reg (Output { label; instr; res_index });
+          true
+        | Some NotSSA -> true
+        | Some
+            (Output
+               { label = old_label;
+                 instr = { desc = Op Move; arg = [| old_input |]; _ };
+                 _
+               })
+          when not (Label.equal label old_label) -> begin
+          match find_common_successor old_label label with
+          | None -> false
+          | Some merge_label ->
+            let succ_block = Cfg.get_block_exn cfg merge_label in
+            let preds = succ_block.predecessors in
+            let n = Label.Set.cardinal preds in
+            let regs = Array.make n Reg.dummy in
+            regs.(predecessor_index preds old_label |> Option.get) <- old_input;
+            regs.(predecessor_index preds label |> Option.get) <- reg;
+            Reg.Tbl.replace table reg (Phi { merge_label; regs });
+            true
+        end
+        | Some (Output { label = old_label; instr = old_instr; _ }) ->
+          if Label.equal label old_label
+          then begin
+            match DLL.prev cell with
+            | Some prev_cell
+              when InstructionId.equal
+                     (DLL.value prev_cell : Cfg.basic Cfg.instruction).id
+                     old_instr.id -> (
+              match[@ocaml.warning "-4"] old_instr.desc, old_instr.arg with
+              | Op Move, [| overwritten_input |] ->
+                Reg.Tbl.replace table reg
+                  (OverwrittenOutput
+                     { label; instr; res_index; overwritten_input });
+                true
+              | _ -> false)
+            | _ -> false
+          end
+          else false
+        | Some (OverwrittenOutput _) -> false
+        | Some (Phi { merge_label; regs }) ->
+          let succ_block = Cfg.get_block_exn cfg merge_label in
+          if not (Label.Set.mem label succ_block.predecessors)
+          then false
+          else begin
+            let i =
+              predecessor_index succ_block.predecessors label |> Option.get
+            in
+            if not (Reg.same regs.(i) Reg.dummy)
+            then false
+            else begin
+              regs.(i) <- reg;
+              true
+            end
+          end
+      in
+      if not success then Reg.Tbl.replace table reg NotSSA
+  in
+  Cfg.iter_blocks_dfs cfg ~f:(fun label block ->
+      DLL.iter_cell block.body ~f:(fun cell ->
+          let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+          Array.iteri (fun i reg -> process_body_def label cell i reg) instr.res));
+  (* Demote incomplete phis (those with remaining Reg.dummy entries) to NotSSA.
+     This happens when not all predecessors of the merge block define the
+     register. *)
+  Reg.Tbl.filter_map_inplace
+    (fun _reg entry ->
+      match[@ocaml.warning "-4"] entry with
+      | Phi { regs; _ } when Array.exists (Reg.same Reg.dummy) regs ->
+        Some NotSSA
+      | _ -> Some entry)
+    table;
+  table
+
+let find table reg = Reg.Tbl.find_opt table reg
+
+let iter table ~f = Reg.Tbl.iter f table
+
+let is_ssa table reg =
+  match Reg.Tbl.find_opt table reg with
+  | Some (Output _ | OverwrittenOutput _ | Phi _) -> true
+  | Some NotSSA | None -> false
+
+let has_ssa_semantics_at table cfg ~at_block reg =
+  match[@ocaml.warning "-4"] Reg.Tbl.find_opt table reg with
+  | Some (Output _ | OverwrittenOutput _) -> true
+  | Some (Phi { merge_label; _ }) ->
+    (* Between the assignment in a predecessor block and the actual control flow
+       edge to the merge block, the observable value of a register and the value
+       according to SSA semantics differ, so we exclude the whole predecessor
+       block. This is an over-approximation, only the part of the block from the
+       assignment to the end is critical. *)
+    not
+      (Label.Set.mem at_block (Cfg.get_block_exn cfg merge_label).predecessors)
+  | Some NotSSA | None -> false

--- a/backend/cfg/cfg_ssa.mli
+++ b/backend/cfg/cfg_ssa.mli
@@ -1,0 +1,71 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Reconstructed SSA information for a CFG.
+
+    The CFG uses pseudo-registers that may be assigned multiple times. In
+    practice, however, the CFGs we construct mostly follow SSA form. This module
+    reconstructs which registers have a single static assignment (SSA) and
+    tracks their defining instruction.
+
+    A register is considered SSA if it has exactly one definition across all
+    reachable blocks, or if its multiple definitions follow a phi-node pattern
+    (each definition in a distinct predecessor of a common merge block).
+    Preassigned (hardware) registers are never tracked. *)
+
+type entry =
+  | Output of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int
+      }
+  | OverwrittenOutput of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int;
+        overwritten_input : Reg.t
+      }
+      (** Some architectures use 2-operand instructions where the result
+          overwrites the first argument (e.g. [r := r xor y] on x86-64). The
+          instruction selection emits a move into the register immediately
+          before the operation:
+          {|
+            r := x       (* preceding move *)
+            r := r xor y (* overwrites r; real input was x *)
+          |}
+          [OverwrittenOutput] records the overwriting instruction together with
+          [overwritten_input] (here [x]), the source of the preceding move. The
+          register is still SSA because the move and the operation form an
+          atomic pair: no other code can observe the intermediate value. *)
+  | Phi of
+      { merge_label : Label.t;
+        regs : Reg.t array
+      }
+      (** The register is assigned in all predecessor blocks of [merge_label].
+          [regs] has one entry per predecessor (in [Label.Set] order): the
+          register carrying the value from that predecessor. Only complete phis
+          (where every predecessor has a definition) are retained; incomplete
+          ones are demoted to [NotSSA]. *)
+  | NotSSA
+
+type t
+
+val build : Cfg.t -> t
+
+val find : t -> Reg.t -> entry option
+
+val iter : t -> f:(Reg.t -> entry -> unit) -> unit
+
+(** [is_ssa t reg] returns [true] if [reg] has a single static assignment
+    (Output, OverwrittenOutput, or Phi). *)
+val is_ssa : t -> Reg.t -> bool
+
+(** [has_ssa_semantics_at t cfg ~at_block reg] checks whether [reg] has an SSA
+    value and if using [reg] in block [block] coincides with SSA semantics. This
+    does *NOT* check for dominance. Instead, the one case this filters out is
+    that we have a phi node and [block] is one of the predecessor blocks of this
+    phi containing an assignment to [reg]. The problem is that in SSA semantics,
+    the assignment happens on the control flow edge and is not observable in the
+    predecessor block. In our CFG, however, the assignment is an explicit
+    instruction and we could well observe the register after the assignment
+    while still in the predecessor block, for example in a terminator. *)
+val has_ssa_semantics_at : t -> Cfg.t -> at_block:Label.t -> Reg.t -> bool

--- a/backend/cfg/cfg_ssa.mli
+++ b/backend/cfg/cfg_ssa.mli
@@ -49,6 +49,8 @@ type entry =
 
 type t
 
+val empty : t
+
 val build : Cfg.t -> t
 
 val find : t -> Reg.t -> entry option

--- a/backend/cfg/cfg_ssa.mli
+++ b/backend/cfg/cfg_ssa.mli
@@ -55,10 +55,6 @@ val find : t -> Reg.t -> entry option
 
 val iter : t -> f:(Reg.t -> entry -> unit) -> unit
 
-(** [is_ssa t reg] returns [true] if [reg] has a single static assignment
-    (Output, OverwrittenOutput, or Phi). *)
-val is_ssa : t -> Reg.t -> bool
-
 (** [has_ssa_semantics_at t cfg ~at_block reg] checks whether [reg] has an SSA
     value and if using [reg] in block [block] coincides with SSA semantics. This
     does *NOT* check for dominance. Instead, the one case this filters out is

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -174,7 +174,17 @@ let dump ppf t ~msg =
     print_phis ppf block;
     DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
         let assign_symbol =
-          if Array.for_all (Cfg_ssa.is_ssa ssa) instr.res then "<-" else ":="
+          if
+            Array.for_all
+              (fun reg ->
+                match[@ocaml.warning "-4"] Cfg_ssa.find ssa reg with
+                | Some (Output { instr = def_instr; _ })
+                | Some (OverwrittenOutput { instr = def_instr; _ }) ->
+                  InstructionId.equal instr.id def_instr.id
+                | _ -> false)
+              instr.res
+          then "<-"
+          else ":="
         in
         fprintf ppf "(id:%a) %a" InstructionId.format instr.id
           (fun ppf i -> Cfg.print_basic' ~assign_symbol ppf i)

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -115,6 +115,7 @@ let is_trap_handler t label =
 
 let dump ppf t ~msg =
   let open Format in
+  let ssa = Cfg_ssa.build t.cfg in
   fprintf ppf "\ncfg for %s\n" msg;
   fprintf ppf "%s\n" t.cfg.fun_name;
   let regalloc =
@@ -139,14 +140,58 @@ let dump ppf t ~msg =
     fprintf ppf "regalloc_params=%s\n" (String.concat ", " regalloc_params));
   fprintf ppf "layout.length=%d\n" (DLL.length t.layout);
   fprintf ppf "blocks.length=%d\n" (Label.Tbl.length t.cfg.blocks);
+  let phis_by_block =
+    let tbl = Label.Tbl.create 16 in
+    Cfg_ssa.iter ssa ~f:(fun reg entry ->
+        match[@ocaml.warning "-4"] (entry : Cfg_ssa.entry) with
+        | Phi { merge_label; regs } ->
+          let existing =
+            match Label.Tbl.find_opt tbl merge_label with
+            | Some l -> l
+            | None -> []
+          in
+          Label.Tbl.replace tbl merge_label ((reg, regs) :: existing)
+        | _ -> ());
+    tbl
+  in
+  let print_phis ppf block =
+    Label.Tbl.find_opt phis_by_block block.Cfg.start
+    |> Option.iter (fun phis ->
+        List.iter
+          (fun (reg, regs) ->
+            fprintf ppf "%a <- phi(" Printreg.reg reg;
+            Array.iteri
+              (fun i r ->
+                if i > 0 then fprintf ppf ", ";
+                fprintf ppf "%a" Printreg.reg r)
+              regs;
+            fprintf ppf ")\n")
+          phis)
+  in
   let print_block label =
     let block = Label.Tbl.find t.cfg.blocks label in
     fprintf ppf "\n%a:\n" Label.format label;
-    let pp_with_id ppf ~pp (instr : _ Cfg.instruction) =
-      fprintf ppf "(id:%a) %a\n" InstructionId.format instr.id pp instr
-    in
-    DLL.iter ~f:(pp_with_id ppf ~pp:Cfg.print_basic) block.body;
-    pp_with_id ppf ~pp:Cfg.print_terminator block.terminator;
+    print_phis ppf block;
+    DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+        let assign_symbol =
+          if Array.for_all (Cfg_ssa.is_ssa ssa) instr.res then "<-" else ":="
+        in
+        fprintf ppf "(id:%a) %a" InstructionId.format instr.id
+          (fun ppf i -> Cfg.print_basic' ~assign_symbol ppf i)
+          instr;
+        Array.iter
+          (fun reg ->
+            match[@ocaml.warning "-4"] Cfg_ssa.find ssa reg with
+            | Some
+                (OverwrittenOutput { instr = ow_instr; overwritten_input; _ })
+              when InstructionId.equal instr.id ow_instr.id ->
+              fprintf ppf " (input %a = %a)" Printreg.reg reg Printreg.reg
+                overwritten_input
+            | _ -> ())
+          instr.res;
+        fprintf ppf "\n");
+    fprintf ppf "(id:%a) %a\n" InstructionId.format block.terminator.id
+      Cfg.print_terminator block.terminator;
     fprintf ppf "\npredecessors:";
     Label.Set.iter (fprintf ppf " %a" Label.format) block.predecessors;
     fprintf ppf "\nsuccessors:";

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -115,7 +115,9 @@ let is_trap_handler t label =
 
 let dump ppf t ~msg =
   let open Format in
-  let ssa = Cfg_ssa.build t.cfg in
+  let ssa =
+    if !Oxcaml_flags.dump_cfg_ssa then Cfg_ssa.build t.cfg else Cfg_ssa.empty
+  in
   fprintf ppf "\ncfg for %s\n" msg;
   fprintf ppf "%s\n" t.cfg.fun_name;
   let regalloc =

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -43,12 +43,12 @@ let call_operation ?(print_reg = Printreg.reg) ppf op arg =
       (if enabled_at_init then "enabled_at_init " else "")
       name handler_code_sym regs arg
 
-let instr' ?(print_reg = Printreg.reg) ppf i =
+let instr' ?(print_reg = Printreg.reg) ?assign_symbol ppf i =
   let reg = print_reg in
   let regs = Printreg.regs' ~print_reg in
   let regsetaddr = Printreg.regsetaddr' ~print_reg in
   let test = Operation.format_test ~print_reg in
-  let operation = Printoperation.operation ~print_reg in
+  let operation = Printoperation.operation ~print_reg ?assign_symbol in
   (if !Oxcaml_flags.davail
    then
      let module RAS = Reg_availability_set in

--- a/backend/printlinear.mli
+++ b/backend/printlinear.mli
@@ -28,7 +28,11 @@ val call_operation :
   unit
 
 val instr' :
-  ?print_reg:(formatter -> Reg.t -> unit) -> formatter -> instruction -> unit
+  ?print_reg:(formatter -> Reg.t -> unit) ->
+  ?assign_symbol:string ->
+  formatter ->
+  instruction ->
+  unit
 
 val instr : formatter -> instruction -> unit
 

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -3,10 +3,11 @@
 open! Int_replace_polymorphic_compare
 open Format
 
-let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
+let operation ?(print_reg = Printreg.reg) ?(assign_symbol = ":=")
+    (op : Operation.t) arg ppf res =
   let reg = print_reg in
   let regs = Printreg.regs' ~print_reg in
-  if Array.length res > 0 then fprintf ppf "%a := " regs res;
+  if Array.length res > 0 then fprintf ppf "%a %s " regs res assign_symbol;
   match op with
   | Move -> regs ppf arg
   | Spill -> fprintf ppf "%a (spill)" regs arg

--- a/backend/printoperation.mli
+++ b/backend/printoperation.mli
@@ -2,6 +2,7 @@
 
 val operation :
   ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  ?assign_symbol:string ->
   Operation.t ->
   Reg.t array ->
   Format.formatter ->

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -45,6 +45,7 @@ let mk_no_ocamlcfg f =
   ("-no-ocamlcfg", Arg.Unit f, " Do not use ocamlcfg (deprecated, does nothing)")
 
 let mk_dcfg f = ("-dcfg", Arg.Unit f, " (undocumented)")
+let mk_dcfg_ssa f = ("-dcfg-ssa", Arg.Unit f, " Dump CFG with SSA annotations")
 
 let mk_dcfg_invariants f =
   ("-dcfg-invariants", Arg.Unit f, " Extra sanity checks on Cfg")
@@ -1179,6 +1180,7 @@ module type Oxcaml_options = sig
   val ddwarf_metrics : unit -> unit
   val ddwarf_metrics_output_file : string -> unit
   val dcfg : unit -> unit
+  val dcfg_ssa : unit -> unit
   val dcfg_invariants : unit -> unit
   val regalloc : Clflags.Register_allocator.t -> unit
   val regalloc_linscan_threshold : int -> unit
@@ -1348,6 +1350,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_ocamlcfg F.ocamlcfg;
       mk_no_ocamlcfg F.no_ocamlcfg;
       mk_dcfg F.dcfg;
+      mk_dcfg_ssa F.dcfg_ssa;
       mk_dcfg_invariants F.dcfg_invariants;
       mk_regalloc F.regalloc;
       mk_regalloc_linscan_threshold F.regalloc_linscan_threshold;
@@ -1548,6 +1551,11 @@ module Oxcaml_options_impl = struct
   let ocamlcfg () = ()
   let no_ocamlcfg () = ()
   let dcfg = set' Oxcaml_flags.dump_cfg
+
+  let dcfg_ssa () =
+    Oxcaml_flags.dump_cfg := true;
+    Oxcaml_flags.dump_cfg_ssa := true
+
   let dcfg_invariants = set' Oxcaml_flags.cfg_invariants
   let regalloc x = Oxcaml_flags.regalloc := x
 

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -31,6 +31,7 @@ module type Oxcaml_options = sig
   val ddwarf_metrics : unit -> unit
   val ddwarf_metrics_output_file : string -> unit
   val dcfg : unit -> unit
+  val dcfg_ssa : unit -> unit
   val dcfg_invariants : unit -> unit
   val regalloc : Clflags.Register_allocator.t -> unit
   val regalloc_linscan_threshold : int -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -14,6 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 let dump_cfg = ref false                (* -dcfg *)
+let dump_cfg_ssa = ref false            (* -dcfg-ssa *)
 let cfg_invariants = ref false          (* -dcfg-invariants *)
 let regalloc = ref Clflags.Register_allocator.Cfg (* -regalloc *)
 let default_regalloc_linscan_threshold = 100_000

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -17,6 +17,7 @@
 (** OxCaml specific command line flags *)
 
 val dump_cfg : bool ref
+val dump_cfg_ssa : bool ref
 val cfg_invariants : bool ref
 val regalloc : Clflags.Register_allocator.t ref
 val default_regalloc_linscan_threshold : int

--- a/dune
+++ b/dune
@@ -637,6 +637,7 @@
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_ssa
   cfg_stack_checks
   cfg_polling
   cfg_simplify


### PR DESCRIPTION
Reconstruct SSA information from the CFG: for each virtual register, determine whether it has a single static assignment (Output), a 2-opcode overwrite pattern (OverwrittenOutput), or a phi-node pattern (Phi) at merge points. This can be used for optimizations by exploring the definition of inputs recursively across block boundaries. The SSA information is cheap to compute, in a single pass over the CFG directly producing a global table from virtual registers to SSA definitions.

The new -dcfg-ssa flag behaves like -dcfg while also computing and printing the new information: SSA assignments print as "<-" instead of ":=", phi nodes are shown at block headers, and 2-opcode overwrites are annotated with their real input register.