### PR TITLE
Gracefully reporting that runtime metaprogramming does not support various language features

### DIFF
--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension runtime_metaprogramming -extension comprehensions";
+ flags = "-extension runtime_metaprogramming -extension comprehensions -extension layout_poly_alpha";
  expect;
 *)
 
@@ -13,6 +13,17 @@ end
 [%%expect {|
 module E : sig type existential = Exists : 'a -> existential end
 |}];;
+
+type pv = [`A | `B]
+[%%expect {|
+type pv = [ `A | `B ]
+|}];;
+
+class cls = object method meth () = 42 end;;
+[%%expect {|
+class cls : object method meth : unit -> int end
+|}];;
+
 #mark_toplevel_in_quotations;;
 
 (* Tests *)
@@ -807,6 +818,39 @@ Error: Module definition using "struct..end"
        as seen at line 1, characters 18-52.
 |}];;
 
+<[ let poly_ foo x = x in foo ]>;;
+[%%expect {|
+Line 1, characters 3-22:
+1 | <[ let poly_ foo x = x in foo ]>;;
+       ^^^^^^^^^^^^^^^^^^^
+Error: Layout polymorphism is not supported inside quoted expressions,
+       as seen at line 1, characters 3-22.
+|}];;
+
+<[
+  function (x: [pv | `A])
+  | #pv -> "something else"
+  | `A -> "A"
+]>;;
+[%%expect {|
+Line 3, characters 4-7:
+3 |   | #pv -> "something else"
+        ^^^
+Error: Adding type constraint patterns (here #pv)
+       is not supported inside quoted expressions,
+       as seen at line 3, characters 4-7.
+|}];;
+
+<[ let f (o : #cls) = o#meth () in f ]>;;
+[%%expect {|
+Line 1, characters 14-18:
+1 | <[ let f (o : #cls) = o#meth () in f ]>;;
+                  ^^^^
+Error: Using class type annotations
+       is not supported inside quoted expressions,
+       as seen at line 1, characters 14-18.
+|}];;
+
 <[ Mod.mk 42 ]>;;
 [%%expect {|
 Line 1, characters 3-9:
@@ -1259,12 +1303,12 @@ Error: Annotating types with kinds
 (* Ptyp_of_kind: (type : value) *)
 <[ fun (x : (type : value)) -> x ]>;;
 [%%expect {|
-Line 1, characters 20-25:
+Line 1, characters 12-26:
 1 | <[ fun (x : (type : value)) -> x ]>;;
-                        ^^^^^
+                ^^^^^^^^^^^^^^
 Error: Annotating types with kinds
        is not supported inside quoted expressions,
-       as seen at line 1, characters 20-25.
+       as seen at line 1, characters 12-26.
 |}];;
 
 (* Pexp_newtype with jkind annotation: fun (type t : value) -> *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -837,6 +837,9 @@ type no_open_quotations_context =
   | Object_field_with_attribute_qt
   | Variant_tag_with_attribute_qt
   | Jkind_annotation_qt
+  | Layout_polymorphism_qt
+  | Tconst_pat_qt of Longident.t
+  | Class_type_qt
 
 let print_structure_components_reason ppf = function
   | Project -> Format_doc.fprintf ppf "have any components"
@@ -5004,6 +5007,13 @@ let print_unsupported_quotation ppf =
       fprintf ppf "Adding attributes on tags in polymorphic variant types"
   | Jkind_annotation_qt ->
       fprintf ppf "Annotating types with kinds"
+  | Layout_polymorphism_qt ->
+      fprintf ppf "Layout polymorphism"
+  | Tconst_pat_qt tconst ->
+      fprintf ppf "Adding type constraint patterns (here #%s)"
+        (Format.asprintf "%a" Pprintast.longident tconst)
+  | Class_type_qt ->
+      fprintf ppf "Using class type annotations"
 
 let print_unbound_in_quotation ppf =
   function

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -234,6 +234,9 @@ type no_open_quotations_context =
   | Object_field_with_attribute_qt
   | Variant_tag_with_attribute_qt
   | Jkind_annotation_qt
+  | Layout_polymorphism_qt
+  | Tconst_pat_qt of Longident.t
+  | Class_type_qt
 
 type none_in_quotations_context =
   | Constructor

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3503,6 +3503,8 @@ and type_pat_aux
         type_pat ~alloc_mode tps category sp_constrained expected_ty sort
       end
   | Ppat_type lid ->
+      Env.check_no_open_quotations sp.ppat_loc !!penv
+        (Env.Tconst_pat_qt lid.txt);
       let (path, p) = build_or_pat !!penv loc lid in
       pure category @@ solve_expected
         { p with pat_extra = (Tpat_type (path, lid), loc, sp.ppat_attributes)
@@ -10331,9 +10333,11 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
     match spat_sexp_list with
     | [] -> false
     | first :: rest ->
-      if first.pvb_is_poly then
+      if first.pvb_is_poly then begin
         Language_extension.assert_enabled ~loc:first.pvb_loc
           Layout_poly Language_extension.Alpha;
+        Env.check_no_open_quotations first.pvb_loc env Layout_polymorphism_qt
+      end;
       List.iter (fun binding ->
         if binding.pvb_is_poly <> first.pvb_is_poly then
           raise (Error(binding.pvb_loc, env, Mixed_poly_nonpoly_bindings))

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -974,6 +974,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let ty, fields = transl_fields env ~policy ~row_context o fields in
       ctyp (Ttyp_object (fields, o)) (newobj ty)
   | Ptyp_class(lid, stl) ->
+      Env.check_no_open_quotations loc env Class_type_qt;
       let (path, decl) =
         match Env.lookup_cltype ~loc:lid.loc lid.txt env with
         | (path, decl) -> (path, decl.clty_hash_type)
@@ -1159,6 +1160,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
   | Ptyp_repr(vars, st) ->
       Language_extension.assert_enabled ~loc Layout_poly
         Language_extension.Alpha;
+      Env.check_no_open_quotations loc env Layout_polymorphism_qt;
       let desc, typ =
         transl_type_repr env ~policy ~row_context mode styp.ptyp_loc
           vars st
@@ -1167,6 +1169,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
   | Ptyp_newlayout _ ->
       Language_extension.assert_enabled ~loc Layout_poly
         Language_extension.Alpha;
+      Env.check_no_open_quotations loc env Layout_polymorphism_qt;
       raise (Error (loc, env, Lpoly_unsupported))
   | Ptyp_package (p, l) ->
     (* CR layouts: right now we're doing a real gross hack where we demand
@@ -1210,6 +1213,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let cty = transl_type new_env ~policy ~row_context mode t in
       ctyp (Ttyp_open (path, mod_ident, cty)) cty.ctyp_type
   | Ptyp_of_kind jkind ->
+      Env.check_no_open_quotations loc env Jkind_annotation_qt;
       let tjkind =
         jkind_of_annotation env (Type_of_kind loc) styp.ptyp_attributes jkind
       in


### PR DESCRIPTION
Three `Translquote` fatal errors are now gracefully reported to the user and avoid crashing the compiler. These are mainly rarely and WIP used language features:
- class types (`Ptyp_class`)
- type constraint patterns
- layout polymorphism

Expect tests are added that demonstrate the graceful error reporting.

These are mostly quick drive-by fixes.