### PR TITLE
Skip `caml_modify` for `non_pointer`s

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -202,11 +202,15 @@ let force_runtime_shape_exn cs =
   match runtime_shape cs with Some s -> s | None -> raise Layout_missing
 
 (* CR mshinwell: it seems like this should move to the frontend *)
+(* The scannable axes in the resulting [mixed_block_element] are always [max] *)
 let rec layout_to_types_layout (ly : Layout.t) : Types.mixed_block_element =
   match ly with
   | Base base -> (
     match base with
-    | Scannable -> Scannable
+    (* CR layouts-scannable: since [Layout.t] does not (currently) store
+       scannable axis information, we are forced to default to max. If
+       [Layout.t] changes to store scannable axis info, change this too. *)
+    | Scannable -> Scannable Jkind_types.Scannable_axes.max
     | Float64 -> Float64
     (* This is a case, where we potentially have mapped [Float_boxed] to
        [Float64], but that is fine, because they are reordered like other mixed

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1753,9 +1753,21 @@ let rec patch_guarded patch = function
       Levent (patch_guarded patch lam, ev)
   | _ -> fatal_error "Lambda.patch_guarded"
 
+let value_kind_of_pointerness = function
+  | Immediate -> Pintval
+  | Pointer -> Pgenval
+
+let pointerness_of_separability sep =
+  if Jkind_axis.Separability.(le sep (upper_bound_if_is_always_gc_ignorable ()))
+  then Immediate else Pointer
+
 let rec transl_mixed_block_element (elt : Types.mixed_block_element) =
   match elt with
-  | Scannable -> Value generic_value
+  | Scannable { separability; _ } ->
+    let raw_kind =
+      value_kind_of_pointerness (pointerness_of_separability separability)
+    in
+    Value { generic_value with raw_kind }
   | Float_boxed -> Float_boxed ()
   | Float64 -> Float64
   | Float32 -> Float32
@@ -1781,7 +1793,11 @@ and transl_mixed_product_shape shape =
 let rec transl_mixed_product_shape_for_read ~get_value_kind ~get_mode shape =
   Array.mapi (fun i (elt : Types.mixed_block_element) ->
     match elt with
-    | Scannable -> Value (get_value_kind i)
+    | Scannable { separability; _ } ->
+      let raw_kind =
+        value_kind_of_pointerness (pointerness_of_separability separability)
+      in
+      Value { (get_value_kind i) with raw_kind }
     | Float_boxed -> Float_boxed (get_mode i)
     | Float64 -> Float64
     | Float32 -> Float32
@@ -1811,6 +1827,9 @@ let mod_field ?(read_semantics=Reads_agree) pos = function
     Pmixedfield([pos], shape_for_read, read_semantics)
 
 let transl_module_representation repr =
+  (* The shape here is potentially an underapproximation, since the scannable
+     axes in [shape] will all be [max]. This should not matter, though, since it
+     is not possible to reassign / directly mutate a [val] in a module. *)
   let shape =
     Array.map
       (fun sort ->
@@ -1821,7 +1840,7 @@ let transl_module_representation repr =
   in
   let is_value (elt : Types.mixed_block_element) =
     match elt with
-    | Scannable -> true
+    | Scannable _ -> true
     | Float_boxed | Float64 | Float32 | Bits8 | Bits16 | Untagged_immediate
     | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 | Word
     | Product _ | Void -> false
@@ -2919,9 +2938,9 @@ let rec mixed_block_element_of_layout (layout : layout) :
   | Punboxed_or_untagged_integer Untagged_int -> Untagged_immediate
   | Psplicevar id -> Splice_variable id
 
-let value_kind_of_value_with_externality ext =
-  let open Jkind_axis.Externality in
-  if le ext (upper_bound_if_is_always_gc_ignorable ()) then Pintval else Pgenval
+let pointerness_of_scannable_with_externality ext =
+  if Jkind_axis.Externality.(le ext (upper_bound_if_is_always_gc_ignorable ()))
+  then Immediate else Pointer
 
 let rec layout_of_mixed_block_element_for_idx_set
   ext (mbe : _ mixed_block_element)
@@ -2933,7 +2952,9 @@ let rec layout_of_mixed_block_element_for_idx_set
       (Array.to_list
         (Array.map (layout_of_mixed_block_element_for_idx_set ext) mbes))
   | Value ({ raw_kind = Pgenval; _ } as value_kind) ->
-    let raw_kind = value_kind_of_value_with_externality ext in
+    let raw_kind =
+      value_kind_of_pointerness (pointerness_of_scannable_with_externality ext)
+    in
     Pvalue { value_kind with raw_kind }
   | Value value_kind -> Pvalue value_kind
   | Float64 | Float_boxed _ -> Punboxed_float Unboxed_float64

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1275,6 +1275,11 @@ val transl_class_path: scoped_location -> Env.t -> Path.t -> lambda
 
 val transl_address : scoped_location -> Persistent_env.address -> lambda
 
+val value_kind_of_pointerness : immediate_or_pointer -> value_kind_non_null
+
+val pointerness_of_separability
+  : Jkind_axis.Separability.t -> immediate_or_pointer
+
 val transl_mixed_product_shape : Types.mixed_product_shape -> mixed_block_shape
 
 val block_shape_of_value_kinds : value_kind list option -> block_shape
@@ -1416,10 +1421,10 @@ val mixed_block_element_of_layout : layout -> 'a mixed_block_element
 val project_from_mixed_block_shape
   : 'a mixed_block_element array -> path:int list -> 'a mixed_block_element
 
-(** [Pintval] if a type of [value] jkind is GC-ignorable based on its provided
-    externality, and [Pgenval] otherwise. *)
-val value_kind_of_value_with_externality
-  : Jkind_axis.Externality.t -> value_kind_non_null
+(** [Immediate] if a type of [scannable] jkind is GC-ignorable based on its
+    provided externality, and [Pointer] otherwise. *)
+val pointerness_of_scannable_with_externality
+  : Jkind_axis.Externality.t -> immediate_or_pointer
 
 (* Translates [Float_boxed] as [Punboxed_float Unboxed_float64], for
    compatibility with block indices. *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4003,9 +4003,8 @@ and do_compile_matching ~scopes value_kind repr partial ctx pmh =
             partial (divide_constructor ~scopes)
             (combine_constructor value_kind ploc arg ph.pat_env ph.pat_unique_barrier cstr partial)
             ctx pm
-      | Array (_, elt_sort, _) ->
-          let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
-          let kind = Typeopt.array_pattern_kind pomega elt_sort in
+      | Array (_, _, _) ->
+          let kind = Typeopt.array_pattern_kind pomega in
           compile_test
             (compile_match ~scopes value_kind repr partial)
             partial (divide_array ~scopes kind)

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -486,10 +486,7 @@ let iterator ~transl_exp ~scopes ~loc :
         (transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable iter_arr_exp)
     in
     let iter_arr_kind =
-      (* CR layouts v4: [~elt_sort:None] here is not ideal and
-         should be fixed. To do that, we will need to store a sort
-         on [Texp_comp_in]. *)
-      Typeopt.array_type_kind ~elt_sort:None ~elt_ty:(Some pattern.pat_type)
+      Typeopt.array_type_kind ~elt_ty:(Some pattern.pat_type)
         iter_arr_exp.exp_env iter_arr_exp.exp_loc iter_arr_exp.exp_type
     in
     let iter_arr_mut =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -734,10 +734,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                 if i <> lbl.lbl_pos then Lambda.generic_value
                 else
                   let pointerness, nullable = maybe_pointer e in
-                  let raw_kind = match pointerness with
-                    | Pointer -> Pgenval
-                    | Immediate -> Pintval
-                  in
+                  let raw_kind = value_kind_of_pointerness pointerness in
                   Lambda.{ raw_kind; nullable })
               ~get_mode:(fun i ->
                 if i <> lbl.lbl_pos then Lambda.alloc_heap
@@ -839,7 +836,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
       let mode = transl_alloc_mode alloc_mode in
       let element_sort = Jkind.Sort.default_for_transl_and_get element_sort in
-      let kind = array_kind e element_sort in
+      let kind = array_kind e in
       let ll =
         transl_list ~scopes
           (List.map (fun e -> (e, element_sort)) expr_list)
@@ -911,13 +908,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let loc = of_location ~scopes e.exp_loc in
       Transl_list_comprehension.comprehension
         ~transl_exp ~scopes ~loc comp
-  | Texp_array_comprehension (_amut, elt_sort, comp) ->
+  | Texp_array_comprehension (_amut, _, comp) ->
       (* We can ignore mutability here since we've already checked in in the
          type checker; both mutable and immutable arrays are created the same
          way *)
       let loc = of_location ~scopes e.exp_loc in
-      let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
-      let array_kind = Typeopt.array_kind e elt_sort in
+      let array_kind = Typeopt.array_kind e in
       begin match array_kind with
       | Pgenarray | Paddrarray | Pgcignorableaddrarray | Pintarray | Pfloatarray
       | Punboxedfloatarray _ | Punboxedoruntaggedintarray _ -> ()
@@ -2196,9 +2192,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                            let pointerness, nullable =
                              maybe_pointer_type env typ
                            in
-                           let raw_kind = match pointerness with
-                             | Pointer -> Pgenval
-                             | Immediate -> Pintval
+                           let raw_kind =
+                             value_kind_of_pointerness pointerness
                            in
                            Lambda.{ raw_kind; nullable })
                        ~get_mode:(fun _i ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1672,12 +1672,8 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       Some (Primitive (Pfield (n, is_int, mut), arity))
   | Primitive (Parraylength t, arity), [p] -> begin
       let loc = to_location loc in
-      (* CR layouts: [~elt_sort:None] here is not ideal and should be
-         fixed. To do that, we will need more checking of primitives
-         in the front end. *)
       let array_type =
-        glb_array_type loc t
-          (array_type_kind ~elt_sort:None ~elt_ty:None env loc p)
+        glb_array_type loc t (array_type_kind ~elt_ty:None env loc p)
       in
       if t = array_type then None
       else Some (Primitive (Parraylength array_type, arity))
@@ -1686,7 +1682,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       let loc = to_location loc in
       let array_ref_type =
         glb_array_ref_type loc rt
-          (array_type_kind ~elt_sort:None ~elt_ty:(Some rest_ty) env loc p1)
+          (array_type_kind ~elt_ty:(Some rest_ty) env loc p1)
       in
       let array_mut = array_type_mut env p1 in
       if rt = array_ref_type && mut = array_mut then None
@@ -1695,8 +1691,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Primitive (Parraysetu (st, index_kind), arity), p1 :: _ :: p3 :: _ -> begin
       let loc = to_location loc in
       let array_set_type =
-        glb_array_set_type loc st
-          (array_type_kind ~elt_sort:None ~elt_ty:(Some p3) env loc p1)
+        glb_array_set_type loc st (array_type_kind ~elt_ty:(Some p3) env loc p1)
       in
       if st = array_set_type then None
       else Some (Primitive (Parraysetu (array_set_type, index_kind), arity))
@@ -1705,7 +1700,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       let loc = to_location loc in
       let array_ref_type =
         glb_array_ref_type loc rt
-          (array_type_kind ~elt_sort:None ~elt_ty:(Some rest_ty) env loc p1)
+          (array_type_kind ~elt_ty:(Some rest_ty) env loc p1)
       in
       let array_mut = array_type_mut env p1 in
       if rt = array_ref_type && mut = array_mut then None
@@ -1714,8 +1709,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Primitive (Parraysets (st, index_kind), arity), p1 :: _ :: p3 :: _ -> begin
       let loc = to_location loc in
       let array_set_type =
-        glb_array_set_type loc st
-          (array_type_kind ~elt_sort:None ~elt_ty:(Some p3) env loc p1)
+        glb_array_set_type loc st (array_type_kind ~elt_ty:(Some p3) env loc p1)
       in
       if st = array_set_type then None
       else Some (Primitive (Parraysets (array_set_type, index_kind), arity))
@@ -1724,7 +1718,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     _ :: p2 :: [] -> begin
       let loc = to_location loc in
       let new_array_kind =
-        array_kind_of_elt ~elt_sort:None env loc p2
+        array_kind_of_elt env loc p2
         |> glb_array_type loc array_kind
       in
       if array_kind = new_array_kind then None
@@ -1736,7 +1730,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     _ :: [] -> begin
       let loc = to_location loc in
       let new_array_kind =
-        array_type_kind ~elt_sort:None ~elt_ty:None env loc rest_ty
+        array_type_kind ~elt_ty:None env loc rest_ty
         |> glb_array_type loc array_kind
       in
       unboxed_product_uninitialized_array_check loc new_array_kind;
@@ -1757,7 +1751,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
        kind.  If you haven't, then taking the glb of both would be just as
        likely to compound your error (e.g., by treating a Pgenarray as a
        Pfloatarray) as to help you. *)
-    let array_kind = array_type_kind ~elt_sort:None ~elt_ty:None env loc p2 in
+    let array_kind = array_type_kind ~elt_ty:None env loc p2 in
     let new_dst_array_set_kind =
       glb_array_set_type loc dst_array_set_kind array_kind
     in
@@ -1766,7 +1760,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       src_mutability; dst_array_set_kind = new_dst_array_set_kind }, arity))
   | Primitive (Parray_element_size_in_bytes _, arity), p1 :: _ -> (
       let array_kind =
-        array_type_kind ~elt_sort:None ~elt_ty:None env (to_location loc) p1
+        array_type_kind ~elt_ty:None env (to_location loc) p1
       in
       Some (Primitive (Parray_element_size_in_bytes array_kind, arity))
     )
@@ -1897,8 +1891,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
          || Path.same p Predef.path_iarray -> ()
      | _ -> err ());
     let ak =
-      Typeopt.array_type_kind ~elt_sort:None ~elt_ty:None
-        env loc array_ty
+      Typeopt.array_type_kind ~elt_ty:None env loc array_ty
     in
     let jkind = Ctype.type_jkind env elt_ty in
     let mbe = Typedecl.mixed_block_element env elt_ty jkind in

--- a/testsuite/tests/slambda/records.ml
+++ b/testsuite/tests/slambda/records.ml
@@ -80,7 +80,8 @@ type s = { e : t; f : t; }
            one =? (apply (field_imm 0 (global Toploop!)) "one"))
           (region
             (mixedfield 0  (value<int>,untagged_immediate)
-              (makelocalblock 0 (?,untagged_immediate) one two_u)))) ⟫ }
+              (makelocalblock 0 (value_or_null<int>,untagged_immediate) one
+                two_u)))) ⟫ }
 - : int = 1
 |}];;
 

--- a/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
@@ -1,0 +1,225 @@
+(* TEST
+ modules = "replace_caml_modify.c";
+ {
+   not-macos;
+   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
+            -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
+   native;
+ }
+*)
+
+(* These tests verify that abstract types with layout value non_pointer don't
+   unnecessarily call [caml_modify]. See [basics.ml] for an explanation. *)
+
+external called_caml_modify : unit -> int
+  = "replace_caml_modify_called_modify" [@@noalloc]
+external reset : unit -> unit = "replace_caml_modify_reset" [@@noalloc]
+
+let test ~(call_pos : [%call_pos]) ~expect_caml_modifies f =
+  reset ();
+  f ();
+  let actual_modifies = called_caml_modify () in
+  if not (expect_caml_modifies = actual_modifies) then
+    failwith @@
+      Format.sprintf
+        "On line %d, expected %d calls to caml_modify, but saw %d"
+        call_pos.pos_lnum expect_caml_modifies actual_modifies
+
+external[@layout_poly] set :
+  ('a : any mod separable).
+  ('a array[@local_opt]) -> (int[@local_opt]) -> 'a -> unit
+  = "%array_safe_set"
+
+external[@layout_poly] unsafe_set_ptr :
+  'a ('b : any).
+  (#('a * ('a, 'b) idx_mut)[@local_opt]) -> ('b[@local_opt]) -> unit
+  = "%unsafe_set_ptr"
+
+
+(* Mutating abstract types of kind value non_pointer should skip caml_modify *)
+
+module Mnp : sig
+  type t : value non_pointer (* not mod external_ *)
+  val mk : int -> t
+end = struct
+  type t = int
+  let mk x = x
+end
+
+let () =
+  let open struct
+    type t = { mutable x : Mnp.t }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let t = { x = Mnp.mk 6 } in
+      t.x <- Mnp.mk 7;
+      ignore (Sys.opaque_identity t))
+
+let () =
+  let open struct
+    type t = { x : string ; mutable y : Mnp.t }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let t = { x = "a" ; y = Mnp.mk 1 } in
+      let idx = (.y) in
+      unsafe_set_ptr #(t, idx) (Mnp.mk 2);
+      ignore (Sys.opaque_identity t))
+
+let () =
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let arr = Array.make 1 (Mnp.mk 6) in
+      arr.(0) <- Mnp.mk 7;
+      ignore (Sys.opaque_identity arr))
+
+(* A product containing only value non_pointers should skip all caml_modifies *)
+
+module Mnpnp : sig
+  type t : value non_pointer & value non_pointer
+  val mk : int -> int -> t
+end = struct
+  type t = #{ x : int; y : int }
+  let mk x y = #{ x ; y }
+end
+
+let () =
+  let open struct
+    type outer = { mutable x : Mnpnp.t }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let outer = { x = Mnpnp.mk 1 2 } in
+      outer.x <- Mnpnp.mk 3 4;
+      ignore (Sys.opaque_identity outer))
+
+let () =
+  let open struct
+    type ('a : value non_pointer & value non_pointer) unboxed = { u : 'a } [@@unboxed]
+    type outer = { mutable x : Mnpnp.t unboxed; }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let outer = { x = { u = Mnpnp.mk 1 2} } in
+      outer.x <- { u = Mnpnp.mk 3 4 };
+      ignore (Sys.opaque_identity outer))
+
+let () =
+  let open struct
+    type inner = { a : int; b : Mnpnp.t }
+    type outer = { mutable x : inner# }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let outer = { x = #{ a = 1; b = Mnpnp.mk 2 3 } } in
+      outer.x <- #{ a = 4; b = Mnpnp.mk 5 6 };
+      ignore (Sys.opaque_identity outer))
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : Mnpnp.t }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let t = { x = "x"; y = Mnpnp.mk 1 2 } in
+      let idx = (.y) in
+      unsafe_set_ptr #(t, idx) (Mnpnp.mk 3 4);
+      ignore (Sys.opaque_identity t))
+
+let () =
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let arr = [| (Mnpnp.mk 1 2) |] in
+      set arr 0 (Mnpnp.mk 3 4);
+      ignore (Sys.opaque_identity arr))
+
+(* A product containing one value non_pointer component should skip caml_modify
+   for that one component *)
+
+module Mnpval : sig
+  type t : value non_pointer & value
+  val mk : int -> string -> t
+end = struct
+  type t = #{ x : int; y : string }
+  let mk x y = #{ x ; y }
+end
+
+let () =
+  let open struct
+    type t = { mutable x : Mnpval.t }
+  end in
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let outer = { x = Mnpval.mk 1 "a" } in
+      outer.x <- Mnpval.mk 2 "b";
+      ignore (Sys.opaque_identity outer))
+
+let () =
+  let open struct
+    type inner = { a : string; b : Mnpval.t }
+    type outer = { mutable x : inner# }
+  end in
+  test ~expect_caml_modifies:2
+    (fun () ->
+      let outer = { x = #{ a = "a"; b = Mnpval.mk 1 "b" } } in
+      outer.x <- #{ a = "c"; b = Mnpval.mk 2 "d" };
+      ignore (Sys.opaque_identity outer))
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : Mnpval.t }
+  end in
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let t = { x = "x"; y = Mnpval.mk 1 "a" } in
+      let idx = (.y) in
+      unsafe_set_ptr #(t, idx) (Mnpval.mk 2 "b");
+      ignore (Sys.opaque_identity t))
+
+let () =
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let arr = [| (Mnpval.mk 1 "a") |] in
+      set arr 0 (Mnpval.mk 2 "b");
+      ignore (Sys.opaque_identity arr))
+
+(* interaction with mixed modules *)
+module type MT = sig
+  type t : value non_pointer & value
+  val t1 : t
+  val t2 : t
+end
+
+let () =
+  let module M : MT = struct
+    type t = #{ x : int; y : string }
+    let t1 = #{ x = 1; y = "a" }
+    let t2 = #{ x = 2; y = "b" }
+  end in
+  let open struct
+    type t = { mutable x : M.t }
+  end in
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let outer = { x = M.t1 } in
+      outer.x <- M.t2;
+      ignore (Sys.opaque_identity outer))
+
+let () =
+  let m =
+    (module struct
+      type t = #{ x : int; y : string }
+      let t1 = #{ x = 1; y = "a" }
+      let t2 = #{ x = 2; y = "b" }
+    end : MT)
+  in
+  let module M = (val m : MT) in
+  let open struct
+    type t = { mutable x : M.t }
+  end in
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let outer = { x = M.t1 } in
+      outer.x <- M.t2;
+      ignore (Sys.opaque_identity outer))

--- a/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
@@ -233,3 +233,101 @@ let () =
       let outer = { x = M.t1 } in
       outer.x <- M.t2;
       ignore (Sys.opaque_identity outer))
+
+(* Interaction with substitution *)
+
+let () =
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let arr = [| (Mnpval.mk 1 "a") |] in
+      set arr 0 (Mnpval.mk 2 "b");
+      ignore (Sys.opaque_identity arr))
+
+let () =
+  let open struct
+    module M : sig
+      type t : value & value
+      type r = { mutable t : t; i : int64# }
+    end with type t := #(int * string) = struct
+      type r = { mutable t : #(int * string); i : int64# }
+    end
+  end in
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let t = { M.t = #(1, "1"); M.i = #1L } in
+      t.t <- #(2, "2");
+      ignore (Sys.opaque_identity t))
+
+let () =
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let arr = [| (Mnpval.mk 1 "a") |] in
+      set arr 0 (Mnpval.mk 2 "b");
+      ignore (Sys.opaque_identity arr))
+
+(* CR layouts-scannable: Record representations can be stale after type
+   substitution, causing an unnecessary caml_modify *)
+let () =
+  let open struct
+    module IS : sig
+      type t : value non_pointer & value
+      val a : t
+      val b : t
+    end = struct
+      type t = #(int * string)
+      let a = #(1, "1")
+      let b = #(2, "2")
+    end
+
+    module M : sig
+      type r = { mutable t : IS.t }
+    end = struct
+      type r = { mutable t : IS.t }
+    end
+
+    module M_with_subst : sig
+      type t : value & value
+      (* When computing the record representation for [r], the compiler hasn't
+         yet seen the sustitution yet, and it doesn't update the record
+         representation upon substituting, so it thinks [r] is a mixed block
+         containing a [value & value]. *)
+      type r = { mutable t : t }
+    end with type t := IS.t = struct
+      type r = { mutable t : IS.t }
+    end
+  end in
+  test ~expect_caml_modifies:1
+    (fun () ->
+      let t = { M.t = IS.a } in
+      t.t <- IS.b;
+      ignore (Sys.opaque_identity t));
+  test ~expect_caml_modifies:2
+    (fun () ->
+      let t = { M_with_subst.t = IS.a } in
+      t.t <- IS.b;
+      ignore (Sys.opaque_identity t))
+
+(* CR layouts-scananble: Test this once abstract kinds can be substituted for
+   subkinds *)
+(*
+let () =
+  let open struct
+    module M : sig
+      kind_ k = value
+      type t : k
+      val x : t
+      val y : t
+      type r = { mutable t : t; i : int64# }
+    end with kind_ k := value non_pointer = struct
+      type t = int
+      type r = { mutable t : t; i : int64# }
+      let x = 1
+      let y = 2
+    end
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let t = { M.t = M.x; M.i = #1L } in
+      t.t <- M.y;
+      ignore (Sys.opaque_identity t))
+*)

--- a/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
@@ -134,6 +134,16 @@ let () =
       set arr 0 (Mnpnp.mk 3 4);
       ignore (Sys.opaque_identity arr))
 
+let () =
+  let open struct
+    type 'a t = { mutable x : 'a or_null }
+  end in
+  test ~expect_caml_modifies:0
+    (fun () ->
+      let t = { x = This 1 } in
+      t.x <- This 2;
+      ignore (Sys.opaque_identity t))
+
 (* A product containing one value non_pointer component should skip caml_modify
    for that one component *)
 

--- a/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
+++ b/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
@@ -1,0 +1,36 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* There is a particularly tricky edge case that arises in Typeopt's
+   [type_representable_layout]. More documentation is present there; this file
+   tests the current behavior. *)
+
+(* CR layouts-scannable: This signature seems needlessly restrictive
+   (but this probably doesn't matter too much). *)
+external weird_id : ('a : any mod separable). 'a array -> int = "%identity"
+let weird_id' arr = weird_id arr
+[%%expect{|
+external weird_id : ('a : any separable). 'a array -> int = "%identity"
+val weird_id' : ('a : value maybe_null). 'a array -> int = <fun>
+|}]
+
+(* This is not sound whenever 'a is not a value, but this is the kind of
+   unsoundness that is generally permitted with [external] declarations *)
+external weird_flarr_len : ('a : any mod separable). 'a array -> int = "%floatarray_length"
+let weird_flarr_len' x = weird_flarr_len x
+[%%expect{|
+external weird_flarr_len : ('a : any separable). 'a array -> int
+  = "%floatarray_length"
+val weird_flarr_len' : ('a : value maybe_null). 'a array -> int = <fun>
+|}]
+
+external product_edge_case : ('a : any mod separable). #('a * 'a) array -> int = "%identity"
+let product_edge_case x = product_edge_case x
+[%%expect{|
+external product_edge_case : ('a : any separable). #('a * 'a) array -> int
+  = "%identity"
+val product_edge_case : ('a : value maybe_null). #('a * 'a) array -> int =
+  <fun>
+|}]

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -677,7 +677,10 @@ Error: Signature mismatch:
 |}]
 
 (* We only compare record representations up to scannable axes for the inclusion
-   check, to support type substitution edge cases *)
+   check, to support type substitution edge cases.
+   See also Note [Ignoring scannable axes in type declaration representations]
+   in typing/types.mli
+*)
 
 module M : sig
   type t
@@ -692,8 +695,8 @@ end
    precise representation, but we accept it as we only compare representations
    up to scannable axes.
 
-   This can lead to a missed [caml_modify] in some uncommon cases: see the test
-   with a "CR layouts-scannable" in
+   This can lead to a unnecessary [caml_modify] in some uncommon cases: see the
+   test with a "CR layouts-scannable" in
    testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
 *)
 type r = M.r = { t : int ; i : int64# }

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -426,24 +426,7 @@ end = struct
   type t = #(int or_null * float#)
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type t = #(int or_null * float#)
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = #(int or_null * float#) end
-       is not included in
-         sig type t : value_or_null non_pointer & float64 end
-       Type declarations do not match:
-         type t = #(int or_null * float#)
-       is not included in
-         type t : value_or_null non_pointer & float64
-       The layout of the first is value maybe_separable maybe_null & float64
-         because it is an unboxed tuple.
-       But the layout of the first must be a sublayout of
-           value non_pointer maybe_null & float64
-         because of the definition of t at line 2, characters 2-38.
+module M : sig type t : value_or_null non_pointer mod external_ & float64 end
 |}]
 
 (* modules and module inclusion *)

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -666,9 +666,38 @@ Error: Signature mismatch:
        is not included in
          sig type r = { r : #(t * s); } and t : value non_pointer and s end
        Type declarations do not match:
-         type r = { r : #(t * s); }
+         type t
        is not included in
-         type r = { r : #(t * s); }
-       Their internal representations differ:
-       This is likely caused by a layout mismatch in a later definition.
+         type t : value non_pointer
+       The layout of the first is value
+         because of the definition of t at line 7, characters 2-7.
+       But the layout of the first must be a sublayout of value non_pointer
+         because of the definition of t at line 3, characters 2-27.
+       Note: The layout of immediate is value non_pointer.
+|}]
+
+(* We only compare record representations up to scannable axes for the inclusion
+   check, to support type substitution edge cases *)
+
+module M : sig
+  type t
+  (* Because [t := int] only via the substitution below, the compiler doesn't
+     realize that [t] is [non_pointer] when computing the type declaration *)
+  type r = { t : t; i : int64# }
+end with type t := int = struct
+  type r = { t : int ; i : int64# }
+end
+
+(* Then, for this check, the new record declaration technically has a more
+   precise representation, but we accept it as we only compare representations
+   up to scannable axes.
+
+   This can lead to a missed [caml_modify] in some uncommon cases: see the test
+   with a "CR layouts-scannable" in
+   testsuite/tests/typing-layouts-caml-modify/non_pointer.ml
+*)
+type r = M.r = { t : int ; i : int64# }
+[%%expect{|
+module M : sig type r = { t : int; i : int64#; } end
+type r = M.r = { t : int; i : int64#; }
 |}]

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -412,12 +412,38 @@ Error: This expression has type "a or_null"
 |}]
 
 module M : sig
+  type t : immediate_or_null
+end = struct
+  type t = int or_null
+end
+[%%expect{|
+module M : sig type t : immediate_or_null end
+|}]
+
+module M : sig
   type t : immediate_or_null & float64
 end = struct
   type t = #(int or_null * float#)
 end
 [%%expect{|
-module M : sig type t : value_or_null non_pointer mod external_ & float64 end
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = #(int or_null * float#)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = #(int or_null * float#) end
+       is not included in
+         sig type t : value_or_null non_pointer & float64 end
+       Type declarations do not match:
+         type t = #(int or_null * float#)
+       is not included in
+         type t : value_or_null non_pointer & float64
+       The layout of the first is value maybe_separable maybe_null & float64
+         because it is an unboxed tuple.
+       But the layout of the first must be a sublayout of
+           value non_pointer maybe_null & float64
+         because of the definition of t at line 2, characters 2-38.
 |}]
 
 (* modules and module inclusion *)
@@ -603,4 +629,63 @@ type check = non_pointer require_non_pointer
 [%%expect{|
 type non_pointer : value non_pointer
 type check = non_pointer require_non_pointer
+|}]
+
+(* Mixed records and mutual recursion edge cases *)
+
+module Equal_layout : sig
+  type t : value non_pointer
+  type s
+  type r = { r : #(t * s) }
+end = struct
+  type t : value non_pointer
+  type s
+  type r = { r : #(t * s) }
+end
+[%%expect{|
+module Equal_layout :
+  sig type t : value non_pointer type s type r = { r : #(t * s); } end
+|}]
+
+module Less_layout : sig
+  type t : value non_pointer
+  type s
+  type r = { r : #(t * s) }
+end = struct
+  type t : value non_pointer
+  type s : value non_pointer
+  type r = { r : #(t * s) }
+end
+[%%expect{|
+module Less_layout :
+  sig type t : value non_pointer type s type r = { r : #(t * s); } end
+|}]
+
+module Not_le_layout : sig
+  type r = { r : #(t * s) }
+  and t : value non_pointer
+  and s
+end = struct
+  type r = { r : #(t * s) }
+  and t
+  and s
+end
+[%%expect{|
+Lines 5-9, characters 6-3:
+5 | ......struct
+6 |   type r = { r : #(t * s) }
+7 |   and t
+8 |   and s
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type r = { r : #(t * s); } and t and s end
+       is not included in
+         sig type r = { r : #(t * s); } and t : value non_pointer and s end
+       Type declarations do not match:
+         type r = { r : #(t * s); }
+       is not included in
+         type r = { r : #(t * s); }
+       Their internal representations differ:
+       This is likely caused by a layout mismatch in a later definition.
 |}]

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -348,6 +348,36 @@ Error: Signature mismatch:
        The first is a record, but the second is an unboxed record.
 |}]
 
+module M : sig
+  (* the error on r gets reported first, since r's definition occurs first,
+     but the real issue is that t is not bits64 in the struct. *)
+  type r = { r : #(t * s) }
+  and t : bits64
+  and s
+end = struct
+  type r = { r : #(t * s) }
+  and t
+  and s
+end
+[%%expect{|
+Lines 7-11, characters 6-3:
+ 7 | ......struct
+ 8 |   type r = { r : #(t * s) }
+ 9 |   and t
+10 |   and s
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type r = { r : #(t * s); } and t and s end
+       is not included in
+         sig type r = { r : #(t * s); } and t : bits64 and s end
+       Type declarations do not match:
+         type r = { r : #(t * s); }
+       is not included in
+         type r = { r : #(t * s); }
+       Their internal representations differ:
+       This is likely caused by a layout mismatch in a later definition.
+|}]
 
 (* Check interference with representation of float arrays. *)
 type t11 = L of float [@@ocaml.unboxed];;

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -679,7 +679,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                   | Outval_record_mixed_block shape ->
                       let fld =
                         match shape.(pos) with
-                        | Scannable -> `Continue (O.field obj pos)
+                        | Scannable _ -> `Continue (O.field obj pos)
                         | Float_boxed | Float64 ->
                             `Continue (O.repr (O.double_field obj pos))
                         | Float32 | Bits8 | Bits16 | Untagged_immediate

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1312,6 +1312,14 @@ module Jkind0 = struct
           name = "any mod everything"
         }
 
+      let scannable =
+        { jkind =
+            mk_jkind (Base (Scannable, Scannable_axes.max))
+              ~crossing:Mode.Crossing.max
+              ~externality:Mod_bounds.Externality.max;
+          name = "scannable"
+        }
+
       let value_or_null =
         { jkind =
             mk_jkind
@@ -1790,6 +1798,8 @@ module Jkind0 = struct
     module Builtin = struct
       let any = max
 
+      let scannable = of_const Const.Builtin.scannable.jkind
+
       let value_or_null = of_const Const.Builtin.value_or_null.jkind
 
       let value = of_const Const.Builtin.value.jkind
@@ -1962,6 +1972,10 @@ module Jkind0 = struct
         fresh_jkind Jkind_desc.Builtin.void ~annotation:(mk_annot "void")
           ~why:(Void_creation why)
         |> mark_best
+
+      let scannable ~why =
+        fresh_jkind Jkind_desc.Builtin.scannable
+          ~annotation:(mk_annot "scannable") ~why:(Scannable_creation why)
 
       let value_or_null ~why =
         match (why : Jkind_intf.History.value_or_null_creation_reason) with

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -453,6 +453,10 @@ module Jkind0 : sig
       (** Value of types of this jkind are not retained at all at runtime *)
       val void : t
 
+      (** Value of types of this jkind can be scanned by the GC, but no other
+          scannable axis information about them is known. *)
+      val scannable : t
+
       (** This is the jkind of normal ocaml values or null pointers *)
       val value_or_null : t
 
@@ -654,6 +658,8 @@ module Jkind0 : sig
       val any : why:Jkind_intf.History.any_creation_reason -> 'd jkind
       val void :
         why:Jkind_intf.History.void_creation_reason -> ('l * disallowed) jkind
+      val scannable :
+        why:Jkind_intf.History.scannable_creation_reason -> 'd Types.jkind
       val value_or_null :
         why:Jkind_intf.History.value_or_null_creation_reason -> 'd jkind
       val value : why:Jkind_intf.History.value_creation_reason -> 'd jkind

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3259,10 +3259,6 @@ let check_type_externality env ty ext =
   | Ok () -> true
   | Error _ -> false
 
-let is_always_gc_ignorable env ty =
-  check_type_externality
-    env ty (Jkind_axis.Externality.upper_bound_if_is_always_gc_ignorable ())
-
 let check_type_nullability env ty null =
   let upper_bound =
     Jkind.set_root_nullability (Jkind.Builtin.any ~why:Dummy_jkind) null
@@ -3271,13 +3267,28 @@ let check_type_nullability env ty null =
   | Ok () -> true
   | Error _ -> false
 
-let check_type_separability env ty sep =
-  let upper_bound =
-    Jkind.set_root_separability (Jkind.Builtin.any ~why:Dummy_jkind) sep
-  in
+let check_type_separability jkind env ty sep =
+  let upper_bound = Jkind.set_root_separability jkind sep in
   match check_type_jkind env ty upper_bound with
   | Ok () -> true
   | Error _ -> false
+
+let is_always_gc_ignorable env ty =
+  (* CR layouts: calling [check_type_jkind] two times (indirectly) is sad. *)
+  check_type_externality env ty
+    (Jkind_axis.Externality.upper_bound_if_is_always_gc_ignorable ())
+  ||
+  (* Checking against the upper bound [scannable non_pointer(64)] ensures that
+     whenever [ty]'s layout is not scannable, the check will be [false]. *)
+  (* CR layouts-scannable: Since we check against [scannable non_pointer(64)],
+     a type of kind [value non_pointer & value non_pointer] will fail to be
+     recognized as being always_gc_ignorable, even though it is. To avoid this,
+     [non_pointer(64)] should imply [external(64)]. *)
+  check_type_separability (Jkind.Builtin.scannable ~why:Dummy_jkind) env ty
+      (Jkind_axis.Separability.upper_bound_if_is_always_gc_ignorable ())
+
+let check_type_separability env ty sep =
+  check_type_separability (Jkind.Builtin.any ~why:Dummy_jkind) env ty sep
 
 let check_type_jkind_exn env texn ty jkind =
   match check_type_jkind env ty jkind with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4207,18 +4207,20 @@ and mcomp_type_decl type_pairs env p1 p2 tl1 tl2 =
     else
       match decl.type_kind, decl'.type_kind with
       | Type_record (lst,r,umc), Type_record (lst',r',umc')
-        when equal_record_representation r r' ->
+        when equal_record_representation_up_to_scannable_axes r r' ->
           mcomp_list type_pairs env tl1 tl2;
           mcomp_record_description type_pairs env lst lst';
           mcomp_unsafe_mode_crossing type_pairs env umc umc'
       | Type_record_unboxed_product (lst,r,umc),
         Type_record_unboxed_product (lst',r',umc')
-        when equal_record_unboxed_product_representation r r' ->
+        when
+          equal_record_unboxed_product_representation_up_to_scannable_axes r r'
+        ->
           mcomp_list type_pairs env tl1 tl2;
           mcomp_record_description type_pairs env lst lst';
           mcomp_unsafe_mode_crossing type_pairs env umc umc'
       | Type_variant (v1,r,umc), Type_variant (v2,r',umc')
-        when equal_variant_representation r r' ->
+        when equal_variant_representation_up_to_scannable_axes r r' ->
           mcomp_list type_pairs env tl1 tl2;
           mcomp_variant_description type_pairs env v1 v2;
           mcomp_unsafe_mode_crossing type_pairs env umc umc'

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -962,6 +962,8 @@ module Record_diffing = struct
   let find_mismatch_in_mixed_record_representations
       (s1 : mixed_product_shape) (s2 : mixed_product_shape)
     =
+    (* It's possible for [s1] to be higher than [s2] here: see
+       Note [Ignoring scannable axes in type declaration representations] *)
     if Types.equal_mixed_product_shape_up_to_scannable_axes s1 s2
     then None
     else

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -962,7 +962,7 @@ module Record_diffing = struct
   let find_mismatch_in_mixed_record_representations
       (s1 : mixed_product_shape) (s2 : mixed_product_shape)
     =
-    if Misc.Le_result.is_le (Types.mixed_product_shape_less_or_equal s1 s2)
+    if Types.equal_mixed_product_shape_up_to_scannable_axes s1 s2
     then None
     else
       let has_float_boxed_on_read fields =

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -334,6 +334,7 @@ type record_mismatch =
   | Ufloat_representation of position
   | Mixed_representation of position
   | Mixed_representation_with_flat_floats of position
+  | Representation_shape_mismatch
 
 type constructor_mismatch =
   | Type of Errortrace.equality_error
@@ -610,6 +611,9 @@ let report_record_mismatch first second decl env ppf err =
       pr "@[<hv>Their internal representations differ:@ %s %s %s.@]"
         (choose ord first second) decl
         "uses a mixed representation where boxed floats are stored flat"
+  | Representation_shape_mismatch ->
+    pr "@[<hv>Their internal representations differ:@;\
+        This is likely caused by a layout mismatch in a later definition.@]"
 
 let report_constructor_mismatch first second decl env ppf err =
   let pr fmt  = Fmt.fprintf ppf fmt in
@@ -958,7 +962,8 @@ module Record_diffing = struct
   let find_mismatch_in_mixed_record_representations
       (s1 : mixed_product_shape) (s2 : mixed_product_shape)
     =
-    if s1 = s2 then None
+    if Misc.Le_result.is_le (Types.mixed_product_shape_less_or_equal s1 s2)
+    then None
     else
       let has_float_boxed_on_read fields =
         Array.exists (function
@@ -971,10 +976,11 @@ module Record_diffing = struct
       else if has_float_boxed_on_read s2
       then Some (Mixed_representation_with_flat_floats Second)
       else
-        Misc.fatal_error
-          "Impossible: the only way for mixed blocks to differ in \
-           representation is if one is a flat float record with a boxed float \
-           field, and the other isn't."
+        (* Before, this case was thought to be impossible. We report the first
+           error when doing the inclusion check: the real culprit may be a
+           layout mismatch that is actually defined later defined mutually
+           recursively with this record. *)
+        Some Representation_shape_mismatch
 
   let compare_with_representation (type rep) ~loc
         (record_form : rep record_form) env params1 params2 l r

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -90,6 +90,7 @@ type record_mismatch =
   | Ufloat_representation of position
   | Mixed_representation of position
   | Mixed_representation_with_flat_floats of position
+  | Representation_shape_mismatch
 
 type constructor_mismatch =
   | Type of Errortrace.equality_error

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -70,12 +70,6 @@ end
 module Scannable_axes = struct
   include Jkind_types.Scannable_axes
 
-  let less_or_equal { nullability = n1; separability = s1 }
-      { nullability = n2; separability = s2 } =
-    Misc.Le_result.combine
-      (Nullability.less_or_equal n1 n2)
-      (Separability.less_or_equal s1 s2)
-
   let le sa1 sa2 = Misc.Le_result.is_le (less_or_equal sa1 sa2)
 
   let meet { nullability = n1; separability = s1 }
@@ -2926,6 +2920,12 @@ module Format_history = struct
       fprintf ppf "it is the primitive immediate_or_null type %s"
         (Ident.name id)
 
+  let format_scannable_creation_reason ppf :
+      History.scannable_creation_reason -> _ = function
+    | Dummy_jkind ->
+      format_with_notify_js ppf
+        "it's assigned a dummy kind that should have been overwritten"
+
   let format_value_or_null_creation_reason ppf ~layout_or_kind :
       History.value_or_null_creation_reason -> _ = function
     | Primitive id ->
@@ -3039,6 +3039,8 @@ module Format_history = struct
       format_immediate_creation_reason ppf immediate
     | Immediate_or_null_creation immediate ->
       format_immediate_or_null_creation_reason ppf immediate
+    | Scannable_creation scannable ->
+      format_scannable_creation_reason ppf scannable
     | Void_creation _ -> .
     | Value_or_null_creation value ->
       format_value_or_null_creation_reason ppf value ~layout_or_kind
@@ -3945,6 +3947,10 @@ module Debug_printers = struct
       History.immediate_or_null_creation_reason -> _ = function
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
 
+  let scannable_creation_reason ppf : History.scannable_creation_reason -> _ =
+    function
+    | Dummy_jkind -> fprintf ppf "Dummy_jkind"
+
   let value_or_null_creation_reason ppf :
       History.value_or_null_creation_reason -> _ = function
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
@@ -4017,6 +4023,8 @@ module Debug_printers = struct
     | Immediate_or_null_creation immediate ->
       fprintf ppf "Immediate_or_null_creation %a"
         immediate_or_null_creation_reason immediate
+    | Scannable_creation scannable ->
+      fprintf ppf "Scannable_creation %a" scannable_creation_reason scannable
     | Value_or_null_creation value ->
       fprintf ppf "Value_or_null_creation %a" value_or_null_creation_reason
         value

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -310,6 +310,8 @@ module Builtin : sig
   (** Value of types of this jkind are not retained at all at runtime *)
   val void : why:History.void_creation_reason -> ('l * disallowed) Types.jkind
 
+  val scannable : why:History.scannable_creation_reason -> 'd Types.jkind
+
   val value_or_null :
     why:History.value_or_null_creation_reason -> 'd Types.jkind
 

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -114,6 +114,14 @@ module Separability = struct
     | Maybe_separable -> "maybe_separable"
 
   let print ppf t = Fmt.fprintf ppf "%s" (to_string t)
+
+  let upper_bound_if_is_always_gc_ignorable () =
+    (* We check that we're compiling to (64-bit) native code before counting
+        Non_pointer64 types as gc_ignorable, because bytecode is intended to be
+        platform independent. *)
+    if !Clflags.native_code && Sys.word_size = 64
+    then Non_pointer64
+    else Non_pointer
 end
 
 module Axis = struct

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -53,6 +53,8 @@ module Separability : sig
     | Maybe_separable
 
   include Axis_ops with type t := t
+
+  val upper_bound_if_is_always_gc_ignorable : unit -> t
 end
 
 module Axis : sig

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -15,6 +15,12 @@
 (* This module contains definitions that we do not otherwise need to repeat
    between the various Jkind modules. See comment in jkind_types.mli. *)
 module type Sort = sig
+  (* CR layouts-scannable: The comment below is no longer entirely accurate,
+     after the addition of scannable axes (which are needed when compiling to
+     determine GC behavior).
+     It may be desirable to make a refined data definition that separates "the
+     thing that stores enough info to compiling" (sort + scannable axes, or
+     similarly layout - any) from "the discrete thing used for unification". *)
   (** A sort classifies how a type is represented at runtime. Every concrete
       jkind has a sort, and knowing the sort is sufficient for knowing the
       calling convention of values of a given type. *)
@@ -412,6 +418,8 @@ module History = struct
 
   type immediate_or_null_creation_reason = Primitive of Ident.t
 
+  type scannable_creation_reason = Dummy_jkind
+
   (* CR layouts v5: make new void_creation_reasons *)
   type void_creation_reason = |
 
@@ -447,6 +455,7 @@ module History = struct
     | Value_creation of value_creation_reason
     | Immediate_creation of immediate_creation_reason
     | Immediate_or_null_creation of immediate_or_null_creation_reason
+    | Scannable_creation of scannable_creation_reason
     | Void_creation of void_creation_reason
     | Any_creation of any_creation_reason
     | Product_creation of product_creation_reason

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -928,6 +928,12 @@ module Scannable_axes = struct
   let equal { nullability = n1; separability = s1 }
       { nullability = n2; separability = s2 } =
     Nullability.equal n1 n2 && Separability.equal s1 s2
+
+  let less_or_equal { nullability = n1; separability = s1 }
+      { nullability = n2; separability = s2 } =
+    Misc.Le_result.combine
+      (Nullability.less_or_equal n1 n2)
+      (Separability.less_or_equal s1 s2)
 end
 
 module Layout = struct

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -124,6 +124,8 @@ module Scannable_axes : sig
   val value_axes : t
 
   val equal : t -> t -> bool
+
+  val less_or_equal : t -> t -> Misc.Le_result.t
 end
 
 module Layout : sig

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -29,6 +29,11 @@
 [@@@warning "+4"]
 
 module Uid = Shape.Uid
+
+(* CR layouts-scannable: As noted on the CR on [Sort] in [jkind_intf.ml], a
+   sort no longer contains sufficient information to compile: it's missing the
+   scannable axes! Once a better data definition for tracking this is added,
+   the meaning of [Layout] below perhaps should change as well. *)
 module Layout = Jkind_types.Sort.Const
 
 type base_layout = Jkind_types.Sort.base
@@ -379,7 +384,10 @@ end
 
 module Type_decl_shape = struct
   let rec mixed_block_shape_to_layout = function
-    | Types.Scannable -> Layout.Base Scannable
+    (* CR layouts-scannable: We forget about the stored scannable axes when
+       converting, since a [Layout.t] (which is a [Sort.Const.t]) doesn't have
+       a place to put them. See the CR on [Layout] at the top of this file. *)
+    | Types.Scannable _ -> Layout.Base Scannable
     | Types.Float_boxed ->
       Layout.Base Float64
       (* [Float_boxed] records are unboxed in the variant at runtime,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6846,12 +6846,12 @@ and type_expect_
           match label.lbl_repres with
           | Record_float -> true
           | Record_mixed mixed -> begin
-              match mixed.(label.lbl_pos) with
-              | Float_boxed -> true
-              | Float64 | Float32 | Scannable | Bits8 | Bits16 | Bits32 | Bits64
-              | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate | Void
-              | Product _ ->
-                false
+            match mixed.(label.lbl_pos) with
+            | Float_boxed -> true
+            | Float64 | Float32 | Scannable _ | Bits8 | Bits16 | Bits32 | Bits64
+            | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate | Void
+            | Product _ ->
+              false
             end
           | _ -> false
         in
@@ -8023,7 +8023,7 @@ and type_block_access env expected_base_ty principal
       | Record_mixed mixed ->
         begin match mixed.(label.lbl_pos) with
         | Float_boxed -> true
-        | Float64 | Float32 | Scannable | Bits8 | Bits16 | Bits32 | Bits64
+        | Float64 | Float32 | Scannable _ | Bits8 | Bits16 | Bits32 | Bits64
         | Vec128 | Vec256 | Vec512 | Word | Product _ | Void
         | Untagged_immediate ->
           false

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1276,7 +1276,7 @@ let record_gets_unboxed_version = function
       Array.exists
         (fun (kind : mixed_block_element) ->
           match kind with
-          | Scannable | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
+          | Scannable _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
           | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate | Void -> false
           | Float_boxed -> true
           | Product shape -> shape_has_float_boxed shape)
@@ -1841,7 +1841,7 @@ module Element_repr = struct
   and t =
     | Unboxed_element of unboxed_element
     | Float_element
-    | Value_element
+    | Value_element of Jkind_types.Scannable_axes.t
     | Void
     (* This type technically permits [Float_element] to appear in an unboxed
        product, but we never generate that and make no attempt to apply the
@@ -1852,7 +1852,10 @@ module Element_repr = struct
   let to_shape_element t : mixed_block_element =
     let rec of_t : t -> mixed_block_element = function
     | Unboxed_element unboxed -> of_unboxed_element unboxed
-    | Float_element | Value_element -> Scannable
+    | Float_element ->
+      (* A (boxed) [float] is separable and not null *)
+      Scannable Jkind_types.Scannable_axes.value_axes
+    | Value_element sa -> Scannable sa
     | Void -> Void
     and of_unboxed_element : unboxed_element -> mixed_block_element = function
       | Float64 -> Float64
@@ -1875,39 +1878,35 @@ module Element_repr = struct
     then Float_element
     else
       let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
-      let sort =
-        match Option.bind layout Jkind.Layout.Const.get_sort with
-        | None ->
-          Misc.fatal_error "Element_repr.classify: unexpected abstract layout"
-        | Some s -> s
-      in
-      let rec sort_to_t : Jkind_types.Sort.Const.t -> t = function
-      | Base Scannable -> Value_element
-      | Base Float64 -> Unboxed_element Float64
-      | Base Float32 -> Unboxed_element Float32
-      | Base Word -> Unboxed_element Word
-      | Base Bits8 -> Unboxed_element Bits8
-      | Base Bits16 -> Unboxed_element Bits16
-      | Base Bits32 -> Unboxed_element Bits32
-      | Base Bits64 -> Unboxed_element Bits64
-      | Base Untagged_immediate -> Unboxed_element Untagged_immediate
-      | Base Vec128 -> Unboxed_element Vec128
-      | Base Vec256 -> Unboxed_element Vec256
-      | Base Vec512 -> Unboxed_element Vec512
-      | Base Void -> Void
+      let rec layout_to_t : Jkind_types.Layout.Const.t -> t = function
+      | Any _ ->
+        Misc.fatal_error "Element_repr.classify: unexpected abstract layout"
+      | Base (Scannable, sa) -> Value_element sa
+      | Base (Float64, _) -> Unboxed_element Float64
+      | Base (Float32, _) -> Unboxed_element Float32
+      | Base (Word, _) -> Unboxed_element Word
+      | Base (Bits8, _) -> Unboxed_element Bits8
+      | Base (Bits16, _) -> Unboxed_element Bits16
+      | Base (Bits32, _) -> Unboxed_element Bits32
+      | Base (Bits64, _) -> Unboxed_element Bits64
+      | Base (Untagged_immediate, _) -> Unboxed_element Untagged_immediate
+      | Base (Vec128, _) -> Unboxed_element Vec128
+      | Base (Vec256, _) -> Unboxed_element Vec256
+      | Base (Vec512, _) -> Unboxed_element Vec512
+      | Base (Void, _) -> Void
       | Product l ->
-        Unboxed_element (Product (Array.of_list (List.map sort_to_t l)))
+        Unboxed_element (Product (Array.of_list (List.map layout_to_t l)))
       | Univar _ -> Misc.fatal_error "sort_to_t: unexpected univar"
       | Genvar _ -> Misc.fatal_error "sort_to_t: unexpected genvar"
       in
-      sort_to_t sort
+      layout_to_t layout
 
   let mixed_product_shape loc ts kind =
     let boxed_elements =
       let rec count_boxed_in_t acc : t -> int = function
         | Unboxed_element u -> count_boxed_in_unboxed_element acc u
         | Void -> acc
-        | Float_element | Value_element -> acc + 1
+        | Float_element | Value_element _ -> acc + 1
       and count_boxed_in_unboxed_element acc : unboxed_element -> int =
         function
         | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
@@ -2072,7 +2071,7 @@ let rec update_decl_jkind env dpath decl =
                              | Vec128 | Vec256 | Vec512 | Word
                              | Untagged_immediate | Product _ ) ->
                repr_summary.non_float64_unboxed_fields <- true
-           | Value_element -> repr_summary.values <- true
+           | Value_element _ -> repr_summary.values <- true
            | Void ->
                repr_summary.voids <- true)
         reprs lbls;
@@ -2102,7 +2101,7 @@ let rec update_decl_jkind env dpath decl =
                   | Unboxed_element (Float32 | Bits8 | Bits16 | Bits32 | Bits64
                                     | Vec128 | Vec256 | Vec512 | Word
                                     | Untagged_immediate | Product _)
-                  | Value_element ->
+                  | Value_element _ ->
                       Misc.fatal_error "Expected only floats and float64s")
                 reprs
               |> Array.of_list
@@ -2122,7 +2121,7 @@ let rec update_decl_jkind env dpath decl =
                 List.find_map
                   (fun ((repr : Element_repr.t), lbl) ->
                      match repr with
-                     | Value_element | Float_element -> None
+                     | Value_element _ | Float_element -> None
                      | _ ->
                        if Types.is_atomic lbl.Types.ld_mutable
                        then Some lbl
@@ -3767,7 +3766,7 @@ let native_repr_of_type env kind ty sort_or_poly =
   | Untagged, Tconstr (_, _, _) ->
     let is_immediate = Ctype.is_always_gc_ignorable env ty in
     let is_non_nullable = Ctype.check_type_nullability env ty Non_null in
-    let is_value =
+    let is_scannable =
       match sort_or_poly with
       | Poly -> false
       | Sort (Base Scannable) -> true
@@ -3775,7 +3774,7 @@ let native_repr_of_type env kind ty sort_or_poly =
       | Sort (Univar _) -> Misc.fatal_error "typedecl: Univar in native repr"
       | Sort (Genvar _) -> Misc.fatal_error "typedecl: Genvar in native repr"
     in
-    if is_immediate && is_non_nullable && is_value
+    if is_immediate && is_non_nullable && is_scannable
     then Some (Unboxed_or_untagged_integer Untagged_int)
     else None
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_float ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1899,7 +1899,11 @@ module Element_repr = struct
       | Univar _ -> Misc.fatal_error "sort_to_t: unexpected univar"
       | Genvar _ -> Misc.fatal_error "sort_to_t: unexpected genvar"
       in
-      layout_to_t layout
+      match layout with
+      | Some layout ->
+        layout_to_t layout
+      | None ->
+        Misc.fatal_error "Element_repr.classify: unexpected missing layout"
 
   let mixed_product_shape loc ts kind =
     let boxed_elements =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -584,6 +584,10 @@ and expression_desc =
   | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
+  (* CR layouts-scannable: The sort here is no longer used. Instead, a layout is
+     computed, since it has scannable axes. This should either be removed
+     (perhaps alongside some other sorts being kept around) or replaced with a
+     (representable) layout. *)
   | Texp_array_comprehension of Types.mutability * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * Jkind.sort * expression

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -132,7 +132,13 @@ let rec layout_is_representable : Jkind.Layout.Const.t -> bool = function
    for nullable jkinds.*)
 let type_representable_layout ~why env loc ty =
   let jkind = Ctype.type_jkind env ty in
-  let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
+  let layout =
+    match Jkind.get_layout_defaulting_to_scannable env jkind with
+    | Some layout -> layout
+    | None ->
+      Misc.fatal_error
+        "Typeopt.type_representable_layout: unexpected missing layout (1)"
+  in
   if layout_is_representable layout then
     layout
   else
@@ -152,7 +158,13 @@ let type_representable_layout ~why env loc ty =
     (match Ctype.type_sort ~why ~fixed:false env ty with
     | Ok _sort ->
       let jkind = Ctype.type_jkind env ty in
-      let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
+      let layout =
+        match Jkind.get_layout_defaulting_to_scannable env jkind with
+        | Some layout -> layout
+        | None ->
+          Misc.fatal_error
+            "Typeopt.type_representable_layout: unexpected missing layout (2)"
+      in
       (match Jkind_types.Layout.Const.get_sort layout with
       | None -> Misc.fatal_error
                    "called type_sort but didn't get a representable layout"

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -27,9 +27,9 @@ type error =
   | Small_number_sort_without_extension of Jkind.Sort.t * type_expr option
   | Simd_sort_without_extension of Jkind.Sort.t * type_expr option
   | Not_a_sort of Env.t * type_expr * Jkind.Violation.t
-  | Unsupported_product_in_lazy of Jkind.Sort.Const.t
+  | Unsupported_product_in_lazy of Jkind.Layout.Const.t
   | Unsupported_vector_in_product_array
-  | Mixed_product_array of Jkind.Sort.Const.t * type_expr
+  | Mixed_product_array of Jkind.Layout.Const.t * type_expr
   | Unsupported_void_in_array
   | Opaque_array_non_value of
       { array_type: type_expr;
@@ -100,6 +100,7 @@ let is_base_type env ty base_ty_path =
 
 let maybe_pointer_type env ty =
   let ty = scrape_ty env ty in
+  (* CR layouts: calling [check_type_jkind] three times (indirectly) is sad *)
   let immediate_or_pointer =
     match Ctype.is_always_gc_ignorable env ty with
     | true -> Immediate
@@ -114,17 +115,50 @@ let maybe_pointer_type env ty =
 
 let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 
-(* CR layouts v2.8: Calling [type_sort] in [typeopt] is not ideal
-   and this function should be removed at some point. To do that, there
-   needs to be a way to store sort vars on [Tconstr]s. That means
-   either introducing a [Tpoly_constr], allow type parameters with
-   sort info, or do something else. Internal ticket 5093. *)
+let rec layout_is_representable : Jkind.Layout.Const.t -> bool = function
+  | Any _ -> false
+  | Base _ -> true
+  | Product sorts ->
+    List.for_all layout_is_representable sorts
+
+(* CR layouts-scannable: calling [type_jkind] here in [typeopt] is not ideal.
+   Removing this function requires more careful tracking of representable
+   layouts in the typedtree (see [Sort] comment in [jkind_intf.ml]).
+
+   This function also may mutate [ty] to constrain its jkind (see below);
+   this is yet another reason why this function could use some attention.
+   Internal ticket 5093 (which references the former name, [type_sort]). *)
 (* CR layouts v3.0: have a better error message
    for nullable jkinds.*)
-let type_sort ~why env loc ty =
-  match Ctype.type_sort ~why ~fixed:false env ty with
-  | Ok sort -> sort
-  | Error err -> raise (Error (loc, Not_a_sort (env, ty, err)))
+let type_representable_layout ~why env loc ty =
+  let jkind = Ctype.type_jkind env ty in
+  let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
+  if layout_is_representable layout then
+    layout
+  else
+    (* Surprisingly, it is possible to reach this branch; for example, when
+       translating [f] in the following example:
+
+       external foo : ('a : any mod separable). 'a array -> int = "%identity"
+       let f x = foo x
+
+       See also (3) in [Note regarding jkind checks on external declarations].
+
+       In this case (at least for now), we want to constrain [ty]'s jkind to
+       be representable, which is achieved by [type_sort]. Recomputing the jkind
+       will then yield one with the new, representable (defaulted) layout. *)
+    (* We postpone calling [type_sort] until this branch to make the common case
+       faster, even though it means that [type_jkind] must be called twice. *)
+    (match Ctype.type_sort ~why ~fixed:false env ty with
+    | Ok _sort ->
+      let jkind = Ctype.type_jkind env ty in
+      let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
+      (match Jkind_types.Layout.Const.get_sort layout with
+      | None -> Misc.fatal_error
+                   "called type_sort but didn't get a representable layout"
+      | Some _ -> layout)
+    (* CR layouts: It seems as if this is unreachable (see ticket above). *)
+    | Error err -> raise (Error (loc, Not_a_sort (env, ty, err))))
 
 (* [classification]s are used for two things: things in arrays, and things in
    lazys. In the former case, we need detailed information about unboxed
@@ -146,10 +180,13 @@ type 'a classification =
 (* Classify a ty into a [classification]. Looks through synonyms, using
    [scrape_ty].  Returning [Any] is safe, though may skip some optimizations.
    See comment on [classification] above to understand [classify_product]. *)
-let classify ~classify_product env ty sort : _ classification =
+let classify ~classify_product env ty layout : _ classification =
   let ty = scrape_ty env ty in
-  match (sort : Jkind.Sort.Const.t) with
-  | Base Scannable -> begin
+  match (layout : Jkind.Layout.Const.t) with
+  | Any _ -> Misc.fatal_error "classify called with non-representable layout"
+  | Base (Scannable, _sa) -> begin
+  (* CR layouts-scannable: Consider using the scannable axes here to avoid
+     these calls. *)
   if Ctype.is_always_gc_ignorable env ty
   then
     if Ctype.check_type_nullability env ty Non_null
@@ -215,41 +252,43 @@ let classify ~classify_product env ty sort : _ classification =
   | Tof_kind _ | Trepr _ ->
       assert false
   end
-  | Base Float64 -> Unboxed_float Unboxed_float64
-  | Base Float32 -> Unboxed_float Unboxed_float32
-  | Base Bits8 -> Unboxed_int Untagged_int8
-  | Base Bits16 -> Unboxed_int Untagged_int16
-  | Base Bits32 -> Unboxed_int Unboxed_int32
-  | Base Bits64 -> Unboxed_int Unboxed_int64
-  | Base Vec128 -> Unboxed_vector Unboxed_vec128
-  | Base Vec256 ->
+  | Base (Float64, _) -> Unboxed_float Unboxed_float64
+  | Base (Float32, _) -> Unboxed_float Unboxed_float32
+  | Base (Bits8, _) -> Unboxed_int Untagged_int8
+  | Base (Bits16, _) -> Unboxed_int Untagged_int16
+  | Base (Bits32, _) -> Unboxed_int Unboxed_int32
+  | Base (Bits64, _) -> Unboxed_int Unboxed_int64
+  | Base (Vec128, _) -> Unboxed_vector Unboxed_vec128
+  | Base (Vec256, _) ->
     if split_vectors
     then Product (Pgcignorableproductarray
                     [ Punboxedvector_ignorable Unboxed_vec128;
                       Punboxedvector_ignorable Unboxed_vec128 ])
     else Unboxed_vector Unboxed_vec256
-  | Base Vec512 -> Unboxed_vector Unboxed_vec512
-  | Base Word -> Unboxed_int Unboxed_nativeint
-  | Base Untagged_immediate -> Unboxed_int Untagged_int
-  | Base Void -> Void
+  | Base (Vec512, _) -> Unboxed_vector Unboxed_vec512
+  | Base (Word, _) -> Unboxed_int Unboxed_nativeint
+  | Base (Untagged_immediate, _) -> Unboxed_int Untagged_int
+  | Base (Void, _) -> Void
   | Product c -> Product (classify_product ty c)
   | Univar _ -> Misc.fatal_error "classify: Univar"
   | Genvar _ -> Misc.fatal_error "classify: Genvar"
 
-let rec scannable_product_array_kind elt_ty_for_error loc sorts =
-  List.map (sort_to_scannable_product_element_kind elt_ty_for_error loc) sorts
+let rec scannable_product_array_kind elt_ty_for_error loc layouts =
+  List.map (sort_to_scannable_product_element_kind elt_ty_for_error loc) layouts
 
 and sort_to_scannable_product_element_kind elt_ty_for_error loc
-      (s : Jkind.Sort.Const.t) =
-  (* Unfortunate: this never returns `Pint_scannable`.  Doing so would require
-     this to traverse the type, rather than just the kind, or to add product
-     kinds. *)
-  match s with
-  | Base Scannable -> Paddr_scannable
-  | Base (Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Word |
-          Untagged_immediate | Vec128 | Vec256 | Vec512) as c ->
+      (layout : Jkind.Layout.Const.t) =
+  match layout with
+  | Any _ -> Misc.fatal_error "sort_to_scannable_product_element_kind called \
+                               with non-representable layout"
+  | Base (Scannable, { separability; _ }) ->
+      let open Jkind_axis.Separability in
+      if le separability (upper_bound_if_is_always_gc_ignorable ())
+        then Pint_scannable else Paddr_scannable
+  | Base ((Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Word |
+          Untagged_immediate | Vec128 | Vec256 | Vec512), _) as c ->
     raise (Error (loc, Mixed_product_array (c, elt_ty_for_error)))
-  | Base Void ->
+  | Base (Void, _) ->
     raise (Error (loc, Unsupported_void_in_array))
   | Product sorts ->
     Pproduct_scannable (scannable_product_array_kind elt_ty_for_error loc sorts)
@@ -258,46 +297,44 @@ and sort_to_scannable_product_element_kind elt_ty_for_error loc
   | Genvar _ ->
     Misc.fatal_error "sort_to_scannable_product_element_kind: Genvar"
 
-let rec ignorable_product_array_kind loc (sorts : Jkind.Sort.Const.t list) =
+let rec ignorable_product_array_kind loc (sorts : Jkind.Layout.Const.t list) =
   match sorts with
-  | [Base Vec128; Base Vec128] ->
+  | [Base (Vec128, _); Base (Vec128, _)] ->
     [ Punboxedvector_ignorable Unboxed_vec128;
       Punboxedvector_ignorable Unboxed_vec128 ]
-  | [Base Vec128; Base Vec128; Base Vec128; Base Vec128] ->
+  | [Base (Vec128, _); Base (Vec128, _); Base (Vec128, _); Base (Vec128, _)] ->
     [ Punboxedvector_ignorable Unboxed_vec128;
       Punboxedvector_ignorable Unboxed_vec128;
       Punboxedvector_ignorable Unboxed_vec128;
       Punboxedvector_ignorable Unboxed_vec128 ]
   | _ -> List.map (sort_to_ignorable_product_element_kind loc) sorts
 
-and sort_to_ignorable_product_element_kind loc (s : Jkind.Sort.Const.t) =
-  match s with
-  | Base Scannable -> Pint_ignorable
-  | Base Float64 -> Punboxedfloat_ignorable Unboxed_float64
-  | Base Float32 -> Punboxedfloat_ignorable Unboxed_float32
-  | Base Bits8 -> Punboxedoruntaggedint_ignorable Untagged_int8
-  | Base Bits16 -> Punboxedoruntaggedint_ignorable Untagged_int16
-  | Base Bits32 -> Punboxedoruntaggedint_ignorable Unboxed_int32
-  | Base Bits64 -> Punboxedoruntaggedint_ignorable Unboxed_int64
-  | Base Word -> Punboxedoruntaggedint_ignorable Unboxed_nativeint
-  | Base Untagged_immediate -> Punboxedoruntaggedint_ignorable Untagged_int
-  | Base (Vec128 | Vec256 | Vec512) ->
+and sort_to_ignorable_product_element_kind loc (layout : Jkind.Layout.Const.t) =
+  match layout with
+  | Any _ -> Misc.fatal_error "sort_to_ignorable_product_element_kind called \
+                               with non-representable layout"
+  (* Scannable axes are irrelevant, since we already know we can ignore *)
+  | Base (Scannable, _sa) -> Pint_ignorable
+  | Base (Float64, _) -> Punboxedfloat_ignorable Unboxed_float64
+  | Base (Float32, _) -> Punboxedfloat_ignorable Unboxed_float32
+  | Base (Bits8, _) -> Punboxedoruntaggedint_ignorable Untagged_int8
+  | Base (Bits16, _) -> Punboxedoruntaggedint_ignorable Untagged_int16
+  | Base (Bits32, _) -> Punboxedoruntaggedint_ignorable Unboxed_int32
+  | Base (Bits64, _) -> Punboxedoruntaggedint_ignorable Unboxed_int64
+  | Base (Word, _) -> Punboxedoruntaggedint_ignorable Unboxed_nativeint
+  | Base (Untagged_immediate, _) -> Punboxedoruntaggedint_ignorable Untagged_int
+  | Base ((Vec128 | Vec256 | Vec512), _) ->
     raise (Error (loc, Unsupported_vector_in_product_array))
-  | Base Void -> raise (Error (loc, Unsupported_void_in_array))
+  | Base (Void, _) -> raise (Error (loc, Unsupported_void_in_array))
   | Product sorts -> Pproduct_ignorable (ignorable_product_array_kind loc sorts)
   | Univar _ ->
     Misc.fatal_error "sort_to_ignorable_product_element_kind: Univar"
   | Genvar _ ->
     Misc.fatal_error "sort_to_ignorable_product_element_kind: Genvar"
 
-let array_kind_of_elt ~elt_sort env loc ty =
-  let elt_sort =
-    match elt_sort with
-    | Some s -> s
-    | None ->
-      Jkind.Sort.default_for_transl_and_get
-        (type_sort ~why:Array_element env loc ty)
-  in
+let array_kind_of_elt env loc ty =
+  let ty = scrape_ty env ty in
+  let elt_layout = type_representable_layout ~why:Array_element env loc ty in
   let elt_ty_for_error = ty in (* report the un-scraped ty in errors *)
   let classify_product ty sorts =
     if Ctype.is_always_gc_ignorable env ty then
@@ -308,7 +345,7 @@ let array_kind_of_elt ~elt_sort env loc ty =
   in
   (* CR dkalinichenko: many checks in [classify] are redundant
      with separability. *)
-  match classify ~classify_product env ty elt_sort with
+  match classify ~classify_product env ty elt_layout with
   | Any ->
     if Config.flat_float_array
       && not (Ctype.check_type_separability env ty Non_float)
@@ -331,11 +368,11 @@ let array_kind_of_elt ~elt_sort env loc ty =
   | Void ->
     raise (Error (loc, Unsupported_void_in_array))
 
-let array_type_kind ~elt_sort ~elt_ty env loc ty =
+let array_type_kind ~elt_ty env loc ty =
   match scrape_poly env ty with
   | Tconstr(p, [elt_ty], _) when Path.same p Predef.path_array
                               || Path.same p Predef.path_iarray ->
-      array_kind_of_elt ~elt_sort env loc elt_ty
+      array_kind_of_elt env loc elt_ty
   | Tconstr(p, [], _) when Path.same p Predef.path_floatarray ->
       Pfloatarray
   | _ ->
@@ -377,15 +414,11 @@ let array_type_mut env ty =
   | Tconstr(p, [_], _) when Path.same p Predef.path_iarray -> Immutable
   | _ -> Mutable
 
-let array_kind exp elt_sort =
-  array_type_kind
-    ~elt_sort:(Some elt_sort) ~elt_ty:None
-    exp.exp_env exp.exp_loc exp.exp_type
+let array_kind exp =
+  array_type_kind ~elt_ty:None exp.exp_env exp.exp_loc exp.exp_type
 
-let array_pattern_kind pat elt_sort =
-  array_type_kind
-    ~elt_sort:(Some elt_sort) ~elt_ty:None
-    pat.pat_env pat.pat_loc pat.pat_type
+let array_pattern_kind pat =
+  array_type_kind ~elt_ty:None pat.pat_env pat.pat_loc pat.pat_type
 
 let bigarray_decode_type env ty tbl dfl =
   match scrape env ty with
@@ -442,9 +475,12 @@ let value_kind_of_scannable_jkind env jkind =
     Jkind.get_externality_upper_bound ~context env jkind
   in
   match layout with
-  (* CR layouts-scannable: use scannable axes to improve codegen *)
-  | Some (Base (Scannable, _)) ->
-    value_kind_of_value_with_externality externality_upper_bound
+  | Some (Base (Scannable, { separability; _ })) -> (
+    (* use the better of the two [immediate_or_pointer]s *)
+    match pointerness_of_separability separability,
+          pointerness_of_scannable_with_externality externality_upper_bound with
+    | Immediate, Immediate | Immediate, Pointer | Pointer, Immediate -> Pintval
+    | Pointer, Pointer -> Pgenval)
   | None
   | Some ( Any _
          | Product _
@@ -648,9 +684,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
   | Tconstr(p, [arg], _)
     when (Path.same p Predef.path_array
           || Path.same p Predef.path_iarray) ->
-    (* CR layouts: [~elt_sort:None] here is bad for performance. To
-       fix it, we need a place to store the sort on a [Tconstr]. *)
-    let ak = array_type_kind ~elt_ty:(Some arg) ~elt_sort:None env loc ty in
+    let ak = array_type_kind ~elt_ty:(Some arg) env loc ty in
     num_nodes_visited, non_nullable (Parrayval ak)
   | Tconstr(p, _, _) -> begin
       (* CR layouts v2.8: The uses of [decl.type_jkind] here are suspect:
@@ -736,14 +770,18 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
       (field : Types.mixed_block_element) ty
   : int * unit Lambda.mixed_block_element =
   match field with
-  | Scannable ->
+  | Scannable { separability } ->
     begin match ty with
     | Some ty ->
       let num_nodes_visited, kind =
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in
       num_nodes_visited, Value kind
-    | None -> num_nodes_visited, Value (nullable Pgenval)
+    | None ->
+      let raw_kind =
+        value_kind_of_pointerness (pointerness_of_separability separability)
+      in
+      num_nodes_visited, Value { generic_value with raw_kind }
     (* CR layouts v7.1: assess whether it is important for performance to
        support deep value_kinds here *)
     end
@@ -1177,12 +1215,18 @@ let function_arg_layout env loc sort ty =
 (** Whether a forward block is needed for a lazy thunk on a value, i.e.
     if the value can be represented as a float/forward/lazy *)
 let lazy_val_requires_forward env loc ty =
-  let sort = Jkind.Sort.Const.for_lazy_body in
-  let classify_product _ sorts =
-    let kind = Jkind.Sort.Const.Product sorts in
-    raise (Error (loc, Unsupported_product_in_lazy kind))
+  let layout =
+    Jkind.Layout.Const.of_sort_const
+      Jkind.Sort.Const.for_lazy_body
+      (* The scannable axes don't matter for the rest of the computation, so
+         setting them to [max] is totally fine. *)
+      Jkind_types.Scannable_axes.max
   in
-  match classify ~classify_product env ty sort with
+  let classify_product _ layouts =
+    let layout = Jkind_types.Layout.Const.Product layouts in
+    raise (Error (loc, Unsupported_product_in_lazy layout))
+  in
+  match classify ~classify_product env ty layout with
   | Any | Lazy -> true
   (* CR layouts: Fix this when supporting lazy unboxed values.
      Blocks with forward_tag can get scanned by the gc thus can't
@@ -1297,9 +1341,9 @@ let report_error ppf = function
            env) err
   | Unsupported_product_in_lazy const ->
       fprintf ppf
-        "Product layout %a detected in [lazy] in [Typeopt.Layout]@ \
+        "Product layout %s detected in [lazy] in [Typeopt.Layout]@ \
          Please report this error to the Jane Street compilers team."
-        Jkind.Sort.Const.format const
+        (Jkind.Layout.Const.to_string const)
   | Unsupported_vector_in_product_array ->
       fprintf ppf
         "Unboxed vector types are not yet supported in arrays of unboxed@ \
@@ -1314,11 +1358,11 @@ let report_error ppf = function
          types.@ But this array operation is peformed for an array whose@ \
          element type is %a, which is an unboxed product@ \
          that is not external and contains a type with the non-scannable@ \
-         layout %a.@ \
+         layout %s.@ \
          @[Hint: if the array contents should not be scanned, annotating@ \
          contained abstract types as [mod external] may resolve this error.@]"
         Printtyp.type_expr elt_ty
-        Jkind.Sort.Const.format const
+        (Jkind.Layout.Const.to_string const)
   | Opaque_array_non_value { array_type; elt_kinding_failure }  ->
       begin match elt_kinding_failure with
       | Some (env, ty, err) ->

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -116,7 +116,7 @@ let maybe_pointer_type env ty =
 let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 
 let rec layout_is_representable : Jkind.Layout.Const.t -> bool = function
-  | Any _ -> false
+  | Any _ | Univar _ | Genvar _ -> false
   | Base _ -> true
   | Product sorts ->
     List.for_all layout_is_representable sorts

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -24,19 +24,18 @@ val maybe_pointer_type : Env.t -> Types.type_expr
 val maybe_pointer : Typedtree.expression
   -> Lambda.immediate_or_pointer * Lambda.nullable
 
-(* Supplying [None] for [elt_sort] should be avoided when possible. It
-   will result in a call to [Ctype.type_sort] which can be expensive. *)
+(* CR layouts-scannable: These functions will call [Ctype.type_sort] and extract
+   the layout in order to compute the array_kind. If (representable) layout info
+   is stored (e.g. in the typedtree) instead of sorts, those layouts can be
+   threaded through these functions to avoid the possibly expensive calls. *)
 val array_type_kind :
-  elt_sort:(Jkind.Sort.Const.t option) -> elt_ty:(Types.type_expr option)
+  elt_ty:(Types.type_expr option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_type_mut : Env.t -> Types.type_expr -> Lambda.mutable_flag
 val array_kind_of_elt :
-  elt_sort:(Jkind.Sort.Const.t option)
-  -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
-val array_kind :
-  Typedtree.expression -> Jkind.Sort.Const.t -> Lambda.array_kind
-val array_pattern_kind :
-  Typedtree.pattern -> Jkind.Sort.Const.t -> Lambda.array_kind
+  Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
+val array_kind : Typedtree.expression -> Lambda.array_kind
+val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
 
 (* If [kind] or [layout] is unknown, attempt to specialize it by examining the
    type parameters of the bigarray. If [kind] or [length] is not unknown, returns

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -479,7 +479,7 @@ and type_origin =
   | Existential of string
 
 and mixed_block_element =
-  | Scannable
+  | Scannable of Jkind_types.Scannable_axes.t
   | Float_boxed
   | Float64
   | Float32
@@ -863,7 +863,7 @@ let compare_tag t1 t2 =
 
 let rec equal_mixed_block_element e1 e2 =
   match e1, e2 with
-  | Scannable, Scannable
+  | Scannable sa1, Scannable sa2 -> Jkind_types.Scannable_axes.equal sa1 sa2
   | Float64, Float64 | Float32, Float32 | Float_boxed, Float_boxed
   | Word, Word | Untagged_immediate, Untagged_immediate
   | Bits8, Bits8 | Bits16, Bits16
@@ -873,14 +873,19 @@ let rec equal_mixed_block_element e1 e2 =
     -> true
   | Product es1, Product es2
     -> Misc.Stdlib.Array.equal equal_mixed_block_element es1 es2
-  | ( Scannable | Float64 | Float32 | Float_boxed | Word | Untagged_immediate
+  | ( Scannable _ | Float64 | Float32 | Float_boxed | Word | Untagged_immediate
     | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512
     | Product _ | Void ), _
     -> false
 
 let rec compare_mixed_block_element e1 e2 =
   match e1, e2 with
-  | Scannable, Scannable | Float_boxed, Float_boxed
+  | Scannable sa1, Scannable sa2 -> (
+    match Jkind_types.Scannable_axes.less_or_equal sa1 sa2 with
+    | Less -> -1
+    | Equal -> 0
+    | Not_le -> 1)
+  | Float_boxed, Float_boxed
   | Float64, Float64 | Float32, Float32
   | Word, Word | Untagged_immediate, Untagged_immediate
   | Bits8, Bits8 | Bits16, Bits16 | Bits32, Bits32 | Bits64, Bits64
@@ -889,8 +894,8 @@ let rec compare_mixed_block_element e1 e2 =
     -> 0
   | Product es1, Product es2
     -> Misc.Stdlib.Array.compare compare_mixed_block_element es1 es2
-  | Scannable, _ -> -1
-  | _, Scannable -> 1
+  | Scannable _, _ -> -1
+  | _, Scannable _ -> 1
   | Float_boxed, _ -> -1
   | _, Float_boxed -> 1
   | Float64, _ -> -1
@@ -966,6 +971,34 @@ let equal_record_representation r1 r2 = match r1, r2 with
 let equal_record_unboxed_product_representation r1 r2 = match r1, r2 with
   | Record_unboxed_product, Record_unboxed_product -> true
 
+(* Returns [Less] when [e1] and [e2] are equal up to the stored scannable axes
+   on a [Scannable], which can be [Less]. *)
+let rec mixed_block_element_less_or_equal e1 e2 =
+  match e1, e2 with
+  | Scannable sa1, Scannable sa2 ->
+    Jkind_types.Scannable_axes.less_or_equal sa1 sa2
+  | Float_boxed, Float_boxed
+  | Float64, Float64 | Float32, Float32
+  | Word, Word | Untagged_immediate, Untagged_immediate
+  | Bits8, Bits8 | Bits16, Bits16 | Bits32, Bits32 | Bits64, Bits64
+  | Vec128, Vec128 | Vec256, Vec256 | Vec512, Vec512
+  | Void, Void
+    -> Misc.Le_result.Equal
+  | Product es1, Product es2 -> mixed_product_shape_less_or_equal es1 es2
+  | ( Scannable _ | Float64 | Float32 | Float_boxed | Word | Untagged_immediate
+    | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512
+    | Product _ | Void ), _
+    -> Misc.Le_result.Not_le
+
+and mixed_product_shape_less_or_equal s1 s2 =
+  if Array.length s1 <> Array.length s2
+  then Misc.Le_result.Not_le
+  else
+    Misc.Stdlib.Array.fold_left2
+      (fun acc e1 e2 ->
+        Misc.Le_result.combine acc (mixed_block_element_less_or_equal e1 e2))
+      Misc.Le_result.Equal s1 s2
+
 let may_equal_constr c1 c2 =
   c1.cstr_arity = c2.cstr_arity
   && (match c1.cstr_tag,c2.cstr_tag with
@@ -1008,9 +1041,14 @@ let record_form_to_string (type rep) (record_form : rep record_form) =
   | Legacy -> "record"
   | Unboxed_product -> "unboxed record"
 
+(* The scannable axes in the resulting [mixed_block_element] are always [max] *)
 let rec mixed_block_element_of_const_sort (sort : Jkind_types.Sort.Const.t) =
   match sort with
-  | Base Scannable -> Scannable
+  (* CR layouts-scannable: since sorts do not store scannable axis information,
+     we are forced to default to max. It would be good to store the scannable
+     axis information, but doing so takes a sizable refactor. See the comment
+     on [Sort] in [jkind_intf.ml] *)
+  | Base Scannable -> Scannable Jkind_types.Scannable_axes.max
   | Base Bits8 -> Bits8
   | Base Bits16 -> Bits16
   | Base Bits32 -> Bits32
@@ -1087,7 +1125,7 @@ let bound_value_identifiers_and_sorts sigs =
   List.filter_map signature_item_representation sigs
 
 let rec mixed_block_element_to_string = function
-  | Scannable -> "Scannable"
+  | Scannable _ -> "Scannable"
   | Float_boxed -> "Float_boxed"
   | Float32 -> "Float32"
   | Float64 -> "Float64"
@@ -1108,7 +1146,7 @@ let rec mixed_block_element_to_string = function
   | Void -> "Void"
 
 let mixed_block_element_to_lowercase_string = function
-  | Scannable -> "value"
+  | Scannable _ -> "scannable"
   | Float_boxed -> "float"
   | Float32 -> "float32"
   | Float64 -> "float64"

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -861,9 +861,9 @@ let compare_tag t1 t2 =
   | Extension _, Null -> -1
   | Null, Extension _ -> 1
 
-let rec equal_mixed_block_element e1 e2 =
+let rec equal_mixed_block_element_up_to_scannable_axes e1 e2 =
   match e1, e2 with
-  | Scannable sa1, Scannable sa2 -> Jkind_types.Scannable_axes.equal sa1 sa2
+  | Scannable _, Scannable _
   | Float64, Float64 | Float32, Float32 | Float_boxed, Float_boxed
   | Word, Word | Untagged_immediate, Untagged_immediate
   | Bits8, Bits8 | Bits16, Bits16
@@ -872,7 +872,8 @@ let rec equal_mixed_block_element e1 e2 =
   | Void, Void
     -> true
   | Product es1, Product es2
-    -> Misc.Stdlib.Array.equal equal_mixed_block_element es1 es2
+    -> Misc.Stdlib.Array.equal
+         equal_mixed_block_element_up_to_scannable_axes es1 es2
   | ( Scannable _ | Float64 | Float32 | Float_boxed | Word | Untagged_immediate
     | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512
     | Product _ | Void ), _
@@ -923,21 +924,23 @@ let rec compare_mixed_block_element e1 e2 =
   | Void, _ -> -1
   | _, Void -> 1
 
-let equal_mixed_product_shape r1 r2 = r1 == r2 ||
-  Misc.Stdlib.Array.equal equal_mixed_block_element r1 r2
+let equal_mixed_product_shape_up_to_scannable_axes r1 r2 = r1 == r2 ||
+  Misc.Stdlib.Array.equal equal_mixed_block_element_up_to_scannable_axes r1 r2
 
-let equal_constructor_representation r1 r2 = r1 == r2 || match r1, r2 with
+let equal_constructor_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
+  match r1, r2 with
   | Constructor_uniform_value, Constructor_uniform_value -> true
   | Constructor_mixed mx1, Constructor_mixed mx2 ->
-      equal_mixed_product_shape mx1 mx2
+      equal_mixed_product_shape_up_to_scannable_axes mx1 mx2
   | (Constructor_mixed _ | Constructor_uniform_value), _ -> false
 
-let equal_variant_representation r1 r2 = r1 == r2 || match r1, r2 with
+let equal_variant_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
+  match r1, r2 with
   | Variant_unboxed, Variant_unboxed ->
       true
   | Variant_boxed cstrs_and_sorts1, Variant_boxed cstrs_and_sorts2 ->
       Misc.Stdlib.Array.equal (fun (cstr1, sorts1) (cstr2, sorts2) ->
-          equal_constructor_representation cstr1 cstr2
+          equal_constructor_representation_up_to_scannable_axes cstr1 cstr2
           && Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal
                sorts1 sorts2)
         cstrs_and_sorts1
@@ -948,7 +951,7 @@ let equal_variant_representation r1 r2 = r1 == r2 || match r1, r2 with
   | (Variant_unboxed | Variant_boxed _ | Variant_extensible | Variant_with_null), _ ->
       false
 
-let equal_record_representation r1 r2 = match r1, r2 with
+let equal_record_representation_up_to_scannable_axes r1 r2 = match r1, r2 with
   | Record_unboxed, Record_unboxed ->
       true
   | Record_inlined (tag1, cr1, vr1), Record_inlined (tag2, cr2, vr2) ->
@@ -956,48 +959,23 @@ let equal_record_representation r1 r2 = match r1, r2 with
          constructor representation. *)
       ignore (cr1 : constructor_representation);
       ignore (cr2 : constructor_representation);
-      equal_tag tag1 tag2 && equal_variant_representation vr1 vr2
+      equal_tag tag1 tag2 &&
+        equal_variant_representation_up_to_scannable_axes vr1 vr2
   | Record_boxed sorts1, Record_boxed sorts2 ->
       Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal sorts1 sorts2
   | Record_float, Record_float ->
       true
   | Record_ufloat, Record_ufloat ->
       true
-  | Record_mixed mx1, Record_mixed mx2 -> equal_mixed_product_shape mx1 mx2
+  | Record_mixed mx1, Record_mixed mx2 ->
+      equal_mixed_product_shape_up_to_scannable_axes mx1 mx2
   | (Record_unboxed | Record_inlined _ | Record_boxed _ | Record_float
     | Record_ufloat | Record_mixed _), _ ->
       false
 
-let equal_record_unboxed_product_representation r1 r2 = match r1, r2 with
+let equal_record_unboxed_product_representation_up_to_scannable_axes r1 r2 =
+  match r1, r2 with
   | Record_unboxed_product, Record_unboxed_product -> true
-
-(* Returns [Less] when [e1] and [e2] are equal up to the stored scannable axes
-   on a [Scannable], which can be [Less]. *)
-let rec mixed_block_element_less_or_equal e1 e2 =
-  match e1, e2 with
-  | Scannable sa1, Scannable sa2 ->
-    Jkind_types.Scannable_axes.less_or_equal sa1 sa2
-  | Float_boxed, Float_boxed
-  | Float64, Float64 | Float32, Float32
-  | Word, Word | Untagged_immediate, Untagged_immediate
-  | Bits8, Bits8 | Bits16, Bits16 | Bits32, Bits32 | Bits64, Bits64
-  | Vec128, Vec128 | Vec256, Vec256 | Vec512, Vec512
-  | Void, Void
-    -> Misc.Le_result.Equal
-  | Product es1, Product es2 -> mixed_product_shape_less_or_equal es1 es2
-  | ( Scannable _ | Float64 | Float32 | Float_boxed | Word | Untagged_immediate
-    | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512
-    | Product _ | Void ), _
-    -> Misc.Le_result.Not_le
-
-and mixed_product_shape_less_or_equal s1 s2 =
-  if Array.length s1 <> Array.length s2
-  then Misc.Le_result.Not_le
-  else
-    Misc.Stdlib.Array.fold_left2
-      (fun acc e1 e2 ->
-        Misc.Le_result.combine acc (mixed_block_element_less_or_equal e1 e2))
-      Misc.Le_result.Equal s1 s2
 
 let may_equal_constr c1 c2 =
   c1.cstr_arity = c2.cstr_arity

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1269,14 +1269,16 @@ val may_equal_constr :
 
 (* Equality *)
 
-(* For record and variant representations to be compatible, they only need to be
+(* Note [Ignoring scannable axes in type declaration representations]:
+
+   For record and variant representations to be compatible, they only need to be
    equal *up to scannable axes.*
 
    This is safe because the only way that only the scannable axes can differ
    between type definitions whose kinds match is through type substitution (or
    perhaps other module typing tricks), which results in one representation
    being *overapproximate* wrt scannable axes - this result in worse codegen but
-   is still sound. *)
+   is still sound. See references to this note. *)
 
 val equal_record_representation_up_to_scannable_axes :
   record_representation -> record_representation -> bool

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1269,13 +1269,22 @@ val may_equal_constr :
 
 (* Equality *)
 
-val equal_record_representation :
+(* For record and variant representations to be compatible, they only need to be
+   equal *up to scannable axes.*
+
+   This is safe because the only way that only the scannable axes can differ
+   between type definitions whose kinds match is through type substitution (or
+   perhaps other module typing tricks), which results in one representation
+   being *overapproximate* wrt scannable axes - this result in worse codegen but
+   is still sound. *)
+
+val equal_record_representation_up_to_scannable_axes :
   record_representation -> record_representation -> bool
 
-val equal_record_unboxed_product_representation :
+val equal_record_unboxed_product_representation_up_to_scannable_axes :
   record_unboxed_product_representation -> record_unboxed_product_representation -> bool
 
-val equal_variant_representation :
+val equal_variant_representation_up_to_scannable_axes :
   variant_representation -> variant_representation -> bool
 
 type 'a gen_label_description =
@@ -1331,7 +1340,7 @@ val bound_value_identifiers_and_sorts :
 
 val signature_item_id : signature_item -> Ident.t
 
-val equal_mixed_block_element :
+val equal_mixed_block_element_up_to_scannable_axes :
   mixed_block_element -> mixed_block_element -> bool
 (* CR layouts: this appears to be dead code *)
 val compare_mixed_block_element :
@@ -1339,8 +1348,8 @@ val compare_mixed_block_element :
 val mixed_block_element_to_string : mixed_block_element -> string
 val mixed_block_element_to_lowercase_string : mixed_block_element -> string
 
-val mixed_product_shape_less_or_equal :
-  mixed_product_shape -> mixed_product_shape -> Misc.Le_result.t
+val equal_mixed_product_shape_up_to_scannable_axes :
+  mixed_product_shape -> mixed_product_shape -> bool
 
 val equal_unsafe_mode_crossing :
   type_equal:(type_expr -> type_expr -> bool) ->

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -896,7 +896,7 @@ and tag = Ordinary of {src_index: int;  (* Unique name (per type) *)
    to appear in any order in a record, and later stages of the compiler
    re-arrange the block. *)
 and mixed_block_element =
-  | Scannable
+  | Scannable of Jkind_types.Scannable_axes.t
   | Float_boxed
   (* A [Float_boxed] is a float that's stored flat but boxed upon projection. *)
   | Float64
@@ -1333,10 +1333,14 @@ val signature_item_id : signature_item -> Ident.t
 
 val equal_mixed_block_element :
   mixed_block_element -> mixed_block_element -> bool
+(* CR layouts: this appears to be dead code *)
 val compare_mixed_block_element :
   mixed_block_element -> mixed_block_element -> int
 val mixed_block_element_to_string : mixed_block_element -> string
 val mixed_block_element_to_lowercase_string : mixed_block_element -> string
+
+val mixed_product_shape_less_or_equal :
+  mixed_product_shape -> mixed_product_shape -> Misc.Le_result.t
 
 val equal_unsafe_mode_crossing :
   type_equal:(type_expr -> type_expr -> bool) ->

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -620,7 +620,8 @@ let (>>) : bind_judg -> term_judg -> term_judg =
   fun binder term mode -> binder mode (term mode)
 
 (* Compute the appropriate [mode] for an array expression *)
-let array_mode exp elt_sort = match Typeopt.array_kind exp elt_sort with
+let array_mode exp =
+  match Typeopt.array_kind exp with
   | Lambda.Pfloatarray ->
     (* (flat) float arrays unbox their elements *)
     Dereference
@@ -750,9 +751,8 @@ let rec expression : Typedtree.expression -> term_judg =
       list expression (List.map (fun (_, e, _) -> e) exprs) << Return
     | Texp_atomic_loc (expr, _, _, _, _) ->
       expression expr << Guard
-    | Texp_array (_, elt_sort, exprs, _) ->
-      let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
-      list expression exprs << array_mode exp elt_sort
+    | Texp_array (_, _, exprs, _) ->
+      list expression exprs << array_mode exp
     | Texp_idx (ba, _uas) ->
       let block_access = function
         | Baccess_field _ -> empty
@@ -766,9 +766,8 @@ let rec expression : Typedtree.expression -> term_judg =
     | Texp_list_comprehension { comp_body; comp_clauses } ->
       join ((expression comp_body << Guard) ::
             comprehension_clauses comp_clauses)
-    | Texp_array_comprehension (_, elt_sort, { comp_body; comp_clauses }) ->
-      let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
-      join ((expression comp_body << array_mode exp elt_sort) ::
+    | Texp_array_comprehension (_, _, { comp_body; comp_clauses }) ->
+      join ((expression comp_body << array_mode exp) ::
             comprehension_clauses comp_clauses)
     | Texp_construct (_, desc, exprs, _) ->
       let access_constructor =
@@ -785,7 +784,7 @@ let rec expression : Typedtree.expression -> term_judg =
             | Constructor_uniform_value -> Guard
             | Constructor_mixed mixed_shape ->
                 (match mixed_shape.(i) with
-                 | Scannable | Float_boxed -> Guard
+                 | Scannable _ | Float_boxed -> Guard
                  | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
                  | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate
                  | Void | Product _ ->
@@ -813,7 +812,7 @@ let rec expression : Typedtree.expression -> term_judg =
           | Record_inlined (_, Constructor_mixed mixed_shape, _)
           | Record_mixed mixed_shape ->
             (match mixed_shape.(i) with
-             | Scannable | Float_boxed -> Guard
+             | Scannable _ | Float_boxed -> Guard
              | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
              | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate
              | Void | Product _ ->

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -87,16 +87,6 @@ let scrape_poly env ty =
   let ty = scrape_ty env ty in
   match get_desc ty with Tpoly (ty, _) -> get_desc ty | d -> d
 
-(* See [scrape_ty]; this returns the [type_desc] of a scraped [type_expr]. *)
-let is_always_gc_ignorable env ty =
-  let ext : Jkind_axis.Externality.t =
-    (* We check that we're compiling to (64-bit) native code before counting
-       External64 types as gc_ignorable, because bytecode is intended to be
-       platform independent. *)
-    if !Clflags.native_code && Sys.word_size = 64 then External64 else External
-  in
-  Ctype.check_type_externality env ty ext
-
 type classification =
   | Int (* any immediate type *)
   | Float
@@ -110,7 +100,7 @@ let classify env ty : classification =
   (* NOTE: this call is redundant, but also does not hurt.
      It is inherited from the original definition. *)
   let ty = scrape_ty env ty in
-  if is_always_gc_ignorable env ty
+  if Ctype.is_always_gc_ignorable env ty
   then Int
   else
     match get_desc ty with


### PR DESCRIPTION
This is a rebased version of @zackbach's https://github.com/oxcaml/oxcaml/pull/5155. See that PR for the description of the core changes, which have already been reviewed.

To review this PR, it should be sufficient to read the below (including the individually linked commits).

### Interaction with abstract kinds
With abstract kinds, `Jkind.get_layout_defaulting_to_scannable` returns a `Layout.Const.t option` instead of a `Layout.Const.t`. It is used in this PR to get the scannable axes of a value in typeopt, so we must now handle `None` values.

Fortunately, everywhere it's called, the layout must be representable, so we can fatal error when it returns `None`. This is done in b8806198c3405a855adc022fb4cea14f0db52465.

### Interaction with type substitution

This PR updates `mixed_block_shape`s to track scannable axes, in order to improve codegen. However, the mixed block shape stored in a `Record_mixed` can be stale after type substitution (which does not update record representations).

To avoid unecessary type errors, we only compare record representations *up to scannable axes*, which is described in this comment:
https://github.com/oxcaml/oxcaml/blob/4f96ded35ce646d3baa3603b620e51d51a651699/typing/types.mli#L1270-L1277
and tested here:
https://github.com/oxcaml/oxcaml/blob/4f96ded35ce646d3baa3603b620e51d51a651699/testsuite/tests/typing-layouts-scannable/non_pointer.ml#L679-L699

Uncommonly, this can cause unnecessary `caml_modify`s, shown here:
https://github.com/oxcaml/oxcaml/blob/4f96ded35ce646d3baa3603b620e51d51a651699/testsuite/tests/typing-layouts-caml-modify/non_pointer.ml#L268-L270

We leave fixing this for a future PR. Stale record representations after substitution is an existing issue, as shown by the failure of the following program to typecheck:
```ocaml
module M : sig
  type f
  type t = { f : f }
end with type f := float = struct
  type t = { f : float }
end
(* Their internal representations differ:
   the first declaration uses unboxed float representation. *)
```

(But in the case of mismatched scannable axes, we should accept the mismatches for backwards compatibility.)

**Diff vs. original PR.** Previously, we checked in the inclusion check that the included record representation has scannable axes that are *lower* than the requirement; with 4f96ded35ce646d3baa3603b620e51d51a651699, we check that representations are equal *up to* scannable axess.   

### Drive-by fatal error fix
Currently, the following program fatal errors...
```ocaml
module M : sig
  type r = { r : #(t * s) }
  and t : bits64
  and s
end = struct
  type r = { r : #(t * s) }
  and t
  and s
end
```

...because we assumed the only way that mixed records can fail the inclusion check is when one record flattens floats and the other doesn't*, but as shown in the program above, it is possible for us to compare records with unequal representations otherwise due to the order in which we typecheck recursive definitions.

We replace this fatal error with a type error that says
```
Modules do not match:
  sig type r = { r : #(t * s); } and t and s end
is not included in
  sig type r = { r : #(t * s); } and t : bits64 and s end
Type declarations do not match:
  type r = { r : #(t * s); }
is not included in
  type r = { r : #(t * s); }
Their internal representations differ:
This is likely caused by a layout mismatch in a later definition.
```

*As in:
```ocaml
module M : sig
  type t
  type r = { t : t }
end = struct
  type t = float
  type r = { t : t }
end
```

### History
There was an interaction with `eval`, but this was fixed by picking up https://github.com/oxcaml/oxcaml/issues/5592. The original description of the interaction is in the collapsed section:
<details>
### Interaction with `eval`
Predating this PR, we use `Ctype.estimate_type_jkind` to get the nullability of a type in `Typeopt.value_kind`: https://github.com/oxcaml/oxcaml/blob/de053b7892ed26565ca6ef711bf10b7b273750d9/typing/typeopt.ml#L736

With this PR, we pass this to `value_kind_of_scannable_jkind`, which computes the `Lambda.value_kind` of a scannable jkind, erroring if provided jkind is not not scannable.

This was, according to the contract of `estimate_type_jkind`, a bug in the original PR: even though it is only called on scannable types in `value_kind`, it's always allowed to return a superkind (namely, `any`), but just never did.

However, with https://github.com/ocaml-flambda/flambda-backend/pull/5402, it became possible for `estimate_type_jkind` to return a non-scannable kind when estimating the kind of a scannable type, namely `('a : scannable) eval`. The declaration for `eval` looks like
```ocaml
type ('a : any) eval : any =  Tquote_eval (Tsplice 'a)
```
and morally has layout `layout_of 'a`, but `estimate_type_jkind` just grabs the `any` off of the type declaration.

This caused a fatal error when building `otherlibs/eval/eval.ml`.

To fix this, we change the contract of `value_kind_of_scannable_jkind` to accept an upper bound on a kind of a scannable type (i.e. accepting `any`, so it can take the result of `estimate_type_jkind`). This is done in commit 0240f216a1d917458dcb966a12fcd68b547cee82.
</details>