### PR TITLE
Replace `local_` with `@local` / `stack` in public docs.

### DIFF
--- a/jane/doc/extensions/_02-stack-allocation/intro.md
+++ b/jane/doc/extensions/_02-stack-allocation/intro.md
@@ -20,9 +20,9 @@ zero-alloc.
 Because of these advantages, values are allocated on a stack whenever
 possible. Not all values can be allocated on a stack: a value that is
 used beyond the scope of its introduction must be on the heap. Accordingly,
-the compiler uses the _locality_ of a value to determine where it will be
-allocated: _local_ values go on the stack, while _global_ ones must go on the
-heap.
+the compiler uses the _locality_ of a value to determine where stack allocation
+is safe: stack-allocated values have mode `@ local`, while values that must be
+used beyond their scope must be _global_ and live on the heap.
 
 Though type inference will infer where stack allocation is possible, it is
 often wise to annotate places where you wish to enforce locality and stack

--- a/jane/doc/extensions/_02-stack-allocation/reference.md
+++ b/jane/doc/extensions/_02-stack-allocation/reference.md
@@ -78,8 +78,8 @@ compile-time by the type checker as follows.
 A function body defines a _region_: a contiguous stretch of code, all of whose
 stack allocations go into the same stack frame.
 A stack-allocated value lives in the region it's allocated in. We say
-the value is _local_ to the region it lives in. A heap-allocated value is
-_global_.
+the value has mode `@ local` in the region it lives in. A heap-allocated value
+is _global_.
 
 We say that a value _escapes_ a region if it is still referenced beyond the end
 of that region. The type-checker guarantees that local values do not escape
@@ -745,7 +745,7 @@ a local string. Like all two-argument functions, it may be partially applied to
 a single argument yielding a closure that accepts the second. However, since
 this closure closes over the first local argument, it must necessarily be local
 itself. Thus, if applied to a single argument, this function in fact returns
-a _local_ closure, making its type equal to the following:
+a closure with mode `@ local`, making its type equal to the following:
 
 ```ocaml
 string @ local -> (string -> string) @ local


### PR DESCRIPTION
Updates the remaining emphasized `local_` prose in the stack allocation docs to use explicit `@ local` wording.

Internal ticket 5369.