### PR TITLE
bigarray: `(unsafe_)get` and `blit` require `@ read` access only

### DIFF
--- a/stdlib/bigarray.ml
+++ b/stdlib/bigarray.ml
@@ -110,7 +110,9 @@ module Genarray = struct
      = "caml_ba_create"
   external get
      : ('a : value_or_null) ('b : any) ('c : any).
-       (('a, 'b, 'c) t[@local_opt]) @ shared -> (int array[@local_opt]) -> 'a
+       (('a, 'b, 'c) t[@local_opt]) @ read
+       -> (int array[@local_opt])
+       -> 'a
      @@ portable
      = "caml_ba_get_generic"
   external set
@@ -192,7 +194,8 @@ module Genarray = struct
      = "caml_ba_slice"
   external blit
      : ('a : any) ('b : any) ('c : any).
-       (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+       (('a, 'b, 'c) t[@local_opt]) @ read
+       -> (('a, 'b, 'c) t[@local_opt])
        -> unit
      @@ portable
      = "caml_ba_blit"
@@ -226,7 +229,7 @@ module Array0 = struct
 
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     @@ portable
     = "caml_ba_blit"
@@ -248,7 +251,7 @@ module Array1 = struct
     Genarray.create kind layout [|dim|]
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> ('a[@local_opt])
     @@ portable
     = "%caml_ba_ref_1"
   external set
@@ -258,7 +261,7 @@ module Array1 = struct
     = "%caml_ba_set_1"
   external unsafe_get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> ('a[@local_opt])
     @@ portable
     = "%caml_ba_unsafe_ref_1"
   external unsafe_set
@@ -300,7 +303,7 @@ module Array1 = struct
     | Fortran_layout -> (Genarray.slice_right a [|n|]: (a, b, c) Genarray.t)
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     @@ portable
     = "caml_ba_blit"
@@ -338,7 +341,10 @@ module Array2 = struct
     Genarray.create kind layout [|dim1; dim2|]
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read
+      -> int
+      -> int
+      -> ('a[@local_opt])
     @@ portable
     = "%caml_ba_ref_2"
   external set
@@ -348,7 +354,10 @@ module Array2 = struct
     = "%caml_ba_set_2"
   external unsafe_get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read
+      -> int
+      -> int
+      -> ('a[@local_opt])
     @@ portable
     = "%caml_ba_unsafe_ref_2"
   external unsafe_set
@@ -394,7 +403,7 @@ module Array2 = struct
   let slice_right a n = Genarray.slice_right a [|n|]
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     @@ portable
     = "caml_ba_blit"
@@ -447,7 +456,7 @@ module Array3 = struct
     Genarray.create kind layout [|dim1; dim2; dim3|]
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> int
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> int -> int
       -> ('a[@local_opt])
     @@ portable
     = "%caml_ba_ref_3"
@@ -459,7 +468,7 @@ module Array3 = struct
      = "%caml_ba_set_3"
   external unsafe_get
      : ('a : value_or_null) ('b : any) ('c : any).
-       (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> int
+       (('a, 'b, 'c) t[@local_opt]) @ read -> int -> int -> int
        -> ('a[@local_opt])
      @@ portable
      = "%caml_ba_unsafe_ref_3"
@@ -513,8 +522,9 @@ module Array3 = struct
   let slice_right_2 a n = Genarray.slice_right a [|n|]
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt]) ->
-      unit
+      (('a, 'b, 'c) t[@local_opt]) @ read
+      -> (('a, 'b, 'c) t[@local_opt])
+      -> unit
     @@ portable
     = "caml_ba_blit"
   external fill

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -412,7 +412,9 @@ module Genarray :
 
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (int array[@local_opt]) -> 'a
+      (('a, 'b, 'c) t[@local_opt]) @ read
+      -> (int array[@local_opt])
+      -> 'a
     = "caml_ba_get_generic"
   (** Read an element of a generic Bigarray.
      [Genarray.get a [|i1; ...; iN|]] returns the element of [a]
@@ -538,7 +540,7 @@ module Genarray :
 
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     = "caml_ba_blit"
   (** Copy all elements of a Bigarray in another Bigarray.
@@ -617,7 +619,7 @@ module Array0 : sig
 
   val get
     : ('a : value_or_null) ('b : any) ('c : any).
-      ('a, 'b, 'c) t @ local shared -> 'a
+      ('a, 'b, 'c) t @ local read -> 'a
   (** [Array0.get a] returns the only element in [a]. *)
 
   val set
@@ -627,7 +629,7 @@ module Array0 : sig
 
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     = "caml_ba_blit"
   (** Copy the first Bigarray to the second Bigarray.
@@ -728,7 +730,7 @@ module Array1 : sig
 
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> ('a[@local_opt])
     = "%caml_ba_ref_1"
   (** [Array1.get a x], or alternatively [a.{x}],
      returns the element of [a] at index [x].
@@ -765,7 +767,7 @@ module Array1 : sig
 
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     = "caml_ba_blit"
   (** Copy the first Bigarray to the second Bigarray.
@@ -786,7 +788,7 @@ module Array1 : sig
 
   external unsafe_get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> ('a[@local_opt])
     = "%caml_ba_unsafe_ref_1"
   (** Like {!Bigarray.Array1.get}, but bounds checking is not always performed.
       Use with caution and only when the program logic guarantees that
@@ -887,7 +889,10 @@ module Array2 :
 
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read
+      -> int
+      -> int
+      -> ('a[@local_opt])
     = "%caml_ba_ref_2"
   (** [Array2.get a x y], also written [a.{x,y}],
      returns the element of [a] at coordinates ([x], [y]).
@@ -942,7 +947,7 @@ module Array2 :
 
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     = "caml_ba_blit"
   (** Copy the first Bigarray to the second Bigarray.
@@ -964,7 +969,10 @@ module Array2 :
 
   external unsafe_get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> ('a[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read
+      -> int
+      -> int
+      -> ('a[@local_opt])
     = "%caml_ba_unsafe_ref_2"
   (** Like {!Bigarray.Array2.get}, but bounds checking is not always
       performed. *)
@@ -1070,7 +1078,7 @@ module Array3 :
 
   external get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> int
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> int -> int
       -> ('a[@local_opt])
     = "%caml_ba_ref_3"
   (** [Array3.get a x y z], also written [a.{x,y,z}],
@@ -1149,7 +1157,7 @@ module Array3 :
 
   external blit
     : ('a : any) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> (('a, 'b, 'c) t[@local_opt])
+      (('a, 'b, 'c) t[@local_opt]) @ read -> (('a, 'b, 'c) t[@local_opt])
       -> unit
     = "caml_ba_blit"
   (** Copy the first Bigarray to the second Bigarray.
@@ -1171,7 +1179,7 @@ module Array3 :
 
   external unsafe_get
     : ('a : value_or_null) ('b : any) ('c : any).
-      (('a, 'b, 'c) t[@local_opt]) @ shared -> int -> int -> int
+      (('a, 'b, 'c) t[@local_opt]) @ read -> int -> int -> int
       -> ('a[@local_opt])
     = "%caml_ba_unsafe_ref_3"
   (** Like {!Bigarray.Array3.get}, but bounds checking is not always

--- a/testsuite/tests/parsing/multi_indices.ml
+++ b/testsuite/tests/parsing/multi_indices.ml
@@ -21,7 +21,7 @@ val ( .%{;..}<- ) :
 
 let (.%{;..}) = A.get;;
 val ( .%{;..} ) :
-  'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ shared -> int array -> 'a =
+  'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ read -> int array -> 'a =
   <fun>
 |}]
 
@@ -59,7 +59,7 @@ val ( .?(;..)<- ) :
 
 let (.?(;..)) = A.get;;
 val ( .?(;..) ) :
-  'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ shared -> int array -> 'a =
+  'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ read -> int array -> 'a =
   <fun>
 |}]
 
@@ -149,15 +149,15 @@ module M =
 module M :
   sig
     val ( .%?(;..) ) :
-      'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ shared -> int array -> 'a
+      'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ read -> int array -> 'a
     val ( .%?(;..)<- ) :
       'a ('b : any) ('c : any). ('a, 'b, 'c) A.t -> int array -> 'a -> unit
     val ( .%![;..] ) :
-      'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ shared -> int array -> 'a
+      'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ read -> int array -> 'a
     val ( .%![;..]<- ) :
       'a ('b : any) ('c : any). ('a, 'b, 'c) A.t -> int array -> 'a -> unit
     val ( .%%{;..} ) :
-      'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ shared -> int array -> 'a
+      'a ('b : any) ('c : any). ('a, 'b, 'c) A.t @ read -> int array -> 'a
     val ( .%%{;..}<- ) :
       'a ('b : any) ('c : any). ('a, 'b, 'c) A.t -> int array -> 'a -> unit
   end


### PR DESCRIPTION
I think, at least.