### PR TITLE
Fix small issues in public documentation

### DIFF
--- a/jane/doc/extensions/_05-modes/reference.md
+++ b/jane/doc/extensions/_05-modes/reference.md
@@ -13,7 +13,7 @@ The mode system in the compiler tracks various properties of values, so that cer
 performance-enhancing operations can be performed safely. For example:
 - Locality tracks escaping. See [the local allocations
   reference](../../stack-allocation/reference)
-- Uniqueness and linearity tracks aliasing. See [the uniqueness reference](../../uniqueness/reference)
+- Uniqueness and linearity track aliasing. See [the uniqueness reference](../../uniqueness/reference)
 - Portability and contention tracks inter-thread sharing.
     <!-- CR zqian: reference for portability and contention -->
 
@@ -21,7 +21,7 @@ performance-enhancing operations can be performed safely. For example:
 `lazy e` contains a thunk that evaluates `e`, as well as a mutable cell to store the
 result of `e`. Upon construction, the mode of `lazy e` cannot be stronger than `e`. For
 example, if `e` is `nonportable`, then `lazy e` cannot be `portable`. Upon destruction
-(forcing a lazy value), the result cannot be stronger than the mode of lazy value. For
+(forcing a lazy value), the result cannot be stronger than the mode of the lazy value. For
 example, forcing a `nonportable` lazy value cannot give a `portable` result. Additionally,
 forcing a lazy value involves accessing the mutable cell and thus requires the lazy value
 to be `uncontended`.
@@ -127,7 +127,7 @@ let () = bar foo (* prints "foo" *)
 Exceptions also cross statefulness and visibility with identical restrictions.
 
 # Modalities
-Modalities, as described in the [syntax](../syntax) section, can be though of as functions
+Modalities, as described in the [syntax](../syntax) section, can be thought of as functions
 from mode to mode. For example, let's imagine one defines a record type with some modality
 `m`:
 

--- a/jane/doc/extensions/_05-modes/syntax.md
+++ b/jane/doc/extensions/_05-modes/syntax.md
@@ -20,7 +20,7 @@ portability ::= `portable` | `corruptible` | `shareable` | `nonportable`
 contention ::= `uncontended` | `shared` | `corrupted` | `contended`
 yield ::= `unyielding` | `yielding`
 fork ::= `forkable` | `unforkable`
-statefulness ::= `stateless` | `writing` | `reading | `stateful`
+statefulness ::= `stateless` | `writing` | `reading` | `stateful`
 visibility ::= `read_write` | `read` | `write` | `immutable`
 
 modes ::= mode
@@ -40,7 +40,7 @@ names.
 It is an error to specify more than one mode along the same axis in one mode
 expression.
 
-To write a mode expression in program, it has to be prefixed by an `@` symbol.
+To write a mode expression in a program, it has to be prefixed by an `@` symbol.
 It can appear in several places in a program as described below.
 
 ## Arrow types

--- a/jane/doc/extensions/_06-kinds/01-intro.md
+++ b/jane/doc/extensions/_06-kinds/01-intro.md
@@ -222,7 +222,7 @@ don't want to restrict the normal `list` type to work only on a subset of
 
 The solution to this problem is the with-bounds: a with-bound in a kind of a
 type makes that type not mode-cross whenever the with-bound also does not
-mode-cross. Add a bound to the `mod` section always *lowers* a kind, while
+mode-cross. Adding a bound to the `mod` section always *lowers* a kind, while
 adding a with-bound always *raises* a kind.
 
 Here is the full kind of `'a list`:

--- a/jane/doc/extensions/_11-miscellaneous-extensions/immutable-arrays.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/immutable-arrays.md
@@ -35,7 +35,7 @@ type `super`, then `sub iarray` is a subtype of `super iarray`, as though you ha
 You can also have *immutable array comprehensions*: `[: x, y for x = 1
 to 3 and y in [: "some"; "thing" :] :]`.
 
-*This extension will appear in OCaml 5.4 as the `Iarray` module. See
+*This extension is available in OCaml 5.4 as the `Iarray` module. See
 [ocaml/ocaml#13097](https://github.com/ocaml/ocaml/pull/13097).* To use this
 extension with the current OxCaml release, you must add `stdlib_stable` as a
 library dependency.

--- a/jane/doc/extensions/_11-miscellaneous-extensions/labeled-tuples.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/labeled-tuples.md
@@ -95,13 +95,13 @@ parameter.
 
 Labels may also be repeated in a tuple, and unlabeled elements can be thought of
 as all sharing the same unique label.  When matching on such a tuple, the first
-occurence of a label in the pattern is bound to the first corresponding label in
+occurrence of a label in the pattern is bound to the first corresponding label in
 the value, and so on.  As a result, it's also now possible to partially match on
 an unlabeled tuple to retrieve the first few elements.
 
 ## Limitations
 
-Parentheses are necessary to disambiguate functions types with labeled arguments
+Parentheses are necessary to disambiguate function types with labeled arguments
 from function types with labeled tuple arguments when the first element of the
 tuple has a label.  `ocamlformat` will handle this for you.
 
@@ -132,4 +132,4 @@ File "foo.ml", line 3, characters 6-12:
 Error: Could not determine the type of this partial tuple pattern.
 ```
 
-*This extension will appear in OCaml 5.4. See [ocaml/ocaml#13498](https://github.com/ocaml/ocaml/pull/13498).*
+*This extension is available in OCaml 5.4. See [ocaml/ocaml#13498](https://github.com/ocaml/ocaml/pull/13498).*

--- a/jane/doc/extensions/_11-miscellaneous-extensions/zero_alloc_check.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/zero_alloc_check.md
@@ -488,9 +488,9 @@ arguments:
 
 The flag can be passed to `dune` build as usual for the entire project or on a
 per-library basis. For example, to disable regular and `opt` checks:
-`(ocamlopt_flags (:standard -zero-alloc-check none)`
+`(ocamlopt_flags (:standard -zero-alloc-check none))`
 
-The check can also be controled on a per-file basis using the top-level attribute
+The check can also be controlled on a per-file basis using the top-level attribute
 `[@@@zero_alloc check]`, `[@@@zero_alloc check_none]`, `[@@@zero_alloc check_all]`,
 `[@@@zero_alloc check_opt]`.
 


### PR DESCRIPTION
Cleans up small issues in the public extension documentation, including typos, grammar, stale wording, and minor example fixes.