### PR TITLE
Two minor arm64 fixes for 5.4

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -23,7 +23,7 @@
 
 #if defined(SYS_macosx)
 
-#define CAMLSEP(x,y) caml_##x##$##y
+#define CAMLSEP(x,y) caml_##x##__##y
 #define LBL(x) L##x
 #define G(r) _##r
 #define GREL(r) _##r@GOTPCREL
@@ -39,7 +39,7 @@ G(name):
 
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)
 
-#define CAMLSEP(x,y) caml_##x##$##y
+#define CAMLSEP(x,y) caml_##x##__##y
 #define LBL(x) .L##x
 #define G(r) r
 #undef  GREL
@@ -56,7 +56,7 @@ G(name):
 
 #else /* Unix-like operating systems using ELF binaries */
 
-#define CAMLSEP(x,y) caml_##x##.##y
+#define CAMLSEP(x,y) caml_##x##__##y
 #define LBL(x) .L##x
 #define G(r) r
 #define GREL(r) r@GOTPCREL

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -71,11 +71,11 @@
 
 /* Globals and labels */
 #if defined(SYS_macosx)
-#define CAMLSEP(x,y) caml_##x##$##y
+#define CAMLSEP(x,y) caml_##x##__##y
 #define G(sym) _##sym
 #define L(lbl) L##lbl
 #else
-#define CAMLSEP(x,y) caml_##x##.##y
+#define CAMLSEP(x,y) caml_##x##__##y
 #define G(sym) sym
 #define L(lbl) .L##lbl
 #endif

--- a/runtime/caml/gc.h
+++ b/runtime/caml/gc.h
@@ -50,7 +50,6 @@
 struct caml_local_arena {
   char* base;
   uintnat length;
-  void* alloc_block;
 };
 typedef struct caml_local_arenas {
   int count;

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -99,23 +99,6 @@ CAMLextern caml_stat_block caml_stat_alloc(asize_t);
 CAMLmalloc(caml_stat_free, 1, 1)
 CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
 
-/* [caml_stat_alloc_aligned(size, modulo, block*)] allocates a memory block of
-   the requested [size] (in bytes), the starting address of which is aligned to
-   the provided [modulo] value. The function returns the aligned address, as
-   well as the unaligned [block] (as an output parameter). It throws an OCaml
-   exception in case the request fails, and so requires the runtime lock.
-*/
-CAMLaligned_alloc(caml_stat_free, 1, 1, 2) CAMLreturns_nonnull()
-CAMLextern void* caml_stat_alloc_aligned(asize_t, int modulo, caml_stat_block*);
-
-/* [caml_stat_alloc_aligned_noexc] is a variant of [caml_stat_alloc_aligned]
-   that returns NULL in case the request fails, and doesn't require the runtime
-   lock to be held.
-*/
-CAMLaligned_alloc(caml_stat_free, 1, 1, 2)
-CAMLextern void* caml_stat_alloc_aligned_noexc(asize_t, int modulo,
-                                               caml_stat_block*);
-
 /* [caml_stat_calloc_noexc(num, size)] allocates a block of memory for an array
    of [num] elements, each of them [size] bytes long, and initializes all its
    bits to zero, effectively allocating a zero-initialized memory block of

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -653,9 +653,6 @@ CAMLextern int caml_read_directory(char_os * dirname,
                                    struct ext_table * contents);
 
 /* Deprecated aliases */
-#define caml_aligned_malloc \
-   CAML_DEPRECATED("caml_aligned_malloc", "caml_stat_alloc_aligned_noexc") \
-   caml_stat_alloc_aligned_noexc
 #define caml_strdup \
    CAML_DEPRECATED("caml_strdup", "caml_stat_strdup") \
    caml_stat_strdup

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -619,7 +619,7 @@ void caml_free_local_arenas(caml_local_arenas* s) {
   if (s == NULL) return;
 
   for (int i = 0; i < s->count; i++) {
-    caml_stat_free(s->arenas[i].alloc_block);
+    caml_stat_free(s->arenas[i].base);
   }
 
   caml_stat_free(s);
@@ -630,7 +630,6 @@ void caml_local_realloc(void)
   caml_local_arenas* s = caml_refresh_locals(Caml_state->current_stack);
   intnat i;
   char* arena;
-  caml_stat_block block;
   if (s == NULL) {
     s = caml_stat_alloc(sizeof(*s));
     s->count = 0;
@@ -650,7 +649,7 @@ void caml_local_realloc(void)
     /* may need to loop, if a very large allocation was requested */
   } while (Caml_state->local_sp + s->next_length < 0);
 
-  arena = caml_stat_alloc_aligned_noexc(s->next_length, 0, &block);
+  arena = caml_stat_alloc_noexc(s->next_length);
   if (arena == NULL)
     caml_fatal_error("Local allocation stack overflow - out of memory");
 #ifdef DEBUG
@@ -667,7 +666,6 @@ void caml_local_realloc(void)
   s->count++;
   s->arenas[s->count-1].length = s->next_length;
   s->arenas[s->count-1].base = arena;
-  s->arenas[s->count-1].alloc_block = block;
   caml_use_local_arenas(s, Caml_state->local_sp);
   CAMLassert(Caml_state->local_limit <= Caml_state->local_sp);
 }
@@ -884,44 +882,6 @@ CAMLexport caml_stat_block caml_stat_alloc_noexc(asize_t sz)
     link_pool_block(pb);
     return &(pb->data);
   }
-}
-
-/* [sz] and [modulo] are numbers of bytes */
-CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
-                                               caml_stat_block *b)
-{
-  char *raw_mem;
-  uintnat aligned_mem;
-  CAMLassert(0 <= modulo);
-  CAMLassert(modulo < Page_size);
-  raw_mem = (char *) caml_stat_alloc_noexc(sz + Page_size);
-  if (raw_mem == NULL) return NULL;
-  *b = raw_mem;
-  raw_mem += modulo;                /* Address to be aligned */
-  aligned_mem = (((uintnat) raw_mem / Page_size + 1) * Page_size);
-#ifdef DEBUG
-  {
-    uintnat *p0 = (void *) *b;
-    uintnat *p1 = (void *) (aligned_mem - modulo);
-    uintnat *p2 = (void *) (aligned_mem - modulo + sz);
-    uintnat *p3 = (void *) ((char *) *b + sz + Page_size);
-    for (uintnat *p = p0; p < p1; p++) *p = Debug_filler_align;
-    for (uintnat *p = p1; p < p2; p++) *p = Debug_uninit_align;
-    for (uintnat *p = p2; p < p3; p++) *p = Debug_filler_align;
-  }
-#endif
-  return (char *) (aligned_mem - modulo);
-}
-
-/* [sz] and [modulo] are numbers of bytes */
-CAMLexport void* caml_stat_alloc_aligned(asize_t sz, int modulo,
-                                         caml_stat_block *b)
-{
-  void *result = caml_stat_alloc_aligned_noexc(sz, modulo, b);
-  /* malloc() may return NULL if size is 0 */
-  if ((result == NULL) && (sz != 0))
-    caml_fatal_out_of_memory();
-  return result;
 }
 
 /* [sz] is a number of bytes */


### PR DESCRIPTION
Two minor fixes:
1. Use the correct string for `CAMLSEP` (was also wrong on amd64 but presumably not used when constructing the frametable symbols)
2. Fix an alignment to 8 bytes instead of providing 0, which causes a compilation error about not being a power of two on recent clang.

With these two, `make install` works on arm64 macOS.