### PR TITLE
layout var instantiation should `fatal_error` instead of `Not_found`

### DIFF
--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -9,6 +9,13 @@ signature such that the inferred signature can be printed and inspected, and we
 never go to lambda. We should add the corresponding positive tests once they can
 go through lambda and middle-end. *)
 
+let poly_ id x = x
+[%%expect{|
+>> Fatal error: layout: unexpected genvar
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
 (* Simple let poly_ with a polymorphic function *)
 module _ : sig
   val id : int

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -600,7 +600,14 @@ module Sort = struct
 
   let rec instance_var v =
     match v.contents with
-    | None -> if is_genvar v then Var (List.assq v !instance_map) else Var v
+    | None when is_genvar v ->
+      begin match List.assq_opt v !instance_map with
+      | Some v' -> Var v'
+      | None ->
+        Misc.fatal_error
+          "generic layout variables found in non-layout instantiation"
+      end
+    | None -> Var v
     | Some t -> instance t
 
   and instance : t -> t = function


### PR DESCRIPTION
Legacy caller might not set up layout instantiation properly, which causes `Not_found` in `instance_var`. This `Not_found` will propagate and be interpreted in ways out of our control.

Instead, in such cases we should just `fatal_error`.

(Currently this can be only be triggered if you write top-level `let poly_` in an expect test).

(found by @Skepfyr )