### PR TITLE
Support long section names for the binary-emitter verifier

### DIFF
--- a/asmcomp/binary_emitter_verify.ml
+++ b/asmcomp/binary_emitter_verify.ml
@@ -166,6 +166,13 @@ let read_text_sections dir =
           then
             let name = "." ^ String.sub f 8 (String.length f - 12) in
             Some (name, read_file (Filename.concat dir f))
+          else if
+            String.starts_with ~prefix:"section_hash-" f
+            && String.ends_with ~suffix:".bin" f
+          then
+            let name_filename = Filename.chop_suffix f "bin" ^ "name" in
+            let name = read_file (Filename.concat dir name_filename) in
+            Some (name, read_file (Filename.concat dir f))
           else None)
     in
     match function_sections with
@@ -195,6 +202,14 @@ let read_text_relocations dir ~include_main_text =
           then
             let name_part = String.sub f 8 (String.length f - 15) in
             Some ("." ^ name_part, read_relocations dir name_part)
+          else if
+            String.starts_with ~prefix:"section_hash-" f
+            && String.ends_with ~suffix:".relocs" f
+          then
+            let name_filename = Filename.chop_suffix f "relocs" ^ "name" in
+            let name = read_file (Filename.concat dir name_filename) in
+            let name_part = String.sub f 8 (String.length f - 15) in
+            Some (name, read_relocations dir name_part)
           else None)
     in
     if include_main_text

--- a/backend/arm64/binary_emitter_helpers.ml
+++ b/backend/arm64/binary_emitter_helpers.ml
@@ -117,6 +117,19 @@ let save_sections_to_files sections section_tbl =
         then "section_" ^ String.sub name 1 (String.length name - 1)
         else "section_" ^ name
       in
+      let safe_name =
+        if String.length safe_name >= 248
+        then (
+          (* [safe_name ^ ".relocs"] will have more than 255 bytes, so let’s
+             save the section name in a separate file *)
+          let h = Digest.BLAKE256.(to_hex (string name)) in
+          let safe_name = "section_hash-" ^ h in
+          let name_filename = Filename.concat dir (safe_name ^ ".name") in
+          Out_channel.with_open_bin name_filename (fun oc ->
+              output_string oc name);
+          safe_name)
+        else safe_name
+      in
       (* Save binary content *)
       let bin_filename = Filename.concat dir (safe_name ^ ".bin") in
       let oc = open_out_bin bin_filename in


### PR DESCRIPTION
This is extracted from the large #5552, as it is independent from (even if required for) the tests of the new name-mangling scheme.

The binary-emitter verifier creates files whose name is a (ELF) section name. When using function sections, those file names can get over the current limit for a file name (255 bytes on Linux), in particular when using the structured name-mangling scheme (as the full path of the function is encoded in the symbol).
This patch changes the way the file is named in cases where this boundary could be reached, using the scheme `section_hash-<h>.<ext>` where `<h>` is the hexadecimal BLAKE256 hash of the section name. A corresponding `section_hash-<h>.name` file is generated alongside to provide the original section name.