### PR TITLE
Fix lambda_to_flambda for matches on GADTs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             ocamlparam: '_,Oclassic=1'
-            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
+            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/gadt_simplified_switch.ml'
 
           - name: runtime4 (aarch64-darwin)
             config: --disable-runtime5 --disable-warn-error

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1734,9 +1734,33 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
                 Flambda_kind.With_subkind.tagged_immediate ) ]
             Not_user_visible (Get_tag scrutinee) ~body
         in
-        if switch.sw_numblocks = 0
+        (* [sw_numblocks] and [sw_numconsts] count the number of block and
+           constant constructors in the _type definition_ of the switch, i.e.
+           one more than the largest possible block / constant tag (this is used
+           by the bytecode compiler).
+
+           If some of these have been eliminated by GADT reasoning, we can end
+           up in a situation where for instance:
+
+           - [sw_numconsts] is non-zero, because there are constant constructors
+           in the type declaration ;
+
+           - [consts] is empty, because all constant constructors are impossible
+           for the current match due to GADT reasoning ;
+
+           - There is no [failaction] (the pattern is exhaustive), because all
+           missing cases have been eliminated by GADT reasoning).
+
+           In this situation, we don't want to introduce the const/block switch
+           on %is_int, as one of the branches is already known to be
+           impossible. *)
+        if
+          switch.sw_numblocks = 0
+          || (Option.is_none failaction && List.is_empty blocks)
         then const_switch, wrappers
-        else if switch.sw_numconsts = 0
+        else if
+          switch.sw_numconsts = 0
+          || (Option.is_none failaction && List.is_empty consts)
         then block_switch, wrappers
         else
           let const_cont = Continuation.create () in

--- a/testsuite/tests/flambda2/examples/tests14.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests14.raw.reference
@@ -50,27 +50,16 @@ let $camlTests14__first_const = Block 0 () in
      where k3 (n : imm tagged) =
        cont k1 (1)
  in
- let code size(30)
+ let code size(12)
        gadt_match_3 (x : [ 0 |1 | 0 of imm tagged ], n : val)
          my_closure _region _ghost_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
-   (let prim = %is_int (x) in
-    let is_scrutinee_int = %tag_imm (prim) in
-    let untagged = %untag_imm (is_scrutinee_int) in
+   (let untagged = %untag_imm (x) in
     switch untagged
-      | 0 -> k4
-      | 1 -> k5)
-     where k5 =
-       let untagged = %untag_imm (x) in
-       switch untagged
-         | 0 -> k1 (n)
-         | 1 -> k3
-     where k4 =
-       let prim = %get_tag (x) in
-       let scrutinee_tag = %tag_imm (prim) in
-       invalid "Zero_switch_arms"
+      | 0 -> k1 (n)
+      | 1 -> k3)
      where k3 =
        let Popaque = %opaque (n) in
        cont k1 (Popaque)

--- a/testsuite/tests/flambda2/examples/tests14.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests14.simplify.reference
@@ -33,22 +33,15 @@ in
 let $camlTests14__needs_try_region_6 =
   closure needs_try_region_2_1 @needs_try_region
 in
-let code loopify(never) size(23) newer_version_of(gadt_match_3)
+let code loopify(never) size(12) newer_version_of(gadt_match_3)
       gadt_match_3_1 (x : [ 0 |1 | 0 of imm tagged ], n : val)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : val =
-  (let prim = %is_int (x) in
-   switch prim
-     | 0 -> k3
-     | 1 -> k4)
-    where k4 =
-      let untagged = %untag_imm (x) in
-      switch untagged
-        | 0 -> k (n)
-        | 1 -> k2
-    where k3 =
-      invalid "Zero_switch_arms"
+  (let untagged = %untag_imm (x) in
+   switch untagged
+     | 0 -> k (n)
+     | 1 -> k2)
     where k2 =
       let Popaque = %opaque (n) in
       cont k (Popaque)

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -1,30 +1,30 @@
-let $camlAlt_ergo__immstring46 = "alt_ergo.ml" in
-let $camlAlt_ergo__const_block48 =
-  Block 0 ($camlAlt_ergo__immstring46, 23, 4)
+let $camlAlt_ergo__immstring42 = "alt_ergo.ml" in
+let $camlAlt_ergo__const_block44 =
+  Block 0 ($camlAlt_ergo__immstring42, 23, 4)
 in
-let $camlAlt_ergo__Pmakeblock51 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block48)
+let $camlAlt_ergo__Pmakeblock47 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block44)
 in
-let $camlAlt_ergo__const_block54 =
-  Block 0 ($camlAlt_ergo__immstring46, 21, 14)
+let $camlAlt_ergo__const_block50 =
+  Block 0 ($camlAlt_ergo__immstring42, 21, 14)
 in
-let $camlAlt_ergo__Pmakeblock57 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block54)
+let $camlAlt_ergo__Pmakeblock53 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block50)
 in
 let code inv_borne_sup_1 deleted in
 let code inv_bornes_2 deleted in
-let $camlAlt_ergo__const_block93 =
-  Block 0 ($camlAlt_ergo__immstring46, 35, 24)
+let $camlAlt_ergo__const_block89 =
+  Block 0 ($camlAlt_ergo__immstring42, 35, 24)
 in
-let $camlAlt_ergo__Pmakeblock96 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block93)
+let $camlAlt_ergo__Pmakeblock92 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block89)
 in
 let code inv_3 deleted in
-let $camlAlt_ergo__const_block107 =
-  Block 0 ($camlAlt_ergo__immstring46, 40, 2)
+let $camlAlt_ergo__const_block103 =
+  Block 0 ($camlAlt_ergo__immstring42, 40, 2)
 in
-let $camlAlt_ergo__Pmakeblock110 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block107)
+let $camlAlt_ergo__Pmakeblock106 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block103)
 in
 let code div_4 deleted in
 let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
@@ -45,8 +45,8 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
     where k3 =
       let untagged = %untag_imm (b) in
       switch untagged
-        | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock51)
-        | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock57)
+        | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock47)
+        | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock53)
     where k2 =
       ((let Pfield = %block_load.[`0`] (b) in
         let Pfield_1 = %block_load.[`0`] (Pfield) in
@@ -118,12 +118,12 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock96)
+    | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock92)
     where k2 =
       let Pfield = %block_load.[`1`] (param) in
       let prim_1 = %is_int (Pfield) in
       (switch prim_1
-         | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock96)
+         | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock92)
          | 1 -> k2
          where k2 =
            let `*match*` = %block_load.[`0`] (param) in
@@ -160,7 +160,7 @@ let code loopify(never) size(11) newer_version_of(div_4)
      where k3 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
        cont k2)
     where k2 =
-      cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock110)
+      cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock106)
 in
 let $camlAlt_ergo__div_9 = closure div_4_1 @div in
 let $camlAlt_ergo = Block 0 ($camlAlt_ergo__div_9) in

--- a/testsuite/tests/flambda2/gadt_simplified_switch.ml
+++ b/testsuite/tests/flambda2/gadt_simplified_switch.ml
@@ -1,0 +1,30 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt.byte with dump-raw;
+   check-fexpr-dump;
+ *)
+
+(* This test is checking that we do not introduce spurious switches on %is_int
+   for GADTs where all of the constant or non-constant constructors have been
+   eliminated. *)
+
+type _ t =
+  | A : string t
+  | B : string t
+  | C : int -> int t
+  | D : int -> int t
+
+let extract_int (x : int t) =
+  (* This should not contain calls to the %is_int primitive *)
+  match x with
+  | C s -> s
+  | D s -> s + 1
+
+let extract_string (x : string t) =
+  (* This should not contain calls to the %is_int primitive *)
+  match x with
+  | A -> "A"
+  | B -> "B"
+

--- a/testsuite/tests/flambda2/gadt_simplified_switch.raw.reference
+++ b/testsuite/tests/flambda2/gadt_simplified_switch.raw.reference
@@ -1,0 +1,42 @@
+(let code size(21)
+       extract_int_0 (x : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   (let prim = %get_tag (x) in
+    let scrutinee_tag = %tag_imm (prim) in
+    let untagged = %untag_imm (scrutinee_tag) in
+    switch untagged
+      | 0 -> k3
+      | 1 -> k4)
+     where k4 =
+       let Pfield = %block_load.[`0`] (x) in
+       let int_add = %int_barith.add (Pfield, 1) in
+       cont k1 (int_add)
+     where k3 =
+       let Pfield = %block_load.[`0`] (x) in
+       cont k1 (Pfield)
+ in
+ let $camlGadt_simplified_switch__immstring21 = "A" in
+ let $camlGadt_simplified_switch__immstring23 = "B" in
+ let code size(11)
+       extract_string_1 (x : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : val =
+   let next_depth = rec_info (succ my_depth) in
+   let untagged = %untag_imm (x) in
+   switch untagged
+     | 0 -> k1 ($camlGadt_simplified_switch__immstring21)
+     | 1 -> k1 ($camlGadt_simplified_switch__immstring23)
+ in
+ let extract_int = closure extract_int_0 @extract_int in
+ let extract_string = closure extract_string_1 @extract_string in
+ let Pmakeblock = %block.[`0`] (extract_int, extract_string) in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in
+    let $camlGadt_simplified_switch = Block 0 (field_0, field_1) in
+    cont done ($camlGadt_simplified_switch)


### PR DESCRIPTION
When there is a match on a value of a GADT type that has both constant and non-constant constructors, but all constant (or non-constant) constructors have been proved impossible by GADT equations, we currently generate a wrapper switch on the `%is_int` primitive, which is wholly unnecessary.

This means that we generate code like the following:

```
  let Pisint = %is_int in
  switch Pisint with
  | 0 -> kconst
  | 1 -> kblock
  where kconst =
    ... code for constant cases ...
  where kblock =
    invalid "Zero_switch_arms"
```

which is just noise and we only really need the "code for constant cases" part.

Ideally, we'd have better information at the lambda level about which constructors are possible or not in a switch, but this is not possible to express in the current representation of a `Lswitch` and likely an invasive change.

Fortunately, there is another very simple fix: we can detect this case in the lambda_to_flambda conversion by avoiding to generate the switch on `%is_int` is there are no constant (resp. non-constant) constructors *and* no failaction, independently of the number of constructors in the type definition.