### PR TITLE
Simplify: count size of lifted constants when doing speculative inlining

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -1007,6 +1007,26 @@ let mk_no_flambda2_speculative_inlining_only_if_arguments_useful f =
          Flambda2.Inlining.Default.speculative_inlining_only_if_arguments_useful)
   )
 
+let mk_flambda2_speculative_inlining_track_lifted_constants f =
+  ( "-flambda2-speculative-inlining-track-lifted-constants",
+    Arg.Unit f,
+    Printf.sprintf
+      " Track the size of lifted constants when doing speculative inlining%s\n\
+      \    (Flambda 2 only)"
+      (format_default
+         Flambda2.Inlining.Default.speculative_inlining_track_lifted_constants)
+  )
+
+let mk_no_flambda2_speculative_inlining_track_lifted_constants f =
+  ( "-no-flambda2-speculative-inlining-track-lifted-constants",
+    Arg.Unit f,
+    Printf.sprintf
+      " Do not track the size of lifted constants when doing speculative\n\
+      \    inlining%s (Flambda 2 only)"
+      (format_not_default
+         Flambda2.Inlining.Default.speculative_inlining_track_lifted_constants)
+  )
+
 let mk_flambda2_inlining_report_bin f =
   ( "-flambda2-inlining-report-bin",
     Arg.Unit f,
@@ -1366,6 +1386,8 @@ module type Oxcaml_options = sig
   val flambda2_inline_threshold : string -> unit
   val flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
   val no_flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
+  val flambda2_speculative_inlining_track_lifted_constants : unit -> unit
+  val no_flambda2_speculative_inlining_track_lifted_constants : unit -> unit
   val flambda2_inlining_report_bin : unit -> unit
   val flambda2_unicode : unit -> unit
   val flambda2_kind_checks : unit -> unit
@@ -1573,6 +1595,10 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.flambda2_speculative_inlining_only_if_arguments_useful;
       mk_no_flambda2_speculative_inlining_only_if_arguments_useful
         F.no_flambda2_speculative_inlining_only_if_arguments_useful;
+      mk_flambda2_speculative_inlining_track_lifted_constants
+        F.flambda2_speculative_inlining_track_lifted_constants;
+      mk_no_flambda2_speculative_inlining_track_lifted_constants
+        F.no_flambda2_speculative_inlining_track_lifted_constants;
       mk_flambda2_inlining_report_bin F.flambda2_inlining_report_bin;
       mk_flambda2_unicode F.flambda2_unicode;
       mk_flambda2_kind_checks F.flambda2_kind_checks;
@@ -2001,6 +2027,12 @@ module Oxcaml_options_impl = struct
 
   let no_flambda2_speculative_inlining_only_if_arguments_useful =
     clear' Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
+
+  let flambda2_speculative_inlining_track_lifted_constants =
+    set' Flambda2.Inlining.speculative_inlining_track_lifted_constants
+
+  let no_flambda2_speculative_inlining_track_lifted_constants =
+    clear' Flambda2.Inlining.speculative_inlining_track_lifted_constants
 
   let flambda2_inlining_report_bin = set' Flambda2.Inlining.report_bin
   let flambda2_unicode = set Flambda2.unicode
@@ -2453,6 +2485,8 @@ module Extra_params = struct
         true
     | "flambda2-speculative-inlining-only-if-arguments-useful" ->
         set' Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
+    | "flambda2-speculative-inlining-track-lifted-constants" ->
+        set' Flambda2.Inlining.speculative_inlining_track_lifted_constants
     | "flambda2-inlining-report-bin" -> set' Flambda2.Inlining.report_bin
     | "flambda2-expert-fallback-inlining-heuristic" ->
         set Flambda2.Expert.fallback_inlining_heuristic

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -174,6 +174,8 @@ module type Oxcaml_options = sig
   val flambda2_inline_threshold : string -> unit
   val flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
   val no_flambda2_speculative_inlining_only_if_arguments_useful : unit -> unit
+  val flambda2_speculative_inlining_track_lifted_constants : unit -> unit
+  val no_flambda2_speculative_inlining_track_lifted_constants : unit -> unit
   val flambda2_inlining_report_bin : unit -> unit
   val flambda2_unicode : unit -> unit
   val flambda2_kind_checks : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -407,6 +407,8 @@ module Flambda2 = struct
       }
 
       let speculative_inlining_only_if_arguments_useful = true
+
+      let speculative_inlining_track_lifted_constants = false
     end
 
     let max_depth = ref (I.default Default.default_arguments.max_depth)
@@ -435,6 +437,9 @@ module Flambda2 = struct
 
     let speculative_inlining_only_if_arguments_useful =
       ref Default.speculative_inlining_only_if_arguments_useful
+
+    let speculative_inlining_track_lifted_constants =
+      ref Default.speculative_inlining_track_lifted_constants
 
     let report_bin = ref false
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -288,6 +288,7 @@ module Flambda2 : sig
     module Default : sig
       val default_arguments : inlining_arguments
       val speculative_inlining_only_if_arguments_useful : bool
+      val speculative_inlining_track_lifted_constants : bool
     end
 
     val oclassic_arguments : inlining_arguments
@@ -313,6 +314,8 @@ module Flambda2 : sig
     val threshold : Clflags.Float_arg_helper.parsed ref
 
     val speculative_inlining_only_if_arguments_useful : bool ref
+
+    val speculative_inlining_track_lifted_constants : bool ref
 
     val report_bin : bool ref
   end

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -288,7 +288,12 @@ let create_let_symbol0 uacc (bound_static : Bound_static.t)
   expr, uacc
 
 let remove_unused_value_slots uacc static_const =
-  Rebuilt_static_const.map_set_of_closures static_const
+  let find_code_metadata code_id =
+    let dacc = UA.creation_dacc uacc in
+    let env = DA.denv dacc in
+    Downwards_env.find_code_exn env code_id |> Code_or_metadata.code_metadata
+  in
+  Rebuilt_static_const.map_set_of_closures static_const ~find_code_metadata
     ~f:(fun set_of_closures ->
       let name_occurrences = UA.used_value_slots uacc in
       let value_slots =

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -123,7 +123,22 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
         in
         rebuild uacc ~after_rebuild:(fun expr uacc -> expr, uacc))
   in
-  UA.cost_metrics uacc
+  let cost_metrics_of_lifted_constants =
+    if Flambda_features.Inlining.speculative_inlining_track_lifted_constants ()
+    then
+      let lifted_constants = UA.lifted_constants uacc in
+      Lifted_constant_state.fold lifted_constants ~init:Cost_metrics.zero
+        ~f:(fun cost_metrics lifted_constant ->
+          List.fold_left
+            (fun cost_metrics definition ->
+              Cost_metrics.( + ) cost_metrics
+                (Rebuilt_static_const.cost_metrics
+                   (Lifted_constant.Definition.defining_expr definition)))
+            cost_metrics
+            (Lifted_constant.definitions lifted_constant))
+    else Cost_metrics.zero
+  in
+  Cost_metrics.( + ) (UA.cost_metrics uacc) cost_metrics_of_lifted_constants
 
 let argument_types_useful dacc apply =
   if

--- a/middle_end/flambda2/simplify/lifting/reification.ml
+++ b/middle_end/flambda2/simplify/lifting/reification.ml
@@ -34,6 +34,7 @@ let create_static_const dacc dbg (to_lift : T.to_lift) : RSC.t =
         Simple.With_debuginfo.create field dbg)
   in
   let art = DA.are_rebuilding_terms dacc in
+  let machine_width = DE.machine_width (DA.denv dacc) in
   match to_lift with
   | Immutable_block { tag; is_unique; shape; fields } ->
     let fields = convert_fields fields in
@@ -41,14 +42,14 @@ let create_static_const dacc dbg (to_lift : T.to_lift) : RSC.t =
       if is_unique then Immutable_unique else Immutable
     in
     RSC.create_block art tag mut shape ~fields
-  | Boxed_float32 f -> RSC.create_boxed_float32 art (Const f)
-  | Boxed_float f -> RSC.create_boxed_float art (Const f)
-  | Boxed_int32 i -> RSC.create_boxed_int32 art (Const i)
-  | Boxed_int64 i -> RSC.create_boxed_int64 art (Const i)
-  | Boxed_nativeint i -> RSC.create_boxed_nativeint art (Const i)
-  | Boxed_vec128 v -> RSC.create_boxed_vec128 art (Const v)
-  | Boxed_vec256 v -> RSC.create_boxed_vec256 art (Const v)
-  | Boxed_vec512 v -> RSC.create_boxed_vec512 art (Const v)
+  | Boxed_float32 f -> RSC.create_boxed_float32 art ~machine_width (Const f)
+  | Boxed_float f -> RSC.create_boxed_float art ~machine_width (Const f)
+  | Boxed_int32 i -> RSC.create_boxed_int32 art ~machine_width (Const i)
+  | Boxed_int64 i -> RSC.create_boxed_int64 art ~machine_width (Const i)
+  | Boxed_nativeint i -> RSC.create_boxed_nativeint art ~machine_width (Const i)
+  | Boxed_vec128 v -> RSC.create_boxed_vec128 art ~machine_width (Const v)
+  | Boxed_vec256 v -> RSC.create_boxed_vec256 art ~machine_width (Const v)
+  | Boxed_vec512 v -> RSC.create_boxed_vec512 art ~machine_width (Const v)
   | Immutable_float32_array { fields } ->
     let fields = List.map (fun f -> Or_variable.Const f) fields in
     RSC.create_immutable_float32_array art fields

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -18,13 +18,22 @@ open! Flambda
 module ART = Are_rebuilding_terms
 module SC = Static_const
 
+(* The cost metrics for sets of closures do *not* include the code size of their
+   code_ids, as it will be counted in the lifted [Code] as well. *)
 type t =
   | Normal of
       { const : Static_const_or_code.t;
-        free_names : Name_occurrences.t
+        free_names : Name_occurrences.t;
+        cost_metrics : Cost_metrics.t
       }
-  | Block_not_rebuilt of { free_names : Name_occurrences.t }
-  | Set_of_closures_not_rebuilt of { free_names : Name_occurrences.t }
+  | Block_not_rebuilt of
+      { free_names : Name_occurrences.t;
+        cost_metrics : Cost_metrics.t
+      }
+  | Set_of_closures_not_rebuilt of
+      { free_names : Name_occurrences.t;
+        cost_metrics : Cost_metrics.t
+      }
   | Code_not_rebuilt of Non_constructed_code.t
 
 type rebuilt_static_const = t
@@ -47,10 +56,19 @@ let is_code t =
   | Code_not_rebuilt _ -> true
   | Set_of_closures_not_rebuilt _ | Block_not_rebuilt _ -> false
 
-let create_normal_non_code const =
+let cost_metrics t =
+  match t with
+  | Normal { cost_metrics; _ }
+  | Block_not_rebuilt { cost_metrics; _ }
+  | Set_of_closures_not_rebuilt { cost_metrics; _ } ->
+    cost_metrics
+  | Code_not_rebuilt code -> Non_constructed_code.cost_metrics code
+
+let create_normal_non_code ~cost_metrics const =
   Normal
     { const = Static_const_or_code.create_static_const const;
-      free_names = Static_const.free_names const
+      free_names = Static_const.free_names const;
+      cost_metrics
     }
 
 let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
@@ -73,17 +91,19 @@ let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
         in
         ( Normal
             { const = Static_const_or_code.create_code code;
-              free_names = Code.free_names code
+              free_names = Code.free_names code;
+              cost_metrics = Code_metadata.cost_metrics code_metadata
             },
           Some code ))
 
 let create_code' code =
   Normal
     { const = Static_const_or_code.create_code code;
-      free_names = Code.free_names code
+      free_names = Code.free_names code;
+      cost_metrics = Code.cost_metrics code
     }
 
-let create_set_of_closures are_rebuilding set =
+let create_set_of_closures are_rebuilding ~find_code_metadata set =
   (* Even if the set of closures was locally allocated, this allocation is
      global. This will not cause leaks, as lifted constants are static and
      therefore only allocated once. *)
@@ -94,13 +114,24 @@ let create_set_of_closures are_rebuilding set =
       (Set_of_closures.function_decls set)
   in
   let free_names = Set_of_closures.free_names set in
+  let cost_metrics =
+    Cost_metrics.set_of_closures
+      ~find_code_characteristics:(fun code_id ->
+        { cost_metrics = Cost_metrics.zero;
+          params_arity =
+            Flambda_arity.num_params
+              (Code_metadata.params_arity (find_code_metadata code_id))
+        })
+      set
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Set_of_closures_not_rebuilt { free_names }
+  then Set_of_closures_not_rebuilt { free_names; cost_metrics }
   else
     Normal
       { const =
           Static_const_or_code.create_static_const (SC.set_of_closures set);
-        free_names
+        free_names;
+        cost_metrics
       }
 
 let free_names_of_fields fields =
@@ -109,53 +140,100 @@ let free_names_of_fields fields =
       Name_occurrences.union free_names (Simple.With_debuginfo.free_names field))
 
 let create_block are_rebuilding tag is_mutable shape ~fields =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.block (List.length fields))
+  in
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let free_names = free_names_of_fields fields in
-    Block_not_rebuilt { free_names }
-  else create_normal_non_code (SC.block tag is_mutable shape fields)
+    Block_not_rebuilt { free_names; cost_metrics }
+  else
+    create_normal_non_code ~cost_metrics (SC.block tag is_mutable shape fields)
 
-let create_boxed_float32 are_rebuilding or_var =
+let create_boxed_float32 are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_float32)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_float32 or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_float32 or_var)
 
-let create_boxed_float are_rebuilding or_var =
+let create_boxed_float are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_float)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_float or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_float or_var)
 
-let create_boxed_int32 are_rebuilding or_var =
+let create_boxed_int32 are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_int32)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_int32 or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_int32 or_var)
 
-let create_boxed_int64 are_rebuilding or_var =
+let create_boxed_int64 are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_int64)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_int64 or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_int64 or_var)
 
-let create_boxed_nativeint are_rebuilding or_var =
+let create_boxed_nativeint are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_nativeint)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_nativeint or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_nativeint or_var)
 
-let create_boxed_vec128 are_rebuilding or_var =
+let create_boxed_vec128 are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_vec128)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_vec128 or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_vec128 or_var)
 
-let create_boxed_vec256 are_rebuilding or_var =
+let create_boxed_vec256 are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_vec256)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_vec256 or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_vec256 or_var)
 
-let create_boxed_vec512 are_rebuilding or_var =
+let create_boxed_vec512 are_rebuilding ~machine_width or_var =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.box_number ~machine_width Naked_vec512)
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
-  else create_normal_non_code (SC.boxed_vec512 or_var)
+  then
+    Block_not_rebuilt
+      { free_names = Or_variable.free_names or_var; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.boxed_vec512 or_var)
 
 let create_immutable_float_block are_rebuilding fields =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.array (List.length fields))
+  in
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let free_names =
@@ -163,10 +241,13 @@ let create_immutable_float_block are_rebuilding fields =
         ~f:(fun free_names field ->
           Name_occurrences.union free_names (Or_variable.free_names field))
     in
-    Block_not_rebuilt { free_names }
-  else create_normal_non_code (SC.immutable_float_block fields)
+    Block_not_rebuilt { free_names; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.immutable_float_block fields)
 
 let create_immutable_naked_number_array builder are_rebuilding fields =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.array (List.length fields))
+  in
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let free_names =
@@ -174,8 +255,8 @@ let create_immutable_naked_number_array builder are_rebuilding fields =
         ~f:(fun free_names field ->
           Name_occurrences.union free_names (Or_variable.free_names field))
     in
-    Block_not_rebuilt { free_names }
-  else create_normal_non_code (builder fields)
+    Block_not_rebuilt { free_names; cost_metrics }
+  else create_normal_non_code ~cost_metrics (builder fields)
 
 let create_immutable_float_array =
   create_immutable_naked_number_array SC.immutable_float_array
@@ -211,28 +292,38 @@ let create_immutable_vec512_array =
   create_immutable_naked_number_array SC.immutable_vec512_array
 
 let create_immutable_value_array are_rebuilding fields =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.array (List.length fields))
+  in
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let free_names = free_names_of_fields fields in
-    Block_not_rebuilt { free_names }
-  else create_normal_non_code (SC.immutable_value_array fields)
+    Block_not_rebuilt { free_names; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.immutable_value_array fields)
 
 let create_empty_array are_rebuilding array_kind =
+  let cost_metrics = Cost_metrics.from_size (Code_size.array 0) in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Name_occurrences.empty }
-  else create_normal_non_code (SC.empty_array array_kind)
+  then Block_not_rebuilt { free_names = Name_occurrences.empty; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.empty_array array_kind)
 
 let create_mutable_string are_rebuilding ~initial_value =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.of_int (String.length initial_value))
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Name_occurrences.empty }
-  else create_normal_non_code (SC.mutable_string ~initial_value)
+  then Block_not_rebuilt { free_names = Name_occurrences.empty; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.mutable_string ~initial_value)
 
 let create_immutable_string are_rebuilding str =
+  let cost_metrics =
+    Cost_metrics.from_size (Code_size.of_int (String.length str))
+  in
   if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Name_occurrences.empty }
-  else create_normal_non_code (SC.immutable_string str)
+  then Block_not_rebuilt { free_names = Name_occurrences.empty; cost_metrics }
+  else create_normal_non_code ~cost_metrics (SC.immutable_string str)
 
-let map_set_of_closures t ~f =
+let map_set_of_closures t ~find_code_metadata ~f =
   match t with
   | Normal { const; _ } -> (
     match const with
@@ -241,11 +332,22 @@ let map_set_of_closures t ~f =
       match const with
       | Set_of_closures set_of_closures ->
         let set_of_closures = f set_of_closures in
+        let cost_metrics =
+          Cost_metrics.set_of_closures
+            ~find_code_characteristics:(fun code_id ->
+              { cost_metrics = Cost_metrics.zero;
+                params_arity =
+                  Flambda_arity.num_params
+                    (Code_metadata.params_arity (find_code_metadata code_id))
+              })
+            set_of_closures
+        in
         Normal
           { const =
               Static_const_or_code.create_static_const
                 (SC.set_of_closures set_of_closures);
-            free_names = Set_of_closures.free_names set_of_closures
+            free_names = Set_of_closures.free_names set_of_closures;
+            cost_metrics
           }
       | Block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
       | Boxed_int64 _ | Boxed_vec128 _ | Boxed_vec256 _ | Boxed_vec512 _
@@ -264,8 +366,8 @@ let map_set_of_closures t ~f =
 let free_names t =
   match t with
   | Normal { free_names; _ } -> free_names
-  | Block_not_rebuilt { free_names }
-  | Set_of_closures_not_rebuilt { free_names } ->
+  | Block_not_rebuilt { free_names; _ }
+  | Set_of_closures_not_rebuilt { free_names; _ } ->
     free_names
   | Code_not_rebuilt code -> Non_constructed_code.free_names code
 
@@ -280,9 +382,9 @@ let to_const t =
 let [@ocamlformat "disable"] print ppf t =
   match t with
   | Normal { const; _ } -> Static_const_or_code.print ppf const
-  | Block_not_rebuilt { free_names = _; } ->
+  | Block_not_rebuilt { free_names = _; cost_metrics = _ } ->
     Format.fprintf ppf "Block_not_rebuilt"
-  | Set_of_closures_not_rebuilt { free_names = _; } ->
+  | Set_of_closures_not_rebuilt { free_names = _; cost_metrics = _} ->
     Format.fprintf ppf "Set_of_closures_not_rebuilt"
   | Code_not_rebuilt code ->
     Format.fprintf ppf "@[<hov 1>(Code_not_rebuilt@ %a)@]"
@@ -291,7 +393,8 @@ let [@ocamlformat "disable"] print ppf t =
 let deleted_code =
   Normal
     { const = Static_const_or_code.deleted_code;
-      free_names = Name_occurrences.empty
+      free_names = Name_occurrences.empty;
+      cost_metrics = Cost_metrics.zero
     }
 
 let make_code_deleted t ~if_code_id_is_member_of =

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -26,6 +26,8 @@ type rebuilt_static_const = t
 
 val print : Format.formatter -> t -> unit
 
+val cost_metrics : t -> Cost_metrics.t
+
 val create_code :
   Are_rebuilding_terms.t ->
   params_and_body:Rebuilt_expr.Function_params_and_body.t ->
@@ -38,7 +40,11 @@ val create_code :
    values are not constructed unnecessarily. *)
 val create_code' : Code.t -> t
 
-val create_set_of_closures : Are_rebuilding_terms.t -> Set_of_closures.t -> t
+val create_set_of_closures :
+  Are_rebuilding_terms.t ->
+  find_code_metadata:(Code_id.t -> Code_metadata.t) ->
+  Set_of_closures.t ->
+  t
 
 val create_block :
   Are_rebuilding_terms.t ->
@@ -50,29 +56,51 @@ val create_block :
 
 val create_boxed_float32 :
   Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
   Numeric_types.Float32_by_bit_pattern.t Or_variable.t ->
   t
 
 val create_boxed_float :
   Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
   Numeric_types.Float_by_bit_pattern.t Or_variable.t ->
   t
 
-val create_boxed_int32 : Are_rebuilding_terms.t -> Int32.t Or_variable.t -> t
+val create_boxed_int32 :
+  Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Int32.t Or_variable.t ->
+  t
 
-val create_boxed_int64 : Are_rebuilding_terms.t -> Int64.t Or_variable.t -> t
+val create_boxed_int64 :
+  Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Int64.t Or_variable.t ->
+  t
 
 val create_boxed_nativeint :
-  Are_rebuilding_terms.t -> Targetint_32_64.t Or_variable.t -> t
+  Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Targetint_32_64.t Or_variable.t ->
+  t
 
 val create_boxed_vec128 :
-  Are_rebuilding_terms.t -> Vector_types.Vec128.Bit_pattern.t Or_variable.t -> t
+  Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Vector_types.Vec128.Bit_pattern.t Or_variable.t ->
+  t
 
 val create_boxed_vec256 :
-  Are_rebuilding_terms.t -> Vector_types.Vec256.Bit_pattern.t Or_variable.t -> t
+  Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Vector_types.Vec256.Bit_pattern.t Or_variable.t ->
+  t
 
 val create_boxed_vec512 :
-  Are_rebuilding_terms.t -> Vector_types.Vec512.Bit_pattern.t Or_variable.t -> t
+  Are_rebuilding_terms.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Vector_types.Vec512.Bit_pattern.t Or_variable.t ->
+  t
 
 val create_immutable_float_block :
   Are_rebuilding_terms.t ->
@@ -131,7 +159,11 @@ val create_mutable_string : Are_rebuilding_terms.t -> initial_value:string -> t
 
 val create_immutable_string : Are_rebuilding_terms.t -> string -> t
 
-val map_set_of_closures : t -> f:(Set_of_closures.t -> Set_of_closures.t) -> t
+val map_set_of_closures :
+  t ->
+  find_code_metadata:(Code_id.t -> Code_metadata.t) ->
+  f:(Set_of_closures.t -> Set_of_closures.t) ->
+  t
 
 val free_names : t -> Name_occurrences.t
 

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -746,12 +746,16 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
         symbol, typ)
       closure_symbols
   in
+  let find_code_metadata code_id =
+    let env = DA.denv dacc in
+    DE.find_code_exn env code_id |> Code_or_metadata.code_metadata
+  in
   let set_of_closures_lifted_constant =
     LC.create_set_of_closures denv ~closure_symbols_with_types
       ~symbol_projections
       (Rebuilt_static_const.create_set_of_closures
          (DE.are_rebuilding_terms denv)
-         set_of_closures)
+         ~find_code_metadata set_of_closures)
   in
   let dacc =
     DA.add_to_lifted_constant_accumulator ~also_add_to_env:() dacc
@@ -1015,13 +1019,17 @@ let simplify_lifted_set_of_closures0 dacc context ~closure_symbols
     simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
       ~closure_bound_names_inside ~value_slots ~value_slot_types
   in
+  let find_code_metadata code_id =
+    let env = DA.denv dacc in
+    Downwards_env.find_code_exn env code_id |> Code_or_metadata.code_metadata
+  in
   let set_of_closures_pattern =
     Bound_static.Pattern.set_of_closures closure_symbols
   in
   let set_of_closures_static_const =
     Rebuilt_static_const.create_set_of_closures
       (DA.are_rebuilding_terms dacc)
-      set_of_closures
+      ~find_code_metadata set_of_closures
   in
   let dacc =
     DA.map_denv dacc

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -115,6 +115,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_float32
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_float or_var ->
@@ -126,6 +127,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_float
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_int32 or_var ->
@@ -137,6 +139,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_int32
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_int64 or_var ->
@@ -148,6 +151,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_int64
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_nativeint or_var ->
@@ -159,6 +163,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_nativeint
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_vec128 or_var ->
@@ -170,6 +175,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_vec128
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_vec256 or_var ->
@@ -181,6 +187,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_vec256
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Boxed_vec512 or_var ->
@@ -192,6 +199,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_vec512
         (DA.are_rebuilding_terms dacc)
+        ~machine_width:(DE.machine_width (DA.denv dacc))
         or_var,
       dacc )
   | Immutable_float_block fields ->

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -500,15 +500,18 @@ let quaternary_prim_size prim =
   | Atomic_compare_exchange_field { atomic_kind = _; args_kind = Any_value } ->
     does_not_need_caml_c_call_extcall_size
 
+let block num_fields = alloc_size + num_fields
+
+let array num_fields = alloc_size + num_fields
+
 let variadic_prim_size prim args =
   match (prim : Flambda_primitive.variadic_primitive) with
   | Begin_region { ghost } -> if ghost then 0 else 1
   | Begin_try_region { ghost } -> if ghost then 0 else 1
-  | Make_block (_, _mut, _alloc_mode)
+  | Make_block (_, _mut, _alloc_mode) -> block (List.length args)
   (* CR mshinwell: I think Make_array for a generic array ("Anything") is more
      expensive than the other cases *)
-  | Make_array (_, _mut, _alloc_mode) ->
-    alloc_size + List.length args
+  | Make_array (_, _mut, _alloc_mode) -> array (List.length args)
 
 let prim ~machine_width (prim : Flambda_primitive.t) =
   match prim with

--- a/middle_end/flambda2/terms/code_size.mli
+++ b/middle_end/flambda2/terms/code_size.mli
@@ -38,6 +38,15 @@ val equal : t -> t -> bool
 
 val print : Format.formatter -> t -> unit
 
+val box_number :
+  machine_width:Target_system.Machine_width.t ->
+  Flambda_kind.Boxable_number.t ->
+  t
+
+val block : int -> t
+
+val array : int -> t
+
 val prim :
   machine_width:Target_system.Machine_width.t -> Flambda_primitive.t -> t
 

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -269,6 +269,9 @@ module Inlining = struct
   let speculative_inlining_only_if_arguments_useful () =
     !Oxcaml_flags.Flambda2.Inlining
      .speculative_inlining_only_if_arguments_useful
+
+  let speculative_inlining_track_lifted_constants () =
+    !Oxcaml_flags.Flambda2.Inlining.speculative_inlining_track_lifted_constants
 end
 
 module Debug = struct

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -159,6 +159,8 @@ module Inlining : sig
   val threshold : round_or_default -> float
 
   val speculative_inlining_only_if_arguments_useful : unit -> bool
+
+  val speculative_inlining_track_lifted_constants : unit -> bool
 end
 
 module Debug : sig


### PR DESCRIPTION
Speculative inlining sometimes thinks that inlining a function caused the code_size to decrease largely, because it could lift a lot of code, which is not included in the code_size of the simplified code. This patch makes it could the size of the lifted constants as well when computing the size of the speculatively inlined version, so that we do not speculatively inline when the gains are simply lifting some code but otherwise small.