### PR TITLE
Dissector support for arm64 Linux

### DIFF
--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -109,8 +109,8 @@ let dump_sizes file_sizes =
 
 let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
     ~startup_obj ~ccobjs ~runtime_libs ~cached_genfns =
-  (* Check that -nodynlink was not used. The dissector requires GOTPCREL
-     relocations which are only emitted when dlcode=true. *)
+  (* Check that -nodynlink was not used. The dissector requires GOT relocations
+     which are only emitted when dlcode=true. *)
   if not !Clflags.dlcode then raise (Error Nodynlink_incompatible);
   (* Check that we're targeting Linux *)
   (match Target_system.system () with
@@ -118,8 +118,11 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
   | Windows _ | MacOS_like | FreeBSD | NetBSD | OpenBSD | Generic_BSD | Solaris
   | Dragonfly | GNU | BeOS | Unknown ->
     Misc.fatal_error "The dissector pass is only supported on Linux targets");
-  (* Check that we're running on a 64-bit architecture. The dissector parses
-     ELF64 files and uses int64 arithmetic extensively. *)
+  (* Check that we're running on a supported 64-bit architecture. *)
+  (match Target_system.architecture () with
+  | X86_64 | AArch64 -> ()
+  | _ ->
+    Misc.fatal_error "The dissector is only supported on x86-64 and AArch64");
   if Sys.word_size <> 64
   then Misc.fatal_error "The dissector requires a 64-bit host architecture";
   (* Collect files to analyze for partitioning. C stubs and runtime libraries

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -74,22 +74,58 @@ let finalize acc =
     convert_to_got = List.rev acc.acc_got
   }
 
-(* Parse RELA entries and extract PLT32 and REX_GOTPCRELX relocations for
+(* Architecture-specific relocation classification. *)
+
+let is_plt_reloc r_type =
+  match Target_system.architecture () with
+  | X86_64 -> Rela.Reloc_type.equal r_type Rela.Reloc_type.plt32
+  | AArch64 ->
+    Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_call26
+    || Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_jump26
+  | arch ->
+    Misc.fatal_errorf "Dissector: unsupported architecture %s"
+      (match arch with
+      | IA32 -> "IA32"
+      | ARM -> "ARM"
+      | POWER -> "POWER"
+      | Z -> "Z"
+      | Riscv -> "Riscv"
+      | X86_64 | AArch64 -> assert false)
+
+let is_got_reloc r_type =
+  match Target_system.architecture () with
+  | X86_64 -> Rela.Reloc_type.equal r_type Rela.Reloc_type.rex_gotpcrelx
+  | AArch64 ->
+    Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_adr_got_page
+    || Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_ld64_got_lo12_nc
+  | _ -> Misc.fatal_error "Dissector: unsupported architecture"
+
+let is_direct_pc_reloc_error r_type =
+  match Target_system.architecture () with
+  | X86_64 -> Rela.Reloc_type.equal r_type Rela.Reloc_type.pc32
+  | AArch64 ->
+    Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_adr_prel_pg_hi21
+    || Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_add_abs_lo12_nc
+  | _ -> Misc.fatal_error "Dissector: unsupported architecture"
+
+(* Parse RELA entries and extract function-call and GOT relocations for
    undefined symbols (st_shndx = SHN_UNDEF). Only undefined symbols need PLT/GOT
    entries since defined symbols can be resolved directly.
 
-   - PLT32: function calls, rewritten to use IPLT
+   On x86-64: - PLT32: function calls, rewritten to use IPLT - REX_GOTPCRELX:
+   GOT-relative references, rewritten to use IGOT
 
-   - REX_GOTPCRELX: GOT-relative references, rewritten to use IGOT.
+   On AArch64: - CALL26/JUMP26: branch instructions, rewritten to use IPLT -
+   ADR_GOT_PAGE/LD64_GOT_LO12_NC: GOT references, rewritten to use IGOT
 
-   PC32 relocations to undefined symbols are an error. They occur when code is
-   compiled with -nodynlink, which is incompatible with the dissector. *)
+   Direct PC-relative relocations to undefined symbols are an error. They occur
+   when code is compiled with -nodynlink, which is incompatible with the
+   dissector. *)
 let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
   let convert_to_plt = ref [] in
   let convert_to_got = ref [] in
   Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
-      (* Check for PC32 relocations to undefined symbols - these are an error *)
-      if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
+      if is_direct_pc_reloc_error entry.r_type
       then
         match Rela.read_symbol_shndx ~symtab_body ~sym_index:entry.r_sym with
         | Some shndx when Rela.Section_index.is_undef shndx ->
@@ -102,15 +138,14 @@ let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
             | None -> "<unknown>"
           in
           Misc.fatal_errorf
-            "Dissector: R_X86_64_PC32 relocation to undefined symbol %s at \
-             offset 0x%Lx. This occurs when code is compiled with -nodynlink. \
-             The dissector requires code to be compiled without -nodynlink \
-             (i.e., with dynamic linking support enabled)."
+            "Dissector: %s relocation to undefined symbol %s at offset 0x%Lx. \
+             This occurs when code is compiled with -nodynlink. The dissector \
+             requires code to be compiled without -nodynlink (i.e., with \
+             dynamic linking support enabled)."
+            (Rela.Reloc_type.name entry.r_type)
             symbol_name entry.r_offset
         | _ -> ()
-      else if
-        Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-        || Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
+      else if is_plt_reloc entry.r_type || is_got_reloc entry.r_type
       then
         (* Only process relocations for undefined symbols *)
         match Rela.read_symbol_shndx ~symtab_body ~sym_index:entry.r_sym with
@@ -139,7 +174,7 @@ let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
             let reloc_entry =
               { Relocation_entry.symbol_name; offset = entry.r_offset }
             in
-            if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
+            if is_plt_reloc entry.r_type
             then convert_to_plt := reloc_entry :: !convert_to_plt
             else convert_to_got := reloc_entry :: !convert_to_got));
   { convert_to_plt = List.rev !convert_to_plt;

--- a/asmcomp/dissector/extract_relocations.mli
+++ b/asmcomp/dissector/extract_relocations.mli
@@ -47,11 +47,13 @@ end
 (** The result of extracting relocations from object files. *)
 type t
 
-(** Returns relocations with type R_X86_64_PLT32 that need PLT entries. *)
+(** Returns function-call relocations that need PLT entries. On x86-64:
+    R_X86_64_PLT32. On AArch64: R_AARCH64_CALL26 and R_AARCH64_JUMP26. *)
 val convert_to_plt : t -> Relocation_entry.t list
 
-(** Returns relocations with type R_X86_64_REX_GOTPCRELX that need GOT entries.
-*)
+(** Returns GOT-relative relocations that need GOT entries. On x86-64:
+    R_X86_64_REX_GOTPCRELX. On AArch64: R_AARCH64_ADR_GOT_PAGE and
+    R_AARCH64_LD64_GOT_LO12_NC. *)
 val convert_to_got : t -> Relocation_entry.t list
 
 (** [extract unix ~filename] reads the ELF object file at [filename] and

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -266,42 +266,97 @@ let build_symbol_rewrite_map ~igot_and_iplt ~relocations =
     (Extract_relocations.convert_to_got relocations);
   plt_map, got_map
 
-(* Rewrite a single .rela.text* section. Looks up each relocation's target
-   symbol and rewrites PLT32/GOTPCRELX relocations to PC32 relocations targeting
-   the synthetic IPLT/IGOT symbols.
+(* Determine the new relocation type when rewriting a PLT relocation (function
+   call) to target an IPLT symbol. *)
+let rewrite_plt_reloc_type r_type =
+  match Target_system.architecture () with
+  | X86_64 ->
+    assert (Rela.Reloc_type.equal r_type Rela.Reloc_type.plt32);
+    Rela.Reloc_type.pc32
+  | AArch64 ->
+    (* CALL26/JUMP26 stay the same type, just retargeted *)
+    r_type
+  | _ -> Misc.fatal_error "Dissector: unsupported architecture"
 
-   - PLT32: function calls -> PC32 to IPLT entry - GOTPCRELX: GOT references ->
-   PC32 to IGOT entry *)
+(* Determine the new relocation type when rewriting a GOT relocation to target
+   an IGOT symbol. *)
+let rewrite_got_reloc_type r_type =
+  match Target_system.architecture () with
+  | X86_64 ->
+    assert (Rela.Reloc_type.equal r_type Rela.Reloc_type.rex_gotpcrelx);
+    Rela.Reloc_type.pc32
+  | AArch64 ->
+    (* GOT-relative → PC-relative addressing *)
+    if Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_adr_got_page
+    then Rela.Reloc_type.aarch64_adr_prel_pg_hi21
+    else if
+      Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_ld64_got_lo12_nc
+    then Rela.Reloc_type.aarch64_ldst64_abs_lo12_nc
+    else
+      Misc.fatal_errorf "Dissector: unexpected AArch64 GOT relocation type %s"
+        (Rela.Reloc_type.name r_type)
+  | _ -> Misc.fatal_error "Dissector: unsupported architecture"
+
+(* Architecture-specific relocation classification. *)
+
+let is_plt_reloc r_type =
+  match Target_system.architecture () with
+  | X86_64 -> Rela.Reloc_type.equal r_type Rela.Reloc_type.plt32
+  | AArch64 ->
+    Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_call26
+    || Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_jump26
+  | _ -> Misc.fatal_error "Dissector: unsupported architecture"
+
+let is_got_reloc r_type =
+  match Target_system.architecture () with
+  | X86_64 -> Rela.Reloc_type.equal r_type Rela.Reloc_type.rex_gotpcrelx
+  | AArch64 ->
+    Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_adr_got_page
+    || Rela.Reloc_type.equal r_type Rela.Reloc_type.aarch64_ld64_got_lo12_nc
+  | _ -> Misc.fatal_error "Dissector: unsupported architecture"
+
+(* Rewrite a single .rela.text* section. Looks up each relocation's target
+   symbol and rewrites function-call and GOT relocations to target the synthetic
+   IPLT/IGOT symbols.
+
+   On x86-64: - PLT32 → PC32 to IPLT entry - REX_GOTPCRELX → PC32 to IGOT entry
+
+   On AArch64: - CALL26/JUMP26 → same type to IPLT entry - ADR_GOT_PAGE →
+   ADR_PREL_PG_HI21 to IGOT entry - LD64_GOT_LO12_NC → LDST64_ABS_LO12_NC to
+   IGOT entry *)
 let rewrite_rela_section ~rela_body ~symtab_body ~strtab_body ~symbol_to_index
     ~plt_rewrite_map ~got_rewrite_map =
   let entries = ref [] in
   Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
       let new_entry =
-        (* Look up the original symbol name for this relocation *)
         let sym_name_opt =
           Rela.read_symbol_name ~symtab_body ~strtab_body ~sym_index:entry.r_sym
         in
         match sym_name_opt with
         | None -> entry
         | Some sym_name -> (
-          (* Check if this relocation type/symbol should be rewritten *)
-          let rewrite_to =
-            if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-            then String.Tbl.find_opt plt_rewrite_map sym_name
-            else if
-              Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
-            then String.Tbl.find_opt got_rewrite_map sym_name
-            else None
+          let rewrite_to, new_r_type =
+            if is_plt_reloc entry.r_type
+            then
+              ( String.Tbl.find_opt plt_rewrite_map sym_name,
+                Some (rewrite_plt_reloc_type entry.r_type) )
+            else if is_got_reloc entry.r_type
+            then
+              ( String.Tbl.find_opt got_rewrite_map sym_name,
+                Some (rewrite_got_reloc_type entry.r_type) )
+            else None, None
           in
-          match rewrite_to with
-          | Some new_sym_name -> (
+          match rewrite_to, new_r_type with
+          | Some new_sym_name, Some new_type -> (
             match String.Tbl.find_opt symbol_to_index new_sym_name with
             | Some idx ->
-              log_verbose "  rewrite reloc at 0x%Lx: %s %s -> PC32 to %s"
+              log_verbose "  rewrite reloc at 0x%Lx: %s %s -> %s to %s"
                 entry.r_offset
                 (Rela.Reloc_type.name entry.r_type)
-                sym_name new_sym_name;
-              { entry with r_sym = idx; r_type = Rela.Reloc_type.pc32 }
+                sym_name
+                (Rela.Reloc_type.name new_type)
+                new_sym_name;
+              { entry with r_sym = idx; r_type = new_type }
             | None ->
               log_verbose
                 "  rewrite reloc at 0x%Lx: %s -> %s NOT FOUND in symtab"
@@ -309,7 +364,7 @@ let rewrite_rela_section ~rela_body ~symtab_body ~strtab_body ~symbol_to_index
                 (Rela.Reloc_type.name entry.r_type)
                 new_sym_name;
               entry)
-          | None -> entry)
+          | _ -> entry)
       in
       entries := new_entry :: !entries);
   List.rev !entries

--- a/asmcomp/dissector/igot.ml
+++ b/asmcomp/dissector/igot.ml
@@ -28,6 +28,7 @@
 (* CR mshinwell: This file needs to be code reviewed *)
 
 module String = Misc.Stdlib.String
+module Rela = Compiler_owee.Owee_elf_relocation
 
 let log_verbose = Dissector_log.log_verbose
 
@@ -105,6 +106,7 @@ module Relocation = struct
   type t =
     { offset : int;
       symbol : string;
+      reloc_type : Rela.Reloc_type.t;
       addend : int64
     }
 
@@ -112,8 +114,16 @@ module Relocation = struct
 
   let symbol r = r.symbol
 
+  let reloc_type r = r.reloc_type
+
   let addend r = r.addend
 end
+
+let abs64_reloc_type =
+  match Target_system.architecture () with
+  | X86_64 -> Rela.Reloc_type.r64
+  | AArch64 -> Rela.Reloc_type.aarch64_abs64
+  | _ -> Misc.fatal_error "Dissector IGOT: unsupported architecture"
 
 let relocations t =
   List.map
@@ -121,6 +131,7 @@ let relocations t =
       Relocation.
         { offset = Entry.offset entry;
           symbol = Entry.original_symbol entry;
+          reloc_type = abs64_reloc_type;
           addend = 0L
         })
     t.entries

--- a/asmcomp/dissector/igot.mli
+++ b/asmcomp/dissector/igot.mli
@@ -31,8 +31,8 @@
 
     The intermediate GOT provides local GOT entries that are within range of
     PC-relative addressing from the code in a partition. Each entry holds the
-    absolute address of an external symbol, filled in by an R_X86_64_64
-    relocation at final link time. *)
+    absolute address of an external symbol, filled in by an absolute 64-bit
+    relocation (R_X86_64_64 or R_AARCH64_ABS64) at final link time. *)
 
 (** Size of each IGOT entry in bytes. *)
 val entry_size : int
@@ -91,10 +91,13 @@ module Relocation : sig
   (** Returns the original external symbol to relocate to. *)
   val symbol : t -> string
 
+  (** Returns the relocation type (R_X86_64_64 or R_AARCH64_ABS64). *)
+  val reloc_type : t -> Compiler_owee.Owee_elf_relocation.Reloc_type.t
+
   (** Returns the relocation addend (always 0 for IGOT). *)
   val addend : t -> int64
 end
 
-(** [relocations t] returns the list of R_X86_64_64 relocations needed to fill
-    the IGOT entries with the addresses of the original symbols. *)
+(** [relocations t] returns the list of absolute 64-bit relocations needed to
+    fill the IGOT entries with the addresses of the original symbols. *)
 val relocations : t -> Relocation.t list

--- a/asmcomp/dissector/iplt.ml
+++ b/asmcomp/dissector/iplt.ml
@@ -28,14 +28,26 @@
 (* CR mshinwell: This file needs to be code reviewed *)
 
 module String = Misc.Stdlib.String
+module Rela = Compiler_owee.Owee_elf_relocation
 
 let log_verbose = Dissector_log.log_verbose
 
-(* Each IPLT entry is 8 bytes: ff 25 XX XX XX XX - jmp [rip + disp32] (6 bytes)
-   90 90 - 2-byte nop padding (two single-byte nops)
+(* Each IPLT entry has architecture-specific size:
 
-   The 4-byte displacement at offset +2 will be filled by a PC32 relocation. *)
-let entry_size = 8
+   x86-64 (8 bytes): ff 25 XX XX XX XX - jmp [rip + disp32] (6 bytes) 90 90 -
+   2-byte nop padding The 4-byte displacement at offset +2 is filled by a PC32
+   relocation.
+
+   AArch64 (16 bytes): adrp x16, #0 - load page address of IGOT entry (4 bytes)
+   ldr x17, [x16, #0] - load target address from IGOT (4 bytes) br x17 - branch
+   to target (4 bytes) nop - padding (4 bytes) The ADRP at offset +0 gets
+   ADR_PREL_PG_HI21, the LDR at offset +4 gets LDST64_ABS_LO12_NC, both pointing
+   to the IGOT symbol. *)
+let entry_size =
+  match Target_system.architecture () with
+  | X86_64 -> 8
+  | AArch64 -> 16
+  | _ -> Misc.fatal_error "Dissector IPLT: unsupported architecture"
 
 (* Delimiter for synthetic symbol names - same as IGOT *)
 let delimiter = "\xf0\x9f\x90\x8d" (* Unicode snake emoji U+1F40D in UTF-8 *)
@@ -68,10 +80,10 @@ type t =
 let iplt_symbol_name ~prefix ~symbol =
   "iplt" ^ delimiter ^ prefix ^ delimiter ^ symbol
 
-(* Build the PLT entry template using X86_binary_emitter. The JMP instruction
-   is: jmp [rip + 0] which encodes as ff 25 00 00 00 00 (6 bytes). We append two
-   NOP instructions (90 90) for padding to reach 8 bytes. *)
-let plt_entry_template =
+(* Build the x86-64 PLT entry template using X86_binary_emitter. jmp [rip + 0]
+   encodes as ff 25 00 00 00 00 (6 bytes), plus two NOP instructions (90 90) for
+   padding to 8 bytes. *)
+let x86_64_plt_entry_template =
   let section =
     { X86_binary_emitter.sec_name = ".text.iplt";
       sec_instrs =
@@ -86,6 +98,56 @@ let plt_entry_template =
   let bytes = X86_binary_emitter.contents buffer in
   assert (String.length bytes = 8);
   bytes
+
+(* Build the AArch64 PLT entry template using the ARM64 binary emitter. Each
+   entry is 16 bytes: adrp x16, dummy@PAGE (4 bytes) ldr x17, [x16,
+   dummy@PAGEOFF] (4 bytes) br x17 (4 bytes) nop (4 bytes) The relocation fields
+   are zeroed on RELA platforms (Linux). *)
+let aarch64_plt_entry_template =
+  let module Ast = Arm64_ast.Ast in
+  let module O = Ast.DSL in
+  let module BE = Arm64_binary_emitter.Binary_emitter in
+  let dummy = Asm_targets.Asm_symbol.create_global "iplt_dummy" in
+  let page_sym =
+    Ast.Symbol.create_symbol (Ast.Symbol.Needs_reloc Ast.Symbol.PAGE) dummy
+  in
+  let pageoff_sym =
+    Ast.Symbol.create_symbol (Ast.Symbol.Needs_reloc Ast.Symbol.PAGE_OFF) dummy
+  in
+  let emitter = BE.create () in
+  BE.add_instruction emitter
+    (Ast.Instruction.I
+       { name = Ast.Instruction_name.ADRP;
+         operands = Pair (O.reg_x 16, O.symbol page_sym)
+       });
+  BE.add_instruction emitter
+    (Ast.Instruction.I
+       { name = Ast.Instruction_name.LDR;
+         operands =
+           Pair
+             ( O.reg_x 17,
+               O.mem_symbol ~base:(Ast.Reg.reg_x 16) ~symbol:pageoff_sym )
+       });
+  BE.add_instruction emitter
+    (Ast.Instruction.I
+       { name = Ast.Instruction_name.BR; operands = Singleton (O.reg_x 17) });
+  BE.add_instruction emitter
+    (Ast.Instruction.I
+       { name = Ast.Instruction_name.NOP; operands = Singleton O.unit_operand });
+  let sections = BE.emit emitter in
+  let text =
+    Arm64_binary_emitter.All_section_states.get_or_create sections
+      Asm_targets.Asm_section.Text
+  in
+  let bytes = BE.Section_state.contents text in
+  assert (String.length bytes = 16);
+  bytes
+
+let plt_entry_template =
+  match Target_system.architecture () with
+  | X86_64 -> x86_64_plt_entry_template
+  | AArch64 -> aarch64_plt_entry_template
+  | _ -> Misc.fatal_error "Dissector IPLT: unsupported architecture"
 
 let build ~prefix ~igot ~symbols =
   (* Remove duplicates while preserving order, and build lookup table *)
@@ -148,6 +210,7 @@ module Relocation = struct
   type t =
     { offset : int;
       symbol : string;
+      reloc_type : Rela.Reloc_type.t;
       addend : int64
     }
 
@@ -155,18 +218,42 @@ module Relocation = struct
 
   let symbol r = r.symbol
 
+  let reloc_type r = r.reloc_type
+
   let addend r = r.addend
 end
 
-(* The displacement field is at offset +2 within each entry *)
-let displacement_offset = 2
-
 let relocations t =
-  List.map
-    (fun entry ->
-      Relocation.
-        { offset = Entry.offset entry + displacement_offset;
-          symbol = Entry.igot_symbol entry;
-          addend = -4L
-        })
-    t.entries
+  match Target_system.architecture () with
+  | X86_64 ->
+    (* x86-64: one PC32 relocation at offset +2 (the disp32 field) *)
+    List.map
+      (fun entry ->
+        Relocation.
+          { offset = Entry.offset entry + 2;
+            symbol = Entry.igot_symbol entry;
+            reloc_type = Rela.Reloc_type.pc32;
+            addend = -4L
+          })
+      t.entries
+  | AArch64 ->
+    (* AArch64: two relocations per entry: offset +0: ADR_PREL_PG_HI21 (ADRP
+       instruction) offset +4: LDST64_ABS_LO12_NC (LDR instruction) *)
+    List.concat_map
+      (fun entry ->
+        let base = Entry.offset entry in
+        let sym = Entry.igot_symbol entry in
+        [ Relocation.
+            { offset = base;
+              symbol = sym;
+              reloc_type = Rela.Reloc_type.aarch64_adr_prel_pg_hi21;
+              addend = 0L
+            };
+          Relocation.
+            { offset = base + 4;
+              symbol = sym;
+              reloc_type = Rela.Reloc_type.aarch64_ldst64_abs_lo12_nc;
+              addend = 0L
+            } ])
+      t.entries
+  | _ -> Misc.fatal_error "Dissector IPLT: unsupported architecture"

--- a/asmcomp/dissector/iplt.mli
+++ b/asmcomp/dissector/iplt.mli
@@ -33,14 +33,18 @@
     PC-relative call/jump instructions from the code in a partition. Each entry
     contains a jump instruction through the corresponding IGOT entry.
 
-    Each PLT entry is 8 bytes:
-
+    On x86-64, each PLT entry is 8 bytes:
     - ff 25 XX XX XX XX : jmp [rip + displacement] (6 bytes)
+    - 90 90 : 2-byte nop padding
+    - One R_X86_64_PC32 relocation at offset +2
 
-    - 90 90 : 2-byte nop padding (two single-byte nops)
-
-    The 4-byte displacement at offset +2 is filled by a PC32 relocation pointing
-    to the corresponding IGOT entry. *)
+    On AArch64, each PLT entry is 16 bytes:
+    - adrp x16, \#0 : load page of IGOT entry (4 bytes)
+    - ldr x17, [x16, \#0] : load address from IGOT (4 bytes)
+    - br x17 : branch to target (4 bytes)
+    - nop : padding (4 bytes)
+    - Two relocations: R_AARCH64_ADR_PREL_PG_HI21 at +0 and
+      R_AARCH64_LDST64_ABS_LO12_NC at +4 *)
 
 (** Size of each IPLT entry in bytes. *)
 val entry_size : int
@@ -100,17 +104,21 @@ val iplt_symbol_name : prefix:string -> symbol:string -> string
 module Relocation : sig
   type t
 
-  (** Returns the offset within the IPLT section (entry_offset + 2). *)
+  (** Returns the offset within the IPLT section. *)
   val offset : t -> int
 
   (** Returns the IGOT symbol to relocate to. *)
   val symbol : t -> string
 
-  (** Returns the relocation addend (-4 to account for RIP pointing past
-      displacement). *)
+  (** Returns the relocation type. *)
+  val reloc_type : t -> Compiler_owee.Owee_elf_relocation.Reloc_type.t
+
+  (** Returns the relocation addend. *)
   val addend : t -> int64
 end
 
-(** [relocations t] returns the list of R_X86_64_PC32 relocations needed to fill
-    the IPLT entries with displacements to their IGOT entries. *)
+(** [relocations t] returns the list of relocations needed to fill the IPLT
+    entries with references to their IGOT entries. On x86-64 this is one
+    R_X86_64_PC32 per entry; on AArch64 it is two per entry
+    (R_AARCH64_ADR_PREL_PG_HI21 and R_AARCH64_LDST64_ABS_LO12_NC). *)
 val relocations : t -> Relocation.t list

--- a/asmcomp/dissector/rewrite_sections.ml
+++ b/asmcomp/dissector/rewrite_sections.ml
@@ -126,7 +126,8 @@ let execute_plan unix ~input_file ~output_file ~header ~sections
     (fun r ->
       write_rela ~cursor ~symbol_to_index:(FRP.symbol_to_index plan)
         ~r_offset:(Igot.Relocation.offset r) ~symbol:(Igot.Relocation.symbol r)
-        ~r_type:Rela.Reloc_type.r64 ~r_addend:(Igot.Relocation.addend r))
+        ~r_type:(Igot.Relocation.reloc_type r)
+        ~r_addend:(Igot.Relocation.addend r))
     (Igot.relocations igot);
   Buf.Write.fixed_bytes
     (Buf.cursor output_buf ~at:(int64_to_int (SL.offset iplt_layout)))
@@ -139,7 +140,8 @@ let execute_plan unix ~input_file ~output_file ~header ~sections
     (fun r ->
       write_rela ~cursor ~symbol_to_index:(FRP.symbol_to_index plan)
         ~r_offset:(Iplt.Relocation.offset r) ~symbol:(Iplt.Relocation.symbol r)
-        ~r_type:Rela.Reloc_type.pc32 ~r_addend:(Iplt.Relocation.addend r))
+        ~r_type:(Iplt.Relocation.reloc_type r)
+        ~r_addend:(Iplt.Relocation.addend r))
     (Iplt.relocations iplt);
   let cursor =
     Buf.cursor output_buf ~at:(int64_to_int (SL.offset symtab_layout))

--- a/dune
+++ b/dune
@@ -728,6 +728,7 @@
   compiler_owee
   gc_timings
   arm64_ast
+  arm64_binary_emitter
   dwarf_low
   dwarf_high
   binary_emitter_intf))

--- a/external/owee/owee_elf_relocation.ml
+++ b/external/owee/owee_elf_relocation.ml
@@ -44,7 +44,7 @@ module Section_index = struct
   let needs_extended t = t >= shn_loreserve
 end
 
-(* x86-64 relocation types *)
+(* Relocation types *)
 module Reloc_type = struct
   type t = int64
 
@@ -52,16 +52,42 @@ module Reloc_type = struct
   let to_int64 t = t
   let of_int64 t = t
 
+  (* x86-64 relocation types *)
   let plt32 = 4L
   let rex_gotpcrelx = 42L
   let r64 = 1L
   let pc32 = 2L
+
+  (* AArch64 relocation types *)
+  let aarch64_abs64 = 257L
+  let aarch64_prel32 = 261L
+  let aarch64_call26 = 283L
+  let aarch64_jump26 = 282L
+  let aarch64_adr_prel_pg_hi21 = 275L
+  let aarch64_add_abs_lo12_nc = 277L
+  let aarch64_ldst64_abs_lo12_nc = 286L
+  let aarch64_adr_got_page = 311L
+  let aarch64_ld64_got_lo12_nc = 312L
 
   let name t =
     if Int64.equal t plt32 then "PLT32"
     else if Int64.equal t rex_gotpcrelx then "REX_GOTPCRELX"
     else if Int64.equal t pc32 then "PC32"
     else if Int64.equal t r64 then "64"
+    else if Int64.equal t aarch64_abs64 then "AARCH64_ABS64"
+    else if Int64.equal t aarch64_prel32 then "AARCH64_PREL32"
+    else if Int64.equal t aarch64_call26 then "AARCH64_CALL26"
+    else if Int64.equal t aarch64_jump26 then "AARCH64_JUMP26"
+    else if Int64.equal t aarch64_adr_prel_pg_hi21
+    then "AARCH64_ADR_PREL_PG_HI21"
+    else if Int64.equal t aarch64_add_abs_lo12_nc
+    then "AARCH64_ADD_ABS_LO12_NC"
+    else if Int64.equal t aarch64_ldst64_abs_lo12_nc
+    then "AARCH64_LDST64_ABS_LO12_NC"
+    else if Int64.equal t aarch64_adr_got_page
+    then "AARCH64_ADR_GOT_PAGE"
+    else if Int64.equal t aarch64_ld64_got_lo12_nc
+    then "AARCH64_LD64_GOT_LO12_NC"
     else Printf.sprintf "type=%Ld" t
 end
 

--- a/external/owee/owee_elf_relocation.mli
+++ b/external/owee/owee_elf_relocation.mli
@@ -62,9 +62,9 @@ module Section_index : sig
       meaning it requires the SHT_SYMTAB_SHNDX extended section index table. *)
 end
 
-(** {1 x86-64 Relocation Types} *)
+(** {1 Relocation Types} *)
 
-(** Abstract type representing an x86-64 relocation type. *)
+(** Abstract type representing an ELF relocation type. *)
 module Reloc_type : sig
   type t
 
@@ -77,6 +77,8 @@ module Reloc_type : sig
   val of_int64 : int64 -> t
   (** Create from a raw ELF relocation type value. *)
 
+  (** {2 x86-64 relocation types} *)
+
   val plt32 : t
   (** R_X86_64_PLT32 relocation type. *)
 
@@ -88,6 +90,37 @@ module Reloc_type : sig
 
   val pc32 : t
   (** R_X86_64_PC32 relocation type (32-bit PC-relative). *)
+
+  (** {2 AArch64 relocation types} *)
+
+  val aarch64_abs64 : t
+  (** R_AARCH64_ABS64 relocation type (64-bit absolute). *)
+
+  val aarch64_prel32 : t
+  (** R_AARCH64_PREL32 relocation type (32-bit PC-relative). *)
+
+  val aarch64_call26 : t
+  (** R_AARCH64_CALL26 relocation type (26-bit PC-relative call). *)
+
+  val aarch64_jump26 : t
+  (** R_AARCH64_JUMP26 relocation type (26-bit PC-relative jump). *)
+
+  val aarch64_adr_prel_pg_hi21 : t
+  (** R_AARCH64_ADR_PREL_PG_HI21 relocation type (page-relative). *)
+
+  val aarch64_add_abs_lo12_nc : t
+  (** R_AARCH64_ADD_ABS_LO12_NC relocation type (low 12-bit ADD). *)
+
+  val aarch64_ldst64_abs_lo12_nc : t
+  (** R_AARCH64_LDST64_ABS_LO12_NC relocation type
+      (low 12-bit load/store). *)
+
+  val aarch64_adr_got_page : t
+  (** R_AARCH64_ADR_GOT_PAGE relocation type (GOT page-relative). *)
+
+  val aarch64_ld64_got_lo12_nc : t
+  (** R_AARCH64_LD64_GOT_LO12_NC relocation type
+      (GOT low 12-bit load). *)
 
   val name : t -> string
   (** [name t] returns a human-readable name for the relocation type.

--- a/oxcaml/tests/dissector/dune
+++ b/oxcaml/tests/dissector/dune
@@ -50,7 +50,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target simple.exe)
@@ -62,7 +61,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target simple.output)
@@ -73,7 +71,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps simple.expected simple.output)
@@ -84,7 +81,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target simple_funcsect.exe)
@@ -96,7 +92,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target simple_funcsect.output)
@@ -107,7 +102,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps simple.expected simple_funcsect.output)
@@ -121,7 +115,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets gen_module_a.cmi gen_module_a.cmx gen_module_a.o)
@@ -132,7 +125,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets gen_module_b.cmi gen_module_b.cmx gen_module_b.o)
@@ -143,7 +135,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets gen_module_c.cmi gen_module_c.cmx gen_module_c.o)
@@ -156,7 +147,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets gen_main.cmi gen_main.cmx gen_main.o)
@@ -171,7 +161,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cross_partition.exe)
@@ -187,7 +176,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cross_partition.output)
@@ -198,7 +186,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cross_partition.expected cross_partition.output)
@@ -209,7 +196,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cross_partition.exe)
@@ -221,7 +207,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cross_partition_fs.exe)
@@ -237,7 +222,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cross_partition_fs.output)
@@ -248,7 +232,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cross_partition.expected cross_partition_fs.output)
@@ -259,7 +242,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps gen_module_a.cmx gen_module_a.o gen_module_b.cmx gen_module_b.o
@@ -373,12 +355,11 @@
      echo 'IGOT verification passed'
    ")))
 
-; Verify IGOT relocations are all R_X86_64_64
+; Verify IGOT relocations are the correct absolute 64-bit type
 (rule
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps gen_module_a.cmx gen_module_a.o gen_module_b.cmx gen_module_b.o
@@ -387,6 +368,15 @@
   (bash "
      set -e
      set +o pipefail
+
+     # Determine expected IGOT relocation type based on architecture
+     ARCH=%{architecture}
+     if [ \"$ARCH\" = \"amd64\" ]; then
+       EXPECTED_RELOC='R_X86_64_64'
+     else
+       EXPECTED_RELOC='R_AARCH64_ABS64'
+     fi
+
      # Build with -ddissector-partitions and capture partition dir from stderr
      OUTPUT=$(%{bin:ocamlopt.opt} -dissector -dissector-partition-size 0.003 -ddissector-partitions \
        gen_module_a.cmx gen_module_b.cmx gen_module_c.cmx gen_main.cmx \
@@ -404,14 +394,14 @@
      for part in $PARTITION_DIR/partition*.o.rewritten; do
        echo \"Checking $part\"
        if readelf -SW \"$part\" 2>/dev/null | grep -q 'data\\.igot'; then
-         # Count total IGOT relocs and R_X86_64_64 relocs
+         # Count total IGOT relocs and expected-type relocs
          TOTAL=$(readelf -r \"$part\" 2>/dev/null | sed -n '/rela.*\\.data\\.igot/,/^Relocation/p' | grep -c '^[0-9a-f]' || true)
-         R64=$(readelf -r \"$part\" 2>/dev/null | sed -n '/rela.*\\.data\\.igot/,/^Relocation/p' | grep -c 'R_X86_64_64' || true)
-         echo \"  IGOT relocs: Total=$TOTAL, R_X86_64_64=$R64\"
+         R64=$(readelf -r \"$part\" 2>/dev/null | sed -n '/rela.*\\.data\\.igot/,/^Relocation/p' | grep -c \"$EXPECTED_RELOC\" || true)
+         echo \"  IGOT relocs: Total=$TOTAL, $EXPECTED_RELOC=$R64\"
 
          if [ \"$TOTAL\" != \"$R64\" ]; then
-           echo \"ERROR: Not all IGOT relocations are R_X86_64_64 in $(basename $part)\"
-           echo \"Total: $TOTAL, R_X86_64_64: $R64\"
+           echo \"ERROR: Not all IGOT relocations are $EXPECTED_RELOC in $(basename $part)\"
+           echo \"Total: $TOTAL, $EXPECTED_RELOC: $R64\"
            echo 'IGOT relocations:'
            readelf -r \"$part\" 2>/dev/null | sed -n '/rela.*\\.data\\.igot/,/^Relocation/p' | head -50
            exit 1
@@ -428,7 +418,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps gen_module_a.cmx gen_module_a.o gen_module_b.cmx gen_module_b.o
@@ -524,7 +513,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets mylib_a.cmi mylib_a.cmx mylib_a.o)
@@ -535,7 +523,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets mylib_b.cmi mylib_b.cmx mylib_b.o)
@@ -547,7 +534,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (targets mylib.cmxa mylib.a)
@@ -559,7 +545,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cmxa_test.exe)
@@ -571,7 +556,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cmxa_test.output)
@@ -582,7 +566,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cmxa_test.expected cmxa_test.output)
@@ -593,7 +576,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cmxa_test.exe)
@@ -605,7 +587,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cclib_test.exe)
@@ -618,7 +599,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cclib_test.output)
@@ -631,7 +611,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cclib_test.output)
@@ -643,7 +622,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cstub.o)
@@ -655,7 +633,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target libcstub.a)
@@ -667,7 +644,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cstub_passthrough.exe)
@@ -681,7 +657,6 @@
 (rule
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (target cstub_passthrough.output)
@@ -694,7 +669,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cstub_passthrough.output)
@@ -705,7 +679,6 @@
  (alias runtest)
  (enabled_if
   (and (= %{context_name} "main")
-       (= %{architecture} "amd64")
        (= %{system} "linux")
        (<> %{env:RUNTIME_DIR=runtime} "runtime4")))
  (deps cstub_passthrough.ml libcstub.a)


### PR DESCRIPTION
## Add ARM64 Linux support to the dissector

  The dissector previously only supported x86-64 Linux. This adds support for AArch64 (ARM64) Linux by handling the ARM64-specific ELF relocation types used for function calls and GOT references, and generating ARM64 PLT stubs
  via the ARM64 binary emitter DSL.

  ### Changes

  **`external/owee/owee_elf_relocation.ml/mli`** — Added AArch64 relocation type constants: `aarch64_abs64`, `aarch64_call26`, `aarch64_jump26`, `aarch64_adr_got_page`, `aarch64_ld64_got_lo12_nc`, `aarch64_adr_prel_pg_hi21`,
  `aarch64_ldst64_abs_lo12_nc`, `aarch64_add_abs_lo12_nc`, `aarch64_prel32`. Updated `name` function.

  **`asmcomp/dissector/extract_relocations.ml`** — Architecture-aware relocation classification: CALL26/JUMP26 → PLT (function calls), ADR_GOT_PAGE/LD64_GOT_LO12_NC → GOT references. Error check for direct PC-relative relocs to
  undefined symbols.

  **`asmcomp/dissector/iplt.ml`** — ARM64 IPLT stubs (16 bytes: ADRP+LDR+BR+NOP) generated via the ARM64 DSL (`Arm64_binary_emitter`), analogous to the x86 case using `X86_binary_emitter`. Two relocations per entry
  (ADR_PREL_PG_HI21 + LDST64_ABS_LO12_NC) vs one on x86.

  **`asmcomp/dissector/igot.ml`** — Added `reloc_type` field to relocations (R_X86_64_64 on x86, R_AARCH64_ABS64 on ARM64).

  **`asmcomp/dissector/form_rewrite_plan.ml`** — Architecture-aware rewriting: on ARM64, CALL26/JUMP26 keep their type (just retargeted to IPLT), GOT relocations convert from GOT-relative to PC-relative (ADR_GOT_PAGE →
  ADR_PREL_PG_HI21, LD64_GOT_LO12_NC → LDST64_ABS_LO12_NC).

  **`asmcomp/dissector/rewrite_sections.ml`** — Uses `reloc_type` from IGOT/IPLT Relocation instead of hardcoded types.

  **`asmcomp/dissector/dissector.ml`** — Added AArch64 to supported architectures.

  **`dune`** — Added `arm64_binary_emitter` library dependency to `ocamloptcomp`.

  **`oxcaml/tests/dissector/dune`** — Removed architecture filter (both amd64 and arm64 supported; Linux-only check remains). Made IGOT relocation type verification architecture-aware.

  **`.mli` files** — Updated doc comments for architecture neutrality.
