### PR TITLE
Move Eval.use_existing_compilerlibs_state_for_artifacts to Opttoploop

### DIFF
--- a/otherlibs/eval/dune
+++ b/otherlibs/eval/dune
@@ -34,7 +34,8 @@
   ; If you edit this list make sure to change
   ; extra_libraries_for_eval in optcompile.ml.
   jit
-  ocamlcommon)
+  ocamlcommon
+  ocamlopttoplevel)
  (flags
   (:standard
    -extension=runtime_metaprogramming

--- a/otherlibs/eval/eval.ml
+++ b/otherlibs/eval/eval.ml
@@ -100,10 +100,8 @@ let read_bundles ~marshalled_cmi_bundle ~marshalled_cmx_bundle =
   cmis := new_cmis;
   cmxs := new_cmxs
 
-let use_existing_compilerlibs_state_for_artifacts = ref false
-
 let read_bundles_from_exe () =
-  assert (not !use_existing_compilerlibs_state_for_artifacts);
+  assert (not (Opttoploop.using_existing_compilerlibs_state_for_artifacts ()));
   let marshalled_cmi_bundle =
     find_bundle_in_exe ~ext:"cmi" bundled_cmis_this_exe
   in
@@ -121,7 +119,9 @@ let eval (expr : 'a expr) =
   (* TODO: assert the JIT is supported *)
   let id = !counter in
   incr counter;
-  if id = 0 && not !use_existing_compilerlibs_state_for_artifacts
+  if
+    id = 0
+    && not (Opttoploop.using_existing_compilerlibs_state_for_artifacts ())
   then read_bundles_from_exe ();
   (* TODO: reset all the things *)
   (* TODO: these flags should maybe be snapshotted and restored *)
@@ -165,7 +165,7 @@ let eval (expr : 'a expr) =
         true)
       !cmxs
   in
-  (if not !use_existing_compilerlibs_state_for_artifacts
+  (if not (Opttoploop.using_existing_compilerlibs_state_for_artifacts ())
    then
      Persistent_env.Persistent_signature.load
        := fun ~allow_hidden:_ ~unit_name ->
@@ -242,6 +242,3 @@ let eval code =
         let backtrace = Printexc.get_raw_backtrace () in
         Location.report_exception Format.std_formatter exn;
         Printexc.raise_with_backtrace exn backtrace)
-
-let use_existing_compilerlibs_state_for_artifacts () =
-  use_existing_compilerlibs_state_for_artifacts := true

--- a/otherlibs/eval/eval.mli
+++ b/otherlibs/eval/eval.mli
@@ -27,10 +27,3 @@
 
 (** Evaluate a quoted OCaml expression at runtime. *)
 val eval : 'a expr @ once -> 'a eval
-
-(** Disallow the reading of bundles from the current executable. Instead, fetch
-    them via the normal mechanisms used by compilerlibs. This should only be
-    used if the compilerlibs state in the process is already set up with the
-    correct [Load_path] information for .cmi and .cmx resolution (as is the case
-    in mdx, for example). *)
-val use_existing_compilerlibs_state_for_artifacts : unit -> unit

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -286,6 +286,14 @@ let run_hooks hook = List.iter (fun f -> f hook) !hooks
 let phrase_seqid = ref 0
 let phrase_name = ref "TOP"
 
+let use_existing_compilerlibs_state_for_artifacts_flag = ref false
+
+let use_existing_compilerlibs_state_for_artifacts () =
+  use_existing_compilerlibs_state_for_artifacts_flag := true
+
+let using_existing_compilerlibs_state_for_artifacts () =
+  !use_existing_compilerlibs_state_for_artifacts_flag
+
 let default_load ppf (program : Lambda.program) =
   let dll =
     if !Clflags.keep_asm_file then !phrase_name ^ ext_dll

--- a/toplevel/native/opttoploop.mli
+++ b/toplevel/native/opttoploop.mli
@@ -185,3 +185,14 @@ val default_lookup : string -> Obj.t option
 val need_symbol : string -> bool
 
 val phrase_name : string ref
+
+(** Disallow the reading of bundles from the current executable. Instead, fetch
+    them via the normal mechanisms used by compilerlibs. This should only be
+    used if the compilerlibs state in the process is already set up with the
+    correct [Load_path] information for .cmi and .cmx resolution (as is the case
+    in mdx, for example). *)
+val use_existing_compilerlibs_state_for_artifacts : unit -> unit
+
+(** Returns [true] iff [use_existing_compilerlibs_state_for_artifacts] has been
+    called. *)
+val using_existing_compilerlibs_state_for_artifacts : unit -> bool


### PR DESCRIPTION
This should hopefully solve the problem with mdx seen on the JS tree (it currently depends on `eval` but we don't want it to "use metaprogramming" by default).