### PR TITLE
Fix annoying REPL issue with the metaprogramming syntax directive

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -929,7 +929,9 @@ and directive already_consumed = parse
         match mode with
         | "quotations" ->
             Syntax_mode.quotations := toggle;
-            token lexbuf
+            let tok = token lexbuf in
+            enqueue_token_from_end_of_lexbuf_window lexbuf SEMISEMI ~len:0;
+            tok
         | _ ->
             directive_error lexbuf ("unknown syntax mode " ^ mode)
               ~already_consumed ~directive:"syntax"


### PR DESCRIPTION
# Status quo
When invoking the REPL, the `#syntax quotations on` line requires that we place a double semicolon on a separate line in order to properly parse the next definition.
```
# #syntax quotations on
;;
# <[42]>;;
```
The cause of this is the way the lexer processes the directive.

# Fix
A `SEMISEMI` token is inserted as a terminator when the line is lexed. While not the most elegant solution, it ensures that the toplevel correctly terminates.