### PR TITLE
[5.4] Fix testsuite when running with `--disable-multidomain`

### DIFF
--- a/external/owee/owee_location.ml
+++ b/external/owee/owee_location.ml
@@ -1,7 +1,6 @@
 type t
 
-external extract : (_ -> _) -> t =
-  "ml_owee_code_pointer" "ml_owee_code_pointer" "noalloc"
+external extract : (_ -> _) -> t = "ml_owee_code_pointer" [@@noalloc]
 
 let count_rows body ~pointers_to_other_sections =
   let open Owee_debug_line in

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -114,11 +114,17 @@ let hasstr = make
     "str library available"
     "str library not available")
 
+(* Upstream's multicore predicate is merged with our older multidomain predicate
+   meaning that tests marked multicore will only run if it both possible and
+   permitted to spawn domains. *)
+let multicore_possible_and_allowed =
+  Domain.recommended_domain_count () >= 2 && Config.multidomain
+
 let multicore = make
   ~name:"multicore"
   ~description:"Pass if running on multicore"
   ~does_something:false
-  (Actions_helpers.predicate (Domain.recommended_domain_count () >= 2)
+  (Actions_helpers.predicate multicore_possible_and_allowed
     "running on multicore"
     "not running on multicore")
 

--- a/runtime/gen_primsc.sh
+++ b/runtime/gen_primsc.sh
@@ -30,7 +30,7 @@ esac
 # float32 primitives contain macros in their definitions, so we preprocess
 # first.  Of course, we must ensure that CAMLprim does not get preprocessed
 # away, hence -DCAML_NO_DEFINE_CAMLprim below.
-CC=$(cat ../Makefile.config | grep '^CC *=' | cut -d= -f2)
+CC=$(cat ../Makefile.config | grep '^CC *=' | cut -d= -f2-)
 OCAMLC_CFLAGS=$(cat ../Makefile.config | grep '^OCAMLC_CFLAGS *=' | cut -d= -f2-)
 
 cat <<'EOF'

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -99,10 +99,13 @@ function record_unexp() {
     errored = 1;
 }
 
-/^ ... testing '[^']*' with / {
-    if (in_test) record_unexp();
-    next;
-}
+# CR-someday dallsopp: this breaks our display of skipped tests (because we
+# still display the with part for skip results, as it's clearer). Resolve or
+# upstream this.
+#/^ ... testing '[^']*' with / {
+#    if (in_test) record_unexp();
+#    next;
+#}
 
 /^ ... testing '[^']*'/ {
     if (in_test) record_unexp();

--- a/testsuite/tests/tool-expect-test/expect_assembly.ml
+++ b/testsuite/tests/tool-expect-test/expect_assembly.ml
@@ -55,12 +55,12 @@ f:
   subq  $8, %rsp
   movq  %rax, %rbx
   movq  camlTOP4__fn$5b$3a1$2c19$2d$2d45$5d_10@GOTPCREL(%rip), %rax
-  call  camlStdlib__List__map_15_113_code@PLT
+  call  camlStdlib__List__map_16_124_code@PLT
 .L113:
   movq  %rax, %rbx
   movq  camlTOP4__fn$5b$3a1$2c60$2d$2d86$5d_11@GOTPCREL(%rip), %rax
   addq  $8, %rsp
-  jmp   camlStdlib__List__map_15_113_code@PLT
+  jmp   camlStdlib__List__map_16_124_code@PLT
 
 f.(fun):
   movq  camlTOP4__fn$5b$3a1$2c60$2d$2d86$5d_11@GOTPCREL(%rip), %rbx

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -441,34 +441,24 @@ let argument_shape (ty, opt) =
 
 let extract_external_declaration outp (v : value_description) =
   (* Based on Primitive.parse_declaration in the compiler. *)
-  let cname, _native_cname, tail =
+  let cname, _native_cname =
     match v.val_prim with
     | [] ->
       (* The compiler does not allow it. *)
       Misc.fatal_errorf "Missing name at %s:%d, found %s"
         v.val_loc.loc_start.pos_fname v.val_loc.loc_start.pos_lnum
         v.val_name.txt
-    | name :: "noalloc" :: name2 :: "float" :: tail -> name, name2, tail
-    | name :: "noalloc" :: name2 :: tail -> name, name2, tail
-    | name :: name2 :: "float" :: tail -> name, name2, tail
-    | name :: "noalloc" :: tail -> name, name, tail
-    | name :: name2 :: tail -> name, name2, tail
-    | name :: tail -> name, name, tail
+    | name :: "noalloc" :: name2 :: "float" :: _ -> name, name2
+    | name :: "noalloc" :: name2 :: _ -> name, name2
+    | name :: name2 :: "float" :: _ -> name, name2
+    | name :: "noalloc" :: _ -> name, name
+    | name :: name2 :: _ -> name, name2
+    | name :: _ -> name, name
   in
   (* compiler intrinsics should not show up in the external declarations *)
   if String.starts_with ~prefix:"%" cname
   then ()
-  else (
-    (match tail with
-    | [] -> ()
-    | tail ->
-      (* The compiler should reject providing additional names in external
-         declarations. *)
-      Misc.fatal_errorf_doc "Unexpected names at %s:%d, found %a"
-        v.val_loc.loc_start.pos_fname v.val_loc.loc_start.pos_lnum
-        (Format_doc.pp_print_list ~pp_sep:Format_doc.pp_print_space
-           Format_doc.pp_print_string)
-        tail);
+  else
     (* TODO: Add support for extracting/checking the native code name. *)
     let args, ret = split_external_type v.val_desc in
     let arg_shapes = List.map argument_shape args in
@@ -476,7 +466,7 @@ let extract_external_declaration outp (v : value_description) =
     outp
       { name = cname;
         desc = { shape = Some { arguments = arg_shapes; return = ret_shape } }
-      })
+      }
 
 let extract_from_typed_tree tt =
   let open Tast_iterator in

--- a/utils/dune
+++ b/utils/dune
@@ -35,7 +35,7 @@
   (with-stdout-to
    %{targets}
    (bash
-    "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml %{c}"))))
+    "`grep '^CPP=' %{conf} | cut -d'=' -f2-` -I ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml %{c}"))))
 
 (rule
  (targets domainstate.mli)
@@ -51,7 +51,7 @@
   (with-stdout-to
    %{targets}
    (bash
-    "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml %{c}"))))
+    "`grep '^CPP=' %{conf} | cut -d'=' -f2-` -I ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml %{c}"))))
 
 (include_subdirs unqualified)
 


### PR DESCRIPTION
A small slew of things:
- The `multicore` action wasn't updated correctly (by me) for 5.4, which causes a whole load of tests previously marked `multidomain` to try to run; they now don't
- While testing that, I found a reference file from the expect_assembly test which needed updating for changed members of the `List` module (I hadn't seen that because I usually run with `--enable-multidomain` which means `--enable-poll-insertion` which disables that test)
- Also while testing that, I found that some of our changes were conflicting badly with a change in testsuite/summarize.awk which was responsible for reducing the display. I'm reasonably confident this was only causing skipped tests not to be displayed in the summary. I've fixed it by disabling the upstream change (I'm not sure it's a good change upstream either, FWIW)
- We're not fixing runtime4 (or ever intending to), so testing it in CI is a waste of resource
- Continuing the quest of meaningful CI, two PRs from main cherry-picked