### PR TITLE
[5.4] Fix incorrect resolution of the shape mechanism

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -154,7 +154,7 @@ let iter_on_occurrences
   let path_in_type typ name =
     match Types.get_desc typ with
     | Tconstr (type_path, _, _) ->
-      Some (Path.Pdot (type_path,  name))
+      Some (Path.Pextra_ty (type_path, Pcstr_ty name))
     | _ -> None
   in
   let add_constructor_description env lid =

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -1119,29 +1119,20 @@ let of_path ~find_shape ~namespace path =
     Path of label of inline record:
       M.t.C.lbl [Pextra_ty(Pextra_ty("M.t", "C"), "lbl")]
     Path of label of implicit unboxed record:
-      M.t#.lbl *)
+      M.t#.lbl [Pextra_ty(Pextra_ty("M.t", Punboxed_ty), "lbl")] *)
   let rec aux : Sig_component_kind.t -> Path.t -> t = fun ns -> function
     | Pident id -> find_shape ns id
-    | Pdot (Pextra_ty (path, Punboxed_ty), name) ->
-      (match ns with
-       Unboxed_label -> ()
-       | _ -> Misc.fatal_error "Shape.of_path");
-      proj (aux Type path) (name, Label)
-    | Pdot (path, name) ->
-      let namespace :  Sig_component_kind.t =
-        match (ns : Sig_component_kind.t) with
-        | Constructor -> Type
-        | Label -> Type
-        | Unboxed_label -> Type
-        | _ -> Module
-      in
-      proj (aux namespace path) (name, ns)
+    | Pdot (path, name) -> proj (aux Module path) (name, ns)
     | Papply (p1, p2) -> app (aux Module p1) ~arg:(aux Module p2)
     | Pextra_ty (path, extra) -> begin
         match extra, ns, path with
         | Pcstr_ty name, Label, Pextra_ty _ ->
             (* Handle the M.t.C.lbl case *)
             proj (aux Constructor path) (name, ns)
+        | Pcstr_ty name, Unboxed_label, Pextra_ty (path', Punboxed_ty) ->
+            (* Implicit-unboxed view of a boxed record: labels are stored in
+               the underlying boxed type's shape under the Label namespace. *)
+            proj (aux Type path') (name, Label)
         | Pcstr_ty name, _, _ -> proj (aux Type path) (name, ns)
         | Pext_ty, _, _ -> aux Extension_constructor path
         | Punboxed_ty, _, _ -> aux ns path


### PR DESCRIPTION
This PR correctly pulls in #13884 from upstream. Previously, we had accidentally only taken part of it, which has led to imprecision in the shape lookups. The PR doesn't contain any test promotions yet, because there is still noise that will disappear after #5859.