### PR TITLE
Remove c[lt]z intrinsics for nonzero args

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -216,10 +216,10 @@ let pseudoregs_for_operation op arg res =
     arg, res
   (* Other instructions are regular *)
   | Intop_atomic { op = Add | Sub | Land | Lor | Lxor; _ }
-  | Intop (Ipopcnt | Iclz _ | Ictz _ | Icomp _ | Iadd)
+  | Intop (Ipopcnt | Iclz | Ictz | Icomp _ | Iadd)
   | Intop_imm
-      ( ( Iadd | Isub | Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz _
-        | Ictz _ ),
+      ( ( Iadd | Isub | Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz
+        | Ictz ),
         _ )
   | Specific
       ( Isextend32 | Izextend32 | Ilea _

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -218,8 +218,7 @@ let pseudoregs_for_operation op arg res =
   | Intop_atomic { op = Add | Sub | Land | Lor | Lxor; _ }
   | Intop (Ipopcnt | Iclz | Ictz | Icomp _ | Iadd)
   | Intop_imm
-      ( ( Iadd | Isub | Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz
-        | Ictz ),
+      ( (Iadd | Isub | Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz | Ictz),
         _ )
   | Specific
       ( Isextend32 | Izextend32 | Ilea _

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -817,7 +817,7 @@ let instr_for_intop = function
   | Ilsl -> I.sal
   | Ilsr -> I.shr
   | Iasr -> I.sar
-  | Idiv | Imod | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _ -> assert false
+  | Idiv | Imod | Ipopcnt | Imulh _ | Iclz | Ictz | Icomp _ -> assert false
 
 let instr_for_floatop (width : Cmm.float_width) op =
   let open Simd_instrs in
@@ -2321,7 +2321,7 @@ let emit_instr ~first ~last ~fallthrough i =
   | Lop (Specific (Ibswap { bitwidth = Sixtyfour })) -> I.bswap (res i 0)
   | Lop (Specific Isextend32) -> I.movsxd (arg32 i 0) (res i 0)
   | Lop (Specific Izextend32) -> I.mov (arg32 i 0) (res32 i 0)
-  | Lop (Intop (Iclz { arg_is_non_zero })) ->
+  | Lop (Intop Iclz) ->
     (* CR-someday gyorsh: can we do it at selection? mshinwell: We need to
        address this and the similar CRs below. My feeling is that we should try
        to do this earlier, based on previous experience with similar things, but
@@ -2329,12 +2329,6 @@ let emit_instr ~first ~last ~fallthrough i =
        situation is fine for now. *)
     if Arch.Extension.enabled LZCNT
     then I.simd lzcnt_r64_r64m64 [| arg i 0; res i 0 |]
-    else if arg_is_non_zero
-    then (
-      (* No need to handle that bsr is undefined on 0 input. *)
-      I.bsr (arg i 0) (res i 0);
-      (* We need (63 - result_of_bsr), which can be done with xor. *)
-      I.xor (int 63) (res i 0))
     else
       let lbl_z = L.create Text in
       let lbl_nz = L.create Text in
@@ -2345,14 +2339,10 @@ let emit_instr ~first ~last ~fallthrough i =
       D.define_label lbl_z;
       I.mov (int 64) (res i 0);
       D.define_label lbl_nz
-  | Lop (Intop (Ictz { arg_is_non_zero })) ->
+  | Lop (Intop Ictz) ->
     (* CR-someday gyorsh: can we do it at selection? *)
     if Arch.Extension.enabled BMI
     then I.simd tzcnt_r64_r64m64 [| arg i 0; res i 0 |]
-    else if arg_is_non_zero
-    then
-      (* No need to handle that bsf is undefined on 0 input. *)
-      I.bsf (arg i 0) (res i 0)
     else
       let lbl_nz = L.create Text in
       I.bsf (arg i 0) (res i 0);

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -549,11 +549,11 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
        | Stackoffset _
        | Intop (Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr
-               | Iasr | Ipopcnt | Iclz _ | Ictz _
+               | Iasr | Ipopcnt | Iclz | Ictz
                )
        | Int128op (Iadd128 | Isub128 | Imul64 _)
        | Intop_imm ((Iadd | Isub | Imul | Imulh _ | Iand | Ior | Ixor | Ilsl
-                    | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ ),_)
+                    | Ilsr | Iasr | Ipopcnt | Iclz | Ictz ),_)
        | Floatop _
        | Csel _
        | Reinterpret_cast _
@@ -704,7 +704,7 @@ let operation_supported = function
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Ccsel _
   | Cbswap _
-  | Cclz _ | Cctz _
+  | Cclz | Cctz
   | Ccmpi _ | Caddv | Cadda
   | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32
   | Ccmpf _

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -263,7 +263,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Op (Int128op (Iadd128 | Isub128 | Imul64 _))
   | Op (Intop_imm ((Imulh _ | Imul | Idiv | Imod), _))
   | Op (Specific (Irdtsc | Irdpmc))
-  | Op (Intop (Ipopcnt | Iclz _ | Ictz _))
+  | Op (Intop (Ipopcnt | Iclz | Ictz))
   | Op (Intop_atomic _)
   | Op
       ( Move | Spill | Reload | Dummy_use
@@ -283,7 +283,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue ->
     (* no rewrite *)
     May_still_have_spilled_registers
-  | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _), _))
+  | Op (Intop_imm ((Ipopcnt | Iclz | Ictz), _))
   | Stack_check _
   | Op (Specific (Illvm_intrinsic _)) ->
     (* should not happen *)

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1404,7 +1404,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
         (* These instructions seem to not have a simd counterpart yet, could
            also implement as a combination of other instructions if needed in
            the future *))
-    | Idiv | Imod | Iclz _ | Ictz _ | Ipopcnt -> None
+    | Idiv | Imod | Iclz | Ictz | Ipopcnt -> None
   in
   match List.hd cfg_ops with
   | Move -> Operation.Move |> make_default ~arg_count ~res_count

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1632,7 +1632,7 @@ let emit_instr env i =
       A.ins2 CNT_vector reg_v8b_7 reg_v8b_7;
       A.ins2 ADDV reg_b7 reg_v8b_7;
       A.ins2 FMOV_fp_to_gp_64 (H.reg_x i.res.(0)) reg_d7)
-  | Lop (Intop (Ictz _)) ->
+  | Lop (Intop Ictz) ->
     (* [ctz Rd, Rn] is optionally supported from Armv8.7, but rbit and clz are
        supported in all ARMv8 CPUs. *)
     if !Arch.feat_cssc
@@ -1640,7 +1640,7 @@ let emit_instr env i =
     else (
       A.ins2 RBIT (H.reg_x i.res.(0)) (H.reg_x i.arg.(0));
       A.ins2 CLZ (H.reg_x i.res.(0)) (H.reg_x i.res.(0)))
-  | Lop (Intop (Iclz _)) -> A.ins2 CLZ (H.reg_x i.res.(0)) (H.reg_x i.arg.(0))
+  | Lop (Intop Iclz) -> A.ins2 CLZ (H.reg_x i.res.(0)) (H.reg_x i.arg.(0))
   | Lop (Intop Iand) ->
     let rd, rn, rm = H.reg_x i.res.(0), H.reg_x i.arg.(0), H.reg_x i.arg.(1) in
     A.ins4 AND_shifted_register rd rn rm O.optional_none
@@ -1682,7 +1682,7 @@ let emit_instr env i =
   | Lop (Intop_imm (Iasr, shift_in_bits)) ->
     A.ins_asr_immediate (H.reg_x i.res.(0)) (H.reg_x i.arg.(0)) ~shift_in_bits
   | Lop
-      (Intop_imm ((Imul | Idiv | Iclz _ | Ictz _ | Ipopcnt | Imod | Imulh _), _))
+      (Intop_imm ((Imul | Idiv | Iclz | Ictz | Ipopcnt | Imod | Imulh _), _))
     ->
     Misc.fatal_errorf "emit_instr: immediate operand not supported for %a"
       Printlinear.instr i

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1681,8 +1681,7 @@ let emit_instr env i =
     A.ins_lsr_immediate (H.reg_x i.res.(0)) (H.reg_x i.arg.(0)) ~shift_in_bits
   | Lop (Intop_imm (Iasr, shift_in_bits)) ->
     A.ins_asr_immediate (H.reg_x i.res.(0)) (H.reg_x i.arg.(0)) ~shift_in_bits
-  | Lop
-      (Intop_imm ((Imul | Idiv | Iclz | Ictz | Ipopcnt | Imod | Imulh _), _))
+  | Lop (Intop_imm ((Imul | Idiv | Iclz | Ictz | Ipopcnt | Imod | Imulh _), _))
     ->
     Misc.fatal_errorf "emit_instr: immediate operand not supported for %a"
       Printlinear.instr i

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -319,7 +319,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
       else
         destroy_neon_reg7
   | Op (Intop (Iadd  | Isub | Imul | Idiv|Imod|Iand|Ior|Ixor|Ilsl
-              |Ilsr|Iasr|Imulh _|Iclz _|Ictz _|Icomp _))
+              |Ilsr|Iasr|Imulh _|Iclz|Ictz|Icomp _))
   | Op (Int128op (Iadd128 | Isub128 | Imul64 _))
   | Op (Specific _
         | Move | Spill | Reload | Dummy_use
@@ -474,7 +474,7 @@ let operation_supported : Cmm.operation -> bool = function
   | Cnegf Float32 | Cabsf Float32 | Caddf Float32
   | Csubf Float32 | Cmulf Float32 | Cdivf Float32
   | Cpackf32
-  | Cclz _ | Cctz _ | Cbswap _
+  | Cclz | Cctz | Cbswap _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -97,11 +97,11 @@ let find_compatible_allocations :
           | Static_cast _ | Dls_get | Tls_get | Domain_index
           | Intop
               ( Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-              | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _ )
+              | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz | Ictz | Icomp _ )
           | Int128op (Iadd128 | Isub128 | Imul64 _)
           | Intop_imm
               ( ( Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-                | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _ ),
+                | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz | Ictz | Icomp _ ),
                 _ )
           | Intop_atomic _ ) ->
         loop allocations (DLL.next cell) ~curr_mode ~curr_size)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -112,7 +112,7 @@ let eval_int_op op (left : nativeint) (right : nativeint) : nativeint option =
      in the future; care is needed as some may clobber registers beyond
      [res.(0)] on certain targets (e.g. [Imul] may not always lower to a form
      writing only to the destination). *)
-  | Imul | Imulh _ | Idiv | Imod | Iclz _ | Ictz _ | Ipopcnt | Icomp _ -> None
+  | Imul | Imulh _ | Idiv | Imod | Iclz | Ictz | Ipopcnt | Icomp _ -> None
 
 let eval_float_op op (left : float) (right : float option) : float option =
   match (op : Operation.float_operation) with

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -810,8 +810,7 @@ end = struct
                   | Intop_imm (Isub, n) -> Some (reg, -n)
                   | Intop_imm
                       ( ( Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-                        | Iasr | Ipopcnt | Imulh _ | Iclz | Ictz | Icomp _
-                          ),
+                        | Iasr | Ipopcnt | Imulh _ | Iclz | Ictz | Icomp _ ),
                         _ )
                   | Opaque | Begin_region | End_region | Dls_get | Tls_get
                   | Domain_index | Poll | Pause | Const_int _ | Const_float32 _

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -810,7 +810,7 @@ end = struct
                   | Intop_imm (Isub, n) -> Some (reg, -n)
                   | Intop_imm
                       ( ( Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-                        | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _
+                        | Iasr | Ipopcnt | Imulh _ | Iclz | Ictz | Icomp _
                           ),
                         _ )
                   | Opaque | Begin_region | End_region | Dls_get | Tls_get

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -72,7 +72,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         (* The remaining operations are simple if their args are *)
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Caddi128
       | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl | Clsr | Casr | Ccmpi _
-      | Caddv | Cadda | Cnegf _ | Cclz _ | Cctz _ | Cpopcnt | Cbswap _ | Ccsel _
+      | Caddv | Cadda | Cnegf _ | Cclz | Cctz | Cpopcnt | Cbswap _ | Ccsel _
       | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32
       | Creinterpret_cast _ | Cstatic_cast _ | Ctuple_field _ | Ccmpf _
       | Cdls_get | Ctls_get | Cdomain_index ->
@@ -129,9 +129,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         | Cprobe_is_enabled _ -> EC.coeffect_only Arbitrary
         | Ctuple_field _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
         | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Cbswap _
-        | Ccsel _ | Cclz _ | Cctz _ | Cpopcnt | Clsl | Clsr | Casr | Ccmpi _
-        | Caddv | Cadda | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _
-        | Cdivf _ | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _ ->
+        | Ccsel _ | Cclz | Cctz | Cpopcnt | Clsl | Clsr | Casr | Ccmpi _ | Caddv
+        | Cadda | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _
+        | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _ ->
           EC.none
       in
       EC.join from_op (EC.join_list_map args effects_of)
@@ -356,10 +356,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Clsl -> select_arith Ilsl args
     | Clsr -> select_arith Ilsr args
     | Casr -> select_arith Iasr args
-    | Cclz { arg_is_non_zero } ->
-      SU.basic_op (Intop (Iclz { arg_is_non_zero })), args
-    | Cctz { arg_is_non_zero } ->
-      SU.basic_op (Intop (Ictz { arg_is_non_zero })), args
+    | Cclz -> SU.basic_op (Intop Iclz), args
+    | Cctz -> SU.basic_op (Intop Ictz), args
     | Cpopcnt -> SU.basic_op (Intop Ipopcnt), args
     | Ccmpi comp -> select_arith_comp comp args
     | Caddv -> select_arith_comm Iadd args

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -558,8 +558,8 @@ type operation =
   | Casr
   | Cbswap of { bitwidth : bswap_bitwidth }
   | Ccsel of machtype
-  | Cclz of { arg_is_non_zero : bool }
-  | Cctz of { arg_is_non_zero : bool }
+  | Cclz
+  | Cctz
   | Cpopcnt
   | Cprefetch of
       { is_write : bool;
@@ -767,9 +767,9 @@ let iter_shallow_tail f = function
         | Ctls_get | Cdomain_index | Cpoll | Cpause | Capply _ | Cextcall _
         | Cload _
         | Cstore (_, _)
-        | Cmulhi _ | Cbswap _ | Ccsel _ | Cclz _ | Cctz _ | Cprefetch _
-        | Catomic _ | Ccmpi _ | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _
-        | Cdivf _ | Creinterpret_cast _ | Cstatic_cast _
+        | Cmulhi _ | Cbswap _ | Ccsel _ | Cclz | Cctz | Cprefetch _ | Catomic _
+        | Ccmpi _ | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _
+        | Creinterpret_cast _ | Cstatic_cast _
         | Ccmpf (_, _)
         | Cprobe _ | Cprobe_is_enabled _
         | Ctuple_field (_, _) ),
@@ -801,7 +801,7 @@ let map_shallow_tail f = function
           | Cendregion | Cdls_get | Ctls_get | Cdomain_index | Cpoll | Cpause
           | Capply _ | Cextcall _ | Cload _
           | Cstore (_, _)
-          | Cmulhi _ | Cbswap _ | Ccsel _ | Cclz _ | Cctz _ | Cprefetch _
+          | Cmulhi _ | Cbswap _ | Ccsel _ | Cclz | Cctz | Cprefetch _
           | Catomic _ | Ccmpi _ | Cnegf _ | Cabsf _ | Caddf _ | Csubf _
           | Cmulf _ | Cdivf _ | Creinterpret_cast _ | Cstatic_cast _
           | Ccmpf (_, _)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -462,8 +462,8 @@ type operation =
   | Casr
   | Cbswap of { bitwidth : bswap_bitwidth }
   | Ccsel of machtype
-  | Cclz of { arg_is_non_zero : bool }
-  | Cctz of { arg_is_non_zero : bool }
+  | Cclz
+  | Cctz
   | Cpopcnt
   | Cprefetch of
       { is_write : bool;

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -105,30 +105,23 @@ let clear_sign_bit arg dbg =
   let mask = Nativeint.lognot (Nativeint.shift_left 1n ((size_int * 8) - 1)) in
   Cop (Cand, [arg; Cconst_natint (mask, dbg)], dbg)
 
-let clz ~arg_is_non_zero bi arg dbg =
-  let op = Cclz { arg_is_non_zero } in
-  if_operation_supported_bi bi op ~f:(fun () ->
-      let res = Cop (op, [make_unsigned_int bi arg dbg], dbg) in
+let clz bi arg dbg =
+  if_operation_supported_bi bi Cclz ~f:(fun () ->
+      let res = Cop (Cclz, [make_unsigned_int bi arg dbg], dbg) in
       let extra_bits = (size_int * 8) - bit_count bi in
       if extra_bits <> 0
       then Cop (Caddi, [res; Cconst_int (-extra_bits, dbg)], dbg)
       else res)
 
-let ctz ~arg_is_non_zero bi arg dbg =
-  let bit_count = bit_count bi in
-  if bit_count = size_int * 8 || arg_is_non_zero
-  then
-    let op = Cctz { arg_is_non_zero } in
-    if_operation_supported_bi bi op ~f:(fun () -> Cop (op, [arg], dbg))
-  else
-    (* regardless of the value of the argument [arg_is_non_zero], always set the
-       corresponding field to [true], because we make it non-zero below by
-       setting bit 32/16/8. *)
-    let op = Cctz { arg_is_non_zero = true } in
-    if_operation_supported_bi bi op ~f:(fun () ->
+let ctz bi arg dbg =
+  if_operation_supported_bi bi Cctz ~f:(fun () ->
+      let bit_count = bit_count bi in
+      if bit_count = size_int * 8
+      then Cop (Cctz, [arg], dbg)
+      else
         (* Set bit 32/16/8 *)
         let mask = Nativeint.shift_left 1n bit_count in
-        Cop (op, [Cop (Cor, [arg; Cconst_natint (mask, dbg)], dbg)], dbg))
+        Cop (Cctz, [Cop (Cor, [arg; Cconst_natint (mask, dbg)], dbg)], dbg))
 
 let popcnt bi arg dbg =
   if_operation_supported_bi bi Cpopcnt ~f:(fun () ->
@@ -868,36 +861,21 @@ let transl_builtin name args dbg typ_res =
   | "caml_float32_of_int64" ->
     Some (Cop (Cstatic_cast (Float_of_int Float32), args, dbg))
   | "caml_int_clz_tagged_to_untagged" ->
-    (* The tag does not change the number of leading zeros. The advantage of
-       keeping the tag is it guarantees that, on x86-64, the input to the BSR
-       instruction is nonzero. *)
-    let op = Cclz { arg_is_non_zero = true } in
-    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+    if_operation_supported Cclz ~f:(fun () -> Cop (Cclz, args, dbg))
   | "caml_int_clz_untagged_to_untagged" ->
-    let op = Cclz { arg_is_non_zero = false } in
-    if_operation_supported op ~f:(fun () ->
+    if_operation_supported Cclz ~f:(fun () ->
         let arg = clear_sign_bit (one_arg name args) dbg in
-        Cop (Caddi, [Cop (op, [arg], dbg); Cconst_int (-1, dbg)], dbg))
+        Cop (Caddi, [Cop (Cclz, [arg], dbg); Cconst_int (-1, dbg)], dbg))
   | "caml_int64_clz_unboxed_to_untagged" ->
-    clz ~arg_is_non_zero:false Unboxed_int64 (one_arg name args) dbg
+    clz Unboxed_int64 (one_arg name args) dbg
   | "caml_int32_clz_unboxed_to_untagged" ->
-    clz ~arg_is_non_zero:false Unboxed_int32 (one_arg name args) dbg
+    clz Unboxed_int32 (one_arg name args) dbg
   | "caml_int16_clz_untagged_to_untagged" ->
-    clz ~arg_is_non_zero:false Untagged_int16 (one_arg name args) dbg
+    clz Untagged_int16 (one_arg name args) dbg
   | "caml_int8_clz_untagged_to_untagged" ->
-    clz ~arg_is_non_zero:false Untagged_int8 (one_arg name args) dbg
+    clz Untagged_int8 (one_arg name args) dbg
   | "caml_nativeint_clz_unboxed_to_untagged" ->
-    clz ~arg_is_non_zero:false Unboxed_nativeint (one_arg name args) dbg
-  | "caml_int64_clz_nonzero_unboxed_to_untagged" ->
-    clz ~arg_is_non_zero:true Unboxed_int64 (one_arg name args) dbg
-  | "caml_int32_clz_nonzero_unboxed_to_untagged" ->
-    clz ~arg_is_non_zero:true Unboxed_int32 (one_arg name args) dbg
-  | "caml_int16_clz_nonzero_untagged_to_untagged" ->
-    clz ~arg_is_non_zero:true Untagged_int16 (one_arg name args) dbg
-  | "caml_int8_clz_nonzero_untagged_to_untagged" ->
-    clz ~arg_is_non_zero:true Untagged_int8 (one_arg name args) dbg
-  | "caml_nativeint_clz_nonzero_unboxed_to_untagged" ->
-    clz ~arg_is_non_zero:true Unboxed_nativeint (one_arg name args) dbg
+    clz Unboxed_nativeint (one_arg name args) dbg
   | "caml_int_popcnt_tagged_to_untagged" ->
     if_operation_supported Cpopcnt ~f:(fun () ->
         (* Having the argument tagged saves a shift, but there is one extra
@@ -938,35 +916,24 @@ let transl_builtin name args dbg typ_res =
        whose corresponding instruction is 1 byte shorter. This will not require
        an extra register, unless both the argument and result of the BSF
        instruction are in the same register. *)
-    let op = Cctz { arg_is_non_zero = true } in
-    if_operation_supported op ~f:(fun () ->
+    if_operation_supported Cctz ~f:(fun () ->
         let c =
           Cop
             ( Clsl,
               [Cconst_int (1, dbg); Cconst_int ((size_int * 8) - 1, dbg)],
               dbg )
         in
-        Cop (op, [Cop (Cor, [one_arg name args; c], dbg)], dbg))
+        Cop (Cctz, [Cop (Cor, [one_arg name args; c], dbg)], dbg))
   | "caml_int8_ctz_untagged_to_untagged" ->
-    ctz ~arg_is_non_zero:false Untagged_int8 (one_arg name args) dbg
+    ctz Untagged_int8 (one_arg name args) dbg
   | "caml_int16_ctz_untagged_to_untagged" ->
-    ctz ~arg_is_non_zero:false Untagged_int16 (one_arg name args) dbg
+    ctz Untagged_int16 (one_arg name args) dbg
   | "caml_int32_ctz_unboxed_to_untagged" ->
-    ctz ~arg_is_non_zero:false Unboxed_int32 (one_arg name args) dbg
+    ctz Unboxed_int32 (one_arg name args) dbg
   | "caml_int64_ctz_unboxed_to_untagged" ->
-    ctz ~arg_is_non_zero:false Unboxed_int64 (one_arg name args) dbg
+    ctz Unboxed_int64 (one_arg name args) dbg
   | "caml_nativeint_ctz_unboxed_to_untagged" ->
-    ctz ~arg_is_non_zero:false Unboxed_nativeint (one_arg name args) dbg
-  | "caml_int8_ctz_nonzero_untagged_to_untagged" ->
-    ctz ~arg_is_non_zero:true Untagged_int8 (one_arg name args) dbg
-  | "caml_int16_ctz_nonzero_untagged_to_untagged" ->
-    ctz ~arg_is_non_zero:true Untagged_int16 (one_arg name args) dbg
-  | "caml_int32_ctz_nonzero_unboxed_to_untagged" ->
-    ctz ~arg_is_non_zero:true Unboxed_int32 (one_arg name args) dbg
-  | "caml_int64_ctz_nonzero_unboxed_to_untagged" ->
-    ctz ~arg_is_non_zero:true Unboxed_int64 (one_arg name args) dbg
-  | "caml_nativeint_ctz_nonzero_unboxed_to_untagged" ->
-    ctz ~arg_is_non_zero:true Unboxed_nativeint (one_arg name args) dbg
+    ctz Unboxed_nativeint (one_arg name args) dbg
   | "caml_signed_int64_mulh_unboxed" ->
     mulhi ~signed:true Unboxed_int64 args dbg
   | "caml_unsigned_int64_mulh_unboxed" ->

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -900,8 +900,8 @@ let int_op t (i : Cfg.basic Cfg.instruction) (op : Operation.integer_operation)
       emit_ins t (I.convert Zext ~arg:bool_res ~to_:T.i64)
     (* ctlz and cttz have a second optional argument that indicates whether 0 is
        poison or not. We pass false to match OCaml's behaviour. *)
-    | Iclz _ -> do_unary_intrinsic_extra_args "ctlz" [V.of_int ~typ:T.i1 0]
-    | Ictz _ -> do_unary_intrinsic_extra_args "cttz" [V.of_int ~typ:T.i1 0]
+    | Iclz -> do_unary_intrinsic_extra_args "ctlz" [V.of_int ~typ:T.i1 0]
+    | Ictz -> do_unary_intrinsic_extra_args "cttz" [V.of_int ~typ:T.i1 0]
     | Ipopcnt -> do_unary_intrinsic "ctpop"
   in
   store_into_reg t i.res.(0) res

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -61,8 +61,8 @@ type integer_operation =
   | Ilsl
   | Ilsr
   | Iasr
-  | Iclz of { arg_is_non_zero : bool }
-  | Ictz of { arg_is_non_zero : bool }
+  | Iclz
+  | Ictz
   | Ipopcnt
   | Icomp of integer_comparison
 
@@ -84,8 +84,8 @@ let string_of_integer_operation = function
   | Ilsl -> " << "
   | Ilsr -> " >>u "
   | Iasr -> " >>s "
-  | Iclz { arg_is_non_zero } -> Printf.sprintf "clz %B " arg_is_non_zero
-  | Ictz { arg_is_non_zero } -> Printf.sprintf "ctz %B " arg_is_non_zero
+  | Iclz -> "clz "
+  | Ictz -> "ctz "
   | Ipopcnt -> "popcnt "
   | Icomp cmp -> string_of_integer_comparison cmp
 
@@ -95,7 +95,7 @@ let string_of_int128_operation = function
   | Imul64 { signed } -> " *" ^ if signed then " " else "u "
 
 let is_unary_integer_operation = function
-  | Iclz _ | Ictz _ | Ipopcnt -> true
+  | Iclz | Ictz | Ipopcnt -> true
   | Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
   | Iasr | Icomp _ ->
     false
@@ -114,62 +114,58 @@ let equal_integer_operation left right =
   | Ilsl, Ilsl -> true
   | Ilsr, Ilsr -> true
   | Iasr, Iasr -> true
-  | ( Iclz { arg_is_non_zero = left_arg_is_non_zero },
-      Iclz { arg_is_non_zero = right_arg_is_non_zero } ) ->
-    Bool.equal left_arg_is_non_zero right_arg_is_non_zero
-  | ( Ictz { arg_is_non_zero = left_arg_is_non_zero },
-      Ictz { arg_is_non_zero = right_arg_is_non_zero } ) ->
-    Bool.equal left_arg_is_non_zero right_arg_is_non_zero
+  | Iclz, Iclz -> true
+  | Ictz, Ictz -> true
   | Ipopcnt, Ipopcnt -> true
   | Icomp left, Icomp right -> equal_integer_comparison left right
   | ( Iadd,
       ( Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Isub,
       ( Iadd | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Imul,
       ( Iadd | Isub | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Imulh _,
       ( Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Idiv,
       ( Iadd | Isub | Imul | Imulh _ | Imod | Iand | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Imod,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Iand | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Iand,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Ior | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Ior,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ixor | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Ixor,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ilsl | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Ilsl,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsr
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Ilsr,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-      | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
+      | Iasr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
   | ( Iasr,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-      | Ilsr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) )
-  | ( Iclz _,
+      | Ilsr | Iclz | Ictz | Ipopcnt | Icomp _ ) )
+  | ( Iclz,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-      | Ilsr | Iasr | Ictz _ | Ipopcnt | Icomp _ ) )
-  | ( Ictz _,
+      | Ilsr | Iasr | Ictz | Ipopcnt | Icomp _ ) )
+  | ( Ictz,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-      | Ilsr | Iasr | Iclz _ | Ipopcnt | Icomp _ ) )
+      | Ilsr | Iasr | Iclz | Ipopcnt | Icomp _ ) )
   | ( Ipopcnt,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-      | Ilsr | Iasr | Iclz _ | Ictz _ | Icomp _ ) )
+      | Ilsr | Iasr | Iclz | Ictz | Icomp _ ) )
   | ( Icomp _,
       ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
-      | Ilsr | Iasr | Iclz _ | Ictz _ | Ipopcnt ) ) ->
+      | Ilsr | Iasr | Iclz | Ictz | Ipopcnt ) ) ->
     false
 
 let equal_int128_operation left right =
@@ -403,8 +399,8 @@ let intop (op : integer_operation) =
   | Ilsr -> " >>u "
   | Iasr -> " >>s "
   | Ipopcnt -> " pop "
-  | Iclz _ -> " clz "
-  | Ictz _ -> " ctz "
+  | Iclz -> " clz "
+  | Ictz -> " ctz "
   | Icomp cmp -> intcomp cmp
 
 let int128op = function

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -56,8 +56,8 @@ type integer_operation =
   | Ilsl
   | Ilsr
   | Iasr
-  | Iclz of { arg_is_non_zero : bool }
-  | Ictz of { arg_is_non_zero : bool }
+  | Iclz
+  | Ictz
   | Ipopcnt
   | Icomp of integer_comparison
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -289,8 +289,8 @@ let operation d = function
   | Cbswap { bitwidth = Sixteen } -> "bswap_16"
   | Cbswap { bitwidth = Thirtytwo } -> "bswap_32"
   | Cbswap { bitwidth = Sixtyfour } -> "bswap_64"
-  | Cclz { arg_is_non_zero } -> Printf.sprintf "clz %B" arg_is_non_zero
-  | Cctz { arg_is_non_zero } -> Printf.sprintf "ctz %B" arg_is_non_zero
+  | Cclz -> "clz"
+  | Cctz -> "ctz"
   | Cpopcnt -> "popcnt"
   | Ccmpi c -> integer_comparison c
   | Caddv -> "+v"

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -192,7 +192,7 @@ let oper_result_type = function
     typ_int
   | Catomic { op = Add | Sub | Land | Lor | Lxor; _ } -> typ_void
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor | Clsl
-  | Clsr | Casr | Cclz _ | Cctz _ | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpf _ ->
+  | Clsr | Casr | Cclz | Cctz | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpf _ ->
     typ_int
   | Caddi128 | Csubi128 | Cmuli64 _ -> typ_int128
   | Caddv -> typ_val

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2617,11 +2617,11 @@ end = struct
         | Const_vec512 _ | Load _ | Floatop _
         | Intop_imm
             ( ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
-              | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ ),
+              | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz | Ictz | Icomp _ ),
               _ )
         | Intop
             ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
-            | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
+            | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz | Ictz | Icomp _ )
         | Int128op (Iadd128 | Isub128 | Imul64 _)
         | Reinterpret_cast
             ( Float32_of_float | Float_of_float32 | Float_of_int64

--- a/oxcaml/tests/simd/scalar_ops.ml
+++ b/oxcaml/tests/simd/scalar_ops.ml
@@ -105,20 +105,8 @@ module Int64 = struct
     = "caml_vec128_unreachable" "caml_int64_clz_unboxed_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external count_leading_zeros_nonzero_arg :
-    (int64[@unboxed]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int64_clz_nonzero_unboxed_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external count_trailing_zeros : (int64[@unboxed]) -> (int[@untagged])
     = "caml_vec128_unreachable" "caml_int64_ctz_unboxed_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
-  (** Same as [count_trailing_zeros] except if the argument is zero, then the
-      result is undefined. Emits more efficient code. *)
-  external count_trailing_zeros_nonzero_arg :
-    (int64[@unboxed]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int64_ctz_nonzero_unboxed_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (** [count_set_bits n] returns the number of bits that are 1 in [n]. *)
@@ -142,11 +130,10 @@ module Int64 = struct
       "caml_int64_shift_right_logical_by_int64_unboxed"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  let check' ~eq ?nonzero ?(trials = 100_000) f g =
-    let nz = Option.value ~default:false nonzero in
+  let check' ~eq ?(trials = 100_000) f g =
     let open Stdlib.Int64 in
     Random.set_state (Random.State.make [| 1234567890 |]);
-    if not nz then eq (f zero) (g zero);
+    eq (f zero) (g zero);
     eq (f one) (g one);
     eq (f minus_one) (g minus_one);
     eq (f max_int) (g max_int);
@@ -154,10 +141,10 @@ module Int64 = struct
     for _ = 1 to trials do
       let i = Random.int64 max_int in
       let i = if Random.bool () then i else neg i in
-      if (not nz) || i <> 0L then eq (f i) (g i)
+      eq (f i) (g i)
     done
 
-  let check ?nonzero f g = check' ~eq:eqi ?nonzero f g
+  let check f g = check' ~eq:eqi f g
 
   let check_shift f g =
     for i = 0 to 63 do
@@ -187,9 +174,7 @@ module Int64 = struct
 
   let () =
     check count_leading_zeros clz;
-    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
     check count_trailing_zeros ctz;
-    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt;
     check_shift shift_left Int64.shift_left;
     check_shift shift_right Int64.shift_right;
@@ -201,20 +186,8 @@ module Int32 = struct
     = "caml_vec128_unreachable" "caml_int32_clz_unboxed_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external count_leading_zeros_nonzero_arg :
-    (int32[@unboxed]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int32_clz_nonzero_unboxed_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external count_trailing_zeros : (int32[@unboxed]) -> (int[@untagged])
     = "caml_vec128_unreachable" "caml_int32_ctz_unboxed_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
-  (** Same as [count_trailing_zeros] except if the argument is zero, then the
-      result is undefined. Emits more efficient code. *)
-  external count_trailing_zeros_nonzero_arg :
-    (int32[@unboxed]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int32_ctz_nonzero_unboxed_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (** [count_set_bits n] returns the number of bits that are 1 in [n]. *)
@@ -238,11 +211,10 @@ module Int32 = struct
       "caml_int32_shift_right_logical_by_int32_unboxed"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  let check' ~eq ?nonzero ?(trials = 100_000) f g =
-    let nz = Option.value ~default:false nonzero in
+  let check' ~eq ?(trials = 100_000) f g =
     let open Stdlib.Int32 in
     Random.set_state (Random.State.make [| 1234567890 |]);
-    if not nz then eq (f zero) (g zero);
+    eq (f zero) (g zero);
     eq (f one) (g one);
     eq (f minus_one) (g minus_one);
     eq (f max_int) (g max_int);
@@ -250,10 +222,10 @@ module Int32 = struct
     for _ = 1 to trials do
       let i = Random.int32 max_int in
       let i = if Random.bool () then i else neg i in
-      if (not nz) || i <> 0l then eq (f i) (g i)
+      eq (f i) (g i)
     done
 
-  let check ?nonzero f g = check' ~eq:eqi ?nonzero f g
+  let check f g = check' ~eq:eqi f g
 
   let check_shift f g =
     for i = 0 to 31 do
@@ -283,9 +255,7 @@ module Int32 = struct
 
   let () =
     check count_leading_zeros clz;
-    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
     check count_trailing_zeros ctz;
-    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt;
     check_shift shift_left Int32.shift_left;
     check_shift shift_right Int32.shift_right;
@@ -297,20 +267,8 @@ module Int16 = struct
     = "caml_vec128_unreachable" "caml_int16_clz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external count_leading_zeros_nonzero_arg :
-    (int16[@untagged]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int16_clz_nonzero_untagged_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external count_trailing_zeros : (int16[@untagged]) -> (int[@untagged])
     = "caml_vec128_unreachable" "caml_int16_ctz_untagged_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
-  (** Same as [count_trailing_zeros] except if the argument is zero, then the
-      result is undefined. Emits more efficient code. *)
-  external count_trailing_zeros_nonzero_arg :
-    (int16[@untagged]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int16_ctz_nonzero_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (** [count_set_bits n] returns the number of bits that are 1 in [n]. *)
@@ -334,11 +292,10 @@ module Int16 = struct
       "caml_int16_shift_right_logical_by_int16_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  let check' ~eq ?nonzero ?(trials = 100_000) f g =
-    let nz = Option.value ~default:false nonzero in
+  let check' ~eq ?(trials = 100_000) f g =
     let open Stdlib_stable.Int16 in
     Random.set_state (Random.State.make [| 1234567890 |]);
-    if not nz then eq (f zero) (g zero);
+    eq (f zero) (g zero);
     eq (f one) (g one);
     eq (f minus_one) (g minus_one);
     eq (f max_int) (g max_int);
@@ -346,10 +303,10 @@ module Int16 = struct
     for _ = 1 to trials do
       let i = Random.int (to_int max_int) |> of_int in
       let i = if Random.bool () then i else neg i in
-      if (not nz) || i <> 0S then eq (f i) (g i)
+      eq (f i) (g i)
     done
 
-  let check ?nonzero f g = check' ~eq:eqi ?nonzero f g
+  let check f g = check' ~eq:eqi f g
 
   let check_shift f g =
     for i = 0 to 15 do
@@ -381,9 +338,7 @@ module Int16 = struct
 
   let () =
     check count_leading_zeros clz;
-    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
     check count_trailing_zeros ctz;
-    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt;
     check_shift shift_left Stdlib_stable.Int16.shift_left;
     check_shift shift_right Stdlib_stable.Int16.shift_right;
@@ -395,20 +350,8 @@ module Int8 = struct
     = "caml_vec128_unreachable" "caml_int8_clz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external count_leading_zeros_nonzero_arg :
-    (int8[@untagged]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int8_clz_nonzero_untagged_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external count_trailing_zeros : (int8[@untagged]) -> (int[@untagged])
     = "caml_vec128_unreachable" "caml_int8_ctz_untagged_to_untagged"
-  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
-  (** Same as [count_trailing_zeros] except if the argument is zero, then the
-      result is undefined. Emits more efficient code. *)
-  external count_trailing_zeros_nonzero_arg :
-    (int8[@untagged]) -> (int[@untagged])
-    = "caml_vec128_unreachable" "caml_int8_ctz_nonzero_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (** [count_set_bits n] returns the number of bits that are 1 in [n]. *)
@@ -431,11 +374,10 @@ module Int8 = struct
     = "caml_vec128_unreachable" "caml_int8_shift_right_logical_by_int8_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  let check' ~eq ?nonzero ?(trials = 100_000) f g =
-    let nz = Option.value ~default:false nonzero in
+  let check' ~eq ?(trials = 100_000) f g =
     let open Stdlib_stable.Int8 in
     Random.set_state (Random.State.make [| 1234567890 |]);
-    if not nz then eq (f zero) (g zero);
+    eq (f zero) (g zero);
     eq (f one) (g one);
     eq (f minus_one) (g minus_one);
     eq (f max_int) (g max_int);
@@ -443,10 +385,10 @@ module Int8 = struct
     for _ = 1 to trials do
       let i = Random.int (to_int max_int) |> of_int in
       let i = if Random.bool () then i else neg i in
-      if (not nz) || i <> 0s then eq (f i) (g i)
+      eq (f i) (g i)
     done
 
-  let check ?nonzero f g = check' ~eq:eqi ?nonzero f g
+  let check f g = check' ~eq:eqi f g
 
   let check_shift f g =
     for i = 0 to 7 do
@@ -478,9 +420,7 @@ module Int8 = struct
 
   let () =
     check count_leading_zeros clz;
-    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
     check count_trailing_zeros ctz;
-    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt;
     check_shift shift_left Stdlib_stable.Int8.shift_left;
     check_shift shift_right Stdlib_stable.Int8.shift_right;

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -38,15 +38,6 @@ clz64:
   ret
 |}]
 
-let clz64_nonzero x =
-  Builtins.int64_clz_nonzero (Int64_u.to_int64 x)
-[%%expect_asm X86_64{|
-clz64_nonzero:
-  lzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
-  ret
-|}]
-
 (* Count leading zeros - int32 *)
 
 (* CR ttebbi: Could use lzcntl directly instead of zero-extend + lzcntq
@@ -61,32 +52,12 @@ clz32:
   ret
 |}]
 
-let clz32_nonzero x =
-  Builtins.int32_clz_nonzero (Int32_u.to_int32 x)
-[%%expect_asm X86_64{|
-clz32_nonzero:
-  movl  %eax, %eax
-  lzcnt %rax, %rax
-  addq  $-32, %rax
-  leaq  1(%rax,%rax), %rax
-  ret
-|}]
-
 (* Count leading zeros - nativeint *)
 
 let clz_native x =
   Builtins.nativeint_clz (Nativeint_u.to_nativeint x)
 [%%expect_asm X86_64{|
 clz_native:
-  lzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
-  ret
-|}]
-
-let clz_native_nonzero x =
-  Builtins.nativeint_clz_nonzero (Nativeint_u.to_nativeint x)
-[%%expect_asm X86_64{|
-clz_native_nonzero:
   lzcnt %rax, %rax
   leaq  1(%rax,%rax), %rax
   ret
@@ -117,15 +88,6 @@ ctz64:
   ret
 |}]
 
-let ctz64_nonzero x =
-  Builtins.int64_ctz_nonzero (Int64_u.to_int64 x)
-[%%expect_asm X86_64{|
-ctz64_nonzero:
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
-  ret
-|}]
-
 (* Count trailing zeros - int32 *)
 
 (* CR ttebbi: We should use the 32bit tzcnt instruction. *)
@@ -139,30 +101,12 @@ ctz32:
   ret
 |}]
 
-let ctz32_nonzero x =
-  Builtins.int32_ctz_nonzero (Int32_u.to_int32 x)
-[%%expect_asm X86_64{|
-ctz32_nonzero:
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
-  ret
-|}]
-
 (* Count trailing zeros - nativeint *)
 
 let ctz_native x =
   Builtins.nativeint_ctz (Nativeint_u.to_nativeint x)
 [%%expect_asm X86_64{|
 ctz_native:
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
-  ret
-|}]
-
-let ctz_native_nonzero x =
-  Builtins.nativeint_ctz_nonzero (Nativeint_u.to_nativeint x)
-[%%expect_asm X86_64{|
-ctz_native_nonzero:
   tzcnt %rax, %rax
   leaq  1(%rax,%rax), %rax
   ret

--- a/testsuite/tests/codegen/intrinsics.ml
+++ b/testsuite/tests/codegen/intrinsics.ml
@@ -1039,29 +1039,14 @@ module Builtins = struct
     = "" "caml_int64_clz_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external int64_clz_nonzero :
-    (int64[@unboxed]) -> (int[@untagged])
-    = "" "caml_int64_clz_nonzero_unboxed_to_untagged"
-    [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external int32_clz :
     (int32[@unboxed]) -> (int[@untagged])
     = "" "caml_int32_clz_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external int32_clz_nonzero :
-    (int32[@unboxed]) -> (int[@untagged])
-    = "" "caml_int32_clz_nonzero_unboxed_to_untagged"
-    [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external nativeint_clz :
     (nativeint[@unboxed]) -> (int[@untagged])
     = "" "caml_nativeint_clz_unboxed_to_untagged"
-    [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
-  external nativeint_clz_nonzero :
-    (nativeint[@unboxed]) -> (int[@untagged])
-    = "" "caml_nativeint_clz_nonzero_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (* Count trailing zeros *)
@@ -1076,29 +1061,14 @@ module Builtins = struct
     = "" "caml_int64_ctz_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external int64_ctz_nonzero :
-    (int64[@unboxed]) -> (int[@untagged])
-    = "" "caml_int64_ctz_nonzero_unboxed_to_untagged"
-    [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external int32_ctz :
     (int32[@unboxed]) -> (int[@untagged])
     = "" "caml_int32_ctz_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external int32_ctz_nonzero :
-    (int32[@unboxed]) -> (int[@untagged])
-    = "" "caml_int32_ctz_nonzero_unboxed_to_untagged"
-    [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
   external nativeint_ctz :
     (nativeint[@unboxed]) -> (int[@untagged])
     = "" "caml_nativeint_ctz_unboxed_to_untagged"
-    [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
-
-  external nativeint_ctz_nonzero :
-    (nativeint[@unboxed]) -> (int[@untagged])
-    = "" "caml_nativeint_ctz_nonzero_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (* Population count *)


### PR DESCRIPTION
The default intrinsics already work for nonzero args on platforms that support [lt]zcnt, which are the only platforms we care about these days.

This will need to wait for a corresponding Iron feature to land before this can build our codebase.