### PR TITLE
Preemptible fibers

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -5435,6 +5435,51 @@ let with_stack_bind ~dbg ~valuec ~exnc ~effc ~dyn ~bind ~f ~arg =
         arg ],
       dbg )
 
+let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg =
+  let sym = Cmm.global_symbol "caml_runstack" in
+  Cop
+    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+      [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
+        Cop
+          ( Cextcall
+              { func = "caml_alloc_stack_preemptible";
+                ty = typ_val;
+                alloc = true;
+                builtin = false;
+                returns = true;
+                effects = Arbitrary_effects;
+                coeffects = Has_coeffects;
+                ty_args = [XInt; XInt; XInt; XInt]
+              },
+            [valuec; exnc; effc; handle_tick],
+            dbg );
+        f;
+        arg ],
+      dbg )
+
+let with_stack_bind_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~dyn ~bind
+    ~f ~arg =
+  let sym = Cmm.global_symbol "caml_runstack" in
+  Cop
+    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+      [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
+        Cop
+          ( Cextcall
+              { func = "caml_alloc_stack_bind_preemptible";
+                ty = typ_val;
+                alloc = true;
+                builtin = false;
+                returns = true;
+                effects = Arbitrary_effects;
+                coeffects = Has_coeffects;
+                ty_args = [XInt; XInt; XInt; XInt; XInt; XInt]
+              },
+            [valuec; exnc; effc; handle_tick; dyn; bind],
+            dbg );
+        f;
+        arg ],
+      dbg )
+
 let resume ~dbg ~cont ~f ~arg =
   (* Rc_normal is required here, because there are some uses of effects with
      repeated resumes, and these should consume O(1) stack space by tail-calling

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1248,6 +1248,28 @@ val with_stack_bind :
   arg:expression ->
   expression
 
+val with_stack_preemptible :
+  dbg:Debuginfo.t ->
+  valuec:expression ->
+  exnc:expression ->
+  effc:expression ->
+  handle_tick:expression ->
+  f:expression ->
+  arg:expression ->
+  expression
+
+val with_stack_bind_preemptible :
+  dbg:Debuginfo.t ->
+  valuec:expression ->
+  exnc:expression ->
+  effc:expression ->
+  handle_tick:expression ->
+  dyn:expression ->
+  bind:expression ->
+  f:expression ->
+  arg:expression ->
+  expression
+
 val resume :
   dbg:Debuginfo.t ->
   cont:expression ->

--- a/bytecomp/blambda.ml
+++ b/bytecomp/blambda.ml
@@ -57,6 +57,8 @@ type context_switch =
   | Reperform
   | With_stack
   | With_stack_bind
+  | With_stack_preemptible
+  | With_stack_bind_preemptible
   | Resume
 
 type comparison = Instruct.comparison =

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -448,6 +448,9 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Presume -> context_switch Resume ~arity:3
     | Pwith_stack -> context_switch With_stack ~arity:5
     | Pwith_stack_bind -> context_switch With_stack_bind ~arity:7
+    | Pwith_stack_preemptible -> context_switch With_stack_preemptible ~arity:6
+    | Pwith_stack_bind_preemptible ->
+      context_switch With_stack_bind_preemptible ~arity:8
     | Preperform -> context_switch Reperform ~arity:3
     | Pmakearray_dynamic (kind, locality, Uninitialized) -> (
       (* Use a dummy initializer to implement the "uninitialized" primitive *)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -538,6 +538,16 @@ and comp_expr stack_info env exp sz cont =
     assert (nargs = 7);
     check_stack stack_info 3;
     comp_args stack_info env args sz (Kwith_stack_bind :: cont)
+  | Context_switch (With_stack_preemptible, args) ->
+    let nargs = List.length args in
+    assert (nargs = 6);
+    check_stack stack_info 3;
+    comp_args stack_info env args sz (Kwith_stack_preemptible :: cont)
+  | Context_switch (With_stack_bind_preemptible, args) ->
+    let nargs = List.length args in
+    assert (nargs = 8);
+    check_stack stack_info 3;
+    comp_args stack_info env args sz (Kwith_stack_bind_preemptible :: cont)
   | Context_switch (Reperform, args) ->
     let nargs = List.length args - 1 in
     assert (nargs = 2);

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -347,6 +347,9 @@ let emit_instr = function
   | Kreperformterm n -> runtime5_only (); out opREPERFORMTERM; out_int n
   | Kwith_stack -> runtime5_only (); out opWITH_STACK
   | Kwith_stack_bind -> runtime5_only (); out opWITH_STACK_BIND
+  | Kwith_stack_preemptible -> runtime5_only (); out opWITH_STACK_PREEMPTIBLE
+  | Kwith_stack_bind_preemptible ->
+    runtime5_only (); out opWITH_STACK_BIND_PREEMPTIBLE
   | Kstop -> out opSTOP
 
 (* Emission of a list of instructions. Include some peephole optimization. *)

--- a/bytecomp/instruct.ml
+++ b/bytecomp/instruct.ml
@@ -133,6 +133,8 @@ type instruction =
   | Kreperformterm of int
   | Kwith_stack
   | Kwith_stack_bind
+  | Kwith_stack_preemptible
+  | Kwith_stack_bind_preemptible
   | Kstop
 
 let immed_min = -0x40000000

--- a/bytecomp/instruct.mli
+++ b/bytecomp/instruct.mli
@@ -161,6 +161,8 @@ type instruction =
   | Kreperformterm of int
   | Kwith_stack
   | Kwith_stack_bind
+  | Kwith_stack_preemptible
+  | Kwith_stack_bind_preemptible
   | Kstop
 
 val immed_min: int

--- a/bytecomp/printblambda.ml
+++ b/bytecomp/printblambda.ml
@@ -214,6 +214,8 @@ let rec blambda ppf = function
       | Reperform -> "reperform"
       | With_stack -> "with_stack"
       | With_stack_bind -> "with_stack_bind"
+      | With_stack_preemptible -> "with_stack_preemptible"
+      | With_stack_bind_preemptible -> "with_stack_bind_preemptible"
       | Resume -> "resume"
     in
     fprintf ppf "@[<2>(%s@ %a)@]" op

--- a/bytecomp/printinstr.ml
+++ b/bytecomp/printinstr.ml
@@ -113,6 +113,8 @@ let instruction ppf = function
   | Kreperformterm n -> fprintf ppf "\treperformterm %i" n
   | Kwith_stack -> fprintf ppf "\twith_stack"
   | Kwith_stack_bind -> fprintf ppf "\twith_stack_bind"
+  | Kwith_stack_preemptible -> fprintf ppf "\twith_stack_preemptible"
+  | Kwith_stack_bind_preemptible -> fprintf ppf "\twith_stack_bind_preemptible"
   | Kstop -> fprintf ppf "\tstop"
   | Kevent ev -> fprintf ppf "\tevent \"%s\" %i-%i"
                          ev.ev_loc.Location.loc_start.Lexing.pos_fname

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -187,6 +187,8 @@ type primitive =
   (* Context switches *)
   | Pwith_stack
   | Pwith_stack_bind
+  | Pwith_stack_preemptible
+  | Pwith_stack_bind_preemptible
   | Pperform
   | Presume
   | Preperform
@@ -2544,7 +2546,8 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pjoin_vec256 | Psplit_vec256 ->
     (* Aborts in bytecode, unboxed in native code *)
     None
-  | Pwith_stack | Pwith_stack_bind | Presume | Pperform | Preperform
+  | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+  | Pwith_stack_bind_preemptible | Presume | Pperform | Preperform
     (* CR mshinwell: check *)
   | Ppoll ->
     Some alloc_heap
@@ -2747,7 +2750,8 @@ let primitive_can_raise prim =
   | Patomic_compare_set_field _ | Patomic_fetch_add_field  | Patomic_add_field
   | Patomic_sub_field  | Patomic_land_field | Patomic_lor_field
   | Patomic_lxor_field  | Patomic_load_field _ | Patomic_set_field _ -> false
-  | Pwith_stack | Pwith_stack_bind | Pperform | Presume
+  | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+  | Pwith_stack_bind_preemptible | Pperform | Presume
   | Preperform -> true (* XXX! *)
   | Pdls_get | Ptls_get | Pdomain_index | Ppoll | Pcpu_relax
   | Preinterpret_tagged_int63_as_unboxed_int64
@@ -3159,7 +3163,8 @@ let primitive_result_layout (p : primitive) =
     layout_any_value
   | (Parray_to_iarray | Parray_of_iarray) -> layout_any_value
   | Pget_header _ -> layout_boxed_int Boxed_nativeint
-  | Pwith_stack | Pwith_stack_bind | Presume | Pperform | Preperform ->
+  | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+  | Pwith_stack_bind_preemptible | Presume | Pperform | Preperform ->
     layout_any_value
   | Patomic_load_field { immediate_or_pointer = Immediate } ->
     layout_int_or_null

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -168,6 +168,8 @@ type primitive =
   (* Context switches *)
   | Pwith_stack
   | Pwith_stack_bind
+  | Pwith_stack_preemptible
+  | Pwith_stack_bind_preemptible
   | Pperform
   | Presume
   | Preperform

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -521,6 +521,8 @@ let primitive ppf = function
   | Pduprecord (rep, size) -> fprintf ppf "duprecord %a %i" record_rep rep size
   | Pwith_stack -> fprintf ppf "with_stack"
   | Pwith_stack_bind -> fprintf ppf "with_stack_bind"
+  | Pwith_stack_preemptible -> fprintf ppf "with_stack_preemptible"
+  | Pwith_stack_bind_preemptible -> fprintf ppf "with_stack_bind_preemptible"
   | Pperform -> fprintf ppf "perform"
   | Presume -> fprintf ppf "resume"
   | Preperform -> fprintf ppf "reperform"
@@ -1069,6 +1071,8 @@ let name_of_primitive = function
   | Popaque _ -> "Popaque"
   | Pwith_stack -> "Pwith_stack"
   | Pwith_stack_bind -> "Pwith_stack_bind"
+  | Pwith_stack_preemptible -> "Pwith_stack_preemptible"
+  | Pwith_stack_bind_preemptible -> "Pwith_stack_bind_preemptible"
   | Presume -> "Presume"
   | Pperform -> "Pperform"
   | Preperform -> "Preperform"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -403,12 +403,13 @@ and fracture_prim lambda prim args loc =
   | Pduprecord _ | Pmake_unboxed_product _ | Punboxed_product_field _
   | Parray_element_size_in_bytes _ | Pmake_idx_field _ | Pmake_idx_mixed_field _
   | Pmake_idx_array _ | Pidx_deepen _ | Pwith_stack | Pwith_stack_bind
-  | Pperform | Presume | Preperform | Pccall _ | Praise _ | Psequand | Psequor
-  | Pnot | Pphys_equal _ | Pscalar _ | Poffsetref _ | Pstringlength
-  | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
-  | Pbytesrefs | Pbytessets | Pmakearray _ | Pmakearray_dynamic _ | Pduparray _
-  | Parrayblit _ | Parraylength _ | Parrayrefu _ | Parraysetu _ | Parrayrefs _
-  | Parraysets _ | Pisint _ | Pisnull | Pisout | Pbigarrayref _ | Pbigarrayset _
+  | Pwith_stack_preemptible | Pwith_stack_bind_preemptible | Pperform | Presume
+  | Preperform | Pccall _ | Praise _ | Psequand | Psequor | Pnot | Pphys_equal _
+  | Pscalar _ | Poffsetref _ | Pstringlength | Pstringrefu | Pstringrefs
+  | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
+  | Pmakearray _ | Pmakearray_dynamic _ | Pduparray _ | Parrayblit _
+  | Parraylength _ | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _
+  | Pisint _ | Pisnull | Pisout | Pbigarrayref _ | Pbigarrayset _
   | Pbigarraydim _ | Pstring_load_i8 _ | Pstring_load_i16 _ | Pstring_load_16 _
   | Pstring_load_32 _ | Pstring_load_f32 _ | Pstring_load_64 _
   | Pstring_load_vec _ | Pbytes_load_i8 _ | Pbytes_load_i16 _ | Pbytes_load_16 _

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -459,28 +459,29 @@ and eval_prim env prim =
   | Pfield_computed _ | Psetfield _ | Psetfield_computed _ | Pfloatfield _
   | Psetfloatfield _ | Psetufloatfield _ | Pufloatfield _ | Pduprecord _
   | Parray_element_size_in_bytes _ | Pmake_idx_field _ | Pwith_stack
-  | Pwith_stack_bind | Pperform | Presume | Preperform | Pccall _ | Praise _
-  | Psequand | Psequor | Pnot | Pphys_equal _ | Pscalar _ | Poffsetref _
-  | Pstringlength | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu
-  | Pbytessetu | Pbytesrefs | Pbytessets | Pmakearray _ | Pmakearray_dynamic _
-  | Pduparray _ | Parrayblit _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Parrayrefs _ | Parraysets _ | Pisint _ | Pisnull | Pisout | Pbigarrayref _
-  | Pbigarrayset _ | Pbigarraydim _ | Pstring_load_i8 _ | Pstring_load_i16 _
-  | Pstring_load_16 _ | Pstring_load_32 _ | Pstring_load_f32 _
-  | Pstring_load_64 _ | Pstring_load_vec _ | Pbytes_load_i8 _
-  | Pbytes_load_i16 _ | Pbytes_load_16 _ | Pbytes_load_32 _ | Pbytes_load_f32 _
-  | Pbytes_load_64 _ | Pbytes_load_vec _ | Pbytes_set_8 _ | Pbytes_set_16 _
-  | Pbytes_set_32 _ | Pbytes_set_f32 _ | Pbytes_set_64 _ | Pbytes_set_vec _
-  | Pbigstring_load_i8 _ | Pbigstring_load_i16 _ | Pbigstring_load_16 _
-  | Pbigstring_load_32 _ | Pbigstring_load_f32 _ | Pbigstring_load_64 _
-  | Pbigstring_load_vec _ | Pbigstring_set_8 _ | Pbigstring_set_16 _
-  | Pbigstring_set_32 _ | Pbigstring_set_f32 _ | Pbigstring_set_64 _
-  | Pbigstring_set_vec _ | Pfloatarray_load_vec _ | Pfloat_array_load_vec _
-  | Pint_array_load_vec _ | Punboxed_float_array_load_vec _
-  | Punboxed_float32_array_load_vec _ | Puntagged_int8_array_load_vec _
-  | Puntagged_int16_array_load_vec _ | Punboxed_int32_array_load_vec _
-  | Punboxed_int64_array_load_vec _ | Punboxed_nativeint_array_load_vec _
-  | Pfloatarray_set_vec _ | Pfloat_array_set_vec _ | Pint_array_set_vec _
+  | Pwith_stack_bind | Pwith_stack_preemptible | Pwith_stack_bind_preemptible
+  | Pperform | Presume | Preperform | Pccall _ | Praise _ | Psequand | Psequor
+  | Pnot | Pphys_equal _ | Pscalar _ | Poffsetref _ | Pstringlength
+  | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
+  | Pbytesrefs | Pbytessets | Pmakearray _ | Pmakearray_dynamic _ | Pduparray _
+  | Parrayblit _ | Parraylength _ | Parrayrefu _ | Parraysetu _ | Parrayrefs _
+  | Parraysets _ | Pisint _ | Pisnull | Pisout | Pbigarrayref _ | Pbigarrayset _
+  | Pbigarraydim _ | Pstring_load_i8 _ | Pstring_load_i16 _ | Pstring_load_16 _
+  | Pstring_load_32 _ | Pstring_load_f32 _ | Pstring_load_64 _
+  | Pstring_load_vec _ | Pbytes_load_i8 _ | Pbytes_load_i16 _ | Pbytes_load_16 _
+  | Pbytes_load_32 _ | Pbytes_load_f32 _ | Pbytes_load_64 _ | Pbytes_load_vec _
+  | Pbytes_set_8 _ | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_f32 _
+  | Pbytes_set_64 _ | Pbytes_set_vec _ | Pbigstring_load_i8 _
+  | Pbigstring_load_i16 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
+  | Pbigstring_load_f32 _ | Pbigstring_load_64 _ | Pbigstring_load_vec _
+  | Pbigstring_set_8 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
+  | Pbigstring_set_f32 _ | Pbigstring_set_64 _ | Pbigstring_set_vec _
+  | Pfloatarray_load_vec _ | Pfloat_array_load_vec _ | Pint_array_load_vec _
+  | Punboxed_float_array_load_vec _ | Punboxed_float32_array_load_vec _
+  | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
+  | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
+  | Punboxed_nativeint_array_load_vec _ | Pfloatarray_set_vec _
+  | Pfloat_array_set_vec _ | Pint_array_set_vec _
   | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
   | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
   | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -907,7 +907,8 @@ let rec choice ctx t =
     | Punbox_unit
 
     (* we don't handle effect or DLS primitives *)
-    | Pwith_stack | Pwith_stack_bind | Pperform | Presume | Preperform
+    | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+    | Pwith_stack_bind_preemptible | Pperform | Presume | Preperform
     | Pdls_get | Ptls_get | Pdomain_index
 
     (* we don't handle atomic primitives *)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1134,6 +1134,12 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%with_stack_bind" ->
       if runtime5 then Primitive (Pwith_stack_bind, 7)
       else Unsupported Pwith_stack_bind
+    | "%with_stack_preemptible" ->
+      if runtime5 then Primitive (Pwith_stack_preemptible, 6)
+      else Unsupported Pwith_stack_preemptible
+    | "%with_stack_bind_preemptible" ->
+      if runtime5 then Primitive (Pwith_stack_bind_preemptible, 8)
+      else Unsupported Pwith_stack_bind_preemptible
     | "%reperform" ->
       if runtime5 then Primitive (Preperform, 3) else Unsupported Preperform
     | "%perform" ->
@@ -2505,7 +2511,8 @@ let lambda_primitive_needs_event_after = function
   | Preinterpret_tuple_as_boxed_vector _
   | Pget_idx _ | Pset_idx _
   | Pget_ptr _ | Pset_ptr _
-  | Pwith_stack | Pwith_stack_bind | Pperform | Preperform | Presume
+  | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+  | Pwith_stack_bind_preemptible | Pperform | Preperform | Presume
   | Ppoll | Pobj_dup | Pget_header _ -> true
   (* [Preinterpret_tagged_int63_as_unboxed_int64] has to allocate in
      bytecode, because int64# is actually represented as a boxed value. *)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -323,6 +323,8 @@ let compute_static_size lam =
     | Pmixedfield _
     | Pwith_stack
     | Pwith_stack_bind
+    | Pwith_stack_preemptible
+    | Pwith_stack_bind_preemptible
     | Pperform
     | Presume
     | Preperform

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1150,6 +1150,21 @@ let close_effect_primitive acc env ~dbg exn_continuation
       C.effect_ (E.with_stack_bind ~valuec ~exnc ~effc ~dyn ~bind ~f ~arg)
     in
     close call_kind
+  | ( Pwith_stack_preemptible,
+      [[valuec]; [exnc]; [effc]; [handle_tick]; [f]; [arg]] ) ->
+    let call_kind =
+      C.effect_
+        (E.with_stack_preemptible ~valuec ~exnc ~effc ~handle_tick ~f ~arg)
+    in
+    close call_kind
+  | ( Pwith_stack_bind_preemptible,
+      [[valuec]; [exnc]; [effc]; [handle_tick]; [dyn]; [bind]; [f]; [arg]] ) ->
+    let call_kind =
+      C.effect_
+        (E.with_stack_bind_preemptible ~valuec ~exnc ~effc ~handle_tick ~dyn
+           ~bind ~f ~arg)
+    in
+    close call_kind
   | Presume, [[cont]; [f]; [arg]] ->
     let call_kind = C.effect_ (E.resume ~cont ~f ~arg) in
     close call_kind
@@ -1281,10 +1296,11 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pjoin_vec256 | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
       | Preinterpret_tuple_as_boxed_vector _ | Pmake_unboxed_product _
       | Punboxed_product_field _ | Parray_element_size_in_bytes _
-      | Pget_header _ | Pwith_stack | Pwith_stack_bind | Pperform | Presume
-      | Preperform | Pmake_idx_field _ | Pmake_idx_mixed_field _
-      | Pmake_idx_array _ | Pidx_deepen _ | Pget_idx _ | Pset_idx _ | Pget_ptr _
-      | Pset_ptr _ | Patomic_exchange_field _ | Patomic_compare_exchange_field _
+      | Pget_header _ | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+      | Pwith_stack_bind_preemptible | Pperform | Presume | Preperform
+      | Pmake_idx_field _ | Pmake_idx_mixed_field _ | Pmake_idx_array _
+      | Pidx_deepen _ | Pget_idx _ | Pset_idx _ | Pget_ptr _ | Pset_ptr _
+      | Patomic_exchange_field _ | Patomic_compare_exchange_field _
       | Patomic_compare_set_field _ | Patomic_fetch_add_field
       | Patomic_add_field | Patomic_sub_field | Patomic_land_field
       | Patomic_lor_field | Patomic_lxor_field | Pdls_get | Ptls_get
@@ -1296,7 +1312,9 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
         assert false
     in
     k acc [Named.create_simple (Simple.symbol sym)]
-  | (Pperform | Pwith_stack | Pwith_stack_bind | Presume | Preperform), args ->
+  | ( ( Pperform | Pwith_stack | Pwith_stack_bind | Pwith_stack_preemptible
+      | Pwith_stack_bind_preemptible | Presume | Preperform ),
+      args ) ->
     let exn_continuation =
       match exn_continuation with
       | None ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3339,7 +3339,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
   | ( ( Pignore | Psequand | Psequor | Pbytes_of_string | Pbytes_to_string
       | Parray_of_iarray | Parray_to_iarray | Pwith_stack | Pwith_stack_bind
-      | Pperform | Presume | Preperform ),
+      | Pwith_stack_preemptible | Pwith_stack_bind_preemptible | Pperform
+      | Presume | Preperform ),
       _ ) ->
     Misc.fatal_errorf
       "[%a] should have been removed by [Lambda_to_flambda.transform_primitive]"

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -1004,6 +1004,23 @@ let rewrite_call_kind env (call_kind : Call_kind.t) =
          ~exnc:(rewrite_simple exnc) ~effc:(rewrite_simple effc)
          ~dyn:(rewrite_simple dyn) ~bind:(rewrite_simple bind)
          ~f:(rewrite_simple f) ~arg:(rewrite_simple arg))
+  | Effect (With_stack_preemptible { valuec; exnc; effc; handle_tick; f; arg })
+    ->
+    Call_kind.effect_
+      (Call_kind.Effect.with_stack_preemptible ~valuec:(rewrite_simple valuec)
+         ~exnc:(rewrite_simple exnc) ~effc:(rewrite_simple effc)
+         ~handle_tick:(rewrite_simple handle_tick)
+         ~f:(rewrite_simple f) ~arg:(rewrite_simple arg))
+  | Effect
+      (With_stack_bind_preemptible
+         { valuec; exnc; effc; handle_tick; dyn; bind; f; arg }) ->
+    Call_kind.effect_
+      (Call_kind.Effect.with_stack_bind_preemptible
+         ~valuec:(rewrite_simple valuec) ~exnc:(rewrite_simple exnc)
+         ~effc:(rewrite_simple effc)
+         ~handle_tick:(rewrite_simple handle_tick)
+         ~dyn:(rewrite_simple dyn) ~bind:(rewrite_simple bind)
+         ~f:(rewrite_simple f) ~arg:(rewrite_simple arg))
   | Effect (Resume { cont; f; arg }) ->
     Call_kind.effect_
       (Call_kind.Effect.resume ~cont:(rewrite_simple cont) ~f:(rewrite_simple f)

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -480,6 +480,17 @@ let traverse_apply denv acc apply : rev_expr =
       List.iter
         (Acc.add_cond_any_usage acc ~denv)
         [valuec; exnc; effc; dyn; bind; f; arg]
+    | Effect
+        (With_stack_preemptible { valuec; exnc; effc; handle_tick; f; arg }) ->
+      List.iter
+        (Acc.add_cond_any_usage acc ~denv)
+        [valuec; exnc; effc; handle_tick; f; arg]
+    | Effect
+        (With_stack_bind_preemptible
+           { valuec; exnc; effc; handle_tick; dyn; bind; f; arg }) ->
+      List.iter
+        (Acc.add_cond_any_usage acc ~denv)
+        [valuec; exnc; effc; handle_tick; dyn; bind; f; arg]
     | Effect (Resume { cont; f; arg }) ->
       List.iter (Acc.add_cond_any_usage acc ~denv) [cont; f; arg]
   in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1366,6 +1366,18 @@ let simplify_effect_op dacc apply (op : Call_kind.Effect.t) ~down_to_up =
         ~exnc:(simplify_simple exnc) ~effc:(simplify_simple effc)
         ~dyn:(simplify_simple dyn) ~bind:(simplify_simple bind)
         ~f:(simplify_simple f) ~arg:(simplify_simple arg)
+    | With_stack_preemptible { valuec; exnc; effc; handle_tick; f; arg } ->
+      E.with_stack_preemptible ~valuec:(simplify_simple valuec)
+        ~exnc:(simplify_simple exnc) ~effc:(simplify_simple effc)
+        ~handle_tick:(simplify_simple handle_tick)
+        ~f:(simplify_simple f) ~arg:(simplify_simple arg)
+    | With_stack_bind_preemptible
+        { valuec; exnc; effc; handle_tick; dyn; bind; f; arg } ->
+      E.with_stack_bind_preemptible ~valuec:(simplify_simple valuec)
+        ~exnc:(simplify_simple exnc) ~effc:(simplify_simple effc)
+        ~handle_tick:(simplify_simple handle_tick)
+        ~dyn:(simplify_simple dyn) ~bind:(simplify_simple bind)
+        ~f:(simplify_simple f) ~arg:(simplify_simple arg)
     | Resume { cont; f; arg } ->
       E.resume ~cont:(simplify_simple cont) ~f:(simplify_simple f)
         ~arg:(simplify_simple arg)

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -69,6 +69,24 @@ module Effect : sig
           f : Simple.t;
           arg : Simple.t
         }
+    | With_stack_preemptible of
+        { valuec : Simple.t;
+          exnc : Simple.t;
+          effc : Simple.t;
+          handle_tick : Simple.t;
+          f : Simple.t;
+          arg : Simple.t
+        }
+    | With_stack_bind_preemptible of
+        { valuec : Simple.t;
+          exnc : Simple.t;
+          effc : Simple.t;
+          handle_tick : Simple.t;
+          dyn : Simple.t;
+          bind : Simple.t;
+          f : Simple.t;
+          arg : Simple.t
+        }
     | Resume of
         { cont : Simple.t;
           f : Simple.t;
@@ -93,6 +111,26 @@ module Effect : sig
     valuec:Simple.t ->
     exnc:Simple.t ->
     effc:Simple.t ->
+    dyn:Simple.t ->
+    bind:Simple.t ->
+    f:Simple.t ->
+    arg:Simple.t ->
+    t
+
+  val with_stack_preemptible :
+    valuec:Simple.t ->
+    exnc:Simple.t ->
+    effc:Simple.t ->
+    handle_tick:Simple.t ->
+    f:Simple.t ->
+    arg:Simple.t ->
+    t
+
+  val with_stack_bind_preemptible :
+    valuec:Simple.t ->
+    exnc:Simple.t ->
+    effc:Simple.t ->
+    handle_tick:Simple.t ->
     dyn:Simple.t ->
     bind:Simple.t ->
     f:Simple.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -487,6 +487,76 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         env,
         res,
         Ece.all )
+    | With_stack_preemptible { valuec; exnc; effc; handle_tick; f; arg } ->
+      let { env; res; expr = { cmm = valuec; free_vars = fv0; effs = _ } } =
+        simple env res valuec
+      in
+      let { env; res; expr = { cmm = exnc; free_vars = fv1; effs = _ } } =
+        simple env res exnc
+      in
+      let { env; res; expr = { cmm = effc; free_vars = fv2; effs = _ } } =
+        simple env res effc
+      in
+      let { env; res; expr = { cmm = handle_tick; free_vars = fv3; effs = _ } }
+          =
+        simple env res handle_tick
+      in
+      let { env; res; expr = { cmm = f; free_vars = fv4; effs = _ } } =
+        simple env res f
+      in
+      let { env; res; expr = { cmm = arg; free_vars = fv5; effs = _ } } =
+        simple env res arg
+      in
+      let free_vars =
+        BV.Set.union
+          (BV.Set.union fv0 (BV.Set.union fv1 fv2))
+          (BV.Set.union fv3 (BV.Set.union fv4 fv5))
+      in
+      ( C.with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg,
+        free_vars,
+        env,
+        res,
+        Ece.all )
+    | With_stack_bind_preemptible
+        { valuec; exnc; effc; handle_tick; dyn; bind; f; arg } ->
+      let { env; res; expr = { cmm = valuec; free_vars = fv0; effs = _ } } =
+        simple env res valuec
+      in
+      let { env; res; expr = { cmm = exnc; free_vars = fv1; effs = _ } } =
+        simple env res exnc
+      in
+      let { env; res; expr = { cmm = effc; free_vars = fv2; effs = _ } } =
+        simple env res effc
+      in
+      let { env; res; expr = { cmm = handle_tick; free_vars = fv3; effs = _ } }
+          =
+        simple env res handle_tick
+      in
+      let { env; res; expr = { cmm = dyn; free_vars = fv4; effs = _ } } =
+        simple env res dyn
+      in
+      let { env; res; expr = { cmm = bind; free_vars = fv5; effs = _ } } =
+        simple env res bind
+      in
+      let { env; res; expr = { cmm = f; free_vars = fv6; effs = _ } } =
+        simple env res f
+      in
+      let { env; res; expr = { cmm = arg; free_vars = fv7; effs = _ } } =
+        simple env res arg
+      in
+      let free_vars =
+        BV.Set.union
+          (BV.Set.union
+             (BV.Set.union fv0 (BV.Set.union fv1 fv2))
+             (BV.Set.union fv3 fv4))
+          (BV.Set.union fv5 (BV.Set.union fv6 fv7))
+      in
+      ( C.with_stack_bind_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~dyn
+          ~bind ~f ~arg,
+        free_vars,
+        env,
+        res,
+        Ece.all )
     | Resume { cont; f; arg } ->
       let { env; res; expr = { cmm = cont; free_vars = fv0; effs = _ } } =
         simple env res cont

--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -398,6 +398,39 @@ and apply_expr ~env ~res e =
           ( "%with_stack_bind",
             [Pv valuec; Pv exnc; Pv effc; Pv dyn; Pv bind; Pv f; Pv arg; unit],
             res )
+        | With_stack_preemptible { valuec; exnc; effc; handle_tick; f; arg } ->
+          let valuec, res = To_jsir_shared.simple ~env ~res valuec in
+          let exnc, res = To_jsir_shared.simple ~env ~res exnc in
+          let effc, res = To_jsir_shared.simple ~env ~res effc in
+          let handle_tick, res = To_jsir_shared.simple ~env ~res handle_tick in
+          let f, res = To_jsir_shared.simple ~env ~res f in
+          let arg, res = To_jsir_shared.simple ~env ~res arg in
+          let unit = Pc (Int Targetint.zero) in
+          ( "%with_stack_preemptible",
+            [Pv valuec; Pv exnc; Pv effc; Pv handle_tick; Pv f; Pv arg; unit],
+            res )
+        | With_stack_bind_preemptible
+            { valuec; exnc; effc; handle_tick; dyn; bind; f; arg } ->
+          let valuec, res = To_jsir_shared.simple ~env ~res valuec in
+          let exnc, res = To_jsir_shared.simple ~env ~res exnc in
+          let effc, res = To_jsir_shared.simple ~env ~res effc in
+          let handle_tick, res = To_jsir_shared.simple ~env ~res handle_tick in
+          let dyn, res = To_jsir_shared.simple ~env ~res dyn in
+          let bind, res = To_jsir_shared.simple ~env ~res bind in
+          let f, res = To_jsir_shared.simple ~env ~res f in
+          let arg, res = To_jsir_shared.simple ~env ~res arg in
+          let unit = Pc (Int Targetint.zero) in
+          ( "%with_stack_bind_preemptible",
+            [ Pv valuec;
+              Pv exnc;
+              Pv effc;
+              Pv handle_tick;
+              Pv dyn;
+              Pv bind;
+              Pv f;
+              Pv arg;
+              unit ],
+            res )
         | Resume { cont; f; arg } ->
           let cont, res = To_jsir_shared.simple ~env ~res cont in
           let f, res = To_jsir_shared.simple ~env ~res f in

--- a/oxcaml/tests/simd/dune.inc
+++ b/oxcaml/tests/simd/dune.inc
@@ -1562,6 +1562,38 @@
    (diff empty.expected probes256.out)))
 
 (executable
+ (name preemption256)
+ (modules preemption256)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (ocamlopt_flags
+  (:standard -extension simd_beta ))
+ (libraries simd_test_builtins stdlib_stable stdlib_upstream_compatible)
+ (foreign_archives stubs))
+
+(rule
+ (alias   runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+  (with-outputs-to
+   preemption256.out
+   (run ./preemption256.exe))))
+
+(rule
+ (alias runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+   (diff empty.expected preemption256.out)))
+
+(executable
  (name arrays256)
  (modules arrays256)
  (enabled_if (= %{context_name} "main"))
@@ -3691,6 +3723,47 @@
  (enabled_if (= %{context_name} "main"))
  (action
    (diff empty.expected probes256_nodynlink.out)))
+
+(rule
+ (alias runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+  (copy preemption256.ml preemption256_nodynlink.ml)))
+
+(executable
+ (name preemption256_nodynlink)
+ (modules preemption256_nodynlink)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (ocamlopt_flags
+  (:standard -extension simd_beta -nodynlink))
+ (libraries simd_test_builtins stdlib_stable stdlib_upstream_compatible)
+ (foreign_archives stubs))
+
+(rule
+ (alias   runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+  (with-outputs-to
+   preemption256_nodynlink.out
+   (run ./preemption256_nodynlink.exe))))
+
+(rule
+ (alias runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+   (diff empty.expected preemption256_nodynlink.out)))
 
 (rule
  (alias runtest)
@@ -6340,6 +6413,47 @@
            (= %{architecture} "amd64")
            (<> %{system} macosx)))
  (action
+  (copy preemption256.ml preemption256_internal_assembler.ml)))
+
+(executable
+ (name preemption256_internal_assembler)
+ (modules preemption256_internal_assembler)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (ocamlopt_flags
+  (:standard -extension simd_beta -internal-assembler))
+ (libraries simd_test_builtins stdlib_stable stdlib_upstream_compatible)
+ (foreign_archives stubs))
+
+(rule
+ (alias   runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+  (with-outputs-to
+   preemption256_internal_assembler.out
+   (run ./preemption256_internal_assembler.exe))))
+
+(rule
+ (alias runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
+   (diff empty.expected preemption256_internal_assembler.out)))
+
+(rule
+ (alias runtest)
+ (enabled_if
+      (and (= %{context_name} "main")
+           (= %{architecture} "amd64")
+           (<> %{system} macosx)))
+ (action
   (copy arrays256.ml arrays256_internal_assembler.ml)))
 
 (executable
@@ -6988,117 +7102,3 @@
            (<> %{system} macosx)))
  (action
    (diff empty.expected ops_int8x32_u_internal_assembler.out)))
-
-(executable
- (name preemption256)
- (modules preemption256)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (ocamlopt_flags
-  (:standard -extension simd_beta ))
- (libraries unix simd_test_builtins stdlib_stable stdlib_upstream_compatible)
- (foreign_archives stubs))
-
-(rule
- (alias   runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-  (with-outputs-to
-   preemption256.out
-   (run ./preemption256.exe))))
-
-(rule
- (alias runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-   (diff empty.expected preemption256.out)))
-
-(rule
- (alias runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-  (copy preemption256.ml preemption256_nodynlink.ml)))
-
-(executable
- (name preemption256_nodynlink)
- (modules preemption256_nodynlink)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (ocamlopt_flags
-  (:standard -extension simd_beta -nodynlink))
- (libraries unix simd_test_builtins stdlib_stable stdlib_upstream_compatible)
- (foreign_archives stubs))
-
-(rule
- (alias   runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-  (with-outputs-to
-   preemption256_nodynlink.out
-   (run ./preemption256_nodynlink.exe))))
-
-(rule
- (alias runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-   (diff empty.expected preemption256_nodynlink.out)))
-
-(rule
- (alias runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-  (copy preemption256.ml preemption256_internal_assembler.ml)))
-
-(executable
- (name preemption256_internal_assembler)
- (modules preemption256_internal_assembler)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (ocamlopt_flags
-  (:standard -extension simd_beta -internal-assembler))
- (libraries unix simd_test_builtins stdlib_stable stdlib_upstream_compatible)
- (foreign_archives stubs))
-
-(rule
- (alias   runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-  (with-outputs-to
-   preemption256_internal_assembler.out
-   (run ./preemption256_internal_assembler.exe))))
-
-(rule
- (alias runtest)
- (enabled_if
-      (and (= %{context_name} "main")
-           (= %{architecture} "amd64")
-           (<> %{system} macosx)))
- (action
-   (diff empty.expected preemption256_internal_assembler.out)))

--- a/oxcaml/tests/simd/gen/gen_dune.ml
+++ b/oxcaml/tests/simd/gen/gen_dune.ml
@@ -40,25 +40,6 @@ let compile ~enabled_if ~extra_flags name =
  (foreign_archives stubs))
 |}
 
-let compile_with_unix ~enabled_if ~extra_flags name =
-  let subst = function
-    | "name" -> name
-    | "enabled_if" -> enabled_if
-    | "extra_flags" -> extra_flags
-    | _ -> assert false
-  in
-  rule ~subst
-    {|
-(executable
- (name ${name})
- (modules ${name})
- ${enabled_if}
- (ocamlopt_flags
-  (:standard -extension simd_beta ${extra_flags}))
- (libraries unix simd_test_builtins stdlib_stable stdlib_upstream_compatible)
- (foreign_archives stubs))
-|}
-
 let run ~enabled_if name =
   let subst = function
     | "enabled_if" -> enabled_if
@@ -146,20 +127,6 @@ let print_test ?extra_flag (name, enabled_if) =
   diff_output ~enabled_if name;
   ()
 
-let print_test_with_unix ?extra_flag (name, enabled_if) =
-  let name, extra_flags =
-    match extra_flag with
-    | None -> name, ""
-    | Some flag ->
-      let new_name = name ^ mangle flag in
-      copy_file ~enabled_if name new_name;
-      new_name, flag
-  in
-  compile_with_unix ~enabled_if ~extra_flags name;
-  run ~enabled_if name;
-  diff_output ~enabled_if name;
-  ()
-
 let () =
   let ops =
     [ "ops";
@@ -236,6 +203,7 @@ let () =
       "test_callee_save_neon_regs", enabled_if_main;
       "probes", enabled_if_main;
       "probes256", enabled_if_main;
+      "preemption256", enabled_if_main_amd64_not_macos;
       "arrays256", enabled_if_main;
       "arrays256_u", enabled_if_main;
       "consts256", enabled_if_main_amd64_not_macos;
@@ -259,16 +227,4 @@ let () =
     (* disable on macos and arm64 *)
     List.map (fun (name, _) -> name, enabled_if_main_amd64_not_macos) tests
   in
-  List.iter (print_test ~extra_flag:"-internal-assembler") tests;
-  (* Tests that need Unix library. The preemption256 test itself checks at
-     runtime whether poll insertion is enabled (via the OXCAML_POLL_INSERTION
-     env var set by make runtest) — without polls in the tight SIMD loop, the
-     preemption tick would never be caught. *)
-  let unix_tests = ["preemption256", enabled_if_main_amd64_not_macos] in
-  List.iter print_test_with_unix unix_tests;
-  List.iter (print_test_with_unix ~extra_flag:"-nodynlink") unix_tests;
-  let unix_tests =
-    List.map (fun (name, _) -> name, enabled_if_main_amd64_not_macos) unix_tests
-  in
-  List.iter (print_test_with_unix ~extra_flag:"-internal-assembler") unix_tests;
-  ()
+  List.iter (print_test ~extra_flag:"-internal-assembler") tests

--- a/oxcaml/tests/simd/gen/gen_dune.ml
+++ b/oxcaml/tests/simd/gen/gen_dune.ml
@@ -260,10 +260,10 @@ let () =
     List.map (fun (name, _) -> name, enabled_if_main_amd64_not_macos) tests
   in
   List.iter (print_test ~extra_flag:"-internal-assembler") tests;
-  (* Tests that need Unix library (for preemption). The test itself checks at
+  (* Tests that need Unix library. The preemption256 test itself checks at
      runtime whether poll insertion is enabled (via the OXCAML_POLL_INSERTION
      env var set by make runtest) — without polls in the tight SIMD loop, the
-     preemption signal would never be caught. *)
+     preemption tick would never be caught. *)
   let unix_tests = ["preemption256", enabled_if_main_amd64_not_macos] in
   List.iter print_test_with_unix unix_tests;
   List.iter (print_test_with_unix ~extra_flag:"-nodynlink") unix_tests;

--- a/oxcaml/tests/simd/preemption256.ml
+++ b/oxcaml/tests/simd/preemption256.ml
@@ -3,8 +3,6 @@
 open Effect
 open Effect.Deep
 
-external preempt_self : unit -> unit = "caml_domain_preempt_self" [@@noalloc]
-
 external int64x4_of_int64s : int64 -> int64 -> int64 -> int64 -> int64x4#
   = "" "vec256_of_int64s"
 [@@noalloc] [@@unboxed]
@@ -39,30 +37,28 @@ let[@inline never] check_ymm_upper_3 name v b c d =
     exit 1
   end
 
-let with_preemption_setup ?(interval = 0.1) ?(repeating = false) f =
-  let it_interval = if repeating then interval else 0. in
-  let _ = Unix.setitimer ITIMER_REAL { it_interval; it_value = interval } in
-  let _ =
-    Sys.set_signal Sys.sigalrm (Signal_handle (fun _ -> preempt_self ()))
-  in
-  let result = f () in
-  let _ = Unix.setitimer ITIMER_REAL { it_interval = 0.; it_value = 0. } in
-  result
-
 let run_with_tick_handler ?(interval = 0.1) ?(repeating = false)
     ?(on_tick = fun () -> ()) computation =
-  with_preemption_setup ~interval ~repeating (fun () ->
-      try_with computation ()
-        { effc =
-            (fun (type a) (e : a t) ->
-              match e with
-              | Preemption ->
-                Some
-                  (fun (k : (a, _) continuation) ->
-                    on_tick ();
-                    continue k ())
-              | _ -> None)
-        })
+  let interval_usec = Int.of_float (interval *. 1_000_000.) in
+  Domain.Tick.with_ ~interval_usec (fun _ ->
+    let preempted_once = ref false in
+    Preemptible.try_with
+      ~on_tick:(fun () ->
+        if !preempted_once && not repeating
+        then Continue
+        else (preempted_once := true; Preempt))
+      computation
+      ()
+      { effc =
+          (fun (type a) (e : a t) ->
+            match e with
+            | Preemption ->
+              Some
+                (fun (k : (a, _) continuation) ->
+                  on_tick ();
+                  continue k ())
+            | _ -> None)
+      })
 
 (* Spins 16 unboxed int64x4 accumulators in a tail-recursive loop, then checks
    their upper lanes. The whole thing is one function because int64x4# can't

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -152,7 +152,7 @@
 #define Handler_value(REG)       0(REG)
 #define Handler_exception(REG)   8(REG)
 #define Handler_effect(REG)     16(REG)
-#define Handler_parent          24
+#define Handler_parent          32
 
 /* struct dynamic_thread_s */
 

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -220,8 +220,8 @@ G(name):
 #define Handler_value(reg)      [reg]
 #define Handler_exception(reg)  [reg, #8]
 #define Handler_effect(reg)     [reg, #16]
-#define Handler_parent(reg)     [reg, #24]
-#define Handler_parent_offset   24
+#define Handler_parent(reg)     [reg, #32]
+#define Handler_parent_offset   32
 
 /* Continuation values
  *

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -72,10 +72,10 @@ int caml_incoming_interrupts_queued(void);
 
 void caml_poll_gc_work(void);
 void caml_handle_gc_interrupt(void);
-void caml_process_tick(void);
 void caml_handle_incoming_interrupts(void);
 void caml_domain_setup_preemption(void);
 void caml_domain_reset_preemption(void);
+value caml_process_tick_exn(void);
 
 CAMLextern void caml_interrupt_self(void);
 void caml_interrupt_all_signal_safe(void);

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -94,6 +94,7 @@ struct stack_info {
 #define Stack_handle_effect(stk) (stk)->handler->handle_effect
 #define Stack_handle_tick(stk) (stk)->handler->handle_tick
 #define Stack_parent(stk) (stk)->handler->parent
+#define Stack_is_preemptible(stk) (Stack_handle_tick(stk) != Val_null)
 
 /* Stack layout for native code. Stack grows downwards.
  *
@@ -292,6 +293,12 @@ extern value caml_global_data;
 #define Trap_pc(tp) (((code_t *)(tp))[0])
 #define Trap_link(tp) ((tp)[1])
 
+/* type tick_outcome in stdlib/effect.ml */
+enum tick_outcome {
+  TICK_RESULT_PREEMPT = 0,
+  TICK_RESULT_CONTINUE = 1
+};
+
 struct stack_cache {
   _Atomic(struct stack_info*) head;
   _Atomic(uintnat) len;
@@ -374,6 +381,8 @@ bool caml_continuation_is_preemption(value cont);
 /* If the given continuation is a preeempted continuation, returns a pointer to
    its [gc_regs] struct, or NULL otherwise */
 value* caml_continuation_gc_regs(value cont);
+
+value caml_tick_fiber_exn(struct stack_info* stack);
 
 CAMLnoret CAMLextern void caml_raise_continuation_already_resumed (void);
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -34,6 +34,7 @@ struct stack_handler {
   value handle_value;
   value handle_exn;
   value handle_effect;
+  value handle_tick; /* tick handler callback, NULL if not preemptible */
   struct stack_info* parent; /* parent OCaml stack if any */
 };
 
@@ -91,6 +92,7 @@ struct stack_info {
 #define Stack_handle_value(stk) (stk)->handler->handle_value
 #define Stack_handle_exception(stk) (stk)->handler->handle_exn
 #define Stack_handle_effect(stk) (stk)->handler->handle_effect
+#define Stack_handle_tick(stk) (stk)->handler->handle_tick
 #define Stack_parent(stk) (stk)->handler->parent
 
 /* Stack layout for native code. Stack grows downwards.
@@ -309,6 +311,11 @@ void caml_scan_stack(
 value caml_alloc_stack(value hval, value hexn, value heff);
 value caml_alloc_stack_bind(value hval, value hexn, value heff, value dyn,
                             value bind);
+value caml_alloc_stack_preemptible(value hval, value hexn, value heff,
+                                   value htick);
+value caml_alloc_stack_bind_preemptible(value hval, value hexn, value heff,
+                                        value htick, value dyn,
+                                        value bind);
 struct stack_info* caml_alloc_stack_noexc(mlsize_t wosize, value hval,
                                           value hexn, value heff,
                                           value dyn, value bind,

--- a/runtime/caml/instruct.h
+++ b/runtime/caml/instruct.h
@@ -65,6 +65,8 @@ enum instructions {
   MAKE_FAUX_MIXEDBLOCK,
   WITH_STACK,
   WITH_STACK_BIND,
+  WITH_STACK_PREEMPTIBLE,
+  WITH_STACK_BIND_PREEMPTIBLE,
 FIRST_UNIMPLEMENTED_OP};
 
 // Think carefully before adding a new bytecode instruction. In general,

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1871,23 +1871,6 @@ void caml_interrupt_self(void)
   interrupt_domain_local(Caml_state);
 }
 
-/* Request that a preemption occur at the next possible time.
- *
- * XXX aspsmith: This function will almost definitely not last long - it's here
- * basically entirely to test preemption while it's under active development.
- * Importantly, eventually the "thing" that gets preempted will be a fiber, not
- * a domain
- */
-CAMLprim value caml_domain_preempt_self(value unit) {
-  CAMLnoalloc;
-  if (Caml_state->preemption != Val_unit) {
-    return Val_unit;
-  }
-  Caml_state->preemption = Val_long(1);
-  caml_interrupt_self();
-  return Val_unit;
-}
-
 /* If a preemption is pending, allocate a 3-word continuation for the preemption
    and store it in Caml_state->preemption
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2254,11 +2254,24 @@ static void tick_thread_wake(void) {}
 
 #endif
 
-void caml_process_tick(void)
+value caml_process_tick_exn(void)
 {
-  if (atomic_exchange(&Caml_state->requested_tick, false)) {
+  CAMLparam0();
+  CAMLlocal1(res);
+  if (atomic_exchange_explicit(&Caml_state->requested_tick, false,
+                               memory_order_acquire)) {
     caml_domain_tick_hook();
+
+    res = caml_tick_fiber_exn(Caml_state->current_stack);
+    if (Is_exception_result(res)) {
+      CAMLreturn(res);
+    }
+
+    if (res == Val_true) {
+      Caml_state->preemption = Val_long(1);
+    }
   }
+  CAMLreturn(Val_unit);
 }
 
 CAMLextern void caml_stop_tick_thread(void)

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -291,8 +291,8 @@ Caml_inline int stack_cache_bucket (mlsize_t wosize) {
 
 static struct stack_info*
 alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
-                             value hexn, value heff, value dyn, value val,
-                             int64_t id)
+                             value hexn, value heff, value htick,
+                             value dyn, value val, int64_t id)
 {
   struct stack_info* stack;
   struct stack_cache* caches = Caml_state->stack_caches;
@@ -340,6 +340,7 @@ alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
   hand->handle_value = hval;
   hand->handle_exn = hexn;
   hand->handle_effect = heff;
+  hand->handle_tick = htick;
   hand->parent = NULL;
   stack->sp = Stack_high(stack);
   stack->exception_ptr = NULL;
@@ -368,16 +369,17 @@ caml_alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
 {
   int cache_bucket = stack_cache_bucket (wosize);
   return alloc_size_class_stack_noexc(wosize, cache_bucket, hval, hexn, heff,
-                                      dyn, val, id);
+                                      /*htick=*/Val_null, dyn, val, id);
 }
 
 #ifdef NATIVE_CODE
 
 value caml_alloc_stack_bind (value hval, value hexn, value heff, value dyn, value val) {
   const int64_t id = atomic_fetch_add(&fiber_id, 1);
-  struct stack_info* stack =
-    alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */,
-                                 hval, hexn, heff, dyn, val, id);
+  struct stack_info *stack =
+      alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */, hval,
+                                   hexn, heff, /*htick=*/Val_null, dyn, val,
+                                   id);
 
   if (!stack)
 #if defined(USE_MMAP_MAP_STACK) || defined(STACK_GUARD_PAGES)
@@ -394,6 +396,33 @@ value caml_alloc_stack_bind (value hval, value hexn, value heff, value dyn, valu
 
 value caml_alloc_stack (value hval, value hexn, value heff) {
   return caml_alloc_stack_bind(hval, hexn, heff, Val_null, Val_null);
+}
+
+value caml_alloc_stack_bind_preemptible(value hval, value hexn, value heff,
+                                        value htick, value dyn,
+                                        value val) {
+  const int64_t id = atomic_fetch_add(&fiber_id, 1);
+  struct stack_info* stack =
+    alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */,
+                                 hval, hexn, heff, htick, dyn, val, id);
+
+  if (!stack)
+#if defined(USE_MMAP_MAP_STACK) || defined(STACK_GUARD_PAGES)
+    caml_raise_out_of_fibers();
+#else
+    caml_raise_out_of_memory();
+#endif
+
+  fiber_debug_log ("Allocate stack=%p of %" ARCH_INTNAT_PRINTF_FORMAT
+                     "u words", stack, caml_fiber_wsz);
+
+  return Val_ptr(stack);
+}
+
+value caml_alloc_stack_preemptible(value hval, value hexn, value heff,
+                                   value htick) {
+  return caml_alloc_stack_bind_preemptible(hval, hexn, heff, htick,
+                                           Val_null, Val_null);
 }
 
 
@@ -650,6 +679,7 @@ void caml_scan_stack(
     f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));
     f(fdata, Stack_handle_exception(stack), &Stack_handle_exception(stack));
     f(fdata, Stack_handle_effect(stack), &Stack_handle_effect(stack));
+    f(fdata, Stack_handle_tick(stack), &Stack_handle_tick(stack));
 
     scan_local_allocations(f, fdata, locals, stack->local_sp);
 
@@ -697,9 +727,10 @@ CAMLprim value caml_alloc_stack_bind(value hval, value hexn, value heff,
 {
   value* sp;
   const int64_t id = atomic_fetch_add(&fiber_id, 1);
-  struct stack_info* stack =
-    alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */,
-                                 hval, hexn, heff, dyn, val, id);
+  struct stack_info *stack =
+      alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */, hval,
+                                   hexn, heff, /*htick=*/Val_null, dyn, val,
+                                   id);
 
   if (!stack)
 #if defined(USE_MMAP_MAP_STACK) || defined(STACK_GUARD_PAGES)
@@ -720,6 +751,39 @@ CAMLprim value caml_alloc_stack_bind(value hval, value hexn, value heff,
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {
   return caml_alloc_stack_bind(hval, hexn, heff, Val_null, Val_null);
+}
+
+CAMLprim value caml_alloc_stack_bind_preemptible(value hval, value hexn,
+                                                 value heff, value htick,
+                                                 value dyn, value val)
+{
+  value* sp;
+  const int64_t id = atomic_fetch_add(&fiber_id, 1);
+  struct stack_info* stack =
+    alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */,
+                                 hval, hexn, heff, htick, dyn, val, id);
+
+  if (!stack)
+#if defined(USE_MMAP_MAP_STACK) || defined(STACK_GUARD_PAGES)
+    caml_raise_out_of_fibers();
+#else
+    caml_raise_out_of_memory();
+#endif
+
+  sp = Stack_high(stack);
+  sp -= 1;
+  sp[0] = Val_long(1);
+
+  stack->sp = sp;
+
+  return Val_ptr(stack);
+}
+
+CAMLprim value caml_alloc_stack_preemptible(value hval, value hexn, value heff,
+                                            value htick)
+{
+  return caml_alloc_stack_bind_preemptible(hval, hexn, heff, htick,
+                                           Val_null, Val_null);
 }
 
 CAMLprim value caml_ensure_stack_capacity(value required_space)
@@ -776,6 +840,8 @@ void caml_scan_stack(
       f(fdata, Stack_handle_exception(stack), &Stack_handle_exception(stack));
     if (is_scannable(fflags, Stack_handle_effect(stack)))
       f(fdata, Stack_handle_effect(stack), &Stack_handle_effect(stack));
+    if (is_scannable(fflags, Stack_handle_tick(stack)))
+      f(fdata, Stack_handle_tick(stack), &Stack_handle_tick(stack));
 
     stack = Stack_parent(stack);
   }
@@ -898,13 +964,14 @@ int caml_try_realloc_stack(asize_t required_space)
                     Bsize_wsize(wsize) * sizeof(value));
   }
 
-  new_stack = caml_alloc_stack_noexc(wsize,
-                                     Stack_handle_value(old_stack),
-                                     Stack_handle_exception(old_stack),
-                                     Stack_handle_effect(old_stack),
-                                     old_stack->dyn,
-                                     old_stack->val,
-                                     old_stack->id);
+  new_stack = alloc_size_class_stack_noexc(wsize, stack_cache_bucket(wsize),
+                                           Stack_handle_value(old_stack),
+                                           Stack_handle_exception(old_stack),
+                                           Stack_handle_effect(old_stack),
+                                           Stack_handle_tick(old_stack),
+                                           old_stack->dyn,
+                                           old_stack->val,
+                                           old_stack->id);
 
   if (!new_stack) return 0;
   memcpy(Stack_high(new_stack) - stack_used,

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1485,7 +1485,7 @@ value caml_tick_fiber_exn(struct stack_info *stack) {
       break;
     default: {
       value exn =
-        caml_failure_exn(caml_alloc_sprintf(
+        caml_failure_exn(caml_copy_string(
           "caml_tick_fiber: tick_handler returned invalid result"));
       CAMLreturn(Make_exception_result(exn));
     }

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1433,6 +1433,46 @@ static void dynamic_flush_cache(dynamic_thread_t thread)
   }
 }
 
+/* Call the tick handler for each running fiber *in reverse order*, stopping as
+   soon as one preempts
+
+   Returns Val_true if a preemption occurred, Val_false if one did not, or an
+   encoded exception result if any of the callbacks raised an exception.
+*/
+value caml_tick_fiber_exn(struct stack_info *stack) {
+  CAMLparam0();
+  CAMLlocal1(res);
+
+  if (Stack_parent(stack)) {
+    res = caml_tick_fiber_exn(Stack_parent(stack));
+    if (Is_exception_result(res) || res == Val_true) {
+      CAMLreturn(res);
+    }
+  }
+
+  if (Stack_is_preemptible(stack)) {
+    res = caml_callback_exn(Stack_handle_tick(stack), Val_unit);
+    if (Is_exception_result(res)) {
+      CAMLreturn(res);
+    }
+
+    switch (Long_val(res)) {
+    case TICK_RESULT_PREEMPT:
+      CAMLreturn(Val_true);
+    case TICK_RESULT_CONTINUE:
+      break;
+    default: {
+      value exn =
+        caml_failure_exn(caml_alloc_sprintf(
+          "caml_tick_fiber: tick_handler returned invalid result"));
+      CAMLreturn(Make_exception_result(exn));
+    }
+    }
+  }
+
+  CAMLreturn(Val_false);
+}
+
 /* parent is NULL for the first thread when systhreads initializes */
 
 CAMLexport dynamic_thread_t caml_dynamic_new_thread(dynamic_thread_t parent)

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1283,7 +1283,7 @@ void caml_continuation_replace(value cont, struct stack_info* stk)
 }
 
 CAMLprim value caml_continuation_update_handler_noexc
-  (value cont, value hval, value hexn, value heff)
+  (value cont, value hval, value hexn, value heff, value htick)
 {
   CAMLnoalloc;
   value stack;
@@ -1299,6 +1299,7 @@ CAMLprim value caml_continuation_update_handler_noexc
   Stack_handle_value(stk) = hval;
   Stack_handle_exception(stk) = hexn;
   Stack_handle_effect(stk) = heff;
+  Stack_handle_tick(stk) = htick;
   caml_continuation_replace(cont, Ptr_val(stack));
 
   return cont;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1305,6 +1305,28 @@ CAMLprim value caml_continuation_update_handler_noexc
   return cont;
 }
 
+/* Update only the tick handler of a continuation, leaving all other handlers
+   unchanged */
+CAMLprim value caml_continuation_update_tick_handler_noexc
+  (value cont, value htick)
+{
+  CAMLnoalloc;
+  value stack;
+  struct stack_info *stk;
+
+  stack = caml_continuation_use_noexc (cont);
+  stk = Ptr_val(stack);
+  if (stk == NULL) {
+    /* The continuation has already been taken */
+    return cont;
+  }
+  while (Stack_parent(stk) != NULL) stk = Stack_parent(stk);
+  Stack_handle_tick(stk) = htick;
+  caml_continuation_replace(cont, Ptr_val(stack));
+
+  return cont;
+}
+
 CAMLprim value caml_drop_continuation (value cont)
 {
   struct stack_info* stk = Ptr_val(caml_continuation_use(cont));

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1285,6 +1285,9 @@ void caml_continuation_replace(value cont, struct stack_info* stk)
 CAMLprim value caml_continuation_update_handler_noexc
   (value cont, value hval, value hexn, value heff, value htick)
 {
+  /* Note: this can be noalloc because, despite participating in marking (by
+     potentially calling [caml_darken_cont], through
+     [caml_continuation_use_noexc]), it can't actually enter the GC */
   CAMLnoalloc;
   value stack;
   struct stack_info* stk;
@@ -1310,6 +1313,9 @@ CAMLprim value caml_continuation_update_handler_noexc
 CAMLprim value caml_continuation_update_tick_handler_noexc
   (value cont, value htick)
 {
+  /* Note: this can be noalloc because, despite participating in marking (by
+     potentially calling [caml_darken_cont], through
+     [caml_continuation_use_noexc]), it can't actually enter the GC */
   CAMLnoalloc;
   value stack;
   struct stack_info *stk;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1527,6 +1527,51 @@ do_resume: {
       goto do_resume;
     }
 
+    Instruct(WITH_STACK_PREEMPTIBLE): {
+      value valuec = accu;
+      value exnc = sp[0];
+      value effc = sp[1];
+      value htick = sp[2];
+      Setup_for_c_call;
+      accu = caml_alloc_stack_preemptible(valuec, exnc, effc, htick);
+      Restore_after_c_call;
+      CAMLnoalloc;
+      resume_fn = sp[3];
+      resume_arg = sp[4];
+      resume_tail = NULL;
+      sp += 5 /* args */ - 5 /* values to be pushed */;
+      sp[0] = Val_long(domain_state->trap_sp_off);
+      sp[1] = Val_long(0);
+      sp[2] = (value)pc;
+      sp[3] = env;
+      sp[4] = Val_long(extra_args);
+      goto do_resume;
+    }
+
+    Instruct(WITH_STACK_BIND_PREEMPTIBLE): {
+      value valuec = accu;
+      value exnc = sp[0];
+      value effc = sp[1];
+      value htick = sp[2];
+      value dyn = sp[3];
+      value bind = sp[4];
+      Setup_for_c_call;
+      accu = caml_alloc_stack_bind_preemptible(valuec, exnc, effc,
+                                               htick, dyn, bind);
+      Restore_after_c_call;
+      CAMLnoalloc;
+      resume_fn = sp[5];
+      resume_arg = sp[6];
+      resume_tail = NULL;
+      sp += 7 /* args */ - 5 /* values to be pushed */;
+      sp[0] = Val_long(domain_state->trap_sp_off);
+      sp[1] = Val_long(0);
+      sp[2] = (value)pc;
+      sp[3] = env;
+      sp[4] = Val_long(extra_args);
+      goto do_resume;
+    }
+
 #ifndef THREADED_CODE
     default:
 #ifdef _MSC_VER

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -443,7 +443,8 @@ value caml_do_pending_actions_flags_exn(int flags)
      this after all other possibly exception-returning actions, we do not need
      to set the action pending flag in case a context switch happens: all
      actions have been processed at this point. */
-  caml_process_tick();
+  exn = caml_process_tick_exn();
+  check_async_exn(exn, "tick handler");
 
   /* Check for a pending preemption
 

--- a/runtime4/caml/instruct.h
+++ b/runtime4/caml/instruct.h
@@ -65,6 +65,8 @@ enum instructions {
   MAKE_FAUX_MIXEDBLOCK,
   WITH_STACK,
   WITH_STACK_BIND,
+  WITH_STACK_PREEMPTIBLE,
+  WITH_STACK_BIND_PREEMPTIBLE,
 FIRST_UNIMPLEMENTED_OP};
 
 // Think carefully before adding a new bytecode instruction. In general,

--- a/runtime4/domain.c
+++ b/runtime4/domain.c
@@ -187,9 +187,3 @@ CAMLprim value caml_effective_tick_interval_usec_bytecode(void)
   caml_failwith("Domains not supported on runtime4");
 }
 
-/* Preemption */
-
-CAMLprim value caml_domain_preempt_self(value eff)
-{
-  caml_failwith("Effects not supported on runtime4");
-}

--- a/runtime4/interp.c
+++ b/runtime4/interp.c
@@ -1229,6 +1229,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(REPERFORMTERM):
     Instruct(WITH_STACK):
     Instruct(WITH_STACK_BIND):
+    Instruct(WITH_STACK_PREEMPTIBLE):
+    Instruct(WITH_STACK_BIND_PREEMPTIBLE):
       caml_fatal_error("Effect primitives not supported on runtime4");
 
 #ifndef THREADED_CODE

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -605,6 +605,11 @@ module Tick = struct
 
     val acquire : interval_usec:int -> t @ unique
     val release : t @ unique -> unit
+    val with_
+      : ('r : value_or_null).
+          interval_usec:int
+      -> (t @ local -> 'r) @ local once
+      -> 'r
   end
 
   module Runtime4 = struct
@@ -615,6 +620,7 @@ module Tick = struct
 
     let acquire ~interval_usec:_ = fail ()
     let release = function | (_ : t) -> .
+    let with_ ~interval_usec:_ _f = fail ()
   end
 
   module Runtime5 = struct
@@ -749,6 +755,17 @@ module Tick = struct
         match Registry.remove registry interval_usec with
         | Null -> set_tick_interval_usec 0
         | This interval -> set_tick_interval_usec interval)
+
+    let with_ ~interval_usec f =
+      let t = acquire ~interval_usec in
+      match f (borrow_ t) with
+      | res ->
+        release t;
+        res
+      | exception exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        release t;
+        Printexc.raise_with_backtrace exn bt
   end
 
   let impl =

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -214,10 +214,10 @@ module Tick : sig @@ portable
 
       In between calling [acquire] and calling [release], the tick thread will
       tick {i at least as frequently} as the provided [interval_usec]. *)
-  type t : mutable_data mod external_ global
+  type t : mutable_data mod external_ global non_float
 
   (** Request that the tick thread tick at least as frequently as
-      [tick_interval] until [release] is called on the returned handle. *)
+      [interval_usec] until [release] is called on the returned handle. *)
   val acquire : interval_usec:int -> t @ unique
 
   (** Release a handle to a tick request.
@@ -227,6 +227,14 @@ module Tick : sig @@ portable
      domain).
   *)
   val release : t @ unique -> unit
+
+  (** [with_ ~interval_usec f] runs [f] with the tick thread ticking at least as
+      frequently as [interval_usec] *)
+  val with_
+    : ('r : value_or_null).
+       interval_usec:int
+    -> (t @ local -> 'r) @ local once
+    -> 'r
 
   (** Returns the interval at which the tick thread will tick, or [Null]
       if no domain has any active tick requests. This is the global minimum

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -68,25 +68,38 @@ external with_stack :
   'd ->
   'b = "%with_stack"
 
+type tick_outcome =
+  | Preempt
+  | Continue
+
+external with_stack_preemptible :
+  ('x -> 'b) ->
+  (exn -> 'b) ->
+  ('a . ('a,'x,'b) effc) ->
+  (unit -> tick_outcome) ->
+  ('d -> 'x) ->
+  'd ->
+  'b = "%with_stack_preemptible"
+
 external update_cont_handler_noexc :
   ('a, 'x, _) cont ->
   ('x -> 'b) ->
   (exn -> 'b) ->
   ('a2 . ('a2, 'x, 'b) effc) ->
+  (unit -> tick_outcome) or_null ->
   ('a, 'x, 'b) cont = "caml_continuation_update_handler_noexc"
 
 (* Retrieve the stack from a [cont]inuation, update its handlers, and run
    [f x] using it. *)
-let with_handler cont valuec exnc (effc : 'a. ('a, _, _) effc) f x =
+let with_handler cont valuec exnc (effc : 'a. ('a, _, _) effc) tickc f x =
   resume
     (* FIXME: There's a race condition here - if multiple threads call
        [with_handler] on the same continuation at once, they could be
        interleaved, causing a segfault rather
        than an exception. *)
-    (update_cont_handler_noexc cont valuec exnc effc) f x
+    (update_cont_handler_noexc cont valuec exnc effc tickc) f x
 
 module Deep = struct
-
   type ('a,'b) continuation =
     | Cont : ('a,'x,'b) cont -> ('a, 'b) continuation [@@unboxed]
 
@@ -127,6 +140,35 @@ module Deep = struct
       | None -> reperform eff k last_fiber
     in
     with_stack (fun x -> x) (fun e -> raise e) effc' comp arg
+
+  module Preemptible = struct
+    type ('a,'b) handler =
+      { retc: 'a -> 'b;
+        exnc: exn -> 'b;
+        effc: 'c.'c t -> (('c,'b) continuation -> 'b) option;
+        tickc: unit -> tick_outcome }
+
+    let match_with comp arg handler =
+      let effc eff k last_fiber =
+        match handler.effc eff with
+        | Some f ->
+          cont_set_last_fiber k last_fiber;
+          f (Cont k)
+        | None -> reperform eff k last_fiber
+      in
+      with_stack_preemptible
+        handler.retc handler.exnc effc handler.tickc
+        comp arg
+
+    let try_with ~on_tick comp arg (handler : _ effect_handler) =
+      match_with comp arg
+        { retc = Fun.id
+        ; exnc = raise
+        ; effc = handler.effc
+        ; tickc = on_tick
+        };
+    ;;
+  end
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =
@@ -175,7 +217,7 @@ module Shallow = struct
           f (Cont k)
       | None -> reperform eff k last_fiber
     in
-    with_handler k handler.retc handler.exnc effc resume_fun v
+    with_handler k handler.retc handler.exnc effc Null resume_fun v
 
   let continue_with k v handler =
     continue_gen k (fun x -> x) v handler
@@ -185,6 +227,34 @@ module Shallow = struct
 
   let discontinue_with_backtrace k v bt handler =
     continue_gen k (fun e -> Printexc.raise_with_backtrace e bt) v handler
+
+  module Preemptible = struct
+    type ('a,'b) handler =
+        { retc: 'a -> 'b;
+          exnc: exn -> 'b;
+          effc: 'c.'c t -> (('c,'a) continuation -> 'b) option;
+          tickc: unit -> tick_outcome }
+
+    let continue_gen (Cont k) resume_fun v handler =
+      let effc eff k last_fiber =
+        match handler.effc eff with
+        | Some f ->
+          cont_set_last_fiber k last_fiber;
+          f (Cont k)
+        | None -> reperform eff k last_fiber
+      in
+      with_handler k handler.retc handler.exnc effc (This handler.tickc)
+        resume_fun v
+
+    let continue_with k v handler =
+      continue_gen k (fun x -> x) v handler
+
+    let discontinue_with k v handler =
+      continue_gen k (fun e -> raise e) v handler
+
+    let discontinue_with_backtrace k v bt handler =
+      continue_gen k (fun e -> Printexc.raise_with_backtrace e bt) v handler
+  end
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -47,6 +47,10 @@ external perform : 'a t -> 'a = "%perform"
 
     @raise Unhandled if there is no handler for [e]. *)
 
+type tick_outcome =
+  | Preempt
+  | Continue
+
 module Deep : sig
   (** Deep handlers *)
 
@@ -99,6 +103,44 @@ module Deep : sig
   (** [try_with f x h] runs the computation [f x] under the handler [h].
 
       @raise Out_of_fibers if unable to allocate a fiber. *)
+
+  module Preemptible : sig
+    (** Preemptible handlers
+
+        Preemptible handlers are like normal handlers, except they also have
+        the ability to receive "ticks" from the runtime, and can decide to
+        preempt the current fiber on tick.
+
+        To set the tick interval, call [Domain.Tick.acquire] before running a
+        preemptible fiber. *)
+
+    type ('a,'b) handler =
+        { retc: 'a -> 'b;
+          exnc: exn -> 'b;
+          effc: 'c.'c t -> (('c,'b) continuation -> 'b) option;
+          tickc: unit -> tick_outcome }
+    (** [('a,'b) handler] is a handler record with four fields -- [retc]
+        is the value handler, [exnc] handles exceptions, [effc] handles the
+        effects performed by the computation enclosed by the handler, and
+        [tickc] handles ticks, deciding whether to preempt. [tickc] should be
+        signal-safe. If [tickc] returns [Preempt], a [Preemption] effect is
+        performed. *)
+
+    val match_with : ('c -> 'a) -> 'c -> ('a,'b) handler -> 'b
+    (** [match_with f x h] runs the computation [f x] in the handler [h].
+
+        @raise Out_of_fibers if unable to allocate a fiber. *)
+
+    val try_with :
+      on_tick:(unit -> tick_outcome) -> ('b -> 'a) -> 'b ->
+      'a effect_handler -> 'a
+      (** [try_with ~on_tick f x h] runs the computation [f x] under the handler
+          [h], calling [on_tick] whenever a tick occurs. [on_tick] should
+          be signal-safe. If it returns [Preempt], a [Preemption] effect is
+          performed.
+
+        @raise Out_of_fibers if unable to allocate a fiber. *)
+  end
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =
@@ -153,6 +195,55 @@ module Shallow : sig
       @raise Continuation_already_resumed if the continuation has already been
       resumed.
    *)
+
+  module Preemptible : sig
+    (** Preemptible handlers
+
+        Preemptible handlers are like normal handlers, except they also have
+        the ability to receive "ticks" from the runtime, and can decide to
+        preempt the current fiber on tick.
+
+        To set the tick interval, call [Domain.Tick.acquire] before running a
+        preemptible fiber. *)
+
+    type ('a,'b) handler =
+        { retc: 'a -> 'b;
+          exnc: exn -> 'b;
+          effc: 'c.'c t -> (('c,'a) continuation -> 'b) option;
+          tickc: unit -> tick_outcome }
+    (** [('a,'b) handler] is a handler record with four fields -- [retc]
+        is the value handler, [exnc] handles exceptions, [effc] handles the
+        effects performed by the computation enclosed by the handler, and
+        [tickc] handles ticks, deciding whether to preempt. [tickc] should be
+        signal-safe. If [tickc] returns [Preempt], a [Preemption] effect is
+        performed. *)
+
+    val continue_with : ('c,'a) continuation -> 'c -> ('a,'b) handler -> 'b
+    (** [continue_with k v h] resumes the continuation [k] with value [v] within
+        the handler [h].
+
+        @raise Continuation_already_resumed if the continuation has already been
+        resumed.
+    *)
+
+    val discontinue_with : ('c,'a) continuation -> exn -> ('a,'b) handler -> 'b
+    (** [discontinue_with k e h] resumes the continuation [k] by raising the
+        exception [e] within the handler [h].
+
+        @raise Continuation_already_resumed if the continuation has already been
+        resumed.
+    *)
+
+    val discontinue_with_backtrace : ('a,'b) continuation -> exn ->
+        Printexc.raw_backtrace -> ('b,'c) handler -> 'c
+    (** [discontinue_with k e bt h] resumes the continuation [k] by raising the
+        exception [e] with the handler [h] using the raw backtrace [bt] as the
+        origin of the exception.
+
+        @raise Continuation_already_resumed if the continuation has already been
+        resumed.
+    *)
+  end
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace =

--- a/testsuite/tests/backtrace/backtrace_effects.byte.reference
+++ b/testsuite/tests/backtrace/backtrace_effects.byte.reference
@@ -1,7 +1,7 @@
 (** get_callstack **)
 Raised by primitive operation at Backtrace_effects.bar in file "backtrace_effects.ml", line 20, characters 13-39
 Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, characters 12-17
-Called from Stdlib__Effect.Deep.match_with in file "stdlib/effect.ml", line 116, characters 4-54
+Called from Stdlib__Effect.Deep.match_with in file "stdlib/effect.ml", line 129, characters 4-54
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14
 (** get_continuation_callstack **)
 Raised by primitive operation at Backtrace_effects.bar in file "backtrace_effects.ml", line 22, characters 4-13
@@ -10,5 +10,5 @@ Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, chara
 Fatal error: exception Stdlib.Exit
 Raised at Backtrace_effects.bar in file "backtrace_effects.ml", line 17, characters 4-14
 Re-raised at Backtrace_effects.baz.(fun) in file "backtrace_effects.ml", line 33, characters 21-28
-Called from Stdlib__Effect.Deep.match_with in file "stdlib/effect.ml", line 116, characters 4-54
+Called from Stdlib__Effect.Deep.match_with in file "stdlib/effect.ml", line 129, characters 4-54
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,4 +1,4 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
-Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 93, characters 28-50
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 106, characters 28-50
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
 43

--- a/testsuite/tests/backtrace/backtrace_effects_nested.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.reference
@@ -1,4 +1,4 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
-Called from Stdlib__Effect.Deep.try_with in file "stdlib/effect.ml", line 129, characters 4-61
+Called from Stdlib__Effect.Deep.try_with in file "stdlib/effect.ml", line 142, characters 4-61
 43

--- a/testsuite/tests/effects/backtrace.byte.reference
+++ b/testsuite/tests/effects/backtrace.byte.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 98, characters 23-57
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 111, characters 23-57
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/backtrace.reference
+++ b/testsuite/tests/effects/backtrace.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml" (inlined), line 39, characters 17-
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 98, characters 23-57
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 111, characters 23-57
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/preemptible_fibers.ml
+++ b/testsuite/tests/effects/preemptible_fibers.ml
@@ -1,0 +1,620 @@
+(* TEST
+   include unix;
+   hasunix;
+   runtime5;
+   poll_insertion;
+   flags += "-alert -unsafe_multidomain -w -21";
+   { native; }
+*)
+
+open Effect
+open Effect.Deep
+
+type _ Effect.t +=
+  | Suspend : unit Effect.t
+
+let busy_wait_for flag =
+  let start_at = Sys.time () in
+  while not !flag do
+    if Sys.time () -. start_at > 5.
+    then failwith "Timed out after 5s!"
+  done
+
+(***********)
+
+let perform_normal_effect () =
+  print_endline "# Perform normal effect";
+  let open struct
+    type _ Effect.t +=
+      | Go : unit Effect.t
+  end
+  in
+  let happened = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> failwith "Should not tick")
+    (fun () -> perform Go)
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Go -> Some (fun (k : (a, _) continuation) ->
+          happened := true;
+          continue k ())
+        | _ -> None)
+    };
+  assert !happened;
+  print_endline "OK"
+;;
+
+let preempt_on_tick () =
+  print_endline "# Preempt on tick";
+  let preempted = ref false in
+  Preemptible.match_with
+    (fun () ->
+       let start_at = Sys.time () in
+       while not (!preempted) do
+         if Sys.time () -. start_at > 5.
+         then failwith "Didn't get preempted after 5s!"
+       done)
+    ()
+    { retc = Fun.id
+    ; exnc = raise
+    ; effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption -> Some (fun (k : (a, _) continuation) ->
+          preempted := true;
+          continue k ())
+        | _ -> None)
+    ; tickc = (fun () -> Preempt)
+    };
+  assert !preempted;
+  print_endline "OK"
+;;
+
+let preempt_after_two_ticks () =
+  print_endline "# Preempt after two ticks";
+  let preempted = ref false in
+  let ticks_received = ref 0 in
+  Preemptible.match_with
+    (fun () ->
+       let start_at = Sys.time () in
+       while not (!preempted) do
+         if Sys.time () -. start_at > 5.
+         then failwith "Didn't get preempted after 5s!"
+       done)
+    ()
+    { retc = Fun.id
+    ; exnc = raise
+    ; effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption -> Some (fun (k : (a, _) continuation) ->
+          preempted := true;
+          continue k ())
+        | _ -> None)
+    ; tickc = (fun () ->
+        incr ticks_received;
+        if !ticks_received = 2
+        then Preempt
+        else Continue)
+    };
+  assert !preempted;
+  print_endline "OK"
+;;
+
+
+let two_preemptible_inner_handles_tick () =
+  print_endline "# Two preemptible fibers, inner handles tick";
+  let outer_ticked = ref false in
+  let inner_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () ->
+      outer_ticked := true;
+      Continue)
+    (fun () ->
+       (* Non-preemptible fiber between the two preemptible ones, so the tick
+          walk must traverse a non-preemptible stack to reach the inner one. *)
+       Effect.Deep.try_with (fun () ->
+         Preemptible.try_with
+           ~on_tick:(fun () -> Preempt)
+           (fun () -> busy_wait_for inner_preempted)
+           ()
+           { effc = (fun (type a) (eff : a Effect.t) ->
+               match eff with
+               | Preemption ->
+                 Some (fun (k : (a, _) continuation) ->
+                   inner_preempted := true;
+                   continue k ())
+               | _ -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc = (fun (type a) (_eff : a Effect.t) -> None)
+    };
+  assert !outer_ticked;
+  assert !inner_preempted;
+  print_endline "OK"
+;;
+
+let two_preemptible_outer_handles_tick () =
+  print_endline "# Two preemptible fibers, outer handles tick";
+  let inner_ticked = ref false in
+  let outer_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Preempt)
+    (fun () ->
+       (* Non-preemptible fiber between preemptible fibers *)
+       Effect.Deep.try_with (fun () ->
+         Preemptible.try_with
+           ~on_tick:(fun () ->
+             inner_ticked := true;
+             Preempt)
+           (fun () -> busy_wait_for outer_preempted)
+           ()
+           { effc =
+               (fun (type a) (_eff : a Effect.t) -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            outer_preempted := true;
+            continue k ())
+        | _ -> None)
+    };
+  assert (not !inner_ticked);
+  assert !outer_preempted;
+  print_endline "OK"
+;;
+
+let resume_preempted_within_preemptible () =
+  print_endline "# Resume preempted within preemptible";
+  let saved_k
+    : (unit, unit) continuation option ref = ref None
+  in
+  let preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Preempt)
+    (fun () -> busy_wait_for preempted)
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            preempted := true;
+            saved_k := Some k)
+        | _ -> None)
+    };
+  assert !preempted;
+  let k =
+    match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  let resumed_ok = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Continue)
+    (fun () ->
+       continue k ();
+       resumed_ok := true)
+    ()
+    { effc =
+        (fun (type a) (_eff : a Effect.t) -> None)
+    };
+  assert !resumed_ok;
+  print_endline "OK"
+;;
+
+let resume_cont_with_nonpreemptible () =
+  print_endline
+    "# Resume cont with non-preemptible within preemptible";
+  let saved_k
+    : (unit, unit) continuation option ref = ref None
+  in
+  (* Create a continuation containing a non-preemptible fiber.
+     The Suspend effect bubbles through the try_with to the outer
+     preemptible handler, so k includes the try_with fiber. *)
+  Preemptible.try_with
+    ~on_tick:(fun () -> Continue)
+    (fun () ->
+       Effect.Deep.try_with
+         (fun () -> Effect.perform Suspend)
+         ()
+         { effc =
+             (fun (type a) (_eff : a Effect.t) -> None)
+         })
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Suspend ->
+          Some (fun (k : (a, _) continuation) ->
+            saved_k := Some k)
+        | _ -> None)
+    };
+  let k =
+    match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  (* Resume k inside a preemptible fiber, then tick.
+     The resumed non-preemptible fiber sits between the outer
+     preemptible fiber and the computation, so the tick must
+     reach through it. *)
+  let preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Preempt)
+    (fun () ->
+       continue k ();
+       busy_wait_for preempted)
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            preempted := true;
+            continue k ())
+        | _ -> None)
+    };
+  assert !preempted;
+  print_endline "OK"
+;;
+
+let resume_preempted_in_fiber_then_tick () =
+  print_endline "# Resume preempted in fiber, then tick";
+  let saved_k
+    : (unit, unit) continuation option ref = ref None
+  in
+  let preempted_1 = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Preempt)
+    (fun () -> busy_wait_for preempted_1)
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            preempted_1 := true;
+            saved_k := Some k)
+        | _ -> None)
+    };
+  assert !preempted_1;
+  let k =
+    match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  let outer_ticked = ref false in
+  let preempted_2 = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () ->
+      outer_ticked := true;
+      Preempt)
+    (fun () ->
+       Effect.Deep.try_with
+         (fun () ->
+            continue k ();
+            busy_wait_for preempted_2)
+         ()
+         { effc =
+             (fun (type a) (_eff : a Effect.t) -> None)
+         })
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            preempted_2 := true;
+            continue k ())
+        | _ -> None)
+    };
+  assert !outer_ticked;
+  assert !preempted_2;
+  print_endline "OK"
+;;
+
+let resume_preempted_with_inner_preemptible () =
+  print_endline
+    "# Resume preempted with inner preemptible, inner ticks";
+  let saved_k
+    : (unit, unit) continuation option ref = ref None
+  in
+  let phase = ref 1 in
+  let preempted_phase_1 = ref false in
+  let preempted_by_c = ref false in
+  (* A: outermost preemptible, catches Preemption in phase 1 *)
+  Preemptible.try_with
+    ~on_tick:(fun () -> Continue)
+    (fun () ->
+       (* Non-preemptible fiber between A and B *)
+       Effect.Deep.try_with (fun () ->
+         (* B: preemptible, preempts in phase 1, continues in phase 2 *)
+         Preemptible.try_with
+           ~on_tick:(fun () ->
+             if !phase = 1 then Preempt else Continue)
+           (fun () ->
+              (* Non-preemptible fiber between B and C *)
+              Effect.Deep.try_with (fun () ->
+                (* C: preemptible, preempts always *)
+                Preemptible.try_with
+                  ~on_tick:(fun () -> Preempt)
+                  (fun () ->
+                     busy_wait_for preempted_phase_1;
+                     busy_wait_for preempted_by_c)
+                  ()
+                  { effc = (fun (type a) (eff : a Effect.t) ->
+                      match eff with
+                      | Preemption ->
+                        if !phase = 2 then
+                          Some (fun (k : (a, _) continuation) ->
+                            preempted_by_c := true;
+                            continue k ())
+                        else None
+                      | _ -> None)
+                  }
+              ) ()
+              { effc =
+                  (fun (type a) (_eff : a Effect.t) -> None)
+              })
+           ()
+           { effc =
+               (fun (type a) (_eff : a Effect.t) -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            preempted_phase_1 := true;
+            saved_k := Some k;
+            phase := 2)
+        | _ -> None)
+    };
+  assert !preempted_phase_1;
+  let k =
+    match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  continue k ();
+  assert !preempted_by_c;
+  print_endline "OK"
+;;
+
+let multiple_nonpreemptible_layers () =
+  print_endline "# Multiple non-preemptible layers between preemptible";
+  let inner_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Continue)
+    (fun () ->
+       Effect.Deep.try_with (fun () ->
+         Effect.Deep.try_with (fun () ->
+           Effect.Deep.try_with (fun () ->
+             Preemptible.try_with
+               ~on_tick:(fun () -> Preempt)
+               (fun () -> busy_wait_for inner_preempted)
+               ()
+               { effc = (fun (type a) (eff : a Effect.t) ->
+                   match eff with
+                   | Preemption ->
+                     Some (fun (k : (a, _) continuation) ->
+                       inner_preempted := true;
+                       continue k ())
+                   | _ -> None)
+               }
+           ) ()
+           { effc =
+               (fun (type a) (_eff : a Effect.t) -> None)
+           }
+         ) ()
+         { effc =
+             (fun (type a) (_eff : a Effect.t) -> None)
+         }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc =
+        (fun (type a) (_eff : a Effect.t) -> None)
+    };
+  assert !inner_preempted;
+  print_endline "OK"
+;;
+
+let inner_preemptible_finishes_then_outer_ticks () =
+  print_endline
+    "# Inner preemptible finishes, outer still gets ticks";
+  let inner_done = ref false in
+  let outer_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Preempt)
+    (fun () ->
+       Effect.Deep.try_with (fun () ->
+         Preemptible.try_with
+           ~on_tick:(fun () -> Continue)
+           (fun () -> inner_done := true)
+           ()
+           { effc =
+               (fun (type a) (_eff : a Effect.t) -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       };
+       assert !inner_done;
+       busy_wait_for outer_preempted)
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            outer_preempted := true;
+            continue k ())
+        | _ -> None)
+    };
+  assert !outer_preempted;
+  print_endline "OK"
+;;
+
+let inner_preemptible_finishes_sibling_ticks () =
+  print_endline
+    "# Inner preemptible finishes, sibling preemptible ticks";
+  let first_done = ref false in
+  let second_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Continue)
+    (fun () ->
+       (* First inner preemptible fiber: finishes immediately *)
+       Effect.Deep.try_with (fun () ->
+         Preemptible.try_with
+           ~on_tick:(fun () -> Continue)
+           (fun () -> first_done := true)
+           ()
+           { effc =
+               (fun (type a) (_eff : a Effect.t) -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       };
+       assert !first_done;
+       (* Second inner preemptible fiber: should get ticks *)
+       Effect.Deep.try_with (fun () ->
+         Preemptible.try_with
+           ~on_tick:(fun () -> Preempt)
+           (fun () -> busy_wait_for second_preempted)
+           ()
+           { effc = (fun (type a) (eff : a Effect.t) ->
+               match eff with
+               | Preemption ->
+                 Some (fun (k : (a, _) continuation) ->
+                   second_preempted := true;
+                   continue k ())
+               | _ -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc =
+        (fun (type a) (_eff : a Effect.t) -> None)
+    };
+  assert !second_preempted;
+  print_endline "OK"
+;;
+
+let three_preemptible_middle_finishes () =
+  print_endline
+    "# Three preemptible fibers, middle finishes, inner ticks";
+  let middle_done = ref false in
+  let inner_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Continue)
+    (fun () ->
+       Effect.Deep.try_with (fun () ->
+         (* Middle preemptible fiber: finishes immediately *)
+         Preemptible.try_with
+           ~on_tick:(fun () -> Continue)
+           (fun () ->
+              middle_done := true;
+              (* Inner preemptible fiber: should get ticks
+                 after middle finishes *)
+              Effect.Deep.try_with (fun () ->
+                Preemptible.try_with
+                  ~on_tick:(fun () -> Preempt)
+                  (fun () -> busy_wait_for inner_preempted)
+                  ()
+                  { effc = (fun (type a) (eff : a Effect.t) ->
+                      match eff with
+                      | Preemption ->
+                        Some (fun (k : (a, _) continuation) ->
+                          inner_preempted := true;
+                          continue k ())
+                      | _ -> None)
+                  }
+              ) ()
+              { effc =
+                  (fun (type a) (_eff : a Effect.t) -> None)
+              })
+           ()
+           { effc =
+               (fun (type a) (_eff : a Effect.t) -> None)
+           }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc =
+        (fun (type a) (_eff : a Effect.t) -> None)
+    };
+  assert !middle_done;
+  assert !inner_preempted;
+  print_endline "OK"
+;;
+
+let multiple_layers_outer_preempts () =
+  print_endline
+    "# Multiple non-preemptible layers, outer preempts";
+  let outer_preempted = ref false in
+  Preemptible.try_with
+    ~on_tick:(fun () -> Preempt)
+    (fun () ->
+       Effect.Deep.try_with (fun () ->
+         Effect.Deep.try_with (fun () ->
+           Preemptible.try_with
+             ~on_tick:(fun () -> Continue)
+             (fun () -> busy_wait_for outer_preempted)
+             ()
+             { effc =
+                 (fun (type a) (_eff : a Effect.t) -> None)
+             }
+         ) ()
+         { effc =
+             (fun (type a) (_eff : a Effect.t) -> None)
+         }
+       ) ()
+       { effc =
+           (fun (type a) (_eff : a Effect.t) -> None)
+       })
+    ()
+    { effc = (fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Preemption ->
+          Some (fun (k : (a, _) continuation) ->
+            outer_preempted := true;
+            continue k ())
+        | _ -> None)
+    };
+  assert !outer_preempted;
+  print_endline "OK"
+;;
+
+let () =
+  Domain.Tick.with_ ~interval_usec:1_000 (fun _ ->
+    perform_normal_effect ();
+    preempt_on_tick ();
+    preempt_after_two_ticks ();
+    two_preemptible_inner_handles_tick ();
+    two_preemptible_outer_handles_tick ();
+    resume_preempted_within_preemptible ();
+    resume_cont_with_nonpreemptible ();
+    resume_preempted_in_fiber_then_tick ();
+    resume_preempted_with_inner_preemptible ();
+    multiple_nonpreemptible_layers ();
+    inner_preemptible_finishes_then_outer_ticks ();
+    inner_preemptible_finishes_sibling_ticks ();
+    three_preemptible_middle_finishes ();
+    multiple_layers_outer_preempts ())
+;;

--- a/testsuite/tests/effects/preemptible_fibers.reference
+++ b/testsuite/tests/effects/preemptible_fibers.reference
@@ -1,0 +1,28 @@
+# Perform normal effect
+OK
+# Preempt on tick
+OK
+# Preempt after two ticks
+OK
+# Two preemptible fibers, inner handles tick
+OK
+# Two preemptible fibers, outer handles tick
+OK
+# Resume preempted within preemptible
+OK
+# Resume cont with non-preemptible within preemptible
+OK
+# Resume preempted in fiber, then tick
+OK
+# Resume preempted with inner preemptible, inner ticks
+OK
+# Multiple non-preemptible layers between preemptible
+OK
+# Inner preemptible finishes, outer still gets ticks
+OK
+# Inner preemptible finishes, sibling preemptible ticks
+OK
+# Three preemptible fibers, middle finishes, inner ticks
+OK
+# Multiple non-preemptible layers, outer preempts
+OK

--- a/testsuite/tests/effects/preemption/basic2.ml
+++ b/testsuite/tests/effects/preemption/basic2.ml
@@ -15,7 +15,7 @@ let () =
   let iters = ref 0 in
 
   ignore (run_with_tick_handler
-    ~interval:0.05
+    ~interval_usec:50_000
     ~repeating:true
     ~on_preemption:(fun _resume -> incr count; Resume)
     (fun () ->

--- a/testsuite/tests/effects/preemption/fast.ml
+++ b/testsuite/tests/effects/preemption/fast.ml
@@ -15,7 +15,7 @@ let () =
   let allocations = ref [] in
 
   let result = run_with_tick_handler
-    ~interval:0.001
+    ~interval_usec:1_000
     ~repeating:true
     ~on_preemption:(fun _resume ->
       incr count;

--- a/testsuite/tests/effects/preemption/gc_in_handler.ml
+++ b/testsuite/tests/effects/preemption/gc_in_handler.ml
@@ -21,7 +21,7 @@ let () =
   in
 
   let result = run_with_tick_handler
-    ~interval:0.02
+    ~interval_usec:20_000
     ~repeating:true
     ~on_preemption:(fun _resume ->
       incr count;

--- a/testsuite/tests/effects/preemption/handle_tick_raises.ml
+++ b/testsuite/tests/effects/preemption/handle_tick_raises.ml
@@ -1,0 +1,28 @@
+(* TEST
+   runtime5;
+   poll_insertion;
+   flags += "-alert -unsafe_multidomain -w -21";
+   exit_status = "2";
+   { native; }
+*)
+
+open Effect
+open Effect.Deep
+
+(* Test that raising from on_tick correctly causes an async exception *)
+
+let () =
+  Domain.Tick.with_ ~interval_usec:1_000 (fun _ ->
+    Preemptible.try_with
+      ~on_tick:(fun () -> failwith "Raise from on_tick")
+      (fun () ->
+         let start_at = Sys.time () in
+         while true do
+           if Sys.time () -. start_at > 5.
+           then failwith "Didn't get preempted after 5s!"
+         done)
+      ()
+      { effc = (fun (type a) (eff : a Effect.t) ->
+          failwith "Should not get effect")
+      })
+;;

--- a/testsuite/tests/effects/preemption/handle_tick_raises.reference
+++ b/testsuite/tests/effects/preemption/handle_tick_raises.reference
@@ -1,0 +1,1 @@
+Fatal error: exception Failure("Raise from on_tick")

--- a/testsuite/tests/effects/preemption/minor_alloc.ml
+++ b/testsuite/tests/effects/preemption/minor_alloc.ml
@@ -1,7 +1,4 @@
 (* TEST
-   modules = "preemption_util.ml";
-   include unix;
-   hasunix;
    runtime5;
    poll_insertion;
    flags += "-alert -unsafe_multidomain -w -21";
@@ -10,7 +7,6 @@
 
 open Effect
 open Effect.Deep
-open Preemption_util
 
 let alloc () =
   let r @ global = ref "hello" in
@@ -29,7 +25,7 @@ let alloc () =
 
 let () =
   Gc.set { (Gc.get ()) with minor_heap_size = 1024 };
-  with_preemption_setup ~interval:0.001 ~repeating:true (fun () ->
+  Domain.Tick.with_ ~interval_usec:1_000 (fun _ ->
     let bang = Atomic.make false in
     let weird = ref [] in
     let f () =
@@ -49,4 +45,6 @@ let () =
         continue k ())
       | _ -> None
     in
-    try_with f () { effc })
+    Preemptible.try_with
+      ~on_tick:(fun () -> Preempt)
+      f () { effc })

--- a/testsuite/tests/effects/preemption/multidomain.ml
+++ b/testsuite/tests/effects/preemption/multidomain.ml
@@ -11,34 +11,33 @@
 
 open Effect
 open Effect.Deep
-open Preemption_util
 
 type _ Effect.t += Bump : int -> int Effect.t
 
 let () =
-  with_preemption_setup ~interval:0.0001 ~repeating:true (fun () ->
-    let workers = Array.init 2 (fun i ->
-      Domain.spawn (fun () ->
-        Gc.set { (Gc.get ()) with minor_heap_size = 1024 };
-        try_with (fun () ->
-          try_with (fun () ->
-            let start = Unix.gettimeofday () in
-            while Unix.gettimeofday () -. start < 20.  do
-              preempt_self ();
-              let n = perform (Bump i) in
-              ignore (Sys.opaque_identity n)
-            done)
-          () { effc = (fun (type a) (e : a t) -> match e with
-            | Bump n -> Some (fun (k : (a,_) continuation) ->
-              let _ = Sys.opaque_identity (ref (n+1)) in
-              continue k (n + 1))
-            | _ -> None) })
-        () { effc = (fun (type a) (e : a t) -> match e with
-          | Preemption -> Some (fun (k : (a,_) continuation) ->
-            Gc.full_major ();
-            continue k ())
-          | _ -> None) }
-      )
-    ) in
-    Unix.sleepf 10.0;
-    Array.iter Domain.join workers)
+  let workers = Array.init 2 (fun i ->
+    Domain.spawn (fun () ->
+      Gc.set { (Gc.get ()) with minor_heap_size = 1024 };
+      Domain.Tick.with_ ~interval_usec:100 (fun _ ->
+        Preemptible.try_with
+          ~on_tick:(fun () -> Preempt)
+          (fun () ->
+            try_with (fun () ->
+              let start = Unix.gettimeofday () in
+              while Unix.gettimeofday () -. start < 20. do
+                let n = perform (Bump i) in
+                ignore (Sys.opaque_identity n)
+              done)
+            () { effc = (fun (type a) (e : a t) -> match e with
+              | Bump n -> Some (fun (k : (a,_) continuation) ->
+                let _ = Sys.opaque_identity (ref (n+1)) in
+                continue k (n + 1))
+              | _ -> None) })
+          ()
+          { effc = (fun (type a) (e : a t) -> match e with
+            | Preemption -> Some (fun (k : (a,_) continuation) ->
+              Gc.full_major ();
+              continue k ())
+            | _ -> None) }))) in
+  Unix.sleepf 10.0;
+  Array.iter Domain.join workers

--- a/testsuite/tests/effects/preemption/multiple_effects.ml
+++ b/testsuite/tests/effects/preemption/multiple_effects.ml
@@ -1,7 +1,4 @@
 (* TEST
-   modules = "preemption_util.ml";
-   include unix;
-   hasunix;
    runtime5;
    poll_insertion;
    flags += "-alert -unsafe_multidomain -w -21";
@@ -10,7 +7,6 @@
 
 open Effect
 open Effect.Deep
-open Preemption_util
 
 type _ Effect.t += Inc : int -> int Effect.t
 type _ Effect.t += Dec : int -> int Effect.t
@@ -18,8 +14,9 @@ type _ Effect.t += Dec : int -> int Effect.t
 let () =
   let preempted = ref false in
 
-  let result = with_preemption_setup (fun () ->
-    try_with
+  let result = Domain.Tick.with_ ~interval_usec:100_000 (fun _ ->
+    Preemptible.try_with
+      ~on_tick:(fun () -> Preempt)
       (fun () ->
          let start_at = Sys.time () in
          let counter = ref 0 in

--- a/testsuite/tests/effects/preemption/multiple_live_continuations.ml
+++ b/testsuite/tests/effects/preemption/multiple_live_continuations.ml
@@ -1,7 +1,4 @@
 (* TEST
-   modules = "preemption_util.ml";
-   include unix;
-   hasunix;
    runtime5;
    poll_insertion;
    flags += "-alert -unsafe_multidomain -w -21";
@@ -10,7 +7,6 @@
 
 open Effect
 open Effect.Deep
-open Preemption_util
 
 let () =
   let n = 5 in
@@ -28,7 +24,7 @@ let () =
       let done_ = ref false in
       let v = ref 0 in
       values := v :: !values;
-      match_with
+      Preemptible.match_with
         (fun () ->
           let start_at = Sys.time () in
           while not !done_ do
@@ -39,6 +35,7 @@ let () =
         ()
         { retc = (fun () -> ());
           exnc = raise;
+          tickc = (fun () -> Preempt);
           effc = fun (type a) (e : a t) ->
             match e with
             | Preemption -> Some (fun (k : (a, _) continuation) ->
@@ -48,6 +45,6 @@ let () =
             | _ -> None }
     end
   in
-  with_preemption_setup ~interval:0.01 ~repeating:true (fun () ->
+  Domain.Tick.with_ ~interval_usec:10_000 (fun _ ->
     collect n);
   List.iter (fun v -> assert (!v > 0)) !values;

--- a/testsuite/tests/effects/preemption/nested_handlers.ml
+++ b/testsuite/tests/effects/preemption/nested_handlers.ml
@@ -1,7 +1,4 @@
 (* TEST
-   modules = "preemption_util.ml";
-   include unix;
-   hasunix;
    runtime5;
    poll_insertion;
    flags += "-alert -unsafe_multidomain -w -21";
@@ -10,7 +7,6 @@
 
 open Effect
 open Effect.Deep
-open Preemption_util
 
 type _ Effect.t += Nested : int -> int Effect.t
 
@@ -24,8 +20,9 @@ let () =
     obj
   in
 
-  let result = with_preemption_setup (fun () ->
-    try_with
+  let result = Domain.Tick.with_ ~interval_usec:100_000 (fun _ ->
+    Preemptible.try_with
+      ~on_tick:(fun () -> Preempt)
       (fun () ->
          let obj = make_finalizable 42 in
          try_with

--- a/testsuite/tests/effects/preemption/preemption_util.ml
+++ b/testsuite/tests/effects/preemption/preemption_util.ml
@@ -1,34 +1,26 @@
 open Effect
 open Effect.Deep
 
-external preempt_self : unit -> unit = "caml_domain_preempt_self"
-[@@noalloc]
-
-let with_preemption_setup ?(interval = 0.05) ?(repeating = false) f =
-  let it_interval = if repeating then interval else 0. in
-  Sys.set_signal Sys.sigalrm (Signal_handle (fun _ -> preempt_self ()))
-  |> ignore;
-  Unix.setitimer ITIMER_REAL { it_interval; it_value = interval } |> ignore;
-  Fun.protect f
-    ~finally:(fun () ->
-      Unix.setitimer ITIMER_REAL { it_interval = 0.; it_value = 0. } |> ignore)
-
 type 'a preemption_action =
   | Resume
   | Handled of 'a
 
-let run_with_tick_handler ?(interval = 0.1) ?(repeating = false)
+let run_with_tick_handler ?(interval_usec = 100_000) ?(repeating = false)
     ~on_preemption computation =
-  with_preemption_setup ~interval ~repeating (fun () ->
-    try_with
-      computation
-      ()
-      { effc = (fun (type a) (e : a t) ->
-          match e with
-          | Preemption -> Some (fun (k : (a, _) continuation) ->
-            let resume () = continue k () in
-            match on_preemption resume with
-            | Resume -> resume ()
-            | Handled result -> result)
-          | _ -> None) }
-  )
+  Domain.Tick.with_ ~interval_usec (fun _ ->
+      let preempted_once = ref false in
+      Preemptible.try_with
+        ~on_tick:(fun () ->
+          if !preempted_once && not repeating
+          then Continue
+          else (preempted_once := true; Preempt))
+        computation
+        ()
+        { effc = (fun (type a) (e : a t) ->
+            match e with
+            | Preemption -> Some (fun (k : (a, _) continuation) ->
+              let resume () = continue k () in
+              match on_preemption resume with
+              | Resume -> resume ()
+              | Handled result -> result)
+            | _ -> None) })

--- a/testsuite/tests/effects/preemption/scheduler.ml
+++ b/testsuite/tests/effects/preemption/scheduler.ml
@@ -1,5 +1,4 @@
 (* TEST
-   modules = "preemption_util.ml";
    include systhreads;
    hassysthreads;
    runtime5;
@@ -11,7 +10,6 @@
 
 open Effect
 open Effect.Shallow
-open Preemption_util
 
 module Work_queue = struct
   type t =
@@ -58,9 +56,10 @@ module Scheduler = struct
         Atomic.incr completed)
       in
       let rec run k =
-        continue_with k ()
+        Preemptible.continue_with k ()
           { retc = (fun _result -> ());
             exnc = raise;
+            tickc = (fun () -> Preempt);
             effc = fun (type a) (e : a t) ->
               match e with
               | Preemption -> Some (fun (k : (a, _) continuation) ->
@@ -85,12 +84,16 @@ let twiddle_refs () =
   done;
   !r
 
+let with_tick f = Domain.Tick.with_ ~interval_usec:1_000 (fun _ -> f ())
+
 let multidomain () =
   let stop = Atomic.make false in
   let work_queue = Work_queue.create () in
   let domains =
     Array.init 8 (fun _ ->
-      Domain.spawn (fun () -> Scheduler.worker ~work_queue ~stop))
+      Domain.spawn (fun () ->
+        with_tick (fun () ->
+          Scheduler.worker ~work_queue ~stop)))
   in
   let result = Atomic.make 0 in
   let completed = Atomic.make 0 in
@@ -125,11 +128,12 @@ let multidomain_multithread () =
   let domains =
     Array.init 2 (fun _ ->
       Domain.spawn (fun () ->
-        let threads = Array.init 4 (fun _ ->
-          Thread.create (fun () -> Scheduler.worker ~work_queue ~stop) ())
-        in
-        Scheduler.worker ~work_queue ~stop;
-        Array.iter Thread.join threads))
+        with_tick (fun () ->
+          let threads = Array.init 4 (fun _ ->
+            Thread.create (fun () -> Scheduler.worker ~work_queue ~stop) ())
+          in
+          Scheduler.worker ~work_queue ~stop;
+          Array.iter Thread.join threads)))
   in
   let result = Atomic.make 0 in
   let completed = Atomic.make 0 in
@@ -160,7 +164,7 @@ let sequential () =
   Printf.printf "  Sequential result: %d\n" !result
 
 let () =
-  with_preemption_setup ~interval:0.001 ~repeating:true (fun () ->
+  with_tick (fun () ->
     multidomain ();
     multithread ();
     multidomain_multithread ();

--- a/testsuite/tests/effects/preemption/shallow_handlers.ml
+++ b/testsuite/tests/effects/preemption/shallow_handlers.ml
@@ -1,0 +1,224 @@
+(* TEST
+   include unix;
+   hasunix;
+   runtime5;
+   poll_insertion;
+   flags += "-alert -unsafe_multidomain -w -21";
+   { native; }
+*)
+
+open Effect
+open Effect.Shallow
+
+let busy_wait_for flag =
+  let start_at = Sys.time () in
+  while not !flag do
+    if Sys.time () -. start_at > 5.
+    then failwith "Timed out after 5s!"
+  done
+
+let busy_wait_for_seconds n =
+  let start_at = Sys.time () in
+  while Sys.time () -. start_at < n do () done
+
+type _ Effect.t += Suspend : unit Effect.t
+type _ Effect.t += Yield : unit Effect.t
+
+(* Resume a saved preemptible continuation with non-preemptible
+   [continue_with]: the resumed body should run uninterrupted, and the
+   original [tickc] should not fire again. The [Yield] performed after
+   resume should be handled by the new (non-preemptible) handler. *)
+let resume_preemptible_as_nonpreemptible () =
+  print_endline "# Resume preemptible cont as non-preemptible";
+  let saved_k : (unit, unit) continuation option ref = ref None in
+  let preempted = ref false in
+  let tick_count = ref 0 in
+  let yields_a = ref 0 in
+  let yields_b = ref 0 in
+  let f = fiber (fun () ->
+    perform Yield;
+    busy_wait_for preempted;
+    perform Yield;
+    (* If the original preemptible handler were still active, this body
+       would tick ~50 times at the 1ms interval. *)
+    busy_wait_for_seconds 0.05)
+  in
+  let rec handler_a k =
+    Preemptible.continue_with k ()
+      { retc = (fun () -> failwith "should be preempted, not return")
+      ; exnc = raise
+      ; tickc = (fun () -> incr tick_count; Preempt)
+      ; effc = (fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Preemption -> Some (fun (k : (a, _) continuation) ->
+            preempted := true;
+            saved_k := Some k)
+          | Yield -> Some (fun (k : (a, _) continuation) ->
+            incr yields_a;
+            handler_a k)
+          | _ -> None)
+      }
+  in
+  handler_a f;
+  let k = match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  let count_at_resume = !tick_count in
+  let yields_a_at_resume = !yields_a in
+  let returned = ref false in
+  let rec handler_b k =
+    continue_with k ()
+      { retc = (fun () -> returned := true)
+      ; exnc = raise
+      ; effc = (fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Yield -> Some (fun (k : (a, _) continuation) ->
+            incr yields_b;
+            handler_b k)
+          | _ -> None)
+      }
+  in
+  handler_b k;
+  assert !returned;
+  assert (!tick_count = count_at_resume);
+  assert (!yields_a = yields_a_at_resume);
+  assert (yields_a_at_resume = 1);
+  assert (!yields_b = 1);
+  print_endline "OK"
+;;
+
+(* Resume a saved non-preemptible continuation with
+   [Preemptible.continue_with]: the new [tickc] should fire and
+   [Preemption] should be performed. The [Yield] performed after resume
+   should be handled by the new (preemptible) handler. *)
+let resume_nonpreemptible_as_preemptible () =
+  print_endline "# Resume non-preemptible cont as preemptible";
+  let saved_k : (unit, unit) continuation option ref = ref None in
+  let preempted = ref false in
+  let yields_a = ref 0 in
+  let yields_b = ref 0 in
+  let f = fiber (fun () ->
+    perform Yield;
+    perform Suspend;
+    perform Yield;
+    busy_wait_for preempted)
+  in
+  let rec handler_a k =
+    continue_with k ()
+      { retc = (fun () -> failwith "should be suspended")
+      ; exnc = raise
+      ; effc = (fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Suspend -> Some (fun (k : (a, _) continuation) ->
+            saved_k := Some k)
+          | Yield -> Some (fun (k : (a, _) continuation) ->
+            incr yields_a;
+            handler_a k)
+          | _ -> None)
+      }
+  in
+  handler_a f;
+  let k = match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  let yields_a_at_resume = !yields_a in
+  let rec handler_b k =
+    Preemptible.continue_with k ()
+      { retc = (fun () -> ())
+      ; exnc = raise
+      ; tickc = (fun () -> Preempt)
+      ; effc = (fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Preemption -> Some (fun (k : (a, _) continuation) ->
+            preempted := true;
+            handler_b k)
+          | Yield -> Some (fun (k : (a, _) continuation) ->
+            incr yields_b;
+            handler_b k)
+          | _ -> None)
+      }
+  in
+  handler_b k;
+  assert !preempted;
+  assert (!yields_a = yields_a_at_resume);
+  assert (yields_a_at_resume = 1);
+  assert (!yields_b = 1);
+  print_endline "OK"
+;;
+
+(* Resume a saved preemptible continuation with a different [tickc] (and
+   different [effc]): only the new [tickc] should fire, and the [Yield]
+   performed after resume should be handled by the new handler. *)
+let resume_preemptible_with_different_tickc () =
+  print_endline "# Resume preemptible cont with different on_tick";
+  let saved_k : (unit, unit) continuation option ref = ref None in
+  let count_a = ref 0 in
+  let count_b = ref 0 in
+  let yields_a = ref 0 in
+  let yields_b = ref 0 in
+  let preempted_a = ref false in
+  let preempted_b = ref false in
+  let f = fiber (fun () ->
+    perform Yield;
+    busy_wait_for preempted_a;
+    perform Yield;
+    busy_wait_for preempted_b)
+  in
+  let rec handler_a k =
+    Preemptible.continue_with k ()
+      { retc = (fun () -> failwith "should be preempted, not return")
+      ; exnc = raise
+      ; tickc = (fun () -> incr count_a; Preempt)
+      ; effc = (fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Preemption -> Some (fun (k : (a, _) continuation) ->
+            preempted_a := true;
+            saved_k := Some k)
+          | Yield -> Some (fun (k : (a, _) continuation) ->
+            incr yields_a;
+            handler_a k)
+          | _ -> None)
+      }
+  in
+  handler_a f;
+  assert !preempted_a;
+  let k = match !saved_k with
+    | Some k -> k
+    | None -> failwith "No continuation saved"
+  in
+  let count_a_at_resume = !count_a in
+  let yields_a_at_resume = !yields_a in
+  let rec handler_b k =
+    Preemptible.continue_with k ()
+      { retc = (fun () -> ())
+      ; exnc = raise
+      ; tickc = (fun () -> incr count_b; Preempt)
+      ; effc = (fun (type a) (eff : a Effect.t) ->
+          match eff with
+          | Preemption -> Some (fun (k : (a, _) continuation) ->
+            preempted_b := true;
+            handler_b k)
+          | Yield -> Some (fun (k : (a, _) continuation) ->
+            incr yields_b;
+            handler_b k)
+          | _ -> None)
+      }
+  in
+  handler_b k;
+  assert !preempted_b;
+  assert (!count_b > 0);
+  assert (!count_a = count_a_at_resume);
+  assert (!yields_a = yields_a_at_resume);
+  assert (yields_a_at_resume = 1);
+  assert (!yields_b = 1);
+  print_endline "OK"
+;;
+
+let () =
+  Domain.Tick.with_ ~interval_usec:1_000 (fun _ ->
+    resume_preemptible_as_nonpreemptible ();
+    resume_nonpreemptible_as_preemptible ();
+    resume_preemptible_with_different_tickc ())
+;;

--- a/testsuite/tests/effects/preemption/shallow_handlers.reference
+++ b/testsuite/tests/effects/preemption/shallow_handlers.reference
@@ -1,0 +1,6 @@
+# Resume preemptible cont as non-preemptible
+OK
+# Resume non-preemptible cont as preemptible
+OK
+# Resume preemptible cont with different on_tick
+OK

--- a/testsuite/tests/effects/preemption/unhandled.ml
+++ b/testsuite/tests/effects/preemption/unhandled.ml
@@ -1,14 +1,12 @@
 (* TEST
-   modules = "preemption_util.ml";
-   include unix;
-   hasunix;
    runtime5;
    poll_insertion;
    flags += "-alert -unsafe_multidomain -w -21";
    { native; }
 *)
 
-open Preemption_util
+open Effect
+open Effect.Deep
 
 let _ = Sys.opaque_identity (Effect.Preemption : unit Effect.t)
 
@@ -26,15 +24,20 @@ let alloc () =
 ;;
 
 let () =
-  with_preemption_setup ~interval:0.001 ~repeating:true (fun () ->
-    let accu = ref [] in
-    for i = 1 to 100_000 do
-      let r = alloc () in
-      accu := r :: !accu;
-      List.iter (fun r ->
-        let (s1, s2, r2) = !r in
-        if not (s1 = "this is a string") then failwith ("s1 = " ^ s1);
-        assert (s2 = "this is another string");
-        assert (!r2 = 42);
-      ) !accu;
-    done)
+  Domain.Tick.with_ ~interval_usec:1_000 (fun _ ->
+    Preemptible.try_with
+      ~on_tick:(fun () -> Preempt)
+      (fun () ->
+        let accu = ref [] in
+        for i = 1 to 100_000 do
+          let r = alloc () in
+          accu := r :: !accu;
+          List.iter (fun r ->
+            let (s1, s2, r2) = !r in
+            if not (s1 = "this is a string") then failwith ("s1 = " ^ s1);
+            assert (s2 = "this is another string");
+            assert (!r2 = 42);
+          ) !accu;
+        done)
+      ()
+      { effc = (fun (type a) (_eff : a Effect.t) -> None) })


### PR DESCRIPTION
based on https://github.com/oxcaml/oxcaml/pull/4881

This PR adds support for "preemptible fibers" to the runtime. These are fibers with an extra "tickc" callback function (which is NULL for all other fibers) which gets called *in reverse order* (from the rootmost fiber first) every time the runtime ticks, and may (or may not) decide to trigger a preemption.

Also, this refactors all the existing tests for preemption to use preemptible fibers rather than an interval timer, and deletes `caml_domain_preempt_self` (which only existed for the sake of testing preemption prior to this PR)

Please review by commits: the commit history has been somewhat carefully crafted to separate out the large, mechanical changes from the especially interesting, high-review-scrutiny changes.