### PR TITLE
`Cfg_quick_hash` module

### DIFF
--- a/backend/cfg/cfg_merge_blocks.ml
+++ b/backend/cfg/cfg_merge_blocks.ml
@@ -5,130 +5,6 @@ module DLL = Oxcaml_utils.Doubly_linked_list
 module Int = Numbers.Int
 module List = ListLabels
 
-(* CR-soon xclerc for xclerc: some work may be needed on the hash functions, as
-   the pass performance seems to be quite sensitive to it. *)
-module Quick_hash : sig
-  val basic_block : Cfg.basic_block -> int
-end = struct
-  (* note: we are hashing a number of mutable elements; this is fine here
-     because we know mutations only happen when the hash value is no longer
-     useful. We implement the hashing functions here, and do not export them
-     because they are probably low-quality, not for general use. *)
-  let[@inline] hash_combine h1 h2 = (h1 * 65599) + h2
-
-  let operation : Operation.t -> int =
-   fun op ->
-    match op with
-    | Move -> 0
-    | Spill -> 1
-    | Reload -> 2
-    | Opaque -> 3
-    | Begin_region -> 4
-    | End_region -> 5
-    | Dls_get -> 6
-    | Tls_get -> 7
-    | Domain_index -> 8
-    | Poll -> 9
-    | Pause -> 10
-    | Const_int _ -> 11
-    | Const_float32 _ -> 12
-    | Const_float _ -> 13
-    | Const_symbol _ -> 14
-    | Const_vec128 _ -> 15
-    | Const_vec256 _ -> 16
-    | Const_vec512 _ -> 17
-    | Stackoffset _ -> 18
-    | Load _ -> 19
-    | Store _ -> 20
-    | Intop _ -> 21
-    | Int128op _ -> 22
-    | Intop_imm _ -> 23
-    | Intop_atomic _ -> 24
-    | Floatop _ -> 25
-    | Csel _ -> 26
-    | Reinterpret_cast _ -> 27
-    | Static_cast _ -> 28
-    | Probe_is_enabled _ -> 29
-    | Specific _ -> 30
-    | Name_for_debugger _ -> 31
-    | Alloc _ -> 32
-
-  let basic : Cfg.basic -> int = function
-    | Op op -> operation op
-    | Reloadretaddr -> 1
-    | Pushtrap { lbl_handler } -> hash_combine 2 (Label.hash lbl_handler)
-    | Poptrap { lbl_handler } -> hash_combine 3 (Label.hash lbl_handler)
-    | Prologue -> 4
-    | Epilogue -> 5
-    | Stack_check { max_frame_size_bytes } ->
-      hash_combine 6 max_frame_size_bytes
-
-  let terminator : Cfg.terminator -> int =
-   fun term ->
-    match term with
-    | Never -> 0
-    | Return -> 1
-    | Always _ -> 2
-    | Parity_test _ -> 3
-    | Truth_test _ -> 4
-    | Float_test _ -> 5
-    | Int_test _ -> 6
-    | Switch _ -> 7
-    | Raise _ -> 8
-    | Tailcall_self _ -> 9
-    | Tailcall_func _ -> 10
-    | Call_no_return _ -> 11
-    | Invalid _ -> 12
-    | Call _ -> 13
-    | Prim _ -> 14
-
-  let rec basic_instruction_cell :
-      Cfg.basic Cfg.instruction DLL.cell option -> fuel:int -> acc:int -> int =
-   fun cell ~fuel ~acc ->
-    if fuel <= 0
-    then acc
-    else
-      match cell with
-      | None -> acc
-      | Some cell ->
-        let instr_hash = basic (DLL.value cell).desc in
-        basic_instruction_cell (DLL.next cell) ~fuel:(pred fuel)
-          ~acc:(hash_combine acc instr_hash)
-
-  let basic_instruction_list : Cfg.basic Cfg.instruction DLL.t -> int =
-   fun l ->
-    (* CR-someday xclerc for xclerc: also use the list length? *)
-    basic_instruction_cell (DLL.hd_cell l) ~fuel:4 ~acc:0
-
-  let basic_block : Cfg.basic_block -> int =
-   fun block ->
-    match block with
-    | { start = _;
-        body;
-        terminator =
-          { desc = terminator_desc;
-            id = _;
-            arg = _;
-            res = _;
-            dbg = _;
-            fdo = _;
-            live = _;
-            stack_offset = _;
-            available_before = _;
-            available_across = _
-          };
-        predecessors = _;
-        stack_offset = _;
-        exn = _;
-        can_raise = _;
-        is_trap_handler = _;
-        cold = _
-      } ->
-      let body_hash = basic_instruction_list body in
-      let term_hash = terminator terminator_desc in
-      hash_combine body_hash term_hash
-end
-
 module Equivalent : sig
   val basic_block :
     equal_reg:(Reg.t -> Reg.t -> bool) ->
@@ -231,7 +107,7 @@ let run :
          lifted? *)
       if (not block.is_trap_handler) && not (Label.equal label cfg.entry_label)
       then begin
-        let block_hash = Quick_hash.basic_block block in
+        let block_hash = Cfg_quick_hash.basic_block block in
         let curr =
           match Int.Tbl.find_opt buckets block_hash with
           | Some l -> l

--- a/backend/cfg/cfg_quick_hash.ml
+++ b/backend/cfg/cfg_quick_hash.ml
@@ -1,0 +1,118 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+let[@inline] hash_combine h1 h2 = (h1 * 65599) + h2
+
+let operation : Operation.t -> int =
+ fun op ->
+  match op with
+  | Move -> 0
+  | Spill -> 1
+  | Reload -> 2
+  | Dummy_use -> 3
+  | Opaque -> 4
+  | Begin_region -> 5
+  | End_region -> 6
+  | Dls_get -> 7
+  | Tls_get -> 8
+  | Domain_index -> 9
+  | Poll -> 10
+  | Pause -> 11
+  | Const_int _ -> 12
+  | Const_float32 _ -> 13
+  | Const_float _ -> 14
+  | Const_symbol _ -> 15
+  | Const_vec128 _ -> 16
+  | Const_vec256 _ -> 17
+  | Const_vec512 _ -> 18
+  | Stackoffset _ -> 19
+  | Load _ -> 20
+  | Store _ -> 21
+  | Intop _ -> 22
+  | Int128op _ -> 23
+  | Intop_imm _ -> 24
+  | Intop_atomic _ -> 25
+  | Floatop _ -> 26
+  | Csel _ -> 27
+  | Reinterpret_cast _ -> 28
+  | Static_cast _ -> 29
+  | Probe_is_enabled _ -> 30
+  | Specific _ -> 31
+  | Name_for_debugger _ -> 32
+  | Alloc _ -> 33
+
+let basic : Cfg.basic -> int = function
+  | Op op -> operation op
+  | Reloadretaddr -> 1
+  | Pushtrap { lbl_handler = _ } -> 2
+  | Poptrap { lbl_handler = _ } -> 3
+  | Prologue -> 4
+  | Epilogue -> 5
+  | Stack_check { max_frame_size_bytes = _ } -> 6
+
+let terminator : Cfg.terminator -> int =
+ fun term ->
+  match term with
+  | Never -> 0
+  | Return -> 1
+  | Always _ -> 2
+  | Parity_test _ -> 3
+  | Truth_test _ -> 4
+  | Float_test _ -> 5
+  | Int_test _ -> 6
+  | Switch _ -> 7
+  | Raise _ -> 8
+  | Tailcall_self _ -> 9
+  | Tailcall_func _ -> 10
+  | Call_no_return _ -> 11
+  | Invalid _ -> 12
+  | Call _ -> 13
+  | Prim _ -> 14
+
+let rec basic_instruction_cell :
+    Cfg.basic Cfg.instruction DLL.cell option -> fuel:int -> acc:int -> int =
+ fun cell ~fuel ~acc ->
+  if fuel <= 0
+  then acc
+  else
+    match cell with
+    | None -> acc
+    | Some cell ->
+      let instr_hash = basic (DLL.value cell).desc in
+      basic_instruction_cell (DLL.next cell) ~fuel:(pred fuel)
+        ~acc:(hash_combine acc instr_hash)
+
+let basic_instruction_list : Cfg.basic Cfg.instruction DLL.t -> int =
+ fun l ->
+  (* CR-someday xclerc for xclerc: also use the list length? *)
+  basic_instruction_cell (DLL.hd_cell l) ~fuel:4 ~acc:0
+
+let basic_block : Cfg.basic_block -> int =
+ fun block ->
+  match block with
+  | { start = _;
+      body;
+      terminator =
+        { desc = terminator_desc;
+          id = _;
+          arg = _;
+          res = _;
+          dbg = _;
+          fdo = _;
+          live = _;
+          stack_offset = _;
+          available_before = _;
+          available_across = _
+        };
+      predecessors = _;
+      stack_offset = _;
+      exn = _;
+      can_raise = _;
+      is_trap_handler = _;
+      cold = _
+    } ->
+    let body_hash = basic_instruction_list body in
+    let term_hash = terminator terminator_desc in
+    hash_combine body_hash term_hash

--- a/backend/cfg/cfg_quick_hash.ml
+++ b/backend/cfg/cfg_quick_hash.ml
@@ -11,37 +11,36 @@ let operation : Operation.t -> int =
   | Move -> 0
   | Spill -> 1
   | Reload -> 2
-  | Dummy_use -> 3
-  | Opaque -> 4
-  | Begin_region -> 5
-  | End_region -> 6
-  | Dls_get -> 7
-  | Tls_get -> 8
-  | Domain_index -> 9
-  | Poll -> 10
-  | Pause -> 11
-  | Const_int _ -> 12
-  | Const_float32 _ -> 13
-  | Const_float _ -> 14
-  | Const_symbol _ -> 15
-  | Const_vec128 _ -> 16
-  | Const_vec256 _ -> 17
-  | Const_vec512 _ -> 18
-  | Stackoffset _ -> 19
-  | Load _ -> 20
-  | Store _ -> 21
-  | Intop _ -> 22
-  | Int128op _ -> 23
-  | Intop_imm _ -> 24
-  | Intop_atomic _ -> 25
-  | Floatop _ -> 26
-  | Csel _ -> 27
-  | Reinterpret_cast _ -> 28
-  | Static_cast _ -> 29
-  | Probe_is_enabled _ -> 30
-  | Specific _ -> 31
-  | Name_for_debugger _ -> 32
-  | Alloc _ -> 33
+  | Opaque -> 3
+  | Begin_region -> 4
+  | End_region -> 5
+  | Dls_get -> 6
+  | Tls_get -> 7
+  | Domain_index -> 8
+  | Poll -> 9
+  | Pause -> 10
+  | Const_int _ -> 11
+  | Const_float32 _ -> 12
+  | Const_float _ -> 13
+  | Const_symbol _ -> 14
+  | Const_vec128 _ -> 15
+  | Const_vec256 _ -> 16
+  | Const_vec512 _ -> 17
+  | Stackoffset _ -> 18
+  | Load _ -> 19
+  | Store _ -> 20
+  | Intop _ -> 21
+  | Int128op _ -> 22
+  | Intop_imm _ -> 23
+  | Intop_atomic _ -> 24
+  | Floatop _ -> 25
+  | Csel _ -> 26
+  | Reinterpret_cast _ -> 27
+  | Static_cast _ -> 28
+  | Probe_is_enabled _ -> 29
+  | Specific _ -> 30
+  | Name_for_debugger _ -> 31
+  | Alloc _ -> 32
 
 let basic : Cfg.basic -> int = function
   | Op op -> operation op

--- a/backend/cfg/cfg_quick_hash.ml
+++ b/backend/cfg/cfg_quick_hash.ml
@@ -49,7 +49,7 @@ let basic : Cfg.basic -> int = function
   | Poptrap { lbl_handler = _ } -> 3
   | Prologue -> 4
   | Epilogue -> 5
-  | Stack_check { max_frame_size_bytes = _ } -> 6
+  | Stack_check { max_frame_size_bytes } -> hash_combine 6 max_frame_size_bytes
 
 let terminator : Cfg.terminator -> int =
  fun term ->

--- a/backend/cfg/cfg_quick_hash.mli
+++ b/backend/cfg/cfg_quick_hash.mli
@@ -1,0 +1,26 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+(* CR-soon xclerc for xclerc: some work may be needed on the hash functions, as
+   the performance of some passes (e.g. `Cfg_merg_blocks`) seems to be quite
+   sensitive to it. *)
+
+(* Note: the functions below are hashing a number of mutable elements; the user
+   have to be sure mutations only happen when the hash value is no longer
+   used. *)
+
+(* Note: the functions below are probably "low quality" as they have to ignore
+   nested values that some passes may want to substitute. For instance, labels
+   and function names are ignored so that the functions can be used to get the
+   same hash value for elements equivalent up to a substitution. *)
+
+val operation : Operation.t -> int
+
+val basic : Cfg.basic -> int
+
+val terminator : Cfg.terminator -> int
+
+val basic_instruction_list : Cfg.basic Cfg.instruction DLL.t -> int
+
+val basic_block : Cfg.basic_block -> int

--- a/dune
+++ b/dune
@@ -637,6 +637,7 @@
   cfg_colours
   cfg_edge
   cfg_intf
+  cfg_quick_hash
   cfg_reducibility
   cfg_to_linear
   cfg_with_layout


### PR DESCRIPTION
This pull request moves the hash functions
from the `Cfg_merge_blocks` module to
a dedicated module.

The hash functions are also tweaked to
only use the constructor and ignore its
payload, so that it can be used for passes
interested in equality up to a renaming.