### PR TITLE
Efficiency improvements for .cmx export

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -25,10 +25,12 @@ let print_view ppf t = Code_id.Map.print Code_or_metadata.print_view ppf t
 
 let empty = Code_id.Map.empty
 
-let free_names t =
+let free_function_slots_and_value_slots t =
   Code_id.Map.fold
-    (fun _code_id code acc ->
-      Name_occurrences.union acc (Code_or_metadata.free_names code))
+    (fun _code_id code_or_metadata acc ->
+      Name_occurrences.union acc
+        (Name_occurrences.restrict_to_value_slots_and_function_slots
+           (Code_or_metadata.free_names code_or_metadata)))
     t Name_occurrences.empty
 
 let add_code ~keep_code code_map t =
@@ -78,19 +80,19 @@ let find t code_id =
     None
   | code_or_metadata -> Some code_or_metadata
 
-let remove_unreachable ~reachable_names t =
-  Code_id.Map.filter
-    (fun code_id _code_or_metadata ->
-      Name_occurrences.mem_code_id reachable_names code_id)
-    t
-
-let remove_unused_value_slots_from_result_types_and_shortcut_aliases
-    ~used_value_slots ~canonicalise t =
-  Code_id.Map.map
-    (fun code_or_metadata ->
-      Code_or_metadata.map_result_types code_or_metadata ~f:(fun result_ty ->
-          Flambda2_types.remove_unused_value_slots_and_shortcut_aliases
-            result_ty ~used_value_slots ~canonicalise))
+let prepare_for_export t ~reachable_names ~used_value_slots ~canonicalise =
+  Code_id.Map.filter_map
+    (fun code_id code_or_metadata ->
+      if not (Name_occurrences.mem_code_id reachable_names code_id)
+      then None
+      else
+        let code_or_metadata =
+          Code_or_metadata.map_result_types code_or_metadata
+            ~f:(fun result_ty ->
+              Flambda2_types.remove_unused_value_slots_and_shortcut_aliases
+                result_ty ~used_value_slots ~canonicalise)
+        in
+        Some code_or_metadata)
     t
 
 let ids_for_export t =

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -27,7 +27,7 @@ val print_view : Format.formatter -> t -> unit
 
 val empty : t
 
-val free_names : t -> Name_occurrences.t
+val free_function_slots_and_value_slots : t -> Name_occurrences.t
 
 val add_code : keep_code:(Code_id.t -> bool) -> Code.t Code_id.Map.t -> t -> t
 
@@ -44,12 +44,11 @@ val find_exn : t -> Code_id.t -> Code_or_metadata.t
     be special handling if a code ID is unbound (see comment in the .ml file) *)
 val find : t -> Code_id.t -> Code_or_metadata.t option
 
-val remove_unreachable : reachable_names:Name_occurrences.t -> t -> t
-
-val remove_unused_value_slots_from_result_types_and_shortcut_aliases :
+val prepare_for_export :
+  t ->
+  reachable_names:Name_occurrences.t ->
   used_value_slots:Value_slot.Set.t ->
   canonicalise:(Simple.t -> Simple.t) ->
-  t ->
   t
 
 val iter_code : t -> f:(Code.t -> unit) -> unit

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -190,10 +190,8 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   let all_code =
     (* CR mshinwell: do we need to remove unused function slot bindings from the
        result types too? *)
-    all_code
-    |> EC.remove_unused_value_slots_from_result_types_and_shortcut_aliases
-         ~used_value_slots ~canonicalise
-    |> EC.remove_unreachable ~reachable_names
+    EC.prepare_for_export all_code ~reachable_names ~used_value_slots
+      ~canonicalise
   in
   let final_typing_env = create_typing_env reachable_names in
   (* We need to re-export offsets for everything reachable from the cmx file;
@@ -204,26 +202,17 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
      function_slots/vars reachable from the code of the current compilation
      unit, but since we also re-export code metadata (including return types)
      from other compilation units, we need to take those into account. *)
-  (* CR gbury: it might be more efficient to not compute the free names for all
-     exported code, but fold over the exported code to avoid allocating some
-     free_names *)
-  let free_names_of_all_code = EC.free_names all_code in
-  let slots_used_in_typing_env =
-    TE.Serializable.free_function_slots_and_value_slots final_typing_env
+  let slot_free_names =
+    Name_occurrences.union
+      (EC.free_function_slots_and_value_slots all_code)
+      (TE.Serializable.free_function_slots_and_value_slots final_typing_env)
   in
   let exported_offsets =
     exported_offsets
     |> Exported_offsets.reexport_function_slots
-         (Name_occurrences.all_function_slots_at_normal_mode
-            free_names_of_all_code)
+         (Name_occurrences.all_function_slots_at_normal_mode slot_free_names)
     |> Exported_offsets.reexport_value_slots
-         (Name_occurrences.all_value_slots_at_normal_mode free_names_of_all_code)
-    |> Exported_offsets.reexport_function_slots
-         (Name_occurrences.all_function_slots_at_normal_mode
-            slots_used_in_typing_env)
-    |> Exported_offsets.reexport_value_slots
-         (Name_occurrences.all_value_slots_at_normal_mode
-            slots_used_in_typing_env)
+         (Name_occurrences.all_value_slots_at_normal_mode slot_free_names)
   in
   let cmx =
     Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -202,7 +202,9 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
      function_slots/vars reachable from the code of the current compilation
      unit, but since we also re-export code metadata (including return types)
      from other compilation units, we need to take those into account. *)
-  let free_slots_of_all_code = EC.free_function_slots_and_value_slots all_code in
+  let free_slots_of_all_code =
+    EC.free_function_slots_and_value_slots all_code
+  in
   let slots_used_in_typing_env =
     TE.Serializable.free_function_slots_and_value_slots final_typing_env
   in

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -202,17 +202,23 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
      function_slots/vars reachable from the code of the current compilation
      unit, but since we also re-export code metadata (including return types)
      from other compilation units, we need to take those into account. *)
-  let slot_free_names =
-    Name_occurrences.union
-      (EC.free_function_slots_and_value_slots all_code)
-      (TE.Serializable.free_function_slots_and_value_slots final_typing_env)
+  let free_slots_of_all_code = EC.free_function_slots_and_value_slots all_code in
+  let slots_used_in_typing_env =
+    TE.Serializable.free_function_slots_and_value_slots final_typing_env
   in
   let exported_offsets =
     exported_offsets
     |> Exported_offsets.reexport_function_slots
-         (Name_occurrences.all_function_slots_at_normal_mode slot_free_names)
+         (Name_occurrences.all_function_slots_at_normal_mode
+            free_slots_of_all_code)
     |> Exported_offsets.reexport_value_slots
-         (Name_occurrences.all_value_slots_at_normal_mode slot_free_names)
+         (Name_occurrences.all_value_slots_at_normal_mode free_slots_of_all_code)
+    |> Exported_offsets.reexport_function_slots
+         (Name_occurrences.all_function_slots_at_normal_mode
+            slots_used_in_typing_env)
+    |> Exported_offsets.reexport_value_slots
+         (Name_occurrences.all_value_slots_at_normal_mode
+            slots_used_in_typing_env)
   in
   let cmx =
     Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -127,6 +127,9 @@ let ids_for_export ~ids_for_export_function_params_and_body
       free_names_of_params_and_body_ids ]
 
 let map_result_types ({ code_metadata; _ } as t) ~f =
-  { t with code_metadata = Code_metadata.map_result_types code_metadata ~f }
+  let code_metadata' = Code_metadata.map_result_types code_metadata ~f in
+  if code_metadata == code_metadata'
+  then t
+  else { t with code_metadata = code_metadata' }
 
 let free_names_of_params_and_body t = t.free_names_of_params_and_body

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -629,8 +629,10 @@ let approx_equal
   && Loopify_attribute.equal loopify1 loopify2
 
 let map_result_types ({ result_types; _ } as t) ~f =
-  { t with
-    result_types =
-      Or_unknown_or_bottom.map result_types
-        ~f:(Result_types.map_result_types ~f)
-  }
+  let result_types' =
+    Or_unknown_or_bottom.map_sharing result_types
+      ~f:(Result_types.map_result_types ~f)
+  in
+  if result_types == result_types'
+  then t
+  else { t with result_types = result_types' }

--- a/middle_end/flambda2/terms/code_or_metadata.ml
+++ b/middle_end/flambda2/terms/code_or_metadata.ml
@@ -217,9 +217,11 @@ let map_result_types t ~f =
      called before output *)
   match view t with
   | Code_present code ->
-    Code_present { code_status = Loaded (Code.map_result_types code ~f) }
+    let code' = Code.map_result_types code ~f in
+    if code == code' then t else Code_present { code_status = Loaded code' }
   | Metadata_only code_metadata ->
-    Metadata_only (Code_metadata.map_result_types code_metadata ~f)
+    let code_metadata' = Code_metadata.map_result_types code_metadata ~f in
+    if code_metadata == code_metadata' then t else Metadata_only code_metadata'
 
 let code_present t =
   match t with Code_present _ -> true | Metadata_only _ -> false

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -151,5 +151,7 @@ let ids_for_export = A.ids_for_export
 let map_result_types t ~f =
   A.pattern_match t
     ~f:(fun { Bound.params; results; other_vars = _ } env_extension ->
-      let env_extension = TEEV.map_types ~f env_extension in
-      create ~params ~results env_extension)
+      let env_extension' = TEEV.map_types ~f env_extension in
+      if env_extension == env_extension'
+      then t
+      else create ~params ~results env_extension')

--- a/middle_end/flambda2/types/env/typing_env_extension.ml
+++ b/middle_end/flambda2/types/env/typing_env_extension.ml
@@ -145,7 +145,9 @@ module With_extra_variables = struct
   let existential_vars { existential_vars; _ } =
     Variable.Map.keys existential_vars
 
-  let map_types { existential_vars; equations } ~f =
-    let equations = Name.Map.map f equations in
-    { existential_vars; equations }
+  let map_types ({ existential_vars; equations } as t) ~f =
+    let equations' = Name.Map.map_sharing f equations in
+    if equations == equations'
+    then t
+    else { existential_vars; equations = equations' }
 end


### PR DESCRIPTION
The essence of this is:
1. Don't traverse and rewrite the result types for code which is not going to be exported (!)  See new function `Exported_code.prepare_for_export`
2. Stop building `Name_occurrences` values and whatnot which are just used for a subsequent fold, then discarded.  Just do the fold instead
3. Some phys-equal fixes.