### PR TITLE
Fix kind annotation check for existential types in patterns

### DIFF
--- a/testsuite/tests/typing-layouts-or-null/existential_kind_annotations.ml
+++ b/testsuite/tests/typing-layouts-or-null/existential_kind_annotations.ml
@@ -1,0 +1,151 @@
+(* TEST
+ expect;
+*)
+
+(* Kind annotations on existential type variables in patterns must not
+   narrow the existential's declared kind. *)
+
+type packed = Packed : ('a : value_or_null). 'a -> packed
+
+[%%expect{|
+type packed = Packed : 'a -> packed
+|}]
+
+(* Matching the declared kind exactly is fine. *)
+
+let h (Packed (type (a : value_or_null)) (x : a)) = ()
+
+[%%expect{|
+val h : packed -> unit = <fun>
+|}]
+
+(* Cannot falsely lower [value_or_null] to [value] *)
+
+type packed = P : ('a : value_or_null). 'a -> packed
+
+let f (P (type (a : value)) (x : a)) = ()
+[%%expect{|
+type packed = P : 'a -> packed
+Line 3, characters 20-25:
+3 | let f (P (type (a : value)) (x : a)) = ()
+                        ^^^^^
+Error: The layout of a is value maybe_separable maybe_null
+         because of the definition of packed at line 1, characters 0-52.
+       But the layout of a must be a sublayout of value
+         because of the annotation on the existential variable a.
+|}]
+
+(* Omitting the kind annotation defaults to [value]. On a [value_or_null]
+   constructor that is also unsound, and is rejected the same way. *)
+
+let k (Packed (type a) (x : a)) = ()
+
+[%%expect{|
+Line 1, characters 20-21:
+1 | let k (Packed (type a) (x : a)) = ()
+                        ^
+Error: The layout of a is value maybe_separable maybe_null
+         because of the definition of packed at line 1, characters 0-57.
+       But the layout of a must be a sublayout of value
+         because it's an unannotated existential type variable.
+|}]
+
+(* Omitting the annotation is fine when the declared kind is [value]. *)
+
+type packed_val = Packed_val : 'a. 'a -> packed_val
+
+let m (Packed_val (type a) (x : a)) = ()
+
+[%%expect{|
+type packed_val = Packed_val : 'a -> packed_val
+val m : packed_val -> unit = <fun>
+|}]
+
+(* Cannot falsely lower [value] to [value non_pointer] *)
+
+type packed = P : ('a : value). 'a -> packed
+
+let f (P (type (a : value non_pointer)) (x : a)) = ()
+[%%expect{|
+type packed = P : 'a -> packed
+Line 3, characters 20-37:
+3 | let f (P (type (a : value non_pointer)) (x : a)) = ()
+                        ^^^^^^^^^^^^^^^^^
+Error: The layout of a is value
+         because of the definition of packed at line 1, characters 0-44.
+       But the layout of a must be a sublayout of value non_pointer
+         because of the annotation on the existential variable a.
+       Note: The layout of immediate is value non_pointer.
+|}]
+
+(* Cannot falsely lower along mode crossing:
+   [value] to [value mod portable] *)
+
+type packed = P : ('a : value). 'a -> packed
+
+let f (P (type (a : value mod portable)) (x : a)) = ()
+[%%expect{|
+type packed = P : 'a -> packed
+Line 3, characters 20-38:
+3 | let f (P (type (a : value mod portable)) (x : a)) = ()
+                        ^^^^^^^^^^^^^^^^^^
+Error: The kind of a is value
+         because of the definition of packed at line 1, characters 0-44.
+       But the kind of a must be a subkind of value mod portable
+         because of the annotation on the existential variable a.
+|}]
+
+(* Cannot falsely lower along a non-modal axis:
+   [value] to [value mod external_] *)
+
+type packed = P : ('a : value). 'a -> packed
+
+let f (P (type (a : value mod external_)) (x : a)) = ()
+[%%expect{|
+type packed = P : 'a -> packed
+Line 3, characters 20-39:
+3 | let f (P (type (a : value mod external_)) (x : a)) = ()
+                        ^^^^^^^^^^^^^^^^^^^
+Error: The kind of a is value
+         because of the definition of packed at line 1, characters 0-44.
+       But the kind of a must be a subkind of value mod external_
+         because of the annotation on the existential variable a.
+|}]
+
+(* Cannot falsely lower [any] to [float64] *)
+
+type ('a : any) with_phantom
+type with_phantom_packed =
+  | P : ('a : any). 'a with_phantom -> with_phantom_packed
+
+let f (P (type (a : float64)) (x : a with_phantom)) = ()
+[%%expect{|
+type ('a : any) with_phantom
+type with_phantom_packed =
+    P : ('a : any). 'a with_phantom -> with_phantom_packed
+Line 5, characters 20-27:
+5 | let f (P (type (a : float64)) (x : a with_phantom)) = ()
+                        ^^^^^^^
+Error: The layout of a is any
+         because of the definition of with_phantom_packed at lines 2-3, characters 0-58.
+       But the layout of a must be a sublayout of float64
+         because of the annotation on the existential variable a.
+|}]
+
+(* Reverse direction *)
+
+type packed = P : ('a : value). 'a -> packed
+
+let f (P (type (a : value_or_null)) (x : a)) = ()
+[%%expect{|
+type packed = P : 'a -> packed
+Line 3, characters 41-42:
+3 | let f (P (type (a : value_or_null)) (x : a)) = ()
+                                             ^
+Error: This pattern matches values of type "a"
+       but a pattern was expected which matches values of type "('a : value)"
+       The layout of a is value maybe_separable maybe_null
+         because of the annotation on the existential variable a.
+       But the layout of a must be a sublayout of value
+         because of the definition of packed at line 1, characters 0-44.
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1577,20 +1577,23 @@ type existential_treatment =
 let instance_constructor existential_treatment cstr =
   For_copy.with_scope (fun copy_scope ->
     let name_counter = ref 0 in
+    let declared_jkind_of existential =
+      match get_desc existential with
+      | Tvar { jkind } -> jkind
+      | Tvariant _ -> Jkind.Builtin.value ~why:Row_variable
+          (* Existential row variable *)
+      | _ -> Misc.fatal_error "Ctype.instance_constructor"
+    in
     let copy_existential =
       match existential_treatment with
-      | Keep_existentials_flexible -> copy copy_scope
+      | Keep_existentials_flexible ->
+          fun existential ->
+            (copy copy_scope existential, declared_jkind_of existential)
       | Make_existentials_abstract penv ->
           fun existential ->
             (* CR layouts v1.5: Add test case that hits this once we have syntax
                for it *)
-            let jkind =
-              match get_desc existential with
-              | Tvar { jkind } -> jkind
-              | Tvariant _ -> Jkind.Builtin.value ~why:Row_variable
-                  (* Existential row variable *)
-              | _ -> assert false
-            in
+            let jkind = declared_jkind_of existential in
             let decl = new_local_type (Existential cstr.cstr_name) jkind in
             let name = existential_name name_counter existential in
             let env = penv.env in
@@ -1603,7 +1606,7 @@ let instance_constructor existential_treatment cstr =
             let tv = copy copy_scope existential in
             assert (is_Tvar tv);
             link_type tv to_unify;
-            tv
+            (tv, jkind)
     in
     let ty_ex = List.map copy_existential cstr.cstr_existentials in
     let ty_res = copy copy_scope cstr.cstr_res in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -215,8 +215,11 @@ type existential_treatment =
 
 val instance_constructor: existential_treatment ->
         constructor_description ->
-        Types.constructor_argument list * type_expr * type_expr list
-        (* Same, for a constructor. Also returns existentials. *)
+        Types.constructor_argument list * type_expr
+          * (type_expr * Types.jkind_lr) list
+        (* Same, for a constructor. The third component pairs each existential
+           with its declared jkind (read from the original, not the copy, so it
+           is unaffected by later unification). *)
 val instance_parameterized_type:
         ?keep_names:bool ->
         type_expr list -> type_expr -> type_expr list * type_expr

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1842,7 +1842,7 @@ let solve_Ppat_unboxed_tuple ~refine ~alloc_mode loc env args expected_ty =
   ann
 
 let solve_constructor_annotation
-    tps (penv : Pattern_env.t) name_list sty ty_args ty_ex cstr_existentials =
+    tps (penv : Pattern_env.t) name_list sty ty_args ty_ex =
   let expansion_scope = penv.equations_scope in
   let existentials =
     List.map
@@ -1910,22 +1910,16 @@ let solve_constructor_annotation
   if existentials <> [] then begin
     let ids = List.map (fun (x, _, _) -> x.txt) existentials in
     let rem =
-      List.fold_left2
-        (fun rem tv cstr_ex_tv ->
+      List.fold_left
+        (fun rem (tv, declared_jkind) ->
           match get_desc tv with
             Tconstr(Path.Pident id, [], _) when List.mem id rem ->
-              let declared_jkind =
-                match get_desc cstr_ex_tv with
-                | Tvar { jkind } -> jkind
-                | Tvariant _ -> Jkind.Builtin.value ~why:Row_variable
-                | _ -> Misc.fatal_error "Typecore.solve_constructor_annotation"
-              in
               check_existential id declared_jkind;
               list_remove id rem
           | _ ->
               raise (Error (cty.ctyp_loc, !!penv,
                             Unbound_existential (ids, ty))))
-        ids ty_ex cstr_existentials
+        ids ty_ex
     in
     if rem <> [] then
       raise (Error (cty.ctyp_loc, !!penv,
@@ -1982,7 +1976,7 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
                   ca.Types.ca_type) ty_args in
             let ty_args_ty, existential_ctyp =
               solve_constructor_annotation tps penv name_list sty ty_args_ty
-                ty_ex constr.cstr_existentials
+                ty_ex
             in
             let ty_args =
               List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1887,7 +1887,7 @@ let solve_constructor_annotation
     match
       List.find_opt (fun (n, _, _) -> Ident.same n.txt id) existentials
     with
-    | None -> ()
+    | None -> assert false
     | Some (name, jkind_annot_opt, annotated_jkind) ->
         let type_equal = Ctype.type_equal !!penv in
         let context = Ctype.mk_jkind_context_always_principal !!penv in
@@ -1904,7 +1904,10 @@ let solve_constructor_annotation
              raise (Error (loc, !!penv,
                            Existential_jkind_mismatch (name.txt, err))))
   in
-  if existentials <> [] then ignore begin
+  (* We don't have to perform checks when [existentials] is empty, because when
+     [name_list] (which has the same length) is empty, [solve_Ppat_construct]
+     uses treatment [Make_existentials_abstract] *)
+  if existentials <> [] then begin
     let ids = List.map (fun (x, _, _) -> x.txt) existentials in
     let rem =
       List.fold_left2
@@ -1928,11 +1931,11 @@ let solve_constructor_annotation
       raise (Error (cty.ctyp_loc, !!penv,
                     Unbound_existential (ids, ty)))
   end;
-  let existentials_out =
+  let existentials =
     List.map (fun (name, jkind_annot_opt, _) -> name, jkind_annot_opt)
       existentials
   in
-  ty_args, Some (existentials_out, cty)
+  ty_args, Some (existentials, cty)
 
 let solve_Ppat_construct ~refine tps penv loc constr no_existentials
         existential_styp expected_ty =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -263,6 +263,7 @@ type error =
   | Andop_type_clash of string * Errortrace.unification_error
   | Bindings_type_clash of Errortrace.unification_error
   | Unbound_existential of Ident.t list * type_expr
+  | Existential_jkind_mismatch of Ident.t * Jkind.Violation.t
   | Missing_type_constraint
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Wrong_expected_record_boxing of
@@ -1841,7 +1842,7 @@ let solve_Ppat_unboxed_tuple ~refine ~alloc_mode loc env args expected_ty =
   ann
 
 let solve_constructor_annotation
-    tps (penv : Pattern_env.t) name_list sty ty_args ty_ex =
+    tps (penv : Pattern_env.t) name_list sty ty_args ty_ex cstr_existentials =
   let expansion_scope = penv.equations_scope in
   let existentials =
     List.map
@@ -1857,7 +1858,7 @@ let solve_constructor_annotation
         let (id, new_env) =
           Env.enter_type ~scope:expansion_scope name.txt decl !!penv in
         Pattern_env.set_env penv new_env;
-        {name with txt = id}, jkind_annot_opt)
+        {name with txt = id}, jkind_annot_opt, jkind)
       name_list
   in
   let cty, ty, force =
@@ -1880,24 +1881,58 @@ let solve_constructor_annotation
           Ttuple tyl -> (List.map snd tyl)
         | _ -> assert false
   in
+  (* Check that the kind from the declaration is a subkind of the kind from
+     the pattern annotation. *)
+  let check_existential id declared_jkind =
+    match
+      List.find_opt (fun (n, _, _) -> Ident.same n.txt id) existentials
+    with
+    | None -> ()
+    | Some (name, jkind_annot_opt, annotated_jkind) ->
+        let type_equal = Ctype.type_equal !!penv in
+        let context = Ctype.mk_jkind_context_always_principal !!penv in
+        (match
+           Jkind.sub_or_error ~type_equal ~context !!penv
+             declared_jkind annotated_jkind
+         with
+         | Ok () -> ()
+         | Error err ->
+             let loc = match jkind_annot_opt with
+               | Some ja -> ja.pjka_loc
+               | None -> name.loc
+             in
+             raise (Error (loc, !!penv,
+                           Existential_jkind_mismatch (name.txt, err))))
+  in
   if existentials <> [] then ignore begin
-    let ids = List.map (fun (x, _) -> x.txt) existentials in
+    let ids = List.map (fun (x, _, _) -> x.txt) existentials in
     let rem =
-      List.fold_left
-        (fun rem tv ->
+      List.fold_left2
+        (fun rem tv cstr_ex_tv ->
           match get_desc tv with
             Tconstr(Path.Pident id, [], _) when List.mem id rem ->
+              let declared_jkind =
+                match get_desc cstr_ex_tv with
+                | Tvar { jkind } -> jkind
+                | Tvariant _ -> Jkind.Builtin.value ~why:Row_variable
+                | _ -> Misc.fatal_error "Typecore.solve_constructor_annotation"
+              in
+              check_existential id declared_jkind;
               list_remove id rem
           | _ ->
               raise (Error (cty.ctyp_loc, !!penv,
                             Unbound_existential (ids, ty))))
-        ids ty_ex
+        ids ty_ex cstr_existentials
     in
     if rem <> [] then
       raise (Error (cty.ctyp_loc, !!penv,
                     Unbound_existential (ids, ty)))
   end;
-  ty_args, Some (existentials, cty)
+  let existentials_out =
+    List.map (fun (name, jkind_annot_opt, _) -> name, jkind_annot_opt)
+      existentials
+  in
+  ty_args, Some (existentials_out, cty)
 
 let solve_Ppat_construct ~refine tps penv loc constr no_existentials
         existential_styp expected_ty =
@@ -1944,7 +1979,7 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
                   ca.Types.ca_type) ty_args in
             let ty_args_ty, existential_ctyp =
               solve_constructor_annotation tps penv name_list sty ty_args_ty
-                ty_ex
+                ty_ex constr.cstr_existentials
             in
             let ty_args =
               List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args
@@ -12255,6 +12290,9 @@ let report_error ~loc env =
         "@[<2>%s:@ %a@]"
         "This type does not bind all existentials in the constructor"
         (Style.as_inline_code pp_type) (ids, ty)
+  | Existential_jkind_mismatch (id, err) ->
+      Location.error_of_printer ~loc
+        (Jkind.Violation.report_with_name ~name:(Ident.name id) env) err
   | Missing_type_constraint ->
       Location.errorf ~loc
         "@[%s@ %s@]"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -312,6 +312,7 @@ type error =
   | Andop_type_clash of string * Errortrace.unification_error
   | Bindings_type_clash of Errortrace.unification_error
   | Unbound_existential of Ident.t list * type_expr
+  | Existential_jkind_mismatch of Ident.t * Jkind.Violation.t
   | Missing_type_constraint
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Wrong_expected_record_boxing of wrong_kind_context * record_form_packed * type_expr


### PR DESCRIPTION
A kind annotation on an existential could silently narrow its declared kind. For example, this was accepted:

```ocaml
type packed = P : ('a : any mod separable). 'a array -> packed
let f (P (type (a : value)) (x : a array)) = ()
```

...as well as the following segfaulting program:
```ocaml
type packed = P : ('a : value_or_null). 'a * 'a -> packed

let foo (P (type a) (x, y : a * a)) =
  ignore (Sys.opaque_identity [| x; y |])

let () = foo (P (This 0., Null))
```

We add a check that the kind annotation matches the existential.
