### PR TITLE
lpoly instance conservatively return rigid var

### DIFF
--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -621,6 +621,10 @@ module Sort = struct
       | None ->
         (* If the caller didn't set up layout instantiation, conservatively
            return a rigid variable (which is not equal to anything) *)
+        (* CR-someday zqian: explicitly distinguish among three cases:
+        - instantiating layouts properly
+        - knowingly instantiating to rigidvar conservatively
+        - unknown context, in which case we should crash *)
         Var (new_rigidvar ())
       end
     | None -> Var v

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -592,6 +592,8 @@ module Sort = struct
 
   let new_genvar () = new_var_unsafe ~level:level_generic
 
+  let new_rigidvar () = new_var_unsafe ~level:level_rigid
+
   let instance_map : (var * var) list ref = ref []
 
   let instance_with ~level vars f =
@@ -617,8 +619,9 @@ module Sort = struct
       begin match List.assq_opt v !instance_map with
       | Some v' -> Var v'
       | None ->
-        Misc.fatal_error
-          "generic layout variables found in non-layout instantiation"
+        (* If the caller didn't set up layout instantiation, conservatively
+           return a rigid variable (which is not equal to anything) *)
+        Var (new_rigidvar ())
       end
     | None -> Var v
     | Some t -> instance t
@@ -731,6 +734,10 @@ module Sort = struct
   and var_default_to_scannable_and_get r : Const.t =
     match r.contents with
     | None when is_genvar r -> Genvar r
+    | None when is_rigidvar r ->
+      Misc.fatal_error
+        "Jkind_types.var_default_to_scannable_and_get: cannot default rigid \
+         variables"
     | None ->
       set r Static.T_option.scannable;
       Static.Const.scannable


### PR DESCRIPTION
When the caller of `instance` doesn't set up layout instantiation, each generic sort variable will be instantiated to a fresh rigid var, which is not equal to anything.

Currently the only such caller is `genprintval.find_printer`. The fact that we conservatively return a rigid var (instead of making `find_printer` set up layout instantiation properly) means top-level won't have a printer for layout-poly values - which is fine because layout-poly values are mostly functions which don't have printers anyway.