### PR TITLE
Persistent modules are always `static`

### DIFF
--- a/testsuite/tests/typing-modes/staticity.ml
+++ b/testsuite/tests/typing-modes/staticity.ml
@@ -380,7 +380,7 @@ module (M @ static) = struct
     let x = Random.bool ()
 end
 [%%expect{|
-module M : sig val x : bool @@ dynamic end
+module M : sig val x : bool end
 |}]
 
 let x = Random.bool ()
@@ -398,7 +398,7 @@ module (M @ static) = struct
     let (Foo x) = Foo (Random.bool ())
 end
 [%%expect{|
-module M : sig val x : bool @@ dynamic end
+module M : sig val x : bool end
 |}]
 
 (* or pattern makes [x] dynamic, even though the RHS is static. *)
@@ -431,14 +431,10 @@ Line 3, characters 22-35:
 Error: The module is "dynamic" but is expected to be "static".
 |}]
 
-(* persistent modules are currently dynamic. *)
-(* CR-soon zqian: remove this restriction *)
+(* persistent modules are always static. *)
 module (L @ static) = List
 [%%expect{|
-Line 1, characters 22-26:
-1 | module (L @ static) = List
-                          ^^^^
-Error: The module is "dynamic" but is expected to be "static".
+module L = List
 |}]
 
 (* primitives are always static, unless you override *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5897,6 +5897,13 @@ let mode_crossing_functor =
 (** The mode crossing of any module. *)
 let mode_crossing_module = Mode.Crossing.max
 
+let mode_crossing_staticity =
+  Crossing.create
+    ~uniqueness:false ~contention:false ~visibility:false
+    ~regionality:false ~linearity:false ~portability:false
+    ~forkable:false ~yielding:false ~statefulness:false
+    ~staticity:true
+
 let zap_modalities_to_floor_if_at_least level =
   if Language_extension.(is_at_least Mode level)
     then Mode.Modality.zap_to_floor

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5875,7 +5875,10 @@ let mode_crossing_structure_memaddr =
     ~forkable:true
     ~yielding:true
     ~statefulness:true
-    ~staticity:false
+    ~staticity:true
+    (* We don't care about a structure's staticity if it doesn't contain any
+      [lpoly] values. Hence, the memory block of the structure crosses
+      staticity. *)
 
 (** The mode crossing of a functor. *)
 let mode_crossing_functor =
@@ -5903,7 +5906,7 @@ let crossing_of_jkind env jkind =
   let context = mk_jkind_context_check_principal env in
   Ikind.crossing_of_jkind ~context env jkind
 
-let crossing_of_ty env ?modalities ty =
+let crossing_of_ty env ?modalities ?val_lpoly ty =
   let principal = is_principal ty in
   let crossing =
     if not principal
@@ -5932,6 +5935,13 @@ let crossing_of_ty env ?modalities ty =
         ikind_crossing)
       else
         jkind_crossing ()
+  in
+  let crossing =
+    match val_lpoly with
+    | Some lpoly when List.is_empty (Types.Lpoly.get_exn lpoly) ->
+      let staticity_ax = Crossing.Axis.Monadic Staticity in
+      Crossing.set staticity_ax (Crossing.Per_axis.min staticity_ax) crossing
+    | _ -> crossing
   in
   match modalities with
   | None -> crossing

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5892,7 +5892,8 @@ let mode_crossing_functor =
     ~forkable:false
     ~yielding:false
     ~statefulness:false
-    ~staticity:false
+    ~staticity:true
+    (* CR-soon zqian: need to revert this once we support static functor application. *)
 
 (** The mode crossing of any module. *)
 let mode_crossing_module = Mode.Crossing.max

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5929,7 +5929,7 @@ let crossing_of_jkind env jkind =
   let context = mk_jkind_context_check_principal env in
   Ikind.crossing_of_jkind ~context env jkind
 
-let crossing_of_ty env ?modalities ?(val_lpoly = Lpoly.determined []) ty =
+let crossing_of_ty env ?modalities ?lpoly ty =
   let principal = is_principal ty in
   let crossing =
     if not principal
@@ -5960,11 +5960,11 @@ let crossing_of_ty env ?modalities ?(val_lpoly = Lpoly.determined []) ty =
         jkind_crossing ()
   in
   let crossing =
-    if List.is_empty (Types.Lpoly.get_exn val_lpoly)
-    then
+    match lpoly with
+    | Some lpoly when List.is_empty (Types.Lpoly.get_exn lpoly) ->
       let staticity_ax = Crossing.Axis.Monadic Staticity in
       Crossing.set staticity_ax (Crossing.Per_axis.min staticity_ax) crossing
-    else crossing
+    | _ -> crossing
   in
   match modalities with
   | None -> crossing

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5888,7 +5888,11 @@ let mode_crossing_structure_memaddr =
     ~forkable:true
     ~yielding:true
     ~statefulness:true
-    ~staticity:false
+    ~staticity:true
+    (* We don't care about a structure's staticity if it doesn't contain any
+      [lpoly] values. Hence, the memory block of the structure crosses
+      staticity. The values contained in a structure have their own staticity
+      separately. *)
 
 (** The mode crossing of a functor. *)
 let mode_crossing_functor =
@@ -5902,10 +5906,19 @@ let mode_crossing_functor =
     ~forkable:false
     ~yielding:false
     ~statefulness:false
-    ~staticity:false
+    ~staticity:true
+    (* Currently we don't support static functor application, and therefore we
+       don't care about the staticity of functors. *)
 
 (** The mode crossing of any module. *)
 let mode_crossing_module = Mode.Crossing.max
+
+let mode_crossing_staticity =
+  Crossing.create
+    ~uniqueness:false ~contention:false ~visibility:false
+    ~regionality:false ~linearity:false ~portability:false
+    ~forkable:false ~yielding:false ~statefulness:false
+    ~staticity:true
 
 let zap_modalities_to_floor_if_at_least level =
   if Language_extension.(is_at_least Mode level)
@@ -5916,7 +5929,7 @@ let crossing_of_jkind env jkind =
   let context = mk_jkind_context_check_principal env in
   Ikind.crossing_of_jkind ~context env jkind
 
-let crossing_of_ty env ?modalities ty =
+let crossing_of_ty env ?modalities ?(val_lpoly = Lpoly.determined []) ty =
   let principal = is_principal ty in
   let crossing =
     if not principal
@@ -5945,6 +5958,13 @@ let crossing_of_ty env ?modalities ty =
         ikind_crossing)
       else
         jkind_crossing ()
+  in
+  let crossing =
+    if List.is_empty (Types.Lpoly.get_exn val_lpoly)
+    then
+      let staticity_ax = Crossing.Axis.Monadic Staticity in
+      Crossing.set staticity_ax (Crossing.Per_axis.min staticity_ax) crossing
+    else crossing
   in
   match modalities with
   | None -> crossing

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -800,6 +800,7 @@ val crossing_of_jkind : Env.t -> 'd Types.jkind -> Mode.Crossing.t
 val crossing_of_ty :
   Env.t ->
   ?modalities:Mode.Modality.Const.t ->
+  ?val_lpoly:Types.Lpoly.t ->
   Types.type_expr ->
   Mode.Crossing.t
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -854,6 +854,8 @@ val mode_crossing_functor : Mode.Crossing.t
 (** The mode crossing of any module. *)
 val mode_crossing_module : Mode.Crossing.t
 
+val mode_crossing_staticity : Mode.Crossing.t
+
 (** Zap a modality to floor if maturity allows, zap to id otherwise. *)
 val zap_modalities_to_floor_if_at_least :
   Language_extension.maturity ->

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -795,11 +795,12 @@ val print_global_state : Format.formatter -> global_state -> unit
 (** Get the crossing of a jkind  *)
 val crossing_of_jkind : Env.t -> 'd Types.jkind -> Mode.Crossing.t
 
-(** Get the crossing of a type wrapped in modalities. Non-principal types get
-    trivial crossing. *)
+(** Get the crossing of a type wrapped in modalities, quantified by layout
+polymorphism. Non-principal types get trivial crossing.*)
 val crossing_of_ty :
   Env.t ->
   ?modalities:Mode.Modality.Const.t ->
+  ?val_lpoly:Types.Lpoly.t ->
   Types.type_expr ->
   Mode.Crossing.t
 
@@ -852,6 +853,8 @@ val mode_crossing_functor : Mode.Crossing.t
 
 (** The mode crossing of any module. *)
 val mode_crossing_module : Mode.Crossing.t
+
+val mode_crossing_staticity : Mode.Crossing.t
 
 (** Zap a modality to floor if maturity allows, zap to id otherwise. *)
 val zap_modalities_to_floor_if_at_least :

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -795,12 +795,12 @@ val print_global_state : Format.formatter -> global_state -> unit
 (** Get the crossing of a jkind  *)
 val crossing_of_jkind : Env.t -> 'd Types.jkind -> Mode.Crossing.t
 
-(** Get the crossing of a type wrapped in modalities, quantified by layout
-polymorphism. Non-principal types get trivial crossing.*)
+(** Get the crossing of a type wrapped in [modalities] and quantified by [lpoly]
+allow more crossing.  Non-principal types get trivial crossing. *)
 val crossing_of_ty :
   Env.t ->
   ?modalities:Mode.Modality.Const.t ->
-  ?val_lpoly:Types.Lpoly.t ->
+  ?lpoly:Types.Lpoly.t ->
   Types.type_expr ->
   Mode.Crossing.t
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1229,8 +1229,7 @@ let mode_unit =
       yielding = Unyielding;
       statefulness = Stateful;
       visibility = Read_write;
-      staticity = Dynamic;
-      (* CR-soon zqian: persistent modules are always static *)
+      staticity = Static;
     }
     ~hint_monadic:hint ~hint_comonadic:hint
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -200,7 +200,7 @@ let value_descriptions ~loc env name
   | Ok () -> ()
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
-  let crossing = Ctype.crossing_of_ty env vd2.val_type in
+  let crossing = Ctype.crossing_of_ty env ~val_lpoly:vd2.val_lpoly vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
     match child_modes_with_modalities name ~modalities mmodes with

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -200,7 +200,9 @@ let value_descriptions ~loc env name
   | Ok () -> ()
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
-  let crossing = Ctype.crossing_of_ty env ~val_lpoly:vd2.val_lpoly vd2.val_type in
+  let crossing =
+    Ctype.crossing_of_ty env ~val_lpoly:vd2.val_lpoly vd2.val_type
+  in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
     match child_modes_with_modalities name ~modalities mmodes with

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -200,7 +200,9 @@ let value_descriptions ~loc env name
   | Ok () -> ()
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
-  let crossing = Ctype.crossing_of_ty env vd2.val_type in
+  let crossing =
+    Ctype.crossing_of_ty env ~val_lpoly:vd2.val_lpoly vd2.val_type
+  in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
     match child_modes_with_modalities name ~modalities mmodes with

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -201,7 +201,7 @@ let value_descriptions ~loc env name
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
   let crossing =
-    Ctype.crossing_of_ty env ~val_lpoly:vd2.val_lpoly vd2.val_type
+    Ctype.crossing_of_ty env ~lpoly:vd2.val_lpoly vd2.val_type
   in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5969,7 +5969,8 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
         Mode.Value.meet (List.map as_single_mode [exp_mode; env_mode])
       in
       Some env_alloc_mode, mode_default exp_mode
-    else None, exp_mode
+    else
+      None, mode_morph (Crossing.apply_right mode_crossing_staticity) exp_mode
   in
   attrs, pat_mode, env_alloc_mode, exp_mode, spat
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -557,6 +557,12 @@ let mode_morph f expected_mode =
   let tuple_modes = None in
   {expected_mode with mode; tuple_modes}
 
+(** Relax an [expected_mode] wrt a crossing. *)
+let mode_crossing crossing expected_mode =
+  let mode = Crossing.apply_right crossing expected_mode.mode in
+  let tuple_modes = Option.map (List.map (fun (m, loc) -> (Crossing.apply_right crossing m, loc))) expected_mode.tuple_modes in
+  { expected_mode with mode; tuple_modes }
+
 (** Similiar to [apply_is_contained_by] but for [expected_mode]. *)
 let mode_is_contained_by is_contained_by ?modalities expected_mode =
   as_single_mode expected_mode
@@ -5970,7 +5976,7 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
       in
       Some env_alloc_mode, mode_default exp_mode
     else
-      None, mode_morph (Crossing.apply_right mode_crossing_staticity) exp_mode
+      None, mode_crossing mode_crossing_staticity exp_mode
   in
   attrs, pat_mode, env_alloc_mode, exp_mode, spat
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -560,7 +560,11 @@ let mode_morph f expected_mode =
 (** Relax an [expected_mode] wrt a crossing. *)
 let mode_crossing crossing expected_mode =
   let mode = Crossing.apply_right crossing expected_mode.mode in
-  let tuple_modes = Option.map (List.map (fun (m, loc) -> (Crossing.apply_right crossing m, loc))) expected_mode.tuple_modes in
+  let tuple_modes =
+    Option.map
+      (List.map (fun (m, loc) -> (Crossing.apply_right crossing m, loc)))
+      expected_mode.tuple_modes
+  in
   { expected_mode with mode; tuple_modes }
 
 (** Similiar to [apply_is_contained_by] but for [expected_mode]. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -559,6 +559,16 @@ let mode_morph f expected_mode =
   let tuple_modes = None in
   {expected_mode with mode; tuple_modes}
 
+(** Relax an [expected_mode] wrt a crossing. *)
+let mode_crossing crossing expected_mode =
+  let mode = Crossing.apply_right crossing expected_mode.mode in
+  let tuple_modes =
+    Option.map
+      (List.map (fun (m, loc) -> (Crossing.apply_right crossing m, loc)))
+      expected_mode.tuple_modes
+  in
+  { expected_mode with mode; tuple_modes }
+
 (** Similiar to [apply_is_contained_by] but for [expected_mode]. *)
 let mode_is_contained_by is_contained_by ?modalities expected_mode =
   as_single_mode expected_mode
@@ -5972,7 +5982,8 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
         Mode.Value.meet (List.map as_single_mode [exp_mode; env_mode])
       in
       Some env_alloc_mode, mode_default exp_mode
-    else None, exp_mode
+    else
+      None, mode_crossing mode_crossing_staticity exp_mode
   in
   attrs, pat_mode, env_alloc_mode, exp_mode, spat
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1817,7 +1817,7 @@ let undo_compress (changes, _old) =
 
 let class_mode =
   let hint : _ Mode.Hint.const = Legacy Class in
-  Mode.Value.(of_const ~hint_monadic:hint ~hint_comonadic:hint Const.legacy)
+  Mode.Value.(of_const ~hint_monadic:hint ~hint_comonadic:hint {Const.legacy with staticity = Static})
 
 let toplevel_mode =
   let hint : _ Mode.Hint.const = Legacy Toplevel in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1817,7 +1817,9 @@ let undo_compress (changes, _old) =
 
 let class_mode =
   let hint : _ Mode.Hint.const = Legacy Class in
-  Mode.Value.(of_const ~hint_monadic:hint ~hint_comonadic:hint {Const.legacy with staticity = Static})
+  Mode.Value.(
+    of_const ~hint_monadic:hint ~hint_comonadic:hint
+      { Const.legacy with staticity = Static })
 
 let toplevel_mode =
   let hint : _ Mode.Hint.const = Legacy Toplevel in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1833,7 +1833,9 @@ let undo_compress (changes, _old) =
 
 let class_mode =
   let hint : _ Mode.Hint.const = Legacy Class in
-  Mode.Value.(of_const ~hint_monadic:hint ~hint_comonadic:hint Const.legacy)
+  Mode.Value.(
+    of_const ~hint_monadic:hint ~hint_comonadic:hint
+      { Const.legacy with staticity = Static })
 
 let toplevel_mode =
   let hint : _ Mode.Hint.const = Legacy Toplevel in


### PR DESCRIPTION
Based on #5662 

This makes persistent modules always `static`. Doing this would stop the compiler from building, and to fix that, we need to add several staticity crossing:
- value description inclusion check crosses staticity if the value is not layout-poly.
- structures memory block always crosses staticity.
- functors crosses staticity (needs to be reversed once we support static functor application)
- `let` bindings crosses staticity if it's not `let poly`.
- classes crosses staticity.

No tests are added - the goal is to make persistent module `static` while keep the compiler building.