### PR TITLE
Get copy of test as modified upstream to work with mark-delay major GC.

### DIFF
--- a/testsuite/tests/weak-ephe-final/ephe_custom.ml
+++ b/testsuite/tests/weak-ephe-final/ephe_custom.ml
@@ -5,13 +5,14 @@ let w = Weak.create 1
 let major_obj () =
   let n = Sys.opaque_identity 42 in
   let v = Sys.opaque_identity (Int64.of_int n) in
-  Gc.minor ();
-  v
+  Gc.full_major ();
+  v (* [v] is unmarked *)
 
 let () =
   Weak.set w 0 (Some (major_obj ()));
-  Gc.major ();
+  (* [v] is unmarked *)
   let x = Option.get (Weak.get_copy w 0) in
+  (* [v] is marked by [Weak.get_copy] (which does not copy the custom object. *)
   Gc.major ();
   Printf.printf "value: %Ld\n%!" x;
   let junk = List.init 1_000_000 Fun.id in


### PR DESCRIPTION
OxCaml has the mark-delay major GC. 5.4 upstream does not. This test changed upstream to work with mark-delay.