### PR TITLE
Structured Fexpr primitive

### DIFF
--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -335,6 +335,17 @@ module Mixed_block_shape = struct
     else
       Misc.Stdlib.Array.compare Flat_suffix_element0.compare flat_suffix1
         flat_suffix2
+
+  let from_prefix_size_and_suffix_elements prefix_size suffix =
+    let field_kinds =
+      Array.of_list
+      @@ List.init prefix_size (fun _ -> Value)
+      @ List.map Flat_suffix_element0.kind suffix
+    in
+    { value_prefix_size = prefix_size;
+      flat_suffix = Array.of_list suffix;
+      field_kinds
+    }
 end
 
 module Scannable_block_shape = struct

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -89,7 +89,7 @@ val is_naked_float : t -> bool
 
 include Container_types.S with type t := t
 
-type flat_suffix_element = private
+type flat_suffix_element =
   | Naked_float
   | Naked_float32
   | Naked_int8
@@ -122,6 +122,9 @@ module Mixed_block_shape : sig
   val compare : t -> t -> int
 
   val print : Format.formatter -> t -> unit
+
+  val from_prefix_size_and_suffix_elements :
+    int -> flat_suffix_element list -> t
 end
 
 module Scannable_block_shape : sig

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -202,12 +202,8 @@ type alloc_mode_for_assignments =
   | Local
 
 type prim_param =
-  | Labeled of
-      { label : string;
-        value : string located
-      }
-  | Positional of string located
-  | Flag of string
+  | Labeled of string located * prim_param list
+  | Anonymous of prim_param list
 
 type prim_op =
   { prim : string;

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -12,49 +12,35 @@ let or_unknown cons =
       ~to_:(fun _ ouk ->
         match (ouk : _ Or_unknown.t) with Unknown -> None | Known v -> Some v))
 
-let target_ocaml_int : Target_ocaml_int.t value_lens =
-  { encode = (fun _ t -> Target_ocaml_int.to_int t |> string_of_int |> wrap_loc);
-    decode =
-      (fun _ s ->
-        (* CR mshinwell: Should get machine_width from fexpr context when
-           available *)
-        let mw = Target_system.Machine_width.Sixty_four in
-        Target_ocaml_int.of_int mw @@ int_of_string (unwrap_loc s))
-  }
+let target_ocaml_int : Target_ocaml_int.t param_cons =
+  D.value
+    { encode =
+        (fun _ t -> Target_ocaml_int.to_int t |> string_of_int |> wrap_loc);
+      decode =
+        (fun _ s ->
+          (* CR mshinwell: Should get machine_width from fexpr context when
+             available *)
+          let mw = Target_system.Machine_width.Sixty_four in
+          Target_ocaml_int.of_int mw @@ int_of_string (unwrap_loc s))
+    }
 
-let scannable_tag : Tag.Scannable.t value_lens =
-  { encode = (fun _ t -> Tag.Scannable.to_int t |> string_of_int |> wrap_loc);
-    decode =
-      (fun _ s -> Tag.Scannable.create_exn @@ int_of_string (unwrap_loc s))
-  }
+let scannable_tag : Tag.Scannable.t param_cons =
+  D.value
+    { encode = (fun _ t -> Tag.Scannable.to_int t |> string_of_int |> wrap_loc);
+      decode =
+        (fun _ s -> Tag.Scannable.create_exn @@ int_of_string (unwrap_loc s))
+    }
 
 let mutability =
   D.(
     default ~def:Mutability.Immutable
-    @@ constructor_flag Mutability.["imm_uniq", Immutable_unique; "mut", Mutable])
+    @@ constructor_flag
+         Mutability.
+           ["immut", Immutable; "imm_uniq", Immutable_unique; "mut", Mutable])
 
 let mutable_flag =
   D.(
     default ~def:Asttypes.Immutable @@ constructor_flag Asttypes.["mut", Mutable])
-
-let mutability_as_value =
-  { decode =
-      (fun _ m : Mutability.t ->
-        match unwrap_loc m with
-        | "immut" -> Immutable
-        | "immut_uniq" -> Immutable_unique
-        | "mut" -> Mutable
-        | _ -> Misc.fatal_error "invalid mutability");
-    encode =
-      (fun _ m ->
-        let s =
-          match (m : Mutability.t) with
-          | Immutable -> "immut"
-          | Immutable_unique -> "immut_uniq"
-          | Mutable -> "mut"
-        in
-        wrap_loc s)
-  }
 
 let standard_int =
   D.(
@@ -69,7 +55,7 @@ let standard_int =
              "nativeint", Naked_nativeint ])
 
 let standard_int_or_float =
-  D.constructor_value
+  D.constructor_flag
     Flambda_kind.Standard_int_or_float.
       [ "tagged_imm", Tagged_immediate;
         "imm", Naked_immediate;
@@ -123,7 +109,7 @@ let block_access_field_kind =
     @@ constructor_flag ["imm", P.Block_access_field_kind.Immediate])
 
 let block_access_kind =
-  let value =
+  let value_k =
     D.(
       param3 block_access_field_kind
         (or_unknown @@ labeled "tag" scannable_tag)
@@ -153,7 +139,7 @@ let block_access_kind =
             match (bak : P.Block_access_kind.t) with
             | Values { field_kind; tag; size } -> Some (field_kind, tag, size)
             | Naked_floats _ | Mixed _ -> None)
-          value ])
+          value_k ])
 
 type block_kind =
   | FNaked_floats
@@ -174,44 +160,45 @@ let block_kind : block_kind param_cons =
           (positional scannable_tag) ])
 
 let string_accessor_width =
-  { decode =
-      (fun _ i : P.string_accessor_width ->
-        let i = unwrap_loc i in
-        match i with
-        | "f32" -> Single
-        | "8" -> Eight
-        | "8s" -> Eight_signed
-        | "16" -> Sixteen
-        | "16s" -> Sixteen_signed
-        | "32" -> Thirty_two
-        | "64" -> Sixty_four
-        | "128a" -> One_twenty_eight { aligned = true }
-        | "128u" -> One_twenty_eight { aligned = false }
-        | "256a" -> Two_fifty_six { aligned = true }
-        | "256u" -> Two_fifty_six { aligned = false }
-        | "512a" -> Five_twelve { aligned = true }
-        | "512u" -> Five_twelve { aligned = false }
-        | _ -> Misc.fatal_errorf "invalid string accessor width '%s'" i);
-    encode =
-      (fun _ saw ->
-        let s =
-          match (saw : P.string_accessor_width) with
-          | Eight -> "8"
-          | Eight_signed -> "8s"
-          | Sixteen -> "16"
-          | Sixteen_signed -> "16s"
-          | Thirty_two -> "32"
-          | Single -> "f32"
-          | Sixty_four -> "64"
-          | One_twenty_eight { aligned = false } -> "128u"
-          | One_twenty_eight { aligned = true } -> "128a"
-          | Two_fifty_six { aligned = false } -> "256u"
-          | Two_fifty_six { aligned = true } -> "256a"
-          | Five_twelve { aligned = false } -> "512u"
-          | Five_twelve { aligned = true } -> "512a"
-        in
-        wrap_loc s)
-  }
+  D.value
+    { decode =
+        (fun _ i : P.string_accessor_width ->
+          let i = unwrap_loc i in
+          match i with
+          | "f32" -> Single
+          | "8" -> Eight
+          | "8s" -> Eight_signed
+          | "16" -> Sixteen
+          | "16s" -> Sixteen_signed
+          | "32" -> Thirty_two
+          | "64" -> Sixty_four
+          | "128a" -> One_twenty_eight { aligned = true }
+          | "128u" -> One_twenty_eight { aligned = false }
+          | "256a" -> Two_fifty_six { aligned = true }
+          | "256u" -> Two_fifty_six { aligned = false }
+          | "512a" -> Five_twelve { aligned = true }
+          | "512u" -> Five_twelve { aligned = false }
+          | _ -> Misc.fatal_errorf "invalid string accessor width '%s'" i);
+      encode =
+        (fun _ saw ->
+          let s =
+            match (saw : P.string_accessor_width) with
+            | Eight -> "8"
+            | Eight_signed -> "8s"
+            | Sixteen -> "16"
+            | Sixteen_signed -> "16s"
+            | Thirty_two -> "32"
+            | Single -> "f32"
+            | Sixty_four -> "64"
+            | One_twenty_eight { aligned = false } -> "128u"
+            | One_twenty_eight { aligned = true } -> "128a"
+            | Two_fifty_six { aligned = false } -> "256u"
+            | Two_fifty_six { aligned = true } -> "256a"
+            | Five_twelve { aligned = false } -> "512u"
+            | Five_twelve { aligned = true } -> "512a"
+          in
+          wrap_loc s)
+    }
 
 let init_or_assign =
   D.(
@@ -379,129 +366,131 @@ let kind =
            "rec_info", K.rec_info ])
 
 let kind_with_subkind =
-  { decode =
-      (fun _ m : Flambda_kind.With_subkind.t ->
-        match unwrap_loc m with
-        | "region" -> Flambda_kind.With_subkind.region
-        | "rec_info" -> Flambda_kind.With_subkind.rec_info
-        | "imm" -> Flambda_kind.With_subkind.naked_immediate
-        | "float32" -> Flambda_kind.With_subkind.naked_float32
-        | "float" -> Flambda_kind.With_subkind.naked_float
-        | "int8" -> Flambda_kind.With_subkind.naked_int8
-        | "int16" -> Flambda_kind.With_subkind.naked_int16
-        | "int32" -> Flambda_kind.With_subkind.naked_int32
-        | "int64" -> Flambda_kind.With_subkind.naked_int64
-        | "nativeint" -> Flambda_kind.With_subkind.naked_nativeint
-        | "vec128" -> Flambda_kind.With_subkind.naked_vec128
-        | "vec256" -> Flambda_kind.With_subkind.naked_vec256
-        | "vec512" -> Flambda_kind.With_subkind.naked_vec512
-        | value ->
-          let nullable, non_null_value_subkind =
-            if String.ends_with ~suffix:"_or_null" value
-            then
-              ( K.With_subkind.Nullable.Nullable,
-                String.sub value 0
-                  (String.length value - String.length "_or_null") )
-            else K.With_subkind.Nullable.Non_nullable, value
-          in
-          let non_null_value_subkind : K.With_subkind.Non_null_value_subkind.t =
-            match non_null_value_subkind with
-            | "value" -> Anything
-            | "boxed_float32" -> Boxed_float32
-            | "boxed_float" -> Boxed_float
-            | "boxed_int32" -> Boxed_int32
-            | "boxed_int64" -> Boxed_int64
-            | "boxed_nativeint" -> Boxed_nativeint
-            | "boxed_vec128" -> Boxed_vec128
-            | "boxed_vec256" -> Boxed_vec256
-            | "boxed_vec512" -> Boxed_vec512
-            | "tagged_imm" -> Tagged_immediate
-            | "variant" ->
-              Format.eprintf "Unsupported value subkind: variant@.";
-              Anything
-            | "float_block" ->
-              Format.eprintf "Unsupported value subkind: float_block@.";
-              Anything
-            | "floatarray" -> Float_array
-            | "imm_array" -> Immediate_array
-            | "array" -> Value_array
-            | "genarray" -> Generic_array
-            | "float32_array" -> Unboxed_float32_array
-            | "int_array" -> Untagged_int_array
-            | "int8_array" -> Untagged_int8_array
-            | "int16_array" -> Untagged_int16_array
-            | "int32_array" -> Unboxed_int32_array
-            | "int64_array" -> Unboxed_int64_array
-            | "nativeint_array" -> Unboxed_nativeint_array
-            | "vec128_array" -> Unboxed_vec128_array
-            | "vec256_array" -> Unboxed_vec256_array
-            | "vec512_array" -> Unboxed_vec512_array
-            | "array#" -> Unboxed_product_array
-            | _ ->
-              Misc.fatal_errorf "Unsupported value subkind: %s"
-                non_null_value_subkind
-          in
-          K.With_subkind.create K.value non_null_value_subkind nullable);
-    encode =
-      (fun _ (m : Flambda_kind.With_subkind.t) ->
-        let s =
-          match Flambda_kind.With_subkind.kind m with
-          | Region -> "region"
-          | Rec_info -> "rec_info"
-          | Naked_number naked_number_kind -> (
-            match naked_number_kind with
-            | Naked_immediate -> "imm"
-            | Naked_float32 -> "float32"
-            | Naked_float -> "float"
-            | Naked_int8 -> "int8"
-            | Naked_int16 -> "int16"
-            | Naked_int32 -> "int32"
-            | Naked_int64 -> "int64"
-            | Naked_nativeint -> "nativeint"
-            | Naked_vec128 -> "vec128"
-            | Naked_vec256 -> "vec256"
-            | Naked_vec512 -> "vec512")
-          | Value -> (
-            let s =
-              match Flambda_kind.With_subkind.non_null_value_subkind m with
-              | Anything -> "value"
-              | Boxed_float32 -> "boxed_float32"
-              | Boxed_float -> "boxed_float"
-              | Boxed_int32 -> "boxed_int32"
-              | Boxed_int64 -> "boxed_int64"
-              | Boxed_nativeint -> "boxed_nativeint"
-              | Boxed_vec128 -> "boxed_vec128"
-              | Boxed_vec256 -> "boxed_vec256"
-              | Boxed_vec512 -> "boxed_vec512"
-              | Tagged_immediate -> "tagged_imm"
-              | Variant { consts = _; non_consts = _ } ->
-                (* CR bclement: need a better support for structural values *)
-                "variant"
-              | Float_block { num_fields = _ } ->
-                (* CR bclement: need a better support for structural values *)
-                "float_block"
-              | Float_array -> "floatarray"
-              | Immediate_array -> "imm_array"
-              | Value_array -> "array"
-              | Generic_array -> "genarray"
-              | Unboxed_float32_array -> "float32_array"
-              | Untagged_int_array -> "int_array"
-              | Untagged_int8_array -> "int8_array"
-              | Untagged_int16_array -> "int16_array"
-              | Unboxed_int32_array -> "int32_array"
-              | Unboxed_int64_array -> "int64_array"
-              | Unboxed_nativeint_array -> "nativeint_array"
-              | Unboxed_vec128_array -> "vec128_array"
-              | Unboxed_vec256_array -> "vec256_array"
-              | Unboxed_vec512_array -> "vec512_array"
-              | Unboxed_product_array -> "array#"
+  D.value
+    { decode =
+        (fun _ m : Flambda_kind.With_subkind.t ->
+          match unwrap_loc m with
+          | "region" -> Flambda_kind.With_subkind.region
+          | "rec_info" -> Flambda_kind.With_subkind.rec_info
+          | "imm" -> Flambda_kind.With_subkind.naked_immediate
+          | "float32" -> Flambda_kind.With_subkind.naked_float32
+          | "float" -> Flambda_kind.With_subkind.naked_float
+          | "int8" -> Flambda_kind.With_subkind.naked_int8
+          | "int16" -> Flambda_kind.With_subkind.naked_int16
+          | "int32" -> Flambda_kind.With_subkind.naked_int32
+          | "int64" -> Flambda_kind.With_subkind.naked_int64
+          | "nativeint" -> Flambda_kind.With_subkind.naked_nativeint
+          | "vec128" -> Flambda_kind.With_subkind.naked_vec128
+          | "vec256" -> Flambda_kind.With_subkind.naked_vec256
+          | "vec512" -> Flambda_kind.With_subkind.naked_vec512
+          | value ->
+            let nullable, non_null_value_subkind =
+              if String.ends_with ~suffix:"_or_null" value
+              then
+                ( K.With_subkind.Nullable.Nullable,
+                  String.sub value 0
+                    (String.length value - String.length "_or_null") )
+              else K.With_subkind.Nullable.Non_nullable, value
             in
-            match Flambda_kind.With_subkind.nullable m with
-            | Nullable -> s ^ "_or_null"
-            | Non_nullable -> s)
-        in
-        wrap_loc s)
-  }
+            let non_null_value_subkind : K.With_subkind.Non_null_value_subkind.t
+                =
+              match non_null_value_subkind with
+              | "value" -> Anything
+              | "boxed_float32" -> Boxed_float32
+              | "boxed_float" -> Boxed_float
+              | "boxed_int32" -> Boxed_int32
+              | "boxed_int64" -> Boxed_int64
+              | "boxed_nativeint" -> Boxed_nativeint
+              | "boxed_vec128" -> Boxed_vec128
+              | "boxed_vec256" -> Boxed_vec256
+              | "boxed_vec512" -> Boxed_vec512
+              | "tagged_imm" -> Tagged_immediate
+              | "variant" ->
+                Format.eprintf "Unsupported value subkind: variant@.";
+                Anything
+              | "float_block" ->
+                Format.eprintf "Unsupported value subkind: float_block@.";
+                Anything
+              | "floatarray" -> Float_array
+              | "imm_array" -> Immediate_array
+              | "array" -> Value_array
+              | "genarray" -> Generic_array
+              | "float32_array" -> Unboxed_float32_array
+              | "int_array" -> Untagged_int_array
+              | "int8_array" -> Untagged_int8_array
+              | "int16_array" -> Untagged_int16_array
+              | "int32_array" -> Unboxed_int32_array
+              | "int64_array" -> Unboxed_int64_array
+              | "nativeint_array" -> Unboxed_nativeint_array
+              | "vec128_array" -> Unboxed_vec128_array
+              | "vec256_array" -> Unboxed_vec256_array
+              | "vec512_array" -> Unboxed_vec512_array
+              | "array#" -> Unboxed_product_array
+              | _ ->
+                Misc.fatal_errorf "Unsupported value subkind: %s"
+                  non_null_value_subkind
+            in
+            K.With_subkind.create K.value non_null_value_subkind nullable);
+      encode =
+        (fun _ (m : Flambda_kind.With_subkind.t) ->
+          let s =
+            match Flambda_kind.With_subkind.kind m with
+            | Region -> "region"
+            | Rec_info -> "rec_info"
+            | Naked_number naked_number_kind -> (
+              match naked_number_kind with
+              | Naked_immediate -> "imm"
+              | Naked_float32 -> "float32"
+              | Naked_float -> "float"
+              | Naked_int8 -> "int8"
+              | Naked_int16 -> "int16"
+              | Naked_int32 -> "int32"
+              | Naked_int64 -> "int64"
+              | Naked_nativeint -> "nativeint"
+              | Naked_vec128 -> "vec128"
+              | Naked_vec256 -> "vec256"
+              | Naked_vec512 -> "vec512")
+            | Value -> (
+              let s =
+                match Flambda_kind.With_subkind.non_null_value_subkind m with
+                | Anything -> "value"
+                | Boxed_float32 -> "boxed_float32"
+                | Boxed_float -> "boxed_float"
+                | Boxed_int32 -> "boxed_int32"
+                | Boxed_int64 -> "boxed_int64"
+                | Boxed_nativeint -> "boxed_nativeint"
+                | Boxed_vec128 -> "boxed_vec128"
+                | Boxed_vec256 -> "boxed_vec256"
+                | Boxed_vec512 -> "boxed_vec512"
+                | Tagged_immediate -> "tagged_imm"
+                | Variant { consts = _; non_consts = _ } ->
+                  (* CR bclement: need a better support for structural values *)
+                  "variant"
+                | Float_block { num_fields = _ } ->
+                  (* CR bclement: need a better support for structural values *)
+                  "float_block"
+                | Float_array -> "floatarray"
+                | Immediate_array -> "imm_array"
+                | Value_array -> "array"
+                | Generic_array -> "genarray"
+                | Unboxed_float32_array -> "float32_array"
+                | Untagged_int_array -> "int_array"
+                | Untagged_int8_array -> "int8_array"
+                | Untagged_int16_array -> "int16_array"
+                | Unboxed_int32_array -> "int32_array"
+                | Unboxed_int64_array -> "int64_array"
+                | Unboxed_nativeint_array -> "nativeint_array"
+                | Unboxed_vec128_array -> "vec128_array"
+                | Unboxed_vec256_array -> "vec256_array"
+                | Unboxed_vec512_array -> "vec512_array"
+                | Unboxed_product_array -> "array#"
+              in
+              match Flambda_kind.With_subkind.nullable m with
+              | Nullable -> s ^ "_or_null"
+              | Non_nullable -> s)
+          in
+          wrap_loc s)
+    }
 
 (* Nullaries *)
 let invalid =
@@ -606,9 +595,8 @@ let duplicate_array =
   D.(
     unary "%duplicate_array"
       ~params:
-        (param3 duplicate_array_kind
-           (positional mutability_as_value)
-           (positional mutability_as_value))
+        (param3 duplicate_array_kind (positional mutability)
+           (positional mutability))
       (fun _ (kind, source_mutability, destination_mutability) ->
         P.Duplicate_array { kind; source_mutability; destination_mutability }))
 

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -108,17 +108,58 @@ let block_access_field_kind =
     default ~def:P.Block_access_field_kind.Any_value
     @@ constructor_flag ["imm", P.Block_access_field_kind.Immediate])
 
+let flat_suffix_element =
+  D.constructor_flag
+    K.
+      [ "float", Naked_float;
+        "float32", Naked_float32;
+        "int8", Naked_int8;
+        "int16", Naked_int16;
+        "int32", Naked_int32;
+        "int64", Naked_int64;
+        "nativeint", Naked_nativeint;
+        "imm", Naked_immediate;
+        "vec128", Naked_vec128;
+        "vec256", Naked_vec256;
+        "vec512", Naked_vec512 ]
+
+let mixed_block_shape =
+  let open D in
+  maps
+    ~from:(fun _ (size, suffix) ->
+      K.Mixed_block_shape.from_prefix_size_and_suffix_elements size suffix)
+    ~to_:(fun _ shape ->
+      K.Mixed_block_shape.(
+        value_prefix_size shape, Array.to_list (flat_suffix shape)))
+    (param2 int (list flat_suffix_element))
+
 let block_access_kind =
   let open D in
+  let tag = or_unknown @@ labeled "tag" scannable_tag in
+  let size = or_unknown @@ labeled "size" target_ocaml_int in
+  let|= mixed_field_kind =
+    let open P.Mixed_block_access_field_kind in
+    let| value_k = block_access_field_kind, fun _ bak -> Value_prefix bak in
+    let| suffix_k = flat_suffix_element, fun _ fse -> Flat_suffix fse in
+    return_either (fun env mfk ->
+        match mfk with
+        | Value_prefix bak -> value_k env bak
+        | Flat_suffix fse -> suffix_k env fse)
+  in
   let|= bak =
     let| naked_float =
-      ( param2 (flag "float") (or_unknown @@ labeled "size" target_ocaml_int),
+      ( param2 (flag "float") size,
         fun _ ((), size) -> P.Block_access_kind.Naked_floats { size } )
     in
+    let| mixed =
+      ( param2
+          (param3 (flag "mixed") tag size)
+          (param2 mixed_field_kind mixed_block_shape),
+        fun _ (((), tag, size), (field_kind, shape)) ->
+          P.Block_access_kind.Mixed { tag; size; field_kind; shape } )
+    in
     let| value_k =
-      ( param3 block_access_field_kind
-          (or_unknown @@ labeled "tag" scannable_tag)
-          (or_unknown @@ labeled "size" target_ocaml_int),
+      ( param3 block_access_field_kind tag size,
         fun _ (field_kind, tag, size) ->
           P.Block_access_kind.Values { field_kind; tag; size } )
     in
@@ -128,7 +169,7 @@ let block_access_kind =
           | Values { field_kind; tag; size } ->
             value_k env (field_kind, tag, size)
           | Naked_floats { size } -> naked_float env ((), size)
-          | Mixed _ -> Misc.fatal_errorf "Unsupported %a" print bak))
+          | Mixed m -> mixed env (((), m.tag, m.size), (m.field_kind, m.shape))))
   in
   bak
 

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -109,55 +109,44 @@ let block_access_field_kind =
     @@ constructor_flag ["imm", P.Block_access_field_kind.Immediate])
 
 let block_access_kind =
-  let value_k =
-    D.(
-      param3 block_access_field_kind
-        (or_unknown @@ labeled "tag" scannable_tag)
-        (or_unknown @@ labeled "size" target_ocaml_int))
+  let open D in
+  let|= bak =
+    let| naked_float =
+      ( param2 (flag "float") (or_unknown @@ labeled "size" target_ocaml_int),
+        fun _ ((), size) -> P.Block_access_kind.Naked_floats { size } )
+    in
+    let| value_k =
+      ( param3 block_access_field_kind
+          (or_unknown @@ labeled "tag" scannable_tag)
+          (or_unknown @@ labeled "size" target_ocaml_int),
+        fun _ (field_kind, tag, size) ->
+          P.Block_access_kind.Values { field_kind; tag; size } )
+    in
+    P.Block_access_kind.(
+      return_either (fun env bak ->
+          match bak with
+          | Values { field_kind; tag; size } ->
+            value_k env (field_kind, tag, size)
+          | Naked_floats { size } -> naked_float env ((), size)
+          | Mixed _ -> Misc.fatal_errorf "Unsupported %a" print bak))
   in
-  let naked_float =
-    D.(param2 (flag "float") (or_unknown @@ labeled "size" target_ocaml_int))
-  in
-  D.(
-    either
-      ~no_match_handler:
-        P.Block_access_kind.(
-          function
-          | Mixed _ as bak -> Misc.fatal_errorf "Unsupported %a" print bak
-          | Values _ | Naked_floats _ -> assert false)
-      [ case
-          ~box:(fun _ ((), size) -> P.Block_access_kind.Naked_floats { size })
-          ~unbox:(fun _ bak ->
-            match (bak : P.Block_access_kind.t) with
-            | Naked_floats { size } -> Some ((), size)
-            | Values _ | Mixed _ -> None)
-          naked_float;
-        case
-          ~box:(fun _ (field_kind, tag, size) ->
-            P.Block_access_kind.Values { field_kind; tag; size })
-          ~unbox:(fun _ bak ->
-            match (bak : P.Block_access_kind.t) with
-            | Values { field_kind; tag; size } -> Some (field_kind, tag, size)
-            | Naked_floats _ | Mixed _ -> None)
-          value_k ])
+  bak
 
 type block_kind =
   | FNaked_floats
   | FValues of Tag.Scannable.t
 
 let block_kind : block_kind param_cons =
-  D.(
-    either
-      [ case
-          ~box:(fun _ () -> FNaked_floats)
-          ~unbox:(fun _ bk ->
-            match bk with FNaked_floats -> Some () | FValues _ -> None)
-          (flag "floats");
-        case
-          ~box:(fun _ tag -> FValues tag)
-          ~unbox:(fun _ bk ->
-            match bk with FValues tag -> Some tag | FNaked_floats -> None)
-          (positional scannable_tag) ])
+  let open D in
+  let|= bk =
+    let| floats = flag "floats", fun _ () -> FNaked_floats in
+    let| values = positional scannable_tag, fun _ tag -> FValues tag in
+    return_either (fun env bk ->
+        match bk with
+        | FNaked_floats -> floats env ()
+        | FValues tag -> values env tag)
+  in
+  bk
 
 let string_accessor_width =
   D.value
@@ -209,38 +198,43 @@ let init_or_assign =
              "lassign", Assignment (Alloc_mode.For_assignments.local ()) ])
 
 let alloc_mode_for_allocation =
-  D.(
-    default ~def:Alloc_mode.For_allocations.heap
-    @@ either
-         [ case (labeled "local" string)
-             ~box:(fun env r ->
-               let region =
-                 if String.equal (unwrap_loc r) "toplevel"
-                 then env.toplevel_region
-                 else Fexpr_to_flambda_commons.find_var env r
-               in
-               Alloc_mode.For_allocations.local ~region)
-             ~unbox:(fun env -> function
-               | Alloc_mode.For_allocations.Local { region } ->
-                 let r =
-                   match
-                     Flambda_to_fexpr_commons.Env.find_region_exn env region
-                   with
-                   | Fexpr.Toplevel -> wrap_loc "toplevel"
-                   | Named s -> s
-                 in
-                 Some r
-               | Alloc_mode.For_allocations.Heap -> None) ])
+  let open D in
+  let|= am =
+    let| local =
+      ( labeled "local" string,
+        fun env r ->
+          let region =
+            if String.equal (unwrap_loc r) "toplevel"
+            then env.toplevel_region
+            else Fexpr_to_flambda_commons.find_var env r
+          in
+          Alloc_mode.For_allocations.local ~region )
+    in
+    let| heap = param0, fun _ () -> Alloc_mode.For_allocations.heap in
+    return_either (fun env -> function
+      | Alloc_mode.For_allocations.Local { region } ->
+        let r =
+          match Flambda_to_fexpr_commons.Env.find_region_exn env region with
+          | Fexpr.Toplevel -> wrap_loc "toplevel"
+          | Named s -> s
+        in
+        local env r
+      | Alloc_mode.For_allocations.Heap -> heap env ())
+  in
+  am
 
 let alloc_mode_for_assignments =
-  D.(
-    default ~def:Alloc_mode.For_assignments.heap
-    @@ either
-         [ case (flag "local")
-             ~box:(fun _env () -> Alloc_mode.For_assignments.local ())
-             ~unbox:(fun _env -> function
-               | Alloc_mode.For_assignments.Local -> Some ()
-               | Alloc_mode.For_assignments.Heap -> None) ])
+  let open D in
+  let|= am =
+    let| local =
+      flag "local", fun _env () -> Alloc_mode.For_assignments.local ()
+    in
+    let| heap = param0, fun _ () -> Alloc_mode.For_assignments.heap in
+    return_either (fun env -> function
+      | Alloc_mode.For_assignments.Local -> local env ()
+      | Alloc_mode.For_assignments.Heap -> heap env ())
+  in
+  am
 
 let boxable_number =
   D.constructor_flag
@@ -274,14 +268,16 @@ let array_kind =
              "gc_ign", Gc_ignorable_values ])
 
 let array_kind_for_length =
-  D.(
-    either
-      P.Array_kind_for_length.
-        [ id_case @@ constructor_flag ["generic", Float_array_opt_dynamic];
-          case array_kind
-            ~box:(fun _ k -> Array_kind k)
-            ~unbox:(fun _ -> function
-              | Float_array_opt_dynamic -> None | Array_kind k -> Some k) ])
+  let open D in
+  let open P.Array_kind_for_length in
+  let|= ak =
+    let| generic = flag "generic", fun _ () -> Float_array_opt_dynamic in
+    let| arrayk = array_kind, fun _ k -> Array_kind k in
+    return_either (fun env -> function
+      | Float_array_opt_dynamic -> generic env ()
+      | Array_kind k -> arrayk env k)
+  in
+  ak
 
 let lazy_tag =
   D.(
@@ -768,45 +764,25 @@ let int_comp =
   let open D in
   let open Flambda_primitive in
   let sign = default ~def:Signed @@ constructor_flag ["unsigned", Unsigned] in
-  let[@warning "-fragile-match"] comp =
-    either
-      [ case
-          (param2 sign (flag "lt"))
-          ~box:(fun _ (s, ()) -> Yielding_bool (Lt s))
-          ~unbox:(fun _ -> function
-            | Yielding_bool (Lt s) -> Some (s, ())
-            | Yielding_bool (Le _ | Gt _ | Ge _ | Eq | Neq)
-            | Yielding_int_like_compare_functions _ ->
-              None);
-        case
-          (param2 sign (flag "le"))
-          ~box:(fun _ (s, ()) -> Yielding_bool (Le s))
-          ~unbox:(fun _ -> function
-            | Yielding_bool (Le s) -> Some (s, ()) | _ -> None);
-        case
-          (param2 sign (flag "gt"))
-          ~box:(fun _ (s, ()) -> Yielding_bool (Gt s))
-          ~unbox:(fun _ -> function
-            | Yielding_bool (Gt s) -> Some (s, ()) | _ -> None);
-        case
-          (param2 sign (flag "ge"))
-          ~box:(fun _ (s, ()) -> Yielding_bool (Ge s))
-          ~unbox:(fun _ -> function
-            | Yielding_bool (Ge s) -> Some (s, ()) | _ -> None);
-        case
-          (param2 sign (flag "qmark"))
-          ~box:(fun _ (s, ()) -> Yielding_int_like_compare_functions s)
-          ~unbox:(fun _ -> function
-            | Yielding_int_like_compare_functions s -> Some (s, ()) | _ -> None);
-        case (flag "eq")
-          ~box:(fun _ () -> Yielding_bool Eq)
-          ~unbox:(fun _ -> function Yielding_bool Eq -> Some () | _ -> None);
-        case (flag "ne")
-          ~box:(fun _ () -> Yielding_bool Neq)
-          ~unbox:(fun _ -> function Yielding_bool Neq -> Some () | _ -> None)
-        (* id_case *)
-        (*   (constructor_flag ["eq", Yielding_bool Eq; "ne", Yielding_bool Neq]); *)
-      ]
+  let|= comp =
+    let| lt = param2 sign (flag "lt"), fun _ (s, ()) -> Yielding_bool (Lt s) in
+    let| le = param2 sign (flag "le"), fun _ (s, ()) -> Yielding_bool (Le s) in
+    let| gt = param2 sign (flag "gt"), fun _ (s, ()) -> Yielding_bool (Gt s) in
+    let| ge = param2 sign (flag "ge"), fun _ (s, ()) -> Yielding_bool (Ge s) in
+    let| qmark =
+      ( param2 sign (flag "qmark"),
+        fun _ (s, ()) -> Yielding_int_like_compare_functions s )
+    in
+    let| eq = flag "eq", fun _ () -> Yielding_bool Eq in
+    let| neq = flag "ne", fun _ () -> Yielding_bool Neq in
+    return_either (fun env -> function
+      | Yielding_bool (Lt s) -> lt env (s, ())
+      | Yielding_bool (Le s) -> le env (s, ())
+      | Yielding_bool (Gt s) -> gt env (s, ())
+      | Yielding_bool (Ge s) -> ge env (s, ())
+      | Yielding_bool Eq -> eq env ()
+      | Yielding_bool Neq -> neq env ()
+      | Yielding_int_like_compare_functions s -> qmark env (s, ()))
   in
   binary "%int_comp" ~params:(param2 standard_int comp) (fun _ (i, c) ->
       P.Int_comp (i, c))

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -534,7 +534,7 @@ let block_load =
 
 let bigarray_length =
   D.(
-    unary "%bigarray_lenght" ~params:(positional int) (fun _ dimension ->
+    unary "%bigarray_length" ~params:(positional int) (fun _ dimension ->
         P.Bigarray_length { dimension }))
 
 let array_length =

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -32,11 +32,11 @@ let scannable_tag : Tag.Scannable.t param_cons =
     }
 
 let mutability =
-  D.(
-    default ~def:Mutability.Immutable
-    @@ constructor_flag
-         Mutability.
-           ["immut", Immutable; "imm_uniq", Immutable_unique; "mut", Mutable])
+  D.constructor_flag
+    Mutability.
+      ["immut", Immutable; "immut_uniq", Immutable_unique; "mut", Mutable]
+
+let opt_mutability = D.default ~def:Mutability.Immutable mutability
 
 let mutable_flag =
   D.(
@@ -152,16 +152,15 @@ let block_access_kind =
         fun _ ((), size) -> P.Block_access_kind.Naked_floats { size } )
     in
     let| mixed =
-      ( param2
-          (param3 (flag "mixed") tag size)
-          (param2 mixed_field_kind mixed_block_shape),
-        fun _ (((), tag, size), (field_kind, shape)) ->
-          P.Block_access_kind.Mixed { tag; size; field_kind; shape } )
+      param5_case
+        ~decode:(fun _ () tag size field_kind shape ->
+          P.Block_access_kind.Mixed { tag; size; field_kind; shape })
+        (flag "mixed") tag size mixed_field_kind mixed_block_shape
     in
     let| value_k =
-      ( param3 block_access_field_kind tag size,
-        fun _ (field_kind, tag, size) ->
-          P.Block_access_kind.Values { field_kind; tag; size } )
+      param3_case block_access_field_kind tag size
+        ~decode:(fun _ field_kind tag size ->
+          P.Block_access_kind.Values { field_kind; tag; size })
     in
     P.Block_access_kind.(
       return_either (fun env bak ->
@@ -169,7 +168,7 @@ let block_access_kind =
           | Values { field_kind; tag; size } ->
             value_k env (field_kind, tag, size)
           | Naked_floats { size } -> naked_float env ((), size)
-          | Mixed m -> mixed env (((), m.tag, m.size), (m.field_kind, m.shape))))
+          | Mixed m -> mixed env ((), m.tag, m.size, m.field_kind, m.shape)))
   in
   bak
 
@@ -570,7 +569,7 @@ let block_load =
   D.(
     unary "%block_load"
       ~params:
-        (param3 block_access_kind mutability (positional target_ocaml_int))
+        (param3 block_access_kind opt_mutability (positional target_ocaml_int))
       (fun _env (kind, mut, field) -> P.Block_load { kind; mut; field }))
 
 let bigarray_length =
@@ -760,7 +759,7 @@ let array_load =
     binary "%array_load"
       ~params:
         (maps
-           (param2 array_kind mutability)
+           (param2 array_kind opt_mutability)
            ~from:(fun _ (k, m) ->
              let lk : P.Array_load_kind.t =
                match (k : P.Array_kind.t) with
@@ -806,13 +805,21 @@ let int_comp =
   let open Flambda_primitive in
   let sign = default ~def:Signed @@ constructor_flag ["unsigned", Unsigned] in
   let|= comp =
-    let| lt = param2 sign (flag "lt"), fun _ (s, ()) -> Yielding_bool (Lt s) in
-    let| le = param2 sign (flag "le"), fun _ (s, ()) -> Yielding_bool (Le s) in
-    let| gt = param2 sign (flag "gt"), fun _ (s, ()) -> Yielding_bool (Gt s) in
-    let| ge = param2 sign (flag "ge"), fun _ (s, ()) -> Yielding_bool (Ge s) in
+    let| lt =
+      param2_case sign (flag "lt") ~decode:(fun _ s () -> Yielding_bool (Lt s))
+    in
+    let| le =
+      param2_case sign (flag "le") ~decode:(fun _ s () -> Yielding_bool (Le s))
+    in
+    let| gt =
+      param2_case sign (flag "gt") ~decode:(fun _ s () -> Yielding_bool (Gt s))
+    in
+    let| ge =
+      param2_case sign (flag "ge") ~decode:(fun _ s () -> Yielding_bool (Ge s))
+    in
     let| qmark =
-      ( param2 sign (flag "qmark"),
-        fun _ (s, ()) -> Yielding_int_like_compare_functions s )
+      param2_case sign (flag "qmark") ~decode:(fun _ s () ->
+          Yielding_int_like_compare_functions s)
     in
     let| eq = flag "eq", fun _ () -> Yielding_bool Eq in
     let| neq = flag "ne", fun _ () -> Yielding_bool Neq in
@@ -1009,7 +1016,7 @@ let begin_try_ghost_region =
 let make_block =
   D.(
     variadic "%block"
-      ~params:(param3 mutability block_kind alloc_mode_for_allocation)
+      ~params:(param3 opt_mutability block_kind alloc_mode_for_allocation)
       (fun _ (m, k, a) n ->
         let kind =
           match k with
@@ -1023,7 +1030,7 @@ let make_block =
 let make_array =
   D.(
     variadic "%array"
-      ~params:(param3 array_kind mutability alloc_mode_for_allocation)
+      ~params:(param3 array_kind opt_mutability alloc_mode_for_allocation)
       (fun _ (k, m, a) _ -> P.Make_array (k, m, a)))
 
 module OfFlambda = struct

--- a/middle_end/flambda2/parser/fexpr_prim_descr.ml
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.ml
@@ -1,10 +1,6 @@
 type param = Fexpr.prim_param =
-  | Labeled of
-      { label : string;
-        value : string Fexpr.located
-      }
-  | Positional of string Fexpr.located
-  | Flag of string
+  | Labeled of string Fexpr.located * param list
+  | Anonymous of param list
 
 type t = Fexpr.prim_op =
   { prim : string;
@@ -36,6 +32,9 @@ type ('a, 'b) map_lens = ('a, 'b, 'a) lens
 
 type 'p value_lens = ('p, string Fexpr.located) map_lens
 
+type ('p, 'args) labeled_lens =
+  ('p, string Fexpr.located * 'args, 'p option) lens
+
 type 'p params_lens = ('p, param list) map_lens
 
 type 'p prim_lens = ('p, t, Simple.t list -> Flambda_primitive.t) lens
@@ -43,14 +42,13 @@ type 'p prim_lens = ('p, t, Simple.t list -> Flambda_primitive.t) lens
 type 'p conv = encode_env -> 'p -> t
 
 type _ param_cons =
-  | CPositional : 'p value_lens -> 'p param_cons
-  | CLabeled : string * 'p value_lens -> 'p param_cons
-  | CFlag : string -> unit param_cons
+  | CVoid : unit param_cons
+  | CAtom : 'p param_cons -> 'p param_cons
+  | CLabeled : ('p, 'a) labeled_lens * 'a param_cons -> 'p param_cons
   | COptional : 'p param_cons -> 'p option param_cons
   | CDefault : 'p param_cons * 'p * ('p -> 'p -> bool) -> 'p param_cons
   | CEither : 'p case_cons list * ('p -> unit) -> 'p param_cons
   | CMap : 'a param_cons * ('b, 'a) map_lens -> 'b param_cons
-  | CParam0 : unit param_cons
   | CParam2 : 'a param_cons * 'b param_cons -> ('a * 'b) param_cons
   | CParam3 :
       'a param_cons * 'b param_cons * 'c param_cons
@@ -67,31 +65,37 @@ let unwrap_loc located = located.Fexpr.txt
    declaration order, consuming the param list on match. *)
 let extract_param (env : decode_env) (params : param list)
     (cons : 'p param_cons) : 'p option * param list =
-  let rec pos conv lp params =
+  let rec value conv lp params =
     match params with
     | [] -> None, lp
-    | Positional p :: rp -> Some (conv env p), lp @ rp
-    | ((Labeled _ | Flag _) as p) :: rp -> pos conv (lp @ [p]) rp
+    | (Labeled (l, args) as p) :: rp -> (
+      match conv env l args with
+      | Some p -> Some p, lp @ rp
+      | None -> value conv (lp @ [p]) rp)
+    | (Anonymous _ as p) :: rp -> value conv (lp @ [p]) rp
   in
-  let rec lbl l conv lp params =
+  let void params = Some (), params in
+  let rec atom : type p.
+      p param_cons -> param list -> param list -> p option * param list =
+   fun cons lp params ->
     match params with
     | [] -> None, lp
-    | (Labeled { label; value } as p) :: rp ->
-      if String.equal l label
-      then Some (conv env value), lp @ rp
-      else lbl l conv (lp @ [p]) rp
-    | ((Positional _ | Flag _) as p) :: rp -> lbl l conv (lp @ [p]) rp
-  in
-  let rec flg f lp params =
-    match params with
-    | [] -> None, lp
-    | (Flag flag as p) :: rp ->
-      if String.equal f flag then Some (), lp @ rp else flg f (lp @ [p]) rp
-    | ((Positional _ | Labeled _) as p) :: rp -> flg f (lp @ [p]) rp
-  in
-  let param0 params = Some (), params in
-  let rec def : type p. p -> p param_cons -> param list -> p option * param list
+    | (Labeled _ as p) :: rp -> atom cons (lp @ [p]) rp
+    | (Anonymous ps as _p) :: _rp -> (
+      match aux cons ps with
+      | None, _ | Some _, _ :: _ -> None, params
+      | Some p, [] -> Some p, params)
+  and lbl : type p a.
+      (p, a) labeled_lens -> a param_cons -> param list -> p option * param list
       =
+   fun lens cons params ->
+    let decode env label args =
+      match aux cons args with
+      | None, _ | Some _, _ :: _ -> None
+      | Some args, [] -> lens.decode env (label, args)
+    in
+    value decode [] params
+  and def : type p. p -> p param_cons -> param list -> p option * param list =
    fun d cons params ->
     match aux cons params with
     | None, params -> Some d, params
@@ -139,14 +143,13 @@ let extract_param (env : decode_env) (params : param list)
       params )
   and aux : type p. p param_cons -> param list -> p option * param list =
     function
-    | CPositional plens -> pos plens.decode []
-    | CLabeled (l, plens) -> lbl l plens.decode []
-    | CFlag f -> flg f []
+    | CLabeled (llens, pc) -> lbl llens pc
     | CDefault (pcons, default, _) -> def default pcons
     | COptional pcons -> opt pcons
     | CEither (cases, _) -> etr cases
     | CMap (pcons, l) -> map pcons l.decode
-    | CParam0 -> param0
+    | CVoid -> void
+    | CAtom pc -> atom pc []
     | CParam2 (pc1, pc2) -> param2 pc1 pc2
     | CParam3 (pc1, pc2, pc3) -> param3 pc1 pc2 pc3
   in
@@ -155,9 +158,12 @@ let extract_param (env : decode_env) (params : param list)
 let rec build_param : type p. encode_env -> p -> p param_cons -> param list =
  fun env p cons ->
   match cons with
-  | CPositional vl -> [Positional (vl.encode env p)]
-  | CLabeled (label, vl) -> [Labeled { label; value = vl.encode env p }]
-  | CFlag flag -> [Flag flag]
+  | CVoid -> []
+  | CLabeled (lens, pcons) ->
+    let label, args = lens.encode env p in
+    let args = build_param env args pcons in
+    [Labeled (label, args)]
+  | CAtom pcons -> [Anonymous (build_param env p pcons)]
   | COptional pcons -> (
     match p with None -> [] | Some p -> build_param env p pcons)
   | CDefault (pcons, default, eq) ->
@@ -170,7 +176,6 @@ let rec build_param : type p. encode_env -> p -> p param_cons -> param list =
     | None -> build_param env p (CEither (cases, f))
     | Some p -> build_param env p param_cons)
   | CMap (pcons, f) -> build_param env (f.encode env p) pcons
-  | CParam0 -> []
   | CParam2 (pc1, pc2) ->
     let p1, p2 = p in
     build_param env p1 pc1 @ build_param env p2 pc2
@@ -211,44 +216,75 @@ module Describe = struct
 
   let todops s = todo0 ("parameter " ^ s)
 
-  let todop s = CPositional (todops s)
-
   let todo s = register_lens s @@ todo0 s
 
-  let int : int value_lens =
-    { encode = (fun _ i -> wrap_loc @@ string_of_int i);
-      decode = (fun _ s -> int_of_string (unwrap_loc s))
-    }
+  let value (vlens : 'a value_lens) : 'a param_cons =
+    let lens =
+      { encode = (fun env p -> vlens.encode env p, ());
+        decode = (fun env (l, ()) -> Some (vlens.decode env l))
+      }
+    in
+    CLabeled (lens, CVoid)
 
-  let bool : bool value_lens =
-    { encode = (fun _ i -> wrap_loc @@ string_of_bool i);
-      decode = (fun _ s -> bool_of_string (unwrap_loc s))
-    }
+  let todop s = value (todops s)
 
-  let string : string Fexpr.located value_lens =
-    { encode = (fun _ s -> s); decode = (fun _ s -> s) }
+  let int : int param_cons =
+    value
+      { encode = (fun _ i -> wrap_loc @@ string_of_int i);
+        decode = (fun _ s -> int_of_string (unwrap_loc s))
+      }
+
+  let bool : bool param_cons =
+    value
+      { encode = (fun _ i -> wrap_loc @@ string_of_bool i);
+        decode = (fun _ s -> bool_of_string (unwrap_loc s))
+      }
+
+  let string : string Fexpr.located param_cons =
+    value { encode = (fun _ s -> s); decode = (fun _ s -> s) }
 
   let diy = string
 
-  let constructor_value (constrs : (string * 'a) list) : 'a value_lens =
+  let constructor_flag ?no_match_handler (constrs : (string * 'a) list) :
+      'a param_cons =
     let rec findc c = function
-      | [] -> Misc.fatal_error "Undefined constructor"
+      | [] ->
+        Option.iter (( |> ) c) no_match_handler;
+        Misc.fatal_error "Undefined constructor"
       | (s, c') :: l -> if Stdlib.( = ) c c' then s else findc c l
     in
     let rec finds s = function
-      | [] -> Misc.fatal_error "Undefined constructor"
-      | (s', c) :: l -> if String.equal s s' then c else finds s l
+      | [] -> None
+      | (s', c) :: l -> if String.equal s s' then Some c else finds s l
     in
-    { encode = (fun _ c -> wrap_loc @@ findc c constrs);
-      decode = (fun _ s -> finds (unwrap_loc s) constrs)
-    }
+    let lens =
+      { encode = (fun _ c -> wrap_loc @@ findc c constrs, ());
+        decode = (fun _ (s, ()) -> finds (unwrap_loc s) constrs)
+      }
+    in
+    CLabeled (lens, CVoid)
 
-  let positional (plens : 'a value_lens) : 'a param_cons = CPositional plens
+  let positional (type a) (pcons : a param_cons) : a param_cons =
+    (* We do not want to default out positional parameters. We can still twist
+       constructors to end with a deeper default, but this should avoid most
+       cases as defaults tend to be at root level *)
+    match pcons with
+    | CDefault (pcons, _, _) -> CAtom pcons
+    | CVoid | CAtom _ | CLabeled _ | COptional _ | CEither _ | CMap _
+    | CParam2 _ | CParam3 _ ->
+      CAtom pcons
 
-  let labeled label (plens : 'a value_lens) : 'a param_cons =
-    CLabeled (label, plens)
+  let labeled label (pcons : 'a param_cons) : 'a param_cons =
+    let lens =
+      { encode = (fun _ p -> wrap_loc label, p);
+        decode =
+          (fun _ (l, p) ->
+            if String.equal label (unwrap_loc l) then Some p else None)
+      }
+    in
+    CLabeled (lens, pcons)
 
-  let flag flag : unit param_cons = CFlag flag
+  let flag flag : unit param_cons = labeled flag CVoid
 
   let default ~(def : 'p) ?(eq : 'p -> 'p -> bool = Stdlib.( = ))
       (pcons : 'p param_cons) : 'p param_cons =
@@ -287,17 +323,7 @@ module Describe = struct
 
   let bool_flag f : bool param_cons = opt_presence @@ option @@ flag f
 
-  let constructor_flag ?no_match_handler (flags : (string * 'p) list) :
-      'p param_cons =
-    either ?no_match_handler
-      (List.map
-         (fun (f, constr) ->
-           case (flag f)
-             ~box:(fun _ () -> constr)
-             ~unbox:(fun _ p -> if Stdlib.( = ) p constr then Some () else None))
-         flags)
-
-  let param0 = CParam0
+  let param0 = CVoid
 
   let param2 pc1 pc2 = CParam2 (pc1, pc2)
 

--- a/middle_end/flambda2/parser/fexpr_prim_descr.ml
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.ml
@@ -64,84 +64,84 @@ let unwrap_loc located = located.Fexpr.txt
 (* Parsing fexpr parameters. Low-brow iteration through constructors in
    declaration order, consuming the param list on match. *)
 let extract_param (env : decode_env) (params : param list)
-    (cons : 'p param_cons) : 'p option * param list =
+    (cons : 'p param_cons) : ('p * param list) option =
   let rec value conv lp params =
     match params with
-    | [] -> None, lp
+    | [] -> None
     | (Labeled (l, args) as p) :: rp -> (
       match conv env l args with
-      | Some p -> Some p, lp @ rp
-      | None -> value conv (lp @ [p]) rp)
-    | (Anonymous _ as p) :: rp -> value conv (lp @ [p]) rp
+      | Some p -> Some (p, List.rev_append lp rp)
+      | None -> value conv (p :: lp) rp)
+    | (Anonymous _ as p) :: rp -> value conv (p :: lp) rp
   in
-  let void params = Some (), params in
+  let void params = Some ((), params) in
   let rec atom : type p.
-      p param_cons -> param list -> param list -> p option * param list =
+      p param_cons -> param list -> param list -> (p * param list) option =
    fun cons lp params ->
     match params with
-    | [] -> None, lp
-    | (Labeled _ as p) :: rp -> atom cons (lp @ [p]) rp
-    | (Anonymous ps as _p) :: _rp -> (
+    | [] -> None
+    | (Labeled _ as p) :: rp -> atom cons (p :: lp) rp
+    | Anonymous ps :: rp -> (
       match aux cons ps with
-      | None, _ | Some _, _ :: _ -> None, params
-      | Some p, [] -> Some p, params)
+      | None | Some (_, _ :: _) -> None
+      | Some (p, []) -> Some (p, List.rev_append lp rp))
   and lbl : type p a.
-      (p, a) labeled_lens -> a param_cons -> param list -> p option * param list
-      =
+      (p, a) labeled_lens ->
+      a param_cons ->
+      param list ->
+      (p * param list) option =
    fun lens cons params ->
     let decode env label args =
       match aux cons args with
-      | None, _ | Some _, _ :: _ -> None
-      | Some args, [] -> lens.decode env (label, args)
+      | None | Some (_, _ :: _) -> None
+      | Some (args, []) -> lens.decode env (label, args)
     in
     value decode [] params
-  and def : type p. p -> p param_cons -> param list -> p option * param list =
+  and def : type p. p -> p param_cons -> param list -> (p * param list) option =
    fun d cons params ->
-    match aux cons params with
-    | None, params -> Some d, params
-    | found, params -> found, params
-  and opt : type p. p param_cons -> param list -> p option option * param list =
+    match aux cons params with None -> Some (d, params) | found -> found
+  and opt : type p. p param_cons -> param list -> (p option * param list) option
+      =
    fun cons params ->
-    let (found : p option), params = aux cons params in
-    Some found, params
-  and etr : type p. p case_cons list -> param list -> p option * param list =
+    match aux cons params with
+    | None -> Some (None, params)
+    | Some (p, params) -> Some (Some p, params)
+  and etr : type p. p case_cons list -> param list -> (p * param list) option =
    fun cases params ->
     match cases with
-    | [] -> None, params
+    | [] -> None
     | Case (conv, param_cons) :: cases -> (
       match aux param_cons params with
-      | Some p, params -> Some (conv.decode env (Some p)), params
-      | None, _ -> etr cases params)
+      | Some (p, params) -> Some (conv.decode env (Some p), params)
+      | None -> etr cases params)
   and map : type a b.
       a param_cons ->
       (decode_env -> a -> b) ->
       param list ->
-      b option * param list =
+      (b * param list) option =
    fun cons f params ->
-    let p, params = aux cons params in
-    Option.map (f env) p, params
+    Option.map (fun (p, params) -> f env p, params) (aux cons params)
   and param2 : type p q.
-      p param_cons -> q param_cons -> param list -> (p * q) option * param list
-      =
+      p param_cons ->
+      q param_cons ->
+      param list ->
+      ((p * q) * param list) option =
    fun pc1 pc2 params ->
-    let p1, params = aux pc1 params in
-    let p2, params = aux pc2 params in
-    Option.bind p1 (fun p1 -> Option.bind p2 (fun p2 -> Some (p1, p2))), params
+    Option.bind (aux pc1 params) (fun (p1, params) ->
+        Option.bind (aux pc2 params) (fun (p2, params) ->
+            Some ((p1, p2), params)))
   and param3 : type p q r.
       p param_cons ->
       q param_cons ->
       r param_cons ->
       param list ->
-      (p * q * r) option * param list =
+      ((p * q * r) * param list) option =
    fun pc1 pc2 pc3 params ->
-    let p1, params = aux pc1 params in
-    let p2, params = aux pc2 params in
-    let p3, params = aux pc3 params in
-    ( Option.bind p1 (fun p1 ->
-          Option.bind p2 (fun p2 ->
-              Option.bind p3 (fun p3 -> Some (p1, p2, p3)))),
-      params )
-  and aux : type p. p param_cons -> param list -> p option * param list =
+    Option.bind (aux pc1 params) (fun (p1, params) ->
+        Option.bind (aux pc2 params) (fun (p2, params) ->
+            Option.bind (aux pc3 params) (fun (p3, params) ->
+                Some ((p1, p2, p3), params))))
+  and aux : type p. p param_cons -> param list -> (p * param list) option =
     function
     | CLabeled (llens, pc) -> lbl llens pc
     | CDefault (pcons, default, _) -> def default pcons
@@ -187,15 +187,16 @@ let lens_of_cons id (cons : 'p param_cons) : 'p params_lens =
   { encode = (fun env p -> build_param env p cons);
     decode =
       (fun env params ->
-        let ps, rem = extract_param env params cons in
-        match ps with
-        | None -> Misc.fatal_errorf "Missing parameter for %s" id
-        | Some ps -> (
+        match extract_param env params cons with
+        | None ->
+          Misc.fatal_errorf "Missing parameter for@ %s%a" id
+            Print_fexpr.prim_params params
+        | Some (ps, rem) -> (
           match rem with
           | [] -> ps
           | _ ->
-            Format.eprintf "Unexpected parameter %a\n" Print_fexpr.prim_params
-              rem;
+            Format.eprintf "Unexpected parameter %a@ in %a\n"
+              Print_fexpr.prim_params rem Print_fexpr.prim_params params;
             ps))
   }
 

--- a/middle_end/flambda2/parser/fexpr_prim_descr.ml
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.ml
@@ -65,15 +65,6 @@ let unwrap_loc located = located.Fexpr.txt
    declaration order, consuming the param list on match. *)
 let extract_param (env : decode_env) (params : param list)
     (cons : 'p param_cons) : ('p * param list) option =
-  let rec value conv lp params =
-    match params with
-    | [] -> None
-    | (Labeled (l, args) as p) :: rp -> (
-      match conv env l args with
-      | Some p -> Some (p, List.rev_append lp rp)
-      | None -> value conv (p :: lp) rp)
-    | (Anonymous _ as p) :: rp -> value conv (p :: lp) rp
-  in
   let void params = Some ((), params) in
   let rec atom : type p.
       p param_cons -> param list -> param list -> (p * param list) option =
@@ -89,14 +80,19 @@ let extract_param (env : decode_env) (params : param list)
       (p, a) labeled_lens ->
       a param_cons ->
       param list ->
+      param list ->
       (p * param list) option =
-   fun lens cons params ->
-    let decode env label args =
+   fun lens cons lp params ->
+    match params with
+    | [] -> None
+    | (Anonymous _ as p) :: rp -> lbl lens cons (p :: lp) rp
+    | (Labeled (label, args) as p) :: rp -> (
       match aux cons args with
-      | None | Some (_, _ :: _) -> None
-      | Some (args, []) -> lens.decode env (label, args)
-    in
-    value decode [] params
+      | None | Some (_, _ :: _) -> lbl lens cons (p :: lp) rp
+      | Some (args, []) ->
+        Option.map
+          (fun p -> p, List.rev_append lp rp)
+          (lens.decode env (label, args)))
   and def : type p. p -> p param_cons -> param list -> (p * param list) option =
    fun d cons params ->
     match aux cons params with None -> Some (d, params) | found -> found
@@ -143,7 +139,7 @@ let extract_param (env : decode_env) (params : param list)
                 Some ((p1, p2, p3), params))))
   and aux : type p. p param_cons -> param list -> (p * param list) option =
     function
-    | CLabeled (llens, pc) -> lbl llens pc
+    | CLabeled (llens, pc) -> lbl llens pc []
     | CDefault (pcons, default, _) -> def default pcons
     | COptional pcons -> opt pcons
     | CEither (cases, _) -> etr cases

--- a/middle_end/flambda2/parser/fexpr_prim_descr.ml
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.ml
@@ -56,6 +56,16 @@ type _ param_cons =
   | CParam3 :
       'a param_cons * 'b param_cons * 'c param_cons
       -> ('a * 'b * 'c) param_cons
+  | CParam4 :
+      'a param_cons * 'b param_cons * 'c param_cons * 'd param_cons
+      -> ('a * 'b * 'c * 'd) param_cons
+  | CParam5 :
+      'a param_cons
+      * 'b param_cons
+      * 'c param_cons
+      * 'd param_cons
+      * 'e param_cons
+      -> ('a * 'b * 'c * 'd * 'e) param_cons
 
 and 'p case_cons =
   | Case : 'a param_cons * (decode_env -> 'a -> 'p) -> 'p case_cons
@@ -146,6 +156,34 @@ let extract_param (env : decode_env) (params : param list)
         Option.bind (aux pc2 params) (fun (p2, params) ->
             Option.bind (aux pc3 params) (fun (p3, params) ->
                 Some ((p1, p2, p3), params))))
+  and param4 : type p q r s.
+      p param_cons ->
+      q param_cons ->
+      r param_cons ->
+      s param_cons ->
+      param list ->
+      ((p * q * r * s) * param list) option =
+   fun pc1 pc2 pc3 pc4 params ->
+    Option.bind (aux pc1 params) (fun (p1, params) ->
+        Option.bind (aux pc2 params) (fun (p2, params) ->
+            Option.bind (aux pc3 params) (fun (p3, params) ->
+                Option.bind (aux pc4 params) (fun (p4, params) ->
+                    Some ((p1, p2, p3, p4), params)))))
+  and param5 : type p q r s t.
+      p param_cons ->
+      q param_cons ->
+      r param_cons ->
+      s param_cons ->
+      t param_cons ->
+      param list ->
+      ((p * q * r * s * t) * param list) option =
+   fun pc1 pc2 pc3 pc4 pc5 params ->
+    Option.bind (aux pc1 params) (fun (p1, params) ->
+        Option.bind (aux pc2 params) (fun (p2, params) ->
+            Option.bind (aux pc3 params) (fun (p3, params) ->
+                Option.bind (aux pc4 params) (fun (p4, params) ->
+                    Option.bind (aux pc5 params) (fun (p5, params) ->
+                        Some ((p1, p2, p3, p4, p5), params))))))
   and aux : type p. p param_cons -> param list -> (p * param list) option =
     function
     | CLabeled (llens, pc) -> lbl llens pc []
@@ -158,6 +196,8 @@ let extract_param (env : decode_env) (params : param list)
     | CAtom pc -> atom pc []
     | CParam2 (pc1, pc2) -> param2 pc1 pc2
     | CParam3 (pc1, pc2, pc3) -> param3 pc1 pc2 pc3
+    | CParam4 (pc1, pc2, pc3, pc4) -> param4 pc1 pc2 pc3 pc4
+    | CParam5 (pc1, pc2, pc3, pc4, pc5) -> param5 pc1 pc2 pc3 pc4 pc5
   in
   aux cons params
 
@@ -183,6 +223,14 @@ let rec build_param : type p. encode_env -> p -> p param_cons -> param list =
   | CParam3 (pc1, pc2, pc3) ->
     let p1, p2, p3 = p in
     build_param env p1 pc1 @ build_param env p2 pc2 @ build_param env p3 pc3
+  | CParam4 (pc1, pc2, pc3, pc4) ->
+    let p1, p2, p3, p4 = p in
+    build_param env p1 pc1 @ build_param env p2 pc2 @ build_param env p3 pc3
+    @ build_param env p4 pc4
+  | CParam5 (pc1, pc2, pc3, pc4, pc5) ->
+    let p1, p2, p3, p4, p5 = p in
+    build_param env p1 pc1 @ build_param env p2 pc2 @ build_param env p3 pc3
+    @ build_param env p4 pc4 @ build_param env p5 pc5
 
 let lens_of_cons id (cons : 'p param_cons) : 'p params_lens =
   { encode = (fun env p -> build_param env p cons);
@@ -271,9 +319,10 @@ module Describe = struct
        constructors to end with a deeper default, but this should avoid most
        cases as defaults tend to be at root level *)
     match pcons with
-    | CDefault (pcons, _, _) -> CAtom pcons
+    | CDefault (_pcons, _, _) ->
+      Misc.fatal_error "Positional parameter does not support defaulting values"
     | CVoid | CAtom _ | CLabeled _ | COptional _ | CEither _ | CList _ | CMap _
-    | CParam2 _ | CParam3 _ ->
+    | CParam2 _ | CParam3 _ | CParam4 _ | CParam5 _ ->
       CAtom pcons
 
   let labeled label (pcons : 'a param_cons) : 'a param_cons =
@@ -344,6 +393,23 @@ module Describe = struct
   let param2 pc1 pc2 = CParam2 (pc1, pc2)
 
   let param3 pc1 pc2 pc3 = CParam3 (pc1, pc2, pc3)
+
+  let param4 pc1 pc2 pc3 pc4 = CParam4 (pc1, pc2, pc3, pc4)
+
+  let param5 pc1 pc2 pc3 pc4 pc5 = CParam5 (pc1, pc2, pc3, pc4, pc5)
+
+  let param2_case ~decode p1 p2 =
+    param2 p1 p2, fun env (c1, c2) -> decode env c1 c2
+
+  let param3_case ~decode p1 p2 p3 =
+    param3 p1 p2 p3, fun env (c1, c2, c3) -> decode env c1 c2 c3
+
+  let param4_case ~decode p1 p2 p3 p4 =
+    param4 p1 p2 p3 p4, fun env (c1, c2, c3, c4) -> decode env c1 c2 c3 c4
+
+  let param5_case ~decode p1 p2 p3 p4 p5 =
+    ( param5 p1 p2 p3 p4 p5,
+      fun env (c1, c2, c3, c4, c5) -> decode env c1 c2 c3 c4 c5 )
 
   let nullary : type p. string -> params:p param_cons -> p cons0 -> p conv =
    fun id ~params cons ->

--- a/middle_end/flambda2/parser/fexpr_prim_descr.ml
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.ml
@@ -51,6 +51,7 @@ type _ param_cons =
       (encode_env -> 'p -> param list) * 'p case_cons list
       -> 'p param_cons
   | CMap : 'a param_cons * ('b, 'a) map_lens -> 'b param_cons
+  | CList : 'a param_cons -> 'a list param_cons
   | CParam2 : 'a param_cons * 'b param_cons -> ('a * 'b) param_cons
   | CParam3 :
       'a param_cons * 'b param_cons * 'c param_cons
@@ -112,6 +113,12 @@ let extract_param (env : decode_env) (params : param list)
       match aux param_cons params with
       | Some (p, params) -> Some (decode env p, params)
       | None -> etr cases params)
+  and list : type a.
+      a param_cons -> a list -> param list -> (a list * param list) option =
+   fun cons acc params ->
+    match aux cons params with
+    | None -> Some (List.rev acc, params) (* Empty list always matchable *)
+    | Some (e, params) -> list cons (e :: acc) params
   and map : type a b.
       a param_cons ->
       (decode_env -> a -> b) ->
@@ -146,6 +153,7 @@ let extract_param (env : decode_env) (params : param list)
     | COptional pcons -> opt pcons
     | CEither (_, cases) -> etr cases
     | CMap (pcons, l) -> map pcons l.decode
+    | CList pcons -> list pcons []
     | CVoid -> void
     | CAtom pc -> atom pc []
     | CParam2 (pc1, pc2) -> param2 pc1 pc2
@@ -167,6 +175,7 @@ let rec build_param : type p. encode_env -> p -> p param_cons -> param list =
   | CDefault (pcons, default, eq) ->
     if eq p default then [] else build_param env p pcons
   | CEither (encode, _) -> encode env p
+  | CList pcons -> List.concat_map (fun pe -> build_param env pe pcons) p
   | CMap (pcons, f) -> build_param env (f.encode env p) pcons
   | CParam2 (pc1, pc2) ->
     let p1, p2 = p in
@@ -263,7 +272,7 @@ module Describe = struct
        cases as defaults tend to be at root level *)
     match pcons with
     | CDefault (pcons, _, _) -> CAtom pcons
-    | CVoid | CAtom _ | CLabeled _ | COptional _ | CEither _ | CMap _
+    | CVoid | CAtom _ | CLabeled _ | COptional _ | CEither _ | CList _ | CMap _
     | CParam2 _ | CParam3 _ ->
       CAtom pcons
 
@@ -284,6 +293,11 @@ module Describe = struct
     CDefault (pcons, def, eq)
 
   let option (pcons : 'p param_cons) : 'p option param_cons = COptional pcons
+
+  let list (pcons : 'p param_cons) : 'p list param_cons =
+    (* Atomize the list to render explicitely the empty list and avoid
+       interleaving of other values *)
+    CAtom (CList pcons)
 
   type 'p encode_case = encode_env -> 'p -> param list
 

--- a/middle_end/flambda2/parser/fexpr_prim_descr.ml
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.ml
@@ -47,7 +47,9 @@ type _ param_cons =
   | CLabeled : ('p, 'a) labeled_lens * 'a param_cons -> 'p param_cons
   | COptional : 'p param_cons -> 'p option param_cons
   | CDefault : 'p param_cons * 'p * ('p -> 'p -> bool) -> 'p param_cons
-  | CEither : 'p case_cons list * ('p -> unit) -> 'p param_cons
+  | CEither :
+      (encode_env -> 'p -> param list) * 'p case_cons list
+      -> 'p param_cons
   | CMap : 'a param_cons * ('b, 'a) map_lens -> 'b param_cons
   | CParam2 : 'a param_cons * 'b param_cons -> ('a * 'b) param_cons
   | CParam3 :
@@ -55,7 +57,7 @@ type _ param_cons =
       -> ('a * 'b * 'c) param_cons
 
 and 'p case_cons =
-  | Case : ('p, 'c option, 'p) lens * 'c param_cons -> 'p case_cons
+  | Case : 'a param_cons * (decode_env -> 'a -> 'p) -> 'p case_cons
 
 let wrap_loc txt = Fexpr.{ txt; loc = Debuginfo.Scoped_location.Loc_unknown }
 
@@ -106,9 +108,9 @@ let extract_param (env : decode_env) (params : param list)
    fun cases params ->
     match cases with
     | [] -> None
-    | Case (conv, param_cons) :: cases -> (
+    | Case (param_cons, decode) :: cases -> (
       match aux param_cons params with
-      | Some (p, params) -> Some (conv.decode env (Some p), params)
+      | Some (p, params) -> Some (decode env p, params)
       | None -> etr cases params)
   and map : type a b.
       a param_cons ->
@@ -142,7 +144,7 @@ let extract_param (env : decode_env) (params : param list)
     | CLabeled (llens, pc) -> lbl llens pc []
     | CDefault (pcons, default, _) -> def default pcons
     | COptional pcons -> opt pcons
-    | CEither (cases, _) -> etr cases
+    | CEither (_, cases) -> etr cases
     | CMap (pcons, l) -> map pcons l.decode
     | CVoid -> void
     | CAtom pc -> atom pc []
@@ -164,13 +166,7 @@ let rec build_param : type p. encode_env -> p -> p param_cons -> param list =
     match p with None -> [] | Some p -> build_param env p pcons)
   | CDefault (pcons, default, eq) ->
     if eq p default then [] else build_param env p pcons
-  | CEither ([], failure) ->
-    failure p;
-    []
-  | CEither (Case (conv, param_cons) :: cases, f) -> (
-    match conv.encode env p with
-    | None -> build_param env p (CEither (cases, f))
-    | Some p -> build_param env p param_cons)
+  | CEither (encode, _) -> encode env p
   | CMap (pcons, f) -> build_param env (f.encode env p) pcons
   | CParam2 (pc1, pc2) ->
     let p1, p2 = p in
@@ -289,25 +285,34 @@ module Describe = struct
 
   let option (pcons : 'p param_cons) : 'p option param_cons = COptional pcons
 
-  let either ?(no_match_handler = fun _ -> ()) (cases : 'p case_cons list) :
-      'p param_cons =
-    CEither (cases, no_match_handler)
+  type 'p encode_case = encode_env -> 'p -> param list
 
-  let case ~(box : _ -> 'c -> 'p) ~(unbox : _ -> 'p -> 'c option)
-      (param_cons : 'c param_cons) : 'p case_cons =
-    Case
-      ( { encode = unbox;
-          decode =
-            (fun e -> function Some p -> box e p | None -> assert false)
-        },
-        param_cons )
+  type 'p build_either = 'p case_cons list -> 'p case_cons list * 'p encode_case
 
-  let id_case (param_cons : 'p param_cons) : 'p case_cons =
-    Case
-      ( { encode = (fun _ p -> Some p);
-          decode = (fun _ -> function Some p -> p | None -> assert false)
-        },
-        param_cons )
+  let bind_case (cases : 'p case_cons list) (cons : 'case param_cons)
+      (box : decode_env -> 'case -> 'p) :
+      'p case_cons list * (encode_env -> 'case -> param list) =
+    let case = Case (cons, box) in
+    let encode env p = build_param env p cons in
+    case :: cases, encode
+
+  let build_match (cases : 'p case_cons list) (destruct_param : 'p encode_case)
+      : 'p param_cons =
+    CEither (destruct_param, List.rev cases)
+
+  let return_either (p : 'p encode_case) : 'p build_either =
+   fun cases -> cases, p
+
+  let ( let| ) ((cons, box) : 'case param_cons * (decode_env -> 'case -> 'p))
+      (f : 'case encode_case -> 'p build_either) : 'p build_either =
+   fun cases ->
+    let cases, encode = bind_case cases cons box in
+    f encode cases
+
+  let ( let|= ) (cb : 'p build_either) (f : 'p param_cons -> 'a) : 'a =
+    let cases, destruct_param = cb [] in
+    let p = build_match cases destruct_param in
+    f p
 
   let maps ~(to_ : encode_env -> 'b -> 'a) ~(from : decode_env -> 'a -> 'b)
       (pcons : 'a param_cons) : 'b param_cons =

--- a/middle_end/flambda2/parser/fexpr_prim_descr.mli
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.mli
@@ -66,11 +66,11 @@ val unwrap_loc : 'a Fexpr.located -> 'a
 
     As {!type:param} shows, there is two kinds of primitive parameter:
     - Tuples, written [.[val1, ..., valN]]
-    - Labeled, written [.label[val1, ..., valN]].
-      They can be without arguments [.label] to denote flags.
-    Both of them can be nested, the dot separator is only for toplevel parameters.
+    - Labeled, written [.label[val1, ..., valN]]. They can be without arguments
+      [.label] to denote flags.
 
-    Flags and labeled can appear in any order, at any positions.
+    Flags and labeled can appear in any order, at any positions. Both of them
+    can be nested, the dot separator is only for toplevel parameters.
 
     The type {!type:value_lens} is used to describe conversions of custom types.
     Label, flags and inner values are all treated the same.
@@ -215,7 +215,6 @@ module Describe : sig
   (** Same as {!val:string}. With some tweaks to the parser, we could call
       actual parsing start-points in it. *)
   val diy : string Fexpr.located param_cons
-
 end
 
 (** Fetch primitive conversion function from registered descriptions *)

--- a/middle_end/flambda2/parser/fexpr_prim_descr.mli
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.mli
@@ -64,13 +64,16 @@ val unwrap_loc : 'a Fexpr.located -> 'a
     The complexity comes from the description of the parameters of the primitive
     variant itself, which can be arbitrary caml values.
 
-    As {!type:param} shows, there is three kinds of primitive parameter:
-    - Positional, written [.(value)]
-    - Flag, written [.flag]
-    - Labeled, written [.label(value)]
+    As {!type:param} shows, there is two kinds of primitive parameter:
+    - Tuples, written [.[val1, ..., valN]]
+    - Labeled, written [.label[val1, ..., valN]].
+      They can be without arguments [.label] to denote flags.
+    Both of them can be nested, the dot separator is only for toplevel parameters.
 
-    Flags and labeled can appear in any order, at any positions. Positional and
-    labeled are provided with {!type:value_lens} to convert their payload.
+    Flags and labeled can appear in any order, at any positions.
+
+    The type {!type:value_lens} is used to describe conversions of custom types.
+    Label, flags and inner values are all treated the same.
 
     The constructors provide composable {!type:param_cons} values. They allow
     the construction of more complex types, such as tuples, list, options or
@@ -112,11 +115,14 @@ module Describe : sig
       cases. *)
   val todop : string -> 'p param_cons
 
+  (** Constructor from simple lens *)
+  val value : 'a value_lens -> 'a param_cons
+
   (** Syntactic positional parameter *)
-  val positional : 'a value_lens -> 'a param_cons
+  val positional : 'a param_cons -> 'a param_cons
 
   (** Syntactic labeled parameter *)
-  val labeled : string -> 'a value_lens -> 'a param_cons
+  val labeled : string -> 'a param_cons -> 'a param_cons
 
   (** Syntactic flag parameter. Flags have no values and the only information
       they carry is their presence. {!val:flag} has little reason to appear by
@@ -198,21 +204,18 @@ module Describe : sig
       Can be extended here. Or defined elsewhere for specific values. *)
 
   (** Raw value *)
-  val string : string Fexpr.located value_lens
+  val string : string Fexpr.located param_cons
 
   (** Parsed as integer. Fails if the string is not one. *)
-  val int : int value_lens
+  val int : int param_cons
 
   (** Parsed as boolean. Fails if the string is not one. *)
-  val bool : bool value_lens
+  val bool : bool param_cons
 
   (** Same as {!val:string}. With some tweaks to the parser, we could call
       actual parsing start-points in it. *)
-  val diy : string Fexpr.located value_lens
+  val diy : string Fexpr.located param_cons
 
-  (** Similar to {!val:constructor_flag} but for payload. Exhaustivity not
-      enforced. *)
-  val constructor_value : (string * 'p) list -> 'p value_lens
 end
 
 (** Fetch primitive conversion function from registered descriptions *)

--- a/middle_end/flambda2/parser/fexpr_prim_descr.mli
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.mli
@@ -174,30 +174,41 @@ module Describe : sig
     'a param_cons ->
     'b param_cons
 
-  (** Simple pattern-matching of parameters. Takes a list of case construction
-      (see {!val:case}) and represents the first that matches in appearance
-      order.
+  (** Pattern maching *)
 
-      Caution: exhaustivity is no enforced. And patterns may be fragile, take
-      care to order them properly to avoid mismatch, especially with optional
-      parameters. *)
-  val either :
-    ?no_match_handler:('p -> unit) -> 'p case_cons list -> 'p param_cons
+  (** Using monadic notation, we define patterns using [let|] binding a
+      [param_cons] and a boxing function, ending with a call to [return_either]
+      with a full pattern matching on the outer type. This is then bound to the
+      resulting [param_cons] with [let|=]. The order of declaration of pattern
+      is the order in which they will be tried against. Example:
 
-  (** Describes a constructor pattern. Takes the construction we want to match.
-      - [~box] allows mapping of the matched value, usually to wrap it in the
-        type of the enclosing {!val:either}.
-      - [~unbox] is the reverse but expect an optional return value, to tell if
-        the value corresponds to the described case. This is the only place
-        where exhaustivity can be enforced. *)
-  val case :
-    box:(decode_env -> 'c -> 'p) ->
-    unbox:(encode_env -> 'p -> 'c option) ->
-    'c param_cons ->
-    'p case_cons
+      {[
+      let|= example =
+          let| b = bool, (fun _ b -> if b then 1 else 0) in
+          let| i = int, (fun _ -> Fun.id) in
+          return_either
+            (fun env p ->
+               match p with
+               | 0 -> b env false
+               | 1 -> b env true
+               | x -> i env x)
+      ]}
 
-  (** Same as {!val:case}, but [~box] and [~unbox] are identity. *)
-  val id_case : 'p param_cons -> 'p case_cons
+      This is a [int param_cons] encoded to either a bool ["true" | "false"] or
+      an int. *)
+
+  type 'p encode_case = encode_env -> 'p -> param list
+
+  type 'p build_either
+
+  val return_either : (encode_env -> 'p -> param list) -> 'p build_either
+
+  val ( let| ) :
+    'case param_cons * (decode_env -> 'case -> 'p) ->
+    ('case encode_case -> 'p build_either) ->
+    'p build_either
+
+  val ( let|= ) : 'p build_either -> ('p param_cons -> 'a) -> 'a
 
   (** {2 Parameter payload descriptors}
 

--- a/middle_end/flambda2/parser/fexpr_prim_descr.mli
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.mli
@@ -153,7 +153,7 @@ module Describe : sig
   val param3 :
     'a param_cons -> 'b param_cons -> 'c param_cons -> ('a * 'b * 'c) param_cons
 
-  (** Triple of constructions. *)
+  (** Quadruple of constructions. *)
   val param4 :
     'a param_cons ->
     'b param_cons ->
@@ -161,7 +161,7 @@ module Describe : sig
     'd param_cons ->
     ('a * 'b * 'c * 'd) param_cons
 
-  (** Triple of constructions. *)
+  (** Quintuple of constructions. *)
   val param5 :
     'a param_cons ->
     'b param_cons ->

--- a/middle_end/flambda2/parser/fexpr_prim_descr.mli
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.mli
@@ -153,6 +153,23 @@ module Describe : sig
   val param3 :
     'a param_cons -> 'b param_cons -> 'c param_cons -> ('a * 'b * 'c) param_cons
 
+  (** Triple of constructions. *)
+  val param4 :
+    'a param_cons ->
+    'b param_cons ->
+    'c param_cons ->
+    'd param_cons ->
+    ('a * 'b * 'c * 'd) param_cons
+
+  (** Triple of constructions. *)
+  val param5 :
+    'a param_cons ->
+    'b param_cons ->
+    'c param_cons ->
+    'd param_cons ->
+    'e param_cons ->
+    ('a * 'b * 'c * 'd * 'e) param_cons
+
   (** Specify a default value for the underlying constructor, which will be used
       if there is no match. In conversion to fexpr, if the provided parameter
       equals the default, no parameter will be produced. [~eq] allows the
@@ -213,6 +230,38 @@ module Describe : sig
     'p build_either
 
   val ( let|= ) : 'p build_either -> ('p param_cons -> 'a) -> 'a
+
+  val param2_case :
+    decode:(decode_env -> 'c1 -> 'c2 -> 'p) ->
+    'c1 param_cons ->
+    'c2 param_cons ->
+    ('c1 * 'c2) param_cons * (decode_env -> 'c1 * 'c2 -> 'p)
+
+  val param3_case :
+    decode:(decode_env -> 'c1 -> 'c2 -> 'c3 -> 'p) ->
+    'c1 param_cons ->
+    'c2 param_cons ->
+    'c3 param_cons ->
+    ('c1 * 'c2 * 'c3) param_cons * (decode_env -> 'c1 * 'c2 * 'c3 -> 'p)
+
+  val param4_case :
+    decode:(decode_env -> 'c1 -> 'c2 -> 'c3 -> 'c4 -> 'p) ->
+    'c1 param_cons ->
+    'c2 param_cons ->
+    'c3 param_cons ->
+    'c4 param_cons ->
+    ('c1 * 'c2 * 'c3 * 'c4) param_cons
+    * (decode_env -> 'c1 * 'c2 * 'c3 * 'c4 -> 'p)
+
+  val param5_case :
+    decode:(decode_env -> 'c1 -> 'c2 -> 'c3 -> 'c4 -> 'c5 -> 'p) ->
+    'c1 param_cons ->
+    'c2 param_cons ->
+    'c3 param_cons ->
+    'c4 param_cons ->
+    'c5 param_cons ->
+    ('c1 * 'c2 * 'c3 * 'c4 * 'c5) param_cons
+    * (decode_env -> 'c1 * 'c2 * 'c3 * 'c4 * 'c5 -> 'p)
 
   (** {2 Parameter payload descriptors}
 

--- a/middle_end/flambda2/parser/fexpr_prim_descr.mli
+++ b/middle_end/flambda2/parser/fexpr_prim_descr.mli
@@ -164,6 +164,10 @@ module Describe : sig
   (** Makes a construction optional. Always matches. *)
   val option : 'p param_cons -> 'p option param_cons
 
+  (** Makes a list of a construction. Atomized to make the list explicit,
+      expects its own level of bracket syntactically *)
+  val list : 'p param_cons -> 'p list param_cons
+
   (** Custom transformation of parameter value.
 
       Labels inverted to be related to the argument. [maps x ~to_ ~from] read

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -4,7 +4,7 @@
 
 flambda_unit: KWD_APPLY SYMBOL LPAREN RPAREN KWD_WITH
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 401.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -18,7 +18,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER IDENT KWD_WITH
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 403.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -32,7 +32,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER KWD_WITH
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 402.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -46,7 +46,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 400.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
@@ -63,7 +63,7 @@ Examples of applications:
 
 flambda_unit: KWD_APPLY KWD_WITH
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 330.
 ##
 ## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -125,7 +125,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT KWD_WITH
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 328.
 ##
 ## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -203,7 +203,7 @@ Examples of code definitions:
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND KWD_WITH
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 182.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -215,7 +215,7 @@ Expected "code" or "symbol".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 181.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
@@ -231,14 +231,14 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ## In state 85, spurious reduction of production alloc_mode_for_allocations_opt ->
 ## In state 90, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
 ## In state 91, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
-## In state 246, spurious reduction of production symbol_binding -> static_closure_binding
+## In state 249, spurious reduction of production symbol_binding -> static_closure_binding
 ##
 
 Expected "and", "with", or "in".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN KWD_WITH
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 450.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -262,7 +262,7 @@ Expected "with", "in", "end", or "and".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_WITH
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 184.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol EQUAL . static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -279,7 +279,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 183.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol . EQUAL static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -313,7 +313,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 466.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -328,9 +328,9 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## In state 35, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
 ## In state 74, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
 ## In state 34, spurious reduction of production atomic_expr -> KWD_SWITCH simple switch
-## In state 444, spurious reduction of production inner_expr -> atomic_expr
-## In state 409, spurious reduction of production expr -> inner_expr
-## In state 460, spurious reduction of production module_ -> expr
+## In state 447, spurious reduction of production inner_expr -> atomic_expr
+## In state 412, spurious reduction of production expr -> inner_expr
+## In state 463, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -339,7 +339,7 @@ Example:
 
 flambda_unit: KWD_WITH
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 465.
 ##
 ## flambda_unit' -> . flambda_unit [ # ]
 ##
@@ -1201,7 +1201,7 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM TILDE
 ##
 ## Ends in an error in state: 157.
 ##
-## prim_op -> PRIM . list(prim_param) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
+## prim_op -> PRIM . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRIM
@@ -1213,9 +1213,7 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT TILDE
 ##
 ## Ends in an error in state: 158.
 ##
-## prim_param -> DOT . IDENT [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-## prim_param -> DOT . LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-## prim_param -> DOT . IDENT LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## list(pair(DOT,prim_param)) -> DOT . prim_param list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## DOT
@@ -1227,22 +1225,10 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 ##
 ## Ends in an error in state: 159.
 ##
-## prim_param -> DOT LBRACK . prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## prim_param -> LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## DOT LBRACK
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT TILDE
-##
-## Ends in an error in state: 162.
-##
-## prim_param -> DOT LBRACK prim_param_val . RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-##
-## The known suffix of the stack is as follows:
-## DOT LBRACK prim_param_val
+## LBRACK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1251,11 +1237,11 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 ##
 ## Ends in an error in state: 164.
 ##
-## prim_param -> DOT IDENT . [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-## prim_param -> DOT IDENT . LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## prim_param -> prim_param_val . [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
+## prim_param -> prim_param_val . LBRACK separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## DOT IDENT
+## prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1264,41 +1250,66 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 ##
 ## Ends in an error in state: 165.
 ##
-## prim_param -> DOT IDENT LBRACK . prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## prim_param -> prim_param_val LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## DOT IDENT LBRACK
+## prim_param_val LBRACK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK IDENT TILDE
-##
-## Ends in an error in state: 166.
-##
-## prim_param -> DOT IDENT LBRACK prim_param_val . RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-##
-## The known suffix of the stack is as follows:
-## DOT IDENT LBRACK prim_param_val
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT RBRACK TILDE
+expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ##
 ## Ends in an error in state: 168.
 ##
-## list(prim_param) -> prim_param . list(prim_param) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
+## separated_nonempty_list(COMMA,prim_param) -> prim_param . [ RBRACK ]
+## separated_nonempty_list(COMMA,prim_param) -> prim_param . COMMA separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
 ##
 ## The known suffix of the stack is as follows:
 ## prim_param
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 164, spurious reduction of production prim_param -> prim_param_val
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
+##
+## Ends in an error in state: 169.
+##
+## separated_nonempty_list(COMMA,prim_param) -> prim_param COMMA . separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
+##
+## The known suffix of the stack is as follows:
+## prim_param COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+expect_test_spec: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
+##
+## Ends in an error in state: 171.
+##
+## list(pair(DOT,prim_param)) -> DOT prim_param . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## DOT prim_param
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 164, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 expect_test_spec: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 174.
 ##
 ## named -> KWD_REC_INFO . rec_info_atom [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1310,7 +1321,7 @@ expect_test_spec: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 
 expect_test_spec: KWD_LET IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 176.
 ##
 ## named -> simple . [ KWD_WITH KWD_IN KWD_AND ]
 ## simple -> simple . TILDE coercion [ TILDE KWD_WITH KWD_IN KWD_AND ]
@@ -1323,7 +1334,7 @@ expect_test_spec: KWD_LET IDENT EQUAL FLOAT SYMBOL
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 186.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1335,7 +1346,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 187.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1347,7 +1358,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL TILDE
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 194.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . SEMICOLON separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
@@ -1360,7 +1371,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBO
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL SEMICOLON TILDE
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 195.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block SEMICOLON . separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
 ##
@@ -1372,7 +1383,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBO
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 197.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK . LPAREN loption(separated_nonempty_list(COMMA,float_or_variable)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1384,7 +1395,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 198.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK LPAREN . loption(separated_nonempty_list(COMMA,float_or_variable)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1396,7 +1407,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 204.
 ##
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable . COMMA separated_nonempty_list(COMMA,float_or_variable) [ RPAREN ]
@@ -1409,7 +1420,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT TIL
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 205.
 ##
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable COMMA . separated_nonempty_list(COMMA,float_or_variable) [ RPAREN ]
 ##
@@ -1421,7 +1432,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT COM
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 207.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,float_or_variable)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1433,7 +1444,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 208.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,float_or_variable)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1445,7 +1456,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 212.
 ##
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable . SEMICOLON separated_nonempty_list(SEMICOLON,float_or_variable) [ RBRACKPIPE ]
@@ -1458,7 +1469,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 213.
 ##
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable SEMICOLON . separated_nonempty_list(SEMICOLON,float_or_variable) [ RBRACKPIPE ]
 ##
@@ -1470,7 +1481,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 217.
 ##
 ## static_data -> STATIC_CONST_BLOCK . mutability tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1482,7 +1493,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 220.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability . tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1494,7 +1505,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE T
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 221.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag . LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1506,7 +1517,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 222.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag LPAREN . loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1518,7 +1529,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL TILDE
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 226.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . [ RPAREN ]
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . COMMA separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
@@ -1531,7 +1542,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL TILD
 
 expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL COMMA TILDE
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 227.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block COMMA . separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
 ##
@@ -1543,7 +1554,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL COMM
 
 expect_test_spec: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 229.
 ##
 ## static_data -> KWD_MUTABLE . STRING [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1555,7 +1566,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 233.
 ##
 ## static_data -> variable . COLON static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1567,7 +1578,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 234.
 ##
 ## static_data -> variable COLON . static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1579,7 +1590,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 235.
 ##
 ## static_data_kind -> KWD_NATIVEINT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1591,7 +1602,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 237.
 ##
 ## static_data_kind -> KWD_INT64 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1603,7 +1614,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 239.
 ##
 ## static_data_kind -> KWD_INT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1615,7 +1626,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 241.
 ##
 ## static_data_kind -> KWD_FLOAT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1627,7 +1638,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 
 expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 243.
 ##
 ## static_data_kind -> KWD_FLOAT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1639,7 +1650,7 @@ expect_test_spec: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 252.
 ##
 ## code -> code_header . kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1651,7 +1662,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 253.
 ##
 ## kinded_args -> LPAREN . separated_nonempty_list(COMMA,kinded_variable) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EQUAL EOF BIGARROW ]
 ##
@@ -1663,7 +1674,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 254.
 ##
 ## kinded_variable -> variable . kind_with_subkind_opt [ RPAREN COMMA ]
 ##
@@ -1675,7 +1686,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 255.
 ##
 ## kind_with_subkind_opt -> COLON . kind_with_subkind [ RPAREN COMMA ]
 ##
@@ -1687,7 +1698,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 256.
 ##
 ## subkind -> LBRACK . ctors RBRACK [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1699,7 +1710,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 257.
 ##
 ## tag -> INT . [ KWD_OF ]
 ## targetint -> INT . [ RBRACK PIPE ]
@@ -1712,7 +1723,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 259.
 ##
 ## ctors_nonempty -> targetint PIPE . ctors_nonempty [ RBRACK ]
 ##
@@ -1724,7 +1735,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE INT TILDE
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 260.
 ##
 ## nonconst_ctor -> tag . KWD_OF kinds_with_subkinds_nonempty [ RBRACK PIPE ]
 ##
@@ -1736,7 +1747,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE 
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 261.
 ##
 ## nonconst_ctor -> tag KWD_OF . kinds_with_subkinds_nonempty [ RBRACK PIPE ]
 ##
@@ -1748,7 +1759,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 262.
 ##
 ## subkind -> KWD_VAL . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_VAL . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1761,7 +1772,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 266.
 ##
 ## naked_number_kind -> KWD_NATIVEINT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_NATIVEINT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1774,7 +1785,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 268.
 ##
 ## naked_number_kind -> KWD_INT64 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_INT64 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1787,7 +1798,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 270.
 ##
 ## naked_number_kind -> KWD_INT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_INT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1800,7 +1811,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 272.
 ##
 ## naked_number_kind -> KWD_IMM . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_IMM . KWD_TAGGED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1814,7 +1825,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 275.
 ##
 ## naked_number_kind -> KWD_FLOAT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_FLOAT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1827,7 +1838,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 277.
 ##
 ## naked_number_kind -> KWD_FLOAT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_FLOAT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1842,7 +1853,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 280.
 ##
 ## subkind -> KWD_FLOAT CARET . plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1854,7 +1865,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 282.
 ##
 ## subkind -> KWD_ANY . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1866,7 +1877,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 288.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . STAR separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
@@ -1879,7 +1890,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 289.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind STAR . separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
 ##
@@ -1891,7 +1902,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 293.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . [ RBRACK ]
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . PIPE separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
@@ -1903,18 +1914,18 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 274, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 283, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 285, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 282, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 284, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
+## In state 277, spurious reduction of production naked_number_kind -> KWD_FLOAT
+## In state 286, spurious reduction of production kind_with_subkind -> naked_number_kind
+## In state 288, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
+## In state 285, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 287, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 294.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor PIPE . separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
 ##
@@ -1926,7 +1937,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE 
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 301.
+## Ends in an error in state: 304.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . COMMA separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
@@ -1939,7 +1950,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILD
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 305.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable COMMA . separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
 ##
@@ -1951,7 +1962,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 307.
 ##
 ## code -> code_header kinded_args . variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1963,7 +1974,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 308.
 ##
 ## code -> code_header kinded_args variable . variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1975,7 +1986,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 309.
 ##
 ## code -> code_header kinded_args variable variable . variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1987,7 +1998,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 310.
 ##
 ## code -> code_header kinded_args variable variable variable . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1999,7 +2010,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 311.
 ##
 ## code -> code_header kinded_args variable variable variable variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2011,7 +2022,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 312.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2023,7 +2034,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 313.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2035,7 +2046,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 314.
 ##
 ## exn_continuation_id -> STAR . continuation_id [ KWD_LOCAL EQUAL COLON ]
 ##
@@ -2047,7 +2058,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 316.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2059,7 +2070,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 317.
 ##
 ## return_arity -> COLON . kinds_with_subkinds [ KWD_LOCAL EQUAL ]
 ##
@@ -2071,7 +2082,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 321.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2083,7 +2094,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_LOCAL TILDE
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 323.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2095,7 +2106,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 324.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2107,7 +2118,7 @@ expect_test_spec: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT 
 
 expect_test_spec: KWD_INVALID TILDE
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 325.
 ##
 ## atomic_expr -> KWD_INVALID . STRING [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2119,7 +2130,7 @@ expect_test_spec: KWD_INVALID TILDE
 
 expect_test_spec: KWD_APPLY KWD_DIRECT TILDE
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 331.
 ##
 ## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2131,7 +2142,7 @@ expect_test_spec: KWD_APPLY KWD_DIRECT TILDE
 
 expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 332.
 ##
 ## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2143,7 +2154,7 @@ expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 333.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2155,7 +2166,7 @@ expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 334.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2167,7 +2178,7 @@ expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 expect_test_spec: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 335.
 ##
 ## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2179,7 +2190,7 @@ expect_test_spec: KWD_APPLY AMP TILDE
 
 expect_test_spec: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 336.
 ##
 ## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2191,7 +2202,7 @@ expect_test_spec: KWD_APPLY AMP IDENT TILDE
 
 expect_test_spec: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 337.
 ##
 ## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2203,7 +2214,7 @@ expect_test_spec: KWD_APPLY AMP IDENT AMP TILDE
 
 expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 339.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2215,7 +2226,7 @@ expect_test_spec: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 
 expect_test_spec: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 341.
 ##
 ## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2227,7 +2238,7 @@ expect_test_spec: KWD_APPLY KWD_CCALL TILDE
 
 expect_test_spec: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 344.
 ##
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
@@ -2241,7 +2252,7 @@ expect_test_spec: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 
 expect_test_spec: KWD_APPLY KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 345.
 ##
 ## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2253,7 +2264,7 @@ expect_test_spec: KWD_APPLY KWD_UNROLL TILDE
 
 expect_test_spec: KWD_APPLY KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 346.
 ##
 ## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2265,7 +2276,7 @@ expect_test_spec: KWD_APPLY KWD_UNROLL LPAREN TILDE
 
 expect_test_spec: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 347.
 ##
 ## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2277,7 +2288,7 @@ expect_test_spec: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED TILDE
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 349.
 ##
 ## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2292,7 +2303,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 350.
 ##
 ## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2307,7 +2318,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED LPAREN TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 351.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2319,7 +2330,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 353.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2331,7 +2342,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 355.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2343,7 +2354,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 357.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2355,7 +2366,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 359.
 ##
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
@@ -2369,7 +2380,7 @@ expect_test_spec: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 360.
 ##
 ## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2381,7 +2392,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 361.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2393,7 +2404,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 362.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -2405,7 +2416,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 360.
+## Ends in an error in state: 363.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -2417,7 +2428,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 364.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -2429,7 +2440,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 366.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2441,7 +2452,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPARE
 
 expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 368.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
@@ -2455,7 +2466,7 @@ expect_test_spec: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPARE
 
 expect_test_spec: KWD_APPLY LPAREN TILDE
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 369.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
@@ -2468,7 +2479,7 @@ expect_test_spec: KWD_APPLY LPAREN TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 370.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
@@ -2483,7 +2494,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT SYMBOL
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 371.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2495,7 +2506,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 374.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2507,7 +2518,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 375.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2519,7 +2530,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 376.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2531,7 +2542,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT T
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 377.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2543,7 +2554,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT 
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 378.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2555,7 +2566,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT 
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 379.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2567,7 +2578,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT 
 
 expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 381.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2579,7 +2590,7 @@ expect_test_spec: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT 
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 382.
 ##
 ## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2591,7 +2602,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 383.
 ##
 ## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2603,7 +2614,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 381.
+## Ends in an error in state: 384.
 ##
 ## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2615,7 +2626,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 385.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
 ## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
@@ -2628,7 +2639,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 389.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -2641,7 +2652,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_I
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 390.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -2653,7 +2664,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT
 
 expect_test_spec: KWD_APPLY LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 396.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2665,7 +2676,7 @@ expect_test_spec: KWD_APPLY LPAREN RPAREN TILDE
 
 expect_test_spec: KWD_APPLY MINUSGREATER TILDE
 ##
-## Ends in an error in state: 394.
+## Ends in an error in state: 397.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2677,7 +2688,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER TILDE
 
 expect_test_spec: KWD_APPLY MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 398.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2689,7 +2700,7 @@ expect_test_spec: KWD_APPLY MINUSGREATER IDENT TILDE
 
 expect_test_spec: KWD_HCF TILDE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 412.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF BIGARROW ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF BIGARROW ]
@@ -2702,7 +2713,7 @@ expect_test_spec: KWD_HCF TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 413.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -2714,7 +2725,7 @@ expect_test_spec: KWD_HCF KWD_WHERE TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 414.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF BIGARROW ]
 ##
@@ -2726,7 +2737,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 416.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -2738,7 +2749,7 @@ expect_test_spec: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 419.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2750,7 +2761,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 419.
+## Ends in an error in state: 422.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2762,7 +2773,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 423.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2774,7 +2785,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 424.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2786,7 +2797,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 425.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
@@ -2799,7 +2810,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 427.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2811,7 +2822,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELET
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 428.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2823,7 +2834,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELET
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 434.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2835,7 +2846,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WIT
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 435.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2847,7 +2858,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN 
 
 expect_test_spec: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 437.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -2860,7 +2871,7 @@ expect_test_spec: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 
 expect_test_spec: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 438.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -2872,7 +2883,7 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 443.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF BIGARROW ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF BIGARROW ]
@@ -2885,7 +2896,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 
 expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 444.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -2897,7 +2908,7 @@ expect_test_spec: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 expect_test_spec: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 449.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -2909,7 +2920,7 @@ expect_test_spec: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILD
 
 expect_test_spec: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 453.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -2921,7 +2932,7 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 expect_test_spec: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 454.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF BIGARROW ]
 ##
@@ -2933,7 +2944,7 @@ expect_test_spec: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 expect_test_spec: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 457.
 ##
 ## atomic_expr -> LPAREN expr . RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF BIGARROW ]
 ##
@@ -2944,14 +2955,14 @@ expect_test_spec: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 409, spurious reduction of production expr -> inner_expr
+## In state 412, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 expect_test_spec: KWD_HCF RPAREN
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 459.
 ##
 ## expect_test_spec -> module_ . BIGARROW module_ EOF [ # ]
 ##
@@ -2962,15 +2973,15 @@ expect_test_spec: KWD_HCF RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 409, spurious reduction of production expr -> inner_expr
-## In state 460, spurious reduction of production module_ -> expr
+## In state 412, spurious reduction of production expr -> inner_expr
+## In state 463, spurious reduction of production module_ -> expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 expect_test_spec: KWD_HCF BIGARROW TILDE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 460.
 ##
 ## expect_test_spec -> module_ BIGARROW . module_ EOF [ # ]
 ##
@@ -2982,7 +2993,7 @@ expect_test_spec: KWD_HCF BIGARROW TILDE
 
 expect_test_spec: KWD_HCF BIGARROW KWD_HCF RPAREN
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 461.
 ##
 ## expect_test_spec -> module_ BIGARROW module_ . EOF [ # ]
 ##
@@ -2993,8 +3004,8 @@ expect_test_spec: KWD_HCF BIGARROW KWD_HCF RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 409, spurious reduction of production expr -> inner_expr
-## In state 460, spurious reduction of production module_ -> expr
+## In state 412, spurious reduction of production expr -> inner_expr
+## In state 463, spurious reduction of production module_ -> expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -4,7 +4,7 @@
 
 flambda_unit: KWD_APPLY SYMBOL LPAREN RPAREN KWD_WITH
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 401.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -18,7 +18,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER IDENT KWD_WITH
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 403.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -32,7 +32,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER KWD_WITH
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 402.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -46,7 +46,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 400.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
@@ -63,7 +63,7 @@ Examples of applications:
 
 flambda_unit: KWD_APPLY KWD_WITH
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 330.
 ##
 ## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -78,7 +78,7 @@ Example of an application:
 
 flambda_unit: KWD_CONT IDENT LPAREN SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 146.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
@@ -92,7 +92,7 @@ Expected a simple value (a symbol, variable, or literal).
 
 flambda_unit: KWD_CONT IDENT LPAREN KWD_WITH
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 145.
 ##
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ RPAREN PIPE MINUSGREATER KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -109,7 +109,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT IDENT KWD_VAL
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 312.
 ##
 ## apply_cont_expr -> continuation . option(trap_action) simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -125,7 +125,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT KWD_WITH
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 307.
 ##
 ## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -151,7 +151,7 @@ Example of a continuation call:
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_WITH
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 120.
 ##
 ## deleted_code -> KWD_CODE code_id . KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -173,7 +173,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_REC KWD_HCF
 ##
 ## Ends in an error in state: 77.
 ##
-## code_header -> KWD_CODE recursive . option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive . option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive
@@ -185,7 +185,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_WITH
 ##
 ## Ends in an error in state: 75.
 ##
-## code_header -> KWD_CODE . recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE . recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ## deleted_code -> KWD_CODE . code_id KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
@@ -203,7 +203,7 @@ Examples of code definitions:
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND KWD_WITH
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 156.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -215,7 +215,7 @@ Expected "code" or "symbol".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 155.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
@@ -231,14 +231,14 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ## In state 49, spurious reduction of production alloc_mode_for_allocations_opt ->
 ## In state 54, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
 ## In state 55, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
-## In state 218, spurious reduction of production symbol_binding -> static_closure_binding
+## In state 223, spurious reduction of production symbol_binding -> static_closure_binding
 ##
 
 Expected "and", "with", or "in".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN KWD_WITH
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 303.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -262,7 +262,7 @@ Expected "with", "in", "end", or "and".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_WITH
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 158.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol EQUAL . static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -279,7 +279,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 157.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol . EQUAL static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -296,7 +296,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET KWD_WITH
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 300.
 ##
 ## let_expr(expr) -> KWD_LET . let_(expr) [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## let_symbol(expr) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
@@ -313,7 +313,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 476.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -326,11 +326,11 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 11, spurious reduction of production option(PIPE) ->
 ## In state 35, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
-## In state 468, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
+## In state 473, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
 ## In state 34, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
-## In state 442, spurious reduction of production inner_expr -> inlined_expr
-## In state 407, spurious reduction of production expr -> inner_expr
-## In state 474, spurious reduction of production module_ -> expr
+## In state 447, spurious reduction of production inner_expr -> inlined_expr
+## In state 412, spurious reduction of production expr -> inner_expr
+## In state 479, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -1078,7 +1078,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 ##
 ## Ends in an error in state: 92.
 ##
-## code_header -> KWD_CODE recursive option(inline) . loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) . loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline)
@@ -1139,7 +1139,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 ##
 ## Ends in an error in state: 102.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt . KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt . KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt
@@ -1151,7 +1151,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 ##
 ## Ends in an error in state: 103.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE . LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE . LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE
@@ -1163,7 +1163,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 ##
 ## Ends in an error in state: 104.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN . code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN . code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN
@@ -1175,7 +1175,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 ##
 ## Ends in an error in state: 106.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size . RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size . RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size
@@ -1187,7 +1187,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 ##
 ## Ends in an error in state: 107.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN . option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN . option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN
@@ -1199,7 +1199,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF T
 ##
 ## Ends in an error in state: 108.
 ##
-## newer_version_of -> KWD_NEWER_VERSION_OF . LPAREN code_id RPAREN [ KWD_TUPLED IDENT ]
+## newer_version_of -> KWD_NEWER_VERSION_OF . LPAREN code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_NEWER_VERSION_OF
@@ -1211,7 +1211,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 ##
 ## Ends in an error in state: 109.
 ##
-## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN . code_id RPAREN [ KWD_TUPLED IDENT ]
+## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN . code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_NEWER_VERSION_OF LPAREN
@@ -1223,7 +1223,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 ##
 ## Ends in an error in state: 110.
 ##
-## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN code_id . RPAREN [ KWD_TUPLED IDENT ]
+## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN code_id . RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_NEWER_VERSION_OF LPAREN code_id
@@ -1235,7 +1235,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 ##
 ## Ends in an error in state: 112.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) . boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) . boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of)
@@ -1247,7 +1247,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 ##
 ## Ends in an error in state: 114.
 ##
-## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) . code_id [ LPAREN IDENT ]
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) . boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED)
@@ -1255,9 +1255,21 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
+##
+## Ends in an error in state: 116.
+##
+## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) . code_id [ LPAREN IDENT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB)
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_LET IDENT TILDE
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 122.
 ##
 ## let_binding -> variable . EQUAL named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1269,7 +1281,7 @@ flambda_unit: KWD_LET IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 123.
 ##
 ## let_binding -> variable EQUAL . named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1281,9 +1293,9 @@ flambda_unit: KWD_LET IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 ##
-## Ends in an error in state: 122.
+## Ends in an error in state: 124.
 ##
-## prim_op -> PRIM . list(prim_param) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
+## prim_op -> PRIM . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRIM
@@ -1293,11 +1305,9 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 125.
 ##
-## prim_param -> DOT . IDENT [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-## prim_param -> DOT . LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-## prim_param -> DOT . IDENT LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## list(pair(DOT,prim_param)) -> DOT . prim_param list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## DOT
@@ -1307,80 +1317,93 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 126.
 ##
-## prim_param -> DOT LBRACK . prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-##
-## The known suffix of the stack is as follows:
-## DOT LBRACK
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT TILDE
-##
-## Ends in an error in state: 127.
-##
-## prim_param -> DOT LBRACK prim_param_val . RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## prim_param -> LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## DOT LBRACK prim_param_val
+## LBRACK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 131.
 ##
-## prim_param -> DOT IDENT . [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-## prim_param -> DOT IDENT . LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## prim_param -> prim_param_val . [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
+## prim_param -> prim_param_val . LBRACK separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## DOT IDENT
+## prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 ##
-## Ends in an error in state: 130.
+## Ends in an error in state: 132.
 ##
-## prim_param -> DOT IDENT LBRACK . prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
+## prim_param -> prim_param_val LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## DOT IDENT LBRACK
+## prim_param_val LBRACK
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK IDENT TILDE
+flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ##
-## Ends in an error in state: 131.
+## Ends in an error in state: 135.
 ##
-## prim_param -> DOT IDENT LBRACK prim_param_val . RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
-##
-## The known suffix of the stack is as follows:
-## DOT IDENT LBRACK prim_param_val
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT RBRACK TILDE
-##
-## Ends in an error in state: 133.
-##
-## list(prim_param) -> prim_param . list(prim_param) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
+## separated_nonempty_list(COMMA,prim_param) -> prim_param . [ RBRACK ]
+## separated_nonempty_list(COMMA,prim_param) -> prim_param . COMMA separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
 ##
 ## The known suffix of the stack is as follows:
 ## prim_param
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 131, spurious reduction of production prim_param -> prim_param_val
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
+##
+## Ends in an error in state: 136.
+##
+## separated_nonempty_list(COMMA,prim_param) -> prim_param COMMA . separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
+##
+## The known suffix of the stack is as follows:
+## prim_param COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
+##
+## Ends in an error in state: 138.
+##
+## list(pair(DOT,prim_param)) -> DOT prim_param . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## DOT prim_param
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 131, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 136.
+## Ends in an error in state: 141.
 ##
 ## named -> KWD_REC_INFO . rec_info_atom [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1392,7 +1415,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 143.
 ##
 ## named -> simple . [ KWD_WITH KWD_IN KWD_AND ]
 ## simple -> simple . TILDE coercion [ TILDE KWD_WITH KWD_IN KWD_AND ]
@@ -1405,7 +1428,7 @@ flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 142.
+## Ends in an error in state: 147.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple COMMA . separated_nonempty_list(COMMA,simple) [ RPAREN ]
 ##
@@ -1417,7 +1440,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 160.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1429,7 +1452,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 161.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1441,7 +1464,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL TILDE
 ##
-## Ends in an error in state: 163.
+## Ends in an error in state: 168.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . SEMICOLON separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
@@ -1454,7 +1477,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL SEMICOLON TILDE
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 169.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block SEMICOLON . separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
 ##
@@ -1466,7 +1489,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 ##
-## Ends in an error in state: 166.
+## Ends in an error in state: 171.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK . LPAREN loption(separated_nonempty_list(COMMA,float_or_variable)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1478,7 +1501,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 172.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK LPAREN . loption(separated_nonempty_list(COMMA,float_or_variable)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1490,7 +1513,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 178.
 ##
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable . COMMA separated_nonempty_list(COMMA,float_or_variable) [ RPAREN ]
@@ -1503,7 +1526,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 179.
 ##
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable COMMA . separated_nonempty_list(COMMA,float_or_variable) [ RPAREN ]
 ##
@@ -1515,7 +1538,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT COMMA T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 181.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,float_or_variable)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1527,7 +1550,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 182.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,float_or_variable)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1539,7 +1562,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 186.
 ##
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable . SEMICOLON separated_nonempty_list(SEMICOLON,float_or_variable) [ RBRACKPIPE ]
@@ -1552,7 +1575,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 187.
 ##
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable SEMICOLON . separated_nonempty_list(SEMICOLON,float_or_variable) [ RBRACKPIPE ]
 ##
@@ -1564,7 +1587,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT SEM
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 191.
 ##
 ## static_data -> STATIC_CONST_BLOCK . mutability tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1576,7 +1599,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 194.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability . tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1588,7 +1611,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 195.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag . LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1600,7 +1623,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 196.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag LPAREN . loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1612,7 +1635,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL TILDE
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 200.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . [ RPAREN ]
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . COMMA separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
@@ -1625,7 +1648,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL COMMA TILDE
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 201.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block COMMA . separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
 ##
@@ -1637,7 +1660,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL COMMA TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 203.
 ##
 ## static_data -> KWD_MUTABLE . STRING [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1649,7 +1672,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 207.
 ##
 ## static_data -> variable . COLON static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1661,7 +1684,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 208.
 ##
 ## static_data -> variable COLON . static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1673,7 +1696,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 209.
 ##
 ## static_data_kind -> KWD_NATIVEINT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1685,7 +1708,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 211.
 ##
 ## static_data_kind -> KWD_INT64 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1697,7 +1720,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 213.
 ##
 ## static_data_kind -> KWD_INT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1709,7 +1732,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 215.
 ##
 ## static_data_kind -> KWD_FLOAT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1721,7 +1744,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 217.
 ##
 ## static_data_kind -> KWD_FLOAT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1733,7 +1756,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 226.
 ##
 ## code -> code_header . kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1745,7 +1768,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 227.
 ##
 ## kinded_args -> LPAREN . separated_nonempty_list(COMMA,kinded_variable) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EQUAL EOF ]
 ##
@@ -1757,7 +1780,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 228.
 ##
 ## kinded_variable -> variable . kind_with_subkind_opt [ RPAREN COMMA ]
 ##
@@ -1769,7 +1792,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 229.
 ##
 ## kind_with_subkind_opt -> COLON . kind_with_subkind [ RPAREN COMMA ]
 ##
@@ -1781,7 +1804,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 230.
 ##
 ## subkind -> LBRACK . ctors RBRACK [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1793,7 +1816,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 231.
 ##
 ## tag -> INT . [ KWD_OF ]
 ## targetint -> INT . [ RBRACK PIPE ]
@@ -1806,7 +1829,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 233.
 ##
 ## ctors_nonempty -> targetint PIPE . ctors_nonempty [ RBRACK ]
 ##
@@ -1818,7 +1841,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE INT TILDE
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 234.
 ##
 ## nonconst_ctor -> tag . KWD_OF kinds_with_subkinds_nonempty [ RBRACK PIPE ]
 ##
@@ -1830,7 +1853,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE INT 
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 235.
 ##
 ## nonconst_ctor -> tag KWD_OF . kinds_with_subkinds_nonempty [ RBRACK PIPE ]
 ##
@@ -1842,7 +1865,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 236.
 ##
 ## subkind -> KWD_VAL . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_VAL . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1855,7 +1878,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 240.
 ##
 ## naked_number_kind -> KWD_NATIVEINT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_NATIVEINT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1868,7 +1891,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 242.
 ##
 ## naked_number_kind -> KWD_INT64 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_INT64 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1881,7 +1904,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 244.
 ##
 ## naked_number_kind -> KWD_INT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_INT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1894,7 +1917,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 246.
 ##
 ## naked_number_kind -> KWD_IMM . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_IMM . KWD_TAGGED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1908,7 +1931,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 249.
 ##
 ## naked_number_kind -> KWD_FLOAT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_FLOAT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1921,7 +1944,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 251.
 ##
 ## naked_number_kind -> KWD_FLOAT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_FLOAT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1936,7 +1959,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 254.
 ##
 ## subkind -> KWD_FLOAT CARET . plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1948,7 +1971,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 256.
 ##
 ## subkind -> KWD_ANY . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1960,7 +1983,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 262.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . STAR separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
@@ -1973,7 +1996,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 263.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind STAR . separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
 ##
@@ -1985,7 +2008,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 267.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . [ RBRACK ]
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . PIPE separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
@@ -1997,18 +2020,18 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 246, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 255, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 257, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 254, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 256, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
+## In state 251, spurious reduction of production naked_number_kind -> KWD_FLOAT
+## In state 260, spurious reduction of production kind_with_subkind -> naked_number_kind
+## In state 262, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
+## In state 259, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 261, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 268.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor PIPE . separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
 ##
@@ -2020,7 +2043,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE TILD
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 273.
+## Ends in an error in state: 278.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . COMMA separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
@@ -2033,7 +2056,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 279.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable COMMA . separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
 ##
@@ -2045,7 +2068,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 281.
 ##
 ## code -> code_header kinded_args . variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2057,7 +2080,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPA
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 282.
 ##
 ## code -> code_header kinded_args variable . variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2069,7 +2092,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 283.
 ##
 ## code -> code_header kinded_args variable variable . variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2081,7 +2104,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILD
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 284.
 ##
 ## code -> code_header kinded_args variable variable variable . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2093,7 +2116,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 285.
 ##
 ## code -> code_header kinded_args variable variable variable variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2105,7 +2128,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 286.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2117,7 +2140,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 288.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2129,7 +2152,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 289.
 ##
 ## exn_continuation_id -> STAR . continuation_id [ KWD_LOCAL EQUAL COLON ]
 ##
@@ -2141,7 +2164,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 291.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2153,7 +2176,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 292.
 ##
 ## return_arity -> COLON . kinds_with_subkinds [ KWD_LOCAL EQUAL ]
 ##
@@ -2165,7 +2188,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 296.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2177,7 +2200,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_LOCAL TILDE
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 298.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2189,7 +2212,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 294.
+## Ends in an error in state: 299.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2201,7 +2224,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 297.
+## Ends in an error in state: 302.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -2213,7 +2236,7 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_INVALID TILDE
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 304.
 ##
 ## atomic_expr -> KWD_INVALID . STRING [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2225,7 +2248,7 @@ flambda_unit: KWD_INVALID TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 313.
 ##
 ## trap_action -> KWD_PUSH . LPAREN continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2237,7 +2260,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 314.
 ##
 ## trap_action -> KWD_PUSH LPAREN . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2249,7 +2272,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 315.
 ##
 ## trap_action -> KWD_PUSH LPAREN continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2261,7 +2284,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 317.
 ##
 ## trap_action -> KWD_POP . LPAREN option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2273,7 +2296,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 318.
 ##
 ## trap_action -> KWD_POP LPAREN . option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2285,7 +2308,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 323.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2297,7 +2320,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 324.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2309,7 +2332,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 327.
 ##
 ## apply_cont_expr -> continuation option(trap_action) . simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2321,7 +2344,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 331.
 ##
 ## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2333,7 +2356,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 332.
 ##
 ## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2345,7 +2368,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 333.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2357,7 +2380,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 334.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2369,7 +2392,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 335.
 ##
 ## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2381,7 +2404,7 @@ flambda_unit: KWD_APPLY AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 336.
 ##
 ## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2393,7 +2416,7 @@ flambda_unit: KWD_APPLY AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 337.
 ##
 ## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2405,7 +2428,7 @@ flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 339.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2417,7 +2440,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 341.
 ##
 ## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2429,7 +2452,7 @@ flambda_unit: KWD_APPLY KWD_CCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 344.
 ##
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2443,7 +2466,7 @@ flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 345.
 ##
 ## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2455,7 +2478,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 346.
 ##
 ## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2467,7 +2490,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 347.
 ##
 ## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2479,7 +2502,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED TILDE
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 349.
 ##
 ## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2494,7 +2517,7 @@ flambda_unit: KWD_APPLY KWD_INLINED TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 350.
 ##
 ## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2509,7 +2532,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 351.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2521,7 +2544,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 353.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2533,7 +2556,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 355.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2545,7 +2568,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 357.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2557,7 +2580,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 359.
 ##
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2571,7 +2594,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 360.
 ##
 ## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2583,7 +2606,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 361.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2595,7 +2618,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 362.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -2607,7 +2630,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 363.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -2619,7 +2642,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 364.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -2631,7 +2654,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 366.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2643,7 +2666,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TI
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 368.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2657,7 +2680,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RP
 
 flambda_unit: KWD_APPLY LPAREN TILDE
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 369.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
@@ -2670,7 +2693,7 @@ flambda_unit: KWD_APPLY LPAREN TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 370.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
@@ -2685,7 +2708,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 371.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2697,7 +2720,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 374.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2709,7 +2732,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 375.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2721,7 +2744,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 376.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2733,7 +2756,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 377.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2745,7 +2768,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 378.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2757,7 +2780,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 379.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2769,7 +2792,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 381.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2781,7 +2804,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 377.
+## Ends in an error in state: 382.
 ##
 ## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2793,7 +2816,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 383.
 ##
 ## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2805,7 +2828,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 384.
 ##
 ## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2817,7 +2840,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 385.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
 ## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
@@ -2830,7 +2853,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 384.
+## Ends in an error in state: 389.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -2843,7 +2866,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO 
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 390.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -2855,7 +2878,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COM
 
 flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 396.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2867,7 +2890,7 @@ flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER TILDE
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 397.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2879,7 +2902,7 @@ flambda_unit: KWD_APPLY MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 398.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2891,7 +2914,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 
 flambda_unit: KWD_HCF TILDE
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 412.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -2904,7 +2927,7 @@ flambda_unit: KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 413.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -2916,7 +2939,7 @@ flambda_unit: KWD_HCF KWD_WHERE TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 414.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF ]
 ##
@@ -2928,7 +2951,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 416.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -2940,7 +2963,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 419.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2952,7 +2975,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 422.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2964,7 +2987,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 423.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2976,7 +2999,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 419.
+## Ends in an error in state: 424.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2988,7 +3011,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 425.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3001,7 +3024,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 427.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3013,7 +3036,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 428.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3025,7 +3048,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 435.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3037,7 +3060,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LB
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 436.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3049,7 +3072,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILD
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 438.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -3062,7 +3085,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 439.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -3074,7 +3097,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 444.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -3087,7 +3110,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 445.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3099,7 +3122,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 450.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3111,7 +3134,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 451.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3123,7 +3146,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 456.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3135,7 +3158,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 457.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3147,7 +3170,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 463.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3159,7 +3182,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WIT
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 459.
+## Ends in an error in state: 464.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3171,7 +3194,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN 
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 469.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3184,7 +3207,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 470.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3196,7 +3219,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 
 flambda_unit: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 474.
 ##
 ## atomic_expr -> LPAREN expr . RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3207,7 +3230,7 @@ flambda_unit: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 407, spurious reduction of production expr -> inner_expr
+## In state 412, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -328,14 +328,17 @@ prim_param_val:
   | i = INT { make_located (fst i) ($startpos, $endpos)}
 
 prim_param:
-  | DOT; flag = IDENT { Flag flag }
-  | DOT LBRACK; p = prim_param_val; RBRACK
-    { Positional p }
-  | DOT; label = IDENT; LBRACK; value = prim_param_val; RBRACK
-    { Labeled { label; value } }
+  | flag = prim_param_val { Labeled (flag, []) }
+  | label = prim_param_val; LBRACK;
+      subvals = separated_nonempty_list(COMMA, prim_param);
+    RBRACK
+    { Labeled (label, subvals) }
+  | LBRACK; ps = separated_nonempty_list(COMMA, prim_param); RBRACK
+    { Anonymous ps }
 
 prim_op:
-  | prim = PRIM; params = prim_param* { { prim; params} }
+  | prim = PRIM; ps = pair(DOT, prim_param)*
+    { { prim; params = List.map snd ps } }
 
 named:
   | s = simple { Simple s }

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -325,14 +325,17 @@ prim_param_val:
   | i = INT { make_located (fst i) ($startpos, $endpos)}
 
 prim_param:
-  | DOT; flag = IDENT { Flag flag }
-  | DOT LBRACK; p = prim_param_val; RBRACK
-    { Positional p }
-  | DOT; label = IDENT; LBRACK; value = prim_param_val; RBRACK
-    { Labeled { label; value } }
+  | flag = prim_param_val { Labeled (flag, []) }
+  | label = prim_param_val; LBRACK;
+      subvals = separated_nonempty_list(COMMA, prim_param);
+    RBRACK
+    { Labeled (label, subvals) }
+  | LBRACK; ps = separated_nonempty_list(COMMA, prim_param); RBRACK
+    { Anonymous ps }
 
 prim_op:
-  | prim = PRIM; params = prim_param* { { prim; params} }
+  | prim = PRIM; ps = pair(DOT, prim_param)*
+    { { prim; params = List.map snd ps } }
 
 named:
   | s = simple { Simple s }

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -368,16 +368,18 @@ let static_data ppf : static_data -> unit = function
 let static_data_binding ppf { symbol = s; defining_expr = sp } =
   Format.fprintf ppf "%a =@ %a" symbol s static_data sp
 
-let prim_param ppf = function
-  | Flag f -> Format.fprintf ppf ".%a" ident f
-  | Positional p -> Format.fprintf ppf ".[`%s`]" p.txt
-  | Labeled { label; value } ->
-    Format.fprintf ppf ".%a[`%s`]" ident label value.txt
+let rec prim_param ppf = function
+  | Labeled (f, []) -> Format.fprintf ppf "%a" ident f.txt
+  | Labeled (label, ps) ->
+    Format.fprintf ppf "%a[%a]" ident label.txt prim_sub_params ps
+  | Anonymous ps -> Format.fprintf ppf "[%a]" prim_sub_params ps
+
+and prim_sub_params ppf params = pp_comma_list prim_param ppf params
 
 let prim_params ppf params =
-  Format.fprintf ppf "%a"
-    (Format.pp_print_list ~pp_sep:(fun _ () -> ()) prim_param)
-    params
+  pp_list
+    (fun ppf -> Format.fprintf ppf ".%a" prim_param)
+    ~sep:empty_fmt ppf params
 
 let prim_op ppf ({ prim; params } : prim_op) =
   Format.fprintf ppf "@[<2>%s%a@]" prim prim_params params

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -401,16 +401,18 @@ let static_data ppf : static_data -> unit = function
 let static_data_binding ppf { symbol = s; defining_expr = sp } =
   Format.fprintf ppf "%a =@ %a" symbol s static_data sp
 
-let prim_param ppf = function
-  | Flag f -> Format.fprintf ppf ".%a" ident f
-  | Positional p -> Format.fprintf ppf ".[`%s`]" p.txt
-  | Labeled { label; value } ->
-    Format.fprintf ppf ".%a[`%s`]" ident label value.txt
+let rec prim_param ppf = function
+  | Labeled (f, []) -> Format.fprintf ppf "%a" ident f.txt
+  | Labeled (label, ps) ->
+    Format.fprintf ppf "%a[%a]" ident label.txt prim_sub_params ps
+  | Anonymous ps -> Format.fprintf ppf "[%a]" prim_sub_params ps
+
+and prim_sub_params ppf params = pp_comma_list prim_param ppf params
 
 let prim_params ppf params =
-  Format.fprintf ppf "%a"
-    (Format.pp_print_list ~pp_sep:(fun _ () -> ()) prim_param)
-    params
+  pp_list
+    (fun ppf -> Format.fprintf ppf ".%a" prim_param)
+    ~sep:empty_fmt ppf params
 
 let prim_op ppf ({ prim; params } : prim_op) =
   (* CR bclement: use [Flambda_primitive.classify_for_printing]. *)

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
@@ -67,7 +67,7 @@ let code loopify(never) size(62) newer_version_of(i_3)
           | 0 -> k3
           | 1 -> k2 (0))
          where k3 =
-           ((let prim = %array_length (if_then_else_result) in
+           ((let prim = %array_length.`imm` (if_then_else_result) in
              let prim_1 = %int_comp.unsigned.lt (0, prim) in
              switch prim_1
                | 0 -> k3

--- a/testsuite/tests/flambda2/examples/arrays_compatibility.simplify.reference
+++ b/testsuite/tests/flambda2/examples/arrays_compatibility.simplify.reference
@@ -34,7 +34,7 @@ let code inline(always) loopify(never) size(60) newer_version_of(convert_fast_1)
           | 1 -> k3
           where k4 =
             let int_sub = %int_barith.sub (line, 1) in
-            ((let prim_2 = %array_length (index) in
+            ((let prim_2 = %array_length.`imm` (index) in
               let prim_3 = %int_comp.unsigned.lt (int_sub, prim_2) in
               switch prim_3
                 | 0 -> k4
@@ -86,7 +86,7 @@ let code loopify(never) size(75) newer_version_of(f_2)
                | 1 -> k3
                where k4 =
                  let int_sub = %int_barith.sub (line, 1) in
-                 ((let prim_2 = %array_length (index) in
+                 ((let prim_2 = %array_length.`imm` (index) in
                    let prim_3 = %int_comp.unsigned.lt (int_sub, prim_2) in
                    switch prim_3
                      | 0 -> k4

--- a/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
@@ -27,8 +27,7 @@ and code loopify(done) size(15) newer_version_of(aux_1)
   cont self
     where rec self =
       let env_2 =
-        %project_value_slot.[`aux`].[`env_1`]
-          ($camlDeleted_code_printing__aux_3)
+        %project_value_slot.[aux].[env_1] ($camlDeleted_code_printing__aux_3)
       in
       let Popaque = %opaque (0) in
       ((let untagged = %untag_imm (Popaque) in

--- a/testsuite/tests/flambda2/examples/functors.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functors.simplify.reference
@@ -24,7 +24,7 @@ apply direct(init_mod_4)
                  my_closure _region _ghost_region my_depth
                  -> k * k1
                  : [ 0 | 0 of val ] =
-           let X = %project_value_slot.[`foo`].[`X`] (my_closure) in
+           let X = %project_value_slot.[foo].[X] (my_closure) in
            let prim = %is_int (t) in
            switch prim
              | 0 -> k2
@@ -65,8 +65,7 @@ apply direct(init_mod_4)
                    my_closure _region _ghost_region my_depth
                    -> k1 * k2
                    : val =
-             let M_1 =
-               %project_value_slot.[`foo_1`].[`M`] ($camlFunctors__foo_6)
+             let M_1 = %project_value_slot.[foo_1].[M] ($camlFunctors__foo_6)
              in
              let Pfield = %block_load.[`0`] (M_1) in
              apply Pfield (42, t) -> k1 * k2

--- a/testsuite/tests/flambda2/examples/inlined_rec.raw.reference
+++ b/testsuite/tests/flambda2/examples/inlined_rec.raw.reference
@@ -12,7 +12,7 @@ let $camlInlined_rec__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let `apply` = %project_value_slot.[`fact`].[`apply`] (my_closure) in
+   let `apply` = %project_value_slot.[fact].[`apply`] (my_closure) in
    (let prim = %int_comp.ne (n, 0) in
     let int_notequal = %tag_imm (prim) in
     (let untagged = %untag_imm (int_notequal) in

--- a/testsuite/tests/flambda2/examples/let_symbol_order_atexit.simplify.reference
+++ b/testsuite/tests/flambda2/examples/let_symbol_order_atexit.simplify.reference
@@ -18,7 +18,7 @@ and code loopify(never) size(8) newer_version_of(do_at_exit_1)
         -> k * k1
         : imm tagged =
   let exit_function_1 =
-    %project_value_slot.[`do_at_exit`].[`exit_function`]
+    %project_value_slot.[do_at_exit].[exit_function]
       ($camlLet_symbol_order_atexit__do_at_exit_5)
   in
   let Pfield = %block_load.mut.[`0`] (exit_function_1) in
@@ -31,7 +31,7 @@ let code loopify(never) size(19) newer_version_of(exit_3)
         -> k * k1
         : val =
   (let exit_function_1 =
-     %project_value_slot.[`do_at_exit`].[`exit_function`]
+     %project_value_slot.[do_at_exit].[exit_function]
        ($camlLet_symbol_order_atexit__do_at_exit_5)
    in
    let Pfield = %block_load.mut.[`0`] (exit_function_1) in

--- a/testsuite/tests/flambda2/examples/lifting.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lifting.simplify.reference
@@ -12,14 +12,11 @@ apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
                       my_closure _region _ghost_region my_depth
                       -> k * k1
                       : imm tagged =
-                let r2_1 =
-                  %project_value_slot.[`f`].[`r2`] ($camlLifting__f_1)
+                let r2_1 = %project_value_slot.[f].[r2] ($camlLifting__f_1)
                 in
-                let r1_1 =
-                  %project_value_slot.[`f`].[`r1`] ($camlLifting__f_1)
+                let r1_1 = %project_value_slot.[f].[r1] ($camlLifting__f_1)
                 in
-                let r0_1 =
-                  %project_value_slot.[`f`].[`r0`] ($camlLifting__f_1)
+                let r0_1 = %project_value_slot.[f].[r0] ($camlLifting__f_1)
                 in
                 let int_add = %int_barith.add (x, r0_1) in
                 let int_add_1 = %int_barith.add (int_add, r1_1) in

--- a/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
+++ b/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
@@ -17,7 +17,7 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
                      (for_counter_naked : int64, n_289_unboxed0 : imm tagged) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
-           let prim_3 = %num_conv.[`tagged_imm`].[`nativeint`] (i) in
+           let prim_3 = %num_conv.[tagged_imm].[`nativeint`] (i) in
            let prim_4 = %string_load.[`8`] (s, prim_3) in
            let c = %tag_imm (prim_4) in
            ((let prim_5 = %int_comp.ne (c, 0) in
@@ -25,9 +25,9 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
                | 0 -> k4
                | 1 -> k5
                where k5 =
-                 let prim_6 = %num_conv.[`tagged_imm`].[`int8`] (c) in
+                 let prim_6 = %num_conv.[tagged_imm].[int8] (c) in
                  let prim_7 =
-                   %num_conv.[`tagged_imm`].[`nativeint`] (n_289_unboxed0)
+                   %num_conv.[tagged_imm].[`nativeint`] (n_289_unboxed0)
                  in
                  let Pbytessetu =
                    %bytes_or_bigstring_set.bytes.[`8`] (s', prim_7, prim_6)

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
@@ -4,7 +4,7 @@ let code loopify(never) size(7) stub
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let f = %project_value_slot.[`partial_f`].[`f`] (my_closure) in
+  let f = %project_value_slot.[partial_f].[f] (my_closure) in
   apply (f : val * val -> imm tagged) (0, param1) -> k * k1
 in
 let code test_0 deleted in

--- a/testsuite/tests/flambda2/examples/phantom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/phantom.simplify.reference
@@ -123,7 +123,7 @@ let code inline(always) loopify(never) size(176) newer_version_of(Make_0)
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
     where k2 (Pccall) =
       let UndecidedLit =
-        %block.imm_uniq.[`248`] ($camlPhantom__immstring11, Pccall)
+        %block.immut_uniq.[`248`] ($camlPhantom__immstring11, Pccall)
       in
       let eval_level = closure eval_level_3_1 @eval_level
       with {
@@ -239,7 +239,7 @@ let code inline(always) loopify(never) size(176) newer_version_of(Make2_5)
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
     where k2 (Pccall) =
       let UndecidedLit =
-        %block.imm_uniq.[`248`] ($camlPhantom__immstring11, Pccall)
+        %block.immut_uniq.[`248`] ($camlPhantom__immstring11, Pccall)
       in
       let eval_level = closure eval_level_3_2 @eval_level
       with {

--- a/testsuite/tests/flambda2/examples/phantom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/phantom.simplify.reference
@@ -17,7 +17,7 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4)
         -> k * k1
         : imm tagged =
   let UndecidedLit =
-    %project_value_slot.[`true_at_level0`].[`UndecidedLit`] (my_closure)
+    %project_value_slot.[true_at_level0].[UndecidedLit] (my_closure)
   in
   let try_region = %begin_try_region () in
   let try_ghost_region = %begin_try_ghost_region () in
@@ -67,7 +67,7 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3)
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let UndecidedLit =
-    %project_value_slot.[`eval_level`].[`UndecidedLit_1`] (my_closure)
+    %project_value_slot.[eval_level].[UndecidedLit_1] (my_closure)
   in
   let Pfield = %block_load.[`1`] (a) in
   let lvl = %block_load.[`3`] (Pfield) in
@@ -152,7 +152,7 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4_1)
         -> k * k1
         : imm tagged =
   let UndecidedLit =
-    %project_value_slot.[`true_at_level0`].[`UndecidedLit`] (my_closure)
+    %project_value_slot.[true_at_level0].[UndecidedLit] (my_closure)
   in
   let try_region = %begin_try_region () in
   let try_ghost_region = %begin_try_ghost_region () in
@@ -202,7 +202,7 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let UndecidedLit =
-    %project_value_slot.[`eval_level`].[`UndecidedLit_1`] (my_closure)
+    %project_value_slot.[eval_level].[UndecidedLit_1] (my_closure)
   in
   let Pfield = %block_load.[`1`] (a) in
   let lvl = %block_load.[`3`] (Pfield) in

--- a/testsuite/tests/flambda2/examples/symbol_projections.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections.simplify.reference
@@ -42,7 +42,7 @@ let $camlSymbol_projections__immstring10 = "FOO" in
             -> k * k1
             : imm tagged =
       let foo_2 =
-        %project_value_slot.[`g`].[`foo_1`] ($camlSymbol_projections__g_3)
+        %project_value_slot.[g].[foo_1] ($camlSymbol_projections__g_3)
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged

--- a/testsuite/tests/flambda2/examples/symbol_projections2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections2.simplify.reference
@@ -38,7 +38,7 @@ and code loopify(never) size(4) newer_version_of(`fn[symbol_projections2.ml:21,8
         -> k * k1
         : imm tagged =
   let v_2 =
-    %project_value_slot.[`fn[symbol_projections2.ml:21,8--17]`].[`v_1`]
+    %project_value_slot.[`fn[symbol_projections2.ml:21,8--17]`].[v_1]
       ($`camlSymbol_projections2__fn[symbol_projections2.ml:21,8--17]_5`)
   in
   let int_add = %int_barith.add (x, v_2) in

--- a/testsuite/tests/flambda2/examples/symbol_projections3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections3.simplify.reference
@@ -47,7 +47,7 @@ let $camlSymbol_projections3__immstring10 = "FOO" in
             -> k * k1
             : imm tagged =
       let foo_2 =
-        %project_value_slot.[`g`].[`foo_1`] ($camlSymbol_projections3__g_3)
+        %project_value_slot.[g].[foo_1] ($camlSymbol_projections3__g_3)
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged

--- a/testsuite/tests/flambda2/examples/symbol_projections4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections4.simplify.reference
@@ -51,7 +51,7 @@ let $camlSymbol_projections4__immstring10 = "FOO" in
             -> k * k1
             : imm tagged =
       let foo_2 =
-        %project_value_slot.[`h`].[`foo_1`] ($camlSymbol_projections4__h_4)
+        %project_value_slot.[h].[foo_1] ($camlSymbol_projections4__h_4)
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged
@@ -72,7 +72,7 @@ let $camlSymbol_projections4__immstring10 = "FOO" in
             -> k * k1
             : imm tagged =
       let foo_2 =
-        %project_value_slot.[`g`].[`foo_2`] ($camlSymbol_projections4__g_5)
+        %project_value_slot.[g].[foo_2] ($camlSymbol_projections4__g_5)
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged

--- a/testsuite/tests/flambda2/examples/symbol_projections6.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections6.simplify.reference
@@ -45,7 +45,7 @@ let $camlSymbol_projections6__immstring10 = "FOO" in
             -> k * k1
             : [ 0 of [ 0 of val |1 of val ] * imm tagged ] =
       let foo_2 =
-        %project_value_slot.[`h`].[`foo_1`] ($camlSymbol_projections6__h_4)
+        %project_value_slot.[h].[foo_1] ($camlSymbol_projections6__h_4)
       in
       (let prim = %int_comp.lt (z, 0) in
        switch prim
@@ -81,7 +81,7 @@ let $camlSymbol_projections6__immstring10 = "FOO" in
             -> k * k1
             : [ 0 of [ 0 of val |1 of val ] * imm tagged ] =
       let foo_2 =
-        %project_value_slot.[`g`].[`foo_2`] ($camlSymbol_projections6__g_5)
+        %project_value_slot.[g].[foo_2] ($camlSymbol_projections6__g_5)
       in
       (let prim = %int_comp.lt (y, 0) in
        switch prim

--- a/testsuite/tests/flambda2/examples/symbol_projections7.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections7.simplify.reference
@@ -9,7 +9,7 @@ and code loopify(never) size(4) newer_version_of(`fn[symbol_projections7.ml:20,4
         -> k * k1
         : imm tagged =
   let y_1 =
-    %project_value_slot.[`fn[symbol_projections7.ml:20,4--18]`].[`y`]
+    %project_value_slot.[`fn[symbol_projections7.ml:20,4--18]`].[y]
       ($`camlSymbol_projections7__fn[symbol_projections7.ml:20,4--18]_2`)
   in
   let int_add = %int_barith.add (x, y_1) in

--- a/testsuite/tests/flambda2/examples/tests.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests.raw.reference
@@ -18,7 +18,7 @@ let $camlTests__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let to_inline = %project_value_slot.[`f`].[`to_inline`] (my_closure) in
+   let to_inline = %project_value_slot.[f].[to_inline] (my_closure) in
    (let prim = %int_comp.lt (c, 0) in
     let int_lessthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_lessthan) in

--- a/testsuite/tests/flambda2/examples/tests11.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests11.raw.reference
@@ -20,7 +20,7 @@ let $camlTests11__first_const = Block 0 () in
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let map_foo =
-     %project_value_slot.[`fn[tests11.ml:23,2--70]`].[`map_foo`] (my_closure)
+     %project_value_slot.[`fn[tests11.ml:23,2--70]`].[map_foo] (my_closure)
    in
    let `fn[tests11.ml:23,52--67]` =
      closure `fn[tests11.ml:23,52--67]_2` @`fn[tests11.ml:23,52--67]`
@@ -51,7 +51,7 @@ let $camlTests11__first_const = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   let bar = %project_value_slot.[`map_foo`].[`bar`] (my_closure) in
+   let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
    apply seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in

--- a/testsuite/tests/flambda2/examples/tests11.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests11.simplify.reference
@@ -26,7 +26,7 @@ let code loopify(never) size(7) newer_version_of(`fn[tests11.ml:23,2--70]_1`)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   let map_foo =
-    %project_value_slot.[`fn[tests11.ml:23,2--70]`].[`map_foo`] (my_closure)
+    %project_value_slot.[`fn[tests11.ml:23,2--70]`].[map_foo] (my_closure)
   in
   apply inlined(never)
     map_foo

--- a/testsuite/tests/flambda2/examples/tests12.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests12.raw.reference
@@ -20,7 +20,7 @@ let $camlTests12__first_const = Block 0 () in
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let map_foo =
-     %project_value_slot.[`fn[tests12.ml:25,2--70]`].[`map_foo`] (my_closure)
+     %project_value_slot.[`fn[tests12.ml:25,2--70]`].[map_foo] (my_closure)
    in
    let `fn[tests12.ml:25,52--67]` =
      closure `fn[tests12.ml:25,52--67]_2` @`fn[tests12.ml:25,52--67]`
@@ -51,7 +51,7 @@ let $camlTests12__first_const = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   let bar = %project_value_slot.[`map_foo`].[`bar`] (my_closure) in
+   let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
    apply seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in

--- a/testsuite/tests/flambda2/examples/tests12.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests12.simplify.reference
@@ -27,7 +27,7 @@ let code loopify(never) size(7) newer_version_of(`fn[tests12.ml:25,2--70]_1`)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   let map_foo =
-    %project_value_slot.[`fn[tests12.ml:25,2--70]`].[`map_foo`] (my_closure)
+    %project_value_slot.[`fn[tests12.ml:25,2--70]`].[map_foo] (my_closure)
   in
   apply inlined(never)
     map_foo

--- a/testsuite/tests/flambda2/examples/tests13.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests13.raw.reference
@@ -20,11 +20,9 @@ let $camlTests13__first_const = Block 0 () in
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let map_foo =
-     %project_value_slot.[`fn[tests13.ml:27,2--118]`].[`map_foo`]
-       (my_closure)
+     %project_value_slot.[`fn[tests13.ml:27,2--118]`].[map_foo] (my_closure)
    in
-   let i =
-     %project_value_slot.[`fn[tests13.ml:27,2--118]`].[`i`] (my_closure)
+   let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
    in
    let j = %int_barith.add (i, 3) in
    let Popaque = %opaque (j) in
@@ -65,7 +63,7 @@ let $camlTests13__first_const = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   let bar = %project_value_slot.[`map_foo`].[`bar`] (my_closure) in
+   let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
    apply seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in

--- a/testsuite/tests/flambda2/examples/tests13.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests13.simplify.reference
@@ -27,9 +27,9 @@ let code loopify(never) size(10) newer_version_of(`fn[tests13.ml:27,2--118]_1`)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   let map_foo =
-    %project_value_slot.[`fn[tests13.ml:27,2--118]`].[`map_foo`] (my_closure)
+    %project_value_slot.[`fn[tests13.ml:27,2--118]`].[map_foo] (my_closure)
   in
-  let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[`i`] (my_closure)
+  let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
   in
   let j = %int_barith.add (i, 3) in
   let Popaque = %opaque (j) in

--- a/testsuite/tests/flambda2/examples/tests14.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests14.raw.reference
@@ -14,7 +14,7 @@ let $camlTests14__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let prim = %num_conv.[`tagged_imm`].[`nativeint`] (n) in
+   let prim = %num_conv.[tagged_imm].[`nativeint`] (n) in
    let prim_1 = %string_load.[`8`] (s, prim) in
    let Pstringrefu = %tag_imm (prim_1) in
    cont k1 (Pstringrefu)

--- a/testsuite/tests/flambda2/examples/tests14.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests14.simplify.reference
@@ -16,7 +16,7 @@ let code loopify(never) size(7) newer_version_of(nth_char_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let prim = %num_conv.[`tagged_imm`].[`nativeint`] (n) in
+  let prim = %num_conv.[tagged_imm].[`nativeint`] (n) in
   let prim_1 = %string_load.[`8`] (s, prim) in
   let Pstringrefu = %tag_imm (prim_1) in
   cont k (Pstringrefu)

--- a/testsuite/tests/flambda2/examples/tests15.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests15.raw.reference
@@ -53,8 +53,8 @@
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let prim = %num_conv.[`tagged_imm`].[`int8`] (120) in
-   let prim_1 = %num_conv.[`tagged_imm`].[`nativeint`] (i) in
+   let prim = %num_conv.[tagged_imm].[int8] (120) in
+   let prim_1 = %num_conv.[tagged_imm].[`nativeint`] (i) in
    let Pbytessetu = %bytes_or_bigstring_set.bytes.[`8`] (b, prim_1, prim) in
    cont k1 (Pbytessetu)
  in

--- a/testsuite/tests/flambda2/examples/tests15.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests15.simplify.reference
@@ -45,7 +45,7 @@ let code loopify(never) size(5) newer_version_of(set_to_x_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let prim = %num_conv.[`tagged_imm`].[`nativeint`] (i) in
+  let prim = %num_conv.[tagged_imm].[`nativeint`] (i) in
   let Pbytessetu = %bytes_or_bigstring_set.bytes.[`8`] (b, prim, 120s) in
   cont k (0)
 in

--- a/testsuite/tests/flambda2/examples/tests5.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests5.raw.reference
@@ -5,7 +5,7 @@ let $camlTests5__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let g = %project_function_slot.[`f`].[`g`] (my_closure) in
+   let g = %project_function_slot.[f].[g] (my_closure) in
    (let prim = %int_comp.lt (x, 4) in
     let int_lessthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_lessthan) in
@@ -26,7 +26,7 @@ let $camlTests5__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let f = %project_function_slot.[`g`].[`f`] (my_closure) in
+   let f = %project_function_slot.[g].[f] (my_closure) in
    (let prim = %int_comp.gt (y, 3) in
     let int_greaterthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_greaterthan) in

--- a/testsuite/tests/flambda2/examples/tests8.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests8.raw.reference
@@ -22,7 +22,7 @@ let $camlTests8__first_const = Block 0 () in
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let map_foo =
-     %project_value_slot.[`fn[tests8.ml:20,12--80]`].[`my_closure`]
+     %project_value_slot.[`fn[tests8.ml:20,12--80]`].[my_closure]
        (my_closure)
    in
    let `fn[tests8.ml:20,62--77]` =

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -27,9 +27,7 @@
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let length_aux =
-     %project_value_slot.[`length`].[`length_aux`] (my_closure)
-   in
+   let length_aux = %project_value_slot.[length].[length_aux] (my_closure) in
    apply direct(length_aux_0)
      (length_aux : _ -> imm tagged) (0, l) -> k1 * k2
  in
@@ -110,9 +108,8 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let cmp = %project_value_slot.[`rev_merge`].[`cmp`] (my_closure) in
-   let rev_append =
-     %project_value_slot.[`rev_merge`].[`rev_append`] (my_closure)
+   let cmp = %project_value_slot.[rev_merge].[cmp] (my_closure) in
+   let rev_append = %project_value_slot.[rev_merge].[rev_append] (my_closure)
    in
    (let prim = %is_int (l1) in
     let Pisint = %tag_imm (prim) in
@@ -208,9 +205,9 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let cmp = %project_value_slot.[`rev_merge_rev`].[`cmp_1`] (my_closure) in
+   let cmp = %project_value_slot.[rev_merge_rev].[cmp_1] (my_closure) in
    let rev_append =
-     %project_value_slot.[`rev_merge_rev`].[`rev_append_1`] (my_closure)
+     %project_value_slot.[rev_merge_rev].[rev_append_1] (my_closure)
    in
    (let prim = %is_int (l1) in
     let Pisint = %tag_imm (prim) in
@@ -303,14 +300,13 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let chop = %project_value_slot.[`sort`].[`chop`] (my_closure) in
-   let cmp = %project_value_slot.[`sort`].[`cmp_2`] (my_closure) in
+   let chop = %project_value_slot.[sort].[chop] (my_closure) in
+   let cmp = %project_value_slot.[sort].[cmp_2] (my_closure) in
    let rev_merge_rev =
-     %project_value_slot.[`sort`].[`rev_merge_rev`] (my_closure)
+     %project_value_slot.[sort].[rev_merge_rev] (my_closure)
    in
-   let rev_merge = %project_value_slot.[`sort`].[`rev_merge`] (my_closure) in
-   let rev_sort = %project_function_slot.[`sort`].[`rev_sort`] (my_closure)
-   in
+   let rev_merge = %project_value_slot.[sort].[rev_merge] (my_closure) in
+   let rev_sort = %project_function_slot.[sort].[rev_sort] (my_closure) in
    (let prim = %int_comp.ne (n, 2) in
     let int_notequal = %tag_imm (prim) in
     (let untagged = %untag_imm (int_notequal) in
@@ -883,15 +879,13 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let chop = %project_value_slot.[`rev_sort`].[`chop`] (my_closure) in
-   let rev_merge =
-     %project_value_slot.[`rev_sort`].[`rev_merge`] (my_closure)
-   in
+   let chop = %project_value_slot.[rev_sort].[chop] (my_closure) in
+   let rev_merge = %project_value_slot.[rev_sort].[rev_merge] (my_closure) in
    let rev_merge_rev =
-     %project_value_slot.[`rev_sort`].[`rev_merge_rev`] (my_closure)
+     %project_value_slot.[rev_sort].[rev_merge_rev] (my_closure)
    in
-   let cmp = %project_value_slot.[`rev_sort`].[`cmp_2`] (my_closure) in
-   let sort = %project_function_slot.[`rev_sort`].[`sort`] (my_closure) in
+   let cmp = %project_value_slot.[rev_sort].[cmp_2] (my_closure) in
+   let sort = %project_function_slot.[rev_sort].[sort] (my_closure) in
    (let prim = %int_comp.ne (n, 2) in
     let int_notequal = %tag_imm (prim) in
     (let untagged = %untag_imm (int_notequal) in
@@ -1467,10 +1461,10 @@
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
    let rev_append =
-     %project_value_slot.[`sort_uniq`].[`rev_append_2`] (my_closure)
+     %project_value_slot.[sort_uniq].[rev_append_2] (my_closure)
    in
-   let chop = %project_value_slot.[`sort_uniq`].[`chop_1`] (my_closure) in
-   let length = %project_value_slot.[`sort_uniq`].[`length`] (my_closure) in
+   let chop = %project_value_slot.[sort_uniq].[chop_1] (my_closure) in
+   let length = %project_value_slot.[sort_uniq].[length] (my_closure) in
    let rev_merge = closure rev_merge_5 @rev_merge
    with { rev_append = rev_append; cmp = cmp }
    in
@@ -1509,9 +1503,8 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let cmp = %project_value_slot.[`sort_1`].[`cmp_3`] (my_closure) in
-   let rev_sort =
-     %project_function_slot.[`sort_1`].[`rev_sort_1`] (my_closure)
+   let cmp = %project_value_slot.[sort_1].[cmp_3] (my_closure) in
+   let rev_sort = %project_function_slot.[sort_1].[rev_sort_1] (my_closure)
    in
    apply direct(rev_sort_11)
      (rev_sort ~ depth my_depth -> next_depth
@@ -1525,9 +1518,8 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let cmp = %project_value_slot.[`rev_sort_1`].[`cmp_3`] (my_closure) in
-   let sort = %project_function_slot.[`rev_sort_1`].[`sort_1`] (my_closure)
-   in
+   let cmp = %project_value_slot.[rev_sort_1].[cmp_3] (my_closure) in
+   let sort = %project_function_slot.[rev_sort_1].[sort_1] (my_closure) in
    (let prim = %int_comp.ne (n, 2) in
     let int_notequal = %tag_imm (prim) in
     (let untagged = %untag_imm (int_notequal) in

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -103,7 +103,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
                 (l1_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  l2_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  accu_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-      let cmp = %project_value_slot.[`rev_merge`].[`cmp`] (my_closure) in
+      let cmp = %project_value_slot.[rev_merge].[cmp] (my_closure) in
       let prim = %is_int (l1_1) in
       (switch prim
          | 0 -> k2
@@ -164,8 +164,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
                 (l1_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  l2_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  accu_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-      let cmp = %project_value_slot.[`rev_merge_rev`].[`cmp_1`] (my_closure)
-      in
+      let cmp = %project_value_slot.[rev_merge_rev].[cmp_1] (my_closure) in
       let prim = %is_int (l1_1) in
       (switch prim
          | 0 -> k2
@@ -219,10 +218,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let rev_merge = %project_value_slot.[`rev_sort`].[`rev_merge`] (my_closure)
-  in
-  let cmp = %project_value_slot.[`rev_sort`].[`cmp_2`] (my_closure) in
-  let sort = %project_function_slot.[`rev_sort`].[`sort`] (my_closure) in
+  let rev_merge = %project_value_slot.[rev_sort].[rev_merge] (my_closure) in
+  let cmp = %project_value_slot.[rev_sort].[cmp_2] (my_closure) in
+  let sort = %project_function_slot.[rev_sort].[sort] (my_closure) in
   (let prim = %int_comp.ne (n, 2) in
    switch prim
      | 0 -> k3
@@ -607,11 +605,10 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let cmp = %project_value_slot.[`sort`].[`cmp_2`] (my_closure) in
-  let rev_merge_rev =
-    %project_value_slot.[`sort`].[`rev_merge_rev`] (my_closure)
+  let cmp = %project_value_slot.[sort].[cmp_2] (my_closure) in
+  let rev_merge_rev = %project_value_slot.[sort].[rev_merge_rev] (my_closure)
   in
-  let rev_sort = %project_function_slot.[`sort`].[`rev_sort`] (my_closure) in
+  let rev_sort = %project_function_slot.[sort].[rev_sort] (my_closure) in
   (let prim = %int_comp.ne (n, 2) in
    switch prim
      | 0 -> k3
@@ -1032,8 +1029,8 @@ let code rec loopify(never) size(77) newer_version_of(rev_sort_11)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let cmp = %project_value_slot.[`rev_sort_1`].[`cmp_3`] (my_closure) in
-  let sort = %project_function_slot.[`rev_sort_1`].[`sort_1`] (my_closure) in
+  let cmp = %project_value_slot.[rev_sort_1].[cmp_3] (my_closure) in
+  let sort = %project_function_slot.[rev_sort_1].[sort_1] (my_closure) in
   (let prim = %int_comp.ne (n, 2) in
    switch prim
      | 0 -> k3
@@ -1076,9 +1073,7 @@ and code rec loopify(never) size(5) newer_version_of(sort_10)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let rev_sort =
-    %project_function_slot.[`sort_1`].[`rev_sort_1`] (my_closure)
-  in
+  let rev_sort = %project_function_slot.[sort_1].[rev_sort_1] (my_closure) in
   apply direct(rev_sort_11_1)
     (rev_sort ~ depth my_depth -> succ my_depth
      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])

--- a/testsuite/tests/flambda2/examples/toplevel_closures.simplify.reference
+++ b/testsuite/tests/flambda2/examples/toplevel_closures.simplify.reference
@@ -8,7 +8,7 @@ and code loopify(never) size(5) newer_version_of(f_0)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let r_1 = %project_value_slot.[`f`].[`r`] ($camlToplevel_closures__f_2) in
+  let r_1 = %project_value_slot.[f].[r] ($camlToplevel_closures__f_2) in
   let Pfield = %block_load.mut.[`0`] (r_1) in
   let int_add = %int_barith.add (x, Pfield) in
   cont k (int_add)
@@ -21,8 +21,7 @@ and code loopify(never) size(8) newer_version_of(g_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let r_1 = %project_value_slot.[`g`].[`r_1`] ($camlToplevel_closures__g_3)
-  in
+  let r_1 = %project_value_slot.[g].[r_1] ($camlToplevel_closures__g_3) in
   let Pfield = %block_load.mut.[`0`] (r_1) in
   let Pfield_1 = %block_load.mut.[`0`] (r_1) in
   let int_add = %int_barith.add (x, Pfield_1) in

--- a/testsuite/tests/flambda2/examples/toplevel_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/toplevel_rec.simplify.reference
@@ -9,7 +9,7 @@ and code rec loopify(never) size(10) newer_version_of(g_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let z_1 = %project_value_slot.[`g`].[`z`] ($camlToplevel_rec__g_3) in
+  let z_1 = %project_value_slot.[g].[z] ($camlToplevel_rec__g_3) in
   (let int_sub = %int_barith.sub (y, 1) in
    apply direct(f_0_1)
      ($camlToplevel_rec__f_2 ~ depth my_depth -> succ my_depth
@@ -24,7 +24,7 @@ and code rec loopify(never) size(10) newer_version_of(f_0)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let z_1 = %project_value_slot.[`f`].[`z`] ($camlToplevel_rec__f_2) in
+  let z_1 = %project_value_slot.[f].[z] ($camlToplevel_rec__f_2) in
   (let int_add = %int_barith.add (x, 1) in
    apply direct(g_1_1)
      ($camlToplevel_rec__g_3 ~ depth my_depth -> succ my_depth

--- a/testsuite/tests/flambda2/examples/unknown/bigarrays.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/bigarrays.simplify.reference
@@ -10,21 +10,21 @@ in
       -> k1 * error)
    where k1 (region_return : val) =
      let `unit` = %end_region (`region`) in
-     ((let prim = %bigarray_lenght.[`1`] (region_return) in
+     ((let prim = %bigarray_length.[`1`] (region_return) in
        let prim_1 = %num_conv.[`imm`].[`nativeint`] (prim) in
        let prim_2 = %int_comp.`nativeint`.unsigned.lt (1n, prim_1) in
        switch prim_2
          | 0 -> k1
          | 1 -> k2)
         where k2 =
-          ((let prim = %bigarray_lenght.[`2`] (region_return) in
+          ((let prim = %bigarray_length.[`2`] (region_return) in
             let prim_1 = %num_conv.[`imm`].[`nativeint`] (prim) in
             let prim_2 = %int_comp.`nativeint`.unsigned.lt (1n, prim_1) in
             switch prim_2
               | 0 -> k1
               | 1 -> k2)
              where k2 =
-               let prim = %bigarray_lenght.[`2`] (region_return) in
+               let prim = %bigarray_length.[`2`] (region_return) in
                let prim_1 = %tag_imm (prim) in
                let prim_2 = %int_barith.add (prim_1, 1) in
                let prim_3 =
@@ -32,7 +32,7 @@ in
                in
                let i = %tag_imm (prim_3) in
                let stdout =
-                 %project_value_slot.[`print_int`].[`stdout`]
+                 %project_value_slot.[print_int].[stdout]
                    ($Stdlib.camlStdlib__print_int_136)
                in
                (apply ccall inlining_state(depth(20))

--- a/testsuite/tests/flambda2/examples/unknown/f.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/f.simplify.reference
@@ -17,7 +17,7 @@ let code loopify(never) size(82) newer_version_of(maxson_0)
     | 0 -> k (0)
     | 1 -> k2
     where k2 =
-      ((let prim_1 = %array_length (a) in
+      ((let prim_1 = %array_length.`float` (a) in
         let prim_2 = %int_comp.unsigned.lt (int_add_2, prim_1) in
         switch prim_2
           | 0 -> k2

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -35,7 +35,7 @@
               apply f (Pfield) -> k3 * k2)
                where k3 (apply_result_1 : val) =
                  let Pmakeblock =
-                   %block.[`0`].`local`[`my_region`]
+                   %block.[`0`].`local`[my_region]
                      (apply_result_1, apply_result)
                  in
                  cont k1 (Pmakeblock)))
@@ -91,7 +91,7 @@
         cont k3)
      where k3 =
        let Pfield = %block_load.[`0`] (l1) in
-       let Pmakeblock = %block.[`0`].`local`[`my_region`] (Pfield, l2) in
+       let Pmakeblock = %block.[`0`].`local`[my_region] (Pfield, l2) in
        let Pfield_1 = %block_load.[`1`] (l1) in
        apply direct(rev_app_4 &my_region &my_ghost_region)
          (my_closure ~ depth my_depth -> next_depth
@@ -108,9 +108,8 @@
          -> k1 * k2
          : [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
-   let rev_app = %project_value_slot.[`find_span`].[`rev_app`] (my_closure)
-   in
-   let spans = %project_function_slot.[`find_span`].[`spans`] (my_closure) in
+   let rev_app = %project_value_slot.[find_span].[rev_app] (my_closure) in
+   let spans = %project_function_slot.[find_span].[spans] (my_closure) in
    (let prim = %is_int (l) in
     let Pisint = %tag_imm (prim) in
     (let untagged = %untag_imm (Pisint) in
@@ -124,7 +123,7 @@
      where k4 =
        let l_1 = %block_load.[`1`] (l) in
        let a = %block_load.[`0`] (l) in
-       let acc_1 = %block.[`0`].`local`[`my_region`] (a, acc) in
+       let acc_1 = %block.[`0`].`local`[my_region] (a, acc) in
        (apply break_here (a) -> k6 * k2
           where k6 (apply_result : imm tagged) =
             ((let untagged = %untag_imm (apply_result) in
@@ -144,11 +143,10 @@
                 (break_here, l_1, acc_1)
                 -> k1 * k2
           where k4 =
-            let Pmakeblock = %block.[`0`].`local`[`my_region`] (acc_1, l_1)
-            in
+            let Pmakeblock = %block.[`0`].`local`[my_region] (acc_1, l_1) in
             cont k1 (Pmakeblock))
      where k3 =
-       let Pmakeblock = %block.[`0`].`local`[`my_region`] (acc, 0) in
+       let Pmakeblock = %block.[`0`].`local`[my_region] (acc, 0) in
        cont k1 (Pmakeblock)
  in
  let code rec size(39)
@@ -158,10 +156,8 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
-   let rev_app = %project_value_slot.[`spans`].[`rev_app`] (my_closure) in
-   let find_span =
-     %project_function_slot.[`spans`].[`find_span`] (my_closure)
-   in
+   let rev_app = %project_value_slot.[spans].[rev_app] (my_closure) in
+   let find_span = %project_function_slot.[spans].[find_span] (my_closure) in
    (let prim = %is_int (l) in
     let Pisint = %tag_imm (prim) in
     (let untagged = %untag_imm (Pisint) in
@@ -198,7 +194,7 @@
                             (apply_result_1 :
                                [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                       let Pmakeblock =
-                        %block.[`0`].`local`[`my_region`]
+                        %block.[`0`].`local`[my_region]
                           (apply_result_1, apply_result)
                       in
                       cont k1 (Pmakeblock))))

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -63,7 +63,7 @@ and code rec loopify(never) size(31) newer_version_of(map_local_1)
              apply f (Pfield) -> k2 * k1)
               where k2 (apply_result_1 : val) =
                 let Pmakeblock =
-                  %block.[`0`].`local`[`my_region`]
+                  %block.[`0`].`local`[my_region]
                     (apply_result_1, apply_result)
                 in
                 cont k (Pmakeblock)))
@@ -165,7 +165,7 @@ apply direct(length_2_1)
                        where k2 =
                          let Pfield = %block_load.[`0`] (l1_1) in
                          let Pmakeblock =
-                           %block.[`0`].`local`[`my_region`] (Pfield, l2_1)
+                           %block.[`0`].`local`[my_region] (Pfield, l2_1)
                          in
                          let Pfield_1 = %block_load.[`1`] (l1_1) in
                          cont self (Pfield_1, Pmakeblock))
@@ -189,14 +189,13 @@ apply direct(length_2_1)
                   | 0 -> k2
                   | 1 -> k3
                   where k3 =
-                    let Pmakeblock =
-                      %block.[`0`].`local`[`my_region`] (acc, 0)
+                    let Pmakeblock = %block.[`0`].`local`[my_region] (acc, 0)
                     in
                     cont k (Pmakeblock)
                   where k2 =
                     let l_1 = %block_load.[`1`] (l) in
                     let a = %block_load.[`0`] (l) in
-                    let acc_1 = %block.[`0`].`local`[`my_region`] (a, acc) in
+                    let acc_1 = %block.[`0`].`local`[my_region] (a, acc) in
                     (apply break_here (a) -> k3 * k1
                        where k3 (param : imm tagged) =
                          let unboxed_field = %untag_imm (param) in
@@ -208,8 +207,7 @@ apply direct(length_2_1)
                             | 1 -> k3
                             where k3 =
                               let Pmakeblock =
-                                %block.[`0`].`local`[`my_region`]
-                                  (acc_1, l_1)
+                                %block.[`0`].`local`[my_region] (acc_1, l_1)
                               in
                               cont k (Pmakeblock)
                             where k2 =
@@ -278,7 +276,7 @@ apply direct(length_2_1)
                                             | 0 of val *
                                                 [ 0 | 0 of val * val ] ]) =
                                    let Pmakeblock =
-                                     %block.[`0`].`local`[`my_region`]
+                                     %block.[`0`].`local`[my_region]
                                        (apply_result_1, apply_result)
                                    in
                                    cont k (Pmakeblock))))

--- a/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
@@ -7,8 +7,8 @@ let code loopify(never) size(16) newer_version_of(f_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let r = %project_value_slot.[`f`].[`r`] (my_closure) in
-  let a = %project_value_slot.[`f`].[`a`] (my_closure) in
+  let r = %project_value_slot.[f].[r] (my_closure) in
+  let a = %project_value_slot.[f].[a] (my_closure) in
   (let untagged = %untag_imm (a) in
    switch untagged
      | 0 -> k (0)
@@ -22,8 +22,8 @@ let code loopify(never) size(20) newer_version_of(g_3)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let s = %project_value_slot.[`g`].[`s`] (my_closure) in
-  let b = %project_value_slot.[`g`].[`b`] (my_closure) in
+  let s = %project_value_slot.[g].[s] (my_closure) in
+  let b = %project_value_slot.[g].[b] (my_closure) in
   (let untagged = %untag_imm (b) in
    switch untagged
      | 0 -> k (0)
@@ -38,10 +38,10 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let b = %project_value_slot.[`h`].[`b`] (my_closure) in
-  let a = %project_value_slot.[`h`].[`a`] (my_closure) in
-  let g = %project_function_slot.[`h`].[`g`] (my_closure) in
-  let f = %project_function_slot.[`h`].[`f`] (my_closure) in
+  let b = %project_value_slot.[h].[b] (my_closure) in
+  let a = %project_value_slot.[h].[a] (my_closure) in
+  let g = %project_function_slot.[h].[g] (my_closure) in
+  let f = %project_function_slot.[h].[f] (my_closure) in
   (let untagged = %untag_imm (b) in
    switch untagged
      | 0 -> k2 (0)
@@ -134,7 +134,7 @@ apply direct(partial_apply1_44) inlined(never) inlining_state(depth(11))
                  my_closure _region _ghost_region my_depth
                  -> k * k1
                  : imm tagged =
-           let r_1 = %project_value_slot.[`f`].[`r`] ($camlOffset__f_7) in
+           let r_1 = %project_value_slot.[f].[r] ($camlOffset__f_7) in
            let int_add = %int_barith.add (r_1, x) in
            cont k (int_add)
            with { a = 1; b = 0; r = r; s = s }

--- a/testsuite/tests/flambda2/examples/unknown/test_cmx_offsets2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_cmx_offsets2.simplify.reference
@@ -1,6 +1,5 @@
 let x =
-  %project_value_slot.[`f`].[`x`]
-    ($Test_cmx_offsets1.camlTest_cmx_offsets1__f_1)
+  %project_value_slot.[f].[x] ($Test_cmx_offsets1.camlTest_cmx_offsets1__f_1)
 in
 let int_add = %int_barith.add (x, 3) in
 let $camlTest_cmx_offsets2 = Block 0 (int_add) in

--- a/testsuite/tests/flambda2/examples/unknown/to_hex.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/to_hex.simplify.reference
@@ -175,7 +175,7 @@ apply ccall
                              %num_conv.[`imm`].[`nativeint`] (cse_param)
                            in
                            let prim_3 =
-                             %num_conv.[`tagged_imm`].[`nativeint`] (i)
+                             %num_conv.[tagged_imm].[`nativeint`] (i)
                            in
                            let prim_4 =
                              %int_comp.`nativeint`.unsigned.lt
@@ -199,11 +199,11 @@ apply ccall
                                  where k4 (apply_result : imm tagged) =
                                    let int_mul = %int_barith.mul (i, 2) in
                                    let prim_4 =
-                                     %num_conv.[`tagged_imm`].[`int8`]
+                                     %num_conv.[tagged_imm].[int8]
                                        (apply_result)
                                    in
                                    let prim_5 =
-                                     %num_conv.[`tagged_imm`].[`nativeint`]
+                                     %num_conv.[tagged_imm].[`nativeint`]
                                        (int_mul)
                                    in
                                    let Pbytessetu =
@@ -222,11 +222,11 @@ apply ccall
                                           %int_barith.add (int_mul, 1)
                                         in
                                         let prim_6 =
-                                          %num_conv.[`tagged_imm`].[`int8`]
+                                          %num_conv.[tagged_imm].[int8]
                                             (apply_result_1)
                                         in
                                         let prim_7 =
-                                          %num_conv.[`tagged_imm`].[`nativeint`]
+                                          %num_conv.[tagged_imm].[`nativeint`]
                                             (int_add)
                                         in
                                         let Pbytessetu_1 =

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
@@ -7,10 +7,10 @@ let code loopify(never) size(7) newer_version_of(`fn[unbox_closure.ml:12,12--25]
         -> k * k1
         : imm tagged =
   let x =
-    %project_value_slot.[`fn[unbox_closure.ml:12,12--25]`].[`x`] (my_closure)
+    %project_value_slot.[`fn[unbox_closure.ml:12,12--25]`].[x] (my_closure)
   in
   let y =
-    %project_value_slot.[`fn[unbox_closure.ml:12,12--25]`].[`y`] (my_closure)
+    %project_value_slot.[`fn[unbox_closure.ml:12,12--25]`].[y] (my_closure)
   in
   let int_add = %int_barith.add (x, y) in
   let int_add_1 = %int_barith.add (int_add, z) in
@@ -21,7 +21,7 @@ let code loopify(never) size(18) newer_version_of(bar_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : val =
-  let x = %project_value_slot.[`bar`].[`x_1`] (my_closure) in
+  let x = %project_value_slot.[bar].[x_1] (my_closure) in
   let Popaque = %opaque (0) in
   let `fn[unbox_closure.ml:12,12--25]` =
     closure `fn[unbox_closure.ml:12,12--25]_2_1`

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
@@ -6,7 +6,7 @@ let code inline(always) loopify(never) size(4) newer_version_of(bar1_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let x = %project_value_slot.[`bar1`].[`x`] (my_closure) in
+  let x = %project_value_slot.[bar1].[x] (my_closure) in
   let int_add = %int_barith.add (x, y) in
   cont k (int_add)
 in
@@ -15,8 +15,8 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar2_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let x = %project_value_slot.[`bar2`].[`x_1`] (my_closure) in
-  let z = %project_value_slot.[`bar2`].[`z`] (my_closure) in
+  let x = %project_value_slot.[bar2].[x_1] (my_closure) in
+  let z = %project_value_slot.[bar2].[z] (my_closure) in
   let int_mul = %int_barith.mul (z, x) in
   let int_mul_1 = %int_barith.mul (int_mul, y) in
   cont k (int_mul_1)

--- a/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(2) newer_version_of(`fn[wrong_allocation_moving.ml:
         -> k * k1
         : float boxed =
   let y =
-    %project_value_slot.[`fn[wrong_allocation_moving.ml:21,15--28]`].[`y`]
+    %project_value_slot.[`fn[wrong_allocation_moving.ml:21,15--28]`].[y]
       (my_closure)
   in
   cont k (y)

--- a/testsuite/tests/flambda2/examples/unroll2.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll2.raw.reference
@@ -27,7 +27,7 @@ let $camlUnroll2__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let foo = %project_value_slot.[`bar`].[`foo`] (my_closure) in
+   let foo = %project_value_slot.[bar].[foo] (my_closure) in
    apply direct(foo_0) unroll(2) foo (x) -> k1 * k2
  in
  let foo = closure foo_0 @foo in

--- a/testsuite/tests/flambda2/examples/unroll3.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll3.raw.reference
@@ -5,7 +5,7 @@ let $camlUnroll3__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let odd = %project_function_slot.[`even`].[`odd`] (my_closure) in
+   let odd = %project_function_slot.[even].[odd] (my_closure) in
    (let prim = %phys_eq (n, 0) in
     let eq = %tag_imm (prim) in
     (let untagged = %untag_imm (eq) in
@@ -26,7 +26,7 @@ let $camlUnroll3__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let even = %project_function_slot.[`odd`].[`even`] (my_closure) in
+   let even = %project_function_slot.[odd].[even] (my_closure) in
    (let prim = %phys_eq (n, 0) in
     let eq = %tag_imm (prim) in
     (let untagged = %untag_imm (eq) in

--- a/testsuite/tests/flambda2/examples/unroll4.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.raw.reference
@@ -4,8 +4,8 @@ let $camlUnroll4__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let k = %project_value_slot.[`even`].[`k`] (my_closure) in
-   let odd = %project_function_slot.[`even`].[`odd`] (my_closure) in
+   let k = %project_value_slot.[even].[k] (my_closure) in
+   let odd = %project_function_slot.[even].[odd] (my_closure) in
    (let prim = %phys_eq (n, 0) in
     let eq = %tag_imm (prim) in
     (let untagged = %untag_imm (eq) in
@@ -27,8 +27,8 @@ let $camlUnroll4__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let k = %project_value_slot.[`odd`].[`k`] (my_closure) in
-   let even = %project_function_slot.[`odd`].[`even`] (my_closure) in
+   let k = %project_value_slot.[odd].[k] (my_closure) in
+   let even = %project_function_slot.[odd].[even] (my_closure) in
    (let prim = %phys_eq (n, 0) in
     let eq = %tag_imm (prim) in
     (let untagged = %untag_imm (eq) in

--- a/testsuite/tests/flambda2/examples/unroll4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.simplify.reference
@@ -5,8 +5,8 @@ let code rec loopify(never) size(26) newer_version_of(odd_2)
       odd_2_1 (n : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
-  let k = %project_value_slot.[`odd`].[`k`] (my_closure) in
-  let even = %project_function_slot.[`odd`].[`even`] (my_closure) in
+  let k = %project_value_slot.[odd].[k] (my_closure) in
+  let even = %project_function_slot.[odd].[even] (my_closure) in
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
@@ -21,8 +21,8 @@ and code rec loopify(never) size(26) newer_version_of(even_1)
       even_1_1 (n : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
-  let k = %project_value_slot.[`even`].[`k`] (my_closure) in
-  let odd = %project_function_slot.[`even`].[`odd`] (my_closure) in
+  let k = %project_value_slot.[even].[k] (my_closure) in
+  let odd = %project_function_slot.[even].[odd] (my_closure) in
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2

--- a/testsuite/tests/flambda2/examples/unroll5.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll5.raw.reference
@@ -27,7 +27,7 @@ let $camlUnroll5__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let foo = %project_value_slot.[`test1`].[`foo`] (my_closure) in
+   let foo = %project_value_slot.[test1].[foo] (my_closure) in
    apply direct(foo_0) foo (x) -> k1 * k2
  in
  let code size(5)
@@ -35,7 +35,7 @@ let $camlUnroll5__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let foo = %project_value_slot.[`test2`].[`foo_1`] (my_closure) in
+   let foo = %project_value_slot.[test2].[foo_1] (my_closure) in
    apply direct(foo_0) unroll(1) foo (x) -> k1 * k2
  in
  let code size(5)
@@ -43,7 +43,7 @@ let $camlUnroll5__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let foo = %project_value_slot.[`test3`].[`foo_2`] (my_closure) in
+   let foo = %project_value_slot.[test3].[foo_2] (my_closure) in
    apply direct(foo_0) unroll(3) foo (x) -> k1 * k2
  in
  let foo = closure foo_0 @foo in

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(12) newer_version_of(g_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let x = %project_value_slot.[`g`].[`x`] (my_closure) in
+  let x = %project_value_slot.[g].[x] (my_closure) in
   let untagged = %untag_imm (b) in
   switch untagged
     | 0 -> k (42)
@@ -17,7 +17,7 @@ let code loopify(never) size(10) newer_version_of(h_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let g = %project_value_slot.[`h`].[`g`] (my_closure) in
+  let g = %project_value_slot.[h].[g] (my_closure) in
   apply direct(g_1_1) (g : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (acc, x) in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
@@ -5,8 +5,8 @@ let $camlArguments_for_unboxed_closure__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let y = %project_value_slot.[`g`].[`y`] (my_closure) in
-   let x = %project_value_slot.[`g`].[`x`] (my_closure) in
+   let y = %project_value_slot.[g].[y] (my_closure) in
+   let x = %project_value_slot.[g].[x] (my_closure) in
    apply h (y) -> k3 * k2
      where k3 (apply_result : imm tagged) =
        let int_add = %int_barith.add (x, apply_result) in
@@ -31,8 +31,8 @@ let $camlArguments_for_unboxed_closure__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let g = %project_value_slot.[`u`].[`g`] (my_closure) in
-   let `id` = %project_value_slot.[`u`].[`id`] (my_closure) in
+   let g = %project_value_slot.[u].[g] (my_closure) in
+   let `id` = %project_value_slot.[u].[`id`] (my_closure) in
    apply direct(g_1) inlined(always) (g : _ -> imm tagged) (`id`) -> k1 * k2
  in
  let code size(65)

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
@@ -13,9 +13,9 @@ let code inline(never) loopify(never) size(10) newer_version_of(u_4)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let g = %project_value_slot.[`u`].[`g`] (my_closure) in
-  let y = %project_value_slot.[`g`].[`y`] (g) in
-  let x = %project_value_slot.[`g`].[`x`] (g) in
+  let g = %project_value_slot.[u].[g] (my_closure) in
+  let y = %project_value_slot.[g].[y] (g) in
+  let x = %project_value_slot.[g].[x] (g) in
   apply direct(id_2_1) inlining_state(depth(1))
     ($camlArguments_for_unboxed_closure__id_6 : _ -> imm tagged)
       (y)
@@ -38,8 +38,8 @@ let code loopify(never) size(11) newer_version_of(g_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let y = %project_value_slot.[`g`].[`y`] (my_closure) in
-  let x = %project_value_slot.[`g`].[`x`] (my_closure) in
+  let y = %project_value_slot.[g].[y] (my_closure) in
+  let x = %project_value_slot.[g].[x] (my_closure) in
   apply h (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in

--- a/testsuite/tests/reaper/code_size.reaper.reference
+++ b/testsuite/tests/reaper/code_size.reaper.reference
@@ -10,7 +10,7 @@ in
 let $camlCode_size__h_4 = closure h_2_1 @h in
 let code loopify(never) size(6) newer_version_of(g_1)
       g_1_1 (y) my_closure _region _ghost_region my_depth -> k * k1 =
-  let x = %project_value_slot.[`g`].[`unboxed_field_x`] (my_closure) in
+  let x = %project_value_slot.[g].[unboxed_field_x] (my_closure) in
   (let Pmakeblock_into_Pmakeblock_field_0 = x in
    apply direct(h_2_1)
      $camlCode_size__h_4 (Pmakeblock_into_Pmakeblock_field_0) -> k2 * k1)

--- a/testsuite/tests/reaper/code_size.simplify.reference
+++ b/testsuite/tests/reaper/code_size.simplify.reference
@@ -8,7 +8,7 @@ in
 let $camlCode_size__h_4 = closure h_2_1 @h in
 let code loopify(never) size(14) newer_version_of(g_1)
       g_1_1 (y) my_closure _region _ghost_region my_depth -> k * k1 =
-  let x = %project_value_slot.[`g`].[`x`] (my_closure) in
+  let x = %project_value_slot.[g].[x] (my_closure) in
   (let Pmakeblock = %block.[`0`] (x, y) in
    apply direct(h_2_1)
      ($camlCode_size__h_4 : _ -> [ 0 of val * val ]) (Pmakeblock) -> k2 * k1)


### PR DESCRIPTION
This improves primitive parametrization of fexprs.

Most of the changes are internal, but the new recursive representation allows to have explicit tuples `.[a, b, c]` and also nest parameters in one another `.label[0, foo, bar[1], [baz]]`.

It should not change the syntax for any implemented primitives.