### PR TITLE
Write codegen tests for recently added shift intrinsics

### DIFF
--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -213,6 +213,123 @@ popcnt_native:
   ret
 |}]
 
+(* Shift left - int64 *)
+
+let int64_shl x y =
+  Builtins.int64_shl (Int64_u.to_int64 x) (Int64_u.to_int64 y)
+  |> Int64_u.of_int64
+[%%expect_asm X86_64{|
+int64_shl:
+  movq  %rbx, %rcx
+  salq  %cl, %rax
+  ret
+|}]
+
+(* Shift left - int32 *)
+
+let int32_shl x y =
+  Builtins.int32_shl (Int32_u.to_int32 x) (Int32_u.to_int32 y)
+  |> Int32_u.of_int32
+[%%expect_asm X86_64{|
+int32_shl:
+  movq  %rbx, %rcx
+  andl  $31, %ecx
+  salq  %cl, %rax
+  movslq %eax, %rax
+  ret
+|}]
+
+(* Shift left - nativeint *)
+
+let nativeint_shl x y =
+  Builtins.nativeint_shl
+    (Nativeint_u.to_nativeint x) (Nativeint_u.to_nativeint y)
+  |> Nativeint_u.of_nativeint
+[%%expect_asm X86_64{|
+nativeint_shl:
+  movq  %rbx, %rcx
+  salq  %cl, %rax
+  ret
+|}]
+
+(* Shift right arithmetic - int64 *)
+
+let int64_sar x y =
+  Builtins.int64_sar (Int64_u.to_int64 x) (Int64_u.to_int64 y)
+  |> Int64_u.of_int64
+[%%expect_asm X86_64{|
+int64_sar:
+  movq  %rbx, %rcx
+  sarq  %cl, %rax
+  ret
+|}]
+
+(* Shift right arithmetic - int32 *)
+
+let int32_sar x y =
+  Builtins.int32_sar (Int32_u.to_int32 x) (Int32_u.to_int32 y)
+  |> Int32_u.of_int32
+[%%expect_asm X86_64{|
+int32_sar:
+  movq  %rbx, %rcx
+  andl  $31, %ecx
+  sarq  %cl, %rax
+  ret
+|}]
+
+(* Shift right arithmetic - nativeint *)
+
+let nativeint_sar x y =
+  Builtins.nativeint_sar
+    (Nativeint_u.to_nativeint x) (Nativeint_u.to_nativeint y)
+  |> Nativeint_u.of_nativeint
+[%%expect_asm X86_64{|
+nativeint_sar:
+  movq  %rbx, %rcx
+  sarq  %cl, %rax
+  ret
+|}]
+
+(* Shift right logical - int64 *)
+
+let int64_shr x y =
+  Builtins.int64_shr (Int64_u.to_int64 x) (Int64_u.to_int64 y)
+  |> Int64_u.of_int64
+[%%expect_asm X86_64{|
+int64_shr:
+  movq  %rbx, %rcx
+  shrq  %cl, %rax
+  ret
+|}]
+
+(* Shift right logical - int32 *)
+
+let int32_shr x y =
+  Builtins.int32_shr (Int32_u.to_int32 x) (Int32_u.to_int32 y)
+  |> Int32_u.of_int32
+[%%expect_asm X86_64{|
+int32_shr:
+  movq  %rbx, %rcx
+  andl  $31, %ecx
+  movl  %eax, %eax
+  shrq  %cl, %rax
+  movslq %eax, %rax
+  ret
+|}]
+
+(* Shift right logical - nativeint *)
+
+let nativeint_shr x y =
+  Builtins.nativeint_shr
+    (Nativeint_u.to_nativeint x) (Nativeint_u.to_nativeint y)
+  |> Nativeint_u.of_nativeint
+[%%expect_asm X86_64{|
+nativeint_shr:
+  movq  %rbx, %rcx
+  shrq  %cl, %rax
+  ret
+|}]
+
 (* High multiply *)
 
 let mulhi_signed x y =

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -655,6 +655,38 @@ clz:
   ret
 |}]
 
+let shl x y = Int16_u.shl x y
+[%%expect_asm X86_64{|
+shl:
+  movq  %rbx, %rcx
+  andl  $15, %ecx
+  salq  %cl, %rax
+  salq  $48, %rax
+  sarq  $48, %rax
+  ret
+|}]
+
+let sar x y = Int16_u.sar x y
+[%%expect_asm X86_64{|
+sar:
+  movq  %rbx, %rcx
+  andl  $15, %ecx
+  sarq  %cl, %rax
+  ret
+|}]
+
+let shr x y = Int16_u.shr x y
+[%%expect_asm X86_64{|
+shr:
+  movq  %rbx, %rcx
+  andl  $15, %ecx
+  andl  $65535, %eax
+  shrq  %cl, %rax
+  salq  $48, %rax
+  sarq  $48, %rax
+  ret
+|}]
+
 let select x y z = Int16_u.select x y z
 [%%expect_asm X86_64{|
 select:

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -645,6 +645,38 @@ clz:
   ret
 |}]
 
+let shl x y = Int8_u.shl x y
+[%%expect_asm X86_64{|
+shl:
+  movq  %rbx, %rcx
+  andl  $7, %ecx
+  salq  %cl, %rax
+  salq  $56, %rax
+  sarq  $56, %rax
+  ret
+|}]
+
+let sar x y = Int8_u.sar x y
+[%%expect_asm X86_64{|
+sar:
+  movq  %rbx, %rcx
+  andl  $7, %ecx
+  sarq  %cl, %rax
+  ret
+|}]
+
+let shr x y = Int8_u.shr x y
+[%%expect_asm X86_64{|
+shr:
+  movq  %rbx, %rcx
+  andl  $7, %ecx
+  andl  $255, %eax
+  shrq  %cl, %rax
+  salq  $56, %rax
+  sarq  $56, %rax
+  ret
+|}]
+
 let select x y z = Int8_u.select x y z
 [%%expect_asm X86_64{|
 select:

--- a/testsuite/tests/codegen/intrinsics.ml
+++ b/testsuite/tests/codegen/intrinsics.ml
@@ -557,6 +557,14 @@ module Int16_u = struct
   external clz : t -> t = "" "caml_bmi_tzcnt_int16"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
+  external shl : t -> t -> t = "" "caml_int16_shift_left_by_int16_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+  external sar : t -> t -> t = "" "caml_int16_shift_right_by_int16_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+  external shr : t -> t -> t
+    = "" "caml_int16_shift_right_logical_by_int16_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
   external select : bool -> t -> t -> t = "" "caml_csel_int16_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 end
@@ -639,6 +647,14 @@ module Int8_u = struct
   external ctz : t -> t = "" "caml_int8_ctz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
   external clz : t -> t = "" "caml_int8_clz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external shl : t -> t -> t = "" "caml_int8_shift_left_by_int8_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+  external sar : t -> t -> t = "" "caml_int8_shift_right_by_int8_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+  external shr : t -> t -> t
+    = "" "caml_int8_shift_right_logical_by_int8_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   external select : bool -> t -> t -> t = "" "caml_csel_int8_untagged"
@@ -1121,6 +1137,54 @@ module Builtins = struct
     (nativeint[@unboxed]) -> (int[@untagged])
     = "" "caml_nativeint_popcnt_unboxed_to_untagged"
     [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (* Shift left *)
+  external int64_shl :
+    (int64[@unboxed]) -> (int64[@unboxed]) -> (int64[@unboxed])
+    = "" "caml_int64_shift_left_by_int64_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external int32_shl :
+    (int32[@unboxed]) -> (int32[@unboxed]) -> (int32[@unboxed])
+    = "" "caml_int32_shift_left_by_int32_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external nativeint_shl :
+    (nativeint[@unboxed]) -> (nativeint[@unboxed]) -> (nativeint[@unboxed])
+    = "" "caml_nativeint_shift_left_by_nativeint_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (* Shift right arithmetic *)
+  external int64_sar :
+    (int64[@unboxed]) -> (int64[@unboxed]) -> (int64[@unboxed])
+    = "" "caml_int64_shift_right_by_int64_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external int32_sar :
+    (int32[@unboxed]) -> (int32[@unboxed]) -> (int32[@unboxed])
+    = "" "caml_int32_shift_right_by_int32_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external nativeint_sar :
+    (nativeint[@unboxed]) -> (nativeint[@unboxed]) -> (nativeint[@unboxed])
+    = "" "caml_nativeint_shift_right_by_nativeint_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (* Shift right logical *)
+  external int64_shr :
+    (int64[@unboxed]) -> (int64[@unboxed]) -> (int64[@unboxed])
+    = "" "caml_int64_shift_right_logical_by_int64_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external int32_shr :
+    (int32[@unboxed]) -> (int32[@unboxed]) -> (int32[@unboxed])
+    = "" "caml_int32_shift_right_logical_by_int32_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external nativeint_shr :
+    (nativeint[@unboxed]) -> (nativeint[@unboxed]) -> (nativeint[@unboxed])
+    = "" "caml_nativeint_shift_right_logical_by_nativeint_unboxed"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
   (* High multiply *)
 


### PR DESCRIPTION
Comments on the codegen are covered by other tests:
* The extra `movq %rbx, %rcx` is addressed in `nativeint_u.ml`
* Removing sign-extensions and using smaller register classes is addressed at the top of `int16_u.ml`