### PR TITLE
Performance monitoring counters for Runtime Events

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3254,6 +3254,14 @@ int main(void) {
 }
 ]])], AC_DEFINE([HAS_FMA]) has_fma=yes, [])
 
+AC_SUBST([perf_counters_supported])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#if !(defined(__linux__) && (defined(__x86_64__) || defined(__i386__)))
+#error perf counters not supported on this target
+#endif
+int main(void) { return 0; }
+]])], perf_counters_supported=yes, [])
+
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
 ocamlc_cflags="$ocamlc_cflags $common_cflags $sharedlib_cflags $CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -3256,7 +3256,7 @@ int main(void) {
 
 AC_SUBST([perf_counters_supported])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#if !(defined(__linux__) && (defined(__x86_64__) || defined(__i386__)))
+#if !(defined(__linux__) && defined(__x86_64__))
 #error perf counters not supported on this target
 #endif
 int main(void) { return 0; }

--- a/external/js_of_ocaml/runtime/js/runtime_events.js
+++ b/external/js_of_ocaml/runtime/js/runtime_events.js
@@ -52,6 +52,12 @@ function caml_ml_runtime_events_are_active() {
   return 0;
 }
 
+//Provides: caml_ml_runtime_events_perf_counters_active
+//Version: >= 5.2
+function caml_ml_runtime_events_perf_counters_active() {
+  return 0;
+}
+
 //Provides: caml_runtime_events_resume
 //Version: >=5.0, < 5.2
 function caml_runtime_events_resume() {

--- a/external/js_of_ocaml/runtime/wasm/runtime_events.wat
+++ b/external/js_of_ocaml/runtime/wasm/runtime_events.wat
@@ -65,6 +65,10 @@
       (param (ref eq)) (result (ref eq))
       (ref.i31 (i32.const 0)))
 
+   (func (export "caml_ml_runtime_events_perf_counters_active")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 0)))
+
    (func (export "caml_ml_runtime_events_create_cursor")
       (param (ref eq)) (result (ref eq))
       (ref.i31 (i32.const 0)))

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -439,14 +439,14 @@ let count_value =
     Runtime_events.User.register "count.value" CustomInt
         Runtime_events.Type.int
 
-let span_event_handler domain_id ts event value =
+let span_event_handler domain_id ts event value _perf_samples =
     (* we're only interested in our CustomSpan event *)
     match Runtime_events.User.tag event, value with
     | CustomSpan, Runtime_events.Type.Begin -> Printf.printf "> count begin\n"
     | CustomSpan, End -> Printf.printf "< count end\n"
     | _ -> ()
 
-let int_event_handler domain_id ts event value =
+let int_event_handler domain_id ts event value _perf_samples =
     (* we're only interested in our CustomInt event *)
     match Runtime_events.User.tag event with
     | CustomInt -> Printf.printf "| count %d\n" value

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -15,6 +15,9 @@
 external runtime_events_are_active : unit -> bool
   = "caml_ml_runtime_events_are_active" [@@noalloc]
 
+external perf_counters_active : unit -> bool
+  = "caml_ml_runtime_events_perf_counters_active" [@@noalloc]
+
 type runtime_counter =
 | EV_C_FORCE_MINOR_ALLOC_SMALL
 | EV_C_FORCE_MINOR_MAKE_VECT

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -209,6 +209,8 @@ let lifecycle_name lifecycle =
   | EV_DOMAIN_SPAWN -> "domain_spawn"
   | EV_DOMAIN_TERMINATE -> "domain_terminate"
 
+type perf_sample = #{ config: int64#; value: int64# }
+
 type cursor
 
 module Timestamp = struct
@@ -339,15 +341,19 @@ end
 
 module Callbacks = struct
 
-  type 'a callback = int -> Timestamp.t -> 'a User.t -> 'a -> unit
+  type 'a callback =
+    int -> Timestamp.t -> 'a User.t -> 'a ->
+    local_ perf_sample array -> unit
   (* Callbacks are bound to a specific event type *)
   type any_callback = U : 'a callback -> any_callback
 
   (* these record callbacks are only called from C code in the runtime
       so we suppress the unused field warning *)
   type[@warning "-unused-field"] t = {
-    runtime_begin: (int -> Timestamp.t -> runtime_phase -> unit) option;
-    runtime_end: (int -> Timestamp.t -> runtime_phase -> unit) option;
+    runtime_begin: (int -> Timestamp.t -> runtime_phase ->
+                    local_ perf_sample array -> unit) option;
+    runtime_end: (int -> Timestamp.t -> runtime_phase ->
+                  local_ perf_sample array -> unit) option;
     runtime_counter: (int -> Timestamp.t -> runtime_counter
                       -> int -> unit) option;
     alloc: (int -> Timestamp.t -> int array -> unit) option;

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -331,7 +331,7 @@ val resume : unit -> unit
 val perf_counters_active : unit -> bool
 (** [perf_counters_active ()] returns [true] if hardware performance counters
    are currently being sampled alongside runtime and user span events. This
-   requires a build with Linux x86 PMC support (see
+   requires a build with Linux x86-64 PMC support (see
    {!Config.perf_counters_supported}), a valid
    [OCAML_RUNTIME_EVENTS_PERF_COUNTERS] configuration, and a successful
    [perf_event_open]/rdpmc setup by the runtime. Returns [false]

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -189,6 +189,11 @@ val runtime_phase_name : runtime_phase -> string
 val runtime_counter_name : runtime_counter -> string
 (** Return a string representation of a given runtime counter type. *)
 
+type perf_sample = #{ config: int64#; value: int64# }
+(** An unboxed record containing a performance counter configuration ID
+    and its corresponding counter value. Used to efficiently pass
+    performance counter data to callbacks without boxing overhead. *)
+
 type cursor
 (** Type of the cursor used when consuming. *)
 
@@ -258,10 +263,10 @@ module Callbacks : sig
   type t
   (** Type of callbacks. *)
 
-  val create : ?runtime_begin:(int -> Timestamp.t -> runtime_phase
-                                -> unit) ->
-             ?runtime_end:(int -> Timestamp.t -> runtime_phase
-                                -> unit) ->
+  val create : ?runtime_begin:(int -> Timestamp.t -> runtime_phase ->
+                                local_ perf_sample array -> unit) ->
+             ?runtime_end:(int -> Timestamp.t -> runtime_phase ->
+                            local_ perf_sample array -> unit) ->
              ?runtime_counter:(int -> Timestamp.t -> runtime_counter
                                 -> int -> unit) ->
              ?alloc:(int -> Timestamp.t -> int array -> unit) ->
@@ -274,9 +279,13 @@ module Callbacks : sig
       existence. After a domain terminates, a newly spawned domain may take
       ownership of the ring buffer. A [runtime_begin] callback is called when
       the runtime enters a new phase (e.g a runtime_begin with EV_MINOR is
-      called at the start of a minor GC). A [runtime_end] callback is called
-      when the runtime leaves a certain phase. The [runtime_counter] callback
-      is called when a counter is emitted by the runtime. [lifecycle] callbacks
+      called at the start of a minor GC). The [runtime_begin] callback receives
+      an array of [perf_sample] unboxed records, each containing a performance
+      counter configuration ID and its corresponding counter value. The array
+      will be empty if no performance counters are available. A [runtime_end]
+      callback is called when the runtime leaves a certain phase and receives
+      the same [perf_sample] array format. The [runtime_counter] callback is
+      called when a counter is emitted by the runtime. [lifecycle] callbacks
       are called when the ring undergoes a change in lifecycle and a consumer
       may need to respond. [alloc] callbacks are currently only called on the
       instrumented runtime. [lost_events] callbacks are called if the consumer
@@ -284,11 +293,15 @@ module Callbacks : sig
       *)
 
   val add_user_event : 'a Type.t ->
-                        (int -> Timestamp.t -> 'a User.t -> 'a -> unit) ->
+                        (int -> Timestamp.t -> 'a User.t -> 'a ->
+                         local_ perf_sample array -> unit) ->
                         t -> t
   (** [add_user_event ty callback t] extends [t] to additionally subscribe to
       user events of type [ty]. When such an event happens, [callback] is called
-      with the corresponding event and payload. *)
+      with the corresponding event, payload, and an array of [perf_sample]
+      unboxed records containing performance counter data. The array will be
+      non-empty only for span events when performance counters are configured
+      via the [OCAML_RUNTIME_EVENTS_PERF_COUNTERS] environment variable. *)
 end
 
 val start : unit -> unit

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -328,6 +328,15 @@ val resume : unit -> unit
    the OCAML_RUNTIME_EVENTS_START environment variable has been set.
 *)
 
+val perf_counters_active : unit -> bool
+(** [perf_counters_active ()] returns [true] if hardware performance counters
+   are currently being sampled alongside runtime and user span events. This
+   requires a build with Linux x86 PMC support (see
+   {!Config.perf_counters_supported}), a valid
+   [OCAML_RUNTIME_EVENTS_PERF_COUNTERS] configuration, and a successful
+   [perf_event_open]/rdpmc setup by the runtime. Returns [false]
+   otherwise. *)
+
 val create_cursor : (string * int) option -> cursor
 (** [create_cursor path_pid] creates a cursor to read from an runtime_events.
    Cursors can be created for runtime_events in and out of process. A

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -191,8 +191,7 @@ val runtime_counter_name : runtime_counter -> string
 
 type perf_sample = #{ config: int64#; value: int64# }
 (** An unboxed record containing a performance counter configuration ID
-    and its corresponding counter value. Used to efficiently pass
-    performance counter data to callbacks without boxing overhead. *)
+    and its corresponding counter value. *)
 
 type cursor
 (** Type of the cursor used when consuming. *)

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -43,7 +43,7 @@
 #include <sys/mman.h>
 #endif
 
-#if defined(__linux__) && (defined(__x86_64__) || defined(__i386__))
+#if defined(__linux__) && defined(__x86_64__)
 #define PERF_COUNTERS
 #endif
 

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -43,10 +43,20 @@
 #include <sys/mman.h>
 #endif
 
+#if defined(__linux__) && (defined(__x86_64__) || defined(__i386__))
+#define PERF_COUNTERS
+#endif
+
+/* Maximum number of perf events - must match runtime/runtime_events.c */
+#define MAX_PERF_EVENTS 20
 
 #if defined(HAS_UNISTD)
 #include <unistd.h>
 #endif
+
+/* Extern declaration for unboxed product array allocation */
+CAMLextern value caml_makearray_dynamic_non_scannable_unboxed_product(
+  value v_num_components, value v_is_local, value v_non_unarized_length);
 
 #define RING_FILE_NAME_MAX_LEN 512
 
@@ -64,9 +74,11 @@ struct caml_runtime_events_cursor {
 #endif
   /* callbacks */
   int (*runtime_begin)(int domain_id, void *callback_data, uint64_t timestamp,
-                        ev_runtime_phase phase);
+                        ev_runtime_phase phase, uint64_t header,
+                        uint64_t *buf, int buf_len);
   int (*runtime_end)(int domain_id, void *callback_data, uint64_t timestamp,
-                      ev_runtime_phase phase);
+                      ev_runtime_phase phase, uint64_t header,
+                      uint64_t *buf, int buf_len);
   int (*runtime_counter)(int domain_id, void *callback_data,
                           uint64_t timestamp, ev_runtime_counter counter,
                           uint64_t val);
@@ -77,14 +89,18 @@ struct caml_runtime_events_cursor {
   int (*lost_events)(int domain_id, void *callback_data, int lost_words);
   /* user events: mapped from type to callback */
   int (*user_unit)(int domain_id, void* callback_data, int64_t timestamp,
-                      uintnat event_id, char* event_name);
+                      uintnat event_id, char* event_name,
+                      uint64_t header, uint64_t *buf, int buf_len);
   int (*user_span)(int domain_id, void* callback_data, int64_t timestamp,
-                      uintnat event_id, char* event_name, ev_user_span value);
+                      uintnat event_id, char* event_name, ev_user_span value,
+                      uint64_t header, uint64_t *buf, int buf_len);
   int (*user_int)(int domain_id, void* callback_data, int64_t timestamp,
-                      uintnat event_id, char* event_name, uint64_t val);
+                      uintnat event_id, char* event_name, uint64_t val,
+                      uint64_t header, uint64_t *buf, int buf_len);
   int (*user_custom)(int domain_id, void *callback_data, int64_t timestamp,
                       uintnat event_id, char* event_name,
-                      uintnat event_data_len, uint64_t* event_data);
+                      uintnat event_data_len, uint64_t* event_data,
+                      uint64_t header, uint64_t *buf, int buf_len);
 };
 
 /* C-API for reading from an runtime_events */
@@ -313,7 +329,10 @@ void caml_runtime_events_set_runtime_begin(
                                       int (*f)(int domain_id,
                                                void *callback_data,
                                                uint64_t timestamp,
-                                               ev_runtime_phase phase)) {
+                                               ev_runtime_phase phase,
+                                               uint64_t header,
+                                               uint64_t *buf,
+                                               int buf_len)) {
   cursor->runtime_begin = f;
 }
 
@@ -321,7 +340,10 @@ void caml_runtime_events_set_runtime_end(
                                     struct caml_runtime_events_cursor *cursor,
                                     int (*f)(int domain_id, void *callback_data,
                                              uint64_t timestamp,
-                                             ev_runtime_phase phase)) {
+                                             ev_runtime_phase phase,
+                                             uint64_t header,
+                                             uint64_t *buf,
+                                             int buf_len)) {
   cursor->runtime_end = f;
 }
 
@@ -360,7 +382,9 @@ void caml_runtime_events_set_user_unit(
                                   int (*f)(int domain_id, void *callback_data,
                                             int64_t timestamp,
                                             uintnat event_id,
-                                            char* event_name)) {
+                                            char* event_name,
+                                            uint64_t header,
+                                            uint64_t *buf, int buf_len)) {
   cursor->user_unit = f;
 }
 
@@ -370,7 +394,9 @@ void caml_runtime_events_set_user_span(
                                             int64_t timestamp,
                                             uintnat event_id,
                                             char* event_name,
-                                            ev_user_span span)) {
+                                            ev_user_span span,
+                                            uint64_t header,
+                                            uint64_t *buf, int buf_len)) {
   cursor->user_span = f;
 }
 
@@ -380,7 +406,9 @@ void caml_runtime_events_set_user_int(
                                             int64_t timestamp,
                                             uintnat event_id,
                                             char* event_name,
-                                            uint64_t val)) {
+                                            uint64_t val,
+                                            uint64_t header,
+                                            uint64_t *buf, int buf_len)) {
   cursor->user_int = f;
 }
 
@@ -391,7 +419,9 @@ void caml_runtime_events_set_user_custom(
                                             uintnat event_id,
                                             char* event_name,
                                             uintnat event_data_len,
-                                            uint64_t* event_data)) {
+                                            uint64_t* event_data,
+                                            uint64_t header,
+                                            uint64_t *buf, int buf_len)) {
   cursor->user_custom = f;
 }
 
@@ -550,7 +580,8 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
         case EV_BEGIN:
           if (cursor->runtime_begin) {
             if( !cursor->runtime_begin(domain_num, callback_data, buf[1],
-                                        RUNTIME_EVENTS_ITEM_ID(header)) ) {
+                                        RUNTIME_EVENTS_ITEM_ID(header),
+                                        header, buf, msg_length) ) {
                                           early_exit = 1;
                                           continue;
                                         }
@@ -559,7 +590,8 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
         case EV_EXIT:
           if (cursor->runtime_end) {
             if( !cursor->runtime_end(domain_num, callback_data, buf[1],
-                                      RUNTIME_EVENTS_ITEM_ID(header)) ) {
+                                      RUNTIME_EVENTS_ITEM_ID(header),
+                                      header, buf, msg_length) ) {
                                         early_exit = 1;
                                         continue;
                                       };
@@ -626,7 +658,8 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
           case EV_USER_MSG_TYPE_UNIT:
             if (cursor->user_unit) {
               if( !cursor->user_unit(domain_num, callback_data, buf[1],
-                                      event_id, event_name) ) {
+                                      event_id, event_name,
+                                      header, buf, msg_length) ) {
                                         early_exit = 1;
                                         continue;
                                       }
@@ -643,7 +676,8 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
               }
 
               if( !cursor->user_span(domain_num, callback_data, buf[1],
-                                      event_id, event_name, event_span) ) {
+                                      event_id, event_name, event_span,
+                                      header, buf, msg_length) ) {
                                         early_exit = 1;
                                         continue;
                                       }
@@ -656,7 +690,8 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
                 return E_CORRUPT_STREAM;
               }
               if( !cursor->user_int(domain_num, callback_data, buf[1],
-                                      event_id, event_name, buf[2]) ) {
+                                      event_id, event_name, buf[2],
+                                      header, buf, msg_length) ) {
                                         early_exit = 1;
                                         continue;
                                       }
@@ -667,7 +702,8 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
               /* msg_length could be genuinely 2 here */
               if( !cursor->user_custom(domain_num, callback_data, buf[1],
                                       event_id, event_name,
-                                      msg_length - 2, &buf[2]) ) {
+                                      msg_length - 2, &buf[2],
+                                      header, buf, msg_length) ) {
                                         early_exit = 1;
                                         continue;
                                       }
@@ -723,21 +759,61 @@ struct callbacks_exception_holder {
   value* wrapper;
 };
 
+/* Extract perf counter data from a ring buffer message into an unboxed
+   product array of #{ config: int64#; value: int64# }. Returns an
+   allocated (possibly empty) array. Must be called within a CAMLparam
+   context and the result must be registered as a local root. */
+static value extract_perf_data(uint64_t header, uint64_t *buf, int buf_len) {
+  value perf_data;
+
+  #ifdef PERF_COUNTERS
+  int nperf = RUNTIME_EVENTS_ITEM_PERF_COUNTERS(header);
+  int perf_start_index = buf_len - (2 * nperf);
+
+  if (nperf > 0 && perf_start_index >= 2) {
+    perf_data = caml_makearray_dynamic_non_scannable_unboxed_product(
+        Val_long(2), Val_true, Val_long(nperf));
+    int64_t* data = (int64_t*)perf_data;
+    for (int i = 0; i < nperf; i++) {
+      data[i*2] = buf[perf_start_index + i];
+      data[i*2 + 1] = buf[perf_start_index + nperf + i];
+    }
+  } else {
+    perf_data = caml_makearray_dynamic_non_scannable_unboxed_product(
+        Val_long(2), Val_true, Val_long(0));
+  }
+  #else
+  (void)header; (void)buf; (void)buf_len;
+  perf_data = caml_makearray_dynamic_non_scannable_unboxed_product(
+      Val_long(2), Val_true, Val_long(0));
+  #endif
+
+  return perf_data;
+}
+
 static int ml_runtime_begin(int domain_id, void *callback_data,
-                             uint64_t timestamp, ev_runtime_phase phase) {
+                             uint64_t timestamp, ev_runtime_phase phase,
+                             uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal5(tmp_callback, ts_val, msg_type, callbacks_root, res);
+  CAMLlocal4(tmp_callback, callbacks_root, res, perf_data);
+  CAMLlocalN(params, 4);
+
+  perf_data = Val_unit;
+
   struct callbacks_exception_holder* holder = callback_data;
 
   callbacks_root = *holder->callbacks_val;
 
   tmp_callback = Field(callbacks_root, 0); /* ev_runtime_begin */
   if (Is_some(tmp_callback)) {
-    ts_val = caml_copy_int64(timestamp);
-    msg_type = Val_long(phase);
+    perf_data = extract_perf_data(header, buf, buf_len);
 
-    res = caml_callback3_exn(Some_val(tmp_callback), Val_long(domain_id),
-                                  ts_val, msg_type);
+    params[0] = Val_long(domain_id);
+    params[1] = caml_copy_int64(timestamp);
+    params[2] = Val_long(phase);
+    params[3] = perf_data;
+
+    res = caml_callbackN_exn(Some_val(tmp_callback), 4, params);
 
     if( Is_exception_result(res) ) {
       res = Extract_exception(res);
@@ -750,20 +826,28 @@ static int ml_runtime_begin(int domain_id, void *callback_data,
 }
 
 static int ml_runtime_end(int domain_id, void *callback_data,
-                           uint64_t timestamp, ev_runtime_phase phase) {
+                           uint64_t timestamp, ev_runtime_phase phase,
+                           uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal5(tmp_callback, ts_val, msg_type, callbacks_root, res);
+  CAMLlocal4(tmp_callback, callbacks_root, res, perf_data);
+  CAMLlocalN(params, 4);
+
+  perf_data = Val_unit;
+
   struct callbacks_exception_holder* holder = callback_data;
 
   callbacks_root = *holder->callbacks_val;
 
   tmp_callback = Field(callbacks_root, 1); /* ev_runtime_end */
   if (Is_some(tmp_callback)) {
-    ts_val = caml_copy_int64(timestamp);
-    msg_type = Val_long(phase);
+    perf_data = extract_perf_data(header, buf, buf_len);
 
-    res = caml_callback3_exn(Some_val(tmp_callback), Val_long(domain_id),
-                             ts_val, msg_type);
+    params[0] = Val_long(domain_id);
+    params[1] = caml_copy_int64(timestamp);
+    params[2] = Val_long(phase);
+    params[3] = perf_data;
+
+    res = caml_callbackN_exn(Some_val(tmp_callback), 4, params);
 
     if( Is_exception_result(res) ) {
       res = Extract_exception(res);
@@ -935,14 +1019,15 @@ static value user_events_find_callback_list_for_event_type(value callbacks_root,
 
 static int user_events_call_callback_list(
   struct callbacks_exception_holder* holder, value callback_list,
-  value params[4]) {
+  value params[5]) {
   CAMLparam5(callback_list, params[0], params[1], params[2], params[3]);
+  CAMLxparam1(params[4]);
   CAMLlocal2(callback, res);
 
   while (Is_block(callback_list)) {
       // two indirections as callback is a list item wrapped in a gadt
     callback = Field(Field(callback_list, 0), 0);
-    res = caml_callbackN_exn(callback, 4, params);
+    res = caml_callbackN_exn(callback, 5, params);
 
     if( Is_exception_result(res) ) {
       res = Extract_exception(res);
@@ -1022,11 +1107,14 @@ static value caml_runtime_events_user_resolve_cached(
 }
 
 static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
-                           uintnat event_id, char* event_name) {
+                           uintnat event_id, char* event_name,
+                           uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal3(callback_list, event, callbacks_root);
-  CAMLlocalN(params, 4);
+  CAMLlocal4(callback_list, event, callbacks_root, perf_data);
+  CAMLlocalN(params, 5);
   CAMLlocal1(wrapper_root);
+
+  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1040,15 +1128,14 @@ static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
                                                                 event);
 
   if (Is_block(callback_list)) {
-    // at least one callback is listening for this event type, so we
-    // deserialize the value and prepare the callback payload
+    perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = Val_unit;
+    params[4] = perf_data;
 
-    // payload is prepared, we call the callbacks sequentially.
     if (user_events_call_callback_list(holder, callback_list, params) == 0) {
       CAMLreturnT(int, 0);
     }
@@ -1059,12 +1146,15 @@ static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
 
 static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
                            uintnat event_id, char* event_name,
-                           ev_user_span span)
+                           ev_user_span span,
+                           uint64_t header, uint64_t *buf, int buf_len)
 {
   CAMLparam0();
-  CAMLlocal3(callback_list, event, callbacks_root);
-  CAMLlocalN(params, 4);
+  CAMLlocal4(callback_list, event, callbacks_root, perf_data);
+  CAMLlocalN(params, 5);
   CAMLlocal1(wrapper_root);
+
+  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1078,15 +1168,14 @@ static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
                                                                 event);
 
   if (Is_block(callback_list)) {
-    // at least one callback is listening for this event type, so we
-    // deserialize the value and prepare the callback payload
+    perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = Val_int(span);
+    params[4] = perf_data;
 
-    // payload is prepared, we call the callbacks sequentially.
     if (user_events_call_callback_list(holder, callback_list, params) == 0) {
       CAMLreturnT(int, 0);
     }
@@ -1097,11 +1186,14 @@ static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
 
 static int ml_user_int(int domain_id, void *callback_data,
                            int64_t timestamp, uintnat event_id,
-                           char* event_name, uint64_t val) {
+                           char* event_name, uint64_t val,
+                           uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal3(callback_list, event, callbacks_root);
-  CAMLlocalN(params, 4);
+  CAMLlocal4(callback_list, event, callbacks_root, perf_data);
+  CAMLlocalN(params, 5);
   CAMLlocal1(wrapper_root);
+
+  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1115,15 +1207,14 @@ static int ml_user_int(int domain_id, void *callback_data,
                                                                 event);
 
   if (Is_block(callback_list)) {
-    // at least one callback is listening for this event type, so we
-    // deserialize the value and prepare the callback payload
+    perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
-    params[3] = Val_int(val);;
+    params[3] = Val_int(val);
+    params[4] = perf_data;
 
-    // payload is prepared, we call the callbacks sequentially.
     if (user_events_call_callback_list(holder, callback_list, params) == 0) {
       CAMLreturnT(int, 0);
     }
@@ -1135,12 +1226,15 @@ static int ml_user_int(int domain_id, void *callback_data,
 static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
                            uintnat event_id, char* event_name,
                            uintnat event_data_len,
-                           uint64_t* event_data) {
+                           uint64_t* event_data,
+                           uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
   CAMLlocal4(callback_list, event, callbacks_root, event_type);
-  CAMLlocalN(params, 4);
+  CAMLlocalN(params, 5);
   CAMLlocal2(wrapper_root, read_buffer);
-  CAMLlocal3(data, record, deserializer);
+  CAMLlocal4(data, record, deserializer, perf_data);
+
+  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1188,10 +1282,13 @@ static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
 
     data = caml_callback2(deserializer, read_buffer, Val_int(caml_string_len));
 
+    perf_data = extract_perf_data(header, buf, buf_len);
+
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = data;
+    params[4] = perf_data;
 
     // payload is prepared, we call the callbacks sequentially.
     if (user_events_call_callback_list(holder, callback_list, params) == 0) {

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -758,8 +758,7 @@ struct callbacks_exception_holder {
 
 /* Extract perf counter data from a ring buffer message into an unboxed
    product array of #{ config: int64#; value: int64# }. Returns an
-   allocated (possibly empty) array. Must be called within a CAMLparam
-   context and the result must be registered as a local root. */
+   allocated (possibly empty) array in the caller's local region. */
 static value extract_perf_data(uint64_t header, uint64_t *buf, int buf_len) {
   value perf_data;
 
@@ -782,39 +781,95 @@ static value extract_perf_data(uint64_t header, uint64_t *buf, int buf_len) {
   return perf_data;
 }
 
+/* Invoke a single consumer callback whose last argument is a local_
+   perf_sample array. Snapshots local_sp, allocates the array in the
+   caller's local region, invokes the callback, then rewinds local_sp
+   to reclaim the array - mirrors the pattern used by callback*_global
+   in runtime/callback.c.
+
+   [params] must already be rooted by the caller (e.g. via CAMLlocalN).
+   The slot at [perf_arg_index] is written by this helper; the caller
+   should leave it uninitialised. Returns 1 on success, 0 if the
+   callback raised (exception stored in holder->exception). */
+static int call_with_perf_samples(
+    value callback,
+    value *params, int params_arity, int perf_arg_index,
+    uint64_t header, uint64_t *buf, int buf_len,
+    struct callbacks_exception_holder *holder)
+{
+  CAMLparam1(callback);
+  intnat local_sp = Caml_state->local_sp;
+  params[perf_arg_index] = extract_perf_data(header, buf, buf_len);
+
+  value res = caml_callbackN_exn(callback, params_arity, params);
+
+  if (Is_exception_result(res)) {
+    res = Extract_exception(res);
+    /* Defensive: OCaml exceptions are heap-allocated today. If that
+       ever changes, the local_sp reset below would free the exception
+       value before the caller's caml_raise reads it. */
+    CAMLassert(!caml_is_stack(res));
+    *holder->exception = res;
+    Caml_state->local_sp = local_sp;
+    CAMLreturnT(int, 0);
+  }
+  /* Callbacks return unit; returning a local value would be a bug. */
+  CAMLassert(!caml_is_stack(res));
+  Caml_state->local_sp = local_sp;
+  CAMLreturnT(int, 1);
+}
+
+/* Like [call_with_perf_samples], but invokes every callback in a list
+   with the same perf_sample array. Stops on the first exception. */
+static int call_list_with_perf_samples(
+    value callback_list,
+    value *params, int params_arity, int perf_arg_index,
+    uint64_t header, uint64_t *buf, int buf_len,
+    struct callbacks_exception_holder *holder)
+{
+  CAMLparam1(callback_list);
+  CAMLlocal1(callback);
+  intnat local_sp = Caml_state->local_sp;
+  params[perf_arg_index] = extract_perf_data(header, buf, buf_len);
+
+  while (Is_block(callback_list)) {
+    /* two indirections as callback is a list item wrapped in a gadt */
+    callback = Field(Field(callback_list, 0), 0);
+    value res = caml_callbackN_exn(callback, params_arity, params);
+
+    if (Is_exception_result(res)) {
+      res = Extract_exception(res);
+      CAMLassert(!caml_is_stack(res));
+      *holder->exception = res;
+      Caml_state->local_sp = local_sp;
+      CAMLreturnT(int, 0);
+    }
+    CAMLassert(!caml_is_stack(res));
+    callback_list = Field(callback_list, 1);
+  }
+
+  Caml_state->local_sp = local_sp;
+  CAMLreturnT(int, 1);
+}
+
 static int ml_runtime_begin(int domain_id, void *callback_data,
                              uint64_t timestamp, ev_runtime_phase phase,
                              uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal4(tmp_callback, callbacks_root, res, perf_data);
+  CAMLlocal2(tmp_callback, callbacks_root);
   CAMLlocalN(params, 4);
 
-  perf_data = Val_unit;
-
   struct callbacks_exception_holder* holder = callback_data;
-
   callbacks_root = *holder->callbacks_val;
 
   tmp_callback = Field(callbacks_root, 0); /* ev_runtime_begin */
   if (Is_some(tmp_callback)) {
-    /* Save local_sp so that the local_ perf_data array allocated by
-       extract_perf_data is freed after the callback returns. Without
-       this, each callback invocation in a read_poll loop would
-       accumulate local arrays until the enclosing OCaml region ends. */
-    intnat local_sp = Caml_state->local_sp;
-    perf_data = extract_perf_data(header, buf, buf_len);
-
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = Val_long(phase);
-    params[3] = perf_data;
-
-    res = caml_callbackN_exn(Some_val(tmp_callback), 4, params);
-    Caml_state->local_sp = local_sp;
-
-    if( Is_exception_result(res) ) {
-      res = Extract_exception(res);
-      *holder->exception = res;
+    /* params[3] is filled in by call_with_perf_samples */
+    if (!call_with_perf_samples(Some_val(tmp_callback), params, 4, 3,
+                                 header, buf, buf_len, holder)) {
       CAMLreturnT(int, 0);
     }
   }
@@ -826,31 +881,20 @@ static int ml_runtime_end(int domain_id, void *callback_data,
                            uint64_t timestamp, ev_runtime_phase phase,
                            uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal4(tmp_callback, callbacks_root, res, perf_data);
+  CAMLlocal2(tmp_callback, callbacks_root);
   CAMLlocalN(params, 4);
 
-  perf_data = Val_unit;
-
   struct callbacks_exception_holder* holder = callback_data;
-
   callbacks_root = *holder->callbacks_val;
 
   tmp_callback = Field(callbacks_root, 1); /* ev_runtime_end */
   if (Is_some(tmp_callback)) {
-    intnat local_sp = Caml_state->local_sp;
-    perf_data = extract_perf_data(header, buf, buf_len);
-
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = Val_long(phase);
-    params[3] = perf_data;
-
-    res = caml_callbackN_exn(Some_val(tmp_callback), 4, params);
-    Caml_state->local_sp = local_sp;
-
-    if( Is_exception_result(res) ) {
-      res = Extract_exception(res);
-      *holder->exception = res;
+    /* params[3] is filled in by call_with_perf_samples */
+    if (!call_with_perf_samples(Some_val(tmp_callback), params, 4, 3,
+                                 header, buf, buf_len, holder)) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1016,30 +1060,6 @@ static value user_events_find_callback_list_for_event_type(value callbacks_root,
   CAMLreturn(Field(tmp_callback_array, event_index));
 }
 
-static int user_events_call_callback_list(
-  struct callbacks_exception_holder* holder, value callback_list,
-  value params[5]) {
-  CAMLparam1(callback_list);
-  CAMLxparamN(params, 5);
-  CAMLlocal2(callback, res);
-
-  while (Is_block(callback_list)) {
-      // two indirections as callback is a list item wrapped in a gadt
-    callback = Field(Field(callback_list, 0), 0);
-    res = caml_callbackN_exn(callback, 5, params);
-
-    if( Is_exception_result(res) ) {
-      res = Extract_exception(res);
-      *holder->exception = res;
-      CAMLreturnT(int, 0);
-    }
-
-    callback_list = Field(callback_list, 1);
-  }
-
-  CAMLreturnT(int, 1);
-}
-
 static value caml_runtime_events_user_resolve_cached(
   value wrapper_root, uintnat event_id, char* event_name,
   ev_user_ml_type event_type)
@@ -1109,11 +1129,9 @@ static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
                            uintnat event_id, char* event_name,
                            uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal4(callback_list, event, callbacks_root, perf_data);
+  CAMLlocal3(callback_list, event, callbacks_root);
   CAMLlocalN(params, 5);
   CAMLlocal1(wrapper_root);
-
-  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1127,18 +1145,13 @@ static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
                                                                 event);
 
   if (Is_block(callback_list)) {
-    intnat local_sp = Caml_state->local_sp;
-    perf_data = extract_perf_data(header, buf, buf_len);
-
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = Val_unit;
-    params[4] = perf_data;
-
-    int ret = user_events_call_callback_list(holder, callback_list, params);
-    Caml_state->local_sp = local_sp;
-    if (ret == 0) {
+    /* params[4] is filled in by call_list_with_perf_samples */
+    if (!call_list_with_perf_samples(callback_list, params, 5, 4,
+                                      header, buf, buf_len, holder)) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1152,11 +1165,9 @@ static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
                            uint64_t header, uint64_t *buf, int buf_len)
 {
   CAMLparam0();
-  CAMLlocal4(callback_list, event, callbacks_root, perf_data);
+  CAMLlocal3(callback_list, event, callbacks_root);
   CAMLlocalN(params, 5);
   CAMLlocal1(wrapper_root);
-
-  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1170,18 +1181,13 @@ static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
                                                                 event);
 
   if (Is_block(callback_list)) {
-    intnat local_sp = Caml_state->local_sp;
-    perf_data = extract_perf_data(header, buf, buf_len);
-
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = Val_int(span);
-    params[4] = perf_data;
-
-    int ret = user_events_call_callback_list(holder, callback_list, params);
-    Caml_state->local_sp = local_sp;
-    if (ret == 0) {
+    /* params[4] is filled in by call_list_with_perf_samples */
+    if (!call_list_with_perf_samples(callback_list, params, 5, 4,
+                                      header, buf, buf_len, holder)) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1194,11 +1200,9 @@ static int ml_user_int(int domain_id, void *callback_data,
                            char* event_name, uint64_t val,
                            uint64_t header, uint64_t *buf, int buf_len) {
   CAMLparam0();
-  CAMLlocal4(callback_list, event, callbacks_root, perf_data);
+  CAMLlocal3(callback_list, event, callbacks_root);
   CAMLlocalN(params, 5);
   CAMLlocal1(wrapper_root);
-
-  perf_data = Val_unit;
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1212,18 +1216,13 @@ static int ml_user_int(int domain_id, void *callback_data,
                                                                 event);
 
   if (Is_block(callback_list)) {
-    intnat local_sp = Caml_state->local_sp;
-    perf_data = extract_perf_data(header, buf, buf_len);
-
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = Val_int(val);
-    params[4] = perf_data;
-
-    int ret = user_events_call_callback_list(holder, callback_list, params);
-    Caml_state->local_sp = local_sp;
-    if (ret == 0) {
+    /* params[4] is filled in by call_list_with_perf_samples */
+    if (!call_list_with_perf_samples(callback_list, params, 5, 4,
+                                      header, buf, buf_len, holder)) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1240,9 +1239,7 @@ static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
   CAMLlocal4(callback_list, event, callbacks_root, event_type);
   CAMLlocalN(params, 5);
   CAMLlocal2(wrapper_root, read_buffer);
-  CAMLlocal4(data, record, deserializer, perf_data);
-
-  perf_data = Val_unit;
+  CAMLlocal3(data, record, deserializer);
 
   struct callbacks_exception_holder* holder = callback_data;
   callbacks_root = *holder->callbacks_val;
@@ -1290,18 +1287,13 @@ static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
 
     data = caml_callback2(deserializer, read_buffer, Val_int(caml_string_len));
 
-    intnat local_sp = Caml_state->local_sp;
-    perf_data = extract_perf_data(header, buf, buf_len);
-
     params[0] = Val_long(domain_id);
     params[1] = caml_copy_int64(timestamp);
     params[2] = event;
     params[3] = data;
-    params[4] = perf_data;
-
-    int ret = user_events_call_callback_list(holder, callback_list, params);
-    Caml_state->local_sp = local_sp;
-    if (ret == 0) {
+    /* params[4] is filled in by call_list_with_perf_samples */
+    if (!call_list_with_perf_samples(callback_list, params, 5, 4,
+                                      header, buf, buf_len, holder)) {
       CAMLreturnT(int, 0);
     }
   }

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -47,9 +47,6 @@
 #define PERF_COUNTERS
 #endif
 
-/* Maximum number of perf events - must match runtime/runtime_events.c */
-#define MAX_PERF_EVENTS 20
-
 #if defined(HAS_UNISTD)
 #include <unistd.h>
 #endif

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1020,8 +1020,8 @@ static value user_events_find_callback_list_for_event_type(value callbacks_root,
 static int user_events_call_callback_list(
   struct callbacks_exception_holder* holder, value callback_list,
   value params[5]) {
-  CAMLparam5(callback_list, params[0], params[1], params[2], params[3]);
-  CAMLxparam1(params[4]);
+  CAMLparam1(callback_list);
+  CAMLxparamN(params, 5);
   CAMLlocal2(callback, res);
 
   while (Is_block(callback_list)) {

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -797,6 +797,11 @@ static int ml_runtime_begin(int domain_id, void *callback_data,
 
   tmp_callback = Field(callbacks_root, 0); /* ev_runtime_begin */
   if (Is_some(tmp_callback)) {
+    /* Save local_sp so that the local_ perf_data array allocated by
+       extract_perf_data is freed after the callback returns. Without
+       this, each callback invocation in a read_poll loop would
+       accumulate local arrays until the enclosing OCaml region ends. */
+    intnat local_sp = Caml_state->local_sp;
     perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
@@ -805,6 +810,7 @@ static int ml_runtime_begin(int domain_id, void *callback_data,
     params[3] = perf_data;
 
     res = caml_callbackN_exn(Some_val(tmp_callback), 4, params);
+    Caml_state->local_sp = local_sp;
 
     if( Is_exception_result(res) ) {
       res = Extract_exception(res);
@@ -831,6 +837,7 @@ static int ml_runtime_end(int domain_id, void *callback_data,
 
   tmp_callback = Field(callbacks_root, 1); /* ev_runtime_end */
   if (Is_some(tmp_callback)) {
+    intnat local_sp = Caml_state->local_sp;
     perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
@@ -839,6 +846,7 @@ static int ml_runtime_end(int domain_id, void *callback_data,
     params[3] = perf_data;
 
     res = caml_callbackN_exn(Some_val(tmp_callback), 4, params);
+    Caml_state->local_sp = local_sp;
 
     if( Is_exception_result(res) ) {
       res = Extract_exception(res);
@@ -1119,6 +1127,7 @@ static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
                                                                 event);
 
   if (Is_block(callback_list)) {
+    intnat local_sp = Caml_state->local_sp;
     perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
@@ -1127,7 +1136,9 @@ static int ml_user_unit(int domain_id, void *callback_data, int64_t timestamp,
     params[3] = Val_unit;
     params[4] = perf_data;
 
-    if (user_events_call_callback_list(holder, callback_list, params) == 0) {
+    int ret = user_events_call_callback_list(holder, callback_list, params);
+    Caml_state->local_sp = local_sp;
+    if (ret == 0) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1159,6 +1170,7 @@ static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
                                                                 event);
 
   if (Is_block(callback_list)) {
+    intnat local_sp = Caml_state->local_sp;
     perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
@@ -1167,7 +1179,9 @@ static int ml_user_span(int domain_id, void *callback_data, int64_t timestamp,
     params[3] = Val_int(span);
     params[4] = perf_data;
 
-    if (user_events_call_callback_list(holder, callback_list, params) == 0) {
+    int ret = user_events_call_callback_list(holder, callback_list, params);
+    Caml_state->local_sp = local_sp;
+    if (ret == 0) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1198,6 +1212,7 @@ static int ml_user_int(int domain_id, void *callback_data,
                                                                 event);
 
   if (Is_block(callback_list)) {
+    intnat local_sp = Caml_state->local_sp;
     perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
@@ -1206,7 +1221,9 @@ static int ml_user_int(int domain_id, void *callback_data,
     params[3] = Val_int(val);
     params[4] = perf_data;
 
-    if (user_events_call_callback_list(holder, callback_list, params) == 0) {
+    int ret = user_events_call_callback_list(holder, callback_list, params);
+    Caml_state->local_sp = local_sp;
+    if (ret == 0) {
       CAMLreturnT(int, 0);
     }
   }
@@ -1273,6 +1290,7 @@ static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
 
     data = caml_callback2(deserializer, read_buffer, Val_int(caml_string_len));
 
+    intnat local_sp = Caml_state->local_sp;
     perf_data = extract_perf_data(header, buf, buf_len);
 
     params[0] = Val_long(domain_id);
@@ -1281,8 +1299,9 @@ static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
     params[3] = data;
     params[4] = perf_data;
 
-    // payload is prepared, we call the callbacks sequentially.
-    if (user_events_call_callback_list(holder, callback_list, params) == 0) {
+    int ret = user_events_call_callback_list(holder, callback_list, params);
+    Caml_state->local_sp = local_sp;
+    if (ret == 0) {
       CAMLreturnT(int, 0);
     }
   }

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -763,7 +763,6 @@ struct callbacks_exception_holder {
 static value extract_perf_data(uint64_t header, uint64_t *buf, int buf_len) {
   value perf_data;
 
-  #ifdef PERF_COUNTERS
   int nperf = RUNTIME_EVENTS_ITEM_PERF_COUNTERS(header);
   int perf_start_index = buf_len - (2 * nperf);
 
@@ -779,11 +778,6 @@ static value extract_perf_data(uint64_t header, uint64_t *buf, int buf_len) {
     perf_data = caml_makearray_dynamic_non_scannable_unboxed_product(
         Val_long(2), Val_true, Val_long(0));
   }
-  #else
-  (void)header; (void)buf; (void)buf_len;
-  perf_data = caml_makearray_dynamic_non_scannable_unboxed_product(
-      Val_long(2), Val_true, Val_long(0));
-  #endif
 
   return perf_data;
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -63,6 +63,7 @@ SetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription);
 #include "caml/debugger.h"
 #include "caml/domain.h"
 #include "caml/fail.h"
+#include "caml/runtime_events.h"
 #include "caml/fiber.h"
 #include "caml/io.h"
 #include "caml/memory.h"
@@ -748,6 +749,8 @@ static void thread_detach_from_runtime(void)
 {
   caml_thread_t th = This_thread;
   CAMLassert(th == Active_thread);
+  /* Clean up per-thread perf counters before detaching */
+  caml_runtime_events_thread_stop();
   /* PR#5188, PR#7220: some of the global runtime state may have
      changed as the thread was running, so we save it in the
      This_thread data to make sure that the cleanup logic
@@ -800,6 +803,7 @@ static void * caml_thread_start(void * v)
   caml_acquire_domain_lock();
 
   thread_init_current(th);
+  caml_runtime_events_thread_start();
 
   clos = Start_closure(Active_thread->descr);
   caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
@@ -870,6 +874,7 @@ CAMLexport int caml_c_thread_register(void)
   /* If it fails, we release the lock and return an error. */
   if (th == NULL) goto out_err;
   thread_init_current(th);
+  caml_runtime_events_thread_start();
   /* We can now allocate the thread descriptor on the major heap */
   th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
 

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -341,6 +341,8 @@ CAMLextern void caml_runtime_events_domain_stop(void);
 CAMLextern void caml_runtime_events_thread_start(void);
 CAMLextern void caml_runtime_events_thread_stop(void);
 
+#define RUNTIME_EVENTS_MAX_PERF_EVENTS 20
+
 #if defined(__linux__) && (defined(__x86_64__) || defined(__i386__))
 #define PERF_COUNTERS
 #endif

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -343,7 +343,13 @@ CAMLextern void caml_runtime_events_thread_stop(void);
 
 #define RUNTIME_EVENTS_MAX_PERF_EVENTS 20
 
-#if defined(__linux__) && (defined(__x86_64__) || defined(__i386__))
+/* The per-event header stores the counter count in 6 bits (bits 30-35);
+   see RUNTIME_EVENTS_HEADER / RUNTIME_EVENTS_ITEM_PERF_COUNTERS above. */
+_Static_assert(RUNTIME_EVENTS_MAX_PERF_EVENTS <= 63,
+               "RUNTIME_EVENTS_MAX_PERF_EVENTS exceeds the 6-bit "
+               "perf_counters field in the event header");
+
+#if defined(__linux__) && defined(__x86_64__)
 #define PERF_COUNTERS
 #endif
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1363,7 +1363,7 @@ static void* domain_thread_func(void* v)
     CAML_GC_MESSAGE(DOMAIN,
                     "Domain starting (unique ID %"ARCH_INTNAT_PRINTF_FORMAT"u)\n",
                     domain_self->unique_id);
-    CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
+    caml_runtime_events_domain_start();
     /* FIXME: ignoring errors during domain initialization is unsafe
        and/or can deadlock. */
     caml_domain_initialize_hook();
@@ -2577,7 +2577,7 @@ static void domain_terminate (void)
       /* We must signal domain termination before releasing [all_domains_lock]:
          after that, this domain will no longer take part in STWs and emitting
          an event could race with runtime events teardown. */
-      CAML_EV_LIFECYCLE(EV_DOMAIN_TERMINATE, getpid());
+      caml_runtime_events_domain_stop();
     }
     caml_plat_unlock(&all_domains_lock);
   }

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -241,9 +241,9 @@ static int perf_events_setup_rdpmc(struct perf_counters* counters)
   return 0;
 }
 
-static const char* perf_events_setup(struct perf_counters* counters)
+static int perf_events_setup(struct perf_counters* counters,
+                             char* err, size_t err_len)
 {
-  static char err[256];
   err[0] = 0;
   memset(counters, 0, sizeof(*counters));
   int leader_fd = -1;
@@ -266,7 +266,7 @@ static const char* perf_events_setup(struct perf_counters* counters)
               leader_fd,
               PERF_FLAG_FD_CLOEXEC);
     if (fd < 0) {
-      snprintf(err, sizeof err, "event %d (r%llx): perf_event_open: %s",
+      snprintf(err, err_len, "event %d (r%llx): perf_event_open: %s",
                i, (unsigned long long)config, strerror(errno));
       break;
     }
@@ -275,7 +275,7 @@ static const char* perf_events_setup(struct perf_counters* counters)
       mmap(NULL, sysconf(_SC_PAGESIZE), PROT_READ, MAP_SHARED, fd, 0);
     if (page == NULL) {
       close(fd);
-      snprintf(err, sizeof err, "event %d (r%llx): mmap: %s",
+      snprintf(err, err_len, "event %d (r%llx): mmap: %s",
                i, (unsigned long long)config, strerror(errno));
       break;
     }
@@ -291,7 +291,7 @@ static const char* perf_events_setup(struct perf_counters* counters)
     } while (page->lock != seq);
 
     if (!rdpmc_ok) {
-      snprintf(err, sizeof err,
+      snprintf(err, err_len,
                "event %d (r%llx): rdpmc reads unavailable (too many counters?)",
                i, (unsigned long long)config);
       close(fd);
@@ -309,13 +309,13 @@ static const char* perf_events_setup(struct perf_counters* counters)
   /* Close the leader fd - mmap keeps the event alive */
   if (leader_fd != -1) close(leader_fd);
   if (err[0] == 0 && perf_events_setup_rdpmc(counters) != 0) {
-    snprintf(err, sizeof err, "events: failed to setup rdpmc info");
+    snprintf(err, err_len, "events: failed to setup rdpmc info");
   }
   if (err[0]) {
     perf_events_teardown(counters);
-    return err;
+    return -1;
   } else {
-    return NULL;
+    return 0;
   }
 }
 
@@ -356,8 +356,8 @@ static struct perf_counters* get_thread_counters(void)
   if (thread_counters == NULL && num_perf_configs > 0) {
     thread_counters = caml_stat_alloc(sizeof(struct perf_counters));
     memset(thread_counters, 0, sizeof(struct perf_counters));
-    const char* err = perf_events_setup(thread_counters);
-    if (err) {
+    char err[256];
+    if (perf_events_setup(thread_counters, err, sizeof err) != 0) {
       caml_gc_log("perf_events setup failed, disabling globally: %s", err);
       atomic_store(&perf_counters_globally_disabled, true);
       caml_stat_free(thread_counters);

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -143,9 +143,7 @@ static void stw_teardown_runtime_events(
   caml_domain_state **participating_domains);
 
 #ifdef PERF_COUNTERS
-enum { MAX_PERF_EVENTS = 20 };
-
-uint64_t perf_counter_configs[MAX_PERF_EVENTS];
+uint64_t perf_counter_configs[RUNTIME_EVENTS_RUNTIME_EVENTS_MAX_PERF_EVENTS];
 
 struct perf_counter_rdpmc_info {
   uint64_t offset;
@@ -154,16 +152,16 @@ struct perf_counter_rdpmc_info {
 };
 struct perf_counters {
   int ncounters;
-  void* mmap_pages[MAX_PERF_EVENTS];
+  void* mmap_pages[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 
   uint32_t* leader_seq_lock;
   uint32_t last_seq;
-  struct perf_counter_rdpmc_info rdpmc_info[MAX_PERF_EVENTS];
+  struct perf_counter_rdpmc_info rdpmc_info[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 };
 
 static CAMLthread_local struct perf_counters* thread_counters = NULL;
 static int num_perf_configs = 0;
-static uint64_t parsed_perf_configs[MAX_PERF_EVENTS];
+static uint64_t parsed_perf_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 static atomic_bool perf_counters_globally_disabled = false;
 
 #define seqlock_barrier() asm volatile("" ::: "memory")
@@ -190,9 +188,9 @@ static const char* parse_perf_config_string(const char* format)
                format);
       return err;
     }
-    if (count >= MAX_PERF_EVENTS) {
+    if (count >= RUNTIME_EVENTS_MAX_PERF_EVENTS) {
       snprintf(err, sizeof err, "events: too many events (max %d)",
-               MAX_PERF_EVENTS);
+               RUNTIME_EVENTS_MAX_PERF_EVENTS);
       return err;
     }
     parsed_perf_configs[count++] = config;
@@ -214,7 +212,7 @@ static void perf_events_teardown(struct perf_counters* counters)
 
 static int perf_events_setup_rdpmc(struct perf_counters* counters)
 {
-  uint32_t seqs[MAX_PERF_EVENTS];
+  uint32_t seqs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
   struct perf_event_mmap_page* pg;
  retry:
   for (int i = 0; i < counters->ncounters; i++) {
@@ -926,7 +924,7 @@ static void write_to_ring(ev_category category, ev_message_type type,
   /* for EV_BEGIN and EV_END events messages may have 0 or more perf counters
     appended to the end of a message */
   if (sample_counters) {
-      uint64_t tmp[MAX_PERF_EVENTS];
+      uint64_t tmp[RUNTIME_EVENTS_MAX_PERF_EVENTS];
       perf_counters = counters->ncounters;
       perf_events_sample(counters, tmp);
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -186,63 +186,51 @@ static void stw_teardown_runtime_events(
    single graceful-degradation path; there is no retry.
 */
 
-/* Process-static config. Populated exactly once by parse_perf_config_string
-   from inside caml_runtime_events_start (STW-protected), cleared by
-   caml_runtime_events_destroy. Read (without atomics) from the event-emit
-   paths, which cannot overlap with start/destroy. */
+/* Process-static config. Populated once by parse_perf_config_string under
+   the start/destroy STW, cleared by destroy. Read without atomics from the
+   event-emit paths, which can't overlap with start/destroy. */
 static uint64_t perf_counter_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 static int num_perf_configs = 0;
 
-/* Cached fields derived from the kernel's perf_event_mmap_page, used on
-   every sample to avoid re-parsing the page. [offset] is the accumulated
-   count from previous scheduling slices; [index] is the RDPMC counter
-   number (as passed to the _rdpmc intrinsic); [width] is the counter bit
-   width used to sign-extend the RDPMC result. */
+/* Cached offset/index/width from the kernel's perf_event_mmap_page, read
+   on every sample to avoid re-parsing the page. */
 struct perf_counter_rdpmc_info {
   uint64_t offset;
   uint32_t index;
   uint16_t width;
 };
 
-/* Per-thread PMC state. Allocated on first sample by get_thread_counters,
-   freed by cleanup_thread_counters. Only the owning thread reads or
-   writes it. */
+/* Per-thread PMC state. Owned exclusively by the thread that allocated it. */
 struct perf_counters {
-  int ncounters;  /* number of counters actually set up; <= num_perf_configs */
+  int ncounters;
   void* mmap_pages[RUNTIME_EVENTS_MAX_PERF_EVENTS];
-
-  /* Pointer into the leader's mmap'd page. All counters in a group share
-     a schedule, so the leader's lock is sufficient to detect re-scheduling
-     of any counter in the group. */
+  /* All counters in a group share a schedule, so the leader's seqlock is
+     sufficient to detect re-scheduling of any counter in the group. */
   uint32_t* leader_seq_lock;
   uint32_t last_seq;
   struct perf_counter_rdpmc_info rdpmc_info[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 };
 
-/* Bumped by caml_runtime_events_destroy. Threads notice the mismatch
-   against their cached thread_counter_generation on their next call to
-   get_thread_counters and tear their state down. Prevents stale
-   mmap_pages surviving a destroy+start cycle. */
+/* Bumped by destroy. Threads see the mismatch on their next call to
+   get_thread_counters and tear down their state so stale mmap_pages don't
+   survive a destroy+start cycle. */
 static _Atomic uint64_t perf_counter_generation = 0;
 
 static CAMLthread_local struct perf_counters* thread_counters = NULL;
 static CAMLthread_local uint64_t thread_counter_generation = 0;
 
-/* Circuit breaker. Flipped to true on the first setup failure seen by
-   any thread; never flipped back within a given start/destroy epoch.
-   Makes subsequent perf_counters_active() return false and subsequent
-   get_thread_counters() return NULL. */
+/* Circuit breaker: flipped on the first setup failure seen by any thread,
+   reset only on destroy. All subsequent get_thread_counters calls return
+   NULL until the next destroy+start. */
 static atomic_bool perf_counters_globally_disabled = false;
 
-/* Compiler-only memory barrier; sufficient on x86 where loads/stores to
-   the kernel's mmap page are not reordered by hardware. Used between the
-   seqlock snapshot, the payload read/write, and the seqlock re-check. */
+/* Compiler-only memory barrier: sufficient on x86 where loads/stores to
+   the kernel's mmap page are not reordered by hardware. */
 #define seqlock_barrier() asm volatile("" ::: "memory")
 
-/* Parse a comma-separated list of hex raw perf event codes, each prefixed
-   with 'r' (e.g. "r3c,r3d"). Populates perf_counter_configs[] and sets
-   num_perf_configs. Returns NULL on success, or a pointer to a static
-   error string on malformed input or too many events. */
+/* Parse a comma-separated list of hex raw perf event codes each prefixed
+   with 'r' (e.g. "r3c,r3d") into perf_counter_configs[]. Returns NULL on
+   success, or a pointer to a static error string on failure. */
 static const char* parse_perf_config_string(const char* format)
 {
   static char err[256];
@@ -287,15 +275,15 @@ static void perf_events_teardown(struct perf_counters* counters)
 }
 
 
-/* Re-populate each counter's rdpmc_info (offset, index, width) from its
-   kernel-mapped metadata page under the page's seqlock. Called once per
-   counter set during setup, and again from perf_events_sample whenever
-   the leader's seqlock has changed (indicating the kernel re-scheduled
-   the counter and the cached info is stale).
+/* Refresh each counter's rdpmc_info from the kernel's metadata page under
+   a seqlock. Called once per counter set during setup, and again from
+   perf_events_sample whenever the leader's seqlock has changed.
 
-   Returns 0 on success, or 1 if the kernel reports the counter cannot
-   be read via RDPMC (cap_user_rdpmc cleared or index == 0, which happens
-   e.g. when too many events contend for hardware counter slots). */
+   Warning: counters->mmap_pages[0..ncounters) must already be populated.
+
+   Returns 0 on success, or 1 if the kernel reports the counter isn't
+   RDPMC-readable (cap_user_rdpmc cleared or index == 0, e.g. when too
+   many events contend for hardware counter slots). */
 static int perf_events_setup_rdpmc(struct perf_counters* counters)
 {
   uint32_t seqs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
@@ -332,19 +320,10 @@ static int perf_events_setup_rdpmc(struct perf_counters* counters)
 }
 
 /* Open the kernel-side perf events for the calling thread, one per
-   configured counter. The first counter is the group leader and is
-   pinned to hardware (.pinned = 1); the rest attach to the leader so
-   they're scheduled and unscheduled together.
-
-   For each counter we:
-     - perf_event_open(2) with the raw event code from the env var;
-     - mmap the metadata page (PROT_READ, one 4K page);
-     - verify RDPMC actually works for this counter by probing it under
-       the seqlock.
-
-   On any failure partway through we record the error in [err] and break;
-   the caller (get_thread_counters) will call perf_events_teardown on
-   the partially-initialised struct and flip the global-disable flag. */
+   configured counter. The first is the pinned group leader; the rest
+   attach to it so the whole group is scheduled together. On failure
+   we record the reason in [err] and break; the caller tears down the
+   partially-initialised struct and flips the global-disable flag. */
 static int perf_events_setup(struct perf_counters* counters,
                              char* err, size_t err_len)
 {
@@ -362,9 +341,7 @@ static int perf_events_setup(struct perf_counters* counters,
       .config = config,
       .sample_type = PERF_SAMPLE_READ,
       .exclude_kernel = 0,
-      /* Pin the leader so the whole group is always scheduled on
-         hardware; if it can't be, the group fails cleanly. */
-      .pinned = (i == 0)
+      .pinned = (i == 0)  /* leader is pinned; group fails cleanly if not */
     };
     int fd =
       syscall(SYS_perf_event_open,
@@ -387,9 +364,8 @@ static int perf_events_setup(struct perf_counters* counters,
     }
     counters->mmap_pages[i] = page;
 
-    /* Probe RDPMC under the seqlock: the kernel may claim
-       cap_user_rdpmc but revoke it while we're executing the
-       instruction, so we retry until we see a consistent snapshot. */
+    /* Reminder: cap_user_rdpmc can be revoked by the kernel mid-read,
+       so probe under the seqlock and retry on a mismatched snapshot. */
     int rdpmc_ok;
     uint32_t seq;
     do {
@@ -429,20 +405,13 @@ static int perf_events_setup(struct perf_counters* counters,
   }
 }
 
-/* Read the current value of each configured counter via userspace RDPMC
-   and write them into [samples] (which must be at least counters->ncounters
-   words). This is the hot path: called once per sampled event from
-   write_to_ring.
+/* Read each configured counter via userspace RDPMC into [samples]. Hot
+   path: called once per sampled event from write_to_ring. The two
+   seqlock checks detect kernel re-scheduling between samples; on a
+   mismatch we refresh rdpmc_info and retry.
 
-   Two seqlock checks protect against the kernel re-scheduling a counter
-   mid-sample:
-     - Before the loop, if the leader's seqlock has advanced since the
-       last sample then our cached rdpmc_info is stale and we must refresh.
-     - After the loop, if the seqlock has advanced during the reads then
-       one or more samples are inconsistent and we retry.
-   The RDPMC result is already a raw counter value; we mask to the
-   hardware counter width to get an unsigned count, then add the kernel's
-   recorded offset to recover the total accumulated count. */
+   Warning: counters must be a fully set-up struct from perf_events_setup,
+   and [samples] must have space for at least counters->ncounters words. */
 static void perf_events_sample(struct perf_counters* counters,
                                uint64_t* samples)
 {
@@ -466,20 +435,15 @@ retry:
 
 static void cleanup_thread_counters(void);
 
-/* Return the calling thread's struct perf_counters, setting it up lazily
-   on first call. Returns NULL (and does no setup) if PMC has been globally
-   disabled by an earlier failure, or if no counters are configured.
-
-   A bumped perf_counter_generation (from caml_runtime_events_destroy)
-   invalidates any existing state for this thread; we tear it down before
-   rebuilding so a destroy+start cycle starts from clean state. */
+/* Return the calling thread's struct perf_counters, allocating and
+   setting it up lazily on first call. Returns NULL if PMC has been
+   globally disabled or no counters are configured. */
 static struct perf_counters* get_thread_counters(void)
 {
   if (atomic_load(&perf_counters_globally_disabled))
     return NULL;
 
-  /* If we were set up in a previous start/destroy epoch, tear down the
-     stale state before (re)building. */
+  /* Tear down state from a previous start/destroy epoch. */
   uint64_t current_gen = atomic_load(&perf_counter_generation);
   if (thread_counters != NULL
       && thread_counter_generation != current_gen) {
@@ -491,8 +455,6 @@ static struct perf_counters* get_thread_counters(void)
     memset(thread_counters, 0, sizeof(struct perf_counters));
     char err[256];
     if (perf_events_setup(thread_counters, err, sizeof err) != 0) {
-      /* First setup failure for any thread in this process trips the
-         global circuit breaker; from now on PMC is off until destroy. */
       caml_gc_log("perf_events setup failed, disabling globally: %s", err);
       atomic_store(&perf_counters_globally_disabled, true);
       caml_stat_free(thread_counters);
@@ -504,9 +466,7 @@ static struct perf_counters* get_thread_counters(void)
   return thread_counters;
 }
 
-/* Tear down the calling thread's PMC state. Called from the domain/thread
-   stop lifecycle hooks, from get_thread_counters when the generation has
-   advanced, and from caml_runtime_events_destroy for the last domain. */
+/* Tear down the calling thread's PMC state. */
 static void cleanup_thread_counters(void)
 {
   if (thread_counters != NULL) {
@@ -981,10 +941,9 @@ static void write_to_ring(ev_category category, ev_message_type type,
   uint64_t length_with_header_ts = event_length + 2;
 
   #ifdef PERF_COUNTERS
-  /* PMC samples are only attached to events that represent a span edge:
-     runtime-phase BEGIN/EXIT and user-span Begin/End. Lifecycle events,
-     counter events, and alloc events don't carry samples. Consumers reading
-     the header's perf-counter field will see 0 for those. */
+  /* Only span-edge events carry PMC samples (runtime BEGIN/EXIT and
+     user-span Begin/End); everything else writes a 0 in the header's
+     perf-counter field. */
   struct perf_counters* counters = get_thread_counters();
   int sample_counters = (counters != NULL && counters->ncounters > 0 &&
                          ((category == EV_RUNTIME &&
@@ -995,8 +954,7 @@ static void write_to_ring(ev_category category, ev_message_type type,
                             type.user == EV_USER_MSG_TYPE_SPAN_END))));
 
   if (sample_counters) {
-    /* Each counter contributes two words to the ring entry: its config
-       id (so the reader knows which event it is) and its sampled value. */
+    /* Two words per counter: config id and sampled value. */
     length_with_header_ts += counters->ncounters * 2;
   }
   #endif

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -45,7 +45,6 @@
 /* hardware events are linux only for now */
 #ifdef PERF_COUNTERS
 #include <linux/perf_event.h>
-#include <linux/hw_breakpoint.h>
 #include <sys/syscall.h>
 #include <x86intrin.h>
 #endif

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -322,7 +322,8 @@ static const char* perf_events_setup(struct perf_counters* counters)
   }
 }
 
-void perf_events_sample(struct perf_counters* counters, uint64_t* samples)
+static void perf_events_sample(struct perf_counters* counters,
+                               uint64_t* samples)
 {
   if (*counters->leader_seq_lock != counters->last_seq)
     perf_events_setup_rdpmc(counters);

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -143,7 +143,7 @@ static void stw_teardown_runtime_events(
   caml_domain_state **participating_domains);
 
 #ifdef PERF_COUNTERS
-uint64_t perf_counter_configs[RUNTIME_EVENTS_RUNTIME_EVENTS_MAX_PERF_EVENTS];
+uint64_t perf_counter_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 
 struct perf_counter_rdpmc_info {
   uint64_t offset;
@@ -901,7 +901,11 @@ static void write_to_ring(ev_category category, ev_message_type type,
     ring_tail_offset = 0;
   }
 
-  uint64_t perf_counters = sample_counters ? counters->ncounters : 0;
+#ifdef PERF_COUNTERS
+  uint64_t num_perf = sample_counters ? counters->ncounters : 0;
+#else
+  uint64_t num_perf = 0;
+#endif
 
   /* Below we write the header. See runtime_events.h for the layout structure
      of event headers.
@@ -912,30 +916,27 @@ static void write_to_ring(ev_category category, ev_message_type type,
                                   category == EV_RUNTIME,
                                   (type.runtime | type.user),
                                   event_id,
-                                  perf_counters);
+                                  num_perf);
 
   ring_ptr[ring_tail_offset++] = timestamp;
   if (content != NULL) {
     memcpy(&ring_ptr[ring_tail_offset], content + word_offset,
            event_length * sizeof(uint64_t));
+    ring_tail_offset += event_length;
   }
 
-  #ifdef PERF_COUNTERS
-  /* for EV_BEGIN and EV_END events messages may have 0 or more perf counters
-    appended to the end of a message */
+#ifdef PERF_COUNTERS
   if (sample_counters) {
       uint64_t tmp[RUNTIME_EVENTS_MAX_PERF_EVENTS];
-      perf_counters = counters->ncounters;
       perf_events_sample(counters, tmp);
 
-      void* ring_events_ptr = &ring_ptr[ring_tail_offset];
-      /* write config first */
-      uint64_t counter_length_bytes = perf_counters * sizeof(uint64_t);
-      memcpy(ring_events_ptr, &perf_counter_configs, counter_length_bytes);
-      ring_events_ptr += counter_length_bytes;
-      memcpy(ring_events_ptr, &tmp, counter_length_bytes);
+      char *dest = (char *)&ring_ptr[ring_tail_offset];
+      uint64_t counter_length_bytes = num_perf * sizeof(uint64_t);
+      memcpy(dest, perf_counter_configs, counter_length_bytes);
+      dest += counter_length_bytes;
+      memcpy(dest, tmp, counter_length_bytes);
   }
-  #endif
+#endif
 
   atomic_store_release(&domain_ring_header->ring_tail,
                        ring_tail + length_with_header_ts);

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -271,14 +271,15 @@ static int perf_events_setup(struct perf_counters* counters,
       break;
     }
     struct perf_event_mmap_page* page;
-    page = counters->mmap_pages[i] =
-      mmap(NULL, sysconf(_SC_PAGESIZE), PROT_READ, MAP_SHARED, fd, 0);
-    if (page == NULL) {
+    page = mmap(NULL, sysconf(_SC_PAGESIZE), PROT_READ, MAP_SHARED, fd, 0);
+    if (page == MAP_FAILED) {
+      counters->mmap_pages[i] = NULL;
       close(fd);
       snprintf(err, err_len, "event %d (r%llx): mmap: %s",
                i, (unsigned long long)config, strerror(errno));
       break;
     }
+    counters->mmap_pages[i] = page;
 
     int rdpmc_ok;
     uint32_t seq;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -410,13 +410,24 @@ static int perf_events_setup(struct perf_counters* counters,
    seqlock checks detect kernel re-scheduling between samples; on a
    mismatch we refresh rdpmc_info and retry.
 
+   If perf_events_setup_rdpmc reports rdpmc currently unavailable
+   (e.g. the counter has been descheduled because the hardware slots
+   are oversubscribed), we write zeros for this event rather than
+   spinning: last_seq isn't advanced on failure, so retrying would
+   loop forever. We'll automatically recover on a later sample once
+   the kernel reschedules the counter.
+
    Warning: counters must be a fully set-up struct from perf_events_setup,
    and [samples] must have space for at least counters->ncounters words. */
 static void perf_events_sample(struct perf_counters* counters,
                                uint64_t* samples)
 {
-  if (*counters->leader_seq_lock != counters->last_seq)
-    perf_events_setup_rdpmc(counters);
+  if (*counters->leader_seq_lock != counters->last_seq) {
+    if (perf_events_setup_rdpmc(counters) != 0) {
+      memset(samples, 0, counters->ncounters * sizeof(uint64_t));
+      return;
+    }
+  }
 retry:
   int n = counters->ncounters;
   for (int i = 0; i < n; i++) {
@@ -428,7 +439,10 @@ retry:
   }
   seqlock_barrier();
   if (*counters->leader_seq_lock != counters->last_seq) {
-    perf_events_setup_rdpmc(counters);
+    if (perf_events_setup_rdpmc(counters) != 0) {
+      memset(samples, 0, counters->ncounters * sizeof(uint64_t));
+      return;
+    }
     goto retry;
   }
 }

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -422,14 +422,14 @@ static int perf_events_setup(struct perf_counters* counters,
 static void perf_events_sample(struct perf_counters* counters,
                                uint64_t* samples)
 {
+  int n = counters->ncounters;
   if (*counters->leader_seq_lock != counters->last_seq) {
     if (perf_events_setup_rdpmc(counters) != 0) {
-      memset(samples, 0, counters->ncounters * sizeof(uint64_t));
+      memset(samples, 0, n * sizeof(uint64_t));
       return;
     }
   }
 retry:
-  int n = counters->ncounters;
   for (int i = 0; i < n; i++) {
     struct perf_counter_rdpmc_info info = counters->rdpmc_info[i];
     uint64_t v = _rdpmc(info.index);
@@ -440,7 +440,7 @@ retry:
   seqlock_barrier();
   if (*counters->leader_seq_lock != counters->last_seq) {
     if (perf_events_setup_rdpmc(counters) != 0) {
-      memset(samples, 0, counters->ncounters * sizeof(uint64_t));
+      memset(samples, 0, n * sizeof(uint64_t));
       return;
     }
     goto retry;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -142,30 +142,107 @@ static void stw_teardown_runtime_events(
   caml_domain_state **participating_domains);
 
 #ifdef PERF_COUNTERS
+/* Hardware performance-monitoring counters (PMC).
+
+   When configured via the OCAML_RUNTIME_EVENTS_PERF_COUNTERS env var, we
+   sample a fixed set of hardware counters on every EV_BEGIN / EV_EXIT
+   runtime-phase event and on every user-span Begin / End event, appending
+   the values to the event's entry in the ring buffer. The sample reads
+   use the x86 userspace RDPMC instruction so we don't pay a syscall per
+   event on the hot path.
+
+   The kernel exposes each counter's current state (offset, hardware index,
+   width, scheduling seqlock) via a page mmap'd from the perf event fd.
+   Reading the counter requires a seqlock dance: snapshot the lock, read
+   index/offset/width, execute RDPMC, re-read the lock, retry if the kernel
+   re-scheduled the counter in between.
+
+   Lifecycle across a process:
+
+   1. The first caml_runtime_events_start (or the first after a destroy)
+      parses the env var into the process-static perf_counter_configs[] /
+      num_perf_configs under the existing start/destroy STW. Subsequent
+      starts without an intervening destroy see num_perf_configs != 0 and
+      skip the parse.
+   2. Each OCaml thread that emits events lazily allocates a per-thread
+      struct perf_counters via get_thread_counters(). The domain/thread
+      lifecycle hooks (caml_runtime_events_domain_start / _thread_start)
+      call get_thread_counters() eagerly so the first event doesn't take
+      the setup cost. perf_events_setup() opens one perf_event per config
+      (first is the pinned group leader), mmaps the metadata page, and
+      records the RDPMC offset/index/width via perf_events_setup_rdpmc.
+   3. On each sampled event, write_to_ring calls perf_events_sample(),
+      which does N userspace RDPMC reads under the leader's seqlock.
+   4. On thread/domain stop, cleanup_thread_counters() munmaps each page.
+      On caml_runtime_events_destroy, num_perf_configs is cleared and
+      perf_counter_generation is bumped so other threads will notice
+      their state is stale on their next event.
+
+   Failure model: any setup failure (perf_event_open denied, mmap failed,
+   RDPMC unavailable, too many counters for the hardware) flips
+   perf_counters_globally_disabled for the remainder of the process. All
+   subsequent get_thread_counters() calls short-circuit and return NULL,
+   so sampling is skipped and callbacks see empty arrays. This is the
+   single graceful-degradation path; there is no retry.
+*/
+
+/* Process-static config. Populated exactly once by parse_perf_config_string
+   from inside caml_runtime_events_start (STW-protected), cleared by
+   caml_runtime_events_destroy. Read (without atomics) from the event-emit
+   paths, which cannot overlap with start/destroy. */
 static uint64_t perf_counter_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 static int num_perf_configs = 0;
 
+/* Cached fields derived from the kernel's perf_event_mmap_page, used on
+   every sample to avoid re-parsing the page. [offset] is the accumulated
+   count from previous scheduling slices; [index] is the RDPMC counter
+   number (as passed to the _rdpmc intrinsic); [width] is the counter bit
+   width used to sign-extend the RDPMC result. */
 struct perf_counter_rdpmc_info {
   uint64_t offset;
   uint32_t index;
   uint16_t width;
 };
+
+/* Per-thread PMC state. Allocated on first sample by get_thread_counters,
+   freed by cleanup_thread_counters. Only the owning thread reads or
+   writes it. */
 struct perf_counters {
-  int ncounters;
+  int ncounters;  /* number of counters actually set up; <= num_perf_configs */
   void* mmap_pages[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 
+  /* Pointer into the leader's mmap'd page. All counters in a group share
+     a schedule, so the leader's lock is sufficient to detect re-scheduling
+     of any counter in the group. */
   uint32_t* leader_seq_lock;
   uint32_t last_seq;
   struct perf_counter_rdpmc_info rdpmc_info[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 };
 
+/* Bumped by caml_runtime_events_destroy. Threads notice the mismatch
+   against their cached thread_counter_generation on their next call to
+   get_thread_counters and tear their state down. Prevents stale
+   mmap_pages surviving a destroy+start cycle. */
 static _Atomic uint64_t perf_counter_generation = 0;
+
 static CAMLthread_local struct perf_counters* thread_counters = NULL;
 static CAMLthread_local uint64_t thread_counter_generation = 0;
+
+/* Circuit breaker. Flipped to true on the first setup failure seen by
+   any thread; never flipped back within a given start/destroy epoch.
+   Makes subsequent perf_counters_active() return false and subsequent
+   get_thread_counters() return NULL. */
 static atomic_bool perf_counters_globally_disabled = false;
 
+/* Compiler-only memory barrier; sufficient on x86 where loads/stores to
+   the kernel's mmap page are not reordered by hardware. Used between the
+   seqlock snapshot, the payload read/write, and the seqlock re-check. */
 #define seqlock_barrier() asm volatile("" ::: "memory")
 
+/* Parse a comma-separated list of hex raw perf event codes, each prefixed
+   with 'r' (e.g. "r3c,r3d"). Populates perf_counter_configs[] and sets
+   num_perf_configs. Returns NULL on success, or a pointer to a static
+   error string on malformed input or too many events. */
 static const char* parse_perf_config_string(const char* format)
 {
   static char err[256];
@@ -210,16 +287,28 @@ static void perf_events_teardown(struct perf_counters* counters)
 }
 
 
+/* Re-populate each counter's rdpmc_info (offset, index, width) from its
+   kernel-mapped metadata page under the page's seqlock. Called once per
+   counter set during setup, and again from perf_events_sample whenever
+   the leader's seqlock has changed (indicating the kernel re-scheduled
+   the counter and the cached info is stale).
+
+   Returns 0 on success, or 1 if the kernel reports the counter cannot
+   be read via RDPMC (cap_user_rdpmc cleared or index == 0, which happens
+   e.g. when too many events contend for hardware counter slots). */
 static int perf_events_setup_rdpmc(struct perf_counters* counters)
 {
   uint32_t seqs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
   struct perf_event_mmap_page* pg;
  retry:
+  /* Phase 1: snapshot each counter's seqlock. */
   for (int i = 0; i < counters->ncounters; i++) {
     pg = counters->mmap_pages[i];
     seqs[i] = pg->lock;
   }
   seqlock_barrier();
+  /* Phase 2: read the rdpmc parameters. If the kernel is mid-update the
+     values may be inconsistent; we'll detect this in Phase 3. */
   for (int i = 0; i < counters->ncounters; i++) {
     pg = counters->mmap_pages[i];
     struct perf_counter_rdpmc_info* info = &counters->rdpmc_info[i];
@@ -231,6 +320,8 @@ static int perf_events_setup_rdpmc(struct perf_counters* counters)
     info->width = pg->pmc_width;
   }
   seqlock_barrier();
+  /* Phase 3: re-read each seqlock. Any change means the kernel re-
+     scheduled a counter during Phase 2 and our read is untrustworthy. */
   for (int i = 0; i < counters->ncounters; i++) {
     pg = counters->mmap_pages[i];
     if (pg->lock != seqs[i])
@@ -240,6 +331,20 @@ static int perf_events_setup_rdpmc(struct perf_counters* counters)
   return 0;
 }
 
+/* Open the kernel-side perf events for the calling thread, one per
+   configured counter. The first counter is the group leader and is
+   pinned to hardware (.pinned = 1); the rest attach to the leader so
+   they're scheduled and unscheduled together.
+
+   For each counter we:
+     - perf_event_open(2) with the raw event code from the env var;
+     - mmap the metadata page (PROT_READ, one 4K page);
+     - verify RDPMC actually works for this counter by probing it under
+       the seqlock.
+
+   On any failure partway through we record the error in [err] and break;
+   the caller (get_thread_counters) will call perf_events_teardown on
+   the partially-initialised struct and flip the global-disable flag. */
 static int perf_events_setup(struct perf_counters* counters,
                              char* err, size_t err_len)
 {
@@ -257,6 +362,8 @@ static int perf_events_setup(struct perf_counters* counters,
       .config = config,
       .sample_type = PERF_SAMPLE_READ,
       .exclude_kernel = 0,
+      /* Pin the leader so the whole group is always scheduled on
+         hardware; if it can't be, the group fails cleanly. */
       .pinned = (i == 0)
     };
     int fd =
@@ -280,6 +387,9 @@ static int perf_events_setup(struct perf_counters* counters,
     }
     counters->mmap_pages[i] = page;
 
+    /* Probe RDPMC under the seqlock: the kernel may claim
+       cap_user_rdpmc but revoke it while we're executing the
+       instruction, so we retry until we see a consistent snapshot. */
     int rdpmc_ok;
     uint32_t seq;
     do {
@@ -319,6 +429,20 @@ static int perf_events_setup(struct perf_counters* counters,
   }
 }
 
+/* Read the current value of each configured counter via userspace RDPMC
+   and write them into [samples] (which must be at least counters->ncounters
+   words). This is the hot path: called once per sampled event from
+   write_to_ring.
+
+   Two seqlock checks protect against the kernel re-scheduling a counter
+   mid-sample:
+     - Before the loop, if the leader's seqlock has advanced since the
+       last sample then our cached rdpmc_info is stale and we must refresh.
+     - After the loop, if the seqlock has advanced during the reads then
+       one or more samples are inconsistent and we retry.
+   The RDPMC result is already a raw counter value; we mask to the
+   hardware counter width to get an unsigned count, then add the kernel's
+   recorded offset to recover the total accumulated count. */
 static void perf_events_sample(struct perf_counters* counters,
                                uint64_t* samples)
 {
@@ -342,11 +466,20 @@ retry:
 
 static void cleanup_thread_counters(void);
 
+/* Return the calling thread's struct perf_counters, setting it up lazily
+   on first call. Returns NULL (and does no setup) if PMC has been globally
+   disabled by an earlier failure, or if no counters are configured.
+
+   A bumped perf_counter_generation (from caml_runtime_events_destroy)
+   invalidates any existing state for this thread; we tear it down before
+   rebuilding so a destroy+start cycle starts from clean state. */
 static struct perf_counters* get_thread_counters(void)
 {
   if (atomic_load(&perf_counters_globally_disabled))
     return NULL;
 
+  /* If we were set up in a previous start/destroy epoch, tear down the
+     stale state before (re)building. */
   uint64_t current_gen = atomic_load(&perf_counter_generation);
   if (thread_counters != NULL
       && thread_counter_generation != current_gen) {
@@ -358,6 +491,8 @@ static struct perf_counters* get_thread_counters(void)
     memset(thread_counters, 0, sizeof(struct perf_counters));
     char err[256];
     if (perf_events_setup(thread_counters, err, sizeof err) != 0) {
+      /* First setup failure for any thread in this process trips the
+         global circuit breaker; from now on PMC is off until destroy. */
       caml_gc_log("perf_events setup failed, disabling globally: %s", err);
       atomic_store(&perf_counters_globally_disabled, true);
       caml_stat_free(thread_counters);
@@ -369,6 +504,9 @@ static struct perf_counters* get_thread_counters(void)
   return thread_counters;
 }
 
+/* Tear down the calling thread's PMC state. Called from the domain/thread
+   stop lifecycle hooks, from get_thread_counters when the generation has
+   advanced, and from caml_runtime_events_destroy for the last domain. */
 static void cleanup_thread_counters(void)
 {
   if (thread_counters != NULL) {
@@ -843,6 +981,10 @@ static void write_to_ring(ev_category category, ev_message_type type,
   uint64_t length_with_header_ts = event_length + 2;
 
   #ifdef PERF_COUNTERS
+  /* PMC samples are only attached to events that represent a span edge:
+     runtime-phase BEGIN/EXIT and user-span Begin/End. Lifecycle events,
+     counter events, and alloc events don't carry samples. Consumers reading
+     the header's perf-counter field will see 0 for those. */
   struct perf_counters* counters = get_thread_counters();
   int sample_counters = (counters != NULL && counters->ncounters > 0 &&
                          ((category == EV_RUNTIME &&
@@ -853,7 +995,9 @@ static void write_to_ring(ev_category category, ev_message_type type,
                             type.user == EV_USER_MSG_TYPE_SPAN_END))));
 
   if (sample_counters) {
-    length_with_header_ts += counters->ncounters * 2; /* two words per counter */
+    /* Each counter contributes two words to the ring entry: its config
+       id (so the reader knows which event it is) and its sampled value. */
+    length_with_header_ts += counters->ncounters * 2;
   }
   #endif
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -809,6 +809,22 @@ CAMLprim value caml_ml_runtime_events_are_active(void) {
   return Val_bool(caml_runtime_events_are_active());
 }
 
+CAMLprim value caml_ml_runtime_events_perf_counters_active(value vunit) {
+  (void)vunit;
+#ifdef PERF_COUNTERS
+  /* Force the lazy per-thread setup so the answer reflects whether PMC will
+     actually be sampled rather than whether it has been attempted yet. */
+  if (num_perf_configs > 0
+      && !atomic_load(&perf_counters_globally_disabled)) {
+    get_thread_counters();
+  }
+  return Val_bool(num_perf_configs > 0
+                  && !atomic_load(&perf_counters_globally_disabled));
+#else
+  return Val_false;
+#endif
+}
+
 
 static struct runtime_events_buffer_header *get_ring_buffer_by_domain_id
                                                               (int domain_id) {

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -674,7 +674,7 @@ static void runtime_events_create_from_stw_single(void) {
       current_user_event = Field(current_user_event, 1);
     }
 
-    #ifdef PERF_COUNTERS
+#ifdef PERF_COUNTERS
     if (num_perf_configs == 0) {
       const char* env =
         caml_secure_getenv(T("OCAML_RUNTIME_EVENTS_PERF_COUNTERS"));
@@ -686,7 +686,7 @@ static void runtime_events_create_from_stw_single(void) {
         }
       }
     }
-    #endif
+#endif
   }
 }
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -143,7 +143,8 @@ static void stw_teardown_runtime_events(
   caml_domain_state **participating_domains);
 
 #ifdef PERF_COUNTERS
-uint64_t perf_counter_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
+static uint64_t perf_counter_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
+static int num_perf_configs = 0;
 
 struct perf_counter_rdpmc_info {
   uint64_t offset;
@@ -160,8 +161,6 @@ struct perf_counters {
 };
 
 static CAMLthread_local struct perf_counters* thread_counters = NULL;
-static int num_perf_configs = 0;
-static uint64_t parsed_perf_configs[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 static atomic_bool perf_counters_globally_disabled = false;
 
 #define seqlock_barrier() asm volatile("" ::: "memory")
@@ -193,7 +192,7 @@ static const char* parse_perf_config_string(const char* format)
                RUNTIME_EVENTS_MAX_PERF_EVENTS);
       return err;
     }
-    parsed_perf_configs[count++] = config;
+    perf_counter_configs[count++] = config;
   }
   num_perf_configs = count;
   return NULL;
@@ -248,7 +247,7 @@ static const char* perf_events_setup(struct perf_counters* counters)
   int leader_fd = -1;
 
   for (int i = 0; i < num_perf_configs; i++) {
-    uint64_t config = parsed_perf_configs[i];
+    uint64_t config = perf_counter_configs[i];
     counters->ncounters++;
 
     struct perf_event_attr attr = {
@@ -296,8 +295,6 @@ static const char* perf_events_setup(struct perf_counters* counters)
       close(fd);
       break;
     }
-
-    perf_counter_configs[i] = config;
 
     if (i == 0) {
       leader_fd = fd;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -42,12 +42,19 @@
 #include <sys/mman.h>
 #endif
 
+/* hardware events is linux only for now */
+#ifdef PERF_COUNTERS
+#include <linux/perf_event.h>
+#include <linux/hw_breakpoint.h>
+#include <sys/syscall.h>
+#include <x86intrin.h>
+#endif
 
 #if defined(HAS_UNISTD)
 #include <unistd.h>
 #endif
 
-#define RUNTIME_EVENTS_VERSION 1
+#define RUNTIME_EVENTS_VERSION 2
 
 /*
 This file contains the implementation for runtime_events's producer. The
@@ -135,6 +142,269 @@ static void stw_teardown_runtime_events(
   void *remove_file_data, int num_participating,
   caml_domain_state **participating_domains);
 
+#ifdef PERF_COUNTERS
+enum { MAX_PERF_EVENTS = 20 };
+
+uint64_t perf_counter_configs[MAX_PERF_EVENTS];
+
+struct perf_counter_rdpmc_info {
+  uint64_t offset;
+  uint32_t index;
+  uint16_t width;
+};
+struct perf_counters {
+  int ncounters;
+  void* mmap_pages[MAX_PERF_EVENTS];
+
+  uint32_t* leader_seq_lock;
+  uint32_t last_seq;
+  struct perf_counter_rdpmc_info rdpmc_info[MAX_PERF_EVENTS];
+};
+
+static CAMLthread_local struct perf_counters* thread_counters = NULL;
+static int num_perf_configs = 0;
+static uint64_t parsed_perf_configs[MAX_PERF_EVENTS];
+static atomic_bool perf_counters_globally_disabled = false;
+
+#define seqlock_barrier() asm volatile("" ::: "memory")
+
+static const char* parse_perf_config_string(const char* format)
+{
+  static char err[256];
+  int count = 0;
+  while (*format != '\0') {
+    if (format[0] != 'r') {
+      snprintf(err, sizeof err,
+               "events '%s': cannot parse (only 'rNNN' events supported)",
+               format);
+      return err;
+    }
+    format++;
+    char* endptr;
+    unsigned long config = strtoul(format, &endptr, 16);
+    if (*endptr == ',') format = endptr + 1;
+    else if (*endptr == '\0') format = endptr;
+    else {
+      snprintf(err, sizeof err,
+               "events '%s': cannot parse (only 'rNNN' events supported)",
+               format);
+      return err;
+    }
+    if (count >= MAX_PERF_EVENTS) {
+      snprintf(err, sizeof err, "events: too many events (max %d)",
+               MAX_PERF_EVENTS);
+      return err;
+    }
+    parsed_perf_configs[count++] = config;
+  }
+  num_perf_configs = count;
+  return NULL;
+}
+
+static void perf_events_teardown(struct perf_counters* counters)
+{
+  /* The mmap reference keeps the perf events alive.
+     Unmapping destroys the events - no need to close fds. */
+  for (int i = 0; i < counters->ncounters; i++) {
+    if (counters->mmap_pages[i] != NULL)
+      munmap(counters->mmap_pages[i], sysconf(_SC_PAGESIZE));
+  }
+}
+
+
+static int perf_events_setup_rdpmc(struct perf_counters* counters)
+{
+  uint32_t seqs[MAX_PERF_EVENTS];
+  struct perf_event_mmap_page* pg;
+ retry:
+  for (int i = 0; i < counters->ncounters; i++) {
+    pg = counters->mmap_pages[i];
+    seqs[i] = pg->lock;
+  }
+  seqlock_barrier();
+  for (int i = 0; i < counters->ncounters; i++) {
+    pg = counters->mmap_pages[i];
+    struct perf_counter_rdpmc_info* info = &counters->rdpmc_info[i];
+    info->offset = pg->offset;
+    if (!(pg->cap_user_rdpmc && pg->index > 0)) {
+      return 1;
+    }
+    info->index = pg->index - 1;
+    info->width = pg->pmc_width;
+  }
+  seqlock_barrier();
+  for (int i = 0; i < counters->ncounters; i++) {
+    pg = counters->mmap_pages[i];
+    if (pg->lock != seqs[i])
+      goto retry;
+  }
+  counters->last_seq = seqs[0];
+  return 0;
+}
+
+static const char* perf_events_setup(struct perf_counters* counters)
+{
+  static char err[256];
+  err[0] = 0;
+  memset(counters, 0, sizeof(*counters));
+  int leader_fd = -1;
+
+  for (int i = 0; i < num_perf_configs; i++) {
+    uint64_t config = parsed_perf_configs[i];
+    counters->ncounters++;
+
+    struct perf_event_attr attr = {
+      .size = sizeof(struct perf_event_attr),
+      .type = PERF_TYPE_RAW,
+      .config = config,
+      .sample_type = PERF_SAMPLE_READ,
+      .exclude_kernel = 0,
+      .pinned = (i == 0)
+    };
+    int fd =
+      syscall(SYS_perf_event_open,
+              &attr, 0, -1,
+              leader_fd,
+              PERF_FLAG_FD_CLOEXEC);
+    if (fd < 0) {
+      snprintf(err, sizeof err, "event %d (r%llx): perf_event_open: %s",
+               i, (unsigned long long)config, strerror(errno));
+      break;
+    }
+    struct perf_event_mmap_page* page;
+    page = counters->mmap_pages[i] =
+      mmap(NULL, sysconf(_SC_PAGESIZE), PROT_READ, MAP_SHARED, fd, 0);
+    if (page == NULL) {
+      close(fd);
+      snprintf(err, sizeof err, "event %d (r%llx): mmap: %s",
+               i, (unsigned long long)config, strerror(errno));
+      break;
+    }
+
+    int rdpmc_ok;
+    uint32_t seq;
+    do {
+      seq = page->lock;
+      seqlock_barrier();
+      rdpmc_ok = page->cap_user_rdpmc && (page->index > 0);
+      if (rdpmc_ok) _rdpmc(page->index - 1);
+      seqlock_barrier();
+    } while (page->lock != seq);
+
+    if (!rdpmc_ok) {
+      snprintf(err, sizeof err,
+               "event %d (r%llx): rdpmc reads unavailable (too many counters?)",
+               i, (unsigned long long)config);
+      close(fd);
+      break;
+    }
+
+    perf_counter_configs[i] = config;
+
+    if (i == 0) {
+      leader_fd = fd;
+      counters->leader_seq_lock = &page->lock;
+      counters->last_seq = (uint32_t)-1;
+    } else {
+      close(fd);
+    }
+  }
+  /* Close the leader fd - mmap keeps the event alive */
+  if (leader_fd != -1) close(leader_fd);
+  if (err[0] == 0 && perf_events_setup_rdpmc(counters) != 0) {
+    snprintf(err, sizeof err, "events: failed to setup rdpmc info");
+  }
+  if (err[0]) {
+    perf_events_teardown(counters);
+    return err;
+  } else {
+    return NULL;
+  }
+}
+
+void perf_events_sample(struct perf_counters* counters, uint64_t* samples)
+{
+  if (*counters->leader_seq_lock != counters->last_seq)
+    perf_events_setup_rdpmc(counters);
+retry:
+  int n = counters->ncounters;
+  for (int i = 0; i < n; i++) {
+    struct perf_counter_rdpmc_info info = counters->rdpmc_info[i];
+    uint64_t v = _rdpmc(info.index);
+    v &= ((uint64_t)(-1)) >> (64 - info.width);
+    v += info.offset;
+    samples[i] = v;
+  }
+  seqlock_barrier();
+  if (*counters->leader_seq_lock != counters->last_seq) {
+    perf_events_setup_rdpmc(counters);
+    goto retry;
+  }
+}
+
+static struct perf_counters* get_thread_counters(void)
+{
+  if (atomic_load(&perf_counters_globally_disabled))
+    return NULL;
+
+  if (thread_counters == NULL && num_perf_configs > 0) {
+    thread_counters = caml_stat_alloc(sizeof(struct perf_counters));
+    memset(thread_counters, 0, sizeof(struct perf_counters));
+    const char* err = perf_events_setup(thread_counters);
+    if (err) {
+      caml_gc_log("perf_events setup failed, disabling globally: %s", err);
+      atomic_store(&perf_counters_globally_disabled, true);
+      caml_stat_free(thread_counters);
+      thread_counters = NULL;
+      return NULL;
+    }
+  }
+  return thread_counters;
+}
+
+static void cleanup_thread_counters(void)
+{
+  if (thread_counters != NULL) {
+    perf_events_teardown(thread_counters);
+    caml_stat_free(thread_counters);
+    thread_counters = NULL;
+  }
+}
+#endif
+
+/* Hook functions for domain and thread lifecycle management.
+   These centralize the lifecycle events and PMC initialization/cleanup. */
+
+CAMLexport void caml_runtime_events_domain_start(void)
+{
+  caml_ev_lifecycle(EV_DOMAIN_SPAWN, getpid());
+#ifdef PERF_COUNTERS
+  get_thread_counters();
+#endif
+}
+
+CAMLexport void caml_runtime_events_domain_stop(void)
+{
+#ifdef PERF_COUNTERS
+  cleanup_thread_counters();
+#endif
+  caml_ev_lifecycle(EV_DOMAIN_TERMINATE, getpid());
+}
+
+CAMLexport void caml_runtime_events_thread_start(void)
+{
+#ifdef PERF_COUNTERS
+  get_thread_counters();
+#endif
+}
+
+CAMLexport void caml_runtime_events_thread_stop(void)
+{
+#ifdef PERF_COUNTERS
+  cleanup_thread_counters();
+#endif
+}
+
 void caml_runtime_events_init(void) {
 
   caml_plat_mutex_init(&user_events_lock);
@@ -182,6 +452,13 @@ static void runtime_events_teardown_from_stw_single(int remove_file) {
 
     caml_stat_free(current_ring_loc);
     current_metadata = NULL;
+
+#ifdef PERF_COUNTERS
+    /* Clean up current thread's counters (if any) */
+    cleanup_thread_counters();
+    num_perf_configs = 0;
+    atomic_store(&perf_counters_globally_disabled, false);
+#endif
 
     atomic_store_release(&runtime_events_enabled, 0);
 }
@@ -390,14 +667,25 @@ static void runtime_events_create_from_stw_single(void) {
 
     caml_ev_lifecycle(EV_RING_START, pid);
 
-
     while (Is_some (current_user_event)) {
       value event = Field(current_user_event, 0);
       events_register_write_buffer(Int_val(Field(event, 0)), Field(event, 1));
       current_user_event = Field(current_user_event, 1);
     }
 
-
+    #ifdef PERF_COUNTERS
+    if (num_perf_configs == 0) {
+      const char* env =
+        caml_secure_getenv(T("OCAML_RUNTIME_EVENTS_PERF_COUNTERS"));
+      if (env) {
+        const char* err = parse_perf_config_string(env);
+        if (err) {
+          caml_gc_log("perf_events config parse failed, disabling: %s", err);
+          num_perf_configs = 0;
+        }
+      }
+    }
+    #endif
   }
 }
 
@@ -531,6 +819,21 @@ static void write_to_ring(ev_category category, ev_message_type type,
   /* account for header and timestamp (which are both uint64) */
   uint64_t length_with_header_ts = event_length + 2;
 
+  #ifdef PERF_COUNTERS
+  struct perf_counters* counters = get_thread_counters();
+  int sample_counters = (counters != NULL && counters->ncounters > 0 &&
+                         ((category == EV_RUNTIME &&
+                           (type.runtime == EV_BEGIN ||
+                            type.runtime == EV_EXIT)) ||
+                          (category == EV_USER &&
+                           (type.user == EV_USER_MSG_TYPE_SPAN_BEGIN ||
+                            type.user == EV_USER_MSG_TYPE_SPAN_END))));
+
+  if (sample_counters) {
+    length_with_header_ts += counters->ncounters * 2; /* two words per counter */
+  }
+  #endif
+
   /* there is a ring buffer (made up of header and data) for each domain */
   struct runtime_events_buffer_header *domain_ring_header =
       get_ring_buffer_by_domain_id(Caml_state->id);
@@ -599,6 +902,8 @@ static void write_to_ring(ev_category category, ev_message_type type,
     ring_tail_offset = 0;
   }
 
+  uint64_t perf_counters = sample_counters ? counters->ncounters : 0;
+
   /* Below we write the header. See runtime_events.h for the layout structure
      of event headers.
   */
@@ -607,13 +912,32 @@ static void write_to_ring(ev_category category, ev_message_type type,
                                   length_with_header_ts,
                                   category == EV_RUNTIME,
                                   (type.runtime | type.user),
-                                  event_id);
+                                  event_id,
+                                  perf_counters);
 
   ring_ptr[ring_tail_offset++] = timestamp;
   if (content != NULL) {
     memcpy(&ring_ptr[ring_tail_offset], content + word_offset,
            event_length * sizeof(uint64_t));
   }
+
+  #ifdef PERF_COUNTERS
+  /* for EV_BEGIN and EV_END events messages may have 0 or more perf counters
+    appended to the end of a message */
+  if (sample_counters) {
+      uint64_t tmp[MAX_PERF_EVENTS];
+      perf_counters = counters->ncounters;
+      perf_events_sample(counters, tmp);
+
+      void* ring_events_ptr = &ring_ptr[ring_tail_offset];
+      /* write config first */
+      uint64_t counter_length_bytes = perf_counters * sizeof(uint64_t);
+      memcpy(ring_events_ptr, &perf_counter_configs, counter_length_bytes);
+      ring_events_ptr += counter_length_bytes;
+      memcpy(ring_events_ptr, &tmp, counter_length_bytes);
+  }
+  #endif
+
   atomic_store_release(&domain_ring_header->ring_tail,
                        ring_tail + length_with_header_ts);
 }

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -160,7 +160,9 @@ struct perf_counters {
   struct perf_counter_rdpmc_info rdpmc_info[RUNTIME_EVENTS_MAX_PERF_EVENTS];
 };
 
+static _Atomic uint64_t perf_counter_generation = 0;
 static CAMLthread_local struct perf_counters* thread_counters = NULL;
+static CAMLthread_local uint64_t thread_counter_generation = 0;
 static atomic_bool perf_counters_globally_disabled = false;
 
 #define seqlock_barrier() asm volatile("" ::: "memory")
@@ -338,10 +340,18 @@ retry:
   }
 }
 
+static void cleanup_thread_counters(void);
+
 static struct perf_counters* get_thread_counters(void)
 {
   if (atomic_load(&perf_counters_globally_disabled))
     return NULL;
+
+  uint64_t current_gen = atomic_load(&perf_counter_generation);
+  if (thread_counters != NULL
+      && thread_counter_generation != current_gen) {
+    cleanup_thread_counters();
+  }
 
   if (thread_counters == NULL && num_perf_configs > 0) {
     thread_counters = caml_stat_alloc(sizeof(struct perf_counters));
@@ -354,6 +364,7 @@ static struct perf_counters* get_thread_counters(void)
       thread_counters = NULL;
       return NULL;
     }
+    thread_counter_generation = current_gen;
   }
   return thread_counters;
 }
@@ -450,10 +461,10 @@ static void runtime_events_teardown_from_stw_single(int remove_file) {
     current_metadata = NULL;
 
 #ifdef PERF_COUNTERS
-    /* Clean up current thread's counters (if any) */
     cleanup_thread_counters();
     num_perf_configs = 0;
     atomic_store(&perf_counters_globally_disabled, false);
+    atomic_fetch_add(&perf_counter_generation, 1);
 #endif
 
     atomic_store_release(&runtime_events_enabled, 0);

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -42,7 +42,7 @@
 #include <sys/mman.h>
 #endif
 
-/* hardware events is linux only for now */
+/* hardware events are linux only for now */
 #ifdef PERF_COUNTERS
 #include <linux/perf_event.h>
 #include <linux/hw_breakpoint.h>

--- a/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -42,7 +42,7 @@ let in_minor = ref false
 let majors = ref 0
 let minors = ref 0
 
-let runtime_begin domain_id ts phase =
+let runtime_begin domain_id ts phase _perf_samples =
     match phase with
     | EV_MAJOR_FINISH_CYCLE ->
         begin
@@ -56,7 +56,7 @@ let runtime_begin domain_id ts phase =
         end
     | _ -> ()
 
-let runtime_end domain_id ts phase =
+let runtime_end domain_id ts phase _perf_samples =
     match phase with
     | EV_MAJOR_FINISH_CYCLE ->
         begin

--- a/testsuite/tests/lib-runtime-events/test_caml_exception.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_exception.ml
@@ -13,7 +13,7 @@ open Runtime_events
 
 exception Test_exception
 
-let runtime_begin domain_id ts phase =
+let runtime_begin domain_id ts phase _perf_samples =
     match phase with
     | EV_MINOR ->
       raise Test_exception

--- a/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
@@ -47,7 +47,7 @@ let find_or_create_phase_count domain_id =
             end
         | Some(pc) -> pc
 
-let runtime_begin domain_id ts phase =
+let runtime_begin domain_id ts phase _perf_samples =
     let phase_count = find_or_create_phase_count domain_id in
     match phase with
     | EV_MAJOR ->
@@ -62,7 +62,7 @@ let runtime_begin domain_id ts phase =
         end
     | _ -> ()
 
-let runtime_end domain_id ts phase =
+let runtime_end domain_id ts phase _perf_samples =
     let phase_count = find_or_create_phase_count domain_id in
     match phase with
         | EV_MAJOR ->

--- a/testsuite/tests/lib-runtime-events/test_caml_reentry.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_reentry.ml
@@ -15,7 +15,7 @@ let () =
     start ();
     let cursor = create_cursor None in
     let empty_callbacks = Callbacks.create () in
-    let runtime_begin domain_id ts phase =
+    let runtime_begin domain_id ts phase _perf_samples =
       match phase with
       | EV_MINOR ->
         ignore(read_poll cursor empty_callbacks None)

--- a/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
@@ -20,7 +20,7 @@ let () =
       Domain.join (Domain.spawn (fun _ -> ()))
     done;
     let cursor = create_cursor None in
-    let runtime_begin domain_id ts phase =
+    let runtime_begin domain_id ts phase _perf_samples =
       match phase with
       | EV_MINOR ->
         got_minor := true

--- a/testsuite/tests/lib-runtime-events/test_caml_stubs_gc.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_stubs_gc.ml
@@ -16,7 +16,7 @@ let got_minor = ref false
 let () =
     start ();
     let cursor = create_cursor None in
-    let runtime_begin domain_id ts phase =
+    let runtime_begin domain_id ts phase _perf_samples =
       match phase with
       | EV_MINOR ->
         Gc.full_major ();

--- a/testsuite/tests/lib-runtime-events/test_compact.ml
+++ b/testsuite/tests/lib-runtime-events/test_compact.ml
@@ -55,7 +55,7 @@ let last = ref NONE
 let () =
     start ();
     let cursor = create_cursor None in
-    let runtime_begin domain_id ts phase =
+    let runtime_begin domain_id ts phase _perf_samples =
       match phase with
       | EV_COMPACT ->
         begin
@@ -79,7 +79,7 @@ let () =
           state := RELEASING
         end
       | _ -> () in
-      let runtime_end domain_id ts phase =
+      let runtime_end domain_id ts phase _perf_samples =
         match phase with
         | EV_COMPACT ->
           begin

--- a/testsuite/tests/lib-runtime-events/test_corrupted.ml
+++ b/testsuite/tests/lib-runtime-events/test_corrupted.ml
@@ -16,8 +16,8 @@
 
 (* CR mslater for nbarnes: this test currently fails on arm64 *)
 
-  let runtime_begin _ _ _ = ()
-  let runtime_end _ _ _ = ()
+  let runtime_begin _ _ _ _ = ()
+  let runtime_end _ _ _ _ = ()
   let runtime_counter _ _ _ _ = ()
   let alloc _ _ _ = ()
   let lifecycle _ _ _ _ = ()
@@ -49,7 +49,7 @@
     let n = Unix.read fd buf 0 (Bytes.length buf) in
     assert (n = Bytes.length buf);
     let version = Bytes.get_int64_ne buf 0 in
-    assert (version = 1L);
+    assert (version = 2L);
     (* this needs to be updated if on-disk layout changes *)
     let data_offset = Bytes.get_int64_ne buf (6*8) in
 
@@ -122,7 +122,7 @@
         Bytes.blit_string original 0 buf 0 (Bytes.length buf);
       done;
       (* restore metadata header, so we have a valid ring again *)
-      write_metadata_header 0 1L (* version *);
+      write_metadata_header 0 2L (* version *);
 
       for is_runtime = 0 to 1 do
         for event_type = 0 to 15 (* event type is 4 bits *) do

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -46,7 +46,7 @@ let callbacks =
   let open Runtime_events in
   let evs = Runtime_events.Callbacks.create ()
   in
-  let id_callback d ts c i =
+  let id_callback _d _ts _c i _perf =
     assert (i = 0)
   in
   Callbacks.add_user_event Runtime_events.Type.int id_callback evs

--- a/testsuite/tests/lib-runtime-events/test_external.ml
+++ b/testsuite/tests/lib-runtime-events/test_external.ml
@@ -19,7 +19,7 @@ let got_major = ref false
 let got_minor = ref false
 let finished = ref false
 
-let runtime_end domain_id ts phase =
+let runtime_end domain_id ts phase _perf_samples =
   match phase with
   | Runtime_events.EV_EXPLICIT_GC_FULL_MAJOR ->
     got_major := true

--- a/testsuite/tests/lib-runtime-events/test_instrumented.ml
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.ml
@@ -21,7 +21,7 @@ let lost_event_words = ref 0
 let alloc domain_id ts counts =
   total_blocks := Array.fold_left ( + ) !total_blocks counts
 
-let runtime_end domain_id ts phase =
+let runtime_end domain_id ts phase _perf_samples =
   match phase with
   | EV_MINOR ->
     total_minors := !total_minors + 1

--- a/testsuite/tests/lib-runtime-events/test_perf_samples.ml
+++ b/testsuite/tests/lib-runtime-events/test_perf_samples.ml
@@ -1,0 +1,89 @@
+(* TEST
+ {
+   runtime4;
+   skip;
+ }{
+   include runtime_events;
+   runtime5;
+   { bytecode; }
+   { native; }
+ }
+*)
+
+(* Tests that:
+ * - the perf_sample array is passed to runtime_begin and runtime_end callbacks
+ * - the perf_sample array is passed to user span callbacks
+ * - when no OCAML_RUNTIME_EVENTS_PERF_COUNTERS env var is set, the array is empty
+ * - the callback signatures match the expected API
+ *)
+
+open Runtime_events
+
+(* External for getting length of unboxed product arrays *)
+external[@layout_poly] array_length : ('a : any mod separable). 'a array -> int =
+  "%array_length"
+
+let samples_seen_begin = ref 0
+let samples_seen_end = ref 0
+let empty_arrays_begin = ref 0
+let empty_arrays_end = ref 0
+
+let runtime_begin _domain_id _ts _phase
+    (local_ perf_samples : perf_sample array) =
+    incr samples_seen_begin;
+    if array_length perf_samples = 0 then
+      incr empty_arrays_begin
+
+let runtime_end _domain_id _ts _phase
+    (local_ perf_samples : perf_sample array) =
+    incr samples_seen_end;
+    if array_length perf_samples = 0 then
+      incr empty_arrays_end
+
+(* User span event testing *)
+type User.tag += PerfSpan
+
+let user_span_event = User.register "perf.span" PerfSpan Type.span
+
+let user_span_begin_seen = ref 0
+let user_span_end_seen = ref 0
+let user_span_empty_arrays = ref 0
+
+let user_span_handler _domain_id _ts _ev v
+    (local_ perf_samples : perf_sample array) =
+  (match v with
+   | Type.Begin -> incr user_span_begin_seen
+   | Type.End -> incr user_span_end_seen);
+  if array_length perf_samples = 0 then
+    incr user_span_empty_arrays
+
+let () =
+    start ();
+    let cursor = create_cursor None in
+    let callbacks =
+      Callbacks.create ~runtime_begin ~runtime_end ()
+      |> Callbacks.add_user_event Type.span user_span_handler
+    in
+    (* Emit user span events *)
+    User.write user_span_event Begin;
+    (* Trigger some GC activity inside the span *)
+    for _ = 1 to 10 do
+      ignore (Sys.opaque_identity (Array.make 1000 0));
+      Gc.minor ()
+    done;
+    User.write user_span_event End;
+    (* Poll for events *)
+    for _ = 0 to 100 do
+      ignore (read_poll cursor callbacks None)
+    done;
+    (* Verify runtime callbacks *)
+    assert (!samples_seen_begin > 0);
+    assert (!samples_seen_end > 0);
+    assert (!empty_arrays_begin = !samples_seen_begin);
+    assert (!empty_arrays_end = !samples_seen_end);
+    (* Verify user span callbacks *)
+    assert (!user_span_begin_seen > 0);
+    assert (!user_span_end_seen > 0);
+    assert (!user_span_empty_arrays =
+            !user_span_begin_seen + !user_span_end_seen);
+    print_endline "perf_samples callback test passed"

--- a/testsuite/tests/lib-runtime-events/test_perf_samples.ml
+++ b/testsuite/tests/lib-runtime-events/test_perf_samples.ml
@@ -20,7 +20,8 @@
 open Runtime_events
 
 (* External for getting length of unboxed product arrays *)
-external[@layout_poly] array_length : ('a : any mod separable). 'a array -> int =
+external[@layout_poly] array_length :
+  ('a : any mod separable). local_ 'a array -> int =
   "%array_length"
 
 let samples_seen_begin = ref 0

--- a/testsuite/tests/lib-runtime-events/test_perf_samples.reference
+++ b/testsuite/tests/lib-runtime-events/test_perf_samples.reference
@@ -1,0 +1,1 @@
+perf_samples callback test passed

--- a/testsuite/tests/lib-runtime-events/test_perf_samples_enabled.ml
+++ b/testsuite/tests/lib-runtime-events/test_perf_samples_enabled.ml
@@ -3,26 +3,18 @@
    include runtime_events;
    set OCAML_RUNTIME_EVENTS_PERF_COUNTERS = "r3c";
    runtime5;
-   { bytecode; }
-   { native; }
+   native;
  }
 *)
 
 (* Tests the PMC-enabled end-to-end path: when
-   OCAML_RUNTIME_EVENTS_PERF_COUNTERS is set and PMC setup succeeds, runtime
-   and user-span callbacks are invoked and at least one callback observes a
-   non-empty perf_sample array. Exercises parse_perf_config_string,
+   OCAML_RUNTIME_EVENTS_PERF_COUNTERS is set and PMC setup succeeds, every
+   runtime and user-span callback receives a perf_sample array of length 1
+   (one counter configured). Exercises parse_perf_config_string,
    perf_events_setup, the header perf-counter bitfield, write_to_ring, and
    extract_perf_data. If PMC is unavailable at runtime (non-Linux, non-x86,
    sandboxed CI, RDPMC-unavailable kernel, etc.) the test exits cleanly as a
-   no-op success.
-
-   Note: we intentionally do not assert on the exact value of array_length
-   here. Native and bytecode unbox unboxed-product arrays differently, so
-   `array_length` on a `local_ perf_sample array` returns the element count
-   in native and the wosize (= element_count * number_of_components) in
-   bytecode. We only check "non-empty" (length > 0), which is consistent
-   across both modes. *)
+   no-op success. *)
 
 open Runtime_events
 
@@ -47,22 +39,22 @@ let () =
   let end_seen = ref 0 in
   let user_begin_seen = ref 0 in
   let user_end_seen = ref 0 in
-  let any_nonempty = ref false in
+  let bad_length = ref 0 in
 
-  let mark_nonempty (local_ samples : perf_sample array) =
-    if array_length samples > 0 then any_nonempty := true
+  let check_length (local_ samples : perf_sample array) =
+    if array_length samples <> 1 then incr bad_length
   in
 
   let runtime_begin _domain_id _ts _phase
       (local_ samples : perf_sample array) =
     incr begin_seen;
-    mark_nonempty samples
+    check_length samples
   in
 
   let runtime_end _domain_id _ts _phase
       (local_ samples : perf_sample array) =
     incr end_seen;
-    mark_nonempty samples
+    check_length samples
   in
 
   let user_span_handler _domain_id _ts _ev v
@@ -70,7 +62,7 @@ let () =
     (match v with
      | Type.Begin -> incr user_begin_seen
      | Type.End -> incr user_end_seen);
-    mark_nonempty samples
+    check_length samples
   in
 
   let cursor = create_cursor None in
@@ -94,5 +86,5 @@ let () =
   assert (!end_seen > 0);
   assert (!user_begin_seen > 0);
   assert (!user_end_seen > 0);
-  assert !any_nonempty;
+  assert (!bad_length = 0);
   done_line ()

--- a/testsuite/tests/lib-runtime-events/test_perf_samples_enabled.ml
+++ b/testsuite/tests/lib-runtime-events/test_perf_samples_enabled.ml
@@ -1,0 +1,98 @@
+(* TEST
+ {
+   include runtime_events;
+   set OCAML_RUNTIME_EVENTS_PERF_COUNTERS = "r3c";
+   runtime5;
+   { bytecode; }
+   { native; }
+ }
+*)
+
+(* Tests the PMC-enabled end-to-end path: when
+   OCAML_RUNTIME_EVENTS_PERF_COUNTERS is set and PMC setup succeeds, runtime
+   and user-span callbacks are invoked and at least one callback observes a
+   non-empty perf_sample array. Exercises parse_perf_config_string,
+   perf_events_setup, the header perf-counter bitfield, write_to_ring, and
+   extract_perf_data. If PMC is unavailable at runtime (non-Linux, non-x86,
+   sandboxed CI, RDPMC-unavailable kernel, etc.) the test exits cleanly as a
+   no-op success.
+
+   Note: we intentionally do not assert on the exact value of array_length
+   here. Native and bytecode unbox unboxed-product arrays differently, so
+   `array_length` on a `local_ perf_sample array` returns the element count
+   in native and the wosize (= element_count * number_of_components) in
+   bytecode. We only check "non-empty" (length > 0), which is consistent
+   across both modes. *)
+
+open Runtime_events
+
+external[@layout_poly] array_length :
+  ('a : any mod separable). local_ 'a array -> int =
+  "%array_length"
+
+let done_line () = print_endline "perf_samples enabled test passed"
+
+type User.tag += PerfSpan
+
+let user_span_event = User.register "perf.span" PerfSpan Type.span
+
+let () =
+  start ();
+  if not (perf_counters_active ()) then begin
+    done_line ();
+    exit 0
+  end;
+
+  let begin_seen = ref 0 in
+  let end_seen = ref 0 in
+  let user_begin_seen = ref 0 in
+  let user_end_seen = ref 0 in
+  let any_nonempty = ref false in
+
+  let mark_nonempty (local_ samples : perf_sample array) =
+    if array_length samples > 0 then any_nonempty := true
+  in
+
+  let runtime_begin _domain_id _ts _phase
+      (local_ samples : perf_sample array) =
+    incr begin_seen;
+    mark_nonempty samples
+  in
+
+  let runtime_end _domain_id _ts _phase
+      (local_ samples : perf_sample array) =
+    incr end_seen;
+    mark_nonempty samples
+  in
+
+  let user_span_handler _domain_id _ts _ev v
+      (local_ samples : perf_sample array) =
+    (match v with
+     | Type.Begin -> incr user_begin_seen
+     | Type.End -> incr user_end_seen);
+    mark_nonempty samples
+  in
+
+  let cursor = create_cursor None in
+  let callbacks =
+    Callbacks.create ~runtime_begin ~runtime_end ()
+    |> Callbacks.add_user_event Type.span user_span_handler
+  in
+
+  User.write user_span_event Begin;
+  for _ = 1 to 10 do
+    ignore (Sys.opaque_identity (Array.make 1000 0));
+    Gc.minor ()
+  done;
+  User.write user_span_event End;
+
+  for _ = 0 to 100 do
+    ignore (read_poll cursor callbacks None)
+  done;
+
+  assert (!begin_seen > 0);
+  assert (!end_seen > 0);
+  assert (!user_begin_seen > 0);
+  assert (!user_end_seen > 0);
+  assert !any_nonempty;
+  done_line ()

--- a/testsuite/tests/lib-runtime-events/test_perf_samples_enabled.reference
+++ b/testsuite/tests/lib-runtime-events/test_perf_samples_enabled.reference
@@ -1,0 +1,1 @@
+perf_samples enabled test passed

--- a/testsuite/tests/lib-runtime-events/test_user_event.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event.ml
@@ -55,23 +55,23 @@ let got_span_end = ref false
 let counter_value = ref 0
 let custom_value = ref ""
 
-let event_handler domain_id ts e () =
+let event_handler _domain_id _ts e () _perf =
   match User.tag e with
   | Libname -> got_event := true
   | _ -> ()
 
-let counter_handler domain_id ts e v =
+let counter_handler _domain_id _ts e v _perf =
   match User.tag e with
   | Counters 2 -> counter_value := v
   | _ -> ()
 
-let span_handler domain_id ts e v =
+let span_handler _domain_id _ts e v _perf =
   match User.tag e with
   | Libname when v = Type.Begin -> got_span_begin := true
   | Libname when v = Type.End -> got_span_end := true
   | _ -> ()
 
-let custom_handler domain_id ts e v =
+let custom_handler _domain_id _ts e v _perf =
   match User.tag e with
   | Libname -> custom_value := v
   | _ -> ()

--- a/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
@@ -49,12 +49,12 @@ let () =
   begin
   Unix.waitpid [] child_pid |> ignore;
   let cursor = create_cursor (Some (parent_cwd, child_pid)) in
-  let callback_counter _ _ ev v =
+  let callback_counter _ _ ev v _perf =
     match User.tag ev with
     | Ev i -> Printf.printf "known event ev %d => %d\n" i v
     | _ -> Printf.printf "unknown event %s => %d\n" (User.name ev) v
   in
-  let callback_span _ _ ev v =
+  let callback_span _ _ ev v _perf =
     Printf.printf "span %s => %b\n" (User.name ev) (v ==  Type.Begin)
   in
   let callbacks =

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -138,6 +138,8 @@ let has_f16c = "@has_f16c@" = "yes"
 
 let has_fma = "@has_fma@" = "yes"
 
+let perf_counters_supported = "@perf_counters_supported@" = "yes"
+
 let as_compress_debug_sections_flag = {@QS@|@as_compress_debug_sections_flag@|@QS@}
 let cc_compress_debug_sections_flag = {@QS@|@cc_compress_debug_sections_flag@|@QS@}
 let objcopy_compress_debug_sections_flag = {@QS@|@objcopy_compress_debug_sections_flag@|@QS@}

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -392,5 +392,10 @@ val has_f16c : bool
 val has_fma : bool
 (* Whether the compiler was configured on a machine with FMA *)
 
+val perf_counters_supported : bool
+(* Whether the runtime was built with Linux x86 hardware performance-counter
+   support (see runtime/runtime_events.c). Only meaningful for runtime5
+   builds. *)
+
 val oxcaml_dwarf : bool
 (* Whether OxCaml DWARF is used by default *)

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -393,9 +393,9 @@ val has_fma : bool
 (* Whether the compiler was configured on a machine with FMA *)
 
 val perf_counters_supported : bool
-(* Whether the runtime was built with Linux x86 hardware performance-counter
-   support (see runtime/runtime_events.c). Only meaningful for runtime5
-   builds. *)
+(* Whether the runtime was built with Linux x86-64 hardware
+   performance-counter support (see runtime/runtime_events.c). Only
+   meaningful for runtime5 builds. *)
 
 val oxcaml_dwarf : bool
 (* Whether OxCaml DWARF is used by default *)


### PR DESCRIPTION
This is a draft PR for the performance monitoring counters in Runtime Events described in: https://toao.com/drafts/free-performance-counters-runtime-events

The runtime-side implementation is described in https://github.com/sadiqj/oxcaml/blob/runtime_events_pmc/runtime/runtime_events.c#L145-L186

On the consumer side, callbacks receive an additional `local_ perf_sample array` parameter with `perf_sample` being an unboxed pair of unboxed int64s `#{ config: int64#; value: int64# }`.

It is Linux x86-64, runtime5 only. Config is exposed via `Config.perf_counters_supported` at compile time. Non-supported platforms/builds the consumer just gets an empty list of performance counters.

At runtime, passing an environment variable with event codes, such as `OCAML_RUNTIME_EVENTS_PERF_COUNTERS=r3c,r3d`, will add these to runtime events begin/end spans.

There is a single test that tests the functionality `test_perf_samples_enabled` but it requires perf counters to be readable in CI.

I was a bit worried about continuously allocating locals during when running callbacks, so the [code in runtime_events_consumer.c](https://github.com/sadiqj/oxcaml/blob/runtime_events_pmc/otherlibs/runtime_events/runtime_events_consumer.c#L784-L853) resets the stack between callbacks.

Questions
--

1. Is a local array of #{ config: int64#; value: int64# } the right api for now?
2. Is the local_sp save/restore between callbacks necessary? A poll could potentially process millions of events, all of which would be stack allocated.