### PR TITLE
Call caml_continuation_use_noexc to resume unhandled continuations

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1336,8 +1336,18 @@ LBL(do_perform):
 LBL(112):
     /* Switch back to original performer before raising Effect.Unhandled
        (no-op unless this is a reperform) */
-        movq    0(%rbx), %r10  /* load performer stack from continuation */
-        subq    $1, %r10       /* r10 := Ptr_val(r10) */
+        movq    %rbx, C_ARG_1
+        SWITCH_OCAML_TO_C
+    /* Save %rax (effect, needed later by caml_raise_unhandled_effect)
+       across the C call. Reserve 16 bytes to keep %rsp 16-byte aligned. */
+        subq    $16, %rsp; CFI_ADJUST(16)
+        movq    %rax, 0(%rsp)
+        C_call  (GCALL(caml_continuation_use_noexc)) /* %rax := stack */
+        movq    %rax, %r10
+        movq    0(%rsp), %rax
+        addq    $16, %rsp; CFI_ADJUST(-16)
+        SWITCH_C_TO_OCAML
+        subq    $1, %r10                /* r10 := Ptr_val(r10) */
         movq    Caml_state(current_stack), %rsi
         SWITCH_OCAML_STACKS
     /* No parent stack. Raise Effect.Unhandled. */

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1348,6 +1348,9 @@ LBL(112):
         addq    $16, %rsp; CFI_ADJUST(-16)
         SWITCH_C_TO_OCAML
         subq    $1, %r10                /* r10 := Ptr_val(r10) */
+    /* Check if stack null, then already used */
+        testq   %r10, %r10
+        jz      LBL(113)
         movq    Caml_state(current_stack), %rsi
         SWITCH_OCAML_STACKS
     /* No parent stack. Raise Effect.Unhandled. */
@@ -1371,6 +1374,11 @@ LBL(112):
 #endif
         movq    %rax, C_ARG_1
         LEA_VAR(caml_raise_unhandled_effect, %rax)
+        jmp     LBL(caml_c_call)
+LBL(113):
+        ENTER_FUNCTION
+        TSAN_ENTER_FUNCTION(0)
+        LEA_VAR(caml_raise_continuation_already_resumed, %rax)
         jmp     LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_perform))

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -1186,7 +1186,17 @@ L(do_perform):
 1:
     /*  switch back to original performer before raising Effect.Unhandled
         (no-op unless this is a reperform) */
-        ldr     x10, [x1] /* load performer stack from continuation */
+        SWITCH_OCAML_TO_C
+    /* Save x0 (effect, needed later by caml_raise_unhandled_effect) and x30
+       across the C call */
+        stp     x0, x30, [sp, -16]!
+        CFI_ADJUST(16)
+        mov     x0, x1 /* pass continuation to caml_continuation_use_noexc */
+        bl      G(caml_continuation_use_noexc) /* x0 := stack */
+        mov     x10, x0
+        ldp     x0, x30, [sp], 16
+        CFI_ADJUST(-16)
+        SWITCH_C_TO_OCAML
         sub     x10, x10, 1 /* x10 := Ptr_val(x10) */
         ldr     x9, Caml_state(current_stack)
         SWITCH_OCAML_STACKS x9, x10

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -1198,6 +1198,8 @@ L(do_perform):
         CFI_ADJUST(-16)
         SWITCH_C_TO_OCAML
         sub     x10, x10, 1 /* x10 := Ptr_val(x10) */
+    /* Check if stack null, then already used */
+        cbz     x10, 2f
         ldr     x9, Caml_state(current_stack)
         SWITCH_OCAML_STACKS x9, x10
     /*  No parent stack. Raise Effect.Unhandled. */
@@ -1216,6 +1218,8 @@ L(do_perform):
         TSAN_RESTORE_CALLER_REGS
 #endif
         ADDRGLOBAL(ADDITIONAL_ARG, caml_raise_unhandled_effect)
+        b       G(caml_c_call)
+2:      ADDRGLOBAL(ADDITIONAL_ARG, caml_raise_continuation_already_resumed)
         b       G(caml_c_call)
         CFI_ENDPROC
 END_FUNCTION(caml_perform)

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -344,6 +344,12 @@ caml_rewrite_exception_stack(struct stack_info *old_stack,
                              struct stack_info *new_stack);
 #endif
 
+/* Consume a continuation, returning Val_ptr(stack)
+
+   Once a continuation object has been made visible to the GC, it *must* be
+   resumed exactly once by calling this function, and must not be resumed any
+   other way (eg by reading the stack out directly).
+ */
 value caml_continuation_use_noexc (value cont);
 value caml_continuation_use (value cont);
 

--- a/testsuite/tests/effects/reperform_consumed_cont.ml
+++ b/testsuite/tests/effects/reperform_consumed_cont.ml
@@ -1,0 +1,62 @@
+(* TEST
+ runtime5;
+ native;
+*)
+
+(* When a reperform reaches the "no parent handler" (unhandled) path, the
+   runtime atomically consumes the continuation via caml_continuation_use_noexc
+   before switching stacks. If the continuation has already been consumed,
+   caml_continuation_use_noexc returns NULL and we should raise
+   [Continuation_already_resumed] instead of proceeding with a NULL stack.
+
+   This test sets up that scenario by calling [reperform] twice on the same
+   continuation from within an unhandled-effect-catching [with_stack]. The
+   first [reperform] raises [Unhandled] via the unhandled path, consuming the
+   continuation as a side effect. The second [reperform] uses the same (now
+   NULL) continuation and must raise [Continuation_already_resumed].
+
+   This is not something that can actually be hit by the stdlib, so we have to
+   use the effect primitives directly.
+*)
+
+open Effect
+
+type _ t += E : unit t
+
+type ('a, 'x, 'b) cont
+type last_fiber [@@immediate]
+
+external with_stack :
+  ('x -> 'b) ->
+  (exn -> 'b) ->
+  ('c t -> ('c, 'x, 'b) cont -> last_fiber -> 'b) ->
+  ('d -> 'x) ->
+  'd ->
+  'b = "%with_stack"
+
+external reperform :
+  'a t -> ('a, _, 'b) cont -> last_fiber -> 'b = "%reperform"
+
+let () =
+  Printexc.record_backtrace false;
+  let saw_unhandled = ref false in
+  let saw_already_resumed = ref false in
+  let effc (type a) (eff : a t) (k : (a, _, _) cont) (lf : last_fiber) =
+    match eff with
+    | E ->
+        (try reperform E k lf
+         with Unhandled _ -> saw_unhandled := true);
+        (try reperform E k lf
+         with Continuation_already_resumed -> saw_already_resumed := true);
+        ()
+    | _ -> reperform eff k lf
+  in
+  with_stack
+    (fun () -> ())
+    (fun e -> raise e)
+    effc
+    (fun () -> perform E)
+    ();
+  Printf.printf "first reperform raised Unhandled: %b\n" !saw_unhandled;
+  Printf.printf "second reperform raised Continuation_already_resumed: %b\n"
+    !saw_already_resumed

--- a/testsuite/tests/effects/reperform_consumed_cont.reference
+++ b/testsuite/tests/effects/reperform_consumed_cont.reference
@@ -1,0 +1,2 @@
+first reperform raised Unhandled: true
+second reperform raised Continuation_already_resumed: true


### PR DESCRIPTION
It's important that, once a continuation has been made visible to the GC, it's only ever consumed via caml_continuation_use_noexc, and that a continuation which has *not* been consumed this way is not resumed. This commit patches a hole in that invariant - if a continuation for an effect is *unhandled*, we would previously just read the stack out of it rather than `use`ing it. This *can* theoretically cause problems, eg if the continuation is promoted in an effect handler which allocates, then reperforms an effect which is destined to be unhandled. Then, a parallel major GC could scan the continuation concurrently with it being discontinued to raise Unhandled.