### PR TITLE
Use /usr/bin/env bash instead of hardcoded /bin/bash

### DIFF
--- a/ 
+++ b/ 
@@ -1,39 +1,3 @@
-#!/usr/bin/env bash
-# Generates an iarray test from a mutable array test.
-#
-# Usage: ./gen_iarray_test.sh <mutable_test.ml> <output_iarray_test.ml>
-#
-# Example:
-#   ./gen_iarray_test.sh ../typing-layouts-arrays/test_ignorable_product_array_1.ml \
-#                        test_ignorable_product_iarray_1.ml
-
-set -e
-
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <mutable_test.ml> <output_iarray_test.ml>" >&2
-    exit 1
-fi
-
-INPUT="$1"
-OUTPUT="$2"
-
-if [ ! -f "$INPUT" ]; then
-    echo "Error: Input file '$INPUT' not found" >&2
-    exit 1
-fi
-
-# Extract the customizable section between the two marker comments.
-# The customizable section starts after "test directory. *)" and ends before
-# "(* Below here is copy pasted".
-# We use awk to avoid issues with multi-line comments containing similar text.
-CUSTOMIZABLE=$(awk '
-    /test directory\. \*\)/ && !started { started=1; next }
-    /^\(\* Below here is copy pasted/ { exit }
-    started { print }
-' "$INPUT")
-
-# Write the header
-cat > "$OUTPUT" << 'HEADER_EOF'
 (* TEST
  include stdlib_stable;
  include stdlib_upstream_compatible;
@@ -61,13 +25,7 @@ open Stdlib_upstream_compatible
 (* This test is auto-generated from the corresponding mutable array test in
    typing-layouts-arrays/ using gen_iarray_test.sh. Do not edit directly.
    See README.md in this test directory. *)
-HEADER_EOF
 
-# Append the customizable section
-echo "$CUSTOMIZABLE" >> "$OUTPUT"
-
-# Append the boilerplate
-cat >> "$OUTPUT" << 'BOILERPLATE_EOF'
 (* Below here is copy pasted due to the absence of layout polymorphism. Don't
    change it.  See README.md in this test directory. *)
 module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
@@ -139,6 +97,3 @@ module UTuple_array_boxed = Test_gen_u_iarray.Make_boxed (struct
     end
   end)
 module _ = Test_gen_u_iarray.Test (UTuple_array_boxed)
-BOILERPLATE_EOF
-
-echo "Generated $OUTPUT from $INPUT"

--- a/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
+++ b/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Filter script for DWARF test output to show only function call frames
 # Removes LLDB commands, process status messages, thread info, and source locations

--- a/oxcaml/tests/owee/generate_expected.sh
+++ b/oxcaml/tests/owee/generate_expected.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generate expected output for owee archive test using system tools
 # This produces the same output format as test_archive.ml
 #

--- a/testsuite/tests/typing-jkind-bounds/poly-variant-limit/gen_types.sh
+++ b/testsuite/tests/typing-jkind-bounds/poly-variant-limit/gen_types.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # This script is used to generate large polymorphic variants. This is used to
 # test how jkind inference handles them.

--- a/tools/apply-diff.sh
+++ b/tools/apply-diff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
  - Follows the convention already used by 31 other scripts in the repo
  - Fixes portability on NixOS, Guix, and other systems where bash is not at `/bin/bash`
  - Extends the same fix from #5822 to the remaining instances
  - Excludes vendored code in `external/`

  ## Changed files
  - `testsuite/tests/typing-layouts-iarrays/gen_iarray_test.sh`
  - `testsuite/tests/typing-jkind-bounds/poly-variant-limit/gen_types.sh`
  - `tools/apply-diff.sh`
  - `oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh`
  - `oxcaml/tests/owee/generate_expected.sh`

  ## Test plan    
  - [x] Verified all other scripts in the repo use env bash
  - [ ] CI passes