### PR TITLE
Fix bug in meet for array element kinds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             ocamlparam: '_,Oclassic=1'
-            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/gadt_simplified_switch.ml'
+            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/array_element_kind_meet.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/gadt_simplified_switch.ml'
 
           - name: runtime4 (aarch64-darwin)
             config: --disable-runtime5 --disable-warn-error
@@ -229,7 +229,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: 'flambda2-expert-cont-lifting-budget=1000,flambda2-expert-cont-spec-budget=100,_'
             ocamlparam: 'flambda2-expert-cont-lifting-budget=1000,flambda2-expert-cont-spec-budget=100,_'
-            disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
+            disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/array_element_kind_meet.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
 
     env:
       J: "8"

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -464,21 +464,23 @@ let[@inline always] join_unknown join_contents (env : Join_env.t)
 (* Note: Bottom is a valid element kind for empty arrays, so this function never
    leads to a general Bottom result *)
 let meet_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
-    (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
+    (element_kind2 : _ Or_unknown_or_bottom.t) :
+    _ Or_unknown_or_bottom.t meet_return_value =
   match element_kind1, element_kind2 with
-  | Unknown, Unknown -> Unknown
-  | Bottom, _ | _, Bottom -> Bottom
-  | Unknown, Ok kind | Ok kind, Unknown -> Ok kind
-  | Ok element_kind1, Ok element_kind2 ->
-    if
-      Flambda_kind.With_subkind.compatible element_kind1
-        ~when_used_at:element_kind2
-    then Ok element_kind1
-    else if
-      Flambda_kind.With_subkind.compatible element_kind2
-        ~when_used_at:element_kind1
-    then Ok element_kind2
-    else Bottom
+  | Unknown, Unknown | Bottom, Bottom -> Both_inputs
+  | Bottom, _ | Ok _, Unknown -> Left_input
+  | _, Bottom | Unknown, Ok _ -> Right_input
+  | Ok element_kind1, Ok element_kind2 -> (
+    match
+      ( Flambda_kind.With_subkind.compatible element_kind1
+          ~when_used_at:element_kind2,
+        Flambda_kind.With_subkind.compatible element_kind2
+          ~when_used_at:element_kind1 )
+    with
+    | true, true -> Both_inputs
+    | true, false -> Left_input
+    | false, true -> Right_input
+    | false, false -> New_result Bottom)
 
 let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
@@ -871,45 +873,20 @@ and meet_head_of_kind_value_non_null env
 and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
     (element_kind2, length2, contents2, alloc_mode2) =
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
-  let rebuild (length, (contents, (alloc_mode, ()))) =
-    TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
-      ~length contents alloc_mode
+  let meet_element_kind =
+    extract_value element_kind element_kind1 element_kind2
   in
-  let sub_result =
-    combine_results env ~rebuild
-      ~meet_ops:
-        [ meet;
-          meet_array_contents ~meet_element_kind:element_kind;
-          meet_alloc_mode ]
-      ~left_inputs:[length1; contents1; alloc_mode1]
-      ~right_inputs:[length2; contents2; alloc_mode2]
-  in
-  (* [element_kind] is computed outside of [combine_results], so the
-     classification returned above does not account for it. If the meet changed
-     [element_kind] relative to one side, that side can no longer be returned
-     verbatim—we must produce [New_result] instead. *)
-  let ek_equal = Or_unknown_or_bottom.equal K.With_subkind.equal in
-  let ek_matches_left = ek_equal element_kind1 element_kind in
-  let ek_matches_right = ek_equal element_kind2 element_kind in
-  match sub_result with
-  | Bottom _ -> sub_result
-  | Ok (sub_rv, env) ->
-    let ek_matches_sub =
-      match sub_rv with
-      | Both_inputs -> ek_matches_left || ek_matches_right
-      | Left_input -> ek_matches_left
-      | Right_input -> ek_matches_right
-      | New_result _ -> false
-    in
-    if ek_matches_sub
-    then sub_result
-    else
-      let result =
-        extract_value sub_rv
-          (rebuild (length1, (contents1, (alloc_mode1, ()))))
-          (rebuild (length2, (contents2, (alloc_mode2, ()))))
-      in
-      Ok (New_result result, env)
+  combine_results env
+    ~rebuild:(fun (length, (contents, (alloc_mode, (element_kind, ())))) ->
+      TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+        ~length contents alloc_mode)
+    ~meet_ops:
+      [ meet;
+        meet_array_contents ~meet_element_kind;
+        meet_alloc_mode;
+        (fun env _element_kind1 _element_kind2 -> Ok (element_kind, env)) ]
+    ~left_inputs:[length1; contents1; alloc_mode1; element_kind1]
+    ~right_inputs:[length2; contents2; alloc_mode2; element_kind2]
 
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -871,16 +871,45 @@ and meet_head_of_kind_value_non_null env
 and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
     (element_kind2, length2, contents2, alloc_mode2) =
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
-  combine_results env
-    ~rebuild:(fun (length, (contents, (alloc_mode, ()))) ->
-      TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
-        ~length contents alloc_mode)
-    ~meet_ops:
-      [ meet;
-        meet_array_contents ~meet_element_kind:element_kind;
-        meet_alloc_mode ]
-    ~left_inputs:[length1; contents1; alloc_mode1]
-    ~right_inputs:[length2; contents2; alloc_mode2]
+  let rebuild (length, (contents, (alloc_mode, ()))) =
+    TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+      ~length contents alloc_mode
+  in
+  let sub_result =
+    combine_results env ~rebuild
+      ~meet_ops:
+        [ meet;
+          meet_array_contents ~meet_element_kind:element_kind;
+          meet_alloc_mode ]
+      ~left_inputs:[length1; contents1; alloc_mode1]
+      ~right_inputs:[length2; contents2; alloc_mode2]
+  in
+  (* [element_kind] is computed outside of [combine_results], so the
+     classification returned above does not account for it. If the meet changed
+     [element_kind] relative to one side, that side can no longer be returned
+     verbatim—we must produce [New_result] instead. *)
+  let ek_equal = Or_unknown_or_bottom.equal K.With_subkind.equal in
+  let ek_matches_left = ek_equal element_kind1 element_kind in
+  let ek_matches_right = ek_equal element_kind2 element_kind in
+  match sub_result with
+  | Bottom _ -> sub_result
+  | Ok (sub_rv, env) ->
+    let ek_matches_sub =
+      match sub_rv with
+      | Both_inputs -> ek_matches_left || ek_matches_right
+      | Left_input -> ek_matches_left
+      | Right_input -> ek_matches_right
+      | New_result _ -> false
+    in
+    if ek_matches_sub
+    then sub_result
+    else
+      let result =
+        extract_value sub_rv
+          (rebuild (length1, (contents1, (alloc_mode1, ()))))
+          (rebuild (length2, (contents2, (alloc_mode2, ()))))
+      in
+      Ok (New_result result, env)
 
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -1012,16 +1012,45 @@ and meet_head_of_kind_value_non_null env
 and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
     (element_kind2, length2, contents2, alloc_mode2) =
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
-  combine_results env
-    ~rebuild:(fun (length, (contents, (alloc_mode, ()))) ->
-      TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
-        ~length contents alloc_mode)
-    ~meet_ops:
-      [ meet;
-        meet_array_contents ~meet_element_kind:element_kind;
-        meet_alloc_mode ]
-    ~left_inputs:[length1; contents1; alloc_mode1]
-    ~right_inputs:[length2; contents2; alloc_mode2]
+  let rebuild (length, (contents, (alloc_mode, ()))) =
+    TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+      ~length contents alloc_mode
+  in
+  let sub_result =
+    combine_results env ~rebuild
+      ~meet_ops:
+        [ meet;
+          meet_array_contents ~meet_element_kind:element_kind;
+          meet_alloc_mode ]
+      ~left_inputs:[length1; contents1; alloc_mode1]
+      ~right_inputs:[length2; contents2; alloc_mode2]
+  in
+  (* [element_kind] is computed outside of [combine_results], so the
+     classification returned above does not account for it. If the meet changed
+     [element_kind] relative to one side, that side can no longer be returned
+     verbatim—we must produce [New_result] instead. *)
+  let ek_equal = Or_unknown_or_bottom.equal K.With_subkind.equal in
+  let ek_matches_left = ek_equal element_kind1 element_kind in
+  let ek_matches_right = ek_equal element_kind2 element_kind in
+  match sub_result with
+  | Bottom _ -> sub_result
+  | Ok (sub_rv, env) ->
+    let ek_matches_sub =
+      match sub_rv with
+      | Both_inputs -> ek_matches_left || ek_matches_right
+      | Left_input -> ek_matches_left
+      | Right_input -> ek_matches_right
+      | New_result _ -> false
+    in
+    if ek_matches_sub
+    then sub_result
+    else
+      let result =
+        extract_value sub_rv
+          (rebuild (length1, (contents1, (alloc_mode1, ()))))
+          (rebuild (length2, (contents2, (alloc_mode2, ()))))
+      in
+      Ok (New_result result, env)
 
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -606,21 +606,23 @@ let n_way_join_relation_simples env simples_opt =
 (* Note: Bottom is a valid element kind for empty arrays, so this function never
    leads to a general Bottom result *)
 let meet_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
-    (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
+    (element_kind2 : _ Or_unknown_or_bottom.t) :
+    _ Or_unknown_or_bottom.t meet_return_value =
   match element_kind1, element_kind2 with
-  | Unknown, Unknown -> Unknown
-  | Bottom, _ | _, Bottom -> Bottom
-  | Unknown, Ok kind | Ok kind, Unknown -> Ok kind
-  | Ok element_kind1, Ok element_kind2 ->
-    if
-      Flambda_kind.With_subkind.compatible element_kind1
-        ~when_used_at:element_kind2
-    then Ok element_kind1
-    else if
-      Flambda_kind.With_subkind.compatible element_kind2
-        ~when_used_at:element_kind1
-    then Ok element_kind2
-    else Bottom
+  | Unknown, Unknown | Bottom, Bottom -> Both_inputs
+  | Bottom, _ | Ok _, Unknown -> Left_input
+  | _, Bottom | Unknown, Ok _ -> Right_input
+  | Ok element_kind1, Ok element_kind2 -> (
+    match
+      ( Flambda_kind.With_subkind.compatible element_kind1
+          ~when_used_at:element_kind2,
+        Flambda_kind.With_subkind.compatible element_kind2
+          ~when_used_at:element_kind1 )
+    with
+    | true, true -> Both_inputs
+    | true, false -> Left_input
+    | false, true -> Right_input
+    | false, false -> New_result Bottom)
 
 let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
@@ -1012,45 +1014,20 @@ and meet_head_of_kind_value_non_null env
 and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
     (element_kind2, length2, contents2, alloc_mode2) =
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
-  let rebuild (length, (contents, (alloc_mode, ()))) =
-    TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
-      ~length contents alloc_mode
+  let meet_element_kind =
+    extract_value element_kind element_kind1 element_kind2
   in
-  let sub_result =
-    combine_results env ~rebuild
-      ~meet_ops:
-        [ meet;
-          meet_array_contents ~meet_element_kind:element_kind;
-          meet_alloc_mode ]
-      ~left_inputs:[length1; contents1; alloc_mode1]
-      ~right_inputs:[length2; contents2; alloc_mode2]
-  in
-  (* [element_kind] is computed outside of [combine_results], so the
-     classification returned above does not account for it. If the meet changed
-     [element_kind] relative to one side, that side can no longer be returned
-     verbatim—we must produce [New_result] instead. *)
-  let ek_equal = Or_unknown_or_bottom.equal K.With_subkind.equal in
-  let ek_matches_left = ek_equal element_kind1 element_kind in
-  let ek_matches_right = ek_equal element_kind2 element_kind in
-  match sub_result with
-  | Bottom _ -> sub_result
-  | Ok (sub_rv, env) ->
-    let ek_matches_sub =
-      match sub_rv with
-      | Both_inputs -> ek_matches_left || ek_matches_right
-      | Left_input -> ek_matches_left
-      | Right_input -> ek_matches_right
-      | New_result _ -> false
-    in
-    if ek_matches_sub
-    then sub_result
-    else
-      let result =
-        extract_value sub_rv
-          (rebuild (length1, (contents1, (alloc_mode1, ()))))
-          (rebuild (length2, (contents2, (alloc_mode2, ()))))
-      in
-      Ok (New_result result, env)
+  combine_results env
+    ~rebuild:(fun (length, (contents, (alloc_mode, (element_kind, ())))) ->
+      TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+        ~length contents alloc_mode)
+    ~meet_ops:
+      [ meet;
+        meet_array_contents ~meet_element_kind;
+        meet_alloc_mode;
+        (fun env _element_kind1 _element_kind2 -> Ok (element_kind, env)) ]
+    ~left_inputs:[length1; contents1; alloc_mode1; element_kind1]
+    ~right_inputs:[length2; contents2; alloc_mode2; element_kind2]
 
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)

--- a/testsuite/tests/flambda2/array_element_kind_meet.ml
+++ b/testsuite/tests/flambda2/array_element_kind_meet.ml
@@ -1,0 +1,19 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte with dump-simplify;
+ check-fexpr-dump;
+*)
+
+(* When a record field is known to be a value array, Is_flat_float_array
+   should be simplified to false and removed by the simplifier. *)
+
+type foo = A | B of string
+
+type t = { a : int; b : int; c : foo array }
+
+let sum (t : t) =
+  Array.fold_left (fun acc x ->
+    match x with A -> acc | B _ -> acc + 1) 0 t.c

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -1,0 +1,44 @@
+let code sum_0 deleted in
+let code loopify(never) size(52) newer_version_of(sum_0)
+      sum_0_1 (t : [ 0 of imm tagged * imm tagged * val array ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = %block_load.[`2`] (t) in
+  let Parraylength = %array_length.generic (Pfield) in
+  let for_stop = %int_barith.sub (Parraylength, 1) in
+  let prim = %int_comp.le (0, for_stop) in
+  switch prim
+    | 0 -> k (0)
+    | 1 -> k2
+    where k2 =
+      let prim_1 = %untag_imm (for_stop) in
+      let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
+      (cont k2 (0L, 0)
+         where rec k2 (for_counter_naked : int64, r_420_unboxed0) =
+           let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
+           let i = %tag_imm (prim_2) in
+           let ifnot_result = %array_load.mut (Pfield, i) in
+           ((let prim_3 = %is_int (ifnot_result) in
+             switch prim_3
+               | 0 -> k4
+               | 1 -> k3 (r_420_unboxed0)
+               where k4 =
+                 let int_add = %int_barith.add (r_420_unboxed0, 1) in
+                 cont k3 (int_add))
+              where k3 (return_val0) =
+                let for_next_naked =
+                  %int_barith.`int64`.add (for_counter_naked, 1L)
+                in
+                let prim_3 =
+                  %int_comp.`int64`.le (for_next_naked, for_stop_naked)
+                in
+                switch prim_3
+                  | 0 -> k (return_val0)
+                  | 1 -> k2 (for_next_naked, return_val0)))
+in
+let $camlArray_element_kind_meet__sum_2 = closure sum_0_1 @sum in
+let $camlArray_element_kind_meet =
+  Block 0 ($camlArray_element_kind_meet__sum_2)
+in
+cont done ($camlArray_element_kind_meet)


### PR DESCRIPTION
In meet_array_type (both `meet_and_join.ml` and `meet_and_n_way_join.ml`), element_kind is met outside of `combine_results`, so the result classification (`Left_input`/`Right_input`/`Both_inputs`) only considers `length`, `contents`, and `alloc_mode`. When `Array_length` simplification meets an array type that has `element_kind = Unknown` (from the shape) with an existing type that has `element_kind = Ok any_value`, the sub-component classification could say `Left_input`, causing the caller to replace the variable's type with the left input — which has `element_kind = Unknown`, discarding the known element kind.

**Fix:** After combine_results, check whether the element_kind meet result matches the side indicated by  the classification. If not, force `New_result` with the correctly rebuilt type.
                                                                                                       
**Test:** `testsuite/tests/flambda2/array_element_kind_meet.ml` — checks that a foo array field in a record produces no `%is_flat_float_array` in the simplified fexpr dump.