### PR TITLE
[5.4] Remove CRs added during the merge

### DIFF
--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -43,9 +43,6 @@ type cmm_label = Label.t
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
-(* CR sspies: Upstream has renamed [Ifar_poll] -> [Ipoll_far] and similarly for
-   [Ifar_alloc]. We should probably do a similar change, but deferred to later
-   (as opposed to taking it during the 5.4 merge). *)
 type specific_operation =
   | Ifar_poll
   | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }

--- a/configure.ac
+++ b/configure.ac
@@ -1193,7 +1193,6 @@ AS_IF(
 ## AC_PROG_CC_C99
 
 ## Determine which flags to use for the C compiler
-dnl CR sspies: outputobj is set earlier, around line 519
 
 AS_CASE([$ocaml_cc_vendor],
   [xlc-*],
@@ -3060,8 +3059,6 @@ AC_ARG_WITH([objcopy],
   [objcopy=$with_objcopy])
 
 ## Frame pointers
-dnl CR sspies: Add aarch64-*-linux*|aarch64-*-darwin* when we support frame pointers on ARM.
-dnl Upstream already has support for these.
 
 AS_IF([test x"$enable_frame_pointers" = "xyes" -o x"$enable_address_sanitizer" = "xyes"],
   [AS_CASE([$target],

--- a/dune
+++ b/dune
@@ -235,7 +235,7 @@
   ctype
   printtyp
   rawprinttyp
-  gprinttyp ;; CR sspies: Not added upstream, let's keep it for now.
+  gprinttyp
   includeclass
   mtype
   envaux

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -421,8 +421,6 @@ let index_occurrences binary_annots =
     in
     (* Shape reduction can be expensive, but the persistent memoization tables
        should make these successive reductions fast. *)
-    (* CR sspies: [index_components] was added during the 5.4 merge and is worth
-       keeping an eye on with respect to how it impacts Merlin. *)
     let rec index_components namespace lid path =
       let module_ = Shape.Sig_component_kind.Module in
       let scraped_path = Path.scrape_extra_ty path in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4583,8 +4583,6 @@ let for_trywith ~scopes ~return_layout loc param pat_act_list =
     None param pat_act_list Partial
 
 let for_handler ~scopes ~return_layout loc param cont cont_tail pat_act_list =
-  (* CR sspies: Hardcoding arg_sort and arg_layout like for_trywith.
-     Revisit whether this choice is actually correct. *)
   compile_matching ~scopes ~arg_sort:Jkind.Sort.Const.for_predef_value
     ~arg_layout:layout_block ~return_layout loc
     ~failer:(Reperform_noloc [param; cont; cont_tail])

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2377,9 +2377,6 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
        ~mode:alloc_heap
        ~ret_mode:(to_locality p.prim_native_repr_res)
 
-(* CR sspies: I didn't attempt to reorder the constructors during the 5.4 merge
-   here. But maybe we should do something to decrease the diff and make the
-   order the same for the constructors that are shared. *)
 let lambda_primitive_needs_event_after = function
   (* We add an event after any primitive resulting in a C call that MAY raise
      an exception or allocate (this is approximated conservatively). These are

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -2,7 +2,6 @@
  flags = "-drawlambda -dlambda -dcanonical-ids";
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* Note: the tests below contain *both* the -drawlambda and
    the -dlambda intermediate representations:

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -2,7 +2,6 @@
  flags = "-nostdlib -nopervasives -dlambda -dcanonical-ids";
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (******************************************************************************)
 

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -3,7 +3,6 @@
  stack-allocation;
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* We explicitly enable the warning (see the discussion in the
    "Warning reference" section of the reference manual), which makes

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -4,7 +4,6 @@
  stack-allocation;
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 #use "contexts_1.ml";;
 (* Notice that (field_mut 1 input) occurs twice, it

--- a/testsuite/tests/messages/precise_locations.ml
+++ b/testsuite/tests/messages/precise_locations.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 type t = (unit, unit, unit, unit) bar
 ;;

--- a/testsuite/tests/messages/spellcheck.ml
+++ b/testsuite/tests/messages/spellcheck.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* The goal of this test is exhaustively cover all spellcheck-style
    error messages in the compiler. *)

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 let _ = Int32.(add 1 2l);;
 [%%expect{|

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* Typing for recursive modules checks scope escape *)
 module type S = sig

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 module type S = sig type t [@@immediate] end;;
 module F (M : S) : S = M;;

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 module M = struct type t = A | B end
 let rec f () = g A

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -2,7 +2,6 @@
  flags = "-no-alias-deps -w +40";
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 module M = struct
   type t = A
   module M : sig

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -2,7 +2,6 @@
  expect;
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 
 (** Gives an example for every [raise(Error(_,_,_)] in typing/typecore.ml

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 type t = A
 let x = A
 module M = struct

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* with module *)
 

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 module C = Char;;
 C.chr 66;;

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 type t = Set.Make(String).t
 [%%expect{|

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 
 

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 class type ct = object end
 module type s = sig type a val one:int type b class two:ct type c type exn+=Three type d end
 module type c12 = sig type a class two:ct type b val one:int type c type exn+=Three type d end

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (********************************** Equality **********************************)
 

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 module type T = sig type t end
 module Fix(F:(T -> T)) = struct

--- a/testsuite/tests/typing-modules/printing.ml
+++ b/testsuite/tests/typing-modules/printing.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* PR#6650 *)
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 (* Subtyping is "syntactic" *)
 fun (x : < x : int >) y z -> (y :> 'a), (x :> 'a), (z :> 'a);;

--- a/testsuite/tests/typing-signatures/nondep_regression.ml
+++ b/testsuite/tests/typing-signatures/nondep_regression.ml
@@ -1,7 +1,6 @@
 (* TEST
  expect;
 *)
-(* CR 5.4-merge: expect tests auto-resolved in favour of upstream *)
 
 type 'a seq = 'a list
 

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -162,8 +162,6 @@ val add_type_declaration_to_preparation :
 val prepared_type_declaration: Ident.t -> type_declaration printer
 
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
-(* CR sspies: oxcaml adds [?abbrev] to [tree_of_modtype_declaration].
-   Implementation is in printtyp.ml. *)
 val tree_of_modtype_declaration:
     ?abbrev:bool -> Ident.t -> modtype_declaration -> out_sig_item
 val tree_of_class_declaration:
@@ -179,8 +177,6 @@ val tree_of_jkind_declaration:
 val tree_of_module:
     Ident.t -> ?ellipsis:bool -> module_declaration -> rec_status ->
     out_sig_item
-(* CR sspies: oxcaml adds [?abbrev] to [tree_of_modtype].
-   Implementation is in printtyp.ml. *)
 val tree_of_modtype: ?abbrev:bool -> module_type -> out_module_type
 val tree_of_signature: Types.signature -> out_sig_item list
 

--- a/utils/symbol.ml
+++ b/utils/symbol.ml
@@ -54,8 +54,8 @@ let force_runtime4_symbols = ref true
 
 
 (* CR sspies: Upstream has changed in 5.4 to use [.] as a separator only on
-   Linux and to use $ on other systems. The mangling convention in OxCaml hasn't
-   been changed yet to match. *)
+   Linux and to use $ on other systems. The mangling convention in OxCaml has
+   not been changed to match during the 5.4 merge. *)
 let upstream_runtime5_symbol_separator =
   match Config.ccomp_type with
   | "msvc" -> '$' (* MASM does not allow for dots in symbol names *)


### PR DESCRIPTION
This PR removes some of the comments added during the merge conflict resolution that do not provide much value anymore. Below are CR comments that will not be removed and hence will become part of the compiler:

**PR 12084 related (linkdeps change):**
  - `optcomp/linkenv.mli:63` — replace is_required/add_required/remove_required with Linkdeps.
  - `optcomp/linkenv.mli:87` — move Missing_implementations/Multiple_definition into Linkdeps.error.
  - `optcomp/optlink.ml:79` — switch scan_file to Linkdeps.add/Linkdeps.required.
  - `optcomp/optlink.ml:382` — move missing-globals check to Linkdeps.check.
  - `testsuite/tests/badly-ordered-deps/main.ml:58` — pull in upstream native dep-check changes.

  **Name mangling:**
  - `utils/symbol.ml:56` — adopt upstream 5.4 symbol separator convention (. on Linux, $ elsewhere).
