### PR TITLE
Annotate `Random.State` as mostly `@ local`

### DIFF
--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -29,7 +29,7 @@ module State = struct
 
   type t = (int64, int64_elt, c_layout) Array1.t
 
-  external next: t -> (int64[@unboxed]) @@ portable
+  external next: t @ local -> (int64[@unboxed]) @@ portable
       = "caml_lxm_next" "caml_lxm_next_unboxed" [@@noalloc]
 
   let create () : t =
@@ -344,7 +344,7 @@ let mk_default () =
 
 (* CR-soon mslater: this is safe since the state is only updated by a C call
    that cannot be preempted, we do not yield, and we do not borrow the state.
-   However, it will not be deterministic in the presence of threads, so it 
+   However, it will not be deterministic in the presence of threads, so it
    should be converted to TLS. *)
 let random_key =
   DLS.new_key
@@ -355,7 +355,7 @@ let random_key =
 
 let[@inline] apply0 f () = f (Obj.magic_uncontended (DLS.get random_key))
 let[@inline] apply1 f v =  f (Obj.magic_uncontended (DLS.get random_key)) v
-let[@inline] apply_in_range f ~min ~max = 
+let[@inline] apply_in_range f ~min ~max =
   f (Obj.magic_uncontended (DLS.get random_key)) ~min ~max
 
 let bits = apply0 State.bits

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -193,29 +193,30 @@ module State : sig
       in a system-dependent way.
       The seed is obtained as described in {!Random.self_init}. *)
 
-  val copy : t -> t
+  val copy : t @ local -> t
   (** Return a copy of the given state. *)
 
-  val bits : t -> int
-  val int : t -> int -> int
-  val full_int : t -> int -> int
-  val int_in_range : t -> min:int -> max:int -> int
-  val int32 : t -> Int32.t -> Int32.t
-  val int32_in_range : t -> min:int32 -> max:int32 -> int32
-  val nativeint : t -> Nativeint.t -> Nativeint.t
-  val nativeint_in_range : t -> min:nativeint -> max:nativeint -> nativeint
-  val int64 : t -> Int64.t -> Int64.t
-  val int64_in_range : t -> min:int64 -> max:int64 -> int64
-  val float : t -> float -> float
-  val bool : t -> bool
-  val bits32 : t -> Int32.t
-  val bits64 : t -> Int64.t
-  val nativebits : t -> Nativeint.t
+  val bits : t @ local -> int
+  val int : t @ local -> int -> int
+  val full_int : t @ local -> int -> int
+  val int_in_range : t @ local -> min:int -> max:int -> int
+  val int32 : t @ local -> Int32.t -> Int32.t
+  val int32_in_range : t @ local -> min:int32 -> max:int32 -> int32
+  val nativeint : t @ local -> Nativeint.t -> Nativeint.t
+  val nativeint_in_range :
+    t @ local -> min:nativeint -> max:nativeint -> nativeint
+  val int64 : t @ local -> Int64.t -> Int64.t
+  val int64_in_range : t @ local -> min:int64 -> max:int64 -> int64
+  val float : t @ local -> float -> float
+  val bool : t @ local -> bool
+  val bits32 : t @ local -> Int32.t
+  val bits64 : t @ local -> Int64.t
+  val nativebits : t @ local -> Nativeint.t
   (** These functions are the same as the basic functions, except that they
       use (and update) the given PRNG state instead of the default one.
   *)
 
-  val split : t -> t
+  val split : t @ local -> t
   (** Draw a fresh PRNG state from the given PRNG state.
       (The given PRNG state is modified.)
       The new PRNG is statistically independent from the given PRNG.


### PR DESCRIPTION
This annotates most functions in `Random.State` as accepting the state as `@ local`.  More functions could be annotated as such, but it would require a bit more changes and so that is skipped for now.