### PR TITLE
[5.4] Fix SIMD/small-number types being accessible with the extension disabled

### DIFF
--- a/testsuite/tests/typing-simd/test_disabled.ml
+++ b/testsuite/tests/typing-simd/test_disabled.ml
@@ -9,7 +9,7 @@ Line 1, characters 9-16:
 1 | type t = int8x16;;
              ^^^^^^^
 Error: Unbound type constructor "int8x16"
-Hint: Did you mean "int16"?
+Hint:              Did you mean "int16"?
 |}];;
 
 type t = int16x8;;
@@ -18,7 +18,7 @@ Line 1, characters 9-16:
 1 | type t = int16x8;;
              ^^^^^^^
 Error: Unbound type constructor "int16x8"
-Hint: Did you mean "int16"?
+Hint:              Did you mean "int16"?
 |}];;
 
 type t = int32x4;;
@@ -27,7 +27,7 @@ Line 1, characters 9-16:
 1 | type t = int32x4;;
              ^^^^^^^
 Error: Unbound type constructor "int32x4"
-Hint: Did you mean "int32"?
+Hint:              Did you mean "int32"?
 |}];;
 
 type t = int64x2;;
@@ -36,7 +36,7 @@ Line 1, characters 9-16:
 1 | type t = int64x2;;
              ^^^^^^^
 Error: Unbound type constructor "int64x2"
-Hint: Did you mean "int64"?
+Hint:              Did you mean "int64"?
 |}];;
 
 type t = float32x4;;
@@ -45,7 +45,7 @@ Line 1, characters 9-18:
 1 | type t = float32x4;;
              ^^^^^^^^^
 Error: Unbound type constructor "float32x4"
-Hint: Did you mean "float32"?
+Hint:              Did you mean "float32"?
 |}];;
 
 type t = float64x2;;
@@ -54,5 +54,5 @@ Line 1, characters 9-18:
 1 | type t = float64x2;;
              ^^^^^^^^^
 Error: Unbound type constructor "float64x2"
-Hint: Did you mean "float32"?
+Hint:              Did you mean "float32"?
 |}];;

--- a/testsuite/tests/typing-simd/test_upstream_compatible.ml
+++ b/testsuite/tests/typing-simd/test_upstream_compatible.ml
@@ -17,7 +17,7 @@ Line 1, characters 9-16:
 1 | type t = int16x8;;
              ^^^^^^^
 Error: Unbound type constructor "int16x8"
-Hint: Did you mean "int64"?
+Hint:              Did you mean "int64"?
 |}];;
 
 type t = int32x4;;
@@ -26,7 +26,7 @@ Line 1, characters 9-16:
 1 | type t = int32x4;;
              ^^^^^^^
 Error: Unbound type constructor "int32x4"
-Hint: Did you mean "int32"?
+Hint:              Did you mean "int32"?
 |}];;
 
 type t = int64x2;;
@@ -35,7 +35,7 @@ Line 1, characters 9-16:
 1 | type t = int64x2;;
              ^^^^^^^
 Error: Unbound type constructor "int64x2"
-Hint: Did you mean "int64"?
+Hint:              Did you mean "int64"?
 |}];;
 
 type t = float32x4;;

--- a/testsuite/tests/typing-small-numbers/test_upstream_compatible.ml
+++ b/testsuite/tests/typing-small-numbers/test_upstream_compatible.ml
@@ -11,7 +11,7 @@ Line 1, characters 9-16:
 1 | type t = float32;;
              ^^^^^^^
 Error: Unbound type constructor "float32"
-Hint:              Did you mean "float", "float32x4" or "float32x8"?
+Hint:              Did you mean "float"?
 |}];;
 
 let _ = 1.0s;;
@@ -123,7 +123,7 @@ Line 1, characters 9-17:
 1 | type t = float32#;;
              ^^^^^^^^
 Error: Unbound type constructor "float32"
-Hint:              Did you mean "float", "float32x4" or "float32x8"?
+Hint:              Did you mean "float"?
 |}];;
 
 let () = ignore #1.0s;;
@@ -266,7 +266,7 @@ Line 1, characters 9-14:
 1 | type t = int16;;
              ^^^^^
 Error: Unbound type constructor "int16"
-Hint:              Did you mean "int", "int16x8", "int32", "int64" or "int8x16"?
+Hint:              Did you mean "int", "int32" or "int64"?
 |}];;
 
 type t = int16#;;
@@ -275,7 +275,7 @@ Line 1, characters 9-15:
 1 | type t = int16#;;
              ^^^^^^
 Error: Unbound type constructor "int16"
-Hint:              Did you mean "int", "int16x8", "int32", "int64" or "int8x16"?
+Hint:              Did you mean "int", "int32" or "int64"?
 |}];;
 
 let f () = #'a';;

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -95,7 +95,7 @@ type type_constr = [
   | data_type_constr
 ]
 
-let non_extension_type_constrs : type_constr list = [
+let base_type_constrs : type_constr list = [
   `Int;
   `Char;
   `String;
@@ -121,6 +121,9 @@ let non_extension_type_constrs : type_constr list = [
   `Code;
   `Idx_imm;
   `Idx_mut;
+]
+
+let or_null_extension_type_constrs : type_constr list = [
   `Or_null;
 ]
 
@@ -160,7 +163,9 @@ let small_number_extension_type_constrs : type_constr list = [
 ]
 
 let all_type_constrs = (
-  non_extension_type_constrs
+  base_type_constrs
+  @ or_null_extension_type_constrs
+  @ small_number_extension_type_constrs
   @ simd_stable_extension_type_constrs
   @ simd_beta_extension_type_constrs
   @ simd_alpha_extension_type_constrs
@@ -1021,7 +1026,7 @@ let build_initial_env add_type add_extension add_jkind empty_env =
   in
   List.fold_left (fun env tconstr ->
     add_type (ident_of_type_constr tconstr) (decl_of_type_constr tconstr) env
-  ) empty_env all_type_constrs
+  ) empty_env base_type_constrs
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[None, type_string; None, type_int; None, type_int]),
@@ -1050,8 +1055,9 @@ let build_initial_env add_type add_extension add_jkind empty_env =
   |> add_predef_jkinds add_jkind
 
 let add_or_null add_type env =
-  let tconstr = `Or_null in
-  add_type (ident_of_type_constr tconstr) (decl_of_type_constr tconstr) env
+  List.fold_left (fun env tconstr ->
+    add_type (ident_of_type_constr tconstr) (decl_of_type_constr tconstr) env
+  ) env or_null_extension_type_constrs
 
 let add_simd_stable_extension_types add_type env =
   List.fold_left (fun env tconstr ->
@@ -1060,7 +1066,10 @@ let add_simd_stable_extension_types add_type env =
 
 let add_simd_beta_extension_types _add_type env = env
 
-let add_simd_alpha_extension_types _add_type env = env
+let add_simd_alpha_extension_types add_type env =
+  List.fold_left (fun env tconstr ->
+    add_type (ident_of_type_constr tconstr) (decl_of_type_constr tconstr) env
+  ) env simd_alpha_extension_type_constrs
 
 let add_small_number_extension_types add_type env =
   List.fold_left (fun env tconstr ->


### PR DESCRIPTION
Title, we didn't get it right during the `predef.ml` merge.

Upstream also slightly changed printing in those tests.