### PR TITLE
[5.4] fix recmod consistency check

### DIFF
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -143,6 +143,7 @@ let rec apply_coercion loc strict restr arg =
       let lam = transl_module_path loc env path in
       name_lambda strict arg Lambda.layout_module
         (fun _ -> apply_coercion loc Alias cc lam)
+  | Tcoerce_invalid -> Misc.fatal_error "Translmod: invalid coercion"
 
 and apply_coercion_field loc get_field (pos, cc) =
   apply_coercion loc Alias cc (get_field pos)
@@ -1074,7 +1075,8 @@ let module_block_size component_names coercion =
   | Tcoerce_structure { pos_cc_list; _ } -> List.length pos_cc_list
   | Tcoerce_functor _
   | Tcoerce_primitive _
-  | Tcoerce_alias _ -> assert false
+  | Tcoerce_alias _
+  | Tcoerce_invalid -> assert false
 
 let transl_implementation compilation_unit impl ~loc =
   reset_labels ();

--- a/testsuite/tests/typing-modules/recursive_coercion.ml
+++ b/testsuite/tests/typing-modules/recursive_coercion.ml
@@ -23,28 +23,10 @@ end = struct
 end
 
 [%%expect{|
-Line 1:
-Error: Modules do not match:
-         sig
-           type 'a repr
-           type ('a, 'permission) t = 'a repr
-           external to_repr : 'a repr -> 'a repr = "%identity"
-         end
-       is not included in
-         sig
-           type 'a repr
-           type ('a, 'permission) t
-           external to_repr : ('a, 'b) t -> 'a repr = "%identity"
-         end
-       Values do not match:
-         external to_repr : 'a repr/1 -> 'a repr/1 = "%identity"
-       is not included in
-         external to_repr : ('a, 'b) t/2 -> 'a repr/2 = "%identity"
-       The type "'a repr/1 -> 'a repr/1" is not compatible with the type
-         "('b, 'c) t/2 -> 'b repr/2"
-       Type "'a repr/1" is not compatible with type "('b, 'c) t/2"
-       Line 7, characters 2-14:
-         Definition of type "repr/1"
-       Line 8, characters 2-36:
-         Definition of type "t/1"
+module rec Bvar :
+  sig
+    type 'a repr
+    type ('a, 'permission) t
+    external to_repr : ('a, 'b) t -> 'a repr = "%identity"
+  end
 |}]

--- a/testsuite/tests/typing-modules/recursive_coercion.ml
+++ b/testsuite/tests/typing-modules/recursive_coercion.ml
@@ -1,0 +1,50 @@
+(* TEST
+ expect;
+*)
+
+(* The inclusion check for [to_repr] below must happen in an environment
+   extended with the content of the module before its definition, so that we can
+   see the two types are equal. It's therefore important we _don't_ do that part
+   of the inclusion check when doing the simplified consistency check for
+   recursive modules that happens first, because it doesn't happen in an
+   extended environment. This test confirms that consistency check doesn't check
+   too much.
+*)
+module rec Bvar : sig
+  type 'a repr
+  type ('a, 'permission) t
+
+  external to_repr : ('a, _) t -> 'a repr = "%identity"
+end = struct
+  type 'a repr
+  type ('a, 'permission) t = 'a repr
+
+  external to_repr : 'a repr -> 'a repr = "%identity"
+end
+
+[%%expect{|
+Line 1:
+Error: Modules do not match:
+         sig
+           type 'a repr
+           type ('a, 'permission) t = 'a repr
+           external to_repr : 'a repr -> 'a repr = "%identity"
+         end
+       is not included in
+         sig
+           type 'a repr
+           type ('a, 'permission) t
+           external to_repr : ('a, 'b) t -> 'a repr = "%identity"
+         end
+       Values do not match:
+         external to_repr : 'a repr/1 -> 'a repr/1 = "%identity"
+       is not included in
+         external to_repr : ('a, 'b) t/2 -> 'a repr/2 = "%identity"
+       The type "'a repr/1 -> 'a repr/1" is not compatible with the type
+         "('b, 'c) t/2 -> 'b repr/2"
+       Type "'a repr/1" is not compatible with type "('b, 'c) t/2"
+       Line 7, characters 2-14:
+         Definition of type "repr/1"
+       Line 8, characters 2-36:
+         Definition of type "t/1"
+|}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -149,46 +149,20 @@ let primitive_descriptions pd1 pd2 =
    there is a context E such that [E |- vd1 <: vd2] for the ordinary subtyping.
    For values, this is the case as soon as the kind of [vd1] is a subkind of the
    [vd2] kind. *)
-let value_descriptions_consistency env vd1 vd2 =
+let value_descriptions_consistency _env vd1 vd2 =
   match (vd1.val_kind, vd2.val_kind) with
   | (Val_prim p1, Val_prim p2) -> begin
-      let locality = [ Mode.Locality.global; Mode.Locality.local ] in
-      let forkable = [ Mode.Forkable.forkable; Mode.Forkable.unforkable ] in
-      let yielding = [ Mode.Yielding.unyielding; Mode.Yielding.yielding ] in
-      List.iter (fun loc ->
-       List.iter (fun fork ->
-        List.iter (fun yield ->
-          let ty1, _, _, _ = Ctype.instance_prim env p1 vd1.val_type in
-          let ty2, mode_l2, mode_fy2, _ =
-            Ctype.instance_prim env p2 vd2.val_type
-          in
-          let mode_f2 = Option.map fst mode_fy2 in
-          let mode_y2 = Option.map snd mode_fy2 in
-          Option.iter (Mode.Locality.equate_exn loc) mode_l2;
-          Option.iter (Mode.Forkable.equate_exn fork) mode_f2;
-          Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
-          try
-            Ctype.moregeneral env true ty1 ty2
-          with Ctype.Moregen err ->
-            raise (Dont_match (Type err))
-        ) yielding
-       ) forkable
-      ) locality;
       match primitive_descriptions p1 p2 with
       | None -> Tcoerce_none
       | Some err -> raise (Dont_match (Primitive_mismatch err))
     end
-  | (Val_prim p, _) ->
-      let _ty, mode_l, _mode_fy, sort =
-        Ctype.instance_prim env p vd1.val_type
-      in
-      let pc =
-        { pc_desc = p; pc_type = vd2.Types.val_type;
-          pc_poly_mode = Option.map Mode.Locality.disallow_right mode_l;
-          pc_poly_sort = sort;
-          pc_env = env; pc_loc = vd1.Types.val_loc; }
-      in
-      Tcoerce_primitive pc
+  | (Val_prim _, _) ->
+      (* Here we can not compute a valid coercion, because it may depend on the
+         local environment of the module, which is not made available in the
+         consistency check. But the coercion computed by the [*_consistency]
+         functions is never used, so it's fine. We return [Tcoerce_invalid] so
+         that if someone ever started using this, they'd get a loud error. *)
+      Tcoerce_invalid
   | (_, Val_prim _) -> raise (Dont_match Not_a_primitive)
   | (_, _) -> Tcoerce_none
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -446,6 +446,8 @@ let rec print_coercion ppf c =
       pr "@[<2>alias %a@ (%a)@]"
         Printtyp.path p
         print_coercion c
+  | Tcoerce_invalid ->
+      pr "invalid_coercion"
 and print_coercion2 ppf (n, c) =
   Format.fprintf ppf "@[%d,@ %a@]" n print_coercion c
 and print_coercion3 ppf (i, n, c) =

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -127,6 +127,9 @@ module Runtime_coercion = struct
           (first_change_under (InBody::path)) res
     | Tcoerce_none -> None
     | Tcoerce_alias _ | Tcoerce_primitive _ -> None
+    | Tcoerce_invalid ->
+      Misc.fatal_error
+        "Includemod_errorprinter.first_change_under: invalid coercion"
 
   (* we search the first point which is not invariant at the current level *)
   and first_item_transposition path pos = function

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -638,6 +638,7 @@ let module_coercion sub = function
   | Tcoerce_primitive {pc_loc; pc_env; _} ->
       sub.location sub pc_loc;
       sub.env sub pc_env
+  | Tcoerce_invalid -> ()
 
 let module_expr sub {mod_loc; mod_desc; mod_mode; mod_env; mod_attributes; _} =
   sub.location sub mod_loc;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -871,6 +871,7 @@ let module_coercion sub = function
   | Tcoerce_primitive pc ->
       Tcoerce_primitive {pc with pc_loc = sub.location sub pc.pc_loc;
                                  pc_env = sub.env sub pc.pc_env}
+  | Tcoerce_invalid -> Tcoerce_invalid
 
 let module_expr sub x =
   let mod_loc = sub.location sub x.mod_loc in

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -645,6 +645,7 @@ and module_coercion =
   | Tcoerce_functor of module_coercion * module_coercion
   | Tcoerce_primitive of primitive_coercion
   | Tcoerce_alias of Env.t * Path.t * module_coercion
+  | Tcoerce_invalid
 
 and module_type =
   { mty_desc: module_type_desc;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -983,6 +983,9 @@ and module_coercion =
         struct module Sub = Some_alias end
       ]}
       Only occurs inside a [Tcoerce_structure] coercion. *)
+  | Tcoerce_invalid
+  (** This coercion is only constructed by the recursive module consistency
+      check, whose result is discarded. It's a bug if it shows up anywhere. *)
 
 and module_type =
   { mty_desc: module_type_desc;

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -360,6 +360,8 @@ let classify_expression : Typedtree.expression -> sd =
             Misc.fatal_error "letrec: primitive coercion on a module"
         | Tcoerce_alias _ ->
             Misc.fatal_error "letrec: alias coercion on a module"
+        | Tcoerce_invalid ->
+            Misc.fatal_error "letrec: invalid coercion on a module"
         end
     | Tmod_unpack (e, _) ->
         classify_expression env e
@@ -1221,6 +1223,8 @@ and modexp : Typedtree.module_expr -> term_judg =
           (* Alias coercions ignore their arguments, but they evaluate
              their alias module 'pth' under another coercion. *)
           coercion coe (fun m -> path pth << m)
+        | Tcoerce_invalid ->
+          Misc.fatal_error "Value_rec_check.modexp: invalid coercion"
       in
       coercion coe (fun m -> modexp mexp << m)
     | Tmod_unpack (e, _) ->


### PR DESCRIPTION
This fixes an issue in our merge related to upstream PR ocaml/ocaml#13055

That PR adds a new "consistency check" which runs before the main includemod check for inclusion of recursive modules. This consistency check is meant just to rule out a specific error related to the arity of type declarations. In our merge, we erroneously included most of the logic of includecore for value declarations in the consistency check.

The extra logic we included requires a valid environment extended with the contents of the module up to the point of the value declaration, but the simple consistency check does not run in an extended environment. This resulted in a fatal error on an example that is included here as a test. The obvious fix is to delete the extra logic from the consistency check, which isn't needed.

There is however an additional complication, which is that the consistency check piggybacks off the existing logic for module inclusion checking, and is therefore forced to return a module coercion. This module coercion is just thrown away, but the types force us to return _something_.

Our module coercions have more in them than upstream, and it's difficult/impossible to compute a valid one in the smaller environment that the consistency check runs in. Rather than returning garbage, we add a new `Tcoerce_invalid` constructor for this case, so that if someone _does_ try to use the coercion from the consistency check in the future, they'll get a loud error.

There are two commits here: the first adds a test case illustrating the problem with our merge, and the second fixes it.