### PR TITLE
Support scannable axes on abstract kinds

### DIFF
--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -83,7 +83,7 @@ float and non-float elements. However, all types in vanilla OCaml are
 
 ### Using scannable axes
 
-Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value` (because `value` is already `separable`, which is lower than `maybe_separable`). Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any`, in which case they take effect *only in the case* that it is lowered to a value layout.
+Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value` (because `value` is already `separable`, which is lower than `maybe_separable`). Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any` and abstract kinds, in which case they take effect *only in the case* that it is lowered to a value layout.
 
 The `mod` syntax may also be written with scannable axes, and has the same effect, but should be considered deprecated: we will remove this syntax so that `mod` is reserved for modal axes.
 

--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -83,7 +83,7 @@ float and non-float elements. However, all types in vanilla OCaml are
 
 ### Using scannable axes
 
-Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value` (because `value` is already `separable`, which is lower than `maybe_separable`). Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any` and abstract kinds, in which case they take effect *only in the case* that it is lowered to a value layout.
+Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value` (because `value` is already `separable`, which is lower than `maybe_separable`). Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any` and abstract kinds.
 
 The `mod` syntax may also be written with scannable axes, and has the same effect, but should be considered deprecated: we will remove this syntax so that `mod` is reserved for modal axes.
 

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -785,32 +785,25 @@ Error: This type "t1" should be an instance of type "('a : any separable)"
          because it's the type argument to the array type.
 |}]
 
-(* CR layouts-scannable: support scannable axes on abstract kinds *)
 type t2 : k mod separable
 type s2 = t2 array
 [%%expect{|
-Line 1, characters 16-25:
-1 | type t2 : k mod separable
-                    ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type t2 : k mod separable
+type s2 = t2 array
 |}]
 
 type ('a : k mod separable) s3 = 'a array
 [%%expect{|
-Line 1, characters 17-26:
-1 | type ('a : k mod separable) s3 = 'a array
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type ('a : k mod separable) s3 = 'a array
 |}]
 
 kind_ k' = k mod separable
 type t4 : k'
 type s4 = t4 array
 [%%expect{|
-Line 1, characters 17-26:
-1 | kind_ k' = k mod separable
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+kind_ k' = k mod separable
+type t4 : k mod separable
+type s4 = t4 array
 |}]
 
 (******************************)

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -786,32 +786,25 @@ Error: This type "t1" should be an instance of type "('a : any separable)"
          because it's the type argument to the array type.
 |}]
 
-(* CR layouts-scannable: support scannable axes on abstract kinds *)
 type t2 : k mod separable
 type s2 = t2 array
 [%%expect{|
-Line 1, characters 16-25:
-1 | type t2 : k mod separable
-                    ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type t2 : k separable
+type s2 = t2 array
 |}]
 
 type ('a : k mod separable) s3 = 'a array
 [%%expect{|
-Line 1, characters 17-26:
-1 | type ('a : k mod separable) s3 = 'a array
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type ('a : k separable) s3 = 'a array
 |}]
 
 kind_ k' = k mod separable
 type t4 : k'
 type s4 = t4 array
 [%%expect{|
-Line 1, characters 17-26:
-1 | kind_ k' = k mod separable
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+kind_ k' = k separable
+type t4 : k separable
+type s4 = t4 array
 |}]
 
 (******************************)

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -785,32 +785,25 @@ Error: This type "t1" should be an instance of type "('a : any separable)"
          because it's the type argument to the array type.
 |}]
 
-(* CR layouts-scannable: support scannable axes on abstract kinds *)
 type t2 : k mod separable
 type s2 = t2 array
 [%%expect{|
-Line 1, characters 16-25:
-1 | type t2 : k mod separable
-                    ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type t2 : k mod separable
+type s2 = t2 array
 |}]
 
 type ('a : k mod separable) s3 = 'a array
 [%%expect{|
-Line 1, characters 17-26:
-1 | type ('a : k mod separable) s3 = 'a array
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type ('a : k mod separable) s3 = 'a array
 |}]
 
 kind_ k' = k mod separable
 type t4 : k'
 type s4 = t4 array
 [%%expect{|
-Line 1, characters 17-26:
-1 | kind_ k' = k mod separable
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+kind_ k' = k mod separable
+type t4 : k mod separable
+type s4 = t4 array
 |}]
 
 (******************************)

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -785,32 +785,25 @@ Error: This type "t1" should be an instance of type "('a : any separable)"
          because it's the type argument to the array type.
 |}]
 
-(* CR layouts-scannable: support scannable axes on abstract kinds *)
 type t2 : k mod separable
 type s2 = t2 array
 [%%expect{|
-Line 1, characters 16-25:
-1 | type t2 : k mod separable
-                    ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type t2 : k separable
+type s2 = t2 array
 |}]
 
 type ('a : k mod separable) s3 = 'a array
 [%%expect{|
-Line 1, characters 17-26:
-1 | type ('a : k mod separable) s3 = 'a array
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type ('a : k separable) s3 = 'a array
 |}]
 
 kind_ k' = k mod separable
 type t4 : k'
 type s4 = t4 array
 [%%expect{|
-Line 1, characters 17-26:
-1 | kind_ k' = k mod separable
-                     ^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+kind_ k' = k separable
+type t4 : k separable
+type s4 = t4 array
 |}]
 
 (******************************)

--- a/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
+++ b/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
@@ -18,8 +18,7 @@ type t : value non_pointer
 type check = t require_non_pointer
 |}]
 
-(* [non_pointer] but not when it's abstract *)
-(* CR layouts-scannable: support scannable axes on abstract kinds *)
+(* The "overwrite" abbreviation form errors on abstract kinds *)
 kind_ k
 type t : k non_pointer
 type check = t require_non_pointer
@@ -28,5 +27,180 @@ kind_ k
 Line 2, characters 11-22:
 2 | type t : k non_pointer
                ^^^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+Error: Abstract kinds with kind abbreviation modifiers are not supported.
+       Hint: Use "mod" to upper-bound an abstract kind.
+|}]
+
+(* [mod non_pointer] (meet form) is supported: the axis hangs around on the
+   abstract kind and reduces on substitution. *)
+kind_ k2
+type t2 : k2 mod non_pointer
+type check2 = t2 require_non_pointer
+[%%expect{|
+kind_ k2
+type t2 : k2 mod non_pointer
+type check2 = t2 require_non_pointer
+|}]
+
+(* Separate scannable axis and k constraints combine *)
+module type S = sig
+  kind_ k
+  type (_ : any separable) a
+  type (_ : k) b
+  type ('a : any) ab = 'a a * 'a b
+  val f : ('a : k mod separable). 'a a -> 'a b
+end
+[%%expect{|
+module type S =
+  sig
+    kind_ k
+    type (_ : any separable) a
+    type (_ : k) b
+    type ('a : k mod separable) ab = 'a a * 'a b
+    val f : ('a : k mod separable). 'a a -> 'a b
+  end
+|}]
+
+(* Same as above, but the scannable axis constraint is less than
+   the universally quantified kind
+*)
+module type Bad = sig
+  kind_ k
+  type (_ : any non_float) a
+  type (_ : k) b
+  val f : ('a : k mod separable). 'a a -> 'a b
+end
+[%%expect{|
+Line 5, characters 10-46:
+5 |   val f : ('a : k mod separable). 'a a -> 'a b
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind k mod separable.
+       But it was inferred to have kind k mod non_float
+         because of the definition of a at line 3, characters 2-28.
+|}]
+
+(* Substitution *)
+module type S_float64 = S with kind_ k := float64
+[%%expect{|
+module type S_float64 =
+  sig
+    type (_ : any separable) a
+    type (_ : float64) b
+    type ('a : float64) ab = 'a a * 'a b
+    val f : ('a : float64). 'a a -> 'a b
+  end
+|}]
+
+module type S_value = S with kind_ k := value
+[%%expect{|
+module type S_value =
+  sig
+    type (_ : any separable) a
+    type _ b
+    type 'a ab = 'a a * 'a b
+    val f : 'a a -> 'a b
+  end
+|}]
+
+module type S_any = S with kind_ k := any
+[%%expect{|
+module type S_any =
+  sig
+    type (_ : any separable) a
+    type (_ : any) b
+    type ('a : any separable) ab = 'a a * 'a b
+    val f : ('a : any separable). 'a a -> 'a b
+  end
+|}]
+
+kind_ k2
+module type S_k2 = S with kind_ k := k2
+[%%expect{|
+kind_ k2
+module type S_k2 =
+  sig
+    type (_ : any separable) a
+    type (_ : k2) b
+    type ('a : k2 mod separable) ab = 'a a * 'a b
+    val f : ('a : k2 mod separable). 'a a -> 'a b
+  end
+|}]
+
+kind_ k2 = value non_float
+module type S_k2 = S with kind_ k := k2
+[%%expect{|
+kind_ k2 = value non_float
+module type S_k2 =
+  sig
+    type (_ : any separable) a
+    type (_ : value non_float) b
+    type ('a : value non_float) ab = 'a a * 'a b
+    val f : ('a : value non_float). 'a a -> 'a b
+  end
+|}]
+
+(* Abstract kind has a lower scannable axis *)
+module type S = sig
+  kind_ k
+  type (_ : any separable) a
+  type (_ : k mod non_float non_null) b
+  type ('a : any) ab = 'a a * 'a b
+  val f : ('a : k mod non_float non_null). 'a a -> 'a b
+end
+[%%expect{|
+module type S =
+  sig
+    kind_ k
+    type (_ : any separable) a
+    type (_ : k mod non_float non_null) b
+    type ('a : k mod non_float non_null) ab = 'a a * 'a b
+    val f : ('a : k mod non_float non_null). 'a a -> 'a b
+  end
+|}]
+
+(* [any] has a lower scannable axis *)
+module type S = sig
+  kind_ k
+  type (_ : any non_float non_null) a
+  type (_ : k mod separable) b
+  type ('a : any) ab = 'a a * 'a b
+  val f : ('a : k mod non_float non_null). 'a a -> 'a b
+end
+[%%expect{|
+module type S =
+  sig
+    kind_ k
+    type (_ : any non_float non_null) a
+    type (_ : k mod separable) b
+    type ('a : k mod non_float non_null) ab = 'a a * 'a b
+    val f : ('a : k mod non_float non_null). 'a a -> 'a b
+  end
+|}]
+
+(* Scannable axes accumulate through a chain of kind aliases. *)
+kind_ k
+kind_ k2 = k mod separable
+kind_ k3 = k2 mod non_null
+[%%expect{|
+kind_ k
+kind_ k2 = k mod separable
+kind_ k3 = k mod separable non_null
+|}]
+
+(* Two Kconstrs with the same path but different sa are incomparable on an
+   abstract kind: neither [k mod non_null] nor [k mod separable] refines the
+   other. *)
+kind_ k
+module type Incompatible = sig
+  type ('a : k mod non_null) a
+  val f : ('a : k mod separable). 'a a -> 'a a
+end
+[%%expect{|
+kind_ k
+Line 4, characters 10-46:
+4 |   val f : ('a : k mod separable). 'a a -> 'a a
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind k mod separable.
+       But it was inferred to have kind k mod separable non_null
+         because of the definition of a at line 3, characters 2-30.
 |}]

--- a/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
+++ b/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
@@ -8,6 +8,11 @@ type ('a : any non_pointer) require_non_pointer
 type ('a : any non_pointer) require_non_pointer
 |}]
 
+type ('a : any non_null) require_non_null
+[%%expect{|
+type ('a : any non_null) require_non_null
+|}]
+
 (* [non_pointer] works on kind constructor when it's concrete *)
 kind_ k = value
 type t : k non_pointer
@@ -36,6 +41,36 @@ type check2 = t2 require_non_pointer
 kind_ k2
 type t2 : k2 non_pointer
 type check2 = t2 require_non_pointer
+|}]
+
+(* [non_null] works on kind constructor when it's concrete *)
+kind_ kn = value_or_null
+type tn : kn non_null
+type checkn = tn require_non_null
+[%%expect{|
+kind_ kn = value_or_null
+type tn : value_maybe_separable
+type checkn = tn require_non_null
+|}]
+
+(* As well as abstract *)
+kind_ kn
+type tn : kn non_null
+type checkn = tn require_non_null
+[%%expect{|
+kind_ kn
+type tn : kn non_null
+type checkn = tn require_non_null
+|}]
+
+(* [mod non_null] works the same *)
+kind_ kn2
+type tn2 : kn2 mod non_null
+type checkn2 = tn2 require_non_null
+[%%expect{|
+kind_ kn2
+type tn2 : kn2 non_null
+type checkn2 = tn2 require_non_null
 |}]
 
 (* Separate scannable axis and k constraints combine *)

--- a/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
+++ b/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
@@ -18,15 +18,284 @@ type t : value non_pointer
 type check = t require_non_pointer
 |}]
 
-(* [non_pointer] but not when it's abstract *)
-(* CR layouts-scannable: support scannable axes on abstract kinds *)
+(* As well as abstract *)
 kind_ k
 type t : k non_pointer
 type check = t require_non_pointer
 [%%expect{|
 kind_ k
-Line 2, characters 11-22:
-2 | type t : k non_pointer
-               ^^^^^^^^^^^
-Error: Abstract kinds with kind modifiers are not yet supported.
+type t : k non_pointer
+type check = t require_non_pointer
+|}]
+
+(* [mod non_pointer] works the same *)
+kind_ k2
+type t2 : k2 mod non_pointer
+type check2 = t2 require_non_pointer
+[%%expect{|
+kind_ k2
+type t2 : k2 non_pointer
+type check2 = t2 require_non_pointer
+|}]
+
+(* Separate scannable axis and k constraints combine *)
+module type S = sig
+  kind_ k
+  type (_ : any separable) a
+  type (_ : k) b
+  type ('a : any) ab = 'a a * 'a b
+  val f : ('a : k mod separable). 'a a -> 'a b
+end
+[%%expect{|
+module type S =
+  sig
+    kind_ k
+    type (_ : any separable) a
+    type (_ : k) b
+    type ('a : k separable) ab = 'a a * 'a b
+    val f : ('a : k separable). 'a a -> 'a b
+  end
+|}]
+
+(* Same as above, but the scannable axis constraint is less than
+   the universally quantified kind
+*)
+module type Bad = sig
+  kind_ k
+  type (_ : any non_float) a
+  type (_ : k) b
+  val f : ('a : k mod separable). 'a a -> 'a b
+end
+[%%expect{|
+Line 5, characters 10-46:
+5 |   val f : ('a : k mod separable). 'a a -> 'a b
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind k separable.
+       But it was inferred to have kind k non_float
+         because of the definition of a at line 3, characters 2-28.
+|}]
+
+(* Substitution *)
+module type S_float64 = S with kind_ k = float64
+[%%expect{|
+module type S_float64 =
+  sig
+    kind_ k = float64
+    type (_ : any separable) a
+    type (_ : float64) b
+    type ('a : float64) ab = 'a a * 'a b
+    val f : ('a : float64). 'a a -> 'a b
+  end
+|}]
+
+module type S_value = S with kind_ k = value
+[%%expect{|
+module type S_value =
+  sig
+    kind_ k = value
+    type (_ : any separable) a
+    type _ b
+    type 'a ab = 'a a * 'a b
+    val f : 'a a -> 'a b
+  end
+|}]
+
+module type S_any = S with kind_ k = any
+[%%expect{|
+module type S_any =
+  sig
+    kind_ k = any
+    type (_ : any separable) a
+    type (_ : any) b
+    type ('a : any separable) ab = 'a a * 'a b
+    val f : ('a : any separable). 'a a -> 'a b
+  end
+|}]
+
+kind_ k2
+module type S_k2 = S with kind_ k = k2
+[%%expect{|
+kind_ k2
+module type S_k2 =
+  sig
+    kind_ k = k2
+    type (_ : any separable) a
+    type (_ : k) b
+    type ('a : k separable) ab = 'a a * 'a b
+    val f : ('a : k separable). 'a a -> 'a b
+  end
+|}]
+
+kind_ k2 = value non_float
+module type S_k2 = S with kind_ k = k2
+[%%expect{|
+kind_ k2 = value non_float
+module type S_k2 =
+  sig
+    kind_ k = value non_float
+    type (_ : any separable) a
+    type (_ : value non_float) b
+    type ('a : value non_float) ab = 'a a * 'a b
+    val f : ('a : value non_float). 'a a -> 'a b
+  end
+|}]
+
+(* Destructive substitution *)
+module type S_float64 = S with kind_ k := float64
+[%%expect{|
+module type S_float64 =
+  sig
+    type (_ : any separable) a
+    type (_ : float64) b
+    type ('a : float64) ab = 'a a * 'a b
+    val f : ('a : float64). 'a a -> 'a b
+  end
+|}]
+
+module type S_value = S with kind_ k := value
+[%%expect{|
+module type S_value =
+  sig
+    type (_ : any separable) a
+    type _ b
+    type 'a ab = 'a a * 'a b
+    val f : 'a a -> 'a b
+  end
+|}]
+
+module type S_any = S with kind_ k := any
+[%%expect{|
+module type S_any =
+  sig
+    type (_ : any separable) a
+    type (_ : any) b
+    type ('a : any separable) ab = 'a a * 'a b
+    val f : ('a : any separable). 'a a -> 'a b
+  end
+|}]
+
+kind_ k2
+module type S_k2 = S with kind_ k := k2
+[%%expect{|
+kind_ k2
+module type S_k2 =
+  sig
+    type (_ : any separable) a
+    type (_ : k2) b
+    type ('a : k2 separable) ab = 'a a * 'a b
+    val f : ('a : k2 separable). 'a a -> 'a b
+  end
+|}]
+
+kind_ k2 = value non_float
+module type S_k2 = S with kind_ k := k2
+[%%expect{|
+kind_ k2 = value non_float
+module type S_k2 =
+  sig
+    type (_ : any separable) a
+    type (_ : value non_float) b
+    type ('a : value non_float) ab = 'a a * 'a b
+    val f : ('a : value non_float). 'a a -> 'a b
+  end
+|}]
+
+(* Abstract kind has a lower scannable axis *)
+module type S = sig
+  kind_ k
+  type (_ : any separable) a
+  type (_ : k mod non_float non_null) b
+  type ('a : any) ab = 'a a * 'a b
+  val f : ('a : k mod non_float non_null). 'a a -> 'a b
+end
+[%%expect{|
+module type S =
+  sig
+    kind_ k
+    type (_ : any separable) a
+    type (_ : k non_float non_null) b
+    type ('a : k non_float non_null) ab = 'a a * 'a b
+    val f : ('a : k non_float non_null). 'a a -> 'a b
+  end
+|}]
+
+(* [any] has a lower scannable axis *)
+module type S = sig
+  kind_ k
+  type (_ : any non_float non_null) a
+  type (_ : k mod separable) b
+  type ('a : any) ab = 'a a * 'a b
+  val f : ('a : k mod non_float non_null). 'a a -> 'a b
+end
+[%%expect{|
+module type S =
+  sig
+    kind_ k
+    type (_ : any non_float non_null) a
+    type (_ : k separable) b
+    type ('a : k non_float non_null) ab = 'a a * 'a b
+    val f : ('a : k non_float non_null). 'a a -> 'a b
+  end
+|}]
+
+(* Scannable axes accumulate through a chain of kind aliases. *)
+kind_ k
+kind_ k2 = k mod separable
+kind_ k3 = k2 mod non_null
+[%%expect{|
+kind_ k
+kind_ k2 = k separable
+kind_ k3 = k separable non_null
+|}]
+
+(* Two Kconstrs with the same path but different sa are incomparable on an
+   abstract kind: neither [k mod non_null] nor [k mod separable] refines the
+   other. *)
+kind_ k
+module type Incompatible = sig
+  type ('a : k mod non_null) a
+  val f : ('a : k mod separable). 'a a -> 'a a
+end
+[%%expect{|
+kind_ k
+Line 4, characters 10-46:
+4 |   val f : ('a : k mod separable). 'a a -> 'a a
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind k separable.
+       But it was inferred to have kind k separable non_null
+         because of the definition of a at line 3, characters 2-30.
+|}]
+
+(* Recursive jkind cycle reporting *)
+module rec M : sig
+  kind_ k = M.k separable
+end = struct
+  kind_ k = M.k separable
+end
+[%%expect{|
+Lines 1-5, characters 0-3:
+1 | module rec M : sig
+2 |   kind_ k = M.k separable
+3 | end = struct
+4 |   kind_ k = M.k separable
+5 | end
+Error: The kind "M.k" is cyclic:
+         "M.k" = "M.k separable"
+|}]
+
+module rec M : sig
+  kind_ k = M.k separable mod global
+end = struct
+  kind_ k = M.k separable mod global
+end
+[%%expect{|
+Lines 1-5, characters 0-3:
+1 | module rec M : sig
+2 |   kind_ k = M.k separable mod global
+3 | end = struct
+4 |   kind_ k = M.k separable mod global
+5 | end
+Error: The kind "M.k" is cyclic:
+         "M.k" = "M.k separable mod global",
+         "M.k separable mod global" contains "M.k"
 |}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -433,7 +433,8 @@ let type_iterators_without_type_expr =
   and it_jkind_declaration it jkd =
     match jkd.jkind_manifest with
     | None -> ()
-    | Some { base = Kconstr p; mod_bounds = _; with_bounds = No_with_bounds } ->
+    | Some { base = Kconstr (p, _); mod_bounds = _;
+             with_bounds = No_with_bounds } ->
       it.it_path p
     | Some { base = Layout _; mod_bounds = _; with_bounds = No_with_bounds } ->
       ()
@@ -1240,7 +1241,7 @@ module Jkind0 = struct
     end)
 
     let of_path path =
-      { base = Kconstr path;
+      { base = Kconstr (path, Jkind_types.Scannable_axes.max);
         mod_bounds = Mod_bounds.max;
         with_bounds = No_with_bounds
       }
@@ -1269,8 +1270,9 @@ module Jkind0 = struct
       | None -> false
       | Some (t1, t2) -> (
         match t1.base, t2.base with
-        | Kconstr p1, Kconstr p2 ->
+        | Kconstr (p1, sa1), Kconstr (p2, sa2) ->
           Path.same p1 p2 &&
+          Jkind_types.Scannable_axes.equal sa1 sa2 &&
           Mod_bounds.equal t1.mod_bounds t2.mod_bounds
         | Kconstr _, Layout _ | Layout _, Kconstr _ -> false
         | Layout l1, Layout l2 ->

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2087,6 +2087,28 @@ module Jkind0 = struct
           fresh_jkind Jkind_desc.Builtin.any
             ~annotation:(mk_annot "any") ~why:(Any_creation why)
 
+      let any_with_nullability nullability
+          ~(why : Jkind_intf.History.any_creation_reason) =
+        fresh_jkind
+          { Jkind_desc.Builtin.any with
+            base =
+              Layout
+                (Jkind_types.Layout.Any
+                   { Jkind_types.Scannable_axes.max with nullability })
+          }
+          ~annotation:None ~why:(Any_creation why)
+
+      let any_with_separability separability
+          ~(why : Jkind_intf.History.any_creation_reason) =
+        fresh_jkind
+          { Jkind_desc.Builtin.any with
+            base =
+              Layout
+                (Jkind_types.Layout.Any
+                   { Jkind_types.Scannable_axes.max with separability })
+          }
+          ~annotation:None ~why:(Any_creation why)
+
       let value_v1_safety_check =
         { jkind = Jkind_desc.Builtin.value_or_null;
           annotation = mk_annot "value";

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1257,6 +1257,13 @@ module Jkind0 = struct
       | Layout l -> (
         match f l with None -> None | Some l -> Some { t with base = Layout l })
 
+    let meet_scannable_axes (base : Jkind_types.Layout.Const.t jkind_base) sa :
+        Jkind_types.Layout.Const.t jkind_base =
+      match base with
+      | Kconstr (p, sa') -> Kconstr (p, Jkind_types.Scannable_axes.meet sa sa')
+      | Layout l ->
+        Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
+
     let map_type_expr f t =
       { t with with_bounds = With_bounds.map_type_expr f t.with_bounds }
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -488,7 +488,8 @@ let type_iterators_without_type_expr =
   and it_jkind_declaration it jkd =
     match jkd.jkind_manifest with
     | None -> ()
-    | Some { base = Kconstr p; mod_bounds = _; with_bounds = No_with_bounds } ->
+    | Some { base = Kconstr (p, _); mod_bounds = _;
+             with_bounds = No_with_bounds } ->
       it.it_path p
     | Some { base = Layout _; mod_bounds = _; with_bounds = No_with_bounds } ->
       ()
@@ -1286,7 +1287,7 @@ module Jkind0 = struct
     end)
 
     let of_path path =
-      { base = Kconstr path;
+      { base = Kconstr (path, Jkind_types.Scannable_axes.max);
         mod_bounds = Mod_bounds.max;
         with_bounds = No_with_bounds
       }
@@ -1315,8 +1316,9 @@ module Jkind0 = struct
       | None -> false
       | Some (t1, t2) -> (
         match t1.base, t2.base with
-        | Kconstr p1, Kconstr p2 ->
+        | Kconstr (p1, sa1), Kconstr (p2, sa2) ->
           Path.same p1 p2 &&
+          Jkind_types.Scannable_axes.equal sa1 sa2 &&
           Mod_bounds.equal t1.mod_bounds t2.mod_bounds
         | Kconstr _, Layout _ | Layout _, Kconstr _ -> false
         | Layout l1, Layout l2 ->

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -665,6 +665,14 @@ module Jkind0 : sig
 
     module Builtin : sig
       val any : why:Jkind_intf.History.any_creation_reason -> 'd jkind
+      val any_with_nullability :
+        Jkind_axis.Nullability.t ->
+        why:Jkind_intf.History.any_creation_reason ->
+        'd jkind
+      val any_with_separability :
+        Jkind_axis.Separability.t ->
+        why:Jkind_intf.History.any_creation_reason ->
+        'd jkind
       val void :
         why:Jkind_intf.History.void_creation_reason -> ('l * disallowed) jkind
       val scannable :

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -419,6 +419,11 @@ module Jkind0 : sig
       ('a -> 'b option) -> ('a, 'd) base_and_axes ->
       ('b, 'd) base_and_axes option
 
+    val meet_scannable_axes :
+      Jkind_types.Layout.Const.t jkind_base ->
+      Jkind_types.Scannable_axes.t ->
+      Jkind_types.Layout.Const.t jkind_base
+
     val try_allow_l :
       ('layout, 'l * 'r) base_and_axes ->
       ('layout, allowed * 'r) base_and_axes option

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7888,7 +7888,7 @@ let clear_hash ()   =
    [jkind_const_desc]s. *)
 let rec nondep_jkind_desc_base env ids ~desc_of_const jkind_desc =
   match jkind_desc.base with
-  | Kconstr p -> begin
+  | Kconstr (p, _sa) -> begin
       match Path.find_free_opt ids p with
       | None -> jkind_desc
       | Some id ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2849,7 +2849,7 @@ let apply_layout_wrapping_l ~env
         when ['a] is [non_float]/[non_pointer64]/[non_pointer], we can give
         ['a or_null] the same separability (per [Jkind.apply_or_null_l]). So
         here we recompute the layout based on the inner jkind. *)
-    begin match Jkind.apply_or_null_l jkind with
+    begin match Jkind.apply_or_null_l env jkind with
     | Ok jkind -> Ok (get_layout jkind)
     | Error () -> Error prev
     end
@@ -2877,14 +2877,15 @@ let apply_jkind_wrapping_l ~env ~level
   end
   |> Result.map (Jkind.apply_modality_l modality)
 
-let apply_jkind_wrapping_r ~unwrapped_ty:{ ty = _; modality; or_null } jkind =
+let apply_jkind_wrapping_r ~env ~unwrapped_ty:{ ty = _; modality; or_null }
+      jkind =
   begin
     if Option.is_some or_null then
       (* The testsuite passes if we replace the body of this [then] with
          [assert false]. But we don't have a principled reason why (one likely
          exists by thinking sufficiently hard about the sole callsite in
          [constrain_type_jkind].) *)
-      match Jkind.apply_or_null_r jkind with
+      match Jkind.apply_or_null_r env jkind with
       | Ok jkind -> jkind
       | Error () ->
         Misc.fatal_error "Ctype.apply_jkind_wrapping_r: nested or_nulls"
@@ -3256,7 +3257,9 @@ let constrain_type_jkind ~fixed env ty jkind =
                let results =
                  Misc.Stdlib.List.map3
                    (fun unwrapped_ty ty's_jkind jkind ->
-                      let jkind = apply_jkind_wrapping_r jkind ~unwrapped_ty in
+                      let jkind =
+                        apply_jkind_wrapping_r ~env jkind ~unwrapped_ty
+                      in
                       match Jkind.extract_layout env ty's_jkind with
                       | Ok (Any _) ->
                         (* We re-estimate in this case rather than reuse the
@@ -3353,7 +3356,7 @@ let constrain_type_jkind ~fixed env ty jkind =
             in
             let jkind = Jkind.apply_modality_r modality jkind in
             match
-              Jkind.apply_or_null_r jkind
+              Jkind.apply_or_null_r env jkind
             with
             | Ok jkind ->
               (match
@@ -8166,7 +8169,7 @@ let clear_hash ()   =
    [jkind_const_desc]s. *)
 let rec nondep_jkind_desc_base env ids ~desc_of_const jkind_desc =
   match jkind_desc.base with
-  | Kconstr p -> begin
+  | Kconstr (p, _sa) -> begin
       match Path.find_free_opt ids p with
       | None -> jkind_desc
       | Some id ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3457,14 +3457,40 @@ let check_type_externality env ty ext =
 
 let check_type_nullability env ty null =
   let upper_bound =
-    Jkind.set_root_nullability (Jkind.Builtin.any ~why:Dummy_jkind) null
+    Jkind.Builtin.any_with_nullability null ~why:Dummy_jkind
   in
   match check_type_jkind env ty upper_bound with
   | Ok () -> true
   | Error _ -> false
 
-let check_type_separability jkind env ty sep =
-  let upper_bound = Jkind.set_root_separability jkind sep in
+let check_type_separability env ty sep =
+  let upper_bound =
+    Jkind.Builtin.any_with_separability sep ~why:Dummy_jkind
+  in
+  match check_type_jkind env ty upper_bound with
+  | Ok () -> true
+  | Error _ -> false
+
+let type_is_gc_ignorable_scannable env ty =
+  (* Checking against the upper bound [scannable non_pointer(64)] ensures that
+     whenever [ty]'s layout is not scannable, the check will be [false]. *)
+  (* CR layouts-scannable: Since we check against [scannable non_pointer(64)],
+     a type of kind [value non_pointer & value non_pointer] will fail to be
+     recognized as being always_gc_ignorable, even though it is. To avoid this,
+     [non_pointer(64)] should imply [external(64)]. *)
+  let scannable = Jkind.Builtin.scannable ~why:Dummy_jkind in
+  let l =
+    match scannable.jkind.base with
+    | Layout l -> l
+    | Kconstr _ ->
+      Misc.fatal_error "Ctype.type_is_gc_ignorable_scannable: abstract Kconstr"
+  in
+  let sep =
+    Jkind_axis.Separability.upper_bound_if_is_always_gc_ignorable ()
+  in
+  let upper_bound =
+    Jkind.set_layout scannable (Jkind.Layout.set_root_separability l sep)
+  in
   match check_type_jkind env ty upper_bound with
   | Ok () -> true
   | Error _ -> false
@@ -3473,18 +3499,7 @@ let is_always_gc_ignorable env ty =
   (* CR layouts: calling [check_type_jkind] two times (indirectly) is sad. *)
   check_type_externality env ty
     (Jkind_axis.Externality.upper_bound_if_is_always_gc_ignorable ())
-  ||
-  (* Checking against the upper bound [scannable non_pointer(64)] ensures that
-     whenever [ty]'s layout is not scannable, the check will be [false]. *)
-  (* CR layouts-scannable: Since we check against [scannable non_pointer(64)],
-     a type of kind [value non_pointer & value non_pointer] will fail to be
-     recognized as being always_gc_ignorable, even though it is. To avoid this,
-     [non_pointer(64)] should imply [external(64)]. *)
-  check_type_separability (Jkind.Builtin.scannable ~why:Dummy_jkind) env ty
-      (Jkind_axis.Separability.upper_bound_if_is_always_gc_ignorable ())
-
-let check_type_separability env ty sep =
-  check_type_separability (Jkind.Builtin.any ~why:Dummy_jkind) env ty sep
+  || type_is_gc_ignorable_scannable env ty
 
 let check_type_jkind_exn env texn ty jkind =
   match check_type_jkind env ty jkind with

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -760,8 +760,8 @@ val check_type_externality :
 val is_always_gc_ignorable : Env.t -> type_expr -> bool
 
 (* Check whether a type's nullability is less than some target.
-   Uses get_nullability which is potentially cheaper than calling type_jkind
-   if all with-bounds are irrelevant. *)
+   Potentially cheaper than just calling [type_jkind], because this can stop
+   expansion once it succeeds. *)
 val check_type_nullability :
   Env.t -> type_expr -> Jkind_axis.Nullability.t -> bool
 

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -298,7 +298,7 @@ module Solver = struct
           let unresolved_base =
             match jkind_desc.base with
             | Types.Layout _ -> None
-            | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
           in
           jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
         in
@@ -314,7 +314,7 @@ module Solver = struct
             let unresolved_base =
               match jkind_desc.base with
               | Types.Layout _ -> None
-              | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
             in
             jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
         in
@@ -359,7 +359,7 @@ module Solver = struct
           let unresolved_base =
             match jkind_desc.base with
             | Types.Layout _ -> None
-            | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
           in
           jkind_desc.mod_bounds, unresolved_base
         | Some env -> (
@@ -369,7 +369,7 @@ module Solver = struct
             let unresolved_base =
               match jkind_desc.base with
               | Types.Layout _ -> None
-              | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
             in
             jkind_desc.mod_bounds, unresolved_base)
       in

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -312,7 +312,7 @@ module Solver = struct
             let unresolved_base =
               match jkind_desc.base with
               | Types.Layout _ -> None
-            | Types.Kconstr (path, _) -> Some path
+              | Types.Kconstr (path, _) -> Some path
             in
             jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
         in
@@ -367,7 +367,7 @@ module Solver = struct
             let unresolved_base =
               match jkind_desc.base with
               | Types.Layout _ -> None
-            | Types.Kconstr (path, _) -> Some path
+              | Types.Kconstr (path, _) -> Some path
             in
             jkind_desc.mod_bounds, unresolved_base)
       in

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -296,7 +296,7 @@ module Solver = struct
           let unresolved_base =
             match jkind_desc.base with
             | Types.Layout _ -> None
-            | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
           in
           jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
         in
@@ -312,7 +312,7 @@ module Solver = struct
             let unresolved_base =
               match jkind_desc.base with
               | Types.Layout _ -> None
-              | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
             in
             jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
         in
@@ -357,7 +357,7 @@ module Solver = struct
           let unresolved_base =
             match jkind_desc.base with
             | Types.Layout _ -> None
-            | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
           in
           jkind_desc.mod_bounds, unresolved_base
         | Some env -> (
@@ -367,7 +367,7 @@ module Solver = struct
             let unresolved_base =
               match jkind_desc.base with
               | Types.Layout _ -> None
-              | Types.Kconstr path -> Some path
+            | Types.Kconstr (path, _) -> Some path
             in
             jkind_desc.mod_bounds, unresolved_base)
       in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -78,12 +78,6 @@ module Scannable_axes = struct
 
   let le sa1 sa2 = Misc.Le_result.is_le (less_or_equal sa1 sa2)
 
-  let meet { nullability = n1; separability = s1 }
-      { nullability = n2; separability = s2 } =
-    { nullability = Nullability.meet n1 n2;
-      separability = Separability.meet s1 s2
-    }
-
   let to_string_list_diff
       ~base:{ nullability = n_against; separability = s_against }
       { nullability; separability } =
@@ -132,18 +126,6 @@ module Layout = struct
       | Univar uv -> Univar uv
       | Genvar v -> Genvar v
 
-    (* if so, scannable axis annotations should not trigger a warning *)
-    let is_scannable_or_any = function
-      | Any _ | Base (Scannable, _) -> true
-      | Base
-          ( ( Void | Untagged_immediate | Float64 | Float32 | Word | Bits8
-            | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 ),
-            _ ) ->
-        false
-      | Product _ -> false
-      | Univar _ -> false
-      | Genvar _ -> false
-
     let rec equal_up_to_scannable_axes c1 c2 =
       match c1, c2 with
       | Base (b1, _), Base (b2, _) -> Sort.equal_base b1 b2
@@ -157,23 +139,6 @@ module Layout = struct
         uv1 == uv2
       | Genvar v1, Genvar v2 -> v1 == v2
       | (Base _ | Any _ | Product _ | Univar _ | Genvar _), _ -> false
-
-    (* Returns [None] if the root has no meaningful scannable axes. *)
-    let get_root_scannable_axes t =
-      match t with
-      | Any sa -> Some sa
-      | Base (_, sa) -> if is_scannable_or_any t then Some sa else None
-      | Product _ -> None
-      | Univar _ -> None
-      | Genvar _ -> None
-
-    let set_root_scannable_axes t sa =
-      match t with
-      | Any _ -> Any sa
-      | Base (b, _) -> if is_scannable_or_any t then Base (b, sa) else t
-      | Product _ -> t
-      | Univar _ -> t
-      | Genvar _ -> t
 
     let to_string t ~include_redundant_scannable_axes =
       let rec to_string nested (t : t) =
@@ -679,7 +644,11 @@ type jkind_context =
 module Base = struct
   let to_string layout_to_string = function
     | Layout l -> layout_to_string l
-    | Kconstr p -> Path.name p
+    | Kconstr (p, sa) -> (
+      match Scannable_axes.to_string_list sa with
+      | [] -> Path.name p
+      | _ :: _ as sa_strs ->
+        Printf.sprintf "%s mod %s" (Path.name p) (String.concat " " sa_strs))
 
   (* This is only correct on bases that have been fully expanded or that come
      from the output of [Base.expand_until_comparable]. See comment on
@@ -687,10 +656,15 @@ module Base = struct
   let sub_expanded base1 base2 =
     match base1, base2 with
     | Layout l1, Layout l2 -> Layout.sub l1 l2
-    | Kconstr k1, Kconstr k2 when Path.same k1 k2 -> Sub_result.Equal
-    | Kconstr _, Layout (Layout.Any sa)
-      when Scannable_axes.equal sa Scannable_axes.max ->
-      Sub_result.Less
+    | Kconstr (k1, sa1), Kconstr (k2, sa2) when Path.same k1 k2 -> (
+      match Scannable_axes.less_or_equal sa1 sa2 with
+      | Equal -> Sub_result.Equal
+      | Less -> Sub_result.Less
+      | Not_le -> Sub_result.Not_le [Layout_disagreement])
+    | Kconstr (_, sa_k), Layout (Layout.Any sa_any) -> (
+      match Scannable_axes.less_or_equal sa_k sa_any with
+      | Equal | Less -> Sub_result.Less
+      | Not_le -> Sub_result.Not_le [Layout_disagreement])
     | Kconstr _, Layout _ | Layout _, Kconstr _ | Kconstr _, Kconstr _ ->
       Sub_result.Not_le [Layout_disagreement]
 
@@ -705,21 +679,31 @@ module Base = struct
     | Kconstr _, Layout _ | Layout _, Kconstr _ -> false
 
   let map_layout ~f b =
-    match b with Layout l -> Layout (f l) | Kconstr b -> Kconstr b
+    match b with Layout l -> Layout (f l) | Kconstr (p, sa) -> Kconstr (p, sa)
 
   let format format_layout ppf base =
     match base with
     | Layout l -> format_layout ppf l
-    | Kconstr p -> Format.fprintf ppf "%s" (Path.name p)
+    | Kconstr (p, sa) -> (
+      let sa_strs = Scannable_axes.to_string_list sa in
+      match sa_strs with
+      | [] -> Format.fprintf ppf "%s" (Path.name p)
+      | _ :: _ ->
+        Format.fprintf ppf "%s mod %s" (Path.name p) (String.concat " " sa_strs)
+      )
 
   let expand_once (type a) env (t : a jkind_base) :
       Layout.Const.t jkind_base option =
     match t with
     | Layout _ -> None
-    | Kconstr p -> (
+    | Kconstr (p, sa) -> (
       match Env.find_jkind p env with
       | (exception Not_found) | { jkind_manifest = None; _ } -> None
-      | { jkind_manifest = Some { base; _ }; _ } -> Some base)
+      | { jkind_manifest = Some { base; _ }; _ } -> (
+        match base with
+        | Kconstr (p', sa') -> Some (Kconstr (p', Scannable_axes.meet sa sa'))
+        | Layout l -> Some (Layout (Layout.Const.meet_root_scannable_axes l sa))
+        ))
 
   let expand_pair env t1 t2 =
     let of_const = map_layout ~f:Layout.of_const in
@@ -751,14 +735,17 @@ module Base = struct
   let rec expand_until_comparable env t1 t2 =
     match t1, t2 with
     | Layout _, Layout _ -> Some (t1, t2)
-    | Kconstr p1, Kconstr p2 when Path.same p1 p2 -> Some (t1, t2)
-    | Kconstr _, Layout (Layout.Any sa)
-      when Scannable_axes.equal sa Scannable_axes.max ->
-      Some (t1, t2)
+    | Kconstr (p1, _), Kconstr (p2, _) when Path.same p1 p2 -> Some (t1, t2)
     | Kconstr _, Layout _ | Layout _, Kconstr _ | Kconstr _, Kconstr _ -> (
       match expand_pair env t1 t2 with
-      | None -> None
-      | Some (t1, t2) -> expand_until_comparable env t1 t2)
+      | Some (t1, t2) -> expand_until_comparable env t1 t2
+      | None -> (
+        (* Stuck on an abstract [Kconstr] with no manifest. [sub_expanded] can
+           still decide [Kconstr _, Layout (Any _)] via the stored [sa] upper
+           bound; other stuck cases fail. *)
+        match t1, t2 with
+        | Kconstr _, Layout (Layout.Any _) -> Some (t1, t2)
+        | _ -> None))
 end
 
 module Base_and_axes = struct
@@ -786,7 +773,7 @@ module Base_and_axes = struct
       (l * r) jkind_const_desc expand_result =
     match t.base with
     | Layout _ -> Not_expanded
-    | Kconstr p -> (
+    | Kconstr (p, sa) -> (
       match Env.find_jkind p env with
       | exception Not_found -> Missing_cmi p
       | { jkind_manifest = None; _ } -> Not_expanded
@@ -797,13 +784,27 @@ module Base_and_axes = struct
         if
           With_bounds.is_empty t.with_bounds
           && Mod_bounds.equal mod_bounds jkind.mod_bounds
+          &&
+          let sa_won't_strengthen_jkind =
+            match jkind.base with
+            | Kconstr (_, sa') -> Scannable_axes.le sa' sa
+            | Layout l -> (
+              match Layout.Const.get_root_scannable_axes l with
+              | None -> true
+              | Some sa' -> Scannable_axes.le sa' sa)
+          in
+          sa_won't_strengthen_jkind
         then
           (* If the expanded base is equal to the original jkind, don't allocate
              a new one. *)
           Expanded jkind
         else
-          Expanded
-            { base = jkind.base; mod_bounds; with_bounds = t.with_bounds })
+          let new_base =
+            match jkind.base with
+            | Kconstr (p', sa') -> Kconstr (p', Scannable_axes.meet sa sa')
+            | Layout l -> Layout (Layout.Const.meet_root_scannable_axes l sa)
+          in
+          Expanded { base = new_base; mod_bounds; with_bounds = t.with_bounds })
 
   let rec fully_expand_aliases_const env t : _ jkind_const_desc =
     match expand_base_once_const env t with
@@ -1408,8 +1409,10 @@ module Jkind_desc = struct
     | Layout l1, Layout l2 ->
       Layout.equate_or_equal ~allow_mutation l1 l2
       && Mod_bounds.equal mod_bounds1 mod_bounds2
-    | Kconstr p1, Kconstr p2
-      when Path.same p1 p2 && Mod_bounds.equal mod_bounds1 mod_bounds2 ->
+    | Kconstr (p1, sa1), Kconstr (p2, sa2)
+      when Path.same p1 p2
+           && Scannable_axes.equal sa1 sa2
+           && Mod_bounds.equal mod_bounds1 mod_bounds2 ->
       true
     | Layout _, Kconstr _ | Kconstr _, Layout _ | Kconstr _, Kconstr _ -> (
       match expand_pair env t1 t2 with
@@ -1495,10 +1498,11 @@ module Jkind_desc = struct
       match Layout.intersection l1 l2 with
       | None -> No_intersection
       | Some l -> make_intersection (Layout l))
-    | Kconstr p1, Kconstr p2 when Path.same p1 p2 -> make_intersection base1
-    | (Layout (Layout.Any sa), base | base, Layout (Layout.Any sa))
-      when Scannable_axes.equal sa Scannable_axes.max ->
-      make_intersection base
+    | Kconstr (p1, sa1), Kconstr (p2, sa2) when Path.same p1 p2 ->
+      make_intersection (Kconstr (p1, Scannable_axes.meet sa1 sa2))
+    | Kconstr (p, sa_k), Layout (Layout.Any sa_any)
+    | Layout (Layout.Any sa_any), Kconstr (p, sa_k) ->
+      make_intersection (Kconstr (p, Scannable_axes.meet sa_k sa_any))
     | Layout _, Kconstr _ | Kconstr _, Layout _ | Kconstr _, Kconstr _ -> (
       match expand_pair env t1 t2 with
       | None -> Unknown
@@ -1510,10 +1514,15 @@ module Jkind_desc = struct
     | Some (t1, t2) -> (
       match t1, t2 with
       | Layout l1, Layout l2 -> Layout.sub l1 l2
-      | Kconstr _, Kconstr _ -> Sub_result.Equal
-      | Kconstr _, Layout (Layout.Any sa)
-        when Scannable_axes.equal sa Scannable_axes.max ->
-        Sub_result.Less
+      | Kconstr (_, sa1), Kconstr (_, sa2) -> (
+        match Scannable_axes.less_or_equal sa1 sa2 with
+        | Equal -> Sub_result.Equal
+        | Less -> Sub_result.Less
+        | Not_le -> Sub_result.Not_le [Layout_disagreement])
+      | Kconstr (_, sa_k), Layout (Layout.Any sa_any) -> (
+        match Scannable_axes.less_or_equal sa_k sa_any with
+        | Equal | Less -> Sub_result.Less
+        | Not_le -> Sub_result.Not_le [Layout_disagreement])
       | Kconstr _, Layout _ | Layout _, Kconstr _ ->
         Misc.fatal_error
           "Jkind.sub_layout: [expand_until_comparable] spec wrong")
@@ -1600,10 +1609,21 @@ module Const = struct
    fun env t ->
     match t.base with
     | Layout l -> Ok l
-    | Kconstr p -> (
+    | Kconstr (p, sa) -> (
       match Env.find_jkind_expansion p env with
       | exception Not_found -> Error p
-      | jkind -> get_layout_result env jkind)
+      | jkind ->
+        (* Propagate the scannable axes upper bound. *)
+        let jkind =
+          match jkind.base with
+          | Layout l ->
+            { jkind with
+              base = Layout (Layout.Const.meet_root_scannable_axes l sa)
+            }
+          | Kconstr (p', sa') ->
+            { jkind with base = Kconstr (p', Scannable_axes.meet sa sa') }
+        in
+        get_layout_result env jkind)
 
   let equal env t1 t2 =
     Jkind_desc.equate_or_equal ~allow_mutation:false env
@@ -1724,24 +1744,31 @@ module Const = struct
       let actual = Base_and_axes.fully_expand_aliases_const env actual in
       let matching_layouts =
         match base_jkind.base, actual.base with
-        | Kconstr p1, Kconstr p2 -> Path.same p1 p2
+        | Kconstr (p1, _), Kconstr (p2, _) -> Path.same p1 p2
         | Layout l1, Layout l2 -> Layout.Const.equal_up_to_scannable_axes l1 l2
         | (Kconstr _ | Layout _), _ -> false
       in
+      (* Scannable axes are printed two ways. For [Layout] bases they decorate
+         the abbreviation (e.g. [value non_pointer]). For [Kconstr] bases they
+         go into the [mod] list alongside modal bounds (e.g. [k mod
+         separable]), because the overwrite-style abbreviation is an error on
+         abstract kinds. *)
       let scannable_axes =
-        match actual.base with
-        | Layout l ->
-          if Layout.Const.is_scannable_or_any l
-          then
-            match base_jkind.base with
-            | Layout base_l -> get_scannable_axes_diff ~base:base_l l
-            | Kconstr _ -> []
-          else []
-        | Kconstr _ -> []
+        match base_jkind.base, actual.base with
+        | Layout base_l, Layout l when Layout.Const.is_scannable_or_any l ->
+          get_scannable_axes_diff ~base:base_l l
+        | (Kconstr _ | Layout _), _ -> []
+      in
+      let kconstr_sa_mods =
+        match base_jkind.base, actual.base with
+        | Kconstr (_, base_sa), Kconstr (_, actual_sa) ->
+          Scannable_axes.to_string_list_diff ~base:base_sa actual_sa
+        | _ -> []
       in
       let modal_bounds =
         get_modal_bounds ~verbosity ~base:base_jkind.mod_bounds
           actual.mod_bounds
+        |> Option.map (fun bounds -> bounds @ kconstr_sa_mods)
       in
       let printable_with_bounds =
         (* This match statement is a bit of a hack. One usage of this function
@@ -1904,14 +1931,23 @@ module Const = struct
   (*******************************)
   (* converting user annotations *)
 
+  (* [f] receives [~abstract:true] when the base is a [Kconstr]. Callers that
+     only make sense on concrete layouts (the overwrite abbreviation form)
+     raise on that case; the meet [mod] form does the same thing regardless. *)
   let apply_kind_modifier env t (modifier : 'a Location.loc option)
-      (f : Scannable_axes.t -> 'a -> Warnings.loc -> Scannable_axes.t) =
+      (f :
+        abstract:bool ->
+        Scannable_axes.t ->
+        'a ->
+        Warnings.loc ->
+        Scannable_axes.t) =
     match modifier with
     | None -> t
     | Some { txt = modifier; loc } -> (
       let t = Base_and_axes.fully_expand_aliases_const env t in
       match t.base with
-      | Kconstr _ -> raise ~loc Abstract_kind_with_kind_modifier
+      | Kconstr (p, sa) ->
+        { t with base = Kconstr (p, f ~abstract:true sa modifier loc) }
       | Layout layout -> (
         match Layout.Const.get_root_scannable_axes layout with
         | None -> t
@@ -1919,11 +1955,13 @@ module Const = struct
           { t with
             base =
               Layout
-                (Layout.Const.set_root_scannable_axes layout (f sa modifier loc))
+                (Layout.Const.set_root_scannable_axes layout
+                   (f ~abstract:false sa modifier loc))
           }))
 
   let set_nullability ~abbrev env (nul : Nullability.t Location.loc option) t =
-    apply_kind_modifier env t nul (fun sa nullability loc ->
+    apply_kind_modifier env t nul (fun ~abstract sa nullability loc ->
+        if abstract then raise ~loc Abstract_kind_with_kind_modifier;
         if nullability = sa.nullability
         then
           Location.prerr_warning loc
@@ -1933,7 +1971,8 @@ module Const = struct
 
   let set_separability ~abbrev env (sep : Separability.t Location.loc option) t
       =
-    apply_kind_modifier env t sep (fun sa separability loc ->
+    apply_kind_modifier env t sep (fun ~abstract sa separability loc ->
+        if abstract then raise ~loc Abstract_kind_with_kind_modifier;
         if separability = sa.separability
         then
           Location.prerr_warning loc
@@ -1942,11 +1981,11 @@ module Const = struct
         { sa with separability })
 
   let meet_nullability env (nul : Nullability.t Location.loc option) t =
-    apply_kind_modifier env t nul (fun sa nullability _loc ->
+    apply_kind_modifier env t nul (fun ~abstract:_ sa nullability _loc ->
         { sa with nullability = Nullability.meet sa.nullability nullability })
 
   let meet_separability env (sep : Separability.t Location.loc option) t =
-    apply_kind_modifier env t sep (fun sa separability _loc ->
+    apply_kind_modifier env t sep (fun ~abstract:_ sa separability _loc ->
         { sa with
           separability = Separability.meet sa.separability separability
         })
@@ -2476,10 +2515,13 @@ let extract_layout : 'l 'r. _ -> ('l * 'r) jkind -> _ =
   (* Don't use [fully_expand_aliases] to avoid computing anything on bounds *)
   match t.jkind.base with
   | Layout l -> Ok l
-  | Kconstr p -> (
+  | Kconstr (p, sa) -> (
     match Env.find_jkind_expansion p env with
     | exception Not_found -> Error p
-    | jkind -> Const.get_layout_result env jkind |> Result.map Layout.of_const)
+    | jkind ->
+      Const.get_layout_result env jkind
+      |> Result.map Layout.of_const
+      |> Result.map (fun l -> Layout.meet_root_scannable_axes l sa))
 
 let extract_layout_opt env t = extract_layout env t |> Result.to_option
 
@@ -2568,21 +2610,23 @@ let set_externality_upper_bound jk externality_upper_bound =
       }
   }
 
+(* Only used by [apply_or_null_l]/[apply_or_null_r], which in turn need
+   [set_root_nullability]/[set_root_separability] to be meaningful. Those
+   setters are no-ops on [Kconstr], so there's nothing useful [apply_or_null]
+   can do with an abstract kind, and [None] is the right answer. *)
 let get_root_scannable_axes jk =
   match jk.jkind.base with
   | Layout l -> Layout.get_root_scannable_axes l
   | Kconstr _ -> None
 
 let get_nullability env jk =
+  (* Expand first so that concrete manifests refine the stored sa of any
+     intermediate [Kconstr]s; then read the resulting scannable axes. *)
+  let expanded = Base_and_axes.fully_expand_aliases env jk.jkind in
   let sa =
-    match get_root_scannable_axes jk with
-    | Some _ as sa -> sa
-    | None -> (
-      (* Expand abstract kinds (Kconstr) to access the layout *)
-      let expanded = Base_and_axes.fully_expand_aliases env jk.jkind in
-      match expanded.base with
-      | Layout l -> Layout.get_root_scannable_axes l
-      | Kconstr _ -> None)
+    match expanded.base with
+    | Layout l -> Layout.get_root_scannable_axes l
+    | Kconstr (_, sa) -> Some sa
   in
   Option.map (fun ({ nullability; _ } : Scannable_axes.t) -> nullability) sa
 
@@ -4144,7 +4188,8 @@ let report_error ~loc : Error.t -> _ = function
     Location.errorf ~loc "Abstract kinds are not yet supported in products."
   | Abstract_kind_with_kind_modifier ->
     Location.errorf ~loc
-      "Abstract kinds with kind modifiers are not yet supported."
+      "Abstract kinds with kind abbreviation modifiers are not supported.@ \
+       Hint: Use \"mod\" to upper-bound an abstract kind."
 
 let () =
   Location.register_error_of_exn (function

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2690,8 +2690,10 @@ let apply_modality_r modality jk =
   { jk with jkind = { jk.jkind with mod_bounds } } |> disallow_left
 
 let apply_or_null_l env jkind =
-  let expanded = Base_and_axes.fully_expand_aliases env jkind.jkind in
-  match Jkind_desc.get_scannable_axes_of_fully_expanded expanded with
+  let jkind =
+    { jkind with jkind = Base_and_axes.fully_expand_aliases env jkind.jkind }
+  in
+  match Jkind_desc.get_scannable_axes_of_fully_expanded jkind.jkind with
   | Some { nullability = Non_null; separability } ->
     let jkind = set_root_nullability jkind Maybe_null in
     let jkind =
@@ -2704,8 +2706,10 @@ let apply_or_null_l env jkind =
   | Some { nullability = Maybe_null; separability = _ } | None -> Error ()
 
 let apply_or_null_r env jkind =
-  let expanded = Base_and_axes.fully_expand_aliases env jkind.jkind in
-  match Jkind_desc.get_scannable_axes_of_fully_expanded expanded with
+  let jkind =
+    { jkind with jkind = Base_and_axes.fully_expand_aliases env jkind.jkind }
+  in
+  match Jkind_desc.get_scannable_axes_of_fully_expanded jkind.jkind with
   | Some { nullability = Maybe_null; separability } ->
     let jkind = set_root_nullability jkind Non_null in
     let jkind =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -72,12 +72,6 @@ module Scannable_axes = struct
 
   let le sa1 sa2 = Misc.Le_result.is_le (less_or_equal sa1 sa2)
 
-  let meet { nullability = n1; separability = s1 }
-      { nullability = n2; separability = s2 } =
-    { nullability = Nullability.meet n1 n2;
-      separability = Separability.meet s1 s2
-    }
-
   (* A scannable axis annotation can only lower, so [base] is only a valid
      prefix when [actual <= base] on every axis. If it's not, return [None]. *)
   let to_string_list_diff
@@ -132,18 +126,6 @@ module Layout = struct
       | Univar uv -> Univar uv
       | Genvar v -> Genvar v
 
-    (* if so, scannable axis annotations should not trigger a warning *)
-    let is_scannable_or_any = function
-      | Any _ | Base (Scannable, _) -> true
-      | Base
-          ( ( Void | Untagged_immediate | Float64 | Float32 | Word | Bits8
-            | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 ),
-            _ ) ->
-        false
-      | Product _ -> false
-      | Univar _ -> false
-      | Genvar _ -> false
-
     let rec equal_up_to_scannable_axes c1 c2 =
       match c1, c2 with
       | Base (b1, _), Base (b2, _) -> Sort.equal_base b1 b2
@@ -157,23 +139,6 @@ module Layout = struct
         uv1 == uv2
       | Genvar v1, Genvar v2 -> v1 == v2
       | (Base _ | Any _ | Product _ | Univar _ | Genvar _), _ -> false
-
-    (* Returns [None] if the root has no meaningful scannable axes. *)
-    let get_root_scannable_axes t =
-      match t with
-      | Any sa -> Some sa
-      | Base (_, sa) -> if is_scannable_or_any t then Some sa else None
-      | Product _ -> None
-      | Univar _ -> None
-      | Genvar _ -> None
-
-    let set_root_scannable_axes t sa =
-      match t with
-      | Any _ -> Any sa
-      | Base (b, _) -> if is_scannable_or_any t then Base (b, sa) else t
-      | Product _ -> t
-      | Univar _ -> t
-      | Genvar _ -> t
 
     (* Compute how to print the layout [scannable sa] *)
     let format_scannable_layout ~include_redundant_scannable_axes
@@ -511,7 +476,6 @@ module Error = struct
     | Unimplemented_syntax
     | With_on_right : (_ * allowed) History.annotation_context -> t
     | Abstract_kind_in_product
-    | Abstract_kind_with_kind_modifier
 
   exception User_error of Location.t * t
 end
@@ -717,7 +681,11 @@ type jkind_context =
 module Base = struct
   let to_string layout_to_string = function
     | Layout l -> layout_to_string l
-    | Kconstr p -> Path.name p
+    | Kconstr (p, sa) -> (
+      match Scannable_axes.to_string_list sa with
+      | [] -> Path.name p
+      | _ :: _ as sa_strs ->
+        Printf.sprintf "%s %s" (Path.name p) (String.concat " " sa_strs))
 
   (* This is only correct on bases that have been fully expanded or that come
      from the output of [Base.expand_until_comparable]. See comment on
@@ -725,10 +693,15 @@ module Base = struct
   let sub_expanded base1 base2 =
     match base1, base2 with
     | Layout l1, Layout l2 -> Layout.sub l1 l2
-    | Kconstr k1, Kconstr k2 when Path.same k1 k2 -> Sub_result.Equal
-    | Kconstr _, Layout (Layout.Any sa)
-      when Scannable_axes.equal sa Scannable_axes.max ->
-      Sub_result.Less
+    | Kconstr (k1, sa1), Kconstr (k2, sa2) when Path.same k1 k2 -> (
+      match Scannable_axes.less_or_equal sa1 sa2 with
+      | Equal -> Sub_result.Equal
+      | Less -> Sub_result.Less
+      | Not_le -> Sub_result.Not_le [Layout_disagreement])
+    | Kconstr (_, sa_k), Layout (Layout.Any sa_any) -> (
+      match Scannable_axes.less_or_equal sa_k sa_any with
+      | Equal | Less -> Sub_result.Less
+      | Not_le -> Sub_result.Not_le [Layout_disagreement])
     | Kconstr _, Layout _ | Layout _, Kconstr _ | Kconstr _, Kconstr _ ->
       Sub_result.Not_le [Layout_disagreement]
 
@@ -743,21 +716,30 @@ module Base = struct
     | Kconstr _, Layout _ | Layout _, Kconstr _ -> false
 
   let map_layout ~f b =
-    match b with Layout l -> Layout (f l) | Kconstr b -> Kconstr b
+    match b with Layout l -> Layout (f l) | Kconstr (p, sa) -> Kconstr (p, sa)
 
   let format format_layout ppf base =
     match base with
     | Layout l -> format_layout ppf l
-    | Kconstr p -> Format.fprintf ppf "%s" (Path.name p)
+    | Kconstr (p, sa) -> (
+      let sa_strs = Scannable_axes.to_string_list sa in
+      match sa_strs with
+      | [] -> Format.fprintf ppf "%s" (Path.name p)
+      | _ :: _ ->
+        Format.fprintf ppf "%s %s" (Path.name p) (String.concat " " sa_strs))
 
   let expand_once (type a) env (t : a jkind_base) :
       Layout.Const.t jkind_base option =
     match t with
     | Layout _ -> None
-    | Kconstr p -> (
+    | Kconstr (p, sa) -> (
       match Env.find_jkind p env with
       | (exception Not_found) | { jkind_manifest = None; _ } -> None
-      | { jkind_manifest = Some { base; _ }; _ } -> Some base)
+      | { jkind_manifest = Some { base; _ }; _ } -> (
+        match base with
+        | Kconstr (p', sa') -> Some (Kconstr (p', Scannable_axes.meet sa sa'))
+        | Layout l -> Some (Layout (Layout.Const.meet_root_scannable_axes l sa))
+        ))
 
   let expand_pair env t1 t2 =
     let of_const = map_layout ~f:Layout.of_const in
@@ -789,14 +771,17 @@ module Base = struct
   let rec expand_until_comparable env t1 t2 =
     match t1, t2 with
     | Layout _, Layout _ -> Some (t1, t2)
-    | Kconstr p1, Kconstr p2 when Path.same p1 p2 -> Some (t1, t2)
-    | Kconstr _, Layout (Layout.Any sa)
-      when Scannable_axes.equal sa Scannable_axes.max ->
-      Some (t1, t2)
+    | Kconstr (p1, _), Kconstr (p2, _) when Path.same p1 p2 -> Some (t1, t2)
     | Kconstr _, Layout _ | Layout _, Kconstr _ | Kconstr _, Kconstr _ -> (
       match expand_pair env t1 t2 with
-      | None -> None
-      | Some (t1, t2) -> expand_until_comparable env t1 t2)
+      | Some (t1, t2) -> expand_until_comparable env t1 t2
+      | None -> (
+        (* Stuck on an abstract [Kconstr] with no manifest. [sub_expanded] can
+           still decide [Kconstr _, Layout (Any _)] via the stored [sa] upper
+           bound; other stuck cases fail. *)
+        match t1, t2 with
+        | Kconstr _, Layout (Layout.Any _) -> Some (t1, t2)
+        | _ -> None))
 end
 
 module Base_and_axes = struct
@@ -824,7 +809,7 @@ module Base_and_axes = struct
       (l * r) jkind_const_desc expand_result =
     match t.base with
     | Layout _ -> Not_expanded
-    | Kconstr p -> (
+    | Kconstr (p, sa) -> (
       match Env.find_jkind p env with
       | exception Not_found -> Missing_cmi p
       | { jkind_manifest = None; _ } -> Not_expanded
@@ -835,13 +820,27 @@ module Base_and_axes = struct
         if
           With_bounds.is_empty t.with_bounds
           && Mod_bounds.equal mod_bounds jkind.mod_bounds
+          &&
+          let sa_won't_strengthen_jkind =
+            match jkind.base with
+            | Kconstr (_, sa') -> Scannable_axes.le sa' sa
+            | Layout l -> (
+              match Layout.Const.get_root_scannable_axes l with
+              | None -> true
+              | Some sa' -> Scannable_axes.le sa' sa)
+          in
+          sa_won't_strengthen_jkind
         then
           (* If the expanded base is equal to the original jkind, don't allocate
              a new one. *)
           Expanded jkind
         else
-          Expanded
-            { base = jkind.base; mod_bounds; with_bounds = t.with_bounds })
+          let new_base =
+            match jkind.base with
+            | Kconstr (p', sa') -> Kconstr (p', Scannable_axes.meet sa sa')
+            | Layout l -> Layout (Layout.Const.meet_root_scannable_axes l sa)
+          in
+          Expanded { base = new_base; mod_bounds; with_bounds = t.with_bounds })
 
   let rec fully_expand_aliases_const env t : _ jkind_const_desc =
     match expand_base_once_const env t with
@@ -1408,6 +1407,13 @@ module Jkind_desc = struct
     | No_intersection
     | Unknown
 
+  (* Precondition: [jk] is fully expanded, if we are to take the stored [sa]
+     from a [Kconstr] . *)
+  let get_scannable_axes_of_fully_expanded jk =
+    match jk.base with
+    | Layout l -> Layout.get_root_scannable_axes l
+    | Kconstr (_, sa) -> Some sa
+
   let unsafely_set_bounds env t ~from =
     let from = Base_and_axes.fully_expand_aliases env from in
     { t with mod_bounds = from.mod_bounds; with_bounds = from.with_bounds }
@@ -1446,8 +1452,10 @@ module Jkind_desc = struct
     | Layout l1, Layout l2 ->
       Layout.equate_or_equal ~allow_mutation l1 l2
       && Mod_bounds.equal mod_bounds1 mod_bounds2
-    | Kconstr p1, Kconstr p2
-      when Path.same p1 p2 && Mod_bounds.equal mod_bounds1 mod_bounds2 ->
+    | Kconstr (p1, sa1), Kconstr (p2, sa2)
+      when Path.same p1 p2
+           && Scannable_axes.equal sa1 sa2
+           && Mod_bounds.equal mod_bounds1 mod_bounds2 ->
       true
     | Layout _, Kconstr _ | Kconstr _, Layout _ | Kconstr _, Kconstr _ -> (
       match expand_pair env t1 t2 with
@@ -1533,10 +1541,11 @@ module Jkind_desc = struct
       match Layout.intersection l1 l2 with
       | None -> No_intersection
       | Some l -> make_intersection (Layout l))
-    | Kconstr p1, Kconstr p2 when Path.same p1 p2 -> make_intersection base1
-    | (Layout (Layout.Any sa), base | base, Layout (Layout.Any sa))
-      when Scannable_axes.equal sa Scannable_axes.max ->
-      make_intersection base
+    | Kconstr (p1, sa1), Kconstr (p2, sa2) when Path.same p1 p2 ->
+      make_intersection (Kconstr (p1, Scannable_axes.meet sa1 sa2))
+    | Kconstr (p, sa_k), Layout (Layout.Any sa_any)
+    | Layout (Layout.Any sa_any), Kconstr (p, sa_k) ->
+      make_intersection (Kconstr (p, Scannable_axes.meet sa_k sa_any))
     | Layout _, Kconstr _ | Kconstr _, Layout _ | Kconstr _, Kconstr _ -> (
       match expand_pair env t1 t2 with
       | None -> Unknown
@@ -1548,10 +1557,15 @@ module Jkind_desc = struct
     | Some (t1, t2) -> (
       match t1, t2 with
       | Layout l1, Layout l2 -> Layout.sub l1 l2
-      | Kconstr _, Kconstr _ -> Sub_result.Equal
-      | Kconstr _, Layout (Layout.Any sa)
-        when Scannable_axes.equal sa Scannable_axes.max ->
-        Sub_result.Less
+      | Kconstr (_, sa1), Kconstr (_, sa2) -> (
+        match Scannable_axes.less_or_equal sa1 sa2 with
+        | Equal -> Sub_result.Equal
+        | Less -> Sub_result.Less
+        | Not_le -> Sub_result.Not_le [Layout_disagreement])
+      | Kconstr (_, sa_k), Layout (Layout.Any sa_any) -> (
+        match Scannable_axes.less_or_equal sa_k sa_any with
+        | Equal | Less -> Sub_result.Less
+        | Not_le -> Sub_result.Not_le [Layout_disagreement])
       | Kconstr _, Layout _ | Layout _, Kconstr _ ->
         Misc.fatal_error
           "Jkind.sub_layout: [expand_until_comparable] spec wrong")
@@ -1629,6 +1643,15 @@ end
 module Const = struct
   include Jkind0.Const
 
+  (* Precondition: [jk] is fully expanded (e.g. via
+     [Base_and_axes.fully_expand_aliases_const]), otherwise the stored [sa] on
+     a [Kconstr] is just the user-written upper bound and may not reflect a
+     tighter manifest. *)
+  let get_scannable_axes_of_fully_expanded jk =
+    match jk.base with
+    | Layout l -> Layout.Const.get_root_scannable_axes l
+    | Kconstr (_, sa) -> Some sa
+
   let expand_once env t =
     match Base_and_axes.expand_base_once_const env t with
     | Expanded t -> Some t
@@ -1638,10 +1661,21 @@ module Const = struct
    fun env t ->
     match t.base with
     | Layout l -> Ok l
-    | Kconstr p -> (
+    | Kconstr (p, sa) -> (
       match Env.find_jkind_expansion p env with
       | exception Not_found -> Error p
-      | jkind -> get_layout_result env jkind)
+      | jkind ->
+        (* Propagate the scannable axes upper bound. *)
+        let jkind =
+          match jkind.base with
+          | Layout l ->
+            { jkind with
+              base = Layout (Layout.Const.meet_root_scannable_axes l sa)
+            }
+          | Kconstr (p', sa') ->
+            { jkind with base = Kconstr (p', Scannable_axes.meet sa sa') }
+        in
+        get_layout_result env jkind)
 
   let equal env t1 t2 =
     Jkind_desc.equate_or_equal ~allow_mutation:false env
@@ -1726,12 +1760,10 @@ module Const = struct
     (* Returns [None] if [actual] has any scannable axis strictly greater
        than [base], and thus can't be printed in terms of [base] *)
     let get_scannable_axes_diff ~base actual =
-      let base_sa = Layout.Const.get_root_scannable_axes base in
-      let actual_sa = Layout.Const.get_root_scannable_axes actual in
-      match base_sa, actual_sa with
+      match base, actual with
       | None, _ | _, None -> Some []
-      | Some base_sa, Some actual_sa ->
-        Scannable_axes.to_string_list_diff ~base:base_sa actual_sa
+      | Some base, Some actual ->
+        Scannable_axes.to_string_list_diff ~base actual
 
     let modalities_of_ignored_axes axes_to_ignore =
       (* The modality is constant along axes to ignore and id along others *)
@@ -1764,20 +1796,14 @@ module Const = struct
       let actual = Base_and_axes.fully_expand_aliases_const env actual in
       let matching_layouts =
         match base_jkind.base, actual.base with
-        | Kconstr p1, Kconstr p2 -> Path.same p1 p2
+        | Kconstr (p1, _), Kconstr (p2, _) -> Path.same p1 p2
         | Layout l1, Layout l2 -> Layout.Const.equal_up_to_scannable_axes l1 l2
         | (Kconstr _ | Layout _), _ -> false
       in
       let scannable_axes =
-        match actual.base with
-        | Layout l ->
-          if Layout.Const.is_scannable_or_any l
-          then
-            match base_jkind.base with
-            | Layout base_l -> get_scannable_axes_diff ~base:base_l l
-            | Kconstr _ -> Some []
-          else Some []
-        | Kconstr _ -> Some []
+        get_scannable_axes_diff
+          ~base:(get_scannable_axes_of_fully_expanded base_jkind)
+          (get_scannable_axes_of_fully_expanded actual)
       in
       let modal_bounds =
         get_modal_bounds ~verbosity ~base:base_jkind.mod_bounds
@@ -1970,24 +1996,29 @@ module Const = struct
     match axis with
     | None -> t
     | Some { txt = axis; loc } -> (
+      let update_sa sa =
+        let sa' = Scannable_axis.lower_axes sa axis in
+        (match prior_annot with
+        | Some (abbrev, rev_axes) when Scannable_axes.equal sa sa' ->
+          Location.prerr_warning loc
+            (Warnings.Redundant_kind_modifier
+               (Format.asprintf "%a%s" Pprintast.longident abbrev
+                  (String.concat ""
+                     (List.rev_map (fun axis -> " " ^ axis) rev_axes))))
+        | _ -> ());
+        sa'
+      in
       let t = Base_and_axes.fully_expand_aliases_const env t in
       match t.base with
-      | Kconstr _ -> raise ~loc Abstract_kind_with_kind_modifier
+      | Kconstr (p, sa) -> { t with base = Kconstr (p, update_sa sa) }
       | Layout layout -> (
         match Layout.Const.get_root_scannable_axes layout with
         | None -> t
         | Some sa ->
-          let sa' = Scannable_axis.lower_axes sa axis in
-          (match prior_annot with
-          | Some (abbrev, rev_axes) when Scannable_axes.equal sa sa' ->
-            Location.prerr_warning loc
-              (Warnings.Redundant_kind_modifier
-                 (Format.asprintf "%a%s" Pprintast.longident abbrev
-                    (String.concat ""
-                       (List.rev_map (fun axis -> " " ^ axis) rev_axes))))
-          | _ -> ());
           { t with
-            base = Layout (Layout.Const.set_root_scannable_axes layout sa')
+            base =
+              Layout
+                (Layout.Const.set_root_scannable_axes layout (update_sa sa))
           }))
 
   let jkind_of_product_annotations (type l r) ~loc env (jkinds : (l * r) t list)
@@ -2500,10 +2531,13 @@ let extract_layout : 'l 'r. _ -> ('l * 'r) jkind -> _ =
   (* Don't use [fully_expand_aliases] to avoid computing anything on bounds *)
   match t.jkind.base with
   | Layout l -> Ok l
-  | Kconstr p -> (
+  | Kconstr (p, sa) -> (
     match Env.find_jkind_expansion p env with
     | exception Not_found -> Error p
-    | jkind -> Const.get_layout_result env jkind |> Result.map Layout.of_const)
+    | jkind ->
+      Const.get_layout_result env jkind
+      |> Result.map Layout.of_const
+      |> Result.map (fun l -> Layout.meet_root_scannable_axes l sa))
 
 let extract_layout_opt env t = extract_layout env t |> Result.to_option
 
@@ -2602,22 +2636,9 @@ let set_externality_upper_bound jk externality_upper_bound =
       }
   }
 
-let get_root_scannable_axes jk =
-  match jk.jkind.base with
-  | Layout l -> Layout.get_root_scannable_axes l
-  | Kconstr _ -> None
-
 let get_nullability env jk =
-  let sa =
-    match get_root_scannable_axes jk with
-    | Some _ as sa -> sa
-    | None -> (
-      (* Expand abstract kinds (Kconstr) to access the layout *)
-      let expanded = Base_and_axes.fully_expand_aliases env jk.jkind in
-      match expanded.base with
-      | Layout l -> Layout.get_root_scannable_axes l
-      | Kconstr _ -> None)
-  in
+  let expanded = Base_and_axes.fully_expand_aliases env jk.jkind in
+  let sa = Jkind_desc.get_scannable_axes_of_fully_expanded expanded in
   Option.map (fun ({ nullability; _ } : Scannable_axes.t) -> nullability) sa
 
 let set_root_nullability jk nullability =
@@ -2668,8 +2689,9 @@ let apply_modality_r modality jk =
   in
   { jk with jkind = { jk.jkind with mod_bounds } } |> disallow_left
 
-let apply_or_null_l jkind =
-  match get_root_scannable_axes jkind with
+let apply_or_null_l env jkind =
+  let expanded = Base_and_axes.fully_expand_aliases env jkind.jkind in
+  match Jkind_desc.get_scannable_axes_of_fully_expanded expanded with
   | Some { nullability = Non_null; separability } ->
     let jkind = set_root_nullability jkind Maybe_null in
     let jkind =
@@ -2681,8 +2703,9 @@ let apply_or_null_l jkind =
     Ok jkind
   | Some { nullability = Maybe_null; separability = _ } | None -> Error ()
 
-let apply_or_null_r jkind =
-  match get_root_scannable_axes jkind with
+let apply_or_null_r env jkind =
+  let expanded = Base_and_axes.fully_expand_aliases env jkind.jkind in
+  match Jkind_desc.get_scannable_axes_of_fully_expanded expanded with
   | Some { nullability = Maybe_null; separability } ->
     let jkind = set_root_nullability jkind Non_null in
     let jkind =
@@ -4212,9 +4235,6 @@ let report_error ~loc : Error.t -> _ = function
       Location.errorf ~loc "'with' syntax is not allowed on a right mode.")
   | Abstract_kind_in_product ->
     Location.errorf ~loc "Abstract kinds are not yet supported in products."
-  | Abstract_kind_with_kind_modifier ->
-    Location.errorf ~loc
-      "Abstract kinds with kind modifiers are not yet supported."
 
 let () =
   Location.register_error_of_exn (function

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2641,28 +2641,6 @@ let get_nullability env jk =
   let sa = Jkind_desc.get_scannable_axes_of_fully_expanded expanded in
   Option.map (fun ({ nullability; _ } : Scannable_axes.t) -> nullability) sa
 
-let set_root_nullability jk nullability =
-  { jk with
-    jkind =
-      { jk.jkind with
-        base =
-          Base.map_layout
-            ~f:(fun l -> Layout.set_root_nullability l nullability)
-            jk.jkind.base
-      }
-  }
-
-let set_root_separability jk separability =
-  { jk with
-    jkind =
-      { jk.jkind with
-        base =
-          Base.map_layout
-            ~f:(fun l -> Layout.set_root_separability l separability)
-            jk.jkind.base
-      }
-  }
-
 let set_layout jk layout =
   { jk with jkind = { jk.jkind with base = Layout layout } }
 
@@ -2695,14 +2673,18 @@ let apply_or_null_l env jkind =
   in
   match Jkind_desc.get_scannable_axes_of_fully_expanded jkind.jkind with
   | Some { nullability = Non_null; separability } ->
-    let jkind = set_root_nullability jkind Maybe_null in
-    let jkind =
-      match separability with
-      | Maybe_separable -> jkind
-      | Separable -> set_root_separability jkind Maybe_separable
-      | Non_float | Non_pointer64 | Non_pointer -> jkind
-    in
-    Ok jkind
+    begin match jkind.jkind.base with
+    | Kconstr _ -> Error ()
+    | Layout l ->
+      let l = Layout.set_root_nullability l Maybe_null in
+      let l =
+        match separability with
+        | Maybe_separable -> l
+        | Separable -> Layout.set_root_separability l Maybe_separable
+        | Non_float | Non_pointer64 | Non_pointer -> l
+      in
+      Ok (set_layout jkind l)
+    end
   | Some { nullability = Maybe_null; separability = _ } | None -> Error ()
 
 let apply_or_null_r env jkind =
@@ -2711,14 +2693,18 @@ let apply_or_null_r env jkind =
   in
   match Jkind_desc.get_scannable_axes_of_fully_expanded jkind.jkind with
   | Some { nullability = Maybe_null; separability } ->
-    let jkind = set_root_nullability jkind Non_null in
-    let jkind =
-      match separability with
-      | Maybe_separable -> jkind
-      | Separable -> set_root_separability jkind Non_float
-      | Non_float | Non_pointer64 | Non_pointer -> jkind
-    in
-    Ok jkind
+    begin match jkind.jkind.base with
+    | Kconstr _ -> Error ()
+    | Layout l ->
+      let l = Layout.set_root_nullability l Non_null in
+      let l =
+        match separability with
+        | Maybe_separable -> l
+        | Separable -> Layout.set_root_separability l Non_float
+        | Non_float | Non_pointer64 | Non_pointer -> l
+      in
+      Ok (set_layout jkind l)
+    end
   | Some { nullability = Non_null; separability = _ } -> Error ()
   | None ->
     Misc.fatal_error "or_null applied to a type without a scannable layout"

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -735,11 +735,8 @@ module Base = struct
     | Kconstr (p, sa) -> (
       match Env.find_jkind p env with
       | (exception Not_found) | { jkind_manifest = None; _ } -> None
-      | { jkind_manifest = Some { base; _ }; _ } -> (
-        match base with
-        | Kconstr (p', sa') -> Some (Kconstr (p', Scannable_axes.meet sa sa'))
-        | Layout l -> Some (Layout (Layout.Const.meet_root_scannable_axes l sa))
-        ))
+      | { jkind_manifest = Some { base; _ }; _ } ->
+        Some (Jkind0.Base_and_axes.meet_scannable_axes base sa))
 
   let expand_pair env t1 t2 =
     let of_const = map_layout ~f:Layout.of_const in
@@ -835,12 +832,11 @@ module Base_and_axes = struct
              a new one. *)
           Expanded jkind
         else
-          let new_base =
-            match jkind.base with
-            | Kconstr (p', sa') -> Kconstr (p', Scannable_axes.meet sa sa')
-            | Layout l -> Layout (Layout.Const.meet_root_scannable_axes l sa)
-          in
-          Expanded { base = new_base; mod_bounds; with_bounds = t.with_bounds })
+          Expanded
+            { base = meet_scannable_axes jkind.base sa;
+              mod_bounds;
+              with_bounds = t.with_bounds
+            })
 
   let rec fully_expand_aliases_const env t : _ jkind_const_desc =
     match expand_base_once_const env t with
@@ -1667,13 +1663,7 @@ module Const = struct
       | jkind ->
         (* Propagate the scannable axes upper bound. *)
         let jkind =
-          match jkind.base with
-          | Layout l ->
-            { jkind with
-              base = Layout (Layout.Const.meet_root_scannable_axes l sa)
-            }
-          | Kconstr (p', sa') ->
-            { jkind with base = Kconstr (p', Scannable_axes.meet sa sa') }
+          { jkind with base = Base_and_axes.meet_scannable_axes jkind.base sa }
         in
         get_layout_result env jkind)
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -116,6 +116,12 @@ module Layout : sig
 
   val sub : Sort.t t -> Sort.t t -> Sub_result.t
 
+  (** Updates the nullability on the layout's scannable axis. *)
+  val set_root_nullability : Sort.t t -> Jkind_axis.Nullability.t -> Sort.t t
+
+  (** Updates the separability on the layout's scannable axis. *)
+  val set_root_separability : Sort.t t -> Jkind_axis.Separability.t -> Sort.t t
+
   module Debug_printers : sig
     val t :
       (Format.formatter -> 'sort -> unit) -> Format.formatter -> 'sort t -> unit
@@ -306,6 +312,18 @@ module Builtin : sig
       But we cannot compile run-time manipulations of values of types with jkind
       [any]. *)
   val any : why:History.any_creation_reason -> 'd Types.jkind
+
+  (** Like [any], but with the given nullability on the scannable axis. *)
+  val any_with_nullability :
+    Jkind_axis.Nullability.t ->
+    why:History.any_creation_reason ->
+    'd Types.jkind
+
+  (** Like [any], but with the given separability on the scannable axis. *)
+  val any_with_separability :
+    Jkind_axis.Separability.t ->
+    why:History.any_creation_reason ->
+    'd Types.jkind
 
   (** Value of types of this jkind are not retained at all at runtime *)
   val void : why:History.void_creation_reason -> ('l * disallowed) Types.jkind
@@ -608,16 +626,6 @@ val set_externality_upper_bound :
 
 (** Gets the nullability from a jkind. Expands abstract kinds if needed. *)
 val get_nullability : Env.t -> 'd Types.jkind -> Jkind_axis.Nullability.t option
-
-(** Computes a jkind that is the same as the input but with an updated
-    nullability on the layout's scannable axis *)
-val set_root_nullability :
-  Types.jkind_r -> Jkind_axis.Nullability.t -> Types.jkind_r
-
-(** Computes a jkind that is the same as the input but with an updated
-    separability on the layout's scannable axis *)
-val set_root_separability :
-  Types.jkind_r -> Jkind_axis.Separability.t -> Types.jkind_r
 
 (** Sets the layout in a jkind. *)
 val set_layout : 'd Types.jkind -> Sort.t Layout.t -> 'd Types.jkind

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -639,13 +639,13 @@ val apply_modality_r :
     Adjusts nullability to be [Maybe_null], and separability to be
     [Maybe_separable] if it is already [Separable]. If the jkind is already
     [Maybe_null], fails. *)
-val apply_or_null_l : Types.jkind_l -> (Types.jkind_l, unit) result
+val apply_or_null_l : Env.t -> Types.jkind_l -> (Types.jkind_l, unit) result
 
 (** Change a jkind to be appropriate for an expectation of a type passed to the
     [or_null] constructor. Adjusts nullability to be [Non_null], and
     separability to be [Non_float] if it is demanded to be [Separable]. If the
     jkind is already [Non_null], fails. *)
-val apply_or_null_r : Types.jkind_r -> (Types.jkind_r, unit) result
+val apply_or_null_r : Env.t -> Types.jkind_r -> (Types.jkind_r, unit) result
 
 (** Extract out component jkinds from the product. Because there are no product
     jkinds, this is a bit of a lie: instead, this decomposes the layout but just

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -928,6 +928,12 @@ module Scannable_axes = struct
   let equal { nullability = n1; separability = s1 }
       { nullability = n2; separability = s2 } =
     Nullability.equal n1 n2 && Separability.equal s1 s2
+
+  let meet { nullability = n1; separability = s1 }
+      { nullability = n2; separability = s2 } =
+    { nullability = Nullability.meet n1 n2;
+      separability = Separability.meet s1 s2
+    }
 end
 
 module Layout = struct
@@ -968,6 +974,38 @@ module Layout = struct
           (Misc.Stdlib.List.map_option get_sort ts)
       | Univar uv -> Some (Sort.Const.Univar uv)
       | Genvar v -> Some (Sort.Const.Genvar v)
+
+    let is_scannable_or_any = function
+      | Any _ | Base (Scannable, _) -> true
+      | Base
+          ( ( Void | Untagged_immediate | Float64 | Float32 | Word | Bits8
+            | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 ),
+            _ ) ->
+        false
+      | Product _ -> false
+      | Univar _ -> false
+      | Genvar _ -> false
+
+    let get_root_scannable_axes t =
+      match t with
+      | Any sa -> Some sa
+      | Base (_, sa) -> if is_scannable_or_any t then Some sa else None
+      | Product _ -> None
+      | Univar _ -> None
+      | Genvar _ -> None
+
+    let set_root_scannable_axes t sa =
+      match t with
+      | Any _ -> Any sa
+      | Base (b, _) -> if is_scannable_or_any t then Base (b, sa) else t
+      | Product _ -> t
+      | Univar _ -> t
+      | Genvar _ -> t
+
+    let meet_root_scannable_axes t sa =
+      match get_root_scannable_axes t with
+      | None -> t
+      | Some sa' -> set_root_scannable_axes t (Scannable_axes.meet sa sa')
 
     module Static = struct
       let scannable_non_null_non_pointer =

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -1010,6 +1010,12 @@ module Scannable_axes = struct
     Misc.Le_result.combine
       (Nullability.less_or_equal n1 n2)
       (Separability.less_or_equal s1 s2)
+
+  let meet { nullability = n1; separability = s1 }
+      { nullability = n2; separability = s2 } =
+    { nullability = Nullability.meet n1 n2;
+      separability = Separability.meet s1 s2
+    }
 end
 
 module Layout = struct
@@ -1050,6 +1056,38 @@ module Layout = struct
           (Misc.Stdlib.List.map_option get_sort ts)
       | Univar uv -> Some (Sort.Const.Univar uv)
       | Genvar v -> Some (Sort.Const.Genvar v)
+
+    let is_scannable_or_any = function
+      | Any _ | Base (Scannable, _) -> true
+      | Base
+          ( ( Void | Untagged_immediate | Float64 | Float32 | Word | Bits8
+            | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 ),
+            _ ) ->
+        false
+      | Product _ -> false
+      | Univar _ -> false
+      | Genvar _ -> false
+
+    let get_root_scannable_axes t =
+      match t with
+      | Any sa -> Some sa
+      | Base (_, sa) -> if is_scannable_or_any t then Some sa else None
+      | Product _ -> None
+      | Univar _ -> None
+      | Genvar _ -> None
+
+    let set_root_scannable_axes t sa =
+      match t with
+      | Any _ -> Any sa
+      | Base (b, _) -> if is_scannable_or_any t then Base (b, sa) else t
+      | Product _ -> t
+      | Univar _ -> t
+      | Genvar _ -> t
+
+    let meet_root_scannable_axes t sa =
+      match get_root_scannable_axes t with
+      | None -> t
+      | Some sa' -> set_root_scannable_axes t (Scannable_axes.meet sa sa')
 
     module Static = struct
       let scannable_non_null_non_pointer =

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -126,6 +126,8 @@ module Scannable_axes : sig
   val equal : t -> t -> bool
 
   val less_or_equal : t -> t -> Misc.Le_result.t
+
+  val meet : t -> t -> t
 end
 
 module Layout : sig
@@ -159,6 +161,20 @@ module Layout : sig
     val max : t
 
     val get_sort : t -> Sort.Const.t option
+
+    val is_scannable_or_any : t -> bool
+
+    (** Returns [None] if the root of [t] has no meaningful scannable axes (e.g.
+        [Base Float64], [Product], [Univar], [Genvar]). *)
+    val get_root_scannable_axes : t -> Scannable_axes.t option
+
+    (** Updates the scannable axes at the root of [t] (changes nothing when
+        [get_root_scannable_axes] would return [None]). *)
+    val set_root_scannable_axes : t -> Scannable_axes.t -> t
+
+    (** Meets [sa] into [t]'s root scannable axes (if [t] has meaningful ones;
+        otherwise returns [t] unchanged). *)
+    val meet_root_scannable_axes : t -> Scannable_axes.t -> t
   end
 
   val of_const : Const.t -> Sort.t t

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -124,6 +124,8 @@ module Scannable_axes : sig
   val value_axes : t
 
   val equal : t -> t -> bool
+
+  val meet : t -> t -> t
 end
 
 module Layout : sig
@@ -157,6 +159,18 @@ module Layout : sig
     val max : t
 
     val get_sort : t -> Sort.Const.t option
+
+    val is_scannable_or_any : t -> bool
+
+    (** Returns [None] if the root of [t] has no meaningful scannable axes (e.g.
+        [Base Float64], [Product], [Univar], [Genvar]). *)
+    val get_root_scannable_axes : t -> Scannable_axes.t option
+
+    val set_root_scannable_axes : t -> Scannable_axes.t -> t
+
+    (** Meets [sa] into [t]'s root scannable axes (if [t] has meaningful ones;
+        otherwise returns [t] unchanged). *)
+    val meet_root_scannable_axes : t -> Scannable_axes.t -> t
   end
 
   val of_const : Const.t -> Sort.t t

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -131,9 +131,16 @@ module Scannable_axes : sig
 end
 
 module Layout : sig
-  (** Note that products have two possible encodings: as [Product ...] or as
+  (** Note that:
+
+      1. Products have two possible encodings: as [Product ...] or as
       [Sort (Product ...]. This duplication is hard to eliminate because of the
-      possibility that a sort variable may be instantiated by a product sort. *)
+      possibility that a sort variable may be instantiated by a product sort.
+
+      2. Scannable axes are meaningful only when the layout might be scannable
+      ([any], [scannable], a sort variable, or an abstract kind). On other
+      layouts they are ignored, so e.g. [float64 non_pointer] is equivalent to
+      [float64]. See [Layout.Const.get_root_scannable_axes]. *)
   type 'sort t =
     | Sort of 'sort * Scannable_axes.t
     | Product of 'sort t list

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -487,16 +487,23 @@ let apply_type_function params args body =
 
 let jkind_desc s jkind =
   match jkind.base with
-  | Kconstr p ->
+  | Kconstr (p, sa) ->
     begin match Path.Map.find p s.jkinds with
     | exception Not_found ->
       let p' = jkind_path s p in
       if Path.compare p' p = 0 then jkind else
-        { jkind with base = Kconstr p' }
-    | Jkind_path p -> { jkind with base = Kconstr p }
+        { jkind with base = Kconstr (p', sa) }
+    | Jkind_path p' -> { jkind with base = Kconstr (p', sa) }
     | Jkind_const { base; mod_bounds; with_bounds = No_with_bounds } ->
+      let new_base =
+        match base with
+        | Kconstr (p', sa') ->
+          Kconstr (p', Jkind_types.Scannable_axes.meet sa sa')
+        | Layout l ->
+          Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
+      in
       let const =
-        { base;
+        { base = new_base;
           mod_bounds = Jkind.Mod_bounds.meet mod_bounds jkind.mod_bounds;
           with_bounds = jkind.with_bounds }
       in
@@ -507,15 +514,22 @@ let jkind_desc s jkind =
 let jkind_const_desc s
       ({ with_bounds = No_with_bounds } as jkind : jkind_const_desc_lr) =
   match jkind.base with
-  | Kconstr p ->
+  | Kconstr (p, sa) ->
     begin match Path.Map.find p s.jkinds with
     | exception Not_found ->
       let p' = jkind_path s p in
       if Path.compare p' p = 0 then jkind else
-        { jkind with base = Kconstr p' }
-    | Jkind_path p -> { jkind with base = Kconstr p }
+        { jkind with base = Kconstr (p', sa) }
+    | Jkind_path p' -> { jkind with base = Kconstr (p', sa) }
     | Jkind_const { base; mod_bounds; with_bounds = No_with_bounds } ->
-      { base;
+      let new_base =
+        match base with
+        | Kconstr (p', sa') ->
+          Kconstr (p', Jkind_types.Scannable_axes.meet sa sa')
+        | Layout l ->
+          Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
+      in
+      { base = new_base;
         mod_bounds = Jkind.Mod_bounds.meet mod_bounds jkind.mod_bounds;
         with_bounds = jkind.with_bounds }
     end

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -581,15 +581,8 @@ let jkind_desc s jkind =
         { jkind with base = Kconstr (p', sa) }
     | Jkind_path p' -> { jkind with base = Kconstr (p', sa) }
     | Jkind_const { base; mod_bounds; with_bounds = No_with_bounds } ->
-      let new_base =
-        match base with
-        | Kconstr (p', sa') ->
-          Kconstr (p', Jkind_types.Scannable_axes.meet sa sa')
-        | Layout l ->
-          Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
-      in
       let const =
-        { base = new_base;
+        { base = Jkind.Base_and_axes.meet_scannable_axes base sa;
           mod_bounds = Jkind.Mod_bounds.meet mod_bounds jkind.mod_bounds;
           with_bounds = jkind.with_bounds }
       in
@@ -611,14 +604,7 @@ let jkind_const_desc s
         { jkind with base = Kconstr (p', sa) }
     | Jkind_path p' -> { jkind with base = Kconstr (p', sa) }
     | Jkind_const { base; mod_bounds; with_bounds = No_with_bounds } ->
-      let new_base =
-        match base with
-        | Kconstr (p', sa') ->
-          Kconstr (p', Jkind_types.Scannable_axes.meet sa sa')
-        | Layout l ->
-          Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
-      in
-      { base = new_base;
+      { base = Jkind.Base_and_axes.meet_scannable_axes base sa;
         mod_bounds = Jkind.Mod_bounds.meet mod_bounds jkind.mod_bounds;
         with_bounds = jkind.with_bounds }
     end

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -573,16 +573,23 @@ let rec layout s l =
 
 let jkind_desc s jkind =
   match jkind.base with
-  | Kconstr p ->
+  | Kconstr (p, sa) ->
     begin match Path.Map.find p s.jkinds with
     | exception Not_found ->
       let p' = jkind_path s p in
       if Path.compare p' p = 0 then jkind else
-        { jkind with base = Kconstr p' }
-    | Jkind_path p -> { jkind with base = Kconstr p }
+        { jkind with base = Kconstr (p', sa) }
+    | Jkind_path p' -> { jkind with base = Kconstr (p', sa) }
     | Jkind_const { base; mod_bounds; with_bounds = No_with_bounds } ->
+      let new_base =
+        match base with
+        | Kconstr (p', sa') ->
+          Kconstr (p', Jkind_types.Scannable_axes.meet sa sa')
+        | Layout l ->
+          Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
+      in
       let const =
-        { base;
+        { base = new_base;
           mod_bounds = Jkind.Mod_bounds.meet mod_bounds jkind.mod_bounds;
           with_bounds = jkind.with_bounds }
       in
@@ -596,15 +603,22 @@ let jkind_desc s jkind =
 let jkind_const_desc s
       ({ with_bounds = No_with_bounds } as jkind : jkind_const_desc_lr) =
   match jkind.base with
-  | Kconstr p ->
+  | Kconstr (p, sa) ->
     begin match Path.Map.find p s.jkinds with
     | exception Not_found ->
       let p' = jkind_path s p in
       if Path.compare p' p = 0 then jkind else
-        { jkind with base = Kconstr p' }
-    | Jkind_path p -> { jkind with base = Kconstr p }
+        { jkind with base = Kconstr (p', sa) }
+    | Jkind_path p' -> { jkind with base = Kconstr (p', sa) }
     | Jkind_const { base; mod_bounds; with_bounds = No_with_bounds } ->
-      { base;
+      let new_base =
+        match base with
+        | Kconstr (p', sa') ->
+          Kconstr (p', Jkind_types.Scannable_axes.meet sa sa')
+        | Layout l ->
+          Layout (Jkind_types.Layout.Const.meet_root_scannable_axes l sa)
+      in
+      { base = new_base;
         mod_bounds = Jkind.Mod_bounds.meet mod_bounds jkind.mod_bounds;
         with_bounds = jkind.with_bounds }
     end

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2726,7 +2726,8 @@ let check_well_founded_jkind_decl env loc recmod_ids path decl =
   match decl.Types.jkind_manifest with
   | None -> ()
   | Some { base = Layout _; _ } -> ()
-  | Some ({ base = Kconstr kpath; mod_bounds = _; with_bounds = No_with_bounds }
+  | Some ({ base = Kconstr (kpath, _); mod_bounds = _;
+            with_bounds = No_with_bounds }
           as manifest) ->
     if not (Path.exists_free recmod_ids kpath) then ()
     else
@@ -2740,7 +2741,7 @@ let check_well_founded_jkind_decl env loc recmod_ids path decl =
         | [] -> [expand]
         | _ :: _ ->
           (match manifest.base with
-           | Kconstr base_path -> [Contains (manifest, base_path); expand]
+           | Kconstr (base_path, _) -> [Contains (manifest, base_path); expand]
            | Layout _ -> assert false)
       in
       let rec follow current acc visited =
@@ -2752,7 +2753,7 @@ let check_well_founded_jkind_decl env loc recmod_ids path decl =
           None
         else
           match (Env.find_jkind current env).jkind_manifest with
-          | Some ({ base = Kconstr next; mod_bounds = _;
+          | Some ({ base = Kconstr (next, _); mod_bounds = _;
                     with_bounds = No_with_bounds } as m) ->
             follow next ((steps_of current m) @ acc) (current :: visited)
           | Some { base = Layout _; _ } | None -> None
@@ -4848,7 +4849,12 @@ module Reaching_path = struct
          : jkind_const_desc_lr ) =
     let pp_base ppf = function
       | Types.Layout l -> Fmt.fprintf ppf "%s" (Jkind.Layout.Const.to_string l)
-      | Kconstr p -> Printtyp.path ppf p
+      | Kconstr (p, sa) ->
+        (match Jkind.Scannable_axes.to_string_list sa with
+         | [] -> Printtyp.path ppf p
+         | _ :: _ as sa_strs ->
+           Fmt.fprintf ppf "%a mod %s" Printtyp.path p
+             (String.concat " " sa_strs))
     in
     let mod_strings =
       Typemode.untransl_mod_bounds mod_bounds

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2470,7 +2470,7 @@ let rec update_decl_jkind env dpath decl =
         in
         begin match
           Jkind.apply_modality_l modality jkind
-          |> Jkind.apply_or_null_l
+          |> Jkind.apply_or_null_l env
         with
         | Ok type_jkind -> cstrs, rep, type_jkind
         | Error () ->
@@ -3030,7 +3030,8 @@ let check_well_founded_jkind_decl env loc recmod_ids path decl =
   match decl.Types.jkind_manifest with
   | None -> ()
   | Some { base = Layout _; _ } -> ()
-  | Some ({ base = Kconstr kpath; mod_bounds = _; with_bounds = No_with_bounds }
+  | Some ({ base = Kconstr (kpath, _); mod_bounds = _;
+            with_bounds = No_with_bounds }
           as manifest) ->
     if not (Path.exists_free recmod_ids kpath) then ()
     else
@@ -3044,7 +3045,7 @@ let check_well_founded_jkind_decl env loc recmod_ids path decl =
         | [] -> [expand]
         | _ :: _ ->
           (match manifest.base with
-           | Kconstr base_path -> [Contains (manifest, base_path); expand]
+           | Kconstr (base_path, _) -> [Contains (manifest, base_path); expand]
            | Layout _ -> assert false)
       in
       let rec follow current acc visited =
@@ -3056,7 +3057,7 @@ let check_well_founded_jkind_decl env loc recmod_ids path decl =
           None
         else
           match (Env.find_jkind current env).jkind_manifest with
-          | Some ({ base = Kconstr next; mod_bounds = _;
+          | Some ({ base = Kconstr (next, _); mod_bounds = _;
                     with_bounds = No_with_bounds } as m) ->
             follow next ((steps_of current m) @ acc) (current :: visited)
           | Some { base = Layout _; _ } | None -> None
@@ -5255,7 +5256,12 @@ module Reaching_path = struct
          : jkind_const_desc_lr ) =
     let pp_base ppf = function
       | Types.Layout l -> Fmt.fprintf ppf "%s" (Jkind.Layout.Const.to_string l)
-      | Kconstr p -> Printtyp.path ppf p
+      | Kconstr (p, sa) ->
+        (match Jkind.Scannable_axes.to_string_list sa with
+         | [] -> Printtyp.path ppf p
+         | _ :: _ as sa_strs ->
+           Fmt.fprintf ppf "%a %s" Printtyp.path p
+             (String.concat " " sa_strs))
     in
     let mod_strings =
       Typemode.untransl_mod_bounds mod_bounds

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -237,7 +237,7 @@ and 'd with_bounds =
 
 and 'layout jkind_base =
   | Layout of 'layout
-  | Kconstr of Path.t
+  | Kconstr of Path.t * Jkind_types.Scannable_axes.t
 
 and ('layout, 'd) base_and_axes =
   { base : 'layout jkind_base;

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -242,7 +242,7 @@ and 'd with_bounds =
 
 and 'layout jkind_base =
   | Layout of 'layout
-  | Kconstr of Path.t
+  | Kconstr of Path.t * Jkind_types.Scannable_axes.t
 
 and ('layout, 'd) base_and_axes =
   { base : 'layout jkind_base;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -384,7 +384,7 @@ and 'd with_bounds =
 
 and 'layout jkind_base =
   | Layout of 'layout
-  | Kconstr of Path.t
+  | Kconstr of Path.t * Jkind_types.Scannable_axes.t
 
 and ('layout, 'd) base_and_axes =
   { base : 'layout jkind_base;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -386,7 +386,7 @@ and 'd with_bounds =
 
 and 'layout jkind_base =
   | Layout of 'layout
-  | Kconstr of Path.t
+  | Kconstr of Path.t * Jkind_types.Scannable_axes.t
 
 and ('layout, 'd) base_and_axes =
   { base : 'layout jkind_base;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1666,7 +1666,7 @@ let transl_type_scheme_lpoly env attrs loc vars inner_type =
         | Tvar { jkind; _ } ->
           let desc = jkind.jkind in
           (match desc.base with
-          | Kconstr (Pident id) ->
+          | Kconstr (Pident id, sa) ->
             let v_opt =
               List.find_map
                 (fun (id', v) ->
@@ -1676,8 +1676,7 @@ let transl_type_scheme_lpoly env attrs loc vars inner_type =
             (match v_opt with
             | Some v ->
               let base : Jkind_types.Sort.t Jkind_types.Layout.t jkind_base
-                = Layout (Sort (Var v, {separability = Maybe_separable;
-                                        nullability = Maybe_null})) in
+                = Layout (Sort (Var v, sa)) in
               let desc = {desc with base} in
               let jkind = {jkind with jkind = desc} in
               Types.set_var_jkind t jkind

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1704,7 +1704,7 @@ let transl_type_scheme_lpoly env attrs loc vars inner_type =
         | Tvar { jkind; _ } ->
           let desc = jkind.jkind in
           (match desc.base with
-          | Kconstr (Pident id) ->
+          | Kconstr (Pident id, sa) ->
             let v_opt =
               List.find_map
                 (fun (id', v) ->
@@ -1714,8 +1714,7 @@ let transl_type_scheme_lpoly env attrs loc vars inner_type =
             (match v_opt with
             | Some v ->
               let base : Jkind_types.Sort.t Jkind_types.Layout.t jkind_base
-                = Layout (Sort (Var v, {separability = Maybe_separable;
-                                        nullability = Maybe_null})) in
+                = Layout (Sort (Var v, sa)) in
               let desc = {desc with base} in
               let jkind = {jkind with jkind = desc} in
               Types.set_var_jkind t jkind


### PR DESCRIPTION
Allow writing nullability/separability upper bounds on abstract kinds. This enables signatures like:
```ocaml
module type S = sig
  kind_ k
  val get : ('a : k separable). 'a array -> 'a
end
```

For review:
- Some code was moved from `typing/jkind.ml` to `typing/jkind_types.ml` so it can be used in `typing/subst.ml`.