### PR TITLE
[5.4] Promote benign changes in typing tests

### DIFF
--- a/testsuite/tests/tool-toplevel/unboxed_data.compilers.reference
+++ b/testsuite/tests/tool-toplevel/unboxed_data.compilers.reference
@@ -6,10 +6,10 @@ val e : nativeint# = <abstr>
 type t = #{ x : int; y : int64#; }
 val a : #(int * int) = <abstr>
 val b : #(float# * int64#) = <abstr>
-val c : string ref# = #{contents = "foo"}
+val c : string ref# = #{Stdlib.contents = "foo"}
 val d : t = <abstr>
 val a : #(int * int) array = <abstr array>
-val b : int ref# array = [|#{contents = 1}; #{contents = 2}|]
+val b : int ref# array = [|#{Stdlib.contents = 1}; #{Stdlib.contents = 2}|]
 val c : t array = <abstr array>
 val x : int64# = <abstr>
 val y : int = 42

--- a/testsuite/tests/tool-toplevel/unboxed_data.compilers.reference
+++ b/testsuite/tests/tool-toplevel/unboxed_data.compilers.reference
@@ -6,10 +6,10 @@ val e : nativeint# = <abstr>
 type t = #{ x : int; y : int64#; }
 val a : #(int * int) = <abstr>
 val b : #(float# * int64#) = <abstr>
-val c : string ref# = #{Stdlib.contents = "foo"}
+val c : string ref# = #{contents = "foo"}
 val d : t = <abstr>
 val a : #(int * int) array = <abstr array>
-val b : int ref# array = [|#{Stdlib.contents = 1}; #{Stdlib.contents = 2}|]
+val b : int ref# array = [|#{contents = 1}; #{contents = 2}|]
 val c : t array = <abstr array>
 val x : int64# = <abstr>
 val y : int = 42

--- a/testsuite/tests/typing-jkind-bounds/error_env.ml
+++ b/testsuite/tests/typing-jkind-bounds/error_env.ml
@@ -105,11 +105,11 @@ val id : 'a -> 'a = <fun>
 Line 5, characters 19-30:
 5 |   require_portable (id (a, b))
                        ^^^^^^^^^^^
-Error: This expression has type "'a t_no_bound * 'b t_with_bound"
-       but an expression was expected of type "('c : value mod portable)"
-       The kind of 'a t_no_bound * 'b t_with_bound is immutable_data with 'a
+Error: This expression has type "unit * 'a t_with_bound"
+       but an expression was expected of type "('b : value mod portable)"
+       The kind of unit * 'a t_with_bound is immutable_data with 'a
          because it's a tuple type.
-       But the kind of 'a t_no_bound * 'b t_with_bound must be a subkind of
+       But the kind of unit * 'a t_with_bound must be a subkind of
            value mod portable
          because of the definition of require_portable at line 1, characters 21-56.
 |}, Principal{|

--- a/testsuite/tests/typing-layouts-iarrays/basics.ml
+++ b/testsuite/tests/typing-layouts-iarrays/basics.ml
@@ -89,13 +89,12 @@ Line 1, characters 28-34:
 Error: Unbound value "(.:())"
 |}];;
 
+(****************************************************)
+(* Test 3.5: operations in the Iarray module work *)
+
 let f (x : float# iarray) = Iarray.length x
 [%%expect{|
-Line 1, characters 28-41:
-1 | let f (x : float# iarray) = Iarray.length x
-                                ^^^^^^^^^^^^^
-Error: Unbound module "Iarray"
-Hint: Did you mean "Array"?
+val f : float# iarray -> int = <fun>
 |}];;
 
 (*****************************************************************

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -28,9 +28,9 @@ Line 1, characters 0-26:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'a t/2"
+         type "'a t"
        but it is used as
-         "'a t/2 t/2".
+         "'a t t".
        All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
@@ -186,9 +186,9 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t/2 t/2"
+         type "('b * 'b) t t"
        but it is used as
-         "('b * 'b) t/2".
+         "('b * 'b) t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -217,9 +217,9 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t/2 t/2"
+         type "'b t t"
        but it is used as
-         "'b t/2".
+         "'b t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -239,9 +239,9 @@ Line 1, characters 19-54:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t/3 t/3"
+         type "'b t t"
        but it is used as
-         "'b t/3".
+         "'b t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 module rec M : sig type 'a t = 'b constraint 'a = ('b * 'b) t end = M;;
@@ -251,9 +251,9 @@ Line 1, characters 19-61:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t/4 t/4"
+         type "('b * 'b) t t"
        but it is used as
-         "('b * 'b) t/4".
+         "('b * 'b) t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -28,9 +28,9 @@ Line 1, characters 0-26:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'a t"
+         type "'a t/2"
        but it is used as
-         "'a t t".
+         "'a t/2 t/2".
        All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
@@ -186,15 +186,19 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t t"
+         type "('b * 'b) t/2 t/2"
        but it is used as
-         "('b * 'b) t".
+         "('b * 'b) t/2".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
 type 'a t = 'a * 'b constraint _ * 'a = 'b t;;
 [%%expect{|
-type 'b t = 'b * 'b
+Line 1, characters 0-44:
+1 | type 'a t = 'a * 'b constraint _ * 'a = 'b t;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A type variable is unbound in this type declaration.
+       In type "'a * 'b" the variable "'b" is unbound
 |}]
 type 'a t = 'a * 'b constraint 'a = 'b t;;
 [%%expect{|
@@ -213,9 +217,9 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t t"
+         type "'b t/2 t/2"
        but it is used as
-         "'b t".
+         "'b t/2".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -235,9 +239,9 @@ Line 1, characters 19-54:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t t"
+         type "'b t/3 t/3"
        but it is used as
-         "'b t".
+         "'b t/3".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 module rec M : sig type 'a t = 'b constraint 'a = ('b * 'b) t end = M;;
@@ -247,9 +251,9 @@ Line 1, characters 19-61:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t t"
+         type "('b * 'b) t/4 t/4"
        but it is used as
-         "('b * 'b) t".
+         "('b * 'b) t/4".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -408,8 +412,12 @@ and 'a id = 'a
 and s = cycle t
 [%%expect{|
 type 'a t constraint 'a = 'b * 'c
-Uncaught exception: Stack overflow
-
+Line 2, characters 0-21:
+2 | type cycle = cycle id
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation "cycle" is cyclic:
+         "cycle" = "cycle id",
+         "cycle id" = "cycle"
 |}]
 
 (* Vanishing constraints should be checked during the translation *)

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -17,11 +17,11 @@ Error: Unbound constructor "A"
 let rec f () = g 42
 and g (x : string) = f ()
 [%%expect{|
-Line 1, characters 17-19:
-1 | let rec f () = g 42
-                     ^^
-Error: The constant "42" has type "int" but an expression was expected of type
-         "string"
+Line 2, characters 6-18:
+2 | and g (x : string) = f ()
+          ^^^^^^^^^^^^
+Error: This pattern matches values of type "string"
+       but a pattern was expected which matches values of type "int"
 |}]
 
 let rec opt_error ?(opt : string) () = f ?opt ()

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -801,6 +801,9 @@ Line 1, characters 26-57:
 1 | let f (x : (module S')) = (x : (module S') :> (module S))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "(module S')" is not a subtype of "(module S)"
+       Modules do not match: S' is not included in S
+       Modalities on foo do not match:
+       The second is global and the first is not.
 |}]
 
 (* module equality/substitution inclusion check doesn't look at modes of modules

--- a/testsuite/tests/typing-modules/abbreviate_in_error_messages.ml
+++ b/testsuite/tests/typing-modules/abbreviate_in_error_messages.ml
@@ -50,11 +50,9 @@ Error: Modules do not match: functor () -> S1 is not included in
          module M6 : sig ... end
          module M7 : sig ... end
        end
-     Modules do not match:
-       functor () -> ...
-     is not included in
-       functor  -> ...
-       An extra argument is provided of module type ()
+     This module should not be a functor, a structure was expected.
+     Moreover, the type of the functor body is incompatible with the expected
+     module type.
 |}]
 
 module Depth = struct

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -91,7 +91,7 @@ Error: This application of the functor "F" is ill-typed.
          (X : x) (Y : y) -> ...
        1. Module X matches the expected module type x
        2. Modules do not match:
-            W : sig type w = W.w end
+            W : w
           is not included in
             y
           The type "y" is required but not provided
@@ -586,7 +586,7 @@ module F : functor (X : a) -> sig type t end
 Line 6, characters 13-17:
 6 |     type t = F(X).t
                  ^^^^
-Error: Modules do not match: a is not included in a/2
+Error: Modules do not match: (a/1 with P.X) is not included in a/2
 Line 3, characters 2-15:
   Definition of module type "a/1"
 Line 1, characters 0-13:
@@ -961,18 +961,7 @@ Error: Signature mismatch:
          sig
            module B :
              sig
-               module C :
-                 sig
-                   module D :
-                     sig
-                       module E :
-                         sig
-                           module F :
-                             (X : sig type x end) (Y : sig type y' end)
-                             (W : sig type w end) -> sig end
-                         end
-                     end
-                 end
+               module C : sig module D : sig module E : sig ... end end end
              end
          end
        is not included in
@@ -1268,12 +1257,15 @@ end
 
 module U = F(PF)(PF)(PF)
 [%%expect {|
-module F : (X : sig type witness module type t module M : t end) -> X.t
+module F :
+  functor (X : sig type witness module type t module M : t end) ->
+    (X.t with X.M)
 module PF :
   sig
     type witness
     module type t =
-      (X : sig type witness module type t module M : t end) -> X.t
+      functor (X : sig type witness module type t module M : t end) ->
+        (X.t with X.M)
     module M = F
   end
 module U :
@@ -1297,7 +1289,9 @@ Error: This application of the functor "F" is ill-typed.
        4. Module PF matches the expected module type
        5. Module PF matches the expected module type
        6. Modules do not match:
-            F : (X : sig type witness module type t module M : t end) -> X.t
+            F :
+            functor (X : sig type witness module type t module M : t end) ->
+              (X.t with X.M)
           is not included in
             $T6 = sig type witness module type t module M : t end
           This module should not be a functor, a structure was expected.
@@ -1495,6 +1489,8 @@ Error: Signature mismatch:
        2. Module types $S2 and $T2 match
        3. Module types X/3.T and X/2.T match
        4. Module types X/3.T and X/2.T match
+Line 1, characters 0-34:
+  Definition of module "X/1"
 |}]
 
 
@@ -1531,8 +1527,8 @@ Error: Signature mismatch:
          sig
            module F :
              sig type wrong end ->
-               (X : sig module type T end) (Res : X.T) (Res : X.T)
-               (Res : X.T) -> X.T
+               functor (X : sig module type T end) (Res : X.T) (Res : X.T)
+                 (Res : X.T) -> (X.T with Res)
          end
        is not included in
          sig
@@ -1568,6 +1564,8 @@ Error: Signature mismatch:
        3. Module types X/2.T and X/2.T match
        4. Module types X/2.T and X/2.T match
        5. An extra argument is provided of module type X/2.T
+Line 1, characters 0-34:
+  Definition of module "X/1"
 |}]
 
 
@@ -1616,10 +1614,8 @@ Error: This application of the functor "F" is ill-typed.
           Constructors have different names, "Y" and "Z".
        4. The following extra argument is provided
               Z : sig type t = Z.t = Z of int end
-File "_none_", line 1:
-  Definition of module "Y"
-Line 6, characters 0-39:
-  Definition of module "Y/2"
+Line 5, characters 0-32:
+  Definition of module "X/1"
 |}]
 
 (** Final state in the presence of extensions
@@ -1658,7 +1654,7 @@ module type Ext = sig module type T module X : T end
 module AExt : sig module type T = A module X = A end
 module FiveArgsExt :
   sig module type T = ty -> ty -> ty -> ty -> ty -> sig end module X : T end
-module Bar : (W : A) (X : Ext) (Y : B) (Z : Ext) -> Z.T
+module Bar : functor (W : A) (X : Ext) (Y : B) (Z : Ext) -> (Z.T with Z.X)
 type fine = Bar(A)(FiveArgsExt)(B)(AExt).a
 |}]
 
@@ -1875,12 +1871,12 @@ Error: This application of the functor "F" is ill-typed.
           is not included in
             type 'a t
           They have different arities.
-          Lines 9-12, characters 0-3:
-            Definition of module "A/1"
        2. Modules do not match:
             $S2 : sig val f : 'a -> 'a end
           is not included in
             $T2 = sig type 'a t val f : 'a A/2.t -> 'a t end
+Lines 9-12, characters 0-3:
+  Definition of module "A/1"
 |}]
 
 
@@ -1971,6 +1967,8 @@ Error: This application of the functor "With_expansion" is ill-typed.
               $T2 = sig module type t = A/2.t end
        3. Module () matches the expected module type
        4. Module () matches the expected module type
+Lines 9-12, characters 0-3:
+  Definition of module "A/1"
 |}]
 
 
@@ -2023,8 +2021,6 @@ Error: This application of the functor "H" is ill-typed.
             $T1 = sig type 'a t type 'a s end
           Type declarations do not match: type t is not included in type 'a t
           They have different arities.
-          Line 5, characters 0-32:
-            Definition of module "X/1"
        2. Modules do not match:
             $S2 : sig val f : 'a -> 'a end
           is not included in
@@ -2036,6 +2032,8 @@ Error: This application of the functor "H" is ill-typed.
           The type "'a X.s -> 'a X.s" is not compatible with the type
             "'a X.s -> 'a"
           Type "'a X.s" is not compatible with type "'a"
+Line 5, characters 0-32:
+  Definition of module "X/1"
 |}]
 
 
@@ -2120,14 +2118,16 @@ Error: The functor application "Set.Make(Set)(A)" is ill-typed.
               module type OrderedType = Set.OrderedType
               module type S = Set.S
               module Make = Set.Make
+              module MakePortable = Set.MakePortable
             end
           is not included in
             Set.OrderedType
           The type "t" is required but not provided
-          File "set.mli", line 52, characters 4-10: Expected declaration
+          File "set.mli", line 57, characters 4-10: Expected declaration
           The value "compare" is required but not provided
-          File "set.mli", line 55, characters 4-31: Expected declaration
-       2. The following extra argument is provided A : sig type a = A.a end
+          File "set.mli", line 60, characters 4-31: Expected declaration
+       2. The following extra argument is provided
+              A : sig module type S = A.S module M = A.M end
 |}]
 
 
@@ -2209,11 +2209,14 @@ Line 1, characters 49-72:
                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig module F : a end
+         sig module F : (a with X) end
        is not included in
          sig module F : empty -> empty end
        In module "F":
-       Modules do not match: a is not included in empty -> empty
+       Modules do not match:
+         ((a with X) with F)
+       is not included in
+         empty -> empty
 |}]
 
 (** Incorrect hint: the compatibility check consider that [X.T] can not be equal
@@ -2276,6 +2279,10 @@ Error: Signature mismatch:
          $T1 = sig val f : t/2 val g : Inner/2.t val h : float end
        Values do not match: val h : float is not included in val h : int
        The type "float" is not compatible with the type "int"
+Line 8, characters 2-8:
+  Definition of type "t/1"
+Line 9, characters 2-33:
+  Definition of module "Inner/1"
 |}]
 
 module M: sig

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -502,23 +502,8 @@ Error: Signature mismatch:
                    module B :
                      sig
                        module C :
-                         (X : sig end) (Y : sig end)
-                         (Z : sig
-                                module D :
-                                  sig
-                                    module E :
-                                      sig
-                                        module F :
-                                          (X : sig end)
-                                          (Arg : sig
-                                                   val two : int
-                                                   val one : int
-                                                 end)
-                                            -> sig end
-                                      end
-                                  end
-                              end)
-                           -> sig end
+                         functor (X : sig end) (Y : sig end)
+                           (Z : sig ... end) -> sig end
                      end
                  end
              end
@@ -532,23 +517,8 @@ Error: Signature mismatch:
                    module B :
                      sig
                        module C :
-                         (X : sig end) (Y : sig end)
-                         (Z : sig
-                                module D :
-                                  sig
-                                    module E :
-                                      sig
-                                        module F :
-                                          (X : sig end)
-                                          (Arg : sig
-                                                   val one : int
-                                                   val two : int
-                                                 end)
-                                            -> sig end
-                                      end
-                                  end
-                              end)
-                           -> sig end
+                         functor (X : sig end) (Y : sig end)
+                           (Z : sig ... end) -> sig end
                      end
                  end
              end
@@ -561,23 +531,8 @@ Error: Signature mismatch:
                  module B :
                    sig
                      module C :
-                       (X : sig end) (Y : sig end)
-                       (Z : sig
-                              module D :
-                                sig
-                                  module E :
-                                    sig
-                                      module F :
-                                        (X : sig end)
-                                        (Arg : sig
-                                                 val two : int
-                                                 val one : int
-                                               end)
-                                          -> sig end
-                                    end
-                                end
-                            end)
-                         -> sig end
+                       functor (X : sig end) (Y : sig end)
+                         (Z : sig module D : sig ... end end) -> sig end
                    end
                end
            end
@@ -589,23 +544,8 @@ Error: Signature mismatch:
                  module B :
                    sig
                      module C :
-                       (X : sig end) (Y : sig end)
-                       (Z : sig
-                              module D :
-                                sig
-                                  module E :
-                                    sig
-                                      module F :
-                                        (X : sig end)
-                                        (Arg : sig
-                                                 val one : int
-                                                 val two : int
-                                               end)
-                                          -> sig end
-                                    end
-                                end
-                            end)
-                         -> sig end
+                       functor (X : sig end) (Y : sig end)
+                         (Z : sig module D : sig ... end end) -> sig end
                    end
                end
            end

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -731,9 +731,9 @@ Error: Multiple definition of the type name "t".
 
 fun x -> (x :> < m : 'a -> 'a > as 'a);;
 [%%expect{|
-- : < m : (< m : 'a > as 'b) -> 'b as 'a; .. > -> 'b = <fun>
+- : < m : (< m : 'a -> 'a > as 'a) -> 'a; .. > -> 'a = <fun>
 |}, Principal{|
-- : < m : < m : 'a > -> < m : 'a > as 'a; .. > -> (< m : 'b -> 'b > as 'b) =
+- : < m : (< m : 'a -> 'a > as 'a) -> 'a; .. > -> (< m : 'b -> 'b > as 'b) =
 <fun>
 |}];;
 

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -305,6 +305,17 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
            ~loc:Location.none Env.Construct)
         Data_types.lbl_res_type_path
 
+    and tree_of_unboxed_product_label =
+      let lbl_res_type_path lbl =
+        match Types.get_desc lbl.Data_types.lbl_res with
+        | Tconstr (p, _, _) -> p
+        | _ -> assert false
+      in
+      tree_of_qualified
+        (Env.lookup_all_labels ~use:false ~record_form:Unboxed_product
+           ~loc:Location.none Env.Construct)
+        lbl_res_type_path
+
     (* An abstract type *)
 
     let abstract_type =
@@ -746,7 +757,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               (* PR#5722: print full module path only
                  for first record field *)
               let lid =
-                if first then tree_of_label env path name
+                if first then tree_of_unboxed_product_label env path name
                 else tree_of_name name
               and v =
                 match print_sort ld_sort with

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -306,15 +306,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
         Data_types.lbl_res_type_path
 
     and tree_of_unboxed_product_label =
-      let lbl_res_type_path lbl =
-        match Types.get_desc lbl.Data_types.lbl_res with
-        | Tconstr (p, _, _) -> p
-        | _ -> assert false
-      in
       tree_of_qualified
         (Env.lookup_all_labels ~use:false ~record_form:Unboxed_product
            ~loc:Location.none Env.Construct)
-        lbl_res_type_path
+        Data_types.gen_lbl_res_type_path
 
     (* An abstract type *)
 

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -92,7 +92,9 @@ let record_form_to_string (type rep) (record_form : rep record_form) =
   | Legacy -> "record"
   | Unboxed_product -> "unboxed record"
 
-let lbl_res_type_path lbl =
+let gen_lbl_res_type_path lbl =
   match get_desc lbl.lbl_res with
   | Tconstr (p, _, _) -> p
   | _ -> assert false
+
+let lbl_res_type_path lbl = gen_lbl_res_type_path lbl

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -93,3 +93,4 @@ val record_form_to_string : _ record_form -> string
 
 (* Type constructor of the label record type. *)
 val lbl_res_type_path : label_description -> Path.t
+val gen_lbl_res_type_path : _ gen_label_description -> Path.t

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4717,6 +4717,7 @@ let report_error ~loc = function
       let reaching_path = Reaching_path.simplify reaching_path in
       Out_type.prepare_for_printing [used_as; defined_as];
       Reaching_path.add_to_preparation reaching_path;
+      Out_type.Ident_names.reset ();
       Location.errorf ~loc
         "This recursive type is not regular.@ \
          @[<v>The type constructor %a is defined as@;<1 2>type %a@ \


### PR DESCRIPTION
Commit-by-commit:

- [`c0a4e1a2f9`](https://github.com/oxcaml/oxcaml/commit/c0a4e1a2f9) — **`typing-jkind-bounds/error_env.ml`**: normalize `'a t_no_bound` to `unit` 
- [`2fada03a0c`](https://github.com/oxcaml/oxcaml/commit/2fada03a0c) — **`typing-misc/let_rec_approx.ml`**: OxCaml has a different error message
- [`27c85a6c89`](https://github.com/oxcaml/oxcaml/commit/27c85a6c89) — **`typing-modes/val_modalities.ml`**: upstream 5.4 improved module errors
- [`c610615a52`](https://github.com/oxcaml/oxcaml/commit/c610615a52) — **`typing-modules/abbreviate_in_error_messages.ml`**: upstream 5.4 improved module errors
- [`6d6a42bf94`](https://github.com/oxcaml/oxcaml/commit/6d6a42bf94) — **`typing-modules/functors.ml`**: upstream 5.4 improved module errors, oxcaml adds module strengthening printing to new tests
- [`1813c98031`](https://github.com/oxcaml/oxcaml/commit/1813c98031) — **`typing-objects/Tests.ml`**: OxCaml has different printing for recursive objects
