### PR TITLE
Represent `float64` records as mixed blocks, add `[@@represent_as_float_array]` 

### DIFF
--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -131,6 +131,7 @@ let builtin_attrs =
   ; "regalloc_param"
   ; "implicit_kind"
   ; "flatten_floats"
+  ; "represent_as_float_array"
   ]
 
 let builtin_attrs =
@@ -519,6 +520,9 @@ let has_unboxed attrs = has_attribute "unboxed" attrs
 let has_boxed attrs = has_attribute "boxed" attrs
 
 let has_flatten_floats attrs = has_attribute "flatten_floats" attrs
+
+let has_represent_as_float_array attrs =
+  has_attribute "represent_as_float_array" attrs
 
 let has_unsafe_allow_any_mode_crossing attrs =
   has_attribute "unsafe_allow_any_mode_crossing" attrs

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -199,6 +199,7 @@ val explicit_arity: Parsetree.attributes -> bool
 val has_unboxed: Parsetree.attributes -> bool
 val has_boxed: Parsetree.attributes -> bool
 val has_flatten_floats: Parsetree.attributes -> bool
+val has_represent_as_float_array: Parsetree.attributes -> bool
 
 val has_unsafe_allow_any_mode_crossing : Parsetree.attributes -> bool
 

--- a/testsuite/tests/codegen/allocation.ml
+++ b/testsuite/tests/codegen/allocation.ml
@@ -75,7 +75,8 @@ spill_slot_lifetime:
   jb    .L116
 .L118:
   leaq  8(%r15), %rax
-  movq  $4350, -8(%rax)
+  movabsq $72057594037932032, %rbx
+  movq  %rbx, -8(%rax)
   vmovsd (%rsp), %xmm1
   vmovsd %xmm1, (%rax)
   vmovsd 8(%rsp), %xmm1

--- a/testsuite/tests/typing-layouts-float64/unboxed_floats.reference
+++ b/testsuite/tests/typing-layouts-float64/unboxed_floats.reference
@@ -145,7 +145,7 @@ Test 10, float# records in recursive groups.
   c: -7.30
   d: -8.40
 Test 11, heterogeneous polymorphic equality.
-  equal: true
+  equal: false
   unequal: false
 Test 12, If-then-else with assert and float64.
   result (1.00): 1.00

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -622,16 +622,6 @@ Error: This expression has type "t",
        which is a boxed record rather than an unboxed one.
 |}]
 
-let _ = #{ b = #5.0 }
-[%%expect{|
-Line 1, characters 11-12:
-1 | let _ = #{ b = #5.0 }
-               ^
-Error: Unbound unboxed record field "b"
-Hint: There is a boxed record field with this name.
-      Note that float- and [@@unboxed]- records don't get unboxed versions.
-|}]
-
 let _ = { u = #5.0 }
 [%%expect{|
 Line 1, characters 10-11:
@@ -649,16 +639,6 @@ Line 1, characters 22-23:
 Error: Unbound record field "u"
 Hint: There is an unboxed record field with this name.
       To project an unboxed record field, use ".#u" instead of ".u".
-|}]
-
-let bad_get t = t.#b
-[%%expect{|
-Line 1, characters 19-20:
-1 | let bad_get t = t.#b
-                       ^
-Error: Unbound unboxed record field "b"
-Hint: There is a boxed record field with this name.
-      Note that float- and [@@unboxed]- records don't get unboxed versions.
 |}]
 
 (*****************************************************************************)

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -199,6 +199,17 @@ type r = { f : float#; si : #(string * int64); }
 type u = r#
 |}]
 
+type ('a : float64) t = { i : 'a ; j : 'a }
+type floatu_t : float64 & float64 = float# t#
+[%%expect{|
+type ('a : float64) t = { i : 'a; j : 'a; }
+Line 2, characters 43-45:
+2 | type floatu_t : float64 & float64 = float# t#
+                                               ^^
+Error: The type "t" has no unboxed version.
+Hint: Float records don't get unboxed versions.
+|}]
+
 (* But not float, mixed float/float#, or [@@unboxed] records *)
 type r = { f : float ; f2 : float }
 type bad = r#
@@ -231,11 +242,12 @@ Error: The type "r" has no unboxed version.
 Hint: [@@unboxed] records don't get unboxed versions.
 |}]
 type ('a : float64) t = { i : 'a ; j : 'a }
+[@@represent_as_float_array]
 type floatu_t : float64 & float64 = float t#
 [%%expect{|
 type ('a : float64) t = { i : 'a; j : 'a; }
-Line 2, characters 42-44:
-2 | type floatu_t : float64 & float64 = float t#
+Line 3, characters 42-44:
+3 | type floatu_t : float64 & float64 = float t#
                                               ^^
 Error: The type "t" has no unboxed version.
 Hint: Float records don't get unboxed versions.

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -203,11 +203,7 @@ type ('a : float64) t = { i : 'a ; j : 'a }
 type floatu_t : float64 & float64 = float# t#
 [%%expect{|
 type ('a : float64) t = { i : 'a; j : 'a; }
-Line 2, characters 43-45:
-2 | type floatu_t : float64 & float64 = float# t#
-                                               ^^
-Error: The type "t" has no unboxed version.
-Hint: Float records don't get unboxed versions.
+type floatu_t = float# t#
 |}]
 
 (* But not float, mixed float/float#, or [@@unboxed] records *)
@@ -251,6 +247,24 @@ Line 3, characters 42-44:
                                               ^^
 Error: The type "t" has no unboxed version.
 Hint: Float records don't get unboxed versions.
+|}]
+
+(* Bad [@@represent_as_float_array] attribute *)
+type t = { f : float }
+[@@represent_as_float_array]
+[%%expect{|
+Lines 1-2, characters 0-28:
+1 | type t = { f : float }
+2 | [@@represent_as_float_array]
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+type ('a : value) t = { a : 'a }
+[@@represent_as_float_array]
+[%%expect{|
+Lines 1-2, characters 0-28:
+1 | type ('a : value) t = { a : 'a }
+2 | [@@represent_as_float_array]
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
 |}]
 
 (* A type can get an unboxed version from both the manifest and kind *)

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -249,24 +249,6 @@ Error: The type "t" has no unboxed version.
 Hint: Float records don't get unboxed versions.
 |}]
 
-(* Bad [@@represent_as_float_array] attribute *)
-type t = { f : float }
-[@@represent_as_float_array]
-[%%expect{|
-Lines 1-2, characters 0-28:
-1 | type t = { f : float }
-2 | [@@represent_as_float_array]
-Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
-|}]
-type ('a : value) t = { a : 'a }
-[@@represent_as_float_array]
-[%%expect{|
-Lines 1-2, characters 0-28:
-1 | type ('a : value) t = { a : 'a }
-2 | [@@represent_as_float_array]
-Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
-|}]
-
 (* A type can get an unboxed version from both the manifest and kind *)
 type r = { i : int ; s : string }
 type r2 = r = { i : int ; s : string }

--- a/testsuite/tests/typing-layouts/represent_as_float_array.ml
+++ b/testsuite/tests/typing-layouts/represent_as_float_array.ml
@@ -1,0 +1,77 @@
+(* TEST
+ flags = "-extension layouts_beta";
+ expect;
+*)
+
+(* Bad [@@represent_as_float_array] attribute *)
+
+type t = { f : float }
+[@@represent_as_float_array]
+[%%expect{|
+Lines 1-2, characters 0-28:
+1 | type t = { f : float }
+2 | [@@represent_as_float_array]
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+
+type ('a : value) t = { a : 'a }
+[@@represent_as_float_array]
+[%%expect{|
+Lines 1-2, characters 0-28:
+1 | type ('a : value) t = { a : 'a }
+2 | [@@represent_as_float_array]
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+
+type t [@@represent_as_float_array]
+[%%expect{|
+type t
+|}]
+
+(* Representation checks *)
+
+module M : sig
+  type r = { f : float# } [@@represent_as_float_array]
+end = struct
+  type r = { f : float# }
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type r = { f : float# }
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type r = { f : float#; } end
+       is not included in
+         sig type r = { f : float#; } end
+       Type declarations do not match:
+         type r = { f : float#; }
+       is not included in
+         type r = { f : float#; }
+       Their internal representations differ:
+       the second declaration uses float# representation.
+|}]
+
+module M : sig
+  type r = { f : float# }
+end = struct
+  type r = { f : float# } [@@represent_as_float_array]
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type r = { f : float# } [@@represent_as_float_array]
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type r = { f : float#; } end
+       is not included in
+         sig type r = { f : float#; } end
+       Type declarations do not match:
+         type r = { f : float#; }
+       is not included in
+         type r = { f : float#; }
+       Their internal representations differ:
+       the first declaration uses float# representation.
+|}]

--- a/testsuite/tests/typing-layouts/represent_as_float_array.ml
+++ b/testsuite/tests/typing-layouts/represent_as_float_array.ml
@@ -28,6 +28,17 @@ type t [@@represent_as_float_array]
 type t
 |}]
 
+(* Can abstract a [@@represent_as_float_array] record *)
+
+module M : sig
+  type r
+end = struct
+  type r = { f : float# } [@@represent_as_float_array]
+end
+[%%expect{|
+module M : sig type r end
+|}]
+
 (* Representation checks *)
 
 module M : sig

--- a/testsuite/tests/typing-layouts/represent_as_float_array.ml
+++ b/testsuite/tests/typing-layouts/represent_as_float_array.ml
@@ -25,7 +25,34 @@ Error: "[@@represent_as_float_array]" can only be used on records whose fields a
 
 type t [@@represent_as_float_array]
 [%%expect{|
-type t
+Line 1, characters 0-35:
+1 | type t [@@represent_as_float_array]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+
+type t = A | B [@@represent_as_float_array]
+[%%expect{|
+Line 1, characters 0-43:
+1 | type t = A | B [@@represent_as_float_array]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+
+type t = .. [@@represent_as_float_array]
+[%%expect{|
+Line 1, characters 0-40:
+1 | type t = .. [@@represent_as_float_array]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+
+type t = #{ f : float# } [@@represent_as_float_array]
+[%%expect{|
+Line 1, characters 0-53:
+1 | type t = #{ f : float# } [@@represent_as_float_array]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
 |}]
 
 (* Can abstract a [@@represent_as_float_array] record *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1312,6 +1312,14 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
          alias). *)
       not (Builtin_attributes.attr_equals_builtin a "deprecated_mutable")
     in
+    let keep_decl_attribute a =
+      (* [@@represent_as_float_array] records don't have unboxed versions, but
+         we still produce one for the phase of typechecking where every record
+         has an unboxed version (see Note [Typechecking unboxed versions of
+         types]). For those unboxed versions, we don't keep the attribute, since
+         it's not valid on an unboxed record. *)
+      not (Builtin_attributes.attr_equals_builtin a "represent_as_float_array")
+    in
     let lbls_unboxed =
       List.map
         (fun (ld : Types.label_declaration) ->
@@ -1380,7 +1388,7 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
         type_is_newtype = false;
         type_expansion_scope = Btype.lowest_level;
         type_loc = decl.type_loc;
-        type_attributes = decl.type_attributes;
+        type_attributes = List.filter keep_decl_attribute decl.type_attributes;
         type_unboxed_default = false;
         type_uid = Uid.unboxed_version decl.type_uid;
         type_unboxed_version = None;
@@ -2036,6 +2044,11 @@ let rec update_decl_jkind env dpath decl =
   let represent_as_float_array =
     Builtin_attributes.has_represent_as_float_array decl.type_attributes
   in
+  if represent_as_float_array then begin
+    match decl.type_kind with
+    | Type_record _ -> ()
+    | _ -> raise (Error (decl.type_loc, Bad_represent_as_float_array_attribute))
+  end;
   (* returns updated labels, updated rep, and updated jkind *)
   let update_record_kind loc lbls rep =
     match lbls, rep with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -157,6 +157,7 @@ type error =
   | Missing_flatten_floats
   | Misplaced_flatten_floats
   | Recursive_jkind_definition of Path.t * Env.t * reaching_kind_path
+  | Bad_represent_as_float_array_attribute
 
 open Typedtree
 
@@ -2032,6 +2033,9 @@ let rec update_decl_jkind env dpath decl =
          voids : bool;
     }
   end in
+  let represent_as_float_array =
+    Builtin_attributes.has_represent_as_float_array decl.type_attributes
+  in
   (* returns updated labels, updated rep, and updated jkind *)
   let update_record_kind loc lbls rep =
     match lbls, rep with
@@ -2090,6 +2094,17 @@ let rec update_decl_jkind env dpath decl =
         let summary : Imm_element_rep.element_repr_summary =
           { values; floats; atomic_floats; float64s;
             non_float64_unboxed_fields; atomic_fields; voids }
+        in
+        let mixed_record () =
+          let shape =
+            Element_repr.mixed_product_shape loc reprs Record
+          in
+          let shape =
+            match shape with
+            | Some x -> x
+            | None -> Misc.fatal_error "expected mixed block"
+          in
+          Record_mixed shape
         in
         match summary with
         (* We store floats flatly in mixed records if all fields are
@@ -2156,15 +2171,7 @@ let rec update_decl_jkind env dpath decl =
         | { float64s = true; voids = true; atomic_fields = false }
         | { values = true; float64s = true; atomic_fields = false }
         | { non_float64_unboxed_fields = true; atomic_fields = false } ->
-            let shape =
-              Element_repr.mixed_product_shape loc reprs Record
-            in
-            let shape =
-              match shape with
-              | Some x -> x
-              | None -> Misc.fatal_error "expected mixed block"
-            in
-            Record_mixed shape
+            mixed_record ()
         (* value-only records are stored as boxed records *)
         | { values = true; float64s = false; non_float64_unboxed_fields = false;
             voids = false }
@@ -2179,7 +2186,10 @@ let rec update_decl_jkind env dpath decl =
         | { values = false; floats = false; atomic_floats = false;
             float64s = true; non_float64_unboxed_fields = false;
             voids = false } ->
-          Record_ufloat
+          if represent_as_float_array then
+            Record_ufloat
+          else
+            mixed_record ()
         (* Records with atomic float fields cannot use flat representation *)
         | { atomic_floats = true; floats; values; _ } ->
           if floats && not values
@@ -2334,6 +2344,8 @@ let rec update_decl_jkind env dpath decl =
       }
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in
+      if represent_as_float_array && rep <> Record_ufloat then
+        raise (Error (decl.type_loc, Bad_represent_as_float_array_attribute));
       (* See Note [Quality of jkinds during inference] for more information about when we
          mark jkinds as best *)
       let type_jkind = Jkind.mark_best type_jkind in
@@ -5431,6 +5443,11 @@ let report_error_doc ppf = function
     fprintf ppf "@[<v>The kind %a is cyclic%a@]"
       (Style.as_inline_code Printtyp.path) path
       Reaching_path.pp_kind_colon reaching_path
+  | Bad_represent_as_float_array_attribute ->
+    fprintf ppf
+      "@[%a can only be used on records whose fields \
+       are all float64.@]"
+      Style.inline_code "[@@represent_as_float_array]"
 
 
 let () =

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -225,6 +225,7 @@ type error =
   | Missing_flatten_floats
   | Misplaced_flatten_floats
   | Recursive_jkind_definition of Path.t * Env.t * reaching_kind_path
+  | Bad_represent_as_float_array_attribute
 
 exception Error of Location.t * error
 


### PR DESCRIPTION
Currently, records whose fields are all `float64` are represented as float array blocks.
```ocaml
type t = { f : float#; g : float# }
```
We change them to be mixed blocks, which makes them consistent with single-constructor variants like the following.
```ocaml
type t = A of float# * float#
```

These records now get unboxed versions, but no longer support polymorphic compare or marshaling. Accordingly, the compiler release with this change must bump the mixed block version. It was already bumped in https://github.com/oxcaml/oxcaml/pull/5774.

### Legacy representation support

As some existing code depends on the old representation, we add the attribute `[@@represent_as_float_array]`, which opts into the old representation. These records still do not get unboxed versions.
```ocaml
type t = { f : float#; g : float# }
[@@represent_as_float_array]
```

It is an error to add this attribute to something other than a `float64` record. 