### PR TITLE
Allow custom or_null payload shapes

### DIFF
--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -186,6 +186,54 @@ Error: Invalid [@or_null] declaration:
        it must have exactly one type parameter.
 |}]
 
+type no_param_nonfloat =
+  | A_nonfloat
+  | B_nonfloat of t_non_float
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type no_param_nonfloat =
+2 |   | A_nonfloat
+3 |   | B_nonfloat of t_non_float
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one type parameter.
+|}]
+
+type float_payload =
+  | Nope_float
+  | Yep_float of float
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type float_payload =
+2 |   | Nope_float
+3 |   | Yep_float of float
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one type parameter.
+|}]
+
+type float_payload_fails_sep = float_payload accepts_sep
+
+[%%expect{|
+Line 1, characters 31-44:
+1 | type float_payload_fails_sep = float_payload accepts_sep
+                                   ^^^^^^^^^^^^^
+Error: Unbound type constructor "float_payload"
+|}]
+
+type float_payload_fails_nonfloat = float_payload accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 36-49:
+1 | type float_payload_fails_nonfloat = float_payload accepts_nonfloat
+                                        ^^^^^^^^^^^^^
+Error: Unbound type constructor "float_payload"
+|}]
+
 (* CR or-null: allow custom [@@or_null] types with unused type parameters.
    Internal ticket 6853. *)
 
@@ -199,6 +247,55 @@ Lines 1-4, characters 0-11:
 1 | type 'a unused_param =
 2 |   | A
 3 |   | B of int
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.
+|}]
+
+type ('a, 'b) multi_param =
+  | Nope_multi
+  | Yep_multi of ('a list * 'b)
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type ('a, 'b) multi_param =
+2 |   | Nope_multi
+3 |   | Yep_multi of ('a list * 'b)
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one type parameter.
+|}]
+
+type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
+
+[%%expect{|
+Line 1, characters 50-61:
+1 | type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
+                                                      ^^^^^^^^^^^
+Error: Unbound type constructor "multi_param"
+|}]
+
+type ('a, 'b) multi_param_succeeds_nonfloat =
+  ('a, 'b) multi_param accepts_nonfloat
+
+[%%expect{|
+Line 2, characters 11-22:
+2 |   ('a, 'b) multi_param accepts_nonfloat
+               ^^^^^^^^^^^
+Error: Unbound type constructor "multi_param"
+|}]
+
+type bad_payload =
+  | Nope_bad
+  | Yep_bad of int t
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type bad_payload =
+2 |   | Nope_bad
+3 |   | Yep_bad of int t
 4 | [@@or_null]
 Error: Invalid [@or_null] declaration:
        it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -177,13 +177,7 @@ type no_param =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type no_param =
-2 |   | A
-3 |   | B of int
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type no_param = A | B of int [@@or_null]
 |}]
 
 type no_param_nonfloat =
@@ -192,13 +186,15 @@ type no_param_nonfloat =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type no_param_nonfloat =
-2 |   | A_nonfloat
-3 |   | B_nonfloat of t_non_float
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type no_param_nonfloat = A_nonfloat | B_nonfloat of t_non_float [@@or_null]
+|}]
+
+type succeeds_sep = no_param_nonfloat accepts_sep
+type succeeds_nonfloat = no_param_nonfloat accepts_nonfloat
+
+[%%expect{|
+type succeeds_sep = no_param_nonfloat accepts_sep
+type succeeds_nonfloat = no_param_nonfloat accepts_nonfloat
 |}]
 
 type float_payload =
@@ -207,13 +203,7 @@ type float_payload =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type float_payload =
-2 |   | Nope_float
-3 |   | Yep_float of float
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type float_payload = Nope_float | Yep_float of float [@@or_null]
 |}]
 
 type float_payload_fails_sep = float_payload accepts_sep
@@ -222,7 +212,13 @@ type float_payload_fails_sep = float_payload accepts_sep
 Line 1, characters 31-44:
 1 | type float_payload_fails_sep = float_payload accepts_sep
                                    ^^^^^^^^^^^^^
-Error: Unbound type constructor "float_payload"
+Error: This type "float_payload" should be an instance of type
+         "('a : any mod separable)"
+       The kind of float_payload is
+           value_or_null mod forkable unyielding many stateless immutable
+         because of the definition of float_payload at lines 1-4, characters 0-11.
+       But the kind of float_payload must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
 type float_payload_fails_nonfloat = float_payload accepts_nonfloat
@@ -231,7 +227,14 @@ type float_payload_fails_nonfloat = float_payload accepts_nonfloat
 Line 1, characters 36-49:
 1 | type float_payload_fails_nonfloat = float_payload accepts_nonfloat
                                         ^^^^^^^^^^^^^
-Error: Unbound type constructor "float_payload"
+Error: This type "float_payload" should be an instance of type
+         "('a : value_or_null mod non_float)"
+       The kind of float_payload is
+           value_or_null mod forkable unyielding many stateless immutable
+         because of the definition of float_payload at lines 1-4, characters 0-11.
+       But the kind of float_payload must be a subkind of
+           value_or_null mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
 (* CR or-null: allow custom [@@or_null] types with unused type parameters.
@@ -243,13 +246,7 @@ type 'a unused_param =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a unused_param =
-2 |   | A
-3 |   | B of int
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.
+type 'a unused_param = A | B of int [@@or_null]
 |}]
 
 type ('a, 'b) multi_param =
@@ -258,32 +255,21 @@ type ('a, 'b) multi_param =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type ('a, 'b) multi_param =
-2 |   | Nope_multi
-3 |   | Yep_multi of ('a list * 'b)
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type ('a, 'b) multi_param = Nope_multi | Yep_multi of ('a list * 'b) [@@or_null]
 |}]
 
 type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
 
 [%%expect{|
-Line 1, characters 50-61:
-1 | type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
-                                                      ^^^^^^^^^^^
-Error: Unbound type constructor "multi_param"
+type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
 |}]
 
 type ('a, 'b) multi_param_succeeds_nonfloat =
   ('a, 'b) multi_param accepts_nonfloat
 
 [%%expect{|
-Line 2, characters 11-22:
-2 |   ('a, 'b) multi_param accepts_nonfloat
-               ^^^^^^^^^^^
-Error: Unbound type constructor "multi_param"
+type ('a, 'b) multi_param_succeeds_nonfloat =
+    ('a, 'b) multi_param accepts_nonfloat
 |}]
 
 type bad_payload =
@@ -292,13 +278,14 @@ type bad_payload =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type bad_payload =
-2 |   | Nope_bad
+Line 3, characters 15-20:
 3 |   | Yep_bad of int t
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.
+                   ^^^^^
+Error: The kind of type "int t" is value_or_null
+         because of the definition of t at lines 1-4, characters 0-11.
+       But the kind of type "int t" must be a subkind of
+           value_or_null mod non_null
+         because the type argument of bad_payload has kind value.
 |}]
 
 (* CR or-null: allow GADT custom [@@or_null] types.
@@ -406,9 +393,9 @@ type ('a : float64) wrong_payload_kind : value_or_null =
 [@@or_null]
 
 [%%expect{|
-Line 1, characters 6-18:
-1 | type ('a : float64) wrong_payload_kind : value_or_null =
-          ^^^^^^^^^^^^
+Line 3, characters 9-11:
+3 |   | B of 'a
+             ^^
 Error: The layout of type "'a" is float64
          because of the annotation on 'a in the declaration of the type
                                       wrong_payload_kind.

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -317,6 +317,23 @@ type ('a, 'b) multi_param_succeeds_nonfloat =
     ('a, 'b) multi_param accepts_nonfloat
 |}]
 
+type ('a, 'b) eq = unit constraint 'a = 'b
+
+[%%expect{|
+type ('b, 'a) eq = unit constraint 'a = 'b
+|}]
+
+type ('a, 'b) inferred_constraint =
+  | Nope_inferred_constraint
+  | Yep_inferred_constraint of ('a, 'b) eq
+[@@or_null]
+
+[%%expect{|
+type ('a, 'b) inferred_constraint =
+    Nope_inferred_constraint
+  | Yep_inferred_constraint of ('a, 'a) eq constraint 'b = 'a [@@or_null]
+|}]
+
 type ('a, 'b) second_param =
   | Nope_second
   | Yep_second of 'b

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -234,6 +234,37 @@ Error: This type "float_payload" should be an instance of type
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
+type portable_payload : value_or_null mod portable =
+  | Portable_none
+  | Portable_some of (unit -> unit) @@ portable
+[@@or_null]
+
+[%%expect{|
+type portable_payload =
+    Portable_none
+  | Portable_some of (unit -> unit) @@ portable [@@or_null]
+|}]
+
+type nonportable_payload : value_or_null mod portable =
+  | Nonportable_none
+  | Nonportable_some of (unit -> unit)
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type nonportable_payload : value_or_null mod portable =
+2 |   | Nonportable_none
+3 |   | Nonportable_some of (unit -> unit)
+4 | [@@or_null]
+Error: The kind of type "nonportable_payload" is
+           value_or_null non_float mod aliased immutable
+         because an [@@or_null] type gets its kind by applying or_null to its
+         payload kind.
+       But the kind of type "nonportable_payload" must be a subkind of
+           value_or_null mod portable
+         because of the annotation on the declaration of the type nonportable_payload.
+|}]
+
 type probe_result : value =
   | Probe_none
   | Probe_some of int

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -273,6 +273,44 @@ type ('a, 'b) multi_param_succeeds_nonfloat =
     ('a, 'b) multi_param accepts_nonfloat
 |}]
 
+type ('a, 'b) second_param =
+  | Nope_second
+  | Yep_second of 'b
+[@@or_null]
+
+[%%expect{|
+type ('a, 'b) second_param = Nope_second | Yep_second of 'b [@@or_null]
+|}]
+
+type second_param_succeeds_sep =
+  (float, t_non_float) second_param accepts_sep
+
+type second_param_succeeds_nonfloat =
+  (float, t_non_float) second_param accepts_nonfloat
+
+[%%expect{|
+type second_param_succeeds_sep =
+    (float, t_non_float) second_param accepts_sep
+type second_param_succeeds_nonfloat =
+    (float, t_non_float) second_param accepts_nonfloat
+|}]
+
+type second_param_fails_nonfloat =
+  (t_non_float, float) second_param accepts_nonfloat
+
+[%%expect{|
+Line 2, characters 2-36:
+2 |   (t_non_float, float) second_param accepts_nonfloat
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type "(t_non_float, float) second_param" should be an instance of type
+         "('a : value_or_null non_float)"
+       The layout of (t_non_float, float) second_param is value_or_null
+         because of the definition of second_param at lines 1-4, characters 0-11.
+       But the layout of (t_non_float, float) second_param must be a sublayout
+           of value_or_null non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
+|}]
+
 type bad_payload =
   | Nope_bad
   | Yep_bad of int t
@@ -504,6 +542,40 @@ end
 
 [%%expect{|
 module M : sig type 'a t = Nope | Yep of 'a [@@or_null] end
+|}]
+
+module New_shape_inclusion : sig
+  type t : value_or_null mod non_float =
+    | New_shape_null
+    | New_shape_payload of t_non_float
+  [@@or_null]
+
+  type ('a, 'b) multi : value_or_null mod non_float =
+    | New_shape_multi_null
+    | New_shape_multi_payload of ('a list * 'b)
+  [@@or_null]
+end = struct
+  type t : value_or_null mod non_float =
+    | New_shape_null
+    | New_shape_payload of t_non_float
+  [@@or_null]
+
+  type ('a, 'b) multi : value_or_null mod non_float =
+    | New_shape_multi_null
+    | New_shape_multi_payload of ('a list * 'b)
+  [@@or_null]
+end
+
+[%%expect{|
+module New_shape_inclusion :
+  sig
+    type t =
+        New_shape_null
+      | New_shape_payload of t_non_float [@@or_null]
+    type ('a, 'b) multi =
+        New_shape_multi_null
+      | New_shape_multi_payload of ('a list * 'b) [@@or_null]
+  end
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -153,8 +153,7 @@ Lines 1-5, characters 0-11:
 Error: Invalid [@or_null] declaration: it must have exactly two constructors.
 |}]
 
-(* CR or-null: allow non-parameterized custom [@@or_null] types.
-   Internal ticket 6853. *)
+(* Non-parameterized custom [@@or_null] types. *)
 
 type no_param =
   | A
@@ -238,8 +237,7 @@ Error: The layout of type "probe_result" is value_or_null non_pointer
          because of the annotation on the declaration of the type probe_result.
 |}]
 
-(* CR or-null: allow custom [@@or_null] types with unused type parameters.
-   Internal ticket 6853. *)
+(* Custom [@@or_null] types with unused type parameters. *)
 
 type 'a unused_param =
   | A
@@ -299,15 +297,15 @@ type second_param_fails_nonfloat =
   (t_non_float, float) second_param accepts_nonfloat
 
 [%%expect{|
-Line 2, characters 2-36:
+Line 2, characters 2-35:
 2 |   (t_non_float, float) second_param accepts_nonfloat
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type "(t_non_float, float) second_param" should be an instance of type
-         "('a : value_or_null non_float)"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type "(t_non_float, float) second_param"
+       should be an instance of type "('a : value_or_null non_float)"
        The layout of (t_non_float, float) second_param is value_or_null
          because of the definition of second_param at lines 1-4, characters 0-11.
-       But the layout of (t_non_float, float) second_param must be a sublayout
-           of value_or_null non_float
+       But the layout of (t_non_float, float) second_param must be a sublayout of
+         value_or_null non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
@@ -569,9 +567,7 @@ end
 [%%expect{|
 module New_shape_inclusion :
   sig
-    type t =
-        New_shape_null
-      | New_shape_payload of t_non_float [@@or_null]
+    type t = New_shape_null | New_shape_payload of t_non_float [@@or_null]
     type ('a, 'b) multi =
         New_shape_multi_null
       | New_shape_multi_payload of ('a list * 'b) [@@or_null]

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -199,7 +199,7 @@ Line 1, characters 31-44:
                                    ^^^^^^^^^^^^^
 Error: This type "float_payload" should be an instance of type
          "('a : any separable)"
-       The layout of float_payload is value maybe_separable maybe_null
+       The layout of float_payload is value_or_null
          because of the definition of float_payload at lines 1-4, characters 0-11.
        But the layout of float_payload must be a sublayout of any separable
          because of the definition of accepts_sep at line 2, characters 0-41.
@@ -213,10 +213,10 @@ Line 1, characters 36-49:
                                         ^^^^^^^^^^^^^
 Error: This type "float_payload" should be an instance of type
          "('a : value_or_null non_float)"
-       The layout of float_payload is value maybe_separable maybe_null
+       The layout of float_payload is value_or_null
          because of the definition of float_payload at lines 1-4, characters 0-11.
        But the layout of float_payload must be a sublayout of
-           value non_float maybe_null
+           value_or_null non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
@@ -231,8 +231,9 @@ Lines 1-4, characters 0-11:
 2 |   | Probe_none
 3 |   | Probe_some of int
 4 | [@@or_null]
-Error: The layout of type "probe_result" is value non_pointer maybe_null
-         because it is the primitive type int.
+Error: The layout of type "probe_result" is value_or_null non_pointer
+         because an [@@or_null] type gets its layout by applying or_null to its
+         payload layout.
        But the layout of type "probe_result" must be a sublayout of value
          because of the annotation on the declaration of the type probe_result.
 |}]
@@ -281,10 +282,10 @@ type bad_payload =
 Line 3, characters 15-20:
 3 |   | Yep_bad of int t
                    ^^^^^
-Error: The layout of type "int t" is value maybe_separable maybe_null
+Error: The layout of type "int t" is value_or_null
          because of the definition of t at lines 1-4, characters 0-11.
        But the layout of type "int t" must be a sublayout of
-           value maybe_separable
+           value_maybe_separable
          because the payload of bad_payload has layout value.
 |}]
 
@@ -389,8 +390,8 @@ Lines 1-4, characters 0-11:
 3 |   | B of 'a
 4 | [@@or_null]
 Error: The layout of type "wrong_result_kind" is value_or_null
-         because of the annotation on 'a in the declaration of the type
-                                      wrong_result_kind.
+         because an [@@or_null] type gets its layout by applying or_null to its
+         payload layout.
        But the layout of type "wrong_result_kind" must be a sublayout of value
          because of the annotation on the declaration of the type wrong_result_kind.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -220,6 +220,23 @@ Error: This type "float_payload" should be an instance of type
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
+type probe_result : value =
+  | Probe_none
+  | Probe_some of int
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type probe_result : value =
+2 |   | Probe_none
+3 |   | Probe_some of int
+4 | [@@or_null]
+Error: The layout of type "probe_result" is value non_pointer maybe_null
+         because it is the primitive type int.
+       But the layout of type "probe_result" must be a sublayout of value
+         because of the annotation on the declaration of the type probe_result.
+|}]
+
 (* CR or-null: allow custom [@@or_null] types with unused type parameters.
    Internal ticket 6853. *)
 

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -153,6 +153,21 @@ Lines 1-5, characters 0-11:
 Error: Invalid [@or_null] declaration: it must have exactly two constructors.
 |}]
 
+type multi_arg_payload =
+  | A
+  | B of int * int
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type multi_arg_payload =
+2 |   | A
+3 |   | B of int * int
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one nullary constructor and one unary constructor.
+|}]
+
 (* Non-parameterized custom [@@or_null] types. *)
 
 type no_param =
@@ -280,6 +295,12 @@ type ('a, 'b) second_param =
 type ('a, 'b) second_param = Nope_second | Yep_second of 'b [@@or_null]
 |}]
 
+type ('a, 'b) swapped = ('b, 'a) second_param
+
+[%%expect{|
+type ('a, 'b) swapped = ('b, 'a) second_param
+|}]
+
 type second_param_succeeds_sep =
   (float, t_non_float) second_param accepts_sep
 
@@ -306,6 +327,31 @@ Error: This type "(t_non_float, float) second_param"
          because of the definition of second_param at lines 1-4, characters 0-11.
        But the layout of (t_non_float, float) second_param must be a sublayout of
          value_or_null non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
+|}]
+
+type swapped_succeeds_nonfloat =
+  (t_non_float, float) swapped accepts_nonfloat
+
+[%%expect{|
+type swapped_succeeds_nonfloat =
+    (t_non_float, float) swapped accepts_nonfloat
+|}]
+
+type swapped_fails_nonfloat =
+  (float, t_non_float) swapped accepts_nonfloat
+
+[%%expect{|
+Line 2, characters 2-30:
+2 |   (float, t_non_float) swapped accepts_nonfloat
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type
+         "(float, t_non_float) swapped" = "(t_non_float, float) second_param"
+       should be an instance of type "('a : value_or_null non_float)"
+       The layout of (float, t_non_float) swapped is value_or_null
+         because of the definition of second_param at lines 1-4, characters 0-11.
+       But the layout of (float, t_non_float) swapped must be a sublayout of
+           value_or_null non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
@@ -572,6 +618,88 @@ module New_shape_inclusion :
         New_shape_multi_null
       | New_shape_multi_payload of ('a list * 'b) [@@or_null]
   end
+|}]
+
+module New_shape_abstract_inclusion : sig
+  type t : value_or_null mod non_float
+
+  type 'a unused : value_or_null mod non_float
+
+  type ('a, 'b) multi : value_or_null mod non_float
+end = struct
+  type t =
+    | New_shape_abstract_null
+    | New_shape_abstract_payload of t_non_float
+  [@@or_null]
+
+  type 'a unused =
+    | New_shape_abstract_unused_null
+    | New_shape_abstract_unused_payload of int
+  [@@or_null]
+
+  type ('a, 'b) multi =
+    | New_shape_abstract_multi_null
+    | New_shape_abstract_multi_payload of ('a list * 'b)
+  [@@or_null]
+end
+
+[%%expect{|
+module New_shape_abstract_inclusion :
+  sig
+    type t : value_or_null non_float
+    type 'a unused : value_or_null non_float
+    type ('a, 'b) multi : value_or_null non_float
+  end
+|}]
+
+module New_shape_second_param_inclusion : sig
+  type ('a, 'b : value mod non_float) second :
+    value_or_null mod non_float
+end = struct
+  type ('a, 'b : value mod non_float) second =
+    | New_shape_second_null
+    | New_shape_second_payload of 'b
+  [@@or_null]
+end
+
+[%%expect{|
+module New_shape_second_param_inclusion :
+  sig type ('a, 'b : value non_float) second : value_or_null non_float end
+|}]
+
+module Bad_second_param_inclusion : sig
+  type ('a, 'b) second : value_or_null mod non_float
+end = struct
+  type ('a, 'b) second =
+    | Bad_null
+    | Bad_payload of 'b
+  [@@or_null]
+end
+
+[%%expect{|
+Lines 3-8, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) second =
+5 |     | Bad_null
+6 |     | Bad_payload of 'b
+7 |   [@@or_null]
+8 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type ('a, 'b) second = Bad_null | Bad_payload of 'b [@@or_null]
+         end
+       is not included in
+         sig type ('a, 'b) second : value_or_null non_float end
+       Type declarations do not match:
+         type ('a, 'b) second = Bad_null | Bad_payload of 'b [@@or_null]
+       is not included in
+         type ('a, 'b) second : value_or_null non_float
+       The layout of the first is value_or_null
+         because of the definition of second at lines 4-7, characters 2-13.
+       But the layout of the first must be a sublayout of
+           value_or_null non_float
+         because of the definition of second at line 2, characters 2-52.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -162,13 +162,7 @@ type no_param =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type no_param =
-2 |   | A
-3 |   | B of int
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type no_param = A | B of int [@@or_null]
 |}]
 
 type no_param_nonfloat =
@@ -177,13 +171,15 @@ type no_param_nonfloat =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type no_param_nonfloat =
-2 |   | A_nonfloat
-3 |   | B_nonfloat of t_non_float
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type no_param_nonfloat = A_nonfloat | B_nonfloat of t_non_float [@@or_null]
+|}]
+
+type succeeds_sep = no_param_nonfloat accepts_sep
+type succeeds_nonfloat = no_param_nonfloat accepts_nonfloat
+
+[%%expect{|
+type succeeds_sep = no_param_nonfloat accepts_sep
+type succeeds_nonfloat = no_param_nonfloat accepts_nonfloat
 |}]
 
 type float_payload =
@@ -192,13 +188,7 @@ type float_payload =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type float_payload =
-2 |   | Nope_float
-3 |   | Yep_float of float
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type float_payload = Nope_float | Yep_float of float [@@or_null]
 |}]
 
 type float_payload_fails_sep = float_payload accepts_sep
@@ -207,7 +197,12 @@ type float_payload_fails_sep = float_payload accepts_sep
 Line 1, characters 31-44:
 1 | type float_payload_fails_sep = float_payload accepts_sep
                                    ^^^^^^^^^^^^^
-Error: Unbound type constructor "float_payload"
+Error: This type "float_payload" should be an instance of type
+         "('a : any separable)"
+       The layout of float_payload is value maybe_separable maybe_null
+         because of the definition of float_payload at lines 1-4, characters 0-11.
+       But the layout of float_payload must be a sublayout of any separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
 type float_payload_fails_nonfloat = float_payload accepts_nonfloat
@@ -216,7 +211,13 @@ type float_payload_fails_nonfloat = float_payload accepts_nonfloat
 Line 1, characters 36-49:
 1 | type float_payload_fails_nonfloat = float_payload accepts_nonfloat
                                         ^^^^^^^^^^^^^
-Error: Unbound type constructor "float_payload"
+Error: This type "float_payload" should be an instance of type
+         "('a : value_or_null non_float)"
+       The layout of float_payload is value maybe_separable maybe_null
+         because of the definition of float_payload at lines 1-4, characters 0-11.
+       But the layout of float_payload must be a sublayout of
+           value non_float maybe_null
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
 (* CR or-null: allow custom [@@or_null] types with unused type parameters.
@@ -228,13 +229,7 @@ type 'a unused_param =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type 'a unused_param =
-2 |   | A
-3 |   | B of int
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.
+type 'a unused_param = A | B of int [@@or_null]
 |}]
 
 type ('a, 'b) multi_param =
@@ -243,32 +238,21 @@ type ('a, 'b) multi_param =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type ('a, 'b) multi_param =
-2 |   | Nope_multi
-3 |   | Yep_multi of ('a list * 'b)
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one type parameter.
+type ('a, 'b) multi_param = Nope_multi | Yep_multi of ('a list * 'b) [@@or_null]
 |}]
 
 type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
 
 [%%expect{|
-Line 1, characters 50-61:
-1 | type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
-                                                      ^^^^^^^^^^^
-Error: Unbound type constructor "multi_param"
+type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
 |}]
 
 type ('a, 'b) multi_param_succeeds_nonfloat =
   ('a, 'b) multi_param accepts_nonfloat
 
 [%%expect{|
-Line 2, characters 11-22:
-2 |   ('a, 'b) multi_param accepts_nonfloat
-               ^^^^^^^^^^^
-Error: Unbound type constructor "multi_param"
+type ('a, 'b) multi_param_succeeds_nonfloat =
+    ('a, 'b) multi_param accepts_nonfloat
 |}]
 
 type bad_payload =
@@ -277,13 +261,14 @@ type bad_payload =
 [@@or_null]
 
 [%%expect{|
-Lines 1-4, characters 0-11:
-1 | type bad_payload =
-2 |   | Nope_bad
+Line 3, characters 15-20:
 3 |   | Yep_bad of int t
-4 | [@@or_null]
-Error: Invalid [@or_null] declaration:
-       it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.
+                   ^^^^^
+Error: The layout of type "int t" is value maybe_separable maybe_null
+         because of the definition of t at lines 1-4, characters 0-11.
+       But the layout of type "int t" must be a sublayout of
+           value maybe_separable
+         because the payload of bad_payload has layout value.
 |}]
 
 (* CR or-null: allow GADT custom [@@or_null] types.
@@ -399,14 +384,14 @@ type ('a : float64) wrong_payload_kind : value_or_null =
 [@@or_null]
 
 [%%expect{|
-Line 1, characters 6-18:
-1 | type ('a : float64) wrong_payload_kind : value_or_null =
-          ^^^^^^^^^^^^
+Line 3, characters 9-11:
+3 |   | B of 'a
+             ^^
 Error: The layout of type "'a" is float64
          because of the annotation on 'a in the declaration of the type
                                       wrong_payload_kind.
        But the layout of type "'a" must be a value layout
-         because the type argument of wrong_payload_kind has layout value.
+         because the payload of wrong_payload_kind has layout value.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -171,6 +171,54 @@ Error: Invalid [@or_null] declaration:
        it must have exactly one type parameter.
 |}]
 
+type no_param_nonfloat =
+  | A_nonfloat
+  | B_nonfloat of t_non_float
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type no_param_nonfloat =
+2 |   | A_nonfloat
+3 |   | B_nonfloat of t_non_float
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one type parameter.
+|}]
+
+type float_payload =
+  | Nope_float
+  | Yep_float of float
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type float_payload =
+2 |   | Nope_float
+3 |   | Yep_float of float
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one type parameter.
+|}]
+
+type float_payload_fails_sep = float_payload accepts_sep
+
+[%%expect{|
+Line 1, characters 31-44:
+1 | type float_payload_fails_sep = float_payload accepts_sep
+                                   ^^^^^^^^^^^^^
+Error: Unbound type constructor "float_payload"
+|}]
+
+type float_payload_fails_nonfloat = float_payload accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 36-49:
+1 | type float_payload_fails_nonfloat = float_payload accepts_nonfloat
+                                        ^^^^^^^^^^^^^
+Error: Unbound type constructor "float_payload"
+|}]
+
 (* CR or-null: allow custom [@@or_null] types with unused type parameters.
    Internal ticket 6853. *)
 
@@ -184,6 +232,55 @@ Lines 1-4, characters 0-11:
 1 | type 'a unused_param =
 2 |   | A
 3 |   | B of int
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.
+|}]
+
+type ('a, 'b) multi_param =
+  | Nope_multi
+  | Yep_multi of ('a list * 'b)
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type ('a, 'b) multi_param =
+2 |   | Nope_multi
+3 |   | Yep_multi of ('a list * 'b)
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one type parameter.
+|}]
+
+type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
+
+[%%expect{|
+Line 1, characters 50-61:
+1 | type ('a, 'b) multi_param_succeeds_sep = ('a, 'b) multi_param accepts_sep
+                                                      ^^^^^^^^^^^
+Error: Unbound type constructor "multi_param"
+|}]
+
+type ('a, 'b) multi_param_succeeds_nonfloat =
+  ('a, 'b) multi_param accepts_nonfloat
+
+[%%expect{|
+Line 2, characters 11-22:
+2 |   ('a, 'b) multi_param accepts_nonfloat
+               ^^^^^^^^^^^
+Error: Unbound type constructor "multi_param"
+|}]
+
+type bad_payload =
+  | Nope_bad
+  | Yep_bad of int t
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type bad_payload =
+2 |   | Nope_bad
+3 |   | Yep_bad of int t
 4 | [@@or_null]
 Error: Invalid [@or_null] declaration:
        it must have exactly one nullary constructor and one unary constructor carrying the sole type parameter.

--- a/testsuite/tests/typing-layouts-or-null/custom_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom_runtime.ml
@@ -23,6 +23,26 @@ type ('a : value) flipped : value_or_null =
   | Nope_last
 [@@or_null]
 
+type no_param =
+  | No_param_null
+  | No_param_payload of int
+[@@or_null]
+
+type float_payload =
+  | Float_null
+  | Float_payload of float
+[@@or_null]
+
+type 'a unused_param =
+  | Unused_null
+  | Unused_payload of int
+[@@or_null]
+
+type ('a, 'b) multi_param =
+  | Multi_null
+  | Multi_payload of ('a list * 'b)
+[@@or_null]
+
 let () =
   match Nope with
   | Nope -> ()
@@ -47,6 +67,54 @@ let () =
   | _ -> assert false
 ;;
 
+let () =
+  match No_param_null with
+  | No_param_null -> ()
+  | No_param_payload _ -> assert false
+;;
+
+let () =
+  match No_param_payload 11 with
+  | No_param_payload 11 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match Float_null with
+  | Float_null -> ()
+  | Float_payload _ -> assert false
+;;
+
+let () =
+  match Float_payload 3.5 with
+  | Float_payload x when x = 3.5 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match (Unused_null : string unused_param) with
+  | Unused_null -> ()
+  | Unused_payload _ -> assert false
+;;
+
+let () =
+  match (Unused_payload 13 : string unused_param) with
+  | Unused_payload 13 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match Multi_null with
+  | Multi_null -> ()
+  | Multi_payload _ -> assert false
+;;
+
+let () =
+  match Multi_payload ([ "a"; "b" ], 2) with
+  | Multi_payload ([ "a"; "b" ], 2) -> ()
+  | _ -> assert false
+;;
+
 let map_t f = function
   | Nope -> Nope
   | Yep x -> Yep (f x)
@@ -54,6 +122,14 @@ let map_t f = function
 let map_flipped f = function
   | Nope_last -> Nope_last
   | Yep_first x -> Yep_first (f x)
+
+let map_float_payload f = function
+  | Float_null -> Float_null
+  | Float_payload x -> Float_payload (f x)
+
+let map_multi_param f g = function
+  | Multi_null -> Multi_null
+  | Multi_payload (xs, y) -> Multi_payload (List.map f xs, g y)
 
 let () =
   match map_t (fun x -> x + 1) (Yep 4) with
@@ -74,6 +150,33 @@ let () =
 ;;
 
 let () =
+  match map_float_payload (( +. ) 0.5) (Float_payload 1.25) with
+  | Float_payload x when x = 1.75 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match map_float_payload (( +. ) 0.5) Float_null with
+  | Float_null -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match
+    map_multi_param String.length succ
+      (Multi_payload ([ "a"; "bc" ], 4))
+  with
+  | Multi_payload ([ 1; 2 ], 5) -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match map_multi_param String.length succ Multi_null with
+  | Multi_null -> ()
+  | _ -> assert false
+;;
+
+let () =
   match (Nope, Yep "payload") with
   | Nope, Yep "payload" -> ()
   | _ -> assert false
@@ -81,9 +184,17 @@ let () =
 
 let make_closure x = fun () -> Yep x
 
+let make_multi_closure xs y = fun () -> Multi_payload (xs, y)
+
 let () =
   match make_closure 7 () with
   | Yep 7 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match make_multi_closure [ 1; 2 ] "closure" () with
+  | Multi_payload ([ 1; 2 ], "closure") -> ()
   | _ -> assert false
 ;;
 
@@ -95,6 +206,28 @@ let () =
   r := Yep "ref";
   match !r with
   | Yep "ref" -> ()
+  | _ -> assert false
+;;
+
+let () =
+  let r = ref No_param_null in
+  (match !r with
+  | No_param_null -> ()
+  | _ -> assert false);
+  r := No_param_payload 21;
+  match !r with
+  | No_param_payload 21 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  let r = ref Multi_null in
+  (match !r with
+  | Multi_null -> ()
+  | _ -> assert false);
+  r := Multi_payload ([ "ref" ], 1);
+  match !r with
+  | Multi_payload ([ "ref" ], 1) -> ()
   | _ -> assert false
 ;;
 
@@ -120,6 +253,34 @@ let () =
 ;;
 
 let () =
+  let bytes = Marshal.to_bytes (No_param_payload 5) [] in
+  match Marshal.from_bytes bytes 0 with
+  | No_param_payload 5 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  let bytes = Marshal.to_bytes Float_null [] in
+  match Marshal.from_bytes bytes 0 with
+  | Float_null -> ()
+  | _ -> assert false
+;;
+
+let () =
+  let bytes = Marshal.to_bytes (Float_payload 2.25) [] in
+  match Marshal.from_bytes bytes 0 with
+  | Float_payload x when x = 2.25 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  let bytes = Marshal.to_bytes (Multi_payload ([ 1; 2 ], "marshal")) [] in
+  match Marshal.from_bytes bytes 0 with
+  | Multi_payload ([ 1; 2 ], "marshal") -> ()
+  | _ -> assert false
+;;
+
+let () =
   assert (Nope = Nope);
   assert (Yep 4 = Yep 4);
   assert (Nope <> Yep 4);
@@ -132,5 +293,21 @@ let () =
   assert (Nope_last <> Yep_first "a");
   assert (compare Nope_last Nope_last = 0);
   assert (compare Nope_last (Yep_first "a") < 0);
-  assert (compare (Yep_first "a") Nope_last > 0)
+  assert (compare (Yep_first "a") Nope_last > 0);
+  assert (No_param_null = No_param_null);
+  assert (No_param_payload 4 = No_param_payload 4);
+  assert (No_param_null <> No_param_payload 4);
+  assert (compare No_param_null (No_param_payload 4) < 0);
+  assert (Float_null = Float_null);
+  assert (Float_payload 1.5 = Float_payload 1.5);
+  assert (Float_null <> Float_payload 1.5);
+  assert (compare Float_null (Float_payload 1.5) < 0);
+  assert ((Unused_null : string unused_param) = Unused_null);
+  assert ((Unused_payload 3 : string unused_param) = Unused_payload 3);
+  assert ((Unused_null : string unused_param) <> Unused_payload 3);
+  assert (compare (Unused_null : string unused_param) (Unused_payload 3) < 0);
+  assert (Multi_null = Multi_null);
+  assert (Multi_payload ([ 1 ], "a") = Multi_payload ([ 1 ], "a"));
+  assert (Multi_null <> Multi_payload ([ 1 ], "a"));
+  assert (compare Multi_null (Multi_payload ([ 1 ], "a")) < 0)
 ;;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2593,12 +2593,12 @@ module Jkind0 = struct
       in
       Builtin.value ~why
 
-    let for_variant_with_null_result path payload_ty =
+    let for_variant_with_null_result path ~modality payload_ty =
       let why : Jkind_intf.History.value_or_null_creation_reason =
         Or_null_payload path
       in
       Builtin.value_or_null ~why
-      |> add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:payload_ty
+      |> add_with_bounds ~modality ~type_expr:payload_ty
       |> mark_best
   end
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2593,12 +2593,12 @@ module Jkind0 = struct
       in
       Builtin.value ~why
 
-    let for_variant_with_null_result path param =
+    let for_variant_with_null_result path payload_ty =
       let why : Jkind_intf.History.value_or_null_creation_reason =
         Or_null_payload path
       in
       Builtin.value_or_null ~why
-      |> add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:param
+      |> add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:payload_ty
       |> mark_best
   end
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2559,11 +2559,7 @@ module Jkind0 = struct
         }
         ~annotation:None ~why:(Any_creation Array_type_argument)
 
-    let for_or_null_argument ident =
-      let why : Jkind_intf.History.value_creation_reason =
-        Type_argument
-          { parent_path = Path.Pident ident; position = 1; arity = 1 }
-      in
+    let for_or_null_payload_with_history why =
       let mod_bounds =
         Mod_bounds.create Mode.Crossing.max
           ~externality:Mod_bounds.Externality.max
@@ -2579,6 +2575,16 @@ module Jkind0 = struct
           with_bounds = No_with_bounds
         }
         ~annotation:None ~why:(Value_creation why)
+
+    let for_or_null_argument ident =
+      let why : Jkind_intf.History.value_creation_reason =
+        Type_argument
+          { parent_path = Path.Pident ident; position = 1; arity = 1 }
+      in
+      for_or_null_payload_with_history why
+
+    let for_or_null_payload path =
+      for_or_null_payload_with_history (Or_null_payload path)
 
     let for_effect_arg ident =
       let why : Jkind_intf.History.value_creation_reason =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2595,8 +2595,7 @@ module Jkind0 = struct
 
     let for_variant_with_null_result path param =
       let why : Jkind_intf.History.value_or_null_creation_reason =
-        Type_argument
-          { parent_path = path; position = 1; arity = 1 }
+        Or_null_payload path
       in
       Builtin.value_or_null ~why
       |> add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:param

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -731,6 +731,7 @@ module Jkind0 : sig
       Types.jkind_l
 
     val for_or_null_argument : Ident.t -> 'd jkind
+    val for_or_null_payload : Path.t -> 'd jkind
     val for_variant_with_null_result : Path.t -> type_expr -> jkind_l
 
     val for_effect_arg : Ident.t -> 'd jkind

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -732,7 +732,8 @@ module Jkind0 : sig
 
     val for_or_null_argument : Ident.t -> 'd jkind
     val for_or_null_payload : Path.t -> 'd jkind
-    val for_variant_with_null_result : Path.t -> type_expr -> jkind_l
+    val for_variant_with_null_result :
+      Path.t -> modality:Mode.Modality.Const.t -> type_expr -> jkind_l
 
     val for_effect_arg : Ident.t -> 'd jkind
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2652,7 +2652,13 @@ let is_principal ty =
 type unwrapped_type_expr =
   { ty : type_expr
   ; modality : Mode.Modality.Const.t
-  ; or_null : (type_declaration * unwrapped_type_expr) option;
+  ; or_null : unwrapped_or_null option;
+  }
+
+and unwrapped_or_null =
+  { decl : type_declaration
+  ; args : type_expr list
+  ; prev : unwrapped_type_expr
   }
 
 let mk_unwrapped_type_expr ty =
@@ -2735,7 +2741,7 @@ let unbox_once env ty =
             Stepped
               { ty = apply ca_type ~extra_substs:[];
                 modality;
-                or_null = Some (decl, ty) }
+                or_null = Some { decl; args; prev = ty } }
           | None ->
             Misc.fatal_error "Invalid constructor for Variant_with_null"
           end
@@ -2844,7 +2850,7 @@ let apply_layout_wrapping_l ~env
     | Error _ -> Jkind_types.Layout.Any Jkind_types.Scannable_axes.max
   in
   match or_null with
-  | Some (_, prev) ->
+  | Some { prev; _ } ->
     (* The layout on ['a or_null] is imprecise - it's always [scannable]. But
         when ['a] is [non_float]/[non_pointer64]/[non_pointer], we can give
         ['a or_null] the same separability (per [Jkind.apply_or_null_l]). So
@@ -2860,17 +2866,19 @@ let apply_jkind_wrapping_l ~env ~level
           ~unwrapped_ty:{ ty; or_null; modality } jkind =
   begin
     match or_null with
-    | Some (decl, _) ->
-      (* We get the mode crossing behavior of the wrapped jkind from the
-          declaration of the [or_null]-like type. *)
-      let instance_jkind =
-        jkind_subst env level decl.type_params [ty] decl.type_jkind
-      in
+    | Some { decl; args; _ } ->
+      (* The declaration supplies the mode crossing behavior of the
+         [or_null]-like type. The stored arguments instantiate that behavior
+         for the wrapper that was unwrapped. *)
       begin match
         apply_layout_wrapping_l ~env
           ~unwrapped_ty:{ ty; modality; or_null } jkind
       with
-      | Ok layout -> Ok (Jkind.set_layout instance_jkind layout)
+      | Ok layout ->
+        let instance_jkind =
+          jkind_subst env level decl.type_params args decl.type_jkind
+        in
+        Ok (Jkind.set_layout instance_jkind layout)
       | Error _ as e -> e
       end
     | None -> Ok jkind

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -644,10 +644,10 @@ val mcomp : Env.t -> type_expr -> type_expr -> unit
 type unwrapped_type_expr =
   { ty : type_expr
   ; modality : Mode.Modality.Const.t
-  ; or_null : (type_declaration * unwrapped_type_expr) option;
-    (* We store the declaration rather than a bool to avoid re-writing the
-       with-bounds of [or_null], and to be more robust for the future where we
-       have user-defined [or_null]-like types
+  ; or_null : unwrapped_or_null option;
+    (* We store the declaration and arguments rather than a bool to avoid
+       re-writing the with-bounds of [or_null], and to be more robust for the
+       future where we have user-defined [or_null]-like types
 
        Note [unwrapped_type_expr backtracking for or_null]:
 
@@ -667,6 +667,12 @@ type unwrapped_type_expr =
        This hack should be removed when we refactor [type_jkind] and
        [estimate_type_jkind] to fix another bug.
     *)
+  }
+
+and unwrapped_or_null =
+  { decl : type_declaration
+  ; args : type_expr list
+  ; prev : unwrapped_type_expr
   }
 
 val get_unboxed_type_representation :

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -669,11 +669,7 @@ type unwrapped_type_expr =
     *)
   }
 
-and unwrapped_or_null =
-  { decl : type_declaration
-  ; args : type_expr list
-  ; prev : unwrapped_type_expr
-  }
+and unwrapped_or_null
 
 val get_unboxed_type_representation :
   Env.t ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -3034,6 +3034,9 @@ module Format_history = struct
       fprintf ppf "the %stype argument of %a has %s value"
         (format_position ~arity position)
         !printtyp_path parent_path layout_or_kind
+    | Or_null_payload parent_path ->
+      fprintf ppf "the payload of %a has %s value" !printtyp_path parent_path
+        layout_or_kind
     | Tuple -> fprintf ppf "it's a tuple type"
     | Row_variable -> format_with_notify_js ppf "it's a row variable"
     | Polymorphic_variant -> fprintf ppf "it's a polymorphic variant type"
@@ -4045,6 +4048,10 @@ module Debug_printers = struct
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
     | Type_argument { parent_path; position; arity } ->
       fprintf ppf "Type_argument (pos %d, arity %d) of %a" position arity
+        (Fmt.compat !printtyp_path)
+        parent_path
+    | Or_null_payload parent_path ->
+      fprintf ppf "Or_null_payload of %a"
         (Fmt.compat !printtyp_path)
         parent_path
     | Tuple -> fprintf ppf "Tuple"

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -3002,6 +3002,11 @@ module Format_history = struct
       fprintf ppf "the %stype argument of %a has %s value_or_null"
         (format_position ~arity position)
         !printtyp_path parent_path layout_or_kind
+    | Or_null_payload _parent_path ->
+      fprintf ppf
+        "an [@@@@or_null] type gets its %s by applying or_null to its@ payload \
+         %s"
+        layout_or_kind layout_or_kind
     | Recmod_fun_arg ->
       fprintf ppf
         "it's the type of the first argument to a function in a recursive \
@@ -4028,6 +4033,10 @@ module Debug_printers = struct
     | Let_rec_variable v -> fprintf ppf "Let_rec_variable %a" Ident.print v
     | Type_argument { parent_path; position; arity } ->
       fprintf ppf "Type_argument (pos %d, arity %d) of %a" position arity
+        (Fmt.compat !printtyp_path)
+        parent_path
+    | Or_null_payload parent_path ->
+      fprintf ppf "Or_null_payload of %a"
         (Fmt.compat !printtyp_path)
         parent_path
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -421,6 +421,7 @@ module History = struct
           arity : int
         }
     (* [position] is 1-indexed *)
+    | Or_null_payload of Path.t
     | Tuple
     | Row_variable
     | Polymorphic_variant

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -400,6 +400,7 @@ module History = struct
           position : int;
           arity : int
         }
+    | Or_null_payload of Path.t
     | Recmod_fun_arg
     | Array_comprehension_element
     | Array_comprehension_iterator_element

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -192,15 +192,7 @@ let check_or_null_decl bad sdecl =
   | Public ->
     ()
 
-let get_or_null_type_param_name bad sdecl params =
-  match sdecl.ptype_params, params with
-  | [({ ptyp_desc = Ptyp_var (name, _); _ }, _)], [_] -> name
-  | [_], [_] ->
-    bad "its single type parameter must be written as a type variable"
-  | _ ->
-    bad "it must have exactly one type parameter"
-
-let check_or_null_constructors bad type_param_name = function
+let check_or_null_constructors bad = function
   | [c1; c2] ->
     let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
       match pcd_res with
@@ -213,27 +205,35 @@ let check_or_null_constructors bad type_param_name = function
     begin match c1.pcd_args, c2.pcd_args with
     | Pcstr_tuple [],
       Pcstr_tuple
-        [{ pca_type = { ptyp_desc = Ptyp_var (name, _); _ }; _ }]
+        [_]
     | Pcstr_tuple
-        [{ pca_type = { ptyp_desc = Ptyp_var (name, _); _ }; _ }],
+        [_],
       Pcstr_tuple [] ->
-      if not (String.equal name type_param_name) then
-        bad "its payload constructor must carry the sole type parameter"
+      ()
     | _ ->
       bad
         "it must have exactly one nullary constructor and one unary \
-         constructor carrying the sole type parameter"
+         constructor"
     end
   | _ ->
     bad "it must have exactly two constructors"
 
-let check_or_null_variant_shape _path params sdecl scstrs =
-  let bad msg =
-    raise (Error (sdecl.ptype_loc, Bad_or_null_attribute msg))
-  in
-  check_or_null_decl bad sdecl;
-  let type_param_name = get_or_null_type_param_name bad sdecl params in
-  check_or_null_constructors bad type_param_name scstrs
+let check_or_null_variant_shape sdecl scstrs =
+  let bad msg = Error (sdecl.ptype_loc, Bad_or_null_attribute msg) in
+  check_or_null_decl (fun msg -> raise (bad msg)) sdecl;
+  check_or_null_constructors (fun msg -> raise (bad msg)) scstrs
+
+let get_or_null_payload_arg cstrs : Types.constructor_argument =
+  match Datarepr.find_variant_with_null_payload cstrs with
+  | Some { payload_arg; _ } -> payload_arg
+  | None -> Misc.fatal_error "Invalid constructor for Variant_with_null"
+
+let constrain_or_null_payload ~env ~id payload_ty payload_loc =
+  let required = Btype.Jkind0.for_or_null_argument id in
+  match Ctype.constrain_type_jkind env payload_ty required with
+  | Ok () -> ()
+  | Error err ->
+    raise (Error (payload_loc, Jkind_mismatch_of_type (env, payload_ty, err)))
 
 (* [make_params] creates sort variables - these can be defaulted away (as in
    transl_type_decl) or unified with existing sort-variable-free types (as in
@@ -995,23 +995,7 @@ let transl_declaration env sdecl (id, uid) =
         Ttype_abstract, Type_abstract Definition,
         Jkind.Builtin.value ~why:Default_type_jkind
       | Ptype_variant scstrs ->
-        if or_null then begin
-          check_or_null_variant_shape path params sdecl scstrs;
-          match sdecl.ptype_params, params with
-          | [({ ptyp_desc = Ptyp_var (_, _);
-                ptyp_loc;
-                _
-              }, _)],
-            [param] ->
-            let required = Btype.Jkind0.for_or_null_argument id in
-            begin match Ctype.constrain_type_jkind env param required with
-            | Ok () -> ()
-            | Error err ->
-              raise
-                (Error (ptyp_loc, Jkind_mismatch_of_type (env, param, err)))
-            end
-          | _ -> assert false
-        end;
+        if or_null then check_or_null_variant_shape sdecl scstrs;
         if List.exists (fun cstr -> cstr.pcd_res <> None) scstrs then begin
           match cstrs with
             [] -> ()
@@ -1062,36 +1046,46 @@ let transl_declaration env sdecl (id, uid) =
             (fun () -> make_cstr scstr)
         in
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
+        let or_null_payload_arg =
+          if or_null then begin
+            let payload_arg = get_or_null_payload_arg cstrs in
+            let payload_ty = payload_arg.Types.ca_type in
+            let payload_loc = payload_arg.Types.ca_loc in
+            constrain_or_null_payload ~env ~id payload_ty payload_loc;
+            Some payload_arg
+          end else
+            None
+        in
         let rep, jkind =
-          if or_null then
-            match params with
-            | [param] ->
-              Variant_with_null,
-              Btype.Jkind0.for_variant_with_null_result path param
-            | _ -> assert false
-          else if unbox then
-            Variant_unboxed,
-            Jkind.of_new_sort ~why:Old_style_unboxed_type
-              ~level:(Ctype.get_current_level ())
-          else
-            (* We mark all arg sorts "void" here.  They are updated later,
-               after the circular type checks make it safe to check sorts.
-               Likewise, [Constructor_uniform_value] is potentially wrong
-               and will be updated later.
-            *)
-            Variant_boxed (
-              Array.map
-                (fun cstr ->
-                   let sorts =
-                     match Types.(cstr.cd_args) with
-                     | Cstr_tuple args ->
-                       Array.make (List.length args) Jkind.Sort.Const.void
-                     | Cstr_record _ -> [| Jkind.Sort.Const.value |]
-                   in
-                   Constructor_uniform_value, sorts)
-                (Array.of_list cstrs)
-            ),
-          Jkind.for_non_float ~why:Boxed_variant
+          match or_null_payload_arg with
+          | Some payload_arg ->
+            let payload_ty = payload_arg.Types.ca_type in
+            Variant_with_null,
+            Btype.Jkind0.for_variant_with_null_result path payload_ty
+          | None ->
+            if unbox then
+              Variant_unboxed,
+              Jkind.of_new_sort ~why:Old_style_unboxed_type
+                ~level:(Ctype.get_current_level ())
+            else
+              (* We mark all arg sorts "void" here.  They are updated later,
+                 after the circular type checks make it safe to check sorts.
+                 Likewise, [Constructor_uniform_value] is potentially wrong
+                 and will be updated later.
+              *)
+              Variant_boxed (
+                Array.map
+                  (fun cstr ->
+                     let sorts =
+                       match Types.(cstr.cd_args) with
+                       | Cstr_tuple args ->
+                         Array.make (List.length args) Jkind.Sort.Const.void
+                       | Cstr_record _ -> [| Jkind.Sort.Const.value |]
+                     in
+                     Constructor_uniform_value, sorts)
+                  (Array.of_list cstrs)
+              ),
+              Jkind.for_non_float ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -195,15 +195,7 @@ let check_or_null_decl bad sdecl =
   | Public ->
     ()
 
-let get_or_null_type_param_name bad sdecl params =
-  match sdecl.ptype_params, params with
-  | [({ ptyp_desc = Ptyp_var (name, _); _ }, _)], [_] -> name
-  | [_], [_] ->
-    bad "its single type parameter must be written as a type variable"
-  | _ ->
-    bad "it must have exactly one type parameter"
-
-let check_or_null_constructors bad type_param_name = function
+let check_or_null_constructors bad = function
   | [c1; c2] ->
     let check_no_gadt ({ pcd_res; _ } : Parsetree.constructor_declaration) =
       match pcd_res with
@@ -216,27 +208,35 @@ let check_or_null_constructors bad type_param_name = function
     begin match c1.pcd_args, c2.pcd_args with
     | Pcstr_tuple [],
       Pcstr_tuple
-        [{ pca_type = { ptyp_desc = Ptyp_var (name, _); _ }; _ }]
+        [_]
     | Pcstr_tuple
-        [{ pca_type = { ptyp_desc = Ptyp_var (name, _); _ }; _ }],
+        [_],
       Pcstr_tuple [] ->
-      if not (String.equal name type_param_name) then
-        bad "its payload constructor must carry the sole type parameter"
+      ()
     | _ ->
       bad
         "it must have exactly one nullary constructor and one unary \
-         constructor carrying the sole type parameter"
+         constructor"
     end
   | _ ->
     bad "it must have exactly two constructors"
 
-let check_or_null_variant_shape _path params sdecl scstrs =
-  let bad msg =
-    raise (Error (sdecl.ptype_loc, Bad_or_null_attribute msg))
-  in
-  check_or_null_decl bad sdecl;
-  let type_param_name = get_or_null_type_param_name bad sdecl params in
-  check_or_null_constructors bad type_param_name scstrs
+let check_or_null_variant_shape sdecl scstrs =
+  let bad msg = Error (sdecl.ptype_loc, Bad_or_null_attribute msg) in
+  check_or_null_decl (fun msg -> raise (bad msg)) sdecl;
+  check_or_null_constructors (fun msg -> raise (bad msg)) scstrs
+
+let get_or_null_payload_arg cstrs : Types.constructor_argument =
+  match Datarepr.find_variant_with_null_payload cstrs with
+  | Some { payload_arg; _ } -> payload_arg
+  | None -> Misc.fatal_error "Invalid constructor for Variant_with_null"
+
+let constrain_or_null_payload ~env ~path payload_ty payload_loc =
+  let required = Btype.Jkind0.for_or_null_payload path in
+  match Ctype.constrain_type_jkind env payload_ty required with
+  | Ok () -> ()
+  | Error err ->
+    raise (Error (payload_loc, Jkind_mismatch_of_type (env, payload_ty, err)))
 
 (* [make_params] creates sort variables - these can be defaulted away (as in
    transl_type_decl) or unified with existing sort-variable-free types (as in
@@ -1031,23 +1031,7 @@ let transl_declaration env sdecl (id, uid) =
         Ttype_abstract, Type_abstract Definition,
         Jkind.Builtin.value ~why:Default_type_jkind
       | Ptype_variant scstrs ->
-        if or_null then begin
-          check_or_null_variant_shape path params sdecl scstrs;
-          match sdecl.ptype_params, params with
-          | [({ ptyp_desc = Ptyp_var (_, _);
-                ptyp_loc;
-                _
-              }, _)],
-            [param] ->
-            let required = Btype.Jkind0.for_or_null_argument id in
-            begin match Ctype.constrain_type_jkind env param required with
-            | Ok () -> ()
-            | Error err ->
-              raise
-                (Error (ptyp_loc, Jkind_mismatch_of_type (env, param, err)))
-            end
-          | _ -> assert false
-        end;
+        if or_null then check_or_null_variant_shape sdecl scstrs;
         if List.exists (fun cstr -> cstr.pcd_res <> None) scstrs then begin
           match cstrs with
             [] -> ()
@@ -1098,36 +1082,46 @@ let transl_declaration env sdecl (id, uid) =
             (fun () -> make_cstr scstr)
         in
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
+        let or_null_payload_arg =
+          if or_null then begin
+            let payload_arg = get_or_null_payload_arg cstrs in
+            let payload_ty = payload_arg.Types.ca_type in
+            let payload_loc = payload_arg.Types.ca_loc in
+            constrain_or_null_payload ~env ~path payload_ty payload_loc;
+            Some payload_arg
+          end else
+            None
+        in
         let rep, jkind =
-          if or_null then
-            match params with
-            | [param] ->
-              Variant_with_null,
-              Btype.Jkind0.for_variant_with_null_result path param
-            | _ -> assert false
-          else if unbox then
-            Variant_unboxed,
-            Jkind.Builtin.any ~why:Old_style_unboxed_type
-          else
-            (* We mark all arg sorts "void" here.  They are updated later,
-               after the circular type checks make it safe to check sorts.
-               Likewise, [Constructor_uniform_value] is potentially wrong
-               and will be updated later.
-            *)
-            Variant_boxed (
-              Array.map
-                (fun cstr ->
-                   let sorts =
-                     match Types.(cstr.cd_args) with
-                     | Cstr_tuple args ->
-                       Array.make (List.length args) Jkind.Sort.Const.void
-                     | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
-                   in
-                   Cstr_layout_known
-                     { shape = Constructor_uniform_value; sorts })
-                (Array.of_list cstrs)
-            ),
-          Jkind.for_non_float ~why:Boxed_variant
+          match or_null_payload_arg with
+          | Some payload_arg ->
+            let payload_ty = payload_arg.Types.ca_type in
+            Variant_with_null,
+            Btype.Jkind0.for_variant_with_null_result path payload_ty
+           | None ->
+             if unbox then
+               Variant_unboxed,
+               Jkind.Builtin.any ~why:Old_style_unboxed_type
+             else
+              (* We mark all arg sorts "void" here.  They are updated later,
+                 after the circular type checks make it safe to check sorts.
+                 Likewise, [Constructor_uniform_value] is potentially wrong
+                 and will be updated later.
+              *)
+              Variant_boxed (
+                Array.map
+                  (fun cstr ->
+                     let sorts =
+                       match Types.(cstr.cd_args) with
+                        | Cstr_tuple args ->
+                          Array.make (List.length args) Jkind.Sort.Const.void
+                        | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
+                      in
+                      Cstr_layout_known
+                        { shape = Constructor_uniform_value; sorts })
+                   (Array.of_list cstrs)
+               ),
+               Jkind.for_non_float ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2466,7 +2466,12 @@ let rec update_decl_jkind env dpath decl =
           Jkind.apply_modality_l modality jkind
           |> Jkind.apply_or_null_l
         with
-        | Ok type_jkind -> cstrs, rep, type_jkind
+        | Ok type_jkind ->
+          let type_jkind =
+            Jkind.History.update_reason type_jkind
+              (Value_or_null_creation (Or_null_payload dpath))
+          in
+          cstrs, rep, type_jkind
         | Error () ->
           Misc.fatal_error
             "Typedecl.update_variant_kind: Variant_with_null payload is \

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -222,9 +222,11 @@ let check_or_null_constructors bad = function
     bad "it must have exactly two constructors"
 
 let check_or_null_variant_shape sdecl scstrs =
-  let bad msg = Error (sdecl.ptype_loc, Bad_or_null_attribute msg) in
-  check_or_null_decl (fun msg -> raise (bad msg)) sdecl;
-  check_or_null_constructors (fun msg -> raise (bad msg)) scstrs
+  let bad msg =
+    raise (Error (sdecl.ptype_loc, Bad_or_null_attribute msg))
+  in
+  check_or_null_decl bad sdecl;
+  check_or_null_constructors bad scstrs
 
 let get_or_null_payload_arg cstrs : Types.constructor_argument =
   match Datarepr.find_variant_with_null_payload cstrs with
@@ -1096,13 +1098,14 @@ let transl_declaration env sdecl (id, uid) =
           match or_null_payload_arg with
           | Some payload_arg ->
             let payload_ty = payload_arg.Types.ca_type in
+            let modality = payload_arg.Types.ca_modalities in
             Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path payload_ty
-           | None ->
-             if unbox then
-               Variant_unboxed,
-               Jkind.Builtin.any ~why:Old_style_unboxed_type
-             else
+            Btype.Jkind0.for_variant_with_null_result path ~modality payload_ty
+          | None ->
+            if unbox then
+              Variant_unboxed,
+              Jkind.Builtin.any ~why:Old_style_unboxed_type
+            else
               (* We mark all arg sorts "void" here.  They are updated later,
                  after the circular type checks make it safe to check sorts.
                  Likewise, [Constructor_uniform_value] is potentially wrong


### PR DESCRIPTION
- allows zero-parameter, unused-parameter, and multi-parameter custom `[@@or_null]` declarations
- infers the result kind from the unary payload type, taking into account separability
- rejects nullable payloads with a proper kind error

The history is split into two commits:
1. test-only coverage showing the old shape restrictions
2. the compiler change plus promoted outputs
