### PR TITLE
Avoid extracting a `Typing_env` from a `Meet_env`

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1601,8 +1601,8 @@ let cut_for_join typing_env ~cut_after =
   in
   incremental_equations, symbol_projections
 
-let cut_and_n_way_join0 ~n_way_join_type ~meet_type ~cut_after source_env
-    joined_envs equations_to_join symbol_projections_to_join =
+let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
+    source_env joined_envs equations_to_join symbol_projections_to_join =
   try
     let empty_bindings =
       Bindings_in_target_env.from_source_env
@@ -1666,7 +1666,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_type ~cut_after source_env
         bindings source_env
     in
     let target_env =
-      ME.add_env_extension ~meet_type target_env
+      ME.add_env_extension ~meet_expanded_head target_env
         (TEE.from_map
            (equations
              : Type_in_target_env.t Name_in_target_env.Map.t
@@ -1851,8 +1851,8 @@ module Analysis = struct
       t.canonical_definitions_at_normal_mode init
 end
 
-let cut_and_n_way_join ~n_way_join_type ~meet_type ~cut_after source_env
-    joined_envs =
+let cut_and_n_way_join ~n_way_join_type ~meet_expanded_head ~cut_after
+    source_env joined_envs =
   let joined_envs, equations_to_join, symbol_projections_to_join =
     Index.fold_list
       (fun index typing_env
@@ -1867,13 +1867,13 @@ let cut_and_n_way_join ~n_way_join_type ~meet_type ~cut_after source_env
       (Index.Map.empty, Index.Map.empty, Index.Map.empty)
   in
   let target_env, _ =
-    cut_and_n_way_join0 ~n_way_join_type ~meet_type ~cut_after source_env
-      joined_envs equations_to_join symbol_projections_to_join
+    cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
+      source_env joined_envs equations_to_join symbol_projections_to_join
   in
   target_env
 
-let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_type ~cut_after
-    source_env joined_envs =
+let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
+    ~cut_after source_env joined_envs =
   let external_ids, joined_envs, equations_to_join, symbol_projections_to_join =
     Index.fold_list
       (fun index (external_id, typing_env)
@@ -1893,8 +1893,8 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_type ~cut_after
   in
   let source_env = ME.create source_env in
   let target_env, bindings =
-    cut_and_n_way_join0 ~n_way_join_type ~meet_type ~cut_after source_env
-      joined_envs equations_to_join symbol_projections_to_join
+    cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
+      source_env joined_envs equations_to_join symbol_projections_to_join
   in
   let target_env = ME.typing_env target_env in
   let join_analysis = Analysis.create ~external_ids ~joined_envs bindings in
@@ -1931,7 +1931,7 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
 
 (** {2:extensions Join of extensions} *)
 
-let prepare_nested_join ~meet_type ~joined_envs ~bindings extensions =
+let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
   let joined_envs_and_extensions =
     List.fold_left
       (fun joined_envs_and_extensions (index, extension) ->
@@ -1947,7 +1947,7 @@ let prepare_nested_join ~meet_type ~joined_envs ~bindings extensions =
         let cut_after = TE.current_scope parent_env in
         let typing_env = TE.increment_scope parent_env in
         match
-          ME.add_env_extension_strict ~meet_type (ME.create typing_env)
+          ME.add_env_extension_strict ~meet_expanded_head (ME.create typing_env)
             extension
         with
         | Bottom ->
@@ -2131,11 +2131,11 @@ let join_aliases_in_env_extension ~joined_envs ~bindings equations_to_join =
         in
         equations_in_target_env, equations_to_join, bindings)
 
-let n_way_join_env_extension ~n_way_join_type ~meet_type t extensions :
+let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
     _ Or_bottom.t =
   let joined_equations =
     try
-      prepare_nested_join ~meet_type ~bindings:t.bindings
+      prepare_nested_join ~meet_expanded_head ~bindings:t.bindings
         ~joined_envs:t.joined_envs extensions
     with Misc.Fatal_error ->
       let bt = Printexc.get_raw_backtrace () in

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -31,14 +31,14 @@ val n_way_join_simples :
 
 val n_way_join_env_extension :
   n_way_join_type:n_way_join_type ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   t ->
   Typing_env_extension.t join_arg list ->
   (Typing_env_extension.t * t) Or_bottom.t
 
 val cut_and_n_way_join :
   n_way_join_type:n_way_join_type ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   cut_after:Scope.t ->
   Meet_env.t ->
   Typing_env.t list ->
@@ -82,7 +82,7 @@ end
 
 val cut_and_n_way_join_with_analysis :
   n_way_join_type:n_way_join_type ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   cut_after:Scope.t ->
   Typing_env.t ->
   ('a * Typing_env.t) list ->

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -151,7 +151,7 @@ let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
       | Bottom _ -> if raise_on_bottom then raise Bottom_equation else t)
     ~name:(fun name ~coercion ->
       adding_equation_for_name t name ~f:(fun t ->
-          let kind = TG.kind (ET.to_type ty) in
+          let kind = ET.kind ty in
           (* Note: this will check that the [existing_ty] has the expected
              kind. *)
           let existing_ty_of_name = TE.find (typing_env t) name (Some kind) in

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -18,6 +18,8 @@ module MTC = More_type_creators
 module TG = Type_grammar
 module TE = Typing_env
 module TEL = Typing_env_level
+module K = Flambda_kind
+module ET = Expand_head.Expanded_type
 
 type t =
   { typing_env : TE.t;
@@ -30,16 +32,30 @@ type 'a meet_return_value =
   | Both_inputs
   | New_result of 'a
 
-type meet_type =
-  t ->
-  Type_grammar.t ->
-  Type_grammar.t ->
-  (Type_grammar.t meet_return_value * t) Or_bottom.t
+type 'a meet_result =
+  | Bottom of unit meet_return_value
+  | Ok of 'a meet_return_value * t
+
+type meet_expanded_head = t -> ET.t -> ET.t -> ET.t meet_result
+
+let map_result ~f = function
+  | Bottom r -> Bottom r
+  | Ok (Left_input, env) -> Ok (Left_input, env)
+  | Ok (Right_input, env) -> Ok (Right_input, env)
+  | Ok (Both_inputs, env) -> Ok (Both_inputs, env)
+  | Ok (New_result x, env) -> Ok (New_result (f x), env)
 
 let create typing_env =
   { typing_env; adding_equations_for_names = Name.Set.empty }
 
 let typing_env { typing_env; _ } = typing_env
+
+let code_age_relation env = TE.code_age_relation (typing_env env)
+
+let code_age_relation_resolver env =
+  TE.code_age_relation_resolver (typing_env env)
+
+let machine_width env = TE.machine_width (typing_env env)
 
 let with_typing_env t typing_env = { t with typing_env }
 
@@ -110,7 +126,7 @@ let replace_concrete_equation t name ty =
 exception Bottom_equation
 
 let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
-    ~(meet_type : meet_type) =
+    ~(meet_expanded_head : meet_expanded_head) =
   (* When adding a type to a canonical name, we need to call [meet] with the
      existing type for that name in order to ensure we record the most precise
      type available.
@@ -130,33 +146,41 @@ let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
      Note also that [p] and [x] may have different name modes! *)
   Simple.pattern_match simple
     ~const:(fun const ->
-      match meet_type t ty (MTC.type_for_const const) with
+      match meet_expanded_head t ty (ET.create_const const) with
       | Ok (_, env) -> env
-      | Bottom -> if raise_on_bottom then raise Bottom_equation else t)
+      | Bottom _ -> if raise_on_bottom then raise Bottom_equation else t)
     ~name:(fun name ~coercion ->
       adding_equation_for_name t name ~f:(fun t ->
-          (* If [(coerce name coercion)] has type [ty], then [name] has type
-             [(coerce ty coercion^-1)]. *)
-          let ty = TG.apply_coercion ty (Coercion.inverse coercion) in
+          let kind = TG.kind (ET.to_type ty) in
           (* Note: this will check that the [existing_ty] has the expected
              kind. *)
-          let existing_ty = TE.find (typing_env t) name (Some (TG.kind ty)) in
-          match meet_type t ty existing_ty with
-          | Bottom ->
+          let existing_ty_of_name = TE.find (typing_env t) name (Some kind) in
+          (* If [name] has type [existing_ty], then [(coerce name coercion)] has
+             type [(coerce ty coercion)]. *)
+          let existing_ty_of_simple =
+            TG.apply_coercion existing_ty_of_name coercion
+          in
+          let existing_ty =
+            Expand_head.expand_head0 (typing_env t) existing_ty_of_simple
+              ~known_canonical_simple_at_in_types_mode:(Some simple)
+          in
+          match meet_expanded_head t ty existing_ty with
+          | Bottom _ ->
             if raise_on_bottom
             then raise Bottom_equation
             else
               map_typing_env t ~f:(fun t ->
-                  TE.replace_equation t name (MTC.bottom (TG.kind ty)))
+                  TE.replace_equation t name (MTC.bottom kind))
           | Ok ((Right_input | Both_inputs), env) -> env
           | Ok (Left_input, env) ->
             map_typing_env env ~f:(fun env ->
-                replace_concrete_equation env name ty)
+                replace_concrete_equation env name (ET.to_type ty))
           | Ok (New_result ty', env) ->
             map_typing_env env ~f:(fun env ->
-                replace_concrete_equation env name ty')))
+                replace_concrete_equation env name (ET.to_type ty'))))
 
-let record_demotion ~raise_on_bottom t kind demoted canonical ~meet_type =
+let record_demotion ~raise_on_bottom t kind demoted canonical
+    ~meet_expanded_head =
   (* We have demoted [demoted], which used to be canonical, to [canonical] in
      the aliases structure.
 
@@ -176,11 +200,15 @@ let record_demotion ~raise_on_bottom t kind demoted canonical ~meet_type =
     map_typing_env t ~f:(fun t ->
         TE.replace_equation t demoted (TG.alias_type_of kind canonical))
   in
+  let ty_of_demoted =
+    Expand_head.expand_head0 (typing_env t) ty_of_demoted
+      ~known_canonical_simple_at_in_types_mode:(Some (Simple.name demoted))
+  in
   add_concrete_equation_on_canonical ~raise_on_bottom t canonical ty_of_demoted
-    ~meet_type
+    ~meet_expanded_head
 
 let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
-    canonical_element2 ~meet_type =
+    canonical_element2 ~meet_expanded_head =
   (* We are adding an equality between two canonical simples [canonical1] and
      [canonical2].
 
@@ -204,9 +232,9 @@ let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
     | Ok { demoted_name; canonical_element; t = typing_env } ->
       let t = with_typing_env t typing_env in
       record_demotion ~raise_on_bottom t kind demoted_name canonical_element
-        ~meet_type
+        ~meet_expanded_head
 
-let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type =
+let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_expanded_head =
   (* We are adding a type [ty] to [simple], which must be canonical. There are
      two general cases to consider:
 
@@ -217,42 +245,46 @@ let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type =
      aliases structure. *)
   match TG.get_alias_opt ty with
   | None ->
-    add_concrete_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type
+    let ty = ET.of_non_alias_type ty in
+    add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
+      ~meet_expanded_head
   | Some alias ->
     let alias =
       TE.get_canonical_simple_ignoring_name_mode (typing_env t) alias
     in
     add_alias_between_canonicals ~raise_on_bottom t (TG.kind ty) simple alias
-      ~meet_type
+      ~meet_expanded_head
 
-let add_equation_on_simple ~raise_on_bottom t simple ty ~meet_type =
+let add_equation_on_simple ~raise_on_bottom t simple ty ~meet_expanded_head =
   let canonical =
     TE.get_canonical_simple_ignoring_name_mode (typing_env t) simple
   in
-  add_equation_on_canonical ~raise_on_bottom t canonical ty ~meet_type
+  add_equation_on_canonical ~raise_on_bottom t canonical ty ~meet_expanded_head
 
-let add_equation ~raise_on_bottom t name ty ~meet_type =
-  add_equation_on_simple ~raise_on_bottom t (Simple.name name) ty ~meet_type
+let add_equation ~raise_on_bottom t name ty ~meet_expanded_head =
+  add_equation_on_simple ~raise_on_bottom t (Simple.name name) ty
+    ~meet_expanded_head
 
 let add_env_extension ~raise_on_bottom t
-    (env_extension : Typing_env_extension.t) ~meet_type =
+    (env_extension : Typing_env_extension.t) ~meet_expanded_head =
   Typing_env_extension.fold
     ~equation:(fun name ty t ->
-      add_equation ~raise_on_bottom t name ty ~meet_type)
+      add_equation ~raise_on_bottom t name ty ~meet_expanded_head)
     env_extension t
 
 let add_env_extension_with_extra_variables t
-    (env_extension : Typing_env_extension.With_extra_variables.t) ~meet_type =
+    (env_extension : Typing_env_extension.With_extra_variables.t)
+    ~meet_expanded_head =
   Typing_env_extension.With_extra_variables.fold
     ~variable:(fun var kind t ->
       map_typing_env t ~f:(fun t ->
           TE.add_variable_definition t var kind Name_mode.in_types))
     ~equation:(fun name ty t ->
-      try add_equation ~raise_on_bottom:true t name ty ~meet_type
+      try add_equation ~raise_on_bottom:true t name ty ~meet_expanded_head
       with Bottom_equation -> map_typing_env ~f:TE.make_bottom t)
     env_extension t
 
-let add_env_extension_from_level t level ~meet_type =
+let add_env_extension_from_level t level ~meet_expanded_head =
   let t =
     map_typing_env t ~f:(fun t ->
         TEL.fold_on_defined_vars
@@ -263,7 +295,7 @@ let add_env_extension_from_level t level ~meet_type =
   let t =
     Name.Map.fold
       (fun name ty t ->
-        try add_equation ~raise_on_bottom:true t name ty ~meet_type
+        try add_equation ~raise_on_bottom:true t name ty ~meet_expanded_head
         with Bottom_equation -> map_typing_env ~f:TE.make_bottom t)
       (TEL.equations level) t
   in
@@ -273,33 +305,39 @@ let add_env_extension_from_level t level ~meet_type =
         (TEL.symbol_projections level)
         t)
 
-let add_equation_strict t name ty ~meet_type : _ Or_bottom.t =
+let add_equation_strict t name ty ~meet_expanded_head : _ Or_bottom.t =
   if TE.is_bottom (typing_env t)
   then Bottom
   else
-    try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_type)
+    try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_expanded_head)
     with Bottom_equation -> Bottom
 
-let add_env_extension_strict t env_extension ~meet_type : _ Or_bottom.t =
+let add_env_extension_strict t env_extension ~meet_expanded_head : _ Or_bottom.t
+    =
   if TE.is_bottom (typing_env t)
   then Bottom
   else
-    try Ok (add_env_extension ~raise_on_bottom:true t env_extension ~meet_type)
+    try
+      Ok
+        (add_env_extension ~raise_on_bottom:true t env_extension
+           ~meet_expanded_head)
     with Bottom_equation -> Bottom
 
-let add_env_extension_maybe_bottom t env_extension ~meet_type =
-  add_env_extension ~raise_on_bottom:false t env_extension ~meet_type
+let add_env_extension_maybe_bottom t env_extension ~meet_expanded_head =
+  add_env_extension ~raise_on_bottom:false t env_extension ~meet_expanded_head
 
-let add_equation t name ty ~meet_type =
-  try add_equation ~raise_on_bottom:true t name ty ~meet_type
+let add_equation t name ty ~meet_expanded_head =
+  try add_equation ~raise_on_bottom:true t name ty ~meet_expanded_head
   with Bottom_equation -> map_typing_env ~f:TE.make_bottom t
 
-let add_equation_on_simple t simple ty ~meet_type =
-  try add_equation_on_simple ~raise_on_bottom:true t simple ty ~meet_type
+let add_equation_on_simple t simple ty ~meet_expanded_head =
+  try
+    add_equation_on_simple ~raise_on_bottom:true t simple ty ~meet_expanded_head
   with Bottom_equation -> map_typing_env ~f:TE.make_bottom t
 
-let add_env_extension t env_extension ~meet_type =
-  try add_env_extension ~raise_on_bottom:true t env_extension ~meet_type
+let add_env_extension t env_extension ~meet_expanded_head =
+  try
+    add_env_extension ~raise_on_bottom:true t env_extension ~meet_expanded_head
   with Bottom_equation -> map_typing_env ~f:TE.make_bottom t
 
 let check_params_and_types ~params ~param_types =
@@ -313,11 +351,11 @@ let check_params_and_types ~params ~param_types =
       (Format.pp_print_list ~pp_sep:Format.pp_print_space TG.print)
       param_types
 
-let add_equations_on_params t ~params ~param_types ~meet_type =
+let add_equations_on_params t ~params ~param_types ~meet_expanded_head =
   check_params_and_types ~params ~param_types;
   List.fold_left2
     (fun t param param_type ->
-      add_equation t (Bound_parameter.name param) param_type ~meet_type)
+      add_equation t (Bound_parameter.name param) param_type ~meet_expanded_head)
     t
     (Bound_parameters.to_list params)
     param_types
@@ -341,3 +379,111 @@ let cut_as_extension env ~cut_after =
 let add_variable_definition env var kind name_mode =
   map_typing_env env ~f:(fun env ->
       TE.add_variable_definition env var kind name_mode)
+
+let add_alias ~raise_on_bottom env simple1 simple2 ~meet_expanded_head =
+  let canonical1 =
+    TE.get_canonical_simple_ignoring_name_mode (typing_env env) simple1
+  in
+  let canonical2 =
+    TE.get_canonical_simple_ignoring_name_mode (typing_env env) simple2
+  in
+  add_alias_between_canonicals ~raise_on_bottom env (Simple.kind canonical1)
+    canonical1 canonical2 ~meet_expanded_head
+
+let add_alias env simple1 simple2 ~meet_expanded_head : _ Or_bottom.t =
+  match
+    add_alias ~raise_on_bottom:true env simple1 simple2 ~meet_expanded_head
+  with
+  | exception Bottom_equation -> Bottom
+  | env -> Ok env
+
+let meet env (t1 : TG.t) (t2 : TG.t) ~(meet_expanded_head : meet_expanded_head)
+    : ET.t meet_result =
+  (* Kind mismatches should have been caught (either turned into Invalid or a
+     fatal error) before we get here. *)
+  if not (K.equal (TG.kind t1) (TG.kind t2))
+  then
+    Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
+      TG.print t2;
+  let kind = TG.kind t1 in
+  let tenv = typing_env env in
+  let simple1 =
+    match
+      TE.get_alias_then_canonical_simple_exn tenv t1
+        ~min_name_mode:Name_mode.in_types
+    with
+    | exception Not_found -> None
+    | canonical_simple -> Some canonical_simple
+  in
+  let simple2 =
+    match
+      TE.get_alias_then_canonical_simple_exn tenv t2
+        ~min_name_mode:Name_mode.in_types
+    with
+    | exception Not_found -> None
+    | canonical_simple -> Some canonical_simple
+  in
+  match simple1 with
+  | None -> (
+    let expanded1 =
+      Expand_head.expand_head0 tenv t1
+        ~known_canonical_simple_at_in_types_mode:simple1
+    in
+    match simple2 with
+    | None ->
+      let expanded2 =
+        Expand_head.expand_head0 tenv t2
+          ~known_canonical_simple_at_in_types_mode:simple2
+      in
+      meet_expanded_head env expanded1 expanded2
+    | Some simple2 -> (
+      (* Here we are meeting a non-alias type on the left with an alias on the
+         right. In all cases, the return type is the alias, so we will always
+         return [Right_input]; the interesting part will be the environment.
+
+         [add_equation] will meet [expanded1] with the existing type of
+         [simple2]. *)
+      match
+        add_concrete_equation_on_canonical ~raise_on_bottom:true env simple2
+          expanded1 ~meet_expanded_head
+      with
+      | exception Bottom_equation -> Bottom (New_result ())
+      | env -> Ok (Right_input, env)))
+  | Some simple1 -> (
+    match simple2 with
+    | None -> (
+      let expanded2 =
+        Expand_head.expand_head0 tenv t2
+          ~known_canonical_simple_at_in_types_mode:simple2
+      in
+      (* We always return [Left_input] (see comment above) *)
+      match
+        add_concrete_equation_on_canonical ~raise_on_bottom:true env simple1
+          expanded2 ~meet_expanded_head
+      with
+      | exception Bottom_equation -> Bottom (New_result ())
+      | env -> Ok (Left_input, env))
+    | Some simple2 -> (
+      (* We are doing a meet between two alias types. Whatever happens, the
+         resulting environment will contain an alias equation between the two
+         inputs, so both the left-hand alias and the right-hand alias are
+         correct results for the meet, allowing us to return [Both_inputs] in
+         all cases.
+
+         [add_alias_between_canonicals] will have called [meet] on the
+         underlying types, so [env] now contains all extra equations arising
+         from meeting the expanded heads.
+
+         Note that [add_alias_between_canonicals] does nothing if [simple1] and
+         [simple2] are equal. *)
+      match
+        add_alias_between_canonicals ~raise_on_bottom:true env kind simple1
+          simple2 ~meet_expanded_head
+      with
+      | exception Bottom_equation -> Bottom (New_result ())
+      | env -> Ok (Both_inputs, env)))
+
+(* CR bclement: is this wrapper really necessary? *)
+let[@inline always] meet_type env t1 t2 ~meet_expanded_head : TG.t meet_result =
+  map_result ~f:ET.to_type
+    ((meet [@inlined never]) env t1 t2 ~meet_expanded_head)

--- a/middle_end/flambda2/types/env/meet_env.mli
+++ b/middle_end/flambda2/types/env/meet_env.mli
@@ -22,11 +22,15 @@ type 'a meet_return_value =
   | Both_inputs
   | New_result of 'a
 
-type meet_type =
+type 'a meet_result =
+  | Bottom of unit meet_return_value
+  | Ok of 'a meet_return_value * t
+
+type meet_expanded_head =
   t ->
-  Type_grammar.t ->
-  Type_grammar.t ->
-  (Type_grammar.t meet_return_value * t) Or_bottom.t
+  Expand_head.Expanded_type.t ->
+  Expand_head.Expanded_type.t ->
+  Expand_head.Expanded_type.t meet_result
 
 val create : Typing_env.t -> t
 
@@ -44,38 +48,50 @@ val use_meet_env_strict : Typing_env.t -> f:(t -> t) -> Typing_env.t Or_bottom.t
 
 val typing_env : t -> Typing_env.t
 
-val add_equation : t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t
+val add_equation :
+  t -> Name.t -> Type_grammar.t -> meet_expanded_head:meet_expanded_head -> t
 
 val add_equation_on_simple :
-  t -> Simple.t -> Type_grammar.t -> meet_type:meet_type -> t
+  t -> Simple.t -> Type_grammar.t -> meet_expanded_head:meet_expanded_head -> t
 
 val add_equation_strict :
-  t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t Or_bottom.t
+  t ->
+  Name.t ->
+  Type_grammar.t ->
+  meet_expanded_head:meet_expanded_head ->
+  t Or_bottom.t
 
 val add_equations_on_params :
   t ->
   params:Bound_parameters.t ->
   param_types:Type_grammar.t list ->
-  meet_type:meet_type ->
+  meet_expanded_head:meet_expanded_head ->
   t
 
-val add_env_extension : t -> Typing_env_extension.t -> meet_type:meet_type -> t
+val add_env_extension :
+  t -> Typing_env_extension.t -> meet_expanded_head:meet_expanded_head -> t
 
 val add_env_extension_maybe_bottom :
-  t -> Typing_env_extension.t -> meet_type:meet_type -> t
+  t -> Typing_env_extension.t -> meet_expanded_head:meet_expanded_head -> t
 
 val add_env_extension_strict :
-  t -> Typing_env_extension.t -> meet_type:meet_type -> t Or_bottom.t
+  t ->
+  Typing_env_extension.t ->
+  meet_expanded_head:meet_expanded_head ->
+  t Or_bottom.t
 
 val add_env_extension_with_extra_variables :
-  t -> Typing_env_extension.With_extra_variables.t -> meet_type:meet_type -> t
+  t ->
+  Typing_env_extension.With_extra_variables.t ->
+  meet_expanded_head:meet_expanded_head ->
+  t
 
 (* CR vlaviron: If the underlying level in the extension defines several
    variables, then there is no guarantee that the binding order in the result
    will match the binding order used to create the level. If they don't match,
    then adding equations in the wrong order can make equations disappear. *)
 val add_env_extension_from_level :
-  t -> Typing_env_level.t -> meet_type:meet_type -> t
+  t -> Typing_env_level.t -> meet_expanded_head:meet_expanded_head -> t
 
 (* The functions below only manipulate the underlying typing env and are
    provided for convenience. *)
@@ -83,6 +99,13 @@ val add_env_extension_from_level :
 val current_scope : t -> Scope.t
 
 val increment_scope : t -> t
+
+val code_age_relation : t -> Code_age_relation.t
+
+val code_age_relation_resolver :
+  t -> Compilation_unit.t -> Code_age_relation.t option
+
+val machine_width : t -> Target_system.Machine_width.t
 
 val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
 
@@ -94,3 +117,17 @@ val cut_as_extension : t -> cut_after:Scope.t -> Typing_env_extension.t
 
 val add_variable_definition :
   t -> Variable.t -> Flambda_kind.t -> Name_mode.t -> t
+
+val add_alias :
+  t ->
+  Simple.t ->
+  Simple.t ->
+  meet_expanded_head:meet_expanded_head ->
+  t Or_bottom.t
+
+val meet_type :
+  t ->
+  Type_grammar.t ->
+  Type_grammar.t ->
+  meet_expanded_head:meet_expanded_head ->
+  Type_grammar.t meet_result

--- a/middle_end/flambda2/types/equal_types_for_debug.ml
+++ b/middle_end/flambda2/types/equal_types_for_debug.ml
@@ -48,17 +48,17 @@ type env =
   { parent_env : TE.t;
     left_env : TE.t;
     right_env : TE.t;
-    meet_type : ME.meet_type;
+    meet_expanded_head : ME.meet_expanded_head;
     config : config;
     renaming : renaming
   }
 
-let create_env ?(config = create_config ()) ~meet_type parent_env left_env
-    right_env =
+let create_env ?(config = create_config ()) ~meet_expanded_head parent_env
+    left_env right_env =
   { parent_env;
     left_env;
     right_env;
-    meet_type;
+    meet_expanded_head;
     config;
     renaming = create_renaming ()
   }
@@ -68,15 +68,19 @@ let extension_env env left_env right_env = { env with left_env; right_env }
 let add_env_extension env ext1 ext2 =
   extension_env env
     (ME.use_meet_env env.left_env ~f:(fun left_env ->
-         ME.add_env_extension ~meet_type:env.meet_type left_env ext1))
+         ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head
+           left_env ext1))
     (ME.use_meet_env env.right_env ~f:(fun right_env ->
-         ME.add_env_extension ~meet_type:env.meet_type right_env ext2))
+         ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head
+           right_env ext2))
 
 let add_env_extension_strict env ext1 ext2 =
   ( ME.use_meet_env_strict env.left_env ~f:(fun left_env ->
-        ME.add_env_extension ~meet_type:env.meet_type left_env ext1),
+        ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head left_env
+          ext1),
     ME.use_meet_env_strict env.right_env ~f:(fun right_env ->
-        ME.add_env_extension ~meet_type:env.meet_type right_env ext2) )
+        ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head
+          right_env ext2) )
 
 let exists_in_parent_env env name =
   TE.mem ~min_name_mode:Name_mode.in_types env.parent_env name
@@ -506,8 +510,8 @@ let rec equal_type env t1 t2 =
       (Expand_head.expand_head env.left_env t1)
       (Expand_head.expand_head env.right_env t2)
 
-let names_with_non_equal_types_level_ignoring_name_mode ?config ~meet_type env
-    level1 level2 =
+let names_with_non_equal_types_level_ignoring_name_mode ?config
+    ~meet_expanded_head env level1 level2 =
   let left_env =
     Typing_env_level.fold_on_defined_vars
       (fun var kind left_env ->
@@ -535,23 +539,26 @@ let names_with_non_equal_types_level_ignoring_name_mode ?config ~meet_type env
       level2 env
   in
   names_with_non_equal_types_env_extension ~equal_type
-    (create_env ?config ~meet_type env left_env right_env)
+    (create_env ?config ~meet_expanded_head env left_env right_env)
     (TEE.from_map (Typing_env_level.equations level1))
     (TEE.from_map (Typing_env_level.equations level2))
 
-let equal_level_ignoring_name_mode ?config ~meet_type env level1 level2 =
+let equal_level_ignoring_name_mode ?config ~meet_expanded_head env level1 level2
+    =
   Name.Set.is_empty
-    (names_with_non_equal_types_level_ignoring_name_mode ?config ~meet_type env
-       level1 level2)
+    (names_with_non_equal_types_level_ignoring_name_mode ?config
+       ~meet_expanded_head env level1 level2)
 
-let names_with_non_equal_types_env_extension ?config ~meet_type env ext1 ext2 =
+let names_with_non_equal_types_env_extension ?config ~meet_expanded_head env
+    ext1 ext2 =
   names_with_non_equal_types_env_extension ~equal_type
-    (create_env ?config ~meet_type env env env)
+    (create_env ?config ~meet_expanded_head env env env)
     ext1 ext2
 
-let equal_env_extension ?config ~meet_type env ext1 ext2 =
+let equal_env_extension ?config ~meet_expanded_head env ext1 ext2 =
   Name.Set.is_empty
-    (names_with_non_equal_types_env_extension ?config ~meet_type env ext1 ext2)
+    (names_with_non_equal_types_env_extension ?config ~meet_expanded_head env
+       ext1 ext2)
 
-let equal_type ?config ~meet_type env t1 t2 =
-  equal_type (create_env ?config ~meet_type env env env) t1 t2
+let equal_type ?config ~meet_expanded_head env t1 t2 =
+  equal_type (create_env ?config ~meet_expanded_head env env env) t1 t2

--- a/middle_end/flambda2/types/equal_types_for_debug.mli
+++ b/middle_end/flambda2/types/equal_types_for_debug.mli
@@ -30,7 +30,7 @@ val create_config : ?ignore_alloc_mode:bool -> unit -> config
 
 val equal_type :
   ?config:config ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   Typing_env.t ->
   Type_grammar.t ->
   Type_grammar.t ->
@@ -38,7 +38,7 @@ val equal_type :
 
 val equal_env_extension :
   ?config:config ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   Typing_env.t ->
   Typing_env_extension.t ->
   Typing_env_extension.t ->
@@ -46,7 +46,7 @@ val equal_env_extension :
 
 val names_with_non_equal_types_env_extension :
   ?config:config ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   Typing_env.t ->
   Typing_env_extension.t ->
   Typing_env_extension.t ->
@@ -54,7 +54,7 @@ val names_with_non_equal_types_env_extension :
 
 val equal_level_ignoring_name_mode :
   ?config:config ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   Typing_env.t ->
   Typing_env_level.t ->
   Typing_env_level.t ->
@@ -62,7 +62,7 @@ val equal_level_ignoring_name_mode :
 
 val names_with_non_equal_types_level_ignoring_name_mode :
   ?config:config ->
-  meet_type:Meet_env.meet_type ->
+  meet_expanded_head:Meet_env.meet_expanded_head ->
   Typing_env.t ->
   Typing_env_level.t ->
   Typing_env_level.t ->

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -71,6 +71,8 @@ module Expanded_type : sig
 
   val to_type : t -> Type_grammar.t
 
+  val kind : t -> K.t
+
   type descr = private
     | Value of Type_grammar.head_of_kind_value
     | Naked_immediate of Type_grammar.head_of_kind_naked_immediate
@@ -137,6 +139,8 @@ end = struct
     { kind : K.t;
       descr : descr Or_unknown_or_bottom.t
     }
+
+  let kind t = t.kind
 
   let descr t = t.descr
 

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -68,6 +68,8 @@ module Expanded_type : sig
 
   val to_type : t -> Type_grammar.t
 
+  val kind : t -> Flambda_kind.t
+
   type descr = private
     | Value of Type_grammar.head_of_kind_value
     | Naked_immediate of Type_grammar.head_of_kind_naked_immediate

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -20,6 +20,8 @@
 module Expanded_type : sig
   type t
 
+  val of_non_alias_type : ?coercion:Coercion.t -> Type_grammar.t -> t
+
   val create_const : Reg_width_const.t -> t
 
   val create_value : Type_grammar.head_of_kind_value -> t

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -19,10 +19,11 @@ module Typing_env = struct
   open Meet_env
 
   let add_equation t name ty =
-    add_equation t name ty ~meet_type:(Meet.meet_type ())
+    add_equation t name ty ~meet_expanded_head:(Meet.meet_expanded_head ())
 
   let add_equation_on_simple t simple ty =
-    add_equation_on_simple t simple ty ~meet_type:(Meet.meet_type ())
+    add_equation_on_simple t simple ty
+      ~meet_expanded_head:(Meet.meet_expanded_head ())
 
   let add_is_null_relation t name ~scrutinee =
     use_meet_env t ~f:(fun t ->
@@ -89,16 +90,17 @@ module Typing_env = struct
   let add_equations_on_params t ~params ~param_types =
     use_meet_env t ~f:(fun t ->
         add_equations_on_params t ~params ~param_types
-          ~meet_type:(Meet.meet_type ()))
+          ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   let add_env_extension t extension =
     use_meet_env t ~f:(fun t ->
-        add_env_extension t extension ~meet_type:(Meet.meet_type ()))
+        add_env_extension t extension
+          ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   let add_env_extension_with_extra_variables t extension =
     use_meet_env t ~f:(fun t ->
         add_env_extension_with_extra_variables t extension
-          ~meet_type:(Meet.meet_type ()))
+          ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   module Alias_set = Aliases.Alias_set
 end
@@ -146,11 +148,14 @@ let remove_outermost_alias env ty =
 
 module Equal_types_for_debug = struct
   let equal_type env t1 t2 =
-    Equal_types_for_debug.equal_type ~meet_type:(Meet.meet_type ()) env t1 t2
+    Equal_types_for_debug.equal_type
+      ~meet_expanded_head:(Meet.meet_expanded_head ())
+      env t1 t2
 
   let equal_env_extension env ext1 ext2 =
-    Equal_types_for_debug.equal_env_extension ~meet_type:(Meet.meet_type ()) env
-      ext1 ext2
+    Equal_types_for_debug.equal_env_extension
+      ~meet_expanded_head:(Meet.meet_expanded_head ())
+      env ext1 ext2
 end
 
 module Rewriter = Traversals

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -51,7 +51,7 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
   let ts = List.rev_map (fun (t, use_id, _) -> use_id, t) ts_and_use_ids in
   let env, analysis =
     Join_env.cut_and_n_way_join_with_analysis
-      ~meet_type:Meet_and_n_way_join.meet_type
+      ~meet_expanded_head:Meet_and_n_way_join.meet_expanded_head
       ~n_way_join_type:Meet_and_n_way_join.n_way_join definition_typing_env
       ~cut_after ts
   in
@@ -90,8 +90,9 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
      in
      let distinct_names =
        Equal_types_for_debug.names_with_non_equal_types_level_ignoring_name_mode
-         ~config ~meet_type:(Meet.meet_type ()) typing_env old_joined_level
-         new_joined_level
+         ~config
+         ~meet_expanded_head:(Meet.meet_expanded_head ())
+         typing_env old_joined_level new_joined_level
      in
      let distinct_names =
        Name.Set.filter
@@ -121,5 +122,5 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
        Format.eprintf "@]@\n%s@." (String.make 60 '=')));
     ( Meet_env.use_meet_env definition_typing_env ~f:(fun target_env ->
           Meet_env.add_env_extension_from_level target_env new_joined_level
-            ~meet_type:(Meet.meet_type ())),
+            ~meet_expanded_head:(Meet.meet_expanded_head ())),
       analysis )

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -92,7 +92,7 @@ let join_types ~env_at_fork envs_with_levels =
         ME.use_meet_env base_env ~f:(fun base_env ->
             ME.add_env_extension_maybe_bottom base_env
               (TEE.from_map joined_types)
-              ~meet_type:Meet_and_join.meet_type)
+              ~meet_expanded_head:Meet_and_join.meet_expanded_head)
       in
       let join_types name joined_ty use_ty =
         let same_unit =
@@ -339,7 +339,7 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
   let result_env =
     ME.use_meet_env definition_typing_env ~f:(fun target_env ->
         ME.add_env_extension_from_level target_env level
-          ~meet_type:Meet_and_join.meet_type)
+          ~meet_expanded_head:Meet_and_join.meet_expanded_head)
   in
   TE.compute_joined_aliases result_env alias_candidates
     (List.map (fun (env_at_use, _, _, _) -> env_at_use) after_cuts)

--- a/middle_end/flambda2/types/meet.ml
+++ b/middle_end/flambda2/types/meet.ml
@@ -29,10 +29,10 @@ let meet env t1 t2 =
     Printexc.raise_with_backtrace Misc.Fatal_error bt
 
 (* Internal use only *)
-let[@inline] meet_type () =
+let[@inline] meet_expanded_head () =
   if Flambda_features.use_n_way_join ()
-  then Meet_and_n_way_join.meet_type
-  else Meet_and_join.meet_type
+  then Meet_and_n_way_join.meet_expanded_head
+  else Meet_and_join.meet_expanded_head
 
 let meet_shape env t ~shape : _ Or_bottom.t =
   if Typing_env.is_bottom env

--- a/middle_end/flambda2/types/meet.mli
+++ b/middle_end/flambda2/types/meet.mli
@@ -19,7 +19,7 @@ val meet :
   Type_grammar.t ->
   (Type_grammar.t * Typing_env.t) Or_bottom.t
 
-val meet_type : unit -> Meet_env.meet_type
+val meet_expanded_head : unit -> Meet_env.meet_expanded_head
 
 val meet_shape :
   Typing_env.t ->

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -49,33 +49,9 @@ let map_return_value f (x : _ meet_return_value) =
   | Both_inputs -> Both_inputs
   | New_result x -> New_result (f x)
 
-type 'a meet_result =
+type 'a meet_result = 'a ME.meet_result =
   | Bottom of unit meet_return_value
   | Ok of 'a meet_return_value * ME.t
-
-let add_equation (simple : Simple.t) ty_of_simple env ~meet_type :
-    unit meet_result =
-  let name name ~coercion:coercion_from_name_to_simple =
-    let coercion_from_simple_to_name =
-      Coercion.inverse coercion_from_name_to_simple
-    in
-    let ty_of_name =
-      TG.apply_coercion ty_of_simple coercion_from_simple_to_name
-    in
-    match ME.add_equation_strict env name ty_of_name ~meet_type with
-    | Ok env -> Ok (New_result (), env)
-    | Bottom -> Bottom (New_result ())
-  in
-  Simple.pattern_match simple ~name ~const:(fun const ->
-      (* A constant is its own most precise type, but we still need to check
-         that is matches the assigned type. *)
-      if Flambda_features.check_light_invariants ()
-      then assert (TG.get_alias_opt ty_of_simple == None);
-      (* Make sure to not use an alias type, or we will loop! *)
-      let concrete_ty_of_const = ET.to_type (ET.create_const const) in
-      match meet_type env concrete_ty_of_const ty_of_simple with
-      | Or_bottom.Ok (_, env) -> Ok (New_result (), env)
-      | Or_bottom.Bottom -> Bottom (New_result ()))
 
 let map_result ~f = function
   | Bottom r -> Bottom r
@@ -283,7 +259,7 @@ type ext =
         when_b : TEE.t
       }
 
-let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
+let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_expanded_head
     ~join_env_extension initial_env val_a1 val_b1 extensions1 val_a2 val_b2
     extensions2 =
   let join_scope = ME.current_scope initial_env in
@@ -295,7 +271,7 @@ let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
   let direct_return r =
     map_env r ~f:(fun scoped_env ->
         ME.add_env_extension_strict initial_env (to_extension scoped_env)
-          ~meet_type)
+          ~meet_expanded_head)
   in
   let env_a, env_b = Or_bottom.Ok env, Or_bottom.Ok env in
   let env_a, env_b =
@@ -303,18 +279,18 @@ let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
     | No_extensions -> env_a, env_b
     | Ext { when_a; when_b } ->
       ( Or_bottom.bind env_a ~f:(fun env ->
-            ME.add_env_extension_strict env when_a ~meet_type),
+            ME.add_env_extension_strict env when_a ~meet_expanded_head),
         Or_bottom.bind env_b ~f:(fun env ->
-            ME.add_env_extension_strict env when_b ~meet_type) )
+            ME.add_env_extension_strict env when_b ~meet_expanded_head) )
   in
   let env_a, env_b =
     match extensions2 with
     | No_extensions -> env_a, env_b
     | Ext { when_a; when_b } ->
       ( Or_bottom.bind env_a ~f:(fun env ->
-            ME.add_env_extension_strict env when_a ~meet_type),
+            ME.add_env_extension_strict env when_a ~meet_expanded_head),
         Or_bottom.bind env_b ~f:(fun env ->
-            ME.add_env_extension_strict env when_b ~meet_type) )
+            ME.add_env_extension_strict env when_b ~meet_expanded_head) )
   in
   let a_result : _ meet_result =
     match env_a with
@@ -387,7 +363,7 @@ let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
     let result_env =
       (* Not strict, as we don't expect to be able to get bottom equations from
          joining non-bottom ones *)
-      ME.add_env_extension initial_env result_extension ~meet_type
+      ME.add_env_extension initial_env result_extension ~meet_expanded_head
     in
     Ok (result, result_env)
 
@@ -397,9 +373,8 @@ let meet_code_id (env : ME.t) (code_id1 : Code_id.t) (code_id2 : Code_id.t) :
   then Ok (Both_inputs, env)
   else
     match
-      Code_age_relation.meet
-        (TE.code_age_relation (ME.typing_env env))
-        ~resolver:(TE.code_age_relation_resolver (ME.typing_env env))
+      Code_age_relation.meet (ME.code_age_relation env)
+        ~resolver:(ME.code_age_relation_resolver env)
         code_id1 code_id2
     with
     | Bottom -> Bottom (New_result ())
@@ -498,105 +473,7 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     then Ok element_kind1
     else Unknown
 
-let rec meet env (t1 : TG.t) (t2 : TG.t) : TG.t meet_result =
-  (* Kind mismatches should have been caught (either turned into Invalid or a
-     fatal error) before we get here. *)
-  if not (K.equal (TG.kind t1) (TG.kind t2))
-  then
-    Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
-      TG.print t2;
-  let kind = TG.kind t1 in
-  let simple1 =
-    match
-      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t1
-        ~min_name_mode:Name_mode.in_types
-    with
-    | exception Not_found -> None
-    | canonical_simple -> Some canonical_simple
-  in
-  let simple2 =
-    match
-      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t2
-        ~min_name_mode:Name_mode.in_types
-    with
-    | exception Not_found -> None
-    | canonical_simple -> Some canonical_simple
-  in
-  match simple1 with
-  | None -> (
-    let expanded1 =
-      Expand_head.expand_head0 (ME.typing_env env) t1
-        ~known_canonical_simple_at_in_types_mode:simple1
-    in
-    match simple2 with
-    | None ->
-      let expanded2 =
-        Expand_head.expand_head0 (ME.typing_env env) t2
-          ~known_canonical_simple_at_in_types_mode:simple2
-      in
-      map_result ~f:ET.to_type (meet_expanded_head env expanded1 expanded2)
-    | Some simple2 -> (
-      (* Here we are meeting a non-alias type on the left with an alias on the
-         right. In all cases, the return type is the alias, so we will always
-         return [Right_input]; the interesting part will be the environment.
-
-         [add_equation] will meet [expanded1] with the existing type of
-         [simple2]. *)
-      let env : unit meet_result =
-        add_equation simple2 (ET.to_type expanded1) env ~meet_type
-      in
-      match env with
-      | Ok (_, env) -> Ok (Right_input, env)
-      | Bottom r -> Bottom r))
-  | Some simple1 -> (
-    match simple2 with
-    | None -> (
-      let expanded2 =
-        Expand_head.expand_head0 (ME.typing_env env) t2
-          ~known_canonical_simple_at_in_types_mode:simple2
-      in
-      (* We always return [Left_input] (see comment above) *)
-      let env : unit meet_result =
-        add_equation simple1 (ET.to_type expanded2) env ~meet_type
-      in
-      match env with
-      | Ok (_, env) -> Ok (Left_input, env)
-      | Bottom r -> Bottom r)
-    | Some simple2 -> (
-      if
-        (* We are doing a meet between two alias types. Whatever happens, the
-           resulting environment will contain an alias equation between the two
-           inputs, so both the left-hand alias and the right-hand alias are
-           correct results for the meet, allowing us to return [Both_inputs] in
-           all cases. *)
-        Simple.equal simple1 simple2
-      then
-        (* The alias is already present; no need to add any equation here *)
-        Ok (Both_inputs, env)
-      else
-        let env =
-          Simple.pattern_match simple2
-            ~name:(fun _ ~coercion:_ ->
-              add_equation simple2
-                (TG.alias_type_of kind simple1)
-                env ~meet_type)
-            ~const:(fun const2 ->
-              Simple.pattern_match simple1
-                ~name:(fun _ ~coercion:_ ->
-                  add_equation simple1
-                    (TG.alias_type_of kind simple2)
-                    env ~meet_type)
-                ~const:(fun const1 : unit meet_result ->
-                  if Reg_width_const.equal const1 const2
-                  then Ok (New_result (), env)
-                  else Bottom (New_result ())))
-        in
-        (* [add_equation] will have called [meet] on the underlying types, so
-           [env] now contains all extra equations arising from meeting the
-           expanded heads. *)
-        match env with
-        | Ok (_, env) -> Ok (Both_inputs, env)
-        | Bottom r -> Bottom r))
+let rec meet env t1 t2 = ME.meet_type env t1 t2 ~meet_expanded_head
 
 and meet_or_unknown_or_bottom : type a b.
     (ME.t -> a -> a -> b meet_result) ->
@@ -697,7 +574,7 @@ and meet_head_of_kind_value env
   map_result
     ~f:(fun (non_null, is_null, _extensions) : TG.head_of_kind_value ->
       { non_null; is_null })
-    (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
+    (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_expanded_head
        ~join_env_extension env non_null1 is_null1 No_extensions non_null2
        is_null2 No_extensions)
 
@@ -940,40 +817,12 @@ and meet_relation env var1 var2 =
   | None, None -> Ok (Both_inputs, env)
   | Some _, None -> Ok (Left_input, env)
   | None, Some _ -> Ok (Right_input, env)
-  | Some var1, Some var2 ->
-    let simple1 =
-      TE.get_canonical_simple_ignoring_name_mode (ME.typing_env env)
-        (Simple.var var1)
-    in
-    let simple2 =
-      TE.get_canonical_simple_ignoring_name_mode (ME.typing_env env)
-        (Simple.var var2)
-    in
-    if Simple.equal simple1 simple2
-    then Ok (Both_inputs, env)
-    else
-      Simple.pattern_match simple1
-        ~const:(fun _ ->
-          Simple.pattern_match simple2
-            ~const:(fun _ : _ meet_result ->
-              (* Distinct constants: this is a bottom result *)
-              Bottom (New_result ()))
-            ~name:(fun _ ~coercion:_ : _ meet_result -> Ok (Right_input, env)))
-        ~name:(fun _ ~coercion:_ ->
-          Simple.pattern_match simple2
-            ~const:(fun _ : _ meet_result -> Ok (Left_input, env))
-            ~name:(fun _ ~coercion:_ ->
-              (* Note: This equality can (rarely?) cause loops due to reductions
-                 that could be stored on the relation variables (if the relation
-                 variable has a [Is_int] / [Get_tag] / [Is_null] type). This is
-                 caught by the safeguard in [Meet_env]. *)
-              match
-                add_equation simple1
-                  (TG.alias_type_of K.naked_immediate simple2)
-                  env ~meet_type
-              with
-              | Ok (_, env) -> Ok (Both_inputs, env)
-              | Bottom r -> Bottom r))
+  | Some var1, Some var2 -> (
+    match
+      ME.add_alias env (Simple.var var1) (Simple.var var2) ~meet_expanded_head
+    with
+    | Ok env -> Ok (Both_inputs, env)
+    | Bottom -> Bottom (New_result ()))
 
 and meet_variant env ~(is_int1 : Variable.t option)
     ~(get_tag1 : Variable.t option)
@@ -1044,9 +893,9 @@ and meet_variant env ~(is_int1 : Variable.t option)
       map_result
         ~f:(fun (imms, (get_tag, blocks), extensions) ->
           get_tag, blocks, imms, extensions)
-        (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
-           ~join_env_extension env imms1 (get_tag1, blocks1) extensions1 imms2
-           (get_tag2, blocks2) extensions2))
+        (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
+           ~meet_expanded_head ~join_env_extension env imms1 (get_tag1, blocks1)
+           extensions1 imms2 (get_tag2, blocks2) extensions2))
     ~left_a:is_int1 ~right_a:is_int2
     ~left_b:(get_tag1, blocks1, imms1, extensions1)
     ~right_b:(get_tag2, blocks2, imms2, extensions2)
@@ -1089,7 +938,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     then bottom_other_side is_null_side
     else
       let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
-      let machine_width = TE.machine_width (ME.typing_env env) in
+      let machine_width = ME.machine_width env in
       match
         ( I.Set.mem (I.zero machine_width) immediates,
           I.Set.mem (I.one machine_width) immediates )
@@ -1116,7 +965,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       if Tag.Set.is_empty tags
       then Bottom (New_result ())
       else
-        let machine_width = TE.machine_width (ME.typing_env env) in
+        let machine_width = ME.machine_width env in
         match
           MTC.blocks_with_these_tags ~machine_width tags
             (Alloc_mode.For_types.unknown ())
@@ -1403,11 +1252,13 @@ and meet_row_like :
       | Ok (maps_to_result, env) -> (
         let env : _ Or_bottom.t =
           match
-            ME.add_env_extension_strict env case1.env_extension ~meet_type
+            ME.add_env_extension_strict env case1.env_extension
+              ~meet_expanded_head
           with
           | Bottom -> Bottom
           | Ok env ->
-            ME.add_env_extension_strict env case2.env_extension ~meet_type
+            ME.add_env_extension_strict env case2.env_extension
+              ~meet_expanded_head
         in
         match env with
         | Bottom -> bottom_case (New_result ())
@@ -1457,7 +1308,7 @@ and meet_row_like :
         | Unknown -> (
           match
             ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_type
+              ~meet_expanded_head
           with
           | Bottom -> None
           | Ok env ->
@@ -1476,7 +1327,7 @@ and meet_row_like :
         | Unknown -> (
           match
             ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_type
+              ~meet_expanded_head
           with
           | Bottom -> None
           | Ok env ->
@@ -1492,7 +1343,8 @@ and meet_row_like :
         Some Unknown
       | Known case, Unknown -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension ~meet_type
+          ME.add_env_extension_strict base_env case.env_extension
+            ~meet_expanded_head
         with
         | Bottom -> None
         | Ok env ->
@@ -1501,7 +1353,8 @@ and meet_row_like :
           Some (Known case))
       | Unknown, Known case -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension ~meet_type
+          ME.add_env_extension_strict base_env case.env_extension
+            ~meet_expanded_head
         with
         | Bottom -> None
         | Ok env ->
@@ -1538,7 +1391,8 @@ and meet_row_like :
     let env : _ Or_bottom.t =
       match !result_env with
       | No_result -> Bottom
-      | Extension ext -> ME.add_env_extension_strict initial_env ext ~meet_type
+      | Extension ext ->
+        ME.add_env_extension_strict initial_env ext ~meet_expanded_head
     in
     let match_with_input v =
       match !result_is_t1, !result_is_t2 with
@@ -1694,14 +1548,6 @@ and meet_function_type (env : ME.t)
     in
     combine_results2 env ~rebuild ~meet_a:meet_code_id ~left_a:code_id1
       ~right_a:code_id2 ~meet_b:meet ~left_b:rec_info1 ~right_b:rec_info2
-
-and meet_type env t1 t2 : _ Or_bottom.t =
-  if TE.is_bottom (ME.typing_env env)
-  then Bottom
-  else
-    match meet env t1 t2 with
-    | Ok (res, env) -> Ok (res, env)
-    | Bottom _ -> Bottom
 
 and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
   (* Kind mismatches should have been caught (either turned into Invalid or a

--- a/middle_end/flambda2/types/meet_and_join.mli
+++ b/middle_end/flambda2/types/meet_and_join.mli
@@ -31,8 +31,4 @@ val join :
 
 (* This function has a slightly different interface; it is meant to be used only
    by functions in Typing_env *)
-val meet_type :
-  Meet_env.t ->
-  Type_grammar.t ->
-  Type_grammar.t ->
-  (Type_grammar.t Meet_env.meet_return_value * Meet_env.t) Or_bottom.t
+val meet_expanded_head : Meet_env.meet_expanded_head

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -39,7 +39,7 @@ let map_return_value f (x : _ meet_return_value) =
   | Both_inputs -> Both_inputs
   | New_result x -> New_result (f x)
 
-type 'a meet_result =
+type 'a meet_result = 'a ME.meet_result =
   | Bottom of unit meet_return_value
   | Ok of 'a meet_return_value * ME.t
 
@@ -48,30 +48,6 @@ type 'a n_way_join_result = 'a Or_unknown.t * Join_env.t
 let map_join_result ~f (v, env) = Or_unknown.map ~f v, env
 
 let ( let>>+ ) x f = map_join_result ~f x
-
-let add_equation (simple : Simple.t) ty_of_simple env ~meet_type :
-    unit meet_result =
-  let name name ~coercion:coercion_from_name_to_simple =
-    let coercion_from_simple_to_name =
-      Coercion.inverse coercion_from_name_to_simple
-    in
-    let ty_of_name =
-      TG.apply_coercion ty_of_simple coercion_from_simple_to_name
-    in
-    match ME.add_equation_strict env name ty_of_name ~meet_type with
-    | Ok env -> Ok (New_result (), env)
-    | Bottom -> Bottom (New_result ())
-  in
-  Simple.pattern_match simple ~name ~const:(fun const ->
-      (* A constant is its own most precise type, but we still need to check
-         that is matches the assigned type. *)
-      if Flambda_features.check_light_invariants ()
-      then assert (TG.get_alias_opt ty_of_simple == None);
-      (* Make sure to not use an alias type, or we will loop! *)
-      let concrete_ty_of_const = ET.to_type (ET.create_const const) in
-      match meet_type env concrete_ty_of_const ty_of_simple with
-      | Or_bottom.Ok (_, env) -> Ok (New_result (), env)
-      | Or_bottom.Bottom -> Bottom (New_result ()))
 
 let map_result ~f = function
   | Bottom r -> Bottom r
@@ -292,8 +268,9 @@ let add_defined_vars env level =
         kind)
     level env
 
-let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type ~n_way_join
-    initial_env val_a1 val_b1 extensions1 val_a2 val_b2 extensions2 =
+let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_expanded_head
+    ~n_way_join initial_env val_a1 val_b1 extensions1 val_a2 val_b2 extensions2
+    =
   let join_scope = ME.current_scope initial_env in
   let env = ME.increment_scope initial_env in
   let direct_return r =
@@ -302,7 +279,7 @@ let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type ~n_way_join
         let level = ME.cut scoped_env ~cut_after:join_scope in
         let initial_env = add_defined_vars initial_env level in
         let ext = TEE.from_map (TEL.equations level) in
-        ME.add_env_extension_strict initial_env ext ~meet_type)
+        ME.add_env_extension_strict initial_env ext ~meet_expanded_head)
   in
   let env_a, env_b = Or_bottom.Ok env, Or_bottom.Ok env in
   let env_a, env_b =
@@ -310,18 +287,18 @@ let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type ~n_way_join
     | No_extensions -> env_a, env_b
     | Ext { when_a; when_b } ->
       ( Or_bottom.bind env_a ~f:(fun env ->
-            ME.add_env_extension_strict env when_a ~meet_type),
+            ME.add_env_extension_strict env when_a ~meet_expanded_head),
         Or_bottom.bind env_b ~f:(fun env ->
-            ME.add_env_extension_strict env when_b ~meet_type) )
+            ME.add_env_extension_strict env when_b ~meet_expanded_head) )
   in
   let env_a, env_b =
     match extensions2 with
     | No_extensions -> env_a, env_b
     | Ext { when_a; when_b } ->
       ( Or_bottom.bind env_a ~f:(fun env ->
-            ME.add_env_extension_strict env when_a ~meet_type),
+            ME.add_env_extension_strict env when_a ~meet_expanded_head),
         Or_bottom.bind env_b ~f:(fun env ->
-            ME.add_env_extension_strict env when_b ~meet_type) )
+            ME.add_env_extension_strict env when_b ~meet_expanded_head) )
   in
   let a_result : _ meet_result =
     match env_a with
@@ -356,8 +333,8 @@ let meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type ~n_way_join
     let result_env =
       (* Not strict, as we don't expect to be able to get bottom equations from
          joining non-bottom ones *)
-      Join_env.cut_and_n_way_join ~meet_type ~n_way_join_type:n_way_join
-        ~cut_after:join_scope initial_env
+      Join_env.cut_and_n_way_join ~meet_expanded_head
+        ~n_way_join_type:n_way_join ~cut_after:join_scope initial_env
         [ME.typing_env env_a; ME.typing_env env_b]
     in
     let when_a_level = ME.cut env_a ~cut_after:join_scope in
@@ -409,9 +386,8 @@ let meet_code_id (env : ME.t) (code_id1 : Code_id.t) (code_id2 : Code_id.t) :
   then Ok (Both_inputs, env)
   else
     match
-      Code_age_relation.meet
-        (TE.code_age_relation (ME.typing_env env))
-        ~resolver:(TE.code_age_relation_resolver (ME.typing_env env))
+      Code_age_relation.meet (ME.code_age_relation env)
+        ~resolver:(ME.code_age_relation_resolver env)
         code_id1 code_id2
     with
     | Bottom -> Bottom (New_result ())
@@ -640,105 +616,7 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     then Ok element_kind1
     else Unknown
 
-let rec meet env (t1 : TG.t) (t2 : TG.t) : TG.t meet_result =
-  (* Kind mismatches should have been caught (either turned into Invalid or a
-     fatal error) before we get here. *)
-  if not (K.equal (TG.kind t1) (TG.kind t2))
-  then
-    Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
-      TG.print t2;
-  let kind = TG.kind t1 in
-  let simple1 =
-    match
-      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t1
-        ~min_name_mode:Name_mode.in_types
-    with
-    | exception Not_found -> None
-    | canonical_simple -> Some canonical_simple
-  in
-  let simple2 =
-    match
-      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t2
-        ~min_name_mode:Name_mode.in_types
-    with
-    | exception Not_found -> None
-    | canonical_simple -> Some canonical_simple
-  in
-  match simple1 with
-  | None -> (
-    let expanded1 =
-      Expand_head.expand_head0 (ME.typing_env env) t1
-        ~known_canonical_simple_at_in_types_mode:simple1
-    in
-    match simple2 with
-    | None ->
-      let expanded2 =
-        Expand_head.expand_head0 (ME.typing_env env) t2
-          ~known_canonical_simple_at_in_types_mode:simple2
-      in
-      map_result ~f:ET.to_type (meet_expanded_head env expanded1 expanded2)
-    | Some simple2 -> (
-      (* Here we are meeting a non-alias type on the left with an alias on the
-         right. In all cases, the return type is the alias, so we will always
-         return [Right_input]; the interesting part will be the environment.
-
-         [add_equation] will meet [expanded1] with the existing type of
-         [simple2]. *)
-      let env : unit meet_result =
-        add_equation simple2 (ET.to_type expanded1) env ~meet_type
-      in
-      match env with
-      | Ok (_, env) -> Ok (Right_input, env)
-      | Bottom r -> Bottom r))
-  | Some simple1 -> (
-    match simple2 with
-    | None -> (
-      let expanded2 =
-        Expand_head.expand_head0 (ME.typing_env env) t2
-          ~known_canonical_simple_at_in_types_mode:simple2
-      in
-      (* We always return [Left_input] (see comment above) *)
-      let env : unit meet_result =
-        add_equation simple1 (ET.to_type expanded2) env ~meet_type
-      in
-      match env with
-      | Ok (_, env) -> Ok (Left_input, env)
-      | Bottom r -> Bottom r)
-    | Some simple2 -> (
-      if
-        (* We are doing a meet between two alias types. Whatever happens, the
-           resulting environment will contain an alias equation between the two
-           inputs, so both the left-hand alias and the right-hand alias are
-           correct results for the meet, allowing us to return [Both_inputs] in
-           all cases. *)
-        Simple.equal simple1 simple2
-      then
-        (* The alias is already present; no need to add any equation here *)
-        Ok (Both_inputs, env)
-      else
-        let env =
-          Simple.pattern_match simple2
-            ~name:(fun _ ~coercion:_ ->
-              add_equation simple2
-                (TG.alias_type_of kind simple1)
-                env ~meet_type)
-            ~const:(fun const2 ->
-              Simple.pattern_match simple1
-                ~name:(fun _ ~coercion:_ ->
-                  add_equation simple1
-                    (TG.alias_type_of kind simple2)
-                    env ~meet_type)
-                ~const:(fun const1 : unit meet_result ->
-                  if Reg_width_const.equal const1 const2
-                  then Ok (New_result (), env)
-                  else Bottom (New_result ())))
-        in
-        (* [add_equation] will have called [meet] on the underlying types, so
-           [env] now contains all extra equations arising from meeting the
-           expanded heads. *)
-        match env with
-        | Ok (_, env) -> Ok (Both_inputs, env)
-        | Bottom r -> Bottom r))
+let rec meet env t1 t2 = ME.meet_type env t1 t2 ~meet_expanded_head
 
 and meet_or_unknown_or_bottom : type a b.
     (ME.t -> a -> a -> b meet_result) ->
@@ -839,8 +717,9 @@ and meet_head_of_kind_value env
   map_result
     ~f:(fun (non_null, is_null, _extensions) : TG.head_of_kind_value ->
       { non_null; is_null })
-    (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type ~n_way_join
-       env non_null1 is_null1 No_extensions non_null2 is_null2 No_extensions)
+    (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_expanded_head
+       ~n_way_join env non_null1 is_null1 No_extensions non_null2 is_null2
+       No_extensions)
 
 and meet_head_of_kind_value_non_null env
     (head1 : TG.head_of_kind_value_non_null)
@@ -1081,40 +960,12 @@ and meet_relation env var1 var2 =
   | None, None -> Ok (Both_inputs, env)
   | Some _, None -> Ok (Left_input, env)
   | None, Some _ -> Ok (Right_input, env)
-  | Some var1, Some var2 ->
-    let simple1 =
-      TE.get_canonical_simple_ignoring_name_mode (ME.typing_env env)
-        (Simple.var var1)
-    in
-    let simple2 =
-      TE.get_canonical_simple_ignoring_name_mode (ME.typing_env env)
-        (Simple.var var2)
-    in
-    if Simple.equal simple1 simple2
-    then Ok (Both_inputs, env)
-    else
-      Simple.pattern_match simple1
-        ~const:(fun _ ->
-          Simple.pattern_match simple2
-            ~const:(fun _ : _ meet_result ->
-              (* Distinct constants: this is a bottom result *)
-              Bottom (New_result ()))
-            ~name:(fun _ ~coercion:_ : _ meet_result -> Ok (Right_input, env)))
-        ~name:(fun _ ~coercion:_ ->
-          Simple.pattern_match simple2
-            ~const:(fun _ : _ meet_result -> Ok (Left_input, env))
-            ~name:(fun _ ~coercion:_ ->
-              (* Note: This equality can (rarely?) cause loops due to reductions
-                 that could be stored on the relation variables (if the relation
-                 variable has a [Is_int] / [Get_tag] / [Is_null] type). This is
-                 caught by the safeguard in [Meet_env]. *)
-              match
-                add_equation simple1
-                  (TG.alias_type_of K.naked_immediate simple2)
-                  env ~meet_type
-              with
-              | Ok (_, env) -> Ok (Both_inputs, env)
-              | Bottom r -> Bottom r))
+  | Some var1, Some var2 -> (
+    match
+      ME.add_alias env (Simple.var var1) (Simple.var var2) ~meet_expanded_head
+    with
+    | Ok env -> Ok (Both_inputs, env)
+    | Bottom -> Bottom (New_result ()))
 
 and meet_variant env ~(is_int1 : Variable.t option)
     ~(get_tag1 : Variable.t option)
@@ -1185,9 +1036,9 @@ and meet_variant env ~(is_int1 : Variable.t option)
       map_result
         ~f:(fun (imms, (get_tag, blocks), extensions) ->
           get_tag, blocks, imms, extensions)
-        (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b ~meet_type
-           ~n_way_join env imms1 (get_tag1, blocks1) extensions1 imms2
-           (get_tag2, blocks2) extensions2))
+        (meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
+           ~meet_expanded_head ~n_way_join env imms1 (get_tag1, blocks1)
+           extensions1 imms2 (get_tag2, blocks2) extensions2))
     ~left_a:is_int1 ~right_a:is_int2
     ~left_b:(get_tag1, blocks1, imms1, extensions1)
     ~right_b:(get_tag2, blocks2, imms2, extensions2)
@@ -1213,7 +1064,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     then bottom_other_side is_int_side
     else
       let rebuild = TG.Head_of_kind_naked_immediate.create_is_int in
-      let machine_width = TE.machine_width (ME.typing_env env) in
+      let machine_width = ME.machine_width env in
       match
         ( I.Set.mem (I.zero machine_width) immediates,
           I.Set.mem (I.one machine_width) immediates )
@@ -1230,7 +1081,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     then bottom_other_side is_null_side
     else
       let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
-      let machine_width = TE.machine_width (ME.typing_env env) in
+      let machine_width = ME.machine_width env in
       match
         ( I.Set.mem (I.zero machine_width) immediates,
           I.Set.mem (I.one machine_width) immediates )
@@ -1248,7 +1099,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       let tags =
         I.Set.fold
           (fun tag tags ->
-            let machine_width = TE.machine_width (ME.typing_env env) in
+            let machine_width = ME.machine_width env in
             match Tag.create_from_targetint machine_width tag with
             | Some tag -> Tag.Set.add tag tags
             | None -> tags (* No blocks exist with this tag *))
@@ -1257,7 +1108,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       if Tag.Set.is_empty tags
       then Bottom (New_result ())
       else
-        let machine_width = TE.machine_width (ME.typing_env env) in
+        let machine_width = ME.machine_width env in
         match
           MTC.blocks_with_these_tags ~machine_width tags
             (Alloc_mode.For_types.unknown ())
@@ -1448,8 +1299,8 @@ and meet_row_like :
        that variables defined in the central env are defined in all the joined
        envs. *)
     let result_env =
-      Join_env.cut_and_n_way_join ~n_way_join_type:n_way_join ~meet_type
-        ~cut_after:common_scope initial_env scoped_envs
+      Join_env.cut_and_n_way_join ~n_way_join_type:n_way_join
+        ~meet_expanded_head ~cut_after:common_scope initial_env scoped_envs
     in
     Variable.Map.fold
       (fun var kind env ->
@@ -1569,11 +1420,13 @@ and meet_row_like :
       | Ok (maps_to_result, env) -> (
         let env : _ Or_bottom.t =
           match
-            ME.add_env_extension_strict env case1.env_extension ~meet_type
+            ME.add_env_extension_strict env case1.env_extension
+              ~meet_expanded_head
           with
           | Bottom -> Bottom
           | Ok env ->
-            ME.add_env_extension_strict env case2.env_extension ~meet_type
+            ME.add_env_extension_strict env case2.env_extension
+              ~meet_expanded_head
         in
         match env with
         | Bottom -> bottom_case (New_result ())
@@ -1625,7 +1478,7 @@ and meet_row_like :
         | Unknown -> (
           match
             ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_type
+              ~meet_expanded_head
           with
           | Bottom -> None
           | Ok env ->
@@ -1644,7 +1497,7 @@ and meet_row_like :
         | Unknown -> (
           match
             ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_type
+              ~meet_expanded_head
           with
           | Bottom -> None
           | Ok env ->
@@ -1660,7 +1513,8 @@ and meet_row_like :
         Some Unknown
       | Known case, Unknown -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension ~meet_type
+          ME.add_env_extension_strict base_env case.env_extension
+            ~meet_expanded_head
         with
         | Bottom -> None
         | Ok env ->
@@ -1669,7 +1523,8 @@ and meet_row_like :
           Some (Known case))
       | Unknown, Known case -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension ~meet_type
+          ME.add_env_extension_strict base_env case.env_extension
+            ~meet_expanded_head
         with
         | Bottom -> None
         | Ok env ->
@@ -1865,14 +1720,6 @@ and meet_function_type (env : ME.t)
     in
     combine_results2 env ~rebuild ~meet_a:meet_code_id ~left_a:code_id1
       ~right_a:code_id2 ~meet_b:meet ~left_b:rec_info1 ~right_b:rec_info2
-
-and meet_type env t1 t2 : _ Or_bottom.t =
-  if TE.is_bottom (ME.typing_env env)
-  then Bottom
-  else
-    match meet env t1 t2 with
-    | Ok (res, env) -> Ok (res, env)
-    | Bottom _ -> Bottom
 
 and n_way_join env (ts : _ Join_env.join_arg list) : TG.t n_way_join_result =
   let kind =
@@ -3093,8 +2940,8 @@ and n_way_join_function_type (env : Join_env.t)
 
 and n_way_join_env_extension env exts =
   match
-    Join_env.n_way_join_env_extension ~n_way_join_type:n_way_join ~meet_type env
-      exts
+    Join_env.n_way_join_env_extension ~n_way_join_type:n_way_join
+      ~meet_expanded_head env exts
   with
   | Bottom -> TEE.empty, env
   | Ok (ext, env) -> ext, env

--- a/middle_end/flambda2/types/meet_and_n_way_join.mli
+++ b/middle_end/flambda2/types/meet_and_n_way_join.mli
@@ -29,8 +29,4 @@ val n_way_join :
 
 (* This function has a slightly different interface; it is meant to be used only
    by functions in Typing_env *)
-val meet_type :
-  Meet_env.t ->
-  Type_grammar.t ->
-  Type_grammar.t ->
-  (Type_grammar.t Meet_env.meet_return_value * Meet_env.t) Or_bottom.t
+val meet_expanded_head : Meet_env.meet_expanded_head

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -1300,7 +1300,8 @@ struct
     let env =
       ME.use_meet_env env ~f:(fun env ->
           ME.add_env_extension_with_extra_variables
-            ~meet_type:(Meet.meet_type ()) env extension)
+            ~meet_expanded_head:(Meet.meet_expanded_head ())
+            env extension)
     in
     let sbs, base_env, new_types, acc =
       Variable.Map.fold
@@ -1351,7 +1352,8 @@ struct
       ME.use_meet_env base_env ~f:(fun env ->
           Name.Map.fold
             (fun name ty env ->
-              ME.add_equation env name ty ~meet_type:(Meet.meet_type ()))
+              ME.add_equation env name ty
+                ~meet_expanded_head:(Meet.meet_expanded_head ()))
             new_types env)
     in
     let subst var =
@@ -1421,6 +1423,7 @@ struct
     ME.use_meet_env base_env ~f:(fun env ->
         Name.Map.fold
           (fun name ty env ->
-            ME.add_equation env name ty ~meet_type:(Meet.meet_type ()))
+            ME.add_equation env name ty
+              ~meet_expanded_head:(Meet.meet_expanded_head ()))
           new_types env)
 end


### PR DESCRIPTION
This patch is mostly a refactoring to centralize the logic of dealing with the meet of names in the `Meet_env` module instead of the `Meet_and_join` / `Meet_and_n_way_join` modules. These two modules are now focused on computing the meet over the structure of the types.

This refactoring makes it easier to encapsulate the environment-related logic inside the `Meet_env`, which gives more flexibility to fix the situations where we lose equations due to "recursive" env extensions (i.e. env extensions on `x` that contain an equation on `x` -- these are currently forbidden, see the comments in `Meet_env`).