### PR TITLE
Update Merlin import script

### DIFF
--- a/external/merlin/import-added-ocaml-source-files.sh
+++ b/external/merlin/import-added-ocaml-source-files.sh
@@ -6,8 +6,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 cd "$(git rev-parse --show-toplevel)"
 
 # Script arguments with their default values
-commitish=main
-repository=https://github.com/ocaml-flambda/flambda-backend
+commitish=HEAD
+repository=.
 subdirectory=.
 old_subdirectory=.
 
@@ -48,14 +48,18 @@ function sorted_files_at_committish() {
   git ls-tree -r --name-only "$1" "$2" | sed "s#^$2/##" | sort
 }
 
-git fetch "$repository" "$(cat external/merlin/upstream/ocaml_flambda/base-rev.txt)"
-git fetch "$repository" "$commitish"
-rev=$(git rev-parse FETCH_HEAD)
+if [ "$repository" != "." ]; then
+  git fetch "$repository" "$(cat external/merlin/upstream/ocaml_flambda/base-rev.txt)"
+  git fetch "$repository" "$commitish"
+  rev=$(git rev-parse FETCH_HEAD)
+else
+  rev=$(git rev-parse "$commitish")
+fi
 
-function files_new_at_fetch_head() {
+function new_files() {
   comm -13 \
     <(sorted_files_at_committish "$(cat external/merlin/upstream/ocaml_flambda/base-rev.txt)" "$old_subdirectory") \
-    <(sorted_files_at_committish FETCH_HEAD "$subdirectory")
+    <(sorted_files_at_committish "$rev" "$subdirectory")
 }
 
 function directories_from_previous_import() {
@@ -65,7 +69,7 @@ function directories_from_previous_import() {
   | xargs -n 1 printf "^%s\n"
 }
 
-files=$(files_new_at_fetch_head | grep -f <(directories_from_previous_import))
+files=$(new_files | grep -f <(directories_from_previous_import))
 
 echo "The script will attempt to import these files added to directories that had previously been imported:"
 echo "$files"
@@ -76,7 +80,7 @@ for file in $files; do
     y|Y|"" )
       echo "Importing $file"
       ocaml_flambda_file=external/merlin/upstream/ocaml_flambda/"${file}"
-      git show "FETCH_HEAD:$file" > "$ocaml_flambda_file"
+      git show "$rev:$file" > "$ocaml_flambda_file"
       cp "$ocaml_flambda_file" "external/merlin/src/ocaml/$file"
       ;;
     * )

--- a/external/merlin/import-added-ocaml-source-files.sh
+++ b/external/merlin/import-added-ocaml-source-files.sh
@@ -7,8 +7,8 @@ subtree_prefix="$(git rev-parse --show-prefix)"
 cd "$(git rev-parse --show-toplevel)"
 
 # Script arguments with their default values
-commitish=main
-repository=https://github.com/ocaml-flambda/flambda-backend
+commitish=HEAD
+repository=.
 subdirectory=.
 old_subdirectory=.
 
@@ -49,14 +49,18 @@ function sorted_files_at_committish() {
   git ls-tree -r --name-only "$1" "$2" | sed "s#^$2/##" | sort
 }
 
-git fetch "$repository" "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")"
-git fetch "$repository" "$commitish"
-rev=$(git rev-parse FETCH_HEAD)
+if [ "$repository" != "." ]; then
+  git fetch "$repository" "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")"
+  git fetch "$repository" "$commitish"
+  rev=$(git rev-parse FETCH_HEAD)
+else
+  rev=$(git rev-parse "$commitish")
+fi
 
-function files_new_at_fetch_head() {
+function new_files() {
   comm -13 \
     <(sorted_files_at_committish "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")" "$old_subdirectory") \
-    <(sorted_files_at_committish FETCH_HEAD "$subdirectory")
+    <(sorted_files_at_committish "$rev" "$subdirectory")
 }
 
 function directories_from_previous_import() {
@@ -66,7 +70,7 @@ function directories_from_previous_import() {
   | xargs -n 1 printf "^%s\n"
 }
 
-files=$(files_new_at_fetch_head | grep -f <(directories_from_previous_import))
+files=$(new_files | grep -f <(directories_from_previous_import))
 
 echo "The script will attempt to import these files added to directories that had previously been imported:"
 echo "$files"
@@ -77,7 +81,7 @@ for file in $files; do
     y|Y|"" )
       echo "Importing $file"
       ocaml_flambda_file="${subtree_prefix}upstream/ocaml_flambda/${file}"
-      git show "FETCH_HEAD:$file" > "$ocaml_flambda_file"
+      git show "$rev:$file" > "$ocaml_flambda_file"
       cp "$ocaml_flambda_file" "${subtree_prefix}src/ocaml/$file"
       ;;
     * )

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -3,20 +3,22 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Script arguments with their default values
-repository=https://github.com/oxcaml/oxcaml
+commitish=HEAD
+repository=.
 subdirectory=.
 old_subdirectory=.
 
 function usage () {
   cat <<USAGE
-Usage: $0 COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]
+Usage: $0 [COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]]
 
 Fetch the new compiler sources and patch Merlin to keep Merlin's local copies of
-things in sync.  By default, this will pull the COMMITISH branch from
-<$repository> and look in "$subdirectory/" for the compiler source, but the
-branch can be overridden by any commitish (branch, tag, full (not abbreviated!)
-commit hash, etc.), the repository can be overridden by any URL, and the
-subdirectory can be overriden by any path (including ".").
+things in sync. By default, this will pull in compiler changes from the local
+repo at the current revision. But you may pass an arbitrary commitish (branch,
+tag, full (not abbreviated!) commit hash, etc.) to important changes from. You
+may also fetch from a remote repository by specifying a REPO, and the
+subdirectory of the repo that the compiler is located in can be overriden by any
+path (including ".").
 
 This attempts to import new files from the compiler by running the
 "import_added_ocaml_source_files.sh" script. If that doesn't work, you can also
@@ -47,14 +49,8 @@ case "$1" in
     ;;
 esac
 
-if [[ $# -gt 0 ]]; then
-  commitish="$1"
-else
-  usage >&2
-  exit 1
-fi
-
 if [[ $# -le 4 ]]; then
+  commitish="${1-$commitish}"
   repository="${2-$repository}"
   # Although the subdirectory arguments are probably no longer useful, it doesn't hurt
   # to keep them around in case they ever are of use.
@@ -65,10 +61,10 @@ else
   exit 1
 fi
 
-if ! git diff --quiet; then
+if ! [ -z "$(git status --porcelain)" ]; then
   echo "Working directory must be clean before using this script,"
   echo "but currently has the following changes:"
-  git diff --stat
+  git status
   exit 1
 fi
 
@@ -80,10 +76,13 @@ current_head="$(git symbolic-ref --short HEAD)"
 # First, add any files that have been added since the last import.
 ./import-added-ocaml-source-files.sh "$commitish" "$repository" "$subdirectory" "$old_subdirectory"
 
-# Then, fetch the new oxcaml sources (which include ocaml-jst) and
-# copy into upstream/ocaml_flambda
-git fetch "$repository" "$commitish"
-rev=$(git rev-parse FETCH_HEAD)
+# Then, get the new oxcaml sources and copy into upstream/ocaml_flambda
+if [ "$repository" != "." ]; then
+  git fetch "$repository" "$commitish"
+  rev=$(git rev-parse FETCH_HEAD)
+else
+  rev=$(git rev-parse "$commitish")
+fi
 cd upstream/ocaml_flambda
 echo $rev > base-rev.txt
 for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
@@ -92,21 +91,19 @@ for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
   else
     git_file="$subdirectory/$file"
   fi
-  git show "FETCH_HEAD:$git_file" > "$file"
+  git show "$rev:$git_file" > "$file"
 done
-git add -u .
+git add --intent-to-add .
 cd ../..
-git commit -m "Import ocaml sources for $(repository-commit "$(git describe --always $rev)")"
 
 # Annotations for diff3 regions; "@" would be more natural than ":" but confuses
 # smerge-mode's highlighting
-short_ocaml_repo="${repository#https://github.com/}"
-old_marker="janestreet/merlin-jst:$current_head"
-parent_marker="$short_ocaml_repo:$old_base_rev"
-new_marker="$short_ocaml_repo:$commitish"
+old_marker="Merlin:$current_head"
+parent_marker="Compiler:$old_base_rev"
+new_marker="Compiler:$commitish"
 
 # Then patch src/ocaml using the changes you just imported
-for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
+for file in $(git diff --no-ext-diff --name-only); do
   file=${file#external/merlin/}
   base=${file#upstream/ocaml_flambda/}
   case $base in
@@ -150,11 +147,9 @@ for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
   # Not all files are necessary
   if [ ! -e $tgt ]; then continue; fi
 
-  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff HEAD^ HEAD -- $file))
+  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file))
   # ignore patch output if it worked
-  if [ $? = 0 ]; then
-    git add -u $tgt
-  else
+  if [ $? != 0 ]; then
     sed -i \
         -e 's!^<<<<<<<$!& '"$old_marker"'!'    \
         -e 's!^|||||||$!& '"$parent_marker"'!' \
@@ -164,3 +159,6 @@ for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
   fi
   rm -f $tgt.orig
 done
+
+git add .
+git commit -m "Automated commit: Import compiler changes from $old_base_rev to $rev"

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -4,20 +4,22 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 subtree_prefix="$(git rev-parse --show-prefix)"
 
 # Script arguments with their default values
-repository=https://github.com/oxcaml/oxcaml
+commitish=HEAD
+repository=.
 subdirectory=.
 old_subdirectory=.
 
 function usage () {
   cat <<USAGE
-Usage: $0 COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]
+Usage: $0 [COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]]
 
 Fetch the new compiler sources and patch Merlin to keep Merlin's local copies of
-things in sync.  By default, this will pull the COMMITISH branch from
-<$repository> and look in "$subdirectory/" for the compiler source, but the
-branch can be overridden by any commitish (branch, tag, full (not abbreviated!)
-commit hash, etc.), the repository can be overridden by any URL, and the
-subdirectory can be overriden by any path (including ".").
+things in sync. By default, this will pull in compiler changes from the local
+repo at the current revision. But you may pass an arbitrary commitish (branch,
+tag, full (not abbreviated!) commit hash, etc.) to important changes from. You
+may also fetch from a remote repository by specifying a REPO, and the
+subdirectory of the repo that the compiler is located in can be overriden by any
+path (including ".").
 
 This attempts to import new files from the compiler by running the
 "import_added_ocaml_source_files.sh" script. If that doesn't work, you can also
@@ -48,14 +50,8 @@ case "$1" in
     ;;
 esac
 
-if [[ $# -gt 0 ]]; then
-  commitish="$1"
-else
-  usage >&2
-  exit 1
-fi
-
 if [[ $# -le 4 ]]; then
+  commitish="${1-$commitish}"
   repository="${2-$repository}"
   # Although the subdirectory arguments are probably no longer useful, it doesn't hurt
   # to keep them around in case they ever are of use.
@@ -66,10 +62,10 @@ else
   exit 1
 fi
 
-if ! git diff --quiet; then
+if ! [ -z "$(git status --porcelain)" ]; then
   echo "Working directory must be clean before using this script,"
   echo "but currently has the following changes:"
-  git diff --stat
+  git status
   exit 1
 fi
 
@@ -81,10 +77,13 @@ current_head="$(git symbolic-ref --short HEAD)"
 # First, add any files that have been added since the last import.
 ./import-added-ocaml-source-files.sh "$commitish" "$repository" "$subdirectory" "$old_subdirectory"
 
-# Then, fetch the new oxcaml sources (which include ocaml-jst) and
-# copy into upstream/ocaml_flambda
-git fetch "$repository" "$commitish"
-rev=$(git rev-parse FETCH_HEAD)
+# Then, get the new oxcaml sources and copy into upstream/ocaml_flambda
+if [ "$repository" != "." ]; then
+  git fetch "$repository" "$commitish"
+  rev=$(git rev-parse FETCH_HEAD)
+else
+  rev=$(git rev-parse "$commitish")
+fi
 cd upstream/ocaml_flambda
 echo $rev > base-rev.txt
 for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
@@ -93,21 +92,19 @@ for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
   else
     git_file="$subdirectory/$file"
   fi
-  git show "FETCH_HEAD:$git_file" > "$file"
+  git show "$rev:$git_file" > "$file"
 done
-git add -u .
+git add --intent-to-add .
 cd ../..
-git commit -m "Import ocaml sources for $(repository-commit "$(git describe --always $rev)")"
 
 # Annotations for diff3 regions; "@" would be more natural than ":" but confuses
 # smerge-mode's highlighting
-short_ocaml_repo="${repository#https://github.com/}"
-old_marker="janestreet/merlin-jst:$current_head"
-parent_marker="$short_ocaml_repo:$old_base_rev"
-new_marker="$short_ocaml_repo:$commitish"
+old_marker="Merlin:$current_head"
+parent_marker="Compiler:$old_base_rev"
+new_marker="Compiler:$commitish"
 
 # Then patch src/ocaml using the changes you just imported
-for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
+for file in $(git diff --no-ext-diff --name-only); do
   file=${file#${subtree_prefix}}
   base=${file#upstream/ocaml_flambda/}
   case $base in
@@ -151,11 +148,9 @@ for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
   # Not all files are necessary
   if [ ! -e $tgt ]; then continue; fi
 
-  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff HEAD^ HEAD -- $file))
+  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file))
   # ignore patch output if it worked
-  if [ $? = 0 ]; then
-    git add -u $tgt
-  else
+  if [ $? != 0 ]; then
     sed -i \
         -e 's!^<<<<<<<$!& '"$old_marker"'!'    \
         -e 's!^|||||||$!& '"$parent_marker"'!' \
@@ -165,3 +160,6 @@ for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
   fi
   rm -f $tgt.orig
 done
+
+git add .
+git commit -m "Automated commit: Import compiler changes from $old_base_rev to $rev"


### PR DESCRIPTION
Update Merlin's `import-ocaml-source.sh` script to pull in changes from the local workspace by default.

## Testing
Testing this was a tad annoying. First, I created the branch [liam-test-import-script](https://github.com/oxcaml/oxcaml/tree/liam-test-import-script). To create it, I:
1. Created the branch, with its head set to the head of this PR.
2. Made commit [ba034f82af](https://github.com/oxcaml/oxcaml/commit/ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a), which commits some dummy changes for us to import.

Then from the liam-test-import-script branch, I performed the following tests, checking that the changes made to the repo match expectations:
```
$ external/merlin/import-ocaml-source.sh 
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
The next patch would empty out the file src/ocaml/typing/foo.ml,
which is already empty!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-48.
[liam-test-import-script 16ce9f01d3] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a
 7 files changed, 24 insertions(+), 14 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
```
```
# Reject the new file
$ external/merlin/import-ocaml-source.sh
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] n
Skipping typing/foo.ml; run './import-added-ocaml-source-files.sh' again in order to make a different decision
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-48.
[liam-test-import-script 81f85942be] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a
 5 files changed, 24 insertions(+), 14 deletions(-)
```
```
# Specify a commit
$ external/merlin/import-ocaml-source.sh ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
The next patch would empty out the file src/ocaml/typing/foo.ml,
which is already empty!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-48.
[liam-test-import-script 5ae21fdbad] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a
 7 files changed, 24 insertions(+), 14 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
```
```
# Fetch the commit from a remote
$ external/merlin/import-ocaml-source.sh ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a https://github.com/oxcaml/oxcaml.git
From https://github.com/oxcaml/oxcaml
 * branch                  eb63e0e41869ede83ad3001e4facdff54383861d -> FETCH_HEAD
From https://github.com/oxcaml/oxcaml
 * branch                  ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a -> FETCH_HEAD
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
From https://github.com/oxcaml/oxcaml
 * branch                  ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a -> FETCH_HEAD
The next patch would empty out the file src/ocaml/typing/foo.ml,
which is already empty!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-48.
[liam-test-import-script d9e8fbf4ad] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a
 7 files changed, 24 insertions(+), 14 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
```
```
# Run from a different directory
$ cd external/merlin
$ ./import-ocaml-source.sh 
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
The next patch would empty out the file src/ocaml/typing/foo.ml,
which is already empty!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-48.
[liam-test-import-script 14bd1cc3a2] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to ba034f82af9828ae1aed31639a5ac7bf3a2d3f5a
 7 files changed, 24 insertions(+), 14 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
```
```
# Remove the new file before importing so that there's no new files
$ git rm typing/foo.ml 
rm 'typing/foo.ml'
$ git commit -m "Delete foo.ml"
[liam-test-import-script 745ba9c658] Delete foo.ml
 1 file changed, 0 insertions(+), 0 deletions(-)
 delete mode 100644 typing/foo.ml
$ external/merlin/import-ocaml-source.sh 
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-48.
[liam-test-import-script 85bddf7793] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to 745ba9c658bb324f9cbda2859fb4d1be6101a833
 5 files changed, 24 insertions(+), 14 deletions(-)
```
```
# Fail when the workspace isn't clean
$ touch foo
$ external/merlin/import-ocaml-source.sh 
Working directory must be clean before using this script,
but currently has the following changes:
On branch liam-test-import-script
Your branch is up to date with 'origin/liam-test-import-script'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        ../../foo

nothing added to commit but untracked files present (use "git add" to track)
```
```
# Try to import the compiler revision that's already been imported
$ external/merlin/import-ocaml-source.sh $(cat external/merlin/upstream/ocaml_flambda/base-rev.txt)
On branch liam-test-import-script
Your branch is up to date with 'origin/liam-test-import-script'.

nothing to commit, working tree clean
```
```
# Import a compiler that has no diff with the previously imported revision, but has a different hash
$ external/merlin/import-ocaml-source.sh HEAD~
[liam-test-import-script d0f944ff6b] Automated commit: Import compiler changes from eb63e0e41869ede83ad3001e4facdff54383861d to c00c4f4eeb9e10883b1cfe83f4bbf58a54941b7f
 1 file changed, 1 insertion(+), 1 deletion(-)
```