### PR TITLE
[5.4] Promotions in the testsuite

### DIFF
--- a/testsuite/tests/messages/spellcheck.ml
+++ b/testsuite/tests/messages/spellcheck.ml
@@ -125,7 +125,7 @@ let _ =
 Line 5, characters 22-33:
 5 |     method update n = foobaz <- n
                           ^^^^^^^^^^^
-Error:   The value "foobaz" is not an instance variable
+Error:   The value "foobaz" is not an instance variable or mutable variable
 Hint: Did you mean "foobar"?
 |}];;
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1014,10 +1014,9 @@ let matches =
 
 [%%expect{|
 type xy = x:int * y:int
-Line 4, characters 9-30:
-4 | let lt = (~x:1, ~y:2, ~x:3, 4)
-             ^^^^^^^^^^^^^^^^^^^^^
-Error: This tuple expression has two labels named "x"
+val lt : x:int * y:int * x:int * int = (~x:1, ~y:2, ~x:3, 4)
+val matches : int = 1
+val matches : int * int = (1, 2)
 |}]
 
 (********************)

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1014,9 +1014,10 @@ let matches =
 
 [%%expect{|
 type xy = x:int * y:int
-val lt : x:int * y:int * x:int * int = (~x:1, ~y:2, ~x:3, 4)
-val matches : int = 1
-val matches : int * int = (1, 2)
+Line 4, characters 9-30:
+4 | let lt = (~x:1, ~y:2, ~x:3, 4)
+             ^^^^^^^^^^^^^^^^^^^^^
+Error: This tuple expression has two labels named "x"
 |}]
 
 (********************)

--- a/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -12,7 +12,7 @@
             structure_item (shortcut_ext_attr.ml[10,179+2]..[30,721+31]) ghost
               Pstr_eval
               expression (shortcut_ext_attr.ml[10,179+2]..[30,721+31]) ghost
-                Pexp_let Nonrec
+                Pexp_let Immutable Nonrec
                 [
                   <def>
                       attribute "foo"
@@ -531,6 +531,8 @@
                 Ptyp_package
                   package_type "M" (shortcut_ext_attr.ml[61,1304+20]..[61,1304+21])
                   []
+        ptype_jkind_annotation =
+          None
     ]
   structure_item (shortcut_ext_attr.ml[64,1353+0]..[67,1409+22])
     Pstr_module
@@ -784,7 +786,8 @@
     Pstr_extension "foo"
     [
       structure_item (shortcut_ext_attr.ml[93,1885+0]..[93,1885+19]) ghost
-        Pstr_include          attribute "foo"
+        Pstr_include        Structure
+          attribute "foo"
             []
         module_expr (shortcut_ext_attr.ml[93,1885+18]..[93,1885+19])
           Pmod_ident "M" (shortcut_ext_attr.ml[93,1885+18]..[93,1885+19])

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -86,7 +86,7 @@ end = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "X/372"
+(apply (field_imm 1 (global Toploop!)) "X/378"
   (let
     (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
        [0: "first" 1]
@@ -109,7 +109,7 @@ let () =
 
 [%%expect{|
 (let
-  (X =? (apply (field_imm 0 (global Toploop!)) "X/372")
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/378")
    *match* =[value<int>]
      (let (xs =[value<addrarray>] (caml_array_make 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -624,7 +624,7 @@ Line 1, characters 11-12:
                ^
 Error: Unbound unboxed record field "b"
 Hint: There is a boxed record field with this name.
-      Note that float- and [@@unboxed]- records don't get unboxed versions.
+Note that float- and [@@unboxed]- records don't get unboxed versions.
 |}]
 
 let _ = { u = #5.0 }
@@ -643,7 +643,7 @@ Line 1, characters 22-23:
                           ^
 Error: Unbound record field "u"
 Hint: There is an unboxed record field with this name.
-      To project an unboxed record field, use ".#u" instead of ".u".
+To project an unboxed record field, use ".#u" instead of ".u".
 |}]
 
 let bad_get t = t.#b
@@ -653,7 +653,7 @@ Line 1, characters 19-20:
                        ^
 Error: Unbound unboxed record field "b"
 Hint: There is a boxed record field with this name.
-      Note that float- and [@@unboxed]- records don't get unboxed versions.
+Note that float- and [@@unboxed]- records don't get unboxed versions.
 |}]
 
 (*****************************************************************************)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1455,7 +1455,7 @@ let foo y =
 [%%expect{|
 val foo : 'a -> 'a = <fun>
 |}, Principal{|
-val foo : '_weak1 -> '_weak1 = <fun>
+val foo : 'a -> 'a = <fun>
 |}]
 let foo (local_ #{ gbl }) = gbl
 [%%expect{|
@@ -1467,7 +1467,7 @@ let foo y =
 [%%expect{|
 val foo : 'a -> 'a = <fun>
 |}, Principal{|
-val foo : '_weak2 -> '_weak2 = <fun>
+val foo : 'a -> 'a = <fun>
 |}]
 
 let foo (local_ imm) =
@@ -1558,7 +1558,7 @@ let foo y =
 [%%expect{|
 val foo : 'a -> 'a = <fun>
 |}, Principal{|
-val foo : '_weak3 -> '_weak3 = <fun>
+val foo : 'a -> 'a = <fun>
 |}]
 let foo (local_ gbl) =
   let _ = #{ gbl } in

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -17,40 +17,40 @@ module C = Char
 module C' :
   sig
     type t = char
-    external code : char -> int = "%identity"
-    val chr : int -> char
-    val escaped : char -> string
-    val compare : t -> t -> int
-    val equal : t -> t -> bool
+    external code : char -> int @@ portable = "%identity"
+    val chr : int -> char @@ portable
+    val escaped : char -> string @@ portable
+    val compare : t -> t -> int @@ portable
+    val equal : t -> t -> bool @@ portable
     module Ascii :
       sig
-        val min : char
-        val max : char
-        val is_valid : char -> bool
-        val is_upper : char -> bool
-        val is_lower : char -> bool
-        val is_letter : char -> bool
-        val is_alphanum : char -> bool
-        val is_white : char -> bool
-        val is_blank : char -> bool
-        val is_graphic : char -> bool
-        val is_print : char -> bool
-        val is_control : char -> bool
-        val is_digit : char -> bool
-        val digit_to_int : char -> int
-        val digit_of_int : int -> char
-        val is_hex_digit : char -> bool
-        val hex_digit_to_int : char -> int
-        val lower_hex_digit_of_int : int -> char
-        val upper_hex_digit_of_int : int -> char
-        val uppercase : char -> char
-        val lowercase : char -> char
+        val min : char @@ portable
+        val max : char @@ portable
+        val is_valid : char -> bool @@ portable
+        val is_upper : char -> bool @@ portable
+        val is_lower : char -> bool @@ portable
+        val is_letter : char -> bool @@ portable
+        val is_alphanum : char -> bool @@ portable
+        val is_white : char -> bool @@ portable
+        val is_blank : char -> bool @@ portable
+        val is_graphic : char -> bool @@ portable
+        val is_print : char -> bool @@ portable
+        val is_control : char -> bool @@ portable
+        val is_digit : char -> bool @@ portable
+        val digit_to_int : char -> int @@ portable
+        val digit_of_int : int -> char @@ portable
+        val is_hex_digit : char -> bool @@ portable
+        val hex_digit_to_int : char -> int @@ portable
+        val lower_hex_digit_of_int : int -> char @@ portable
+        val upper_hex_digit_of_int : int -> char @@ portable
+        val uppercase : char -> char @@ portable
+        val lowercase : char -> char @@ portable
       end
-    val lowercase_ascii : char -> char
-    val uppercase_ascii : char -> char
-    val seeded_hash : int -> t -> int
-    val hash : t -> int
-    external unsafe_chr : int -> char = "%identity"
+    val lowercase_ascii : char -> char @@ portable
+    val uppercase_ascii : char -> char @@ portable
+    val seeded_hash : int -> t -> int @@ portable
+    val hash : t -> int @@ portable
+    external unsafe_chr : int -> char @@ portable = "%identity"
   end
 - : char = 'B'
 module C3 :
@@ -83,35 +83,35 @@ module C4 = F(struct end);;
 C4.chr 66;;
 [%%expect{|
 module F :
-  (X : sig end) ->
+  functor (X : sig end) ->
     sig
       type t = char
-      external code : char -> int = "%identity"
-      val chr : int -> char
-      val escaped : char -> string
-      val compare : t -> t -> int
-      val equal : t -> t -> bool
+      external code : char -> int @@ portable = "%identity"
+      val chr : int -> char @@ portable
+      val escaped : char -> string @@ portable
+      val compare : t -> t -> int @@ portable
+      val equal : t -> t -> bool @@ portable
       module Ascii = Char.Ascii
-      val lowercase_ascii : char -> char
-      val uppercase_ascii : char -> char
-      val seeded_hash : int -> t -> int
-      val hash : t -> int
-      external unsafe_chr : int -> char = "%identity"
+      val lowercase_ascii : char -> char @@ portable
+      val uppercase_ascii : char -> char @@ portable
+      val seeded_hash : int -> t -> int @@ portable
+      val hash : t -> int @@ portable
+      external unsafe_chr : int -> char @@ portable = "%identity"
     end
 module C4 :
   sig
     type t = char
-    external code : char -> int = "%identity"
-    val chr : int -> char
-    val escaped : char -> string
-    val compare : t -> t -> int
-    val equal : t -> t -> bool
+    external code : char -> int @@ portable = "%identity"
+    val chr : int -> char @@ portable
+    val escaped : char -> string @@ portable
+    val compare : t -> t -> int @@ portable
+    val equal : t -> t -> bool @@ portable
     module Ascii = Char.Ascii
-    val lowercase_ascii : char -> char
-    val uppercase_ascii : char -> char
-    val seeded_hash : int -> t -> int
-    val hash : t -> int
-    external unsafe_chr : int -> char = "%identity"
+    val lowercase_ascii : char -> char @@ portable
+    val uppercase_ascii : char -> char @@ portable
+    val seeded_hash : int -> t -> int @@ portable
+    val hash : t -> int @@ portable
+    external unsafe_chr : int -> char @@ portable = "%identity"
   end
 - : char = 'B'
 |}];;

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -63,7 +63,7 @@ module M :
   end
 module type S =
   sig
-    module F : (X : T) -> T
+    module F : functor (X : T) -> T @@ stateless
     module rec Fixed : sig type t = F(Fixed).t end
   end
 module Id : functor (X : T) -> sig type t = X.t end
@@ -122,8 +122,8 @@ module Foo (F : T -> T) = struct
 module M = Foo(Id);;
 M.f 5;;
 [%%expect{|
-module Foo : (F : T -> T) -> sig val f : Fix(F).Fixed.t -> Fix(F).Fixed.t end
-module M : sig val f : Fix(Id).Fixed.t -> Fix(Id).Fixed.t end
+module Foo :
+  functor (F : T -> T) -> sig val f : Fix(F).Fixed.t -> Fix(F).Fixed.t end
 Line 1:
 Error: In the signature of Fix(Id):
        The definition of "Fixed.t" contains a cycle:

--- a/testsuite/tests/typing-signatures/els.ocaml.reference
+++ b/testsuite/tests/typing-signatures/els.ocaml.reference
@@ -81,11 +81,12 @@ module type WEAPON_LIB =
     module T :
       sig type t = t val eq : t -> t -> bool val to_string : t -> string end
     module Make :
-      (TV : sig
-              type combined
-              type t = t/2
-              val map : (combined -> t) * (t -> combined)
-            end)
+      functor
+        (TV : sig
+                type combined
+                type t = t
+                val map : (combined -> t) * (t -> combined)
+              end)
         -> USERCODE(TV).F
   end
 module type X = functor (X : CORE) -> BARECODE

--- a/testsuite/tests/typing-signatures/nondep_regression.ml
+++ b/testsuite/tests/typing-signatures/nondep_regression.ml
@@ -14,5 +14,5 @@ module H = Make (struct type t end)
 [%%expect{|
 type 'a seq = 'a list
 module Make : functor (A : sig type t end) -> sig type t = A.t seq end
-module H : sig type t end
+module H : sig type t : value mod non_float end
 |}]


### PR DESCRIPTION
This PR resolves a couple of test suite failures in the testsuite by accepting the promotions.

- `testsuite/tests/messages/spellcheck.ml` matches printing in OxCaml `5.2.0minus-31` here
- `testsuite/tests/parsing/shortcut_ext_attr.compilers.reference` straightforward promotion
- `testsuite/tests/typing-layouts-or-null/non_float_array.ml` ident changed
- `testsuite/tests/typing-layouts-products/basics_unboxed_records.ml` whitespace
- `testsuite/tests/typing-local/local.ml` looks like a strict improvement.
- `testsuite/tests/typing-modules/aliases.ml` portability annotations, `Char` is portable in the stdlib
- `testsuite/tests/typing-modules/pr7726.ml` matches printing in OxCaml `5.2.0minus-31` here
- `testsuite/tests/typing-signatures/els.ocaml.reference` matches OxCaml `5.2.0minus-31`
- `testsuite/tests/typing-signatures/nondep_regression.ml`  matches OxCaml `5.2.0minus-31` except for CR