### PR TITLE
Allow [@@or_null] GADTs

### DIFF
--- a/external/merlin/src/ocaml/typing/btype.ml
+++ b/external/merlin/src/ocaml/typing/btype.ml
@@ -2482,6 +2482,23 @@ module Jkind0 = struct
       (orphaned_type_var_list @ domain)
       (type_of_kind_list @ range)
 
+  (* Wraps [gadt_payload_subst] with the [cd_res] unpacking shared by the two
+     [Variant_with_null] sites that project a GADT payload onto instantiated
+     head arguments: the declaration jkind ([Typedecl.update_decl_jkind]) and
+     each use site ([Ctype.unbox_once]). A non-GADT payload ([cstr_res = None])
+     needs no projection. *)
+  let variant_constructor_gadt_extra_substs
+      ~projected_params ~cstr_res ~payload_tys ~get_free_vars =
+    match cstr_res with
+    | None -> []
+    | Some res ->
+      let res_args =
+        match get_desc res with
+        | Tconstr (_, args, _) -> args
+        | _ -> Misc.fatal_error "cd_res must be Tconstr"
+      in
+      gadt_payload_subst ~projected_params ~res_args ~payload_tys ~get_free_vars
+
   let for_boxed_variant ~loc ~decl_params ~type_apply ~get_free_vars cstrs =
     let base =
       let all_args_void =

--- a/external/merlin/src/ocaml/typing/btype.mli
+++ b/external/merlin/src/ocaml/typing/btype.mli
@@ -742,6 +742,13 @@ module Jkind0 : sig
       get_free_vars:(Types.type_expr list -> TypeSet.t) ->
       (Types.type_expr * Types.type_expr) list
 
+    val variant_constructor_gadt_extra_substs :
+      projected_params:Types.type_expr list ->
+      cstr_res:Types.type_expr option ->
+      payload_tys:Types.type_expr list ->
+      get_free_vars:(Types.type_expr list -> TypeSet.t) ->
+      (Types.type_expr * Types.type_expr) list
+
     val for_boxed_variant :
       loc:Location.t ->
       decl_params:Types.type_expr list ->

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -2836,10 +2836,23 @@ let unbox_once env ty =
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some
-              { payload_arg = { ca_type; ca_modalities = modality; _ };
-                _ } ->
+              { payload_cstr = { cd_res; _ };
+                payload_arg = { ca_type; ca_modalities = modality; _ } } ->
+            (* A GADT [@@or_null] wrapper needs the same B1-B4 projection as
+               boxed and unboxed GADTs, projected onto the instantiated head
+               arguments of the wrapper type. This keeps the unwrapped
+               payload's jkind honest -- in particular a [float] payload stays
+               [maybe_separable] once wrapped, so it cannot enter a flat float
+               array. A non-GADT payload needs no projection. *)
+            let extra_substs =
+              Btype.Jkind0.variant_constructor_gadt_extra_substs
+                ~projected_params:args
+                ~cstr_res:cd_res
+                ~payload_tys:[ca_type]
+                ~get_free_vars:(free_variable_set_of_list env)
+            in
             Stepped
-              { ty = apply ca_type ~extra_substs:[];
+              { ty = apply ca_type ~extra_substs;
                 modality;
                 or_null = Some { decl; args; prev = ty } }
           | None ->
@@ -2871,15 +2884,37 @@ let contained_without_boxing env ty =
          [update_decl_jkind] has filled in the argument sorts, and the
          callers of this function run before that on the current
          recursive group. Returning the arguments of both constructors
-         does not depend on constructor order or sorts. *)
+         does not depend on constructor order or sorts.
+
+         A GADT constructor's argument types are constructor-local, so
+         they get the same B1-B4 projection onto the instantiated head
+         arguments as in [unbox_once]: without it, edges through a GADT
+         payload variable are invisible to the unboxed-recursion check,
+         which then accepts an unboxed cycle re-entering through the
+         payload of a widened-parameter GADT [@@or_null] that the
+         projected (and non-GADT) form rejects. *)
       List.concat_map
         (fun (cstr : constructor_declaration) ->
            match cstr.cd_args with
            | Cstr_tuple cargs ->
+             let payload_tys =
+               List.map
+                 (fun (carg : constructor_argument) -> carg.ca_type)
+                 cargs
+             in
+             let extra_substs =
+               Btype.Jkind0.variant_constructor_gadt_extra_substs
+                 ~projected_params:args
+                 ~cstr_res:cstr.cd_res
+                 ~payload_tys
+                 ~get_free_vars:(free_variable_set_of_list env)
+             in
+             let extra_params, extra_args = List.split extra_substs in
              List.map
-               (fun (carg : constructor_argument) ->
-                  apply env type_params carg.ca_type args)
-               cargs
+               (fun ty ->
+                  apply env (extra_params @ type_params) ty
+                    (extra_args @ args))
+               payload_tys
            | Cstr_record _ -> [])
         cstrs
     | _ | exception Not_found ->

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -197,14 +197,6 @@ let check_or_null_decl bad sdecl =
 
 let check_or_null_constructors bad = function
   | [c1; c2] ->
-    let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
-      match pcd_res with
-      | None -> ()
-      | Some _ ->
-        bad "GADT constructors are not supported with [@@or_null]"
-    in
-    check_no_gadt c1;
-    check_no_gadt c2;
     let check_args ({ pcd_args; _ } : Parsetree.constructor_declaration) =
       match pcd_args with
       | Pcstr_tuple [] | Pcstr_tuple [_] -> ()
@@ -1152,12 +1144,29 @@ let transl_declaration env sdecl (id, uid) =
               bad_or_null_payload_count sdecl.ptype_loc
             | _ :: _ -> ()
             end;
-            Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path
-              (List.map
-                 (fun (arg : Types.constructor_argument) ->
-                    arg.ca_modalities, arg.ca_type)
-                 unary_args)
+            let jkind =
+              if List.exists
+                   (fun (c : Types.constructor_declaration) ->
+                     c.cd_res <> None)
+                   cstrs
+              then
+                (* For a GADT [@@or_null], a constructor's argument type
+                   lives in the constructor's local scope and may mention
+                   existential variables; adding it as a with-bound during
+                   the recursive-group phase would capture an out-of-scope
+                   variable. Use a bound-free [value_or_null] default here,
+                   just like boxed variants use a bound-free default; the
+                   real with-bounds are computed later in
+                   [update_decl_jkind]. *)
+                Jkind.Builtin.value_or_null ~why:(Or_null_payload path)
+              else
+                Btype.Jkind0.for_variant_with_null_result path
+                  (List.map
+                     (fun (arg : Types.constructor_argument) ->
+                        arg.ca_modalities, arg.ca_type)
+                     unary_args)
+            in
+            Variant_with_null, jkind
           end
           else if unbox then
             Variant_unboxed,
@@ -2555,7 +2564,9 @@ let rec update_decl_jkind env dpath decl =
                  | Some sort when Jkind.Sort.Const.all_void sort ->
                    (* The null constructor. *)
                    begin match !null_payload with
-                   | None -> null_payload := Some (ca_modalities, ca_type)
+                   | None ->
+                     null_payload :=
+                       Some (cstr.cd_res, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
                    Some sort
@@ -2564,7 +2575,9 @@ let rec update_decl_jkind env dpath decl =
                    constrain_or_null_payload ~env ~path:dpath ca_type ca_loc;
                    let jkind = Ctype.type_jkind env ca_type in
                    begin match !payload with
-                   | None -> payload := Some (jkind, ca_modalities, ca_type)
+                   | None ->
+                     payload :=
+                       Some (cstr.cd_res, jkind, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
                    sort_of_jkind jkind
@@ -2574,32 +2587,76 @@ let rec update_decl_jkind env dpath decl =
                Misc.fatal_error "Invalid constructor for Variant_with_null")
           cstrs
       in
+      (* For a GADT [@@or_null] a constructor's argument type lives in the
+         constructor's local scope: it mentions the constructor's own copies
+         of the declaration parameters (refined by the result-type indices)
+         and may mention existentials. Project it onto the declaration
+         parameters using Steps B1-B4 of Note [With-bounds for GADTs]
+         (orphaned existentials become [Tof_kind]), exactly as
+         [for_boxed_variant] does for boxed GADTs. The projected type is
+         expressed purely in the declaration parameters, so it can feed the
+         ordinary non-GADT jkind computation below and yields a precise
+         declaration jkind (e.g. [immediate_or_null] for a ground [int]
+         payload). Separability is kept honest per instantiation by
+         [Ctype.unbox_once], not by this declaration jkind. *)
+      let project cstr_res ty =
+        let extra_substs =
+          Btype.Jkind0.variant_constructor_gadt_extra_substs
+            ~projected_params:decl.type_params
+            ~cstr_res
+            ~payload_tys:[ty]
+            ~get_free_vars:(Ctype.free_variable_set_of_list env)
+        in
+        match extra_substs with
+        | [] -> ty
+        | _ ->
+          let domain, range = List.split extra_substs in
+          Ctype.apply env domain ty range
+      in
       begin match !payload with
-      | Some (jkind, modality, payload_type) ->
-        begin match
-          Jkind.for_or_null_variant env ~payload_type ~modality
-            ~payload_jkind:jkind
-        with
-        | Ok type_jkind ->
-          let type_jkind =
+      | Some (cd_res, jkind, modality, payload_type) ->
+        let payload_type = project cd_res payload_type in
+        let jkind =
+          match cd_res with
+          | None -> jkind
+          | Some _ -> Ctype.type_jkind env payload_type
+        in
+        let type_jkind =
+          match
+            Jkind.for_or_null_variant env ~payload_type ~modality
+              ~payload_jkind:jkind
+          with
+          | Ok type_jkind ->
             (* A void argument of the null constructor still counts
                towards the bounds of the declaration: matching on the null
                constructor synthesizes a value of that type. *)
-            match !null_payload with
+            begin match !null_payload with
             | None -> type_jkind
-            | Some (modality, type_expr) ->
+            | Some (null_cd_res, modality, type_expr) ->
+              let type_expr = project null_cd_res type_expr in
               Btype.Jkind0.add_with_bounds ~modality ~type_expr type_jkind
-          in
-          let type_jkind =
-            Jkind.History.update_reason type_jkind
-              (Value_or_null_creation (Or_null_payload dpath))
-          in
-          cstrs, rep, type_jkind
-        | Error () ->
-          Misc.fatal_error
-            "Typedecl.update_variant_kind: Variant_with_null payload is \
-             already maybe-null"
-        end
+            end
+          | Error () ->
+            begin match cd_res with
+            | Some _ ->
+              (* A GADT payload's parameter is constructor-local, so
+                 [constrain_or_null_payload] does not narrow the declaration
+                 parameter: a widened parameter (e.g. [('a : any)]) can reach
+                 here with a non-[value] layout that [for_or_null_variant]
+                 rejects. Fall back to the conservative [value_or_null]
+                 jkind, which is always sound. *)
+              Jkind.Builtin.value_or_null ~why:(Or_null_payload dpath)
+            | None ->
+              Misc.fatal_error
+                "Typedecl.update_variant_kind: Variant_with_null payload is \
+                 already maybe-null"
+            end
+        in
+        let type_jkind =
+          Jkind.History.update_reason type_jkind
+            (Value_or_null_creation (Or_null_payload dpath))
+        in
+        cstrs, rep, type_jkind
       | None -> bad_or_null_payload_count loc
       end
     | [{Types.cd_args} as cstr], Variant_unboxed -> begin

--- a/external/merlin/src/ocaml/typing/typeopt.ml
+++ b/external/merlin/src/ocaml/typing/typeopt.ml
@@ -889,6 +889,12 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
   | Variant_with_null -> begin
     match Datarepr.find_variant_with_null_payload cstrs with
     | Some { payload_arg = { Types.ca_type = ty; _ }; _ } ->
+      (* [ty] is used raw: [params]/[args] are not substituted, and a GADT
+         payload is not projected out of its constructor-local scope. Both
+         lose precision only (an opaque variable yields a generic value
+         kind); the result stays sound because indices not matching the
+         payload constructor's result type are inhabited only by the null
+         value, which every nullable kind admits. *)
       let num_nodes_visited, kind =
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.ml
@@ -2481,6 +2481,23 @@ module Jkind0 = struct
       (orphaned_type_var_list @ domain)
       (type_of_kind_list @ range)
 
+  (* Wraps [gadt_payload_subst] with the [cd_res] unpacking shared by the two
+     [Variant_with_null] sites that project a GADT payload onto instantiated
+     head arguments: the declaration jkind ([Typedecl.update_decl_jkind]) and
+     each use site ([Ctype.unbox_once]). A non-GADT payload ([cstr_res = None])
+     needs no projection. *)
+  let variant_constructor_gadt_extra_substs
+      ~projected_params ~cstr_res ~payload_tys ~get_free_vars =
+    match cstr_res with
+    | None -> []
+    | Some res ->
+      let res_args =
+        match get_desc res with
+        | Tconstr (_, args, _) -> args
+        | _ -> Misc.fatal_error "cd_res must be Tconstr"
+      in
+      gadt_payload_subst ~projected_params ~res_args ~payload_tys ~get_free_vars
+
   let for_boxed_variant ~loc ~decl_params ~type_apply ~get_free_vars cstrs =
     let base =
       let all_args_void =

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.mli
@@ -743,6 +743,13 @@ module Jkind0 : sig
       get_free_vars:(Types.type_expr list -> TypeSet.t) ->
       (Types.type_expr * Types.type_expr) list
 
+    val variant_constructor_gadt_extra_substs :
+      projected_params:Types.type_expr list ->
+      cstr_res:Types.type_expr option ->
+      payload_tys:Types.type_expr list ->
+      get_free_vars:(Types.type_expr list -> TypeSet.t) ->
+      (Types.type_expr * Types.type_expr) list
+
     val for_boxed_variant :
       loc:Location.t ->
       decl_params:Types.type_expr list ->

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -2804,10 +2804,23 @@ let unbox_once env ty =
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some
-              { payload_arg = { ca_type; ca_modalities = modality; _ };
-                _ } ->
+              { payload_cstr = { cd_res; _ };
+                payload_arg = { ca_type; ca_modalities = modality; _ } } ->
+            (* A GADT [@@or_null] wrapper needs the same B1-B4 projection as
+               boxed and unboxed GADTs, projected onto the instantiated head
+               arguments of the wrapper type. This keeps the unwrapped
+               payload's jkind honest -- in particular a [float] payload stays
+               [maybe_separable] once wrapped, so it cannot enter a flat float
+               array. A non-GADT payload needs no projection. *)
+            let extra_substs =
+              Btype.Jkind0.variant_constructor_gadt_extra_substs
+                ~projected_params:args
+                ~cstr_res:cd_res
+                ~payload_tys:[ca_type]
+                ~get_free_vars:(free_variable_set_of_list env)
+            in
             Stepped
-              { ty = apply ca_type ~extra_substs:[];
+              { ty = apply ca_type ~extra_substs;
                 modality;
                 or_null = Some { decl; args; prev = ty } }
           | None ->
@@ -2839,15 +2852,37 @@ let contained_without_boxing env ty =
          [update_decl_jkind] has filled in the argument sorts, and the
          callers of this function run before that on the current
          recursive group. Returning the arguments of both constructors
-         does not depend on constructor order or sorts. *)
+         does not depend on constructor order or sorts.
+
+         A GADT constructor's argument types are constructor-local, so
+         they get the same B1-B4 projection onto the instantiated head
+         arguments as in [unbox_once]: without it, edges through a GADT
+         payload variable are invisible to the unboxed-recursion check,
+         which then accepts an unboxed cycle re-entering through the
+         payload of a widened-parameter GADT [@@or_null] that the
+         projected (and non-GADT) form rejects. *)
       List.concat_map
         (fun (cstr : constructor_declaration) ->
            match cstr.cd_args with
            | Cstr_tuple cargs ->
+             let payload_tys =
+               List.map
+                 (fun (carg : constructor_argument) -> carg.ca_type)
+                 cargs
+             in
+             let extra_substs =
+               Btype.Jkind0.variant_constructor_gadt_extra_substs
+                 ~projected_params:args
+                 ~cstr_res:cstr.cd_res
+                 ~payload_tys
+                 ~get_free_vars:(free_variable_set_of_list env)
+             in
+             let extra_params, extra_args = List.split extra_substs in
              List.map
-               (fun (carg : constructor_argument) ->
-                  apply env type_params carg.ca_type args)
-               cargs
+               (fun ty ->
+                  apply env (extra_params @ type_params) ty
+                    (extra_args @ args))
+               payload_tys
            | Cstr_record _ -> [])
         cstrs
     | _ | exception Not_found ->

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
@@ -197,14 +197,6 @@ let check_or_null_decl bad sdecl =
 
 let check_or_null_constructors bad = function
   | [c1; c2] ->
-    let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
-      match pcd_res with
-      | None -> ()
-      | Some _ ->
-        bad "GADT constructors are not supported with [@@or_null]"
-    in
-    check_no_gadt c1;
-    check_no_gadt c2;
     let check_args ({ pcd_args; _ } : Parsetree.constructor_declaration) =
       match pcd_args with
       | Pcstr_tuple [] | Pcstr_tuple [_] -> ()
@@ -1149,12 +1141,29 @@ let transl_declaration env sdecl (id, uid) =
               bad_or_null_payload_count sdecl.ptype_loc
             | _ :: _ -> ()
             end;
-            Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path
-              (List.map
-                 (fun (arg : Types.constructor_argument) ->
-                    arg.ca_modalities, arg.ca_type)
-                 unary_args)
+            let jkind =
+              if List.exists
+                   (fun (c : Types.constructor_declaration) ->
+                     c.cd_res <> None)
+                   cstrs
+              then
+                (* For a GADT [@@or_null], a constructor's argument type
+                   lives in the constructor's local scope and may mention
+                   existential variables; adding it as a with-bound during
+                   the recursive-group phase would capture an out-of-scope
+                   variable. Use a bound-free [value_or_null] default here,
+                   just like boxed variants use a bound-free default; the
+                   real with-bounds are computed later in
+                   [update_decl_jkind]. *)
+                Jkind.Builtin.value_or_null ~why:(Or_null_payload path)
+              else
+                Btype.Jkind0.for_variant_with_null_result path
+                  (List.map
+                     (fun (arg : Types.constructor_argument) ->
+                        arg.ca_modalities, arg.ca_type)
+                     unary_args)
+            in
+            Variant_with_null, jkind
           end
           else if unbox then
             Variant_unboxed,
@@ -2552,7 +2561,9 @@ let rec update_decl_jkind env dpath decl =
                  | Some sort when Jkind.Sort.Const.all_void sort ->
                    (* The null constructor. *)
                    begin match !null_payload with
-                   | None -> null_payload := Some (ca_modalities, ca_type)
+                   | None ->
+                     null_payload :=
+                       Some (cstr.cd_res, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
                    Some sort
@@ -2561,7 +2572,9 @@ let rec update_decl_jkind env dpath decl =
                    constrain_or_null_payload ~env ~path:dpath ca_type ca_loc;
                    let jkind = Ctype.type_jkind env ca_type in
                    begin match !payload with
-                   | None -> payload := Some (jkind, ca_modalities, ca_type)
+                   | None ->
+                     payload :=
+                       Some (cstr.cd_res, jkind, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
                    sort_of_jkind jkind
@@ -2571,32 +2584,76 @@ let rec update_decl_jkind env dpath decl =
                Misc.fatal_error "Invalid constructor for Variant_with_null")
           cstrs
       in
+      (* For a GADT [@@or_null] a constructor's argument type lives in the
+         constructor's local scope: it mentions the constructor's own copies
+         of the declaration parameters (refined by the result-type indices)
+         and may mention existentials. Project it onto the declaration
+         parameters using Steps B1-B4 of Note [With-bounds for GADTs]
+         (orphaned existentials become [Tof_kind]), exactly as
+         [for_boxed_variant] does for boxed GADTs. The projected type is
+         expressed purely in the declaration parameters, so it can feed the
+         ordinary non-GADT jkind computation below and yields a precise
+         declaration jkind (e.g. [immediate_or_null] for a ground [int]
+         payload). Separability is kept honest per instantiation by
+         [Ctype.unbox_once], not by this declaration jkind. *)
+      let project cstr_res ty =
+        let extra_substs =
+          Btype.Jkind0.variant_constructor_gadt_extra_substs
+            ~projected_params:decl.type_params
+            ~cstr_res
+            ~payload_tys:[ty]
+            ~get_free_vars:(Ctype.free_variable_set_of_list env)
+        in
+        match extra_substs with
+        | [] -> ty
+        | _ ->
+          let domain, range = List.split extra_substs in
+          Ctype.apply env domain ty range
+      in
       begin match !payload with
-      | Some (jkind, modality, payload_type) ->
-        begin match
-          Jkind.for_or_null_variant env ~payload_type ~modality
-            ~payload_jkind:jkind
-        with
-        | Ok type_jkind ->
-          let type_jkind =
+      | Some (cd_res, jkind, modality, payload_type) ->
+        let payload_type = project cd_res payload_type in
+        let jkind =
+          match cd_res with
+          | None -> jkind
+          | Some _ -> Ctype.type_jkind env payload_type
+        in
+        let type_jkind =
+          match
+            Jkind.for_or_null_variant env ~payload_type ~modality
+              ~payload_jkind:jkind
+          with
+          | Ok type_jkind ->
             (* A void argument of the null constructor still counts
                towards the bounds of the declaration: matching on the null
                constructor synthesizes a value of that type. *)
-            match !null_payload with
+            begin match !null_payload with
             | None -> type_jkind
-            | Some (modality, type_expr) ->
+            | Some (null_cd_res, modality, type_expr) ->
+              let type_expr = project null_cd_res type_expr in
               Btype.Jkind0.add_with_bounds ~modality ~type_expr type_jkind
-          in
-          let type_jkind =
-            Jkind.History.update_reason type_jkind
-              (Value_or_null_creation (Or_null_payload dpath))
-          in
-          cstrs, rep, type_jkind
-        | Error () ->
-          Misc.fatal_error
-            "Typedecl.update_variant_kind: Variant_with_null payload is \
-             already maybe-null"
-        end
+            end
+          | Error () ->
+            begin match cd_res with
+            | Some _ ->
+              (* A GADT payload's parameter is constructor-local, so
+                 [constrain_or_null_payload] does not narrow the declaration
+                 parameter: a widened parameter (e.g. [('a : any)]) can reach
+                 here with a non-[value] layout that [for_or_null_variant]
+                 rejects. Fall back to the conservative [value_or_null]
+                 jkind, which is always sound. *)
+              Jkind.Builtin.value_or_null ~why:(Or_null_payload dpath)
+            | None ->
+              Misc.fatal_error
+                "Typedecl.update_variant_kind: Variant_with_null payload is \
+                 already maybe-null"
+            end
+        in
+        let type_jkind =
+          Jkind.History.update_reason type_jkind
+            (Value_or_null_creation (Or_null_payload dpath))
+        in
+        cstrs, rep, type_jkind
       | None -> bad_or_null_payload_count loc
       end
     | [{Types.cd_args} as cstr], Variant_unboxed -> begin

--- a/external/merlin/upstream/ocaml_flambda/typing/typeopt.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typeopt.ml
@@ -923,6 +923,12 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
   | Variant_with_null -> begin
     match Datarepr.find_variant_with_null_payload cstrs with
     | Some { payload_arg = { Types.ca_type = ty; _ }; _ } ->
+      (* [ty] is used raw: [params]/[args] are not substituted, and a GADT
+         payload is not projected out of its constructor-local scope. Both
+         lose precision only (an opaque variable yields a generic value
+         kind); the result stays sound because indices not matching the
+         payload constructor's result type are inhabited only by the null
+         value, which every nullable kind admits. *)
       let num_nodes_visited, kind =
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -324,6 +324,21 @@ Error: Invalid [@or_null] declaration:
        GADT constructors are not supported with [@@or_null].
 |}]
 
+type 'a existential_gadt =
+  | Nothing : 'a existential_gadt
+  | Something : 'b -> 'a existential_gadt
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type 'a existential_gadt =
+2 |   | Nothing : 'a existential_gadt
+3 |   | Something : 'b -> 'a existential_gadt
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       GADT constructors are not supported with [@@or_null].
+|}]
+
 type ('a : value_or_null) widened_bad_jkind =
   | A
   | B of 'a

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -297,13 +297,44 @@ type 'a gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a gadt =
-2 |   | A : 'a gadt
-3 |   | B : 'a -> 'a gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a gadt = A : 'a gadt | B : 'a -> 'a gadt [@@or_null]
+|}]
+
+type gadt_succeeds_sep = int gadt accepts_sep
+type gadt_succeeds_nonfloat = int gadt accepts_nonfloat
+
+[%%expect{|
+type gadt_succeeds_sep = int gadt accepts_sep
+type gadt_succeeds_nonfloat = int gadt accepts_nonfloat
+|}]
+
+type gadt_fails_sep = float gadt accepts_sep
+
+[%%expect{|
+Line 1, characters 22-32:
+1 | type gadt_fails_sep = float gadt accepts_sep
+                          ^^^^^^^^^^
+Error: This type "float gadt" should be an instance of type
+         "('a : any mod separable)"
+       The kind of float gadt is value_or_null
+         because of the definition of gadt at lines 1-4, characters 0-11.
+       But the kind of float gadt must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type gadt_fails_nonfloat = float gadt accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 27-37:
+1 | type gadt_fails_nonfloat = float gadt accepts_nonfloat
+                               ^^^^^^^^^^
+Error: This type "float gadt" should be an instance of type
+         "('a : value_or_null mod non_float)"
+       The kind of float gadt is value_or_null
+         because of the definition of gadt at lines 1-4, characters 0-11.
+       But the kind of float gadt must be a subkind of
+           value_or_null mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
 (* CR or-null: allow GADT custom [@@or_null] types with concrete indices.
@@ -315,13 +346,9 @@ type 'a concrete_gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a concrete_gadt =
-2 |   | Null : int concrete_gadt
-3 |   | This : string -> bool concrete_gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a concrete_gadt =
+    Null : int concrete_gadt
+  | This : string -> bool concrete_gadt [@@or_null]
 |}]
 
 type 'a existential_gadt =
@@ -330,13 +357,62 @@ type 'a existential_gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a existential_gadt =
-2 |   | Nothing : 'a existential_gadt
-3 |   | Something : 'b -> 'a existential_gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a existential_gadt =
+    Nothing : 'a existential_gadt
+  | Something : 'b -> 'a existential_gadt [@@or_null]
+|}]
+
+module _ = struct
+  let _ : int existential_gadt = Something 3.14
+end
+
+[%%expect{|
+|}]
+
+type existential_fails_sep = int existential_gadt accepts_sep
+
+[%%expect{|
+Line 1, characters 29-49:
+1 | type existential_fails_sep = int existential_gadt accepts_sep
+                                 ^^^^^^^^^^^^^^^^^^^^
+Error: This type "int existential_gadt" should be an instance of type
+         "('a : any mod separable)"
+       The kind of int existential_gadt is value_or_null
+         because of the definition of existential_gadt at lines 1-4, characters 0-11.
+       But the kind of int existential_gadt must be a subkind of
+           any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type existential_fails_nonfloat = int existential_gadt accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 34-54:
+1 | type existential_fails_nonfloat = int existential_gadt accepts_nonfloat
+                                      ^^^^^^^^^^^^^^^^^^^^
+Error: This type "int existential_gadt" should be an instance of type
+         "('a : value_or_null mod non_float)"
+       The kind of int existential_gadt is value_or_null
+         because of the definition of existential_gadt at lines 1-4, characters 0-11.
+       But the kind of int existential_gadt must be a subkind of
+           value_or_null mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
+|}]
+
+type 'a bad_gadt_payload =
+  | Nope_bad_gadt : 'a bad_gadt_payload
+  | Yep_bad_gadt : int t -> 'a bad_gadt_payload
+[@@or_null]
+
+[%%expect{|
+Line 3, characters 19-24:
+3 |   | Yep_bad_gadt : int t -> 'a bad_gadt_payload
+                       ^^^^^
+Error: The kind of type "int t" is value_or_null
+         because of the definition of t at lines 1-4, characters 0-11.
+       But the kind of type "int t" must be a subkind of
+           value_or_null mod non_null
+         because the type argument of bad_gadt_payload has kind value.
 |}]
 
 type ('a : value_or_null) widened_bad_jkind =

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -420,8 +420,8 @@ Error: The layout of type "int t" is value_or_null
          because the payload of bad_payload has layout value.
 |}]
 
-(* CR or-null: allow GADT custom [@@or_null] types.
-   Internal ticket 6854. *)
+(* GADT custom [@@or_null] types are allowed. See gadts.ml for a thorough
+   treatment; here we just check the basic accepted forms. *)
 
 type 'a gadt =
   | A : 'a gadt
@@ -429,17 +429,10 @@ type 'a gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a gadt =
-2 |   | A : 'a gadt
-3 |   | B : 'a -> 'a gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a gadt = A : 'a gadt | B : 'a -> 'a gadt [@@or_null]
 |}]
 
-(* CR or-null: allow GADT custom [@@or_null] types with concrete indices.
-   Internal ticket 6854. *)
+(* GADTs with concrete indices are allowed too. *)
 
 type 'a concrete_gadt =
   | Null : int concrete_gadt
@@ -447,13 +440,9 @@ type 'a concrete_gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a concrete_gadt =
-2 |   | Null : int concrete_gadt
-3 |   | This : string -> bool concrete_gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a concrete_gadt =
+    Null : int concrete_gadt
+  | This : string -> bool concrete_gadt [@@or_null]
 |}]
 
 type ('a : any) widened_bad_jkind =

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -877,8 +877,8 @@ Error: The layout of type "int t" is value_or_null
          because the payload of bad_payload has layout value.
 |}]
 
-(* CR or-null: allow GADT custom [@@or_null] types.
-   Internal ticket 6854. *)
+(* GADT custom [@@or_null] types are allowed. See gadts.ml for a thorough
+   treatment; here we just check the basic accepted forms. *)
 
 type 'a gadt =
   | A : 'a gadt
@@ -886,17 +886,10 @@ type 'a gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a gadt =
-2 |   | A : 'a gadt
-3 |   | B : 'a -> 'a gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a gadt = A : 'a gadt | B : 'a -> 'a gadt [@@or_null]
 |}]
 
-(* CR or-null: allow GADT custom [@@or_null] types with concrete indices.
-   Internal ticket 6854. *)
+(* GADTs with concrete indices are allowed too. *)
 
 type 'a concrete_gadt =
   | Null : int concrete_gadt
@@ -904,13 +897,9 @@ type 'a concrete_gadt =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a concrete_gadt =
-2 |   | Null : int concrete_gadt
-3 |   | This : string -> bool concrete_gadt
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       GADT constructors are not supported with [@@or_null].
+type 'a concrete_gadt =
+    Null : int concrete_gadt
+  | This : string -> bool concrete_gadt [@@or_null]
 |}]
 
 type ('a : any) widened_bad_jkind =

--- a/testsuite/tests/typing-layouts-or-null/gadts.ml
+++ b/testsuite/tests/typing-layouts-or-null/gadts.ml
@@ -1,0 +1,324 @@
+(* TEST
+ flags = "-w -181";
+ expect;
+*)
+
+(* Basic GADT [@@or_null]: the null constructor and the (unboxed) payload
+   constructor may carry return-type indices. *)
+type _ t =
+  | Null : int t
+  | This : string -> string t
+[@@or_null]
+
+[%%expect{|
+type _ t = Null : int t | This : string -> string t [@@or_null]
+|}]
+
+(* Construction and matching, with GADT refinement. *)
+let n : int t = Null
+let s : string t = This "hi"
+let get_str (x : string t) = match x with This s -> s
+
+[%%expect{|
+val n : int t = Null
+val s : string t = This "hi"
+val get_str : string t -> string = <fun>
+|}]
+
+(* Refinement is sound: [Null : int t] cannot have type [string t]. *)
+let bad (x : string t) = match x with Null -> assert false
+
+[%%expect{|
+Line 1, characters 38-42:
+1 | let bad (x : string t) = match x with Null -> assert false
+                                          ^^^^
+Error: This pattern matches values of type "int t"
+       but a pattern was expected which matches values of type "string t"
+       Type "int" is not compatible with type "string"
+|}]
+
+(* Declaration-jkind precision: a GADT [@@or_null] payload is projected onto
+   the declaration parameters, so a ground payload gets the same precise
+   declaration jkind as its non-GADT twin. A ground [int] payload gives
+   [immediate_or_null] (matching [type t = Null | This of int [@@or_null]]),
+   not the conservative [value_or_null]. *)
+module Ground_precise : sig type t : immediate_or_null end = struct
+  type t = GN : t | GT : int -> t [@@or_null]
+end
+
+[%%expect{|
+module Ground_precise : sig type t : immediate_or_null end
+|}]
+
+(* But a ground [float] payload is unboxed, so the type is nullable-float: its
+   declaration jkind is [value_or_null], not [immediate_or_null]. *)
+module Float_conservative : sig type t : immediate_or_null end = struct
+  type t = FN : t | FT : float -> t [@@or_null]
+end
+
+[%%expect{|
+Lines 1-3, characters 65-3:
+1 | .................................................................struct
+2 |   type t = FN : t | FT : float -> t [@@or_null]
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = FN : t | FT : float -> t [@@or_null] end
+       is not included in
+         sig type t : immediate_or_null end
+       Type declarations do not match:
+         type t = FN : t | FT : float -> t [@@or_null]
+       is not included in
+         type t : immediate_or_null
+       The layout of the first is value_or_null
+         because of the definition of t at line 2, characters 2-47.
+       But the layout of the first must be a sublayout of
+           value_or_null non_pointer
+         because of the definition of t at line 1, characters 32-58.
+|}]
+
+module Float_ok : sig type t : value_or_null end = struct
+  type t = FN : t | FT : float -> t [@@or_null]
+end
+
+[%%expect{|
+module Float_ok : sig type t : value_or_null end
+|}]
+
+(* A polymorphic GADT covers indices whose payload could be [float], so its
+   declaration jkind is not [immediate_or_null]. *)
+module Poly_conservative : sig type _ f : immediate_or_null end = struct
+  type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null]
+end
+
+[%%expect{|
+Lines 1-3, characters 66-3:
+1 | ..................................................................struct
+2 |   type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null]
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null] end
+       is not included in
+         sig type _ f : immediate_or_null end
+       Type declarations do not match:
+         type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null]
+       is not included in
+         type _ f : immediate_or_null
+       The layout of the first is value_or_null
+         because of the definition of f at line 2, characters 2-52.
+       But the layout of the first must be a sublayout of
+           value_or_null non_pointer
+         because of the definition of f at line 1, characters 31-59.
+|}]
+
+(* (a) The declaration's jkind must remain honest: it is [value_or_null],
+   never [value]. *)
+type _ a1 : value = Null : int a1 | This : string -> string a1 [@@or_null]
+
+[%%expect{|
+Line 1, characters 0-74:
+1 | type _ a1 : value = Null : int a1 | This : string -> string a1 [@@or_null]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "a1" is value_or_null non_float
+         because an [@@or_null] type gets its layout by applying or_null to its
+         payload layout.
+       But the layout of type "a1" must be a sublayout of value
+         because of the annotation on the declaration of the type a1.
+|}]
+
+type _ a2 : value_or_null = Null : int a2 | This : string -> string a2
+[@@or_null]
+
+[%%expect{|
+type _ a2 = Null : int a2 | This : string -> string a2 [@@or_null]
+|}]
+
+(* (b) A GADT whose payload could be [float] must not become a flat float
+   array element. The payload is unboxed and a NULL is not a float, so the
+   separability is read (per instantiation) from the unwrapped payload:
+   [float f] is [maybe_separable] (a NULL could not sit in a flat float array),
+   whereas [int f] is [non_float]. Thus [float f array] is a type error while
+   [int f array] is allowed -- a NULL can never reach a flat float array. *)
+type _ f = FNull : 'a f | FThis : 'a -> 'a f [@@or_null]
+
+[%%expect{|
+type _ f = FNull : 'a f | FThis : 'a -> 'a f [@@or_null]
+|}]
+
+let mk_float_arr (x : float f) = [| x |]
+
+[%%expect{|
+Line 1, characters 36-37:
+1 | let mk_float_arr (x : float f) = [| x |]
+                                        ^
+Error: The value "x" has type "float f" but an expression was expected of type
+         "('a : value_maybe_null)"
+       The layout of float f is value_or_null
+         because of the definition of f at line 1, characters 0-56.
+       But the layout of float f must be a sublayout of value_maybe_null
+         because it's the type of an array element.
+|}]
+
+let mk_int_arr (x : int f) = [| x |]
+
+[%%expect{|
+val mk_int_arr : int f -> int f array = <fun>
+|}]
+
+(* A widened [('a : any)] parameter is not narrowed by the GADT payload (the
+   payload variable is constructor-local), so it reaches the declaration-jkind
+   computation with a non-[value] layout that [apply_or_null] cannot process.
+   This is handled by falling back to the conservative [value_or_null] jkind
+   rather than crashing. *)
+type ('a : any) widened_any_gadt =
+  | Any_null : 'a widened_any_gadt
+  | Any_this : 'a -> 'a widened_any_gadt
+[@@or_null]
+
+[%%expect{|
+type ('a : any) widened_any_gadt =
+    Any_null : 'a widened_any_gadt
+  | Any_this : 'a -> 'a widened_any_gadt [@@or_null]
+|}]
+
+(* The payload of an [@@or_null] constructor must still be a [value]: a
+   [float64] parameter is rejected. *)
+type ('a : float64) widened_float64_gadt =
+  | F_null : 'a widened_float64_gadt
+  | F_this : 'a -> 'a widened_float64_gadt
+[@@or_null]
+
+[%%expect{|
+Line 3, characters 13-15:
+3 |   | F_this : 'a -> 'a widened_float64_gadt
+                 ^^
+Error: The layout of type "'a" is float64
+         because of the annotation on 'a in the declaration of the type
+                                      widened_float64_gadt.
+       But the layout of type "'a" must be a value layout
+         because the payload of widened_float64_gadt has layout value.
+|}]
+
+(* (c) Exhaustiveness stays sound: omitting a reachable constructor warns. *)
+type _ u = UNull : 'a u | UThis : 'a -> 'a u [@@or_null]
+let full (type a) (x : a u) = match x with UNull -> None | UThis v -> Some v
+
+[%%expect{|
+type _ u = UNull : 'a u | UThis : 'a -> 'a u [@@or_null]
+val full : 'a u -> 'a option = <fun>
+|}]
+
+(* Omitting a reachable constructor is correctly flagged as non-exhaustive.
+   (The named counter-example can be imprecise for [Variant_with_null] -- here
+   [UThis] is the missing case but [UNull] is reported -- but the match is
+   always soundly flagged; this is a pre-existing quirk of the null-tag
+   counter-example generation, not a soundness gap.) *)
+let missing_this (type a) (x : a u) = match x with UNull -> ()
+
+[%%expect{|
+Line 1, characters 38-62:
+1 | let missing_this (type a) (x : a u) = match x with UNull -> ()
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "UNull"
+
+val missing_this : 'a u -> unit = <fun>
+|}]
+
+(* (d) Abstraction: a [value_or_null] signature accepts the GADT impl; a
+   [value] (non-null) signature is rejected. *)
+module Ok : sig type _ t : value_or_null end = struct
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end
+
+[%%expect{|
+module Ok : sig type _ t : value_or_null end
+|}]
+
+module Bad : sig type _ t : value end = struct
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end
+
+[%%expect{|
+Lines 1-3, characters 40-3:
+1 | ........................................struct
+2 |   type _ t = Null : int t | This : string -> string t [@@or_null]
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type _ t = Null : int t | This : string -> string t [@@or_null]
+         end
+       is not included in
+         sig type _ t end
+       Type declarations do not match:
+         type _ t = Null : int t | This : string -> string t [@@or_null]
+       is not included in
+         type _ t
+       The layout of the first is value_or_null non_float
+         because of the definition of t at line 2, characters 2-65.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 1, characters 17-33.
+|}]
+
+(* (e) Nested [@@or_null] stays blocked: the payload must be non-null. *)
+type _ nested =
+  | NNull : int nested
+  | NThis : string or_null -> string nested
+[@@or_null]
+
+[%%expect{|
+Line 3, characters 12-26:
+3 |   | NThis : string or_null -> string nested
+                ^^^^^^^^^^^^^^
+Error: The layout of type "string or_null" is value_or_null
+         because it is the primitive type or_null.
+       But the layout of type "string or_null" must be a sublayout of
+           value_maybe_separable
+         because the payload of nested has layout value.
+|}]
+
+(* Existentials in the payload are allowed; when the payload's jkind is read
+   (at use sites) the existentials are projected away, so they do not leak into
+   the type's kind. *)
+type _ e =
+  | ENull : int e
+  | EThis : ('b * ('b -> 'a)) -> 'a e
+[@@or_null]
+
+[%%expect{|
+type _ e = ENull : int e | EThis : ('b * ('b -> 'a)) -> 'a e [@@or_null]
+|}]
+
+(* The [@@or_null] shape check is retained under GADT syntax: exactly one
+   nullary and one unary constructor, both tuples (no inline records). *)
+type _ inline =
+  | INull : int inline
+  | IThis : { x : string } -> string inline
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type _ inline =
+2 |   | INull : int inline
+3 |   | IThis : { x : string } -> string inline
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one nullary constructor and one unary constructor.
+|}]
+
+type _ two_args =
+  | TNull : int two_args
+  | TThis : string * int -> string two_args
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type _ two_args =
+2 |   | TNull : int two_args
+3 |   | TThis : string * int -> string two_args
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one nullary constructor and one unary constructor.
+|}]

--- a/testsuite/tests/typing-layouts-or-null/gadts.ml
+++ b/testsuite/tests/typing-layouts-or-null/gadts.ml
@@ -1,0 +1,656 @@
+(* TEST
+ flags = "-w -181";
+ expect;
+*)
+
+(* Basic GADT [@@or_null]: the null constructor and the (unboxed) payload
+   constructor may carry return-type indices. *)
+type _ t =
+  | Null : int t
+  | This : string -> string t
+[@@or_null]
+
+[%%expect{|
+type _ t = Null : int t | This : string -> string t [@@or_null]
+|}]
+
+(* Construction and matching, with GADT refinement. *)
+let n : int t = Null
+let s : string t = This "hi"
+let get_str (x : string t) = match x with This s -> s
+
+[%%expect{|
+val n : int t = Null
+val s : string t = This "hi"
+val get_str : string t -> string = <fun>
+|}]
+
+(* Refinement is sound: [Null : int t] cannot have type [string t]. *)
+let bad (x : string t) = match x with Null -> assert false
+
+[%%expect{|
+Line 1, characters 38-42:
+1 | let bad (x : string t) = match x with Null -> assert false
+                                          ^^^^
+Error: This pattern matches values of type "int t"
+       but a pattern was expected which matches values of type "string t"
+       Type "int" is not compatible with type "string"
+|}]
+
+(* Declaration-jkind precision: a GADT [@@or_null] payload is projected onto
+   the declaration parameters, so a ground payload gets the same precise
+   declaration jkind as its non-GADT twin. A ground [int] payload gives
+   [immediate_or_null] (matching [type t = Null | This of int [@@or_null]]),
+   not the conservative [value_or_null]. *)
+module Ground_precise : sig type t : immediate_or_null end = struct
+  type t = GN : t | GT : int -> t [@@or_null]
+end
+
+[%%expect{|
+module Ground_precise : sig type t : immediate_or_null end
+|}]
+
+(* But a ground [float] payload is unboxed, so the type is nullable-float: its
+   declaration jkind is [value_or_null], not [immediate_or_null]. *)
+module Float_conservative : sig type t : immediate_or_null end = struct
+  type t = FN : t | FT : float -> t [@@or_null]
+end
+
+[%%expect{|
+Lines 1-3, characters 65-3:
+1 | .................................................................struct
+2 |   type t = FN : t | FT : float -> t [@@or_null]
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = FN : t | FT : float -> t [@@or_null] end
+       is not included in
+         sig type t : immediate_or_null end
+       Type declarations do not match:
+         type t = FN : t | FT : float -> t [@@or_null]
+       is not included in
+         type t : immediate_or_null
+       The layout of the first is value_or_null
+         because of the definition of t at line 2, characters 2-47.
+       But the layout of the first must be a sublayout of
+           value_or_null non_pointer
+         because of the definition of t at line 1, characters 32-58.
+|}]
+
+module Float_ok : sig type t : value_or_null end = struct
+  type t = FN : t | FT : float -> t [@@or_null]
+end
+
+[%%expect{|
+module Float_ok : sig type t : value_or_null end
+|}]
+
+(* A polymorphic GADT covers indices whose payload could be [float], so its
+   declaration jkind is not [immediate_or_null]. *)
+module Poly_conservative : sig type _ f : immediate_or_null end = struct
+  type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null]
+end
+
+[%%expect{|
+Lines 1-3, characters 66-3:
+1 | ..................................................................struct
+2 |   type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null]
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null] end
+       is not included in
+         sig type _ f : immediate_or_null end
+       Type declarations do not match:
+         type _ f = PN : 'a f | PT : 'a -> 'a f [@@or_null]
+       is not included in
+         type _ f : immediate_or_null
+       The layout of the first is value_or_null
+         because of the definition of f at line 2, characters 2-52.
+       But the layout of the first must be a sublayout of
+           value_or_null non_pointer
+         because of the definition of f at line 1, characters 31-59.
+|}]
+
+(* (a) The declaration's jkind must remain honest: it is [value_or_null],
+   never [value]. *)
+type _ a1 : value = Null : int a1 | This : string -> string a1 [@@or_null]
+
+[%%expect{|
+Line 1, characters 0-74:
+1 | type _ a1 : value = Null : int a1 | This : string -> string a1 [@@or_null]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "a1" is value_or_null non_float
+         because an [@@or_null] type gets the layout of or_null
+         applied to its payload type.
+       But the layout of type "a1" must be a sublayout of value
+         because of the annotation on the declaration of the type a1.
+|}]
+
+type _ a2 : value_or_null = Null : int a2 | This : string -> string a2
+[@@or_null]
+
+[%%expect{|
+type _ a2 = Null : int a2 | This : string -> string a2 [@@or_null]
+|}]
+
+(* (b) A GADT whose payload could be [float] must not become a flat float
+   array element. The payload is unboxed and a NULL is not a float, so the
+   separability is read (per instantiation) from the unwrapped payload:
+   [float f] is [maybe_separable] (a NULL could not sit in a flat float array),
+   whereas [int f] is [non_float]. Thus [float f array] is a type error while
+   [int f array] is allowed -- a NULL can never reach a flat float array. *)
+type _ f = FNull : 'a f | FThis : 'a -> 'a f [@@or_null]
+
+[%%expect{|
+type _ f = FNull : 'a f | FThis : 'a -> 'a f [@@or_null]
+|}]
+
+let mk_float_arr (x : float f) = [| x |]
+
+[%%expect{|
+Line 1, characters 36-37:
+1 | let mk_float_arr (x : float f) = [| x |]
+                                        ^
+Error: The value "x" has type "float f" but an expression was expected of type
+         "('a : value_maybe_null)"
+       The layout of float f is value_or_null
+         because of the definition of f at line 1, characters 0-56.
+       But the layout of float f must be a sublayout of value_maybe_null
+         because it's the type of an array element.
+|}]
+
+let mk_int_arr (x : int f) = [| x |]
+
+[%%expect{|
+val mk_int_arr : int f -> int f array = <fun>
+|}]
+
+(* A widened [('a : any)] parameter is not narrowed by the GADT payload (the
+   payload variable is constructor-local), so it reaches the declaration-jkind
+   computation with a non-[value] layout that [apply_or_null] cannot process.
+   This is handled by falling back to the conservative [value_or_null] jkind
+   rather than crashing. *)
+type ('a : any) widened_any_gadt =
+  | Any_null : 'a widened_any_gadt
+  | Any_this : 'a -> 'a widened_any_gadt
+[@@or_null]
+
+[%%expect{|
+type ('a : any) widened_any_gadt =
+    Any_null : 'a widened_any_gadt
+  | Any_this : 'a -> 'a widened_any_gadt [@@or_null]
+|}]
+
+(* The payload of an [@@or_null] constructor must still be a [value]: a
+   [float64] parameter is rejected. *)
+type ('a : float64) widened_float64_gadt =
+  | F_null : 'a widened_float64_gadt
+  | F_this : 'a -> 'a widened_float64_gadt
+[@@or_null]
+
+[%%expect{|
+Line 3, characters 13-15:
+3 |   | F_this : 'a -> 'a widened_float64_gadt
+                 ^^
+Error: The layout of type "'a" is float64
+         because of the annotation on 'a in the declaration of the type
+                                      widened_float64_gadt.
+       But the layout of type "'a" must be a value layout
+         because the payload of widened_float64_gadt has layout value.
+|}]
+
+(* (c) Exhaustiveness stays sound: omitting a reachable constructor warns. *)
+type _ u = UNull : 'a u | UThis : 'a -> 'a u [@@or_null]
+let full (type a) (x : a u) = match x with UNull -> None | UThis v -> Some v
+
+[%%expect{|
+type _ u = UNull : 'a u | UThis : 'a -> 'a u [@@or_null]
+val full : 'a u -> 'a option = <fun>
+|}]
+
+(* Omitting a reachable constructor is correctly flagged as non-exhaustive.
+   (The named counter-example can be imprecise for [Variant_with_null] -- here
+   [UThis] is the missing case but [UNull] is reported -- but the match is
+   always soundly flagged; this is a pre-existing quirk of the null-tag
+   counter-example generation, not a soundness gap.) *)
+let missing_this (type a) (x : a u) = match x with UNull -> ()
+
+[%%expect{|
+Line 1, characters 38-62:
+1 | let missing_this (type a) (x : a u) = match x with UNull -> ()
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "UNull"
+
+val missing_this : 'a u -> unit = <fun>
+|}]
+
+(* (d) Abstraction: a [value_or_null] signature accepts the GADT impl; a
+   [value] (non-null) signature is rejected. *)
+module Ok : sig type _ t : value_or_null end = struct
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end
+
+[%%expect{|
+module Ok : sig type _ t : value_or_null end
+|}]
+
+module Bad : sig type _ t : value end = struct
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end
+
+[%%expect{|
+Lines 1-3, characters 40-3:
+1 | ........................................struct
+2 |   type _ t = Null : int t | This : string -> string t [@@or_null]
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type _ t = Null : int t | This : string -> string t [@@or_null]
+         end
+       is not included in
+         sig type _ t end
+       Type declarations do not match:
+         type _ t = Null : int t | This : string -> string t [@@or_null]
+       is not included in
+         type _ t
+       The layout of the first is value_or_null non_float
+         because of the definition of t at line 2, characters 2-65.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 1, characters 17-33.
+|}]
+
+(* (e) Nested [@@or_null] stays blocked: the payload must be non-null. *)
+type _ nested =
+  | NNull : int nested
+  | NThis : string or_null -> string nested
+[@@or_null]
+
+[%%expect{|
+Line 3, characters 12-26:
+3 |   | NThis : string or_null -> string nested
+                ^^^^^^^^^^^^^^
+Error: The layout of type "string or_null" is value_or_null
+         because it is the primitive type or_null.
+       But the layout of type "string or_null" must be a sublayout of
+           value_maybe_separable
+         because the payload of nested has layout value.
+|}]
+
+(* Existentials in the payload are allowed; when the payload's jkind is read
+   (at use sites) the existentials are projected away, so they do not leak into
+   the type's kind. *)
+type _ e =
+  | ENull : int e
+  | EThis : ('b * ('b -> 'a)) -> 'a e
+[@@or_null]
+
+[%%expect{|
+type _ e = ENull : int e | EThis : ('b * ('b -> 'a)) -> 'a e [@@or_null]
+|}]
+
+(* The [@@or_null] shape check is retained under GADT syntax: each
+   constructor must be nullary or unary, and a tuple (no inline records). *)
+type _ inline =
+  | INull : int inline
+  | IThis : { x : string } -> string inline
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type _ inline =
+2 |   | INull : int inline
+3 |   | IThis : { x : string } -> string inline
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       each constructor must be nullary or unary.
+|}]
+
+type _ two_args =
+  | TNull : int two_args
+  | TThis : string * int -> string two_args
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type _ two_args =
+2 |   | TNull : int two_args
+3 |   | TThis : string * int -> string two_args
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       each constructor must be nullary or unary.
+|}]
+
+(* (f) GADT with a unary all-void null constructor: newly expressible now
+   that the GADT gate is gone and the shape check is per-constructor. The
+   all-void argument classifies the constructor as the null case, exactly as
+   for non-GADT custom or_nulls. *)
+type void : void mod everything
+external void : unit -> void = "%unbox_unit"
+
+type _ vn =
+  | VNull : void -> int vn
+  | VThis : 'a -> 'a vn
+[@@or_null]
+
+[%%expect{|
+type void : void mod everything
+external void : unit -> void = "%unbox_unit"
+type _ vn = VNull : void -> int vn | VThis : 'a -> 'a vn [@@or_null]
+|}]
+
+(* Constructor order does not matter. *)
+type _ vn_flipped =
+  | WThis : 'a -> 'a vn_flipped
+  | WNull : void -> int vn_flipped
+[@@or_null]
+
+[%%expect{|
+type _ vn_flipped =
+    WThis : 'a -> 'a vn_flipped
+  | WNull : void -> int vn_flipped [@@or_null]
+|}]
+
+(* The null constructor's void payload enters the declaration's kind as a
+   with-bound (projected with the null constructor's own result type);
+   [void mod everything] crosses everything, so a ground [int] payload still
+   yields [immediate_or_null]. *)
+module Void_null_precise : sig type t : immediate_or_null end = struct
+  type t = VN : void -> t | VT : int -> t [@@or_null]
+end
+
+[%%expect{|
+module Void_null_precise : sig type t : immediate_or_null end
+|}]
+
+(* The projected null with-bound is observable: a null payload of plain
+   kind [void] does not cross portability, so it blocks a [mod portable]
+   signature that the [void mod everything] payload above satisfies. *)
+type nonportable_void : void
+module Void_null_bound_blocks : sig
+  type t : value_or_null mod portable
+end = struct
+  type t = BN : nonportable_void -> t | BT : int -> t [@@or_null]
+end
+
+[%%expect{|
+type nonportable_void : void
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type t = BN : nonportable_void -> t | BT : int -> t [@@or_null]
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = BN : nonportable_void -> t | BT : int -> t [@@or_null]
+         end
+       is not included in
+         sig type t : value_or_null mod portable end
+       Type declarations do not match:
+         type t = BN : nonportable_void -> t | BT : int -> t [@@or_null]
+       is not included in
+         type t : value_or_null mod portable
+       The kind of the first is immediate_or_null with nonportable_void
+         because of the definition of t at line 5, characters 2-65.
+       But the kind of the first must be a subkind of
+           value_or_null mod portable
+         because of the definition of t at line 3, characters 2-37.
+|}]
+
+(* An existential void payload on the null constructor is projected too: the
+   orphaned constructor-local variable becomes a [(type : ...)] bound rather
+   than escaping its scope. *)
+type _ evn =
+  | EVNull : ('v : void). 'v -> int evn
+  | EVThis : 'a -> 'a evn
+[@@or_null]
+
+[%%expect{|
+type _ evn = EVNull : ('v : void). 'v -> int evn | EVThis : 'a -> 'a evn [@@or_null]
+|}]
+
+(* The projected existential bound is observable, exactly like the concrete
+   [nonportable_void] bound above: plain [(type : void)] does not cross
+   portability. *)
+module Evn_bound_blocks : sig
+  type _ t : value_or_null mod portable
+end = struct
+  type _ t =
+    | EN : ('v : void). 'v -> int t
+    | ET : int -> 'a t
+  [@@or_null]
+end
+
+[%%expect{|
+Lines 3-8, characters 6-3:
+3 | ......struct
+4 |   type _ t =
+5 |     | EN : ('v : void). 'v -> int t
+6 |     | ET : int -> 'a t
+7 |   [@@or_null]
+8 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type _ t = EN : ('v : void). 'v -> int t | ET : int -> 'a t [@@or_null]
+         end
+       is not included in
+         sig type _ t : value_or_null mod portable end
+       Type declarations do not match:
+         type _ t = EN : ('v : void). 'v -> int t | ET : int -> 'a t [@@or_null]
+       is not included in
+         type _ t : value_or_null mod portable
+       The kind of the first is value_or_null non_pointer mod external_
+         because of the definition of t at lines 4-7, characters 2-13.
+       But the kind of the first must be a subkind of
+           value_or_null mod portable
+         because of the definition of t at line 2, characters 2-39.
+|}]
+
+(* (g) Recursive groups: during the group's translation the GADT or_null has
+   a conservative temporary jkind; the final jkinds are then recomputed in
+   dependency order, so a sibling consuming the finished type still sees the
+   precise kind. *)
+type 'a rt = RN : 'b rt | RT : 'c -> 'c rt [@@or_null]
+and rbox = RB of int rt
+
+[%%expect{|
+type 'a rt = RN : 'b rt | RT : 'c -> 'c rt [@@or_null]
+and rbox = RB of int rt
+|}]
+
+module Group_precise : sig
+  type t : immediate_or_null
+  type box = B of t
+end = struct
+  type t = GN : t | GT : int -> t [@@or_null]
+  and box = B of t
+end
+
+[%%expect{|
+module Group_precise : sig type t : immediate_or_null type box = B of t end
+|}]
+
+(* A GADT or_null and a void-null or_null in one recursive group, both with
+   payloads from the group. *)
+type ga = GAN : ga | GAT : grec -> ga [@@or_null]
+and grec = { g : int }
+and gvn = GVN : void -> gvn | GVT : grec -> gvn [@@or_null]
+
+[%%expect{|
+type ga = GAN : ga | GAT : grec -> ga [@@or_null]
+and grec = { g : int; }
+and gvn = GVN : void -> gvn | GVT : grec -> gvn [@@or_null]
+|}]
+
+(* (h) Mode crossing flows through the projected payload with-bound: an
+   [int] payload crosses portability and contention... *)
+module Crossing_ok : sig
+  type t : value_or_null mod portable contended
+end = struct
+  type t = PN : t | PT : int -> t [@@or_null]
+end
+
+[%%expect{|
+module Crossing_ok : sig type t : value_or_null mod portable contended end
+|}]
+
+(* ... while a function payload does not cross portability. *)
+module Crossing_bad : sig
+  type t : value_or_null mod portable
+end = struct
+  type t = QN : t | QT : (int -> int) -> t [@@or_null]
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = QN : t | QT : (int -> int) -> t [@@or_null]
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = QN : t | QT : (int -> int) -> t [@@or_null] end
+       is not included in
+         sig type t : value_or_null mod portable end
+       Type declarations do not match:
+         type t = QN : t | QT : (int -> int) -> t [@@or_null]
+       is not included in
+         type t : value_or_null mod portable
+       The kind of the first is value_or_null non_float mod aliased immutable
+         because of the definition of t at line 4, characters 2-54.
+       But the kind of the first must be a subkind of
+           value_or_null mod portable
+         because of the definition of t at line 2, characters 2-37.
+|}]
+
+(* An existential payload constrained to a crossing kind keeps the crossing
+   through the [(type : ...)] projection. *)
+module Crossing_existential : sig
+  type t : value_or_null mod portable
+end = struct
+  type t =
+    | XN : t
+    | XT : ('b : value mod portable). 'b -> t
+  [@@or_null]
+end
+
+[%%expect{|
+module Crossing_existential : sig type t : value_or_null mod portable end
+|}]
+
+(* (i) Module inclusion compares GADT or_null constructors including their
+   result types. *)
+module Incl_ok : sig
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end = struct
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end
+
+[%%expect{|
+module Incl_ok :
+  sig type _ t = Null : int t | This : string -> string t [@@or_null] end
+|}]
+
+module Incl_bad : sig
+  type _ t = Null : int t | This : string -> string t [@@or_null]
+end = struct
+  type _ t = Null : bool t | This : string -> string t [@@or_null]
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type _ t = Null : bool t | This : string -> string t [@@or_null]
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type _ t = Null : bool t | This : string -> string t [@@or_null]
+         end
+       is not included in
+         sig
+           type _ t = Null : int t | This : string -> string t [@@or_null]
+         end
+       Type declarations do not match:
+         type _ t = Null : bool t | This : string -> string t [@@or_null]
+       is not included in
+         type _ t = Null : int t | This : string -> string t [@@or_null]
+       Constructors do not match:
+         "Null : bool t"
+       is not the same as:
+         "Null : int t"
+       The type "bool t" is not equal to the type "int t"
+       Type "bool" is not equal to type "int"
+|}]
+
+(* (j) The unboxed-recursion check sees through GADT payload variables. A
+   widened declaration parameter lets the or_null type be indexed by a
+   maybe-null type (only the payload constructor's local variable is
+   constrained to [value]), so an unboxed cycle can re-enter through the
+   payload variable. The B1-B4 projection in [contained_without_boxing]
+   makes that edge visible, and the cycle is rejected exactly like its
+   ordinary unboxed-GADT counterpart. Without the projection this
+   declaration was accepted (the payload edge was invisible). *)
+type w = W of w t [@@unboxed]
+and ('a : value_or_null) t =
+  | N : 'b t
+  | T : ('c : value). 'c -> 'c t
+[@@or_null]
+
+[%%expect{|
+Line 1, characters 0-29:
+1 | type w = W of w t [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "w" is recursive without boxing:
+         "w" contains "w t",
+         "w t" contains "w"
+|}]
+
+(* The same or_null declaration without the cycle stays accepted. *)
+type ('a : value_or_null) widened_ok =
+  | WON : 'b widened_ok
+  | WOT : ('c : value). 'c -> 'c widened_ok
+[@@or_null]
+
+[%%expect{|
+type ('a : value_or_null) widened_ok =
+    WON : 'b widened_ok
+  | WOT : 'c -> 'c widened_ok [@@or_null]
+|}]
+
+(* A repeated result variable keeps the first-occurrence projection (BW1 of
+   Note [With-bounds for GADTs]): at [(w, int) t] the payload ['c] projects
+   to [w] even though the second index would force [w = int], so the cycle
+   check rejects this declaration although [T] is uninhabitable at that
+   index and [W N] would be a value of [w]. This is the checker's
+   established index-insensitive conservatism, not something specific to
+   [@@or_null]: the ordinary unboxed GADT below is rejected identically by
+   the pre-existing projection in [unbox_once]. *)
+type w2 = W2 of (w2, int) t2 [@@unboxed]
+and ('a : value_or_null, 'b : value_or_null) t2 =
+  | N2 : ('d : value_or_null). ('d, int) t2
+  | T2 : ('c : value). 'c -> ('c, 'c) t2
+[@@or_null]
+
+[%%expect{|
+Line 1, characters 0-40:
+1 | type w2 = W2 of (w2, int) t2 [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "w2" is recursive without boxing:
+         "w2" contains "(w2, int) t2",
+         "(w2, int) t2" contains "w2"
+|}]
+
+type v = V of (v, int) u [@@unboxed]
+and ('a, 'b) u = MkU : 'c -> ('c, 'c) u [@@unboxed]
+
+[%%expect{|
+Line 1, characters 0-36:
+1 | type v = V of (v, int) u [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "v" is recursive without boxing:
+         "v" contains "(v, int) u",
+         "(v, int) u" contains "v"
+|}]

--- a/testsuite/tests/typing-layouts-or-null/gadts_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/gadts_runtime.ml
@@ -1,0 +1,162 @@
+(* TEST
+ flambda2;
+ {
+   native;
+ } {
+   flags = "-O3";
+   native;
+ } {
+   flags = "-Oclassic";
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+(* Runtime behaviour of custom [@@or_null] GADTs. The type-level acceptance
+   and rejection of these declarations is pinned by gadts.ml; here we
+   construct, match, [map], array-fold and marshal them to check the NULL /
+   payload discrimination survives to run time under native, -O3, -Oclassic
+   and bytecode. *)
+
+(* Polymorphic GADT: the nullary constructor is NULL, the unary one is the
+   unboxed payload. *)
+type 'a gadt =
+  | A : 'a gadt
+  | B : 'a -> 'a gadt
+[@@or_null]
+
+(* Concrete-index GADT: each constructor fixes the index type, so matching
+   also refines it. *)
+type 'a concrete_gadt =
+  | Null : int concrete_gadt
+  | This : string -> bool concrete_gadt
+[@@or_null]
+
+(* Compound payload that mentions the constructor's index inside a tuple. *)
+type 'a compound_gadt =
+  | Comp_null : 'a compound_gadt
+  | Comp : ('a * int) -> 'a compound_gadt
+[@@or_null]
+
+(* Existential payload: the [B] argument type is not the index. *)
+type 'a existential_gadt =
+  | Nothing : 'a existential_gadt
+  | Something : 'b -> 'a existential_gadt
+[@@or_null]
+
+let map_gadt : type a b. (a -> b) -> a gadt -> b gadt =
+ fun f -> function
+  | A -> A
+  | B x -> B (f x)
+
+(* Polymorphic GADT construct / match at two indices. *)
+let () =
+  (match (A : int gadt) with
+   | A -> ()
+   | B _ -> assert false);
+  (match B 3 with
+   | B 3 -> ()
+   | _ -> assert false);
+  (match (A : string gadt) with
+   | A -> ()
+   | B _ -> assert false);
+  (match B "custom" with
+   | B "custom" -> ()
+   | _ -> assert false)
+;;
+
+(* [map] preserves NULL and transforms the payload. *)
+let () =
+  (match map_gadt (fun x -> x + 1) (B 4) with
+   | B 5 -> ()
+   | _ -> assert false);
+  (match map_gadt (fun x -> x + 1) A with
+   | A -> ()
+   | _ -> assert false);
+  (match map_gadt String.length (B "abcd") with
+   | B 4 -> ()
+   | _ -> assert false)
+;;
+
+(* Concrete-index GADT: match refines the index at run time. *)
+let concrete_len : type a. a concrete_gadt -> int = function
+  | Null -> -1
+  | This s -> String.length s
+
+let () =
+  assert (concrete_len (Null : int concrete_gadt) = -1);
+  assert (concrete_len (This "hello") = 5);
+  (match (This "hi" : bool concrete_gadt) with
+   | This "hi" -> ()
+   | This _ -> assert false)
+;;
+
+(* Compound payload mentioning the index. *)
+let () =
+  (match Comp ("x", 7) with
+   | Comp ("x", 7) -> ()
+   | _ -> assert false);
+  (match (Comp_null : string compound_gadt) with
+   | Comp_null -> ()
+   | Comp _ -> assert false);
+  let get_snd : type a. a compound_gadt -> int = function
+    | Comp_null -> 0
+    | Comp (_, n) -> n
+  in
+  assert (get_snd (Comp ("y", 9)) = 9);
+  assert (get_snd (Comp_null : int compound_gadt) = 0)
+;;
+
+(* Existential payload. *)
+let () =
+  (match (Something 3.14 : int existential_gadt) with
+   | Something _ -> ()
+   | Nothing -> assert false);
+  (match (Nothing : int existential_gadt) with
+   | Nothing -> ()
+   | Something _ -> assert false)
+;;
+
+(* [int gadt array]: the conservative decl jkind is refined to separable at
+   the use site, so a value array with NULL slots builds and folds. *)
+let sum_int_gadt (arr : int gadt array) =
+  Array.fold_left (fun acc x -> match x with A -> acc | B n -> acc + n) 0 arr
+
+let () =
+  let arr = [| B 1; A; B 3; A; B 4 |] in
+  assert (Array.length arr = 5);
+  assert (sum_int_gadt arr = 8);
+  arr.(1) <- B 10;
+  assert (sum_int_gadt arr = 18);
+  arr.(0) <- A;
+  assert (sum_int_gadt arr = 17)
+;;
+
+(* Marshalling round-trips NULL and payload. *)
+let () =
+  let bytes = Marshal.to_bytes (B 9) [] in
+  (match Marshal.from_bytes bytes 0 with
+   | B 9 -> ()
+   | _ -> assert false);
+  let bytes = Marshal.to_bytes (A : int gadt) [] in
+  (match Marshal.from_bytes bytes 0 with
+   | A -> ()
+   | _ -> assert false);
+  let bytes = Marshal.to_bytes (This "round") [] in
+  (match (Marshal.from_bytes bytes 0 : bool concrete_gadt) with
+   | This "round" -> ()
+   | _ -> assert false)
+;;
+
+(* Structural comparison discriminates NULL from payload. *)
+let () =
+  assert ((A : int gadt) = A);
+  assert (B 4 = B 4);
+  assert ((A : int gadt) <> B 4);
+  assert (compare (A : int gadt) (B 4) < 0);
+  assert (compare (B 4) (A : int gadt) > 0);
+  assert (compare (B 4) (B 5) < 0)
+;;
+
+let () = print_endline "All tests passed!"

--- a/testsuite/tests/typing-layouts-or-null/gadts_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/gadts_runtime.ml
@@ -1,0 +1,255 @@
+(* TEST
+ flambda2;
+ {
+   native;
+ } {
+   flags = "-O3";
+   native;
+ } {
+   flags = "-Oclassic";
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+(* Runtime behaviour of custom [@@or_null] GADTs. The type-level acceptance
+   and rejection of these declarations is pinned by gadts.ml; here we
+   construct, match, [map], array-fold and marshal them to check the NULL /
+   payload discrimination survives to run time under native, -O3, -Oclassic
+   and bytecode. *)
+
+(* Polymorphic GADT: the nullary constructor is NULL, the unary one is the
+   unboxed payload. *)
+type 'a gadt =
+  | A : 'a gadt
+  | B : 'a -> 'a gadt
+[@@or_null]
+
+(* Concrete-index GADT: each constructor fixes the index type, so matching
+   also refines it. *)
+type 'a concrete_gadt =
+  | Null : int concrete_gadt
+  | This : string -> bool concrete_gadt
+[@@or_null]
+
+(* Compound payload that mentions the constructor's index inside a tuple. *)
+type 'a compound_gadt =
+  | Comp_null : 'a compound_gadt
+  | Comp : ('a * int) -> 'a compound_gadt
+[@@or_null]
+
+(* Existential payload: the [B] argument type is not the index. *)
+type 'a existential_gadt =
+  | Nothing : 'a existential_gadt
+  | Something : 'b -> 'a existential_gadt
+[@@or_null]
+
+let map_gadt : type a b. (a -> b) -> a gadt -> b gadt =
+ fun f -> function
+  | A -> A
+  | B x -> B (f x)
+
+(* Polymorphic GADT construct / match at two indices. *)
+let () =
+  (match (A : int gadt) with
+   | A -> ()
+   | B _ -> assert false);
+  (match B 3 with
+   | B 3 -> ()
+   | _ -> assert false);
+  (match (A : string gadt) with
+   | A -> ()
+   | B _ -> assert false);
+  (match B "custom" with
+   | B "custom" -> ()
+   | _ -> assert false)
+;;
+
+(* [map] preserves NULL and transforms the payload. *)
+let () =
+  (match map_gadt (fun x -> x + 1) (B 4) with
+   | B 5 -> ()
+   | _ -> assert false);
+  (match map_gadt (fun x -> x + 1) A with
+   | A -> ()
+   | _ -> assert false);
+  (match map_gadt String.length (B "abcd") with
+   | B 4 -> ()
+   | _ -> assert false)
+;;
+
+(* Concrete-index GADT: match refines the index at run time. *)
+let concrete_len : type a. a concrete_gadt -> int = function
+  | Null -> -1
+  | This s -> String.length s
+
+let () =
+  assert (concrete_len (Null : int concrete_gadt) = -1);
+  assert (concrete_len (This "hello") = 5);
+  (match (This "hi" : bool concrete_gadt) with
+   | This "hi" -> ()
+   | This _ -> assert false)
+;;
+
+(* Compound payload mentioning the index. *)
+let () =
+  (match Comp ("x", 7) with
+   | Comp ("x", 7) -> ()
+   | _ -> assert false);
+  (match (Comp_null : string compound_gadt) with
+   | Comp_null -> ()
+   | Comp _ -> assert false);
+  let get_snd : type a. a compound_gadt -> int = function
+    | Comp_null -> 0
+    | Comp (_, n) -> n
+  in
+  assert (get_snd (Comp ("y", 9)) = 9);
+  assert (get_snd (Comp_null : int compound_gadt) = 0)
+;;
+
+(* Existential payload. *)
+let () =
+  (match (Something 3.14 : int existential_gadt) with
+   | Something _ -> ()
+   | Nothing -> assert false);
+  (match (Nothing : int existential_gadt) with
+   | Nothing -> ()
+   | Something _ -> assert false)
+;;
+
+(* [int gadt array]: the conservative decl jkind is refined to separable at
+   the use site, so a value array with NULL slots builds and folds. *)
+let sum_int_gadt (arr : int gadt array) =
+  Array.fold_left (fun acc x -> match x with A -> acc | B n -> acc + n) 0 arr
+
+let () =
+  let arr = [| B 1; A; B 3; A; B 4 |] in
+  assert (Array.length arr = 5);
+  assert (sum_int_gadt arr = 8);
+  arr.(1) <- B 10;
+  assert (sum_int_gadt arr = 18);
+  arr.(0) <- A;
+  assert (sum_int_gadt arr = 17)
+;;
+
+(* Marshalling round-trips NULL and payload. *)
+let () =
+  let bytes = Marshal.to_bytes (B 9) [] in
+  (match Marshal.from_bytes bytes 0 with
+   | B 9 -> ()
+   | _ -> assert false);
+  let bytes = Marshal.to_bytes (A : int gadt) [] in
+  (match Marshal.from_bytes bytes 0 with
+   | A -> ()
+   | _ -> assert false);
+  let bytes = Marshal.to_bytes (This "round") [] in
+  (match (Marshal.from_bytes bytes 0 : bool concrete_gadt) with
+   | This "round" -> ()
+   | _ -> assert false)
+;;
+
+(* Structural comparison discriminates NULL from payload. *)
+let () =
+  assert ((A : int gadt) = A);
+  assert (B 4 = B 4);
+  assert ((A : int gadt) <> B 4);
+  assert (compare (A : int gadt) (B 4) < 0);
+  assert (compare (B 4) (A : int gadt) > 0);
+  assert (compare (B 4) (B 5) < 0)
+;;
+
+(* Float payload GADT: boxed float payloads construct, match and compare;
+   the type never enters a flat float array (gadts.ml pins the rejection). *)
+type _ fp =
+  | FNull : int fp
+  | FThis : float -> float fp
+[@@or_null]
+
+let fp_to_float : type a. a fp -> float = function
+  | FNull -> 0.
+  | FThis f -> f
+
+let () =
+  (match FThis 3.5 with
+   | FThis f -> assert (f = 3.5));
+  (match (FNull : int fp) with
+   | FNull -> ()
+   (* The wildcard avoids warning 8: exhaustiveness does not refine [FThis]
+      away at the [int] index for [Variant_with_null] (the same pre-existing
+      counter-example imprecision pinned in gadts.ml). *)
+   | _ -> assert false);
+  assert (fp_to_float (FThis 2.25) = 2.25);
+  assert (fp_to_float (FNull : int fp) = 0.);
+  assert (FThis 1.5 < FThis 2.5);
+  assert ((FNull : int fp) = FNull)
+;;
+
+(* Polymorphic GADT at a [float] index. *)
+let () =
+  (match map_gadt (fun x -> x +. 1.0) (B 2.5) with
+   | B f -> assert (f = 3.5)
+   | A -> assert false);
+  (match (A : float gadt) with
+   | A -> ()
+   | B _ -> assert false)
+;;
+
+(* GADT with a unary all-void null constructor: construction evaluates the
+   void argument (and its effects) before producing NULL, and matching
+   synthesizes the void binding. *)
+type void : void mod everything
+external void : unit -> void = "%unbox_unit"
+
+let[@inline never] use_void (v : void) =
+  let _ : void = v in
+  1
+
+type _ vg =
+  | VNull : void -> int vg
+  | VThis : int -> int vg
+[@@or_null]
+
+let () =
+  (match VNull (void ()) with
+   | VNull v when use_void v = 1 -> ()
+   | _ -> assert false);
+  let effects = ref 0 in
+  let void_effect () =
+    incr effects;
+    void ()
+  in
+  (match VNull (void_effect ()) with
+   | VNull _ -> assert (!effects = 1)
+   | VThis _ -> assert false);
+  (match VThis 7 with
+   | VThis 7 -> ()
+   | _ -> assert false);
+  assert (VNull (void ()) <> VThis 0);
+  let to_int : int vg -> int = function
+    | VNull _ -> 0
+    | VThis n -> n
+  in
+  assert (to_int (VNull (void ())) = 0);
+  assert (to_int (VThis 9) = 9);
+  let arr = [| VThis 1; VNull (void ()); VThis 3 |] in
+  let sum = Array.fold_left (fun acc x -> acc + to_int x) 0 arr in
+  assert (sum = 4)
+;;
+
+(* Flipped constructor order for the void-null GADT. *)
+type _ wg =
+  | WThis : int -> int wg
+  | WNull : void -> int wg
+[@@or_null]
+
+let () =
+  (match WNull (void ()) with
+   | WNull _ -> ()
+   | WThis _ -> assert false);
+  (match WThis 5 with
+   | WThis 5 -> ()
+   | _ -> assert false)
+;;
+
+let () = print_endline "All tests passed!"

--- a/testsuite/tests/typing-layouts-or-null/gadts_runtime.reference
+++ b/testsuite/tests/typing-layouts-or-null/gadts_runtime.reference
@@ -1,0 +1,1 @@
+All tests passed!

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2411,6 +2411,22 @@ module Jkind0 = struct
       (orphaned_type_var_list @ domain)
       (type_of_kind_list @ range)
 
+  let variant_constructor_gadt_extra_substs
+      ~projected_params ~cstr_res ~payload_tys ~get_free_vars =
+    match cstr_res with
+    | None -> []
+    | Some res ->
+      let res_args =
+        match get_desc res with
+        | Tconstr (_, args, _) -> args
+        | _ -> Misc.fatal_error "cd_res must be Tconstr"
+      in
+      gadt_payload_subst
+        ~projected_params
+        ~res_args
+        ~payload_tys
+        ~get_free_vars
+
   let project_variant_constructor_arg_tys
       ~decl_params ~type_apply ~get_free_vars cstr =
     let cstr_arg_tys =
@@ -2418,26 +2434,18 @@ module Jkind0 = struct
       | Cstr_tuple args -> List.map (fun arg -> arg.ca_type) args
       | Cstr_record lbls -> List.map (fun lbl -> lbl.ld_type) lbls
     in
-    match cstr.cd_res with
-    | None -> cstr_arg_tys
-    | Some res ->
-      let res_args =
-        match get_desc res with
-        | Tconstr (_, args, _) -> args
-        | _ -> Misc.fatal_error "cd_res must be Tconstr"
-      in
-      let extra_substs =
-        gadt_payload_subst
-          ~projected_params:decl_params
-          ~res_args
-          ~payload_tys:cstr_arg_tys
-          ~get_free_vars
-      in
-      if Misc.Stdlib.List.is_empty extra_substs then
-        cstr_arg_tys
-      else
-        let domain, range = List.split extra_substs in
-        List.map (fun ty -> type_apply domain ty range) cstr_arg_tys
+    let extra_substs =
+      variant_constructor_gadt_extra_substs
+        ~projected_params:decl_params
+        ~cstr_res:cstr.cd_res
+        ~payload_tys:cstr_arg_tys
+        ~get_free_vars
+    in
+    if Misc.Stdlib.List.is_empty extra_substs then
+      cstr_arg_tys
+    else
+      let domain, range = List.split extra_substs in
+      List.map (fun ty -> type_apply domain ty range) cstr_arg_tys
 
   let for_boxed_variant ~loc ~decl_params ~type_apply ~get_free_vars cstrs =
     let base =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2411,6 +2411,34 @@ module Jkind0 = struct
       (orphaned_type_var_list @ domain)
       (type_of_kind_list @ range)
 
+  let project_variant_constructor_arg_tys
+      ~decl_params ~type_apply ~get_free_vars cstr =
+    let cstr_arg_tys =
+      match cstr.cd_args with
+      | Cstr_tuple args -> List.map (fun arg -> arg.ca_type) args
+      | Cstr_record lbls -> List.map (fun lbl -> lbl.ld_type) lbls
+    in
+    match cstr.cd_res with
+    | None -> cstr_arg_tys
+    | Some res ->
+      let res_args =
+        match get_desc res with
+        | Tconstr (_, args, _) -> args
+        | _ -> Misc.fatal_error "cd_res must be Tconstr"
+      in
+      let extra_substs =
+        gadt_payload_subst
+          ~projected_params:decl_params
+          ~res_args
+          ~payload_tys:cstr_arg_tys
+          ~get_free_vars
+      in
+      if Misc.Stdlib.List.is_empty extra_substs then
+        cstr_arg_tys
+      else
+        let domain, range = List.split extra_substs in
+        List.map (fun ty -> type_apply domain ty range) cstr_arg_tys
+
   let for_boxed_variant ~loc ~decl_params ~type_apply ~get_free_vars cstrs =
     let base =
       let all_args_void =
@@ -2451,47 +2479,19 @@ module Jkind0 = struct
     in
     let base = mark_best base in
     let add_with_bounds_for_cstr jkind_so_far cstr =
-      let cstr_arg_tys, cstr_arg_modalities =
+      let cstr_arg_modalities =
         match cstr.cd_args with
         | Cstr_tuple args ->
-          List.fold_left
-            (fun (tys, ms) arg -> arg.ca_type :: tys, arg.ca_modalities :: ms)
-            ([], []) args
+          List.map (fun arg -> arg.ca_modalities) args
         | Cstr_record lbls ->
-          List.fold_left
-            (fun (tys, ms) lbl -> lbl.ld_type :: tys, lbl.ld_modalities :: ms)
-            ([], []) lbls
+          List.map (fun lbl -> lbl.ld_modalities) lbls
       in
       let cstr_arg_tys =
-        match cstr.cd_res with
-        | None -> cstr_arg_tys
-        | Some res ->
-          (* See Note [With-bounds for GADTs] for an overview. *)
-          let apply_subst domain range tys =
-            if Misc.Stdlib.List.is_empty domain
-            then tys
-            else List.map (fun ty -> type_apply domain ty range) tys
-          in
-          let res_args =
-            match get_desc res with
-            | Tconstr (_, args, _) -> args
-            | _ -> Misc.fatal_error "cd_res must be Tconstr"
-          in
-          let extra_substs =
-            gadt_payload_subst
-              ~projected_params:decl_params
-              ~res_args
-              ~payload_tys:cstr_arg_tys
-              ~get_free_vars
-          in
-          let domain, range = List.split extra_substs in
-          let cstr_arg_tys =
-            apply_subst
-              domain
-              range
-              cstr_arg_tys
-          in
-          cstr_arg_tys
+        project_variant_constructor_arg_tys
+          ~decl_params
+          ~type_apply
+          ~get_free_vars
+          cstr
       in
       List.fold_left2
         (fun jkind type_expr modality ->

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2469,6 +2469,23 @@ module Jkind0 = struct
       (orphaned_type_var_list @ domain)
       (type_of_kind_list @ range)
 
+  (* Wraps [gadt_payload_subst] with the [cd_res] unpacking shared by the two
+     [Variant_with_null] sites that project a GADT payload onto instantiated
+     head arguments: the declaration jkind ([Typedecl.update_decl_jkind]) and
+     each use site ([Ctype.unbox_once]). A non-GADT payload ([cstr_res = None])
+     needs no projection. *)
+  let variant_constructor_gadt_extra_substs
+      ~projected_params ~cstr_res ~payload_tys ~get_free_vars =
+    match cstr_res with
+    | None -> []
+    | Some res ->
+      let res_args =
+        match get_desc res with
+        | Tconstr (_, args, _) -> args
+        | _ -> Misc.fatal_error "cd_res must be Tconstr"
+      in
+      gadt_payload_subst ~projected_params ~res_args ~payload_tys ~get_free_vars
+
   let for_boxed_variant ~loc ~decl_params ~type_apply ~get_free_vars cstrs =
     let base =
       let all_args_void =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2481,6 +2481,23 @@ module Jkind0 = struct
       (orphaned_type_var_list @ domain)
       (type_of_kind_list @ range)
 
+  (* Wraps [gadt_payload_subst] with the [cd_res] unpacking shared by the two
+     [Variant_with_null] sites that project a GADT payload onto instantiated
+     head arguments: the declaration jkind ([Typedecl.update_decl_jkind]) and
+     each use site ([Ctype.unbox_once]). A non-GADT payload ([cstr_res = None])
+     needs no projection. *)
+  let variant_constructor_gadt_extra_substs
+      ~projected_params ~cstr_res ~payload_tys ~get_free_vars =
+    match cstr_res with
+    | None -> []
+    | Some res ->
+      let res_args =
+        match get_desc res with
+        | Tconstr (_, args, _) -> args
+        | _ -> Misc.fatal_error "cd_res must be Tconstr"
+      in
+      gadt_payload_subst ~projected_params ~res_args ~payload_tys ~get_free_vars
+
   let for_boxed_variant ~loc ~decl_params ~type_apply ~get_free_vars cstrs =
     let base =
       let all_args_void =

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -711,6 +711,16 @@ module Jkind0 : sig
       payload_tys:Types.type_expr list ->
       get_free_vars:(Types.type_expr list -> TypeSet.t) ->
       (Types.type_expr * Types.type_expr) list
+    val project_variant_constructor_arg_tys :
+      decl_params:Types.type_expr list ->
+      type_apply:
+        (Types.type_expr list ->
+        Types.type_expr ->
+        Types.type_expr list ->
+        Types.type_expr) ->
+      get_free_vars:(Types.type_expr list -> TypeSet.t) ->
+      Types.constructor_declaration ->
+      Types.type_expr list
     val for_boxed_variant :
       loc:Location.t ->
       decl_params:Types.type_expr list ->

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -711,6 +711,12 @@ module Jkind0 : sig
       payload_tys:Types.type_expr list ->
       get_free_vars:(Types.type_expr list -> TypeSet.t) ->
       (Types.type_expr * Types.type_expr) list
+    val variant_constructor_gadt_extra_substs :
+      projected_params:Types.type_expr list ->
+      cstr_res:Types.type_expr option ->
+      payload_tys:Types.type_expr list ->
+      get_free_vars:(Types.type_expr list -> TypeSet.t) ->
+      (Types.type_expr * Types.type_expr) list
     val project_variant_constructor_arg_tys :
       decl_params:Types.type_expr list ->
       type_apply:

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -737,6 +737,13 @@ module Jkind0 : sig
       get_free_vars:(Types.type_expr list -> TypeSet.t) ->
       (Types.type_expr * Types.type_expr) list
 
+    val variant_constructor_gadt_extra_substs :
+      projected_params:Types.type_expr list ->
+      cstr_res:Types.type_expr option ->
+      payload_tys:Types.type_expr list ->
+      get_free_vars:(Types.type_expr list -> TypeSet.t) ->
+      (Types.type_expr * Types.type_expr) list
+
     val for_boxed_variant :
       loc:Location.t ->
       decl_params:Types.type_expr list ->

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -743,6 +743,13 @@ module Jkind0 : sig
       get_free_vars:(Types.type_expr list -> TypeSet.t) ->
       (Types.type_expr * Types.type_expr) list
 
+    val variant_constructor_gadt_extra_substs :
+      projected_params:Types.type_expr list ->
+      cstr_res:Types.type_expr option ->
+      payload_tys:Types.type_expr list ->
+      get_free_vars:(Types.type_expr list -> TypeSet.t) ->
+      (Types.type_expr * Types.type_expr) list
+
     val for_boxed_variant :
       loc:Location.t ->
       decl_params:Types.type_expr list ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2600,14 +2600,9 @@ let unbox_once env ty =
             (* Unboxed GADT wrappers need the same B1-B4 projection as boxed
                GADTs, but projected onto the instantiated head arguments of the
                wrapper type rather than the declaration parameters. *)
-            let res_args =
-              match get_desc cstr.Types.cstr_res with
-              | Tconstr (_, res_args, _) -> res_args
-              | _ -> Misc.fatal_error "Ctype.unbox_once: cstr_res"
-            in
-            Btype.Jkind0.gadt_payload_subst
+            Btype.Jkind0.variant_constructor_gadt_extra_substs
               ~projected_params:args
-              ~res_args
+              ~cstr_res:(Some cstr.Types.cstr_res)
               ~payload_tys:[ty2]
               ~get_free_vars:(free_variable_set_of_list env)
           | Type_variant ([{ cstr_generalized = false }], _, _) -> []
@@ -2634,22 +2629,14 @@ let unbox_once env ty =
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some
-              { payload_cstr = { Types.cd_res; _ };
+              { payload_cstr;
                 payload_arg = { ca_type = ty; ca_modalities = modality; _ } } ->
             let extra_substs =
-              match cd_res with
-              | Some res ->
-                let res_args =
-                  match get_desc res with
-                  | Tconstr (_, res_args, _) -> res_args
-                  | _ -> Misc.fatal_error "Ctype.unbox_once: Variant_with_null"
-                in
-                Btype.Jkind0.gadt_payload_subst
-                  ~projected_params:args
-                  ~res_args
-                  ~payload_tys:[ty]
-                  ~get_free_vars:(free_variable_set_of_list env)
-              | None -> []
+              Btype.Jkind0.variant_constructor_gadt_extra_substs
+                ~projected_params:args
+                ~cstr_res:payload_cstr.cd_res
+                ~payload_tys:[ty]
+                ~get_free_vars:(free_variable_set_of_list env)
             in
             Stepped_or_null
               { ty = apply ty ~extra_substs;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2634,10 +2634,25 @@ let unbox_once env ty =
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some
-              { payload_arg = { ca_type = ty; ca_modalities = modality; _ };
-                _ } ->
+              { payload_cstr = { Types.cd_res; _ };
+                payload_arg = { ca_type = ty; ca_modalities = modality; _ } } ->
+            let extra_substs =
+              match cd_res with
+              | Some res ->
+                let res_args =
+                  match get_desc res with
+                  | Tconstr (_, res_args, _) -> res_args
+                  | _ -> Misc.fatal_error "Ctype.unbox_once: Variant_with_null"
+                in
+                Btype.Jkind0.gadt_payload_subst
+                  ~projected_params:args
+                  ~res_args
+                  ~payload_tys:[ty]
+                  ~get_free_vars:(free_variable_set_of_list env)
+              | None -> []
+            in
             Stepped_or_null
-              { ty = apply ty ~extra_substs:[];
+              { ty = apply ty ~extra_substs;
                 modality }
           | None ->
             Misc.fatal_error "Invalid constructor for Variant_with_null"

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2782,10 +2782,23 @@ let unbox_once env ty =
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some
-              { payload_arg = { ca_type; ca_modalities = modality; _ };
-                _ } ->
+              { payload_cstr = { cd_res; _ };
+                payload_arg = { ca_type; ca_modalities = modality; _ } } ->
+            (* A GADT [@@or_null] wrapper needs the same B1-B4 projection as
+               boxed and unboxed GADTs, projected onto the instantiated head
+               arguments of the wrapper type. This keeps the unwrapped
+               payload's jkind honest -- in particular a [float] payload stays
+               [maybe_separable] once wrapped, so it cannot enter a flat float
+               array. A non-GADT payload needs no projection. *)
+            let extra_substs =
+              Btype.Jkind0.variant_constructor_gadt_extra_substs
+                ~projected_params:args
+                ~cstr_res:cd_res
+                ~payload_tys:[ca_type]
+                ~get_free_vars:(free_variable_set_of_list env)
+            in
             Stepped
-              { ty = apply ca_type ~extra_substs:[];
+              { ty = apply ca_type ~extra_substs;
                 modality;
                 or_null = Some { decl; args; prev = ty } }
           | None ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2804,10 +2804,23 @@ let unbox_once env ty =
         | Type_variant (cstrs, Variant_with_null, _) ->
           begin match Datarepr.find_variant_with_null_payload cstrs with
           | Some
-              { payload_arg = { ca_type; ca_modalities = modality; _ };
-                _ } ->
+              { payload_cstr = { cd_res; _ };
+                payload_arg = { ca_type; ca_modalities = modality; _ } } ->
+            (* A GADT [@@or_null] wrapper needs the same B1-B4 projection as
+               boxed and unboxed GADTs, projected onto the instantiated head
+               arguments of the wrapper type. This keeps the unwrapped
+               payload's jkind honest -- in particular a [float] payload stays
+               [maybe_separable] once wrapped, so it cannot enter a flat float
+               array. A non-GADT payload needs no projection. *)
+            let extra_substs =
+              Btype.Jkind0.variant_constructor_gadt_extra_substs
+                ~projected_params:args
+                ~cstr_res:cd_res
+                ~payload_tys:[ca_type]
+                ~get_free_vars:(free_variable_set_of_list env)
+            in
             Stepped
-              { ty = apply ca_type ~extra_substs:[];
+              { ty = apply ca_type ~extra_substs;
                 modality;
                 or_null = Some { decl; args; prev = ty } }
           | None ->
@@ -2839,15 +2852,37 @@ let contained_without_boxing env ty =
          [update_decl_jkind] has filled in the argument sorts, and the
          callers of this function run before that on the current
          recursive group. Returning the arguments of both constructors
-         does not depend on constructor order or sorts. *)
+         does not depend on constructor order or sorts.
+
+         A GADT constructor's argument types are constructor-local, so
+         they get the same B1-B4 projection onto the instantiated head
+         arguments as in [unbox_once]: without it, edges through a GADT
+         payload variable are invisible to the unboxed-recursion check,
+         which then accepts an unboxed cycle re-entering through the
+         payload of a widened-parameter GADT [@@or_null] that the
+         projected (and non-GADT) form rejects. *)
       List.concat_map
         (fun (cstr : constructor_declaration) ->
            match cstr.cd_args with
            | Cstr_tuple cargs ->
+             let payload_tys =
+               List.map
+                 (fun (carg : constructor_argument) -> carg.ca_type)
+                 cargs
+             in
+             let extra_substs =
+               Btype.Jkind0.variant_constructor_gadt_extra_substs
+                 ~projected_params:args
+                 ~cstr_res:cstr.cd_res
+                 ~payload_tys
+                 ~get_free_vars:(free_variable_set_of_list env)
+             in
+             let extra_params, extra_args = List.split extra_substs in
              List.map
-               (fun (carg : constructor_argument) ->
-                  apply env type_params carg.ca_type args)
-               cargs
+               (fun ty ->
+                  apply env (extra_params @ type_params) ty
+                    (extra_args @ args))
+               payload_tys
            | Cstr_record _ -> [])
         cstrs
     | _ | exception Not_found ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -194,14 +194,6 @@ let check_or_null_decl bad sdecl =
 
 let check_or_null_constructors bad = function
   | [c1; c2] ->
-    let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
-      match pcd_res with
-      | None -> ()
-      | Some _ ->
-        bad "GADT constructors are not supported with [@@or_null]"
-    in
-    check_no_gadt c1;
-    check_no_gadt c2;
     begin match c1.pcd_args, c2.pcd_args with
     | Pcstr_tuple [],
       Pcstr_tuple
@@ -995,8 +987,14 @@ let transl_declaration env sdecl (id, uid) =
         Ttype_abstract, Type_abstract Definition,
         Jkind.Builtin.value ~why:Default_type_jkind
       | Ptype_variant scstrs ->
+        let has_gadt =
+          List.exists
+            (fun ({ pcd_res; _ } : Parsetree.constructor_declaration) ->
+              Option.is_some pcd_res)
+            scstrs
+        in
         if or_null then check_or_null_variant_shape sdecl scstrs;
-        if List.exists (fun cstr -> cstr.pcd_res <> None) scstrs then begin
+        if has_gadt then begin
           match cstrs with
             [] -> ()
           | (_,_,loc)::_ ->
@@ -1059,9 +1057,12 @@ let transl_declaration env sdecl (id, uid) =
         let rep, jkind =
           match or_null_payload_arg with
           | Some payload_arg ->
-            let payload_ty = payload_arg.Types.ca_type in
             Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path payload_ty
+            if has_gadt then
+              Jkind.Builtin.value_or_null ~why:(Primitive Predef.ident_or_null)
+            else
+              let payload_ty = payload_arg.Types.ca_type in
+              Btype.Jkind0.for_variant_with_null_result path payload_ty
           | None ->
             if unbox then
               Variant_unboxed,
@@ -2198,9 +2199,21 @@ let rec update_decl_jkind env dpath decl =
     | _, Variant_with_null ->
       begin match Datarepr.find_variant_with_null_payload cstrs with
       | Some
-          { payload_cstr = { Types.cd_uid; _ };
+          { payload_cstr = ({ Types.cd_uid; cd_res; _ } as payload_cstr);
             payload_arg = { ca_type = ty; ca_modalities = modality; _ } } ->
-        let jkind = Ctype.type_jkind env ty in
+        let projected_payload_ty =
+          match
+            Btype.Jkind0.project_variant_constructor_arg_tys
+              ~decl_params:decl.type_params
+              ~type_apply:(Ctype.apply env)
+              ~get_free_vars:(Ctype.free_variable_set_of_list env)
+              payload_cstr
+          with
+          | [payload_ty] -> payload_ty
+          | [] | _ :: _ :: _ ->
+            Misc.fatal_error "Invalid constructor for Variant_with_null"
+        in
+        let jkind = Ctype.type_jkind env projected_payload_ty in
         let sort = Jkind.sort_of_jkind env jkind in
         let ca_sort = Jkind.Sort.default_to_value_and_get sort in
         let cstrs =
@@ -2218,15 +2231,21 @@ let rec update_decl_jkind env dpath decl =
                else cstr)
             cstrs
         in
-        begin match
-          Jkind.apply_modality_l modality jkind
-          |> Jkind.apply_or_null_l
-        with
-        | Ok type_jkind -> cstrs, rep, type_jkind
-        | Error () ->
-          Misc.fatal_error
-            "Typedecl.update_variant_kind: Variant_with_null payload is \
-             already maybe-null"
+        begin match cd_res with
+        | Some _ ->
+          cstrs, rep,
+          Jkind.Builtin.value_or_null ~why:(Primitive Predef.ident_or_null)
+        | None ->
+          begin match
+            Jkind.apply_modality_l modality (Ctype.type_jkind env ty)
+            |> Jkind.apply_or_null_l
+          with
+          | Ok type_jkind -> cstrs, rep, type_jkind
+          | Error () ->
+            Misc.fatal_error
+              "Typedecl.update_variant_kind: Variant_with_null payload is \
+               already maybe-null"
+          end
         end
       | None ->
         Misc.fatal_error "Invalid constructor for Variant_with_null"

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -198,14 +198,6 @@ let check_or_null_decl bad sdecl =
 
 let check_or_null_constructors bad = function
   | [c1; c2] ->
-    let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
-      match pcd_res with
-      | None -> ()
-      | Some _ ->
-        bad "GADT constructors are not supported with [@@or_null]"
-    in
-    check_no_gadt c1;
-    check_no_gadt c2;
     begin match c1.pcd_args, c2.pcd_args with
     | Pcstr_tuple [],
       Pcstr_tuple
@@ -1136,8 +1128,25 @@ let transl_declaration env sdecl (id, uid) =
           | Some payload_arg ->
             let payload_ty = payload_arg.Types.ca_type in
             let modality = payload_arg.Types.ca_modalities in
-            Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path ~modality payload_ty
+            let jkind =
+              if List.exists
+                   (fun (c : Types.constructor_declaration) ->
+                     c.cd_res <> None)
+                   cstrs
+              then
+                (* For a GADT [@@or_null], the payload type lives in the
+                   constructor's local scope and may mention existential
+                   variables; adding it as a with-bound during the
+                   recursive-group phase would capture an out-of-scope
+                   variable. Use a bound-free [value_or_null] default here,
+                   just like boxed variants use a bound-free default; the real
+                   with-bounds are computed later in [update_decl_jkind]. *)
+                Jkind.Builtin.value_or_null ~why:(Or_null_payload path)
+              else
+                Btype.Jkind0.for_variant_with_null_result path ~modality
+                  payload_ty
+            in
+            Variant_with_null, jkind
           | None ->
             if unbox then
               Variant_unboxed,
@@ -2532,7 +2541,7 @@ let rec update_decl_jkind env dpath decl =
     | _, Variant_with_null ->
       begin match Datarepr.find_variant_with_null_payload cstrs with
       | Some
-          { payload_cstr = { Types.cd_uid; _ };
+          { payload_cstr = { Types.cd_uid; cd_res; _ };
             payload_arg = { ca_type = ty; ca_modalities = modality; _ } } ->
         let jkind = Ctype.type_jkind env ty in
         let sort = Jkind.sort_of_jkind env jkind in
@@ -2553,21 +2562,60 @@ let rec update_decl_jkind env dpath decl =
                else cstr)
             cstrs
         in
-        begin match
-          Jkind.apply_modality_l modality jkind
-          |> Jkind.apply_or_null_l env
-        with
-        | Ok type_jkind ->
-          let type_jkind =
-            Jkind.History.update_reason type_jkind
-              (Value_or_null_creation (Or_null_payload dpath))
+        (* For a GADT [@@or_null] the payload type lives in the constructor's
+           local scope: it mentions the constructor's own copies of the
+           declaration parameters (refined by the result-type indices) and may
+           mention existentials. Project it onto the declaration parameters
+           using Steps B1-B4 of Note [With-bounds for GADTs] (orphaned
+           existentials become [Tof_kind]), exactly as [for_boxed_variant]
+           does for boxed GADTs. The projected payload is expressed purely in
+           the declaration parameters, so it can feed the ordinary non-GADT
+           jkind computation below and yields a precise declaration jkind (e.g.
+           [immediate_or_null] for a ground [int] payload). Separability is
+           kept honest per instantiation by [Ctype.unbox_once], not by this
+           declaration jkind. *)
+        let payload_ty =
+          let extra_substs =
+            Btype.Jkind0.variant_constructor_gadt_extra_substs
+              ~projected_params:decl.type_params
+              ~cstr_res:cd_res
+              ~payload_tys:[ty]
+              ~get_free_vars:(Ctype.free_variable_set_of_list env)
           in
-          cstrs, rep, type_jkind
-        | Error () ->
-          Misc.fatal_error
-            "Typedecl.update_variant_kind: Variant_with_null payload is \
-             already maybe-null"
-        end
+          match extra_substs with
+          | [] -> ty
+          | _ ->
+            let domain, range = List.split extra_substs in
+            Ctype.apply env domain ty range
+        in
+        let payload_jkind = Ctype.type_jkind env payload_ty in
+        let type_jkind =
+          match
+            Jkind.apply_modality_l modality payload_jkind
+            |> Jkind.apply_or_null_l env
+          with
+          | Ok type_jkind -> type_jkind
+          | Error () ->
+            begin match cd_res with
+            | Some _ ->
+              (* A GADT payload's parameter is constructor-local, so
+                 [constrain_or_null_payload] does not narrow the declaration
+                 parameter: a widened parameter (e.g. [('a : any)]) can reach
+                 here with a non-[value] layout that [apply_or_null_l] rejects.
+                 Fall back to the conservative [value_or_null] jkind, which is
+                 always sound. *)
+              Jkind.Builtin.value_or_null ~why:(Or_null_payload dpath)
+            | None ->
+              Misc.fatal_error
+                "Typedecl.update_variant_kind: Variant_with_null payload is \
+                 already maybe-null"
+            end
+        in
+        let type_jkind =
+          Jkind.History.update_reason type_jkind
+            (Value_or_null_creation (Or_null_payload dpath))
+        in
+        cstrs, rep, type_jkind
       | None ->
         Misc.fatal_error "Invalid constructor for Variant_with_null"
       end

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -197,14 +197,6 @@ let check_or_null_decl bad sdecl =
 
 let check_or_null_constructors bad = function
   | [c1; c2] ->
-    let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
-      match pcd_res with
-      | None -> ()
-      | Some _ ->
-        bad "GADT constructors are not supported with [@@or_null]"
-    in
-    check_no_gadt c1;
-    check_no_gadt c2;
     let check_args ({ pcd_args; _ } : Parsetree.constructor_declaration) =
       match pcd_args with
       | Pcstr_tuple [] | Pcstr_tuple [_] -> ()
@@ -1149,12 +1141,29 @@ let transl_declaration env sdecl (id, uid) =
               bad_or_null_payload_count sdecl.ptype_loc
             | _ :: _ -> ()
             end;
-            Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path
-              (List.map
-                 (fun (arg : Types.constructor_argument) ->
-                    arg.ca_modalities, arg.ca_type)
-                 unary_args)
+            let jkind =
+              if List.exists
+                   (fun (c : Types.constructor_declaration) ->
+                     c.cd_res <> None)
+                   cstrs
+              then
+                (* For a GADT [@@or_null], a constructor's argument type
+                   lives in the constructor's local scope and may mention
+                   existential variables; adding it as a with-bound during
+                   the recursive-group phase would capture an out-of-scope
+                   variable. Use a bound-free [value_or_null] default here,
+                   just like boxed variants use a bound-free default; the
+                   real with-bounds are computed later in
+                   [update_decl_jkind]. *)
+                Jkind.Builtin.value_or_null ~why:(Or_null_payload path)
+              else
+                Btype.Jkind0.for_variant_with_null_result path
+                  (List.map
+                     (fun (arg : Types.constructor_argument) ->
+                        arg.ca_modalities, arg.ca_type)
+                     unary_args)
+            in
+            Variant_with_null, jkind
           end
           else if unbox then
             Variant_unboxed,
@@ -2552,7 +2561,9 @@ let rec update_decl_jkind env dpath decl =
                  | Some sort when Jkind.Sort.Const.all_void sort ->
                    (* The null constructor. *)
                    begin match !null_payload with
-                   | None -> null_payload := Some (ca_modalities, ca_type)
+                   | None ->
+                     null_payload :=
+                       Some (cstr.cd_res, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
                    Some sort
@@ -2561,7 +2572,9 @@ let rec update_decl_jkind env dpath decl =
                    constrain_or_null_payload ~env ~path:dpath ca_type ca_loc;
                    let jkind = Ctype.type_jkind env ca_type in
                    begin match !payload with
-                   | None -> payload := Some (jkind, ca_modalities, ca_type)
+                   | None ->
+                     payload :=
+                       Some (cstr.cd_res, jkind, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
                    sort_of_jkind jkind
@@ -2571,32 +2584,76 @@ let rec update_decl_jkind env dpath decl =
                Misc.fatal_error "Invalid constructor for Variant_with_null")
           cstrs
       in
+      (* For a GADT [@@or_null] a constructor's argument type lives in the
+         constructor's local scope: it mentions the constructor's own copies
+         of the declaration parameters (refined by the result-type indices)
+         and may mention existentials. Project it onto the declaration
+         parameters using Steps B1-B4 of Note [With-bounds for GADTs]
+         (orphaned existentials become [Tof_kind]), exactly as
+         [for_boxed_variant] does for boxed GADTs. The projected type is
+         expressed purely in the declaration parameters, so it can feed the
+         ordinary non-GADT jkind computation below and yields a precise
+         declaration jkind (e.g. [immediate_or_null] for a ground [int]
+         payload). Separability is kept honest per instantiation by
+         [Ctype.unbox_once], not by this declaration jkind. *)
+      let project cstr_res ty =
+        let extra_substs =
+          Btype.Jkind0.variant_constructor_gadt_extra_substs
+            ~projected_params:decl.type_params
+            ~cstr_res
+            ~payload_tys:[ty]
+            ~get_free_vars:(Ctype.free_variable_set_of_list env)
+        in
+        match extra_substs with
+        | [] -> ty
+        | _ ->
+          let domain, range = List.split extra_substs in
+          Ctype.apply env domain ty range
+      in
       begin match !payload with
-      | Some (jkind, modality, payload_type) ->
-        begin match
-          Jkind.for_or_null_variant env ~payload_type ~modality
-            ~payload_jkind:jkind
-        with
-        | Ok type_jkind ->
-          let type_jkind =
+      | Some (cd_res, jkind, modality, payload_type) ->
+        let payload_type = project cd_res payload_type in
+        let jkind =
+          match cd_res with
+          | None -> jkind
+          | Some _ -> Ctype.type_jkind env payload_type
+        in
+        let type_jkind =
+          match
+            Jkind.for_or_null_variant env ~payload_type ~modality
+              ~payload_jkind:jkind
+          with
+          | Ok type_jkind ->
             (* A void argument of the null constructor still counts
                towards the bounds of the declaration: matching on the null
                constructor synthesizes a value of that type. *)
-            match !null_payload with
+            begin match !null_payload with
             | None -> type_jkind
-            | Some (modality, type_expr) ->
+            | Some (null_cd_res, modality, type_expr) ->
+              let type_expr = project null_cd_res type_expr in
               Btype.Jkind0.add_with_bounds ~modality ~type_expr type_jkind
-          in
-          let type_jkind =
-            Jkind.History.update_reason type_jkind
-              (Value_or_null_creation (Or_null_payload dpath))
-          in
-          cstrs, rep, type_jkind
-        | Error () ->
-          Misc.fatal_error
-            "Typedecl.update_variant_kind: Variant_with_null payload is \
-             already maybe-null"
-        end
+            end
+          | Error () ->
+            begin match cd_res with
+            | Some _ ->
+              (* A GADT payload's parameter is constructor-local, so
+                 [constrain_or_null_payload] does not narrow the declaration
+                 parameter: a widened parameter (e.g. [('a : any)]) can reach
+                 here with a non-[value] layout that [for_or_null_variant]
+                 rejects. Fall back to the conservative [value_or_null]
+                 jkind, which is always sound. *)
+              Jkind.Builtin.value_or_null ~why:(Or_null_payload dpath)
+            | None ->
+              Misc.fatal_error
+                "Typedecl.update_variant_kind: Variant_with_null payload is \
+                 already maybe-null"
+            end
+        in
+        let type_jkind =
+          Jkind.History.update_reason type_jkind
+            (Value_or_null_creation (Or_null_payload dpath))
+        in
+        cstrs, rep, type_jkind
       | None -> bad_or_null_payload_count loc
       end
     | [{Types.cd_args} as cstr], Variant_unboxed -> begin

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -923,6 +923,12 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
   | Variant_with_null -> begin
     match Datarepr.find_variant_with_null_payload cstrs with
     | Some { payload_arg = { Types.ca_type = ty; _ }; _ } ->
+      (* [ty] is used raw: [params]/[args] are not substituted, and a GADT
+         payload is not projected out of its constructor-local scope. Both
+         lose precision only (an opaque variable yields a generic value
+         kind); the result stays sound because indices not matching the
+         payload constructor's result type are inhabited only by the null
+         value, which every nullable kind admits. *)
       let num_nodes_visited, kind =
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in


### PR DESCRIPTION
## Summary
- allow `[@@or_null]` on two-constructor GADT variants: the constructors may carry result-type indices and existential payloads
- a GADT constructor's argument type lives in the constructor's local scope, so it is projected onto the declaration parameters / instantiated head arguments using Steps B1-B4 of Note [With-bounds for GADTs] (shared helper `Btype.Jkind0.variant_constructor_gadt_extra_substs`) at three sites: the declaration jkind (`Typedecl.update_decl_jkind`), each unboxing step (`Ctype.unbox_once`), and the contained-without-boxing walk feeding the unboxed-recursion check and the jkind update order (`Ctype.contained_without_boxing`)
- during the recursive-group phase a GADT `[@@or_null]` gets a bound-free `value_or_null` temporary jkind (a with-bound on a constructor-local type would capture an out-of-scope variable); the precise jkind is computed in `update_decl_jkind`, falling back to bound-free `value_or_null` for widened declaration parameters
- composes with void null payloads (#6383) and precise custom or_null kinds (#6500): the null constructor may be unary all-void, with its (projected) payload entering the declaration kind as a with-bound
- typing and runtime tests: polymorphic / concrete-index / existential GADTs, unary void null constructors in both orders, recursive groups, mode crossing through projected with-bounds, module inclusion, unboxed-recursion boundary cases (including the conservative first-occurrence rejection for repeated result indices, pinned against its ordinary unboxed-GADT precedent), and float/void payload runtime behaviour

Originally stacked on #5830; since rebased on main after #5830, #6383 and #6500 landed and reworked the same code. The final commit is the automated Merlin import.
