### PR TITLE
Patricia trees: additional union_total function families to avoid allocations

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -36,6 +36,15 @@ module Make_map (T : Thing) (Set : Set_plus_stdlib with type elt = T.t) = struct
 
   let of_list l = List.fold_left (fun map (id, v) -> add id v map) empty l
 
+  let union_total f t1 t2 =
+    union (fun key datum1 datum2 -> Some (f key datum1 datum2)) t1 t2
+
+  let union_total_shared f t1 t2 = union_total f t1 t2
+
+  let union_left_biased t1 t2 = union_total (fun _ left _right -> left) t1 t2
+
+  let union_right_biased t1 t2 = union_total (fun _ _left right -> right) t1 t2
+
   let disjoint_union ?eq ?print m1 m2 =
     ignore print;
     union

--- a/middle_end/flambda2/algorithms/container_types_intf.ml
+++ b/middle_end/flambda2/algorithms/container_types_intf.ml
@@ -152,10 +152,8 @@ module type Map = sig
   val merge :
     (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
 
-  (* CR lmaurer: It's mentioned in [Stdlib.Map], but we really should be rid of
-     the option type here. Surely anything that doesn't always return [Some] is
-     niche enough that it can use [merge] (and we can generalize [merge] to
-     cover it efficiently). *)
+  (** When the function always returns [Some _], [union_total] has better
+      performance. *)
   val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
 
   (** [union_sharing f m1 m2] is a version of [union f m1 m2] that maximizes
@@ -166,6 +164,24 @@ module type Map = sig
       exploits sharing of [m1] and [m2] to avoid calling [f] when possible,
       assuming that [f x x = Some x] for all [x]s. *)
   val union_shared : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  (** [union_total f m1 m2] is the same as
+      [union (fun k x y -> Some (f k x y)) m1 m2] *)
+  val union_total : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+
+  (** [union_total_shared f m1 m2] is a version of [union_total f m1 m2] that
+      also exploits sharing of [m1] and [m2] to avoid calling [f] when possible,
+      assuming that [f k x x = x] for all keys [k] and values [x]. It also
+      maximises sharing with [m1]. *)
+  val union_total_shared : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+
+  (** [union_left_biased m1 m2] is the same as
+      [union_total_shared (fun _ l _ -> l) m1 m2] *)
+  val union_left_biased : 'a t -> 'a t -> 'a t
+
+  (** [union_right_biased m1 m2] is the same as
+      [union_total_shared (fun _ _ r -> r) m1 m2] *)
+  val union_right_biased : 'a t -> 'a t -> 'a t
 
   val update_many :
     (key -> 'a option -> 'b -> 'a option) -> 'a t -> 'b t -> 'a t

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -355,6 +355,14 @@ module Tree_operations (Tree : Tree) : sig
 
   val union_shared : ('a, 'a, 'a) Merge_callback.t -> 'a t -> 'a t -> 'a t
 
+  val union_total : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+
+  val union_total_shared : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+
+  val union_left_biased : 'a t -> 'a t -> 'a t
+
+  val union_right_biased : 'a t -> 'a t -> 'a t
+
   val update_many :
     (key -> 'a option -> 'b -> 'a option) -> 'a t -> 'b t -> 'a t
 
@@ -646,7 +654,7 @@ end = struct
 
   let no_phys_eq_shortcut _iv _t0 _t1 = None
 
-  let phys_eq_shortcut_union_left _iv t0 t1 = if t0 == t1 then Some t0 else None
+  let phys_eq_shortcut_union _iv t0 t1 = if t0 == t1 then Some t0 else None
 
   let phys_eq_shortcut_diff iv t0 t1 =
     if t0 == t1 then Some (empty iv) else None
@@ -800,8 +808,7 @@ end = struct
 
   let rec union_shared f t0 t1 =
     let iv = is_value_of t0 in
-    pattern_match_pair_merge_sharing
-      ~phys_eq_shortcut:phys_eq_shortcut_union_left
+    pattern_match_pair_merge_sharing ~phys_eq_shortcut:phys_eq_shortcut_union
       ~phys_eq_check_branch_right:phys_eq_check_branch
       ~phys_eq_check_leaf_right:phys_eq_check_leaf
       ~only_left:(fun t0 -> t0)
@@ -809,6 +816,52 @@ end = struct
       ~both_sides:(fun t0 t1 -> union_shared f t0 t1)
       iv
       (fun[@inline] k t t' -> Merge_callback.call_union f k t t')
+      t0 t1
+
+  let rec union_total f t0 t1 =
+    let iv = is_value_of t0 in
+    pattern_match_pair_merge
+      ~only_left:(fun t0 -> t0)
+      ~only_right:(fun t1 -> t1)
+      ~both_sides:(fun t0 t1 -> union_total f t0 t1)
+      iv
+      (fun[@inline] k t t' -> Some (f k t t'))
+      t0 t1
+
+  let rec union_total_shared f t0 t1 =
+    let iv = is_value_of t0 in
+    pattern_match_pair_merge_sharing ~phys_eq_shortcut:phys_eq_shortcut_union
+      ~phys_eq_check_branch_right:phys_eq_check_branch
+      ~phys_eq_check_leaf_right:phys_eq_check_leaf
+      ~only_left:(fun t0 -> t0)
+      ~only_right:(fun t1 -> t1)
+      ~both_sides:(fun t0 t1 -> union_total_shared f t0 t1)
+      iv
+      (fun[@inline] k t t' -> Some (f k t t'))
+      t0 t1
+
+  let rec union_left_biased t0 t1 =
+    let iv = is_value_of t0 in
+    pattern_match_pair_merge_sharing ~phys_eq_shortcut:phys_eq_shortcut_union
+      ~phys_eq_check_branch_right:phys_eq_check_branch
+      ~phys_eq_check_leaf_right:phys_eq_check_leaf
+      ~only_left:(fun t0 -> t0)
+      ~only_right:(fun t1 -> t1)
+      ~both_sides:(fun t0 t1 -> union_left_biased t0 t1)
+      iv
+      (fun[@inline] _k t _t' -> Some t)
+      t0 t1
+
+  let rec union_right_biased t0 t1 =
+    let iv = is_value_of t0 in
+    pattern_match_pair_merge_sharing ~phys_eq_shortcut:phys_eq_shortcut_union
+      ~phys_eq_check_branch_right:phys_eq_check_branch
+      ~phys_eq_check_leaf_right:phys_eq_check_leaf
+      ~only_left:(fun t0 -> t0)
+      ~only_right:(fun t1 -> t1)
+      ~both_sides:(fun t0 t1 -> union_right_biased t0 t1)
+      iv
+      (fun[@inline] _k _t t' -> Some t')
       t0 t1
 
   let rec diff f t0 t1 =

--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -52,7 +52,7 @@ let add_code ~keep_code code_map t =
 let mark_as_imported t =
   Code_id.Map.map_sharing Code_or_metadata.remember_only_metadata t
 
-let merge t1 t2 = Code_id.Map.union Code_or_metadata.merge t1 t2
+let merge t1 t2 = Code_id.Map.union_total Code_or_metadata.merge t1 t2
 
 let mem code_id t = Code_id.Map.mem code_id t
 

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -181,13 +181,13 @@ module Map = struct
   let is_empty = Int.Map.is_empty
 
   let concat ~earlier:tables1 ~later:tables2 =
-    Int.Map.union
+    Int.Map.union_total
       (fun _ (Binding (id1, table1)) (Binding (id2, table2)) ->
         let table =
           concat (Id.is_trie id1) ~earlier:table1
             ~later:(Id.cast_exn id2 id1 table2)
         in
-        Some (Binding (id1, table)))
+        Binding (id1, table))
       tables1 tables2
 
   let fold ~f m ~init = Int.Map.fold (fun _ binding acc -> f binding acc) m init

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -238,9 +238,9 @@ end = struct
   let diff t1 t2 = N.Map.diff_domains t1 t2
 
   let union t1 t2 =
-    N.Map.union
+    N.Map.union_total
       (fun _name for_one_name1 for_one_name2 ->
-        Some (For_one_name.union for_one_name1 for_one_name2))
+        For_one_name.union for_one_name1 for_one_name2)
       t1 t2
 
   let keys t = N.Map.keys t
@@ -649,6 +649,29 @@ let binary_op ~for_names ~for_continuations ~for_function_slots ~for_value_slots
     newer_version_of_code_ids
   }
 
+let is_empty
+    { names;
+      continuations;
+      continuations_with_traps;
+      continuations_in_trap_actions;
+      function_slots_in_projections;
+      value_slots_in_projections;
+      function_slots_in_declarations;
+      value_slots_in_declarations;
+      code_ids;
+      newer_version_of_code_ids
+    } =
+  For_names.is_empty names
+  && For_continuations.is_empty continuations
+  && For_continuations.is_empty continuations_with_traps
+  && For_continuations.is_empty continuations_in_trap_actions
+  && For_function_slots.is_empty function_slots_in_projections
+  && For_value_slots.is_empty value_slots_in_projections
+  && For_function_slots.is_empty function_slots_in_declarations
+  && For_value_slots.is_empty value_slots_in_declarations
+  && For_code_ids.is_empty code_ids
+  && For_code_ids.is_empty newer_version_of_code_ids
+
 let diff
     { names = names1;
       continuations = continuations1;
@@ -716,11 +739,16 @@ let diff
   }
 
 let union t1 t2 =
-  binary_op ~for_names:For_names.union
-    ~for_continuations:For_continuations.union
-    ~for_function_slots:For_function_slots.union
-    ~for_value_slots:For_value_slots.union ~for_code_ids:For_code_ids.union t1
-    t2
+  if is_empty t1
+  then t2
+  else if is_empty t2
+  then t1
+  else
+    binary_op ~for_names:For_names.union
+      ~for_continuations:For_continuations.union
+      ~for_function_slots:For_function_slots.union
+      ~for_value_slots:For_value_slots.union ~for_code_ids:For_code_ids.union t1
+      t2
 
 let equal t1 t2 =
   binary_conjunction ~for_names:For_names.equal
@@ -764,8 +792,7 @@ let inter_domain_is_non_empty t1 t2 =
     ~for_value_slots:For_value_slots.inter_domain_is_non_empty
     ~for_code_ids:For_code_ids.inter_domain_is_non_empty t1 t2
 
-let rec union_list ts =
-  match ts with [] -> empty | t :: ts -> union t (union_list ts)
+let union_list ts = List.fold_left union empty ts
 
 let function_slots_in_normal_projections t =
   For_function_slots.fold_with_mode t.function_slots_in_projections

--- a/middle_end/flambda2/nominal/permutation.ml
+++ b/middle_end/flambda2/nominal/permutation.ml
@@ -74,10 +74,6 @@ module Make (N : Container_types.S) = struct
     invariant t;
     t
 
-  (* CR-someday lmaurer: Define [N.Map.left_union] so we don't have this Some
-     silliness. *)
-  let left_union map1 map2 = N.Map.union (fun _k l _r -> Some l) map1 map2
-
   let compose ~second ~first =
     (* Find the triples [n1, n2, n3] where [first n1 = n2] and [second n2 =
        n3]. *)
@@ -87,7 +83,7 @@ module Make (N : Container_types.S) = struct
     (* Take the union of the forward directions, taking the first in case of a
        collision (since the first is the one that will actually act on the
        key) *)
-    let forwards = left_union first.forwards second.forwards in
+    let forwards = N.Map.union_left_biased first.forwards second.forwards in
     (* Add a correction for each chained triple [n1, n2, n3]. The above left
        union maps [n1] to [n2], and we need it to map to [n3] instead. One might
        worry that the left union also includes an erroneous binding from [n2] to
@@ -103,7 +99,7 @@ module Make (N : Container_types.S) = struct
     in
     (* Similarly, take the union of the backward directions, only now the second
        permutation wins because it acts first *)
-    let backwards = left_union second.backwards first.backwards in
+    let backwards = N.Map.union_left_biased second.backwards first.backwards in
     (* Again, correct for each chained triple *)
     let backwards =
       N.Map.fold (fun _ (n1, n3) -> add_to_map n3 n1) chained backwards

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.ml
@@ -64,8 +64,8 @@ let all_continuations_used t = Continuation.Map.keys t.continuation_uses
 
 let union t1 t2 =
   let continuation_uses =
-    Continuation.Map.union
-      (fun _ uses1 uses2 -> Some (Continuation_uses.union uses1 uses2))
+    Continuation.Map.union_total
+      (fun _ uses1 uses2 -> Continuation_uses.union uses1 uses2)
       t1.continuation_uses t2.continuation_uses
   in
   { continuation_uses }

--- a/middle_end/flambda2/terms/code_or_metadata.ml
+++ b/middle_end/flambda2/terms/code_or_metadata.ml
@@ -140,7 +140,7 @@ let merge code_id t1 t2 =
   match t1, t2 with
   | Metadata_only cm1, Metadata_only cm2 ->
     if Code_metadata.approx_equal cm1 cm2
-    then Some t1
+    then t1
     else
       Misc.fatal_errorf
         "Code id %a is imported with different code metadata (%a and %a)"
@@ -152,7 +152,7 @@ let merge code_id t1 t2 =
   | (Code_present { code_status } as t), Metadata_only cm_imported ->
     let cm_present = code_status_metadata code_status in
     if Code_metadata.approx_equal cm_present cm_imported
-    then Some t
+    then t
     else
       Misc.fatal_errorf
         "Code_id %a is present with code metadata@ %abut imported with code \

--- a/middle_end/flambda2/terms/code_or_metadata.mli
+++ b/middle_end/flambda2/terms/code_or_metadata.mli
@@ -34,7 +34,7 @@ val print : Format.formatter -> t -> unit
 
 val print_view : Format.formatter -> t -> unit
 
-val merge : Code_id.t -> t -> t -> t option
+val merge : Code_id.t -> t -> t -> t
 
 val create : Code.t -> t
 

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -42,15 +42,13 @@ module Map_to_canonical = struct
       map1 map2
 
   let union map1 map2 =
-    Name.Map.union
+    Name.Map.union_total_shared
       (fun elt coercion1 coercion2 ->
-        match coercion1, coercion2 with
-        | coercion1, coercion2 ->
-          if Coercion.equal coercion1 coercion2
-          then Some coercion1
-          else
-            fatal_inconsistent ~func_name:"Aliases.Map_to_canonical.union" elt
-              coercion1 coercion2)
+        if Coercion.equal coercion1 coercion2
+        then coercion1
+        else
+          fatal_inconsistent ~func_name:"Aliases.Map_to_canonical.union" elt
+            coercion1 coercion2)
       map1 map2
 
   let ids_for_export t =
@@ -120,7 +118,7 @@ end = struct
       let aliases_union : Map_to_canonical.t =
         Name_mode.Map.fold
           (fun _name_mode map acc ->
-            Name.Map.union
+            Name.Map.union_total
               (fun elt _coercion1 _coercion2 ->
                 Misc.fatal_errorf
                   "[Aliases_of_canonical_element.invariant]: element %a \
@@ -184,8 +182,8 @@ end = struct
 
   let union t1 t2 =
     let aliases : Map_to_canonical.t Name_mode.Map.t =
-      Name_mode.Map.union
-        (fun _order elts1 elts2 -> Some (Map_to_canonical.union elts1 elts2))
+      Name_mode.Map.union_total_shared
+        (fun _order elts1 elts2 -> Map_to_canonical.union elts1 elts2)
         t1.aliases t2.aliases
     in
     let t = { aliases; all = Map_to_canonical.union t1.all t2.all } in

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -140,10 +140,10 @@ let merge t1 t2 =
   in
   let aliases = Aliases.empty in
   let symbol_projections =
-    Variable.Map.union
+    Variable.Map.union_total_shared
       (fun var proj1 proj2 ->
         if Symbol_projection.equal proj1 proj2
-        then Some proj1
+        then proj1
         else
           Misc.fatal_errorf
             "Cannot merge symbol projections for %a:@ %a@ and@ %a"

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -2051,9 +2051,7 @@ let prepare_nested_join ~meet_type ~joined_envs ~bindings extensions =
          we want maximum sharing with [diff] (see the computation of
          [previous_equations] below). *)
       let current_equations =
-        Name.Map.union_sharing
-          (fun _ diff_ty _previous_ty -> Some diff_ty)
-          diff_equations previous_equations
+        Name.Map.union_left_biased diff_equations previous_equations
       in
       (* Drop variables from the previous level if they get a more precise type
          in the current level (otherwise they would appear in both $Pi$ and $Δi$
@@ -2079,13 +2077,10 @@ let prepare_nested_join ~meet_type ~joined_envs ~bindings extensions =
           Bindings_in_target_env.definition_of_local_variables_in_one_joined_env
             bindings index
         in
-        Name.Map.union
-          (fun _ previous _defining_eqn ->
-            (* Sometimes we might have already added the defining equation of an
-               existential due to [replay_definition_of_aliases_in_target_env],
-               which is fine. *)
-            Some previous)
-          previous_equations
+        (* Sometimes we might have already added the defining equation of an
+           existential due to [replay_definition_of_aliases_in_target_env],
+           which is fine. *)
+        Name.Map.union_left_biased previous_equations
           (Name.var_map
              (defining_equations_of_existential_vars
                : Type_in_one_joined_env.t Variable_in_target_env.Map.t

--- a/middle_end/flambda2/types/env/typing_env_level.ml
+++ b/middle_end/flambda2/types/env/typing_env_level.ml
@@ -147,7 +147,7 @@ let add_or_replace_equation t name ty =
 
 let concat ~earlier:(t1 : t) ~later:(t2 : t) =
   let defined_vars =
-    Variable.Map.union
+    Variable.Map.union_total
       (fun var _data1 _data2 ->
         Misc.fatal_errorf
           "Cannot concatenate levels that have overlapping defined variables \
@@ -156,7 +156,7 @@ let concat ~earlier:(t1 : t) ~later:(t2 : t) =
       t1.defined_vars t2.defined_vars
   in
   let binding_times =
-    Binding_time.Map.union
+    Binding_time.Map.union_total
       (fun _binding_time vars1 vars2 ->
         (* CR vlaviron: Technically this is feasible, as we can allow several
            variables with the same binding time, but it should only come from
@@ -170,12 +170,10 @@ let concat ~earlier:(t1 : t) ~later:(t2 : t) =
   in
   let equations =
     (* We rely on the fact that equations in later levels are more precise *)
-    Name.Map.union (fun _ _ty1 ty2 -> Some ty2) t1.equations t2.equations
+    Name.Map.union_right_biased t1.equations t2.equations
   in
   let symbol_projections =
-    Variable.Map.union
-      (fun _var _proj1 proj2 -> Some proj2)
-      t1.symbol_projections t2.symbol_projections
+    Variable.Map.union_right_biased t1.symbol_projections t2.symbol_projections
   in
   { defined_vars; binding_times; equations; symbol_projections }
 

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -178,10 +178,10 @@ let construct_joined_level envs_with_levels ~env_at_fork ~allowed ~joined_types
             (TEL.defined_variables_with_kinds t)
         in
         let defined_vars =
-          Variable.Map.union
+          Variable.Map.union_total_shared
             (fun var kind1 kind2 ->
               if K.equal kind1 kind2
-              then Some kind1
+              then kind1
               else
                 Misc.fatal_errorf
                   "Cannot join levels that disagree on the kind of \
@@ -197,8 +197,8 @@ let construct_joined_level envs_with_levels ~env_at_fork ~allowed ~joined_types
             (TEL.variables_by_binding_time t)
         in
         let binding_times =
-          Binding_time.Map.union
-            (fun _bt vars1 vars2 -> Some (Variable.Set.union vars1 vars2))
+          Binding_time.Map.union_total_shared
+            (fun _bt vars1 vars2 -> Variable.Set.union vars1 vars2)
             binding_times binding_times_this_level
         in
         defined_vars, binding_times)

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -1427,11 +1427,11 @@ and meet_row_like :
   let add_extra_variables_and_extract_extension scoped_env =
     let level = ME.cut scoped_env ~cut_after:common_scope in
     extra_variables
-      := Variable.Map.union
+      := Variable.Map.union_total_shared
            (fun var k1 k2 ->
              if not (K.equal k1 k2)
              then Misc.fatal_errorf "Different kinds for %a" Variable.print var;
-             Some k1)
+             k1)
            !extra_variables
            (TEL.defined_variables_with_kinds level);
     TEE.from_map (TEL.equations level)


### PR DESCRIPTION
Extracted from #5627, but using the factorized patricia tree implementation. I have not tested how much of a gain this is.
Note that there are no callback functions as in #5770, because `union_total` does not make sense compared to `union` on sets.