### PR TITLE
[5.4] Fix error location after merge

### DIFF
--- a/testsuite/tests/packs/inconsistent/main.compilers.reference
+++ b/testsuite/tests/packs/inconsistent/main.compilers.reference
@@ -1,3 +1,5 @@
-File "main.ml", line 1:
+File "main.ml", line 28, characters 11-30:
+28 | module _ = Use_member_directly
+                ^^^^^^^^^^^^^^^^^^^
 Error: The file subdir/use_member_directly.cmi
        is imported both as Pack.Member and as Member.

--- a/testsuite/tests/packs/inconsistent/main.compilers.reference
+++ b/testsuite/tests/packs/inconsistent/main.compilers.reference
@@ -1,5 +1,3 @@
-File "main.ml", line 28, characters 11-30:
-28 | module _ = Use_member_directly
-                ^^^^^^^^^^^^^^^^^^^
+File "main.ml", line 1:
 Error: The file subdir/use_member_directly.cmi
        is imported both as Pack.Member and as Member.

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -5235,7 +5235,7 @@ let report_lookup_error_doc loc env = function
         "The type %a has no unboxed version."
         quoted_longident lid
   | Error_from_persistent_env err ->
-      Location.error_of_printer_file Persistent_env.report_error_doc err
+      Location.error_of_printer ~loc Persistent_env.report_error_doc err
   | Mutable_value_used_in_closure ctx ->
       Location.errorf ~loc
         "Mutable variable cannot be used inside %t."


### PR DESCRIPTION
Upstream ocaml/ocaml#13838 removed a wrapper around env errors that we were relying on to get a good location for the `Error_from_persistent_env` case, and in the merge we were lazy and used the whole file as the location rather than the correct one. Happily the correct one is directly available.

Two commits: the first promotes the bad output, and the second repairs it.