### PR TITLE
Affinity: use information from phi moves

### DIFF
--- a/backend/regalloc/regalloc_affinity.ml
+++ b/backend/regalloc/regalloc_affinity.ml
@@ -50,13 +50,45 @@ let temp_and_phys_reg_of_instr :
     | _ -> None)
   | _ -> None
 
-type t = affinity list Reg.Tbl.t
+module Classes : sig
+  type t
 
-let compute : Cfg_with_infos.t -> t =
- fun cfg_with_infos ->
-  let res = Reg.Tbl.create 17 in
+  val make : unit -> t
+
+  val find : t -> Reg.t -> Reg.t
+
+  val unite : t -> Reg.t -> Reg.t -> unit
+end = struct
+  (* pointer to "parent", missing key means identity *)
+  type t = Reg.t Reg.Tbl.t
+
+  let make () = Reg.Tbl.create 32
+
+  let rec find : t -> Reg.t -> Reg.t =
+   fun t reg ->
+    match Reg.Tbl.find_opt t reg with
+    | None -> reg
+    | Some parent -> if Reg.same reg parent then reg else find t parent
+
+  let unite : t -> Reg.t -> Reg.t -> unit =
+   fun t left right ->
+    let left = find t left in
+    let right = find t right in
+    Reg.Tbl.replace t left right
+end
+
+type t =
+  { classes : Classes.t;
+    affinity : affinity list Reg.Tbl.t
+  }
+
+let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
+ fun cfg_with_infos phi_moves ->
+  let classes = Classes.make () in
+  List.iter (fun (left, right) -> Classes.unite classes left right) phi_moves;
+  let affinity = Reg.Tbl.create 17 in
   match Lazy.force Regalloc_utils.affinity with
-  | false -> res
+  | false -> { classes; affinity }
   | true ->
     let priorities : int Phys_reg.Tbl.t Reg.Tbl.t = Reg.Tbl.create 17 in
     Cfg.iter_blocks (Cfg_with_infos.cfg cfg_with_infos) ~f:(fun label block ->
@@ -76,8 +108,9 @@ let compute : Cfg_with_infos.t -> t =
             match temp_and_phys_reg_of_instr instr with
             | None -> ()
             | Some (temp, phys_reg) ->
+              let temp = Classes.find classes temp in
               incr_move priorities ~temp ~phys_reg ~delta));
-    (* CR xclerc for xclerc: consider switching from list to (dynamic array). *)
+    (* CR xclerc for xclerc: consider switching from list to (dynamic) array. *)
     Reg.Tbl.iter
       (fun temp phys_reg_tbl ->
         let affinity_list =
@@ -86,9 +119,12 @@ let compute : Cfg_with_infos.t -> t =
               if priority <= 0 then acc else { priority; phys_reg } :: acc)
             phys_reg_tbl []
         in
-        Reg.Tbl.replace res temp (List.sort compare_desc_proprity affinity_list))
+        Reg.Tbl.replace affinity temp
+          (List.sort compare_desc_proprity affinity_list))
       priorities;
-    res
+    { classes; affinity }
 
 let get : t -> Reg.t -> affinity list =
- fun t reg -> match Reg.Tbl.find_opt t reg with None -> [] | Some list -> list
+ fun t reg ->
+  let reg = Classes.find t.classes reg in
+  match Reg.Tbl.find_opt t.affinity reg with None -> [] | Some list -> list

--- a/backend/regalloc/regalloc_affinity.mli
+++ b/backend/regalloc/regalloc_affinity.mli
@@ -3,11 +3,7 @@
 (** This module implements a basic variant of affinity: we compute the numbers
     of moves between temporaries and physical registers, and use this
     information in register allocators to try to assign a temporary to a
-    physical register with high affinity.
-
-    This could be extended to the phi moves introduced during splitting, but
-    this basic version already seems useful, in particular for the linscan and
-    greedy allocators. *)
+    physical register with high affinity. *)
 
 type affinity =
   { priority : int;
@@ -18,7 +14,7 @@ type t
 
 (** Computes the affinities for the passed CFG, i.e. for each temporary the
     number of times it moves from/to a given physical register. *)
-val compute : Cfg_with_infos.t -> t
+val compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t
 
 (** Returns the affinities for the passed temporary in descending order (i.e.
     from the highest to the lowest affinity), returning an empty list if the

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -443,22 +443,22 @@ let prelude :
     Reg.Set.cardinal cfg_infos.arg
   in
   if debug then Utils.log "#temporaries(before):%d" num_temporaries;
-  let cfg_infos, stack_slots =
+  let cfg_infos, stack_slots, phi_moves =
     if
       num_temporaries >= threshold_split_live_ranges
       || Flambda2_ui.Flambda_features.classic_mode ()
-    then cfg_infos, Regalloc_stack_slots.make ()
+    then cfg_infos, Regalloc_stack_slots.make (), []
     else if Lazy.force Regalloc_split_utils.split_live_ranges
     then
-      let stack_slots =
+      let stack_slots, phi_moves =
         Profile.record ~accumulate:true "split"
           (fun () -> Regalloc_split.split_live_ranges cfg_with_infos)
           ()
       in
-      collect_cfg_infos cfg_with_layout, stack_slots
-    else cfg_infos, Regalloc_stack_slots.make ()
+      collect_cfg_infos cfg_with_layout, stack_slots, phi_moves
+    else cfg_infos, Regalloc_stack_slots.make (), []
   in
-  cfg_infos, stack_slots, Regalloc_affinity.compute cfg_with_infos
+  cfg_infos, stack_slots, Regalloc_affinity.compute cfg_with_infos phi_moves
 
 let make_dummy_use :
     Cfg.t -> copy:_ Cfg.instruction -> reg:Reg.t -> Cfg.basic Cfg.instruction =

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -360,6 +360,7 @@ let insert_reloads :
   if debug then dedent ()
 
 let add_phi_moves_to_instr_list :
+    phi_moves:(Reg.t * Reg.t) list ref ->
     instr_id:InstructionId.sequence ->
     before:Cfg.basic_block ->
     phi:Cfg.basic_block ->
@@ -367,7 +368,7 @@ let add_phi_moves_to_instr_list :
     Reg.Set.t ->
     Cfg.basic_instruction_list ->
     unit =
- fun ~instr_id ~before ~phi substs to_unify instrs ->
+ fun ~phi_moves ~instr_id ~before ~phi substs to_unify instrs ->
   let before_subst = Substitution.for_label substs before.start in
   let phi_subst = Substitution.for_label substs phi.start in
   Reg.Set.iter
@@ -382,6 +383,7 @@ let add_phi_moves_to_instr_list :
             Printreg.reg to_
       | false ->
         if debug then log "phi %a -> %a" Printreg.reg from Printreg.reg to_;
+        phi_moves := (from, to_) :: !phi_moves;
         let phi_move =
           Move.make_instr Move.Plain
             ~id:(InstructionId.get_and_incr instr_id)
@@ -393,8 +395,13 @@ let add_phi_moves_to_instr_list :
 (* Insert phi moves: - to the predecessor block if the edge is an "always" one;
    - to a newly-inserted block otherwise. Returns `true` iff at least one block
    was inserted. *)
-let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
+let insert_phi_moves :
+    State.t ->
+    Cfg_with_infos.t ->
+    Substitution.map ->
+    bool * (Reg.t * Reg.t) list =
  fun state cfg_with_infos substs ->
+  let phi_moves = ref [] in
   let block_inserted = ref false in
   Label.Map.iter
     (fun label to_unify ->
@@ -418,13 +425,14 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
             assert false
           | Tailcall_self _ -> ()
           | Always _ ->
-            add_phi_moves_to_instr_list ~instr_id ~before:predecessor_block
-              ~phi:block substs to_unify predecessor_block.body
+            add_phi_moves_to_instr_list ~phi_moves ~instr_id
+              ~before:predecessor_block ~phi:block substs to_unify
+              predecessor_block.body
           | Switch _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
           | Call _ | Prim _ | Invalid _ ->
             let instrs = DLL.make_empty () in
-            add_phi_moves_to_instr_list ~instr_id ~before:predecessor_block
-              ~phi:block substs to_unify instrs;
+            add_phi_moves_to_instr_list ~phi_moves ~instr_id
+              ~before:predecessor_block ~phi:block substs to_unify instrs;
             (* CR-soon xclerc for xclerc: now that we preprocess critical nodes,
                no insertion should occur here. *)
             let inserted_blocks =
@@ -455,10 +463,11 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
               ()))
         block.predecessors)
     (State.phi_at_beginning state);
-  !block_inserted
+  !block_inserted, !phi_moves
 
 let split_at_destruction_points :
-    Cfg_with_infos.t -> (Regalloc_stack_slots.t * bool) option =
+    Cfg_with_infos.t ->
+    (Regalloc_stack_slots.t * bool * (Reg.t * Reg.t) list) option =
  fun cfg_with_infos ->
   if debug
   then (
@@ -499,7 +508,7 @@ let split_at_destruction_points :
     Profile.record ~accumulate:true "insert_reloads"
       (fun () -> insert_reloads state cfg_with_infos substs stack_subst)
       ();
-    let block_inserted =
+    let block_inserted, phi_moves =
       Profile.record ~accumulate:true "insert_phi_moves"
         (fun () -> insert_phi_moves state cfg_with_infos substs)
         ()
@@ -508,9 +517,10 @@ let split_at_destruction_points :
     then (
       Regalloc_irc_utils.log_cfg_with_infos cfg_with_infos;
       dedent ());
-    Some (State.stack_slots state, block_inserted)
+    Some (State.stack_slots state, block_inserted, phi_moves)
 
-let split_live_ranges : Cfg_with_infos.t -> Regalloc_stack_slots.t =
+let split_live_ranges :
+    Cfg_with_infos.t -> Regalloc_stack_slots.t * (Reg.t * Reg.t) list =
  fun cfg_with_infos ->
   (* CR-soon xclerc for xclerc: support closure, flambda, and
      flambda2/classic *)
@@ -526,8 +536,8 @@ let split_live_ranges : Cfg_with_infos.t -> Regalloc_stack_slots.t =
     ()
   | true, true -> assert false);
   match split_at_destruction_points cfg_with_infos with
-  | None -> Regalloc_stack_slots.make ()
-  | Some (stack_slots, block_inserted) ->
+  | None -> Regalloc_stack_slots.make (), []
+  | Some (stack_slots, block_inserted, phi_moves) ->
     Cfg_with_infos.invalidate_liveness cfg_with_infos;
     if block_inserted
     then Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos;
@@ -535,4 +545,4 @@ let split_live_ranges : Cfg_with_infos.t -> Regalloc_stack_slots.t =
       Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
         cfg_with_infos
     in
-    stack_slots
+    stack_slots, phi_moves

--- a/backend/regalloc/regalloc_split.mli
+++ b/backend/regalloc/regalloc_split.mli
@@ -13,4 +13,5 @@
     The algorithm is an adaptation of the one rewriting a CFG to put it in SSA
     form: we simply consider that new names are introduced at destruction
     points. *)
-val split_live_ranges : Cfg_with_infos.t -> Regalloc_stack_slots.t
+val split_live_ranges :
+  Cfg_with_infos.t -> Regalloc_stack_slots.t * (Reg.t * Reg.t) list

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -455,16 +455,16 @@ spilled_phi_merge:
   movq  48(%rsp), %rbx
   call  *%rdi
 .L120:
-  movq  (%rsp), %rsi
+  movq  (%rsp), %rax
   movq  8(%rsp), %rbp
   movq  16(%rsp), %rbx
-  movq  24(%rsp), %rdx
-  movq  32(%rsp), %rax
-  movq  40(%rsp), %rdi
-  movq  %rsi, (%rsp)
-  movq  %rdx, 24(%rsp)
-  movq  %rax, %r12
-  movq  %rdi, %r13
+  movq  24(%rsp), %rdi
+  movq  32(%rsp), %r8
+  movq  40(%rsp), %r9
+  movq  %rax, (%rsp)
+  movq  %rdi, 24(%rsp)
+  movq  %r8, %r12
+  movq  %r9, %r13
 .L114:
   movq  %rbp, %rax
   movq  24(%rsp), %rdi


### PR DESCRIPTION
This pull request extends the support
for affinity in register allocation, by using
the information about _phi_ moves.

During the split preprocessing pass, we
rename temporaries, and may have as
a consequence to insert _phi_ moves.

We use these moves to construct
equivalent classes of temporaries (_i.e._
if two temporaries are linked by a _phi_
move they are in the same class).
Then, affinity is tracked essentially
per-class rather than per-temporary,
by using the canonical element of
the class as the key in the existing
tables.

The effects are limited:

- IRC: deletes ~0.5% of moves;
- Linscan: deletes ~2.2% of moves;
- Greedy: deletes ~1.7% of moves;

and basically no effects on spills/reloads
(*i.e.* less than 0.1% are deleted).
