### PR TITLE
[5.4] Promote virtually all warnings tests

### DIFF
--- a/testsuite/tests/warnings/w47_inline.compilers.reference
+++ b/testsuite/tests/warnings/w47_inline.compilers.reference
@@ -12,25 +12,25 @@ File "w47_inline.ml", line 15, characters 23-29:
 15 | let d = (fun x -> x) [@inline malformed attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute inline.
-  It must be either 'never', 'always', 'hint' or empty
+  It must be either 'never', 'always', 'available' or empty
 
 File "w47_inline.ml", line 16, characters 23-29:
 16 | let e = (fun x -> x) [@inline malformed_attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute inline.
-  It must be either 'never', 'always', 'hint' or empty
+  It must be either 'never', 'always', 'available' or empty
 
 File "w47_inline.ml", line 17, characters 23-29:
 17 | let f = (fun x -> x) [@inline : malformed_attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute inline.
-  It must be either 'never', 'always', 'hint' or empty
+  It must be either 'never', 'always', 'available' or empty
 
 File "w47_inline.ml", line 18, characters 23-29:
 18 | let g = (fun x -> x) [@inline ? malformed_attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute inline.
-  It must be either 'never', 'always', 'hint' or empty
+  It must be either 'never', 'always', 'available' or empty
 
 File "w47_inline.ml", line 23, characters 15-22:
 23 | let k x = (a [@inlined malformed]) x (* rejected *)

--- a/testsuite/tests/warnings/w55.flambda.reference
+++ b/testsuite/tests/warnings/w55.flambda.reference
@@ -8,10 +8,6 @@ File "w55.ml", line 31, characters 10-27:
 31 | let i x = (!r [@inlined]) x
                ^^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline:
-  [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
-
-File "w55.ml", line 39, characters 12-30:
-39 | let b x y = (a [@inlined]) x y
-                 ^^^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline:
-  [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+  
+  the optimizer did not know what function was being applied
+  (the full inlining stack was: w55.ml:31,10--27)


### PR DESCRIPTION
Diff in the PR is ridiculous, but 

```
git diff 5.2.0minus-31 -- testsuite/tests/warnings/{w47_inline.compilers.reference,w53.compilers.reference,w55.flambda.reference}
```

will reveal that it's all message formatting (i.e. quotes and double-quotes)