### PR TITLE
[5.4] Mis-merge in bytecode Dynlink

### DIFF
--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -222,7 +222,8 @@ module Bytecode = struct
         let toc_pos = input_binary_int ic in  (* Go to table of contents *)
         seek_in ic toc_pos;
         let lib = (input_value ic : library) in
-        Dll.open_dlls Dll.For_execution lib.lib_dllibs;
+        Dll.open_dlls Dll.For_execution
+          (List.map Dll.extract_dll_name lib.lib_dllibs);
         handle, lib.lib_units
       end else begin
         raise (DT.Error (Not_a_bytecode_file file_name))


### PR DESCRIPTION
Mis-merge from 5.4, since we haven't merged #5420 (i.e. we've backed out ocaml/ocaml#11996 at the moment). The rest of the diff against 5.2.0minus-31 for otherlibs/dynlink/byte/dynlink.ml looks correct to me (ocaml/ocaml#13376)