### PR TITLE
[5.4] Fix `test_untypeast.ml`

### DIFF
--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -131,24 +131,6 @@ let (foo : 'a -> 'a) = ( (fun x -> x : 'a -> 'a)) in foo
 - : unit = ()
 |}];;
 
-(***********************************)
-(* Untypeast/pprintast correctly handle value binding type annotations. *)
-
-run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |}
-
-[%%expect{|
-let foo : 'a . 'a -> 'a = fun x -> x in foo
-- : unit = ()
-|}];;
-
-run {| let foo : type a . a -> a = fun x -> x in foo |}
-
-[%%expect{|
-let foo : 'a . 'a -> 'a = fun (type a) -> (fun x -> x : a -> a) in foo
-- : unit = ()
-|}]
-
-
 let run s =
   let pe = Parse.implementation (Lexing.from_string s) in
   let te,_,_,_,_,_ = Typemod.type_structure (Lazy.force Env.initial) pe in


### PR DESCRIPTION
The merge of this file just left two copies of the test, ours and the upstream one. And since ours has diffs, the upstream one didn't pass. Resolved by deleting the upstream one.