### PR TITLE
[5.4] Two more test failures

### DIFF
--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -25,6 +25,7 @@ module Example = struct
   end
 
   let longident        = parse longident "No.Longidents.Require.extensions"
+  let constr           = longident
   let expression       = parse expression "[x for x = 1 to 10]"
   let pattern          = parse pattern "[:_:]"
   let core_type        = parse core_type "local_ ('a : value) -> unit"
@@ -153,6 +154,7 @@ end = struct
   ;;
 
   let longident = test "longident" longident Example.longident
+  let constr = test "constr" constr Example.constr
   let expression = test "expression" expression Example.expression
   let pattern = test "pattern" pattern Example.pattern
   let core_type = test "core_type" core_type Example.core_type
@@ -185,8 +187,10 @@ end = struct
 
   module Doc = struct
     let longident = Doc.longident
+    let constr = Doc.constr
     let tyvar = Doc.tyvar
     let jkind_annotation = Doc.jkind_annotation
+    let nominal_exp = Doc.nominal_exp
   end
 end
 

--- a/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -3,6 +3,8 @@
 
 longident: No.Longidents.Require.extensions
 
+constr: No.Longidents.Require.extensions
+
 expression: [x for x = 1 to 10]
 
 pattern: [:_:]
@@ -67,6 +69,8 @@ mode: global
 --------------------------------
 
 longident: No.Longidents.Require.extensions
+
+constr: No.Longidents.Require.extensions
 
 expression: [x for x = 1 to 10]
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -238,8 +238,7 @@ let number = function
   | Incompatible_with_upstream _ -> 187
   | Degraded_to_partial_match -> 74
   | Unnecessarily_partial_tuple_pattern -> 75
-  | Unerasable_position_argument -> 188
-  (* 189 was [Unnecessarily_partial_tuple_pattern], now upstream as 75 *)
+  | Unerasable_position_argument -> 188 (* 189 is now upstream as 75 *)
   | Probe_name_too_long _ -> 190
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199


### PR DESCRIPTION
I've been focusing specifically tests which _aren't_ fixed by running `make promote-failed` (this would allow us to create a dummy branch committing failing test reference files, but allowing the whole of the rest of CI to run which will might reveal some more useful things).

Two fixes here:
- The mnemonics.mll actually parses utils/warnings.ml and isn't able to cope with a whole-line comment. I think the easiest is just to stop it being one line, which I've done (while sticking to 80ch)
- Fixes upstream related to pretty-printing with reserved identifiers caused a bit of refactoring in `Pprintast` which affects our pprintast_unconditional test. For the test's purposes, longident got split into two parts, and longident was already uninteresting for the test, so it's a pretty mechanical update to it.