### PR TITLE
Flambda2: remove imported_names

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -246,8 +246,7 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
       TE.Serializable.create typing_env ~reachable_names
     in
     let free_names_of_name name =
-      Some (T.free_names
-        (TE.Pre_serializable.find typing_env name))
+      Some (T.free_names (TE.Pre_serializable.find typing_env name))
     in
     prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
       ~used_value_slots ~canonicalise ~exported_offsets all_code

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -21,7 +21,6 @@ module Imported_unit_map = Global_module.Name.Map
 
 type loader =
   { get_module_info : Compilation_unit.t -> Flambda_cmx_format.t option;
-    mutable imported_names : Name.Set.t;
     mutable imported_code : Exported_code.t;
     mutable imported_units : TE.Serializable.t option Imported_unit_map.t
   }
@@ -49,9 +48,6 @@ let load_cmx_file_contents loader comp_unit =
           let typing_env, all_code =
             Flambda_cmx_format.import_typing_env_and_code cmx
           in
-          let newly_imported_names = TE.Serializable.name_domain typing_env in
-          loader.imported_names
-            <- Name.Set.union newly_imported_names loader.imported_names;
           loader.imported_code <- EC.merge all_code loader.imported_code;
           let offsets = Flambda_cmx_format.exported_offsets cmx in
           Exported_offsets.import_offsets offsets;
@@ -98,7 +94,6 @@ let predefined_exception_typing_env () =
 let create_loader ~get_module_info =
   let loader =
     { get_module_info;
-      imported_names = Name.Set.empty;
       imported_code = Exported_code.empty;
       imported_units = Imported_unit_map.empty
     }
@@ -108,11 +103,7 @@ let create_loader ~get_module_info =
     <- Imported_unit_map.singleton
          (Compilation_unit.Name.to_global_name Compilation_unit.Name.predef_exn)
          (Some predefined_exception_typing_env);
-  loader.imported_names
-    <- TE.Serializable.name_domain predefined_exception_typing_env;
   loader
-
-let get_imported_names loader () = loader.imported_names
 
 let get_imported_code loader () = loader.imported_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -246,8 +246,8 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
       TE.Serializable.create typing_env ~reachable_names
     in
     let free_names_of_name name =
-      Option.map T.free_names
-        (TE.Pre_serializable.find_or_missing typing_env name)
+      Some (T.free_names
+        (TE.Pre_serializable.find typing_env name))
     in
     prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
       ~used_value_slots ~canonicalise ~exported_offsets all_code

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -22,8 +22,6 @@ type loader
 val create_loader :
   get_module_info:(Compilation_unit.t -> Flambda_cmx_format.t option) -> loader
 
-val get_imported_names : loader -> unit -> Name.Set.t
-
 val get_imported_code : loader -> unit -> Exported_code.t
 
 val load_cmx_file_contents :

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -24,8 +24,6 @@ module TE = Flambda2_types.Typing_env
 type resolver =
   Compilation_unit.t -> Flambda2_types.Typing_env.Serializable.t option
 
-type get_imported_names = unit -> Name.Set.t
-
 type get_imported_code = unit -> Exported_code.t
 
 module Disable_inlining_reason = struct
@@ -217,11 +215,10 @@ let define_extra_variable t var kind =
   (define_variable0 [@inlined hint]) ~extra:true t var kind
 
 let create ~round ~machine_width ~(resolver : resolver)
-    ~(get_imported_names : get_imported_names)
     ~(get_imported_code : get_imported_code) ~propagating_float_consts
     ~unit_toplevel_exn_continuation ~unit_toplevel_return_continuation
     ~toplevel_my_region ~toplevel_my_ghost_region =
-  let typing_env = TE.create ~machine_width ~resolver ~get_imported_names in
+  let typing_env = TE.create ~machine_width ~resolver in
   let t =
     { round;
       machine_width;

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -19,8 +19,6 @@ open! Flambda.Import
 type resolver =
   Compilation_unit.t -> Flambda2_types.Typing_env.Serializable.t option
 
-type get_imported_names = unit -> Name.Set.t
-
 type get_imported_code = unit -> Exported_code.t
 
 type t
@@ -34,7 +32,6 @@ val create :
   round:int ->
   machine_width:Target_system.Machine_width.t ->
   resolver:resolver ->
-  get_imported_names:get_imported_names ->
   get_imported_code:get_imported_code ->
   propagating_float_consts:bool ->
   unit_toplevel_exn_continuation:Continuation.t ->

--- a/middle_end/flambda2/simplify/flow/flow_analysis.ml
+++ b/middle_end/flambda2/simplify/flow/flow_analysis.ml
@@ -202,7 +202,8 @@ let added_useful_alias_in_loop typing_env (acc : T.Acc.t)
                  false)
                ~symbol:(fun sym ~coercion:_ ->
                  let ty =
-                   Typing_env.find typing_env (Name.symbol sym) (Some Flambda_kind.value)
+                   Typing_env.find typing_env (Name.symbol sym)
+                     (Some Flambda_kind.value)
                  in
                  not (Flambda2_types.is_unknown typing_env ty)))
            continuation_param_aliases.lets_to_introduce)

--- a/middle_end/flambda2/simplify/flow/flow_analysis.ml
+++ b/middle_end/flambda2/simplify/flow/flow_analysis.ml
@@ -201,11 +201,10 @@ let added_useful_alias_in_loop typing_env (acc : T.Acc.t)
                     point *)
                  false)
                ~symbol:(fun sym ~coercion:_ ->
-                 match
-                   Typing_env.find_or_missing typing_env (Name.symbol sym)
-                 with
-                 | None -> false
-                 | Some ty -> not (Flambda2_types.is_unknown typing_env ty)))
+                 let ty =
+                   Typing_env.find typing_env (Name.symbol sym) (Some Flambda_kind.value)
+                 in
+                 not (Flambda2_types.is_unknown typing_env ty)))
            continuation_param_aliases.lets_to_introduce)
     (Continuation.Map.to_seq acc.map)
     (Continuation.Map.to_seq result.aliases_result.continuation_parameters)

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -33,8 +33,7 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   let resolver = Flambda_cmx.load_cmx_file_contents cmx_loader in
   let get_imported_code = Flambda_cmx.get_imported_code cmx_loader in
   let denv =
-    DE.create ~round ~machine_width ~resolver
-      ~get_imported_code
+    DE.create ~round ~machine_width ~resolver ~get_imported_code
       ~propagating_float_consts:(Flambda_features.float_const_prop ())
       ~unit_toplevel_return_continuation:return_continuation
       ~unit_toplevel_exn_continuation:exn_continuation ~toplevel_my_region

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -31,10 +31,9 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   let toplevel_my_ghost_region = FU.toplevel_my_ghost_region unit in
   let module_symbol = FU.module_symbol unit in
   let resolver = Flambda_cmx.load_cmx_file_contents cmx_loader in
-  let get_imported_names = Flambda_cmx.get_imported_names cmx_loader in
   let get_imported_code = Flambda_cmx.get_imported_code cmx_loader in
   let denv =
-    DE.create ~round ~machine_width ~resolver ~get_imported_names
+    DE.create ~round ~machine_width ~resolver
       ~get_imported_code
       ~propagating_float_consts:(Flambda_features.float_const_prop ())
       ~unit_toplevel_return_continuation:return_continuation

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -69,19 +69,6 @@ let closure_bound_names_inside_functions_exactly_one_set t =
 
 let previously_free_depth_variables t = t.previously_free_depth_variables
 
-let compute_value_slot_types_inside_function ~value_slot_types
-    ~degraded_value_slots =
-  Value_slot.Map.mapi
-    (fun value_slot type_prior_to_sets ->
-      let type_prior_to_sets =
-        (* See comment below about [degraded_value_slots]. *)
-        if Value_slot.Set.mem value_slot degraded_value_slots
-        then T.unknown (Value_slot.kind value_slot)
-        else type_prior_to_sets
-      in
-      type_prior_to_sets)
-    value_slot_types
-
 let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
     ~closure_bound_names_all_sets ~value_slot_types_inside_functions_all_sets
     ~old_to_new_code_ids_all_sets =
@@ -263,35 +250,23 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
        knowing it prohibits us from inlining it. *)
     |> DE.set_rebuild_terms
   in
-  (* We collect a set of "degraded value slots" whose types involve imported
-     variables from missing .cmx files. Since we don't know the kind of these
-     variables, we can't run the code below that checks if they might need
-     binding as "never inline" depth variables (since we don't know if a given
-     variable is a depth variable or not). Instead we will treat the whole value
-     slot as having [Unknown] type. *)
-  let degraded_value_slots = ref Value_slot.Set.empty in
   let free_depth_variables =
     List.concat_map
       (fun value_slot_types ->
         Value_slot.Map.mapi
-          (fun value_slot ty ->
+          (fun _value_slot ty ->
             let vars = TE.free_names_transitive (DE.typing_env denv) ty in
             NO.fold_variables vars ~init:Variable.Set.empty
               ~f:(fun free_depth_variables var ->
-                let ty_opt =
-                  TE.find_or_missing
+                let ty =
+                  TE.find
                     (DE.typing_env denv_inside_functions)
                     (Name.var var)
+                    None
                 in
-                match ty_opt with
-                | None ->
-                  degraded_value_slots
-                    := Value_slot.Set.add value_slot !degraded_value_slots;
-                  free_depth_variables
-                | Some ty -> (
-                  match T.kind ty with
-                  | Rec_info -> Variable.Set.add var free_depth_variables
-                  | Value | Naked_number _ | Region -> free_depth_variables)))
+                match T.kind ty with
+                | Rec_info -> Variable.Set.add var free_depth_variables
+                | Value | Naked_number _ | Region -> free_depth_variables))
           value_slot_types
         |> Value_slot.Map.data)
       value_slot_types_all_sets
@@ -319,19 +294,8 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
           (T.this_rec_info Rec_info_expr.do_not_inline))
       free_depth_variables denv_inside_functions
   in
-  let value_slot_types_all_sets_inside_functions_rev =
-    List.fold_left
-      (fun value_slot_types_all_sets_inside_functions_rev value_slot_types ->
-        let value_slot_types_inside_function =
-          compute_value_slot_types_inside_function ~value_slot_types
-            ~degraded_value_slots:!degraded_value_slots
-        in
-        value_slot_types_inside_function
-        :: value_slot_types_all_sets_inside_functions_rev)
-      [] value_slot_types_all_sets
-  in
   let value_slot_types_inside_functions_all_sets =
-    List.rev value_slot_types_all_sets_inside_functions_rev
+    value_slot_types_all_sets
   in
   let old_to_new_code_ids_all_sets =
     compute_old_to_new_code_ids_all_sets denv ~all_sets_of_closures

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -261,8 +261,7 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
                 let ty =
                   TE.find
                     (DE.typing_env denv_inside_functions)
-                    (Name.var var)
-                    None
+                    (Name.var var) None
                 in
                 match T.kind ty with
                 | Rec_info -> Variable.Set.add var free_depth_variables
@@ -294,9 +293,7 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
           (T.this_rec_info Rec_info_expr.do_not_inline))
       free_depth_variables denv_inside_functions
   in
-  let value_slot_types_inside_functions_all_sets =
-    value_slot_types_all_sets
-  in
+  let value_slot_types_inside_functions_all_sets = value_slot_types_all_sets in
   let old_to_new_code_ids_all_sets =
     compute_old_to_new_code_ids_all_sets denv ~all_sets_of_closures
   in

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -11,7 +11,6 @@ let _test_recursive_meet () =
   let env =
     TE.create
       ~resolver:(fun _ -> None)
-      ~get_imported_names:(fun () -> Name.Set.empty)
       ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
@@ -64,7 +63,6 @@ let _test_bottom_detection () =
   let env =
     TE.create
       ~resolver:(fun _ -> None)
-      ~get_imported_names:(fun () -> Name.Set.empty)
       ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
@@ -100,7 +98,6 @@ let _test_bottom_recursive () =
   let env =
     TE.create
       ~resolver:(fun _ -> None)
-      ~get_imported_names:(fun () -> Name.Set.empty)
       ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
@@ -146,7 +143,6 @@ let test_double_recursion () =
   let env =
     TE.create
       ~resolver:(fun _ -> None)
-      ~get_imported_names:(fun () -> Name.Set.empty)
       ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -8,11 +8,7 @@ module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
 
 let _test_recursive_meet () =
-  let env =
-    TE.create
-      ~resolver:(fun _ -> None)
-      ~machine_width:Sixty_four
-  in
+  let env = TE.create ~resolver:(fun _ -> None) ~machine_width:Sixty_four in
   let var_x = Variable.create "x" Flambda_kind.value in
   let var_y = Variable.create "y" Flambda_kind.value in
   let var_z = Variable.create "z" Flambda_kind.value in
@@ -60,11 +56,7 @@ let _test_recursive_meet () =
   | Bottom -> Format.eprintf "Bottom@."
 
 let _test_bottom_detection () =
-  let env =
-    TE.create
-      ~resolver:(fun _ -> None)
-      ~machine_width:Sixty_four
-  in
+  let env = TE.create ~resolver:(fun _ -> None) ~machine_width:Sixty_four in
   let var_x = Variable.create "x" Flambda_kind.value in
   let n_x = Name.var var_x in
   let nb_x = Bound_name.create n_x Name_mode.normal in
@@ -95,11 +87,7 @@ let _test_bottom_detection () =
   | Bottom -> Format.eprintf "Bottom@."
 
 let _test_bottom_recursive () =
-  let env =
-    TE.create
-      ~resolver:(fun _ -> None)
-      ~machine_width:Sixty_four
-  in
+  let env = TE.create ~resolver:(fun _ -> None) ~machine_width:Sixty_four in
   let var_x = Variable.create "x" Flambda_kind.value in
   let n_x = Name.var var_x in
   let nb_x = Bound_name.create n_x Name_mode.normal in
@@ -140,11 +128,7 @@ let _test_bottom_recursive () =
     Format.eprintf "Bottom@."
 
 let test_double_recursion () =
-  let env =
-    TE.create
-      ~resolver:(fun _ -> None)
-      ~machine_width:Sixty_four
-  in
+  let env = TE.create ~resolver:(fun _ -> None) ~machine_width:Sixty_four in
   let var_x = Variable.create "x" Flambda_kind.value in
   let var_y = Variable.create "y" Flambda_kind.value in
   let var_z = Variable.create "z" Flambda_kind.value in

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -10,8 +10,7 @@ module TE = T.Typing_env
 
 let create_env () =
   let resolver _ = None in
-  let get_imported_names () = Name.Set.empty in
-  TE.create ~resolver ~get_imported_names ~machine_width:Sixty_four
+  TE.create ~resolver ~machine_width:Sixty_four
 
 let test_meet_chains_two_vars () =
   let env = create_env () in

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -654,9 +654,9 @@ end = struct
   let machine_width { source_env; _ } = TE.machine_width source_env
 
   let exists_in_source_env { source_env } var =
-    if TE.variable_definitely_not_in_scope source_env var
-    then None
-    else Some (Variable_in_source_env.create var)
+    if TE.mem source_env (Name.var var)
+    then Some (Variable_in_source_env.create var)
+    else None
 
   let exists_at_name_mode ~min_name_mode { source_env } var =
     if TE.mem ~min_name_mode source_env (Name.var var)
@@ -1283,15 +1283,15 @@ end = struct
     Index.Map.filter_map
       (fun _index (env, _) ->
         if
-          TE.variable_definitely_not_in_scope env
-            (var : Variable_in_one_joined_env.t :> Variable.t)
-        then None
-        else
+          TE.mem env
+            (Name.var (var : Variable_in_one_joined_env.t :> Variable.t))
+        then
           let canonical =
             get_canonical_simple_ignoring_name_mode env
               (Simple_in_one_joined_env.var var)
           in
-          Some (Type_in_one_joined_env.alias_type_of kind canonical))
+          Some (Type_in_one_joined_env.alias_type_of kind canonical)
+        else None)
       (envs_and_equations t)
 
   let expand_heads t types =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -408,8 +408,6 @@ let check_optional_kind_matches name ty kind_opt =
         "Kind %a of type@ %a@ for %a@ doesn't match expected kind %a" K.print
         ty_kind TG.print ty Name.print name K.print kind
 
-exception Missing_cmx_and_kind
-
 (* CR-someday mshinwell: [kind] could also take a [subkind] *)
 let find_with_binding_time_and_mode' t name kind =
   (* Note that [Pre_serializable] (below) assumes this function only looks up
@@ -445,12 +443,10 @@ let find_with_binding_time_and_mode' t name kind =
             (* .cmx file missing *)
             check_optional_kind_matches name (fst initial_symbol_type) kind;
             initial_symbol_type)
-          ~var:(fun _ ->
-            match kind with
-            | Some kind ->
-              (* See comment below about binding times. *)
-              MTC.unknown kind, Binding_time.With_name_mode.imported_variables
-            | None -> raise Missing_cmx_and_kind)
+          ~var:(fun var ->
+            let ty = MTC.unknown (Variable.kind var) in
+            check_optional_kind_matches name ty kind;
+            ty, Binding_time.With_name_mode.imported_variables)
       | Some t -> (
         match
           Name.Map.find name (Cached_level.names_to_types t.just_after_level)
@@ -481,25 +477,15 @@ let find_with_binding_time_and_mode' t name kind =
     check_optional_kind_matches name ty kind;
     if t.is_bottom then MTC.bottom_like ty, binding_time_and_mode else found
 
-(* This version doesn't check min_binding_time. This ensures that no allocation
-   occurs when we're not interested in the name mode. *)
-let find_with_binding_time_and_mode_unscoped t name kind =
-  try find_with_binding_time_and_mode' t name kind
-  with Missing_cmx_and_kind ->
-    Misc.fatal_errorf
-      "Don't know kind of variable %a from another unit whose .cmx file is \
-       unavailable"
-      Name.print name
-
 let find t name kind =
   let ty, _binding_time_and_mode =
-    find_with_binding_time_and_mode_unscoped t name kind
+    find_with_binding_time_and_mode' t name kind
   in
   ty
 
 let find_with_binding_time_and_mode t name kind =
   let ((ty, binding_time_and_mode) as found) =
-    find_with_binding_time_and_mode_unscoped t name kind
+    find_with_binding_time_and_mode' t name kind
   in
   let scoped_mode =
     Binding_time.With_name_mode.scoped_name_mode binding_time_and_mode
@@ -515,11 +501,6 @@ let find_with_binding_time_and_mode t name kind =
       Binding_time.With_name_mode.create
         (Binding_time.With_name_mode.binding_time binding_time_and_mode)
         scoped_mode )
-
-let find_or_missing t name =
-  match find_with_binding_time_and_mode' t name None with
-  | ty, _ -> Some ty
-  | exception Missing_cmx_and_kind -> None
 
 let find_params t params =
   List.map
@@ -1076,7 +1057,7 @@ module Pre_serializable : sig
     used_value_slots:Value_slot.Set.t ->
     t * (Simple.t -> Simple.t)
 
-  val find_or_missing : t -> Name.t -> Type_grammar.t option
+  val find : t -> Name.t -> Type_grammar.t
 end = struct
   type t = typing_env
 
@@ -1087,7 +1068,7 @@ end = struct
     in
     { t with current_level }, One_level.canonicalise current_level
 
-  let find_or_missing = find_or_missing
+  let find env name = find env name None
 end
 
 module Serializable : sig

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -107,7 +107,6 @@ type t =
   { machine_width : Target_system.Machine_width.t;
     resolver : Compilation_unit.t -> serializable option;
     binding_time_resolver : Name.t -> Binding_time.With_name_mode.t;
-    get_imported_names : unit -> Name.Set.t;
     defined_symbols : Symbol.Set.t;
     code_age_relation : Code_age_relation.t;
     prev_levels : One_level.t list;
@@ -142,7 +141,7 @@ let aliases t =
 
 (* CR-someday mshinwell: Should print name occurrence kinds *)
 let [@ocamlformat "disable"] print ppf
-      ({ resolver = _; binding_time_resolver = _;get_imported_names = _;
+      ({ resolver = _; binding_time_resolver = _;
          prev_levels; current_level; next_binding_time = _;
          defined_symbols; code_age_relation; min_binding_time;
          is_bottom; machine_width = _
@@ -341,8 +340,6 @@ let binding_time_resolver resolver name =
 
 let resolver t = t.resolver
 
-let get_imported_names t = t.get_imported_names
-
 let code_age_relation_resolver t comp_unit =
   match t.resolver comp_unit with
   | None -> None
@@ -350,11 +347,10 @@ let code_age_relation_resolver t comp_unit =
 
 let current_scope t = One_level.scope t.current_level
 
-let create ~machine_width ~resolver ~get_imported_names =
+let create ~machine_width ~resolver =
   { machine_width;
     resolver;
     binding_time_resolver = binding_time_resolver resolver;
-    get_imported_names;
     prev_levels = [];
     (* Since [Scope.prev] may be used in the simplifier on this scope, in order
        to allow an efficient implementation of [cut] (see below), we always
@@ -551,36 +547,15 @@ let binding_time_and_mode_of_simple t simple =
     ~const:(fun _ -> Binding_time.With_name_mode.consts)
     ~name:(fun name ~coercion:_ -> binding_time_and_mode t name)
 
-let variable_definitely_not_in_scope t var =
-  (* If we have an equation, we might be in scope.
-
-     If we have no equation, and we are from the current compilation unit, we
-     are definitely not in scope (we add an equation with an unknown type and
-     the binding time when defining a variable).
-
-     If we have no equation, but we are defined in another compilation unit, we
-     are either in scope (defined in the other compilation unit), or there is a
-     inconsistency. We ignore that last possibility and simply say that
-     variables defined in another compilation unit might be in scope. *)
-  (not (Name.Map.mem (Name.var var) (names_to_types t)))
-  && Compilation_unit.is_current (Variable.compilation_unit var)
-
 let mem ?min_name_mode t name =
-  (* CR bclement: Consider checking the compilation unit instead of the
-     [get_imported_names] map so that we treat variables from missing cmxes as
-     being in the environment (see also the comment in
-     [variable_definitely_not_in_scope]).
-
-     If we do this, we can get rid of [variable_definitely_not_in_scope] and use
-     [mem] directly instead. *)
   Name.pattern_match name
     ~var:(fun _var ->
       let name_mode =
         match Name.Map.find name (names_to_types t) with
         | exception Not_found ->
-          if Name.Set.mem name (t.get_imported_names ())
-          then Some Name_mode.in_types
-          else None
+          if Compilation_unit.is_current (Name.compilation_unit name)
+          then None
+          else Some Name_mode.in_types
         | _ty, binding_time_and_mode ->
           let scoped_name_mode =
             Binding_time.With_name_mode.scoped_name_mode binding_time_and_mode
@@ -596,10 +571,8 @@ let mem ?min_name_mode t name =
         | None -> false
         | Some c -> c <= 0))
     ~symbol:(fun sym ->
-      (* CR mshinwell: This might not take account of symbols in missing .cmx
-         files *)
       Symbol.Set.mem sym t.defined_symbols
-      || Name.Set.mem name (t.get_imported_names ()))
+      || not (Compilation_unit.is_current (Name.compilation_unit name)))
 
 let mem_simple ?min_name_mode t simple =
   Simple.pattern_match simple
@@ -794,8 +767,7 @@ let invariant_for_new_equation (t : t) name ty =
   then (
     invariant_for_alias t name ty;
     let defined_names =
-      Name_occurrences.create_names
-        (Name.Set.union (name_domain t) (t.get_imported_names ()))
+      Name_occurrences.create_names (name_domain t)
         Name_mode.in_types
     in
     let free_names = Name_occurrences.with_only_names (TG.free_names ty) in
@@ -804,7 +776,12 @@ let invariant_for_new_equation (t : t) name ty =
       let unbound_names =
         Name_occurrences.diff free_names ~without:defined_names
       in
-      Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound names@ (%a):@ %a"
+      let has_local_unbound_name =
+        Name_occurrences.fold_names unbound_names ~init:false ~f:(fun acc name ->
+            acc || Compilation_unit.is_current (Name.compilation_unit name))
+      in
+      if has_local_unbound_name then
+      Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound local names@ (%a):@ %a"
         Name.print name TG.print ty Name_occurrences.print unbound_names print t)
 
 let replace_equation (t : t) name ty =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -767,8 +767,7 @@ let invariant_for_new_equation (t : t) name ty =
   then (
     invariant_for_alias t name ty;
     let defined_names =
-      Name_occurrences.create_names (name_domain t)
-        Name_mode.in_types
+      Name_occurrences.create_names (name_domain t) Name_mode.in_types
     in
     let free_names = Name_occurrences.with_only_names (TG.free_names ty) in
     if not (Name_occurrences.subset_domain free_names defined_names)
@@ -777,12 +776,16 @@ let invariant_for_new_equation (t : t) name ty =
         Name_occurrences.diff free_names ~without:defined_names
       in
       let has_local_unbound_name =
-        Name_occurrences.fold_names unbound_names ~init:false ~f:(fun acc name ->
+        Name_occurrences.fold_names unbound_names ~init:false
+          ~f:(fun acc name ->
             acc || Compilation_unit.is_current (Name.compilation_unit name))
       in
-      if has_local_unbound_name then
-      Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound local names@ (%a):@ %a"
-        Name.print name TG.print ty Name_occurrences.print unbound_names print t)
+      if has_local_unbound_name
+      then
+        Misc.fatal_errorf
+          "New equation@ %a@ =@ %a@ has unbound local names@ (%a):@ %a"
+          Name.print name TG.print ty Name_occurrences.print unbound_names print
+          t)
 
 let replace_equation (t : t) name ty =
   (if Flambda_features.Debug.concrete_types_only_on_canonicals ()

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -26,7 +26,7 @@ module Pre_serializable : sig
     used_value_slots:Value_slot.Set.t ->
     t * (Simple.t -> Simple.t)
 
-  val find_or_missing : t -> Name.t -> Type_grammar.t option
+  val find : t -> Name.t -> Type_grammar.t
 end
 
 module Serializable : sig
@@ -136,8 +136,6 @@ val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
     be omitted. Such omission will cause an error if the name satisfies
     [variable_is_from_missing_cmx_file]. *)
 val find : t -> Name.t -> Flambda_kind.t option -> Type_grammar.t
-
-val find_or_missing : t -> Name.t -> Type_grammar.t option
 
 val find_params : t -> Bound_parameters.t -> Type_grammar.t list
 

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -84,7 +84,6 @@ val print : Format.formatter -> t -> unit
 val create :
   machine_width:Target_system.Machine_width.t ->
   resolver:(Compilation_unit.t -> Serializable.t option) ->
-  get_imported_names:(unit -> Name.Set.t) ->
   t
 
 val machine_width : t -> Target_system.Machine_width.t
@@ -96,8 +95,6 @@ val make_bottom : t -> t
 val closure_env : t -> t
 
 val resolver : t -> Compilation_unit.t -> Serializable.t option
-
-val get_imported_names : t -> unit -> Name.Set.t
 
 val code_age_relation_resolver :
   t -> Compilation_unit.t -> Code_age_relation.t option
@@ -145,8 +142,6 @@ val find_or_missing : t -> Name.t -> Type_grammar.t option
 val find_params : t -> Bound_parameters.t -> Type_grammar.t list
 
 val variable_is_from_missing_cmx_file : t -> Name.t -> bool
-
-val variable_definitely_not_in_scope : t -> Variable.t -> bool
 
 val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -159,7 +159,6 @@ module Typing_env : sig
   val create :
     machine_width:Target_system.Machine_width.t ->
     resolver:(Compilation_unit.t -> Serializable.t option) ->
-    get_imported_names:(unit -> Name.Set.t) ->
     t
 
   val machine_width : t -> Target_system.Machine_width.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -123,7 +123,7 @@ module Typing_env : sig
       used_value_slots:Value_slot.Set.t ->
       t * (Simple.t -> Simple.t)
 
-    val find_or_missing : t -> Name.t -> flambda_type option
+    val find : t -> Name.t -> flambda_type
   end
 
   module Serializable : sig
@@ -202,8 +202,6 @@ module Typing_env : sig
   val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
 
   val find : t -> Name.t -> Flambda_kind.t option -> flambda_type
-
-  val find_or_missing : t -> Name.t -> flambda_type option
 
   val find_params : t -> Bound_parameters.t -> flambda_type list
 

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -1151,42 +1151,41 @@ let prove_alloc_mode_of_boxed_number env t =
 
 let never_holds_locally_allocated_values env var : _ proof_of_property =
   let ty = TE.find env (Name.var var) None in
-    match expand_head env ty with
-    | Value (Ok { non_null = Unknown | Bottom; _ }) | Value (Unknown | Bottom)
-      ->
-      Unknown
-    | Value (Ok { non_null = Ok value_head; _ }) -> (
-      match value_head with
-      | Variant { blocks; _ } -> (
-        match blocks with
-        | Unknown -> Unknown
-        | Known blocks -> (
-          if TG.Row_like_for_blocks.is_bottom blocks
-          then Proved ()
-          else
-            match blocks.alloc_mode with
-            | Heap -> Proved ()
-            | Local | Heap_or_local -> Unknown))
-      | Boxed_float32 (_, alloc_mode)
-      | Boxed_float (_, alloc_mode)
-      | Boxed_int32 (_, alloc_mode)
-      | Boxed_int64 (_, alloc_mode)
-      | Boxed_nativeint (_, alloc_mode)
-      | Boxed_vec128 (_, alloc_mode)
-      | Boxed_vec256 (_, alloc_mode)
-      | Boxed_vec512 (_, alloc_mode)
-      | Mutable_block { alloc_mode }
-      | Closures { alloc_mode; _ }
-      | Array { alloc_mode; _ } -> (
-        match alloc_mode with
-        | Heap -> Proved ()
-        | Local | Heap_or_local -> Unknown)
-      | String _ -> Proved ())
-    | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
-    | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _
-    | Naked_vec256 _ | Naked_vec512 _ | Naked_nativeint _ | Rec_info _
-    | Region _ ->
-      Proved ()
+  match expand_head env ty with
+  | Value (Ok { non_null = Unknown | Bottom; _ }) | Value (Unknown | Bottom) ->
+    Unknown
+  | Value (Ok { non_null = Ok value_head; _ }) -> (
+    match value_head with
+    | Variant { blocks; _ } -> (
+      match blocks with
+      | Unknown -> Unknown
+      | Known blocks -> (
+        if TG.Row_like_for_blocks.is_bottom blocks
+        then Proved ()
+        else
+          match blocks.alloc_mode with
+          | Heap -> Proved ()
+          | Local | Heap_or_local -> Unknown))
+    | Boxed_float32 (_, alloc_mode)
+    | Boxed_float (_, alloc_mode)
+    | Boxed_int32 (_, alloc_mode)
+    | Boxed_int64 (_, alloc_mode)
+    | Boxed_nativeint (_, alloc_mode)
+    | Boxed_vec128 (_, alloc_mode)
+    | Boxed_vec256 (_, alloc_mode)
+    | Boxed_vec512 (_, alloc_mode)
+    | Mutable_block { alloc_mode }
+    | Closures { alloc_mode; _ }
+    | Array { alloc_mode; _ } -> (
+      match alloc_mode with
+      | Heap -> Proved ()
+      | Local | Heap_or_local -> Unknown)
+    | String _ -> Proved ())
+  | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
+  | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _
+  | Naked_vec256 _ | Naked_vec512 _ | Naked_nativeint _ | Rec_info _ | Region _
+    ->
+    Proved ()
 
 let prove_physical_equality env t1 t2 =
   let incompatible_naked_numbers t1 t2 =

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -1150,9 +1150,7 @@ let prove_alloc_mode_of_boxed_number env t =
   gen_value_to_proof prove_alloc_mode_of_boxed_number_value env t
 
 let never_holds_locally_allocated_values env var : _ proof_of_property =
-  match TE.find_or_missing env (Name.var var) with
-  | None -> Unknown
-  | Some ty -> (
+  let ty = TE.find env (Name.var var) None in
     match expand_head env ty with
     | Value (Ok { non_null = Unknown | Bottom; _ }) | Value (Unknown | Bottom)
       ->
@@ -1188,7 +1186,7 @@ let never_holds_locally_allocated_values env var : _ proof_of_property =
     | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _
     | Naked_vec256 _ | Naked_vec512 _ | Naked_nativeint _ | Rec_info _
     | Region _ ->
-      Proved ())
+      Proved ()
 
 let prove_physical_equality env t1 t2 =
   let incompatible_naked_numbers t1 t2 =

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -1273,7 +1273,6 @@ struct
       =
     let base_env =
       TE.create ~resolver:(TE.resolver env)
-        ~get_imported_names:(TE.get_imported_names env)
         ~machine_width:(TE.machine_width env)
     in
     let base_env =
@@ -1376,7 +1375,6 @@ struct
        [rewrite_env_extension_with_extra_variables] above. *)
     let base_env =
       TE.create ~resolver:(TE.resolver env)
-        ~get_imported_names:(TE.get_imported_names env)
         ~machine_width:(TE.machine_width env)
     in
     let base_env =


### PR DESCRIPTION
This should not be needed anymore, and shows up in profiles when loading cmx files.
