### PR TITLE
Dissector: link partitions in parallel using `make -j`

### DIFF
--- a/asmcomp/dissector/partial_link.ml
+++ b/asmcomp/dissector/partial_link.ml
@@ -63,6 +63,14 @@ let write_response_file ~filename files =
     files;
   close_out oc
 
+(* Build the linker command for one partition. *)
+let partition_cmd ~output_file ~response_file =
+  (* Config.native_pack_linker is something like "ld -r -o " *)
+  Printf.sprintf "%s%s --whole-archive @%s --no-whole-archive"
+    Config.native_pack_linker
+    (Filename.quote output_file)
+    (Filename.quote response_file)
+
 let link_one_partition ~temp_dir ~partition_index partition =
   let response_file =
     Filename.concat temp_dir (Printf.sprintf "partition%d.txt" partition_index)
@@ -73,13 +81,7 @@ let link_one_partition ~temp_dir ~partition_index partition =
   write_response_file ~filename:response_file (Partition.files partition);
   Misc.try_finally
     (fun () ->
-      (* Config.native_pack_linker is something like "ld -r -o " *)
-      let cmd =
-        Printf.sprintf "%s%s --whole-archive @%s --no-whole-archive"
-          Config.native_pack_linker
-          (Filename.quote output_file)
-          (Filename.quote response_file)
-      in
+      let cmd = partition_cmd ~output_file ~response_file in
       let exit_code = Ccomp.command cmd in
       (if exit_code <> 0
        then
@@ -90,8 +92,91 @@ let link_one_partition ~temp_dir ~partition_index partition =
       Partition.Linked.create ~partition ~linked_object:output_file)
     ~always:(fun () -> Misc.remove_file response_file)
 
+(* Write a Makefile that links all partitions as independent targets so that
+   make -j can run them concurrently. The recipes use '@' to suppress echoing
+   since we print the commands ourselves when -verbose is set. *)
+let write_parallel_makefile ~filename jobs =
+  let oc = open_out filename in
+  (try
+     output_string oc "all:";
+     List.iter
+       (fun (output_file, _) ->
+         output_char oc ' ';
+         output_string oc output_file)
+       jobs;
+     output_char oc '\n';
+     List.iter
+       (fun (output_file, cmd) ->
+         Printf.fprintf oc "\n%s:\n\t@%s\n" output_file cmd)
+       jobs
+   with exn ->
+     close_out oc;
+     raise exn);
+  close_out oc
+
 let link_partitions ~temp_dir partitions =
-  List.mapi
-    (fun partition_index partition ->
-      link_one_partition ~temp_dir ~partition_index partition)
-    partitions
+  match partitions with
+  | [] -> []
+  | [partition] ->
+    (* Single partition: no benefit from the make -j overhead. *)
+    [link_one_partition ~temp_dir ~partition_index:0 partition]
+  | _ ->
+    (* Multiple partitions: prepare response files and commands, then run all
+       linker invocations concurrently via make -j. *)
+    let jobs =
+      List.mapi
+        (fun partition_index partition ->
+          let response_file =
+            Filename.concat temp_dir
+              (Printf.sprintf "partition%d.txt" partition_index)
+          in
+          let output_file =
+            Filename.concat temp_dir
+              (Printf.sprintf "partition%d.o" partition_index)
+          in
+          write_response_file ~filename:response_file
+            (Partition.files partition);
+          let cmd = partition_cmd ~output_file ~response_file in
+          if !Clflags.verbose then Printf.eprintf "+ %s\n%!" cmd;
+          partition_index, cmd, output_file, response_file, partition)
+        partitions
+    in
+    let makefile = Filename.concat temp_dir "partitions.mk" in
+    Misc.try_finally
+      (fun () ->
+        write_parallel_makefile ~filename:makefile
+          (List.map (fun (_, cmd, out, _, _) -> out, cmd) jobs);
+        let make_cmd =
+          Printf.sprintf "make -j -f %s" (Filename.quote makefile)
+        in
+        let exit_code = Ccomp.command make_cmd in
+        (if exit_code <> 0
+         then
+           (* Identify the first partition whose output file is absent. *)
+           let failed_opt =
+             List.find_opt
+               (fun (_, _, output_file, _, _) ->
+                 not (Sys.file_exists output_file))
+               jobs
+           in
+           let partition_index, _, _, _, partition =
+             match failed_opt with
+             | Some job -> job
+             | None ->
+               (* All outputs exist but make still reported failure; fall back
+                  to reporting partition 0. *)
+               List.hd jobs
+           in
+           let files =
+             List.map MOF.File_size.filename (Partition.files partition)
+           in
+           raise (Error (Linker_error { partition_index; exit_code; files })));
+        List.map
+          (fun (_, _, output_file, _, partition) ->
+            Partition.Linked.create ~partition ~linked_object:output_file)
+          jobs)
+      ~always:(fun () ->
+        Misc.remove_file makefile;
+        List.iter
+          (fun (_, _, _, response_file, _) -> Misc.remove_file response_file)
+          jobs)


### PR DESCRIPTION
Previously `link_partitions` ran the `ld -r` invocations sequentially (`List.mapi` over `link_one_partition`). For a binary split into N partitions each invocation had to complete before the next could start, even though they are entirely independent.

The dissector is Linux-only and `make` is always present when building OCaml. For N > 1 partitions, write a temporary `Makefile` with one rule per partition and invoke `make -j`, which spawns all `ld -r` processes concurrently. This avoids the need for `Thread` or direct `Unix` module access (both of which are not linked into the compiler).

The single-partition case continues to use the direct path with no `Makefile` overhead. On failure, the first missing output file identifies which partition failed for error reporting.