### PR TITLE
Delete `equal_obj` and `equal_morph`, using compare instead

### DIFF
--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -306,14 +306,6 @@ module Per_axis = struct
       | Nullability -> Nullability.print
       | Separability -> Separability.print
 
-    let equal_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
-     fun a b ->
-      match a, b with
-      | Externality, Externality -> Some Refl
-      | Nullability, Nullability -> Some Refl
-      | Separability, Separability -> Some Refl
-      | _ -> None
-
     let compare_obj : type a b. a t -> b t -> (a, b) Misc.comparison =
      fun a b ->
       match a, b with
@@ -361,13 +353,6 @@ module Per_axis = struct
   let print : type a. a t -> Fmt.formatter -> a -> unit = function
     | Modal ax -> Mode.Crossing.Per_axis.print ax
     | Nonmodal ax -> Nonmodal.print ax
-
-  let equal_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
-   fun a b ->
-    match a, b with
-    | Modal ax0, Modal ax1 -> Mode.Crossing.Per_axis.equal_obj ax0 ax1
-    | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.equal_obj ax0 ax1
-    | _ -> None
 
   let compare_obj : type a b. a t -> b t -> (a, b) Misc.comparison =
    fun a b ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1076,6 +1076,14 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.le a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.le a b
 
+  let compare : type a. a obj -> a -> a -> (a, a) Misc.comparison =
+   fun obj c1 c2 ->
+    if le obj c1 c2
+    then begin
+      if le obj c2 c1 then Equal else Less_than
+    end
+    else Greater_than
+
   let equal : type a. a obj -> a -> a -> bool =
    fun obj a b ->
     match obj with
@@ -1564,12 +1572,10 @@ module Lattices_mono = struct
       | Equal -> Equal)
     | Min_with _, _ -> Less_than
     | _, Min_with _ -> Greater_than
-    | Meet_const c1, Meet_const c2 ->
-      if c1 = c2 then Equal else if c1 < c2 then Less_than else Greater_than
+    | Meet_const c1, Meet_const c2 -> compare dst c1 c2
     | Meet_const _, _ -> Less_than
     | _, Meet_const _ -> Greater_than
-    | Imply_const c1, Imply_const c2 ->
-      if c1 = c2 then Equal else if c1 < c2 then Less_than else Greater_than
+    | Imply_const c1, Imply_const c2 -> compare dst c1 c2
     | Imply_const _, _ -> Less_than
     | _, Imply_const _ -> Greater_than
     | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Equal

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1165,30 +1165,6 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.print
     | Comonadic_with_regionality -> Comonadic_with_regionality.print
 
-  let equal_obj : type a b. a obj -> b obj -> (a, b) Misc.eq option =
-   fun a b ->
-    match a, b with
-    | Locality, Locality -> Some Refl
-    | Regionality, Regionality -> Some Refl
-    | Uniqueness_op, Uniqueness_op -> Some Refl
-    | Contention_op, Contention_op -> Some Refl
-    | Visibility_op, Visibility_op -> Some Refl
-    | Linearity, Linearity -> Some Refl
-    | Portability, Portability -> Some Refl
-    | Forkable, Forkable -> Some Refl
-    | Yielding, Yielding -> Some Refl
-    | Statefulness, Statefulness -> Some Refl
-    | Staticity_op, Staticity_op -> Some Refl
-    | Monadic_op, Monadic_op -> Some Refl
-    | Comonadic_with_locality, Comonadic_with_locality -> Some Refl
-    | Comonadic_with_regionality, Comonadic_with_regionality -> Some Refl
-    | ( ( Locality | Regionality | Uniqueness_op | Contention_op | Visibility_op
-        | Linearity | Portability | Forkable | Yielding | Statefulness
-        | Staticity_op | Monadic_op | Comonadic_with_locality
-        | Comonadic_with_regionality ),
-        _ ) ->
-      None
-
   let compare_obj : type a b. a obj -> b obj -> (a, b) Misc.comparison =
    fun a b ->
     match a, b with
@@ -1552,66 +1528,6 @@ module Lattices_mono = struct
       let dst0 = proj_obj Areality dst in
       let src0 = src dst0 f in
       comonadic_with_obj src0
-
-  let rec equal_morph : type a1 l1 r1 a2 b l2 r2.
-      b obj ->
-      (a1, b, l1 * r1) morph ->
-      (a2, b, l2 * r2) morph ->
-      (a1, a2) Misc.eq option =
-   fun _dst f1 f2 ->
-    match f1, f2 with
-    | Id, Id -> Some Refl
-    | Proj (src1, ax1), Proj (src2, ax2) -> (
-      match equal_obj src1 src2 with
-      | Some Refl -> (
-        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
-      | None -> None)
-    | Max_with ax1, Max_with ax2 -> (
-      match Axis.equal ax1 ax2 with Some Refl -> Some Refl | None -> None)
-    | Min_with ax1, Min_with ax2 -> (
-      match Axis.equal ax1 ax2 with Some Refl -> Some Refl | None -> None)
-    | Meet_const c1, Meet_const c2 ->
-      (* This polymorphic equality is correct only if runtime representation
-         uniquely identifies a constant, which could be false. For example,
-         the lattice of rational number would be represented as the tuple of
-         numerator and denominator, and (9,4) and (18, 8) means the same
-         thing. However, even in that case, it's not unsound, as [equal_morph] is
-         not requird to be complete: i.e., it's allowed to return [None] when
-         it should return [Some Refl]. It would cause duplication but not error. *)
-      if c1 = c2 then Some Refl else None
-    | Imply_const c1, Imply_const c2 -> if c1 = c2 then Some Refl else None
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Some Refl
-    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 -> begin
-      match equal_obj a1 a2 with None -> None | Some Refl -> Some Refl
-    end
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Some Refl
-    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 -> begin
-      match equal_obj a1 a2 with None -> None | Some Refl -> Some Refl
-    end
-    | Local_to_regional, Local_to_regional -> Some Refl
-    | Locality_as_regionality, Locality_as_regionality -> Some Refl
-    | Global_to_regional, Global_to_regional -> Some Refl
-    | Regional_to_local, Regional_to_local -> Some Refl
-    | Regional_to_global, Regional_to_global -> Some Refl
-    | Compose (f1, g1), Compose (f2, g2) -> (
-      match equal_morph _dst f1 f2 with
-      | None -> None
-      | Some Refl -> (
-        match equal_morph (src _dst f1) g1 g2 with
-        | None -> None
-        | Some Refl -> Some Refl))
-    | Map_comonadic f, Map_comonadic g -> (
-      match equal_morph (proj_obj Areality _dst) f g with
-      | Some Refl -> Some Refl
-      | None -> None)
-    | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_const _
-        | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
-        | Monadic_to_comonadic_max | Comonadic_to_monadic_max _
-        | Local_to_regional | Locality_as_regionality | Global_to_regional
-        | Regional_to_local | Regional_to_global | Compose _ | Map_comonadic _
-        | Imply_const _ ),
-        _ ) ->
-      None
 
   let rec compare_morph : type a1 l1 r1 a2 b l2 r2.
       b obj ->
@@ -2707,9 +2623,9 @@ module Report = struct
 
   let equal_mode : type a b. a C.obj -> b C.obj -> a -> b -> bool =
    fun a_obj b_obj a b ->
-    match C.equal_obj a_obj b_obj with
-    | Some Refl -> Misc.Le_result.equal ~le:(C.le a_obj) a b
-    | None -> false
+    match C.compare_obj a_obj b_obj with
+    | Equal -> Misc.Le_result.equal ~le:(C.le a_obj) a b
+    | Less_than | Greater_than -> false
 
   let rec print_ahint : type a l r.
       ?sub:bool ->
@@ -3462,11 +3378,6 @@ module Comonadic_with (Areality : Areality) = struct
         let obj = (proj_obj [@inlined hint]) ax in
         (C.min [@inlined hint]) obj
 
-      let equal_obj ax1 ax2 =
-        let obj1 = proj_obj ax1 in
-        let obj2 = proj_obj ax2 in
-        C.equal_obj obj1 obj2
-
       let compare_obj ax1 ax2 =
         let obj1 = proj_obj ax1 in
         let obj2 = proj_obj ax2 in
@@ -3607,11 +3518,6 @@ module Monadic = struct
       let min ax =
         let obj = (proj_obj [@inlined hint]) ax in
         (C.max [@inlined hint]) obj
-
-      let equal_obj ax1 ax2 =
-        let obj1 = proj_obj ax1 in
-        let obj2 = proj_obj ax2 in
-        C.equal_obj obj1 obj2
 
       let compare_obj ax1 ax2 =
         let obj1 = proj_obj ax1 in
@@ -5201,15 +5107,6 @@ module Crossing = struct
       | P (Monadic ax) -> P (Monadic ax)
       | P (Comonadic ax) -> P (Comonadic ax)
 
-    let equal : type a b. a t -> b t -> (a, b) Misc.eq option =
-     fun ax1 ax2 ->
-      match ax1, ax2 with
-      | Monadic ax1, Monadic ax2 -> (
-        match Axis.equal ax1 ax2 with Some Refl -> Some Refl | None -> None)
-      | Comonadic ax1, Comonadic ax2 -> (
-        match Axis.equal ax1 ax2 with Some Refl -> Some Refl | None -> None)
-      | Monadic _, Comonadic _ | Comonadic _, Monadic _ -> None
-
     let compare : type a b. a t -> b t -> (a, b) Misc.comparison =
      fun ax1 ax2 ->
       match ax1, ax2 with
@@ -5274,8 +5171,6 @@ module Crossing = struct
       | Comonadic ax -> Comonadic.Atom.print ax
 
     let print_obj = Axis.print
-
-    let equal_obj = Axis.equal
 
     let compare_obj = Axis.compare
   end

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -764,9 +764,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     Morphvar.(
       disallow_left (disallow_right mv0) == disallow_left (disallow_right mv1))
     ||
-    match C.equal_morph dst f0 f1 with
-    | None -> false
-    | Some Refl -> v0 == v1
+    match C.compare_morph dst f0 f1 with
+    | Less_than | Greater_than -> false
+    | Equal -> v0 == v1
 
   let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -276,8 +276,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     { mutable vlower : 'a lmorphvar VarMap.t;
           (** A list of variables directly under the current variable. Each is a
               pair [f] [v], and we have [f v <= u] where [u] is the current
-              variable. TODO: consider using hashset for quicker deduplication
-          *)
+              variable. *)
       mutable upper : 'a;  (** The precise upper bound of the variable *)
       mutable upper_hint : ('a, right_only) Comp_hint.t;
           (** Hints for [upper] *)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -47,6 +47,8 @@ module type Lattices = sig
 
   val print : 'a obj -> Fmt.formatter -> 'a elt -> unit
 
+  (** Compares two objects. Used for deduplication only; it is sound (but not
+      recommended) to return a nonzero value for equal objects. *)
   val compare_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.comparison
 
   val print_obj : Fmt.formatter -> 'a obj -> unit

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -47,8 +47,6 @@ module type Lattices = sig
 
   val print : 'a obj -> Fmt.formatter -> 'a elt -> unit
 
-  val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.eq option
-
   val compare_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.comparison
 
   val print_obj : Fmt.formatter -> 'a obj -> unit
@@ -151,17 +149,8 @@ module type Lattices_mono = sig
   (** Apply morphism on constant *)
   val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
 
-  (** Checks if two morphisms are equal. Used for deduplication only; it is fine
-      (but not recommended) to return [Not_equal] for equal morphisms. *)
-  val equal_morph :
-    'b obj ->
-    ('a0, 'b, 'l0 * 'r0) morph ->
-    ('a1, 'b, 'l1 * 'r1) morph ->
-    ('a0, 'a1) Misc.eq option
-
-  (** Compares two morphisms. Should be compatible with [equal_morph]. Used for
-      deduplication only; it is fine (but not recommended) to return a nonzero
-      value for equal morphisms. *)
+  (** Compares two morphisms. Used for deduplication only; it is fine (but not
+      recommended) to return a nonzero value for equal morphisms. *)
   val compare_morph :
     'b obj ->
     ('a0, 'b, 'd0) morph ->


### PR DESCRIPTION
What the title says - it also reduces memory allocation and indirection.