### PR TITLE
simplify: update recursive flag

### DIFF
--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -499,10 +499,10 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~poll_attribute:(Code.poll_attribute code)
       ~regalloc_attribute:(Code.regalloc_attribute code)
       ~regalloc_param_attribute:(Code.regalloc_param_attribute code)
-      ~cold:(Code.cold code) ~is_a_functor ~is_opaque
-      ~recursive:(Code.recursive code) ~cost_metrics ~inlining_arguments ~dbg
-      ~is_tupled:(Code.is_tupled code) ~is_my_closure_used ~inlining_decision
-      ~absolute_history ~relative_history ~loopify
+      ~cold:(Code.cold code) ~is_a_functor ~is_opaque ~recursive ~cost_metrics
+      ~inlining_arguments ~dbg ~is_tupled:(Code.is_tupled code)
+      ~is_my_closure_used ~inlining_decision ~absolute_history ~relative_history
+      ~loopify
   in
   let code =
     let are_rebuilding = DA.are_rebuilding_terms dacc_after_body in

--- a/middle_end/flambda2/tests/mlexamples/local.flt
+++ b/middle_end/flambda2/tests/mlexamples/local.flt
@@ -501,7 +501,7 @@ apply direct(length_2_1)
             where k2 =
               let `unit` = %end_region (`region`) in
               let unit_1 = %end_ghost_region (ghost_region) in
-              let code rec loopify(done) size(22) newer_version_of(rev_app_4)
+              let code loopify(done) size(22) newer_version_of(rev_app_4)
                     rev_app_4_1
                       (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                        l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])


### PR DESCRIPTION
The CI on #5793 is currently broken, because when the reaper wants to update the inlining decision after recomputing the code size, it uses the `recursive` flag stored in code metadata. However, simplify computes a recursive flag from the body of the simplified closure, uses it to compute the inlining decision, but does not update the code metadata. In the case of a `[@tail_mod_cons]` function, the toplevel function is marked non-recursive in the code metadata, but simplify decides it is recursive, and therefore, not inlinable; but the reaper sees the old non-recursive flag and sets the function to inlinable.