### PR TITLE
[5.4] Type checker fixes

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -591,41 +591,23 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           else
             true, O.obj obj
         in
-        let {cd_id;cd_args;cd_res} =
-          try
-            (* CR dkalinichenko: this is broken for unboxed variants:
-               unless the tag of the inner value just happens to be 0,
-               [Datarepr.find_constr_by_tag] will fail. *)
-            let {cstr_uid} =
-              Datarepr.find_constr_by_tag ~constant tag cstrs
-            in
-            List.find (fun {cd_uid} -> Uid.equal cd_uid cstr_uid)
-              constr_list
-          with
-          | Datarepr.Constr_not_found | Not_found ->
-            (* If a [Variant_with_null] is not a [Null],
-               it's guaranteed to be [This value]. *)
+        let analyse {cd_id;cd_args;cd_res} =
+          let type_params =
+            match cd_res with
+              Some t ->
+                begin match get_desc t with
+                  Tconstr (_,params,_) ->
+                    params
+                | _ -> assert false end
+            | None -> type_params
+          in
+          let unbx =
             match rep with
-            | Variant_with_null -> List.nth constr_list 1
-            | _ -> raise Datarepr.Constr_not_found
-        in
-        let type_params =
-          match cd_res with
-            Some t ->
-              begin match get_desc t with
-                Tconstr (_,params,_) ->
-                  params
-              | _ -> assert false end
-          | None -> type_params
-        in
-        let unbx =
-          match rep with
-          | Variant_unboxed -> true
-          | Variant_with_null when tag = -1 -> false
-          | Variant_with_null -> true
-          | Variant_boxed _ | Variant_extensible -> false
-        in
-        begin
+            | Variant_unboxed -> true
+            | Variant_with_null when tag = -1 -> false
+            | Variant_with_null -> true
+            | Variant_boxed _ | Variant_extensible -> false
+          in
           match cd_args with
           | Cstr_tuple l ->
               let ty_args =
@@ -653,7 +635,24 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               in
               Oval_constr(tree_of_constr env path (Ident.name cd_id),
                           [ r ])
-        end
+      in
+      try
+        (* CR dkalinichenko: this is broken for unboxed variants:
+            unless the tag of the inner value just happens to be 0,
+            [Datarepr.find_constr_by_tag] will fail. *)
+        let {cstr_uid} =
+          Datarepr.find_constr_by_tag ~constant tag cstrs
+        in
+        List.find (fun {cd_uid} -> Uid.equal cd_uid cstr_uid)
+          constr_list
+        |> analyse
+      with
+      | Datarepr.Constr_not_found | Not_found ->
+        (* If a [Variant_with_null] is not a [Null],
+            it's guaranteed to be [This value]. *)
+        match rep with
+        | Variant_with_null -> analyse (List.nth constr_list 1)
+        | _ -> Oval_stuff "<unknown constructor>"
 
       and tree_of_record depth path type_params ty_list obj lbl_list rep =
         match check_depth depth obj ty with

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -5171,7 +5171,8 @@ let report_error_doc = function
         (Location.Doc.loc ~capitalize_first:false) defined_at
   | Incomplete_instantiation { unset_param } ->
       Location.errorf ~loc:Location.none
-        "@[<hov>Not enough instance arguments: the parameter@ %a@ is required.@]"
+        "@[<hov>Not enough instance arguments: \
+           the parameter@ %a@ is required.@]"
         Global_module.Parameter_name.print unset_param
   | Toplevel_splice loc ->
       Location.errorf ~loc

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4923,7 +4923,7 @@ let report_lookup_error_doc loc env = function
                boxed field must come from a record that didn't get an unboxed
                version. *)
             [ Location.msg
-                "Note that float- and [@@unboxed]- records don't get \
+                "Note that float- and [@@@@unboxed]- records don't get \
                   unboxed versions." ]
           | Legacy, Projection ->
             let print_projection ppf (op, lid) =
@@ -5098,7 +5098,7 @@ let report_lookup_error_doc loc env = function
         match decl.type_kind with
         | Type_record (_, Record_unboxed, _) ->
           [Location.msg
-             "@{<hint>Hint@}: [@@unboxed] records don't get unboxed \
+             "@{<hint>Hint@}: [@@@@unboxed] records don't get unboxed \
               versions."]
         | Type_record (_, (Record_float | Record_ufloat |
                            Record_mixed _), _) ->
@@ -5166,18 +5166,18 @@ let report_error_doc = function
   | Lookup_error(loc, t, err) -> report_lookup_error_doc loc t err
   | Implicit_jkind_already_defined { name; defined_at; loc } ->
       Location.errorf ~loc
-        "<hov>The implicit kind for %a is already defined at %a."
+        "@[<hov>The implicit kind for %a is already defined at %a.@]"
         Style.inline_code name
         (Location.Doc.loc ~capitalize_first:false) defined_at
   | Incomplete_instantiation { unset_param } ->
       Location.errorf ~loc:Location.none
-        "<hov>Not enough instance arguments: the parameter@ %a@ is required."
+        "@[<hov>Not enough instance arguments: the parameter@ %a@ is required.@]"
         Global_module.Parameter_name.print unset_param
   | Toplevel_splice loc ->
       Location.errorf ~loc
-        "<hov>Splices ($) are not allowed in the initial stage,@ \
+        "@[<hov>Splices ($) are not allowed in the initial stage,@ \
          as encountered at %a.@,\
-         Did you forget to insert a quotation?"
+         Did you forget to insert a quotation?@]"
         (Location.Doc.loc ~capitalize_first:false) loc
   | Unsupported_inside_quotation (loc, context) ->
       Location.errorf ~loc

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4927,7 +4927,7 @@ let report_lookup_error_doc loc env = function
                   unboxed versions." ]
           | Legacy, Projection ->
             let print_projection ppf (op, lid) =
-              fprintf ppf "%s%a" op quoted_longident lid
+              fprintf ppf "%s%a" op Pprintast.Doc.longident lid
             in
             [ Location.msg
                 "To project an unboxed record field, use %a instead of %a."

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -497,7 +497,8 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
         (trace false (incompatibility_phrase trace_format)) tr
         (pp_print_option pp_doc) mis;
       if env <> Env.empty && not jkind_error
-       (* the jkinds mechanism has its own way of reporting missing cmis *)
+       (* the jkinds mechanism has its own way of reporting missing cmis
+          CR jkinds: streamline these *)
       then warn_on_missing_defs env ppf head;
        Internal_names.print_explanations env ppf;
        Ident_conflicts.err_print ppf

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -434,10 +434,12 @@ let prepare_expansion_head empty_tr = function
       Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
   | _ -> None
 
-let head_error_printer mode txt_got txt_but = function
+let head_error_printer ~var_jkinds mode txt_got txt_but = function
   | None -> Format_doc.Doc.empty
   | Some d ->
-      let d = Errortrace.map_diff (trees_of_type_expansion mode) d in
+      let d =
+        Errortrace.map_diff (trees_of_type_expansion' ~var_jkinds mode) d
+      in
       doc_printf "%a@;<1 2>%a@ %a@;<1 2>%a"
         pp_doc txt_got pp_type_expansion d.Errortrace.got
         pp_doc txt_but pp_type_expansion d.Errortrace.expected
@@ -460,6 +462,13 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
          Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded})
       tr
   in
+  let jkind_error = match Misc.last tr with
+    | Some (Bad_jkind _ | Bad_jkind_sort _ | Unequal_var_jkinds _
+           | Unequal_tof_kind_jkinds _) ->
+        true
+    | _ ->
+        false
+  in
   match tr with
   | [] -> assert false
   | (elt :: tr) as full_trace ->
@@ -468,7 +477,9 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
       let head = prepare_expansion_head (tr=[] && last=None) elt in
       let tr = List.map (Errortrace.map_diff prepare_expansion) tr in
       let last = Option.map (Errortrace.map_diff prepare_expansion) last in
-      let head_error = head_error_printer mode txt1 txt2 head in
+      let head_error =
+        head_error_printer ~var_jkinds:jkind_error mode txt1 txt2 head
+      in
       let tr = trees_of_trace mode tr in
       let last =
         Option.map (Errortrace.map_diff (trees_of_type_expansion mode)) last in
@@ -485,7 +496,8 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
         pp_doc ty_expect_explanation
         (trace false (incompatibility_phrase trace_format)) tr
         (pp_print_option pp_doc) mis;
-      if env <> Env.empty
+      if env <> Env.empty && not jkind_error
+       (* the jkinds mechanism has its own way of reporting missing cmis *)
       then warn_on_missing_defs env ppf head;
        Internal_names.print_explanations env ppf;
        Ident_conflicts.err_print ppf

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -408,7 +408,7 @@ and print_out_type_mode ~arg mode ppf ty =
   in
   if parens then
     pp_print_char ppf '(';
-  print_out_type_2 ~arg ppf ty;
+  print_out_type_2 ppf ty;
   if parens then
     pp_print_char ppf ')';
   print_out_modes ppf mode
@@ -422,7 +422,7 @@ and print_out_type_1 ppf =
       pp_print_space ppf ();
       print_out_ret ppf ty2;
       pp_close_box ppf ()
-  | ty -> print_out_type_2 ~arg:false ppf ty
+  | ty -> print_out_type_2 ppf ty
 
 and print_out_arg am ppf ty =
   print_out_type_mode ~arg:true am ppf ty
@@ -442,25 +442,16 @@ and print_out_ret ppf =
   | Otyp_ret (Orm_any rm, ty) -> print_out_type_mode ~arg:false rm ppf ty
   | _ -> assert false
 
-and print_out_type_2 ~arg ppf =
+and print_out_type_2 ppf =
   function
     Otyp_tuple tyl ->
-      (* Tuples require parens in argument function argument position (~arg)
-         when the first element has a label. *)
-      let parens =
-        match tyl with
-        | (Some _, _) :: _ -> arg
-        | _ -> false
-      in
-      if parens then pp_print_char ppf '(';
       let print_elem ppf (label, ty) =
         pp_open_box ppf 0;
         print_label_type ppf label;
         print_simple_out_type ppf ty;
         pp_close_box ppf ()
       in
-      fprintf ppf "@[<0>%a@]" (print_typlist print_elem " *") tyl;
-      if parens then pp_print_char ppf ')'
+      fprintf ppf "@[<0>%a@]" (print_typlist print_elem " *") tyl
   | ty -> print_simple_out_type ppf ty
 and print_simple_out_type ppf =
   function
@@ -772,7 +763,7 @@ let rec print_out_class_type ppf =
       in
       fprintf ppf "@[%a%a@]" pr_tyl tyl print_ident id
   | Octy_arrow (lab, ty, cty) ->
-      let print_type = print_out_type_2 ~arg:true in
+      let print_type = print_out_type_mode ~arg:true [] in
       fprintf ppf "@[%t ->@ %a@]"
         (fun ppf -> print_arg_label_and_out_type ppf lab ty ~print_type)
         print_out_class_type cty

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -338,12 +338,6 @@ let print_out_modes ppf l =
   | _ -> pp_print_string ppf " @ ");
   pp_print_list ~pp_sep:pp_print_space print_out_mode ppf l
 
-(* Labeled tuples with the first element labeled sometimes require parens. *)
-let is_initially_labeled_tuple ty =
-  match ty with
-  | Otyp_tuple ((Some _, _) :: _) -> true
-  | _ -> false
-
 let print_out_modality = pp_print_string
 
 let print_out_modalities ppf l =
@@ -398,19 +392,8 @@ let rec print_out_type_0 ppf =
   | ty ->
       print_out_type_1 ppf ty
 
-(* We must parenthesize a labeled tuple with the first element labeled when:
-   - It is an argument to a function ([~arg])
-   - Or, there is at least one mode to print.
- *)
 and print_out_type_mode ~arg mode ppf ty =
-  let parens =
-    is_initially_labeled_tuple ty && arg
-  in
-  if parens then
-    pp_print_char ppf '(';
-  print_out_type_2 ppf ty;
-  if parens then
-    pp_print_char ppf ')';
+  print_out_type_2 ~arg ppf ty;
   print_out_modes ppf mode
 
 and print_out_type_1 ppf =
@@ -422,7 +405,7 @@ and print_out_type_1 ppf =
       pp_print_space ppf ();
       print_out_ret ppf ty2;
       pp_close_box ppf ()
-  | ty -> print_out_type_2 ppf ty
+  | ty -> print_out_type_2 ~arg:false ppf ty
 
 and print_out_arg am ppf ty =
   print_out_type_mode ~arg:true am ppf ty
@@ -442,16 +425,25 @@ and print_out_ret ppf =
   | Otyp_ret (Orm_any rm, ty) -> print_out_type_mode ~arg:false rm ppf ty
   | _ -> assert false
 
-and print_out_type_2 ppf =
+and print_out_type_2 ~arg ppf =
   function
     Otyp_tuple tyl ->
+      (* Tuples require parens in argument function argument position (~arg)
+         when the first element has a label. *)
+      let parens =
+        match tyl with
+        | (Some _, _) :: _ -> arg
+        | _ -> false
+      in
+      if parens then pp_print_char ppf '(';
       let print_elem ppf (label, ty) =
         pp_open_box ppf 0;
         print_label_type ppf label;
         print_simple_out_type ppf ty;
         pp_close_box ppf ()
       in
-      fprintf ppf "@[<0>%a@]" (print_typlist print_elem " *") tyl
+      fprintf ppf "@[<0>%a@]" (print_typlist print_elem " *") tyl;
+      if parens then pp_print_char ppf ')'
   | ty -> print_simple_out_type ppf ty
 and print_simple_out_type ppf =
   function
@@ -763,7 +755,7 @@ let rec print_out_class_type ppf =
       in
       fprintf ppf "@[%a%a@]" pr_tyl tyl print_ident id
   | Octy_arrow (lab, ty, cty) ->
-      let print_type = print_out_type_mode ~arg:true [] in
+      let print_type = print_out_type_2 ~arg:true in
       fprintf ppf "@[%t ->@ %a@]"
         (fun ppf -> print_arg_label_and_out_type ppf lab ty ~print_type)
         print_out_class_type cty

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -99,6 +99,9 @@ val tree_of_typexp: type_or_scheme -> type_expr -> out_type
 
 val tree_of_type_scheme: type_expr -> out_type
 
+val tree_of_modalities:
+  Types.mutability -> Mode.Modality.Const.t -> Outcometree.out_mode list
+
 
 val prepared_type_scheme: type_expr printer
 val prepared_type_expr: type_expr printer

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -120,6 +120,8 @@ val type_expr_with_reserved_names: type_expr printer
 type 'a diff = Same of 'a | Diff of 'a * 'a
 val trees_of_type_expansion:
   type_or_scheme -> Errortrace.expanded_type -> out_type diff
+val trees_of_type_expansion':
+  var_jkinds:bool -> type_or_scheme -> Errortrace.expanded_type -> out_type diff
 val prepare_expansion: Errortrace.expanded_type -> Errortrace.expanded_type
 val pp_type_expansion: out_type diff printer
 val hide_variant_name: Types.type_expr -> Types.type_expr

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -63,6 +63,7 @@ module Doc = struct
     !Oprint.out_ident ppf (tree_of_path p)
 
   let () = Env.print_path := path
+  let () = Env.print_type_expr := type_expr
 
   let type_path ppf p = !Oprint.out_ident ppf (tree_of_type_path p)
 
@@ -185,3 +186,9 @@ let string_of_label : Types.arg_label -> string = function
 
 let () = Jkind.set_printtyp_path Doc.path
 let () = Mode.print_longident := Doc.longident
+let () =
+  Jkind.set_outcometrees_of_types (fun tys ->
+    prepare_for_printing tys;
+    List.map (tree_of_typexp Type) tys);
+  Jkind.set_outcometree_of_modalities tree_of_modalities;
+  Jkind.set_print_type_expr Doc.type_expr

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -191,3 +191,4 @@ let row_field = raw_field
 let row_desc = raw_row_desc
 
 let () = Btype.print_raw := type_expr
+let () = Jkind.set_raw_type_expr type_expr

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -29,18 +29,18 @@ type result =
 let rec print_result fmt result =
   match result with
   | Resolved uid ->
-      Format.fprintf fmt "@[Resolved: %a@]@;" Uid.print uid
+      Format.fprintf fmt "@[Resolved:@ %a@]" Uid.print uid
   | Resolved_alias (uid, r) ->
-      Format.fprintf fmt "@[Alias: %a -> %a@]@;"
+      Format.fprintf fmt "@[Alias:@ %a@] ->@ %a"
         Uid.print uid print_result r
   | Unresolved shape ->
-      Format.fprintf fmt "@[Unresolved: %a@]@;" print shape
+      Format.fprintf fmt "@[Unresolved:@ %a@]" print shape
   | Approximated (Some uid) ->
-      Format.fprintf fmt "@[Approximated: %a@]@;" Uid.print uid
+      Format.fprintf fmt "@[Approximated:@ %a@]" Uid.print uid
   | Approximated None ->
-      Format.fprintf fmt "@[Approximated: No uid@]@;"
+      Format.fprintf fmt "Approximated: No uid"
   | Internal_error_missing_uid ->
-      Format.fprintf fmt "@[Missing uid@]@;"
+      Format.fprintf fmt "Missing uid"
 
 module Diagnostics = struct
   type diagnostics =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4606,7 +4606,7 @@ let report_error ~loc = function
       Out_type.reset ();
       Reaching_path.add_to_preparation reaching_path;
       Location.errorf ~loc
-        "<v>The definition of %a is recursive without boxing%a"
+        "@[<v>The definition of %a is recursive without boxing%a@]"
         Style.inline_code s
         Reaching_path.pp_colon reaching_path
   | Definition_mismatch (ty, env, err) ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1851,7 +1851,7 @@ let report_error_doc loc env = function
            ~offender:(fun ppf -> pp_type ppf typ)
            ~level:(get_current_level ())) err
   | Bad_jkind_annot(ty, violation) ->
-    Location.errorf ~loc "<b 2>Bad layout annotation:@ %a"
+    Location.errorf ~loc "@[<b 2>Bad layout annotation:@ %a@]"
       (Jkind.Violation.report_with_offender
          ~offender:(fun ppf -> pp_type ppf ty)
          ~level:(get_current_level ())) violation


### PR DESCRIPTION
Fixes to the 5.4 type checker:
- Plumbed in the kinds printer which got lost in the code motion caused by the refactoring of https://github.com/ocaml/ocaml/pull/13336
- We were double-printing parentheses on labeled tuple types since we had both upstream's version and our own - one set will do, I went the version here that hooks our need to add brackets for mode annotations into the plumbing now already there for labeled tuples.