### PR TITLE
Rephrase "upstream compiler" in public include-functor docs.

### DIFF
--- a/jane/doc/extensions/_11-miscellaneous-extensions/include-functor.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/include-functor.md
@@ -79,8 +79,8 @@ end
 
 ## Details and Limitations
 
-This extension is not available in the upstream compiler, so publicly
-released code should not use it.  We plan to upstream it in the
+This extension is not available in stock OCaml, so publicly
+released code should not use it. We plan to contribute it to OCaml in the
 future.
 
 To include a functor `F`, it must have a module type of the form:


### PR DESCRIPTION
Replaces the public include-functor docs wording around "upstream compiler" with stock OCaml / contribute-to-OCaml phrasing.

Internal ticket 5370.