### PR TITLE
Fix failing test on nixos

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/poly-variant-limit/test_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/poly-variant-limit/test_ikinds.ml
@@ -4,7 +4,7 @@
  setup-ocamlc.byte-build-env;
 
  (* Generate a file that defines some large polymorphic variants. *)
- script = "/bin/bash gen_types.sh types.ml";
+ script = "/usr/bin/env bash gen_types.sh types.ml";
  script;
  module = "types.ml";
  ocamlc.byte;


### PR DESCRIPTION
Once again, change `/bin/bash` to `/usr/bin/env bash`.