### PR TITLE
Add inlining size limits for functors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             ocamlparam: '_,Oclassic=1'
-            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
+            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
 
           - name: runtime4 (aarch64-darwin)
             config: --disable-runtime5 --disable-warn-error

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -948,6 +948,27 @@ let mk_flambda2_inline_large_function_size f =
       \     (Flambda 2 only)"
       Flambda2_inlining_default.default_arguments.large_function_size )
 
+let mk_flambda2_inline_small_functor_size f =
+  ( "-flambda2-inline-small-functor-size",
+    Arg.String f,
+    Printf.sprintf
+      "<int>|<round>=<int>[,...]\n\
+      \     Functors with a cost less than this will always be inlined\n\
+      \     unless an attribute instructs otherwise (default %d)\n\
+      \     (Flambda 2 only)"
+      Flambda2_inlining_default.default_arguments.small_functor_size )
+
+let mk_flambda2_inline_large_functor_size f =
+  ( "-flambda2-inline-large-functor-size",
+    Arg.String f,
+    Printf.sprintf
+      "<int>|<round>=<int>[,...]\n\
+      \     Functors with a cost greater than this will never be inlined\n\
+      \     unless an attribute instructs otherwise (default %d); speculative\n\
+      \     inlining will be disabled if equal to the small functor size\n\
+      \     (Flambda 2 only)"
+      Flambda2_inlining_default.default_arguments.large_functor_size )
+
 let mk_flambda2_inline_threshold f =
   ( "-flambda2-inline-threshold",
     Arg.String f,
@@ -1334,6 +1355,8 @@ module type Oxcaml_options = sig
   val flambda2_inline_poly_compare_cost : string -> unit
   val flambda2_inline_small_function_size : string -> unit
   val flambda2_inline_large_function_size : string -> unit
+  val flambda2_inline_small_functor_size : string -> unit
+  val flambda2_inline_large_functor_size : string -> unit
   val flambda2_inline_threshold : string -> unit
   val flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
   val no_flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
@@ -1536,6 +1559,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.flambda2_inline_small_function_size;
       mk_flambda2_inline_large_function_size
         F.flambda2_inline_large_function_size;
+      mk_flambda2_inline_small_functor_size F.flambda2_inline_small_functor_size;
+      mk_flambda2_inline_large_functor_size F.flambda2_inline_large_functor_size;
       mk_flambda2_inline_threshold F.flambda2_inline_threshold;
       mk_flambda2_speculative_inlining_only_if_arguments_useful
         F.flambda2_speculative_inlining_only_if_arguments_useful;
@@ -1937,6 +1962,16 @@ module Oxcaml_options_impl = struct
     Clflags.Int_arg_helper.parse spec
       "Syntax: -flambda2-inline-large-function-size <int> | <round>=<int>[,...]"
       Flambda2.Inlining.large_function_size
+
+  let flambda2_inline_small_functor_size spec =
+    Clflags.Int_arg_helper.parse spec
+      "Syntax: -flambda2-inline-small-functor-size <int> | <round>=<int>[,...]"
+      Flambda2.Inlining.small_functor_size
+
+  let flambda2_inline_large_functor_size spec =
+    Clflags.Int_arg_helper.parse spec
+      "Syntax: -flambda2-inline-large-functor-size <int> | <round>=<int>[,...]"
+      Flambda2.Inlining.large_functor_size
 
   let flambda2_inline_threshold spec =
     Clflags.Float_arg_helper.parse spec
@@ -2368,6 +2403,16 @@ module Extra_params = struct
         Clflags.Int_arg_helper.parse v
           "Bad syntax in OCAMLPARAM for 'flambda2-inline-large-function-size'"
           Flambda2.Inlining.large_function_size;
+        true
+    | "flambda2-inline-small-functor-size" ->
+        Clflags.Int_arg_helper.parse v
+          "Bad syntax in OCAMLPARAM for 'flambda2-inline-small-functor-size'"
+          Flambda2.Inlining.small_functor_size;
+        true
+    | "flambda2-inline-large-functor-size" ->
+        Clflags.Int_arg_helper.parse v
+          "Bad syntax in OCAMLPARAM for 'flambda2-inline-large-functor-size'"
+          Flambda2.Inlining.large_functor_size;
         true
     | "flambda2-inline-threshold" ->
         Clflags.Float_arg_helper.parse v

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -168,6 +168,8 @@ module type Oxcaml_options = sig
   val flambda2_inline_poly_compare_cost : string -> unit
   val flambda2_inline_small_function_size : string -> unit
   val flambda2_inline_large_function_size : string -> unit
+  val flambda2_inline_small_functor_size : string -> unit
+  val flambda2_inline_large_functor_size : string -> unit
   val flambda2_inline_threshold : string -> unit
   val flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
   val no_flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -380,6 +380,8 @@ module Flambda2 = struct
       poly_compare_cost : float;
       small_function_size : int;
       large_function_size : int;
+      small_functor_size : int;
+      large_functor_size : int;
       threshold : float;
     }
 
@@ -397,6 +399,8 @@ module Flambda2 = struct
         poly_compare_cost = 10. /. cost_divisor;
         small_function_size = 10;
         large_function_size = 10;
+        small_functor_size = 10;
+        large_functor_size = 20;
         threshold = 10.;
       }
 
@@ -419,6 +423,11 @@ module Flambda2 = struct
       ref (I.default Default.default_arguments.small_function_size)
     let large_function_size =
       ref (I.default Default.default_arguments.large_function_size)
+
+    let small_functor_size =
+      ref (I.default Default.default_arguments.small_functor_size)
+    let large_functor_size =
+      ref (I.default Default.default_arguments.large_functor_size)
 
     let threshold = ref (F.default Default.default_arguments.threshold)
 
@@ -454,6 +463,12 @@ module Flambda2 = struct
       set_int large_function_size
         Default.default_arguments.large_function_size
         (Some arg.large_function_size);
+      set_int small_functor_size
+        Default.default_arguments.small_functor_size
+        (Some arg.small_functor_size);
+      set_int large_functor_size
+        Default.default_arguments.large_functor_size
+        (Some arg.large_functor_size);
       set_float threshold Default.default_arguments.threshold
         (Some arg.threshold)
 
@@ -462,6 +477,7 @@ module Flambda2 = struct
       (* We set the small and large function sizes to the same value here to
          recover "classic mode" semantics (no speculative inlining). *)
       large_function_size = Default.default_arguments.small_function_size;
+      large_functor_size = Default.default_arguments.small_functor_size;
       (* [threshold] matches the current compiler's default.  (The factor of
          8 in that default is accounted for by [cost_divisor], above.) *)
       threshold = 10.;
@@ -478,6 +494,9 @@ module Flambda2 = struct
       poly_compare_cost = 3.0 *. Default.default_arguments.poly_compare_cost;
       small_function_size = 10 * Default.default_arguments.small_function_size;
       large_function_size = 50 * Default.default_arguments.large_function_size;
+      small_functor_size = 10 * Default.default_arguments.small_function_size;
+      large_functor_size =
+        2 * 50 * Default.default_arguments.large_function_size;
       threshold = 100.;
     }
 

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -494,11 +494,12 @@ module Flambda2 = struct
       poly_compare_cost = 3.0 *. Default.default_arguments.poly_compare_cost;
       small_function_size = 10 * Default.default_arguments.small_function_size;
       large_function_size = 50 * Default.default_arguments.large_function_size;
-      small_functor_size = 10 * Default.default_arguments.small_function_size;
+      small_functor_size = 10 * Default.default_arguments.small_functor_size;
       (* This allows functors 50% larger than those in [Stdlib.Map] and
          [Stdlib.Set] to be eligible for speculative inlining. *)
       large_functor_size =
-        15 * 50 * Default.default_arguments.large_function_size;
+        (* 7.5 * 50 * ... *)
+        15 * 25 * Default.default_arguments.large_functor_size;
       threshold = 100.;
     }
 

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -495,8 +495,10 @@ module Flambda2 = struct
       small_function_size = 10 * Default.default_arguments.small_function_size;
       large_function_size = 50 * Default.default_arguments.large_function_size;
       small_functor_size = 10 * Default.default_arguments.small_function_size;
+      (* This allows functors 50% larger than those in [Stdlib.Map] and
+         [Stdlib.Set] to be eligible for speculative inlining. *)
       large_functor_size =
-        2 * 50 * Default.default_arguments.large_function_size;
+        15 * 50 * Default.default_arguments.large_function_size;
       threshold = 100.;
     }
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -280,6 +280,8 @@ module Flambda2 : sig
       poly_compare_cost : float;
       small_function_size : int;
       large_function_size : int;
+      small_functor_size : int;
+      large_functor_size : int;
       threshold : float;
     }
 
@@ -304,6 +306,9 @@ module Flambda2 : sig
 
     val small_function_size : Clflags.Int_arg_helper.parsed ref
     val large_function_size : Clflags.Int_arg_helper.parsed ref
+
+    val small_functor_size : Clflags.Int_arg_helper.parsed ref
+    val large_functor_size : Clflags.Int_arg_helper.parsed ref
 
     val threshold : Clflags.Float_arg_helper.parsed ref
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -439,10 +439,11 @@ module Acc = struct
                   (Code_metadata.inline metadata)
                   (Code_metadata.cost_metrics metadata)
               with
-              | Attribute_inline | Small_function _ -> approx
+              | Attribute_inline | Small_function _ | Small_functor _ -> approx
               | Not_yet_decided | Never_inline_attribute | Stub | Recursive
-              | Function_body_too_large _ | Speculatively_inlinable _
-              | Functor _ | Jsir_inlining_disabled ->
+              | Function_body_too_large _ | Functor_body_too_large _
+              | Speculatively_inlinable _ | Speculatively_inlinable_functor _
+              | Jsir_inlining_disabled ->
                 Value_approximation.Closure_approximation
                   { code_id;
                     function_slot;

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -156,10 +156,9 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
     ~return_arity : Call_site_inlining_decision_type.t =
   let denv = DA.denv dacc in
   let disable_inlining = DE.disable_inlining denv in
-  let decision =
-    Code_or_metadata.code_metadata code_or_metadata
-    |> Code_metadata.inlining_decision
-  in
+  let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
+  let decision = Code_metadata.inlining_decision code_metadata in
+  let is_a_functor = Code_metadata.is_a_functor code_metadata in
   let in_a_stub, doing_speculative_inlining =
     match disable_inlining with
     | Disable_inlining Stub -> true, false
@@ -227,9 +226,12 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
             Float.compare evaluated_to threshold <= 0
           in
           if is_under_inline_threshold
-          then Speculatively_inline { cost_metrics; evaluated_to; threshold }
+          then
+            Speculatively_inline
+              { cost_metrics; evaluated_to; threshold; is_a_functor }
           else
-            Speculatively_not_inline { cost_metrics; evaluated_to; threshold })
+            Speculatively_not_inline
+              { cost_metrics; evaluated_to; threshold; is_a_functor })
 
 let get_rec_info dacc ~function_type =
   let rec_info = FT.rec_info function_type in

--- a/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
@@ -26,15 +26,18 @@ let make_decision0 ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
     if stub
     then Stub
     else
-      let large_function_size =
-        Inlining_arguments.large_function_size args |> Code_size.of_int
-      in
-      let small_function_size =
-        Inlining_arguments.small_function_size args |> Code_size.of_int
+      let large_size, small_size =
+        if is_a_functor
+        then
+          ( Inlining_arguments.large_functor_size args |> Code_size.of_int,
+            Inlining_arguments.small_functor_size args |> Code_size.of_int )
+        else
+          ( Inlining_arguments.large_function_size args |> Code_size.of_int,
+            Inlining_arguments.small_function_size args |> Code_size.of_int )
       in
       let size = Cost_metrics.size metrics in
-      let is_small = Code_size.( <= ) size small_function_size in
-      let is_large = Code_size.( <= ) large_function_size size in
+      let is_small = Code_size.( <= ) size small_size in
+      let is_large = Code_size.( <= ) large_size size in
       let is_recursive =
         match recursive with Recursive -> true | Non_recursive -> false
       in
@@ -47,17 +50,26 @@ let make_decision0 ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
         && not can_inline_recursive_functions
       then Recursive
       else if is_a_functor
-      then Functor { size }
-      else if is_large && not (Inline_attribute.equal inline Available_inline)
-      then Function_body_too_large large_function_size
-      else if is_small
       then
-        Small_function { size = Cost_metrics.size metrics; small_function_size }
+        if is_large && not (Inline_attribute.equal inline Available_inline)
+        then Functor_body_too_large large_size
+        else if is_small
+        then Small_functor { size; small_functor_size = small_size }
+        else
+          Speculatively_inlinable_functor
+            { size;
+              small_functor_size = small_size;
+              large_functor_size = large_size
+            }
+      else if is_large && not (Inline_attribute.equal inline Available_inline)
+      then Function_body_too_large large_size
+      else if is_small
+      then Small_function { size; small_function_size = small_size }
       else
         Speculatively_inlinable
-          { size = Cost_metrics.size metrics;
-            small_function_size;
-            large_function_size
+          { size;
+            small_function_size = small_size;
+            large_function_size = large_size
           }
 
 let make_decision ~inlining_arguments ~inline ~stub ~cost_metrics ~is_a_functor

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -37,7 +37,8 @@ type t =
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
-        threshold : float
+        threshold : float;
+        is_a_functor : bool
       }
   | Attribute_always
   | Replay_history_says_must_inline
@@ -47,7 +48,8 @@ type t =
   | Speculatively_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
-        threshold : float
+        threshold : float;
+        is_a_functor : bool
       }
   | Jsir_inlining_disabled
 
@@ -87,26 +89,32 @@ let [@ocamlformat "disable"] print ppf t =
       unroll_to
   | Continue_unrolling ->
     Format.fprintf ppf "Continue_unrolling"
-  | Speculatively_not_inline { cost_metrics; threshold; evaluated_to; } ->
+  | Speculatively_not_inline { cost_metrics; threshold; evaluated_to;
+                                is_a_functor; } ->
     Format.fprintf ppf
       "@[<hov 1>(Speculatively_not_inline@ \
         @[<hov 1>(cost_metrics@ %a)@]@ \
         @[<hov 1>(evaluated_to@ %f)@]@ \
-        @[<hov 1>(threshold@ %f)@]\
+        @[<hov 1>(threshold@ %f)@]@ \
+        @[<hov 1>(is_a_functor@ %b)@]\
         )@]"
       Cost_metrics.print cost_metrics
       evaluated_to
       threshold
-  | Speculatively_inline { cost_metrics; threshold; evaluated_to; } ->
+      is_a_functor
+  | Speculatively_inline { cost_metrics; threshold; evaluated_to;
+                            is_a_functor; } ->
     Format.fprintf ppf
       "@[<hov 1>(Speculatively_inline@ \
         @[<hov 1>(cost_metrics@ %a)@]@ \
         @[<hov 1>(evaluated_to@ %f)@]@ \
-        @[<hov 1>(threshold@ %f)@]\
+        @[<hov 1>(threshold@ %f)@]@ \
+        @[<hov 1>(is_a_functor@ %b)@]\
         )@]"
       Cost_metrics.print cost_metrics
       evaluated_to
       threshold
+      is_a_functor
   | Jsir_inlining_disabled -> Format.fprintf ppf "Jsir_inlining_disabled"
 
 type can_inline =
@@ -198,15 +206,19 @@ let report_reason fmt t =
       "this@ function@ was@ decided@ to@ be@ always@ inlined@ at@ its@ \
        definition@ site (annotated@ by@ [@inlined always]@ or@ determined@ to@ \
        be@ small@ enough)"
-  | Speculatively_not_inline { cost_metrics; evaluated_to; threshold } ->
+  | Speculatively_not_inline
+      { cost_metrics; evaluated_to; threshold; is_a_functor } ->
     Format.fprintf fmt
-      "the@ function@ was@ not@ inlined@ after@ speculation@ as@ its@ cost@ \
-       metrics were=%a,@ which@ was@ evaluated@ to@ %f > threshold %f"
+      "the@ %s@ was@ not@ inlined@ after@ speculation@ as@ its@ cost@ metrics \
+       were=%a,@ which@ was@ evaluated@ to@ %f > threshold %f"
+      (if is_a_functor then "functor" else "function")
       Cost_metrics.print cost_metrics evaluated_to threshold
-  | Speculatively_inline { cost_metrics; evaluated_to; threshold } ->
+  | Speculatively_inline { cost_metrics; evaluated_to; threshold; is_a_functor }
+    ->
     Format.fprintf fmt
-      "the@ function@ was@ inlined@ after@ speculation@ as@ its@ cost@ metrics \
+      "the@ %s@ was@ inlined@ after@ speculation@ as@ its@ cost@ metrics \
        were=%a,@ which@ was@ evaluated@ to@ %f <= threshold %f"
+      (if is_a_functor then "functor" else "function")
       Cost_metrics.print cost_metrics evaluated_to threshold
   | Jsir_inlining_disabled ->
     Format.fprintf fmt

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -30,7 +30,8 @@ type t =
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
-        threshold : float
+        threshold : float;
+        is_a_functor : bool
       }
   | Attribute_always
   | Replay_history_says_must_inline
@@ -40,7 +41,8 @@ type t =
   | Speculatively_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
-        threshold : float
+        threshold : float;
+        is_a_functor : bool
       }
   | Jsir_inlining_disabled
 

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -193,6 +193,10 @@ module Context = struct
             `Int (Inlining_arguments.large_function_size args);
             `String "branch cost";
             `Float (Inlining_arguments.branch_cost args) ];
+          [ `String "small functor size";
+            `Int (Inlining_arguments.small_functor_size args);
+            `String "large functor size";
+            `Int (Inlining_arguments.large_functor_size args) ];
           [ `String "threshold";
             `Float (Inlining_arguments.threshold args);
             `String "indirect call cost";

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -18,18 +18,27 @@ type t =
   | Not_yet_decided
   | Never_inline_attribute
   | Function_body_too_large of Code_size.t
+  | Functor_body_too_large of Code_size.t
   | Stub
   | Attribute_inline
   | Small_function of
       { size : Code_size.t;
         small_function_size : Code_size.t
       }
+  | Small_functor of
+      { size : Code_size.t;
+        small_functor_size : Code_size.t
+      }
   | Speculatively_inlinable of
       { size : Code_size.t;
         small_function_size : Code_size.t;
         large_function_size : Code_size.t
       }
-  | Functor of { size : Code_size.t }
+  | Speculatively_inlinable_functor of
+      { size : Code_size.t;
+        small_functor_size : Code_size.t;
+        large_functor_size : Code_size.t
+      }
   | Recursive
   | Jsir_inlining_disabled
 
@@ -42,6 +51,10 @@ let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf
       "@[<hov 1>(Function_body_too_large@ %a)@]"
       Code_size.print large_function_size
+  | Functor_body_too_large large_functor_size ->
+    Format.fprintf ppf
+      "@[<hov 1>(Functor_body_too_large@ %a)@]"
+      Code_size.print large_functor_size
   | Stub ->
     Format.fprintf ppf "Stub"
   | Attribute_inline ->
@@ -54,6 +67,14 @@ let [@ocamlformat "disable"] print ppf t =
         )@]"
       Code_size.print size
       Code_size.print small_function_size
+  | Small_functor {size; small_functor_size} ->
+    Format.fprintf ppf
+      "@[<hov 1>(Small_functor@ \
+        @[<hov 1>(size@ %a)@]@ \
+        @[<hov 1>(small_functor_size@ %a)@]\
+        )@]"
+      Code_size.print size
+      Code_size.print small_functor_size
   | Speculatively_inlinable {size;
                               small_function_size;
                               large_function_size} ->
@@ -66,12 +87,17 @@ let [@ocamlformat "disable"] print ppf t =
       Code_size.print size
       Code_size.print small_function_size
       Code_size.print large_function_size
-  | Functor { size } ->
+  | Speculatively_inlinable_functor
+      { size; small_functor_size; large_functor_size } ->
     Format.fprintf ppf
-      "@[<hov 1>(Functor@ \
-        @[<hov 1>(size@ %a)@]\
+      "@[<hov 1>(Speculatively_inlinable_functor@ \
+        @[<hov 1>(size@ %a)@]@ \
+        @[<hov 1>(small_functor_size@ %a)@]@ \
+        @[<hov 1>(large_functor_size@ %a)@]\
         )@]"
       Code_size.print size
+      Code_size.print small_functor_size
+      Code_size.print large_functor_size
   | Recursive ->
     Format.fprintf ppf "Recursive"
   | Jsir_inlining_disabled ->
@@ -88,6 +114,11 @@ let report_decision ppf t =
       "the@ function's@ body@ is@ too@ large,@ more@ specifically,@ it@ is@ \
        larger@ than@ the@ large@ function@ size:@ %a"
       Code_size.print large_function_size
+  | Functor_body_too_large large_functor_size ->
+    Format.fprintf ppf
+      "the@ functor's@ body@ is@ too@ large,@ more@ specifically,@ it@ is@ \
+       larger@ than@ the@ large@ functor@ size:@ %a"
+      Code_size.print large_functor_size
   | Stub -> Format.fprintf ppf "the@ function@ is@ a@ stub"
   | Attribute_inline ->
     Format.fprintf ppf
@@ -97,6 +128,11 @@ let report_decision ppf t =
       "the@ function's@ body@ is@ smaller@ than@ the@ threshold@ size@ for@ \
        small@ functions: size=%a <= large@ function@ size=%a"
       Code_size.print size Code_size.print small_function_size
+  | Small_functor { size; small_functor_size } ->
+    Format.fprintf ppf
+      "the@ functor's@ body@ is@ smaller@ than@ the@ threshold@ size@ for@ \
+       small@ functors: size=%a <= small@ functor@ size=%a"
+      Code_size.print size Code_size.print small_functor_size
   | Speculatively_inlinable { size; small_function_size; large_function_size }
     ->
     Format.fprintf ppf
@@ -105,10 +141,14 @@ let report_decision ppf t =
        function@ size=%a < size=%a < large@ function@ size=%a"
       Code_size.print small_function_size Code_size.print size Code_size.print
       large_function_size
-  | Functor _ ->
+  | Speculatively_inlinable_functor
+      { size; small_functor_size; large_functor_size } ->
     Format.fprintf ppf
-      "this@ function@ is@ a@ functor@ (so@ the@ large@ function@ threshold@ \
-       was@ not@ applied)"
+      "the@ functor's@ body@ is@ between@ the@ threshold@ size@ for@ small@ \
+       functors and the@ threshold@ size@ for@ large@ functors: small@ \
+       functor@ size=%a < size=%a < large@ functor@ size=%a"
+      Code_size.print small_functor_size Code_size.print size Code_size.print
+      large_functor_size
   | Recursive -> Format.fprintf ppf "this@ function@ is@ recursive"
   | Jsir_inlining_disabled ->
     Format.fprintf ppf
@@ -122,10 +162,12 @@ type inlining_behaviour =
 let behaviour t =
   match t with
   | Not_yet_decided | Never_inline_attribute | Function_body_too_large _
-  | Recursive | Jsir_inlining_disabled ->
+  | Functor_body_too_large _ | Recursive | Jsir_inlining_disabled ->
     Cannot_be_inlined
-  | Stub | Attribute_inline | Small_function _ -> Must_be_inlined
-  | Functor _ | Speculatively_inlinable _ -> Could_possibly_be_inlined
+  | Stub | Attribute_inline | Small_function _ | Small_functor _ ->
+    Must_be_inlined
+  | Speculatively_inlinable_functor _ | Speculatively_inlinable _ ->
+    Could_possibly_be_inlined
 
 let report fmt t =
   Format.fprintf fmt
@@ -144,8 +186,9 @@ let must_be_inlined t =
 let has_attribute_inline t =
   match t with
   | Attribute_inline -> true
-  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _ | Stub
-  | Small_function _ | Speculatively_inlinable _ | Functor _ | Recursive
+  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _
+  | Functor_body_too_large _ | Stub | Small_function _ | Small_functor _
+  | Speculatively_inlinable _ | Speculatively_inlinable_functor _ | Recursive
   | Jsir_inlining_disabled ->
     false
 
@@ -163,11 +206,18 @@ let equal t1 t2 =
     true
   | Function_body_too_large size1, Function_body_too_large size2 ->
     Code_size.equal size1 size2
+  | Functor_body_too_large size1, Functor_body_too_large size2 ->
+    Code_size.equal size1 size2
   | ( Small_function { size = size1; small_function_size = small_function_size1 },
       Small_function
         { size = size2; small_function_size = small_function_size2 } ) ->
     Code_size.equal size1 size2
     && Code_size.equal small_function_size1 small_function_size2
+  | ( Small_functor { size = size1; small_functor_size = small_functor_size1 },
+      Small_functor { size = size2; small_functor_size = small_functor_size2 } )
+    ->
+    Code_size.equal size1 size2
+    && Code_size.equal small_functor_size1 small_functor_size2
   | ( Speculatively_inlinable
         { size = size1;
           small_function_size = small_function_size1;
@@ -181,12 +231,25 @@ let equal t1 t2 =
     Code_size.equal size1 size2
     && Code_size.equal small_function_size1 small_function_size2
     && Code_size.equal large_function_size1 large_function_size2
-  | Functor { size = size1 }, Functor { size = size2 } ->
+  | ( Speculatively_inlinable_functor
+        { size = size1;
+          small_functor_size = small_functor_size1;
+          large_functor_size = large_functor_size1
+        },
+      Speculatively_inlinable_functor
+        { size = size2;
+          small_functor_size = small_functor_size2;
+          large_functor_size = large_functor_size2
+        } ) ->
     Code_size.equal size1 size2
+    && Code_size.equal small_functor_size1 small_functor_size2
+    && Code_size.equal large_functor_size1 large_functor_size2
   | Recursive, Recursive -> true
   | Jsir_inlining_disabled, Jsir_inlining_disabled -> true
   | ( ( Not_yet_decided | Never_inline_attribute | Function_body_too_large _
-      | Stub | Attribute_inline | Small_function _ | Speculatively_inlinable _
-      | Functor _ | Recursive | Jsir_inlining_disabled ),
+      | Functor_body_too_large _ | Stub | Attribute_inline | Small_function _
+      | Small_functor _ | Speculatively_inlinable _
+      | Speculatively_inlinable_functor _ | Recursive | Jsir_inlining_disabled
+        ),
       _ ) ->
     false

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -21,6 +21,8 @@ type t =
   | Functor_body_too_large of Code_size.t
   | Stub
   | Attribute_inline
+  (* CR mshinwell/bclement: we could consider combining Small_function and
+     Small_functor in the future, with a flag for functors *)
   | Small_function of
       { size : Code_size.t;
         small_function_size : Code_size.t

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -18,18 +18,27 @@ type t =
   | Not_yet_decided
   | Never_inline_attribute
   | Function_body_too_large of Code_size.t
+  | Functor_body_too_large of Code_size.t
   | Stub
   | Attribute_inline
   | Small_function of
       { size : Code_size.t;
         small_function_size : Code_size.t
       }
+  | Small_functor of
+      { size : Code_size.t;
+        small_functor_size : Code_size.t
+      }
   | Speculatively_inlinable of
       { size : Code_size.t;
         small_function_size : Code_size.t;
         large_function_size : Code_size.t
       }
-  | Functor of { size : Code_size.t }
+  | Speculatively_inlinable_functor of
+      { size : Code_size.t;
+        small_functor_size : Code_size.t;
+        large_functor_size : Code_size.t
+      }
   | Recursive
   | Jsir_inlining_disabled
 

--- a/middle_end/flambda2/terms/inlining_arguments.ml
+++ b/middle_end/flambda2/terms/inlining_arguments.ml
@@ -25,6 +25,8 @@ module Args = struct
       poly_compare_cost : float;
       small_function_size : int;
       large_function_size : int;
+      small_functor_size : int;
+      large_functor_size : int;
       threshold : float
     }
 
@@ -39,6 +41,8 @@ module Args = struct
         poly_compare_cost;
         small_function_size;
         large_function_size;
+        small_functor_size;
+        large_functor_size;
         threshold
       } opt_level =
     let module I = Flambda_features.Inlining in
@@ -53,6 +57,8 @@ module Args = struct
     && Float.equal poly_compare_cost (I.poly_compare_cost round_or_default)
     && Int.equal small_function_size (I.small_function_size round_or_default)
     && Int.equal large_function_size (I.large_function_size round_or_default)
+    && Int.equal small_functor_size (I.small_functor_size round_or_default)
+    && Int.equal large_functor_size (I.large_functor_size round_or_default)
     && Float.equal threshold (I.threshold round_or_default)
 
   let[@ocamlformat "disable"] print ppf t =
@@ -60,6 +66,7 @@ module Args = struct
           call_cost; alloc_cost; prim_cost; branch_cost;
           indirect_call_cost; poly_compare_cost;
           small_function_size; large_function_size;
+          small_functor_size; large_functor_size;
           threshold;
         } = t
     in
@@ -83,6 +90,8 @@ module Args = struct
          @[<hov 1>(poly_compare_cost@ %f)@]@ \
          @[<hov 1>(small_function_size@ %d)@]@ \
          @[<hov 1>(large_function_size@ %d)@]@ \
+         @[<hov 1>(small_functor_size@ %d)@]@ \
+         @[<hov 1>(large_functor_size@ %d)@]@ \
          @[<hov 1>(threshold@ %f)@]\
          )@]"
         max_inlining_depth
@@ -95,6 +104,8 @@ module Args = struct
         poly_compare_cost
         small_function_size
         large_function_size
+        small_functor_size
+        large_functor_size
         threshold
 
   let equal t1 t2 =
@@ -108,6 +119,8 @@ module Args = struct
           poly_compare_cost = t1_poly_compare_cost;
           small_function_size = t1_small_function_size;
           large_function_size = t1_large_function_size;
+          small_functor_size = t1_small_functor_size;
+          large_functor_size = t1_large_functor_size;
           threshold = t1_threshold
         } =
       t1
@@ -122,6 +135,8 @@ module Args = struct
           poly_compare_cost = t2_poly_compare_cost;
           small_function_size = t2_small_function_size;
           large_function_size = t2_large_function_size;
+          small_functor_size = t2_small_functor_size;
+          large_functor_size = t2_large_functor_size;
           threshold = t2_threshold
         } =
       t2
@@ -136,6 +151,8 @@ module Args = struct
     && Float.compare t1_poly_compare_cost t2_poly_compare_cost = 0
     && t1_small_function_size = t2_small_function_size
     && t1_large_function_size = t2_large_function_size
+    && t1_small_functor_size = t2_small_functor_size
+    && t1_large_functor_size = t2_large_functor_size
     && Float.compare t1_threshold t2_threshold = 0
 
   let ( <= ) t1 t2 =
@@ -157,6 +174,8 @@ module Args = struct
           poly_compare_cost = t1_poly_compare_cost;
           small_function_size = t1_small_function_size;
           large_function_size = t1_large_function_size;
+          small_functor_size = t1_small_functor_size;
+          large_functor_size = t1_large_functor_size;
           threshold = t1_threshold
         } =
       t1
@@ -171,6 +190,8 @@ module Args = struct
           poly_compare_cost = t2_poly_compare_cost;
           small_function_size = t2_small_function_size;
           large_function_size = t2_large_function_size;
+          small_functor_size = t2_small_functor_size;
+          large_functor_size = t2_large_functor_size;
           threshold = t2_threshold
         } =
       t2
@@ -185,6 +206,8 @@ module Args = struct
     && Float.compare t1_poly_compare_cost t2_poly_compare_cost <= 0
     && t1_small_function_size <= t2_small_function_size
     && t1_large_function_size <= t2_large_function_size
+    && t1_small_functor_size <= t2_small_functor_size
+    && t1_large_functor_size <= t2_large_functor_size
     && Float.compare t1_threshold t2_threshold <= 0
 
   let meet t1 t2 =
@@ -198,6 +221,8 @@ module Args = struct
           poly_compare_cost = t1_poly_compare_cost;
           small_function_size = t1_small_function_size;
           large_function_size = t1_large_function_size;
+          small_functor_size = t1_small_functor_size;
+          large_functor_size = t1_large_functor_size;
           threshold = t1_threshold
         } =
       t1
@@ -212,6 +237,8 @@ module Args = struct
           poly_compare_cost = t2_poly_compare_cost;
           small_function_size = t2_small_function_size;
           large_function_size = t2_large_function_size;
+          small_functor_size = t2_small_functor_size;
+          large_functor_size = t2_large_functor_size;
           threshold = t2_threshold
         } =
       t2
@@ -226,6 +253,8 @@ module Args = struct
       poly_compare_cost = Float.min t1_poly_compare_cost t2_poly_compare_cost;
       small_function_size = min t1_small_function_size t2_small_function_size;
       large_function_size = min t1_large_function_size t2_large_function_size;
+      small_functor_size = min t1_small_functor_size t2_small_functor_size;
+      large_functor_size = min t1_large_functor_size t2_large_functor_size;
       threshold = Float.min t1_threshold t2_threshold
     }
 
@@ -241,6 +270,8 @@ module Args = struct
       poly_compare_cost = I.poly_compare_cost (Round round);
       small_function_size = I.small_function_size (Round round);
       large_function_size = I.large_function_size (Round round);
+      small_functor_size = I.small_functor_size (Round round);
+      large_functor_size = I.large_functor_size (Round round);
       threshold = I.threshold (Round round)
     }
 end
@@ -266,6 +297,10 @@ let poly_compare_cost t = t.Args.poly_compare_cost
 let small_function_size t = t.Args.small_function_size
 
 let large_function_size t = t.Args.large_function_size
+
+let small_functor_size t = t.Args.small_functor_size
+
+let large_functor_size t = t.Args.large_functor_size
 
 let threshold t = t.Args.threshold
 

--- a/middle_end/flambda2/terms/inlining_arguments.mli
+++ b/middle_end/flambda2/terms/inlining_arguments.mli
@@ -50,4 +50,8 @@ val small_function_size : t -> int
 
 val large_function_size : t -> int
 
+val small_functor_size : t -> int
+
+val large_functor_size : t -> int
+
 val threshold : t -> float

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -251,6 +251,16 @@ module Inlining = struct
     | Round round -> IH.get ~key:round !I.large_function_size
     | Default opt_level -> (default_for_opt_level opt_level).large_function_size
 
+  let small_functor_size round_or_default =
+    match round_or_default with
+    | Round round -> IH.get ~key:round !I.small_functor_size
+    | Default opt_level -> (default_for_opt_level opt_level).small_functor_size
+
+  let large_functor_size round_or_default =
+    match round_or_default with
+    | Round round -> IH.get ~key:round !I.large_functor_size
+    | Default opt_level -> (default_for_opt_level opt_level).large_functor_size
+
   let threshold round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.threshold

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -152,6 +152,10 @@ module Inlining : sig
 
   val large_function_size : round_or_default -> int
 
+  val small_functor_size : round_or_default -> int
+
+  val large_functor_size : round_or_default -> int
+
   val threshold : round_or_default -> float
 
   val speculative_inlining_only_if_arguments_useful : unit -> bool

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
@@ -13,7 +13,7 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=[] : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=(:: ({ key = "key1"; value = 100 }, [])) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=(:: ({ key = "key2"; value = 200 }, (:: ({ key = "key1"; value = 100 }, [])))) : StringStore.t @ value)
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_set_operations [inlined] Test_simple_functor_dwarf.MakeSet.mem
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_set_operations(set={ root = (Node { value = 30; left = (Node { value = 20; left = (Node { value = 10; left = Empty; right = Empty; height = 1 }); right = Empty; height = 2 }); right = Empty; height = 3 }); count = 3 } : IntSet.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_store_operations(store=(:: ({ key = 2; value = 200 }, (:: ({ key = 1; value = 100 }, [])))) : IntStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 42; computed = 6.28; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 0; computed = 3.14; status = `Success } : IntCompute.result @ value)

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -65,10 +65,10 @@ let is_randomized () = Atomic.get randomized
 module Rng : sig
   val bits : unit -> int
 end = struct
-  (* This is safe since [bits] is a C call that cannot be preempted, 
+  (* This is safe since [bits] is a C call that cannot be preempted,
      we do not yield, and we do not borrow the state. *)
   let key = Domain.Safe.DLS.new_key Random.State.make_self_init
-  let[@inline] bits () = 
+  let[@inline] bits () =
     Random.State.bits (Obj.magic_uncontended (Domain.Safe.DLS.get key))
 end
 
@@ -490,7 +490,7 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
     let to_seq = to_seq
     let to_seq_keys = to_seq_keys
     let to_seq_values = to_seq_values
-  end
+  end [@@inline available]
 
 module Make(H: HashedType): (S with type key = H.t) =
   struct
@@ -504,7 +504,7 @@ module Make(H: HashedType): (S with type key = H.t) =
       let tbl = create 16 in
       replace_seq tbl i;
       tbl
-  end
+  end [@@inline available]
 
 module MakeSeededPortable(H: sig @@ portable include SeededHashedType end)
   : sig @@ portable include SeededS with type key = H.t end =
@@ -639,7 +639,7 @@ module MakeSeededPortable(H: sig @@ portable include SeededHashedType end)
     let to_seq = to_seq
     let to_seq_keys = to_seq_keys
     let to_seq_values = to_seq_values
-  end
+  end [@@inline available]
 
 module MakePortable(H: sig @@ portable include HashedType end)
   : sig @@ portable include S with type key = H.t end =
@@ -654,7 +654,7 @@ module MakePortable(H: sig @@ portable include HashedType end)
       let tbl = create 16 in
       replace_seq tbl i;
       tbl
-  end
+  end [@@inline available]
 
 (* Polymorphic hash function-based tables *)
 (* Code included below the functorial interface to guard against accidental

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -1025,4 +1025,4 @@ module MakePortable(Ord: sig @@ portable include OrderedType end) = struct
             end
       in
       seq_of_enum_ (aux low m End)
-end
+end [@@inline available]

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -1177,4 +1177,4 @@ module MakePortable(Ord: sig @@ portable include OrderedType end) =
             end
       in
       seq_of_enum_ (aux low s End)
-  end
+ end [@@inline available]

--- a/testsuite/tests/flambda2/examples/functor_call.ml
+++ b/testsuite/tests/flambda2/examples/functor_call.ml
@@ -2,6 +2,7 @@
  compile_only = "true";
  modules = "functor_with_rec.ml";
  flambda2;
+ ocamlopt_flags = "-O3";
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-simplify;
  check-fexpr-dump;

--- a/testsuite/tests/flambda2/examples/functor_call.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functor_call.simplify.reference
@@ -9,7 +9,7 @@ let code inline(always) loopify(never) size(5) newer_version_of(test_3)
   cont k (int_greaterthan)
 in
 let $camlFunctor_call__test_4 = closure test_3_1 @test in
-let $camlFunctor_call__Pmakeblock129 = Block 0 ($camlFunctor_call__test_4) in
+let $camlFunctor_call__Pmakeblock133 = Block 0 ($camlFunctor_call__test_4) in
 let code loopify(done) size(16) newer_version_of(foo_1_1)
       foo_1 (x : imm tagged)
         my_closure _region _ghost_region my_depth
@@ -25,11 +25,11 @@ let code loopify(done) size(16) newer_version_of(foo_1_1)
            let int_add = %int_barith.add (x_1, 1) in
            cont self (int_add))
 in
-let $camlFunctor_call__foo_6 =
+let $camlFunctor_call__foo_5 =
   closure foo_1 @foo
-  with { X = $camlFunctor_call__Pmakeblock129 }
+  with { X = $camlFunctor_call__Pmakeblock133 }
 in
 let $camlFunctor_call =
-  Block 0 ($camlFunctor_call__Pmakeblock129, $camlFunctor_call__foo_6)
+  Block 0 ($camlFunctor_call__Pmakeblock133, $camlFunctor_call__foo_5)
 in
 cont done ($camlFunctor_call)

--- a/testsuite/tests/flambda2/stdlib_functor_inlining.ml
+++ b/testsuite/tests/flambda2/stdlib_functor_inlining.ml
@@ -41,12 +41,13 @@ module S1 = (Set.Make [@inlined]) (Ord_key)
 module S2 = (Set.MakePortable [@inlined]) (Ord_key)
 
 (* Use something from each resulting module to prevent them being discarded
-   entirely. *)
-let _ = H1.create 0
-let _ = H2.create 0
-let _ = H3.create 0
-let _ = H4.create 0
-let _ = M1.empty
-let _ = M2.empty
-let _ = S1.empty
-let _ = S2.empty
+   entirely. [Sys.opaque_identity] is used to stop the optimizer removing the
+   allocations/uses. *)
+let _ = Sys.opaque_identity (H1.create 0 : int H1.t)
+let _ = Sys.opaque_identity (H2.create 0 : int H2.t)
+let _ = Sys.opaque_identity (H3.create 0 : int H3.t)
+let _ = Sys.opaque_identity (H4.create 0 : int H4.t)
+let _ = Sys.opaque_identity (M1.empty : int M1.t)
+let _ = Sys.opaque_identity (M2.empty : int M2.t)
+let _ = Sys.opaque_identity (S1.empty : S1.t)
+let _ = Sys.opaque_identity (S2.empty : S2.t)

--- a/testsuite/tests/flambda2/stdlib_functor_inlining.ml
+++ b/testsuite/tests/flambda2/stdlib_functor_inlining.ml
@@ -1,0 +1,52 @@
+(* TEST
+ compile_only = "true";
+ flags = "-w +a-70 -warn-error +55";
+ flambda2;
+ ocamlopt_flags = "-O3";
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+(* This test checks that the functors exposed in the stdlib interfaces of
+   Hashtbl, Map and Set can all be inlined at -O3.  Warning 55 ("inlining
+   impossible") would cause a test failure if any of them could not be
+   inlined at the [@inlined] functor application below. *)
+
+module H_key = struct
+  type t = int
+  let equal = Int.equal
+  let hash = Hashtbl.hash
+end
+
+module H_seeded_key = struct
+  type t = int
+  let equal = Int.equal
+  let seeded_hash = Hashtbl.seeded_hash
+end
+
+module Ord_key = struct
+  type t = int
+  let compare = Int.compare
+end
+
+module H1 = (Hashtbl.Make [@inlined]) (H_key)
+module H2 = (Hashtbl.MakePortable [@inlined]) (H_key)
+module H3 = (Hashtbl.MakeSeeded [@inlined]) (H_seeded_key)
+module H4 = (Hashtbl.MakeSeededPortable [@inlined]) (H_seeded_key)
+
+module M1 = (Map.Make [@inlined]) (Ord_key)
+module M2 = (Map.MakePortable [@inlined]) (Ord_key)
+
+module S1 = (Set.Make [@inlined]) (Ord_key)
+module S2 = (Set.MakePortable [@inlined]) (Ord_key)
+
+(* Use something from each resulting module to prevent them being discarded
+   entirely. *)
+let _ = H1.create 0
+let _ = H2.create 0
+let _ = H3.create 0
+let _ = H4.create 0
+let _ = M1.empty
+let _ = M2.empty
+let _ = S1.empty
+let _ = S2.empty


### PR DESCRIPTION
Currently, inlining of functors obeys the small function size threshold, but does not obey the large function size threshold (over which functions are deemed ineligible for inlining unless there is an appropriate attribute).  This patch provides separate limits for functors, including a large threshold, which is currently set at twice that for functions by default.

This dramatically reduces the time spent during speculative inlining when large functors are involved.  Such functors should be annotated with attributes if they are to be inlined.  (In addition, function return type tracking is enabled for functors by default at `-O3`, which means some optimizations can still be performed even if the functor in question is not inlined.)