### PR TITLE
Continuation_uses_env: refine arg types based on arity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: 'O3=1,flambda2-match-in-match=1,_'
             ocamlparam: 'O3=1,flambda2-match-in-match=1,_'
-            disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/basic-modules/recursive_module_init.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
+            disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/basic-modules/recursive_module_init.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/simplify/variant_unboxing.ml'
             sysdeps: gdb
 
     env:

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.ml
@@ -14,31 +14,94 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module DE = Downwards_env
 module T = Flambda2_types
 
-type t = { continuation_uses : Continuation_uses.t Continuation.Map.t }
+type t =
+  { continuation_uses : Continuation_uses.t Continuation.Map.t;
+    continuation_arities : [`Unarized] Flambda_arity.t Continuation.Map.t
+  }
 
-let [@ocamlformat "disable"] print ppf { continuation_uses; } =
+let [@ocamlformat "disable"] print ppf { continuation_uses; continuation_arities } =
   Format.fprintf ppf "@[<hov 1>(\
-      @[<hov 1>(continuation_uses@ %a)@]\
+      @[<hov 1>(continuation_uses@ %a)@]@ \
+      @[<hov 1>(continuation_arities@ %a)@]\
       )@]"
     (Continuation.Map.print Continuation_uses.print) continuation_uses
+    (Continuation.Map.print Flambda_arity.print) continuation_arities
 
-let empty = { continuation_uses = Continuation.Map.empty }
+let empty =
+  { continuation_uses = Continuation.Map.empty;
+    continuation_arities = Continuation.Map.empty
+  }
+
+let record_continuation t cont arity =
+  let continuation_arities =
+    Continuation.Map.update cont
+      (function
+        | Some _ ->
+          Misc.fatal_errorf
+            "[CUE.record_continuation]: continuation %a already present in \
+             continuation_uses_env"
+            Continuation.print cont
+        | None -> Some arity)
+      t.continuation_arities
+  in
+  { t with continuation_arities }
+
+let record_continuation_arity t (handlers : Original_handlers.t) =
+  match handlers with
+  | Non_recursive { cont; params; _ } ->
+    record_continuation t cont (Bound_parameters.arity params)
+  | Recursive { invariant_params; continuation_handlers; _ } ->
+    let invariant_arity = Bound_parameters.arity invariant_params in
+    Continuation.Lmap.fold
+      (fun cont (handler : One_recursive_handler.t) cont_uses_env ->
+        record_continuation cont_uses_env cont
+          (Flambda_arity.concat invariant_arity
+             (Bound_parameters.arity handler.params)))
+      continuation_handlers t
 
 let add_continuation_use t cont kind ~id ~env_at_use ~arg_types =
+  let arity =
+    match Continuation.Map.find_opt cont t.continuation_arities with
+    | None ->
+      Misc.fatal_errorf
+        "[CUE.add_continuation_use]: Continuation %a not found in \
+         continuation_uses_env %a"
+        Continuation.print cont print t
+    | Some arity -> arity
+  in
+  let arg_types, env_at_use =
+    (* Refine types based on arity of continuation *)
+    let tenv = DE.typing_env env_at_use in
+    let machine_width = T.Typing_env.machine_width tenv in
+    let tenv, arg_types =
+      Misc.Stdlib.List.fold_left_map2
+        (fun tenv arg_type kind ->
+          let kind_ty = T.unknown_with_subkind ~machine_width kind in
+          match T.meet tenv arg_type kind_ty with
+          | Bottom ->
+            (* CR bclement: We should make the use invalid, but it's annoying to
+               propagate that information from here, so just ignore it. *)
+            tenv, arg_type
+          | Ok (arg_type, env) -> env, arg_type)
+        tenv arg_types
+        (Flambda_arity.unarized_components arity)
+    in
+    arg_types, DE.with_typing_env env_at_use tenv
+  in
   let use = One_continuation_use.create kind ~env_at_use id ~arg_types in
   let continuation_uses =
     Continuation.Map.update cont
       (function
         | None ->
-          let arity = T.arity_of_list arg_types in
           let uses = Continuation_uses.create cont arity in
           Some (Continuation_uses.add_use uses use)
         | Some uses -> Some (Continuation_uses.add_use uses use))
       t.continuation_uses
   in
-  { continuation_uses }
+  { t with continuation_uses }
 
 let record_continuation_use t cont kind ~env_at_use ~arg_types =
   let id = Apply_cont_rewrite_id.create () in
@@ -62,27 +125,43 @@ let num_continuation_uses t cont =
 let all_continuations_used t = Continuation.Map.keys t.continuation_uses
 
 let union t1 t2 =
+  let continuation_arities =
+    Continuation.Map.union_total_shared
+      (fun cont arity1 arity2 ->
+        if arity1 == arity2
+        then arity1
+        else
+          Misc.fatal_errorf "Continuation %a was declared several times"
+            Continuation.print cont)
+      t1.continuation_arities t2.continuation_arities
+  in
   let continuation_uses =
     Continuation.Map.union_total
       (fun _ uses1 uses2 -> Continuation_uses.union uses1 uses2)
       t1.continuation_uses t2.continuation_uses
   in
-  { continuation_uses }
+  { continuation_uses; continuation_arities }
 
 let remove t cont =
-  { continuation_uses = Continuation.Map.remove cont t.continuation_uses }
+  { continuation_uses = Continuation.Map.remove cont t.continuation_uses;
+    continuation_arities = Continuation.Map.remove cont t.continuation_arities
+  }
 
 let delete_continuation_uses = remove
 
 let clear_continuation_uses t cont =
-  { continuation_uses =
+  { t with
+    continuation_uses =
       Continuation.Map.update cont
         (Option.map Continuation_uses.clear_uses)
         t.continuation_uses
   }
 
-let mark_non_inlinable { continuation_uses } =
+let mark_non_inlinable { continuation_uses; continuation_arities } =
   let continuation_uses =
     Continuation.Map.map Continuation_uses.mark_non_inlinable continuation_uses
   in
-  { continuation_uses }
+  { continuation_uses; continuation_arities }
+
+let reset_uses { continuation_uses = _; continuation_arities } =
+  { continuation_uses = Continuation.Map.empty; continuation_arities }

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.mli
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.mli
@@ -22,9 +22,14 @@ val empty : t
 
 include Continuation_uses_env_intf.S with type t := t
 
+val record_continuation_arity : t -> Original_handlers.t -> t
+
 val get_continuation_uses : t -> Continuation.t -> Continuation_uses.t option
 
 val remove : t -> Continuation.t -> t
+
+(* Remove all uses, but keep declared continuations *)
+val reset_uses : t -> t
 
 val clear_continuation_uses : t -> Continuation.t -> t
 

--- a/middle_end/flambda2/simplify/env/continuation_uses_env_intf.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env_intf.ml
@@ -17,10 +17,8 @@
 module type S = sig
   type t
 
-  (** We don't have an interface that insists on adding continuations before
-      seeing their uses. This would be problematic when inserting wrappers,
-      where we have already advanced past the point at which such wrappers would
-      need to be defined, before knowing that a wrapper is needed. *)
+  val record_continuation :
+    t -> Continuation.t -> [`Unarized] Flambda_arity.t -> t
 
   val record_continuation_use :
     t ->

--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -126,6 +126,12 @@ let[@inline always] with_denv t denv = { t with denv }
 let with_continuation_uses_env t ~cont_uses_env =
   { t with continuation_uses_env = cont_uses_env }
 
+let record_continuation t cont arity =
+  let cont_uses_env =
+    CUE.record_continuation t.continuation_uses_env cont arity
+  in
+  with_continuation_uses_env t ~cont_uses_env
+
 let record_continuation_use t cont use_kind ~env_at_use ~arg_types =
   let cont_uses_env, id =
     CUE.record_continuation_use t.continuation_uses_env cont use_kind

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -30,6 +30,11 @@ let simplify_toplevel_common dacc simplify ~params ~implicit_params
          (Flow.Acc.init_toplevel ~dummy_toplevel_cont
             (Bound_parameters.append params implicit_params))
   in
+  let dacc = DA.record_continuation dacc return_continuation return_arity in
+  let dacc =
+    DA.record_continuation dacc exn_continuation
+      (Flambda_arity.create [Singleton K.With_subkind.any_value])
+  in
   let expr, uacc =
     simplify dacc ~down_to_up:(fun dacc ~rebuild ->
         let dacc =

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -1154,6 +1154,10 @@ let rec compute_specialized_continuation ~replay ~simplify_expr ~original_cont
             (One_continuation_use.id use)
             ~old:original_cont ~specialized:cont
         in
+        let cont_uses_env =
+          CUE.record_continuation cont_uses_env cont
+            (Bound_parameters.arity params)
+        in
         let data =
           { data with
             consts_lifted_after_fork;
@@ -1213,15 +1217,16 @@ and specialize_continuation_if_needed ~simplify_expr dacc
           let replay_history = DE.replay_history denv in
           Some (replay_history, always_inline)
         in
+        (* Remove the (generic) continuation uses from the CUE, since we will
+           then add uses for each of the specialized continuation. *)
+        let cont_uses_env = CUE.remove data.cont_uses_env_after_body cont in
         (* Use the dacc after the body to ignore any lifted constants or other
            information coming from the first traversal of the handler. We still
            reset a few values that come from the dacc after simplification of
            the handler, see comment above. *)
         let dacc = data.dacc_after_body in
         let dacc = DA.with_continuation_lifting_budget dacc lifting_budget in
-        (* Remove the (generic) continuation uses from the CUE, since we will
-           then add uses for each of the specialized continuation. *)
-        let cont_uses_env = CUE.remove data.cont_uses_env_after_body cont in
+        let dacc = DA.with_continuation_uses_env dacc ~cont_uses_env in
         (* We need to drop the constants lifted during the first downwards
            traversal of the handler. *)
         let consts_lifted_after_fork = data.consts_lifted_during_body in
@@ -1243,6 +1248,18 @@ and after_downwards_traversal_of_body_and_handlers ~simplify_expr ~denv_for_join
   (* At this point we have done a downwards traversal on the body and all the
      handlers. *)
   let dacc, lifted_conts = DA.get_and_clear_lifted_continuations dacc in
+  let data =
+    match lifted_conts with
+    | [] -> data
+    | _ :: _ ->
+      let cont_uses_env_after_body =
+        List.fold_left
+          (fun cont_uses_env_after_body (_denv, lifted_cont) ->
+            CUE.record_continuation_arity cont_uses_env_after_body lifted_cont)
+          data.cont_uses_env_after_body lifted_conts
+      in
+      { data with cont_uses_env_after_body }
+  in
   let down_to_up =
     down_to_up_for_lifted_continuations ~simplify_expr ~denv_for_join
       lifted_conts ~down_to_up
@@ -1413,7 +1430,10 @@ and prepare_dacc_for_handlers dacc ~replay ~env_at_fork ~params ~is_recursive
 
 and simplify_handler ~simplify_expr ~is_recursive ~is_exn_handler
     ~invariant_params ~params cont dacc handler k =
-  let dacc = DA.with_continuation_uses_env dacc ~cont_uses_env:CUE.empty in
+  let dacc =
+    DA.with_continuation_uses_env dacc
+      ~cont_uses_env:(CUE.reset_uses (DA.continuation_uses_env dacc))
+  in
   let dacc =
     DA.map_flow_acc
       ~f:
@@ -1936,6 +1956,10 @@ let simplify_let_cont0 ~(simplify_expr : _ Simplify_common.expr_simplifier) dacc
     then dacc
     else DA.map_denv dacc ~f:DE.set_has_seen_a_non_liftable_continuation
   in
+  let cont_uses_env =
+    CUE.record_continuation_arity (DA.continuation_uses_env dacc) handlers
+  in
+  let dacc = DA.with_continuation_uses_env dacc ~cont_uses_env in
   let body = data.body in
   let data : after_downwards_traversal_of_body_data =
     { denv_for_join; prior_lifted_constants; handlers }

--- a/testsuite/tests/flambda2/simplify/variant_unboxing.ml
+++ b/testsuite/tests/flambda2/simplify/variant_unboxing.ml
@@ -1,0 +1,56 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte with dump-raw, dump-simplify;
+ check-fexpr-dump;
+*)
+
+module type Tree = sig
+  type 'a t
+
+  type 'a descr =
+    | Empty
+    | Leaf of int * 'a
+    | Branch of int * 'a t * 'a t
+
+  val descr : 'a t -> 'a descr
+end
+
+module Set0 = struct
+  type 'a t =
+    | Empty
+    | Leaf : int -> unit t
+    | Branch : int * unit t * unit t -> unit t
+
+  type 'a descr =
+    | Empty
+    | Leaf of int * 'a
+    | Branch of int * 'a t * 'a t
+
+  (* In the [Branch] case, the block given as input is reused. *)
+  let descr (type a) : a t -> a descr =
+    function
+    | Empty -> Empty
+    | Leaf elt -> Leaf (elt, ())
+    | Branch (a, b, c) -> Branch (a, b, c)
+end
+
+module _ : Tree = Set0
+
+module Tree_operations (Tree : Tree) = struct
+  open Tree
+
+  let is_empty t =
+    (* This function doesn't have a value_kind for [t], as it is abstract.
+       When it gets inlined below, [descr] will be inlined as well, but
+       it returns [t] in one case. At that point, we need to use the value_kind
+       of [descr t] to be able to perform variant unboxing. *)
+    match descr t with Empty -> true | Leaf _ | Branch _ -> false
+end
+[@@inline always]
+
+module Set = struct
+  include Tree_operations(Set0)
+end

--- a/testsuite/tests/flambda2/simplify/variant_unboxing.raw.reference
+++ b/testsuite/tests/flambda2/simplify/variant_unboxing.raw.reference
@@ -1,0 +1,96 @@
+let $camlVariant_unboxing__first_const_0 = Block 0 () in
+(let code size(52)
+       descr_0
+         (param :
+            [ 0 | 0 of imm tagged
+            |1 of imm tagged *
+               [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] *
+               [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] ])
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 | 0 of imm tagged * val
+           |1 of imm tagged *
+              [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] *
+              [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] ] =
+   let next_depth = rec_info (succ my_depth) in
+   (let prim = %is_int (param) in
+    let is_scrutinee_int = %tag_imm (prim) in
+    let untagged = %untag_imm (is_scrutinee_int) in
+    switch untagged
+      | 0 -> k5
+      | 1 -> k6)
+     where k6 =
+       let untagged = %untag_imm (param) in
+       cont k1 (0)
+     where k5 =
+       let prim = %get_tag (param) in
+       let scrutinee_tag = %tag_imm (prim) in
+       let untagged = %untag_imm (scrutinee_tag) in
+       switch untagged
+         | 0 -> k3
+         | 1 -> k4
+     where k4 =
+       let Pfield = %block_load.[`2`] (param) in
+       let Pfield_1 = %block_load.[`1`] (param) in
+       let Pfield_2 = %block_load.[`0`] (param) in
+       let Pmakeblock =
+         %block.[`1`].my_alloc_region (Pfield_2, Pfield_1, Pfield)
+       in
+       cont k1 (Pmakeblock)
+     where k3 =
+       let Pfield = %block_load.[`0`] (param) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, 0) in
+       cont k1 (Pmakeblock)
+ in
+ let code size(12)
+       is_empty_2 (t : val)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   let Tree = %project_value_slot.[is_empty].[Tree] (my_closure) in
+   (let Pfield = %block_load.[`0`] (Tree) in
+    apply &my_alloc_region Pfield (t) -> k3 * k2)
+     where k3
+             (`*match*` :
+                [ 0 | 0 of imm tagged * val |1 of imm tagged * val * val ]) =
+       let prim = %is_int (`*match*`) in
+       let Pisint = %tag_imm (prim) in
+       cont k1 (Pisint)
+ in
+ let code inline(always) loopify(never) size(27)
+       Tree_operations_1 (Tree : val)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : val =
+   let next_depth = rec_info (succ my_depth) in
+   let is_empty = closure is_empty_2 @is_empty &my_alloc_region
+   with { Tree = Tree }
+   in
+   let Pmakeblock = %block.[`0`].my_alloc_region (is_empty) in
+   cont k1 (Pmakeblock)
+ in
+ (let descr = closure descr_0 @descr &toplevel.alloc_region in
+  let Pmakeblock = %block.[`0`].`toplevel` (descr) in
+  cont k1 (Pmakeblock))
+   where k1 (Set0 : val) =
+     let Tree_operations =
+       closure Tree_operations_1 @Tree_operations &toplevel.alloc_region
+     in
+     (apply direct(Tree_operations_1 &toplevel.alloc_region)
+        (Tree_operations : _ -> val) (Set0) -> k2 * error
+        where k2 (include : val) =
+          let Pfield = %block_load.[`0`] (include) in
+          let Pmakeblock = %block.[`0`].`toplevel` (Pfield) in
+          cont k1 (Pmakeblock)
+        where k1 (Set : val) =
+          let Pmakeblock =
+            %block.[`0`].`toplevel` (Set0, Tree_operations, Set)
+          in
+          cont k (Pmakeblock)))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (module_block) in
+    let $camlVariant_unboxing = Block 0 (field_0, field_1, field_2) in
+    cont done ($camlVariant_unboxing)

--- a/testsuite/tests/flambda2/simplify/variant_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/variant_unboxing.simplify.reference
@@ -1,0 +1,89 @@
+let code descr_0 deleted in
+let code is_empty_2 deleted in
+let code Tree_operations_1 deleted in
+let code loopify(never) size(32) newer_version_of(descr_0)
+      descr_0_1
+        (param :
+           [ 0 | 0 of imm tagged
+           |1 of imm tagged *
+              [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] *
+              [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] ])
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 | 0 of imm tagged * val
+          |1 of imm tagged *
+             [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] *
+             [ 0 | 0 of imm tagged |1 of imm tagged * val * val ] ] =
+  (let prim = %is_int (param) in
+   switch prim
+     | 0 -> k3
+     | 1 -> k (0))
+    where k3 =
+      let prim = %get_tag (param) in
+      switch prim
+        | 0 -> k2
+        | 1 -> k (param)
+    where k2 =
+      let Pfield = %block_load.[`0`] (param) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, 0) in
+      cont k (Pmakeblock)
+in
+let $camlVariant_unboxing__descr_1 =
+  closure descr_0_1 @descr &toplevel.alloc_region
+in
+let $camlVariant_unboxing__Pmakeblock_2 =
+  Block 0 ($camlVariant_unboxing__descr_1)
+in
+let code loopify(never) size(12) newer_version_of(is_empty_2)
+      is_empty_2_1 (t : val)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Tree = %project_value_slot.[is_empty].[Tree] (my_closure) in
+  (let Pfield = %block_load.[`0`] (Tree) in
+   apply &my_alloc_region Pfield (t) -> k2 * k1)
+    where k2
+            (`*match*` :
+               [ 0 | 0 of imm tagged * val |1 of imm tagged * val * val ]) =
+      let prim = %is_int (`*match*`) in
+      let Pisint = %tag_imm (prim) in
+      cont k (Pisint)
+in
+let code inline(always) loopify(never) size(27) newer_version_of(Tree_operations_1)
+      Tree_operations_1_1 (Tree : val)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : val =
+  let is_empty = closure is_empty_2_1 @is_empty &my_alloc_region
+  with { Tree = Tree }
+  in
+  let Pmakeblock = %block.[`0`].my_alloc_region (is_empty) in
+  cont k (Pmakeblock)
+in
+let $camlVariant_unboxing__Tree_operations_3 =
+  closure Tree_operations_1_1 @Tree_operations &toplevel.alloc_region
+in
+let code loopify(never) size(5) newer_version_of(is_empty_2_1)
+      is_empty_2_2 (t : val)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %is_int (t) in
+   cont k2 (prim))
+    where k2 (is_int : imm) =
+      let Pisint = %tag_imm (is_int) in
+      cont k (Pisint)
+in
+let $camlVariant_unboxing__is_empty_4 =
+  closure is_empty_2_2 @is_empty &toplevel.alloc_region
+  with { Tree = $camlVariant_unboxing__Pmakeblock_2 }
+in
+let $camlVariant_unboxing__Pmakeblock_6 =
+  Block 0 ($camlVariant_unboxing__is_empty_4)
+in
+let $camlVariant_unboxing =
+  Block 0 ($camlVariant_unboxing__Pmakeblock_2,
+           $camlVariant_unboxing__Tree_operations_3,
+           $camlVariant_unboxing__Pmakeblock_6)
+in
+cont done ($camlVariant_unboxing)


### PR DESCRIPTION
 We record continuations with their arity in the `Continuation_uses_env`, in order to be able to refine the types of the arguments based on the arity of the continuation. This is necessary to restore variant unboxing in some cases.