### PR TITLE
serialize `val_lpoly` and `val_type` in one go

### DIFF
--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -95,7 +95,31 @@ let deserialize data =
   let map_type_expr _ n =
     lazy(Marshal.from_bytes data n : Types.type_expr) |> Subst.Lazy.of_lazy
   in
-  Deserialize.signature {map_signature; map_type_expr}
+  let map_value_description _ (vd : Serialized.value_description) =
+    (* See comments in [serialize] about [vars] and [ty]. *)
+    let lpoly_type =
+      lazy (Marshal.from_bytes data vd.val_type :
+        Jkind_types.Sort.var list * Types.type_expr)
+    in
+    let val_lpoly =
+      lazy (Lazy.force lpoly_type |> fst |> Types.Lpoly.determined)
+      |> Subst.Lazy.of_lazy
+    in
+    let val_type =
+      lazy (Lazy.force lpoly_type |> snd) |> Subst.Lazy.of_lazy
+    in
+    Subst.Lazy.{
+      val_type;
+      val_lpoly;
+      val_modalities = vd.val_modalities;
+      val_kind = vd.val_kind;
+      val_zero_alloc = vd.val_zero_alloc;
+      val_attributes = vd.val_attributes;
+      val_loc = vd.val_loc;
+      val_uid = vd.val_uid;
+    }
+  in
+  Deserialize.signature {map_signature; map_type_expr; map_value_description}
 
 module Serialize = Types.Map_wrapped(Subst.Lazy)(Serialized)
 
@@ -113,7 +137,24 @@ let serialize oc base =
     |> marshal
   in
   let map_type_expr _ ty = Subst.Lazy.force_type_expr ty |> marshal in
-  Serialize.signature {map_signature; map_type_expr}
+  let map_value_description _ (vd : Subst.Lazy.value_description) =
+    (* [val_type] and [val_lpoly] are marshalled in one-go to preserve physical
+       identity of sort variables. The result is stored in [val_type], and
+       [val_lpoly] is set to [-1] (to be ignored upon unmarshalling) *)
+    let vars = Types.Lpoly.get_exn (Subst.Lazy.force_lpoly vd.val_lpoly) in
+    let ty = Subst.Lazy.force_type_expr vd.val_type in
+    Serialized.{
+      val_type = marshal (vars, ty);
+      val_lpoly = -1; (* invalid offset *)
+      val_modalities = vd.val_modalities;
+      val_kind = vd.val_kind;
+      val_zero_alloc = vd.val_zero_alloc;
+      val_attributes = vd.val_attributes;
+      val_loc = vd.val_loc;
+      val_uid = vd.val_uid;
+    }
+  in
+  Serialize.signature {map_signature; map_type_expr; map_value_description}
 
 let input_cmi_lazy ic =
   let read_bytes n =

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -1049,7 +1049,19 @@ let to_lazy =
     lazy (List.map (To_lazy.signature_item m) sg) |> Wrap.of_lazy
   in
   let map_type_expr _ = Wrap.of_value in
-  To_lazy.{map_signature; map_type_expr}
+  let map_value_description _ (vd : Types.value_description) =
+    Lazy_types.{
+      val_type = Wrap.of_value vd.val_type;
+      val_lpoly = Wrap.of_value vd.val_lpoly;
+      val_modalities = vd.val_modalities;
+      val_kind = vd.val_kind;
+      val_zero_alloc = vd.val_zero_alloc;
+      val_attributes = vd.val_attributes;
+      val_loc = vd.val_loc;
+      val_uid = vd.val_uid;
+    }
+  in
+  To_lazy.{map_signature; map_type_expr; map_value_description}
 
 let lazy_value_description = To_lazy.value_description to_lazy
 let lazy_module_decl = To_lazy.module_declaration to_lazy
@@ -1063,6 +1075,8 @@ module From_lazy = Types.Map_wrapped(Lazy_types)(Types)
 let force_type_expr ty = Wrap.force (fun _ s ty ->
   let loc = Option.value s.loc ~default:Location.none in
   For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)) ty
+
+let force_lpoly lpoly = Wrap.force (fun _ _ x -> x) lpoly
 
 let rec subst_lazy_value_description s descr =
   let val_modalities =
@@ -1226,7 +1240,19 @@ and from_lazy =
     List.map (From_lazy.signature_item m) items
   in
   let map_type_expr _ = force_type_expr in
-  From_lazy.{map_signature; map_type_expr}
+  let map_value_description _ (vd : Lazy_types.value_description) =
+    Types.{
+      val_type = force_type_expr vd.val_type;
+      val_lpoly = force_lpoly vd.val_lpoly;
+      val_modalities = vd.val_modalities;
+      val_kind = vd.val_kind;
+      val_zero_alloc = vd.val_zero_alloc;
+      val_attributes = vd.val_attributes;
+      val_loc = vd.val_loc;
+      val_uid = vd.val_uid;
+    }
+  in
+  From_lazy.{map_signature; map_type_expr; map_value_description}
 
 and force_value_description vd = From_lazy.value_description from_lazy vd
 and force_module_decl d = From_lazy.module_declaration from_lazy d
@@ -1271,6 +1297,7 @@ module Lazy = struct
   let force_functor_parameter = force_functor_parameter
   let force_value_description = force_value_description
   let force_type_expr = force_type_expr
+  let force_lpoly = force_lpoly
 end
 
 let signature sc s sg =

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -195,4 +195,5 @@ module Lazy : sig
   val force_functor_parameter : functor_parameter -> Types.functor_parameter
   val force_value_description : value_description -> Types.value_description
   val force_type_expr : type_expr wrapped -> type_expr
+  val force_lpoly : Types.Lpoly.t wrapped -> Types.Lpoly.t
 end

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -667,7 +667,7 @@ module type Wrapped = sig
     { val_type: type_expr wrapped;                (* Type of the value *)
       val_modalities : Mode.Modality.t;     (* Modalities on the value *)
       val_kind: value_kind;
-      val_lpoly: Lpoly.t;
+      val_lpoly: Lpoly.t wrapped;
       val_loc: Location.t;
       val_zero_alloc: Zero_alloc.t;
       val_attributes: Parsetree.attributes;
@@ -755,7 +755,9 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
   type mapper =
     {
       map_signature: mapper -> signature -> To.signature;
-      map_type_expr: mapper -> type_expr wrapped -> type_expr To.wrapped
+      map_type_expr: mapper -> type_expr wrapped -> type_expr To.wrapped;
+      map_value_description:
+        mapper -> value_description -> To.value_description;
     }
 
   let signature m = m.map_signature m
@@ -773,18 +775,7 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
       | Unit -> To.Unit
       | Named (id,mty,mm) -> To.Named (id, module_type m mty,mm)
 
-  let value_description m {val_type; val_modalities; val_kind; val_lpoly;
-                           val_zero_alloc; val_attributes; val_loc; val_uid} =
-    To.{
-      val_type = m.map_type_expr m val_type;
-      val_modalities;
-      val_kind;
-      val_lpoly;
-      val_zero_alloc;
-      val_attributes;
-      val_loc;
-      val_uid
-    }
+  let value_description m vd = m.map_value_description m vd
 
   let module_declaration m {md_type; md_modalities; md_attributes;
     md_loc; md_uid} =

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1147,7 +1147,7 @@ module type Wrapped = sig
       have been applied and we have the real mode of the value. The original
       modalities shouldn't be looked again and is replaced by [undefined]. *)
       val_kind: value_kind;
-      val_lpoly: Lpoly.t;
+      val_lpoly: Lpoly.t wrapped;
       (** Guaranteed [determined] for all values visible outside [type_let].
           May be [to_generalize] during intermediate stages of typing a
           [let poly_] binding. See [Lpoly]. *)
@@ -1211,7 +1211,9 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) : sig
   type mapper =
     {
       map_signature: mapper -> From.signature -> To.signature;
-      map_type_expr: mapper -> type_expr From.wrapped -> type_expr To.wrapped
+      map_type_expr: mapper -> type_expr From.wrapped -> type_expr To.wrapped;
+      map_value_description:
+        mapper -> From.value_description -> To.value_description;
     }
 
   val value_description :


### PR DESCRIPTION
We currently rely on the physical equality between sort vars. Therefore, `val_lpoly` and `val_type` must be serialized in one `marshall` call to preserve sharing (and hence the proper quanlification).