### PR TITLE
[5.4] Clear free lists when orphaning available pools.

### DIFF
--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -197,6 +197,7 @@ void caml_orphan_shared_heap(struct caml_heap_state* heap) {
     released +=
       move_all_pools(&heap->avail_pools[i],
                      &pool_freelist.global_avail_pools[i], NULL);
+    heap->free.lists[i] = NULL;
 
     released +=
       move_all_pools(&heap->full_pools[i],


### PR DESCRIPTION
New free lists array (used for fast-path minor GC promotion) needs to be kept in sync with the `avail_pools` everywhere, including when orphaning the heap.