### PR TITLE
Fix kind errors in Type_grammar.must_be_singleton

### DIFF
--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -4474,8 +4474,7 @@ let rec must_be_singleton t ~machine_width : RWC.t option =
     | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias is) -> (
       match Int8.Set.get_singleton is with
-      | Some i ->
-        Some (RWC.naked_int8 i)
+      | Some i -> Some (RWC.naked_int8 i)
       | None -> None))
   | Naked_int16 ty -> (
     match TD.descr ty with
@@ -4483,8 +4482,7 @@ let rec must_be_singleton t ~machine_width : RWC.t option =
     | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias is) -> (
       match Int16.Set.get_singleton is with
-      | Some i ->
-        Some (RWC.naked_int16 i)
+      | Some i -> Some (RWC.naked_int16 i)
       | None -> None))
   | Naked_int32 ty -> (
     match TD.descr ty with

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -4475,7 +4475,7 @@ let rec must_be_singleton t ~machine_width : RWC.t option =
     | Ok (No_alias is) -> (
       match Int8.Set.get_singleton is with
       | Some i ->
-        Some (RWC.naked_immediate (Target_ocaml_int.of_int8 machine_width i))
+        Some (RWC.naked_int8 i)
       | None -> None))
   | Naked_int16 ty -> (
     match TD.descr ty with
@@ -4484,7 +4484,7 @@ let rec must_be_singleton t ~machine_width : RWC.t option =
     | Ok (No_alias is) -> (
       match Int16.Set.get_singleton is with
       | Some i ->
-        Some (RWC.naked_immediate (Target_ocaml_int.of_int16 machine_width i))
+        Some (RWC.naked_int16 i)
       | None -> None))
   | Naked_int32 ty -> (
     match TD.descr ty with


### PR DESCRIPTION
Some recent additions for naked int8 and int16 values assigned the wrong kinds here.