### PR TITLE
[5.4] Fix test_longident.ml

### DIFF
--- a/testsuite/tests/compiler-libs/test_longident.ml
+++ b/testsuite/tests/compiler-libs/test_longident.ml
@@ -1,6 +1,5 @@
 (* TEST
- flags = "-I ${ocamlsrcdir}/parsing -I ${ocamlsrcdir}/toplevel";
- include ocamltoplevel;
+ flags = "-I ${ocamlsrcdir}/parsing";
  expect;
 *)
 [@@@alert "-deprecated"]


### PR DESCRIPTION
This adopts test-fixing part of https://github.com/ocaml/ocaml/pull/14749 for the 5.4 merge (which is how I found the upstream problem). We hit the issue because our expect tests _do_ permit libraries to be loaded, so the test previously hits the "you can't use ocamltoplevel.cma in the toplevel" error.