### PR TITLE
Fix pr5985.ml

### DIFF
--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -67,7 +67,7 @@ Line 1, characters 0-37:
 1 | type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the GADT constructor
-         "A : 'a -> [< `X of 'a ] t"
+         "A : 'a -> [< `X of 'a ] t/2"
        the type variable "'a" cannot be deduced from the type parameters.
 |}];;
 
@@ -103,7 +103,7 @@ Line 3, characters 2-29:
 3 |   type _ t = T : 'a -> 'a s t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the GADT constructor
-         "T : 'a -> 'a s t"
+         "T : 'a -> 'a s t/2"
        the type variable "'a" cannot be deduced from the type parameters.
 |}];;
 (* Otherwise we can write the following *)

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -67,7 +67,7 @@ Line 1, characters 0-37:
 1 | type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the GADT constructor
-         "A : 'a -> [< `X of 'a ] t/2"
+         "A : 'a -> [< `X of 'a ] t"
        the type variable "'a" cannot be deduced from the type parameters.
 |}];;
 
@@ -103,7 +103,7 @@ Line 3, characters 2-29:
 3 |   type _ t = T : 'a -> 'a s t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the GADT constructor
-         "T : 'a -> 'a s t/2"
+         "T : 'a -> 'a s t"
        the type variable "'a" cannot be deduced from the type parameters.
 |}];;
 (* Otherwise we can write the following *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4616,6 +4616,12 @@ let variance_error ~loc ~v1 ~v2 =
   let open Typedecl_variance in
   function
   | Variance_variable_error { error; variable; context } ->
+      (* CR dkalinichenko: OxCaml changes the [Ident_names] map from
+         stateless to stateful. Normally, it would be reset by
+         [Printtyp.wrap_printing_env], but [Variance_variable_error]
+         lacks the [env]. Therefore, we clear [Ident_names] manually.
+         It'd be good to come up with a better solution. *)
+      Out_type.Ident_names.reset ();
       Out_type.prepare_for_printing [ variable ];
       let intro = variance_context context in
       Location.errorf ~loc "%a%t" pp_doc intro


### PR DESCRIPTION
Fix the test pr5985.ml by calling `Out_type.Ident_names.reset ();` before printing. Before the merge, we called `Printtyp.Naming_context.reset ()`.