### PR TITLE
Restrict value kind computation in classic mode

### DIFF
--- a/driver/boot_ocamlopt.ml
+++ b/driver/boot_ocamlopt.ml
@@ -1,4 +1,5 @@
 let () =
+  Typeopt.use_shallow_value_kinds := Flambda2_ui.Flambda_features.classic_mode;
   exit (Optmaindriver.main (module Unix : Compiler_owee.Unix_intf.S) Sys.argv
     Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/driver/oxcaml_main.ml
+++ b/driver/oxcaml_main.ml
@@ -1,4 +1,5 @@
 let () =
+  Typeopt.use_shallow_value_kinds := Flambda2_ui.Flambda_features.classic_mode;
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()
    | Bytecode | Other _ -> ());

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1083,11 +1083,26 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
          non_nullable (Pvariant { consts = []; non_consts }))
     end
 
+let use_shallow_value_kinds : (unit -> bool) ref = ref (fun () -> false)
+
+(* In shallow mode, we start recursion at [depth = 1]. That preserves the
+   top-level shape: a tuple / variant / record is processed normally at
+   depth 1 (since [cannot_proceed] requires [depth >= 2]), so its outer
+   [Pvariant { ... }] structure is retained, and primitive types (int, float,
+   int32, arrays, etc.) match before any depth check anyway. The increment
+   to 2 performed inside those branches before recursing into field types
+   is what trips [cannot_proceed], so we avoid the potentially expensive
+   deep walk into fields without losing the outer structural information
+   that downstream passes (tupled-function flattening, [@unboxable]) rely
+   on. *)
+let initial_depth () =
+  if !use_shallow_value_kinds () then 1 else 0
+
 let value_kind env loc ty =
   try
     let (_num_nodes_visited, value_kind) =
-      value_kind env ~loc ~visited:Numbers.Int.Set.empty ~depth:0
-        ~num_nodes_visited:0 ty
+      value_kind env ~loc ~visited:Numbers.Int.Set.empty
+        ~depth:(initial_depth ()) ~num_nodes_visited:0 ty
     in
     value_kind
   with
@@ -1098,7 +1113,7 @@ let transl_mixed_block_element env loc ty mbe =
   try
     let (_num_nodes_visited, value_kind) =
       value_kind_mixed_block_field env ~loc ~visited:Numbers.Int.Set.empty
-        ~depth:0 ~num_nodes_visited:0 mbe (Some ty)
+        ~depth:(initial_depth ()) ~num_nodes_visited:0 mbe (Some ty)
     in
     value_kind
   with

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -81,6 +81,19 @@ val transl_mixed_block_element :
   Env.t -> Location.t -> Types.type_expr -> Types.mixed_block_element
   -> unit Lambda.mixed_block_element
 
+(* If set to a function returning [true], [value_kind],
+   [transl_mixed_block_element] and [layout] (for value-sorted types) will
+   skip recursion into the fields of variants, records and tuples, taking a
+   cheap approximation ([Pgenval]) for field kinds. The outer structure of
+   the type is preserved (e.g., a tuple is still [Pvariant { consts = [];
+   non_consts = [0, Constructor_uniform [...]] }]), and precise kinds are
+   still returned for primitive types (int, float, int32, arrays, etc.), so
+   user-written [[@unboxable]] attributes and tupled-function flattening
+   continue to work. Intended for Flambda 2 classic mode, where the
+   field-by-field detailed kind information is rarely used by the
+   optimizer. *)
+val use_shallow_value_kinds : (unit -> bool) ref
+
 val classify_lazy_argument : Typedtree.expression ->
                              [ `Constant_or_function
                              | `Float_that_cannot_be_shortcut


### PR DESCRIPTION
## Summary

In Flambda 2 classic mode, the detailed subkind information produced by `Typeopt.value_kind` is rarely consumed by the optimizer — it mostly propagates through the Lambda/Flambda representations unused. But `value_kind` still pays the full cost of recursively walking variants, records and tuples, which can be expensive for large programs.

This PR adds a hook that lets classic mode skip the deep recursion while preserving precise kinds for primitive types.

## Mechanism [superceded - see next comment]

`typing/typeopt.{ml,mli}` gains two hooks:

- **`use_shallow_value_kinds : (unit -> bool) ref`** — when it returns `true`, the public entry points `value_kind`, `transl_mixed_block_element` and (transitively) `layout` start the internal recursion at `depth = 2`. That is exactly the threshold at which the existing `cannot_proceed` guard triggers, so:
  - the top-level match on primitive types (`int`, `float`, `int32`/`int64`/`nativeint`, arrays, vectors, etc.) still fires — it runs *before* any depth check — so precise kinds are returned for the common cases, and user-written `[@unboxable]` attributes continue to work for primitives;
  - any descent into a variant, record or tuple immediately takes the `cannot_proceed` branch, returning the cheap approximation derived from the type's jkind rather than walking each field recursively.

- **`with_deep_value_kinds : (unit -> 'a) -> 'a`** — dynamic-scoped override. Inside the callback, shallow mode is forced off, so nested `value_kind`/`layout` calls produce the full precise structure. Used at the uncommon sites that genuinely need it.

`driver/oxcaml_main.ml` and `driver/boot_ocamlopt.ml` install the hook at ocamlopt startup:

```ocaml
Typeopt.use_shallow_value_kinds := Flambda2_ui.Flambda_features.classic_mode
```

This keeps the dependency direction clean: `typing/` does not grow a dependency on `flambda2_ui`; the driver wires it up.

## Tupled-function flattening

`Translcore.transl_tupled_function` is the one site that needs the deep kind info: tuple-flattening inspects `arg_layout` and requires the precise `Pvariant { consts = []; non_consts = [0, Constructor_uniform _] }` structure. In shallow mode that would collapse to `Pgenval` and the invariant-check `fatal_error` would fire.

Rather than degrading to a graceful fallback (which would silently disable the optimization and weaken the invariant check), this PR wraps the `layout_pat` call here in `Typeopt.with_deep_value_kinds`. Tupled functions are uncommon enough that paying for a deep computation at this one site is fine, and the fatal-error arm remains a genuine invariant check.

## Behavior change to flag

`[@unboxable]` on a **record or variant** parameter/return in classic mode will now emit `Unboxing_impossible` where it previously succeeded, because `unboxing_kind` in `lambda_to_flambda.ml` needs field-level detail that the shallow path no longer computes. `[@unboxable]` on primitive types (the common case) is unaffected. Tests do not exercise the record/variant case; users who hit this can raise the optimization level.

## Test plan

- [x] `make -s boot-compiler`
- [x] `make -s test` — 6515 passed, 0 failed, 259 skipped (unchanged vs. `main`)