### PR TITLE
Rephrase "upstream compiler" in docs.

### DIFF
--- a/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
+++ b/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
@@ -1192,8 +1192,8 @@ access `mood` even if a `Thing.t` is `contended`, and in fact we can mark `t` as
 [`Atomic` module], as it has many useful operations,
 from `compare_exchange` to atomic logical bitwise XOR. Also, note that we're
 using Core's `Atomic` here rather than the `Atomic` from OxCaml's standard
-library, which hews closer to the upstream OCaml standard library and doesn't
-support mode crossing.
+library, which hews closer to the OCaml standard library and doesn't support
+mode crossing.
 
 [crosses contention]: #mode-crossing
 [`Atomic` module]: https://github.com/janestreet/portable/blob/master/kernel/src/atomic.mli

--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -600,11 +600,11 @@ OxCaml provides mechanisms to assert your code depends on the current
 representation. The mechanism depends on whether you are writing C bindings
 or (unsafe) OCaml code.
 
-Note also that, while unboxed types are generally considered an "upstream
-compatible" (because they can be erased while preserving behavior), depending on
-the exact representation of mixed blocks is not. Thus, use of these mechanisms is
-also a sign that your code may need a custom mechanism if it is intended to work
-both in OxCaml and upstream OCaml.
+Note also that, while unboxed types are generally considered compatible with
+stock OCaml (because they can be erased while preserving behavior), depending on
+the exact representation of mixed blocks is not. Thus, use of these mechanisms
+is also a sign that your code may need a custom mechanism if it is intended to
+work both with OxCaml and with stock OCaml.
 
 ### In C bindings
 

--- a/jane/doc/extensions/_10-templates/01-intro.md
+++ b/jane/doc/extensions/_10-templates/01-intro.md
@@ -20,8 +20,8 @@ For example, consider the identity function:
 let id : 'a. 'a -> 'a = fun x -> x
 ```
 
-In upstream OCaml, this is about as polymorphic as you can get! I can call `id x` on any
-value `x`, regardless of its type, and get the same value back out.
+In stock OCaml, this is about as polymorphic as you can get! I can call `id x`
+on any value `x`, regardless of its type, and get the same value back out.
 
 But in OxCaml, things are more complex. If my value is stack-allocated, then it will be at 
 mode `local`, so my identity function had better not do anything funny like stick it in a 
@@ -218,4 +218,3 @@ val%template min_inan : t @ m -> t @ m -> t @ m
 val%template max_inan : t @ m -> t @ m -> t @ m
 [@@mode m = (global, local)]
 ```
-

--- a/jane/doc/extensions/_11-miscellaneous-extensions/include-functor.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/include-functor.md
@@ -79,8 +79,8 @@ end
 
 ## Details and Limitations
 
-This extension is not available in the upstream compiler, so publicly
-released code should not use it.  We plan to upstream it in the
+This extension is not available in stock OCaml, so publicly
+released code should not use it. We plan to contribute it to OCaml in the
 future.
 
 To include a functor `F`, it must have a module type of the form:


### PR DESCRIPTION
Replaces prose uses of "upstream" in public docs with stock OCaml / OCaml-compatible phrasing.

Internal ticket 5370.