### PR TITLE
Improve argument_types_useful check

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -18,7 +18,6 @@ open! Flambda.Import
 module DE = Downwards_env
 module DA = Downwards_acc
 module T = Flambda2_types
-module TE = T.Typing_env
 module UA = Upwards_acc
 module UE = Upwards_env
 
@@ -159,21 +158,23 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   in
   Cost_metrics.( + ) (UA.cost_metrics uacc) cost_metrics_of_lifted_constants
 
-let argument_types_useful dacc apply =
+let argument_types_useful dacc ~apply ~code_or_metadata =
   if
     not
       (Flambda_features.Inlining.speculative_inlining_only_if_arguments_useful
          ())
   then true
   else
+    let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
+    let arity = Code_metadata.params_arity code_metadata in
     let typing_env = DE.typing_env (DA.denv dacc) in
-    List.exists
-      (fun simple ->
+    List.exists2
+      (fun full_kind simple ->
         Simple.pattern_match simple
           ~name:(fun name ~coercion:_ ->
-            let ty = TE.find typing_env name None in
-            not (T.is_unknown_maybe_null typing_env ty))
+            T.type_is_useful full_kind typing_env name)
           ~const:(fun _ -> true))
+      (Flambda_arity.unarize arity)
       (Apply.args apply)
 
 let inlining_does_decrease_code_size ~code_or_metadata cost_metrics =
@@ -241,7 +242,7 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
               "Unexpected call site inlinine decision for speculative inlining";
           counters)
       (fun () : Call_site_inlining_decision_type.t ->
-        if not (argument_types_useful dacc apply)
+        if not (argument_types_useful dacc ~apply ~code_or_metadata)
         then Argument_types_not_useful
         else
           let cost_metrics =

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -173,7 +173,20 @@ let argument_types_useful dacc ~apply ~code_or_metadata =
         Simple.pattern_match simple
           ~name:(fun name ~coercion:_ ->
             T.type_is_useful full_kind typing_env name)
-          ~const:(fun _ -> true))
+          ~const:(fun const ->
+            (* If the kind already restricts the possible values to a single
+               constant (e.g. unit type), even a constant can be not useful. *)
+            match Reg_width_const.is_tagged_immediate const with
+            | None -> true
+            | Some const ->
+              not
+                (Flambda_kind.With_subkind.equal full_kind
+                   (Flambda_kind.With_subkind.create Flambda_kind.value
+                      (Variant
+                         { consts = Target_ocaml_int.Set.singleton const;
+                           non_consts = Tag.Scannable.Map.empty
+                         })
+                      Non_nullable))))
       (Flambda_arity.unarize arity)
       (Apply.args apply)
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -18,6 +18,7 @@ open! Flambda.Import
 module DE = Downwards_env
 module DA = Downwards_acc
 module T = Flambda2_types
+module TE = T.Typing_env
 module UA = Upwards_acc
 module UE = Upwards_env
 
@@ -158,6 +159,14 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   in
   Cost_metrics.( + ) (UA.cost_metrics uacc) cost_metrics_of_lifted_constants
 
+type argument_types_useful =
+  | Coarse
+  | Fine
+
+let argument_types_useful =
+  Oxcaml_args.Extra_options.symbol __LOC__ "argument-types-useful" Coarse
+    ["coarse", Coarse; "fine", Fine]
+
 let argument_types_useful dacc ~apply ~code_or_metadata =
   if
     not
@@ -165,30 +174,42 @@ let argument_types_useful dacc ~apply ~code_or_metadata =
          ())
   then true
   else
-    let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
-    let arity = Code_metadata.params_arity code_metadata in
     let typing_env = DE.typing_env (DA.denv dacc) in
-    List.exists2
-      (fun full_kind simple ->
-        Simple.pattern_match simple
-          ~name:(fun name ~coercion:_ ->
-            T.type_is_useful full_kind typing_env name)
-          ~const:(fun const ->
-            (* If the kind already restricts the possible values to a single
-               constant (e.g. unit type), even a constant can be not useful. *)
-            match Reg_width_const.is_tagged_immediate const with
-            | None -> true
-            | Some const ->
-              not
-                (Flambda_kind.With_subkind.equal full_kind
-                   (Flambda_kind.With_subkind.create Flambda_kind.value
-                      (Variant
-                         { consts = Target_ocaml_int.Set.singleton const;
-                           non_consts = Tag.Scannable.Map.empty
-                         })
-                      Non_nullable))))
-      (Flambda_arity.unarize arity)
-      (Apply.args apply)
+    match argument_types_useful () with
+    | Coarse ->
+      List.exists
+        (fun simple ->
+          Simple.pattern_match simple
+            ~name:(fun name ~coercion:_ ->
+              let ty = TE.find typing_env name None in
+              not (T.is_unknown_maybe_null typing_env ty))
+            ~const:(fun _ -> true))
+        (Apply.args apply)
+    | Fine ->
+      let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
+      let arity = Code_metadata.params_arity code_metadata in
+      List.exists2
+        (fun full_kind simple ->
+          Simple.pattern_match simple
+            ~name:(fun name ~coercion:_ ->
+              T.type_is_useful full_kind typing_env name)
+            ~const:(fun const ->
+              (* If the kind already restricts the possible values to a single
+                 constant (e.g. unit type), even a constant can be not
+                 useful. *)
+              match Reg_width_const.is_tagged_immediate const with
+              | None -> true
+              | Some const ->
+                not
+                  (Flambda_kind.With_subkind.equal full_kind
+                     (Flambda_kind.With_subkind.create Flambda_kind.value
+                        (Variant
+                           { consts = Target_ocaml_int.Set.singleton const;
+                             non_consts = Tag.Scannable.Map.empty
+                           })
+                        Non_nullable))))
+        (Flambda_arity.unarize arity)
+        (Apply.args apply)
 
 let inlining_does_decrease_code_size ~code_metadata cost_metrics =
   let[@ocamlformat "break-infix=fit-or-vertical"] original_code_size =

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -167,7 +167,7 @@ let argument_types_useful =
   Oxcaml_args.Extra_options.symbol __LOC__ "argument-types-useful" Coarse
     ["coarse", Coarse; "fine", Fine]
 
-let argument_types_useful dacc ~apply ~code_or_metadata =
+let argument_types_useful dacc ~apply ~code_metadata =
   if
     not
       (Flambda_features.Inlining.speculative_inlining_only_if_arguments_useful
@@ -186,7 +186,6 @@ let argument_types_useful dacc ~apply ~code_or_metadata =
             ~const:(fun _ -> true))
         (Apply.args apply)
     | Fine ->
-      let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
       let arity = Code_metadata.params_arity code_metadata in
       List.exists2
         (fun full_kind simple ->
@@ -281,7 +280,7 @@ let might_inline dacc ~apply ~code_metadata ~function_type ~simplify_expr
               "Unexpected call site inlinine decision for speculative inlining";
           counters)
       (fun () : Call_site_inlining_decision_type.t ->
-        if not (argument_types_useful dacc ~apply ~code_or_metadata)
+        if not (argument_types_useful dacc ~apply ~code_metadata)
         then Argument_types_not_useful
         else if not (code_present ())
         then Missing_code

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -18,7 +18,6 @@ open! Flambda.Import
 module DE = Downwards_env
 module DA = Downwards_acc
 module T = Flambda2_types
-module TE = T.Typing_env
 module UA = Upwards_acc
 module UE = Upwards_env
 
@@ -159,21 +158,23 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   in
   Cost_metrics.( + ) (UA.cost_metrics uacc) cost_metrics_of_lifted_constants
 
-let argument_types_useful dacc apply =
+let argument_types_useful dacc ~apply ~code_or_metadata =
   if
     not
       (Flambda_features.Inlining.speculative_inlining_only_if_arguments_useful
          ())
   then true
   else
+    let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
+    let arity = Code_metadata.params_arity code_metadata in
     let typing_env = DE.typing_env (DA.denv dacc) in
-    List.exists
-      (fun simple ->
+    List.exists2
+      (fun full_kind simple ->
         Simple.pattern_match simple
           ~name:(fun name ~coercion:_ ->
-            let ty = TE.find typing_env name None in
-            not (T.is_unknown_maybe_null typing_env ty))
+            T.type_is_useful full_kind typing_env name)
           ~const:(fun _ -> true))
+      (Flambda_arity.unarize arity)
       (Apply.args apply)
 
 let inlining_does_decrease_code_size ~code_metadata cost_metrics =
@@ -246,7 +247,7 @@ let might_inline dacc ~apply ~code_metadata ~function_type ~simplify_expr
               "Unexpected call site inlinine decision for speculative inlining";
           counters)
       (fun () : Call_site_inlining_decision_type.t ->
-        if not (argument_types_useful dacc apply)
+        if not (argument_types_useful dacc ~apply ~code_or_metadata)
         then Argument_types_not_useful
         else if not (code_present ())
         then Missing_code

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -18,6 +18,7 @@ open! Flambda.Import
 module DE = Downwards_env
 module DA = Downwards_acc
 module T = Flambda2_types
+module TE = T.Typing_env
 module UA = Upwards_acc
 module UE = Upwards_env
 
@@ -158,6 +159,14 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   in
   Cost_metrics.( + ) (UA.cost_metrics uacc) cost_metrics_of_lifted_constants
 
+type argument_types_useful =
+  | Coarse
+  | Fine
+
+let argument_types_useful =
+  Oxcaml_args.Extra_options.symbol __LOC__ "argument-types-useful" Coarse
+    ["coarse", Coarse; "fine", Fine]
+
 let argument_types_useful dacc ~apply ~code_or_metadata =
   if
     not
@@ -165,30 +174,42 @@ let argument_types_useful dacc ~apply ~code_or_metadata =
          ())
   then true
   else
-    let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
-    let arity = Code_metadata.params_arity code_metadata in
     let typing_env = DE.typing_env (DA.denv dacc) in
-    List.exists2
-      (fun full_kind simple ->
-        Simple.pattern_match simple
-          ~name:(fun name ~coercion:_ ->
-            T.type_is_useful full_kind typing_env name)
-          ~const:(fun const ->
-            (* If the kind already restricts the possible values to a single
-               constant (e.g. unit type), even a constant can be not useful. *)
-            match Reg_width_const.is_tagged_immediate const with
-            | None -> true
-            | Some const ->
-              not
-                (Flambda_kind.With_subkind.equal full_kind
-                   (Flambda_kind.With_subkind.create Flambda_kind.value
-                      (Variant
-                         { consts = Target_ocaml_int.Set.singleton const;
-                           non_consts = Tag.Scannable.Map.empty
-                         })
-                      Non_nullable))))
-      (Flambda_arity.unarize arity)
-      (Apply.args apply)
+    match argument_types_useful () with
+    | Coarse ->
+      List.exists
+        (fun simple ->
+          Simple.pattern_match simple
+            ~name:(fun name ~coercion:_ ->
+              let ty = TE.find typing_env name None in
+              not (T.is_unknown_maybe_null typing_env ty))
+            ~const:(fun _ -> true))
+        (Apply.args apply)
+    | Fine ->
+      let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
+      let arity = Code_metadata.params_arity code_metadata in
+      List.exists2
+        (fun full_kind simple ->
+          Simple.pattern_match simple
+            ~name:(fun name ~coercion:_ ->
+              T.type_is_useful full_kind typing_env name)
+            ~const:(fun const ->
+              (* If the kind already restricts the possible values to a single
+                 constant (e.g. unit type), even a constant can be not
+                 useful. *)
+              match Reg_width_const.is_tagged_immediate const with
+              | None -> true
+              | Some const ->
+                not
+                  (Flambda_kind.With_subkind.equal full_kind
+                     (Flambda_kind.With_subkind.create Flambda_kind.value
+                        (Variant
+                           { consts = Target_ocaml_int.Set.singleton const;
+                             non_consts = Tag.Scannable.Map.empty
+                           })
+                        Non_nullable))))
+        (Flambda_arity.unarize arity)
+        (Apply.args apply)
 
 let inlining_does_decrease_code_size ~code_or_metadata cost_metrics =
   let[@ocamlformat "break-infix=fit-or-vertical"] original_code_size =

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -784,8 +784,33 @@ let is_useful_set (type a) (module S : Container_types_intf.Set with type t = a)
     _env (s : a) =
   match S.get_singleton s with Some _ -> true | None -> false
 
+exception Maybe_useful
+
 let rec is_useful full_kind env t =
-  let expanded = expand_head env t in
+  match TG.get_alias_opt t with
+  | None -> is_useful_expanded_head full_kind env (ET.of_non_alias_type t)
+  | Some simple -> (
+    (* A symbol or a variable that has a canonical at the normal name mode (i.e.
+       a canonical that is available in terms) is maybe useful, as we can access
+       it directly instead of using projections from the argument. *)
+    match
+      Simple.pattern_match' simple ~const:ET.create_const
+        ~var:(fun var ~coercion:_ ->
+          match
+            TE.get_canonical_simple_exn env (Simple.var var)
+              ~min_name_mode:Name_mode.normal
+          with
+          | exception Not_found -> expand_head env t
+          | _canonical -> raise_notrace Maybe_useful)
+        ~symbol:(fun _symbol ~coercion:_ ->
+          (* A symbol is always useful, as we can use the symbol directly
+             instead of going through the projections from the parameter. *)
+          raise_notrace Maybe_useful)
+    with
+    | exception Maybe_useful -> true
+    | expanded -> is_useful_expanded_head full_kind env expanded)
+
+and is_useful_expanded_head full_kind env expanded =
   is_useful_or_unknown_or_bottom is_useful_expanded_head_descr full_kind env
     (ET.descr expanded)
 
@@ -942,9 +967,8 @@ and is_useful_head_of_kind_value_non_null env
     false
 
 and is_useful_variant ~consts ~non_consts env ~immediates ~blocks =
-  match is_useful_tagged_immediate ~consts env ~immediates with
-  | true -> true
-  | false -> is_useful_block ~non_consts env ~blocks
+  is_useful_tagged_immediate ~consts env ~immediates
+  || is_useful_block ~non_consts env ~blocks
 
 and is_useful_tagged_immediate ~consts env ~immediates =
   if Target_ocaml_int.Set.is_empty consts
@@ -968,62 +992,52 @@ and is_useful_tagged_immediate ~consts env ~immediates =
         false)
 
 and is_useful_block ~non_consts env ~blocks =
+  (* If the kind knows there are no non-constant constructors, no type is going
+     to be more precise. *)
   if Tag.Scannable.Map.is_empty non_consts
   then false
   else
     match (blocks : TG.row_like_for_blocks Or_unknown.t) with
     | Unknown -> false
     | Known row_like_for_blocks ->
-      if TG.Row_like_for_blocks.is_bottom row_like_for_blocks
-      then true
-      else if
-        Tag.Scannable.Map.exists
-          (fun tag (_block_shape, field_kinds) ->
-            let tag = Tag.Scannable.to_tag tag in
-            let[@local] process_case
-                (row_like_block_case : TG.row_like_block_case) =
-              (* Note: if there is a mismatch in the number of fields, it is OK
-                 to return [true]; we should be able to prove [Bottom] during
-                 inlining. *)
-              let types = row_like_block_case.maps_to in
-              try
-                List.iteri
-                  (fun ix field_kind ->
-                    if ix < Array.length types
-                    then
-                      match is_useful field_kind env types.(ix) with
-                      | true -> raise Exit
-                      | false -> ()
-                    else raise Exit)
-                  field_kinds;
-                false
-              with Exit -> true
-            in
-            match Tag.Map.find tag row_like_for_blocks.known_tags with
-            | Unknown -> false
-            | Known row_like_block_case -> process_case row_like_block_case
-            | exception Not_found -> (
-              match row_like_for_blocks.other_tags with
-              | Bottom -> true
-              | Ok row_like_block_case -> process_case row_like_block_case))
-          non_consts
-      then true
-      else false
+      TG.Row_like_for_blocks.is_bottom row_like_for_blocks
+      || Tag.Scannable.Map.exists
+           (fun tag (_block_shape, field_kinds) ->
+             let tag = Tag.Scannable.to_tag tag in
+             let[@local] process_case
+                 (row_like_block_case : TG.row_like_block_case) =
+               (* Note: if there is a mismatch in the number of fields, it is OK
+                  to return [true]; we should be able to prove [Bottom] during
+                  inlining. *)
+               let types = row_like_block_case.maps_to in
+               try
+                 List.iteri
+                   (fun ix field_kind ->
+                     if
+                       ix >= Array.length types
+                       || is_useful field_kind env types.(ix)
+                     then raise_notrace Maybe_useful)
+                   field_kinds;
+                 false
+               with Maybe_useful -> true
+             in
+             match Tag.Map.find tag row_like_for_blocks.known_tags with
+             | Unknown -> false
+             | Known row_like_block_case -> process_case row_like_block_case
+             | exception Not_found -> (
+               match row_like_for_blocks.other_tags with
+               | Bottom -> true
+               | Ok row_like_block_case -> process_case row_like_block_case))
+           non_consts
 
 and is_useful_float_block ~num_fields:_ env ~blocks =
   match (blocks : TG.row_like_for_blocks Or_unknown.t) with
   | Unknown -> false
   | Known row_like_for_blocks -> (
     let[@local] process_case (row_like_block_case : TG.row_like_block_case) =
-      if
-        Array.exists
-          (fun ty ->
-            match is_useful K.With_subkind.naked_float env ty with
-            | true -> true
-            | false -> false)
-          row_like_block_case.maps_to
-      then true
-      else false
+      Array.exists
+        (fun ty -> is_useful K.With_subkind.naked_float env ty)
+        row_like_block_case.maps_to
     in
     match Tag.Map.find Tag.double_array_tag row_like_for_blocks.known_tags with
     | Unknown -> false
@@ -1037,26 +1051,25 @@ and is_useful_array (known_element_kind : _ Or_unknown.t) env ~element_kind
     ~length ~contents:_ ~alloc_mode:_ =
   (* If we know the length, that's maybe useful (we could eliminate some bounds
      check). *)
-  match is_useful K.With_subkind.tagged_immediate env length with
-  | true -> true
-  | false -> (
-    (* If the [known_element_kind] from the kind can be used as the
-       [element_kind] from the types, the [element_kind] is not more precise.
+  is_useful K.With_subkind.tagged_immediate env length
+  (* If the [known_element_kind] from the kind can be used as the [element_kind]
+     from the types, the [element_kind] is not more precise.
 
-       But if it can't (not compatible), then the [element_kind] from the types
-       is more precise than the one from the kind -- that's maybe useful.
+     But if it can't (not compatible), then the [element_kind] from the types is
+     more precise than the one from the kind -- that's maybe useful.
 
-       If the element kind from the kind is not known, but the kind from the
-       type is known (including if it is bottom, in which case this must be an
-       empty array), it is maybe useful. *)
-    match known_element_kind, (element_kind : _ Or_unknown_or_bottom.t) with
-    | Unknown, (Ok _ | Bottom) -> true
-    | Known known_element_kind, Ok element_kind
-      when not
-             (K.With_subkind.compatible known_element_kind
-                ~when_used_at:element_kind) ->
-      true
-    | (Unknown | Known _), (Unknown | Bottom | Ok _) -> false)
+     If the element kind from the kind is not known, but the kind from the type
+     is known (including if it is bottom, in which case this must be an empty
+     array), it is maybe useful. *)
+  ||
+  match known_element_kind, (element_kind : _ Or_unknown_or_bottom.t) with
+  | Unknown, (Ok _ | Bottom) -> true
+  | Known known_element_kind, Ok element_kind
+    when not
+           (K.With_subkind.compatible known_element_kind
+              ~when_used_at:element_kind) ->
+    true
+  | (Unknown | Known _), (Unknown | Bottom | Ok _) -> false
 
 and is_useful_head_of_kind_naked_immediate
     (consts : Target_ocaml_int.Set.t Or_unknown.t) env
@@ -1067,7 +1080,7 @@ and is_useful_head_of_kind_naked_immediate
   | Known consts, Naked_immediates set ->
     (* The type is useful as long as we can eliminate at least one of the
        constructors. *)
-    if I.Set.subset consts set then false else true
+    not (I.Set.subset consts set)
   | (Known _ | Unknown), (Is_null _ | Is_int _ | Get_tag _) -> false
 
 and is_useful_head_of_kind_naked_float32 env head =
@@ -1145,5 +1158,11 @@ and is_useful_head_of_kind_rec_info _env _head = false
 and is_useful_head_of_kind_region _env () = false
 
 let type_is_useful full_kind env name =
+  (* Always expand the type of the argument to a concrete type: knowing that we
+     have a name for the argument is not actually useful for the simplification
+     of the function, as that is always true.
+
+     On the other hand, knowing a name for the inner (structural) components of
+     the argument is maybe useful, as it can allow to remove projections. *)
   let ty = TE.find env name (Some (K.With_subkind.kind full_kind)) in
-  is_useful full_kind env ty
+  is_useful_expanded_head full_kind env (expand_head env ty)

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -1075,13 +1075,19 @@ and is_useful_head_of_kind_naked_immediate
     (consts : Target_ocaml_int.Set.t Or_unknown.t) env
     (head : TG.head_of_kind_naked_immediate) =
   let module I = Target_ocaml_int in
-  match consts, head with
-  | Unknown, Naked_immediates set -> is_useful_set (module I.Set) env set
-  | Known consts, Naked_immediates set ->
+  let descr = TG.Head_of_kind_naked_immediate.descr head in
+  (* If we know that this is the is_int or the get_tag of another variable, then
+     the type is maybe useful because we could eliminate the corresponding
+     primitive. *)
+  (not (TG.Relation.Map.is_empty descr.inverse_relations))
+  ||
+  match consts, descr.naked_immediates with
+  | Unknown, Known set -> is_useful_set (module I.Set) env set
+  | Known consts, Known set ->
     (* The type is useful as long as we can eliminate at least one of the
        constructors. *)
     not (I.Set.subset consts set)
-  | (Known _ | Unknown), (Is_null _ | Is_int _ | Get_tag _) -> false
+  | (Known _ | Unknown), Unknown -> false
 
 and is_useful_head_of_kind_naked_float32 env head =
   is_useful_set

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -773,3 +773,377 @@ let make_suitable_for_environment env (to_erase : to_erase) bind_to_and_types =
           then env_extension
           else TEEV.add_or_replace_equation env_extension lhs ty)
         TEEV.empty equations
+
+let[@inline] is_useful_or_unknown_or_bottom is_useful_head kind env
+    (input : _ Or_unknown_or_bottom.t) =
+  match input with
+  | Unknown | Bottom -> false
+  | Ok head -> is_useful_head kind env head
+
+let is_useful_set (type a) (module S : Container_types_intf.Set with type t = a)
+    _env (s : a) =
+  match S.get_singleton s with Some _ -> true | None -> false
+
+let rec is_useful full_kind env t =
+  let expanded = expand_head env t in
+  is_useful_or_unknown_or_bottom is_useful_expanded_head_descr full_kind env
+    (ET.descr expanded)
+
+and is_useful_expanded_head_descr full_kind env (descr : ET.descr) =
+  match descr, K.With_subkind.kind full_kind with
+  | Value head, Value ->
+    is_useful_head_of_kind_value env
+      (K.With_subkind.nullable full_kind)
+      (K.With_subkind.non_null_value_subkind full_kind)
+      head
+  | Naked_immediate head, Naked_number Naked_immediate ->
+    is_useful_head_of_kind_naked_immediate Or_unknown.Unknown env head
+  | Naked_float32 head, Naked_number Naked_float32 ->
+    is_useful_head_of_kind_naked_float32 env head
+  | Naked_float head, Naked_number Naked_float ->
+    is_useful_head_of_kind_naked_float env head
+  | Naked_int8 head, Naked_number Naked_int8 ->
+    is_useful_head_of_kind_naked_int8 env head
+  | Naked_int16 head, Naked_number Naked_int16 ->
+    is_useful_head_of_kind_naked_int16 env head
+  | Naked_int32 head, Naked_number Naked_int32 ->
+    is_useful_head_of_kind_naked_int32 env head
+  | Naked_int64 head, Naked_number Naked_int64 ->
+    is_useful_head_of_kind_naked_int64 env head
+  | Naked_nativeint head, Naked_number Naked_nativeint ->
+    is_useful_head_of_kind_naked_nativeint env head
+  | Naked_vec128 head, Naked_number Naked_vec128 ->
+    is_useful_head_of_kind_naked_vec128 env head
+  | Naked_vec256 head, Naked_number Naked_vec256 ->
+    is_useful_head_of_kind_naked_vec256 env head
+  | Naked_vec512 head, Naked_number Naked_vec512 ->
+    is_useful_head_of_kind_naked_vec512 env head
+  | Rec_info head, Rec_info -> is_useful_head_of_kind_rec_info env head
+  | Region head, Region -> is_useful_head_of_kind_region env head
+  | ( ( Value _ | Naked_immediate _ | Naked_float32 _ | Naked_float _
+      | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
+      | Naked_nativeint _ | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _
+      | Rec_info _ | Region _ ),
+      ( Value
+      | Naked_number
+          ( Naked_immediate | Naked_float32 | Naked_float | Naked_int8
+          | Naked_int16 | Naked_int32 | Naked_int64 | Naked_nativeint
+          | Naked_vec128 | Naked_vec256 | Naked_vec512 )
+      | Rec_info | Region ) ) ->
+    false
+
+and is_useful_head_of_kind_value env (nullable : K.With_subkind.Nullable.t)
+    non_null_value_subkind ({ non_null; is_null } : TG.head_of_kind_value) =
+  match is_null, nullable with
+  | Not_null, Nullable ->
+    (* If the kind thinks we are nullable but the type knows we are not null,
+       that's maybe useful. *)
+    true
+  | (Not_null | Maybe_null _), (Nullable | Non_nullable) ->
+    is_useful_or_unknown_or_bottom is_useful_head_of_kind_value_non_null env
+      non_null_value_subkind non_null
+
+and is_useful_head_of_kind_value_non_null env
+    (non_null_value_subkind : K.With_subkind.Non_null_value_subkind.t)
+    (non_null : TG.head_of_kind_value_non_null) =
+  match non_null_value_subkind, non_null with
+  | ( Anything,
+      ( Variant _ | Mutable_block _ | Boxed_float32 _ | Boxed_float _
+      | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _ | Boxed_vec128 _
+      | Boxed_vec256 _ | Boxed_vec512 _ | Closures _ | String _ | Array _ ) ) ->
+    true
+  | Boxed_float32, Boxed_float32 (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_float32 env ty
+  | Boxed_float, Boxed_float (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_float env ty
+  | Boxed_int32, Boxed_int32 (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_int32 env ty
+  | Boxed_int64, Boxed_int64 (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_int64 env ty
+  | Boxed_nativeint, Boxed_nativeint (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_nativeint env ty
+  | Boxed_vec128, Boxed_vec128 (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_vec128 env ty
+  | Boxed_vec256, Boxed_vec256 (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_vec256 env ty
+  | Boxed_vec512, Boxed_vec512 (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_vec512 env ty
+  | Tagged_immediate, Variant { immediates; _ } -> (
+    match immediates with
+    | Unknown -> false
+    | Known ty -> is_useful K.With_subkind.naked_immediate env ty)
+  | Variant { consts; non_consts }, Variant { immediates; blocks; _ } ->
+    is_useful_variant ~consts ~non_consts env ~immediates ~blocks
+  | Variant _, Mutable_block _ -> false
+  | Float_block { num_fields }, Variant { blocks; _ } ->
+    is_useful_float_block ~num_fields env ~blocks
+  | Float_block { num_fields = _ }, Mutable_block _ -> false
+  | Float_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_float) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Immediate_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.tagged_immediate) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Value_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.any_value) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Generic_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array Or_unknown.Unknown env ~element_kind ~length ~contents
+      ~alloc_mode
+  | Unboxed_float32_array, Array { element_kind; length; contents; alloc_mode }
+    ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_float32) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Untagged_int_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_immediate) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Untagged_int8_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_int8) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Untagged_int16_array, Array { element_kind; length; contents; alloc_mode }
+    ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_int16) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_int32_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_int32) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_int64_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_int64) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | ( Unboxed_nativeint_array,
+      Array { element_kind; length; contents; alloc_mode } ) ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_nativeint) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_vec128_array, Array { element_kind; length; contents; alloc_mode }
+    ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_vec128) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_vec256_array, Array { element_kind; length; contents; alloc_mode }
+    ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_vec256) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_vec512_array, Array { element_kind; length; contents; alloc_mode }
+    ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_vec512) env
+      ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_product_array, Array { element_kind; length; contents; alloc_mode }
+    ->
+    is_useful_array Or_unknown.Unknown env ~element_kind ~length ~contents
+      ~alloc_mode
+  | ( ( Boxed_float32 | Boxed_float | Boxed_int32 | Boxed_int64
+      | Boxed_nativeint | Boxed_vec128 | Boxed_vec256 | Boxed_vec512
+      | Tagged_immediate | Variant _ | Float_block _ | Float_array
+      | Immediate_array | Value_array | Generic_array | Unboxed_float32_array
+      | Untagged_int_array | Untagged_int8_array | Untagged_int16_array
+      | Unboxed_int32_array | Unboxed_int64_array | Unboxed_nativeint_array
+      | Unboxed_vec128_array | Unboxed_vec256_array | Unboxed_vec512_array
+      | Unboxed_product_array ),
+      _ ) ->
+    false
+
+and is_useful_variant ~consts ~non_consts env ~immediates ~blocks =
+  match is_useful_tagged_immediate ~consts env ~immediates with
+  | true -> true
+  | false -> is_useful_block ~non_consts env ~blocks
+
+and is_useful_tagged_immediate ~consts env ~immediates =
+  if Target_ocaml_int.Set.is_empty consts
+  then false
+  else
+    match (immediates : _ Or_unknown.t) with
+    | Unknown -> false
+    | Known ty -> (
+      let expanded = expand_head env ty in
+      match ET.descr expanded with
+      | Unknown -> false
+      | Bottom -> true
+      | Ok (Naked_immediate head) ->
+        is_useful_head_of_kind_naked_immediate (Or_unknown.Known consts) env
+          head
+      | Ok
+          ( Value _ | Naked_float32 _ | Naked_float _ | Naked_int8 _
+          | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
+          | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Rec_info _
+          | Region _ ) ->
+        false)
+
+and is_useful_block ~non_consts env ~blocks =
+  if Tag.Scannable.Map.is_empty non_consts
+  then false
+  else
+    match (blocks : TG.row_like_for_blocks Or_unknown.t) with
+    | Unknown -> false
+    | Known row_like_for_blocks ->
+      if TG.Row_like_for_blocks.is_bottom row_like_for_blocks
+      then true
+      else if
+        Tag.Scannable.Map.exists
+          (fun tag (_block_shape, field_kinds) ->
+            let tag = Tag.Scannable.to_tag tag in
+            let[@local] process_case
+                (row_like_block_case : TG.row_like_block_case) =
+              (* Note: if there is a mismatch in the number of fields, it is OK
+                 to return [true]; we should be able to prove [Bottom] during
+                 inlining. *)
+              let types = row_like_block_case.maps_to in
+              try
+                List.iteri
+                  (fun ix field_kind ->
+                    if ix < Array.length types
+                    then
+                      match is_useful field_kind env types.(ix) with
+                      | true -> raise Exit
+                      | false -> ()
+                    else raise Exit)
+                  field_kinds;
+                false
+              with Exit -> true
+            in
+            match Tag.Map.find tag row_like_for_blocks.known_tags with
+            | Unknown -> false
+            | Known row_like_block_case -> process_case row_like_block_case
+            | exception Not_found -> (
+              match row_like_for_blocks.other_tags with
+              | Bottom -> true
+              | Ok row_like_block_case -> process_case row_like_block_case))
+          non_consts
+      then true
+      else false
+
+and is_useful_float_block ~num_fields:_ env ~blocks =
+  match (blocks : TG.row_like_for_blocks Or_unknown.t) with
+  | Unknown -> false
+  | Known row_like_for_blocks -> (
+    let[@local] process_case (row_like_block_case : TG.row_like_block_case) =
+      if
+        Array.exists
+          (fun ty ->
+            match is_useful K.With_subkind.naked_float env ty with
+            | true -> true
+            | false -> false)
+          row_like_block_case.maps_to
+      then true
+      else false
+    in
+    match Tag.Map.find Tag.double_array_tag row_like_for_blocks.known_tags with
+    | Unknown -> false
+    | Known row_like_block_case -> process_case row_like_block_case
+    | exception Not_found -> (
+      match row_like_for_blocks.other_tags with
+      | Bottom -> true
+      | Ok row_like_block_case -> process_case row_like_block_case))
+
+and is_useful_array (known_element_kind : _ Or_unknown.t) env ~element_kind
+    ~length ~contents:_ ~alloc_mode:_ =
+  (* If we know the length, that's maybe useful (we could eliminate some bounds
+     check). *)
+  match is_useful K.With_subkind.tagged_immediate env length with
+  | true -> true
+  | false -> (
+    (* If the [known_element_kind] from the kind can be used as the
+       [element_kind] from the types, the [element_kind] is not more precise.
+
+       But if it can't (not compatible), then the [element_kind] from the types
+       is more precise than the one from the kind -- that's maybe useful.
+
+       If the element kind from the kind is not known, but the kind from the
+       type is known (including if it is bottom, in which case this must be an
+       empty array), it is maybe useful. *)
+    match known_element_kind, (element_kind : _ Or_unknown_or_bottom.t) with
+    | Unknown, (Ok _ | Bottom) -> true
+    | Known known_element_kind, Ok element_kind
+      when not
+             (K.With_subkind.compatible known_element_kind
+                ~when_used_at:element_kind) ->
+      true
+    | (Unknown | Known _), (Unknown | Bottom | Ok _) -> false)
+
+and is_useful_head_of_kind_naked_immediate
+    (consts : Target_ocaml_int.Set.t Or_unknown.t) env
+    (head : TG.head_of_kind_naked_immediate) =
+  let module I = Target_ocaml_int in
+  match consts, head with
+  | Unknown, Naked_immediates set -> is_useful_set (module I.Set) env set
+  | Known consts, Naked_immediates set ->
+    (* The type is useful as long as we can eliminate at least one of the
+       constructors. *)
+    if I.Set.subset consts set then false else true
+  | (Known _ | Unknown), (Is_null _ | Is_int _ | Get_tag _) -> false
+
+and is_useful_head_of_kind_naked_float32 env head =
+  is_useful_set
+    (module Numeric_types.Float32_by_bit_pattern.Set)
+    env
+    (head
+      : TG.head_of_kind_naked_float32
+      :> Numeric_types.Float32_by_bit_pattern.Set.t)
+
+and is_useful_head_of_kind_naked_float env head =
+  is_useful_set
+    (module Numeric_types.Float_by_bit_pattern.Set)
+    env
+    (head
+      : TG.head_of_kind_naked_float
+      :> Numeric_types.Float_by_bit_pattern.Set.t)
+
+and is_useful_head_of_kind_naked_int8 env head =
+  is_useful_set
+    (module Numeric_types.Int8.Set)
+    env
+    (head : TG.head_of_kind_naked_int8 :> Numeric_types.Int8.Set.t)
+
+and is_useful_head_of_kind_naked_int16 env head =
+  is_useful_set
+    (module Numeric_types.Int16.Set)
+    env
+    (head : TG.head_of_kind_naked_int16 :> Numeric_types.Int16.Set.t)
+
+and is_useful_head_of_kind_naked_int32 env head =
+  is_useful_set
+    (module Numeric_types.Int32.Set)
+    env
+    (head : TG.head_of_kind_naked_int32 :> Numeric_types.Int32.Set.t)
+
+and is_useful_head_of_kind_naked_int64 env head =
+  is_useful_set
+    (module Numeric_types.Int64.Set)
+    env
+    (head : TG.head_of_kind_naked_int64 :> Numeric_types.Int64.Set.t)
+
+and is_useful_head_of_kind_naked_nativeint env head =
+  is_useful_set
+    (module Targetint_32_64.Set)
+    env
+    (head : TG.head_of_kind_naked_nativeint :> Targetint_32_64.Set.t)
+
+and is_useful_head_of_kind_naked_vec128 env head =
+  is_useful_set
+    (module Vector_types.Vec128.Bit_pattern.Set)
+    env
+    (head
+      : TG.head_of_kind_naked_vec128
+      :> Vector_types.Vec128.Bit_pattern.Set.t)
+
+and is_useful_head_of_kind_naked_vec256 env head =
+  is_useful_set
+    (module Vector_types.Vec256.Bit_pattern.Set)
+    env
+    (head
+      : TG.head_of_kind_naked_vec256
+      :> Vector_types.Vec256.Bit_pattern.Set.t)
+
+and is_useful_head_of_kind_naked_vec512 env head =
+  is_useful_set
+    (module Vector_types.Vec512.Bit_pattern.Set)
+    env
+    (head
+      : TG.head_of_kind_naked_vec512
+      :> Vector_types.Vec512.Bit_pattern.Set.t)
+
+and is_useful_head_of_kind_rec_info _env _head = false
+
+and is_useful_head_of_kind_region _env () = false
+
+let type_is_useful full_kind env name =
+  let ty = TE.find env name (Some (K.With_subkind.kind full_kind)) in
+  is_useful full_kind env ty

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -843,17 +843,19 @@ and is_useful_expanded_head_descr full_kind env (descr : ET.descr) =
     is_useful_head_of_kind_naked_vec256 env head
   | Naked_vec512 head, Naked_number Naked_vec512 ->
     is_useful_head_of_kind_naked_vec512 env head
+  | Naked_mask head, Naked_number Naked_mask ->
+    is_useful_head_of_kind_naked_mask env head
   | Rec_info head, Rec_info -> is_useful_head_of_kind_rec_info env head
   | Region head, Region -> is_useful_head_of_kind_region env head
   | ( ( Value _ | Naked_immediate _ | Naked_float32 _ | Naked_float _
       | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
       | Naked_nativeint _ | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _
-      | Rec_info _ | Region _ ),
+      | Rec_info _ | Region _ | Naked_mask _ ),
       ( Value
       | Naked_number
           ( Naked_immediate | Naked_float32 | Naked_float | Naked_int8
           | Naked_int16 | Naked_int32 | Naked_int64 | Naked_nativeint
-          | Naked_vec128 | Naked_vec256 | Naked_vec512 )
+          | Naked_vec128 | Naked_vec256 | Naked_vec512 | Naked_mask )
       | Rec_info | Region ) ) ->
     false
 
@@ -875,7 +877,8 @@ and is_useful_head_of_kind_value_non_null env
   | ( Anything,
       ( Variant _ | Mutable_block _ | Boxed_float32 _ | Boxed_float _
       | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _ | Boxed_vec128 _
-      | Boxed_vec256 _ | Boxed_vec512 _ | Closures _ | String _ | Array _ ) ) ->
+      | Boxed_vec256 _ | Boxed_vec512 _ | Boxed_mask _ | Closures _ | String _
+      | Array _ ) ) ->
     true
   | Boxed_float32, Boxed_float32 (ty, _alloc_mode) ->
     is_useful K.With_subkind.naked_float32 env ty
@@ -893,6 +896,8 @@ and is_useful_head_of_kind_value_non_null env
     is_useful K.With_subkind.naked_vec256 env ty
   | Boxed_vec512, Boxed_vec512 (ty, _alloc_mode) ->
     is_useful K.With_subkind.naked_vec512 env ty
+  | Boxed_mask, Boxed_mask (ty, _alloc_mode) ->
+    is_useful K.With_subkind.naked_mask env ty
   | Tagged_immediate, Variant { immediates; _ } -> (
     match immediates with
     | Unknown -> false
@@ -951,18 +956,21 @@ and is_useful_head_of_kind_value_non_null env
     ->
     is_useful_array (Or_unknown.Known K.With_subkind.naked_vec512) env
       ~element_kind ~length ~contents ~alloc_mode
+  | Unboxed_mask_array, Array { element_kind; length; contents; alloc_mode } ->
+    is_useful_array (Or_unknown.Known K.With_subkind.naked_mask) env
+      ~element_kind ~length ~contents ~alloc_mode
   | Unboxed_product_array, Array { element_kind; length; contents; alloc_mode }
     ->
     is_useful_array Or_unknown.Unknown env ~element_kind ~length ~contents
       ~alloc_mode
   | ( ( Boxed_float32 | Boxed_float | Boxed_int32 | Boxed_int64
       | Boxed_nativeint | Boxed_vec128 | Boxed_vec256 | Boxed_vec512
-      | Tagged_immediate | Variant _ | Float_block _ | Float_array
+      | Boxed_mask | Tagged_immediate | Variant _ | Float_block _ | Float_array
       | Immediate_array | Value_array | Generic_array | Unboxed_float32_array
       | Untagged_int_array | Untagged_int8_array | Untagged_int16_array
       | Unboxed_int32_array | Unboxed_int64_array | Unboxed_nativeint_array
       | Unboxed_vec128_array | Unboxed_vec256_array | Unboxed_vec512_array
-      | Unboxed_product_array ),
+      | Unboxed_mask_array | Unboxed_product_array ),
       _ ) ->
     false
 
@@ -987,8 +995,8 @@ and is_useful_tagged_immediate ~consts env ~immediates =
       | Ok
           ( Value _ | Naked_float32 _ | Naked_float _ | Naked_int8 _
           | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-          | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Rec_info _
-          | Region _ ) ->
+          | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Naked_mask _
+          | Rec_info _ | Region _ ) ->
         false)
 
 and is_useful_block ~non_consts env ~blocks =
@@ -1158,6 +1166,12 @@ and is_useful_head_of_kind_naked_vec512 env head =
     (head
       : TG.head_of_kind_naked_vec512
       :> Vector_types.Vec512.Bit_pattern.Set.t)
+
+and is_useful_head_of_kind_naked_mask env head =
+  is_useful_set
+    (module Vector_types.Mask.Bit_pattern.Set)
+    env
+    (head : TG.head_of_kind_naked_mask :> Vector_types.Mask.Bit_pattern.Set.t)
 
 and is_useful_head_of_kind_rec_info _env _head = false
 

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -1052,6 +1052,7 @@ and is_useful_array (known_element_kind : _ Or_unknown.t) env ~element_kind
   (* If we know the length, that's maybe useful (we could eliminate some bounds
      check). *)
   is_useful K.With_subkind.tagged_immediate env length
+  ||
   (* If the [known_element_kind] from the kind can be used as the [element_kind]
      from the types, the [element_kind] is not more precise.
 
@@ -1061,7 +1062,6 @@ and is_useful_array (known_element_kind : _ Or_unknown.t) env ~element_kind
      If the element kind from the kind is not known, but the kind from the type
      is known (including if it is bottom, in which case this must be an empty
      array), it is maybe useful. *)
-  ||
   match known_element_kind, (element_kind : _ Or_unknown_or_bottom.t) with
   | Unknown, (Ok _ | Bottom) -> true
   | Known known_element_kind, Ok element_kind

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -161,3 +161,6 @@ val make_suitable_for_environment :
   (Name.t * Type_grammar.t) list ->
   (* these [Name.t] values are called the "bind-to" names *)
   Typing_env_extension.With_extra_variables.t
+
+val type_is_useful :
+  Flambda_kind.With_subkind.t -> Typing_env.t -> Name.t -> bool

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -365,6 +365,17 @@ val make_suitable_for_environment :
   (Name.t * flambda_type) list ->
   Typing_env_extension.With_extra_variables.t
 
+(** [type_is_useful full_kind env ty] returns [true] if knowing the type of
+    [name] (which is known to have kind [full_kind]) in environment [env] is
+    useful.
+
+    The exact definition of being "useful" is left to the typing env, and is an
+    approximation of the answer to the question: is the current type of [name]
+    in [env] more precise (in the sense that it would generally allow to [prove]
+    more properties) than [full_kind]? *)
+val type_is_useful :
+  Flambda_kind.With_subkind.t -> Typing_env.t -> Name.t -> bool
+
 val apply_coercion : flambda_type -> Coercion.t -> flambda_type
 
 (** Construct a bottom type of the given kind. *)

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -363,6 +363,17 @@ val make_suitable_for_environment :
   (Name.t * flambda_type) list ->
   Typing_env_extension.With_extra_variables.t
 
+(** [type_is_useful full_kind env ty] returns [true] if knowing the type of
+    [name] (which is known to have kind [full_kind]) in environment [env] is
+    useful.
+
+    The exact definition of being "useful" is left to the typing env, and is an
+    approximation of the answer to the question: is the current type of [name]
+    in [env] more precise (in the sense that it would generally allow to [prove]
+    more properties) than [full_kind]? *)
+val type_is_useful :
+  Flambda_kind.With_subkind.t -> Typing_env.t -> Name.t -> bool
+
 val apply_coercion : flambda_type -> Coercion.t -> flambda_type
 
 (** Construct a bottom type of the given kind. *)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.ml
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.ml
@@ -1,0 +1,28 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0";
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt with dump-raw, dump-simplify;
+   check-fexpr-dump;
+ *)
+
+type int_box = Box of int
+
+let unbox_int_and_add_one (Box x) =
+  (* Assume the body of this function is larger than the small function size,
+     which we enforce by setting it to [0] in this test. *)
+  x + 1
+
+let[@inline] unbox_int_and_add_one_wrapper (x : int_box) =
+  (* This call does not pass the "argument types useful" check, because we
+     don't have more precise information about [x] in [g] than what we have
+     from the value kinds on the parameters of [f]. *)
+  unbox_int_and_add_one x
+
+let box_int_then_call_unbox_int_and_add_one_wrapper (x : int) =
+  (* This call should pass the "argument types useful" check: we don't know
+     anything more precise about the value of the argument, but we do know that
+     it's first field is available as a variable in the program -- we want to
+     speculatively inline, because we could eliminate projection primitives. *)
+  unbox_int_and_add_one_wrapper (Box x)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.ml
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.ml
@@ -23,6 +23,6 @@ let[@inline] unbox_int_and_add_one_wrapper (x : int_box) =
 let box_int_then_call_unbox_int_and_add_one_wrapper (x : int) =
   (* This call should pass the "argument types useful" check: we don't know
      anything more precise about the value of the argument, but we do know that
-     it's first field is available as a variable in the program -- we want to
+     its first field is available as a variable in the program -- we want to
      speculatively inline, because we could eliminate projection primitives. *)
   unbox_int_and_add_one_wrapper (Box x)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.ml
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.ml
@@ -1,7 +1,7 @@
 (* TEST
    compile_only = "true";
    flambda2;
-   ocamlopt_flags += " -flambda2-inline-small-function-size 0";
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0 -X argument-types-useful=fine";
    setup-ocamlopt.opt-build-env;
    ocamlopt.opt with dump-raw, dump-simplify;
    check-fexpr-dump;

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.raw.reference
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.raw.reference
@@ -1,0 +1,65 @@
+let $camlArgument_types_useful__first_const = Block 0 () in
+(let code size(4)
+       unbox_int_and_add_one_0 (param : [ 0 of imm tagged ])
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   let Pfield = %block_load.[`0`] (param) in
+   let int_add = %int_barith.add (Pfield, 1) in
+   cont k1 (int_add)
+ in
+ let code inline(always) size(5)
+       unbox_int_and_add_one_wrapper_1 (x : [ 0 of imm tagged ])
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   let unbox_int_and_add_one =
+     %project_value_slot.[unbox_int_and_add_one_wrapper].[unbox_int_and_add_one]
+       (my_closure)
+   in
+   apply direct(unbox_int_and_add_one_0)
+     (unbox_int_and_add_one : _ -> imm tagged) (x) -> k1 * k2
+ in
+ let code size(11)
+       box_int_then_call_unbox_int_and_add_one_wrapper_2 (x : imm tagged)
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   let unbox_int_and_add_one_wrapper =
+     %project_value_slot.[box_int_then_call_unbox_int_and_add_one_wrapper].[unbox_int_and_add_one_wrapper]
+       (my_closure)
+   in
+   let Pmakeblock = %block.[`0`] (x) in
+   apply direct(unbox_int_and_add_one_wrapper_1)
+     (unbox_int_and_add_one_wrapper : _ -> imm tagged)
+       (Pmakeblock)
+       -> k1 * k2
+ in
+ let unbox_int_and_add_one =
+   closure unbox_int_and_add_one_0 @unbox_int_and_add_one
+ in
+ let unbox_int_and_add_one_wrapper =
+   closure unbox_int_and_add_one_wrapper_1 @unbox_int_and_add_one_wrapper
+ with { unbox_int_and_add_one = unbox_int_and_add_one }
+ in
+ let box_int_then_call_unbox_int_and_add_one_wrapper =
+   closure box_int_then_call_unbox_int_and_add_one_wrapper_2
+     @box_int_then_call_unbox_int_and_add_one_wrapper
+ with { unbox_int_and_add_one_wrapper = unbox_int_and_add_one_wrapper }
+ in
+ let Pmakeblock =
+   %block.[`0`]
+     (unbox_int_and_add_one,
+      unbox_int_and_add_one_wrapper,
+      box_int_then_call_unbox_int_and_add_one_wrapper)
+ in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (module_block) in
+    let $camlArgument_types_useful = Block 0 (field_0, field_1, field_2) in
+    cont done ($camlArgument_types_useful)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.raw.reference
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.raw.reference
@@ -1,7 +1,7 @@
 let $camlArgument_types_useful__first_const = Block 0 () in
 (let code size(4)
        unbox_int_and_add_one_0 (param : [ 0 of imm tagged ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -11,7 +11,7 @@ let $camlArgument_types_useful__first_const = Block 0 () in
  in
  let code inline(always) size(5)
        unbox_int_and_add_one_wrapper_1 (x : [ 0 of imm tagged ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -19,12 +19,12 @@ let $camlArgument_types_useful__first_const = Block 0 () in
      %project_value_slot.[unbox_int_and_add_one_wrapper].[unbox_int_and_add_one]
        (my_closure)
    in
-   apply direct(unbox_int_and_add_one_0)
+   apply direct(unbox_int_and_add_one_0 &my_alloc_region)
      (unbox_int_and_add_one : _ -> imm tagged) (x) -> k1 * k2
  in
  let code size(11)
        box_int_then_call_unbox_int_and_add_one_wrapper_2 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -32,26 +32,28 @@ let $camlArgument_types_useful__first_const = Block 0 () in
      %project_value_slot.[box_int_then_call_unbox_int_and_add_one_wrapper].[unbox_int_and_add_one_wrapper]
        (my_closure)
    in
-   let Pmakeblock = %block.[`0`] (x) in
-   apply direct(unbox_int_and_add_one_wrapper_1)
+   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+   apply direct(unbox_int_and_add_one_wrapper_1 &my_alloc_region)
      (unbox_int_and_add_one_wrapper : _ -> imm tagged)
        (Pmakeblock)
        -> k1 * k2
  in
  let unbox_int_and_add_one =
    closure unbox_int_and_add_one_0 @unbox_int_and_add_one
+     &toplevel.alloc_region
  in
  let unbox_int_and_add_one_wrapper =
    closure unbox_int_and_add_one_wrapper_1 @unbox_int_and_add_one_wrapper
+     &toplevel.alloc_region
  with { unbox_int_and_add_one = unbox_int_and_add_one }
  in
  let box_int_then_call_unbox_int_and_add_one_wrapper =
    closure box_int_then_call_unbox_int_and_add_one_wrapper_2
-     @box_int_then_call_unbox_int_and_add_one_wrapper
+     @box_int_then_call_unbox_int_and_add_one_wrapper &toplevel.alloc_region
  with { unbox_int_and_add_one_wrapper = unbox_int_and_add_one_wrapper }
  in
  let Pmakeblock =
-   %block.[`0`]
+   %block.[`0`].`toplevel`
      (unbox_int_and_add_one,
       unbox_int_and_add_one_wrapper,
       box_int_then_call_unbox_int_and_add_one_wrapper)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.simplify.reference
@@ -1,0 +1,46 @@
+let code unbox_int_and_add_one_0 deleted in
+let code unbox_int_and_add_one_wrapper_1 deleted in
+let code box_int_then_call_unbox_int_and_add_one_wrapper_2 deleted in
+let code loopify(never) size(4) newer_version_of(unbox_int_and_add_one_0)
+      unbox_int_and_add_one_0_1 (param : [ 0 of imm tagged ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = %block_load.[`0`] (param) in
+  let int_add = %int_barith.add (Pfield, 1) in
+  cont k (int_add)
+in
+let $camlArgument_types_useful__unbox_int_and_add_one_3 =
+  closure unbox_int_and_add_one_0_1 @unbox_int_and_add_one
+in
+let code inline(always) loopify(never) size(4) newer_version_of(unbox_int_and_add_one_wrapper_1)
+      unbox_int_and_add_one_wrapper_1_1 (x : [ 0 of imm tagged ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  apply direct(unbox_int_and_add_one_0_1)
+    ($camlArgument_types_useful__unbox_int_and_add_one_3 : _ -> imm tagged)
+      (x)
+      -> k * k1
+in
+let $camlArgument_types_useful__unbox_int_and_add_one_wrapper_4 =
+  closure unbox_int_and_add_one_wrapper_1_1 @unbox_int_and_add_one_wrapper
+in
+let code loopify(never) size(3) newer_version_of(box_int_then_call_unbox_int_and_add_one_wrapper_2)
+      box_int_then_call_unbox_int_and_add_one_wrapper_2_1 (x : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, 1) in
+  cont k (int_add)
+in
+let $camlArgument_types_useful__box_int_then_call_unbox_int_and_add_one_wrapper_5 =
+  closure box_int_then_call_unbox_int_and_add_one_wrapper_2_1
+    @box_int_then_call_unbox_int_and_add_one_wrapper
+in
+let $camlArgument_types_useful =
+  Block 0 ($camlArgument_types_useful__unbox_int_and_add_one_3,
+           $camlArgument_types_useful__unbox_int_and_add_one_wrapper_4,
+           $camlArgument_types_useful__box_int_then_call_unbox_int_and_add_one_wrapper_5)
+in
+cont done ($camlArgument_types_useful)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.simplify.reference
@@ -3,7 +3,7 @@ let code unbox_int_and_add_one_wrapper_1 deleted in
 let code box_int_then_call_unbox_int_and_add_one_wrapper_2 deleted in
 let code loopify(never) size(4) newer_version_of(unbox_int_and_add_one_0)
       unbox_int_and_add_one_0_1 (param : [ 0 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`0`] (param) in
@@ -12,23 +12,25 @@ let code loopify(never) size(4) newer_version_of(unbox_int_and_add_one_0)
 in
 let $camlArgument_types_useful__unbox_int_and_add_one_3 =
   closure unbox_int_and_add_one_0_1 @unbox_int_and_add_one
+    &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(4) newer_version_of(unbox_int_and_add_one_wrapper_1)
       unbox_int_and_add_one_wrapper_1_1 (x : [ 0 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(unbox_int_and_add_one_0_1)
+  apply direct(unbox_int_and_add_one_0_1 &my_alloc_region)
     ($camlArgument_types_useful__unbox_int_and_add_one_3 : _ -> imm tagged)
       (x)
       -> k * k1
 in
 let $camlArgument_types_useful__unbox_int_and_add_one_wrapper_4 =
   closure unbox_int_and_add_one_wrapper_1_1 @unbox_int_and_add_one_wrapper
+    &toplevel.alloc_region
 in
 let code loopify(never) size(3) newer_version_of(box_int_then_call_unbox_int_and_add_one_wrapper_2)
       box_int_then_call_unbox_int_and_add_one_wrapper_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_add = %int_barith.add (x, 1) in
@@ -36,7 +38,7 @@ let code loopify(never) size(3) newer_version_of(box_int_then_call_unbox_int_and
 in
 let $camlArgument_types_useful__box_int_then_call_unbox_int_and_add_one_wrapper_5 =
   closure box_int_then_call_unbox_int_and_add_one_wrapper_2_1
-    @box_int_then_call_unbox_int_and_add_one_wrapper
+    @box_int_then_call_unbox_int_and_add_one_wrapper &toplevel.alloc_region
 in
 let $camlArgument_types_useful =
   Block 0 ($camlArgument_types_useful__unbox_int_and_add_one_3,


### PR DESCRIPTION
The `argument_types_useful` check is intended to improve compilation times by skipping speculative inlining if the argument types are not "useful".

At the moment, being "useful" is very restrictive: the argument types are useful as long as we know *anything* about any argument other than its nullability.

This patch makes the check less restrictive: we now have a explicit notion of "usefulness" relative to the full kind of the argument. An argument type is now "useful" if it gives more precise structural information (typically, regarding possible constructors in variants) than the full kind of the corresponding parameter.

Without this change, when compiling the compiler we had the following statistics on speculative inlining:

 - Argument types not useful: 4,482
 - Speculation says to inline: 2,510
 - Speculation says NOT to inline: 13,075

With this change, we now have the following statistics (the delta does not sum to exactly 100 because these numbers come from compiling the compiler with this PR applied, while the previous numbers did not have the PR applied):

 - Argument types not useful: 7,975 (+3,493)
 - Speculation says to inline: 2,344 (-166)
 - Speculation says NOT to inline: 9,739 (-3,336)

This is a total of 3,493 (~ 20%) of the speculative inling avoided, 3,336 (~ 95%) of which would have failed anyways. I have not looked at the remaining 166 tests yet, but it is likely that a significant portion of these are situations where we choose to speculatively inline but it is not actually beneficial (there are known issues around this, e.g. #5143 and #5141).

Fixes #5150