### PR TITLE
Remove unique_ and once_ legacy mode prefix syntax

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -78,7 +78,6 @@ let keyword_table =
     "nonrec", NONREC;
     "object", OBJECT;
     "of", OF;
-    "once_", ONCE;
     "open", OPEN;
     "or", OR;
     "overwrite_", OVERWRITE;
@@ -96,7 +95,6 @@ let keyword_table =
     "true", TRUE;
     "try", TRY;
     "type", TYPE;
-    "unique_", UNIQUE;
     "val", VAL;
     "virtual", VIRTUAL;
     "when", WHEN;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1076,7 +1076,6 @@ let maybe_pmod_constraint mode expr =
 %token NONREC                 "nonrec"
 %token OBJECT                 "object"
 %token OF                     "of"
-%token ONCE                   "once_"
 %token OPEN                   "open"
 %token <string> OPTLABEL      "?label:" (* just an example *)
 %token OR                     "or"
@@ -1121,7 +1120,6 @@ let maybe_pmod_constraint mode expr =
 %token TYPE                   "type"
 %token <string> UIDENT        "UIdent" (* just an example *)
 %token UNDERSCORE             "_"
-%token UNIQUE                 "unique_"
 %token VAL                    "val"
 %token VIRTUAL                "virtual"
 %token WHEN                   "when"
@@ -4681,10 +4679,6 @@ strict_function_or_labeled_tuple_type:
 %inline mode_legacy:
    | LOCAL
        { mkloc (Mode "local") (make_loc $sloc) }
-   | UNIQUE
-       { mkloc (Mode "unique") (make_loc $sloc) }
-   | ONCE
-       { mkloc (Mode "once") (make_loc $sloc) }
 ;
 
 %inline mode_expr_legacy:

--- a/testsuite/tests/parsetree/modes_ast_mapper.ml
+++ b/testsuite/tests/parsetree/modes_ast_mapper.ml
@@ -40,7 +40,7 @@ let test mapper s =
 
 let () =
   test mapper "let f (local_ x) = x";
-  test mapper "let unique_ f (local_ x) = x";
+  test mapper "let (f @ unique) (local_ x) = x";
   test mapper "let local_ f x: int -> int = x";
   test mapper "module M : sig val x : string -> string @ foo @@ bar hello end = struct end";
   ()

--- a/testsuite/tests/parsetree/modes_ast_mapper.reference
+++ b/testsuite/tests/parsetree/modes_ast_mapper.reference
@@ -1,8 +1,8 @@
 modes: local [File "_none_", line 1, characters 7-13]
 ------------------------------
-modes: unique [File "_none_", line 1, characters 4-11]
-modes: local [File "_none_", line 1, characters 15-21]
-modes: unique [File "_none_", line 1, characters 4-11]
+modes: unique [File "_none_", line 1, characters 9-15]
+modes: local [File "_none_", line 1, characters 18-24]
+modes: unique [File "_none_", line 1, characters 9-15]
 ------------------------------
 modes: local [File "_none_", line 1, characters 4-10]
 modes: local [File "_none_", line 1, characters 4-10]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -486,9 +486,9 @@ type t =
 type fn = local_ int @ portable contended -> local_ int @ portable contended ;;
 type nested_fn = (local_ int @ portable once -> local_ int @ portable once) @ portable once -> local_ int @ portable once;;
 type ('a, 'b) labeled_fn =
-  a:local_ unique_ 'a @ portable contended -> ?b:local_ once_ 'b @ portable contended ->  local_ 'a @ contended portable-> (int -> local_ 'b @ unique once) @ portable;;
+  a:local_ 'a @ unique portable contended -> ?b:local_ 'b @ once portable contended ->  local_ 'a @ contended portable-> (int -> local_ 'b @ unique once) @ portable;;
 type typvar_fn =
-  a:local_ unique_ ('a 'b. 'a) @ portable contended -> unit
+  a:local_ ('a 'b. 'a) @ unique portable contended -> unit
 
 [%%expect{|
 type fn = int @ local portable contended -> int @ local portable contended

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -46,11 +46,11 @@ module Hidden_int64_u :
 module Immediate : sig
   val id : ('a : immediate). 'a -> 'a
   val ignore : ('a : immediate). 'a -> unit
-  val unique : ('a : immediate). unique_ 'a -> 'a
+  val unique : ('a : immediate). 'a @ unique -> 'a
 end = struct
   let id x = x
   let ignore _ = ()
-  let unique (unique_ x) = x
+  let unique (x @ unique) = x
 end
 
 [%%expect{|
@@ -65,11 +65,11 @@ module Immediate :
 module Float_u : sig
   val id : ('a : float64). 'a -> 'a
   val ignore : ('a : float64). 'a -> unit
-  val unique : ('a : float64). unique_ 'a -> 'a
+  val unique : ('a : float64). 'a @ unique -> 'a
 end = struct
   let id x = x
   let ignore _ = ()
-  let unique (unique_ x) = x
+  let unique (x @ unique) = x
 end
 
 [%%expect{|
@@ -84,11 +84,11 @@ module Float_u :
 module Int64_u : sig
   val id : ('a : bits64). 'a -> 'a
   val ignore : ('a : bits64). 'a -> unit
-  val unique : ('a : bits64). unique_ 'a -> 'a
+  val unique : ('a : bits64). 'a @ unique -> 'a
 end = struct
   let id x = x
   let ignore _ = ()
-  let unique (unique_ x) = x
+  let unique (x @ unique) = x
 end
 
 [%%expect{|
@@ -266,49 +266,49 @@ Line 2, characters 71-72:
 Error: This value is "local" but is expected to be "global".
 |}]
 
-let string_duplicate = let once_ x : string = "hello" in Fun.id x
+let string_duplicate = let (x @ once) : string = "hello" in Fun.id x
 
 [%%expect{|
 val string_duplicate : string = "hello"
 |}]
 
-let int_duplicate = let once_ x : int = 5 in Fun.id x
+let int_duplicate = let (x @ once) : int = 5 in Fun.id x
 
 [%%expect{|
 val int_duplicate : int = 5
 |}]
 
-let string_list_duplicate = let once_ x : string list = ["hi";"bye"] in Fun.id x
+let string_list_duplicate = let (x @ once) : string list = ["hi";"bye"] in Fun.id x
 
 [%%expect{|
 val string_list_duplicate : string list = ["hi"; "bye"]
 |}]
 
-let int_list_duplicate = let once_ x : int list = [4;5] in Fun.id x
+let int_list_duplicate = let (x @ once) : int list = [4;5] in Fun.id x
 
 [%%expect{|
 val int_list_duplicate : int list = [4; 5]
 |}]
 
 let hidden_string_duplicate =
-  let once_ x : Hidden_string.t = Hidden_string.hide "hello" in Fun.id x
+  let (x @ once) : Hidden_string.t = Hidden_string.hide "hello" in Fun.id x
 
 [%%expect{|
-Line 2, characters 71-72:
-2 |   let once_ x : Hidden_string.t = Hidden_string.hide "hello" in Fun.id x
-                                                                           ^
+Line 2, characters 74-75:
+2 |   let (x @ once) : Hidden_string.t = Hidden_string.hide "hello" in Fun.id x
+                                                                              ^
 Error: This value is "once" but is expected to be "many".
 |}]
 
 let hidden_int_duplicate =
-  let once_ x : Hidden_int.t = Hidden_int.hide 42 in Fun.id x
+  let (x @ once) : Hidden_int.t = Hidden_int.hide 42 in Fun.id x
 
 [%%expect{|
 val hidden_int_duplicate : Hidden_int.t = <abstr>
 |}]
 
 let hidden_string_list_duplicate =
-  let once_ x : Hidden_string.t list =
+  let (x @ once) : Hidden_string.t list =
     [Hidden_string.hide "hi"; Hidden_string.hide "bye"]
   in Fun.id x
 
@@ -320,7 +320,7 @@ Error: This value is "once" but is expected to be "many".
 |}]
 
 let hidden_int_list_duplicate =
-  let once_ x : Hidden_int.t list =
+  let (x @ once) : Hidden_int.t list =
     [Hidden_int.hide 2; Hidden_int.hide 3]
   in Fun.id x
 
@@ -328,72 +328,72 @@ let hidden_int_list_duplicate =
 val hidden_int_list_duplicate : Hidden_int.t list = [<abstr>; <abstr>]
 |}]
 
-let float_duplicate = let once_ x : float = 3.14 in Fun.id x
+let float_duplicate = let (x @ once) : float = 3.14 in Fun.id x
 
 [%%expect{|
 val float_duplicate : float = 3.14
 |}]
 
-let float_u_duplicate () = let once_ x : float# = #3.14 in Float_u.id x
+let float_u_duplicate () = let (x @ once) : float# = #3.14 in Float_u.id x
 
 [%%expect{|
 val float_u_duplicate : unit -> float# = <fun>
 |}]
 
-let int64_u_duplicate () = let once_ x : int64# = #314L in Int64_u.id x
+let int64_u_duplicate () = let (x @ once) : int64# = #314L in Int64_u.id x
 
 [%%expect{|
 val int64_u_duplicate : unit -> int64# = <fun>
 |}]
 
 let hidden_float_u_duplicate () =
-  let once_ x : Hidden_float_u.t = Hidden_float_u.hide #3.14 in Float_u.id x
+  let (x @ once) : Hidden_float_u.t = Hidden_float_u.hide #3.14 in Float_u.id x
 
 [%%expect{|
 val hidden_float_u_duplicate : unit -> Hidden_float_u.t = <fun>
 |}]
 
 let hidden_int64_u_duplicate () =
-  let once_ x : Hidden_int64_u.t = Hidden_int64_u.hide #314L in Int64_u.id x
+  let (x @ once) : Hidden_int64_u.t = Hidden_int64_u.hide #314L in Int64_u.id x
 
 [%%expect{|
 val hidden_int64_u_duplicate : unit -> Hidden_int64_u.t = <fun>
 |}]
 
 let float_u_record_duplicate =
-  let once_ x : float_u_record = { x = #3.14; y = #2.718 } in Fun.id x
+  let (x @ once) : float_u_record = { x = #3.14; y = #2.718 } in Fun.id x
 
 [%%expect{|
 val float_u_record_duplicate : float_u_record = {x = <abstr>; y = <abstr>}
 |}]
 
 let float_u_record_list_duplicate =
-  let once_ x : float_u_record list = [] in Fun.id x
+  let (x @ once) : float_u_record list = [] in Fun.id x
 
 [%%expect{|
 val float_u_record_list_duplicate : float_u_record list = []
 |}]
 
-let function_duplicate = let once_ x : int -> int = fun y -> y in Fun.id x
+let function_duplicate = let (x @ once) : int -> int = fun y -> y in Fun.id x
 
 [%%expect{|
-Line 1, characters 73-74:
-1 | let function_duplicate = let once_ x : int -> int = fun y -> y in Fun.id x
-                                                                             ^
+Line 1, characters 76-77:
+1 | let function_duplicate = let (x @ once) : int -> int = fun y -> y in Fun.id x
+                                                                                ^
 Error: This value is "once" but is expected to be "many".
 |}]
 
 let function_list_duplicate =
-  let once_ x : (int -> int) list = [(fun y -> y); fun z -> z + 1] in Fun.id x
+  let (x @ once) : (int -> int) list = [(fun y -> y); fun z -> z + 1] in Fun.id x
 
 [%%expect{|
-Line 2, characters 77-78:
-2 |   let once_ x : (int -> int) list = [(fun y -> y); fun z -> z + 1] in Fun.id x
-                                                                                 ^
+Line 2, characters 80-81:
+2 |   let (x @ once) : (int -> int) list = [(fun y -> y); fun z -> z + 1] in Fun.id x
+                                                                                    ^
 Error: This value is "once" but is expected to be "many".
 |}]
 
-let unique (unique_ x) = x
+let unique (x @ unique) = x
 
 [%%expect{|
 val unique : 'a @ unique -> 'a = <fun>

--- a/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -225,38 +225,38 @@ Error: This value is "local" to the parent region
 |}]
 
 type t_value
-let value_duplicate : once_ _ -> t_value = fun x -> x
+let value_duplicate : _ @ once -> t_value = fun x -> x
 
 [%%expect{|
 type t_value
-Line 2, characters 52-53:
-2 | let value_duplicate : once_ _ -> t_value = fun x -> x
-                                                        ^
+Line 2, characters 53-54:
+2 | let value_duplicate : _ @ once -> t_value = fun x -> x
+                                                         ^
 Error: This value is "once" but is expected to be "many".
 |}]
 
-let int_duplicate : once_ _ -> int = fun x -> x
+let int_duplicate : _ @ once -> int = fun x -> x
 
 [%%expect{|
 val int_duplicate : int @ once -> int = <fun>
 |}]
 
-let value_list_duplicate : once_ _ -> t_value list = fun x -> x
+let value_list_duplicate : _ @ once -> t_value list = fun x -> x
 
 [%%expect{|
-Line 1, characters 62-63:
-1 | let value_list_duplicate : once_ _ -> t_value list = fun x -> x
-                                                                  ^
+Line 1, characters 63-64:
+1 | let value_list_duplicate : _ @ once -> t_value list = fun x -> x
+                                                                   ^
 Error: This value is "once" but is expected to be "many".
 |}]
 
-let int_list_duplicate : once_ _ -> int list = fun x -> x
+let int_list_duplicate : _ @ once -> int list = fun x -> x
 
 [%%expect{|
 val int_list_duplicate : int list @ once -> int list = <fun>
 |}]
 
-let hidden_string_duplicate : once_ _ -> Hidden_string.t =
+let hidden_string_duplicate : _ @ once -> Hidden_string.t =
   fun x -> x
 
 [%%expect{|
@@ -266,33 +266,33 @@ Line 2, characters 11-12:
 Error: This value is "once" but is expected to be "many".
 |}]
 
-let hidden_int_duplicate : once_ _ -> Hidden_int.t =
+let hidden_int_duplicate : _ @ once -> Hidden_int.t =
   fun x -> x
 
 [%%expect{|
 val hidden_int_duplicate : Hidden_int.t @ once -> Hidden_int.t = <fun>
 |}]
 
-let float_duplicate : once_ _ -> float = fun x -> x
+let float_duplicate : _ @ once -> float = fun x -> x
 
 [%%expect{|
 val float_duplicate : float @ once -> float = <fun>
 |}]
 
-let float_u_duplicate : once_ _ -> float# = fun x -> x
+let float_u_duplicate : _ @ once -> float# = fun x -> x
 
 [%%expect{|
 val float_u_duplicate : float# @ once -> float# = <fun>
 |}]
 
-let hidden_float_u_duplicate : once_ _ -> Hidden_float_u.t = fun x -> x
+let hidden_float_u_duplicate : _ @ once -> Hidden_float_u.t = fun x -> x
 
 [%%expect{|
 val hidden_float_u_duplicate : Hidden_float_u.t @ once -> Hidden_float_u.t =
   <fun>
 |}]
 
-let float_u_record_duplicate : once_ _ -> float_u_record =
+let float_u_record_duplicate : _ @ once -> float_u_record =
   fun x -> x
 
 [%%expect{|
@@ -301,7 +301,7 @@ val float_u_record_duplicate : float_u_record @ once -> float_u_record =
 |}]
 
 let float_u_record_list_duplicate :
-  once_ _ -> float_u_record list =
+  _ @ once -> float_u_record list =
   fun x -> x
 
 [%%expect{|
@@ -309,16 +309,16 @@ val float_u_record_list_duplicate :
   float_u_record list @ once -> float_u_record list = <fun>
 |}]
 
-let function_duplicate : once_ _ -> (int -> int) = fun x -> x
+let function_duplicate : _ @ once -> (int -> int) = fun x -> x
 
 [%%expect{|
-Line 1, characters 60-61:
-1 | let function_duplicate : once_ _ -> (int -> int) = fun x -> x
-                                                                ^
+Line 1, characters 61-62:
+1 | let function_duplicate : _ @ once -> (int -> int) = fun x -> x
+                                                                 ^
 Error: This value is "once" but is expected to be "many".
 |}]
 
-let function_list_duplicate : once_ _ -> (int -> int) list =
+let function_list_duplicate : _ @ once -> (int -> int) list =
   fun x -> x
 
 [%%expect{|
@@ -328,46 +328,46 @@ Line 2, characters 11-12:
 Error: This value is "once" but is expected to be "many".
 |}]
 
-let string_unshare : _ -> unique_ string = fun x -> x
+let string_unshare : _ -> string @ unique = fun x -> x
 
 [%%expect{|
-Line 1, characters 52-53:
-1 | let string_unshare : _ -> unique_ string = fun x -> x
-                                                        ^
+Line 1, characters 53-54:
+1 | let string_unshare : _ -> string @ unique = fun x -> x
+                                                         ^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let int_unshare : _ -> unique_ int = fun x -> x
+let int_unshare : _ -> int @ unique = fun x -> x
 
 [%%expect{|
 val int_unshare : int -> int @ unique = <fun>
 |}]
 
-let string_list_unshare : _ -> unique_ string list = fun x -> x
+let string_list_unshare : _ -> string list @ unique = fun x -> x
 
 [%%expect{|
-Line 1, characters 62-63:
-1 | let string_list_unshare : _ -> unique_ string list = fun x -> x
-                                                                  ^
+Line 1, characters 63-64:
+1 | let string_list_unshare : _ -> string list @ unique = fun x -> x
+                                                                   ^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let int_list_unshare : _ -> unique_ int list = fun x -> x
+let int_list_unshare : _ -> int list @ unique = fun x -> x
 
 [%%expect{|
-Line 1, characters 56-57:
-1 | let int_list_unshare : _ -> unique_ int list = fun x -> x
-                                                            ^
+Line 1, characters 57-58:
+1 | let int_list_unshare : _ -> int list @ unique = fun x -> x
+                                                             ^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let function_unshare : _ -> unique_ (int -> int) = fun x -> x
+let function_unshare : _ -> (int -> int) @ unique = fun x -> x
 
 [%%expect{|
 val function_unshare : (int -> int) -> (int -> int) @ unique = <fun>
 |}]
 
-let hidden_string_unshare : _ -> unique_ Hidden_string.t =
+let hidden_string_unshare : _ -> Hidden_string.t @ unique =
   fun x -> x
 
 [%%expect{|
@@ -377,36 +377,36 @@ Line 2, characters 11-12:
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let hidden_int_unshare : _ -> unique_ Hidden_int.t =
+let hidden_int_unshare : _ -> Hidden_int.t @ unique =
   fun x -> x
 
 [%%expect{|
 val hidden_int_unshare : Hidden_int.t -> Hidden_int.t @ unique = <fun>
 |}]
 
-let float_unshare : _ -> unique_ float = fun x -> x
+let float_unshare : _ -> float @ unique = fun x -> x
 
 [%%expect{|
-Line 1, characters 50-51:
-1 | let float_unshare : _ -> unique_ float = fun x -> x
-                                                      ^
+Line 1, characters 51-52:
+1 | let float_unshare : _ -> float @ unique = fun x -> x
+                                                       ^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let float_u_unshare : _ -> unique_ float# = fun x -> x
+let float_u_unshare : _ -> float# @ unique = fun x -> x
 
 [%%expect{|
 val float_u_unshare : float# -> float# @ unique = <fun>
 |}]
 
-let hidden_float_u_unshare : _ -> unique_ Hidden_float_u.t = fun x -> x
+let hidden_float_u_unshare : _ -> Hidden_float_u.t @ unique = fun x -> x
 
 [%%expect{|
 val hidden_float_u_unshare : Hidden_float_u.t -> Hidden_float_u.t @ unique =
   <fun>
 |}]
 
-let float_u_record_unshare : _ -> unique_ float_u_record =
+let float_u_record_unshare : _ -> float_u_record @ unique =
   fun x -> x
 
 [%%expect{|
@@ -417,7 +417,7 @@ Error: This value is "aliased" but is expected to be "unique".
 |}]
 
 let float_u_record_list_unshare :
-  _ -> unique_ float_u_record list =
+  _ -> float_u_record list @ unique =
   fun x -> x
 
 [%%expect{|
@@ -427,16 +427,16 @@ Line 3, characters 11-12:
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let hidden_function_unshare : _ -> unique_ (int, int) Hidden_function.t = fun x -> x
+let hidden_function_unshare : _ -> (int, int) Hidden_function.t @ unique = fun x -> x
 
 [%%expect{|
-Line 1, characters 83-84:
-1 | let hidden_function_unshare : _ -> unique_ (int, int) Hidden_function.t = fun x -> x
-                                                                                       ^
+Line 1, characters 84-85:
+1 | let hidden_function_unshare : _ -> (int, int) Hidden_function.t @ unique = fun x -> x
+                                                                                        ^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let function_list_unshare : _ -> unique_ (int -> int) list =
+let function_list_unshare : _ -> (int -> int) list @ unique =
   fun x -> x
 
 [%%expect{|

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -34,7 +34,7 @@ Error: The value "s" is "local"
 
 (* class can refer to external unique things, but only as aliased. *)
 let foo () =
-    let unique_ s = "hello" in
+    let (s @ unique) = "hello" in
     let module M = struct
     class cla = object
         val k = unique_use s

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -261,7 +261,7 @@ Error: Found a aliased value where a unique value was expected
 *)
 
 (* arrow types *)
-type r = local_ string @ unique once -> unique_ string @ local once
+type r = local_ string @ unique once -> string @ local unique once
 [%%expect{|
 type r = string @ local unique once -> string @ local unique once
 |}]
@@ -296,12 +296,12 @@ Error: The locality axis has already been specified.
 |}]
 
 (* Mixing legacy and new modes *)
-type r = local_ unique_ once_ string -> string
+type r = local_ string @ unique once -> string
 [%%expect{|
 type r = string @ local unique once -> string
 |}]
 
-type r = local_ unique_ once_ string @ portable contended -> string
+type r = local_ string @ unique once portable contended -> string
 [%%expect{|
 type r = string @ local unique once portable contended -> string
 |}]

--- a/testsuite/tests/typing-modes/syntax-error.compilers.reference
+++ b/testsuite/tests/typing-modes/syntax-error.compilers.reference
@@ -65,7 +65,7 @@ Line 5, characters 8-9:
             ^
 Error: Syntax error
 Line 2, characters 26-28:
-2 | type r = local_ string @  -> unique_ string @ ;;
+2 | type r = local_ string @  -> string @ ;;
                               ^^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 37-39:

--- a/testsuite/tests/typing-modes/syntax-error.ml
+++ b/testsuite/tests/typing-modes/syntax-error.ml
@@ -55,7 +55,7 @@ let foo () =
   ~(bar @ ), ~(biz @ )
 ;;
 
-type r = local_ string @  -> unique_ string @ ;;
+type r = local_ string @  -> string @ ;;
 
 type r = local_ string * y:string @  -> local_ string * w:string @;;
 

--- a/testsuite/tests/typing-unique/borrow.ml
+++ b/testsuite/tests/typing-unique/borrow.ml
@@ -2,7 +2,7 @@
   expect;
 *)
 
-let unique_use (local_ unique_ _x) = ()
+let unique_use (_x @ local unique) = ()
 [%%expect{|
 val unique_use : 'a @ local unique -> unit = <fun>
 |}]
@@ -17,12 +17,12 @@ let local_aliased_use (local_ a) = ()
 val local_aliased_use : 'a @ local -> unit = <fun>
 |}]
 
-let unique_aliased_use (local_ unique_ x) (local_ y) = ()
+let unique_aliased_use (x @ local unique) (local_ y) = ()
 [%%expect{|
 val unique_aliased_use : 'a @ local unique -> 'b @ local -> unit = <fun>
 |}]
 
-let aliased_unique_use (local_ x) (local_ unique_ y) = ()
+let aliased_unique_use (local_ x) (y @ local unique) = ()
 [%%expect{|
 val aliased_unique_use : 'a @ local -> 'b @ local unique -> unit = <fun>
 |}]
@@ -48,7 +48,7 @@ Error: This value is "local" because it is borrowed.
 |}]
 
 let foo () =
-  let unique_ y = "hello" in
+  let (y @ unique) = "hello" in
   let x = borrow_ y in
   unique_use y
 [%%expect{|
@@ -70,7 +70,7 @@ Lines 3-4, characters 2-14:
 
 (* CR-someday zqian: support non-shallow borrowing *)
 let foo () =
-  let unique_ y = "hello" in
+  let (y @ unique) = "hello" in
   let y0, y1 = borrow_ y, borrow_ y in
   ()
 [%%expect{|
@@ -107,7 +107,7 @@ val foo : unit -> unit = <fun>
 
 (* borrowed values are aliased and cannot be used as unique *)
 let foo () =
-  let unique_ y = "hello" in
+  let (y @ unique) = "hello" in
   unique_use (borrow_ y);
   ()
 [%%expect{|
@@ -379,7 +379,7 @@ Error: This value is "aliased" because it is borrowed,
 
 (* borrowed values are local and cannot escape *)
 let foo () =
-  let unique_ y = "hello" in
+  let (y @ unique) = "hello" in
   match borrow_ y with
   | x -> ignore (global_aliased_use x)
 [%%expect{|
@@ -475,7 +475,7 @@ Line 4, characters 28-29:
 
 (* You can't use x uniquely after aliased usage *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   global_aliased_use x;
   unique_use x;
   ()
@@ -492,7 +492,7 @@ Line 3, characters 21-22:
 
 (* unless if you borrow it *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   local_aliased_use (borrow_ x);
   unique_use x;
   ()
@@ -502,7 +502,7 @@ val foo : unit -> unit = <fun>
 
 (* borrow after unique usage is bad *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   unique_use x;
   local_aliased_use (borrow_ x);
   ()
@@ -520,7 +520,7 @@ Line 3, characters 13-14:
 
 (* multiple borrowing is fine *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   aliased_aliased_use (borrow_ x) (borrow_ x);
   unique_use x;
   ()
@@ -530,7 +530,7 @@ val foo : unit -> unit = <fun>
 
 (* but you need to borrow both of course *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   aliased_aliased_use (borrow_ x) x;
   unique_use x;
   ()
@@ -552,7 +552,7 @@ Line 3, characters 34-35:
 |}]
 
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   local_aliased_use (borrow_ (global_aliased_use x));
   unique_use x;
   ()
@@ -569,7 +569,7 @@ Line 3, characters 49-50:
 
 (* borrowed values are aliased *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   unique_use (borrow_ x);
   ()
 [%%expect{|
@@ -582,7 +582,7 @@ Error: This value is "aliased" because it is borrowed,
 
 (* borrowed values are local and cannot escape *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   global_aliased_use (borrow_ x);
   ()
 [%%expect{|
@@ -596,7 +596,7 @@ Error: This value is "local" because it is borrowed.
 (* CR-soon zqian: The following should pass, once we distinguish stack region
 and ghost region, and allow functions to have "stack" as return mode. *)
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   local_returning (borrow_ x);
   ()
 [%%expect{|
@@ -609,7 +609,7 @@ Error: This value is "local"
 |}]
 
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   aliased_unique_use (borrow_ x) x;
   ()
 [%%expect{|
@@ -716,7 +716,7 @@ Error: The value is "once" but expected to be "many" because it is to be borrowe
 
 let aliased_local_and_legacy_use (a @ aliased local) () = ();;
 let foo () =
-  let unique_ x = "hello" in
+  let (x @ unique) = "hello" in
   let f = aliased_local_and_legacy_use (borrow_ x) in
   unique_use x;
   f ();

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -864,14 +864,11 @@ type 'a mutable_record = { mutable m : 'a }
 let mutable_field_aliased r =
   let y = OptionA "foo" in
   r.m <- y;
-  (r @ unique), y
+  (r : @ unique), y
 [%%expect{|
 type 'a mutable_record = { mutable m : 'a; }
-Line 6, characters 3-4:
-6 |   (r @ unique), y
-       ^
-Error: This expression has type "options mutable_record"
-       but an expression was expected of type "'a list"
+val mutable_field_aliased :
+  options mutable_record @ unique -> options mutable_record * options = <fun>
 |}]
 
 let mutable_field_aliased r =

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -8,7 +8,7 @@ type record_update = { x : string; y : string }
 type record_update = { x : string; y : string; }
 |}]
 
-let update (unique_ r : record_update) =
+let update (r : record_update @ unique) =
   let x = overwrite_ r with { x = "foo" } in
   x.x
 [%%expect{|
@@ -21,7 +21,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : record_update) =
+let update (r : record_update @ unique) =
   let x = overwrite_ r with ({ x = "foo" } : record_update) in
   x.x
 [%%expect{|
@@ -77,7 +77,7 @@ Line 2, characters 21-22:
    - the resulting value can be local/global
    - the value written in the record can be local/global *)
 
-let gc_soundness_bug (local_ unique_ r) (local_ x) =
+let gc_soundness_bug (r @ local unique) (local_ x) =
   exclave_ overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 31-32:
@@ -89,7 +89,7 @@ Error: This value is "local"
          which is expected to be "global".
 |}]
 
-let disallowed_by_locality (local_ unique_ r) (local_ x) =
+let disallowed_by_locality (r @ local unique) (local_ x) =
   overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 22-23:
@@ -101,7 +101,7 @@ Error: This value is "local" to the parent region
          which is expected to be "global".
 |}]
 
-let gc_soundness_bug (unique_ r) (local_ x) =
+let gc_soundness_bug (r @ unique) (local_ x) =
   exclave_ overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 31-32:
@@ -113,7 +113,7 @@ Error: This value is "local"
          which is expected to be "global".
 |}]
 
-let disallowed_by_locality (unique_ r) (local_ x) =
+let disallowed_by_locality (r @ unique) (local_ x) =
   overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 22-23:
@@ -125,7 +125,7 @@ Error: This value is "local" to the parent region
          which is expected to be "global".
 |}]
 
-let gc_soundness_no_bug (local_ unique_ r) x =
+let gc_soundness_no_bug (r @ local unique) x =
   exclave_ overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 11-34:
@@ -140,7 +140,7 @@ Uncaught exception: Misc.Fatal_error
 (* This code should fail if we used a real allocation { r with x } here.
    But we don't: the overwritten record may be regional in this case since
    no allocation takes place. We check four related cases below. *)
-let returning_regional (local_ unique_ r) x =
+let returning_regional (r @ local unique) x =
   overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 2-25:
@@ -189,7 +189,7 @@ Line 3, characters 22-23:
 Error: The value "r" is local, so it cannot be used inside an exclave_
 |}]
 
-let disallowed_by_regionality (local_ unique_ r) x =
+let disallowed_by_regionality (r @ local unique) x =
   let r = overwrite_ r with { x } in
   let ref = ref r in
   ref
@@ -200,7 +200,7 @@ Line 3, characters 16-17:
 Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
-let gc_soundness_no_bug (unique_ r) x =
+let gc_soundness_no_bug (r @ unique) x =
   exclave_ overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 11-34:
@@ -212,7 +212,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let gc_soundness_no_bug (unique_ r) x =
+let gc_soundness_no_bug (r @ unique) x =
   overwrite_ r with { x }
 [%%expect{|
 Line 2, characters 2-25:
@@ -864,21 +864,24 @@ type 'a mutable_record = { mutable m : 'a }
 let mutable_field_aliased r =
   let y = OptionA "foo" in
   r.m <- y;
-  (unique_ r), y
+  (r @ unique), y
 [%%expect{|
 type 'a mutable_record = { mutable m : 'a; }
-val mutable_field_aliased :
-  options mutable_record @ unique -> options mutable_record * options = <fun>
+Line 6, characters 3-4:
+6 |   (r @ unique), y
+       ^
+Error: This expression has type "options mutable_record"
+       but an expression was expected of type "'a list"
 |}]
 
 let mutable_field_aliased r =
-  unique_ r.m
+  (r.m : @ unique)
 [%%expect{|
-Line 2, characters 10-13:
-2 |   unique_ r.m
-              ^^^
+Line 2, characters 3-6:
+2 |   (r.m : @ unique)
+       ^^^
 Error: This value is "aliased"
-         because it is the field "m" (with some modality) of the record at line 2, characters 10-11.
+         because it is the field "m" (with some modality) of the record at line 2, characters 3-4.
        However, the highlighted expression is expected to be "unique".
 |}]
 
@@ -1065,7 +1068,7 @@ type tuple_unlabeled = string * string
 type tuple_unlabeled = string * string
 |}]
 
-let update (unique_ r : tuple_unlabeled) : tuple_unlabeled =
+let update (r : tuple_unlabeled @ unique) : tuple_unlabeled =
   let x = overwrite_ r with (_, _) in
   x
 [%%expect{|
@@ -1078,7 +1081,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : tuple_unlabeled) : tuple_unlabeled =
+let update (r : tuple_unlabeled @ unique) : tuple_unlabeled =
   let x = overwrite_ r with ("foo", _) in
   x
 [%%expect{|
@@ -1091,7 +1094,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : tuple_unlabeled) : tuple_unlabeled =
+let update (r : tuple_unlabeled @ unique) : tuple_unlabeled =
   let x = overwrite_ r with ("foo", "bar") in
   x
 [%%expect{|
@@ -1104,7 +1107,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : tuple_unlabeled) : tuple_unlabeled =
+let update (r : tuple_unlabeled @ unique) : tuple_unlabeled =
   let x = overwrite_ r with ("foo", "bar", "baz") in
 x
 [%%expect{|
@@ -1121,7 +1124,7 @@ type tuple_labeled = x:string * y:string
 type tuple_labeled = x:string * y:string
 |}]
 
-let update (unique_ r : tuple_labeled) : tuple_labeled =
+let update (r : tuple_labeled @ unique) : tuple_labeled =
   let x = overwrite_ r with (~x:"foo", _) in
   x
 [%%expect{|
@@ -1134,7 +1137,7 @@ Error: This expression has type "x:string * 'a"
 |}]
 
 (* CR uniqueness: Would be good to support [~y:_], without the parentheses, if possible *)
-let update (unique_ r : tuple_labeled) : tuple_labeled =
+let update (r : tuple_labeled @ unique) : tuple_labeled =
   let x = overwrite_ r with (~x:(_), ~y:(_)) in
   x
 [%%expect{|
@@ -1147,7 +1150,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : tuple_labeled) : tuple_labeled =
+let update (r : tuple_labeled @ unique) : tuple_labeled =
   let x = overwrite_ r with (~x:"foo", ~y:(_)) in
   x
 [%%expect{|
@@ -1160,7 +1163,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : tuple_labeled) : tuple_labeled =
+let update (r : tuple_labeled @ unique) : tuple_labeled =
   let x = overwrite_ r with (~x:"foo", ~y:"bar") in
   x
 [%%expect{|
@@ -1180,13 +1183,13 @@ Uncaught exception: Misc.Fatal_error
    Currently these are syntax errors. *)
 
 (*
-let update (unique_ r : tuple_labeled) : tuple_labeled =
+let update (r : tuple_labeled @ unique) : tuple_labeled =
   let x = overwrite_ r with (~x:"foo", ..) in
   x
 [%%expect{|
 |}]
 
-let update (unique_ r : tuple_labeled) : tuple_labeled =
+let update (r : tuple_labeled @ unique) : tuple_labeled =
   let x = overwrite_ r with (~x:"foo") in
   x
 [%%expect{|

--- a/testsuite/tests/typing-unique/overwriting_lift_constants.ml
+++ b/testsuite/tests/typing-unique/overwriting_lift_constants.ml
@@ -49,7 +49,7 @@ let test3 () =
 
 (* Since the tail was marked unique, it can not be lifted out *)
 let constant_list_unique x =
-  let unique_ y = 2 :: [] in x :: y
+  let (y @ unique) = 2 :: [] in x :: y
 
 let test4 () =
   List.hd (constant_list_unique 1) == List.hd (constant_list_unique 2),
@@ -57,8 +57,8 @@ let test4 () =
 
 (* Since the tail was marked unique, it can not be lifted out *)
 let constant_list_unique2 x =
-  let unique_ z = [] in
-  let unique_ y = 2 :: z in x :: y
+  let (z @ unique) = [] in
+  let (y @ unique) = 2 :: z in x :: y
 
 let test5 () =
   List.hd (constant_list_unique2 1) == List.hd (constant_list_unique2 2),

--- a/testsuite/tests/typing-unique/overwriting_lift_constants_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_lift_constants_bug.ml
@@ -10,31 +10,31 @@
 type point = { dim : int; x : float; y : float; z : float }
 
 let constant_lift b =
-  let unique_ p = { dim = 3; x = 1.0; y = 2.0; z = 3.0 } in
+  let (p @ unique) = { dim = 3; x = 1.0; y = 2.0; z = 3.0 } in
   if b then p else overwrite_ p with { x = 2.0 }
 
 type fpoint = { x : float; y : float; z : float }
 
 let fconstant_lift b =
-  let unique_ p = { x = 1.0; y = 2.0; z = 3.0 } in
+  let (p @ unique) = { x = 1.0; y = 2.0; z = 3.0 } in
   if b then p else overwrite_ p with { x = 2.0 }
 
 type mpoint = { dim : int option; x : float#; y : float#; z : float# }
 
 let mconstant_lift b =
-  let unique_ p = { dim = Some 3; x = #1.0; y = #2.0; z = #3.0 } in
+  let (p @ unique) = { dim = Some 3; x = #1.0; y = #2.0; z = #3.0 } in
   if b then p else overwrite_ p with { x = #2.0 }
 
 type ufpoint = { x : float#; y : float#; z : float# }
 
 let ufconstant_lift b =
-  let unique_ p = { x = #1.0; y = #2.0; z = #3.0 } in
+  let (p @ unique) = { x = #1.0; y = #2.0; z = #3.0 } in
   if b then p else overwrite_ p with { x = #2.0 }
 
 type utpoint = { xy : #(float * float); z : float }
 
 let ufconstant_lift b =
-  let unique_ p = { xy = #(1.0, 2.0); z = 3.0 } in
+  let (p @ unique) = { xy = #(1.0, 2.0); z = 3.0 } in
   if b then p else overwrite_ p with { xy = #(2.0, 2.0) }
 
 let () =

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -22,7 +22,7 @@ let aliased_use x = x
 val aliased_use : 'a -> 'a = <fun>
 |}]
 
-let unique_use (unique_ x) = x
+let unique_use (x @ unique) = x
 [%%expect{|
 (let (unique_use/293 = (function {nlocal = 0} x/295? x/295))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/293))
@@ -437,7 +437,7 @@ let match_guard r =
 val match_guard : record @ unique -> record * string = <fun>
 |}]
 
-let match_guard_unique (unique_ r) =
+let match_guard_unique (r @ unique) =
   match r with
   | { y } when String.equal ((unique_use r).x) "" -> y
   | _ -> ""
@@ -461,7 +461,7 @@ type option_record = { x : string option; y : string option }
 type option_record = { x : string option; y : string option; }
 |}]
 
-let check_heap_alloc_in_overwrite (unique_ r : option_record) =
+let check_heap_alloc_in_overwrite (r : option_record @ unique) =
   overwrite_ r with { x = Some "" }
 [%%expect{|
 Line 2, characters 2-35:
@@ -473,7 +473,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let check_heap_alloc_in_overwrite (local_ unique_ r : option_record) =
+let check_heap_alloc_in_overwrite (r : option_record @ local unique) =
   overwrite_ r with { x = Some "" }
 [%%expect{|
 Line 2, characters 2-35:
@@ -494,7 +494,7 @@ type mutable_record = { mutable x : string; y : string }
 type mutable_record = { mutable x : string; y : string; }
 |}]
 
-let update (unique_ r : mutable_record) =
+let update (r : mutable_record @ unique) =
   let x = overwrite_ r with { x = "foo" } in
   x.x
 [%%expect{|
@@ -507,7 +507,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let update (unique_ r : mutable_record) =
+let update (r : mutable_record @ unique) =
   let x = overwrite_ r with { y = "foo" } in
   x.x
 [%%expect{|

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -3,86 +3,86 @@
 *)
 
 (* unique means the value is the only usage *)
-let dup x = unique_ (x, x)
+let dup x = ((x, x) : @ unique)
 [%%expect{|
-Line 1, characters 24-25:
-1 | let dup x = unique_ (x, x)
-                            ^
+Line 1, characters 17-18:
+1 | let dup x = ((x, x) : @ unique)
+                     ^
 Error: This value is used here, but it is also being used as unique at:
-Line 1, characters 21-22:
-1 | let dup x = unique_ (x, x)
-                         ^
+Line 1, characters 14-15:
+1 | let dup x = ((x, x) : @ unique)
+                  ^
 
 |}]
 
 (* unique value can be used more than once *)
-let dup (unique_ x) = (x, x)
+let dup (x @ unique) = (x, x)
 [%%expect{|
 val dup : 'a @ unique -> 'a * 'a = <fun>
 |}]
 
 (* once value can be used only once*)
-let dup (once_ x) = (x, x)
+let dup (x @ once) = (x, x)
 [%%expect{|
-Line 1, characters 24-25:
-1 | let dup (once_ x) = (x, x)
-                            ^
+Line 1, characters 25-26:
+1 | let dup (x @ once) = (x, x)
+                             ^
 Error: This value is used here,
        but it is defined as once and is also being used at:
-Line 1, characters 21-22:
-1 | let dup (once_ x) = (x, x)
-                         ^
+Line 1, characters 22-23:
+1 | let dup (x @ once) = (x, x)
+                          ^
 
 |}]
 
-let dup (unique_ x) = (unique_ x, x, x)
+let dup (x @ unique) = ((x : @ unique), x, x)
 [%%expect{|
-Line 1, characters 34-35:
-1 | let dup (unique_ x) = (unique_ x, x, x)
-                                      ^
+Line 1, characters 40-41:
+1 | let dup (x @ unique) = ((x : @ unique), x, x)
+                                            ^
 Error: This value is used here, but it is also being used as unique at:
-Line 1, characters 31-32:
-1 | let dup (unique_ x) = (unique_ x, x, x)
-                                   ^
+Line 1, characters 24-38:
+1 | let dup (x @ unique) = ((x : @ unique), x, x)
+                            ^^^^^^^^^^^^^^
 
 |}]
 
-let dup (unique_ x) = (x, (unique_ x), x)
+let dup (x @ unique) = (x, (x : @ unique), x)
 [%%expect{|
-Line 1, characters 26-37:
-1 | let dup (unique_ x) = (x, (unique_ x), x)
-                              ^^^^^^^^^^^
+Line 1, characters 27-41:
+1 | let dup (x @ unique) = (x, (x : @ unique), x)
+                               ^^^^^^^^^^^^^^
 Error: This value is used here as unique, but it is also being used at:
-Line 1, characters 23-24:
-1 | let dup (unique_ x) = (x, (unique_ x), x)
-                           ^
+Line 1, characters 24-25:
+1 | let dup (x @ unique) = (x, (x : @ unique), x)
+                            ^
 
 |}]
 
 
-let dup (unique_ x) = ((unique_ x), x)
+let dup (x @ unique) = ((x : @ unique), x)
 [%%expect{|
-Line 1, characters 36-37:
-1 | let dup (unique_ x) = ((unique_ x), x)
-                                        ^
+Line 1, characters 40-41:
+1 | let dup (x @ unique) = ((x : @ unique), x)
+                                            ^
 Error: This value is used here, but it is also being used as unique at:
-Line 1, characters 23-34:
-1 | let dup (unique_ x) = ((unique_ x), x)
-                           ^^^^^^^^^^^
+Line 1, characters 24-38:
+1 | let dup (x @ unique) = ((x : @ unique), x)
+                            ^^^^^^^^^^^^^^
 
 |}]
 
 (* below we define a tuple that can be used multiple times,
   but manually relax it to once *)
-let dup x = once_ (x, x)
+let dup x = ((x, x) : @ once)
 [%%expect{|
 val dup : 'a -> 'a * 'a @ once = <fun>
 |}]
 
 (* closing over unique values gives once closure  *)
 let f () =
-  let unique_ k = [1;2;3] in
-  let g () = (unique_ k) @ [1;2;3] in
+  let (k @ unique) = [1;2;3] in
+  let g () = (k : @ unique) @ [1;2;3] in
   g () @ g ()
 [%%expect{|
 Line 4, characters 9-10:
@@ -99,7 +99,7 @@ Line 4, characters 2-3:
 (* but if the closure doesn't utilize the uniqueness,
   then it's not once *)
 let f () =
-  let unique_ k = [1;2;3] in
+  let (k @ unique) = [1;2;3] in
   let g () = k @ [1;2;3] in
   g () @ g ()
 [%%expect{|
@@ -107,9 +107,9 @@ val f : unit -> int list = <fun>
 |}]
 
 (* closing over once values gives once closure *)
-(* note that in g we don't annotate k; because once_ is already the most relaxed mode *)
+(* note that in g we don't annotate k; because once is already the most relaxed mode *)
 let f () =
-  let once_ k = [(fun x -> x)] in
+  let (k @ once) = [(fun x -> x)] in
   let g () = k @ [(fun x -> x)] in
   g () @ g ()
 [%%expect{|
@@ -122,7 +122,7 @@ Error: This value is "once" but is expected to be "many".
 (* variables inside loops will be made both aliased and many *)
 (* the following is fine, because k inside loop is aliased *)
 let f () =
-  let unique_ k = "foo" in
+  let (k @ unique) = "foo" in
   for i = 1 to 5 do
     ignore k
   done
@@ -133,7 +133,7 @@ val f : unit -> unit = <fun>
 
 (* The following is bad, because k is once and cannot be used more than once*)
 let f () =
-  let once_ k = fun x -> x in
+  let (k @ once) = fun x -> x in
   for i = 1 to 5 do
     k
   done
@@ -148,22 +148,22 @@ Error: The value "k" is "once"
 
 (* The following is bad, because k is used uniquely *)
 let f () =
-  let unique_ k = "foo" in
+  let (k @ unique) = "foo" in
   for i = 1 to 5 do
-    unique_ k
+    (k : @ unique)
   done
 [%%expect{|
-Line 4, characters 12-13:
-4 |     unique_ k
-                ^
+Line 4, characters 5-6:
+4 |     (k : @ unique)
+         ^
 Error: This value is "aliased"
          because it is used in a loop (at lines 3-5, characters 2-6).
        However, the highlighted expression is expected to be "unique".
 |}]
 
 let f =
-  let unique_ a = "hello" in
-  let g (unique_ a) = a in
+  let (a @ unique) = "hello" in
+  let g (a @ unique) = a in
   for i = 0 to 5 do
     let _ = g a in ()
   done;
@@ -178,9 +178,9 @@ Error: This value is "aliased"
 |}]
 
 let f =
-  let g (unique_ a) = a in
+  let g (a @ unique) = a in
   for i = 0 to 5 do
-    let unique_ a = 3 in
+    let (a @ unique) = 3 in
     let _ = g a in ()
   done;
   ()
@@ -194,16 +194,16 @@ val x : string = "foo"
 |}]
 
 (* Top-level must be many *)
-let once_ foo = "foo"
+let (foo @ once) = "foo"
 [%%expect{|
-Line 1, characters 4-21:
-1 | let once_ foo = "foo"
-        ^^^^^^^^^^^^^^^^^
+Line 1, characters 5-24:
+1 | let (foo @ once) = "foo"
+         ^^^^^^^^^^^^^^^^^^^
 Error: This value is "once" but is expected to be "many".
 |}]
 
 (* the following is fine - we relax many to once *)
-let foo () = once_ x
+let foo () = (x : @ once)
 [%%expect{|
 val foo : unit -> string @ once = <fun>
 |}];;
@@ -215,18 +215,18 @@ val foo : unit -> string @ once = <fun>
 |}]
 
 (* top-level must be aliased; the following unique is weakened to aliased *)
-let unique_ foo = "foo"
+let (foo @ unique) = "foo"
 [%%expect{|
 val foo : string = "foo"
 |}]
 
 
 (* the following is bad - trying to tighten aliased to unique *)
-let foo () = unique_ x
+let foo () = (x : @ unique)
 [%%expect{|
-Line 1, characters 21-22:
-1 | let foo () = unique_ x
-                         ^
+Line 1, characters 14-15:
+1 | let foo () = (x : @ unique)
+                  ^
 Error: This value is "aliased" but is expected to be "unique".
 |}];;
 
@@ -242,16 +242,16 @@ type 'a glob = { glob: 'a @@ aliased many } [@@unboxed]
 [%%expect{|
 type 'a glob = { glob : 'a @@ many aliased; } [@@unboxed]
 |}]
-let dup (glob : 'a) : 'a glob * 'a glob = unique_ ({glob}, {glob})
+let dup (glob : 'a) : 'a glob * 'a glob = (({glob}, {glob}) : @ unique)
 [%%expect{|
 val dup : 'a -> 'a glob * 'a glob = <fun>
 |}]
 
 (* For strict type/mode match we need module *)
 module M : sig
-  val drop : unique_ 'a -> unique_ unit
+  val drop : 'a @ unique -> unit @ unique
   end = struct
-  let drop (unique_ x) = unique_ ()
+  let drop (x @ unique) = (() : @ unique)
 end
 [%%expect{|
 module M : sig val drop : 'a @ unique -> unit @ unique end
@@ -259,7 +259,7 @@ module M : sig val drop : 'a @ unique -> unit @ unique end
 
 (* In the following we won't use module *)
 (* printed modes are imprecise *)
-let unique_id : unique_ 'a -> unique_ 'a = fun x -> x
+let unique_id : 'a @ unique -> 'a @ unique = fun x -> x
 [%%expect{|
 val unique_id : 'a @ unique -> 'a @ unique = <fun>
 |}]
@@ -270,122 +270,122 @@ val aliased_id : 'a -> 'a = <fun>
 |}]
 
 let tail_unique _x =
-  let unique_ y = "foo" in unique_id y
+  let (y @ unique) = "foo" in unique_id y
 [%%expect{|
 val tail_unique : 'a -> string = <fun>
 |}]
 
-let tail_unique : unique_ 'a list -> unique_ 'a list = function
+let tail_unique : 'a list @ unique -> 'a list @ unique = function
   | [] -> []
   | _ :: xx -> xx
 [%%expect{|
 val tail_unique : 'a list @ unique -> 'a list @ unique = <fun>
 |}]
 
-let higher_order (f : unique_ 'a -> unique_ 'b) (unique_ x : 'a) = unique_ f x
+let higher_order (f : 'a @ unique -> 'b @ unique) (x : 'a @ unique) = (f x : @ unique)
 [%%expect{|
 val higher_order : ('a @ unique -> 'b @ unique) -> 'a @ unique -> 'b = <fun>
 |}]
 
-let higher_order2 (f : 'a -> unique_ 'b) (x : 'a) = unique_ f x
+let higher_order2 (f : 'a -> 'b @ unique) (x : 'a) = (f x : @ unique)
 [%%expect{|
 val higher_order2 : ('a -> 'b @ unique) -> 'a -> 'b = <fun>
 |}]
 
-let higher_order3 (f : 'a -> 'b) (unique_ x : 'a) = unique_ f x
+let higher_order3 (f : 'a -> 'b) (x : 'a @ unique) = (f x : @ unique)
 [%%expect{|
-Line 1, characters 60-63:
-1 | let higher_order3 (f : 'a -> 'b) (unique_ x : 'a) = unique_ f x
-                                                                ^^^
+Line 1, characters 54-57:
+1 | let higher_order3 (f : 'a -> 'b) (x : 'a @ unique) = (f x : @ unique)
+                                                          ^^^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let higher_order4 (f : unique_ 'a -> 'b) (x : 'a) = f (aliased_id x)
+let higher_order4 (f : 'a @ unique -> 'b) (x : 'a) = f (aliased_id x)
 [%%expect{|
-Line 1, characters 54-68:
-1 | let higher_order4 (f : unique_ 'a -> 'b) (x : 'a) = f (aliased_id x)
-                                                          ^^^^^^^^^^^^^^
+Line 1, characters 55-69:
+1 | let higher_order4 (f : 'a @ unique -> 'b) (x : 'a) = f (aliased_id x)
+                                                           ^^^^^^^^^^^^^^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let higher_order5 (unique_ x) = let f (unique_ x) = unique_ x in higher_order f x
+let higher_order5 (x @ unique) = let f (x @ unique) = (x : @ unique) in higher_order f x
 [%%expect{|
 val higher_order5 : 'a @ unique -> 'a = <fun>
 |}]
 
-let higher_order6 (unique_ x) = let f (unique_ x) = unique_ x in higher_order2 f x
+let higher_order6 (x @ unique) = let f (x @ unique) = (x : @ unique) in higher_order2 f x
 [%%expect{|
-Line 1, characters 79-80:
-1 | let higher_order6 (unique_ x) = let f (unique_ x) = unique_ x in higher_order2 f x
-                                                                                   ^
+Line 1, characters 86-87:
+1 | let higher_order6 (x @ unique) = let f (x @ unique) = (x : @ unique) in higher_order2 f x
+                                                                                          ^
 Error: This expression has type "'a @ unique -> 'a"
        but an expression was expected of type "'b -> 'c @ unique"
 |}]
 
-let inf1 (unique_ x : float) = unique_ let y = x in y
+let inf1 (x : float @ unique) = (let y = x in y : @ unique)
 [%%expect{|
 val inf1 : float @ unique -> float = <fun>
 |}]
 
-let inf2 (b : bool) (unique_ x : float) = unique_ let y = if b then x else 1.0 in y
+let inf2 (b : bool) (x : float @ unique) = (let y = if b then x else 1.0 in y : @ unique)
 [%%expect{|
 val inf2 : bool -> float @ unique -> float = <fun>
 |}]
 
-let inf3 : bool -> float -> unique_ float -> float = fun b y x ->
-  let _ = aliased_id y in let unique_ z = if b then x else y in z
+let inf3 : bool -> float -> float @ unique -> float = fun b y x ->
+  let _ = aliased_id y in let (z @ unique) = if b then x else y in z
 [%%expect{|
-Line 2, characters 59-60:
-2 |   let _ = aliased_id y in let unique_ z = if b then x else y in z
-                                                               ^
+Line 2, characters 62-63:
+2 |   let _ = aliased_id y in let (z @ unique) = if b then x else y in z
+                                                                  ^
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
-let inf4 (b : bool) (y : float) (unique_ x : float) =
-  let _ = aliased_id y in let unique_ z = if b then x else y in z
+let inf4 (b : bool) (y : float) (x : float @ unique) =
+  let _ = aliased_id y in let (z @ unique) = if b then x else y in z
 [%%expect{|
-Line 2, characters 59-60:
-2 |   let _ = aliased_id y in let unique_ z = if b then x else y in z
-                                                               ^
+Line 2, characters 62-63:
+2 |   let _ = aliased_id y in let (z @ unique) = if b then x else y in z
+                                                                  ^
 Error: This value is used here as unique, but it has already been used at:
 Line 2, characters 21-22:
-2 |   let _ = aliased_id y in let unique_ z = if b then x else y in z
+2 |   let _ = aliased_id y in let (z @ unique) = if b then x else y in z
                          ^
 
 |}]
 
 
-let inf5 (b : bool) (y : float) (unique_ x : float) =
-  let z = if b then x else y in unique_ z
+let inf5 (b : bool) (y : float) (x : float @ unique) =
+  let z = if b then x else y in (z : @ unique)
 [%%expect{|
 val inf5 : bool -> float @ unique -> float @ unique -> float = <fun>
 |}]
 
-let inf6 (unique_ x) = let f x = x in higher_order f x
+let inf6 (x @ unique) = let f x = x in higher_order f x
 [%%expect{|
 val inf6 : 'a @ unique -> 'a = <fun>
 |}]
 
-let unique_default_args ?(unique_ x = 1.0) () = x
+let unique_default_args ?(x @ unique = 1.0) () = x
 [%%expect{|
 val unique_default_args : ?x:float @ unique -> unit -> float = <fun>
 |}]
 
 (* Unique Local *)
 
-let ul (unique_ local_ x) = x
+let ul (x @ unique local) = x
 [%%expect{|
 val ul : 'a @ local unique -> 'a @ local = <fun>
 |}]
 
-let ul_ret x = exclave_ unique_ x
+let ul_ret x = exclave_ (x : @ unique)
 [%%expect{|
 val ul_ret : 'a @ unique -> 'a @ local = <fun>
 |}]
 
 let rec foo =
   fun (local_ o) ->
-  match (unique_ o) with
+  match (o : @ unique) with
   | Some () -> foo None
   | None -> ()
 [%%expect{|
@@ -393,7 +393,7 @@ val foo : unit option @ local unique -> unit = <fun>
 |}]
 
 let rec bar =
-  fun (unique_ o) ->
+  fun (o @ unique) ->
   match o with
   | Some () -> ()
   | None -> bar (local_ Some ()) [@nontail]
@@ -401,12 +401,12 @@ let rec bar =
 val bar : unit option @ local unique -> unit = <fun>
 |}]
 
-let foo : local_ unique_ string -> unit = fun (local_ s) -> ()
+let foo : string @ local unique -> unit = fun (local_ s) -> ()
 [%%expect{|
 val foo : string @ local unique -> unit = <fun>
 |}]
 
-let bar : local_ unique_ string -> unit = fun (unique_ s) -> ()
+let bar : string @ local unique -> unit = fun (s @ unique) -> ()
 [%%expect{|
 val bar : string @ local unique -> unit = <fun>
 |}]
@@ -414,7 +414,7 @@ val bar : string @ local unique -> unit = <fun>
 (* Currying *)
 
 let curry =
-  let foo ~a ~b ~c ~d = (a, b, c, (unique_ d)) in
+  let foo ~a ~b ~c ~d = (a, b, c, (d : @ unique)) in
   foo ~a:3 ~c:4
 [%%expect{|
 val curry : b:'_weak1 -> d:'_weak2 @ unique -> int * '_weak1 * int * '_weak2 =
@@ -424,7 +424,7 @@ val curry : b:'_weak1 -> d:'_weak2 @ unique -> int * '_weak1 * int * '_weak2 =
 (* the following two failed because top-level must be many *)
 (* TODO: maybe a particular error for that? *)
 let curry =
-  let foo ~a ~b ~c ~d = (a, b, (unique_ c), (unique_ d)) in
+  let foo ~a ~b ~c ~d = (a, b, (c : @ unique), (d : @ unique)) in
   foo ~a:3 ~c:4
 [%%expect{|
 Line 3, characters 2-15:
@@ -434,7 +434,7 @@ Error: This value is "once" but is expected to be "many".
 |}]
 
 let curry =
-  let foo ~a ~b ~c ~d = ((unique_ a), b, c, d) in
+  let foo ~a ~b ~c ~d = ((a : @ unique), b, c, d) in
   foo ~a:3 ~c:4
 [%%expect{|
 Line 3, characters 2-15:
@@ -444,7 +444,7 @@ Error: This value is "once" but is expected to be "many".
 |}]
 
 let curry =
-  let foo ~a ~b ~c ~d = (a, (unique_ b), c, unique_ d) in
+  let foo ~a ~b ~c ~d = (a, (b : @ unique), c, (d : @ unique)) in
   foo ~a:3 ~c:4
 [%%expect{|
 val curry :
@@ -453,7 +453,7 @@ val curry :
 |}]
 
 let curry =
-  let foo ~a ~b ~c ~d = (a, b, (unique_ c), unique_ d) in
+  let foo ~a ~b ~c ~d = (a, b, (c : @ unique), (d : @ unique)) in
   let bar = foo ~a:3 ~b:2 ~c:4 in
   (bar ~d:3, bar ~d:5)
 [%%expect{|
@@ -469,7 +469,7 @@ Line 4, characters 3-6:
 |}]
 
 let curry =
-  let foo ~a ~b ~c ~d = (a, b, (unique_ c), unique_ d) in
+  let foo ~a ~b ~c ~d = (a, b, (c : @ unique), (d : @ unique)) in
   let bar = foo ~a:3 ~c:4 in
   let baz = bar ~b:4 in (baz ~d:3, baz ~d:5)
 [%%expect{|
@@ -485,8 +485,8 @@ Line 4, characters 25-28:
 |}]
 
 let curry =
-  let unique_ x = "foo" in
-  let foo () = unique_ x in
+  let (x @ unique) = "foo" in
+  let foo () = (x : @ unique) in
   (foo (), foo ())
 [%%expect{|
 Line 4, characters 11-14:
@@ -505,36 +505,36 @@ type box = { x : int }
 type box = { x : int; }
 |}]
 
-let curry (unique_ b1 : box) (unique_ b2 : box) = ()
+let curry (b1 : box @ unique) (b2 : box @ unique) = ()
 [%%expect{|
 val curry : box @ unique -> box @ unique -> unit = <fun>
 |}]
 
-let curry : unique_ box -> unique_ box -> unit = fun b1 b2 -> ()
+let curry : box @ unique -> box @ unique -> unit = fun b1 b2 -> ()
 [%%expect{|
 val curry : box @ unique -> box @ unique -> unit = <fun>
 |}]
 
-let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
+let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> ()
 [%%expect{|
-Line 1, characters 51-66:
-1 | let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
-                                                       ^^^^^^^^^^^^^^^
+Line 1, characters 53-68:
+1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> ()
+                                                         ^^^^^^^^^^^^^^^
 Error: This function when partially applied returns a value which is "once",
        but expected to be "many".
 |}]
 
-let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
+let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> ()
 [%%expect{|
-Line 1, characters 51-80:
-1 | let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
-                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 53-82:
+1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> ()
+                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This function when partially applied returns a value which is "once",
        but expected to be "many".
 |}]
 
 (* For nested functions, inner functions are not constrained *)
-let no_curry : unique_ box -> (unique_ box -> unit) = fun b1 -> fun b2 -> ()
+let no_curry : box @ unique -> (box @ unique -> unit) = fun b1 -> fun b2 -> ()
 [%%expect{|
 val no_curry : box @ unique -> (box @ unique -> unit) = <fun>
 |}]
@@ -542,7 +542,7 @@ val no_curry : box @ unique -> (box @ unique -> unit) = <fun>
 (* If both type and mode are wrong, complain about type *)
 let f () =
   let id2 (x : string) = aliased_id x in
-  let unique_ r = 42 in
+  let (r @ unique) = 42 in
   id2 r
 [%%expect{|
 Line 4, characters 6-7:
@@ -567,7 +567,7 @@ val return_global : 'a @ local -> int = <fun>
 type tree = Leaf | Node of tree * tree
 let rec make_tree = fun n ->
   if n <= 0 then Leaf
-  else let unique_ x = make_tree (n - 1)
+  else let (x @ unique) = make_tree (n - 1)
        in Node (x, x)
 [%%expect{|
 type tree = Leaf | Node of tree * tree
@@ -583,7 +583,7 @@ Line 5, characters 16-17:
 
 (* Uniqueness is unbroken by the implicit positional argument. *)
 let f ~(call_pos : [%call_pos]) () =
-  let unique_ x = call_pos in
+  let (x @ unique) = call_pos in
   (x, x)
 ;;
 [%%expect{|
@@ -592,16 +592,16 @@ val f : call_pos:[%call_pos] -> unit -> lexing_position * lexing_position =
 |}]
 
 let f ~(call_pos : [%call_pos]) () =
-  unique_ (call_pos, call_pos)
+  ((call_pos, call_pos) : @ unique)
 ;;
 [%%expect{|
-Line 2, characters 21-29:
-2 |   unique_ (call_pos, call_pos)
-                         ^^^^^^^^
+Line 2, characters 14-22:
+2 |   ((call_pos, call_pos) : @ unique)
+                  ^^^^^^^^
 Error: This value is used here, but it is also being used as unique at:
-Line 2, characters 11-19:
-2 |   unique_ (call_pos, call_pos)
-               ^^^^^^^^
+Line 2, characters 4-12:
+2 |   ((call_pos, call_pos) : @ unique)
+        ^^^^^^^^
 
 |}]
 

--- a/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/testsuite/tests/typing-unique/unique_analysis.ml
@@ -5,7 +5,7 @@
 (* This file is to test uniqueness_analysis.ml *)
 
 (* First some helper functions *)
-let unique_id : unique_ 'a -> unique_ 'a = fun x -> x
+let unique_id : 'a @ unique -> 'a @ unique = fun x -> x
 [%%expect{|
 val unique_id : 'a @ unique -> 'a @ unique = <fun>
 |}]
@@ -15,7 +15,7 @@ let aliased_id : 'a -> 'a = fun x -> x
 val aliased_id : 'a -> 'a = <fun>
 |}]
 
-let ignore_once: once_ 'a -> unit = fun x -> ()
+let ignore_once: 'a @ once -> unit = fun x -> ()
 
 type box = { x : int }
 [%%expect{|
@@ -23,7 +23,7 @@ val ignore_once : 'a @ once -> unit = <fun>
 type box = { x : int; }
 |}]
 
-let update : unique_ box -> unique_ box = unique_id
+let update : box @ unique -> box @ unique = unique_id
 [%%expect{|
 val update : box @ unique -> box @ unique = <fun>
 |}]
@@ -31,35 +31,35 @@ val update : box @ unique -> box @ unique = <fun>
 
 (* testing Texp_ifthenelse  *)
 
-let branching (unique_ x) = unique_ if true then x else x
+let branching (x @ unique) = (if true then x else x : @ unique)
 [%%expect{|
 val branching : 'a @ unique -> 'a = <fun>
 |}]
 
 (* Uniqueness and linearity have similar restrictions on control-flow.
    Therefore, in the rest we will only constrain uniqueness *)
-let branching (once_ x) = if true then x else x
+let branching (x @ once) = (if true then x else x : @ unique)
 [%%expect{|
-val branching : 'a @ once -> 'a @ once = <fun>
+val branching : 'a @ unique once -> 'a @ once = <fun>
 |}]
 
 let branching b =
-  let unique_ r = { x = 23 } in
+  let (r @ unique) = { x = 23 } in
   if b then update r
        else update r
 [%%expect{|
 val branching : bool -> box = <fun>
 |}]
 
-let sequence (unique_ x) = unique_ let y = x in (x, y)
+let sequence (x @ unique) = (let y = x in (x, y) : @ unique)
 [%%expect{|
-Line 1, characters 52-53:
-1 | let sequence (unique_ x) = unique_ let y = x in (x, y)
-                                                        ^
+Line 1, characters 46-47:
+1 | let sequence (x @ unique) = (let y = x in (x, y) : @ unique)
+                                                  ^
 Error: This value is used here, but it is also being used as unique at:
-Line 1, characters 49-50:
-1 | let sequence (unique_ x) = unique_ let y = x in (x, y)
-                                                     ^
+Line 1, characters 43-44:
+1 | let sequence (x @ unique) = (let y = x in (x, y) : @ unique)
+                                               ^
 
 |}]
 
@@ -88,116 +88,116 @@ Line 3, characters 18-19:
 
 |}]
 
-let children_unique (unique_ xs : float list) =
+let children_unique (xs : float list @ unique) =
   match xs with
   | [] -> (0., [])
-  | x :: xx -> unique_ (x, xx)
+  | x :: xx -> ((x, xx) : @ unique)
 [%%expect{|
 val children_unique : float list @ unique -> float * float list = <fun>
 |}]
 
-let borrow_match (unique_ fs : 'a list) =
+let borrow_match (fs : 'a list @ unique) =
   match fs with
   | [] -> []
-  | x :: xs as gs -> unique_ gs
+  | x :: xs as gs -> (gs : @ unique)
 [%%expect{|
 val borrow_match : 'a list @ unique -> 'a list = <fun>
 |}]
 
-let borrow_match (unique_ fs : 'a list) =
+let borrow_match (fs : 'a list @ unique) =
   match fs with
     | [] -> []
-    | x :: xs -> unique_ fs
+    | x :: xs -> (fs : @ unique)
 [%%expect{|
 val borrow_match : 'a list @ unique -> 'a list = <fun>
 |}]
 
-let dup_child (unique_ fs : 'a list) =
+let dup_child (fs : 'a list @ unique) =
   match fs with
   | [] -> ([], [])
-  | x :: xs as gs -> (unique_ gs), xs
+  | x :: xs as gs -> ((gs : @ unique)), xs
 [%%expect{|
-Line 4, characters 35-37:
-4 |   | x :: xs as gs -> (unique_ gs), xs
-                                       ^^
+Line 4, characters 40-42:
+4 |   | x :: xs as gs -> ((gs : @ unique)), xs
+                                            ^^
 Error: This value is used here,
        but it is part of a value that is also being used as unique at:
-Line 4, characters 21-33:
-4 |   | x :: xs as gs -> (unique_ gs), xs
-                         ^^^^^^^^^^^^
+Line 4, characters 21-38:
+4 |   | x :: xs as gs -> ((gs : @ unique)), xs
+                         ^^^^^^^^^^^^^^^^^
 
 |}]
 
-let dup_child (unique_ fs : 'a list) =
+let dup_child (fs : 'a list @ unique) =
   match fs with
   | [] -> ([], [])
-  | x :: xs as gs -> gs, unique_ xs
+  | x :: xs as gs -> gs, (xs : @ unique)
 [%%expect{|
-Line 4, characters 25-35:
-4 |   | x :: xs as gs -> gs, unique_ xs
-                             ^^^^^^^^^^
+Line 4, characters 25-40:
+4 |   | x :: xs as gs -> gs, (xs : @ unique)
+                             ^^^^^^^^^^^^^^^
 Error: This value is used here as unique,
        but it is part of a value that is also being used at:
 Line 4, characters 21-23:
-4 |   | x :: xs as gs -> gs, unique_ xs
+4 |   | x :: xs as gs -> gs, (xs : @ unique)
                          ^^
 
 |}]
-let dup_child (unique_ fs : 'a list) =
+let dup_child (fs : 'a list @ unique) =
   match fs with
   | [] -> ([], [])
-  | x :: xs as gs -> (unique_ xs), gs
+  | x :: xs as gs -> ((xs : @ unique)), gs
 [%%expect{|
-Line 4, characters 35-37:
-4 |   | x :: xs as gs -> (unique_ xs), gs
-                                       ^^
+Line 4, characters 40-42:
+4 |   | x :: xs as gs -> ((xs : @ unique)), gs
+                                            ^^
 Error: This value is used here,
        but part of it is also being used as unique at:
-Line 4, characters 21-33:
-4 |   | x :: xs as gs -> (unique_ xs), gs
-                         ^^^^^^^^^^^^
+Line 4, characters 21-38:
+4 |   | x :: xs as gs -> ((xs : @ unique)), gs
+                         ^^^^^^^^^^^^^^^^^
 
 |}]
-let dup_child (unique_ fs : 'a list) =
+let dup_child (fs : 'a list @ unique) =
   match fs with
   | [] -> ([], [])
-  | x :: xs as gs -> xs, unique_ gs
+  | x :: xs as gs -> xs, (gs : @ unique)
 [%%expect{|
-Line 4, characters 25-35:
-4 |   | x :: xs as gs -> xs, unique_ gs
-                             ^^^^^^^^^^
+Line 4, characters 25-40:
+4 |   | x :: xs as gs -> xs, (gs : @ unique)
+                             ^^^^^^^^^^^^^^^
 Error: This value is used here as unique,
        but part of it is also being used at:
 Line 4, characters 21-23:
-4 |   | x :: xs as gs -> xs, unique_ gs
+4 |   | x :: xs as gs -> xs, (gs : @ unique)
                          ^^
 
 |}]
 
 
 
-let or_patterns1 : unique_ float list -> float list -> float =
+let or_patterns1 : float list @ unique -> float list -> float =
   fun x y -> match x, y with
-  | z :: _, _ | _, z :: _ -> unique_ z
+  | z :: _, _ | _, z :: _ -> (z : @ unique)
   | _, _ -> 42.0
 [%%expect{|
-Line 3, characters 37-38:
-3 |   | z :: _, _ | _, z :: _ -> unique_ z
-                                         ^
+Line 3, characters 30-31:
+3 |   | z :: _, _ | _, z :: _ -> (z : @ unique)
+                                  ^
 Error: This value is "aliased"
          because it is contained (via constructor "::") in the value at line 3, characters 19-25
          which is "aliased".
        However, the highlighted expression is expected to be "unique".
 |}]
 
-let or_patterns2 : float list -> unique_ float list -> float =
+let or_patterns2 : float list -> float list @ unique -> float =
   fun x y -> match x, y with
-  | z :: _, _ | _, z :: _ -> unique_ z
+  | z :: _, _ | _, z :: _ -> (z : @ unique)
   | _, _ -> 42.0
 [%%expect{|
-Line 3, characters 37-38:
-3 |   | z :: _, _ | _, z :: _ -> unique_ z
-                                         ^
+Line 3, characters 30-31:
+3 |   | z :: _, _ | _, z :: _ -> (z : @ unique)
+                                  ^
 Error: This value is "aliased"
          because it is contained (via constructor "::") in the value at line 3, characters 4-10
          which is "aliased".
@@ -205,7 +205,7 @@ Error: This value is "aliased"
 |}]
 
 let or_patterns3 p =
-  let unique_ x = 3 in let unique_ y = 4 in
+  let (x @ unique) = 3 in let (y @ unique) = 4 in
   match p, x, y with
   | true, z, _ | false, _, z -> let _ = unique_id z in unique_id y
 [%%expect{|
@@ -220,7 +220,7 @@ Line 4, characters 50-51:
 |}]
 
 let or_patterns4 p =
-  let unique_ x = 3 in let unique_ y = 4 in
+  let (x @ unique) = 3 in let (y @ unique) = 4 in
   match p, x, y with
   | true, z, _ | false, _, z -> let _ = unique_id x in unique_id y
 [%%expect{|
@@ -228,7 +228,7 @@ val or_patterns4 : bool -> int = <fun>
 |}]
 
 let or_patterns5 p =
-  let unique_ x = 3 in let unique_ y = 4 in
+  let (x @ unique) = 3 in let (y @ unique) = 4 in
   match p, x, y with
   | true, z, _ | false, _, z -> let _ = unique_id z in unique_id x
 [%%expect{|
@@ -243,16 +243,16 @@ Line 4, characters 50-51:
 |}]
 
 let mark_top_aliased =
-  let unique_ xs = 2 :: 3 :: [] in
+  let (xs @ unique) = 2 :: 3 :: [] in
   match xs with
   | x :: xx ->
       let _ = unique_id xs in
-      unique_ xx
+      (xx : @ unique)
   | [] -> []
 [%%expect{|
-Line 6, characters 6-16:
-6 |       unique_ xx
-          ^^^^^^^^^^
+Line 6, characters 6-21:
+6 |       (xx : @ unique)
+          ^^^^^^^^^^^^^^^
 Error: This value is used here,
        but it is part of a value that has already been used as unique at:
 Line 5, characters 24-26:
@@ -262,14 +262,14 @@ Line 5, characters 24-26:
 |}]
 
 let mark_top_aliased =
-  let unique_ xs = 2 :: 3 :: [] in
+  let (xs @ unique) = 2 :: 3 :: [] in
   let _ = unique_id xs in
   match xs with
-  | x :: xx -> unique_ xx
+  | x :: xx -> (xx : @ unique)
   | [] -> []
 [%%expect{|
 Line 5, characters 4-11:
-5 |   | x :: xx -> unique_ xx
+5 |   | x :: xx -> (xx : @ unique)
         ^^^^^^^
 Error: This value is read from here,
        but it has already been used as unique at:
@@ -297,7 +297,7 @@ val mark_aliased_in_one_branch : bool -> float @ unique -> float * float =
 
 let expr_tuple_match f x y =
   match f x, y with
-  | (a, b), c -> unique_ (a, c)
+  | (a, b), c -> ((a, c) : @ unique)
 [%%expect{|
 val expr_tuple_match :
   ('a -> 'b * 'c @ unique) -> 'a -> 'd @ unique -> 'b * 'd = <fun>
@@ -305,7 +305,7 @@ val expr_tuple_match :
 
 let expr_tuple_match f x y =
   match f x, y with
-  | (a, b) as t, c -> let d = unique_id t in unique_ (c, d)
+  | (a, b) as t, c -> let d = unique_id t in ((c, d) : @ unique)
 [%%expect{|
 val expr_tuple_match :
   ('a -> 'b * 'c @ unique) -> 'a -> 'd @ unique -> 'd * ('b * 'c) = <fun>
@@ -313,15 +313,15 @@ val expr_tuple_match :
 
 let expr_tuple_match f x y =
   match f x, y with
-  | (a, b) as t, c -> let d = unique_id t in unique_ (a, d)
+  | (a, b) as t, c -> let d = unique_id t in ((a, d) : @ unique)
 [%%expect{|
-Line 3, characters 54-55:
-3 |   | (a, b) as t, c -> let d = unique_id t in unique_ (a, d)
-                                                          ^
+Line 3, characters 47-48:
+3 |   | (a, b) as t, c -> let d = unique_id t in ((a, d) : @ unique)
+                                                   ^
 Error: This value is used here,
        but it is part of a value that has already been used as unique at:
 Line 3, characters 40-41:
-3 |   | (a, b) as t, c -> let d = unique_id t in unique_ (a, d)
+3 |   | (a, b) as t, c -> let d = unique_id t in ((a, d) : @ unique)
                                             ^
 
 |}]
@@ -368,7 +368,7 @@ Line 2, characters 12-13:
 |}]
 
 let unique_match_on a b =
-  let unique_ t = (a, b) in t
+  let (t @ unique) = (a, b) in t
 [%%expect{|
 val unique_match_on : 'a @ unique -> 'b @ unique -> 'a * 'b = <fun>
 |}]
@@ -378,33 +378,33 @@ type ('a, 'b) record = { foo : 'a; bar : 'b }
 type ('a, 'b) record = { foo : 'a; bar : 'b; }
 |}]
 
-let match_function : unique_ 'a * 'b -> 'a * ('a * 'b) =
+let match_function : ('a * 'b) @ unique -> 'a * ('a * 'b) =
   function
-  | (a, b) as t -> unique_ (a, t)
+  | (a, b) as t -> ((a, t) : @ unique)
 [%%expect{|
-Line 3, characters 31-32:
-3 |   | (a, b) as t -> unique_ (a, t)
-                                   ^
+Line 3, characters 24-25:
+3 |   | (a, b) as t -> ((a, t) : @ unique)
+                            ^
 Error: This value is used here,
        but part of it is also being used as unique at:
-Line 3, characters 28-29:
-3 |   | (a, b) as t -> unique_ (a, t)
-                                ^
+Line 3, characters 21-22:
+3 |   | (a, b) as t -> ((a, t) : @ unique)
+                         ^
 
 |}]
 
 let tuple_parent_marked a b =
   match (a, b) with
-  | ((_, a), b) as t -> unique_ (a, t)
+  | ((_, a), b) as t -> ((a, t) : @ unique)
 [%%expect{|
-Line 3, characters 36-37:
-3 |   | ((_, a), b) as t -> unique_ (a, t)
-                                        ^
+Line 3, characters 29-30:
+3 |   | ((_, a), b) as t -> ((a, t) : @ unique)
+                                 ^
 Error: This value is used here,
        but part of it is also being used as unique at:
-Line 3, characters 33-34:
-3 |   | ((_, a), b) as t -> unique_ (a, t)
-                                     ^
+Line 3, characters 26-27:
+3 |   | ((_, a), b) as t -> ((a, t) : @ unique)
+                              ^
 
 |}]
 
@@ -432,7 +432,7 @@ type point = { dim : int; x : float; y : float; z : float; }
 let record_mode_vars (p : point) =
   let x = unique_id p.x in
   let y = (p.y, p.y) in
-  (x, y, unique_ p.z)
+  (x, y, (p.z : @ unique))
 [%%expect{|
 val record_mode_vars : point @ unique -> float * (float * float) * float =
   <fun>
@@ -441,7 +441,7 @@ val record_mode_vars : point @ unique -> float * (float * float) * float =
 let record_mode_vars (p : point) =
   let x = unique_id p.x in
   let y = (p.x, p.y) in
-  (x, y, unique_ p.z)
+  (x, y, (p.z : @ unique))
 [%%expect{|
 Line 3, characters 11-14:
 3 |   let y = (p.x, p.y) in
@@ -456,7 +456,7 @@ Line 2, characters 20-23:
 let record_mode_vars (p : point) =
   let y = (p.x, p.y) in
   let x = unique_id p.x in
-  (x, y, unique_ p.z)
+  (x, y, (p.z : @ unique))
 [%%expect{|
 Line 3, characters 20-23:
 3 |   let x = unique_id p.x in
@@ -470,7 +470,7 @@ Line 2, characters 11-14:
 
 (* testing Texp_function; closure over implicit borrowing *)
 let foo () =
-  let unique_ r = {dim=1; x=2.0; y=3.0; z=4.0} in
+  let (r @ unique) = {dim=1; x=2.0; y=3.0; z=4.0} in
   let _bar () = match r with
     | {dim; x; y; z} -> ()
    in
@@ -499,7 +499,7 @@ val foo : unit -> point = <fun>
 |}]
 
 let foo () =
-  let unique_ r = {dim=1; x=2.0; y=3.0; z=4.0} in
+  let (r @ unique) = {dim=1; x=2.0; y=3.0; z=4.0} in
   let _l = lazy (r.z) in
   unique_id r
 [%%expect{|
@@ -589,7 +589,7 @@ val foo : unit -> unit = <fun>
 
  (* Similarly for linearity *)
 let foo () =
-  let r = once_ {x = Value.mk (); y = Value.mk ()} in
+  let r = ({x = Value.mk (); y = Value.mk ()} : @ once) in
   ignore_once r.y;
   ignore_once r;
 [%%expect{|
@@ -597,7 +597,7 @@ val foo : unit -> unit = <fun>
 |}]
 
 let foo () =
-  let r = once_ {x = Value.mk (); y = Value.mk ()} in
+  let r = ({x = Value.mk (); y = Value.mk ()} : @ once) in
   ignore_once r.x;
   ignore_once r;
 [%%expect{|
@@ -633,7 +633,7 @@ Line 3, characters 21-24:
 (* testing record update in the presense of modalities *)
 let foo () =
   let r = {x = Value.mk (); y = Value.mk ()} in
-  ignore (unique_ {r with x = Value.mk ()});
+  ignore (({r with x = Value.mk ()} : @ unique));
   (* r.y has been used aliased; in the following we will use r as unique *)
   ignore (unique_id r)
 [%%expect{|
@@ -642,7 +642,7 @@ val foo : unit -> unit = <fun>
 
 let foo () =
   let r = {x = Value.mk (); y = Value.mk ()} in
-  ignore (unique_ {r with y = Value.mk ()});
+  ignore (({r with y = Value.mk ()} : @ unique));
   (* r.x has been used unique; in the following we will use r as unique *)
   ignore (unique_id r)
 [%%expect{|
@@ -651,9 +651,9 @@ Line 5, characters 20-21:
                         ^
 Error: This value is used here,
        but part of it has already been used as unique at:
-Line 3, characters 19-20:
-3 |   ignore (unique_ {r with y = Value.mk ()});
-                       ^
+Line 3, characters 12-13:
+3 |   ignore (({r with y = Value.mk ()} : @ unique));
+                ^
 
 |}]
 
@@ -676,7 +676,7 @@ val foo : unit -> unit = <fun>
 
  (* Similarly for linearity *)
 let foo () =
-  let r = once_ (R_aliased (Value.mk (), Value.mk ())) in
+  let r = (R_aliased (Value.mk (), Value.mk ()) : @ once) in
   let R_aliased (_, y) = r in
   ignore_once y;
   ignore_once r;
@@ -685,7 +685,7 @@ val foo : unit -> unit = <fun>
 |}]
 
 let foo () =
-  let r = once_ (R_aliased (Value.mk (), Value.mk ())) in
+  let r = (R_aliased (Value.mk (), Value.mk ()) : @ once) in
   let R_aliased (x, _) = r in
   ignore_once x;
   ignore_once r;
@@ -793,7 +793,7 @@ Line 3, characters 20-21:
 
 let foo () =
   let t = #("hello", "world") in
-  let unique_use_tuple : ('a : value & value). unique_ 'a -> unit = fun _ -> () in
+  let unique_use_tuple : ('a : value & value). 'a @ unique -> unit = fun _ -> () in
   unique_use_tuple t;
   let #(_, _) = t in
   ()

--- a/testsuite/tests/typing-unique/unique_documentation.ml
+++ b/testsuite/tests/typing-unique/unique_documentation.ml
@@ -11,7 +11,7 @@
 type t = Con of { field : int list }
 
 let free : t @ unique -> unit = fun t -> ()
-let free_field (unique_ i) = ()
+let free_field (i @ unique) = ()
 let store : t @ aliased -> unit = fun t -> ()
 let store_field i = ()
 let flip_coin () = true
@@ -193,7 +193,7 @@ Error: The value "set" is "once"
 |}]
 
 let set_all_zero arr =
-  let size (unique_ arr) = 10, arr in
+  let size (arr @ unique) = 10, arr in
   let rec loop idx arr =
     if idx == 0 then arr
     else loop (idx - 1) (Unique_array.set arr idx 0)
@@ -210,7 +210,7 @@ val set_all_zero : 'a @ unique -> 'a = <fun>
 type t = { field1 : t; field2 : t }
 
 let free : t @ unique -> unit = fun t -> ()
-let free_field (unique_ i) = ()
+let free_field (i @ unique) = ()
 let store : t @ aliased -> unit = fun t -> ()
 let store_field i = ()
 let flip_coin () = true

--- a/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -4,20 +4,20 @@
 
 (* This file tests the interaction between a module/class and its surrounding environment *)
 
-let unique_id (unique_ x) = ignore x
+let unique_id (x @ unique) = ignore x
 
 
 (* you cannot use env vars as unique in classes/objects  *)
 let texp_object () =
   let x = "foo" in
   object (self)
-  val bar = unique_ x
+  val bar = (x : @ unique)
   end;
 [%%expect{|
 val unique_id : 'a @ unique -> unit = <fun>
-Line 8, characters 20-21:
-8 |   val bar = unique_ x
-                        ^
+Line 8, characters 13-14:
+8 |   val bar = (x : @ unique)
+                 ^
 Error: This value is "aliased"
          because it is used in an object (at lines 7-9, characters 2-5).
        However, the highlighted expression is expected to be "unique".
@@ -45,14 +45,14 @@ Line 3, characters 12-13:
 let texp_letmodule () =
   let x = "foo" in
   let module Bar = struct
-    let y = unique_ x
+    let y = (x : @ unique)
   end
   in
   ()
 [%%expect{|
-Line 4, characters 12-21:
-4 |     let y = unique_ x
-                ^^^^^^^^^
+Line 4, characters 12-26:
+4 |     let y = (x : @ unique)
+                ^^^^^^^^^^^^^^
 Error: This value is aliased but used as unique.
 Hint: This value comes from outside the current module or class.
 |}]
@@ -79,12 +79,12 @@ Line 3, characters 12-13:
 
 let texp_open () =
   let x = "foo" in
-  let open (struct let y = unique_ x end) in
+  let open (struct let y = (x : @ unique) end) in
   ()
 [%%expect{|
-Line 3, characters 27-36:
-3 |   let open (struct let y = unique_ x end) in
-                               ^^^^^^^^^
+Line 3, characters 27-41:
+3 |   let open (struct let y = (x : @ unique) end) in
+                               ^^^^^^^^^^^^^^
 Error: This value is aliased but used as unique.
 Hint: This value comes from outside the current module or class.
 |}]
@@ -109,13 +109,13 @@ module type bar = sig val y : string end
 
 let texp_pack () =
   let x = "foo" in
-  let z = (module struct let y = unique_ x end : bar) in
+  let z = (module struct let y = (x : @ unique) end : bar) in
   ()
 [%%expect{|
 module type bar = sig val y : string end
-Line 5, characters 33-42:
-5 |   let z = (module struct let y = unique_ x end : bar) in
-                                     ^^^^^^^^^
+Line 5, characters 33-47:
+5 |   let z = (module struct let y = (x : @ unique) end : bar) in
+                                     ^^^^^^^^^^^^^^
 Error: This value is aliased but used as unique.
 Hint: This value comes from outside the current module or class.
 |}]

--- a/testsuite/tests/typing-unique/unique_typedecl.ml
+++ b/testsuite/tests/typing-unique/unique_typedecl.ml
@@ -2,24 +2,24 @@
  expect;
 *)
 
-(* This file tests how unique_ and once_ are interpreated in signatures
+(* This file tests how unique and once are interpreted in signatures
    especially when currying is involved *)
 
-(* When a [unique_] argument appears in a function type with multiple arguments,
-return modes are implicitly once_ until the final argument. *)
+(* When a [unique] argument appears in a function type with multiple arguments,
+return modes are implicitly once until the final argument. *)
 type equ_fn = unit
 constraint
-'a -> unique_ 'b -> 'c -> 'd -> 'e
-= 'a -> unique_ 'b -> once_ ('c -> once_ ('d -> 'e))
+'a -> 'b @ unique -> 'c -> 'd -> 'e
+= 'a -> 'b @ unique -> ('c -> ('d -> 'e) @ once) @ once
 [%%expect{|
 type equ_fn = unit
 |}]
 
-(* similar for once_ *)
+(* similar for once *)
 type equ_fn = unit
 constraint
-'a -> once_ 'b -> 'c -> 'd -> 'e
-= 'a -> once_ 'b -> once_ ('c -> once_ ('d -> 'e))
+'a -> 'b @ once -> 'c -> 'd -> 'e
+= 'a -> 'b @ once -> ('c -> ('d -> 'e) @ once) @ once
 [%%expect{|
 type equ_fn = unit
 |}]
@@ -29,12 +29,12 @@ type equ_fn = unit
    except for some backward compatibility issues *)
 type equ_fn = unit
 constraint
-'a -> unique_ 'b -> 'c -> 'd -> 'e
-= 'a -> unique_ 'b -> unique_ once_ ('c -> unique_ once_ ('d -> 'e))
+'a -> 'b @ unique -> 'c -> 'd -> 'e
+= 'a -> 'b @ unique -> ('c -> ('d -> 'e) @ unique once) @ unique once
 [%%expect{|
-Lines 3-4, characters 0-68:
-3 | 'a -> unique_ 'b -> 'c -> 'd -> 'e
-4 | = 'a -> unique_ 'b -> unique_ once_ ('c -> unique_ once_ ('d -> 'e))
+Lines 3-4, characters 0-69:
+3 | 'a -> 'b @ unique -> 'c -> 'd -> 'e
+4 | = 'a -> 'b @ unique -> ('c -> ('d -> 'e) @ unique once) @ unique once
 Error: The type constraints are not consistent.
        Type "'a -> 'b @ unique -> 'c -> 'd -> 'e" is not compatible with type
          "'a -> 'b @ unique -> ('c -> ('d -> 'e) @ unique once) @ unique once"
@@ -42,27 +42,27 @@ Error: The type constraints are not consistent.
          "'b @ unique -> ('c -> ('d -> 'e) @ unique once) @ unique once"
 |}]
 
-type distinct_sarg = unit constraint unique_ int -> int = int -> int
+type distinct_sarg = unit constraint int @ unique -> int = int -> int
 [%%expect{|
-Line 1, characters 37-68:
-1 | type distinct_sarg = unit constraint unique_ int -> int = int -> int
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 37-69:
+1 | type distinct_sarg = unit constraint int @ unique -> int = int -> int
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type "int @ unique -> int" is not compatible with type "int -> int"
 |}]
-type distinct_sret = unit constraint int -> unique_ int = int -> int
+type distinct_sret = unit constraint int -> int @ unique = int -> int
 [%%expect{|
-Line 1, characters 37-68:
-1 | type distinct_sret = unit constraint int -> unique_ int = int -> int
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 37-69:
+1 | type distinct_sret = unit constraint int -> int @ unique = int -> int
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type "int -> int @ unique" is not compatible with type "int -> int"
 |}]
-type distinct_sarg_sret = unit constraint unique_ int -> int = unique_ int -> unique_ int
+type distinct_sarg_sret = unit constraint int @ unique -> int = int @ unique -> int @ unique
 [%%expect{|
-Line 1, characters 42-89:
-1 | type distinct_sarg_sret = unit constraint unique_ int -> int = unique_ int -> unique_ int
-                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 42-92:
+1 | type distinct_sarg_sret = unit constraint int @ unique -> int = int @ unique -> int @ unique
+                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type "int @ unique -> int" is not compatible with type
          "int @ unique -> int @ unique"


### PR DESCRIPTION
## Summary

- Remove `unique_` and `once_` as legacy keyword-prefix mode syntax from the lexer and parser
- Convert all test files to use the modern `@ mode` syntax (e.g. `(x @ unique)`, `ty @ once`)
- The `local_` prefix is intentionally kept

## Test plan

- [ ] `make -s boot-compiler` passes
- [ ] `make -s test` passes (6612 tests passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)