### PR TITLE
Fix bug in merged mmap_ba.c

### DIFF
--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -61,7 +61,7 @@ static struct custom_operations caml_ba_mapped_ops = {
 CAMLexport value
 caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
 {
-  uintnat asize, num_elts = 1, mem_bytes, mem_words;
+  uintnat asize, mem_words;
   value res;
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
@@ -69,20 +69,9 @@ caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
   CAMLassert(0 <= num_dims);
   CAMLassert(num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) < CAML_BA_FIRST_UNIMPLEMENTED_KIND);
-  for (int i = 0; i < num_dims; i++) {
-    num_elts *= dim[i];
-    dimcopy[i] = dim[i];
-  }
+  for (int i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);
   res = caml_alloc_custom(&caml_ba_mapped_ops, asize, 0, 1);
-  mem_bytes = num_elts * caml_ba_element_size[flags & CAML_BA_KIND_MASK];
-  mem_words = (mem_bytes + sizeof(value) - 1) / sizeof(value);
-#ifdef CAML_RUNTIME_5
-  caml_memprof_sample_block(res, mem_words, mem_words, CAML_MEMPROF_SRC_CUSTOM);
-#else
-  (void)mem_words; /* unused in runtime4 */
-  caml_memprof_track_custom(res, mem_bytes);
-#endif
   b = Caml_ba_array_val(res);
   b->data = data;
   b->num_dims = num_dims;
@@ -90,7 +79,12 @@ caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
   b->proxy = NULL;
   for (int i = 0; i < num_dims; i++) b->dim[i] = dimcopy[i];
   mem_words = (caml_ba_byte_size(b) + sizeof(value) - 1) / sizeof(value);
+#ifdef CAML_RUNTIME_5
   caml_memprof_sample_block(
     res, mem_words, mem_words, CAML_MEMPROF_SRC_MAP_FILE);
+#else
+  (void)mem_words; /* unused in runtime4 */
+  caml_memprof_track_custom(res, caml_ba_byte_size(b));
+#endif
   return res;
 }


### PR DESCRIPTION
This bug causes a test suite failure (`statmemprof/bigarray`). This version of the fix tries to stick as close as possible to the 5.4 code.