### PR TITLE
First-class modules in quotes

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2763,7 +2763,7 @@ let assert_no_jkinds jkind =
     jkind
 
 (* Approximate the [core_type] for type annotation from a given [type_expr].
-   Used for annotating polymorphic applications with higher-rank types. *)
+   Used for annotating the results of type inspections in quotes. *)
 let type_for_annotation ~env ~loc typ =
   let unwrap_univar ty =
     match get_desc ty with
@@ -2853,8 +2853,8 @@ let type_for_annotation ~env ~loc typ =
           Ttyp_constr (Predef.path_box, mkloc lident loc, [go ty])
         | Tsplice _ ->
           fatal_errorf
-            "Translquote [at %a]:@ Explicitly quantified type variables@ \
-             cannot be spliced@ within quoted higher-rank function types"
+            "Translquote [at %a]:@ Splices cannot appear in type annotations \
+             inserted in quotations@ for higher-rank or package types."
             Location.print_loc_in_lowercase loc
         | Tquote_eval _ ->
           let lident = Untypeast.lident_of_path Predef.path_eval in
@@ -2917,6 +2917,12 @@ and quote_pat_extra ~env ~scopes loc pat_lam extra =
   | Tpat_inspected_type (Polymorphic_parameter (Param ty)) ->
     Pat.constraint_ loc pat_lam
       (type_for_annotation ~env ~loc:(to_location loc) ty
+      |> quote_core_type ~scopes)
+      (Modes.wrap Modes.legacy)
+    |> Pat.wrap
+  | Tpat_inspected_type (Module_pack pty) ->
+    Pat.constraint_ loc pat_lam
+      (type_for_annotation ~env ~loc:(to_location loc) pty
       |> quote_core_type ~scopes)
       (Modes.wrap Modes.legacy)
     |> Pat.wrap
@@ -3625,6 +3631,14 @@ and quote_expression_extra ~env ~scopes _stage extra lambda =
          (Modes.wrap Modes.legacy)
       |> Type_constraint.wrap)
     |> Exp_desc.wrap
+  | Texp_inspected_type (Module_pack pty) ->
+    Exp_desc.constraint_ loc (mk_exp_noattr loc lambda)
+      (Type_constraint.constraint_ loc
+         (type_for_annotation ~env ~loc:(to_location loc) pty
+         |> quote_core_type ~scopes)
+         (Modes.wrap Modes.legacy)
+      |> Type_constraint.wrap)
+    |> Exp_desc.wrap
   | Texp_ghost_region -> lambda
   | Texp_borrowed ->
     Exp_desc.borrow loc (mk_exp_noattr loc lambda) |> Exp_desc.wrap
@@ -3638,8 +3652,7 @@ and update_env_with_extra ~loc extra =
     fatal_errorf "Translquote [at %a]: Texp_poly not implemented"
       Location.print_loc (to_location loc)
   | Texp_mode _ -> ()
-  | Texp_inspected_type (Label_disambiguation _) -> ()
-  | Texp_inspected_type (Polymorphic_parameter _) -> ()
+  | Texp_inspected_type _ -> ()
   | Texp_ghost_region -> ()
   | Texp_borrowed -> ()
 
@@ -3652,8 +3665,7 @@ and update_env_without_extra ~loc extra =
     fatal_errorf "Translquote [at %a]: Texp_poly not implemented"
       Location.print_loc (to_location loc)
   | Texp_mode _ -> ()
-  | Texp_inspected_type (Label_disambiguation _) -> ()
-  | Texp_inspected_type (Polymorphic_parameter _) -> ()
+  | Texp_inspected_type _ -> ()
   | Texp_ghost_region -> ()
   | Texp_borrowed -> ()
 

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1545,10 +1545,10 @@ module Ast = struct
     match pat with
     | PatConstant c when is_negative_const c ->
       pp fmt "(@[%a@])" (print_pat env) pat
-    | PatAny | PatVar _ | PatConstraint _ | PatConstant _ | PatTuple _
-    | PatUnboxedUnit | PatUnboxedBool _ | PatUnboxedTuple _
-    | PatConstruct (_, None) | PatVariant (_, None)
-    | PatRecord _ | PatUnboxedRecord _ | PatArray _ ->
+    | PatAny | PatVar _ | PatConstant _ | PatTuple _ | PatUnboxedUnit
+    | PatUnboxedBool _ | PatUnboxedTuple _ | PatVariant (_, None)
+    | PatConstruct (_, None) | PatRecord _ | PatUnboxedRecord _ | PatArray _
+    | PatConstraint _ ->
       print_pat env fmt pat
     | _ -> pp fmt "(@[%a@])" (print_pat env) pat
 

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1545,8 +1545,9 @@ module Ast = struct
     match pat with
     | PatConstant c when is_negative_const c ->
       pp fmt "(@[%a@])" (print_pat env) pat
-    | PatAny | PatVar _ | PatConstant _ | PatTuple _ | PatUnboxedUnit
-    | PatUnboxedBool _ | PatUnboxedTuple _ | PatVariant (_, None)
+    | PatAny | PatVar _ | PatConstraint _ | PatConstant _ | PatTuple _
+    | PatUnboxedUnit | PatUnboxedBool _ | PatUnboxedTuple _
+    | PatConstruct (_, None) | PatVariant (_, None)
     | PatRecord _ | PatUnboxedRecord _ | PatArray _ ->
       print_pat env fmt pat
     | _ -> pp fmt "(@[%a@])" (print_pat env) pat
@@ -1809,9 +1810,11 @@ module Ast = struct
 
   and print_param env fmt = function
     | Pparam_val (arg_lab, None, pat) ->
-      pp fmt "@ %a%a" print_arg_lab arg_lab (print_pat env) pat
+      pp fmt "@ %a%a" print_arg_lab arg_lab
+        (print_pat_with_parens env) pat
     | Pparam_val (arg_lab, Some exp, pat) ->
-      pp fmt "@ %a(%a=@[%a@])" print_arg_lab arg_lab (print_pat env) pat
+      pp fmt "@ %a(%a=@[%a@])" print_arg_lab arg_lab
+        (print_pat_with_parens env) pat
         (print_exp env) exp
     | Pparam_newtype ty -> pp fmt "@ (type@ %a)" (Var.Type_constr.print env) ty
 

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1599,21 +1599,12 @@ module Ast = struct
       pp fmt "%a@ |@ %a" (print_pat env) pat1 (print_pat env) pat2
     | PatConstraint (pat, ty, modes) ->
       maybe_parens with_parens fmt (fun fmt () ->
-        let print_type =
-          match pat, ty with
-          | PatUnpack _, TypePackage pty ->
-            (* Package types should not be preceded by "module"
-               inside unpack patterns, so we have a separate case *)
-            fun fmt () -> print_package_type env fmt pty
-          | _ ->
-            fun fmt () -> print_core_type env fmt ty
-        in
         pp fmt "%a@ :@ %a%a"
-          (print_pat env) pat print_type ()
+          (print_pat env) pat (print_core_type env) ty
           print_mode_constraint modes)
     | PatLazy pat -> pp fmt "lazy@ (%a)" (print_pat env) pat
     | PatAnyModule -> pp fmt "module _"
-    | PatUnpack v -> pp fmt "module@ %a" (Var.Module.print env) v
+    | PatUnpack v -> pp fmt "(module@ %a)" (Var.Module.print env) v
     | PatException pat -> pp fmt "(exception@ %a)" (print_pat env) pat
 
   and print_mode_constraint fmt = function

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -270,6 +270,17 @@ val x0 : <[[> `C of int ] as '_weak3]> expr = <[`C 543]>
 - : <[int * int -> int]> expr = <[fun (x, y) -> x + y]>
 |}];;
 
+<[ fun (Some x) -> x ]>;;
+[%%expect {|
+Line 1, characters 7-15:
+1 | <[ fun (Some x) -> x ]>;;
+           ^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "None"
+
+- : <[$('a) option -> $('a)]> expr = <[fun (Some (x)) -> x]>
+|}];;
+
 <[ function | _ -> 12 ]>;;
 [%%expect {|
 - : <[$('a) -> int]> expr = <[function | _ -> 12]>

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -841,9 +841,23 @@ module Mod : sig type t = int val mk : 'a -> 'a end
 |}];;
 
 <[fun (module M : Hashtbl.S) x -> M.clear (M.create x)]>;;
+(* CR metaprogramming jbachurski: Eliminating the duplicate type constraint
+   to make the printer output nicer is tracked by internal ticket 7290. *)
 [%%expect {|
 - : <[(module Hashtbl.S) -> int -> unit]> expr =
-<[fun ((module M) : (module Stdlib.Hashtbl.S)) x -> M.clear (M.create x)]>
+<[
+  fun (((module M) : (module Stdlib.Hashtbl.S)) : (module Stdlib.Hashtbl.S))
+    x -> M.clear (M.create x)
+]>
+|}];;
+
+<[fun (module M : Hashtbl.S) -> (module M : Hashtbl.S)]>;;
+[%%expect {|
+- : <[(module Hashtbl.S) -> (module Hashtbl.S)]> expr =
+<[
+  fun (((module M) : (module Stdlib.Hashtbl.S)) : (module Stdlib.Hashtbl.S))
+    -> ((module M) : (module Stdlib.Hashtbl.S))
+]>
 |}];;
 
 <[ fun (module _ : S) x -> 42 ]>;;
@@ -1689,7 +1703,7 @@ exception E
 <[ fun (module M : T) -> let open M in foo + 1 ]>
 [%%expect {|
 - : <[(module T) -> int]> expr =
-<[fun (module M : T) -> let open! M in M.foo + 1]>
+<[fun (((module M) : (module T)) : (module T)) -> let open! M in M.foo + 1]>
 |}];;
 
 (* Cross-stage open *)

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -843,7 +843,7 @@ module Mod : sig type t = int val mk : 'a -> 'a end
 <[fun (module M : Hashtbl.S) x -> M.clear (M.create x)]>;;
 [%%expect {|
 - : <[(module Hashtbl.S) -> int -> unit]> expr =
-<[fun (module M : Stdlib.Hashtbl.S) x -> M.clear (M.create x)]>
+<[fun ((module M) : (module Stdlib.Hashtbl.S)) x -> M.clear (M.create x)]>
 |}];;
 
 <[ fun (module _ : S) x -> 42 ]>;;

--- a/testsuite/tests/quotation/typing/inspection/pack.ml
+++ b/testsuite/tests/quotation/typing/inspection/pack.ml
@@ -1,0 +1,117 @@
+(* TEST
+ include eval;
+ modules = "pack_types.ml util.ml";
+ flags = "-extension runtime_metaprogramming -uses-metaprogramming";
+ native;
+*)
+
+#syntax quotations on
+
+open Util
+open Pack_types
+
+(* Trivial cases without package constraints *)
+
+let () =
+  let (f : <[(module S) -> int]> expr) =
+    <[fun (module M) -> M.i]>
+  in
+  test <[ ignore (((fun x -> x) $f) : (module S) -> int) ]>
+;;
+
+let () =
+  let (f : <[(module S) -> (module S)]> expr) =
+    <[fun (module M) -> (module M)]>
+  in
+  test <[ ignore (((fun x -> x) $f) : (module S) -> (module S)) ]>
+;;
+
+(* Package constraint in pattern *)
+
+let () =
+  let (f : <[(module S with type t = 'a) -> 'a]> expr) =
+    <[fun (type a) (module M : S with type t = a) -> M.x]>
+  in
+  test <[ ignore (((fun x -> x) $f) : (module S with type t = 'a) -> 'a) ]>
+;;
+let () =
+  let (f : <[((module S with type t = string) as 'b) -> 'b]> expr) =
+    <[fun (module M : S with type t = string) -> (module M)]>
+  in
+  test <[
+    ignore (((fun x -> x) $f) :
+      (module S with type t = string) -> (module S with type t = string)) ]>
+;;
+let () =
+  let (f : <[((module S with type t = 'a) as 'b) -> 'b]> expr) =
+    <[fun (type a) (module M : S with type t = a) ->
+        (module M : S with type t = a)]>
+  in
+  test <[
+    ignore (((fun x -> x) $f) :
+      (module S with type t = 'a) -> (module S with type t = 'a)) ]>
+;;
+
+(* Package constraint inferred from the rest of the pattern *)
+
+(* M.t = string *)
+let () =
+  let (f : <[w -> int]> expr) =
+    <[fun (W (module M)) -> M.i]>
+  in
+  test <[ ignore (((fun x -> x) $f) : w -> int) ]>
+;;
+let () =
+  let (f : <[w -> string]> expr) =
+    <[fun (W (module M)) -> M.x]>
+  in
+  test <[ ignore (((fun x -> x) $f) : w -> string) ]>
+;;
+let () =
+  let (f : <[w -> w]> expr) =
+    <[fun (W (module M)) -> W (module M)]>
+  in
+  test <[ ignore (((fun x -> x) $f) : w -> w) ]>
+;;
+
+(* M.t = int * string *)
+let () =
+  let (f : <[v -> int]> expr) =
+    <[fun (V (module M)) -> M.i]>
+  in
+  test <[ ignore (((fun x -> x) $f) : v -> int) ]>
+;;
+let () =
+  let (f : <[v -> string]> expr) =
+    <[fun (V (module M)) -> snd M.x]>
+  in
+  test <[ ignore (((fun x -> x) $f) : v -> string) ]>
+;;
+let () =
+  let (f : <[v -> v]> expr) =
+    <[fun (V (module M)) -> V (module M)]>
+  in
+  test <[ ignore (((fun x -> x) $f) : v -> v) ]>
+;;
+
+(* M.t = 'a * b, where 'a and 'b are type parameters:
+   These tests will fail if the inserted annotation
+   relies on inferring the concrete type constraint. *)
+let () =
+  let (f : <[(int, string) u -> int]> expr) =
+    <[fun (U (module M)) -> M.i]>
+  in
+  test <[ ignore (((fun x -> x) $f) : (int, string) u -> int) ]>
+;;
+let () =
+  let (f : <[(int, string) u -> string]> expr) =
+    <[fun (U (module M)) -> snd M.x]>
+  in
+  test <[ ignore (((fun x -> x) $f) : (int, string) u -> string) ]>
+;;
+let () =
+  let (f : <[(int, string) u -> (int, string) u]> expr) =
+    <[fun (U (module M)) -> U (module M)]>
+  in
+  test <[ ignore (((fun x -> x) $f) : (int, string) u -> (int, string) u) ]>
+;;

--- a/testsuite/tests/quotation/typing/inspection/pack.reference
+++ b/testsuite/tests/quotation/typing/inspection/pack.reference
@@ -1,0 +1,107 @@
+Stdlib.ignore
+  ((fun x -> x) (fun ((module M) : (module Pack_types.S)) -> M.i) : (module
+  Pack_types.S) -> int)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun ((module M) : (module Pack_types.S)) -> ((module M) : (module
+        Pack_types.S)))
+  : (module Pack_types.S) -> (module Pack_types.S))
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun (type a) (((module M) : (module Pack_types.S with type t = a)) :
+        (module Pack_types.S with type t = a)) -> M.x)
+  : (module Pack_types.S with type t = 'a) -> 'a)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun (((module M) : (module Pack_types.S with type t = string)) :
+        (module Pack_types.S with type t = string)) -> ((module M) : (module
+        Pack_types.S with type t = string)))
+  : (module Pack_types.S with type t = string) -> (module
+  Pack_types.S with type t = string))
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun (type a) (((module M) : (module Pack_types.S with type t = a)) :
+        (module Pack_types.S with type t = a)) -> ((module M) : (module
+        Pack_types.S with type t = a)))
+  : (module Pack_types.S with type t = 'a) -> (module
+  Pack_types.S with type t = 'a))
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.W
+         (((module M) : (module Pack_types.S with type t = string))))
+        -> M.i)
+  : Pack_types.w -> int)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.W
+         (((module M) : (module Pack_types.S with type t = string))))
+        -> M.x)
+  : Pack_types.w -> string)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.W
+         (((module M) : (module Pack_types.S with type t = string))))
+        ->
+        Pack_types.W ((module M) : (module Pack_types.S with type t = M.t)))
+  : Pack_types.w -> Pack_types.w)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.V
+         (((module M) : (module Pack_types.S with type t = int * string))))
+        -> M.i)
+  : Pack_types.v -> int)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.V
+         (((module M) : (module Pack_types.S with type t = int * string))))
+        -> Stdlib.snd M.x)
+  : Pack_types.v -> string)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.V
+         (((module M) : (module Pack_types.S with type t = int * string))))
+        ->
+        Pack_types.V ((module M) : (module Pack_types.S with type t = M.t)))
+  : Pack_types.v -> Pack_types.v)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.U
+         (((module M) : (module Pack_types.S with type t = int * string))))
+        -> M.i)
+  : (int, string) Pack_types.u -> int)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.U
+         (((module M) : (module Pack_types.S with type t = int * string))))
+        -> Stdlib.snd M.x)
+  : (int, string) Pack_types.u -> string)
+
+Stdlib.ignore
+  ((fun x -> x)
+     (fun
+        (Pack_types.U
+         (((module M) : (module Pack_types.S with type t = int * string))))
+        ->
+        Pack_types.U ((module M) : (module Pack_types.S with type t = M.t)))
+  : (int, string) Pack_types.u -> (int, string) Pack_types.u)
+

--- a/testsuite/tests/quotation/typing/inspection/pack_splice_in_constraint.ml
+++ b/testsuite/tests/quotation/typing/inspection/pack_splice_in_constraint.ml
@@ -1,0 +1,58 @@
+(* TEST
+ flags = "-extension runtime_metaprogramming";
+ expect;
+*)
+
+#syntax quotations on
+
+type t
+module type S = sig
+  type t
+  val x : t
+  val i : int
+end
+#mark_toplevel_in_quotations;;
+[%%expect {|
+type t
+module type S = sig type t val x : t val i : int end
+|}]
+
+(* Obviously fine, nothing is spliced *)
+let _ = <[ fun (module M : S with type t = t) -> M.x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}]
+
+(* Not fine -- there's a wildcard, which is a type variable under the hood,
+   and unpacking needs to have package constraints with closed types *)
+let _ = <[ fun (module M : S with type t = _) -> M.x ]>
+[%%expect {|
+Line 1, characters 23-24:
+1 | let _ = <[ fun (module M : S with type t = _) -> M.x ]>
+                           ^
+Error: The type of this packed module contains variables:
+       "(module S with type t = 'a)"
+|}]
+
+(* Since we erase [$int] into [_] under quotes,
+   the below should fail with an error like the above to be consistent. *)
+(* CR metaprogramming jbachurski: This should fail gracefully.
+   See ticket 7081. *)
+let _ = <[ fun (module M : S with type t = $t) -> M.x ]>
+[%%expect {|
+>> Fatal error: Translquote [at line 1, characters 23-24]:
+Splices cannot appear in type annotations inserted in quotations
+for higher-rank or package types.
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+let _ = <[ <[ fun (module M : S with type t = $t) -> M.x ]> ]>
+[%%expect {|
+>> Fatal error: Translquote [at line 1, characters 26-27]:
+Splices cannot appear in type annotations inserted in quotations
+for higher-rank or package types.
+Uncaught exception: Misc.Fatal_error
+
+|}]

--- a/testsuite/tests/quotation/typing/inspection/pack_types.ml
+++ b/testsuite/tests/quotation/typing/inspection/pack_types.ml
@@ -1,0 +1,11 @@
+module type S = sig
+  type t
+  val x : t
+  val i : int
+end
+
+type w = W : (module S with type t = string) -> w
+
+type v = V : (module S with type t = int * string) -> v
+
+type ('a, 'b) u = U : (module S with type t = 'a * 'b) -> ('a, 'b) u

--- a/testsuite/tests/quotation/typing/inspection/poly_quote.ml
+++ b/testsuite/tests/quotation/typing/inspection/poly_quote.ml
@@ -7,7 +7,8 @@
 
 (* This test file tests that constructing a higher-rank function
    of quotes under quotes fails gracefully until they are supported,
-   and the corresponding test in [poly.ml] can be enabled. *)
+   and the corresponding test in [poly.ml] can be enabled.
+   See ticket 6357. *)
 
 (* This type should be the same as [B.t3''] *)
 let (f : <[
@@ -20,8 +21,8 @@ let (f : <[
 
 [%%expect {|
 >> Fatal error: Translquote [at line 5, characters 8-9]:
-Explicitly quantified type variables cannot be spliced
-within quoted higher-rank function types
+Splices cannot appear in type annotations inserted in quotations
+for higher-rank or package types.
 Uncaught exception: Misc.Fatal_error
 
 |}]

--- a/testsuite/tests/quotation/typing/quotes_splices/unify.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/unify.ml
@@ -91,19 +91,19 @@ let _ : <[<[<['a]>]>]> -> <[<[<['a]>]>]> = fun (() as x) -> x
 let _ : <[ $('a) -> $('a) ]> expr  =
   <[fun (() as x) -> x]>
 [%%expect {|
-- : <[unit -> unit]> expr = <[fun () as x -> x]>
+- : <[unit -> unit]> expr = <[fun (() as x) -> x]>
 |}]
 (* $($('a)) ~ unit *)
 let _ : <[ <[ $($('a)) -> $($('a)) ]> expr ]> expr =
   <[<[fun (() as x) -> x]>]>
 [%%expect {|
-- : <[<[unit -> unit]> expr]> expr = <[<[fun () as x -> x]>]>
+- : <[<[unit -> unit]> expr]> expr = <[<[fun (() as x) -> x]>]>
 |}]
 (* $($($('a))) ~ unit *)
 let _ : <[ <[ <[ $($($('a))) -> $($($('a))) ]> expr ]> expr ]> expr =
   <[<[<[fun (() as x) -> x]>]>]>
 [%%expect {|
-- : <[<[<[unit -> unit]> expr]> expr]> expr = <[<[<[fun () as x -> x]>]>]>
+- : <[<[<[unit -> unit]> expr]> expr]> expr = <[<[<[fun (() as x) -> x]>]>]>
 |}]
 
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -474,6 +474,8 @@ and type_inspection : type a. _ -> _ -> a type_inspection -> unit =
   | Polymorphic_parameter param ->
     line i ppf "Polymorphic_parameter\n";
     poly_param (i+1) ppf param;
+  | Module_pack pty ->
+    line i ppf "Module_pack %a\n" Rawprinttyp.type_expr pty;
 
 and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   line i ppf "pattern %a\n" fmt_location x.pat_loc;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -283,6 +283,7 @@ let pat_extra sub (e, loc, attrs) =
   | Tpat_constraint (ct, ma) -> sub.typ sub ct; sub.modes sub ma
   | Tpat_inspected_type (Label_disambiguation _) -> ()
   | Tpat_inspected_type (Polymorphic_parameter (Param _)) -> ()
+  | Tpat_inspected_type (Module_pack _) -> ()
 
 let pat
   : type k . iterator -> k general_pattern -> unit
@@ -338,6 +339,7 @@ let extra sub = function
   | Texp_inspected_type (Label_disambiguation _) -> ()
   | Texp_inspected_type (Polymorphic_parameter (Method _)) -> ()
   | Texp_inspected_type (Polymorphic_parameter (Arrow _)) -> ()
+  | Texp_inspected_type (Module_pack _) -> ()
 
 let function_param sub { fp_loc; fp_kind; fp_newtypes; fp_mode; _ } =
   sub.location sub fp_loc;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -340,6 +340,7 @@ let pat_extra sub = function
     Tpat_constraint (sub.typ sub ct, sub.modes sub ma)
   | Tpat_inspected_type (Label_disambiguation _) as d -> d
   | Tpat_inspected_type (Polymorphic_parameter (Param _)) as d -> d
+  | Tpat_inspected_type (Module_pack _) as d -> d
 
 let pat
   : type k . mapper -> k general_pattern -> k general_pattern
@@ -455,6 +456,7 @@ let extra sub = function
   | Texp_inspected_type (Label_disambiguation _) as d -> d
   | Texp_inspected_type (Polymorphic_parameter (Method _)) as d -> d
   | Texp_inspected_type (Polymorphic_parameter (Arrow _)) as d -> d
+  | Texp_inspected_type (Module_pack _) as d -> d
 
 let function_body sub body =
   match body with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3502,12 +3502,21 @@ and type_pat_aux
         pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_unpack name ->
       let t = instance expected_ty in
+      let pat_extra = [
+        Tpat_unpack, name.loc, sp.ppat_attributes;
+        (* [t] is intentionally not instantiated here, as it is still refined
+           e.g. in [map_half_typed_cases]. Ideally, we'd copy it after that.
+           However, at that point it is required to be closed, and hence
+           hopefully nothing surprising happens to it. *)
+        Tpat_inspected_type (Module_pack t), loc, []
+        ]
+      in
       begin match name.txt with
       | None ->
           rvp {
             pat_desc = Tpat_any;
             pat_loc = sp.ppat_loc;
-            pat_extra=[Tpat_unpack, name.loc, sp.ppat_attributes];
+            pat_extra;
             pat_type = t;
             pat_attributes = [];
             pat_env = !!penv;
@@ -3526,7 +3535,7 @@ and type_pat_aux
             pat_desc = Tpat_var { id; name = v; uid; sort;
                                   mode = alloc_mode.mode };
             pat_loc = sp.ppat_loc;
-            pat_extra=[Tpat_unpack, loc, sp.ppat_attributes];
+            pat_extra;
             pat_type = t;
             pat_attributes = [];
             pat_env = !!penv;
@@ -8264,12 +8273,17 @@ and type_expect_
               raise (Error (loc, env, Not_a_packed_module ty_expected))
           in
           let (modl, pack') = !type_package env m pack in
+          let exp_type = newty (Tpackage pack') in
+          let exp_extra =
+            Texp_inspected_type (Module_pack (Ctype.instance exp_type))
+          in
           let mode = Typedtree.mode_without_locks_exn modl.mod_mode in
           submode ~loc ~env mode expected_mode;
           rue {
             exp_desc = Texp_pack modl;
-            exp_loc = loc; exp_extra = [];
-            exp_type = newty (Tpackage pack');
+            exp_loc = loc;
+            exp_extra = [exp_extra, loc, []];
+            exp_type;
             exp_attributes = sexp.pexp_attributes;
             exp_env = env }
       end

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -149,6 +149,7 @@ type label_ambiguity =
 type _ type_inspection =
   | Label_disambiguation : label_ambiguity -> [< `pat | `exp ] type_inspection
   | Polymorphic_parameter : 'a poly_param -> 'a type_inspection
+  | Module_pack : type_expr -> [< `pat | `exp ] type_inspection
 
 and _ poly_param =
   | Param : type_expr -> [`pat] poly_param

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -151,7 +151,11 @@ type label_ambiguity =
 
 type _ type_inspection =
   | Label_disambiguation : label_ambiguity -> [< `pat | `exp ] type_inspection
+  (** Label (e.g. record field or variant constructor) disambiguation *)
   | Polymorphic_parameter : 'a poly_param -> 'a type_inspection
+  (** Polymorphic parameter uses (e.g. polymorphic object method) *)
+  | Module_pack : Types.type_expr -> [< `pat | `exp ] type_inspection
+  (** Package types (first-class modules) *)
 
 and _ poly_param =
   | Param : Types.type_expr -> [ `pat ] poly_param


### PR DESCRIPTION
This PR contains:

* Drive-by changes necessary for module (un)packing to work in quotes (until now, only unpacking _mostly_ worked). These are broken down into individual commits. 
* Logic necessary to insert annotations for unannotated packing expressions and unpacking patterns, as these have to be known for a non-HM type inspection. This is the last commit.

There's a test file, `pack_splice_in_constraint.ml`, showing how to trigger some corner case fatal errors right now. These can only happen at metaprogram compilation. As these are tied to of other pieces of work like supporting stage >1 splices (tickets linked), I'd prefer to solve them in separate PRs.

## Review notes

Nothing particularly non-trivial is done to insert the necessary annotations. Module packing is entirely clean, but unpacking is a bit trickier -- the typing logic there is a bit awkward due to the complexities of patterns (particularly GADTs):

* Initially, the typed-tree is constructed unchecked, after which routines like `map_half_typed_cases` might refine the known type, and only eventually check that the unpacking has a package type that is known to be well-formed (e.g. every type is constrained with a closed type expression). 
* We'd really rather construct the `Typedtree` after those checks happen, as that's really when the type is inspected ('determined'). 
* But this seems really annoying to do, so I just keep the type expression as-is in the `Typedtree` and let it flow to be unified later on. Since it is checked to be closed, nothing too surprising should happen to it (unless there's some crazy logic that mutates closed type expressions).