### PR TITLE
Fix ppx-rewriters link on templates intro page.

### DIFF
--- a/jane/doc/extensions/_10-templates/01-intro.md
+++ b/jane/doc/extensions/_10-templates/01-intro.md
@@ -44,9 +44,9 @@ let id : 'a. 'a @ global -> 'a @ global = fun x -> x
 
 The implementation of these two functions is obviously identical, so it would be nice if
 we could just write it once, but get two copies of the function with different modes.
-Conveniently, we've written a 
-[preprocessor](https://dune.readthedocs.io/en/stable/reference/preprocessing-spec.html#using-ppx-rewriters) 
-to do exactly that: `ppx_template`. Much like templates in C++, this allows us to define 
+Conveniently, we've written a
+[preprocessor](https://ocaml.org/docs/metaprogramming#ppx-rewriters)
+to do exactly that: `ppx_template`. Much like templates in C++, this allows us to define
 the function once, polymorphic over some mode variable, while the compiler will 
 instantiate the template for each value of the variable. Thus our two identity functions 
 can be written as:
@@ -218,4 +218,3 @@ val%template min_inan : t @ m -> t @ m -> t @ m
 val%template max_inan : t @ m -> t @ m -> t @ m
 [@@mode m = (global, local)]
 ```
-


### PR DESCRIPTION
Replaces the Dune preprocessing-spec link with the OCaml metaprogramming ppx-rewriters documentation link.

Internal ticket 5371.