### PR TITLE
Represent all-value/void mixed records and variants as uniform blocks

### DIFF
--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -612,7 +612,7 @@ To ensure that your C code will need to be updated when the layout changes, use
 the `Assert_mixed_block_layout_v#` family of macros. For example,
 
 ```
-Assert_mixed_block_layout_v5;
+Assert_mixed_block_layout_v6;
 ```
 
 Write the above in statement context, i.e. either at the top-level of a file or
@@ -642,7 +642,7 @@ type t =
 Here is the recommend way to access fields:
 
 ```c
-Assert_mixed_block_layout_v5;
+Assert_mixed_block_layout_v6;
 #define Foo_t_x(foo) (*(int32_t*)&Field(foo, 0))
 #define Foo_t_y(foo) (*(int32_t*)&Field(foo, 1))
 ```

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -694,22 +694,25 @@ let block_shape_of_value_kinds (vks : value_kind list option) : block_shape =
   | None -> All_value
   | Some vks -> Shape (Array.of_list (List.map (fun vk -> Value vk) vks))
 
+(* CR rtjoa: This function is redundant with [Mixed_product_bytes], but it's
+   duplicated for now. We should fix the module dependency structure *)
+let rec is_value_or_void_element : _ mixed_block_element -> bool = function
+  | Value _ -> true
+  | Product elts -> Array.for_all is_value_or_void_element elts
+  | Splice_variable _ -> error (Slambda_unsupported "mixed blocks")
+  | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
+  | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
+    false
+(* CR layout poly: This function probably shouldn't exist at all and we should
+   merge mixed_block_shape and block_shape. *)
 let mixed_block_of_block_shape (shape : block_shape) : mixed_block_shape option
     =
   match shape with
   | All_value -> None
   | Shape shape ->
-    let is_uniform =
-      Array.for_all
-        (function
-          | Value _ -> true
-          (* CR layout poly: This function probably shouldn't exist at all
-             and we should merge mixed_block_shape and block_shape. *)
-          | Splice_variable _ -> error (Slambda_unsupported "mixed blocks")
-          | _ -> false)
-        shape
-    in
-    if is_uniform then None else Some shape
+    if Array.for_all is_value_or_void_element shape
+    then None
+    else Some shape
 
 let is_uniform_block_shape (shape : block_shape) : bool =
   Option.is_none (mixed_block_of_block_shape shape)
@@ -1896,28 +1899,6 @@ let transl_prim mod_name name =
   | path, _ -> transl_value_path Loc_unknown env path
   | exception Not_found ->
       fatal_error ("Primitive " ^ name ^ " not found.")
-
-let block_of_module_representation ~loc = function
-  | Module_value_only _ -> Pmakeblock(0, Immutable, All_value, alloc_heap)
-  | Module_mixed (shape, _) ->
-    let rec count_values shape =
-      Array.fold_left
-        (fun acc elt ->
-          match elt with
-          | Value _ -> acc + 1
-          | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16 | Bits32
-          | Bits64 | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate -> acc
-          | Product product_shape -> acc + count_values product_shape
-          (* CR layout poly: We need to support this for relatively simple
-             layout poly usecases, however it should be easy to move this assert
-             to after slambdaeval (or maybe during?). *)
-          | Splice_variable _ ->
-            error ~loc (Slambda_unsupported "mixed modules"))
-        0 shape
-    in
-    Typedecl.assert_mixed_product_support loc Module
-      ~value_prefix_len:(count_values shape);
-    Pmakeblock(0, Immutable, Shape shape, alloc_heap)
 
 (* Compile a sequence of expressions *)
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1288,9 +1288,9 @@ val block_shape_of_value_kinds : value_kind list option -> block_shape
    Errors if there's a splice variable *)
 val is_uniform_block_shape : block_shape -> bool
 
-(* Returns [None] if contains all values,
-   returns the [mixed_block_shape] if it has at least one non-value.
-   Errors if there's a splice variable *)
+(* Returns [None] if contains all values (including products of values
+   and void), returns the [mixed_block_shape] if it has at least one
+   non-value. Errors if there's a splice variable *)
 val mixed_block_of_block_shape : block_shape -> mixed_block_shape option
 
 val transl_mixed_product_shape_for_read :
@@ -1300,9 +1300,6 @@ val transl_mixed_product_shape_for_read :
 
 val transl_module_representation :
   Types.module_representation -> module_representation
-
-val block_of_module_representation :
-  loc:Warnings.loc -> module_representation -> primitive
 
 val make_sequence: ('a -> lambda) -> 'a list -> lambda
 

--- a/lambda/mixed_product_bytes.ml
+++ b/lambda/mixed_product_bytes.ml
@@ -65,7 +65,31 @@ let rec count (el : _ Lambda.mixed_block_element) : t =
   | Splice_variable _ ->
     Misc.fatal_error "Mixed_product_bytes_count: layout poly not supported"
 
+let rec count_types_element (elt : Types.mixed_block_element) : t =
+  match elt with
+  | Scannable _ -> { value = 8; flat = 0 }
+  | Float_boxed | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Word
+  | Untagged_immediate ->
+    { value = 0; flat = 8 }
+  | Vec128 -> { value = 0; flat = 16 }
+  | Vec256 -> { value = 0; flat = 32 }
+  | Vec512 -> { value = 0; flat = 64 }
+  | Product elts ->
+    Array.fold_left (fun acc e -> add acc (count_types_element e)) zero elts
+  | Void -> zero
+
+let count_types_shape shape =
+  Array.fold_left (fun acc elt -> add acc (count_types_element elt)) zero shape
+
 let has_value_and_flat { value; flat } = value > 0 && flat > 0
+
+let all_value { flat; _ } = Byte_count.is_zero flat
+
+let shape_is_all_value shape = all_value (count (Product shape))
+
+let value_prefix_len t = Byte_count.on_64_bit_arch t.value / 8
+
+let types_shape_is_all_value shape = all_value (count_types_shape shape)
 
 module Wrt_path = struct
   type nonrec t =

--- a/lambda/mixed_product_bytes.mli
+++ b/lambda/mixed_product_bytes.mli
@@ -54,7 +54,19 @@ val add : t -> t -> t
 
 val count : _ Lambda.mixed_block_element -> t
 
+val count_types_shape : Types.mixed_product_shape -> t
+
 val has_value_and_flat : t -> bool
+
+val value_prefix_len : t -> int
+
+val all_value : t -> bool
+
+(* shape_is_all_value shape = all_value (count (Product shape)) *)
+val shape_is_all_value : _ Lambda.mixed_block_element array -> bool
+
+(* shape_is_all_value shape = all_value (count_types_shape shape) *)
+val types_shape_is_all_value : Types.mixed_product_shape -> bool
 
 (** A path into a mixed block element (identifying some subelement) can be
     considered to partition the mixed block element into three parts: to the

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -557,6 +557,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             | exception Not_constant -> None
             | constants -> (
               match cstr.cstr_shape with
+              | Constructor_mixed shape
+                when Mixed_product_bytes.types_shape_is_all_value shape ->
+                  Some (Const_block(runtime_tag, constants))
               | Constructor_mixed shape ->
                   (* CR layouts v5: once all-void records are allowed, handle
                      constructors with all-void inline records, which are stored
@@ -2231,6 +2234,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lconst(match cl with [v] -> v | _ -> assert false)
         | Record_float ->
             Lconst(Const_float_block(List.map extract_float cl))
+        | Record_mixed shape
+          when Mixed_product_bytes.types_shape_is_all_value shape ->
+            Lconst(Const_block(0, cl))
         | Record_mixed shape ->
             if !Clflags.native_code then
               let shape = Lambda.transl_mixed_product_shape shape in
@@ -2240,6 +2246,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                  be supported in bytecode. See symtable.ml for the difficulty.
               *)
               raise Not_constant
+        | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+          when Mixed_product_bytes.types_shape_is_all_value shape ->
+            Lconst(Const_block(0, cl))
         | Record_inlined (_, Constructor_mixed _, Variant_boxed _)
         | Record_ufloat ->
             (* CR layouts v5.1: We should support structured constants for

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -559,7 +559,13 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
               match cstr.cstr_shape with
               | Constructor_mixed shape
                 when Mixed_product_bytes.types_shape_is_all_value shape ->
-                  Some (Const_block(runtime_tag, constants))
+                  (* Note [Constant all-value mixed records]:
+                     Currently unreachable: mixed constructors with all-value
+                     shapes require void or product fields, which don't have
+                     constant representations, so [extract_constant] raises
+                     [Not_constant] first. *)
+                  (* Some (Const_block(runtime_tag, constants)) *)
+                  None
               | Constructor_mixed shape ->
                   (* CR layouts v5: once all-void records are allowed, handle
                      constructors with all-void inline records, which are stored
@@ -2236,7 +2242,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lconst(Const_float_block(List.map extract_float cl))
         | Record_mixed shape
           when Mixed_product_bytes.types_shape_is_all_value shape ->
-            Lconst(Const_block(0, cl))
+            (* Currently unreachable; see Note [Constant all-value
+               mixed records]. *)
+            (* Lconst(Const_block(0, cl)) *)
+            raise Not_constant
         | Record_mixed shape ->
             if !Clflags.native_code then
               let shape = Lambda.transl_mixed_product_shape shape in
@@ -2247,10 +2256,13 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
               *)
               raise Not_constant
         | Record_inlined
-            (Ordinary { runtime_tag; _ }, Constructor_mixed shape,
+            (Ordinary { runtime_tag = _; _ }, Constructor_mixed shape,
              Variant_boxed _)
           when Mixed_product_bytes.types_shape_is_all_value shape ->
-            Lconst(Const_block(runtime_tag, cl))
+            (* Currently unreachable; see Note [Constant all-value
+               mixed records]. *)
+            (* Lconst(Const_block(runtime_tag, cl)) *)
+            raise Not_constant
         | Record_inlined (_, Constructor_mixed _, Variant_boxed _)
         | Record_ufloat ->
             (* CR layouts v5.1: We should support structured constants for

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2246,9 +2246,11 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                  be supported in bytecode. See symtable.ml for the difficulty.
               *)
               raise Not_constant
-        | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+        | Record_inlined
+            (Ordinary { runtime_tag; _ }, Constructor_mixed shape,
+             Variant_boxed _)
           when Mixed_product_bytes.types_shape_is_all_value shape ->
-            Lconst(Const_block(0, cl))
+            Lconst(Const_block(runtime_tag, cl))
         | Record_inlined (_, Constructor_mixed _, Variant_boxed _)
         | Record_ufloat ->
             (* CR layouts v5.1: We should support structured constants for

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -92,6 +92,18 @@ let transl_type_extension ~scopes env rootpath tyext body =
     tyext.tyext_constructors
     body
 
+let block_of_module_representation ~loc = function
+  | Module_value_only _ -> Pmakeblock(0, Immutable, All_value, alloc_heap)
+  | Module_mixed (shape, _) ->
+    let mpb = Mixed_product_bytes.count (Product shape) in
+    (* All-value/void shapes compile to uniform blocks, so the scannable
+       prefix length limit doesn't apply. *)
+    if not (Mixed_product_bytes.all_value mpb)
+    then
+      Typedecl.assert_mixed_product_support loc Module
+        ~value_prefix_len:(Mixed_product_bytes.value_prefix_len mpb);
+    Pmakeblock(0, Immutable, Shape shape, alloc_heap)
+
 (* Compile a coercion *)
 
 let rec apply_coercion loc strict restr arg =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -196,6 +196,16 @@ let compute_static_size lam =
               join_sizes action size (compute_expression_size env action))
             size cases)
         Unreachable all_cases
+  (* In native code, void fields are erased, so the runtime block size is the
+     number of value fields only. In bytecode, void fields are kept, so the
+     block size includes all fields. *)
+  and all_value_mixed_block_size shape =
+    if !Clflags.native_code then
+      Mixed_product_bytes.value_prefix_len
+        (Mixed_product_bytes.count (Product shape))
+    else Array.length shape
+  and all_value_mixed_block_size_types shape =
+    all_value_mixed_block_size (Lambda.transl_mixed_product_shape shape)
   and size_of_primitive env p args =
     match p with
     | Pignore
@@ -241,6 +251,15 @@ let compute_static_size lam =
             Block (Float_record size)
         | Record_inlined (_, Constructor_mixed shape,
                           (Variant_boxed _ | Variant_extensible))
+          when Mixed_product_bytes.types_shape_is_all_value shape ->
+            Block (Regular_block
+              (all_value_mixed_block_size_types shape))
+        | Record_mixed shape
+          when Mixed_product_bytes.types_shape_is_all_value shape ->
+            Block (Regular_block
+              (all_value_mixed_block_size_types shape))
+        | Record_inlined (_, Constructor_mixed shape,
+                          (Variant_boxed _ | Variant_extensible))
         | Record_mixed shape ->
             Block (Mixed_record (Lambda.transl_mixed_product_shape shape))
         | Record_unboxed | Record_ufloat
@@ -256,7 +275,12 @@ let compute_static_size lam =
            should merge Regular_block and Mixed_record (and fix the error
            produced by [mixed_block_of_block_shape]). *)
         (match Lambda.mixed_block_of_block_shape shape with
-         | None -> Block (Regular_block (List.length args))
+         | None ->
+           let size = match shape with
+             | All_value -> List.length args
+             | Shape shape -> all_value_mixed_block_size shape
+           in
+           Block (Regular_block size)
          | Some arr -> Block (Mixed_record arr))
     | Pmakelazyblock _ ->
         Block (Regular_block (List.length args))

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -251,17 +251,13 @@ let compute_static_size lam =
             Block (Float_record size)
         | Record_inlined (_, Constructor_mixed shape,
                           (Variant_boxed _ | Variant_extensible))
-          when Mixed_product_bytes.types_shape_is_all_value shape ->
-            Block (Regular_block
-              (all_value_mixed_block_size_types shape))
-        | Record_mixed shape
-          when Mixed_product_bytes.types_shape_is_all_value shape ->
-            Block (Regular_block
-              (all_value_mixed_block_size_types shape))
-        | Record_inlined (_, Constructor_mixed shape,
-                          (Variant_boxed _ | Variant_extensible))
         | Record_mixed shape ->
-            Block (Mixed_record (Lambda.transl_mixed_product_shape shape))
+            if Mixed_product_bytes.types_shape_is_all_value shape
+            then
+              Block (Regular_block
+                (all_value_mixed_block_size_types shape))
+            else
+              Block (Mixed_record (Lambda.transl_mixed_product_shape shape))
         | Record_unboxed | Record_ufloat
         | Record_inlined (_, _, (Variant_unboxed | Variant_with_null)) ->
             Misc.fatal_error "size_of_primitive"

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -3871,31 +3871,9 @@ let bind_static_consts_and_code acc body =
    determining [field_count]. *)
 let final_module_block_representation acc
     ~(module_repr : Lambda.module_representation) =
-  match module_repr with
-  | Module_value_only { field_count } ->
-    let block_access _pos : P.Block_access_kind.t =
-      Values
-        { tag = Known Tag.Scannable.zero;
-          size =
-            Known (Target_ocaml_int.of_int (Acc.machine_width acc) field_count);
-          field_kind = Any_value
-        }
-    in
-    ( K.Scannable_block_shape.Value_only,
-      field_count,
-      block_access,
-      fun _ -> K.value )
-  | Module_mixed (shape, _) -> (
-    let shape =
-      K.Mixed_block_lambda_shape.of_mixed_block_elements shape
-        ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
-    in
-    let flattened_reordered_shape =
-      K.Mixed_block_lambda_shape.flattened_reordered_shape shape
-    in
-    let field_count = Array.length flattened_reordered_shape in
-    match K.Scannable_block_shape.from_mixed_block_shape shape with
-    | Value_only ->
+  let (block_shape : K.Scannable_block_shape.t), block_access, field_count =
+    match module_repr with
+    | Module_value_only { field_count } ->
       let block_access _pos : P.Block_access_kind.t =
         Values
           { tag = Known Tag.Scannable.zero;
@@ -3905,26 +3883,33 @@ let final_module_block_representation acc
             field_kind = Any_value
           }
       in
-      ( K.Scannable_block_shape.Value_only,
-        field_count,
-        block_access,
-        fun _ -> K.value )
-    | Mixed_record kind_shape ->
-      let field_kinds = K.Mixed_block_shape.field_kinds kind_shape in
-      let block_shape = K.Scannable_block_shape.Mixed_record kind_shape in
-      let block_access pos : P.Block_access_kind.t =
-        let field_kind =
-          Lambda_to_flambda_primitives_helpers.mixed_block_access_field_kind
-            flattened_reordered_shape.(pos)
-        in
-        Mixed
-          { tag = Known Tag.Scannable.zero;
-            size = Unknown;
-            field_kind;
-            shape = kind_shape
-          }
+      Value_only, block_access, field_count
+    | Module_mixed (shape, _) ->
+      let shape =
+        K.Mixed_block_lambda_shape.of_mixed_block_elements shape
+          ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
       in
-      block_shape, field_count, block_access, fun pos -> field_kinds.(pos))
+      let flattened_reordered_shape =
+        K.Mixed_block_lambda_shape.flattened_reordered_shape shape
+      in
+      let block_shape = K.Scannable_block_shape.from_mixed_block_shape shape in
+      let field_count = Array.length flattened_reordered_shape in
+      let block_access pos : P.Block_access_kind.t =
+        Lambda_to_flambda_primitives_helpers
+        .block_access_kind_of_mixed_field_element
+          ~tag:(Known Tag.Scannable.zero) ~size:Unknown ~kind_shape:block_shape
+          flattened_reordered_shape.(pos)
+      in
+      block_shape, block_access, field_count
+  in
+  let kind_of_field =
+    match block_shape with
+    | Value_only -> fun _ -> K.value
+    | Mixed_record shape ->
+      let field_kinds = K.Mixed_block_shape.field_kinds shape in
+      fun pos -> field_kinds.(pos)
+  in
+  block_shape, field_count, block_access, kind_of_field
 
 let wrap_final_module_block acc env ~program ~prog_return_cont
     ~(module_repr : Lambda.module_representation) ~return_cont ~module_symbol =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -3880,6 +3880,29 @@ let final_module_block_representation acc
       field_count,
       block_access,
       fun _ -> K.value )
+  | Module_mixed (shape, _)
+    when Mixed_product_bytes.shape_is_all_value shape ->
+    let shape =
+      K.Mixed_block_lambda_shape.of_mixed_block_elements shape
+        ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
+    in
+    let flattened_reordered_shape =
+      K.Mixed_block_lambda_shape.flattened_reordered_shape shape
+    in
+    let field_count = Array.length flattened_reordered_shape in
+    let block_access _pos : P.Block_access_kind.t =
+      Values
+        { tag = Known Tag.Scannable.zero;
+          size =
+            Known
+              (Target_ocaml_int.of_int (Acc.machine_width acc) field_count);
+          field_kind = Any_value
+        }
+    in
+    ( K.Scannable_block_shape.Value_only,
+      field_count,
+      block_access,
+      fun _ -> K.value )
   | Module_mixed (shape, _) ->
     let shape =
       K.Mixed_block_lambda_shape.of_mixed_block_elements shape

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -285,12 +285,12 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
         args
     in
     let block_shape : K.Scannable_block_shape.t =
-      match K.Mixed_block_shape.from_mixed_block_shape shape with
-      | Some kind_shape -> Mixed_record kind_shape
-      | None ->
+      match K.Scannable_block_shape.from_mixed_block_shape shape with
+      | Value_only ->
         (* See Note [Constant all-value mixed records] in translcore.ml *)
         Misc.fatal_error
-          "Const_mixed_block: from_mixed_block_shape returned None"
+          "Const_mixed_block: from_mixed_block_shape returned Value_only"
+      | Mixed_record _ as block_shape -> block_shape
     in
     let acc, fields =
       List.fold_left_map
@@ -3894,8 +3894,8 @@ let final_module_block_representation acc
       K.Mixed_block_lambda_shape.flattened_reordered_shape shape
     in
     let field_count = Array.length flattened_reordered_shape in
-    match K.Mixed_block_shape.from_mixed_block_shape shape with
-    | None ->
+    match K.Scannable_block_shape.from_mixed_block_shape shape with
+    | Value_only ->
       let block_access _pos : P.Block_access_kind.t =
         Values
           { tag = Known Tag.Scannable.zero;
@@ -3909,7 +3909,7 @@ let final_module_block_representation acc
         field_count,
         block_access,
         fun _ -> K.value )
-    | Some kind_shape ->
+    | Mixed_record kind_shape ->
       let field_kinds = K.Mixed_block_shape.field_kinds kind_shape in
       let block_shape = K.Scannable_block_shape.Mixed_record kind_shape in
       let block_access pos : P.Block_access_kind.t =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -288,6 +288,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
       match K.Mixed_block_shape.from_mixed_block_shape shape with
       | Some kind_shape -> Mixed_record kind_shape
       | None ->
+        (* See Note [Constant all-value mixed records] in translcore.ml *)
         Misc.fatal_error
           "Const_mixed_block: from_mixed_block_shape returned None"
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -284,7 +284,13 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
           | Float_boxed _ -> unbox_float_constant arg)
         args
     in
-    let kind_shape = K.Mixed_block_shape.from_mixed_block_shape shape in
+    let block_shape : K.Scannable_block_shape.t =
+      match K.Mixed_block_shape.from_mixed_block_shape shape with
+      | Some kind_shape -> Mixed_record kind_shape
+      | None ->
+        Misc.fatal_error
+          "Const_mixed_block: from_mixed_block_shape returned None"
+    in
     let acc, fields =
       List.fold_left_map
         (fun acc c ->
@@ -293,9 +299,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
         acc args
     in
     let const : SC.t =
-      SC.block
-        (Tag.Scannable.create_exn tag)
-        Immutable (Mixed_record kind_shape) fields
+      SC.block (Tag.Scannable.create_exn tag) Immutable block_shape fields
     in
     register_const acc dbg const "const_mixed_block"
   | Const_null -> acc, reg_width RWC.const_null, "null"
@@ -3880,8 +3884,7 @@ let final_module_block_representation acc
       field_count,
       block_access,
       fun _ -> K.value )
-  | Module_mixed (shape, _)
-    when Mixed_product_bytes.shape_is_all_value shape ->
+  | Module_mixed (shape, _) -> (
     let shape =
       K.Mixed_block_lambda_shape.of_mixed_block_elements shape
         ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
@@ -3890,44 +3893,37 @@ let final_module_block_representation acc
       K.Mixed_block_lambda_shape.flattened_reordered_shape shape
     in
     let field_count = Array.length flattened_reordered_shape in
-    let block_access _pos : P.Block_access_kind.t =
-      Values
-        { tag = Known Tag.Scannable.zero;
-          size =
-            Known
-              (Target_ocaml_int.of_int (Acc.machine_width acc) field_count);
-          field_kind = Any_value
-        }
-    in
-    ( K.Scannable_block_shape.Value_only,
-      field_count,
-      block_access,
-      fun _ -> K.value )
-  | Module_mixed (shape, _) ->
-    let shape =
-      K.Mixed_block_lambda_shape.of_mixed_block_elements shape
-        ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
-    in
-    let flattened_reordered_shape =
-      K.Mixed_block_lambda_shape.flattened_reordered_shape shape
-    in
-    let field_count = Array.length flattened_reordered_shape in
-    let kind_shape = K.Mixed_block_shape.from_mixed_block_shape shape in
-    let field_kinds = K.Mixed_block_shape.field_kinds kind_shape in
-    let block_shape = K.Scannable_block_shape.Mixed_record kind_shape in
-    let block_access pos : P.Block_access_kind.t =
-      let field_kind =
-        Lambda_to_flambda_primitives_helpers.mixed_block_access_field_kind
-          flattened_reordered_shape.(pos)
+    match K.Mixed_block_shape.from_mixed_block_shape shape with
+    | None ->
+      let block_access _pos : P.Block_access_kind.t =
+        Values
+          { tag = Known Tag.Scannable.zero;
+            size =
+              Known
+                (Target_ocaml_int.of_int (Acc.machine_width acc) field_count);
+            field_kind = Any_value
+          }
       in
-      Mixed
-        { tag = Known Tag.Scannable.zero;
-          size = Unknown;
-          field_kind;
-          shape = kind_shape
-        }
-    in
-    block_shape, field_count, block_access, fun pos -> field_kinds.(pos)
+      ( K.Scannable_block_shape.Value_only,
+        field_count,
+        block_access,
+        fun _ -> K.value )
+    | Some kind_shape ->
+      let field_kinds = K.Mixed_block_shape.field_kinds kind_shape in
+      let block_shape = K.Scannable_block_shape.Mixed_record kind_shape in
+      let block_access pos : P.Block_access_kind.t =
+        let field_kind =
+          Lambda_to_flambda_primitives_helpers.mixed_block_access_field_kind
+            flattened_reordered_shape.(pos)
+        in
+        Mixed
+          { tag = Known Tag.Scannable.zero;
+            size = Unknown;
+            field_kind;
+            shape = kind_shape
+          }
+      in
+      block_shape, field_count, block_access, fun pos -> field_kinds.(pos))
 
 let wrap_final_module_block acc env ~program ~prog_return_cont
     ~(module_repr : Lambda.module_representation) ~return_cont ~module_symbol =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -122,26 +122,27 @@ let convert_block_shape ~machine_width (shape : L.block_shape) ~num_fields =
   match shape with
   | All_value -> List.init num_fields (fun _field -> K.With_subkind.any_value)
   | Shape shape ->
-    let shape_length = Array.length shape in
-    if num_fields <> shape_length
+    (* This function is only called for uniform block shapes. We flatten
+       products of values into individual value fields. *)
+    let rec collect_value_fields acc (elem : unit L.mixed_block_element) =
+      match elem with
+      | L.Value vk ->
+        K.With_subkind.from_lambda_value_kind ~machine_width vk :: acc
+      | Product elts -> Array.fold_left collect_value_fields acc elts
+      | Float_boxed ()
+      | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256
+      | Vec512 | Word | Untagged_immediate | Splice_variable _ ->
+        Misc.fatal_error "convert_block_shape: non-uniform shape"
+    in
+    let fields = Array.fold_left collect_value_fields [] shape |> List.rev in
+    let fields_length = List.length fields in
+    if num_fields <> fields_length
     then
       Misc.fatal_errorf
         "Flambda_arity.of_block_shape: num_fields is %d yet the shape has %d \
          fields"
-        num_fields shape_length;
-    (* This function is only called for uniform block shapes *)
-    Array.to_list
-      (Array.map
-         (fun (elem : unit L.mixed_block_element) ->
-           match elem with
-           | L.Value vk ->
-             K.With_subkind.from_lambda_value_kind ~machine_width vk
-           | Float_boxed ()
-           | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Vec128
-           | Vec256 | Vec512 | Word | Untagged_immediate | Product _
-           | Splice_variable _ ->
-             Misc.fatal_error "convert_block_shape: non-uniform shape")
-         shape)
+        num_fields fields_length;
+    fields
 
 let check_float_array_optimisation_enabled name =
   if not (Flambda_features.flat_float_array ())
@@ -2092,6 +2093,27 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Record_float | Record_ufloat ->
         Naked_floats
           { length = Target_ocaml_int.of_int machine_width num_fields }
+      | Record_inlined
+          (Ordinary { runtime_tag; _ }, Constructor_mixed shape, Variant_boxed _)
+        when Mixed_product_bytes.types_shape_is_all_value shape ->
+        let num_fields =
+          Mixed_product_bytes.value_prefix_len
+            (Mixed_product_bytes.count_types_shape shape)
+        in
+        Values
+          { tag = Tag.Scannable.create_exn runtime_tag;
+            length = Target_ocaml_int.of_int machine_width num_fields
+          }
+      | Record_mixed shape
+        when Mixed_product_bytes.types_shape_is_all_value shape ->
+        let num_fields =
+          Mixed_product_bytes.value_prefix_len
+            (Mixed_product_bytes.count_types_shape shape)
+        in
+        Values
+          { tag = Tag.Scannable.zero;
+            length = Target_ocaml_int.of_int machine_width num_fields
+          }
       | Record_inlined (_, Constructor_mixed _, _) | Record_mixed _ -> Mixed
       | Record_inlined
           ( Ordinary { runtime_tag; _ },
@@ -2571,6 +2593,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Pmixedfield (field_path, shape, sem), [[arg]] ->
     if List.length field_path < 1
     then Misc.fatal_error "Pmixedfield: field_path must be non-empty";
+    let is_uniform = Mixed_product_bytes.shape_is_all_value shape in
     let shape =
       Mixed_block_shape.of_mixed_block_elements shape
         ~print_locality:Printlambda.locality_mode
@@ -2587,25 +2610,35 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         let imm = Target_ocaml_int.of_int machine_width new_index in
         check_non_negative_imm imm "Pmixedfield";
         let mutability = convert_field_read_semantics sem in
+        let field_elt = flattened_reordered_shape.(new_index) in
+        let mixed_field_kind = H.mixed_block_access_field_kind field_elt in
         let block_access : P.Block_access_kind.t =
-          let field_kind =
-            H.mixed_block_access_field_kind
-              flattened_reordered_shape.(new_index)
-          in
-          Mixed
-            { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }
+          if is_uniform
+          then
+            match mixed_field_kind with
+            | Value_prefix field_kind ->
+              Values { tag = Unknown; size = Unknown; field_kind }
+            | Flat_suffix _ ->
+              Misc.fatal_error "Pmixedfield: flat element in uniform shape"
+          else
+            Mixed
+              { tag = Unknown;
+                field_kind = mixed_field_kind;
+                shape = kind_shape;
+                size = Unknown
+              }
         in
-        let block_access : H.expr_primitive =
+        let prim : H.expr_primitive =
           Unary
             ( Block_load { kind = block_access; mut = mutability; field = imm },
               arg )
         in
-        match flattened_reordered_shape.(new_index) with
+        match field_elt with
         | Float_boxed (mode : Lambda.locality_mode) ->
-          box_float mode block_access ~current_region
+          box_float mode prim ~current_region
         | Value _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
         | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
-          block_access)
+          prim)
       new_indexes
   | ( Psetfield (index, immediate_or_pointer, initialization_or_assignment),
       [[block]; [value]] ) ->
@@ -2646,6 +2679,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [[block]; values] ) ->
     if List.length field_path < 1
     then Misc.fatal_error "Psetmixedfield: field_path must be non-empty";
+    let is_uniform = Mixed_product_bytes.shape_is_all_value shape in
     let shape =
       Mixed_block_shape.of_mixed_block_elements shape
         ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
@@ -2668,21 +2702,29 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         (fun new_index value : H.expr_primitive ->
           let imm = Target_ocaml_int.of_int machine_width new_index in
           check_non_negative_imm imm "Psetmixedfield";
+          let field_elt = flattened_reordered_shape.(new_index) in
+          let mixed_field_kind = H.mixed_block_access_field_kind field_elt in
           let block_access : P.Block_access_kind.t =
-            Mixed
-              { field_kind =
-                  H.mixed_block_access_field_kind
-                    flattened_reordered_shape.(new_index);
-                shape = kind_shape;
-                tag = Unknown;
-                size = Unknown
-              }
+            if is_uniform
+            then
+              match mixed_field_kind with
+              | Value_prefix field_kind ->
+                Values { tag = Unknown; size = Unknown; field_kind }
+              | Flat_suffix _ ->
+                Misc.fatal_error "Psetmixedfield: flat element in uniform shape"
+            else
+              Mixed
+                { field_kind = mixed_field_kind;
+                  shape = kind_shape;
+                  tag = Unknown;
+                  size = Unknown
+                }
           in
           let init_or_assign =
             convert_init_or_assign initialization_or_assignment
           in
           let value : H.simple_or_prim =
-            match flattened_reordered_shape.(new_index) with
+            match field_elt with
             | Value _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
             | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
               value

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1842,12 +1842,12 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           args
       in
       let kind_shape =
-        match K.Mixed_block_shape.from_mixed_block_shape shape with
-        | Some kind_shape -> kind_shape
-        | None ->
+        match K.Scannable_block_shape.from_mixed_block_shape shape with
+        | Mixed_record kind_shape -> kind_shape
+        | Value_only ->
           Misc.fatal_error
             "Pmakeblock: mixed_block_of_block_shape returned Some but \
-             from_mixed_block_shape returned None"
+             from_mixed_block_shape returned Value_only"
       in
       [Variadic (Make_block (Mixed (tag, kind_shape), mutability, mode), args)])
   | Pmakelazyblock lazy_tag, [[arg]] -> [Unary (Make_lazy lazy_tag, arg)]
@@ -2599,7 +2599,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let flattened_reordered_shape =
       Mixed_block_shape.flattened_reordered_shape shape
     in
-    let kind_shape = K.Mixed_block_shape.from_mixed_block_shape shape in
+    let kind_shape = K.Scannable_block_shape.from_mixed_block_shape shape in
     let new_indexes =
       Mixed_block_shape.lookup_path_producing_new_indexes shape field_path
     in
@@ -2670,7 +2670,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let flattened_reordered_shape =
       Mixed_block_shape.flattened_reordered_shape shape
     in
-    let kind_shape = K.Mixed_block_shape.from_mixed_block_shape shape in
+    let kind_shape = K.Scannable_block_shape.from_mixed_block_shape shape in
     let new_indexes =
       Mixed_block_shape.lookup_path_producing_new_indexes shape field_path
     in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2610,20 +2610,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         check_non_negative_imm imm "Pmixedfield";
         let mutability = convert_field_read_semantics sem in
         let field_elt = flattened_reordered_shape.(new_index) in
-        let block_access : P.Block_access_kind.t =
-          match kind_shape with
-          | None ->
-            let field_kind =
-              match H.mixed_block_access_field_kind field_elt with
-              | Value_prefix field_kind -> field_kind
-              | Flat_suffix _ ->
-                Misc.fatal_error "Pmixedfield: flat element in uniform shape"
-            in
-            Values { tag = Unknown; size = Unknown; field_kind }
-          | Some kind_shape ->
-            let field_kind = H.mixed_block_access_field_kind field_elt in
-            Mixed
-              { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }
+        let block_access =
+          H.block_access_kind_of_mixed_field_element ~kind_shape field_elt
         in
         let prim : H.expr_primitive =
           Unary
@@ -2699,25 +2687,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           let imm = Target_ocaml_int.of_int machine_width new_index in
           check_non_negative_imm imm "Psetmixedfield";
           let field_elt = flattened_reordered_shape.(new_index) in
-          let block_access : P.Block_access_kind.t =
-            match kind_shape with
-            | None ->
-              let field_kind =
-                match H.mixed_block_access_field_kind field_elt with
-                | Value_prefix field_kind -> field_kind
-                | Flat_suffix _ ->
-                  Misc.fatal_error
-                    "Psetmixedfield: flat element in uniform shape"
-              in
-              Values { tag = Unknown; size = Unknown; field_kind }
-            | Some kind_shape ->
-              let field_kind = H.mixed_block_access_field_kind field_elt in
-              Mixed
-                { field_kind;
-                  shape = kind_shape;
-                  tag = Unknown;
-                  size = Unknown
-                }
+          let block_access =
+            H.block_access_kind_of_mixed_field_element ~kind_shape field_elt
           in
           let init_or_assign =
             convert_init_or_assign initialization_or_assignment

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2094,22 +2094,16 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         Naked_floats
           { length = Target_ocaml_int.of_int machine_width num_fields }
       | Record_inlined
-          (Ordinary { runtime_tag; _ }, Constructor_mixed shape, Variant_boxed _)
+          ( Ordinary { runtime_tag; _ },
+            Constructor_mixed shape,
+            Variant_boxed _ )
         when Mixed_product_bytes.types_shape_is_all_value shape ->
-        let num_fields =
-          Mixed_product_bytes.value_prefix_len
-            (Mixed_product_bytes.count_types_shape shape)
-        in
         Values
           { tag = Tag.Scannable.create_exn runtime_tag;
             length = Target_ocaml_int.of_int machine_width num_fields
           }
       | Record_mixed shape
         when Mixed_product_bytes.types_shape_is_all_value shape ->
-        let num_fields =
-          Mixed_product_bytes.value_prefix_len
-            (Mixed_product_bytes.count_types_shape shape)
-        in
         Values
           { tag = Tag.Scannable.zero;
             length = Target_ocaml_int.of_int machine_width num_fields

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1846,11 +1846,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         | Some kind_shape -> kind_shape
         | None ->
           Misc.fatal_error
-            "Pmakeblock: mixed_block_of_block_shape returned Some \
-             but from_mixed_block_shape returned None"
+            "Pmakeblock: mixed_block_of_block_shape returned Some but \
+             from_mixed_block_shape returned None"
       in
-      [Variadic
-         (Make_block (Mixed (tag, kind_shape), mutability, mode), args)])
+      [Variadic (Make_block (Mixed (tag, kind_shape), mutability, mode), args)])
   | Pmakelazyblock lazy_tag, [[arg]] -> [Unary (Make_lazy lazy_tag, arg)]
   | Pmake_unboxed_product layouts, _ ->
     (* CR mshinwell: this should check the unarized lengths of [layouts] and

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2610,7 +2610,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         let mutability = convert_field_read_semantics sem in
         let field_elt = flattened_reordered_shape.(new_index) in
         let block_access =
-          H.block_access_kind_of_mixed_field_element ~kind_shape field_elt
+          H.block_access_kind_of_mixed_field_element ~kind_shape ~tag:Unknown
+            ~size:Unknown field_elt
         in
         let prim : H.expr_primitive =
           Unary
@@ -2687,7 +2688,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           check_non_negative_imm imm "Psetmixedfield";
           let field_elt = flattened_reordered_shape.(new_index) in
           let block_access =
-            H.block_access_kind_of_mixed_field_element ~kind_shape field_elt
+            H.block_access_kind_of_mixed_field_element ~kind_shape ~tag:Unknown
+              ~size:Unknown field_elt
           in
           let init_or_assign =
             convert_init_or_assign initialization_or_assignment

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1841,8 +1841,16 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
             | Float_boxed _ -> unbox_float arg)
           args
       in
-      let kind_shape = K.Mixed_block_shape.from_mixed_block_shape shape in
-      [Variadic (Make_block (Mixed (tag, kind_shape), mutability, mode), args)])
+      let kind_shape =
+        match K.Mixed_block_shape.from_mixed_block_shape shape with
+        | Some kind_shape -> kind_shape
+        | None ->
+          Misc.fatal_error
+            "Pmakeblock: mixed_block_of_block_shape returned Some \
+             but from_mixed_block_shape returned None"
+      in
+      [Variadic
+         (Make_block (Mixed (tag, kind_shape), mutability, mode), args)])
   | Pmakelazyblock lazy_tag, [[arg]] -> [Unary (Make_lazy lazy_tag, arg)]
   | Pmake_unboxed_product layouts, _ ->
     (* CR mshinwell: this should check the unarized lengths of [layouts] and
@@ -2094,9 +2102,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         Naked_floats
           { length = Target_ocaml_int.of_int machine_width num_fields }
       | Record_inlined
-          ( Ordinary { runtime_tag; _ },
-            Constructor_mixed shape,
-            Variant_boxed _ )
+          (Ordinary { runtime_tag; _ }, Constructor_mixed shape, Variant_boxed _)
         when Mixed_product_bytes.types_shape_is_all_value shape ->
         Values
           { tag = Tag.Scannable.create_exn runtime_tag;
@@ -2587,7 +2593,6 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Pmixedfield (field_path, shape, sem), [[arg]] ->
     if List.length field_path < 1
     then Misc.fatal_error "Pmixedfield: field_path must be non-empty";
-    let is_uniform = Mixed_product_bytes.shape_is_all_value shape in
     let shape =
       Mixed_block_shape.of_mixed_block_elements shape
         ~print_locality:Printlambda.locality_mode
@@ -2605,22 +2610,20 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         check_non_negative_imm imm "Pmixedfield";
         let mutability = convert_field_read_semantics sem in
         let field_elt = flattened_reordered_shape.(new_index) in
-        let mixed_field_kind = H.mixed_block_access_field_kind field_elt in
         let block_access : P.Block_access_kind.t =
-          if is_uniform
-          then
-            match mixed_field_kind with
-            | Value_prefix field_kind ->
-              Values { tag = Unknown; size = Unknown; field_kind }
-            | Flat_suffix _ ->
-              Misc.fatal_error "Pmixedfield: flat element in uniform shape"
-          else
+          match kind_shape with
+          | None ->
+            let field_kind =
+              match H.mixed_block_access_field_kind field_elt with
+              | Value_prefix field_kind -> field_kind
+              | Flat_suffix _ ->
+                Misc.fatal_error "Pmixedfield: flat element in uniform shape"
+            in
+            Values { tag = Unknown; size = Unknown; field_kind }
+          | Some kind_shape ->
+            let field_kind = H.mixed_block_access_field_kind field_elt in
             Mixed
-              { tag = Unknown;
-                field_kind = mixed_field_kind;
-                shape = kind_shape;
-                size = Unknown
-              }
+              { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }
         in
         let prim : H.expr_primitive =
           Unary
@@ -2673,7 +2676,6 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [[block]; values] ) ->
     if List.length field_path < 1
     then Misc.fatal_error "Psetmixedfield: field_path must be non-empty";
-    let is_uniform = Mixed_product_bytes.shape_is_all_value shape in
     let shape =
       Mixed_block_shape.of_mixed_block_elements shape
         ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
@@ -2697,18 +2699,21 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           let imm = Target_ocaml_int.of_int machine_width new_index in
           check_non_negative_imm imm "Psetmixedfield";
           let field_elt = flattened_reordered_shape.(new_index) in
-          let mixed_field_kind = H.mixed_block_access_field_kind field_elt in
           let block_access : P.Block_access_kind.t =
-            if is_uniform
-            then
-              match mixed_field_kind with
-              | Value_prefix field_kind ->
-                Values { tag = Unknown; size = Unknown; field_kind }
-              | Flat_suffix _ ->
-                Misc.fatal_error "Psetmixedfield: flat element in uniform shape"
-            else
+            match kind_shape with
+            | None ->
+              let field_kind =
+                match H.mixed_block_access_field_kind field_elt with
+                | Value_prefix field_kind -> field_kind
+                | Flat_suffix _ ->
+                  Misc.fatal_error
+                    "Psetmixedfield: flat element in uniform shape"
+              in
+              Values { tag = Unknown; size = Unknown; field_kind }
+            | Some kind_shape ->
+              let field_kind = H.mixed_block_access_field_kind field_elt in
               Mixed
-                { field_kind = mixed_field_kind;
+                { field_kind;
                   shape = kind_shape;
                   tag = Unknown;
                   size = Unknown

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -517,11 +517,11 @@ let mixed_block_access_field_kind
   | Float_boxed _ -> Flat_suffix K.Flat_suffix_element.naked_float
 
 let block_access_kind_of_mixed_field_element
-    ~(kind_shape : K.Mixed_block_shape.t option)
+    ~(kind_shape : K.Scannable_block_shape.t)
     (elt : 'a Mixed_block_shape.Singleton_mixed_block_element.t) :
     P.Block_access_kind.t =
   match kind_shape with
-  | None -> (
+  | Value_only -> (
     match mixed_block_access_field_kind elt with
     | Value_prefix field_kind ->
       Values { tag = Unknown; size = Unknown; field_kind }
@@ -529,6 +529,6 @@ let block_access_kind_of_mixed_field_element
       Misc.fatal_error
         "block_access_kind_of_mixed_field_element: flat element in uniform \
          shape")
-  | Some kind_shape ->
+  | Mixed_record kind_shape ->
     let field_kind = mixed_block_access_field_kind elt in
     Mixed { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -503,6 +503,8 @@ let convert_block_access_field_kind_from_value_kind
   | Pboxedvectorval _ ->
     Any_value
 
+(* This function shouldn't be used directly since lambda mixed blocks with an
+   empty flat suffix are translated to value-only blocks in flambda. *)
 let mixed_block_access_field_kind
     (elt : 'a Mixed_block_shape.Singleton_mixed_block_element.t) :
     P.Mixed_block_access_field_kind.t =
@@ -517,18 +519,17 @@ let mixed_block_access_field_kind
   | Float_boxed _ -> Flat_suffix K.Flat_suffix_element.naked_float
 
 let block_access_kind_of_mixed_field_element
-    ~(kind_shape : K.Scannable_block_shape.t)
+    ~(kind_shape : K.Scannable_block_shape.t) ~tag ~size
     (elt : 'a Mixed_block_shape.Singleton_mixed_block_element.t) :
     P.Block_access_kind.t =
   match kind_shape with
   | Value_only -> (
     match mixed_block_access_field_kind elt with
-    | Value_prefix field_kind ->
-      Values { tag = Unknown; size = Unknown; field_kind }
+    | Value_prefix field_kind -> Values { tag; size; field_kind }
     | Flat_suffix _ ->
       Misc.fatal_error
         "block_access_kind_of_mixed_field_element: flat element in uniform \
          shape")
   | Mixed_record kind_shape ->
     let field_kind = mixed_block_access_field_kind elt in
-    Mixed { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }
+    Mixed { tag; field_kind; shape = kind_shape; size }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -527,9 +527,8 @@ let block_access_kind_of_mixed_field_element
       Values { tag = Unknown; size = Unknown; field_kind }
     | Flat_suffix _ ->
       Misc.fatal_error
-        "block_access_kind_of_mixed_field_element: \
-         flat element in uniform shape")
+        "block_access_kind_of_mixed_field_element: flat element in uniform \
+         shape")
   | Some kind_shape ->
     let field_kind = mixed_block_access_field_kind elt in
-    Mixed
-      { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }
+    Mixed { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -515,3 +515,21 @@ let mixed_block_access_field_kind
       (K.Flat_suffix_element.from_singleton_mixed_block_element
          mixed_block_element)
   | Float_boxed _ -> Flat_suffix K.Flat_suffix_element.naked_float
+
+let block_access_kind_of_mixed_field_element
+    ~(kind_shape : K.Mixed_block_shape.t option)
+    (elt : 'a Mixed_block_shape.Singleton_mixed_block_element.t) :
+    P.Block_access_kind.t =
+  match kind_shape with
+  | None -> (
+    match mixed_block_access_field_kind elt with
+    | Value_prefix field_kind ->
+      Values { tag = Unknown; size = Unknown; field_kind }
+    | Flat_suffix _ ->
+      Misc.fatal_error
+        "block_access_kind_of_mixed_field_element: \
+         flat element in uniform shape")
+  | Some kind_shape ->
+    let field_kind = mixed_block_access_field_kind elt in
+    Mixed
+      { tag = Unknown; field_kind; shape = kind_shape; size = Unknown }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -88,13 +88,11 @@ val bind_recs :
   (Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) ->
   Expr_with_acc.t
 
-val mixed_block_access_field_kind :
-  'a Mixed_block_shape.Singleton_mixed_block_element.t ->
-  Flambda_primitive.Mixed_block_access_field_kind.t
-
 (** Returns the appropriate [Block_access_kind.t] for accessing a field of a
     mixed block element. *)
 val block_access_kind_of_mixed_field_element :
   kind_shape:Flambda_kind.Scannable_block_shape.t ->
+  tag:Tag.Scannable.t Or_unknown.t ->
+  size:Target_ocaml_int.t Or_unknown.t ->
   'a Mixed_block_shape.Singleton_mixed_block_element.t ->
   Flambda_primitive.Block_access_kind.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -91,3 +91,11 @@ val bind_recs :
 val mixed_block_access_field_kind :
   'a Mixed_block_shape.Singleton_mixed_block_element.t ->
   Flambda_primitive.Mixed_block_access_field_kind.t
+
+(** Returns the appropriate [Block_access_kind.t] for accessing a field of a
+    mixed block element. When [kind_shape] is [None] (all-value shape), returns
+    [Values]; when [Some], returns [Mixed]. *)
+val block_access_kind_of_mixed_field_element :
+  kind_shape:Flambda_kind.Mixed_block_shape.t option ->
+  'a Mixed_block_shape.Singleton_mixed_block_element.t ->
+  Flambda_primitive.Block_access_kind.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -93,9 +93,8 @@ val mixed_block_access_field_kind :
   Flambda_primitive.Mixed_block_access_field_kind.t
 
 (** Returns the appropriate [Block_access_kind.t] for accessing a field of a
-    mixed block element. When [kind_shape] is [None] (all-value shape), returns
-    [Values]; when [Some], returns [Mixed]. *)
+    mixed block element. *)
 val block_access_kind_of_mixed_field_element :
-  kind_shape:Flambda_kind.Mixed_block_shape.t option ->
+  kind_shape:Flambda_kind.Scannable_block_shape.t ->
   'a Mixed_block_shape.Singleton_mixed_block_element.t ->
   Flambda_primitive.Block_access_kind.t

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -336,19 +336,24 @@ module Mixed_block_shape = struct
       Misc.Stdlib.Array.compare Flat_suffix_element0.compare flat_suffix1
         flat_suffix2
 
-  let from_mixed_block_shape (shape : _ Mixed_block_lambda_shape.t) : t =
-    let value_prefix_kinds =
-      Array.map (fun _ -> value) (Mixed_block_shape.value_prefix shape)
-    in
-    let flat_suffix =
-      Array.map Flat_suffix_element0.from_singleton_mixed_block_element
-        (Mixed_block_shape.flat_suffix shape)
-    in
-    let flat_suffix_kinds = Array.map Flat_suffix_element0.kind flat_suffix in
-    { flat_suffix;
-      value_prefix_size = Array.length value_prefix_kinds;
-      field_kinds = Array.concat [value_prefix_kinds; flat_suffix_kinds]
-    }
+  let from_mixed_block_shape (shape : _ Mixed_block_lambda_shape.t) : t option =
+    let lambda_flat_suffix = Mixed_block_shape.flat_suffix shape in
+    if Array.length lambda_flat_suffix = 0
+    then None
+    else
+      let value_prefix_kinds =
+        Array.map (fun _ -> value) (Mixed_block_shape.value_prefix shape)
+      in
+      let flat_suffix =
+        Array.map Flat_suffix_element0.from_singleton_mixed_block_element
+          lambda_flat_suffix
+      in
+      let flat_suffix_kinds = Array.map Flat_suffix_element0.kind flat_suffix in
+      Some
+        { flat_suffix;
+          value_prefix_size = Array.length value_prefix_kinds;
+          field_kinds = Array.concat [value_prefix_kinds; flat_suffix_kinds]
+        }
 end
 
 module Scannable_block_shape = struct
@@ -1015,9 +1020,6 @@ module With_subkind = struct
                         List.map (from_lambda_value_kind ~machine_width) fields
                       )
                     | Constructor_mixed mixed_block_shape ->
-                      let is_uniform =
-                        Mixed_product_bytes.shape_is_all_value mixed_block_shape
-                      in
                       let mixed_block_shape =
                         Mixed_block_lambda_shape.of_mixed_block_elements
                           ~print_locality:(fun ppf () ->
@@ -1052,14 +1054,15 @@ module With_subkind = struct
                           (Array.map from_mixed_block_element
                              flattened_reordered_shape)
                       in
-                      if is_uniform
-                      then Scannable Value_only, fields
-                      else
-                        let mixed_block_shape =
+                      let block_shape : Block_shape.t =
+                        match
                           Mixed_block_shape.from_mixed_block_shape
                             mixed_block_shape
-                        in
-                        Scannable (Mixed_record mixed_block_shape), fields
+                        with
+                        | None -> Scannable Value_only
+                        | Some s -> Scannable (Mixed_record s)
+                      in
+                      block_shape, fields
                   in
                   Tag.Scannable.Map.add tag shape_and_fields non_consts
                 | None ->

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -1015,6 +1015,9 @@ module With_subkind = struct
                         List.map (from_lambda_value_kind ~machine_width) fields
                       )
                     | Constructor_mixed mixed_block_shape ->
+                      let is_uniform =
+                        Mixed_product_bytes.shape_is_all_value mixed_block_shape
+                      in
                       let mixed_block_shape =
                         Mixed_block_lambda_shape.of_mixed_block_elements
                           ~print_locality:(fun ppf () ->
@@ -1040,20 +1043,23 @@ module With_subkind = struct
                         | Word -> naked_nativeint
                         | Untagged_immediate -> naked_immediate
                       in
-                      let fields : t array =
+                      let fields : t list =
                         let flattened_reordered_shape =
                           Mixed_block_lambda_shape.flattened_reordered_shape
                             mixed_block_shape
                         in
-                        Array.map from_mixed_block_element
-                          flattened_reordered_shape
+                        Array.to_list
+                          (Array.map from_mixed_block_element
+                             flattened_reordered_shape)
                       in
-                      let mixed_block_shape =
-                        Mixed_block_shape.from_mixed_block_shape
-                          mixed_block_shape
-                      in
-                      ( Scannable (Mixed_record mixed_block_shape),
-                        Array.to_list fields )
+                      if is_uniform
+                      then Scannable Value_only, fields
+                      else
+                        let mixed_block_shape =
+                          Mixed_block_shape.from_mixed_block_shape
+                            mixed_block_shape
+                        in
+                        Scannable (Mixed_record mixed_block_shape), fields
                   in
                   Tag.Scannable.Map.add tag shape_and_fields non_consts
                 | None ->

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -335,25 +335,6 @@ module Mixed_block_shape = struct
     else
       Misc.Stdlib.Array.compare Flat_suffix_element0.compare flat_suffix1
         flat_suffix2
-
-  let from_mixed_block_shape (shape : _ Mixed_block_lambda_shape.t) : t option =
-    let lambda_flat_suffix = Mixed_block_shape.flat_suffix shape in
-    if Array.length lambda_flat_suffix = 0
-    then None
-    else
-      let value_prefix_kinds =
-        Array.map (fun _ -> value) (Mixed_block_shape.value_prefix shape)
-      in
-      let flat_suffix =
-        Array.map Flat_suffix_element0.from_singleton_mixed_block_element
-          lambda_flat_suffix
-      in
-      let flat_suffix_kinds = Array.map Flat_suffix_element0.kind flat_suffix in
-      Some
-        { flat_suffix;
-          value_prefix_size = Array.length value_prefix_kinds;
-          field_kinds = Array.concat [value_prefix_kinds; flat_suffix_kinds]
-        }
 end
 
 module Scannable_block_shape = struct
@@ -386,6 +367,25 @@ module Scannable_block_shape = struct
     match t with
     | Value_only -> Value
     | Mixed_record t -> (Mixed_block_shape.field_kinds t).(index)
+
+  let from_mixed_block_shape (shape : _ Mixed_block_lambda_shape.t) : t =
+    let lambda_flat_suffix = Mixed_block_lambda_shape.flat_suffix shape in
+    if Array.length lambda_flat_suffix = 0
+    then Value_only
+    else
+      let value_prefix_kinds =
+        Array.map (fun _ -> value) (Mixed_block_lambda_shape.value_prefix shape)
+      in
+      let flat_suffix =
+        Array.map Flat_suffix_element0.from_singleton_mixed_block_element
+          lambda_flat_suffix
+      in
+      let flat_suffix_kinds = Array.map Flat_suffix_element0.kind flat_suffix in
+      Mixed_record
+        { flat_suffix;
+          value_prefix_size = Array.length value_prefix_kinds;
+          field_kinds = Array.concat [value_prefix_kinds; flat_suffix_kinds]
+        }
 end
 
 module Block_shape = struct
@@ -1055,12 +1055,9 @@ module With_subkind = struct
                              flattened_reordered_shape)
                       in
                       let block_shape : Block_shape.t =
-                        match
-                          Mixed_block_shape.from_mixed_block_shape
-                            mixed_block_shape
-                        with
-                        | None -> Scannable Value_only
-                        | Some s -> Scannable (Mixed_record s)
+                        Scannable
+                          (Scannable_block_shape.from_mixed_block_shape
+                             mixed_block_shape)
                       in
                       block_shape, fields
                   in

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -107,7 +107,9 @@ module Mixed_block_lambda_shape = Mixed_block_shape
 module Mixed_block_shape : sig
   type t
 
-  val from_mixed_block_shape : _ Mixed_block_lambda_shape.t -> t
+  (** Returns [None] if the shape is all-value (no flat suffix), meaning callers
+      should use [Scannable_block_shape.Value_only] instead. *)
+  val from_mixed_block_shape : _ Mixed_block_lambda_shape.t -> t option
 
   val field_kinds : t -> kind array
 

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -107,10 +107,6 @@ module Mixed_block_lambda_shape = Mixed_block_shape
 module Mixed_block_shape : sig
   type t
 
-  (** Returns [None] if the shape is all-value (no flat suffix), meaning callers
-      should use [Scannable_block_shape.Value_only] instead. *)
-  val from_mixed_block_shape : _ Mixed_block_lambda_shape.t -> t option
-
   val field_kinds : t -> kind array
 
   val value_prefix_size : t -> int
@@ -143,6 +139,8 @@ module Scannable_block_shape : sig
   val print : Format.formatter -> t -> unit
 
   val element_kind : t -> int -> kind
+
+  val from_mixed_block_shape : _ Mixed_block_lambda_shape.t -> t
 end
 
 module Block_shape : sig

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -174,6 +174,7 @@ COMPILERLIBS_SOURCES=\
   typing/type_shape.ml \
   typing/typedtree.ml \
   lambda/debuginfo.ml \
+  lambda/mixed_product_bytes.ml \
   lambda/lambda.ml \
   lambda/runtimedef.ml \
   lambda/static_label.ml \

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -165,6 +165,7 @@
   static_label
   slambdaident
   lambda
+  mixed_product_bytes
   runtimedef
   runtimetags
   structured_mangling
@@ -389,6 +390,8 @@
 
 (copy_files ../../lambda/slambdaident.ml)
 
+(copy_files ../../lambda/mixed_product_bytes.ml)
+
 (copy_files ../../lambda/lambda.ml)
 
 (copy_files ../../lambda/runtimedef.ml)
@@ -583,6 +586,8 @@
 
 (copy_files ../../lambda/slambdaident.mli)
 
+(copy_files ../../lambda/mixed_product_bytes.mli)
+
 (copy_files ../../lambda/lambda.mli)
 
 (copy_files ../../lambda/runtimedef.mli)
@@ -754,15 +759,16 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Printtyp.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Includecore.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typedtree.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Static_label.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Slambdaident.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Lambda.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Mixed_product_bytes.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typedecl_properties.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typedecl_separability.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typedecl_variance.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typetexp.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typedecl.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Mtype.cmo
-  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Static_label.cmo
-  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Slambdaident.cmo
-  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Lambda.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Dll.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Instruct.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Meta.cmo
@@ -875,15 +881,16 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Printtyp.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Includecore.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typedtree.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Static_label.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Slambdaident.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lambda.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Mixed_product_bytes.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typedecl_properties.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typedecl_separability.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typedecl_variance.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typetexp.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typedecl.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Mtype.cmx
-  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Static_label.cmx
-  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Slambdaident.cmx
-  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lambda.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Dll.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Instruct.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Meta.cmx

--- a/otherlibs/stdlib_upstream_compatible/stdlib_upstream_compatible.ml
+++ b/otherlibs/stdlib_upstream_compatible/stdlib_upstream_compatible.ml
@@ -3,4 +3,4 @@ module Int32_u = Int32_u
 module Int64_u = Int64_u
 module Nativeint_u = Nativeint_u
 
-let mixed_block_layout_v5 = ()
+let mixed_block_layout_v6 = ()

--- a/otherlibs/stdlib_upstream_compatible/stdlib_upstream_compatible.mli
+++ b/otherlibs/stdlib_upstream_compatible/stdlib_upstream_compatible.mli
@@ -3,11 +3,11 @@ module Int32_u = Int32_u
 module Int64_u = Int64_u
 module Nativeint_u = Nativeint_u
 
-val mixed_block_layout_v5 : unit
+val mixed_block_layout_v6 : unit
 (** OCaml code that depends on the layout of mixed blocks (via [Obj.magic] or
     similar) should include a reference to this value. The value will be removed
     and replaced with one with an incremented name when the representation of
     mixed blocks changes, alerting maintainers of code that reference this value
     to consider whether updates are needed. It is similar in purpose to
-    [Assert_mixed_block_layout_v5], a macro used by C code that depends on the
+    [Assert_mixed_block_layout_v6], a macro used by C code that depends on the
     mixed block representation for the same reason. *)

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -688,7 +688,8 @@ CAMLextern value caml_set_oo_id(value obj);
 #define Assert_mixed_block_layout_v2 _Static_assert(0, "")
 #define Assert_mixed_block_layout_v3 _Static_assert(0, "")
 #define Assert_mixed_block_layout_v4 _Static_assert(0, "")
-#define Assert_mixed_block_layout_v5 _Static_assert(1, "")
+#define Assert_mixed_block_layout_v5 _Static_assert(0, "")
+#define Assert_mixed_block_layout_v6 _Static_assert(1, "")
 
 /* Header for out-of-heap blocks. */
 

--- a/runtime4/caml/mlvalues.h
+++ b/runtime4/caml/mlvalues.h
@@ -660,7 +660,8 @@ CAMLextern value caml_set_oo_id(value obj);
 #define Assert_mixed_block_layout_v2 _Static_assert(0, "")
 #define Assert_mixed_block_layout_v3 _Static_assert(0, "")
 #define Assert_mixed_block_layout_v4 _Static_assert(0, "")
-#define Assert_mixed_block_layout_v5 _Static_assert(1, "")
+#define Assert_mixed_block_layout_v5 _Static_assert(0, "")
+#define Assert_mixed_block_layout_v6 _Static_assert(1, "")
 
 /* Header for out-of-heap blocks. */
 

--- a/testsuite/tests/lib-obj/uniform_or_mixed.bytecode.reference
+++ b/testsuite/tests/lib-obj/uniform_or_mixed.bytecode.reference
@@ -2,6 +2,11 @@ t_uniform1: uniform
 t_uniform2.0: uniform
 t_uniform2.1: uniform
 t_uniform3: uniform
+t_uniform_vv: mixed (scannable_prefix_len = 1)
+t_uniform_vv rec: mixed (scannable_prefix_len = 2)
+t_uniform_vu: mixed (scannable_prefix_len = 2)
+t_uniform_vu_variant: mixed (scannable_prefix_len = 2)
+t_uniform_vu_variant rec: mixed (scannable_prefix_len = 1)
 t_mixed0: mixed (scannable_prefix_len = 1)
 t_mixed1: mixed (scannable_prefix_len = 2)
 t_mixed2: mixed (scannable_prefix_len = 3)

--- a/testsuite/tests/lib-obj/uniform_or_mixed.bytecode.reference
+++ b/testsuite/tests/lib-obj/uniform_or_mixed.bytecode.reference
@@ -2,11 +2,11 @@ t_uniform1: uniform
 t_uniform2.0: uniform
 t_uniform2.1: uniform
 t_uniform3: uniform
-t_uniform_vv: mixed (scannable_prefix_len = 1)
-t_uniform_vv rec: mixed (scannable_prefix_len = 2)
-t_uniform_vu: mixed (scannable_prefix_len = 2)
-t_uniform_vu_variant: mixed (scannable_prefix_len = 2)
-t_uniform_vu_variant rec: mixed (scannable_prefix_len = 1)
+t_uniform_vv: uniform
+t_uniform_vv rec: uniform
+t_uniform_vu: uniform
+t_uniform_vu_variant: uniform
+t_uniform_vu_variant rec: uniform
 t_mixed0: mixed (scannable_prefix_len = 1)
 t_mixed1: mixed (scannable_prefix_len = 2)
 t_mixed2: mixed (scannable_prefix_len = 3)

--- a/testsuite/tests/lib-obj/uniform_or_mixed.ml
+++ b/testsuite/tests/lib-obj/uniform_or_mixed.ml
@@ -46,6 +46,23 @@ let () = run "t_uniform2.0" (Float.Array.create 0 : t_uniform2)
 let () = run "t_uniform2.1" (Float.Array.create 1 : t_uniform2)
 let () = run "t_uniform3" ((fun x -> x) : t_uniform3)
 
+(* These types are "mixed" in the type system (they use unboxed types or
+   products) but all their runtime fields are values or void, so they should
+   compile to uniform blocks. *)
+type t_uniform_vv = { ss : #( string * string ) }
+type t_uniform_vu = { s : string; u : unit# }
+type t_uniform_vu_variant = A of string * unit#
+
+let () = run "t_uniform_vv" ({ ss = #("a", "b") } : t_uniform_vv)
+let () =
+  let rec x : t_uniform_vv = { ss = #("a", "b") } in
+  run "t_uniform_vv rec" x
+let () = run "t_uniform_vu" ({ s = "hello"; u = #() } : t_uniform_vu)
+let () = run "t_uniform_vu_variant" (A ("x", #()) : t_uniform_vu_variant)
+let () =
+  let rec x : t_uniform_vu_variant = A ("x", #()) in
+  run "t_uniform_vu_variant rec" x
+
 let () = run "t_mixed0" ({ x = #4L } : t_mixed0)
 let () = run "t_mixed1" ({ x = ""; y = #5L } : t_mixed1)
 let () = run "t_mixed2" ({ x = ""; y = ""; z = #5L }: t_mixed2)

--- a/testsuite/tests/lib-obj/uniform_or_mixed.native.reference
+++ b/testsuite/tests/lib-obj/uniform_or_mixed.native.reference
@@ -2,11 +2,11 @@ t_uniform1: uniform
 t_uniform2.0: uniform
 t_uniform2.1: uniform
 t_uniform3: uniform
-t_uniform_vv: mixed (scannable_prefix_len = 2)
-t_uniform_vv rec: mixed (scannable_prefix_len = 2)
-t_uniform_vu: mixed (scannable_prefix_len = 1)
-t_uniform_vu_variant: mixed (scannable_prefix_len = 1)
-t_uniform_vu_variant rec: mixed (scannable_prefix_len = 1)
+t_uniform_vv: uniform
+t_uniform_vv rec: uniform
+t_uniform_vu: uniform
+t_uniform_vu_variant: uniform
+t_uniform_vu_variant rec: uniform
 t_mixed0: mixed (scannable_prefix_len = 0)
 t_mixed1: mixed (scannable_prefix_len = 1)
 t_mixed2: mixed (scannable_prefix_len = 2)

--- a/testsuite/tests/lib-obj/uniform_or_mixed.native.reference
+++ b/testsuite/tests/lib-obj/uniform_or_mixed.native.reference
@@ -2,6 +2,11 @@ t_uniform1: uniform
 t_uniform2.0: uniform
 t_uniform2.1: uniform
 t_uniform3: uniform
+t_uniform_vv: mixed (scannable_prefix_len = 2)
+t_uniform_vv rec: mixed (scannable_prefix_len = 2)
+t_uniform_vu: mixed (scannable_prefix_len = 1)
+t_uniform_vu_variant: mixed (scannable_prefix_len = 1)
+t_uniform_vu_variant rec: mixed (scannable_prefix_len = 1)
 t_mixed0: mixed (scannable_prefix_len = 0)
 t_mixed1: mixed (scannable_prefix_len = 1)
 t_mixed2: mixed (scannable_prefix_len = 2)

--- a/testsuite/tests/mixed-modules/typing.ml
+++ b/testsuite/tests/mixed-modules/typing.ml
@@ -2003,11 +2003,71 @@ module Big_module_of_unboxed_products_of_values = struct
   let x24 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
   let x25 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
   let x26 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+end
+[%%expect{|
+module Big_module_of_unboxed_products_of_values :
+  sig
+    val x1 : #(int * int * int * int * int * int * int * int * int * int)
+    val x2 : #(int * int * int * int * int * int * int * int * int * int)
+    val x3 : #(int * int * int * int * int * int * int * int * int * int)
+    val x4 : #(int * int * int * int * int * int * int * int * int * int)
+    val x5 : #(int * int * int * int * int * int * int * int * int * int)
+    val x6 : #(int * int * int * int * int * int * int * int * int * int)
+    val x7 : #(int * int * int * int * int * int * int * int * int * int)
+    val x8 : #(int * int * int * int * int * int * int * int * int * int)
+    val x9 : #(int * int * int * int * int * int * int * int * int * int)
+    val x10 : #(int * int * int * int * int * int * int * int * int * int)
+    val x11 : #(int * int * int * int * int * int * int * int * int * int)
+    val x12 : #(int * int * int * int * int * int * int * int * int * int)
+    val x13 : #(int * int * int * int * int * int * int * int * int * int)
+    val x14 : #(int * int * int * int * int * int * int * int * int * int)
+    val x15 : #(int * int * int * int * int * int * int * int * int * int)
+    val x16 : #(int * int * int * int * int * int * int * int * int * int)
+    val x17 : #(int * int * int * int * int * int * int * int * int * int)
+    val x18 : #(int * int * int * int * int * int * int * int * int * int)
+    val x19 : #(int * int * int * int * int * int * int * int * int * int)
+    val x20 : #(int * int * int * int * int * int * int * int * int * int)
+    val x21 : #(int * int * int * int * int * int * int * int * int * int)
+    val x22 : #(int * int * int * int * int * int * int * int * int * int)
+    val x23 : #(int * int * int * int * int * int * int * int * int * int)
+    val x24 : #(int * int * int * int * int * int * int * int * int * int)
+    val x25 : #(int * int * int * int * int * int * int * int * int * int)
+    val x26 : #(int * int * int * int * int * int * int * int * int * int)
+  end
+|}]
+
+module Big_module_of_unboxed_products_of_values_and_f64 = struct
+  let x1 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x2 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x3 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x4 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x5 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x6 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x7 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x8 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x9 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x10 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x11 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x12 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x13 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x14 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x15 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x16 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x17 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x18 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x19 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x20 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x21 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x22 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x23 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x24 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x25 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let x26 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
   let f64 = #0.
 end
 [%%expect{|
-Lines 1-29, characters 50-3:
- 1 | ..................................................struct
+Lines 1-29, characters 58-3:
+ 1 | ..........................................................struct
  2 |   let x1 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
  3 |   let x2 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
  4 |   let x3 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)

--- a/testsuite/tests/mixed-modules/typing.ml
+++ b/testsuite/tests/mixed-modules/typing.ml
@@ -2003,19 +2003,20 @@ module Big_module_of_unboxed_products_of_values = struct
   let x24 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
   let x25 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
   let x26 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+  let f64 = #0.
 end
 [%%expect{|
-Lines 1-28, characters 50-3:
+Lines 1-29, characters 50-3:
  1 | ..................................................struct
  2 |   let x1 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
  3 |   let x2 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
  4 |   let x3 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
  5 |   let x4 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 ...
-25 |   let x24 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 26 |   let x25 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 27 |   let x26 = #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-28 | end
+28 |   let f64 = #0.
+29 | end
 Error: Mixed modules may contain at most 254 value fields prior to the flat suffix, but this one contains 260.
 |}]
 

--- a/testsuite/tests/mixed-modules/uniform_product.ml
+++ b/testsuite/tests/mixed-modules/uniform_product.ml
@@ -1,0 +1,1 @@
+let foobar = Sys.opaque_identity #("foo", "bar")

--- a/testsuite/tests/mixed-modules/uniform_product_test.ml
+++ b/testsuite/tests/mixed-modules/uniform_product_test.ml
@@ -1,0 +1,14 @@
+(* TEST
+ readonly_files = "uniform_product.ml";
+ setup-ocamlopt.opt-build-env;
+ module = "uniform_product.ml";
+ ocamlopt.opt;
+ module = "uniform_product_test.ml";
+ ocamlopt.opt;
+ module = "";
+ all_modules = "uniform_product.cmx uniform_product_test.cmx";
+ ocamlopt.opt;
+ run;
+*)
+
+let foo = let #(foo, _) = Uniform_product.foobar in foo

--- a/testsuite/tests/nested-mixed-records/tests.reference
+++ b/testsuite/tests/nested-mixed-records/tests.reference
@@ -1,4 +1,4 @@
-size=mixed[3/3] value.str="something" value.sub.#i32=123 value.sub.#i64=456 
+size=uniform[3] value.str="something" value.sub.#i32=123 value.sub.#i64=456 
 size=mixed[1/3] value.str="something" value.sub.#i32=123 value.sub.#i64=456 
 size=mixed[2/3] value.i=987 value.sub.#i32=123 value.sub.#i64=456 
 size=mixed[0/3] value.i=987 value.sub.#i32=123 value.sub.#i64=456 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2375,7 +2375,58 @@ type r_254 =
     f253 : string;
     f254 : string;
   }
-
+type r_254_f64 =
+  { a : thirty_two_values#;
+    b : thirty_two_values#;
+    c : thirty_two_values#;
+    d : thirty_two_values#;
+    e : thirty_two_values#;
+    f : thirty_two_values#;
+    g : thirty_two_values#;
+    h : #(eight_values * eight_values * eight_values);
+    f249 : string;
+    f250 : string;
+    f251 : string;
+    f252 : string;
+    f253 : string;
+    f254 : string;
+    f64 : float#;
+  }
+type r_255 =
+  { a : thirty_two_values#;
+    b : thirty_two_values#;
+    c : thirty_two_values#;
+    d : thirty_two_values#;
+    e : thirty_two_values#;
+    f : thirty_two_values#;
+    g : thirty_two_values#;
+    h : #(eight_values * eight_values * eight_values);
+    f249 : string;
+    f250 : string;
+    f251 : string;
+    f252 : string;
+    f253 : string;
+    f254 : string;
+    f255 : string;
+  }
+type r_255_void =
+  { a : thirty_two_values#;
+    b : thirty_two_values#;
+    c : thirty_two_values#;
+    d : thirty_two_values#;
+    e : thirty_two_values#;
+    f : thirty_two_values#;
+    g : thirty_two_values#;
+    h : #(eight_values * eight_values * eight_values);
+    f249 : string;
+    f250 : string;
+    f251 : string;
+    f252 : string;
+    f253 : string;
+    f254 : string;
+    f255 : #(string * unit#);
+    v : unit#;
+  }
 [%%expect{|
 type eight_values
   : value & value & value & value & value & value & value & value
@@ -2401,9 +2452,61 @@ type r_254 = {
   f253 : string;
   f254 : string;
 }
+type r_254_f64 = {
+  a : thirty_two_values#;
+  b : thirty_two_values#;
+  c : thirty_two_values#;
+  d : thirty_two_values#;
+  e : thirty_two_values#;
+  f : thirty_two_values#;
+  g : thirty_two_values#;
+  h : #(eight_values * eight_values * eight_values);
+  f249 : string;
+  f250 : string;
+  f251 : string;
+  f252 : string;
+  f253 : string;
+  f254 : string;
+  f64 : float#;
+}
+type r_255 = {
+  a : thirty_two_values#;
+  b : thirty_two_values#;
+  c : thirty_two_values#;
+  d : thirty_two_values#;
+  e : thirty_two_values#;
+  f : thirty_two_values#;
+  g : thirty_two_values#;
+  h : #(eight_values * eight_values * eight_values);
+  f249 : string;
+  f250 : string;
+  f251 : string;
+  f252 : string;
+  f253 : string;
+  f254 : string;
+  f255 : string;
+}
+type r_255_void = {
+  a : thirty_two_values#;
+  b : thirty_two_values#;
+  c : thirty_two_values#;
+  d : thirty_two_values#;
+  e : thirty_two_values#;
+  f : thirty_two_values#;
+  g : thirty_two_values#;
+  h : #(eight_values * eight_values * eight_values);
+  f249 : string;
+  f250 : string;
+  f251 : string;
+  f252 : string;
+  f253 : string;
+  f254 : string;
+  f255 : #(string * unit#);
+  v : unit#;
+}
 |}]
 
-type r_255 =
+type r_255_f64 =
   { a : thirty_two_values#;
     b : thirty_two_values#;
     c : thirty_two_values#;
@@ -2418,21 +2521,21 @@ type r_255 =
     f252 : string;
     f253 : string;
     f254 : string;
-    f255 : string;
+    f255 : #(string * unit#);
+    f64 : float#;
   }
-
 [%%expect{|
-Lines 1-17, characters 0-3:
- 1 | type r_255 =
+Lines 1-18, characters 0-3:
+ 1 | type r_255_f64 =
  2 |   { a : thirty_two_values#;
  3 |     b : thirty_two_values#;
  4 |     c : thirty_two_values#;
  5 |     d : thirty_two_values#;
 ...
-14 |     f253 : string;
 15 |     f254 : string;
-16 |     f255 : string;
-17 |   }
+16 |     f255 : #(string * unit#);
+17 |     f64 : float#;
+18 |   }
 Error: Mixed records may contain at most 254 value fields prior to the flat suffix, but this one contains 255.
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2349,11 +2349,8 @@ Error: The kind of type "record" is value non_float mod immutable with 'a
          because of the annotation on the declaration of the type record.
 |}]
 
-(*******************************************************************************)
-(* Test 22: You can't defeat the value prefix size limit with nested products. *)
-
-(* And note that blocks with products are always mixed blocks, so we don't
-   need to add any unboxed types to hit the limit. *)
+(****************************************************************************)
+(* Test 22: Product components counted correctly for the value prefix limit *)
 
 type eight_values :
   value & value & value & value & value & value & value & value

--- a/testsuite/tests/typing-layouts-void/void_extended_tests.reference
+++ b/testsuite/tests/typing-layouts-void/void_extended_tests.reference
@@ -6,13 +6,13 @@ Test 1: equality, comparison, hashing, and marshalling
   Compare vh1 vh2: 0
   Hash vh1: 129913994
   Hash vh2: 129913994
-  Equality pv1 = pv2: failed (compare: mixed block value)
-  Compare pv1 pv2: failed (compare: mixed block value)
-  Equality r1 = r2: failed (compare: mixed block value)
-  Compare r1 r2: failed (compare: mixed block value)
+  Equality pv1 = pv2: true
+  Compare pv1 pv2: 0
+  Equality r1 = r2: true
+  Compare r1 r2: 0
   Marshalling void_holder succeeded, equality: true
-  Marshalling variant_with_void failed: Invalid_argument("output_value: mixed block")
-  Marshalling record_with_void failed: Invalid_argument("output_value: mixed block")
+  Marshalling variant_with_void succeeded, equality: true
+  Marshalling record_with_void succeeded, equality: true
   Unboxed products with void: cannot test equality/comparison/hashing
   (These operations are not supported on unboxed types containing void)
 Test 2: higher-order functions with void arguments/returns

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1912,26 +1912,23 @@ module Element_repr = struct
         Misc.fatal_error "Element_repr.classify: unexpected missing layout"
 
   let mixed_product_shape loc ts kind =
-    let boxed_elements =
-      let rec count_boxed_in_t acc : t -> int = function
-        | Unboxed_element u -> count_boxed_in_unboxed_element acc u
-        | Void -> acc
-        | Float_element | Value_element _ -> acc + 1
-      and count_boxed_in_unboxed_element acc : unboxed_element -> int =
-        function
-        | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-        | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate -> acc
-        | Product l -> Array.fold_left count_boxed_in_t acc l
-      in
-      List.fold_left (fun acc (t,_) -> count_boxed_in_t acc t) 0 ts
-    in
     let mixed =
       List.exists
         (function ((Unboxed_element _ | Void), _) -> true | _ -> false) ts
     in
     if not mixed then None else begin
-      assert_mixed_product_support loc kind ~value_prefix_len:boxed_elements;
-      Some (List.map (fun (t,_) -> to_shape_element t) ts |> Array.of_list)
+      let shape =
+        List.map (fun (t,_) -> to_shape_element t) ts |> Array.of_list
+      in
+      (* All-value/void shapes will compile to uniform blocks, so the
+         scannable prefix length limit doesn't apply. *)
+      let mpb = Mixed_product_bytes.count_types_shape shape in
+      if not (Mixed_product_bytes.all_value mpb)
+      then
+        assert_mixed_product_support loc kind
+          ~value_prefix_len:
+            (Mixed_product_bytes.value_prefix_len mpb);
+      Some shape
     end
 end
 


### PR DESCRIPTION
Represent all-value/void mixed records and variants as uniform blocks. We also:
- Remove the mixed block restriction for these records (so they are no longer limited to 254 `value`s).
- Bump the mixed block version to v6.

## Summary

First, let's define the following:
- **Mixed records/variants:** records/variants that contain both values and non-values (incl. void and products)
- **Mixed blocks:** runtime property of blocks which may contain non-scanned bytes, and thus don't support poly compare or marshaling

Currently, all mixed records compile to mixed blocks (modulo float records). This includes the following: 
```ocaml
type r = { ss : #( string * string ) }
type s = { s : string; u : unit# }
type t = A of string * unit#
```

This is unnecessary since all their runtime fields are GC-scannable values. This PR changes the compiler to emit uniform blocks for these cases, which enables poly compare and marshalling to work on them, and for them to be exempt from the mixed block restriction of containing no more than 254 values.

Because we are changing runtime representations, we update the mixed block version.

## Notes for review
`block_of_module_representation` was moved from `lambda/lambda.ml` to `lambda/translmod.ml` so `typing/` can depend on `lambda/mixed_product_bytes.ml`, which depends on `lambda.ml`. (This may seem odd, but I argue it's reasonable: where `typing/` depends on it, we really do care about the mixed block representation, such as for the scannable prefix typing restriction. This dependency thus reflects the actual logical dependency of typechecking on our runtime restrictions).