### PR TITLE
Make scannable axes meet instead of override

### DIFF
--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -45,7 +45,9 @@ The `value` layout describes the representation of "vanilla" OCaml values. In Ox
 The most general of the `value`-like layouts is `scannable`, whose only requirement of its elements is that they can be scanned by the GC.
 We call the sublayouts of `scannable` the "value layouts" (choosing to emphasize the more familiar layout, `value`, instead of the top of the lattice, `scannable`).
 
-All value layouts can be written as modifications of each other; for example, `value` is `scannable non_null separable`. Below, we describe the two axes that modify value layouts, also known as the "scannable axes": nullability and separability.
+For all abbreviations, see the [kinds documentation](../../kinds/syntax).
+
+Below, we describe the two axes that modify value layouts, also known as the "scannable axes": nullability and separability.
 
 ### Nullability
 
@@ -55,7 +57,7 @@ type. The axis has two possible values, with `non_null < maybe_null`. A type may
 be `non_null` only if none of its values are `NULL`.
 
 The kind of values with `NULL` added as a possibility is written
-`value_or_null`, which is equivalent to `value maybe_null maybe_separable`.
+`value_or_null`.
 
 Types that don't have `NULL` as a possible value are
 compatible with `or_null`, a non-allocating option type that is built into
@@ -75,15 +77,15 @@ This axis has five possible values, with `non_pointer < non_pointer64 < non_floa
 - A type is `non_float` if none of its values are floats.
 - A type is `separable` if either all or none of its values are floats. In order for the float array optimization to be sound, only `separable` types may be stored in `array`s.
 
-The `value_or_null` layout is considered `maybe_separable`, since `float or_null` has both float
-and non-float elements. However, all types in vanilla OCaml are `separable`.
+The `value_or_null` layout is `maybe_separable`, since `float or_null` has both
+float and non-float elements. However, all types in vanilla OCaml are
+`separable`.
 
 ### Using scannable axes
 
-Scannable axes written after a value layout overwrite the previous value of the axis. They can also be written after non-value layouts, but have no effect, e.g. `float64 = float64 non_null = float64 maybe_null`. Scannable axes can also be written on `any`, in which case they take effect *only in the case* that it is lowered to a value layout. For example, `float64` and `value` are both sublayouts of `any non_null`, but not `value maybe_null`.
+Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value`. Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any`, in which case they take effect *only in the case* that it is lowered to a value layout.
 
-We also support the `mod` syntax for scannable axes, which only lowers the scannable axis (takes the meet). For example, `value mod non_pointer` is equivalent to `value non_pointer`, but `value mod maybe_separable` is equivalent to `value`.
-(This support is meant to be transitional; we expect to remove this eventually. New code should write the scannable axes before the `mod`.)
+The `mod` syntax may also be written with scannable axes, and has the same effect. Eventually, we plan to deprecate this syntax so `mod` is reserved for modal axes.
 
 ### Relationship between `immediate` and value layouts
 

--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -83,9 +83,9 @@ float and non-float elements. However, all types in vanilla OCaml are
 
 ### Using scannable axes
 
-Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value`. Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any`, in which case they take effect *only in the case* that it is lowered to a value layout.
+Scannable axes can be written after a layout to lower the axis. For example, `value non_pointer` lowers `value` to have separability `non_pointer`, but `value maybe_separable` is equivalent to `value` (because `value` is already `separable`, which is lower than `maybe_separable`). Scannable axes written after non-value layouts have no effect, e.g. `float64 = float64 non_null`. Scannable axes can also be written on `any`, in which case they take effect *only in the case* that it is lowered to a value layout.
 
-The `mod` syntax may also be written with scannable axes, and has the same effect. Eventually, we plan to deprecate this syntax so `mod` is reserved for modal axes.
+The `mod` syntax may also be written with scannable axes, and has the same effect, but should be considered deprecated: we will remove this syntax so that `mod` is reserved for modal axes.
 
 ### Relationship between `immediate` and value layouts
 

--- a/jane/doc/extensions/_06-kinds/02-syntax.md
+++ b/jane/doc/extensions/_06-kinds/02-syntax.md
@@ -121,7 +121,7 @@ The abbreviations defined in the language are as follows:
 
 * `any_non_null = any non_null separable`
 
-* `value = scannable non_null separable`
+* `value = value_or_null non_null separable`
 
     This is the kind of typical OCaml values, as they have been before OxCaml
     was invented. When a kind is unknown (but `any` would not be an appropriate
@@ -137,12 +137,12 @@ The abbreviations defined in the language are as follows:
     This is the kind of `int` and types like it (including enumerations and
     `bool`). It is the OxCaml equivalent of OCaml's `[@@immediate]` attribute.
 
-* `immediate_or_null = value non_pointer maybe_null mod everything`
+* `immediate_or_null = value_or_null non_pointer mod everything`
 
     This is the kind of `int or_null` and similar types.
 
 * `immediate64 = value non_pointer64 mod global aliased many contended portable
-                 forkable unyielding immutable stateless external64 non_float`
+                 forkable unyielding immutable stateless external64`
 
     This is just like `immediate`, but applies only on 64-bit machines. On a
     32-bit machine, value whose types are `immediate64` may be
@@ -172,6 +172,12 @@ The abbreviations defined in the language are as follows:
     call to `caml_modify` (on 64-bit machines). See also the documentation on
     [externality][].
 
+* `immediate64_or_null = value_or_null non_pointer64 mod global aliased many
+                         contended portable forkable unyielding immutable
+                         stateless external64`
+
+    This is the kind of `(_ : immediate64) or_null` and similar types.
+
 * `immutable_data = value non_float mod many contended portable forkable
                     unyielding immutable stateless`
 
@@ -179,17 +185,38 @@ The abbreviations defined in the language are as follows:
     old data", we mean that values of types of this kind contain no pointers to
     functions. The type `string` has this kind.
 
+
+* `immutable_data_or_null = value_or_null non_float mod many contended portable
+                            forkable unyielding immutable stateless`
+
+    This is the kind of `(_ : immutable_data) or_null` and similar types.
+
 * `sync_data = value non_float mod many contended portable forkable unyielding
                stateless`
 
    This is a suitable kind of plain old data that the type system guarantees can be mutated only
    safely in parallel, similar to the `Sync` trait in Rust.
 
+* `sync_data_or_null = value_or_null non_float mod many contended portable
+                       forkable unyielding stateless`
+
+    This is the kind of `(_ : sync_data) or_null` and similar types.
+
 * `mutable_data = value non_float mod many portable forkable unyielding
                   stateless`
 
     This is a suitable kind for plain old data that may be mutable. The
     type `int ref` has this kind.
+
+
+* `mutable_data_or_null = value non_float mod many portable forkable unyielding
+                          stateless`
+
+    This is the kind of `(_ : mutable_data) or_null` and similar types.
+
+* `value_maybe_separable = value_or_null non_null`
+
+* `value_maybe_null = value_or_null separable`
 
 ## Implications
 
@@ -455,9 +482,7 @@ defined in the OCaml [manual][].
 
 **Note on syntax for scannable axes:** Previously, scannable axes used to be
 non-modal axes, and were written like `value mod non_null`, which upper-bounds
-the nullability to `non_null`. Now, we can also write them as `value non_null`,
-which overrides the nullability to `non_null`. We will soon remove the ability
-to upper-bound scannable axes via the `mod` syntax.
+the nullability to `non_null`. Now, we can also write them as `value non_null`.
 
 First we define the syntax for kinds:
 

--- a/jane/doc/extensions/_06-kinds/02-syntax.md
+++ b/jane/doc/extensions/_06-kinds/02-syntax.md
@@ -209,7 +209,7 @@ The abbreviations defined in the language are as follows:
     type `int ref` has this kind.
 
 
-* `mutable_data_or_null = value non_float mod many portable forkable unyielding
+* `mutable_data_or_null = value_or_null non_float mod many portable forkable unyielding
                           stateless`
 
     This is the kind of `(_ : mutable_data) or_null` and similar types.
@@ -481,8 +481,9 @@ lists containing one or more repetitions. Any nonterminal not defined here is
 defined in the OCaml [manual][].
 
 **Note on syntax for scannable axes:** Previously, scannable axes used to be
-non-modal axes, and were written like `value mod non_null`, which upper-bounds
-the nullability to `non_null`. Now, we can also write them as `value non_null`.
+non-modal axes, and were written like `value mod non_pointer`, which
+upper-bounds the separability to `non_pointer`. Now, we can also write them as
+`value non_pointer`.
 
 First we define the syntax for kinds:
 

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -27,7 +27,7 @@ module M = struct
 end
 
 [%%expect{|
-module M : sig val f : ('elt : value maybe_null). 'elt -> 'elt array end
+module M : sig val f : ('elt : value_maybe_null). 'elt -> 'elt array end
 |}]
 
 (* Implicit kind without jkind annotation fails. *)

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -922,7 +922,7 @@ let f x =
   | _ -> assert false;;
 
 [%%expect{|
-val f : ('a : value maybe_null). 'a iarray -> 'a iarray = <fun>
+val f : ('a : value_maybe_null). 'a iarray -> 'a iarray = <fun>
 |}]
 
 (******************)

--- a/testsuite/tests/parsing/extended_indexoperators.ml
+++ b/testsuite/tests/parsing/extended_indexoperators.ml
@@ -68,7 +68,7 @@ let (#?) x y = (x, y);;
 val ( #? ) : 'a -> 'b -> 'a * 'b = <fun>
 
 let (.%()) x y = x.(y);;
-val ( .%() ) : ('a : value maybe_null). 'a array -> int -> 'a = <fun>
+val ( .%() ) : ('a : value_maybe_null). 'a array -> int -> 'a = <fun>
 
 let x = [|0|];;
 val x : int array = [|0|]

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1700,7 +1700,7 @@ type extensible = ..
 
 (* Since the kind is [best], it should normalize away *)
 module M : sig
-  type t : immediate non_float with extensible
+  type t : value non_float mod everything with extensible
 end = struct
   type t : value mod non_float
 end

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1700,7 +1700,7 @@ type extensible = ..
 
 (* Since the kind is [best], it should normalize away *)
 module M : sig
-  type t : immediate non_float with extensible
+  type t : value non_float mod everything with extensible
 end = struct
   type t : value mod non_float
 end

--- a/testsuite/tests/typing-jkind-bounds/predefs_are_best.ml
+++ b/testsuite/tests/typing-jkind-bounds/predefs_are_best.ml
@@ -30,7 +30,7 @@ type t : immediate
 |}]
 
 module M : sig
-  type t : immediate non_float with string
+  type t : immutable_data with string
 end = struct
   type t = int list
 end

--- a/testsuite/tests/typing-jkind-bounds/predefs_are_best_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/predefs_are_best_ikinds.ml
@@ -30,7 +30,7 @@ type t : immediate
 |}]
 
 module M : sig
-  type t : immediate non_float with string
+  type t : immutable_data with string
 end = struct
   type t = int list
 end

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -310,37 +310,37 @@ type trec_rec_succeeds =
 (* Future tests for when we start adding row variables to with-bounds. *)
 
 type 'a t1 = [< `A of string | `B of int ] as 'a
-type 'a t2 : immediate non_float with 'a t1 = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
+type 'a t2 : value non_float mod everything with 'a t1 = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
 [%%expect{|
 type 'a t1 = 'a constraint 'a = [< `A of string | `B of int ]
-Line 2, characters 0-57:
-2 | type 'a t2 : immediate non_float with 'a t1 = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-68:
+2 | type 'a t2 : value non_float mod everything with 'a t1 = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
            immediate non_float with [< `A of string | `B of int ] t1
          because of the annotation on the declaration of the type t2.
 |}]
-type t3 : immediate non_float with [ `A of string] t1 = C of string  (* should be accepted *)
+type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
 [%%expect{|
 type t3 = C of string
 |}]
 
 type 'a t1 = [> `A of string | `B of int ] as 'a
-type 'a t2 : immediate non_float with 'a t1 = C of string  (* should be rejected *)
+type 'a t2 : value non_float mod everything with 'a t1 = C of string  (* should be rejected *)
 [%%expect{|
 type 'a t1 = 'a constraint 'a = [> `A of string | `B of int ]
-Line 2, characters 0-57:
-2 | type 'a t2 : immediate non_float with 'a t1 = C of string  (* should be rejected *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-68:
+2 | type 'a t2 : value non_float mod everything with 'a t1 = C of string  (* should be rejected *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
            immediate non_float with [> `A of string | `B of int ] t1
          because of the annotation on the declaration of the type t2.
 |}]
-type t3 : immediate non_float with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
+type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
 [%%expect{|
 type t3 = C of string
 |}]
@@ -351,13 +351,13 @@ end
 module M1 : S = struct
   type t = [ `A of string ]
 end
-type t2 : immediate non_float with M1.t = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
+type t2 : value non_float mod everything with M1.t = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
 [%%expect{|
 module type S = sig type t = private [< `A of string | `B of int ] end
 module M1 : S
-Line 7, characters 0-53:
-7 | type t2 : immediate non_float with M1.t = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 7, characters 0-64:
+7 | type t2 : value non_float mod everything with M1.t = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
@@ -368,7 +368,7 @@ Error: The kind of type "t2" is immutable_data
 module M2 : S with type t = [ `A of string ] = struct
   type t = [ `A of string ]
 end
-type t3 : immediate non_float with M2.t = C of string (* should be accepted *)
+type t3 : value non_float mod everything with M2.t = C of string (* should be accepted *)
 [%%expect{|
 module M2 : sig type t = [ `A of string ] end
 type t3 = C of string
@@ -379,13 +379,13 @@ type (_, _) eq = Refl : ('a, 'a) eq
 (* I'm not sure whether module substitution over a non-static private row type preserves the Tvariant structure; so I made this harder case, too *)
 let sneaky (x : (M1.t, [ `A of string ]) eq) = match x with
   | Refl -> let open struct
-    type t4 : immediate non_float with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
+    type t4 : value non_float mod everything with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
   end in ()
 [%%expect{|
 type (_, _) eq = Refl : ('a, 'a) eq
-Line 6, characters 4-57:
-6 |     type t4 : immediate non_float with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 6, characters 4-68:
+6 |     type t4 : value non_float mod everything with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t4" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t4" must be a subkind of
@@ -399,13 +399,13 @@ end
 module M1 : S = struct
   type t = [ `A of string | `B of int | `C of (int -> int) ref ]
 end
-type t2 : immediate non_float with M1.t = C of string  (* should be rejected *)
+type t2 : value non_float mod everything with M1.t = C of string  (* should be rejected *)
 [%%expect{|
 module type S = sig type t = private [> `A of string | `B of int ] end
 module M1 : S
-Line 7, characters 0-53:
-7 | type t2 : immediate non_float with M1.t = C of string  (* should be rejected *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 7, characters 0-64:
+7 | type t2 : value non_float mod everything with M1.t = C of string  (* should be rejected *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
@@ -470,7 +470,7 @@ end
 module M2 : S2 with type t = [ `A of string | `B of int ] = struct
   type t = [ `A of string | `B of int ]
 end
-type t3 : immediate non_float with M2.t = C of string (* should be accepted *)
+type t3 : value non_float mod everything with M2.t = C of string (* should be accepted *)
 [%%expect{|
 module type S2 = sig type t = private [< `A of string | `B of int ] end
 module M2 : sig type t = [ `A of string | `B of int ] end
@@ -479,12 +479,12 @@ type t3 = C of string
 
 let sneaky (x : (M1.t, [ `A of string | `B of int ]) eq) = match x with
   | Refl -> let open struct
-    type t4 : immediate non_float with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
+    type t4 : value non_float mod everything with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
   end in ()
 [%%expect{|
-Line 3, characters 4-57:
-3 |     type t4 : immediate non_float with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 4-68:
+3 |     type t4 : value non_float mod everything with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t4" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t4" must be a subkind of

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -325,14 +325,14 @@ Error: The layout of type "t2" is value non_float
        Note: The kinds mutable_data, immutable_data, and sync_data have
        the layout value non_float.
 |}]
-type t3 : immediate non_float with [ `A of string] t1 = C of string  (* should be accepted *)
+type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
 (* CR layouts v2.8: This should be accepted, but still fails in principal mode.
    ikinds regression vs non-ikinds.
    Internal ticket 6481. *)
 [%%expect{|
-Line 1, characters 0-67:
-1 | type t3 : immediate non_float with [ `A of string] t1 = C of string  (* should be accepted *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-78:
+1 | type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t3" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t3" must be a subkind of immutable_data
@@ -354,14 +354,14 @@ Error: The layout of type "t2" is value non_float
        Note: The kinds mutable_data, immutable_data, and sync_data have
        the layout value non_float.
 |}]
-type t3 : immediate non_float with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
+type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
 (* CR layouts v2.8: This should be accepted, but still fails in principal mode.
    ikinds regression vs non-ikinds.
    Internal ticket 6481. *)
 [%%expect{|
-Line 1, characters 0-85:
-1 | type t3 : immediate non_float with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-96:
+1 | type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t3" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t3" must be a subkind of immutable_data
@@ -393,7 +393,7 @@ Error: The layout of type "t2" is value non_float
 module M2 : S with type t = [ `A of string ] = struct
   type t = [ `A of string ]
 end
-type t3 : immediate non_float with M2.t = C of string (* should be accepted *)
+type t3 : value non_float mod everything with M2.t = C of string (* should be accepted *)
 [%%expect{|
 module M2 : sig type t = [ `A of string ] end
 type t3 = C of string
@@ -499,7 +499,7 @@ end
 module M2 : S2 with type t = [ `A of string | `B of int ] = struct
   type t = [ `A of string | `B of int ]
 end
-type t3 : immediate non_float with M2.t = C of string (* should be accepted *)
+type t3 : value non_float mod everything with M2.t = C of string (* should be accepted *)
 [%%expect{|
 module type S2 = sig type t = private [< `A of string | `B of int ] end
 module M2 : sig type t = [ `A of string | `B of int ] end

--- a/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -136,7 +136,7 @@ let d (x : 'a array) = get x 0
 [%%expect{|
 external get : ('a : any separable). 'a array -> int -> float
   = "%floatarray_safe_get"
-val d : ('a : value maybe_null). 'a array -> float = <fun>
+val d : ('a : value_maybe_null). 'a array -> float = <fun>
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"
@@ -288,7 +288,7 @@ Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
                                            ^^^^^
 Error: This expression has type "float#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -304,7 +304,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42l in
                                            ^^^^
 Error: This expression has type "int32#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of int32# is bits32
          because it is the unboxed version of the primitive type int32.
        But the layout of int32# must be a value layout
@@ -320,7 +320,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42L in
                                            ^^^^
 Error: This expression has type "int64#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a value layout
@@ -336,7 +336,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42n in
                                            ^^^^
 Error: This expression has type "nativeint#"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of nativeint# is word
          because it is the unboxed version of the primitive type nativeint.
        But the layout of nativeint# must be a value layout
@@ -352,7 +352,7 @@ Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0s in
                                            ^^^^^^
 Error: This expression has type "float32#"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of float32# is float32
          because it is the unboxed version of the primitive type float32.
        But the layout of float32# must be a value layout

--- a/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -133,7 +133,7 @@ let d (x : 'a array) = get x 0
 [%%expect{|
 external get : ('a : any separable). 'a array -> int -> float
   = "%floatarray_safe_get"
-val d : ('a : value maybe_null). 'a array -> float = <fun>
+val d : ('a : value_maybe_null). 'a array -> float = <fun>
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"
@@ -285,7 +285,7 @@ Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
                                            ^^^^^
 Error: This expression has type "float#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -301,7 +301,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42l in
                                            ^^^^
 Error: This expression has type "int32#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of int32# is bits32
          because it is the unboxed version of the primitive type int32.
        But the layout of int32# must be a value layout
@@ -317,7 +317,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42L in
                                            ^^^^
 Error: This expression has type "int64#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a value layout
@@ -333,7 +333,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42n in
                                            ^^^^
 Error: This expression has type "nativeint#"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of nativeint# is word
          because it is the unboxed version of the primitive type nativeint.
        But the layout of nativeint# must be a value layout
@@ -349,7 +349,7 @@ Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0s in
                                            ^^^^^^
 Error: This expression has type "float32#"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of float32# is float32
          because it is the unboxed version of the primitive type float32.
        But the layout of float32# must be a value layout

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -1002,7 +1002,7 @@ type ('a, 'b : any) an_idx = ('a, 'b) idx_imm
 type ('a : any separable) an_array = 'a iarray
 external ok : ('a : any separable). int -> ('a an_array, 'a) an_idx
   = "%unsafe_array_idx" [@@layout_poly]
-val use_ok : ('a : value maybe_null). unit -> ('a an_array, 'a) an_idx =
+val use_ok : ('a : value_maybe_null). unit -> ('a an_array, 'a) an_idx =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-layouts-iarrays/basics.ml
+++ b/testsuite/tests/typing-layouts-iarrays/basics.ml
@@ -130,7 +130,7 @@ let d (x : 'a iarray) = get x 0
 [%%expect{|
 external get : ('a : any separable). 'a iarray -> int -> float
   = "%floatarray_safe_get"
-val d : ('a : value maybe_null). 'a iarray -> float = <fun>
+val d : ('a : value_maybe_null). 'a iarray -> float = <fun>
 |}];;
 
 external get : int32# iarray -> int -> float = "%floatarray_safe_get"
@@ -269,7 +269,7 @@ Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [: x :]; #42.0 in
                                            ^^^^^
 Error: This expression has type "float#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -285,7 +285,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [: x :]; #42l in
                                            ^^^^
 Error: This expression has type "int32#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of int32# is bits32
          because it is the unboxed version of the primitive type int32.
        But the layout of int32# must be a value layout
@@ -301,7 +301,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [: x :]; #42L in
                                            ^^^^
 Error: This expression has type "int64#" but an expression was expected of type
-         "('a : value maybe_null)"
+         "('a : value_maybe_null)"
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a value layout
@@ -317,7 +317,7 @@ Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [: x :]; #42n in
                                            ^^^^
 Error: This expression has type "nativeint#"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of nativeint# is word
          because it is the unboxed version of the primitive type nativeint.
        But the layout of nativeint# must be a value layout
@@ -333,7 +333,7 @@ Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [: x :]; #42.0s in
                                            ^^^^^^
 Error: This expression has type "float32#"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of float32# is float32
          because it is the unboxed version of the primitive type float32.
        But the layout of float32# must be a value layout

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -499,7 +499,7 @@ let x = `A Null
 let y = `B (This "idea")
 
 [%%expect{|
-val x : ('a : value maybe_separable). [> `A of 'a or_null ] = `A Null
+val x : ('a : value_maybe_separable). [> `A of 'a or_null ] = `A Null
 val y : [> `B of string or_null ] = `B (This "idea")
 |}]
 
@@ -525,8 +525,8 @@ let f arr = [| This x for x in arr |]
 let g arr = [: This x for x in arr :]
 
 [%%expect{|
-val f : ('a : value maybe_separable). 'a array -> 'a or_null array = <fun>
-val g : ('a : value maybe_separable). 'a iarray -> 'a or_null iarray = <fun>
+val f : ('a : value_maybe_separable). 'a array -> 'a or_null array = <fun>
+val g : ('a : value_maybe_separable). 'a iarray -> 'a or_null iarray = <fun>
 |}]
 
 

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -320,7 +320,7 @@ let should_work_option3 = None
 
 [%%expect{|
 val should_work_option1 : float or_null option = Some (This 3.4)
-val should_work_option2 : ('a : value maybe_separable). 'a or_null option =
+val should_work_option2 : ('a : value_maybe_separable). 'a or_null option =
   Some Null
 val should_work_option3 : 'a option = None
 |}]

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -231,7 +231,7 @@ type ('a : value_or_null) widened_bad_jkind =
 [@@or_null]
 
 [%%expect{|
-type ('a : value maybe_separable) widened_bad_jkind = A | B of 'a [@@or_null]
+type ('a : value_maybe_separable) widened_bad_jkind = A | B of 'a [@@or_null]
 |}]
 
 type ('a : any) widened_any : value_or_null =
@@ -240,7 +240,7 @@ type ('a : any) widened_any : value_or_null =
 [@@or_null]
 
 [%%expect{|
-type ('a : value maybe_separable) widened_any = A | B of 'a [@@or_null]
+type ('a : value_maybe_separable) widened_any = A | B of 'a [@@or_null]
 |}]
 
 type ('a : value_or_null) widened_nullable : value_or_null =
@@ -249,7 +249,7 @@ type ('a : value_or_null) widened_nullable : value_or_null =
 [@@or_null]
 
 [%%expect{|
-type ('a : value maybe_separable) widened_nullable = A | B of 'a [@@or_null]
+type ('a : value_maybe_separable) widened_nullable = A | B of 'a [@@or_null]
 |}]
 
 type ('a : immediate) widened_immediate : value_or_null =

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -13,7 +13,7 @@ let mk_gen (x : 'a) = [| x |]
 [%%expect{|
 (let (mk_gen = (function {nlocal = 0} x? : genarray (makearray[gen] x)))
   (apply (field_imm 1 (global Toploop!)) "mk_gen" mk_gen))
-val mk_gen : ('a : value maybe_null). 'a -> 'a array = <fun>
+val mk_gen : ('a : value_maybe_null). 'a -> 'a array = <fun>
 |}]
 
 let get_gen (xs : 'a array) i = xs.(i)
@@ -23,7 +23,7 @@ let get_gen (xs : 'a array) i = xs.(i)
      (function {nlocal = 0} xs[value<genarray>] i[value<int>]
        (array.get[gen indexed by int] xs i)))
   (apply (field_imm 1 (global Toploop!)) "get_gen" get_gen))
-val get_gen : ('a : value maybe_null). 'a array -> int -> 'a = <fun>
+val get_gen : ('a : value_maybe_null). 'a array -> int -> 'a = <fun>
 |}]
 
 let set_gen (xs : 'a array) x i = xs.(i) <- x
@@ -33,7 +33,7 @@ let set_gen (xs : 'a array) x i = xs.(i) <- x
      (function {nlocal = 0} xs[value<genarray>] x? i[value<int>] : int
        (array.set[gen indexed by int] xs i x)))
   (apply (field_imm 1 (global Toploop!)) "set_gen" set_gen))
-val set_gen : ('a : value maybe_null). 'a array -> 'a -> int -> unit = <fun>
+val set_gen : ('a : value_maybe_null). 'a array -> 'a -> int -> unit = <fun>
 |}]
 
 (* [non_float] arrays are [addrarray]s. Operations on [addrarray]s

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -146,7 +146,7 @@ Line 1, characters 24-26:
 1 | type ('a : float64) t = 'a or_null [@@or_null_reexport]
                             ^^
 Error: This type "('a : float64)" should be an instance of type
-         "('b : value maybe_separable)"
+         "('b : value_maybe_separable)"
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must be a value layout
@@ -164,13 +164,13 @@ let fail = Or_null.This (Or_null.This 5)
 [%%expect{|
 module Or_null :
   sig
-    type ('a : value maybe_separable) t = 'a or_null = Null | This of 'a [@@or_null_reexport]
+    type ('a : value_maybe_separable) t = 'a or_null = Null | This of 'a [@@or_null_reexport]
   end
 Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
-       but an expression was expected of type "('b : value maybe_separable)"
+       but an expression was expected of type "('b : value_maybe_separable)"
        The layout of 'a Or_null.t is value maybe_separable maybe_null
          because it is the primitive type or_null.
        But the layout of 'a Or_null.t must be a sublayout of

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -517,7 +517,7 @@ Line 1, characters 13-18:
 1 | type fails = t_b64 or_null accepts_maybesep
                  ^^^^^
 Error: This type "t_b64" should be an instance of type
-         "('a : value maybe_separable)"
+         "('a : value_maybe_separable)"
        The layout of t_b64 is bits64
          because of the definition of t_b64 at line 1, characters 0-19.
        But the layout of t_b64 must be a value layout
@@ -528,7 +528,7 @@ type t_maybesep_val : value_or_null mod non_null
 type succeeds = t_maybesep_val or_null
 
 [%%expect{|
-type t_maybesep_val : value maybe_separable
+type t_maybesep_val : value_maybe_separable
 type succeeds = t_maybesep_val or_null
 |}]
 
@@ -691,7 +691,7 @@ type unbx = { unbx : t_maybesep_val; } [@@unboxed]
 type ('a : value_or_null mod non_null) unbx' = Unbx of 'a [@@unboxed]
 
 [%%expect{|
-type ('a : value maybe_separable) unbx' = Unbx of 'a [@@unboxed]
+type ('a : value_maybe_separable) unbx' = Unbx of 'a [@@unboxed]
 |}]
 
 (* Separability and unboxed records. *)
@@ -959,7 +959,7 @@ module type S0 = sig
 end
 
 [%%expect{|
-module type S0 = sig type t : value maybe_null end
+module type S0 = sig type t : value_maybe_null end
 |}]
 
 module M5 : S0 = struct
@@ -995,7 +995,7 @@ Error: Signature mismatch:
        Type declarations do not match:
          type t = float or_null
        is not included in
-         type t : value maybe_null
+         type t : value_maybe_null
        The layout of the first is value maybe_separable maybe_null
          because it is the primitive type or_null.
        But the layout of the first must be a sublayout of value maybe_null

--- a/testsuite/tests/typing-layouts-or-null/separability_bug.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_bug.ml
@@ -73,7 +73,7 @@ let peek  (aon : 'a portended or_null) =
 ;;
 [%%expect{|
 type ('a : value_or_null) portended = { a : 'a; } [@@unboxed]
-val peek : ('a : value maybe_separable) 'b. 'a portended or_null -> 'b =
+val peek : ('a : value_maybe_separable) 'b. 'a portended or_null -> 'b =
   <fun>
 |}]
 
@@ -84,7 +84,7 @@ val peek : ('a : value maybe_separable) 'b. 'a portended or_null -> 'b =
    [type_approx]. *)
 let rec ok () : 'a or_null = Null
 [%%expect{|
-val ok : ('a : value maybe_separable). unit -> 'a or_null = <fun>
+val ok : ('a : value_maybe_separable). unit -> 'a or_null = <fun>
 |}]
 let rec bad () : float# or_null = Null
 [%%expect{|
@@ -92,7 +92,7 @@ Line 1, characters 17-23:
 1 | let rec bad () : float# or_null = Null
                      ^^^^^^
 Error: This type "float#" should be an instance of type
-         "('a : value maybe_separable)"
+         "('a : value_maybe_separable)"
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -104,7 +104,7 @@ Line 1, characters 17-27:
 1 | let rec bad () : 'a or_null or_null = Null
                      ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type
-         "('b : value maybe_separable)"
+         "('b : value_maybe_separable)"
        The layout of 'a or_null is value maybe_separable maybe_null
          because it is the primitive type or_null.
        But the layout of 'a or_null must be a sublayout of

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -98,7 +98,7 @@ Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
-         "('a : value maybe_separable)"
+         "('a : value_maybe_separable)"
        The layout of int or_null is value maybe_separable maybe_null
          because it is the primitive type or_null.
        But the layout of int or_null must be a sublayout of

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1716,7 +1716,7 @@ Line 1, characters 31-37:
 1 | let _ = Array.init 3 (fun _ -> #(1,2))
                                    ^^^^^^
 Error: This expression has type "#('a * 'b)"
-       but an expression was expected of type "('c : value maybe_null)"
+       but an expression was expected of type "('c : value_maybe_null)"
        The layout of #('a * 'b) is
            '_representable_layout_13 & '_representable_layout_14
          because it is an unboxed tuple.
@@ -1802,7 +1802,7 @@ Line 2, characters 31-50:
 2 | let _ = Array.init 3 (fun _ -> #{ i1 = 1; i2 = 2 })
                                    ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "array_init_record"
-       but an expression was expected of type "('a : value maybe_null)"
+       but an expression was expected of type "('a : value_maybe_null)"
        The layout of array_init_record is
            value non_pointer & value non_pointer
          because of the definition of array_init_record at line 1, characters 0-48.
@@ -2181,7 +2181,7 @@ let g (x : 'a) = f () x
 
 [%%expect{|
 val f : ('a : any separable & value). unit -> 'a -> 'a = <fun>
-val g : ('a : value maybe_null & value). 'a -> 'a = <fun>
+val g : ('a : value_maybe_null & value). 'a -> 'a = <fun>
 |}]
 
 (* test subjkinding *)

--- a/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
+++ b/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
@@ -13,7 +13,7 @@ external weird_id : ('a : any mod separable). 'a array -> int = "%identity"
 let weird_id' arr = weird_id arr
 [%%expect{|
 external weird_id : ('a : any separable). 'a array -> int = "%identity"
-val weird_id' : ('a : value maybe_null). 'a array -> int = <fun>
+val weird_id' : ('a : value_maybe_null). 'a array -> int = <fun>
 |}]
 
 (* This is not sound whenever 'a is not a value, but this is the kind of
@@ -23,7 +23,7 @@ let weird_flarr_len' x = weird_flarr_len x
 [%%expect{|
 external weird_flarr_len : ('a : any separable). 'a array -> int
   = "%floatarray_length"
-val weird_flarr_len' : ('a : value maybe_null). 'a array -> int = <fun>
+val weird_flarr_len' : ('a : value_maybe_null). 'a array -> int = <fun>
 |}]
 
 external product_edge_case : ('a : any mod separable). #('a * 'a) array -> int = "%identity"
@@ -31,6 +31,6 @@ let product_edge_case x = product_edge_case x
 [%%expect{|
 external product_edge_case : ('a : any separable). #('a * 'a) array -> int
   = "%identity"
-val product_edge_case : ('a : value maybe_null). #('a * 'a) array -> int =
+val product_edge_case : ('a : value_maybe_null). #('a * 'a) array -> int =
   <fun>
 |}]

--- a/testsuite/tests/typing-layouts-scannable/mutual_recursion.ml
+++ b/testsuite/tests/typing-layouts-scannable/mutual_recursion.ml
@@ -3,10 +3,10 @@
  expect;
 *)
 
-type t_maybeptr_val : value maybe_separable
+type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 [%%expect{|
-type t_maybeptr_val : value maybe_separable
+type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 |}]
 
@@ -86,7 +86,7 @@ Error: The layout of type "a" is value
 (* These almost demonstrate the bad mutual recursion behavior, but work. *)
 
 type a : value non_pointer = #{ b : b }
-and b : value maybe_separable = #{ i : t_nonptr_val }
+and b : value_maybe_separable = #{ i : t_nonptr_val }
 [%%expect{|
 type a = #{ b : b; }
 and b = #{ i : t_nonptr_val; }

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -20,9 +20,9 @@ type ('a : any non_pointer, 'b : any maybe_separable, 'c : any) t;;
 type ('a : any non_pointer, 'b : any, 'c : any) t
 |}]
 
-type t : value non_pointer & value maybe_separable & float64
+type t : value non_pointer & value_maybe_separable & float64
 [%%expect{|
-type t : value non_pointer & value maybe_separable & float64
+type t : value non_pointer & value_maybe_separable & float64
 |}]
 
 (* Checking non_pointer annotations, based on [typing-layouts-or-null/separability.ml]
@@ -38,10 +38,10 @@ type t_maybeptr : any
 type t_nonptr : any non_pointer
 |}]
 
-type t_maybeptr_val : value maybe_separable
+type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 [%%expect{|
-type t_maybeptr_val : value maybe_separable
+type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 |}]
 
@@ -52,10 +52,10 @@ type ('a : any) accepts_maybeptr
 type ('a : any non_pointer) accepts_nonptr
 |}]
 
-type ('a : value maybe_separable) accepts_maybeptr_val
+type ('a : value_maybe_separable) accepts_maybeptr_val
 type ('a : value non_pointer) accepts_nonptr_val
 [%%expect{|
-type ('a : value maybe_separable) accepts_maybeptr_val
+type ('a : value_maybe_separable) accepts_maybeptr_val
 type ('a : value non_pointer) accepts_nonptr_val
 |}]
 
@@ -249,10 +249,10 @@ Error: This type "t_maybeptr_val" should be an instance of type
 
 (* unboxed records *)
 
-type t_maybeptr_val : value maybe_separable
+type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 [%%expect{|
-type t_maybeptr_val : value maybe_separable
+type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 |}]
 
@@ -293,7 +293,7 @@ let f x =
 val f : ('a : value_or_null non_pointer). 'a -> unit = <fun>
 |}]
 
-let f (type a : value maybe_separable) (x : a) =
+let f (type a : value_maybe_separable) (x : a) =
   let require_np (y : (_ : value non_pointer)) = () in
   require_np y
 [%%expect{|
@@ -311,7 +311,7 @@ val f : ('a : float64). 'a -> unit = <fun>
 |}]
 
 let f (type a : value non_pointer) (x : a) =
-  (* here, y is value maybe_separable *)
+  (* here, y is value_maybe_separable *)
   let g y = () in
   g x
 [%%expect{|
@@ -319,7 +319,7 @@ val f : ('a : value non_pointer). 'a -> unit = <fun>
 |}]
 
 let f (t : (_ : value non_pointer & value)) =
-  (* here, x is value maybe_separable *)
+  (* here, x is value_maybe_separable *)
   let g (type a : value non_pointer) (x : a) = () in
   let #(np, v) = t in
   g np
@@ -457,7 +457,7 @@ Error: Signature mismatch:
 module M1 : sig
   type ('a : value non_pointer) t : value
 end = struct
-  type ('a : value maybe_separable) t = t_nonptr_val
+  type ('a : value_maybe_separable) t = t_nonptr_val
 end
 [%%expect{|
 module M1 : sig type ('a : value non_pointer) t end

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -37,17 +37,20 @@ type t : value separable
 Line 1, characters 15-24:
 1 | type t : value separable
                    ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 15-24:
 1 | type t : value separable
                    ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 15-24:
 1 | type t : value separable
                    ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 type t
 |}]
@@ -57,32 +60,38 @@ type t : value_or_null maybe_null maybe_separable
 Line 1, characters 23-33:
 1 | type t : value_or_null maybe_null maybe_separable
                            ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value_or_null".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value_or_null".
 
 Line 1, characters 34-49:
 1 | type t : value_or_null maybe_null maybe_separable
                                       ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value_or_null".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value_or_null".
 
 Line 1, characters 23-33:
 1 | type t : value_or_null maybe_null maybe_separable
                            ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value_or_null".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value_or_null".
 
 Line 1, characters 34-49:
 1 | type t : value_or_null maybe_null maybe_separable
                                       ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value_or_null".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value_or_null".
 
 Line 1, characters 23-33:
 1 | type t : value_or_null maybe_null maybe_separable
                            ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value_or_null".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value_or_null".
 
 Line 1, characters 34-49:
 1 | type t : value_or_null maybe_null maybe_separable
                                       ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value_or_null".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value_or_null".
 
 type t : value_or_null
 |}]
@@ -92,17 +101,20 @@ type t : immediate non_pointer
 Line 1, characters 19-30:
 1 | type t : immediate non_pointer
                        ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "immediate".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "immediate".
 
 Line 1, characters 19-30:
 1 | type t : immediate non_pointer
                        ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "immediate".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "immediate".
 
 Line 1, characters 19-30:
 1 | type t : immediate non_pointer
                        ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "immediate".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "immediate".
 
 type t : immediate
 |}]
@@ -112,19 +124,40 @@ type t : value non_null maybe_null
 Line 1, characters 15-23:
 1 | type t : value non_null maybe_null
                    ^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_null" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+Line 1, characters 24-34:
+1 | type t : value non_null maybe_null
+                            ^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 15-23:
 1 | type t : value non_null maybe_null
                    ^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_null" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+Line 1, characters 24-34:
+1 | type t : value non_null maybe_null
+                            ^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 15-23:
 1 | type t : value non_null maybe_null
                    ^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_null" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-type t : value maybe_null
+Line 1, characters 24-34:
+1 | type t : value non_null maybe_null
+                            ^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+type t
 |}]
 
 type t : value maybe_separable non_pointer
@@ -132,72 +165,66 @@ type t : value maybe_separable non_pointer
 Line 1, characters 15-30:
 1 | type t : value maybe_separable non_pointer
                    ^^^^^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 15-30:
 1 | type t : value maybe_separable non_pointer
                    ^^^^^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 15-30:
 1 | type t : value maybe_separable non_pointer
                    ^^^^^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 type t : value non_pointer
 |}]
 
 type t : value non_pointer separable
 [%%expect{|
-Line 1, characters 15-26:
+Line 1, characters 27-36:
 1 | type t : value non_pointer separable
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "separable" later.
+                               ^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 27-36:
 1 | type t : value non_pointer separable
                                ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value".
-
-Line 1, characters 15-26:
-1 | type t : value non_pointer separable
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "separable" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 27-36:
 1 | type t : value non_pointer separable
                                ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value".
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
-1 | type t : value non_pointer separable
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "separable" later.
-
-Line 1, characters 27-36:
-1 | type t : value non_pointer separable
-                               ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier is already implied by the kind "value".
-
-type t
+type t : value non_pointer
 |}]
 
 type t : value non_pointer non_pointer
 [%%expect{|
-Line 1, characters 15-26:
+Line 1, characters 27-38:
 1 | type t : value non_pointer non_pointer
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                               ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 27-38:
 1 | type t : value non_pointer non_pointer
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                               ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 27-38:
 1 | type t : value non_pointer non_pointer
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                               ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 type t : value non_pointer
 |}]
@@ -207,32 +234,38 @@ type t : value non_pointer maybe_separable non_pointer
 Line 1, characters 27-42:
 1 | type t : value non_pointer maybe_separable non_pointer
                                ^^^^^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 43-54:
 1 | type t : value non_pointer maybe_separable non_pointer
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
-
-Line 1, characters 27-42:
-1 | type t : value non_pointer maybe_separable non_pointer
-                               ^^^^^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
-
-Line 1, characters 15-26:
-1 | type t : value non_pointer maybe_separable non_pointer
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                                               ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 27-42:
 1 | type t : value non_pointer maybe_separable non_pointer
                                ^^^^^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 43-54:
 1 | type t : value non_pointer maybe_separable non_pointer
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                                               ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+Line 1, characters 27-42:
+1 | type t : value non_pointer maybe_separable non_pointer
+                               ^^^^^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+Line 1, characters 43-54:
+1 | type t : value non_pointer maybe_separable non_pointer
+                                               ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 type t : value non_pointer
 |}]
@@ -242,34 +275,58 @@ type t : value non_pointer maybe_null non_pointer maybe_null
 Line 1, characters 27-37:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                ^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_null" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 38-49:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                                          ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+Line 1, characters 50-60:
+1 | type t : value non_pointer maybe_null non_pointer maybe_null
+                                                      ^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 27-37:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                ^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_null" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 38-49:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                                          ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+Line 1, characters 50-60:
+1 | type t : value non_pointer maybe_null non_pointer maybe_null
+                                                      ^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 Line 1, characters 27-37:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                ^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_null" later.
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-Line 1, characters 15-26:
+Line 1, characters 38-49:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                   ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                                          ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
-type t : value_or_null non_pointer
+Line 1, characters 50-60:
+1 | type t : value non_pointer maybe_null non_pointer maybe_null
+                                                      ^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
+
+type t : value non_pointer
 |}]
 
 type t : void non_pointer
@@ -314,30 +371,15 @@ type t : void
 
 type t : void non_pointer maybe_separable
 [%%expect{|
-Line 1, characters 14-25:
-1 | type t : void non_pointer maybe_separable
-                  ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_separable" later.
-
 Line 1, characters 9-41:
 1 | type t : void non_pointer maybe_separable
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer maybe_separable" have no effect on the kind "void".
 
-Line 1, characters 14-25:
-1 | type t : void non_pointer maybe_separable
-                  ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_separable" later.
-
 Line 1, characters 9-41:
 1 | type t : void non_pointer maybe_separable
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer maybe_separable" have no effect on the kind "void".
-
-Line 1, characters 14-25:
-1 | type t : void non_pointer maybe_separable
-                  ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "maybe_separable" later.
 
 Line 1, characters 9-41:
 1 | type t : void non_pointer maybe_separable
@@ -354,10 +396,11 @@ Line 1, characters 9-25:
              ^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "void".
 
-Line 1, characters 34-45:
+Line 1, characters 46-57:
 1 | type t : void non_pointer & value non_pointer non_pointer mod global with int
-                                      ^^^^^^^^^^^
-Warning 185 [overridden-kind-modifier]: This kind modifier is overridden by "non_pointer" later.
+                                                  ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
+already implied by the kind "value".
 
 type t : void mod global & value non_pointer mod global
 |}]

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -67,7 +67,7 @@ Line 1, characters 34-49:
 1 | type t : value_or_null maybe_null maybe_separable
                                       ^^^^^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value_or_null".
+already implied by the kind "value_or_null maybe_null".
 
 Line 1, characters 23-33:
 1 | type t : value_or_null maybe_null maybe_separable
@@ -79,7 +79,7 @@ Line 1, characters 34-49:
 1 | type t : value_or_null maybe_null maybe_separable
                                       ^^^^^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value_or_null".
+already implied by the kind "value_or_null maybe_null".
 
 Line 1, characters 23-33:
 1 | type t : value_or_null maybe_null maybe_separable
@@ -91,7 +91,7 @@ Line 1, characters 34-49:
 1 | type t : value_or_null maybe_null maybe_separable
                                       ^^^^^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value_or_null".
+already implied by the kind "value_or_null maybe_null".
 
 type t : value_or_null
 |}]
@@ -131,7 +131,7 @@ Line 1, characters 24-34:
 1 | type t : value non_null maybe_null
                             ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_null".
 
 Line 1, characters 15-23:
 1 | type t : value non_null maybe_null
@@ -143,7 +143,7 @@ Line 1, characters 24-34:
 1 | type t : value non_null maybe_null
                             ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_null".
 
 Line 1, characters 15-23:
 1 | type t : value non_null maybe_null
@@ -155,7 +155,7 @@ Line 1, characters 24-34:
 1 | type t : value non_null maybe_null
                             ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_null".
 
 type t
 |}]
@@ -189,19 +189,19 @@ Line 1, characters 27-36:
 1 | type t : value non_pointer separable
                                ^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 27-36:
 1 | type t : value non_pointer separable
                                ^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 27-36:
 1 | type t : value non_pointer separable
                                ^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 type t : value non_pointer
 |}]
@@ -212,19 +212,19 @@ Line 1, characters 27-38:
 1 | type t : value non_pointer non_pointer
                                ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 27-38:
 1 | type t : value non_pointer non_pointer
                                ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 27-38:
 1 | type t : value non_pointer non_pointer
                                ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 type t : value non_pointer
 |}]
@@ -235,37 +235,37 @@ Line 1, characters 27-42:
 1 | type t : value non_pointer maybe_separable non_pointer
                                ^^^^^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 43-54:
 1 | type t : value non_pointer maybe_separable non_pointer
                                                ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_separable".
 
 Line 1, characters 27-42:
 1 | type t : value non_pointer maybe_separable non_pointer
                                ^^^^^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 43-54:
 1 | type t : value non_pointer maybe_separable non_pointer
                                                ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_separable".
 
 Line 1, characters 27-42:
 1 | type t : value non_pointer maybe_separable non_pointer
                                ^^^^^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 43-54:
 1 | type t : value non_pointer maybe_separable non_pointer
                                                ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_separable".
 
 type t : value non_pointer
 |}]
@@ -276,55 +276,55 @@ Line 1, characters 27-37:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 38-49:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                           ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_null".
 
 Line 1, characters 50-60:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                                       ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_null non_pointer".
 
 Line 1, characters 27-37:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 38-49:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                           ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_null".
 
 Line 1, characters 50-60:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                                       ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_null non_pointer".
 
 Line 1, characters 27-37:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 Line 1, characters 38-49:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                           ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_null".
 
 Line 1, characters 50-60:
 1 | type t : value non_pointer maybe_null non_pointer maybe_null
                                                       ^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer maybe_null non_pointer".
 
 type t : value non_pointer
 |}]
@@ -400,7 +400,7 @@ Line 1, characters 46-57:
 1 | type t : void non_pointer & value non_pointer non_pointer mod global with int
                                                   ^^^^^^^^^^^
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one, is
-already implied by the kind "value".
+already implied by the kind "value non_pointer".
 
 type t : void mod global & value non_pointer mod global
 |}]

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension layouts_alpha -w +183..185";
+ flags = "-extension layouts_alpha -w +183..184";
  expect;
 *)
 

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -659,7 +659,7 @@ let id' x = id x
 [%%expect{|
 external id : ('a : any separable). 'a t -> int = "%array_length"
   [@@layout_poly]
-val id' : ('a : value maybe_null). 'a t -> int = <fun>
+val id' : ('a : value_maybe_null). 'a t -> int = <fun>
 |}]
 
 external id : ('a : any mod separable). 'a t -> int = "%identity"
@@ -667,7 +667,7 @@ let id' x = id x
 
 [%%expect{|
 external id : ('a : any separable). 'a t -> int = "%identity"
-val id' : ('a : value maybe_null). 'a t -> int = <fun>
+val id' : ('a : value_maybe_null). 'a t -> int = <fun>
 |}]
 
 
@@ -776,7 +776,7 @@ Error:
        The kind of 'a -> 'b is value non_float mod aliased immutable
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of
-           value maybe_null mod portable contended
+           value_maybe_null mod portable contended
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -337,7 +337,7 @@ let foo (r @ shared) =
     | [| x; y |] -> ()
     | _ -> ()
 [%%expect{|
-val foo : ('a : value maybe_null). 'a array @ shared -> unit = <fun>
+val foo : ('a : value_maybe_null). 'a array @ shared -> unit = <fun>
 |}]
 
 (* Closing over write gives nonportable *)

--- a/testsuite/tests/typing-modes/staticity.ml
+++ b/testsuite/tests/typing-modes/staticity.ml
@@ -190,7 +190,7 @@ let foo (b @ dynamic) @ static =
     match[@warning "-8"] b with
     | [| |] -> "hello"
 [%%expect{|
-val foo : ('a : value maybe_null). 'a array -> string = <fun>
+val foo : ('a : value_maybe_null). 'a array -> string = <fun>
 |}]
 
 (* Testing exceptions *)

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1332,6 +1332,28 @@ module Jkind0 = struct
           name = "value_or_null"
         }
 
+      let value_maybe_null =
+        { jkind =
+            mk_jkind
+              (Base
+                (Scannable,
+                  { nullability = Maybe_null; separability = Separable }))
+              ~crossing:Mode.Crossing.max
+              ~externality:Mod_bounds.Externality.max;
+          name = "value_maybe_null"
+        }
+
+      let value_maybe_separable =
+        { jkind =
+            mk_jkind
+              (Base
+                (Scannable,
+                  { nullability = Non_null; separability = Maybe_separable }))
+              ~crossing:Mode.Crossing.max
+              ~externality:Mod_bounds.Externality.max;
+          name = "value_maybe_separable"
+        }
+
       let value_or_null_mod_everything =
         { jkind =
             mk_jkind
@@ -1352,25 +1374,39 @@ module Jkind0 = struct
           name = "value"
         }
 
-      let immutable_data =
+      let immutable_data_mod_bounds =
         let open Mod_bounds in
+        let crossing =
+          Crossing.create ~regionality:false ~linearity:true ~portability:true
+            ~forkable:true ~yielding:true ~uniqueness:false ~contention:true
+            ~statefulness:true ~visibility:true ~staticity:false
+        in
+        create crossing ~externality:Externality.max
+
+      let immutable_data =
         { jkind =
             { base =
                 Layout
                   (Base
                     (Scannable,
                       { nullability = Non_null; separability = Non_float }));
-              mod_bounds =
-                (let crossing =
-                   Crossing.create ~regionality:false ~linearity:true
-                     ~portability:true ~forkable:true ~yielding:true
-                     ~uniqueness:false ~contention:true ~statefulness:true
-                     ~visibility:true ~staticity:false
-                 in
-                 create crossing ~externality:Externality.max);
+              mod_bounds = immutable_data_mod_bounds;
               with_bounds = No_with_bounds
             };
           name = "immutable_data"
+        }
+
+      let immutable_data_or_null =
+        { jkind =
+            { base =
+                Layout
+                  (Base
+                    (Scannable,
+                      { nullability = Maybe_null; separability = Non_float }));
+              mod_bounds = immutable_data_mod_bounds;
+              with_bounds = No_with_bounds
+            };
+          name = "immutable_data_or_null"
         }
 
       let exn =
@@ -1394,46 +1430,74 @@ module Jkind0 = struct
           name = "exn"
         }
 
-      let sync_data =
+      let sync_data_mod_bounds =
         let open Mod_bounds in
+        let crossing =
+          Crossing.create ~regionality:false ~linearity:true ~portability:true
+            ~forkable:true ~yielding:true ~uniqueness:false ~contention:true
+            ~statefulness:true ~visibility:false ~staticity:false
+        in
+        create crossing ~externality:Externality.max
+
+      let sync_data =
         { jkind =
             { base =
                 Layout
                   (Base
                     (Scannable,
                       { nullability = Non_null; separability = Non_float }));
-              mod_bounds =
-                (let crossing =
-                   Crossing.create ~regionality:false ~linearity:true
-                     ~portability:true ~forkable:true ~yielding:true
-                     ~uniqueness:false ~contention:true ~statefulness:true
-                     ~visibility:false ~staticity:false
-                 in
-                 create crossing ~externality:Externality.max);
+              mod_bounds = sync_data_mod_bounds;
               with_bounds = No_with_bounds
             };
           name = "sync_data"
         }
 
-      let mutable_data =
+      let sync_data_or_null =
+        { jkind =
+            { base =
+                Layout
+                  (Base
+                    (Scannable,
+                      { nullability = Maybe_null; separability = Non_float }));
+              mod_bounds = sync_data_mod_bounds;
+              with_bounds = No_with_bounds
+            };
+          name = "sync_data_or_null"
+        }
+
+      let mutable_data_mod_bounds =
         let open Mod_bounds in
+        let crossing =
+          Crossing.create ~regionality:false ~linearity:true ~portability:true
+            ~forkable:true ~yielding:true ~contention:false ~uniqueness:false
+            ~statefulness:true ~visibility:false ~staticity:false
+        in
+        create crossing ~externality:Externality.max
+
+      let mutable_data =
         { jkind =
             { base =
                 Layout
                   (Base
                     (Scannable,
                       { nullability = Non_null; separability = Non_float }));
-              mod_bounds =
-                (let crossing =
-                   Crossing.create ~regionality:false ~linearity:true
-                     ~portability:true ~forkable:true ~yielding:true
-                     ~contention:false ~uniqueness:false ~statefulness:true
-                     ~visibility:false ~staticity:false
-                 in
-                 create crossing ~externality:Externality.max);
+              mod_bounds = mutable_data_mod_bounds;
               with_bounds = No_with_bounds
             };
           name = "mutable_data"
+        }
+
+      let mutable_data_or_null =
+        { jkind =
+            { base =
+                Layout
+                  (Base
+                    (Scannable,
+                      { nullability = Maybe_null; separability = Non_float }));
+              mod_bounds = mutable_data_mod_bounds;
+              with_bounds = No_with_bounds
+            };
+          name = "mutable_data_or_null"
         }
 
       let void =
@@ -1721,11 +1785,16 @@ module Jkind0 = struct
 
       let builtins =
         [ any;
+          value_maybe_null;
+          value_maybe_separable;
           value_or_null;
           value;
           immutable_data;
+          immutable_data_or_null;
           sync_data;
+          sync_data_or_null;
           mutable_data;
+          mutable_data_or_null;
           void;
           immediate;
           immediate_or_null;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1785,6 +1785,8 @@ module Jkind0 = struct
 
       let builtins =
         [ any;
+          (* Order matters: value_maybe_null comes before value_or_null because
+             we prefer to print the latter. *)
           value_maybe_null;
           value_maybe_separable;
           value_or_null;

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1912,11 +1912,11 @@ module Const = struct
 
     let annot_of_nullability_annot :
         Nullability.t Location.loc option -> t Location.loc option =
-     fun x -> Option.map (fun x -> Location.map (fun x -> Nullability x) x) x
+      Option.map (Location.map (fun x -> Nullability x))
 
     let annot_of_separability_annot :
         Separability.t Location.loc option -> t Location.loc option =
-     fun x -> Option.map (fun x -> Location.map (fun x -> Separability x) x) x
+      Option.map (Location.map (fun x -> Separability x))
   end
 
   let apply_scannable_axis ?prior_annot env
@@ -2029,6 +2029,8 @@ module Const = struct
       in
       let mod_bounds = Mod_bounds.meet base.mod_bounds mod_bounds in
       { base = base.base; mod_bounds; with_bounds = No_with_bounds }
+      (* For scannable axes in mod bounds, we do not print redundancy warnings,
+         as scannable axes in mod bounds will be deprecated anyway *)
       |> apply_scannable_axis env
            (Scannable_axis.annot_of_nullability_annot nullability)
       |> apply_scannable_axis env

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1898,11 +1898,32 @@ module Const = struct
   (*******************************)
   (* converting user annotations *)
 
-  let apply_kind_modifier env t (modifier : 'a Location.loc option)
-      (f : Scannable_axes.t -> 'a -> Warnings.loc -> Scannable_axes.t) =
-    match modifier with
+  module Scannable_axis = struct
+    type t =
+      | Nullability of Nullability.t
+      | Separability of Separability.t
+
+    let lower_axes (sa : Scannable_axes.t) (axis : t) =
+      match axis with
+      | Nullability axis ->
+        { sa with nullability = Nullability.meet sa.nullability axis }
+      | Separability axis ->
+        { sa with separability = Separability.meet sa.separability axis }
+
+    let annot_of_nullability_annot :
+        Nullability.t Location.loc option -> t Location.loc option =
+     fun x -> Option.map (fun x -> Location.map (fun x -> Nullability x) x) x
+
+    let annot_of_separability_annot :
+        Separability.t Location.loc option -> t Location.loc option =
+     fun x -> Option.map (fun x -> Location.map (fun x -> Separability x) x) x
+  end
+
+  let apply_scannable_axis ?abbrev env
+      (axis : Scannable_axis.t Location.loc option) t =
+    match axis with
     | None -> t
-    | Some { txt = modifier; loc } -> (
+    | Some { txt = axis; loc } -> (
       let t = Base_and_axes.fully_expand_aliases_const env t in
       match t.base with
       | Kconstr _ -> raise ~loc Abstract_kind_with_kind_modifier
@@ -1910,40 +1931,16 @@ module Const = struct
         match Layout.Const.get_root_scannable_axes layout with
         | None -> t
         | Some sa ->
+          let sa' = Scannable_axis.lower_axes sa axis in
+          (match abbrev with
+          | Some abbrev when Scannable_axes.equal sa sa' ->
+            Location.prerr_warning loc
+              (Warnings.Redundant_kind_modifier
+                 (Format.asprintf "%a" Pprintast.longident abbrev))
+          | _ -> ());
           { t with
-            base =
-              Layout
-                (Layout.Const.set_root_scannable_axes layout (f sa modifier loc))
+            base = Layout (Layout.Const.set_root_scannable_axes layout sa')
           }))
-
-  let set_nullability ~abbrev env (nul : Nullability.t Location.loc option) t =
-    apply_kind_modifier env t nul (fun sa nullability loc ->
-        if nullability = sa.nullability
-        then
-          Location.prerr_warning loc
-            (Warnings.Redundant_kind_modifier
-               (Format.asprintf "%a" Pprintast.longident abbrev));
-        { sa with nullability })
-
-  let set_separability ~abbrev env (sep : Separability.t Location.loc option) t
-      =
-    apply_kind_modifier env t sep (fun sa separability loc ->
-        if separability = sa.separability
-        then
-          Location.prerr_warning loc
-            (Warnings.Redundant_kind_modifier
-               (Format.asprintf "%a" Pprintast.longident abbrev));
-        { sa with separability })
-
-  let meet_nullability env (nul : Nullability.t Location.loc option) t =
-    apply_kind_modifier env t nul (fun sa nullability _loc ->
-        { sa with nullability = Nullability.meet sa.nullability nullability })
-
-  let meet_separability env (sep : Separability.t Location.loc option) t =
-    apply_kind_modifier env t sep (fun sa separability _loc ->
-        { sa with
-          separability = Separability.meet sa.separability separability
-        })
 
   let jkind_of_product_annotations (type l r) ~loc env (jkinds : (l * r) t list)
       =
@@ -1972,49 +1969,24 @@ module Const = struct
     }
 
   let transl_scannable_axes sa_annots =
-    let set_or_warn ~loc ~to_ ~to_string cur_axis =
-      match cur_axis with
-      | Some overridden_by ->
-        Location.prerr_warning loc
-          (Warnings.Overridden_kind_modifier
-             (to_string (Location.get_txt overridden_by)));
-        cur_axis
-      | None -> Some (Location.mkloc to_ loc)
-    in
-    (* This will compute and report errors from right-to-left, which enables
-       better error messages while traversing the list only once. It comes at
-       the cost of warnings being reported in a slightly weirder order. *)
-    List.fold_right
-      (fun ({ txt; loc } : string Location.loc) (nullability, separability) ->
+    List.map
+      (fun ({ txt; loc } : string Location.loc) ->
         match txt with
         | "non_pointer" ->
-          ( nullability,
-            Separability.(
-              set_or_warn ~loc ~to_:Non_pointer ~to_string separability) )
+          Location.mkloc (Scannable_axis.Separability Non_pointer) loc
         | "non_pointer64" ->
-          ( nullability,
-            Separability.(
-              set_or_warn ~loc ~to_:Non_pointer64 ~to_string separability) )
+          Location.mkloc (Scannable_axis.Separability Non_pointer64) loc
         | "non_float" ->
-          ( nullability,
-            Separability.(
-              set_or_warn ~loc ~to_:Non_float ~to_string separability) )
+          Location.mkloc (Scannable_axis.Separability Non_float) loc
         | "separable" ->
-          ( nullability,
-            Separability.(
-              set_or_warn ~loc ~to_:Separable ~to_string separability) )
+          Location.mkloc (Scannable_axis.Separability Separable) loc
         | "maybe_separable" ->
-          ( nullability,
-            Separability.(
-              set_or_warn ~loc ~to_:Maybe_separable ~to_string separability) )
-        | "non_null" ->
-          ( Nullability.(set_or_warn ~loc ~to_:Non_null ~to_string nullability),
-            separability )
+          Location.mkloc (Scannable_axis.Separability Maybe_separable) loc
+        | "non_null" -> Location.mkloc (Scannable_axis.Nullability Non_null) loc
         | "maybe_null" ->
-          ( Nullability.(set_or_warn ~loc ~to_:Maybe_null ~to_string nullability),
-            separability )
+          Location.mkloc (Scannable_axis.Nullability Maybe_null) loc
         | _ -> raise ~loc (Unknown_kind_modifier txt))
-      sa_annots (None, None)
+      sa_annots
 
   let rec of_user_written_annotation_unchecked_level : type l r.
       use_abstract_jkinds:bool ->
@@ -2028,7 +2000,7 @@ module Const = struct
     | Pjk_abbreviation (name, sa_annot) ->
       let p, _ = Env.lookup_jkind ~use:use_abstract_jkinds ~loc name.txt env in
       let jkind_without_sa = of_path p in
-      let nullability, separability = transl_scannable_axes sa_annot in
+      let scannable_annots = transl_scannable_axes sa_annot in
       if
         sa_annot <> []
         &&
@@ -2040,9 +2012,10 @@ module Const = struct
           (Warnings.Ignored_kind_modifier
              ( Format.asprintf "%a" Pprintast.longident name.txt,
                List.map Location.get_txt sa_annot ));
-      jkind_without_sa
-      |> set_nullability ~abbrev:name.txt env nullability
-      |> set_separability ~abbrev:name.txt env separability
+      List.fold_left
+        (fun jkind sa ->
+          apply_scannable_axis ~abbrev:name.txt env (Some sa) jkind)
+        jkind_without_sa scannable_annots
       |> allow_left |> allow_right
     | Pjk_mod (base, modifiers) ->
       let base =
@@ -2056,8 +2029,10 @@ module Const = struct
       in
       let mod_bounds = Mod_bounds.meet base.mod_bounds mod_bounds in
       { base = base.base; mod_bounds; with_bounds = No_with_bounds }
-      |> meet_nullability env nullability
-      |> meet_separability env separability
+      |> apply_scannable_axis env
+           (Scannable_axis.annot_of_nullability_annot nullability)
+      |> apply_scannable_axis env
+           (Scannable_axis.annot_of_separability_annot separability)
     | Pjk_product ts ->
       let jkinds =
         List.map

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1919,7 +1919,7 @@ module Const = struct
      fun x -> Option.map (fun x -> Location.map (fun x -> Separability x) x) x
   end
 
-  let apply_scannable_axis ?abbrev env
+  let apply_scannable_axis ?prior_annot env
       (axis : Scannable_axis.t Location.loc option) t =
     match axis with
     | None -> t
@@ -1932,11 +1932,13 @@ module Const = struct
         | None -> t
         | Some sa ->
           let sa' = Scannable_axis.lower_axes sa axis in
-          (match abbrev with
-          | Some abbrev when Scannable_axes.equal sa sa' ->
+          (match prior_annot with
+          | Some (abbrev, rev_axes) when Scannable_axes.equal sa sa' ->
             Location.prerr_warning loc
               (Warnings.Redundant_kind_modifier
-                 (Format.asprintf "%a" Pprintast.longident abbrev))
+                 (Format.asprintf "%a%s" Pprintast.longident abbrev
+                    (String.concat ""
+                       (List.rev_map (fun axis -> " " ^ axis) rev_axes))))
           | _ -> ());
           { t with
             base = Layout (Layout.Const.set_root_scannable_axes layout sa')
@@ -1968,25 +1970,19 @@ module Const = struct
       with_bounds
     }
 
-  let transl_scannable_axes sa_annots =
-    List.map
-      (fun ({ txt; loc } : string Location.loc) ->
-        match txt with
-        | "non_pointer" ->
-          Location.mkloc (Scannable_axis.Separability Non_pointer) loc
-        | "non_pointer64" ->
-          Location.mkloc (Scannable_axis.Separability Non_pointer64) loc
-        | "non_float" ->
-          Location.mkloc (Scannable_axis.Separability Non_float) loc
-        | "separable" ->
-          Location.mkloc (Scannable_axis.Separability Separable) loc
-        | "maybe_separable" ->
-          Location.mkloc (Scannable_axis.Separability Maybe_separable) loc
-        | "non_null" -> Location.mkloc (Scannable_axis.Nullability Non_null) loc
-        | "maybe_null" ->
-          Location.mkloc (Scannable_axis.Nullability Maybe_null) loc
-        | _ -> raise ~loc (Unknown_kind_modifier txt))
-      sa_annots
+  let transl_scannable_axis ({ txt; loc } : string Location.loc) =
+    match txt with
+    | "non_pointer" ->
+      Location.mkloc (Scannable_axis.Separability Non_pointer) loc
+    | "non_pointer64" ->
+      Location.mkloc (Scannable_axis.Separability Non_pointer64) loc
+    | "non_float" -> Location.mkloc (Scannable_axis.Separability Non_float) loc
+    | "separable" -> Location.mkloc (Scannable_axis.Separability Separable) loc
+    | "maybe_separable" ->
+      Location.mkloc (Scannable_axis.Separability Maybe_separable) loc
+    | "non_null" -> Location.mkloc (Scannable_axis.Nullability Non_null) loc
+    | "maybe_null" -> Location.mkloc (Scannable_axis.Nullability Maybe_null) loc
+    | _ -> raise ~loc (Unknown_kind_modifier txt)
 
   let rec of_user_written_annotation_unchecked_level : type l r.
       use_abstract_jkinds:bool ->
@@ -2000,7 +1996,6 @@ module Const = struct
     | Pjk_abbreviation (name, sa_annot) ->
       let p, _ = Env.lookup_jkind ~use:use_abstract_jkinds ~loc name.txt env in
       let jkind_without_sa = of_path p in
-      let scannable_annots = transl_scannable_axes sa_annot in
       if
         sa_annot <> []
         &&
@@ -2012,11 +2007,16 @@ module Const = struct
           (Warnings.Ignored_kind_modifier
              ( Format.asprintf "%a" Pprintast.longident name.txt,
                List.map Location.get_txt sa_annot ));
-      List.fold_left
-        (fun jkind sa ->
-          apply_scannable_axis ~abbrev:name.txt env (Some sa) jkind)
-        jkind_without_sa scannable_annots
-      |> allow_left |> allow_right
+      let jkind, _abbrev =
+        List.fold_left
+          (fun (jkind, rev_axes) axis ->
+            ( apply_scannable_axis ~prior_annot:(name.txt, rev_axes) env
+                (Some (transl_scannable_axis axis))
+                jkind,
+              axis.Location.txt :: rev_axes ))
+          (jkind_without_sa, []) sa_annot
+      in
+      allow_left jkind |> allow_right
     | Pjk_mod (base, modifiers) ->
       let base =
         of_user_written_annotation_unchecked_level ~use_abstract_jkinds env

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -1291,7 +1291,8 @@ let message = function
       "A generative functor\n\
        should be applied to '()'; using '(struct end)' is deprecated."
   | Redundant_kind_modifier abbrev ->
-      "This kind modifier is already implied by the kind \"" ^ abbrev ^ "\"."
+      "This kind modifier, or a stronger one, is\n\
+       already implied by the kind \"" ^ abbrev ^ "\"."
   | Ignored_kind_modifier (abbrev, modifiers) ->
       Printf.sprintf
       "The kind modifier(s) \"%s\" have no effect on the kind \"%s\"."

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -132,7 +132,6 @@ type t =
   (* Oxcaml specific warnings: numbers should go down from 199 *)
   | Redundant_kind_modifier of string       (* 183 *)
   | Ignored_kind_modifier of string * string list (* 184 *)
-  | Overridden_kind_modifier of string      (* 185 *)
   | Unmutated_mutable of string             (* 186 *)
   | Incompatible_with_upstream of upstream_compat_warning (* 187 *)
   | Unerasable_position_argument            (* 188 *)
@@ -236,7 +235,6 @@ let number = function
   | Generative_application_expects_unit -> 73
   | Redundant_kind_modifier _ -> 183
   | Ignored_kind_modifier _ -> 184
-  | Overridden_kind_modifier _ -> 185
   | Unmutated_mutable _ -> 186
   | Incompatible_with_upstream _ -> 187
   | Unerasable_position_argument -> 188
@@ -611,10 +609,6 @@ let descriptions = [
        the following description) should be updated in tandem. *)
     description = "A nullability or separability axis annotation appears on \
                    a non-value, non-any layout.";
-    since = since 5 2 };
-  { number = 185;
-    names = ["overridden-kind-modifier"];
-    description = "A kind modifier is present but overridden later.";
     since = since 5 2 };
   { number = 186;
     names = ["unmutated-mutable"];
@@ -1008,7 +1002,7 @@ let parse_options errflag s =
   alerts
 
 (* If you change these, don't forget to change them in man/ocamlc.m *)
-let defaults_w = "+a-4-7-9-27-29-30-32..42-44-45-48-50-60-66..70-183..185"
+let defaults_w = "+a-4-7-9-27-29-30-32..42-44-45-48-50-60-66..70-183..184"
 let defaults_warn_error = "-a"
 let default_disabled_alerts = [ "unstable"; "unsynchronized_access" ]
 
@@ -1297,8 +1291,6 @@ let message = function
       Printf.sprintf
       "The kind modifier(s) \"%s\" have no effect on the kind \"%s\"."
       (String.concat " " modifiers) abbrev
-  | Overridden_kind_modifier overridden_by ->
-      "This kind modifier is overridden by \"" ^ overridden_by ^ "\" later."
   | Unmutated_mutable v -> "mutable variable " ^ v ^ " was never mutated."
   | Incompatible_with_upstream (Non_value_sort layout) ->
       Printf.sprintf

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -136,7 +136,6 @@ type t =
 (* Oxcaml specific warnings: numbers should go down from 199 *)
   | Redundant_kind_modifier of string       (* 183 *)
   | Ignored_kind_modifier of string * string list (* 184 *)
-  | Overridden_kind_modifier of string      (* 185 *)
   | Unmutated_mutable of string             (* 186 *)
   | Incompatible_with_upstream of upstream_compat_warning (* 187 *)
   | Unerasable_position_argument            (* 188 *)


### PR DESCRIPTION
Previously, a scannable modifier written after a layout overrode that axis on the abbreviation (e.g. `value maybe_null` was a strict superkind of `value`).

With this change, scannable modifiers now take the meet — they can only lower an axis, matching `mod`. `value maybe_null` now means `value` (with a `Redundant_kind_modifier` warning), and `Overridden_kind_modifier` is no longer emitted.

To keep readable spellings for kinds above `value`, which improves type/error printing, we add the abbreviations `value_maybe_null`, `value_maybe_separable`, `immutable_data_or_null`, `mutable_data_or_null`, and `sync_data_or_null`.