### PR TITLE
Test parallelism alerts

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -261,9 +261,9 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
         c_headers_flags;
         Ocaml_flags.stdlib;
         directory_flags env;
-        flags env;
         libraries;
         backend_default_flags env Compiler.target;
+        flags env;
         backend_flags env Compiler.target;
         compile_flags;
         output;
@@ -309,9 +309,9 @@ let compile_module (compiler : Ocaml_compilers.compiler) module_ log env =
     Ocaml_flags.stdlib;
     c_headers_flags;
     directory_flags env;
-    flags env;
     libraries Compiler.target env;
     backend_default_flags env Compiler.target;
+    flags env;
     backend_flags env Compiler.target;
     compile_only_flag_opt;
     module_;

--- a/testsuite/tests/parallel/unsafe_alert.compilers.reference
+++ b/testsuite/tests/parallel/unsafe_alert.compilers.reference
@@ -1,5 +1,5 @@
-File "unsafe_alert.ml", line 9, characters 8-20:
-9 | let _ = Domain.spawn (fun () -> ())
+File "unsafe_alert.ml", line 8, characters 8-20:
+8 | let _ = Domain.spawn (fun () -> ())
             ^^^^^^^^^^^^
 Alert unsafe_multidomain: Stdlib.Domain.spawn
 Use [Domain.Safe.spawn].

--- a/testsuite/tests/parallel/unsafe_alert.ml
+++ b/testsuite/tests/parallel/unsafe_alert.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert +unsafe_multidomain";
  multicore;
  { bytecode; }
  { native; }


### PR DESCRIPTION
In the merge we have changed the testsuite to turn off the parallelism alerts. They need to be turned on for the tests which actually test for them.