### PR TITLE
Fixes for `make runtest`

### DIFF
--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -196,5 +196,5 @@ let _ =
     Compilation_unit.create Compilation_unit.Prefix.empty linkage_name
   in
   let unit_info = Unit_info.make_dummy ~input_name:"camlTest" comp_unit in
-  Env.set_unit_name (Some unit_info);
+  Env.set_current_unit (Some unit_info);
   test_double_recursion ()

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -437,7 +437,7 @@ let test_meet_bottom_after_alias () =
 let () =
   let comp_unit = "Meet_test" |> Compilation_unit.of_string in
   let unit_info = Unit_info.make_dummy ~input_name:"meet_test" comp_unit in
-  Env.set_unit_name (Some unit_info);
+  Env.set_current_unit (Some unit_info);
   Format.eprintf "MEET CHAINS WITH TWO VARS@\n@.";
   test_meet_chains_two_vars ();
   Format.eprintf "@.MEET CHAINS WITH THREE VARS@\n@.";

--- a/middle_end/flambda2/tests/tools/fldiff.ml
+++ b/middle_end/flambda2/tests/tools/fldiff.ml
@@ -10,7 +10,7 @@ let _ =
       Parse_flambda.make_compilation_unit ~filename:file1 ~extension:".fl" ()
     in
     let unit_info = Unit_info.make_dummy ~input_name:file1 modname1 in
-    Env.set_unit_name (Some unit_info);
+    Env.set_current_unit (Some unit_info);
     match Compare.flambda_units unit2 unit1 with
     | Equivalent -> ()
     | Different { approximant = unit2' } ->

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -36,7 +36,7 @@ let run_expect_test ~get_module_info ~extension ~filename
     ({ before; after = expected } : Fexpr.expect_test_spec) : Test_outcome.t =
   let comp_unit = Parse_flambda.make_compilation_unit ~extension ~filename () in
   let unit_info = Unit_info.make_dummy ~input_name:filename comp_unit in
-  Env.set_unit_name (Some unit_info);
+  Env.set_current_unit (Some unit_info);
   let before_fl = Fexpr_to_flambda.conv comp_unit before in
   check_invariants before_fl;
   let cmx_loader = Flambda_cmx.create_loader ~get_module_info in

--- a/middle_end/flambda2/tests/tools/parseflambda.ml
+++ b/middle_end/flambda2/tests/tools/parseflambda.ml
@@ -16,7 +16,7 @@ let parse_flambda filename =
       Parse_flambda.make_compilation_unit ~extension:".fl" ~filename ()
     in
     let unit_info = Unit_info.make_dummy ~input_name:filename comp_unit in
-    Env.set_unit_name (Some unit_info);
+    Env.set_current_unit (Some unit_info);
     Format.printf "%a@.@." Print_fexpr.flambda_unit unit;
     let fl2 = Fexpr_to_flambda.conv comp_unit unit in
     Format.printf "flambda:@.%a@.@." Flambda_unit.print fl2;

--- a/middle_end/flambda2/tests/tools/roundtrip.ml
+++ b/middle_end/flambda2/tests/tools/roundtrip.ml
@@ -31,7 +31,7 @@ let () =
     let unit_info = Unit_info.make_dummy ~input_name:file modname in
     (* Need to get this right or the conversion will complain about binding
        non-local symbols *)
-    Env.set_unit_name (Some unit_info);
+    Env.set_current_unit (Some unit_info);
     let unit =
       match Parse_flambda.parse file with
       | Ok unit -> unit

--- a/oxcaml/tests/backend/zero_alloc_checker/fail15.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail15.output
@@ -1,5 +1,6 @@
 File "fail15.ml", line 6, characters 42-52:
-Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the zero_alloc attribute is used more than once
+  on this expression
 
 File "fail15.ml", line 8, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Fail15.call (camlFail15.call_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/t6.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/t6.output
@@ -1,2 +1,3 @@
 File "t6.ml", line 32, characters 5-15:
-Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the zero_alloc attribute is used more than once
+  on this expression

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_on_call.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_on_call.output
@@ -1,6 +1,6 @@
 File "test_assume_on_call.ml", line 3, characters 34-44:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-Only the following combinations are supported in this context: 'zero_alloc assume', 'zero_alloc assume_unless_opt', `zero_alloc assume strict`, `zero_alloc assume error`,`zero_alloc assume never_returns_normally`,`zero_alloc assume never_returns_normally strict`.
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  Only the following combinations are supported in this context: 'zero_alloc assume', 'zero_alloc assume_unless_opt', `zero_alloc assume strict`, `zero_alloc assume error`,`zero_alloc assume never_returns_normally`,`zero_alloc assume never_returns_normally strict`.
 
 File "test_assume_on_call.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call.test1_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.output
@@ -1,6 +1,6 @@
 File "test_assume_unless_opt_on_call.ml", line 6, characters 9-19:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_assume_unless_opt_on_call.ml", line 5, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call.test_warning (camlTest_assume_unless_opt_on_call.test_warning_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call2.output
@@ -1,6 +1,6 @@
 File "test_assume_unless_opt_on_call2.ml", line 6, characters 9-19:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_assume_unless_opt_on_call2.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.bar (camlTest_assume_unless_opt_on_call2.bar_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig.output
@@ -1,3 +1,3 @@
 File "test_assume_unless_opt_sig.ml", line 19, characters 29-39:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The payload "assume_unless_opt" is not supported in signatures.
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  The payload "assume_unless_opt" is not supported in signatures.

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig2.output
@@ -1,6 +1,6 @@
 File "test_assume_unless_opt_sig2.ml", line 19, characters 29-39:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The payload "assume_unless_opt" is not supported in signatures.
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  The payload "assume_unless_opt" is not supported in signatures.
 
 File "test_assume_unless_opt_sig2.ml", line 4, characters 23-33:
 Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_fail_in_opt_only.foo (camlTest_assume_unless_opt_sig2.foo_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attr_unused.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attr_unused.output
@@ -1,9 +1,9 @@
 File "test_attr_unused.ml", line 14, characters 0-15:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-A constant payload of type ident was expected
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  A constant payload of type ident was expected
 
 File "test_attr_unused.ml", line 16, characters 27-37:
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the zero_alloc attribute cannot appear in this context
 
 File "test_attr_unused.ml", line 8, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_attr_unused.g (camlTest_attr_unused.g_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attribute_error_duplicate.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attribute_error_duplicate.output
@@ -1,20 +1,22 @@
 File "test_attribute_error_duplicate.ml", line 1, characters 26-36:
-Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the zero_alloc attribute is used more than once
+  on this expression
 
 File "test_attribute_error_duplicate.ml", line 6, characters 5-15:
-Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
+Warning 54 [duplicated-attribute]: the zero_alloc attribute is used more than once
+  on this expression
 
 File "test_attribute_error_duplicate.ml", line 9, characters 5-15:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_attribute_error_duplicate.ml", line 11, characters 5-15:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_attribute_error_duplicate.ml", line 13, characters 5-15:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate.test1_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.opt.output
@@ -1,14 +1,14 @@
 File "test_custom_error_msg.ml", line 19, characters 3-13:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The "custom_error_message" payload is not supported with "assume".
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  The "custom_error_message" payload is not supported with "assume".
 
 File "test_custom_error_msg.ml", line 25, characters 3-13:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_custom_error_msg.ml", line 27, characters 57-67:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_custom_error_msg.ml", line 2, characters 3-13:
 Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.foo (camlTest_custom_error_msg.foo_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.output
@@ -1,14 +1,14 @@
 File "test_custom_error_msg.ml", line 19, characters 3-13:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-The "custom_error_message" payload is not supported with "assume".
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  The "custom_error_message" payload is not supported with "assume".
 
 File "test_custom_error_msg.ml", line 25, characters 3-13:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_custom_error_msg.ml", line 27, characters 57-67:
-Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
+Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
+  It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_custom_error_msg.ml", line 2, characters 3-13:
 Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.foo (camlTest_custom_error_msg.foo_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_misplaced_assume.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_misplaced_assume.output
@@ -1,5 +1,5 @@
 File "test_misplaced_assume.ml", line 5, characters 33-43:
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+Warning 53 [misplaced-attribute]: the zero_alloc attribute cannot appear in this context
 
 File "test_misplaced_assume.ml", line 5, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_misplaced_assume.foo (camlTest_misplaced_assume.foo_HIDE_STAMP).

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -477,10 +477,7 @@ G(CAMLSEP(hot,code_begin)):
 
         TEXT_SECTION(CAMLSEP(hot,code_end))
         .globl  G(CAMLSEP(hot,code_end))
-        .globl  G(CAMLSEP(hot,code_end))
-        .globl  G(caml_hot__code_end)
 G(CAMLSEP(hot,code_end)):
-G(caml_hot__code_end):
 #endif
 
 /******************************************************************************/

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -108,15 +108,11 @@
 #if defined(FUNCTION_SECTIONS)
         TEXT_SECTION(CAMLSEP(hot,code_begin))
         .globl  G(CAMLSEP(hot,code_begin))
-        .globl  G(caml_hot.code_begin)
 G(CAMLSEP(hot,code_begin)):
-G(caml_hot.code_begin):
 
         TEXT_SECTION(CAMLSEP(hot,code_end))
         .globl  G(CAMLSEP(hot,code_end))
-        .globl  G(caml_hot.code_end)
 G(CAMLSEP(hot,code_end)):
-G(caml_(hot.code_end):
 #endif
 
 #if defined(SYS_macosx)


### PR DESCRIPTION
This PR contains the fixes needed to get `make runtest` to pass.

1. Removing duplicate labels and dot labels in the assembly files
2. Pulling through the `set_unit_name` -> `set_current_unit` renaming
3. Promoting the zero alloc errors with the new formatting