### PR TITLE
Prevent bits8/16 parameters in C calls

### DIFF
--- a/jane/doc/extensions/_11-miscellaneous-extensions/small-numbers.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/small-numbers.md
@@ -139,21 +139,48 @@ operations, and results are sign-extended after every operation. The peephole
 optimizer can remove some unnecessary sign-extensions, but there is still a
 noticeable performance decrease compared to C.
 
-### C ABI
+### C ABI {#small-int-c-abi}
 
-Both tagged and untagged `int8`s and `int16`s may be passed to C stubs.
+Both tagged and untagged `int8`s and `int16`s may be passed to C stubs, though
+parameters of layout `bits8` and `bits16` (such as `int8#`) are banned by
+default. Small int parameters should be sign/zero-extended to 32 bits
+before being passed to C stubs.
 
 ```ocaml
+external sign_extend_int16 : int16# -> int32# = "%int32#_of_int16#"
+external sign_extend_int8 : int8# -> int32# = "%int32#_of_int8#"
+
 external int16_stub : (int16[@unboxed]) -> (int16[@unboxed]) =
   "tagged_int16_stub" "untagged_int16_stub"
 
-external int16_hash_stub : int16# -> int16# =
+external int16_hash_stub : int32# -> int16# =
   "tagged_int16_stub" "untagged_int16_stub"
+
+let int16_hash_stub (x : int16#) : int16# =
+  int16_hash_stub (sign_extend_int16 x)
 
 external int8_stub : (int8[@unboxed]) -> (int8[@unboxed]) =
   "tagged_int8_stub" "untagged_int8_stub"
 
-external int8_hash_stub : int8# -> int8# =
+external int8_hash_stub : int32# -> int8# =
+  "tagged_int8_stub" "untagged_int8_stub"
+
+let int8_hash_stub (x : int8#) : int8# =
+  int8_hash_stub (sign_extend_int8 x)
+```
+
+Parameters of layout `bits8` and `bits16` are banned since Clang expects such
+parameters to be sign/zero-extended to 32 bits. OxCaml's calling convention will
+soon match that of System V and GCC, which treats all the upper bits as garbage.
+If you are absolutely sure your C function does not use the upper bits, you may
+use the `[@unsafe_unextended]` attribute to pass `bits8` and `bits16`
+parameters.
+
+```ocaml
+external int16_hash_stub : (int16#[@unsafe_unextended]) -> int16# =
+  "tagged_int16_stub" "untagged_int16_stub"
+
+external int8_hash_stub : (int8#[@unsafe_unextended]) -> int8# =
   "tagged_int8_stub" "untagged_int8_stub"
 ```
 
@@ -208,7 +235,15 @@ like `int8# array`s.
 
 Untagged chars may be passed to C stubs:
 ```ocaml
-external char_hash_stub : char# -> char# =
+external char_hash_stub : (char[@untagged]) -> char# =
+  "tagged_char_stub" "untagged_char_stub"
+```
+
+For reasons discussed in the [Small Int C ABI](#small-int-c-abi) section,
+`char#` parameters are not recommended, but are possible with
+`[@unsafe_unextended]`:
+```ocaml
+external char_hash_stub : (char#[@unsafe_unextended]) -> char# =
   "tagged_char_stub" "untagged_char_stub"
 ```
 

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -200,6 +200,8 @@ let extern_repr_of_native_repr:
   | Unboxed_float f, _ -> Unboxed_float f
   | Unboxed_or_untagged_integer i, _ -> Unboxed_or_untagged_integer i
   | Unboxed_vector i, _ -> Unboxed_vector i
+  | Unextended_bits8, _ -> Same_as_ocaml_repr Jkind.Sort.Const.bits8
+  | Unextended_bits16, _ -> Same_as_ocaml_repr Jkind.Sort.Const.bits16
   | Unpacked_product sort, _ ->
     (* The product sort is unarized into separate C arguments by
        [unarize_extern_repr] in [closure_conversion.ml]. *)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -112,6 +112,7 @@ let builtin_attrs =
   ; "zero_alloc"
   ; "untagged"
   ; "unpacked"
+  ; "unsafe_unextended"
   ; "poll"
   ; "loop"
   ; "tail_mod_cons"

--- a/testsuite/tests/lib-smallint/test_int16_u.ml
+++ b/testsuite/tests/lib-smallint/test_int16_u.ml
@@ -161,7 +161,8 @@ let () =
   ()
 
 (* test that the value is stored sign-extended in the register *)
-external get_register : Smallint.t -> nativeint = "get_register_bytecode" "get_register"
+external get_register : (Smallint.t[@unsafe_unextended]) -> nativeint
+  = "get_register_bytecode" "get_register"
 
 let () =
   assert (get_register (Smallint.shift_left (Smallint.max_int()) 1) = -2n);

--- a/testsuite/tests/lib-smallint/test_int8_u.ml
+++ b/testsuite/tests/lib-smallint/test_int8_u.ml
@@ -161,7 +161,8 @@ let () =
   ()
 
 (* test that the value is stored sign-extended in the register *)
-external get_register : Smallint.t -> nativeint = "get_register_bytecode" "get_register"
+external get_register : (Smallint.t[@unsafe_unextended]) -> nativeint
+  = "get_register_bytecode" "get_register"
 
 let () =
   assert (get_register (Smallint.shift_left (Smallint.max_int()) 1) = -2n);

--- a/testsuite/tests/typing-layouts-bits16/basics.ml
+++ b/testsuite/tests/typing-layouts-bits16/basics.ml
@@ -399,7 +399,9 @@ val f9_3 : unit -> int16# t_bits16_id = <fun>
    - if using a non-value layout in an external, you must supply separate
      bytecode and native code implementations,
    - [@unboxed] is allowed on unboxed types but has no effect. Same is not
-     true for [@untagged].
+     true for [@untagged]. Since [int16] is not upstream compatible, there is no
+     reason to write [int16#[@unboxed]], and because of [[@unsafe_unextended]],
+     this isn't even possible for C stub parameters.
 *)
 
 external f10_1 : int -> bool -> int16# = "foo";;
@@ -422,7 +424,37 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int16#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : int16# -> bool -> string = "foo" "bar"
+Line 1, characters 17-53:
+1 | external f10_6 : (int16#[@unboxed]) -> bool -> string  = "foo" "bar";;
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: Arguments with layout bits8 or bits16 are not allowed in C stubs
+      except in "[@@builtin]"s. You may also annotate such an argument with
+      "[@unsafe_unextended]" if you are absolutely sure your C stub does not read
+      the garbage upper bits.
+|}];;
+
+external f10_6_1 : (int16#[@unboxed][@unsafe_unextended]) -> unit
+  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 28-35:
+1 | external f10_6_1 : (int16#[@unboxed][@unsafe_unextended]) -> unit
+                                ^^^^^^^
+Error: Too many "[@@unboxed]"/"[@@untagged]"/"[@@unpacked]"/"[@@unsafe_unextended]" attributes
+|}];;
+
+external f10_6_2 : (#(int16# * int)[@unpacked]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 19-65:
+1 | external f10_6_2 : (#(int16# * int)[@unpacked]) -> bool -> string  = "foo" "bar";;
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: Arguments with layout bits8 or bits16 are not allowed in C stubs
+      except in "[@@builtin]"s. You may also annotate such an argument with
+      "[@unsafe_unextended]" if you are absolutely sure your C stub does not read
+      the garbage upper bits.
 |}];;
 
 external f10_7 : string -> (int16#[@unboxed])  = "foo" "bar";;
@@ -451,6 +483,16 @@ Line 1, characters 29-35:
                                  ^^^^^^
 Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
+|}];;
+
+external f10_11 : string -> (int16#[@unsafe_unextended])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 18-56:
+1 | external f10_11 : string -> (int16#[@unsafe_unextended])  = "foo" "bar";;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: The "[@unsafe_unextended]" attribute is not allowed on C stub returns.
 |}];;
 
 (*************************************************)

--- a/testsuite/tests/typing-layouts-bits16/c_api.ml
+++ b/testsuite/tests/typing-layouts-bits16/c_api.ml
@@ -27,15 +27,15 @@ let print_int16u s f = print_int16 s (to_int16 f)
 
 (* Various combinations of arguments int16, int16 [@unboxed], and
    int16# *)
-external lognot_UtoU : int16# -> int16# =
+external lognot_UtoU : (int16#[@unsafe_unextended]) -> int16# =
   "lognot_bytecode" "lognot_UtoU"
 external lognot_BtoU : int16 -> int16# =
   "lognot_bytecode" "lognot_BtoU"
-external lognot_UtoB : int16# -> int16 =
+external lognot_UtoB : (int16#[@unsafe_unextended]) -> int16 =
   "lognot_bytecode" "lognot_UtoB"
 external lognot_BUtoU : (int16[@unboxed]) -> int16# =
   "lognot_bytecode" "lognot_UtoU"
-external lognot_UtoBU : int16# -> (int16[@unboxed]) =
+external lognot_UtoBU : (int16#[@unsafe_unextended]) -> (int16[@unboxed]) =
   "lognot_bytecode" "lognot_UtoU"
 
 let () =
@@ -60,8 +60,8 @@ let () =
 
 (* If there are more than 5 args, you get an array in bytecode *)
 external sum_7 :
-  int16# -> int16 -> int16# -> int16 ->
-  int16# -> int16 -> int16# -> int16# =
+  (int16#[@unsafe_unextended]) -> int16 -> (int16#[@unsafe_unextended]) -> int16 ->
+  (int16#[@unsafe_unextended]) -> int16 -> (int16#[@unsafe_unextended]) -> int16# =
   "sum_7_bytecode" "sum_7_UBUBUBUtoU"
 
 let _ =

--- a/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -459,6 +459,15 @@ Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
+external f10_11 : (int32#[@unsafe_unextended]) -> unit
+  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 19-25:
+1 | external f10_11 : (int32#[@unsafe_unextended]) -> unit
+                       ^^^^^^
+Error: Only types with layout bits8 or bits16 can be marked "unsafe_unextended".
+|}];;
+
 (*************************************************)
 (* Test 11: bits32 banned in extensible variants *)
 

--- a/testsuite/tests/typing-layouts-bits8/basics.ml
+++ b/testsuite/tests/typing-layouts-bits8/basics.ml
@@ -399,7 +399,9 @@ val f9_3 : unit -> int8# t_bits8_id = <fun>
    - if using a non-value layout in an external, you must supply separate
      bytecode and native code implementations,
    - [@unboxed] is allowed on unboxed types but has no effect. Same is not
-     true for [@untagged].
+     true for [@untagged]. Since [int8] is not upstream compatible, there is no
+     reason to write [int8#[@unboxed]], and because of [[@unsafe_unextended]],
+     this isn't even possible for C stub parameters.
 *)
 
 external f10_1 : int -> bool -> int8# = "foo";;
@@ -422,7 +424,37 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int8#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : int8# -> bool -> string = "foo" "bar"
+Line 1, characters 17-52:
+1 | external f10_6 : (int8#[@unboxed]) -> bool -> string  = "foo" "bar";;
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: Arguments with layout bits8 or bits16 are not allowed in C stubs
+      except in "[@@builtin]"s. You may also annotate such an argument with
+      "[@unsafe_unextended]" if you are absolutely sure your C stub does not read
+      the garbage upper bits.
+|}];;
+
+external f10_6_1 : (int8#[@unboxed][@unsafe_unextended]) -> unit
+  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 27-34:
+1 | external f10_6_1 : (int8#[@unboxed][@unsafe_unextended]) -> unit
+                               ^^^^^^^
+Error: Too many "[@@unboxed]"/"[@@untagged]"/"[@@unpacked]"/"[@@unsafe_unextended]" attributes
+|}];;
+
+external f10_6_2 : (#(int8# * int)[@unpacked]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 19-64:
+1 | external f10_6_2 : (#(int8# * int)[@unpacked]) -> bool -> string  = "foo" "bar";;
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: Arguments with layout bits8 or bits16 are not allowed in C stubs
+      except in "[@@builtin]"s. You may also annotate such an argument with
+      "[@unsafe_unextended]" if you are absolutely sure your C stub does not read
+      the garbage upper bits.
 |}];;
 
 external f10_7 : string -> (int8#[@unboxed])  = "foo" "bar";;
@@ -451,6 +483,16 @@ Line 1, characters 29-34:
                                  ^^^^^
 Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
+|}];;
+
+external f10_11 : string -> (int8#[@unsafe_unextended])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 18-55:
+1 | external f10_11 : string -> (int8#[@unsafe_unextended])  = "foo" "bar";;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: The "[@unsafe_unextended]" attribute is not allowed on C stub returns.
 |}];;
 
 (*************************************************)

--- a/testsuite/tests/typing-layouts-bits8/c_api.ml
+++ b/testsuite/tests/typing-layouts-bits8/c_api.ml
@@ -27,15 +27,15 @@ let print_int8u s f = print_int8 s (to_int8 f)
 
 (* Various combinations of arguments int8, int8 [@unboxed], and
    int8# *)
-external lognot_UtoU : int8# -> int8# =
+external lognot_UtoU : (int8#[@unsafe_unextended]) -> int8# =
   "lognot_bytecode" "lognot_UtoU"
 external lognot_BtoU : int8 -> int8# =
   "lognot_bytecode" "lognot_BtoU"
-external lognot_UtoB : int8# -> int8 =
+external lognot_UtoB : (int8#[@unsafe_unextended]) -> int8 =
   "lognot_bytecode" "lognot_UtoB"
 external lognot_BUtoU : (int8[@unboxed]) -> int8# =
   "lognot_bytecode" "lognot_UtoU"
-external lognot_UtoBU : int8# -> (int8[@unboxed]) =
+external lognot_UtoBU : (int8#[@unsafe_unextended]) -> (int8[@unboxed]) =
   "lognot_bytecode" "lognot_UtoU"
 
 let () =
@@ -60,8 +60,8 @@ let () =
 
 (* If there are more than 5 args, you get an array in bytecode *)
 external sum_7 :
-  int8# -> int8 -> int8# -> int8 ->
-  int8# -> int8 -> int8# -> int8# =
+  (int8#[@unsafe_unextended]) -> int8 -> (int8#[@unsafe_unextended]) -> int8 ->
+  (int8#[@unsafe_unextended]) -> int8 -> (int8#[@unsafe_unextended]) -> int8# =
   "sum_7_bytecode" "sum_7_UBUBUBUtoU"
 
 let _ =

--- a/testsuite/tests/typing-layouts-bits8/unboxed_bool_runtime_test.ml
+++ b/testsuite/tests/typing-layouts-bits8/unboxed_bool_runtime_test.ml
@@ -33,8 +33,8 @@ let ocaml_unbox = function
   | false -> #false
   | true -> #true
 
-external c_not : bool# -> bool# = "not_bytecode" "not" 
-external c_box : bool# -> bool = "box_bytecode" "box" 
+external c_not : (bool#[@unsafe_unextended]) -> bool# = "not_bytecode" "not"
+external c_box : (bool#[@unsafe_unextended]) -> bool = "box_bytecode" "box"
 external c_unbox : bool -> bool# = "unbox_bytecode" "unbox" 
 
 (****************************)

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1549,7 +1549,7 @@ external ext_unpack_unboxed :
 Line 2, characters 31-38:
 2 |   (#(int * bool) [@unpacked] [@unboxed]) -> int = "foo" "bar"
                                    ^^^^^^^
-Error: Too many "[@@unboxed]"/"[@@untagged]"/"[@@unpacked]" attributes
+Error: Too many "[@@unboxed]"/"[@@untagged]"/"[@@unpacked]"/"[@@unsafe_unextended]" attributes
 |}]
 
 (***********************************)

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -42,6 +42,8 @@ type native_repr =
   | Unboxed_vector of boxed_vector
   | Unboxed_or_untagged_integer of unboxed_or_untagged_integer
   | Unpacked_product of Jkind_types.Sort.Const.t
+  | Unextended_bits8
+  | Unextended_bits16
 
 type effects = No_effects | Only_generative_effects | Arbitrary_effects
 type coeffects = No_coeffects | Has_coeffects
@@ -73,6 +75,8 @@ type wrong_repr_error =
   | Expected_value_prim
   | Product_return
   | Unpacked_product_return
+  | Unextended_return
+  | Small_int_arg
   | Repr_mismatch
 [@@immediate]
 
@@ -102,7 +106,9 @@ let check_ocaml_value = function
   | _, Unboxed_float _
   | _, Unboxed_vector _
   | _, Unboxed_or_untagged_integer _
-  | _, Unpacked_product _ -> Bad_attribute
+  | _, Unpacked_product _
+  | _, Unextended_bits8
+  | _, Unextended_bits16 -> Bad_attribute
 
 let is_builtin_prim_name name = String.length name > 0 && name.[0] = '%'
 
@@ -257,6 +263,7 @@ let rec add_native_repr_attributes ty attrs =
 let oattr_unboxed = { oattr_name = "unboxed" }
 let oattr_untagged = { oattr_name = "untagged" }
 let oattr_unpacked = { oattr_name = "unpacked" }
+let oattr_unsafe_unextended = { oattr_name = "unsafe_unextended" }
 let oattr_noalloc = { oattr_name = "noalloc" }
 let oattr_builtin = { oattr_name = "builtin" }
 let oattr_no_effects = { oattr_name = "no_effects" }
@@ -286,6 +293,8 @@ let print p osig_val_decl =
     | _, Unboxed_or_untagged_integer (Unboxed_int64 | Unboxed_int32
                                     | Unboxed_nativeint) ->
       true
+    | _, Unextended_bits8
+    | _, Unextended_bits16
     | _, Same_as_ocaml_repr (Base Void) -> false
       (* The [@unboxed] attribute is not supported on void in our compiler
          or the upstream compiler. *)
@@ -306,6 +315,8 @@ let print p osig_val_decl =
     | _, Unboxed_or_untagged_integer (Unboxed_int64 | Unboxed_int32
                                     | Unboxed_nativeint)
     | _, Unpacked_product _
+    | _, Unextended_bits8
+    | _, Unextended_bits16
     | _, Repr_poly -> false
   in
   let all_unboxed = for_all needs_unboxed_attribute in
@@ -352,6 +363,7 @@ let print p osig_val_decl =
                                    | Untagged_int16) ->
        if all_untagged then [] else [oattr_untagged]
      | Unpacked_product _ -> [oattr_unpacked]
+     | Unextended_bits8 | Unextended_bits16 -> [oattr_unsafe_unextended]
      | Same_as_ocaml_repr _->
        if all_unboxed || not (needs_unboxed_attribute (m, repr))
        then []
@@ -431,35 +443,50 @@ let equal_native_repr nr1 nr2 =
   | Repr_poly, Repr_poly -> true
   | Repr_poly, (Unboxed_float _ | Unboxed_or_untagged_integer _
                | Unboxed_vector _ | Same_as_ocaml_repr _
-               | Unpacked_product _)
+               | Unpacked_product _ | Unextended_bits8 | Unextended_bits16)
   | (Unboxed_float _ | Unboxed_or_untagged_integer _
     | Unboxed_vector _ | Same_as_ocaml_repr _
-    | Unpacked_product _), Repr_poly
+    | Unpacked_product _ | Unextended_bits8 | Unextended_bits16), Repr_poly
     -> false
   | Same_as_ocaml_repr s1, Same_as_ocaml_repr s2 ->
     Jkind_types.Sort.Const.equal s1 s2
   | Same_as_ocaml_repr _,
     (Unboxed_float _ | Unboxed_or_untagged_integer _ |
-     Unboxed_vector _ | Unpacked_product _) -> false
+     Unboxed_vector _ | Unpacked_product _ |
+     Unextended_bits8 | Unextended_bits16) -> false
   | Unboxed_float f1, Unboxed_float f2 -> equal_boxed_float f1 f2
   | Unboxed_float _,
     (Same_as_ocaml_repr _ | Unboxed_or_untagged_integer _ |
-     Unboxed_vector _ | Unpacked_product _) -> false
+     Unboxed_vector _ | Unpacked_product _ |
+     Unextended_bits8 | Unextended_bits16) -> false
   | Unboxed_vector vi1, Unboxed_vector vi2 ->
     equal_unboxed_vector_size (unboxed_vector vi1) (unboxed_vector vi2)
   | Unboxed_vector _,
     (Same_as_ocaml_repr _ | Unboxed_float _ |
-     Unboxed_or_untagged_integer _ | Unpacked_product _) -> false
+     Unboxed_or_untagged_integer _ | Unpacked_product _ |
+     Unextended_bits8 | Unextended_bits16) -> false
   | Unboxed_or_untagged_integer bi1, Unboxed_or_untagged_integer bi2 ->
     equal_unboxed_or_untagged_integer bi1 bi2
   | Unboxed_or_untagged_integer _,
     (Same_as_ocaml_repr _ | Unboxed_float _ |
-     Unboxed_vector _ | Unpacked_product _) -> false
+     Unboxed_vector _ | Unpacked_product _ |
+     Unextended_bits8 | Unextended_bits16) -> false
   | Unpacked_product s1, Unpacked_product s2 ->
     Jkind_types.Sort.Const.equal s1 s2
   | Unpacked_product _,
     (Same_as_ocaml_repr _ | Unboxed_float _ |
-     Unboxed_vector _ | Unboxed_or_untagged_integer _) -> false
+     Unboxed_vector _ | Unboxed_or_untagged_integer _ |
+     Unextended_bits8 | Unextended_bits16) -> false
+  | Unextended_bits8, Unextended_bits8 -> true
+  | Unextended_bits8,
+    (Same_as_ocaml_repr _ | Unboxed_float _ |
+     Unboxed_vector _ | Unboxed_or_untagged_integer _ |
+     Unpacked_product _ | Unextended_bits16) -> false
+  | Unextended_bits16, Unextended_bits16 -> true
+  | Unextended_bits16,
+    (Same_as_ocaml_repr _ | Unboxed_float _ |
+     Unboxed_vector _ | Unboxed_or_untagged_integer _ |
+     Unpacked_product _ | Unextended_bits8) -> false
 
 let equal_effects ef1 ef2 =
   match ef1, ef2 with
@@ -502,7 +529,8 @@ module Repr_check = struct
   let value_or_unboxed_or_untagged = function
     | Same_as_ocaml_repr (Base Scannable)
     | Unboxed_float _ | Unboxed_or_untagged_integer _ | Unboxed_vector _ -> true
-    | Same_as_ocaml_repr _ | Repr_poly | Unpacked_product _ -> false
+    | Same_as_ocaml_repr _ | Repr_poly | Unpacked_product _ | Unextended_bits8
+    | Unextended_bits16 -> false
 
   let sort_is_product : Jkind_types.Sort.Const.t -> bool = function
     | Product _ -> true
@@ -510,17 +538,34 @@ module Repr_check = struct
     | Univar _ -> Misc.fatal_error "sort_is_product: univar"
     | Genvar _ -> Misc.fatal_error "sort_is_product: genvar"
 
-  let c_stub_arg_errors = function
+  let rec sort_contains_bits8_or_bits16 : Jkind_types.Sort.Const.t -> bool =
+    function
+    | Product sorts -> List.exists sort_contains_bits8_or_bits16 sorts
+    | Base (Bits8 | Bits16) -> true
+    | Base _ -> false
+    | Univar _ -> Misc.fatal_error "sort_contains_bits8_or_bits16: univar"
+    | Genvar _ -> Misc.fatal_error "sort_contains_bits8_or_bits16: genvar"
+
+  let c_stub_arg_errors ~builtin = function
     | Same_as_ocaml_repr s ->
-      if sort_is_product s then [Product_arg] else []
+      (if sort_is_product s then [Product_arg] else []) @
+      (if not builtin && sort_contains_bits8_or_bits16 s
+       then [Small_int_arg]
+       else [])
+    | Unpacked_product s ->
+      if not builtin && sort_contains_bits8_or_bits16 s
+      then [Small_int_arg]
+      else []
+    | Unextended_bits8 | Unextended_bits16
     | Unboxed_float _ | Unboxed_or_untagged_integer _ | Unboxed_vector _
-    | Unpacked_product _ | Repr_poly -> []
+    | Repr_poly -> []
 
   let c_stub_return_errors = function
     | Same_as_ocaml_repr (Base _)
     | Unboxed_float _ | Unboxed_or_untagged_integer _ | Unboxed_vector _
     | Repr_poly -> []
     | Unpacked_product _ -> [Unpacked_product_return]
+    | Unextended_bits8 | Unextended_bits16 -> [Unextended_return]
     | Same_as_ocaml_repr (Product [s1; s2]) ->
       if (sort_is_product s1) ||
          (sort_is_product s2)
@@ -570,12 +615,13 @@ module Repr_check = struct
             else [Expected_value_prim]))
       prim
 
-  let check_c_stub prim =
+  let check_c_stub ~builtin prim =
     (* C externals are allowed to return a tuple, but may not take products as
        arguments or return products with more than two elements. *)
     let arity = List.length prim.prim_native_repr_args in
     let checks =
-      (List.init arity (fun _ -> c_stub_arg_errors))
+      (List.init arity
+         (fun _ -> c_stub_arg_errors ~builtin))
       @ [c_stub_return_errors]
     in
     check checks prim
@@ -1068,7 +1114,8 @@ let prim_has_valid_reprs ~loc prim =
                        | "%sendcache"
                      |}
                   *)
-                else check_c_stub)
+                else
+                  check_c_stub ~builtin:prim.prim_c_builtin)
   in
   match check prim with
   | Success -> ()
@@ -1173,6 +1220,20 @@ let report_error ppf err =
           "@.@{<hint>Hint@}: @[<v>\
            The %a attribute is not allowed on C stub returns.@]"
           Style.inline_code "[@unpacked]"
+      | Unextended_return ->
+        Format_doc.fprintf ppf
+          "@.@{<hint>Hint@}: @[<v>\
+           The %a attribute is not allowed on C stub returns.@]"
+          Style.inline_code "[@unsafe_unextended]"
+      | Small_int_arg ->
+        Format_doc.fprintf ppf
+          "@.@{<hint>Hint@}: @[<v>\
+           Arguments with layout bits8 or bits16 are not allowed in C stubs@ \
+           except in %as. You may also annotate such an argument with@ \
+           %a if you are absolutely sure your C stub does not read@ \
+           the garbage upper bits.@]"
+          Style.inline_code "[@@builtin]"
+          Style.inline_code "[@unsafe_unextended]"
       | Repr_mismatch -> ()
         (* The error message already says "wrong layout", so a hint here would
            be redundant. *))

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -46,6 +46,8 @@ type native_repr =
   | Unboxed_vector of boxed_vector
   | Unboxed_or_untagged_integer of unboxed_or_untagged_integer
   | Unpacked_product of Jkind_types.Sort.Const.t
+  | Unextended_bits8
+  | Unextended_bits16
 (* CR mshinwell/ccasinghino: should we actually use
    "any_locality_mode Scalar.Integral.Width.t" here rather than defining an
    additional unboxed_or_untagged_integer type? *)
@@ -156,6 +158,8 @@ type wrong_repr_error =
   | Expected_value_prim
   | Product_return
   | Unpacked_product_return
+  | Unextended_return
+  | Small_int_arg
   | Repr_mismatch
 
 type error =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -25,7 +25,7 @@ open Typetexp
 
 module String = Misc.Stdlib.String
 
-type native_repr_kind = Unboxed | Untagged | Unpacked
+type native_repr_kind = Unboxed | Untagged | Unpacked | Unsafe_unextended
 
 type jkind_sort_loc =
   | Cstr_tuple of { unboxed : bool }
@@ -4138,16 +4138,19 @@ let get_native_repr_attribute attrs ~global_repr =
     Attr_helper.get_no_payload_attribute "unboxed"  attrs,
     Attr_helper.get_no_payload_attribute "untagged" attrs,
     Attr_helper.get_no_payload_attribute "unpacked" attrs,
+    Attr_helper.get_no_payload_attribute "unsafe_unextended" attrs,
     global_repr
   with
-  | None, None, None, None -> Native_repr_attr_absent
-  | None, None, None, Some repr -> Native_repr_attr_present repr
-  | Some _, None, None, None -> Native_repr_attr_present Unboxed
-  | None, Some _, None, None -> Native_repr_attr_present Untagged
-  | None, None, Some _, None -> Native_repr_attr_present Unpacked
-  | Some { Location.loc }, _, _, _
-  | _, Some { Location.loc }, _, _
-  | _, _, Some { Location.loc }, _ ->
+  | None, None, None, None, None -> Native_repr_attr_absent
+  | None, None, None, None, Some repr -> Native_repr_attr_present repr
+  | Some _, None, None, None, None -> Native_repr_attr_present Unboxed
+  | None, Some _, None, None, None -> Native_repr_attr_present Untagged
+  | None, None, Some _, None, None -> Native_repr_attr_present Unpacked
+  | None, None, None, Some _, None -> Native_repr_attr_present Unsafe_unextended
+  | Some { Location.loc }, _, _, _, _
+  | _, Some { Location.loc }, _, _, _
+  | _, _, Some { Location.loc }, _, _
+  | _, _, _, Some { Location.loc }, _ ->
     raise (Error (loc, Multiple_native_repr_attributes))
 
 let is_upstream_compatible_non_value_unbox env ty =
@@ -4393,6 +4396,17 @@ let make_native_repr
   | Native_repr_attr_present Unpacked, (Sort (Base _) | Poly) ->
     raise (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type Unpacked))
   | Native_repr_attr_present Unpacked, Sort (Univar _ | Genvar _) ->
+    Misc.fatal_error "typedecl: Univar/Genvar in concrete type"
+  | Native_repr_attr_present Unsafe_unextended, Sort (Base Bits8) ->
+    Unextended_bits8
+  | Native_repr_attr_present Unsafe_unextended, Sort (Base Bits16) ->
+    Unextended_bits16
+  | Native_repr_attr_present Unsafe_unextended,
+    (Poly | Sort (Product _ | Base (Scannable | Void | Bits32 | Bits64 | Word |
+      Untagged_immediate | Float32 | Float64 | Vec128 | Vec256 | Vec512))) ->
+    raise
+      (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type Unsafe_unextended))
+  | Native_repr_attr_present Unsafe_unextended, Sort (Univar _ | Genvar _) ->
     Misc.fatal_error "typedecl: Univar/Genvar in concrete type"
 
 let prim_const_mode m =
@@ -5604,10 +5618,11 @@ let report_error ~loc = function
   | Val_in_structure ->
       Location.errorf ~loc "Value declarations are only allowed in signatures"
   | Multiple_native_repr_attributes ->
-      Location.errorf ~loc "Too many %a/%a/%a attributes"
+      Location.errorf ~loc "Too many %a/%a/%a/%a attributes"
         Style.inline_code "[@@unboxed]"
         Style.inline_code "[@@untagged]"
         Style.inline_code "[@@unpacked]"
+        Style.inline_code "[@@unsafe_unextended]"
   | Cannot_unbox_or_untag_type Unboxed ->
       Location.errorf ~loc
         "Don't know how to unbox this type.@ \
@@ -5629,6 +5644,10 @@ let report_error ~loc = function
         "Don't know how to unpack this type.@ \
          Only types with product layouts can be marked %a."
         Style.inline_code "unpacked"
+  | Cannot_unbox_or_untag_type Unsafe_unextended ->
+      Location.errorf ~loc
+        "@[Only types with layout bits8 or bits16 can be marked %a.@]"
+        Style.inline_code "unsafe_unextended"
   | Deep_unbox_or_untag_attribute kind ->
       Location.errorf ~loc
         "The attribute %a should be attached to@ \
@@ -5638,7 +5657,8 @@ let report_error ~loc = function
         (match kind with
          | Unboxed -> "@unboxed"
          | Untagged -> "@untagged"
-         | Unpacked -> "@unpacked")
+         | Unpacked -> "@unpacked"
+         | Unsafe_unextended -> "@unsafe_unextended")
   | Jkind_mismatch_of_path (env, dpath, v) ->
     (* the type is always printed just above, so print out just the head of the
        path instead of something like [t/3] *)

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -120,7 +120,7 @@ val update_record_representation:
 val mixed_block_element :
     Env.t -> type_expr -> _ jkind -> mixed_block_element option
 
-type native_repr_kind = Unboxed | Untagged | Unpacked
+type native_repr_kind = Unboxed | Untagged | Unpacked | Unsafe_unextended
 
 (* Records reason for a jkind representability requirement in errors. *)
 type jkind_sort_loc =


### PR DESCRIPTION
Exceptions are `[@@builtin]`s and parameters tagged with `[@unsafe_unextended]`. This restriction does not apply to, e.g. `(int16[@unboxed])`, since tagged integers are sign-extended instead of having garbage in their upper bits. It is not possible to put `[@unsafe_unextended]` on a component of an unpacked product.

The following is tested:

  - `[@unsafe_unextended]` does allow bits8/16 parameters
  - `[@@builtin]`s don't require `[@unsafe_unextended]` (see `oxcaml/tests/simd/scalar_ops.ml`)
  - Error for a bits8/16 parameter is not annotated with `[@unsafe_unextended]`
  - Error for a bits8/16 parameter in a product
  - Error for a return annotated with `[@unsafe_unextended]`
  - Error for `[@unsafe_unextended]` on a non-bits8/16 layout errors

Docs have been updated.

This change is implemented using `Repr_check.sort_contains_bits8_or_bits16` in `typing/primitives.ml`, which is used to check `native_repr`s of the form `Same_as_ocaml_repr s`. The check is not done for `[@@builtin]`s, and `native_repr` is extended with the constructors `Unextended_bits8` and `Unextended_bits16` to bypass the check for `int8/16#[@unsafe_unextended]`.

Previously, parameters like `(int8#[@unboxed])` were allowed, but there wasn't any reason to use `[@unboxed]` since `int8` is not upstream-compatible. Now, such parameters require `[@unsafe_unextended]`, but to simplify the implementation, we don't allow `(int8#[@unboxed][@unsafe_unextended])`.
