### PR TITLE
Use Envaux.Module_not_found instead of Not_found

### DIFF
--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -74,7 +74,9 @@ let rec env_from_summary ~allow_missing_modules sum subst =
           if allow_missing_modules then
             (try Env.open_signature_by_path path' env with
             | Not_found -> env)
-          else Env.open_signature_by_path path' env
+          else
+            (try Env.open_signature_by_path path' env with
+            | Not_found -> raise (Error (Module_not_found path')))
       | Env_functor_arg(Env_module(s, id, pres, desc, mode, locks), id')
             when Ident.same id id' ->
           let desc =


### PR DESCRIPTION
Surprisingly there were no uses of the Envaux.Module_not_found exception before, although it fits very nicely in here so I'd guess it disappeared in a conflict reoslution or suchlike.