### PR TITLE
[5.4] Improve backtraces for effects

### DIFF
--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -83,11 +83,11 @@ module Deep = struct
   type ('a,'b) continuation_ =
     | Cont : ('a,'x,'b) cont -> ('a, 'b) continuation_ [@@unboxed]
 
-  let continue (Cont k) v = resume k (fun x-> x) v
+  let[@inline] continue (Cont k) v = resume k (fun x-> x) v
 
-  let discontinue (Cont k) e = resume k (fun e -> raise e) e
+  let[@inline] discontinue (Cont k) e = resume k (fun e -> raise e) e
 
-  let discontinue_with_backtrace (Cont k) e bt =
+  let[@inline] discontinue_with_backtrace (Cont k) e bt =
     resume k (fun e -> Printexc.raise_with_backtrace e bt) e
 
   type ('a,'b) handler =
@@ -100,9 +100,9 @@ module Deep = struct
 
   (* CR effect-syntax: Upstream the 3-parameter version of continuation and use
      it to maintain type safety here. *)
-  let to_continuation (f : _ continuation -> 'a) (k : _ continuation_) =
+  let[@inline] to_continuation (f : _ continuation -> 'a) (k : _ continuation_) =
     f (Obj.magic k)
-  let of_continuation (f : _ continuation_ -> 'a) (k : _ continuation) =
+  let[@inline] of_continuation (f : _ continuation_ -> 'a) (k : _ continuation) =
     f (Obj.magic k)
 
   let match_with comp arg handler =
@@ -124,9 +124,9 @@ module Deep = struct
     in
     with_stack (fun x -> x) (fun e -> raise e) effc' comp arg
 
-  let continue k = of_continuation continue k
-  let discontinue k = of_continuation discontinue k
-  let discontinue_with_backtrace k =
+  let[@inline] continue k = of_continuation continue k
+  let[@inline] discontinue k = of_continuation discontinue k
+  let[@inline] discontinue_with_backtrace k =
     of_continuation discontinue_with_backtrace k
 
   external get_callstack :

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -100,9 +100,12 @@ module Deep = struct
 
   (* CR effect-syntax: Upstream the 3-parameter version of continuation and use
      it to maintain type safety here. *)
-  let[@inline] to_continuation (f : _ continuation -> 'a) (k : _ continuation_) =
+  let[@inline] to_continuation (f : _ continuation -> 'a) (k : _ continuation_)
+      =
     f (Obj.magic k)
-  let[@inline] of_continuation (f : _ continuation_ -> 'a) (k : _ continuation) =
+
+  let[@inline] of_continuation (f : _ continuation_ -> 'a) (k : _ continuation)
+      =
     f (Obj.magic k)
 
   let match_with comp arg handler =

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,4 +1,6 @@
-Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 21, characters 2-11
-Called from Stdlib__Effect.Deep.continue in file "effect.ml" (inlined), line 60, characters 4-65
-Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 29, characters 16-29
+Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 86, characters 37-59
+Called from Stdlib__Effect.Deep.of_continuation in file "stdlib/effect.ml" (inlined), line 106, characters 4-19
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 127, characters 28-54
+Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
 43


### PR DESCRIPTION
This PR adds inlining annotations to improve the backtraces we get for effect handlers.