### PR TITLE
improved codegen for int comparisons

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2211,13 +2211,35 @@ let emit_instr ~first ~last ~fallthrough i =
     D.define_label lbl_after_poll
   | Lop Pause -> I.pause ()
   | Lop (Intop (Icomp cmp)) ->
-    I.cmp (arg i 1) (arg i 0);
-    I.set (cond cmp) al;
-    I.movzx al (res i 0)
+    if
+      Reg.is_reg i.res.(0)
+      && not
+           (Reg.equal_location i.res.(0).loc i.arg.(0).loc
+           || Reg.equal_location i.res.(0).loc i.arg.(1).loc)
+    then begin
+      I.xor (res32 i 0) (res32 i 0);
+      I.cmp (arg i 1) (arg i 0);
+      I.set (cond cmp) (res8 i 0)
+    end
+    else begin
+      I.cmp (arg i 1) (arg i 0);
+      I.set (cond cmp) al;
+      I.movzx al (res i 0)
+    end
   | Lop (Intop_imm (Icomp cmp, n)) ->
-    I.cmp (int n) (arg i 0);
-    I.set (cond cmp) al;
-    I.movzx al (res i 0)
+    if
+      Reg.is_reg i.res.(0)
+      && not (Reg.equal_location i.res.(0).loc i.arg.(0).loc)
+    then begin
+      I.xor (res32 i 0) (res32 i 0);
+      I.cmp (int n) (arg i 0);
+      I.set (cond cmp) (res8 i 0)
+    end
+    else begin
+      I.cmp (int n) (arg i 0);
+      I.set (cond cmp) al;
+      I.movzx al (res i 0)
+    end
   | Lop (Intop_imm (Iand, n))
     when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
     I.and_ (int n) (res32 i 0)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1058,6 +1058,16 @@ let mk_not dbg cmm =
 let mk_compare_ints_untagged dbg a1 a2 =
   bind "int_cmp" a2 (fun a2 ->
       bind "int_cmp" a1 (fun a1 ->
+          (* Three-way compare via csel(a1>=a2, a1>a2, -1):
+
+             a1 < a2 => csel(0, _, -1) = -1
+
+             a1 = a2 => csel(1, 0, _) = 0
+
+             a1 > a2 => csel(1, 1, _) = 1
+
+             Compared to (a1 > a2) - (a1 < a2), this encoding uses one fewer
+             instruction and has good latency without resorting to tricks. *)
           let cond = Cop (Ccmpi Cge, [a1; a2], dbg) in
           let ifso = Cop (Ccmpi Cgt, [a1; a2], dbg) in
           let ifnot = Cconst_int (-1, dbg) in
@@ -1066,6 +1076,8 @@ let mk_compare_ints_untagged dbg a1 a2 =
 let mk_unsigned_compare_ints_untagged dbg a1 a2 =
   bind "uint_cmp" a2 (fun a2 ->
       bind "uint_cmp" a1 (fun a1 ->
+          (* Same encoding as [mk_compare_ints_untagged] but with unsigned
+             comparisons. *)
           let cond = Cop (Ccmpi Cuge, [a1; a2], dbg) in
           let ifso = Cop (Ccmpi Cugt, [a1; a2], dbg) in
           let ifnot = Cconst_int (-1, dbg) in

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1058,16 +1058,18 @@ let mk_not dbg cmm =
 let mk_compare_ints_untagged dbg a1 a2 =
   bind "int_cmp" a2 (fun a2 ->
       bind "int_cmp" a1 (fun a1 ->
-          let op1 = Cop (Ccmpi Cgt, [a1; a2], dbg) in
-          let op2 = Cop (Ccmpi Clt, [a1; a2], dbg) in
-          sub_int op1 op2 dbg))
+          let cond = Cop (Ccmpi Cge, [a1; a2], dbg) in
+          let ifso = Cop (Ccmpi Cgt, [a1; a2], dbg) in
+          let ifnot = Cconst_int (-1, dbg) in
+          Cop (Ccsel typ_int, [cond; ifso; ifnot], dbg)))
 
 let mk_unsigned_compare_ints_untagged dbg a1 a2 =
   bind "uint_cmp" a2 (fun a2 ->
       bind "uint_cmp" a1 (fun a1 ->
-          let op1 = Cop (Ccmpi Cugt, [a1; a2], dbg) in
-          let op2 = Cop (Ccmpi Cult, [a1; a2], dbg) in
-          sub_int op1 op2 dbg))
+          let cond = Cop (Ccmpi Cuge, [a1; a2], dbg) in
+          let ifso = Cop (Ccmpi Cugt, [a1; a2], dbg) in
+          let ifnot = Cconst_int (-1, dbg) in
+          Cop (Ccsel typ_int, [cond; ifso; ifnot], dbg)))
 
 let mk_compare_ints dbg a1 a2 =
   match a1, a2 with

--- a/testsuite/tests/codegen/check_elimination.ml
+++ b/testsuite/tests/codegen/check_elimination.ml
@@ -103,9 +103,9 @@ search:
   jmp   .L131
 .L116:
   movq  (%rbx), %rax
+  xorl  %esi, %esi
   cmpq  %rax, %rdi
-  setl  %al
-  movzbq %al, %rsi
+  setl  %sil
   testq %rsi, %rsi
   je    .L123
   movq  8(%rbx), %rax

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -103,9 +103,9 @@ let combine_comparisons r f =
 [%%expect_asm X86_64{|
 combine_comparisons:
   movq  (%rax), %rbx
+  xorl  %eax, %eax
   cmpq  $41, %rbx
   setl  %al
-  movzbq %al, %rax
   cmpq  $11, %rbx
   jle   .L114
   testq %rax, %rax
@@ -149,9 +149,9 @@ let branch_and_return o =
 [%%expect_asm X86_64{|
 branch_and_return:
   movq  %rax, %rbx
+  xorl  %eax, %eax
   cmpq  $1, %rbx
   setne %al
-  movzbq %al, %rax
   leaq  1(%rax,%rax), %rax
   cmpq  $3, %rax
   jne   .L107

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -126,9 +126,9 @@ let repeat_comparisons r _f =
 [%%expect_asm X86_64{|
 repeat_comparisons:
   movq  (%rax), %rbx
+  xorl  %eax, %eax
   cmpq  $11, %rbx
   setg  %al
-  movzbq %al, %rax
   cmpq  $11, %rbx
   jle   .L113
   testq %rax, %rax

--- a/testsuite/tests/codegen/int.ml
+++ b/testsuite/tests/codegen/int.ml
@@ -273,13 +273,12 @@ let compare (x : int) (y : int) = compare x y
 [%%expect_asm X86_64{|
 compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 
@@ -301,13 +300,12 @@ let equal_using_compare (x : int) (y : int) =
 [%%expect_asm X86_64{|
 equal_using_compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   cmpq  $1, %rax
   sete  %al
   movzbq %al, %rax

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -239,13 +239,12 @@ let compare x y = Int16_u.compare x y
 [%%expect_asm X86_64{|
 compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 
@@ -293,13 +292,12 @@ let unsigned_compare x y = Int16_u.unsigned_compare x y
 [%%expect_asm X86_64{|
 unsigned_compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setb  %al
-  movzbq %al, %rsi
   seta  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovae %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int32_u.ml
+++ b/testsuite/tests/codegen/int32_u.ml
@@ -50,18 +50,17 @@ bswap:
   ret
 |}]
 
-(* CR ttebbi: Subtraction should be done on byte registers. *)
+(* CR ttebbi: `movq  $-1, %rsi` has a large encoding. *)
 let compare x y = Int32_u.compare x y
 [%%expect_asm X86_64{|
 compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -524,13 +524,12 @@ let compare x y = Int64_u.compare x y
 [%%expect_asm X86_64{|
 compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 
@@ -542,13 +541,12 @@ unsigned_compare:
   subq  %rax, %rbx
   movabsq $-9223372036854775808, %rax
   subq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 
@@ -567,13 +565,12 @@ let equal_using_compare x y = Int64_u.compare x y = 0
 [%%expect_asm X86_64{|
 equal_using_compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   cmpq  $1, %rax
   sete  %al
   movzbq %al, %rax

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -226,13 +226,12 @@ let compare x y = Int8_u.compare x y
 [%%expect_asm X86_64{|
 compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setl  %al
-  movzbq %al, %rsi
   setg  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 
@@ -280,13 +279,12 @@ let unsigned_compare x y = Int8_u.unsigned_compare x y
 [%%expect_asm X86_64{|
 unsigned_compare:
   movq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
-  setb  %al
-  movzbq %al, %rsi
   seta  %al
-  movzbq %al, %rax
-  subq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
+  cmovae %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/select.ml
+++ b/testsuite/tests/codegen/select.ml
@@ -50,9 +50,9 @@ let select_cmp_twice (x : int) (y: int) =
 [%%expect_asm X86_64{|
 select_cmp_twice:
   movq  %rax, %rdi
+  xorl  %eax, %eax
   cmpq  %rbx, %rdi
   setl  %al
-  movzbq %al, %rax
   leaq  1(%rax,%rax), %rax
   movl  $41, %esi
   movl  $21, %edx


### PR DESCRIPTION
For plain bit-result comparisons, using xor before instead of zero-extending the register afterwards saves 1 byte of instruction encoding and reduces chain latency by 1 (at least on some microarchitectures).

The new lowering for 3-way comparisons is `select (x >= y) (x > y) -1` instead of `(x > y) - (x < y)`, which saves 1 cycle of chain latency and one instruction, and would also save quite some binary encoding size if not for the unfortunately large encoding of the -1 constant. We could improve that in the future by adding an x86 peephole rule to turn
```
movq  $-1, %rsi
xorl  %eax, %eax
```
into
```
xorl  %eax, %eax
leaq -1(%rax), %rsi
```