### PR TITLE
flambda2: Provide initial type when defining a variable

### DIFF
--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -376,10 +376,11 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
           in
           (* We need to add the new variable to the typing env in order to be
              able to compute binding times for the following rounds. *)
+          let kind = K.With_subkind.kind (BP.kind extra_param) in
           let typing_env_with_extra_params =
             TE.add_definition typing_env_with_extra_params
               (Bound_name.create (BP.name extra_param) Name_mode.normal)
-              (K.With_subkind.kind (BP.kind extra_param))
+              kind (T.unknown kind)
           in
           extra_bindings, typing_env_with_extra_params)
     in

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -172,7 +172,7 @@ let define_continuations ~can_be_lifted t conts =
   in
   { t with replay_history }
 
-let define_variable0 ~extra t var kind =
+let define_variable0 ~extra t var kind ty =
   let replay_history =
     if extra
     then t.replay_history
@@ -196,7 +196,7 @@ let define_variable0 ~extra t var kind =
   in
   let typing_env =
     let var = Bound_name.create_var var in
-    TE.add_definition t.typing_env var kind
+    TE.add_definition t.typing_env var kind ty
   in
   let variables_defined_at_toplevel =
     if t.at_unit_toplevel
@@ -211,10 +211,10 @@ let define_variable0 ~extra t var kind =
   }
 
 let define_variable t var kind =
-  (define_variable0 [@inlined hint]) ~extra:false t var kind
+  (define_variable0 [@inlined hint]) ~extra:false t var kind (T.unknown kind)
 
 let define_extra_variable t var kind =
-  (define_variable0 [@inlined hint]) ~extra:true t var kind
+  (define_variable0 [@inlined hint]) ~extra:true t var kind (T.unknown kind)
 
 let create ~round ~machine_width ~(resolver : resolver)
     ~(get_imported_names : get_imported_names)
@@ -368,12 +368,15 @@ let enter_set_of_closures
     has_seen_a_non_liftable_continuation = false
   }
 
-let define_symbol t sym kind =
+let define_symbol0 t sym kind ty =
   let typing_env =
     let sym = Bound_name.create (Name.symbol sym) Name_mode.normal in
-    TE.add_definition t.typing_env sym kind
+    TE.add_definition t.typing_env sym kind ty
   in
   { t with typing_env }
+
+let define_symbol t sym kind =
+  (define_symbol0 [@inlined hint]) t sym kind (T.unknown kind)
 
 let define_name t name kind =
   Name.pattern_match (Bound_name.name name)
@@ -387,17 +390,12 @@ let define_name t name kind =
     ~symbol:(fun[@inline] sym -> (define_symbol [@inlined hint]) t sym kind)
 
 let add_variable0 ~extra t var ty =
-  let t = (define_variable0 [@inlined hint]) ~extra t var (T.kind ty) in
-  { t with
-    typing_env = TE.add_equation t.typing_env (Name.var (Bound_var.var var)) ty
-  }
+  (define_variable0 [@inlined hint]) ~extra t var (T.kind ty) ty
 
 let add_variable t var ty =
   (add_variable0 [@inlined hint]) ~extra:false t var ty
 
-let add_symbol t sym ty =
-  let t = (define_symbol [@inlined hint]) t sym (T.kind ty) in
-  { t with typing_env = TE.add_equation t.typing_env (Name.symbol sym) ty }
+let add_symbol t sym ty = (define_symbol0 [@inlined hint]) t sym (T.kind ty) ty
 
 let add_name t name ty =
   Name.pattern_match (Bound_name.name name)
@@ -448,7 +446,8 @@ let define_parameters ~extra t ~params =
     (fun t param ->
       let param_var, param_duid = BP.var_and_uid param in
       let var = Bound_var.create param_var param_duid Name_mode.normal in
-      define_variable0 ~extra t var (K.With_subkind.kind (BP.kind param)))
+      let kind = K.With_subkind.kind (BP.kind param) in
+      define_variable0 ~extra t var kind (T.unknown kind))
     t
     (Bound_parameters.to_list params)
 

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -180,7 +180,8 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
            { Extra_param_and_args.param = var; param_debug_uid = _; args = _ }
          ->
         let name = Bound_name.create (Name.var var) Name_mode.normal in
-        TE.add_definition acc name (K.Block_shape.element_kind shape index))
+        let kind = K.Block_shape.element_kind shape index in
+        TE.add_definition acc name kind (T.unknown kind))
       tenv field_vars
   in
   let shape =

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -246,7 +246,8 @@ let add_env_extension_with_extra_variables t
   Typing_env_extension.With_extra_variables.fold
     ~variable:(fun var kind t ->
       map_typing_env t ~f:(fun t ->
-          TE.add_variable_definition t var kind Name_mode.in_types))
+          TE.add_variable_definition t var kind (MTC.unknown kind)
+            Name_mode.in_types))
     ~equation:(fun name ty t ->
       try add_equation ~raise_on_bottom:true t name ty ~meet_type
       with Bottom_equation -> map_typing_env ~f:TE.make_bottom t)
@@ -257,7 +258,8 @@ let add_env_extension_from_level t level ~meet_type =
     map_typing_env t ~f:(fun t ->
         TEL.fold_on_defined_vars
           (fun var kind t ->
-            TE.add_variable_definition t var kind Name_mode.in_types)
+            TE.add_variable_definition t var kind (MTC.unknown kind)
+              Name_mode.in_types)
           level t)
   in
   let t =
@@ -327,7 +329,8 @@ let current_scope env = TE.current_scope (typing_env env)
 let increment_scope env = map_typing_env env ~f:TE.increment_scope
 
 let add_definition env bound_name kind =
-  map_typing_env env ~f:(fun env -> TE.add_definition env bound_name kind)
+  map_typing_env env ~f:(fun env ->
+      TE.add_definition env bound_name kind (MTC.unknown kind))
 
 let add_symbol_projection env var symbol_projection =
   map_typing_env env ~f:(fun env ->
@@ -340,4 +343,4 @@ let cut_as_extension env ~cut_after =
 
 let add_variable_definition env var kind name_mode =
   map_typing_env env ~f:(fun env ->
-      TE.add_variable_definition env var kind name_mode)
+      TE.add_variable_definition env var kind (MTC.unknown kind) name_mode)

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -691,7 +691,7 @@ let with_aliases t ~aliases =
 
 let cached t = One_level.just_after_level t.current_level
 
-let add_variable_definition t var kind name_mode =
+let add_variable_definition t var kind ty name_mode =
   (* We can add equations in our own compilation unit on variables and symbols
      defined in another compilation unit. However we can't define other
      compilation units' variables or symbols (except for predefined symbols such
@@ -715,8 +715,8 @@ let add_variable_definition t var kind name_mode =
       var kind t.next_binding_time
   in
   let just_after_level =
-    Cached_level.add_or_replace_binding (cached t) name (MTC.unknown kind)
-      t.next_binding_time name_mode
+    Cached_level.add_or_replace_binding (cached t) name ty t.next_binding_time
+      name_mode
   in
   let current_level =
     One_level.create (current_scope t) level ~just_after_level
@@ -757,18 +757,6 @@ let add_symbol_projection t var proj =
 
 let find_symbol_projection t var =
   Cached_level.find_symbol_projection (cached t) var
-
-let add_definition t (name : Bound_name.t) kind =
-  let name_mode = Bound_name.name_mode name in
-  Name.pattern_match (Bound_name.name name)
-    ~var:(fun var -> add_variable_definition t var kind name_mode)
-    ~symbol:(fun sym ->
-      if not (Name_mode.equal name_mode Name_mode.normal)
-      then
-        Misc.fatal_errorf
-          "Cannot define symbol %a with name mode that is not `normal'"
-          Bound_name.print name;
-      add_symbol_definition t sym)
 
 let invariant_for_alias (t : t) name ty =
   (* Check that no canonical element gets an [Equals] type *)
@@ -860,6 +848,25 @@ let replace_equation (t : t) name ty =
   in
   with_current_level t ~current_level
 
+let add_definition t (name : Bound_name.t) kind ty =
+  let name_mode = Bound_name.name_mode name in
+  Name.pattern_match (Bound_name.name name)
+    ~var:(fun var -> add_variable_definition t var kind ty name_mode)
+    ~symbol:(fun sym ->
+      if not (Name_mode.equal name_mode Name_mode.normal)
+      then
+        Misc.fatal_errorf
+          "Cannot define symbol %a with name mode that is not `normal'"
+          Bound_name.print name;
+      if not (K.equal (TG.kind ty) K.value)
+      then
+        Misc.fatal_errorf "Cannot define symbol %a with non-value kind"
+          Bound_name.print name;
+      let t = add_symbol_definition t sym in
+      if TG.is_obviously_unknown ty
+      then t
+      else replace_equation t (Name.symbol sym) ty)
+
 let aliases_add t ~canonical_element1 ~canonical_element2 =
   (* This may raise [Binding_time_resolver_failure]. *)
   Aliases.add ~binding_time_resolver:t.binding_time_resolver (aliases t)
@@ -890,8 +897,8 @@ let add_definitions_of_params t ~params =
       let name =
         Bound_name.create (Bound_parameter.name param) Name_mode.normal
       in
-      add_definition t name
-        (Flambda_kind.With_subkind.kind (Bound_parameter.kind param)))
+      let kind = Flambda_kind.With_subkind.kind (Bound_parameter.kind param) in
+      add_definition t name kind (MTC.unknown kind))
     t
     (Bound_parameters.to_list params)
 

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -107,9 +107,9 @@ val current_scope : t -> Scope.t
 val increment_scope : t -> t
 
 val add_variable_definition :
-  t -> Variable.t -> Flambda_kind.t -> Name_mode.t -> t
+  t -> Variable.t -> Flambda_kind.t -> Type_grammar.t -> Name_mode.t -> t
 
-val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
+val add_definition : t -> Bound_name.t -> Flambda_kind.t -> Type_grammar.t -> t
 
 val replace_equation : t -> Name.t -> Type_grammar.t -> t
 

--- a/middle_end/flambda2/types/equal_types_for_debug.ml
+++ b/middle_end/flambda2/types/equal_types_for_debug.ml
@@ -518,7 +518,8 @@ let names_with_non_equal_types_level_ignoring_name_mode ?config ~meet_type env
                    so we do not equip them with a [Flambda_debug_uid.t]. See
                    #3967. *)
                 Name_mode.in_types))
-          kind)
+          kind
+          (More_type_creators.unknown kind))
       level1 env
   in
   let right_env =
@@ -531,7 +532,8 @@ let names_with_non_equal_types_level_ignoring_name_mode ?config ~meet_type env
                    so we do not equip them with a [Flambda_debug_uid.t]. See
                    #3967. *)
                 Name_mode.in_types))
-          kind)
+          kind
+          (More_type_creators.unknown kind))
       level2 env
   in
   names_with_non_equal_types_env_extension ~equal_type

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -175,7 +175,7 @@ module Typing_env : sig
 
   val increment_scope : t -> t
 
-  val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
+  val add_definition : t -> Bound_name.t -> Flambda_kind.t -> flambda_type -> t
 
   val add_definitions_of_params : t -> params:Bound_parameters.t -> t
 

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -52,7 +52,7 @@ let join_types ~env_at_fork envs_with_levels =
                                at runtime, so we do not equip them with a
                                [Flambda_debug_uid.t]. See #3967. *)
                             Name_mode.in_types))
-                      kind)
+                      kind (MTC.unknown kind))
                 vars base_env)
             (TEL.variables_by_binding_time level)
             base_env

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -1283,7 +1283,9 @@ struct
       Symbol.Set.fold
         (fun symbol base_env ->
           let bound_name = Bound_name.create_symbol symbol in
-          let base_env = TE.add_definition base_env bound_name K.value in
+          let base_env =
+            TE.add_definition base_env bound_name K.value (MTC.unknown K.value)
+          in
           base_env)
         (TE.defined_symbols env) base_env
     in
@@ -1294,7 +1296,7 @@ struct
             Bound_name.create_var
               (Bound_var.create var Flambda_debug_uid.none Name_mode.normal)
           in
-          TE.add_definition env bound_name kind)
+          TE.add_definition env bound_name kind (MTC.unknown K.value))
         live_vars env
     in
     let env =
@@ -1316,8 +1318,9 @@ struct
                 Bound_name.create_var
                   (Bound_var.create var' Flambda_debug_uid.none Name_mode.normal)
               in
+              let kind = TG.kind ty' in
               let base_env =
-                TE.add_definition base_env bound_name (TG.kind ty')
+                TE.add_definition base_env bound_name kind (MTC.unknown kind)
               in
               let new_types = Name.Map.add (Name.var var') ty' new_types in
               Var.Map.add var var' sbs, base_env, new_types, acc))
@@ -1343,7 +1346,8 @@ struct
                         (Bound_var.create var_after_rewrite
                            Flambda_debug_uid.none Name_mode.in_types)
                     in
-                    TE.add_definition base_env bound_name kind))
+                    TE.add_definition base_env bound_name kind
+                      (MTC.unknown kind)))
             aliases_of_name base_env)
         aliases_of_names base_env
     in
@@ -1396,7 +1400,9 @@ struct
             :: acc.names_to_process
           in
           let bound_name = Bound_name.create_symbol symbol in
-          let base_env = TE.add_definition base_env bound_name K.value in
+          let base_env =
+            TE.add_definition base_env bound_name K.value (MTC.unknown K.value)
+          in
           base_env, { aliases_of_names; names_to_process })
         (TE.defined_symbols env) (base_env, empty)
     in
@@ -1414,7 +1420,7 @@ struct
                       (Bound_var.create var_after_rewrite Flambda_debug_uid.none
                          Name_mode.in_types)
                   in
-                  TE.add_definition base_env bound_name kind))
+                  TE.add_definition base_env bound_name kind (MTC.unknown kind)))
             aliases_of_name base_env)
         aliases_of_names base_env
     in


### PR DESCRIPTION
Currently when we use the `DA.add_variable` / `DE.add_variable` helpers we are first defining the variable in the typing env with an "unknown" type, followed by adding an equation on that variable. This involves calling `find` on the variable, which is guaranteed to find the "unknown" type we have just added, and then `meet`ing that "unknown" with the newly added type, which always returns the newly added type unchanged.

Instead, this patch allows directly providing the new type to the typing env when the variable is defined, avoiding a useless call to `find` for every newly defined variable. The calls to `find` are relatively cheap, but we do a lot of them, so we might as well avoid the useless ones.