### PR TITLE
dissector: build IGOT/IPLT per partition; process sequentially

### DIFF
--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -163,27 +163,35 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
     with Partial_link.Error err -> raise (Error (Partial_link_error err))
   in
   log "partially linked %d partition(s)" (List.length linked_partitions);
-  let relocations =
-    Extract_relocations.extract_from_linked_partitions unix linked_partitions
+  (* Extract relocations and rewrite each partition immediately so each
+     partition's Extract_relocations.t is freed before the next begins, rather
+     than accumulating all simultaneously. *)
+  let total_plt, total_got =
+    List.fold_left
+      (fun (plt_acc, got_acc) linked ->
+        let kind = Partition.kind (Partition.Linked.partition linked) in
+        let prefix = Partition.symbol_prefix kind in
+        let input_file = Partition.Linked.linked_object linked in
+        let relocations =
+          Profile.record_call ~accumulate:true "dissector/extract_relocations"
+            (fun () -> Extract_relocations.extract unix ~filename:input_file)
+        in
+        let n_plt = Extract_relocations.num_plt relocations in
+        let n_got = Extract_relocations.num_got relocations in
+        let igot_and_iplt = Build_igot_and_iplt.build ~prefix relocations in
+        log "built IGOT with %d entries, IPLT with %d entries (prefix=%s)"
+          (Igot.num_entries (Build_igot_and_iplt.igot igot_and_iplt))
+          (Iplt.num_entries (Build_igot_and_iplt.iplt igot_and_iplt))
+          prefix;
+        let output_file = input_file ^ ".rewritten" in
+        Profile.record_call ~accumulate:true "dissector/rewrite" (fun () ->
+            Rewrite_sections.rewrite unix ~input_file ~output_file
+              ~partition_kind:kind ~igot_and_iplt ~relocations);
+        log "rewrote %s -> %s" input_file output_file;
+        plt_acc + n_plt, got_acc + n_got)
+      (0, 0) linked_partitions
   in
-  log "found %d PLT relocations and %d GOT relocations"
-    (List.length (Extract_relocations.convert_to_plt relocations))
-    (List.length (Extract_relocations.convert_to_got relocations));
-  List.iter
-    (fun linked ->
-      let kind = Partition.kind (Partition.Linked.partition linked) in
-      let prefix = Partition.symbol_prefix kind in
-      let igot_and_iplt = Build_igot_and_iplt.build ~prefix relocations in
-      log "built IGOT with %d entries, IPLT with %d entries (prefix=%s)"
-        (List.length (Igot.entries (Build_igot_and_iplt.igot igot_and_iplt)))
-        (List.length (Iplt.entries (Build_igot_and_iplt.iplt igot_and_iplt)))
-        prefix;
-      let input_file = Partition.Linked.linked_object linked in
-      let output_file = input_file ^ ".rewritten" in
-      Rewrite_sections.rewrite unix ~input_file ~output_file
-        ~partition_kind:kind ~igot_and_iplt ~relocations;
-      log "rewrote %s -> %s" input_file output_file)
-    linked_partitions;
+  log "total: %d PLT relocations, %d GOT relocations" total_plt total_got;
   let existing_script = extract_linker_script_from_ccopts !Clflags.all_ccopts in
   (match existing_script with
   | Some path -> log "found existing linker script: %s" path

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -167,30 +167,35 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
     with Partial_link.Error err -> raise (Error (Partial_link_error err))
   in
   log "partially linked %d partition(s)" (List.length linked_partitions);
-  let relocations =
-    Profile.record_call "dissector/extract_relocations" (fun () ->
-        Extract_relocations.extract_from_linked_partitions unix
-          linked_partitions)
+  (* For each partition, we extract the relocations and then rewrite it
+     immediately. This avoids holding on to relocations (of other partitions)
+     for longer than necessary. *)
+  let total_plt, total_got =
+    List.fold_left
+      (fun (plt_acc, got_acc) linked ->
+        let kind = Partition.kind (Partition.Linked.partition linked) in
+        let prefix = Partition.symbol_prefix kind in
+        let input_file = Partition.Linked.linked_object linked in
+        let relocations =
+          Profile.record_call ~accumulate:true "dissector/extract_relocations"
+            (fun () -> Extract_relocations.extract unix ~filename:input_file)
+        in
+        let n_plt = Extract_relocations.num_plt relocations in
+        let n_got = Extract_relocations.num_got relocations in
+        let igot_and_iplt = Build_igot_and_iplt.build ~prefix relocations in
+        log "built IGOT with %d entries, IPLT with %d entries (prefix=%s)"
+          (Igot.num_entries (Build_igot_and_iplt.igot igot_and_iplt))
+          (Iplt.num_entries (Build_igot_and_iplt.iplt igot_and_iplt))
+          prefix;
+        let output_file = input_file ^ ".rewritten" in
+        Profile.record_call ~accumulate:true "dissector/rewrite" (fun () ->
+            Rewrite_sections.rewrite unix ~input_file ~output_file
+              ~partition_kind:kind ~igot_and_iplt ~relocations);
+        log "rewrote %s -> %s" input_file output_file;
+        plt_acc + n_plt, got_acc + n_got)
+      (0, 0) linked_partitions
   in
-  log "found %d PLT relocations and %d GOT relocations"
-    (List.length (Extract_relocations.convert_to_plt relocations))
-    (List.length (Extract_relocations.convert_to_got relocations));
-  List.iter
-    (fun linked ->
-      let kind = Partition.kind (Partition.Linked.partition linked) in
-      let prefix = Partition.symbol_prefix kind in
-      let igot_and_iplt = Build_igot_and_iplt.build ~prefix relocations in
-      log "built IGOT with %d entries, IPLT with %d entries (prefix=%s)"
-        (List.length (Igot.entries (Build_igot_and_iplt.igot igot_and_iplt)))
-        (List.length (Iplt.entries (Build_igot_and_iplt.iplt igot_and_iplt)))
-        prefix;
-      let input_file = Partition.Linked.linked_object linked in
-      let output_file = input_file ^ ".rewritten" in
-      Profile.record_call ~accumulate:true "dissector/rewrite" (fun () ->
-          Rewrite_sections.rewrite unix ~input_file ~output_file
-            ~partition_kind:kind ~igot_and_iplt ~relocations);
-      log "rewrote %s -> %s" input_file output_file)
-    linked_partitions;
+  log "total: %d PLT relocations, %d GOT relocations" total_plt total_got;
   let existing_script = extract_linker_script_from_ccopts !Clflags.all_ccopts in
   (match existing_script with
   | Some path -> log "found existing linker script: %s" path

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -45,33 +45,47 @@ end
 
 type t =
   { convert_to_plt : Relocation_entry.t list;
-    convert_to_got : Relocation_entry.t list
+    convert_to_got : Relocation_entry.t list;
+    num_plt : int;
+    num_got : int
   }
 
 let convert_to_plt t = t.convert_to_plt
 
 let convert_to_got t = t.convert_to_got
 
-let empty = { convert_to_plt = []; convert_to_got = [] }
+let num_plt t = t.num_plt
+
+let num_got t = t.num_got
+
+let empty =
+  { convert_to_plt = []; convert_to_got = []; num_plt = 0; num_got = 0 }
 
 (* Accumulator for efficient merging - stores lists in reverse order *)
 type accumulator =
   { acc_plt : Relocation_entry.t list;
-    acc_got : Relocation_entry.t list
+    acc_got : Relocation_entry.t list;
+    acc_num_plt : int;
+    acc_num_got : int
   }
 
-let empty_accumulator = { acc_plt = []; acc_got = [] }
+let empty_accumulator =
+  { acc_plt = []; acc_got = []; acc_num_plt = 0; acc_num_got = 0 }
 
 (* Add entries to accumulator - O(n) where n is size of entries being added *)
 let accumulate acc entries =
   { acc_plt = List.rev_append entries.convert_to_plt acc.acc_plt;
-    acc_got = List.rev_append entries.convert_to_got acc.acc_got
+    acc_got = List.rev_append entries.convert_to_got acc.acc_got;
+    acc_num_plt = acc.acc_num_plt + entries.num_plt;
+    acc_num_got = acc.acc_num_got + entries.num_got
   }
 
 (* Finalize accumulator into result - reverses the lists *)
 let finalize acc =
   { convert_to_plt = List.rev acc.acc_plt;
-    convert_to_got = List.rev acc.acc_got
+    convert_to_got = List.rev acc.acc_got;
+    num_plt = acc.acc_num_plt;
+    num_got = acc.acc_num_got
   }
 
 (* Parse RELA entries and extract PLT32 and REX_GOTPCRELX relocations for
@@ -142,9 +156,12 @@ let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
             if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
             then convert_to_plt := reloc_entry :: !convert_to_plt
             else convert_to_got := reloc_entry :: !convert_to_got));
-  { convert_to_plt = List.rev !convert_to_plt;
-    convert_to_got = List.rev !convert_to_got
-  }
+  let rev_and_count lst =
+    List.fold_left (fun (acc, n) x -> x :: acc, n + 1) ([], 0) lst
+  in
+  let convert_to_plt, num_plt = rev_and_count !convert_to_plt in
+  let convert_to_got, num_got = rev_and_count !convert_to_got in
+  { convert_to_plt; convert_to_got; num_plt; num_got }
 
 (* Find a section by name *)
 let find_section sections name =
@@ -207,14 +224,3 @@ let extract_into_accumulator (unix : (module Compiler_owee.Unix_intf.S))
 
 let extract unix ~filename =
   finalize (extract_into_accumulator unix ~filename empty_accumulator)
-
-let extract_from_linked_partitions unix linked_partitions =
-  let acc =
-    List.fold_left
-      (fun acc linked ->
-        extract_into_accumulator unix
-          ~filename:(Partition.Linked.linked_object linked)
-          acc)
-      empty_accumulator linked_partitions
-  in
-  finalize acc

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -45,33 +45,47 @@ end
 
 type t =
   { convert_to_plt : Relocation_entry.t list;
-    convert_to_got : Relocation_entry.t list
+    convert_to_got : Relocation_entry.t list;
+    num_plt : int;
+    num_got : int
   }
 
 let convert_to_plt t = t.convert_to_plt
 
 let convert_to_got t = t.convert_to_got
 
-let empty = { convert_to_plt = []; convert_to_got = [] }
+let num_plt t = t.num_plt
+
+let num_got t = t.num_got
+
+let empty =
+  { convert_to_plt = []; convert_to_got = []; num_plt = 0; num_got = 0 }
 
 (* Accumulator for efficient merging - stores lists in reverse order *)
 type accumulator =
   { acc_plt : Relocation_entry.t list;
-    acc_got : Relocation_entry.t list
+    acc_got : Relocation_entry.t list;
+    acc_num_plt : int;
+    acc_num_got : int
   }
 
-let empty_accumulator = { acc_plt = []; acc_got = [] }
+let empty_accumulator =
+  { acc_plt = []; acc_got = []; acc_num_plt = 0; acc_num_got = 0 }
 
 (* Add entries to accumulator - O(n) where n is size of entries being added *)
 let accumulate acc entries =
   { acc_plt = List.rev_append entries.convert_to_plt acc.acc_plt;
-    acc_got = List.rev_append entries.convert_to_got acc.acc_got
+    acc_got = List.rev_append entries.convert_to_got acc.acc_got;
+    acc_num_plt = acc.acc_num_plt + entries.num_plt;
+    acc_num_got = acc.acc_num_got + entries.num_got
   }
 
 (* Finalize accumulator into result - reverses the lists *)
 let finalize acc =
   { convert_to_plt = List.rev acc.acc_plt;
-    convert_to_got = List.rev acc.acc_got
+    convert_to_got = List.rev acc.acc_got;
+    num_plt = acc.acc_num_plt;
+    num_got = acc.acc_num_got
   }
 
 (* Parse RELA entries and extract PLT32 and REX_GOTPCRELX relocations for
@@ -142,9 +156,12 @@ let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
             if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
             then convert_to_plt := reloc_entry :: !convert_to_plt
             else convert_to_got := reloc_entry :: !convert_to_got));
-  { convert_to_plt = List.rev !convert_to_plt;
-    convert_to_got = List.rev !convert_to_got
-  }
+  let rev_and_count lst =
+    List.fold_left (fun (acc, n) x -> x :: acc, n + 1) ([], 0) lst
+  in
+  let convert_to_plt, num_plt = rev_and_count !convert_to_plt in
+  let convert_to_got, num_got = rev_and_count !convert_to_got in
+  { convert_to_plt; convert_to_got; num_plt; num_got }
 
 (* Find a section by name *)
 let find_section sections name =
@@ -207,15 +224,3 @@ let extract_into_accumulator (unix : (module Compiler_owee.Unix_intf.S))
 
 let extract unix ~filename =
   finalize (extract_into_accumulator unix ~filename empty_accumulator)
-
-let extract_from_linked_partitions unix linked_partitions =
-  let acc =
-    List.fold_left
-      (fun acc linked ->
-        extract_into_accumulator unix
-          ~filename:(Partition.Linked.linked_object linked)
-          acc)
-      empty_accumulator linked_partitions
-  in
-  Gc.compact ();
-  finalize acc

--- a/asmcomp/dissector/extract_relocations.mli
+++ b/asmcomp/dissector/extract_relocations.mli
@@ -54,16 +54,15 @@ val convert_to_plt : t -> Relocation_entry.t list
 *)
 val convert_to_got : t -> Relocation_entry.t list
 
+(** Returns the number of PLT relocations (O(1)). *)
+val num_plt : t -> int
+
+(** Returns the number of GOT relocations (O(1)). *)
+val num_got : t -> int
+
 (** [extract unix ~filename] reads the ELF object file at [filename] and
     extracts relocations from the .rela.text section that need to be converted
     for the medium code model.
 
     Returns the lists of PLT32 and REX_GOTPCRELX relocations found. *)
 val extract : (module Compiler_owee.Unix_intf.S) -> filename:string -> t
-
-(** [extract_from_linked_partitions unix linked_partitions] extracts relocations
-    from all the partially-linked object files.
-
-    Returns combined relocation information from all partitions. *)
-val extract_from_linked_partitions :
-  (module Compiler_owee.Unix_intf.S) -> Partition.Linked.t list -> t

--- a/asmcomp/dissector/igot.ml
+++ b/asmcomp/dissector/igot.ml
@@ -56,6 +56,7 @@ end
 
 type t =
   { entries : Entry.t list;
+    num_entries : int;
     by_original_symbol : Entry.t String.Tbl.t;
     section_data : bytes
   }
@@ -90,10 +91,13 @@ let build ~prefix ~symbols =
       unique_symbols
   in
   (* Section data is zero-initialized *)
-  let section_data = Bytes.make (List.length entries * entry_size) '\x00' in
-  { entries; by_original_symbol; section_data }
+  let num_entries = String.Tbl.length by_original_symbol in
+  let section_data = Bytes.make (num_entries * entry_size) '\x00' in
+  { entries; num_entries; by_original_symbol; section_data }
 
 let entries t = t.entries
+
+let num_entries t = t.num_entries
 
 let section_data t = t.section_data
 

--- a/asmcomp/dissector/igot.mli
+++ b/asmcomp/dissector/igot.mli
@@ -67,6 +67,9 @@ val build : prefix:string -> symbols:string list -> t
 (** Returns the list of entries in the IGOT. *)
 val entries : t -> Entry.t list
 
+(** Returns the number of entries in the IGOT (O(1)). *)
+val num_entries : t -> int
+
 (** Returns the section data (zero-initialized). *)
 val section_data : t -> bytes
 

--- a/asmcomp/dissector/iplt.ml
+++ b/asmcomp/dissector/iplt.ml
@@ -61,6 +61,7 @@ end
 
 type t =
   { entries : Entry.t list;
+    num_entries : int;
     by_original_symbol : Entry.t String.Tbl.t;
     section_data : bytes
   }
@@ -134,9 +135,11 @@ let build ~prefix ~igot ~symbols =
     Bytes.blit_string plt_entry_template 0 section_data (i * entry_size)
       entry_size
   done;
-  { entries; by_original_symbol; section_data }
+  { entries; num_entries; by_original_symbol; section_data }
 
 let entries t = t.entries
+
+let num_entries t = t.num_entries
 
 let section_data t = t.section_data
 

--- a/asmcomp/dissector/iplt.mli
+++ b/asmcomp/dissector/iplt.mli
@@ -82,6 +82,9 @@ val build : prefix:string -> igot:Igot.t -> symbols:string list -> t
 (** Returns the list of entries in the IPLT. *)
 val entries : t -> Entry.t list
 
+(** Returns the number of entries in the IPLT (O(1)). *)
+val num_entries : t -> int
+
 (** Returns the section data (machine code). *)
 val section_data : t -> bytes
 


### PR DESCRIPTION
Previously, `extract_from_linked_partitions` merged relocations from every partition into a single flat list. Each partition's IGOT/IPLT was then built from this merged set, so every partition received entries for every external symbol referenced anywhere in the program.

For a binary split into N partitions each referencing ~K/N unique external symbols, this produced N*K IGOT entries and IPLT stubs in total — rather than K. The final binary carries all of these because per-partition symbols have distinct names (different prefix) and are not deduplicated by the linker.

Fix by processing partitions sequentially: extract relocations for one partition, build and emit its IGOT/IPLT sized to only its own symbols, then move on to the next. This also means each partition's `Extract_relocations.t` is freed before the next begins, rather than all living simultaneously.

Remove `extract_from_linked_partitions` entirely: the sequential fold in `dissector.ml` calls `Extract_relocations.extract` directly.

To support O(1) relocation counting (needed for the log summary), add `num_plt` and `num_got` accessors to `Extract_relocations.t`, and `num_entries` to `Igot.t` and `Iplt.t`.