### PR TITLE
Affinity: minor refactorings

### DIFF
--- a/backend/regalloc/regalloc_affinity.ml
+++ b/backend/regalloc/regalloc_affinity.ml
@@ -79,7 +79,7 @@ end
 
 type t =
   { classes : Classes.t;
-    affinity : affinity list Reg.Tbl.t
+    affinity : affinity array Reg.Tbl.t
   }
 
 let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
@@ -110,34 +110,43 @@ let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
             | Some (temp, phys_reg) ->
               let temp = Classes.find classes temp in
               incr_move priorities ~temp ~phys_reg ~delta));
-    (* CR xclerc for xclerc: consider switching from list to (dynamic) array. *)
+    (* CR-someday xclerc for xclerc: consider switching to a heap, since we are
+       only interested in extracting according to priority. *)
     Reg.Tbl.iter
       (fun temp phys_reg_tbl ->
-        let affinity_list =
-          Phys_reg.Tbl.fold
-            (fun phys_reg priority acc ->
-              if priority <= 0 then acc else { priority; phys_reg } :: acc)
-            phys_reg_tbl []
-        in
-        Reg.Tbl.replace affinity temp
-          (List.sort compare_desc_proprity affinity_list))
+        let affinities = Dynarray.create () in
+        Phys_reg.Tbl.iter
+          (fun phys_reg priority ->
+            if priority > 0
+            then Dynarray.add_last affinities { priority; phys_reg })
+          phys_reg_tbl;
+        let affinities = Dynarray.to_array affinities in
+        Array.sort compare_desc_proprity affinities;
+        Reg.Tbl.replace affinity temp affinities)
       priorities;
     { classes; affinity }
 
-type affinities = affinity list ref
+type affinities =
+  { mutable next_index : int;
+    affinities : affinity array
+  }
 
 let get : t -> Reg.t -> affinities =
  fun t reg ->
   let reg = Classes.find t.classes reg in
-  let res =
-    match Reg.Tbl.find_opt t.affinity reg with None -> [] | Some list -> list
+  let affinities =
+    match Reg.Tbl.find_opt t.affinity reg with
+    | None -> [||]
+    | Some array -> array
   in
-  ref res
+  { next_index = 0; affinities }
 
 let next : affinities -> affinity option =
  fun aff ->
-  match !aff with
-  | [] -> None
-  | hd :: tl ->
-    aff := tl;
-    Some hd
+  let idx = aff.next_index in
+  if idx >= Array.length aff.affinities
+  then None
+  else
+    let res = aff.affinities.(idx) in
+    aff.next_index <- succ idx;
+    Some res

--- a/backend/regalloc/regalloc_affinity.ml
+++ b/backend/regalloc/regalloc_affinity.ml
@@ -124,7 +124,20 @@ let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
       priorities;
     { classes; affinity }
 
-let get : t -> Reg.t -> affinity list =
+type affinities = affinity list ref
+
+let get : t -> Reg.t -> affinities =
  fun t reg ->
   let reg = Classes.find t.classes reg in
-  match Reg.Tbl.find_opt t.affinity reg with None -> [] | Some list -> list
+  let res =
+    match Reg.Tbl.find_opt t.affinity reg with None -> [] | Some list -> list
+  in
+  ref res
+
+let next : affinities -> affinity option =
+ fun aff ->
+  match !aff with
+  | [] -> None
+  | hd :: tl ->
+    aff := tl;
+    Some hd

--- a/backend/regalloc/regalloc_affinity.ml
+++ b/backend/regalloc/regalloc_affinity.ml
@@ -82,10 +82,12 @@ type t =
     affinity : affinity array Reg.Tbl.t
   }
 
-let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
+let compute : Cfg_with_infos.t -> Regalloc_split.phi_move list -> t =
  fun cfg_with_infos phi_moves ->
   let classes = Classes.make () in
-  List.iter (fun (left, right) -> Classes.unite classes left right) phi_moves;
+  List.iter
+    (fun { Regalloc_split.src; dst } -> Classes.unite classes src dst)
+    phi_moves;
   let affinity = Reg.Tbl.create 17 in
   match Lazy.force Regalloc_utils.affinity with
   | false -> { classes; affinity }

--- a/backend/regalloc/regalloc_affinity.ml
+++ b/backend/regalloc/regalloc_affinity.ml
@@ -79,13 +79,15 @@ end
 
 type t =
   { classes : Classes.t;
-    affinity : affinity list Reg.Tbl.t
+    affinity : affinity array Reg.Tbl.t
   }
 
-let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
+let compute : Cfg_with_infos.t -> Regalloc_split.phi_move list -> t =
  fun cfg_with_infos phi_moves ->
   let classes = Classes.make () in
-  List.iter (fun (left, right) -> Classes.unite classes left right) phi_moves;
+  List.iter
+    (fun { Regalloc_split.src; dst } -> Classes.unite classes src dst)
+    phi_moves;
   let affinity = Reg.Tbl.create 17 in
   match Lazy.force Regalloc_utils.affinity with
   | false -> { classes; affinity }
@@ -110,21 +112,43 @@ let compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t =
             | Some (temp, phys_reg) ->
               let temp = Classes.find classes temp in
               incr_move priorities ~temp ~phys_reg ~delta));
-    (* CR xclerc for xclerc: consider switching from list to (dynamic) array. *)
+    (* CR-someday xclerc for xclerc: consider switching to a heap, since we are
+       only interested in extracting according to priority. *)
     Reg.Tbl.iter
       (fun temp phys_reg_tbl ->
-        let affinity_list =
-          Phys_reg.Tbl.fold
-            (fun phys_reg priority acc ->
-              if priority <= 0 then acc else { priority; phys_reg } :: acc)
-            phys_reg_tbl []
-        in
-        Reg.Tbl.replace affinity temp
-          (List.sort compare_desc_proprity affinity_list))
+        let affinities = Dynarray.create () in
+        Phys_reg.Tbl.iter
+          (fun phys_reg priority ->
+            if priority > 0
+            then Dynarray.add_last affinities { priority; phys_reg })
+          phys_reg_tbl;
+        let affinities = Dynarray.to_array affinities in
+        Array.sort compare_desc_proprity affinities;
+        Reg.Tbl.replace affinity temp affinities)
       priorities;
     { classes; affinity }
 
-let get : t -> Reg.t -> affinity list =
+type affinities =
+  { mutable next_index : int;
+    affinities : affinity array
+  }
+
+let get : t -> Reg.t -> affinities =
  fun t reg ->
   let reg = Classes.find t.classes reg in
-  match Reg.Tbl.find_opt t.affinity reg with None -> [] | Some list -> list
+  let affinities =
+    match Reg.Tbl.find_opt t.affinity reg with
+    | None -> [||]
+    | Some array -> array
+  in
+  { next_index = 0; affinities }
+
+let next : affinities -> affinity option =
+ fun aff ->
+  let idx = aff.next_index in
+  if idx >= Array.length aff.affinities
+  then None
+  else
+    let res = aff.affinities.(idx) in
+    aff.next_index <- succ idx;
+    Some res

--- a/backend/regalloc/regalloc_affinity.mli
+++ b/backend/regalloc/regalloc_affinity.mli
@@ -14,9 +14,14 @@ type t
 
 (** Computes the affinities for the passed CFG, i.e. for each temporary the
     number of times it moves from/to a given physical register. *)
-val compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t
+val compute : Cfg_with_infos.t -> Regalloc_split.phi_move list -> t
+
+type affinities
 
 (** Returns the affinities for the passed temporary in descending order (i.e.
-    from the highest to the lowest affinity), returning an empty list if the
-    temporary has no affinity with any physical register. *)
-val get : t -> Reg.t -> affinity list
+    from the highest to the lowest affinity), use `next` to get the elements in
+    order. *)
+val get : t -> Reg.t -> affinities
+
+(** Returns the next affinity if there is one, `None` otherwise *)
+val next : affinities -> affinity option

--- a/backend/regalloc/regalloc_affinity.mli
+++ b/backend/regalloc/regalloc_affinity.mli
@@ -14,7 +14,7 @@ type t
 
 (** Computes the affinities for the passed CFG, i.e. for each temporary the
     number of times it moves from/to a given physical register. *)
-val compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t
+val compute : Cfg_with_infos.t -> Regalloc_split.phi_move list -> t
 
 type affinities
 

--- a/backend/regalloc/regalloc_affinity.mli
+++ b/backend/regalloc/regalloc_affinity.mli
@@ -16,7 +16,12 @@ type t
     number of times it moves from/to a given physical register. *)
 val compute : Cfg_with_infos.t -> (Reg.t * Reg.t) list -> t
 
+type affinities
+
 (** Returns the affinities for the passed temporary in descending order (i.e.
-    from the highest to the lowest affinity), returning an empty list if the
-    temporary has no affinity with any physical register. *)
-val get : t -> Reg.t -> affinity list
+    from the highest to the lowest affinity), use `next` to get the elements in
+    order. *)
+val get : t -> Reg.t -> affinities
+
+(** Returns the next affinity if there is one, `None` otherwise *)
+val next : affinities -> affinity option

--- a/backend/regalloc/regalloc_affinity.mli
+++ b/backend/regalloc/regalloc_affinity.mli
@@ -23,5 +23,8 @@ type affinities
     order. *)
 val get : t -> Reg.t -> affinities
 
+(* CR-someday mslater for xclerc: consider a stateless `iter` or `iter_until`
+   function, that wouldn't need to store an index.*)
+
 (** Returns the next affinity if there is one, `None` otherwise *)
 val next : affinities -> affinity option

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -484,16 +484,17 @@ module Hardware_registers = struct
       (reg : Reg.t) (interval : Interval.t) : Hardware_register.t option =
     let reg_class = Regs.Reg_class.of_machtype reg.typ in
     let hardware_regs = Regs.Reg_class_tbl.find t reg_class in
-    let rec find = function
-      | [] -> None
-      | { Regalloc_affinity.priority = _; phys_reg } :: tl ->
+    let rec find aff =
+      match Regalloc_affinity.next aff with
+      | None -> None
+      | Some { Regalloc_affinity.priority = _; phys_reg } ->
         let reg_index_in_class : int = Regs.index_in_class phys_reg in
         let hardware_reg : Hardware_register.t =
           hardware_regs.(reg_index_in_class)
         in
         if not (overlap hardware_reg interval)
         then Some hardware_reg
-        else find tl
+        else find aff
     in
     find (Regalloc_affinity.get affinities reg)
 

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -338,14 +338,15 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
         !first_avail
       in
       (* returns the index of the first available physical register in the
-         passed affinity list *)
-      let rec get_available = function
-        | [] -> get_first_available ()
-        | { Regalloc_affinity.priority = _; phys_reg } :: tl ->
+         passed affinities *)
+      let rec get_available aff =
+        match Regalloc_affinity.next aff with
+        | None -> get_first_available ()
+        | Some { Regalloc_affinity.priority = _; phys_reg } ->
           let idx = Regs.index_in_class phys_reg in
           if idx >= 0 && idx < reg_num_avail && Array.unsafe_get ok_colors idx
           then idx
-          else get_available tl
+          else get_available aff
       in
       let rec mark_adjacent_colors_and_get_available (adj : Reg.t list) : int =
         match adj with

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -179,13 +179,14 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
         else assign_first (succ idx)
       in
       (* assigns the available register with the highest affinity *)
-      let rec assign_affinity = function
-        | [] -> assign_first 0
-        | { Regalloc_affinity.priority = _; phys_reg } :: tl ->
+      let rec assign_affinity aff =
+        match Regalloc_affinity.next aff with
+        | None -> assign_first 0
+        | Some { Regalloc_affinity.priority = _; phys_reg } ->
           let idx = Regs.index_in_class phys_reg in
           if idx >= 0 && idx < num_available_registers && available.(idx)
           then do_assign ~phys_reg
-          else assign_affinity tl
+          else assign_affinity aff
       in
       assign_affinity (Regalloc_affinity.get (State.affinity state) reg))
   | Reg _ | Stack _ -> Not_spilling

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -450,7 +450,7 @@ let prelude :
     then cfg_infos, Regalloc_stack_slots.make (), []
     else if Lazy.force Regalloc_split_utils.split_live_ranges
     then
-      let stack_slots, phi_moves =
+      let { Regalloc_split.stack_slots; phi_moves } =
         Profile.record ~accumulate:true "split"
           (fun () -> Regalloc_split.split_live_ranges cfg_with_infos)
           ()

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -359,8 +359,13 @@ let insert_reloads :
     (State.definitions_at_beginning state);
   if debug then dedent ()
 
+type phi_move =
+  { src : Reg.t;
+    dst : Reg.t
+  }
+
 let add_phi_moves_to_instr_list :
-    phi_moves:(Reg.t * Reg.t) list ref ->
+    phi_moves:phi_move list ref ->
     instr_id:InstructionId.sequence ->
     before:Cfg.basic_block ->
     phi:Cfg.basic_block ->
@@ -383,7 +388,7 @@ let add_phi_moves_to_instr_list :
             Printreg.reg to_
       | false ->
         if debug then log "phi %a -> %a" Printreg.reg from Printreg.reg to_;
-        phi_moves := (from, to_) :: !phi_moves;
+        phi_moves := { src = from; dst = to_ } :: !phi_moves;
         let phi_move =
           Move.make_instr Move.Plain
             ~id:(InstructionId.get_and_incr instr_id)
@@ -392,14 +397,12 @@ let add_phi_moves_to_instr_list :
         DLL.add_end instrs phi_move)
     to_unify
 
-(* Insert phi moves: - to the predecessor block if the edge is an "always" one;
-   - to a newly-inserted block otherwise. Returns `true` iff at least one block
-   was inserted. *)
+(*= Insert phi moves:
+  - to the predecessor block if the edge is an "always" one;
+  - to a newly-inserted block otherwise.
+  Returns `true` iff at least one block was inserted. *)
 let insert_phi_moves :
-    State.t ->
-    Cfg_with_infos.t ->
-    Substitution.map ->
-    bool * (Reg.t * Reg.t) list =
+    State.t -> Cfg_with_infos.t -> Substitution.map -> bool * phi_move list =
  fun state cfg_with_infos substs ->
   let phi_moves = ref [] in
   let block_inserted = ref false in
@@ -466,8 +469,7 @@ let insert_phi_moves :
   !block_inserted, !phi_moves
 
 let split_at_destruction_points :
-    Cfg_with_infos.t ->
-    (Regalloc_stack_slots.t * bool * (Reg.t * Reg.t) list) option =
+    Cfg_with_infos.t -> (Regalloc_stack_slots.t * bool * phi_move list) option =
  fun cfg_with_infos ->
   if debug
   then (
@@ -519,8 +521,12 @@ let split_at_destruction_points :
       dedent ());
     Some (State.stack_slots state, block_inserted, phi_moves)
 
-let split_live_ranges :
-    Cfg_with_infos.t -> Regalloc_stack_slots.t * (Reg.t * Reg.t) list =
+type split_result =
+  { stack_slots : Regalloc_stack_slots.t;
+    phi_moves : phi_move list
+  }
+
+let split_live_ranges : Cfg_with_infos.t -> split_result =
  fun cfg_with_infos ->
   (* CR-soon xclerc for xclerc: support closure, flambda, and
      flambda2/classic *)
@@ -535,14 +541,17 @@ let split_live_ranges :
        "Regalloc_split: classic mode is currently not supported" *)
     ()
   | true, true -> assert false);
-  match split_at_destruction_points cfg_with_infos with
-  | None -> Regalloc_stack_slots.make (), []
-  | Some (stack_slots, block_inserted, phi_moves) ->
-    Cfg_with_infos.invalidate_liveness cfg_with_infos;
-    if block_inserted
-    then Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos;
-    let (_ : Cfg_with_infos.t) =
-      Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
-        cfg_with_infos
-    in
-    stack_slots, phi_moves
+  let stack_slots, phi_moves =
+    match split_at_destruction_points cfg_with_infos with
+    | None -> Regalloc_stack_slots.make (), []
+    | Some (stack_slots, block_inserted, phi_moves) ->
+      Cfg_with_infos.invalidate_liveness cfg_with_infos;
+      if block_inserted
+      then Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos;
+      let (_ : Cfg_with_infos.t) =
+        Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
+          cfg_with_infos
+      in
+      stack_slots, phi_moves
+  in
+  { stack_slots; phi_moves }

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -358,8 +358,13 @@ let insert_reloads :
     (State.definitions_at_beginning state);
   if debug then dedent ()
 
+type phi_move =
+  { src : Reg.t;
+    dst : Reg.t
+  }
+
 let add_phi_moves_to_instr_list :
-    phi_moves:(Reg.t * Reg.t) list ref ->
+    phi_moves:phi_move list ref ->
     instr_id:InstructionId.sequence ->
     before:Cfg.basic_block ->
     phi:Cfg.basic_block ->
@@ -382,7 +387,7 @@ let add_phi_moves_to_instr_list :
             Printreg.reg to_
       | false ->
         if debug then log "phi %a -> %a" Printreg.reg from Printreg.reg to_;
-        phi_moves := (from, to_) :: !phi_moves;
+        phi_moves := { src = from; dst = to_ } :: !phi_moves;
         let phi_move =
           Move.make_instr Move.Plain
             ~id:(InstructionId.get_and_incr instr_id)
@@ -391,14 +396,12 @@ let add_phi_moves_to_instr_list :
         DLL.add_end instrs phi_move)
     to_unify
 
-(* Insert phi moves: - to the predecessor block if the edge is an "always" one;
-   - to a newly-inserted block otherwise. Returns `true` iff at least one block
-   was inserted. *)
+(*= Insert phi moves:
+  - to the predecessor block if the edge is an "always" one;
+  - to a newly-inserted block otherwise.
+  Returns `true` iff at least one block was inserted. *)
 let insert_phi_moves :
-    State.t ->
-    Cfg_with_infos.t ->
-    Substitution.map ->
-    bool * (Reg.t * Reg.t) list =
+    State.t -> Cfg_with_infos.t -> Substitution.map -> bool * phi_move list =
  fun state cfg_with_infos substs ->
   let phi_moves = ref [] in
   let block_inserted = ref false in
@@ -465,8 +468,7 @@ let insert_phi_moves :
   !block_inserted, !phi_moves
 
 let split_at_destruction_points :
-    Cfg_with_infos.t ->
-    (Regalloc_stack_slots.t * bool * (Reg.t * Reg.t) list) option =
+    Cfg_with_infos.t -> (Regalloc_stack_slots.t * bool * phi_move list) option =
  fun cfg_with_infos ->
   if debug
   then (
@@ -518,8 +520,12 @@ let split_at_destruction_points :
       dedent ());
     Some (State.stack_slots state, block_inserted, phi_moves)
 
-let split_live_ranges :
-    Cfg_with_infos.t -> Regalloc_stack_slots.t * (Reg.t * Reg.t) list =
+type split_result =
+  { stack_slots : Regalloc_stack_slots.t;
+    phi_moves : phi_move list
+  }
+
+let split_live_ranges : Cfg_with_infos.t -> split_result =
  fun cfg_with_infos ->
   (* CR-soon xclerc for xclerc: support closure, flambda, and
      flambda2/classic *)
@@ -534,14 +540,17 @@ let split_live_ranges :
        "Regalloc_split: classic mode is currently not supported" *)
     ()
   | true, true -> assert false);
-  match split_at_destruction_points cfg_with_infos with
-  | None -> Regalloc_stack_slots.make (), []
-  | Some (stack_slots, block_inserted, phi_moves) ->
-    Cfg_with_infos.invalidate_liveness cfg_with_infos;
-    if block_inserted
-    then Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos;
-    let (_ : Cfg_with_infos.t) =
-      Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
-        cfg_with_infos
-    in
-    stack_slots, phi_moves
+  let stack_slots, phi_moves =
+    match split_at_destruction_points cfg_with_infos with
+    | None -> Regalloc_stack_slots.make (), []
+    | Some (stack_slots, block_inserted, phi_moves) ->
+      Cfg_with_infos.invalidate_liveness cfg_with_infos;
+      if block_inserted
+      then Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos;
+      let (_ : Cfg_with_infos.t) =
+        Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
+          cfg_with_infos
+      in
+      stack_slots, phi_moves
+  in
+  { stack_slots; phi_moves }

--- a/backend/regalloc/regalloc_split.mli
+++ b/backend/regalloc/regalloc_split.mli
@@ -1,5 +1,15 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+type phi_move =
+  { src : Reg.t;
+    dst : Reg.t
+  }
+
+type split_result =
+  { stack_slots : Regalloc_stack_slots.t;
+    phi_moves : phi_move list
+  }
+
 (** Splits the live ranges of registers by introducing new registers at
     destruction points. Destructions points are locations where all hardware
     registers are clobbered. This means that all registers live at such points
@@ -13,5 +23,4 @@
     The algorithm is an adaptation of the one rewriting a CFG to put it in SSA
     form: we simply consider that new names are introduced at destruction
     points. *)
-val split_live_ranges :
-  Cfg_with_infos.t -> Regalloc_stack_slots.t * (Reg.t * Reg.t) list
+val split_live_ranges : Cfg_with_infos.t -> split_result


### PR DESCRIPTION
This pull requests tweaks affinity to:

- [introduce an abstract type](5190a8ba557df035e54d7be2f0e153aff70e4f90) for the affinities
  of a temporary (thus allowing to switch to
  another representation easily)
- [switches from a list to a (dynamic) array](03fda88e6000bf0839a2e7b826d7b2ee2a0b1576)
  for the affinities of a temporary;
- [introduce a dedicate type for the return](99081eb5d999967c4636a038e017f5895b398aac)
  of `Regalloc_split.split_live_ranges`.