### PR TITLE
Document mutable field modalities

### DIFF
--- a/jane/doc/extensions/_02-stack-allocation/reference.md
+++ b/jane/doc/extensions/_02-stack-allocation/reference.md
@@ -707,11 +707,15 @@ let f () =
 
 ### Mutability
 
-Mutable fields are always `global_`, including array elements. That is, while
-you may create local `ref`s or arrays, their contents must always be global.
-Should you need to put a local value into one of these
-places, you may want to check out
+Mutable fields and array elements require their contents to be `global`. That
+is, while you may create local `ref`s or arrays, the values stored in them must
+always be global. Should you need to put a local value into one of these places,
+you may want to check out
 [`ppx_globalize`](https://github.com/janestreet/ppx_globalize).
+
+This is one part of a broader rule for mutable fields; see the
+[modes syntax](../../modes/syntax#record-fields) section for the full
+mutable-field rule.
 
 This restriction may be lifted somewhat in future: the tricky part is that
 naively permitting mutability might allow an older local mutable value to be

--- a/jane/doc/extensions/_05-modes/syntax.md
+++ b/jane/doc/extensions/_05-modes/syntax.md
@@ -201,6 +201,41 @@ type r = {x : string @@ modalities}
 type r = {x : string @ modes -> string @ modes @@ modalities}
 ```
 
+Mutable record fields, including fields marked `[@atomic]`, differ from
+immutable fields in two ways. First, their default field modality is not the
+identity. For construction and reads, a plain mutable field behaves as if its
+field type were annotated with `@@ global many dynamic`. For example, `ref` is
+defined as a mutable record with one field:
+
+```ocaml
+type 'a ref = { mutable contents : 'a }
+```
+
+The implicit mutable-field modality means that `ref` behaves as if the
+`contents` field were annotated with `@@ global many dynamic`.
+
+As a modality, `global` implies `aliased`, `forkable`, and `unyielding`. For the
+locality, uniqueness, and linearity axes, the important part is therefore
+`@@ global many aliased`.
+
+This means that constructing a plain mutable field requires `global` and `many`
+contents. Reading such a field yields an `aliased` value, even if the record
+itself is `unique`.
+
+Explicit field modalities can override these defaults for construction and
+reads. For example:
+
+```ocaml
+type t = { mutable x : string option @@ local }
+```
+
+The `@@ local` annotation can allow local contents when constructing a
+non-escaping record, and reading `x` from a local record yields a local value.
+
+Second, assignment has a separate mutable-write rule. Even for a field annotated
+`@@ local`, a later assignment to the field must store a value that is `global`
+and `many`.
+
 ## Constructor fields
 Constructor fields can have modalities:
 ```ocaml


### PR DESCRIPTION
Documents the implied modalities for mutable fields using `ref` as the concrete example. The stack-allocation mutability links to the broader rule.

Internal ticket 5344