### PR TITLE
CFG: Duplicate comparisons in block terminators and select/cmov

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -414,6 +414,8 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg_combine
   ++ cfg_with_layout_profile ~accumulate:true "cfg_cse" CSE.cfg_with_layout
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg_cse
+  ++ cfg_with_layout_profile ~accumulate:true "cfg_duplicate_comparisons"
+       Cfg_duplicate_comparisons.run
   ++ Cfg_with_infos.make
   ++ cfg_with_infos_profile ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
   ++ save_cfg_before_regalloc

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -42,6 +42,8 @@ cfg/**/*.ml
 cfg/**/*.mli
 cfg/vectorize.ml
 cfg/vectorize.mli
+cfg/cfg_ssa.ml
+cfg/cfg_ssa.mli
 vectorize_utils.ml
 vectorize_utils.mli
 cfg_selectgen.ml

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -414,7 +414,8 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
 
 let dump_terminator ?sep ppf terminator = dump_terminator' ?sep ppf terminator
 
-let print_basic' ?print_reg ppf (instruction : basic instruction) =
+let print_basic' ?print_reg ?assign_symbol ppf (instruction : basic instruction)
+    =
   let desc = Cfg_to_linear_desc.from_basic instruction.desc in
   let instruction =
     { Linear.desc;
@@ -428,7 +429,7 @@ let print_basic' ?print_reg ppf (instruction : basic instruction) =
       available_across = instruction.available_across
     }
   in
-  Printlinear.instr' ?print_reg ppf instruction
+  Printlinear.instr' ?print_reg ?assign_symbol ppf instruction
 
 let print_basic ppf i = print_basic' ppf i
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -184,6 +184,13 @@ val print_terminator : Format.formatter -> terminator instruction -> unit
 
 val print_basic : Format.formatter -> basic instruction -> unit
 
+val print_basic' :
+  ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  ?assign_symbol:string ->
+  Format.formatter ->
+  basic instruction ->
+  unit
+
 val print_instruction' :
   ?print_reg:(Format.formatter -> Reg.t -> unit) ->
   Format.formatter ->

--- a/backend/cfg/cfg_duplicate_comparisons.ml
+++ b/backend/cfg/cfg_duplicate_comparisons.ml
@@ -1,0 +1,137 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+(** Walk the SSA chain from [reg] upward looking for a comparison instruction,
+    following through moves. *)
+let rec find_comparison table reg =
+  match Cfg_ssa.find table reg with
+  | None | Some NotSSA | Some (Phi _) | Some (OverwrittenOutput _) -> None
+  | Some (Output { instr; _ }) -> (
+    match[@ocaml.warning "-4"] instr.desc with
+    | Op Move -> find_comparison table instr.arg.(0)
+    | Op (Intop (Icomp _) | Intop_imm (Icomp _, _) | Floatop (_, Icompf _)) ->
+      Some instr
+    | _ -> None)
+
+let all_args_usable cfg table ~from_block args =
+  Array.for_all
+    (Cfg_ssa.has_ssa_semantics_at table cfg ~at_block:from_block)
+    args
+
+let signedness_of_cmp (cmp : Cmm.integer_comparison) : Scalar.Signedness.t =
+  match cmp with
+  | Ceq | Cne | Clt | Cgt | Cle | Cge -> Signed
+  | Cult | Cugt | Cule | Cuge -> Unsigned
+
+let int_test_of_cmp ~ifso ~ifnot cmp ~imm : Cfg.terminator =
+  let lt, eq, gt =
+    match (cmp : Cmm.integer_comparison) with
+    | Ceq -> ifnot, ifso, ifnot
+    | Cne -> ifso, ifnot, ifso
+    | Clt -> ifso, ifnot, ifnot
+    | Cgt -> ifnot, ifnot, ifso
+    | Cle -> ifso, ifso, ifnot
+    | Cge -> ifnot, ifso, ifso
+    | Cult -> ifso, ifnot, ifnot
+    | Cugt -> ifnot, ifnot, ifso
+    | Cule -> ifso, ifso, ifnot
+    | Cuge -> ifnot, ifso, ifso
+  in
+  Int_test { lt; eq; gt; is_signed = signedness_of_cmp cmp; imm }
+
+let float_test_of_cmp ~ifso ~ifnot width cmp : Cfg.terminator =
+  let lt, eq, gt, uo =
+    match (cmp : Cmm.float_comparison) with
+    | CFeq -> ifnot, ifso, ifnot, ifnot
+    | CFneq -> ifso, ifnot, ifso, ifso
+    | CFlt -> ifso, ifnot, ifnot, ifnot
+    | CFnlt -> ifnot, ifso, ifso, ifso
+    | CFgt -> ifnot, ifnot, ifso, ifnot
+    | CFngt -> ifso, ifso, ifnot, ifso
+    | CFle -> ifso, ifso, ifnot, ifnot
+    | CFnle -> ifnot, ifnot, ifso, ifso
+    | CFge -> ifnot, ifso, ifso, ifnot
+    | CFnge -> ifso, ifnot, ifnot, ifso
+  in
+  Float_test { width; lt; eq; gt; uo }
+
+let terminator_of_comparison ~ifso ~ifnot
+    (cmp_instr : Cfg.basic Cfg.instruction) =
+  match[@ocaml.warning "-4"] cmp_instr.desc with
+  | Op (Intop (Icomp cmp)) ->
+    Some (int_test_of_cmp ~ifso ~ifnot cmp ~imm:None, cmp_instr.arg)
+  | Op (Intop_imm (Icomp cmp, n)) ->
+    Some (int_test_of_cmp ~ifso ~ifnot cmp ~imm:(Some n), cmp_instr.arg)
+  | Op (Floatop (width, Icompf cmp)) ->
+    Some (float_test_of_cmp ~ifso ~ifnot width cmp, cmp_instr.arg)
+  | _ -> None
+
+let test_of_comparison (cmp_instr : Cfg.basic Cfg.instruction) =
+  match[@ocaml.warning "-4"] cmp_instr.desc with
+  | Op (Intop (Icomp cmp)) -> Some (Operation.Iinttest cmp, cmp_instr.arg)
+  | Op (Intop_imm (Icomp cmp, n)) ->
+    Some (Operation.Iinttest_imm (cmp, n), cmp_instr.arg)
+  | Op (Floatop (width, Icompf cmp)) ->
+    Some (Operation.Ifloattest (width, cmp), cmp_instr.arg)
+  | _ -> None
+
+let try_replace_terminator cfg table (block : Cfg.basic_block) ~ifso ~ifnot
+    cmp_instr =
+  if all_args_usable cfg table ~from_block:block.start cmp_instr.Cfg.arg
+  then
+    match terminator_of_comparison ~ifso ~ifnot cmp_instr with
+    | Some (new_desc, new_arg) ->
+      block.terminator
+        <- { block.terminator with desc = new_desc; arg = new_arg }
+    | None -> ()
+
+let optimize_terminator cfg table (block : Cfg.basic_block) =
+  match[@ocaml.warning "-4"] block.terminator.desc with
+  | Truth_test { ifso; ifnot } -> (
+    let reg = block.terminator.arg.(0) in
+    match find_comparison table reg with
+    | Some cmp_instr ->
+      try_replace_terminator cfg table block ~ifso ~ifnot cmp_instr
+    | None -> ())
+  | _ -> ()
+
+let optimize_csel cfg table ~from_block
+    (cell : Cfg.basic Cfg.instruction DLL.cell) =
+  let instr = DLL.value cell in
+  match[@ocaml.warning "-4"] instr.desc with
+  | Op (Csel ((Itruetest | Ifalsetest) as test)) -> (
+    let test_reg = instr.arg.(0) in
+    let n = Array.length instr.arg in
+    let v_true = instr.arg.(n - 2) in
+    let v_false = instr.arg.(n - 1) in
+    match find_comparison table test_reg with
+    | None -> ()
+    | Some cmp_instr -> (
+      if not (all_args_usable cfg table ~from_block cmp_instr.arg)
+      then ()
+      else
+        match test_of_comparison cmp_instr with
+        | None -> ()
+        | Some (new_test, new_cmp_args) ->
+          let swap = match test with Ifalsetest -> true | _ -> false in
+          let v_true, v_false =
+            if swap then v_false, v_true else v_true, v_false
+          in
+          let new_arg = Array.concat [new_cmp_args; [| v_true; v_false |]] in
+          DLL.set_value cell
+            { instr with
+              desc = Cfg.Op (Operation.Csel new_test);
+              arg = new_arg
+            }))
+  | _ -> ()
+
+let run (cfg_with_layout : Cfg_with_layout.t) : Cfg_with_layout.t =
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  let table = Cfg_ssa.build cfg in
+  Cfg.iter_blocks cfg ~f:(fun _label block ->
+      optimize_terminator cfg table block;
+      DLL.iter_cell block.body
+        ~f:(optimize_csel cfg table ~from_block:block.start));
+  cfg_with_layout

--- a/backend/cfg/cfg_duplicate_comparisons.mli
+++ b/backend/cfg/cfg_duplicate_comparisons.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -74,13 +74,22 @@ let build (cfg : Cfg.t) : t =
         | Some (Output { label = old_label; instr = old_instr; _ }) ->
           if Label.equal label old_label
           then begin
+            (* Detect 2-operand instructions where the result overwrites an
+               input. Instruction selection emits these as a move-then-operate
+               pair:
+
+               reg := overwritten_input; reg := op(reg, y)
+
+               We require old_instr to be the immediately preceding. As a
+               consequence, we only support a single overwritten output. *)
             match DLL.prev cell with
             | Some prev_cell
               when InstructionId.equal
                      (DLL.value prev_cell : Cfg.basic Cfg.instruction).id
                      old_instr.id -> (
               match[@ocaml.warning "-4"] old_instr.desc, old_instr.arg with
-              | Op Move, [| overwritten_input |] ->
+              | Op Move, [| overwritten_input |]
+                when Array.exists (Reg.same reg) instr.arg ->
                 Reg.Tbl.replace table reg
                   (OverwrittenOutput
                      { label; instr; res_index; overwritten_input });
@@ -90,21 +99,13 @@ let build (cfg : Cfg.t) : t =
           end
           else false
         | Some (OverwrittenOutput _) -> false
-        | Some (Phi { merge_label; regs }) ->
+        | Some (Phi { merge_label; regs }) -> (
           let succ_block = Cfg.get_block_exn cfg merge_label in
-          if not (Label.Set.mem label succ_block.predecessors)
-          then false
-          else begin
-            let i =
-              predecessor_index succ_block.predecessors label |> Option.get
-            in
-            if not (Reg.same regs.(i) Reg.dummy)
-            then false
-            else begin
-              regs.(i) <- reg;
-              true
-            end
-          end
+          match predecessor_index succ_block.predecessors label with
+          | Some i when Reg.same regs.(i) Reg.dummy ->
+            regs.(i) <- reg;
+            true
+          | _ -> false)
       in
       if not success then Reg.Tbl.replace table reg NotSSA
   in

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -23,6 +23,8 @@ type entry =
 
 type t = entry Reg.Tbl.t
 
+let empty : t = Reg.Tbl.create 0
+
 let build (cfg : Cfg.t) : t =
   let table : t = Reg.Tbl.create 64 in
   let predecessor_index preds label =

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -61,17 +61,17 @@ let build (cfg : Cfg.t) : t =
                  _
                })
           when not (Label.equal label old_label) -> begin
-          match find_common_successor old_label label with
-          | None -> false
-          | Some merge_label ->
+          match find_common_successor old_label label, instr with
+          | Some merge_label, { desc = Op Move; arg = [| new_input |]; _ } ->
             let succ_block = Cfg.get_block_exn cfg merge_label in
             let preds = succ_block.predecessors in
             let n = Label.Set.cardinal preds in
             let regs = Array.make n Reg.dummy in
             regs.(predecessor_index preds old_label |> Option.get) <- old_input;
-            regs.(predecessor_index preds label |> Option.get) <- reg;
+            regs.(predecessor_index preds label |> Option.get) <- new_input;
             Reg.Tbl.replace table reg (Phi { merge_label; regs });
             true
+          | _ -> false
         end
         | Some (Output { label = old_label; instr = old_instr; _ }) ->
           if Label.equal label old_label
@@ -103,9 +103,10 @@ let build (cfg : Cfg.t) : t =
         | Some (OverwrittenOutput _) -> false
         | Some (Phi { merge_label; regs }) -> (
           let succ_block = Cfg.get_block_exn cfg merge_label in
-          match predecessor_index succ_block.predecessors label with
-          | Some i when Reg.same regs.(i) Reg.dummy ->
-            regs.(i) <- reg;
+          match predecessor_index succ_block.predecessors label, instr with
+          | Some i, { desc = Op Move; arg = [| input |]; _ }
+            when Reg.same regs.(i) Reg.dummy ->
+            regs.(i) <- input;
             true
           | _ -> false)
       in

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -128,11 +128,6 @@ let find table reg = Reg.Tbl.find_opt table reg
 
 let iter table ~f = Reg.Tbl.iter f table
 
-let is_ssa table reg =
-  match Reg.Tbl.find_opt table reg with
-  | Some (Output _ | OverwrittenOutput _ | Phi _) -> true
-  | Some NotSSA | None -> false
-
 let has_ssa_semantics_at table cfg ~at_block reg =
   match[@ocaml.warning "-4"] Reg.Tbl.find_opt table reg with
   | Some (Output _ | OverwrittenOutput _) -> true

--- a/backend/cfg/cfg_ssa.ml
+++ b/backend/cfg/cfg_ssa.ml
@@ -1,0 +1,147 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+type entry =
+  | Output of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int
+      }
+  | OverwrittenOutput of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int;
+        overwritten_input : Reg.t
+      }
+  | Phi of
+      { merge_label : Label.t;
+        regs : Reg.t array
+      }
+  | NotSSA
+
+type t = entry Reg.Tbl.t
+
+let build (cfg : Cfg.t) : t =
+  let table : t = Reg.Tbl.create 64 in
+  let predecessor_index preds label =
+    let i =
+      Label.Set.fold
+        (fun l acc -> if Label.equal label l then 0 else acc + 1)
+        preds 0
+    in
+    let n = Label.Set.cardinal preds in
+    if i < n then Some (n - 1 - i) else None
+  in
+  let find_common_successor label1 label2 =
+    let block1 = Cfg.get_block_exn cfg label1 in
+    let block2 = Cfg.get_block_exn cfg label2 in
+    let succs1 = Cfg.successor_labels ~normal:true ~exn:true block1 in
+    let succs2 = Cfg.successor_labels ~normal:true ~exn:true block2 in
+    Label.Set.min_elt_opt (Label.Set.inter succs1 succs2)
+  in
+  let process_body_def label cell res_index reg =
+    if reg.Reg.preassigned
+    then ()
+    else
+      let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+      let success =
+        match[@ocaml.warning "-fragile-match"] Reg.Tbl.find_opt table reg with
+        | None ->
+          Reg.Tbl.replace table reg (Output { label; instr; res_index });
+          true
+        | Some NotSSA -> true
+        | Some
+            (Output
+               { label = old_label;
+                 instr = { desc = Op Move; arg = [| old_input |]; _ };
+                 _
+               })
+          when not (Label.equal label old_label) -> begin
+          match find_common_successor old_label label with
+          | None -> false
+          | Some merge_label ->
+            let succ_block = Cfg.get_block_exn cfg merge_label in
+            let preds = succ_block.predecessors in
+            let n = Label.Set.cardinal preds in
+            let regs = Array.make n Reg.dummy in
+            regs.(predecessor_index preds old_label |> Option.get) <- old_input;
+            regs.(predecessor_index preds label |> Option.get) <- reg;
+            Reg.Tbl.replace table reg (Phi { merge_label; regs });
+            true
+        end
+        | Some (Output { label = old_label; instr = old_instr; _ }) ->
+          if Label.equal label old_label
+          then begin
+            match DLL.prev cell with
+            | Some prev_cell
+              when InstructionId.equal
+                     (DLL.value prev_cell : Cfg.basic Cfg.instruction).id
+                     old_instr.id -> (
+              match[@ocaml.warning "-4"] old_instr.desc, old_instr.arg with
+              | Op Move, [| overwritten_input |] ->
+                Reg.Tbl.replace table reg
+                  (OverwrittenOutput
+                     { label; instr; res_index; overwritten_input });
+                true
+              | _ -> false)
+            | _ -> false
+          end
+          else false
+        | Some (OverwrittenOutput _) -> false
+        | Some (Phi { merge_label; regs }) ->
+          let succ_block = Cfg.get_block_exn cfg merge_label in
+          if not (Label.Set.mem label succ_block.predecessors)
+          then false
+          else begin
+            let i =
+              predecessor_index succ_block.predecessors label |> Option.get
+            in
+            if not (Reg.same regs.(i) Reg.dummy)
+            then false
+            else begin
+              regs.(i) <- reg;
+              true
+            end
+          end
+      in
+      if not success then Reg.Tbl.replace table reg NotSSA
+  in
+  Cfg.iter_blocks_dfs cfg ~f:(fun label block ->
+      DLL.iter_cell block.body ~f:(fun cell ->
+          let (instr : Cfg.basic Cfg.instruction) = DLL.value cell in
+          Array.iteri (fun i reg -> process_body_def label cell i reg) instr.res));
+  (* Demote incomplete phis (those with remaining Reg.dummy entries) to NotSSA.
+     This happens when not all predecessors of the merge block define the
+     register. *)
+  Reg.Tbl.filter_map_inplace
+    (fun _reg entry ->
+      match[@ocaml.warning "-4"] entry with
+      | Phi { regs; _ } when Array.exists (Reg.same Reg.dummy) regs ->
+        Some NotSSA
+      | _ -> Some entry)
+    table;
+  table
+
+let find table reg = Reg.Tbl.find_opt table reg
+
+let iter table ~f = Reg.Tbl.iter f table
+
+let is_ssa table reg =
+  match Reg.Tbl.find_opt table reg with
+  | Some (Output _ | OverwrittenOutput _ | Phi _) -> true
+  | Some NotSSA | None -> false
+
+let has_ssa_semantics_at table cfg ~at_block reg =
+  match[@ocaml.warning "-4"] Reg.Tbl.find_opt table reg with
+  | Some (Output _ | OverwrittenOutput _) -> true
+  | Some (Phi { merge_label; _ }) ->
+    (* Between the assignment in a predecessor block and the actual control flow
+       edge to the merge block, the observable value of a register and the value
+       according to SSA semantics differ, so we exclude the whole predecessor
+       block. This is an over-approximation, only the part of the block from the
+       assignment to the end is critical. *)
+    not
+      (Label.Set.mem at_block (Cfg.get_block_exn cfg merge_label).predecessors)
+  | Some NotSSA | None -> false

--- a/backend/cfg/cfg_ssa.mli
+++ b/backend/cfg/cfg_ssa.mli
@@ -1,0 +1,71 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Reconstructed SSA information for a CFG.
+
+    The CFG uses pseudo-registers that may be assigned multiple times. In
+    practice, however, the CFGs we construct mostly follow SSA form. This module
+    reconstructs which registers have a single static assignment (SSA) and
+    tracks their defining instruction.
+
+    A register is considered SSA if it has exactly one definition across all
+    reachable blocks, or if its multiple definitions follow a phi-node pattern
+    (each definition in a distinct predecessor of a common merge block).
+    Preassigned (hardware) registers are never tracked. *)
+
+type entry =
+  | Output of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int
+      }
+  | OverwrittenOutput of
+      { label : Label.t;
+        instr : Cfg.basic Cfg.instruction;
+        res_index : int;
+        overwritten_input : Reg.t
+      }
+      (** Some architectures use 2-operand instructions where the result
+          overwrites the first argument (e.g. [r := r xor y] on x86-64). The
+          instruction selection emits a move into the register immediately
+          before the operation:
+          {|
+            r := x       (* preceding move *)
+            r := r xor y (* overwrites r; real input was x *)
+          |}
+          [OverwrittenOutput] records the overwriting instruction together with
+          [overwritten_input] (here [x]), the source of the preceding move. The
+          register is still SSA because the move and the operation form an
+          atomic pair: no other code can observe the intermediate value. *)
+  | Phi of
+      { merge_label : Label.t;
+        regs : Reg.t array
+      }
+      (** The register is assigned in all predecessor blocks of [merge_label].
+          [regs] has one entry per predecessor (in [Label.Set] order): the
+          register carrying the value from that predecessor. Only complete phis
+          (where every predecessor has a definition) are retained; incomplete
+          ones are demoted to [NotSSA]. *)
+  | NotSSA
+
+type t
+
+val build : Cfg.t -> t
+
+val find : t -> Reg.t -> entry option
+
+val iter : t -> f:(Reg.t -> entry -> unit) -> unit
+
+(** [is_ssa t reg] returns [true] if [reg] has a single static assignment
+    (Output, OverwrittenOutput, or Phi). *)
+val is_ssa : t -> Reg.t -> bool
+
+(** [has_ssa_semantics_at t cfg ~at_block reg] checks whether [reg] has an SSA
+    value and if using [reg] in block [block] coincides with SSA semantics. This
+    does *NOT* check for dominance. Instead, the one case this filters out is
+    that we have a phi node and [block] is one of the predecessor blocks of this
+    phi containing an assignment to [reg]. The problem is that in SSA semantics,
+    the assignment happens on the control flow edge and is not observable in the
+    predecessor block. In our CFG, however, the assignment is an explicit
+    instruction and we could well observe the register after the assignment
+    while still in the predecessor block, for example in a terminator. *)
+val has_ssa_semantics_at : t -> Cfg.t -> at_block:Label.t -> Reg.t -> bool

--- a/backend/cfg/cfg_ssa.mli
+++ b/backend/cfg/cfg_ssa.mli
@@ -49,6 +49,8 @@ type entry =
 
 type t
 
+val empty : t
+
 val build : Cfg.t -> t
 
 val find : t -> Reg.t -> entry option

--- a/backend/cfg/cfg_ssa.mli
+++ b/backend/cfg/cfg_ssa.mli
@@ -55,10 +55,6 @@ val find : t -> Reg.t -> entry option
 
 val iter : t -> f:(Reg.t -> entry -> unit) -> unit
 
-(** [is_ssa t reg] returns [true] if [reg] has a single static assignment
-    (Output, OverwrittenOutput, or Phi). *)
-val is_ssa : t -> Reg.t -> bool
-
 (** [has_ssa_semantics_at t cfg ~at_block reg] checks whether [reg] has an SSA
     value and if using [reg] in block [block] coincides with SSA semantics. This
     does *NOT* check for dominance. Instead, the one case this filters out is

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -174,7 +174,17 @@ let dump ppf t ~msg =
     print_phis ppf block;
     DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
         let assign_symbol =
-          if Array.for_all (Cfg_ssa.is_ssa ssa) instr.res then "<-" else ":="
+          if
+            Array.for_all
+              (fun reg ->
+                match[@ocaml.warning "-4"] Cfg_ssa.find ssa reg with
+                | Some (Output { instr = def_instr; _ })
+                | Some (OverwrittenOutput { instr = def_instr; _ }) ->
+                  InstructionId.equal instr.id def_instr.id
+                | _ -> false)
+              instr.res
+          then "<-"
+          else ":="
         in
         fprintf ppf "(id:%a) %a" InstructionId.format instr.id
           (fun ppf i -> Cfg.print_basic' ~assign_symbol ppf i)

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -115,6 +115,7 @@ let is_trap_handler t label =
 
 let dump ppf t ~msg =
   let open Format in
+  let ssa = Cfg_ssa.build t.cfg in
   fprintf ppf "\ncfg for %s\n" msg;
   fprintf ppf "%s\n" t.cfg.fun_name;
   let regalloc =
@@ -139,14 +140,58 @@ let dump ppf t ~msg =
     fprintf ppf "regalloc_params=%s\n" (String.concat ", " regalloc_params));
   fprintf ppf "layout.length=%d\n" (DLL.length t.layout);
   fprintf ppf "blocks.length=%d\n" (Label.Tbl.length t.cfg.blocks);
+  let phis_by_block =
+    let tbl = Label.Tbl.create 16 in
+    Cfg_ssa.iter ssa ~f:(fun reg entry ->
+        match[@ocaml.warning "-4"] (entry : Cfg_ssa.entry) with
+        | Phi { merge_label; regs } ->
+          let existing =
+            match Label.Tbl.find_opt tbl merge_label with
+            | Some l -> l
+            | None -> []
+          in
+          Label.Tbl.replace tbl merge_label ((reg, regs) :: existing)
+        | _ -> ());
+    tbl
+  in
+  let print_phis ppf block =
+    Label.Tbl.find_opt phis_by_block block.Cfg.start
+    |> Option.iter (fun phis ->
+        List.iter
+          (fun (reg, regs) ->
+            fprintf ppf "%a <- phi(" Printreg.reg reg;
+            Array.iteri
+              (fun i r ->
+                if i > 0 then fprintf ppf ", ";
+                fprintf ppf "%a" Printreg.reg r)
+              regs;
+            fprintf ppf ")\n")
+          phis)
+  in
   let print_block label =
     let block = Label.Tbl.find t.cfg.blocks label in
     fprintf ppf "\n%a:\n" Label.format label;
-    let pp_with_id ppf ~pp (instr : _ Cfg.instruction) =
-      fprintf ppf "(id:%a) %a\n" InstructionId.format instr.id pp instr
-    in
-    DLL.iter ~f:(pp_with_id ppf ~pp:Cfg.print_basic) block.body;
-    pp_with_id ppf ~pp:Cfg.print_terminator block.terminator;
+    print_phis ppf block;
+    DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+        let assign_symbol =
+          if Array.for_all (Cfg_ssa.is_ssa ssa) instr.res then "<-" else ":="
+        in
+        fprintf ppf "(id:%a) %a" InstructionId.format instr.id
+          (fun ppf i -> Cfg.print_basic' ~assign_symbol ppf i)
+          instr;
+        Array.iter
+          (fun reg ->
+            match[@ocaml.warning "-4"] Cfg_ssa.find ssa reg with
+            | Some
+                (OverwrittenOutput { instr = ow_instr; overwritten_input; _ })
+              when InstructionId.equal instr.id ow_instr.id ->
+              fprintf ppf " (input %a = %a)" Printreg.reg reg Printreg.reg
+                overwritten_input
+            | _ -> ())
+          instr.res;
+        fprintf ppf "\n");
+    fprintf ppf "(id:%a) %a\n" InstructionId.format block.terminator.id
+      Cfg.print_terminator block.terminator;
     fprintf ppf "\npredecessors:";
     Label.Set.iter (fprintf ppf " %a" Label.format) block.predecessors;
     fprintf ppf "\nsuccessors:";

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -115,7 +115,9 @@ let is_trap_handler t label =
 
 let dump ppf t ~msg =
   let open Format in
-  let ssa = Cfg_ssa.build t.cfg in
+  let ssa =
+    if !Oxcaml_flags.dump_cfg_ssa then Cfg_ssa.build t.cfg else Cfg_ssa.empty
+  in
   fprintf ppf "\ncfg for %s\n" msg;
   fprintf ppf "%s\n" t.cfg.fun_name;
   let regalloc =

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -43,12 +43,12 @@ let call_operation ?(print_reg = Printreg.reg) ppf op arg =
       (if enabled_at_init then "enabled_at_init " else "")
       name handler_code_sym regs arg
 
-let instr' ?(print_reg = Printreg.reg) ppf i =
+let instr' ?(print_reg = Printreg.reg) ?assign_symbol ppf i =
   let reg = print_reg in
   let regs = Printreg.regs' ~print_reg in
   let regsetaddr = Printreg.regsetaddr' ~print_reg in
   let test = Operation.format_test ~print_reg in
-  let operation = Printoperation.operation ~print_reg in
+  let operation = Printoperation.operation ~print_reg ?assign_symbol in
   (if !Oxcaml_flags.davail
    then
      let module RAS = Reg_availability_set in

--- a/backend/printlinear.mli
+++ b/backend/printlinear.mli
@@ -28,7 +28,11 @@ val call_operation :
   unit
 
 val instr' :
-  ?print_reg:(formatter -> Reg.t -> unit) -> formatter -> instruction -> unit
+  ?print_reg:(formatter -> Reg.t -> unit) ->
+  ?assign_symbol:string ->
+  formatter ->
+  instruction ->
+  unit
 
 val instr : formatter -> instruction -> unit
 

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -3,10 +3,11 @@
 open! Int_replace_polymorphic_compare
 open Format
 
-let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
+let operation ?(print_reg = Printreg.reg) ?(assign_symbol = ":=")
+    (op : Operation.t) arg ppf res =
   let reg = print_reg in
   let regs = Printreg.regs' ~print_reg in
-  if Array.length res > 0 then fprintf ppf "%a := " regs res;
+  if Array.length res > 0 then fprintf ppf "%a %s " regs res assign_symbol;
   match op with
   | Move -> regs ppf arg
   | Spill -> fprintf ppf "%a (spill)" regs arg

--- a/backend/printoperation.mli
+++ b/backend/printoperation.mli
@@ -2,6 +2,7 @@
 
 val operation :
   ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  ?assign_symbol:string ->
   Operation.t ->
   Reg.t array ->
   Format.formatter ->

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -45,6 +45,7 @@ let mk_no_ocamlcfg f =
   ("-no-ocamlcfg", Arg.Unit f, " Do not use ocamlcfg (deprecated, does nothing)")
 
 let mk_dcfg f = ("-dcfg", Arg.Unit f, " (undocumented)")
+let mk_dcfg_ssa f = ("-dcfg-ssa", Arg.Unit f, " Dump CFG with SSA annotations")
 
 let mk_dcfg_invariants f =
   ("-dcfg-invariants", Arg.Unit f, " Extra sanity checks on Cfg")
@@ -1179,6 +1180,7 @@ module type Oxcaml_options = sig
   val ddwarf_metrics : unit -> unit
   val ddwarf_metrics_output_file : string -> unit
   val dcfg : unit -> unit
+  val dcfg_ssa : unit -> unit
   val dcfg_invariants : unit -> unit
   val regalloc : Clflags.Register_allocator.t -> unit
   val regalloc_linscan_threshold : int -> unit
@@ -1348,6 +1350,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_ocamlcfg F.ocamlcfg;
       mk_no_ocamlcfg F.no_ocamlcfg;
       mk_dcfg F.dcfg;
+      mk_dcfg_ssa F.dcfg_ssa;
       mk_dcfg_invariants F.dcfg_invariants;
       mk_regalloc F.regalloc;
       mk_regalloc_linscan_threshold F.regalloc_linscan_threshold;
@@ -1548,6 +1551,11 @@ module Oxcaml_options_impl = struct
   let ocamlcfg () = ()
   let no_ocamlcfg () = ()
   let dcfg = set' Oxcaml_flags.dump_cfg
+
+  let dcfg_ssa () =
+    Oxcaml_flags.dump_cfg := true;
+    Oxcaml_flags.dump_cfg_ssa := true
+
   let dcfg_invariants = set' Oxcaml_flags.cfg_invariants
   let regalloc x = Oxcaml_flags.regalloc := x
 

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -31,6 +31,7 @@ module type Oxcaml_options = sig
   val ddwarf_metrics : unit -> unit
   val ddwarf_metrics_output_file : string -> unit
   val dcfg : unit -> unit
+  val dcfg_ssa : unit -> unit
   val dcfg_invariants : unit -> unit
   val regalloc : Clflags.Register_allocator.t -> unit
   val regalloc_linscan_threshold : int -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -14,6 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 let dump_cfg = ref false                (* -dcfg *)
+let dump_cfg_ssa = ref false            (* -dcfg-ssa *)
 let cfg_invariants = ref false          (* -dcfg-invariants *)
 let regalloc = ref Clflags.Register_allocator.Cfg (* -regalloc *)
 let default_regalloc_linscan_threshold = 100_000

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -17,6 +17,7 @@
 (** OxCaml specific command line flags *)
 
 val dump_cfg : bool ref
+val dump_cfg_ssa : bool ref
 val cfg_invariants : bool ref
 val regalloc : Clflags.Register_allocator.t ref
 val default_regalloc_linscan_threshold : int

--- a/dune
+++ b/dune
@@ -637,6 +637,7 @@
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_duplicate_comparisons
   cfg_ssa
   cfg_stack_checks
   cfg_polling

--- a/dune
+++ b/dune
@@ -637,6 +637,7 @@
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_ssa
   cfg_stack_checks
   cfg_polling
   cfg_simplify

--- a/testsuite/tests/codegen/bytes.ml
+++ b/testsuite/tests/codegen/bytes.ml
@@ -355,6 +355,22 @@ string_get_float32_indexed_by_int64:
   ret
 |}]
 
+(* CR ttebbi: We convert the loaded char to int before comparing against a
+   constant, this could be a comparison against an untagged constant instead. *)
+let string_unsafe_get_and_use (t : string) : bool =
+    let first_char = String.unsafe_get t 0 in
+    first_char == 'A'
+[%%expect_asm X86_64{|
+string_unsafe_get_and_use:
+  movzbq (%rax), %rax
+  leaq  1(%rax,%rax), %rax
+  cmpq  $131, %rax
+  sete  %al
+  movzbq %al, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
 let str_length (s : string) = String.length s
 [%%expect_asm X86_64{|
 str_length:

--- a/testsuite/tests/codegen/check_elimination.ml
+++ b/testsuite/tests/codegen/check_elimination.ml
@@ -76,3 +76,85 @@ arr_sum:
   movl  $1, %eax
   ret
 |}]
+
+(* CR ttebbi: The generated control flow branches three (!) times on
+   should_continue. In block 123, we can even statically know that the bit is 1.
+   Additionally, we materialise the should_continue bit. *)
+let search ~target (start : int list) =
+  let node = ref start in
+  while
+    match !node with
+    | [] -> false
+    | x :: xs ->
+      let should_continue = target < x in
+      if should_continue then node := xs;
+      should_continue
+  do () done;
+  !node
+;;
+[%%expect_asm X86_64{|
+search:
+  movq  %rax, %rdi
+  testb $1, %bl
+  je    .L116
+.L114:
+  xorl  %esi, %esi
+  movq  %rbx, %rax
+  jmp   .L131
+.L116:
+  movq  (%rbx), %rax
+  cmpq  %rax, %rdi
+  setl  %al
+  movzbq %al, %rsi
+  testq %rsi, %rsi
+  je    .L123
+  movq  8(%rbx), %rax
+  testq %rsi, %rsi
+  jne   .L129
+  jmp   .L131
+.L123:
+  movq  %rbx, %rax
+  testq %rsi, %rsi
+  je    .L131
+.L129:
+  movq  %rax, %rbx
+  testb $1, %bl
+  je    .L116
+  jmp   .L114
+.L131:
+  ret
+|}]
+
+(* CR ttebbi: The second branch is always true. *)
+let redundant_compare (x: int) = if x > 0 && x > 5 then 100 else 200
+[%%expect_asm X86_64{|
+redundant_compare:
+  cmpq  $1, %rax
+  jle   .L110
+  cmpq  $11, %rax
+  jle   .L107
+  movl  $201, %eax
+  ret
+.L107:
+  movl  $401, %eax
+  ret
+.L110:
+  movl  $401, %eax
+  ret
+|}]
+
+(* CR ttebbi: We don't learn that x is 3 in the first case. *)
+let learn_from_branch (x : int) : int =
+  match x with
+  | 3 -> x * 2
+  | _ -> 100
+[%%expect_asm X86_64{|
+learn_from_branch:
+  cmpq  $7, %rax
+  je    .L105
+  movl  $201, %eax
+  ret
+.L105:
+  leaq  -1(%rax,%rax), %rax
+  ret
+|}]

--- a/testsuite/tests/codegen/check_elimination.ml
+++ b/testsuite/tests/codegen/check_elimination.ml
@@ -102,12 +102,12 @@ search:
   movq  %rbx, %rax
   jmp   .L131
 .L116:
-  movq  (%rbx), %rax
-  cmpq  %rax, %rdi
+  movq  (%rbx), %rdx
+  cmpq  %rdx, %rdi
   setl  %al
   movzbq %al, %rsi
-  testq %rsi, %rsi
-  je    .L123
+  cmpq  %rdx, %rdi
+  jge   .L123
   movq  8(%rbx), %rax
   testq %rsi, %rsi
   jne   .L129

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -90,25 +90,19 @@ logand_branch:
 |}]
 
 
-(* CR ttebbi: We materialize comparison result bits despite
-   only using them for a single branch. Also, the `_ -> 0`
-   case is duplicated for no good reason. *)
-let combine_comparisons r f =
+(* CR ttebbi: The `_ -> 0` case is duplicated for no good reason. *)
+let combine_comparisons r x f =
   match !r > 5, !r < 20 with
   | true, true -> !r
   | _ -> 0
 ;;
 [%%expect_asm X86_64{|
 combine_comparisons:
-  movq  (%rax), %rbx
-  cmpq  $41, %rbx
-  setl  %al
-  movzbq %al, %rax
-  cmpq  $11, %rbx
+  movq  (%rax), %rax
+  cmpq  $11, %rax
   jle   .L114
-  testq %rax, %rax
-  je    .L111
-  movq  %rbx, %rax
+  cmpq  $41, %rax
+  jge   .L111
   ret
 .L111:
   movl  $1, %eax
@@ -126,14 +120,11 @@ let repeat_comparisons r _f =
   if a && b then 1 else 2
 [%%expect_asm X86_64{|
 repeat_comparisons:
-  movq  (%rax), %rbx
-  cmpq  $11, %rbx
-  setg  %al
-  movzbq %al, %rax
-  cmpq  $11, %rbx
+  movq  (%rax), %rax
+  cmpq  $11, %rax
   jle   .L113
-  testq %rax, %rax
-  je    .L110
+  cmpq  $11, %rax
+  jle   .L110
   movl  $3, %eax
   ret
 .L110:
@@ -335,7 +326,7 @@ let is_int_constant () : bool =
    Obj.repr (Some 3) |> Obj.is_int
 [%%expect_asm X86_64{|
 is_int_constant:
-  movq  camlTOP25__const_block785@GOTPCREL(%rip), %rax
+  movq  camlTOP25__const_block788@GOTPCREL(%rip), %rax
   andl  $1, %eax
   leaq  1(%rax,%rax), %rax
   ret
@@ -382,13 +373,13 @@ let branch_or_tailcall x =
 branch_or_tailcall:
   cmpq  $5, %rax
   jbe   .L105
-  movq  camlTOP28__Pmakeblock918@GOTPCREL(%rip), %rax
+  movq  camlTOP28__Pmakeblock921@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
 .L105:
-  movq  camlTOP28__switch_block919@GOTPCREL(%rip), %rbx
+  movq  camlTOP28__switch_block922@GOTPCREL(%rip), %rbx
   movq  -4(%rbx,%rax,4), %rax
   ret
 |}]

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -73,6 +73,23 @@ do_intersect:
 |}]
 
 
+(* CR ttebbi: We could merge the and and cmp instructions *)
+let logand_branch x y f = if x land (1 lsl 4) <> 0 then f()
+[%%expect_asm X86_64{|
+logand_branch:
+  movq  %rdi, %rbx
+  andl  $33, %eax
+  cmpq  $1, %rax
+  je    .L108
+  movl  $1, %eax
+  movq  (%rbx), %rdi
+  jmp   *%rdi
+.L108:
+  movl  $1, %eax
+  ret
+|}]
+
+
 (* CR ttebbi: We materialize comparison result bits despite
    only using them for a single branch. Also, the `_ -> 0`
    case is duplicated for no good reason. *)
@@ -100,6 +117,33 @@ combine_comparisons:
   movl  $1, %eax
   ret
 |}]
+
+(* CR ttebbi: We branch twice on the same comparison, even though we realise
+   it is the same one. *)
+let repeat_comparisons r _f =
+  let a = !r > 5 in
+  let b = !r > 5 in
+  if a && b then 1 else 2
+[%%expect_asm X86_64{|
+repeat_comparisons:
+  movq  (%rax), %rbx
+  cmpq  $11, %rbx
+  setg  %al
+  movzbq %al, %rax
+  cmpq  $11, %rbx
+  jle   .L113
+  testq %rax, %rax
+  je    .L110
+  movl  $3, %eax
+  ret
+.L110:
+  movl  $5, %eax
+  ret
+.L113:
+  movl  $5, %eax
+  ret
+|}]
+
 
 (* CR ttebbi: We materialize the boolean needlessly. *)
 let branch_and_return o =
@@ -278,7 +322,7 @@ opaque_int:
 
 (* Tag test for variant discrimination *)
 
-let is_int (x : 'a) = obj_is_int x
+let is_int (x : 'a) = Obj.is_int (Obj.repr x)
 [%%expect_asm X86_64{|
 is_int:
   andl  $1, %eax
@@ -286,7 +330,18 @@ is_int:
   ret
 |}]
 
-let is_int_branch (x : 'a) f = if obj_is_int x then f()
+(* CR ttebbi: We should constant-fold this. *)
+let is_int_constant () : bool =
+   Obj.repr (Some 3) |> Obj.is_int
+[%%expect_asm X86_64{|
+is_int_constant:
+  movq  camlTOP25__const_block785@GOTPCREL(%rip), %rax
+  andl  $1, %eax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let is_int_branch (x : 'a) f = if Obj.is_int(Obj.repr x) then f()
 [%%expect_asm X86_64{|
 is_int_branch:
   testb $1, %al
@@ -301,7 +356,7 @@ is_int_branch:
 
 
 (* CR ttebbi: https://github.com/oxcaml/oxcaml/issues/2521 *)
-let is_block_branch (x : 'a) f = if not(obj_is_int x) then f()
+let is_block_branch (x : 'a) f = if not(Obj.is_int(Obj.repr x)) then f()
 [%%expect_asm X86_64{|
 is_block_branch:
   testb $1, %al
@@ -327,13 +382,13 @@ let branch_or_tailcall x =
 branch_or_tailcall:
   cmpq  $5, %rax
   jbe   .L105
-  movq  camlTOP25__Pmakeblock786@GOTPCREL(%rip), %rax
+  movq  camlTOP28__Pmakeblock918@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
 .L105:
-  movq  camlTOP25__switch_block787@GOTPCREL(%rip), %rbx
+  movq  camlTOP28__switch_block919@GOTPCREL(%rip), %rbx
   movq  -4(%rbx,%rax,4), %rax
   ret
 |}]

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -358,6 +358,15 @@ to_int:
   ret
 |}]
 
+(* CR ttebbi: This is the identity. *)
+let int_roundtrip x = Int64_u.of_int x |> Int64_u.to_int
+[%%expect_asm X86_64{|
+int_roundtrip:
+  sarq  $1, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
 let unsigned_to_int x = Int64_u.unsigned_to_int x
 [%%expect_asm X86_64{|
 unsigned_to_int:

--- a/testsuite/tests/codegen/intrinsics.ml
+++ b/testsuite/tests/codegen/intrinsics.ml
@@ -559,6 +559,9 @@ module Bytes = struct
 end
 
 module String = struct
+  external unsafe_get : (string[@local_opt]) -> int -> char
+    @@ portable = "%string_unsafe_get"
+
   external unsafe_get_int32_ne : (string[@local_opt]) -> int -> int32#
     @@ portable = "%caml_string_get32u#" [@@warning "-187"]
 
@@ -754,7 +757,14 @@ external cpu_relax : unit -> unit @@ portable = "%cpu_relax"
 
 external opaque : 'a -> 'a = "%opaque"
 
-external obj_is_int : 'a -> bool = "%obj_is_int"
+module Obj = struct
+
+  type t
+
+  external repr : 'a -> t @@ portable = "%obj_magic"
+  external is_int : t @ contended -> bool @@ portable = "%obj_is_int"
+  external magic : 'a -> 'b @@ portable = "%obj_magic"
+end
 
 external get_header : 'a -> nativeint = "%get_header"
   [@@warning "-187"]

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -32,6 +32,15 @@ mutable_load:
   ret
 |}]
 
+(* CR ttebbi: There is no need to load the stored value. *)
+let write_then_read r = r := 5; !r
+[%%expect_asm X86_64{|
+write_then_read:
+  movq  $11, (%rax)
+  movq  (%rax), %rax
+  ret
+|}]
+
 let mutable_load_branch r b =
   let x = !r in
   x + if b then !r else 7

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -267,3 +267,43 @@ M.f:
   vxorpd %xmm0, %xmm0, %xmm0
   ret
 |}]
+
+
+(* CR ttebbi: We should branch first and loop afterwards.*)
+let loop_invariant_code (should_call_f : bool) (f : unit -> unit) =
+  for _ = 0 to 9 do
+    if should_call_f then f ()
+  done
+[%%expect_asm X86_64{|
+loop_invariant_code:
+  subq  $24, %rsp
+  movq  %rax, (%rsp)
+  movq  %rbx, 8(%rsp)
+  movl  $1, %edi
+  cmpq  $1, %rax
+  je    .L118
+.L113:
+  movq  %rdi, 16(%rsp)
+  movl  $1, %eax
+  movq  (%rbx), %rdi
+  call  *%rdi
+.L130:
+  movq  (%rsp), %rax
+  movq  8(%rsp), %rbx
+  movq  16(%rsp), %rdi
+  cmpq  $19, %rdi
+  je    .L123
+  jmp   .L120
+.L118:
+  cmpq  $19, %rdi
+  je    .L123
+.L120:
+  addq  $2, %rdi
+  cmpq  $1, %rax
+  je    .L118
+  jmp   .L113
+.L123:
+  movl  $1, %eax
+  addq  $24, %rsp
+  ret
+|}]

--- a/testsuite/tests/codegen/select.ml
+++ b/testsuite/tests/codegen/select.ml
@@ -41,6 +41,27 @@ select_cmp:
   ret
 |}]
 
+(* CR ttebbi: We shouldn't materialize the bit, and ideally even share the
+   cmp instructions. *)
+let select_cmp_twice (x : int) (y: int) =
+  (Builtins.select (x < y) x y) + (Builtins.select (x < y) 10 20)
+[%%expect_asm X86_64{|
+select_cmp_twice:
+  movq  %rax, %rdi
+  cmpq  %rbx, %rdi
+  setl  %al
+  movzbq %al, %rax
+  leaq  1(%rax,%rax), %rax
+  movl  $41, %esi
+  movl  $21, %edx
+  cmpq  $1, %rax
+  cmovne %rdx, %rsi
+  cmpq  $1, %rax
+  cmovne %rdi, %rbx
+  leaq  -1(%rbx,%rsi), %rax
+  ret
+|}]
+
 
 (* CR ttebbi: We could constant-fold this. *)
 let select_constant (x : int) = Builtins.select true x 55


### PR DESCRIPTION
Branching on a materialized bit is about as expensive as re-doing a comparison. But using a shared bit requires additional code to first materialize this bit.
This PR removes all direct uses of comparisons by CFG block terminators and conditional select by replacing the branch predicate with the comparison, reducing the cases where we have to materialize a bit.