### PR TITLE
[5.4] Another `typedecl.ml` printing fix

### DIFF
--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -28,9 +28,9 @@ Line 1, characters 0-26:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'a t/2"
+         type "'a t"
        but it is used as
-         "'a t/2 t/2".
+         "'a t t".
        All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
@@ -186,9 +186,9 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t/2 t/2"
+         type "('b * 'b) t t"
        but it is used as
-         "('b * 'b) t/2".
+         "('b * 'b) t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -217,9 +217,9 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t/2 t/2"
+         type "'b t t"
        but it is used as
-         "'b t/2".
+         "'b t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -239,9 +239,9 @@ Line 1, characters 19-54:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t/3 t/3"
+         type "'b t t"
        but it is used as
-         "'b t/3".
+         "'b t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 module rec M : sig type 'a t = 'b constraint 'a = ('b * 'b) t end = M;;
@@ -251,9 +251,9 @@ Line 1, characters 19-61:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t/4 t/4"
+         type "('b * 'b) t t"
        but it is used as
-         "('b * 'b) t/4".
+         "('b * 'b) t".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -28,9 +28,9 @@ Line 1, characters 0-26:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'a t"
+         type "'a t/2"
        but it is used as
-         "'a t t".
+         "'a t/2 t/2".
        All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
@@ -186,15 +186,19 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t t"
+         type "('b * 'b) t/2 t/2"
        but it is used as
-         "('b * 'b) t".
+         "('b * 'b) t/2".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
 type 'a t = 'a * 'b constraint _ * 'a = 'b t;;
 [%%expect{|
-type 'b t = 'b * 'b
+Line 1, characters 0-44:
+1 | type 'a t = 'a * 'b constraint _ * 'a = 'b t;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A type variable is unbound in this type declaration.
+       In type "'a * 'b" the variable "'b" is unbound
 |}]
 type 'a t = 'a * 'b constraint 'a = 'b t;;
 [%%expect{|
@@ -213,9 +217,9 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t t"
+         type "'b t/2 t/2"
        but it is used as
-         "'b t".
+         "'b t/2".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -235,9 +239,9 @@ Line 1, characters 19-54:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "'b t t"
+         type "'b t/3 t/3"
        but it is used as
-         "'b t".
+         "'b t/3".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 module rec M : sig type 'a t = 'b constraint 'a = ('b * 'b) t end = M;;
@@ -247,9 +251,9 @@ Line 1, characters 19-61:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor "t" is defined as
-         type "('b * 'b) t t"
+         type "('b * 'b) t/4 t/4"
        but it is used as
-         "('b * 'b) t".
+         "('b * 'b) t/4".
        All uses need to match the definition for the recursive type to be regular.
 |}]
 
@@ -408,8 +412,12 @@ and 'a id = 'a
 and s = cycle t
 [%%expect{|
 type 'a t constraint 'a = 'b * 'c
-Uncaught exception: Stack overflow
-
+Line 2, characters 0-21:
+2 | type cycle = cycle id
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation "cycle" is cyclic:
+         "cycle" = "cycle id",
+         "cycle id" = "cycle"
 |}]
 
 (* Vanishing constraints should be checked during the translation *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4717,6 +4717,7 @@ let report_error ~loc = function
       let reaching_path = Reaching_path.simplify reaching_path in
       Out_type.prepare_for_printing [used_as; defined_as];
       Reaching_path.add_to_preparation reaching_path;
+      Out_type.Ident_names.reset ();
       Location.errorf ~loc
         "This recursive type is not regular.@ \
          @[<v>The type constructor %a is defined as@;<1 2>type %a@ \


### PR DESCRIPTION
Like in https://github.com/oxcaml/oxcaml/pull/5918, call `Out_type.Ident_names.reset` when needed.

Also, promote two fixes to an unbound variable bug and a stack overflow in the compiler.