### PR TITLE
Make large_functor_size effectively ignored by default

### DIFF
--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -400,7 +400,9 @@ module Flambda2 = struct
         small_function_size = 10;
         large_function_size = 10;
         small_functor_size = 10;
-        large_functor_size = 20;
+        (* CR mshinwell: lower to: large_functor_size = 20, once we're happy
+           inlining behaviour is ok *)
+        large_functor_size = 2000000;
         threshold = 10.;
       }
 

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
@@ -13,7 +13,7 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=[] : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=(:: ({ key = "key1"; value = 100 }, [])) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=(:: ({ key = "key2"; value = 200 }, (:: ({ key = "key1"; value = 100 }, [])))) : StringStore.t @ value)
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_set_operations(set={ root = (Node { value = 30; left = (Node { value = 20; left = (Node { value = 10; left = Empty; right = Empty; height = 1 }); right = Empty; height = 2 }); right = Empty; height = 3 }); count = 3 } : IntSet.t @ value)
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_set_operations [inlined] Test_simple_functor_dwarf.MakeSet.mem
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_store_operations(store=(:: ({ key = 2; value = 200 }, (:: ({ key = 1; value = 100 }, [])))) : IntStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 42; computed = 6.28; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 0; computed = 3.14; status = `Success } : IntCompute.result @ value)


### PR DESCRIPTION
#5878 added a new upper limit for functor inlining, but actually I'd like to effectively disable this by default, so we can roll this out using a command-line flag (`-flambda2-inline-large-functor-size`).