### PR TITLE
Fix O(N²) data structures in the linker's module tracking

### DIFF
--- a/optcomp/linkenv.ml
+++ b/optcomp/linkenv.ml
@@ -48,8 +48,8 @@ exception Error of error
 type t =
   { crc_interfaces : Cmi_consistbl.t;
     crc_implementations : Cmx_consistbl.t;
-    mutable implementations : CU.t list;
-    mutable cmx_required : CU.t list;
+    mutable implementations : CU.Set.t;
+    mutable cmx_required : CU.Set.t;
     interfaces : unit CU.Name.Tbl.t;
     implementations_defined : string CU.Tbl.t;
     mutable quoted_globals : CU.Name.Set.t;
@@ -66,8 +66,8 @@ let create () =
   in
   { crc_interfaces = Cmi_consistbl.create ();
     crc_implementations = Cmx_consistbl.create ();
-    implementations = [];
-    cmx_required = [];
+    implementations = CU.Set.empty;
+    cmx_required = CU.Set.empty;
     interfaces = CU.Name.Tbl.create 100;
     implementations_defined = CU.Tbl.create 100;
     quoted_globals;
@@ -112,10 +112,10 @@ let check_cmx_consistency t file_name cmxs =
       (fun import ->
         let name = Import_info.cu import in
         let crco = Import_info.crc import in
-        t.implementations <- name :: t.implementations;
+        t.implementations <- CU.Set.add name t.implementations;
         match crco with
         | None ->
-          if List.mem name t.cmx_required
+          if CU.Set.mem name t.cmx_required
           then raise (Error (Missing_cmx (file_name, name)))
         | Some crc ->
           Cmx_consistbl.check t.crc_implementations name () crc file_name)
@@ -134,10 +134,11 @@ let check_consistency t ~unit cmis cmxs =
      let source = CU.Tbl.find t.implementations_defined unit.name in
      raise (Error (Multiple_definition (ui_unit, unit.file_name, source)))
    with Not_found -> ());
-  t.implementations <- unit.name :: t.implementations;
+  t.implementations <- CU.Set.add unit.name t.implementations;
   Cmx_consistbl.check t.crc_implementations unit.name () unit.crc unit.file_name;
   CU.Tbl.replace t.implementations_defined unit.name unit.file_name;
-  if CU.is_packed unit.name then t.cmx_required <- unit.name :: t.cmx_required
+  if CU.is_packed unit.name
+  then t.cmx_required <- CU.Set.add unit.name t.cmx_required
 
 let extract_crc_interfaces t =
   CU.Name.Tbl.fold
@@ -147,10 +148,12 @@ let extract_crc_interfaces t =
     t.interfaces []
 
 let extract_crc_implementations t =
-  Cmx_consistbl.extract t.implementations t.crc_implementations
-  |> List.map (fun (cu, crc) ->
+  CU.Map.fold
+    (fun cu crc acc ->
       let crc = Option.map (fun ((), crc) -> crc) crc in
-      Import_info.create_normal cu ~crc)
+      Import_info.create_normal cu ~crc :: acc)
+    (Cmx_consistbl.extract_map t.implementations t.crc_implementations)
+    []
 
 (* Add C objects and options and "custom" info from a library descriptor. See
    bytecomp/bytelink.ml for comments on the order of C objects. *)

--- a/optcomp/linkenv.ml
+++ b/optcomp/linkenv.ml
@@ -157,12 +157,11 @@ let extract_crc_interfaces t =
     t.interfaces []
 
 let extract_crc_implementations t =
-  CU.Map.fold
-    (fun cu crc acc ->
+  Cmx_consistbl.fold_map t.implementations ~init:[]
+    ~f:(fun acc cu crc ->
       let crc = Option.map (fun ((), crc) -> crc) crc in
       Import_info.create_normal cu ~crc :: acc)
-    (Cmx_consistbl.extract_map t.implementations t.crc_implementations)
-    []
+    t.crc_implementations
 
 (* Add C objects and options and "custom" info from a library descriptor. See
    bytecomp/bytelink.ml for comments on the order of C objects. *)

--- a/optcomp/linkenv.ml
+++ b/optcomp/linkenv.ml
@@ -49,8 +49,8 @@ exception Error of error
 type t =
   { crc_interfaces : Cmi_consistbl.t;
     crc_implementations : Cmx_consistbl.t;
-    mutable implementations : CU.t list;
-    mutable cmx_required : CU.t list;
+    mutable implementations : CU.Set.t;
+    mutable cmx_required : CU.Set.t;
     interfaces : unit CU.Name.Tbl.t;
     implementations_defined : string CU.Tbl.t;
     mutable quoted_cmi : CU.Name.Set.t;
@@ -70,8 +70,8 @@ let create () =
   in
   { crc_interfaces = Cmi_consistbl.create ();
     crc_implementations = Cmx_consistbl.create ();
-    implementations = [];
-    cmx_required = [];
+    implementations = CU.Set.empty;
+    cmx_required = CU.Set.empty;
     interfaces = CU.Name.Tbl.create 100;
     implementations_defined = CU.Tbl.create 100;
     quoted_cmi;
@@ -121,10 +121,10 @@ let check_cmx_consistency t file_name cmxs =
       (fun import ->
         let name = Import_info.cu import in
         let crco = Import_info.crc import in
-        t.implementations <- name :: t.implementations;
+        t.implementations <- CU.Set.add name t.implementations;
         match crco with
         | None ->
-          if List.mem name t.cmx_required
+          if CU.Set.mem name t.cmx_required
           then raise (Error (Missing_cmx (file_name, name)))
         | Some crc ->
           Cmx_consistbl.check t.crc_implementations name () crc file_name)
@@ -143,10 +143,11 @@ let check_consistency t ~unit cmis cmxs =
      let source = CU.Tbl.find t.implementations_defined unit.name in
      raise (Error (Multiple_definition (ui_unit, unit.file_name, source)))
    with Not_found -> ());
-  t.implementations <- unit.name :: t.implementations;
+  t.implementations <- CU.Set.add unit.name t.implementations;
   Cmx_consistbl.check t.crc_implementations unit.name () unit.crc unit.file_name;
   CU.Tbl.replace t.implementations_defined unit.name unit.file_name;
-  if CU.is_packed unit.name then t.cmx_required <- unit.name :: t.cmx_required
+  if CU.is_packed unit.name
+  then t.cmx_required <- CU.Set.add unit.name t.cmx_required
 
 let extract_crc_interfaces t =
   CU.Name.Tbl.fold
@@ -156,10 +157,12 @@ let extract_crc_interfaces t =
     t.interfaces []
 
 let extract_crc_implementations t =
-  Cmx_consistbl.extract t.implementations t.crc_implementations
-  |> List.map (fun (cu, crc) ->
+  CU.Map.fold
+    (fun cu crc acc ->
       let crc = Option.map (fun ((), crc) -> crc) crc in
-      Import_info.create_normal cu ~crc)
+      Import_info.create_normal cu ~crc :: acc)
+    (Cmx_consistbl.extract_map t.implementations t.crc_implementations)
+    []
 
 (* Add C objects and options and "custom" info from a library descriptor. See
    bytecomp/bytelink.ml for comments on the order of C objects. *)

--- a/utils/consistbl.ml
+++ b/utils/consistbl.ml
@@ -80,6 +80,12 @@ end) = struct
       mod_names
       Module_name.Map.empty
 
+  let fold_map mod_names ~init ~f tbl =
+    Module_name.Set.fold
+      (fun name result -> f result name (find tbl name))
+      mod_names
+      init
+
   let filter p tbl =
     let to_remove = ref [] in
     Module_name.Tbl.iter

--- a/utils/consistbl.mli
+++ b/utils/consistbl.mli
@@ -66,6 +66,14 @@ end) : sig
     Module_name.Set.t -> t -> (Data.t * Digest.t) option Module_name.Map.t
         (* Like [extract] but with a more sophisticated type. *)
 
+  val fold_map :
+    Module_name.Set.t -> init:'a
+      -> f:('a -> Module_name.t -> (Data.t * Digest.t) option -> 'a)
+      -> t -> 'a
+        (* Like [extract_map], but can be used to avoid constructing an
+           intermediate [Map] for the result, when it feeds directly into
+           something else. *)
+
   val filter: (Module_name.t -> bool) -> t -> unit
         (* [filter pred tbl] removes from [tbl] table all (name, CRC) pairs
            such that [pred name] is [false]. *)


### PR DESCRIPTION
Two fields in `linkenv.t` accumulated entries per-import across all linked modules, causing quadratic behaviour for large programs:

- `implementations` was a `CU.t list` that grew with one entry per import seen (not per module), then `List.sort_uniq`'d at extract time inside `Consistbl.extract`. Switch to `CU.Set` so each add is O(log N) and the result is already sorted.

- `cmx_required` was a `CU.t list` of packed-module CUs that was scanned with `List.mem` for every import that lacks a CRC. Switch to `CU.Set` so membership tests are O(log N) instead of O(N).