### PR TITLE
[5.4] Correct compilation of effect syntax

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2675,9 +2675,10 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
         let val_cases = transl_cases ~scopes return_sort val_caselist in
         let param, param_duid = Typecore.name_cases "param" val_caselist in
         let body =
-          Matching.for_function ~scopes
-            ~arg_sort:body_sort ~arg_layout:body_layout ~return_layout
-            e.exp_loc None (Lvar param) val_cases partial
+          maybe_region_layout return_layout
+            (Matching.for_function ~scopes
+              ~arg_sort:body_sort ~arg_layout:body_layout ~return_layout
+              e.exp_loc None (Lvar param) val_cases partial)
         in
         lfunction ~kind:(Curried {nlocal=0})
           ~params:[mk_param param param_duid body_layout]
@@ -2688,8 +2689,9 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
     let exn_cases = transl_cases ~scopes return_sort exn_caselist in
     let param, param_duid = Typecore.name_cases "exn" exn_caselist in
     let body =
-      Matching.for_trywith ~scopes ~return_layout e.exp_loc
-        (Lvar param) exn_cases
+      maybe_region_layout return_layout
+        (Matching.for_trywith ~scopes ~return_layout e.exp_loc
+          (Lvar param) exn_cases)
     in
     lfunction ~kind:(Curried {nlocal=0})
       ~params:[mk_param param param_duid layout_exception] ~return:return_layout
@@ -2702,8 +2704,9 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
     let cont_tail = Ident.create_local "ktail" in
     let eff_cases = transl_cases ~scopes ~cont return_sort eff_caselist in
     let body =
-      Matching.for_handler ~scopes ~return_layout e.exp_loc (Lvar param)
-        (Lvar cont) (Lvar cont_tail) eff_cases
+      maybe_region_layout return_layout
+        (Matching.for_handler ~scopes ~return_layout e.exp_loc (Lvar param)
+          (Lvar cont) (Lvar cont_tail) eff_cases)
     in
     lfunction ~kind:(Curried {nlocal=0})
       ~params:[mk_param param param_duid Lambda.layout_block;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2719,7 +2719,9 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
      the thunk. We always use the thunk path because we cannot verify that the
      arg has layout [value] from [Lapply]. *)
   let (body_fun, arg) =
-    let body = transl_exp ~scopes body_sort body in
+    let body =
+      maybe_region_layout body_layout (transl_exp ~scopes body_sort body)
+    in
     let param = Ident.create_local "param" in
     (lfunction ~kind:(Curried {nlocal=0})
        ~params:[mk_param param Lambda.debug_uid_none Lambda.layout_int]

--- a/testsuite/tests/typing-local/effects.ml
+++ b/testsuite/tests/typing-local/effects.ml
@@ -205,10 +205,60 @@ let g1 () = assert (g1' () = 123)
 
 (* ------------------------------------------------------------------------ *)
 
+type _ Effect.t += Eff_syntax : int t
+exception Exn_syntax
+
+let[@inline never] effect_syntax_value_case () =
+  let result =
+    match perform Eff_syntax with
+    | x ->
+      let r = opaque (local_ ref x) in
+      !r
+    | effect Eff_syntax, k -> continue k 42
+  in
+  assert (result = 42)
+
+let[@inline never] effect_syntax_exception_case () =
+  let result =
+    try raise Exn_syntax with
+    | Exn_syntax ->
+      let r = opaque (local_ ref 42) in
+      !r
+    | effect Eff_syntax, _ -> 0
+  in
+  assert (result = 42)
+
+let[@inline never] effect_syntax_effect_case () =
+  let result =
+    match perform Eff_syntax with
+    | x -> x
+    | effect Eff_syntax, k ->
+      let r = opaque (local_ ref 41) in
+      continue k (!r + 1)
+  in
+  assert (result = 42)
+
+let[@inline never] effect_syntax_body () =
+  let result =
+    match
+      let r = opaque (local_ ref 1) in
+      perform Eff_syntax + !r
+    with
+    | x -> x
+    | effect Eff_syntax, _ -> 42
+  in
+  assert (result = 42)
+
+(* ------------------------------------------------------------------------ *)
+
 let () =
   print_endline "f1"; f1 ();
   print_endline "f2"; f2 ();
   print_endline "f3"; f3 ();
   print_endline "f4"; f4 ();
   print_endline "f5"; f5 ();
-  print_endline "g1"; g1 ()
+  print_endline "g1"; g1 ();
+  effect_syntax_value_case ();
+  effect_syntax_exception_case ();
+  effect_syntax_effect_case ();
+  effect_syntax_body ()


### PR DESCRIPTION
This fixes the compilation errors for the remaining effect-syntax tests. The change displays very poorly here, but is simply passing the lambda for the value, effects, exceptions functions generated for the effect syntax to `maybe_region_layout`.