### PR TITLE
Add fine-grained profiling to the linker scan-file loop

### DIFF
--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -64,12 +64,17 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
     then
       (* This is a cmx file. It must be linked in any case. Read the infos to
          see which modules it requires. *)
-      let info, crc = read_unit_info file_name in
+      let info, crc =
+        Profile.record_call ~accumulate:true "link/scan/read_cmx" (fun () ->
+            read_unit_info file_name)
+      in
       Unit (file_name, info, crc)
     else if Filename.check_suffix file_name Backend.ext_flambda_lib
     then
       let infos =
-        try read_library_info file_name
+        try
+          Profile.record_call ~accumulate:true "link/scan/read_cmxa" (fun () ->
+              read_library_info file_name)
         with Compilenv.Error (Not_a_unit_info filename) ->
           raise (Linkenv.Error (Not_an_object_file filename))
       in
@@ -111,9 +116,11 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
       let object_file_name =
         Filename.chop_suffix file_name Backend.ext_flambda_obj ^ Backend.ext_obj
       in
-      Linkenv.check_consistency linkenv ~unit
-        (Array.of_list info.ui_imports_cmi)
-        (Array.of_list info.ui_imports_cmx);
+      Profile.record_call ~accumulate:true "link/scan/check_consistency"
+        (fun () ->
+          Linkenv.check_consistency linkenv ~unit
+            (Array.of_list info.ui_imports_cmi)
+            (Array.of_list info.ui_imports_cmx));
       let cached_genfns_imports =
         Generic_fns.Tbl.add ~imports:cached_genfns_imports genfns
           info.ui_generic_fns
@@ -256,7 +263,8 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         in
         let linkenv = Linkenv.create () in
         let full_paths, ml_objfiles, units_tolink, cached_genfns_imports =
-          scan_user_supplied_files linkenv ~genfns ~objfiles
+          Profile.record_call "link/scan/user_files_pass1" (fun () ->
+              scan_user_supplied_files linkenv ~genfns ~objfiles)
         in
         let uses_eval =
           (* This query must come after scan_file has been called on objfiles,
@@ -350,7 +358,8 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
                 objfiles
             in
             let _full_paths, ml_objfiles, units_tolink, cached_genfns_imports =
-              scan_user_supplied_files linkenv ~genfns ~objfiles
+              Profile.record_call "link/scan/user_files_pass2" (fun () ->
+                  scan_user_supplied_files linkenv ~genfns ~objfiles)
             in
             ( linkenv,
               _full_paths,
@@ -371,10 +380,11 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         let _full_paths, ml_objfiles, units_tolink, cached_genfns_imports =
           (* This is just for any stdlib and eval support files which are
              needed. *)
-          List.fold_right
-            (scan_file linkenv ~shared:false genfns)
-            stdlib_and_support_files_for_eval
-            ([], ml_objfiles, units_tolink, cached_genfns_imports)
+          Profile.record_call "link/scan/stdlib_and_eval_support" (fun () ->
+              List.fold_right
+                (scan_file linkenv ~shared:false genfns)
+                stdlib_and_support_files_for_eval
+                ([], ml_objfiles, units_tolink, cached_genfns_imports))
         in
         (if not shared
          then


### PR DESCRIPTION
The `-dtimings`/`-dprofile` flags already instrument `make_startup_file` and `link_object` (the `ld` call), but not the scan-file loop that reads every `.cmx`/`.cmxa` and performs CRC consistency checks. Add `Profile.record_call` wrappers so that each sub-phase is separately visible:

    link/scan/user_files        — all user-supplied .cmx/.cmxa files
    link/scan/stdlib            — stdlib and eval-support files
    link/scan/read_cmx          — per-file: read and deserialize one .cmx
    link/scan/read_cmxa         — per-file: read one .cmxa library index
    link/scan/check_consistency — per-file: CRC consistency check

`read_cmx`, `read_cmxa`, and `check_consistency` use `~accumulate:true` so they sum across all iterations rather than nesting.