### PR TITLE
Fix bug involving effects, callbacks and locals

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -283,7 +283,7 @@ static void caml_thread_scan_roots(
         if (th->current_stack != NULL)
           caml_do_local_roots(action, fflags, fdata,
                               th->local_roots, th->current_stack, th->gc_regs,
-                              th->dynamic);
+                              th->dynamic, th->c_stack);
       }
       th = th->next;
     } while (th != active);

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1371,7 +1371,7 @@ LBL(do_perform):
 1:      movq    %rdi, 8(%rbx) /* Set the last fiber field in the continuation */
         movq    Stack_handler(%rsi), %r11  /* %r11 := old stack -> handler */
         movq    Handler_parent(%r11), %r10 /* %r10 := parent stack */
-        cmpq    $0, %r10                   /* parent is NULL? */
+        cmpq    $1, Handler_effect(%r11)   /* handler is Val_unit? */
         je      LBL(112)
 #if defined(WITH_THREAD_SANITIZER)
      /* Save non-callee-saved registers %rax, %rdi, %rsi, %r10, %r11 before C

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -1229,7 +1229,9 @@ L(do_perform):
         str     x3, [x1, 8] /* Set the last_fiber field in the continuation */
         ldr     x9, Stack_handler(x2)  /* x9 := old stack -> handler */
         ldr     x10, Handler_parent(x9) /* x10 := parent stack */
-        cbz     x10, 1f
+        ldr     TMP, Handler_effect(x9)
+        cmp     TMP, 1
+        beq     1f
 #if defined(WITH_THREAD_SANITIZER)
     /* Save non-callee-saved registers x0, x1, x2, x3, x9 and x10 */
         stp     x0, x1, [sp, -16]!

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -47,35 +47,26 @@
 
 /*
  * These functions are to ensure effects are handled correctly inside
- * callbacks. There are two aspects:
- *  - we clear the stack parent for a callback to force an Effect.Unhandled
- *  exception rather than effects being passed over the callback
- *  - we register the stack parent as a local root while the callback
- * is executing to ensure that the garbage collector follows the
- * stack parent
+ * callbacks, by saving and restoring exception and effect handlers.
  */
-Caml_inline value alloc_and_clear_stack_parent(caml_domain_state* domain_state)
+Caml_inline void save_stack_handlers(caml_domain_state* domain_state,
+                                     value* hexn, value* heff)
 {
-  struct stack_info* parent_stack = Stack_parent(domain_state->current_stack);
-  if (parent_stack == NULL) {
-    return Val_unit;
-  } else {
-    value cont = caml_alloc_2(Cont_tag, Val_ptr(parent_stack), Val_long(0));
-    Stack_parent(domain_state->current_stack) = NULL;
-    caml_dynamic_cache_flush(domain_state->dynamic_bindings);
-    return cont;
-  }
+  struct stack_info* stk = domain_state->current_stack;
+  *hexn = Stack_handle_exception(stk);
+  *heff = Stack_handle_effect(stk);
+  Stack_handle_exception(stk) = Val_unit;
+  Stack_handle_effect(stk) = Val_unit;
 }
 
-Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
-                                      value cont)
+Caml_inline void restore_stack_handlers(caml_domain_state* domain_state,
+                                        value hexn, value heff)
 {
-  CAMLassert(Stack_parent(domain_state->current_stack) == NULL);
-  if (Is_block(cont)) {
-    struct stack_info* parent_stack = Ptr_val(caml_continuation_use(cont));
-    Stack_parent(domain_state->current_stack) = parent_stack;
-    caml_dynamic_cache_flush(domain_state->dynamic_bindings);
-  }
+  struct stack_info* stk = domain_state->current_stack;
+  CAMLassert(Stack_handle_exception(stk) == Val_unit);
+  CAMLassert(Stack_handle_effect(stk) == Val_unit);
+  Stack_handle_exception(stk) = hexn;
+  Stack_handle_effect(stk) = heff;
 }
 
 static value raise_if_exception(value res)
@@ -118,7 +109,7 @@ void caml_init_callbacks(void)
 static value caml_callbackN_exn0(value closure, int narg, value args[])
 {
   CAMLparam1(closure); /* no need to register args as roots, see below */
-  CAMLlocal1(cont);
+  CAMLlocal2(hexn, heff);
   value res;
   caml_domain_state* domain_state = Caml_state;
 
@@ -140,10 +131,7 @@ static value caml_callbackN_exn0(value closure, int narg, value args[])
   domain_state->current_stack->sp[narg + 1] = Val_unit;    /* environment */
   domain_state->current_stack->sp[narg + 2] = Val_long(0); /* extra args */
 
-  cont = alloc_and_clear_stack_parent(domain_state);
-  /* This can call the GC and invalidate the values [args].
-     However, they are never used afterwards,
-     as they were copied into the root [domain_state->current_stack]. */
+  save_stack_handlers(domain_state, &hexn, &heff);
 
   caml_update_young_limit_after_c_call(domain_state);
   res = caml_bytecode_interpreter(Code_val(closure), 0 /* unknown size */,
@@ -152,7 +140,7 @@ static value caml_callbackN_exn0(value closure, int narg, value args[])
   if (Is_exception_result(res))
     domain_state->current_stack->sp += narg + 3; /* PR#3419 */
 
-  restore_stack_parent(domain_state, cont);
+  restore_stack_handlers(domain_state, hexn, heff);
 
   CAMLreturn (res);
 }
@@ -250,21 +238,16 @@ static value callback(value closure, value arg)
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack)) {
-    value cont, res;
+    value hexn, heff, res;
 
-    /* [closure] and [arg] need to be preserved across the allocation
-       of the stack parent, but need not and should not be registered
-       as roots past this allocation. */
-    Begin_roots2(closure, arg);
-    cont = alloc_and_clear_stack_parent(domain_state);
-    End_roots();
+    save_stack_handlers(domain_state, &hexn, &heff);
 
-    Begin_roots1(cont);
+    Begin_roots2(hexn, heff);
     caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback_asm(domain_state, closure, &arg);
     End_roots();
 
-    restore_stack_parent(domain_state, cont);
+    restore_stack_handlers(domain_state, hexn, heff);
 
     return res;
   } else {
@@ -282,20 +265,17 @@ static value callback2(value closure, value arg1, value arg2)
   CAMLassert(arg1 != 0);
 
   if (Stack_parent(domain_state->current_stack)) {
-    value cont, res;
+    value hexn, heff, res;
 
-    /* Root registration policy: see caml_callback_exn. */
-    Begin_roots3(closure, arg1, arg2);
-    cont = alloc_and_clear_stack_parent(domain_state);
-    End_roots();
+    save_stack_handlers(domain_state, &hexn, &heff);
 
-    Begin_roots1(cont);
+    Begin_roots2(hexn, heff);
     value args[] = {arg1, arg2};
     caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback2_asm(domain_state, closure, args);
     End_roots();
 
-    restore_stack_parent(domain_state, cont);
+    restore_stack_handlers(domain_state, hexn, heff);
 
     return res;
   } else {
@@ -312,20 +292,18 @@ static value callback3(value closure, value arg1, value arg2, value arg3)
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack))  {
-    value cont, res;
+    value hexn, heff, res;
 
     /* Root registration policy: see caml_callback_exn. */
-    Begin_roots4(closure, arg1, arg2, arg3);
-    cont = alloc_and_clear_stack_parent(domain_state);
-    End_roots();
+    save_stack_handlers(domain_state, &hexn, &heff);
 
-    Begin_root(cont);
+    Begin_roots2(hexn, heff);
     value args[] = {arg1, arg2, arg3};
     caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback3_asm(domain_state, closure, args);
     End_roots();
 
-    restore_stack_parent(domain_state, cont);
+    restore_stack_handlers(domain_state, hexn, heff);
 
     return res;
   } else {

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -46,7 +46,8 @@ CAMLextern void caml_do_local_roots(
   struct caml__roots_block* local_roots,
   struct stack_info *current_stack,
   value * v_gc_regs,
-  dynamic_cache_t dynamic_bindings);
+  dynamic_cache_t dynamic_bindings,
+  struct c_stack_link* c_stack);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -834,7 +834,8 @@ CAMLexport void caml_do_local_roots (
   struct caml__roots_block *local_roots,
   struct stack_info *current_stack,
   value * v_gc_regs,
-  dynamic_cache_t dynamic_bindings)
+  dynamic_cache_t dynamic_bindings,
+  struct c_stack_link* c_stack)
 {
 #ifdef NATIVE_CODE
   caml_local_arenas* locals = caml_refresh_locals(current_stack);
@@ -842,6 +843,12 @@ CAMLexport void caml_do_local_roots (
 
   caml_dynamic_cache_scan_roots(dynamic_bindings, f, fflags, fdata);
   for (struct caml__roots_block *lr = local_roots; lr != NULL; lr = lr->next) {
+#ifdef NATIVE_CODE
+    while (c_stack != NULL && (uintnat)c_stack < (uintnat)lr) {
+      c_stack = c_stack->prev;
+      if (c_stack != NULL) locals = caml_refresh_locals(c_stack->stack);
+    }
+#endif
     for (int i = 0; i < lr->ntables; i++){
       for (int j = 0; j < lr->nitems; j++){
         value *sp = &(lr->tables[i][j]);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -844,6 +844,9 @@ CAMLexport void caml_do_local_roots (
   caml_dynamic_cache_scan_roots(dynamic_bindings, f, fflags, fdata);
   for (struct caml__roots_block *lr = local_roots; lr != NULL; lr = lr->next) {
 #ifdef NATIVE_CODE
+    /* c_stack marks the boundary between C stack segments. Distinct C stack
+       segments may have distinct ML fiber stacks, so when we change stack
+       segment we need to find the appropriate local arenas. */
     while (c_stack != NULL && (uintnat)c_stack < (uintnat)lr) {
       c_stack = c_stack->prev;
       if (c_stack != NULL) locals = caml_refresh_locals(c_stack->stack);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1030,7 +1030,7 @@ value caml_bytecode_interpreter(code_t prog, asize_t prog_size,
       }
     raise_notrace:
       if (domain_state->trap_sp_off > 0) {
-        if (Stack_parent(domain_state->current_stack) == NULL) {
+        if (Stack_handle_exception(domain_state->current_stack) == Val_unit) {
           domain_state->external_raise = initial_external_raise;
           domain_state->external_raise_async = initial_external_raise_async;
           domain_state->trap_sp_off = initial_trap_sp_off;
@@ -1040,6 +1040,7 @@ value caml_bytecode_interpreter(code_t prog, asize_t prog_size,
         } else {
           struct stack_info* old_stack = domain_state->current_stack;
           struct stack_info* parent_stack = Stack_parent(old_stack);
+          CAMLassert(parent_stack != NULL);
           value hexn = Stack_handle_exception(old_stack);
           old_stack->sp = sp;
           domain_state->current_stack = parent_stack;
@@ -1489,7 +1490,7 @@ do_resume: {
       struct stack_info* parent_stack = Stack_parent(old_stack);
 
       check_trap_barrier_for_effect (domain_state);
-      if (parent_stack == NULL) {
+      if (Stack_handle_effect(old_stack) == Val_unit) {
         Setup_for_c_call;
         accu = caml_make_unhandled_effect_exn(accu);
         Restore_after_c_call;
@@ -1537,7 +1538,7 @@ do_resume: {
       sp[0] = Val_long(domain_state->trap_sp_off);
       sp[1] = Val_long(extra_args);
 
-      if (parent == NULL) {
+      if (Stack_handle_effect(self) == Val_unit) {
         Setup_for_c_call;
         resume_arg = caml_make_unhandled_effect_exn(eff);
         accu = caml_continuation_use(cont);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -765,7 +765,8 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
   caml_do_local_roots(
     &oldify_one, oldify_scanning_flags, &st,
     domain->local_roots, domain->current_stack, domain->gc_regs,
-    domain->dynamic_bindings);
+    domain->dynamic_bindings,
+    domain->c_stack);
 
   scan_roots_hook = atomic_load(&caml_scan_roots_hook);
   if (scan_roots_hook != NULL)

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -40,7 +40,8 @@ void caml_do_roots (
   scan_roots_hook hook;
   caml_do_local_roots(f, fflags, fdata,
                       d->local_roots, d->current_stack, d->gc_regs,
-                      d->dynamic_bindings);
+                      d->dynamic_bindings,
+                      d->c_stack);
   hook = atomic_load(&caml_scan_roots_hook);
   if (hook != NULL) (*hook)(f, fflags, fdata, d);
   caml_final_do_roots(f, fflags, fdata, d, do_final_val);

--- a/testsuite/tests/callback/callback_effects_locals.ml
+++ b/testsuite/tests/callback/callback_effects_locals.ml
@@ -1,0 +1,27 @@
+(* TEST
+ modules = "callback_effects_locals_.c";
+ native;
+*)
+type 'a box = { unbox: 'a @@ global } [@@boxed]
+
+external callback : 'a box @ local -> (unit -> unit) -> 'a = "cb"
+
+let wrap_callback ch f =
+  callback (stack_ {unbox=Array.init 5 (fun i -> String.make (Sys.opaque_identity i) ch)}) f
+  |> Array.iter print_endline
+
+let wrap_fiber f =
+  Effect.Deep.try_with f () { effc = fun _ -> None }
+
+let f () =
+  Gc.minor ();
+  wrap_callback 'c' (fun () ->
+    wrap_fiber (fun () ->
+      wrap_callback 'b' (fun () ->
+        wrap_fiber (fun () ->
+          wrap_callback 'a' (fun () ->
+            wrap_fiber (fun () ->
+              Gc.minor ();
+              List.init 1000 ref |> Sys.opaque_identity |> ignore))))))
+
+let () = (Sys.opaque_identity f) ()

--- a/testsuite/tests/callback/callback_effects_locals.reference
+++ b/testsuite/tests/callback/callback_effects_locals.reference
@@ -1,0 +1,15 @@
+
+a
+aa
+aaa
+aaaa
+
+b
+bb
+bbb
+bbbb
+
+c
+cc
+ccc
+cccc

--- a/testsuite/tests/callback/callback_effects_locals_.c
+++ b/testsuite/tests/callback/callback_effects_locals_.c
@@ -1,0 +1,8 @@
+#include <caml/memory.h>
+#include <caml/callback.h>
+
+value cb(value loc, value cb) {
+  CAMLparam2(loc, cb);
+  caml_callback(cb, Val_unit);
+  CAMLreturn(Field(loc,0));
+}

--- a/testsuite/tests/callback/dynamic_callback.ml
+++ b/testsuite/tests/callback/dynamic_callback.ml
@@ -29,5 +29,5 @@ let () =
     on_fresh_stack (fun () ->
       Printf.printf "before callback [expect 17]: %s\n" (print_dyn d);
       call_from_c (fun () ->
-        Printf.printf "inside callback [expect null]: %s\n" (print_dyn d));
+        Printf.printf "inside callback [expect 17]: %s\n" (print_dyn d));
       Printf.printf "after callback [expect 17]: %s\n" (print_dyn d)))

--- a/testsuite/tests/callback/dynamic_callback.reference
+++ b/testsuite/tests/callback/dynamic_callback.reference
@@ -1,3 +1,3 @@
 before callback [expect 17]: 17
-inside callback [expect null]: null
+inside callback [expect 17]: 17
 after callback [expect 17]: 17


### PR DESCRIPTION
This is a fix for a tricky GC bug where roots are scanned with the wrong local arenas, since the local C roots need not all come from the same fiber (as the code currently assumes).

There are three commits:

  1. The core of the fix, which updates the current local arena at each `struct c_stack_link`
  2. A refactoring of how callbacks prevent effects traversing the C boundary:
      - instead of clearing `Stack_parent` (which breaks the chain of stacks used in stack traversal), clear `Stack_handle_(effect/exception)` instead.
      - A side effect of this is that dynamic bindings now work through C callbacks. I think this is an improvement, but it is an observable change.
  3. A testcase, which reliably segfaults without both (1) and (2), and passes afterwards.