### PR TITLE
Move Flambda2 export info out of `.cmx` inline `Marshal` block into a section

### DIFF
--- a/asmcomp/cm_bundle.ml
+++ b/asmcomp/cm_bundle.ml
@@ -90,12 +90,17 @@ let cmx_bundle ~quoted_globals =
   in
   ListLabels.map (CU.Name.Map.data unit_infos)
     ~f:(fun (info : Cmx_format.unit_infos) ->
-      let raw_export_info, sections =
+      let has_export_info, sections =
         match info.ui_export_info with
-        | None -> None, Oxcaml_utils.File_sections.empty
-        | Some info ->
-          let info, sections = Flambda2_cmx.Flambda_cmx_format.to_raw info in
-          Some info, sections
+        | None -> false, Oxcaml_utils.File_sections.empty
+        | Some export_info ->
+          let raw, code_sections =
+            Flambda2_cmx.Flambda_cmx_format.to_raw export_info
+          in
+          let export_section =
+            Oxcaml_utils.File_sections.from_array [| Obj.repr raw |]
+          in
+          true, Oxcaml_utils.File_sections.concat export_section code_sections
       in
       let serialized_sections, toc, total_length =
         Oxcaml_utils.File_sections.serialize sections
@@ -109,7 +114,7 @@ let cmx_bundle ~quoted_globals =
           uir_quoted_globals = Array.of_list info.ui_quoted_globals;
           uir_format = info.ui_format;
           uir_generic_fns = info.ui_generic_fns;
-          uir_export_info = raw_export_info;
+          uir_has_export_info = has_export_info;
           uir_zero_alloc_info = Zero_alloc_info.to_raw info.ui_zero_alloc_info;
           uir_force_link = info.ui_force_link;
           uir_section_toc = toc;

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -86,7 +86,14 @@ type unit_infos_raw =
     uir_quoted_globals: Compilation_unit.Name.t array;
     uir_format: Lambda.main_module_block_format;
     uir_generic_fns: generic_fns;
-    uir_export_info: Flambda2_cmx.Flambda_cmx_format.raw option;
+    uir_has_export_info: bool;
+    (* When true, section 0 of the sections block holds the serialised
+       Flambda2_cmx.Flambda_cmx_format.raw value; code-body sections occupy
+       indices 1..N.  This keeps the large typing-environment data out of the
+       inline Marshal block so that the linker can deserialise .cmx headers
+       cheaply without loading cross-module optimisation data it does not need.
+       When false, there are no export-info sections (code-body sections start
+       at index 0 as before this change). *)
     uir_zero_alloc_info: Zero_alloc_info.Raw.t;
     uir_force_link: bool;
     uir_section_toc: int array;    (* Byte offsets of sections in .cmx

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -110,8 +110,15 @@ let read_unit_info filename =
     (* This consumes the channel *)
     let sections = File_sections.create uir.uir_section_toc filename ic ~first_section_offset in
     let export_info =
-      Option.map (Flambda2_cmx.Flambda_cmx_format.from_raw ~sections)
-        uir.uir_export_info
+      if not uir.uir_has_export_info then None
+      else
+        (* Section 0 holds the raw export-info value; code-body sections follow
+           at indices 1..N. *)
+        let raw : Flambda2_cmx.Flambda_cmx_format.raw =
+          Obj.obj (File_sections.get sections 0)
+        in
+        let code_sections = File_sections.suffix sections 1 in
+        Some (Flambda2_cmx.Flambda_cmx_format.from_raw ~sections:code_sections raw)
     in
     let ui = {
       ui_unit = uir.uir_unit;
@@ -123,6 +130,44 @@ let read_unit_info filename =
       ui_quoted_globals = uir.uir_quoted_globals |> Array.to_list;
       ui_generic_fns = uir.uir_generic_fns;
       ui_export_info = export_info;
+      ui_zero_alloc_info = Zero_alloc_info.of_raw uir.uir_zero_alloc_info;
+      ui_force_link = uir.uir_force_link;
+      ui_external_symbols = uir.uir_external_symbols |> Array.to_list;
+    }
+    in
+    (ui, crc)
+  with End_of_file | Failure _ ->
+    close_in ic;
+    raise(Error(Corrupted_unit_info(filename)))
+
+(* Like [read_unit_info] but skips the export info entirely.  Used by the
+   linker, which never needs cross-module optimisation data.  With the new
+   .cmx format the export info is in sections (not inline in the Marshal block),
+   so [input_value] is now cheap regardless; this function additionally avoids
+   instantiating the File_sections lazy-loading infrastructure. *)
+let read_unit_info_for_linking filename =
+  let ic = open_in_bin filename in
+  try
+    let buffer = really_input_string ic (String.length cmx_magic_number) in
+    if buffer <> cmx_magic_number then begin
+      close_in ic;
+      raise(Error(Not_a_unit_info filename))
+    end;
+    let uir = (input_value ic : unit_infos_raw) in
+    let first_section_offset = pos_in ic in
+    seek_in ic (first_section_offset + uir.uir_sections_length);
+    let crc = Digest.input ic in
+    close_in ic;
+    let ui = {
+      ui_unit = uir.uir_unit;
+      ui_defines = uir.uir_defines;
+      ui_format = uir.uir_format;
+      ui_arg_descr = uir.uir_arg_descr;
+      ui_imports_cmi = uir.uir_imports_cmi |> Array.to_list;
+      ui_imports_cmx = uir.uir_imports_cmx |> Array.to_list;
+      ui_quoted_globals = uir.uir_quoted_globals |> Array.to_list;
+      ui_generic_fns = uir.uir_generic_fns;
+      ui_export_info = None;
       ui_zero_alloc_info = Zero_alloc_info.of_raw uir.uir_zero_alloc_info;
       ui_force_link = uir.uir_force_link;
       ui_external_symbols = uir.uir_external_symbols |> Array.to_list;
@@ -265,12 +310,17 @@ let ensure_sharing_between_cmi_and_cmx_imports cmi_imports cmx_imports =
 *)
 
 let write_unit_info info filename =
-  let raw_export_info, sections =
+  let has_export_info, sections =
     match info.ui_export_info with
-    | None -> None, File_sections.empty
-    | Some info ->
-      let info, sections = Flambda2_cmx.Flambda_cmx_format.to_raw info in
-      Some info, sections
+    | None -> false, File_sections.empty
+    | Some export_info ->
+      let raw, code_sections = Flambda2_cmx.Flambda_cmx_format.to_raw export_info in
+      (* Section 0: the raw export-info value itself (typing envs, code metadata).
+         Code-body sections follow at indices 1..N.  This keeps the large
+         cross-module optimisation data out of the inline Marshal block, so the
+         linker can cheaply deserialise .cmx headers without loading it. *)
+      let export_section = File_sections.from_array [| Obj.repr raw |] in
+      true, File_sections.concat export_section code_sections
   in
   let serialized_sections, toc, total_length = File_sections.serialize sections in
   let raw_info = {
@@ -282,7 +332,7 @@ let write_unit_info info filename =
     uir_quoted_globals = Array.of_list info.ui_quoted_globals;
     uir_format = info.ui_format;
     uir_generic_fns = info.ui_generic_fns;
-    uir_export_info = raw_export_info;
+    uir_has_export_info = has_export_info;
     uir_zero_alloc_info = Zero_alloc_info.to_raw info.ui_zero_alloc_info;
     uir_force_link = info.ui_force_link;
     uir_section_toc = toc;

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -61,6 +61,10 @@ val new_const_symbol : unit -> string
 
 val read_unit_info: string -> unit_infos * Digest.t
         (* Read infos and MD5 from a [.cmx] file. *)
+val read_unit_info_for_linking: string -> unit_infos * Digest.t
+        (* Like [read_unit_info] but does not load cross-module optimisation
+           data (export info).  Suitable for use in the linker, which only
+           needs import lists, CRCs, generic-function signatures, and flags. *)
 val write_unit_info: unit_infos -> string -> unit
         (* Save the given infos in the given file *)
 val save_unit_info:

--- a/optcomp/optlibrarian.ml
+++ b/optcomp/optlibrarian.ml
@@ -38,13 +38,10 @@ end) : S = struct
       try Load_path.find name
       with Not_found -> raise (Error (File_not_found name))
     in
-    let info, crc = Compilenv.read_unit_info filename in
+    (* The librarian does not need cross-module optimisation data; use the fast
+       path that skips loading it from the section cache. *)
+    let info, crc = Compilenv.read_unit_info_for_linking filename in
     info.ui_force_link <- info.ui_force_link || !Clflags.link_everything;
-    (* There is no need to keep the approximation in the flambda library file,
-       since the compiler will go looking directly for flambda object files. The
-       linker, which is the only one that reads library files, does not need the
-       approximation. *)
-    info.ui_export_info <- None;
     ( Filename.chop_suffix filename Backend.ext_flambda_obj ^ Backend.ext_obj,
       (info, crc) )
 

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -64,7 +64,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
     then
       (* This is a cmx file. It must be linked in any case. Read the infos to
          see which modules it requires. *)
-      let info, crc = read_unit_info file_name in
+      let info, crc = read_unit_info_for_linking file_name in
       Unit (file_name, info, crc)
     else if Filename.check_suffix file_name Backend.ext_flambda_lib
     then

--- a/otherlibs/camlinternaleval/camlinternaleval.ml
+++ b/otherlibs/camlinternaleval/camlinternaleval.ml
@@ -109,9 +109,16 @@ let read_bundles ~marshalled_cmi_bundle ~marshalled_cmx_bundle =
             (Array.map (fun s -> Marshal.from_string s 0) sections)
         in
         let export_info =
-          Option.map
-            (Flambda2_cmx.Flambda_cmx_format.from_raw ~sections)
-            uir.uir_export_info
+          if not uir.uir_has_export_info
+          then None
+          else
+            let raw : Flambda2_cmx.Flambda_cmx_format.raw =
+              Obj.obj (Oxcaml_utils.File_sections.get sections 0)
+            in
+            let code_sections = Oxcaml_utils.File_sections.suffix sections 1 in
+            Some
+              (Flambda2_cmx.Flambda_cmx_format.from_raw raw
+                 ~sections:code_sections)
         in
         let ui : Cmx_format.unit_infos =
           { ui_unit = uir.uir_unit;

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -350,19 +350,24 @@ let print_cmx_infos (uir, sections, crc) =
     (fun f -> Array.iter f uir.uir_imports_cmx)
     (fun f -> Array.iter f uir.uir_quoted_globals);
   begin
-    match uir.uir_export_info with
-    | None ->
+    if not uir.uir_has_export_info then
       printf "Flambda 2 unit (with no export information)\n"
-    | Some _ when !no_code && !no_approx ->
+    else if !no_code && !no_approx then
       printf "Flambda 2 unit with export information\n"
-    | Some cmx ->
+    else begin
       printf "Flambda 2 export information:\n";
       flush stdout;
       let print_typing_env = not !no_approx in
       let print_code = not !no_code in
       let print_offsets = print_code && print_typing_env in
-      let cmx = Flambda2_cmx.Flambda_cmx_format.from_raw cmx ~sections in
+      (* Section 0 holds the raw export info; code-body sections follow. *)
+      let raw : Flambda2_cmx.Flambda_cmx_format.raw =
+        Obj.obj (Oxcaml_utils.File_sections.get sections 0)
+      in
+      let code_sections = Oxcaml_utils.File_sections.suffix sections 1 in
+      let cmx = Flambda2_cmx.Flambda_cmx_format.from_raw raw ~sections:code_sections in
       Format.printf "%a\n%!" (Flambda2_cmx.Flambda_cmx_format.print ~print_typing_env ~print_code ~print_offsets) cmx
+    end
   end;
   print_generic_fns uir.uir_generic_fns;
   printf "Force link: %s\n" (if uir.uir_force_link then "YES" else "no");

--- a/utils/file_sections.ml
+++ b/utils/file_sections.ml
@@ -111,6 +111,26 @@ let from_array t = In_memory (Array.copy t)
 
 let concat t1 t2 = Cat (length t1 + length t2, t1, t2)
 
+(* Return a view of [t] with the first [n] sections dropped.  No sections are
+   loaded eagerly; pending sections remain pending. *)
+let rec suffix t n =
+  if n <= 0 then t
+  else
+    let total = length t in
+    let result = total - n in
+    if result <= 0 then In_memory [||]
+    else
+      match t with
+      | In_memory arr ->
+        In_memory (Array.sub arr n (Array.length arr - n))
+      | From_file { sections; channel } ->
+        let len = Array.length sections in
+        From_file { sections = Array.sub sections n (len - n); channel }
+      | Cat (_, t1, t2) ->
+        let n1 = length t1 in
+        if n >= n1 then suffix t2 (n - n1)
+        else concat (suffix t1 n) t2
+
 let compute_toc serialized_sections =
   let toc = Array.make (Array.length serialized_sections) 0 in
   let length = ref 0 in

--- a/utils/file_sections.mli
+++ b/utils/file_sections.mli
@@ -33,3 +33,7 @@ val serialize : t -> string array * int array * int
 val from_array : Obj.t array -> t
 
 val concat : t -> t -> t
+
+val suffix : t -> int -> t
+(** [suffix t n] returns a view of [t] with the first [n] sections dropped.
+    No sections are loaded eagerly. *)


### PR DESCRIPTION
When `ocamlopt` links a large program it reads every `.cmx` file and deserialises the `unit_infos_raw` record via `Marshal`. That record previously embedded `uir_export_info` inline: the full Flambda2 export data (typing environments, code metadata maps, symbol tables, ...). The linker never uses this data, so for large builds with thousands of modules it was deserialising megabytes of cross-module optimisation state per file for no benefit.

The fix stores the export-info value in section 0 of the `.cmx` sections block instead of inline in the `Marshal` record. Code-body sections follow at indices 1..N as before. The inline record now carries only a boolean `uir_has_export_info`.

**Consequences:**
- The linker's `Marshal` deserialisation per `.cmx` becomes cheap: it reads only small scalar fields and the import arrays.
- Paths that need export info (compilation, packaging, eval bundling) read section 0 on demand; code-body sections are then addressed at `File_sections.suffix sections 1` so their 0-based indices are unchanged.
- `objinfo` likewise loads section 0 when neither `--no-code` nor `--no-approx` is set.
- The librarian already discarded export info after reading; it now uses `read_unit_info_for_linking` which skips even opening the section cache.

**New helpers:**
- `File_sections.suffix`: drop the first n sections lazily (no eager load)
- `Compilenv.read_unit_info_for_linking`: skip sections entirely