### PR TITLE
[5.4] Accept promotions for typing-implicit-source-positions

### DIFF
--- a/testsuite/tests/typing-implicit-source-positions/let_operators.ml
+++ b/testsuite/tests/typing-implicit-source-positions/let_operators.ml
@@ -52,7 +52,7 @@ let _ =
 val ( >>| ) :
   call_pos:[%call_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b = <fun>
 - : lexing_position =
-{pos_fname = ""; pos_lnum = 3; pos_bol = 1140; pos_cnum = 1144}
+{pos_fname = ""; pos_lnum = 3; pos_bol = 1331; pos_cnum = 1335}
 |}]
 
 (* TEST

--- a/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -196,7 +196,7 @@ let a, b = fully_applied_class#a, fully_applied_class#b
 val a : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 val b : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 4512; pos_cnum = 4538}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 4516; pos_cnum = 4542}
 |}]
 
 class c :
@@ -217,7 +217,7 @@ let x, y = (new c ~y:pos_a ())#xy
 
 [%%expect{|
 val x : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 5199; pos_cnum = 5211}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 5203; pos_cnum = 5215}
 val y : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 |}]


### PR DESCRIPTION
Offsets shifted by message formatting in tests above - clear when diff'd against the 5.4 tag.

IIUC correctly expect tests shim around the line numbers to be display within the block itself, but we can't do that with `pos_bol` and `pos_cnum` because they're used for display and need to refer to the actual file.

It is possible we could harden these particular tests to display positions relative to each other, but it's probably not worth worrying about.