### PR TITLE
Correctly replay inlining decisions when doing continuation specialization

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -746,6 +746,9 @@ let must_inline t = Replay_history.must_inline t.replay_history
 
 let replay_history t = t.replay_history
 
+let record_inlining_decision ~apply decision t =
+  { t with replay_history = Replay_history.record_inlining_decision ~apply decision t.replay_history; }
+
 let map_specialization_cost ~f t =
   let specialization_cost = f t.specialization_cost in
   { t with specialization_cost }

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -747,7 +747,10 @@ let must_inline t = Replay_history.must_inline t.replay_history
 let replay_history t = t.replay_history
 
 let record_inlining_decision ~apply decision t =
-  { t with replay_history = Replay_history.record_inlining_decision ~apply decision t.replay_history; }
+  { t with
+    replay_history =
+      Replay_history.record_inlining_decision ~apply decision t.replay_history
+  }
 
 let map_specialization_cost ~f t =
   let specialization_cost = f t.specialization_cost in

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -239,6 +239,8 @@ val replay_history : t -> Replay_history.t
 
 val with_replay_history : (Replay_history.t * bool) option -> t -> t
 
+val record_inlining_decision : apply:Apply_expr.t -> Call_site_inlining_decision_type.t -> t -> t
+
 val with_join_analysis :
   Apply_cont_rewrite_id.t Join_analysis.t option -> t -> t
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -239,7 +239,8 @@ val replay_history : t -> Replay_history.t
 
 val with_replay_history : (Replay_history.t * bool) option -> t -> t
 
-val record_inlining_decision : apply:Apply_expr.t -> Call_site_inlining_decision_type.t -> t -> t
+val record_inlining_decision :
+  apply:Apply_expr.t -> Call_site_inlining_decision_type.t -> t -> t
 
 val with_join_analysis :
   Apply_cont_rewrite_id.t Join_analysis.t option -> t -> t

--- a/middle_end/flambda2/simplify/env/replay_history.ml
+++ b/middle_end/flambda2/simplify/env/replay_history.ml
@@ -22,11 +22,20 @@ module Action = struct
   type t =
     | Bound_variable of Variable.t
     | Bound_continuations of Continuation.t list
+    | Inlining_decision of Call_site_inlining_decision_type.t * Apply_expr.t
+    (* the apply is here for debug pruposes *)
 
   let[@ocamlformat "disable"] print ppf = function
     | Bound_variable v -> Variable.print ppf v
     | Bound_continuations l ->
-        Format.pp_print_list ~pp_sep:Format.pp_print_space Continuation.print ppf l
+      Format.pp_print_list ~pp_sep:Format.pp_print_space Continuation.print ppf l
+    | Inlining_decision (decision, apply) ->
+      Format.fprintf ppf "@[<hov 1>(inlining_decision@ \
+        @[<hov 1>(decision@ %a)@]@ \
+        @[<hov 1>(apply@ %a)@]\
+        )@]"
+      Call_site_inlining_decision_type.print decision
+      Apply_expr.print apply
 end
 
 (* Type def *)
@@ -109,6 +118,9 @@ let error_not_renamed_version_of replay old_action new_action =
      action: %a@ new action: %a@ replay: %a"
     Action.print old_action Action.print new_action print replay
 
+let check_coherent_inlining_decisions _old_decision _new_decision =
+  ()
+
 let define_variable var replay =
   let action : Action.t = Bound_variable var in
   match replay with
@@ -126,7 +138,8 @@ let define_variable var replay =
       else
         let variables = Variable.Map.add var prev_var variables in
         Replaying { previous_history; variables; continuations; always_inline }
-    | Bound_continuations _ -> error_mismatched_action replay prev_bound action)
+    | Bound_continuations _
+    | Inlining_decision _ -> error_mismatched_action replay prev_bound action)
   | Replaying { previous_history = []; _ } -> error_empty_history replay action
 
 let define_continuations ~can_be_lifted conts replay =
@@ -158,7 +171,22 @@ let define_continuations ~can_be_lifted conts replay =
             continuations prev_conts conts
         in
         Replaying { previous_history; variables; continuations; always_inline }
-    | Bound_variable _ -> error_mismatched_action replay prev_bound action)
+    | Bound_variable _ | Inlining_decision _ -> error_mismatched_action replay prev_bound action)
+  | Replaying { previous_history = []; _ } -> error_empty_history replay action
+
+let record_inlining_decision ~apply decision replay =
+  let action : Action.t = Inlining_decision (decision, apply) in
+  match replay with
+  | First_pass { history } -> First_pass { history = action :: history }
+  | Replaying {
+      previous_history = prev_bound :: previous_history;
+      variables; continuations; always_inline;
+    } ->
+      (match prev_bound with
+       | Inlining_decision (prev_decision, _apply) ->
+           check_coherent_inlining_decisions prev_decision decision;
+           Replaying { previous_history; variables; continuations; always_inline; }
+       | Bound_variable _ | Bound_continuations _ -> error_mismatched_action replay prev_bound action)
   | Replaying { previous_history = []; _ } -> error_empty_history replay action
 
 (* Inspection API *)
@@ -184,4 +212,12 @@ let replay_continuation_mapping = function
   | Replaying
       { continuations; previous_history = _; variables = _; always_inline = _ }
     ->
-    Replayed continuations
+      Replayed continuations
+
+let replay_inlining_decision = function
+  | First_pass _ -> Still_recording
+  | Replaying { previous_history = Inlining_decision (decision, _apply) :: _; _ } ->
+      Replayed decision
+  | Replaying { previous_history = ([] | (Bound_variable _ | Bound_continuations _) :: _); _ } ->
+      Misc.fatal_errorf "Cannot replay: the last action was not an inlining decision"
+

--- a/middle_end/flambda2/simplify/env/replay_history.ml
+++ b/middle_end/flambda2/simplify/env/replay_history.ml
@@ -23,7 +23,7 @@ module Action = struct
     | Bound_variable of Variable.t
     | Bound_continuations of Continuation.t list
     | Inlining_decision of Call_site_inlining_decision_type.t * Apply_expr.t
-    (* the apply is here for debug pruposes *)
+  (* the apply is here for debug pruposes *)
 
   let[@ocamlformat "disable"] print ppf = function
     | Bound_variable v -> Variable.print ppf v
@@ -118,8 +118,7 @@ let error_not_renamed_version_of replay old_action new_action =
      action: %a@ new action: %a@ replay: %a"
     Action.print old_action Action.print new_action print replay
 
-let check_coherent_inlining_decisions _old_decision _new_decision =
-  ()
+let check_coherent_inlining_decisions _old_decision _new_decision = ()
 
 let define_variable var replay =
   let action : Action.t = Bound_variable var in
@@ -138,8 +137,8 @@ let define_variable var replay =
       else
         let variables = Variable.Map.add var prev_var variables in
         Replaying { previous_history; variables; continuations; always_inline }
-    | Bound_continuations _
-    | Inlining_decision _ -> error_mismatched_action replay prev_bound action)
+    | Bound_continuations _ | Inlining_decision _ ->
+      error_mismatched_action replay prev_bound action)
   | Replaying { previous_history = []; _ } -> error_empty_history replay action
 
 let define_continuations ~can_be_lifted conts replay =
@@ -171,22 +170,26 @@ let define_continuations ~can_be_lifted conts replay =
             continuations prev_conts conts
         in
         Replaying { previous_history; variables; continuations; always_inline }
-    | Bound_variable _ | Inlining_decision _ -> error_mismatched_action replay prev_bound action)
+    | Bound_variable _ | Inlining_decision _ ->
+      error_mismatched_action replay prev_bound action)
   | Replaying { previous_history = []; _ } -> error_empty_history replay action
 
 let record_inlining_decision ~apply decision replay =
   let action : Action.t = Inlining_decision (decision, apply) in
   match replay with
   | First_pass { history } -> First_pass { history = action :: history }
-  | Replaying {
-      previous_history = prev_bound :: previous_history;
-      variables; continuations; always_inline;
-    } ->
-      (match prev_bound with
-       | Inlining_decision (prev_decision, _apply) ->
-           check_coherent_inlining_decisions prev_decision decision;
-           Replaying { previous_history; variables; continuations; always_inline; }
-       | Bound_variable _ | Bound_continuations _ -> error_mismatched_action replay prev_bound action)
+  | Replaying
+      { previous_history = prev_bound :: previous_history;
+        variables;
+        continuations;
+        always_inline
+      } -> (
+    match prev_bound with
+    | Inlining_decision (prev_decision, _apply) ->
+      check_coherent_inlining_decisions prev_decision decision;
+      Replaying { previous_history; variables; continuations; always_inline }
+    | Bound_variable _ | Bound_continuations _ ->
+      error_mismatched_action replay prev_bound action)
   | Replaying { previous_history = []; _ } -> error_empty_history replay action
 
 (* Inspection API *)
@@ -212,12 +215,16 @@ let replay_continuation_mapping = function
   | Replaying
       { continuations; previous_history = _; variables = _; always_inline = _ }
     ->
-      Replayed continuations
+    Replayed continuations
 
 let replay_inlining_decision = function
   | First_pass _ -> Still_recording
-  | Replaying { previous_history = Inlining_decision (decision, _apply) :: _; _ } ->
-      Replayed decision
-  | Replaying { previous_history = ([] | (Bound_variable _ | Bound_continuations _) :: _); _ } ->
-      Misc.fatal_errorf "Cannot replay: the last action was not an inlining decision"
-
+  | Replaying
+      { previous_history = Inlining_decision (decision, _apply) :: _; _ } ->
+    Replayed decision
+  | Replaying
+      { previous_history = [] | (Bound_variable _ | Bound_continuations _) :: _;
+        _
+      } ->
+    Misc.fatal_errorf
+      "Cannot replay: the last action was not an inlining decision"

--- a/middle_end/flambda2/simplify/env/replay_history.mli
+++ b/middle_end/flambda2/simplify/env/replay_history.mli
@@ -70,6 +70,8 @@ val define_variable : Variable.t -> t -> t
 (** Define a new set of bound mutually recursive continuations. *)
 val define_continuations : can_be_lifted:bool -> Continuation.t list -> t -> t
 
+val record_inlining_decision : apply:Apply_expr.t -> Call_site_inlining_decision_type.t -> t -> t
+
 (** {2 Inspection API} *)
 
 (** Returns [true] is the replay history was created with the `always_inline`
@@ -91,3 +93,7 @@ val replay_variable_mapping : t -> Variable.t Variable.Map.t replay_result
     pass. *)
 val replay_continuation_mapping :
   t -> Continuation.t Continuation.Map.t replay_result
+
+val replay_inlining_decision :
+  t -> Call_site_inlining_decision_type.t replay_result
+

--- a/middle_end/flambda2/simplify/env/replay_history.mli
+++ b/middle_end/flambda2/simplify/env/replay_history.mli
@@ -70,7 +70,8 @@ val define_variable : Variable.t -> t -> t
 (** Define a new set of bound mutually recursive continuations. *)
 val define_continuations : can_be_lifted:bool -> Continuation.t list -> t -> t
 
-val record_inlining_decision : apply:Apply_expr.t -> Call_site_inlining_decision_type.t -> t -> t
+val record_inlining_decision :
+  apply:Apply_expr.t -> Call_site_inlining_decision_type.t -> t -> t
 
 (** {2 Inspection API} *)
 
@@ -96,4 +97,3 @@ val replay_continuation_mapping :
 
 val replay_inlining_decision :
   t -> Call_site_inlining_decision_type.t replay_result
-

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -197,7 +197,7 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
         | Doing_speculative_inlining | Unrolling_depth_exceeded
         | Max_inlining_depth_exceeded | Recursion_depth_exceeded
         | Never_inlined_attribute | Attribute_always
-        | Replay_history_says_must_inline | Begin_unrolling _
+        | Replay_history_says_must_inline _ | Begin_unrolling _
         | Continue_unrolling | Definition_says_inline _ | Jsir_inlining_disabled
           ->
           (* These can't be returned by the speculative inlining cases below. *)
@@ -248,7 +248,8 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
     then
       Misc.fatal_errorf
         "Deciding not to inline an [Apply], but the replay_history says we \
-         should inline"
+         should inline.@ Replay_history: %a"
+        Replay_history.print (DE.replay_history (DA.denv dacc))
   in
   let rec_info = get_rec_info dacc ~function_type in
   let inlined = Apply.inlined apply in
@@ -339,7 +340,13 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
               fail_if_must_inline ();
               Recursion_depth_exceeded)
             else if must_inline
-            then Replay_history_says_must_inline
+            then
+              match Replay_history.replay_inlining_decision (DE.replay_history (DA.denv dacc)) with
+              | Still_recording ->
+                  Misc.fatal_errorf "Internal assumption broken: DE.says must_inline
+                  (presumably because of the replay history), but the replay history is still recoding."
+              | Replayed decision ->
+                  Replay_history_says_must_inline decision
             else
               might_inline dacc ~apply ~code_or_metadata ~function_type
                 ~simplify_expr ~return_arity

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -249,7 +249,8 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
       Misc.fatal_errorf
         "Deciding not to inline an [Apply], but the replay_history says we \
          should inline.@ Replay_history: %a"
-        Replay_history.print (DE.replay_history (DA.denv dacc))
+        Replay_history.print
+        (DE.replay_history (DA.denv dacc))
   in
   let rec_info = get_rec_info dacc ~function_type in
   let inlined = Apply.inlined apply in
@@ -341,12 +342,16 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
               Recursion_depth_exceeded)
             else if must_inline
             then
-              match Replay_history.replay_inlining_decision (DE.replay_history (DA.denv dacc)) with
+              match
+                Replay_history.replay_inlining_decision
+                  (DE.replay_history (DA.denv dacc))
+              with
               | Still_recording ->
-                  Misc.fatal_errorf "Internal assumption broken: DE.says must_inline
-                  (presumably because of the replay history), but the replay history is still recoding."
-              | Replayed decision ->
-                  Replay_history_says_must_inline decision
+                Misc.fatal_errorf
+                  "Internal assumption broken: DE.says must_inline\n\
+                  \                  (presumably because of the replay \
+                   history), but the replay history is still recoding."
+              | Replayed decision -> Replay_history_says_must_inline decision
             else
               might_inline dacc ~apply ~code_or_metadata ~function_type
                 ~simplify_expr ~return_arity

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -248,6 +248,9 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
       | Do_not_inline { erase_attribute_if_ignored } ->
         Do_not_inline { erase_attribute = erase_attribute_if_ignored }
       | Inline { unroll_to; was_inline_always } ->
+        let dacc =
+          DA.map_denv dacc ~f:(DE.record_inlining_decision ~apply decision)
+        in
         let dacc, inlined =
           Inlining_transforms.inline dacc ~apply ~unroll_to ~was_inline_always
             function_type

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -41,7 +41,7 @@ type t =
         is_a_functor : bool
       }
   | Attribute_always
-  | Replay_history_says_must_inline
+  | Replay_history_says_must_inline of t
   | Begin_unrolling of int
   | Continue_unrolling
   | Definition_says_inline of { was_inline_always : bool }
@@ -53,7 +53,7 @@ type t =
       }
   | Jsir_inlining_disabled
 
-let [@ocamlformat "disable"] print ppf t =
+let [@ocamlformat "disable"] rec print ppf t =
   match t with
   | Missing_code -> Format.fprintf ppf "Missing_code"
   | Definition_says_not_to_inline ->
@@ -73,8 +73,8 @@ let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "Never_inlined_attribute"
   | Attribute_always ->
     Format.fprintf ppf "Attribute_always"
-  | Replay_history_says_must_inline ->
-    Format.fprintf ppf "Replay_history_says_must_inline"
+  | Replay_history_says_must_inline t' ->
+    Format.fprintf ppf "Replay_history_says_must_inline(%a)" print t'
   | Definition_says_inline { was_inline_always } ->
     Format.fprintf ppf
       "@[<hov 1>(Definition_says_inline@ \
@@ -124,7 +124,7 @@ type can_inline =
         was_inline_always : bool
       }
 
-let can_inline (t : t) : can_inline =
+let rec can_inline (t : t) : can_inline =
   match t with
   | Missing_code | In_a_stub | Doing_speculative_inlining
   | Max_inlining_depth_exceeded | Recursion_depth_exceeded
@@ -155,13 +155,12 @@ let can_inline (t : t) : can_inline =
   | Speculatively_inline _ ->
     Inline { unroll_to = None; was_inline_always = false }
   | Attribute_always -> Inline { unroll_to = None; was_inline_always = true }
-  | Replay_history_says_must_inline ->
-    Inline { unroll_to = None; was_inline_always = false }
+  | Replay_history_says_must_inline t' -> can_inline t'
   | Jsir_inlining_disabled ->
     Do_not_inline { erase_attribute_if_ignored = false }
 
 (* CR mshinwell/gbury: tidy up by using Format.pp_print_text *)
-let report_reason fmt t =
+let rec report_reason fmt t =
   match (t : t) with
   | Missing_code ->
     Format.fprintf fmt
@@ -189,14 +188,15 @@ let report_reason fmt t =
     Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
-  | Replay_history_says_must_inline ->
+  | Replay_history_says_must_inline t' ->
     (* CR gbury: We could decide not to include in the inlining report inlining
        decisions that were made during replays (e.g. continuation
        specialization), or alternatively to store the initial inlining decision
        so that we can report it each time. *)
     Format.fprintf fmt
       "the@ call@ was@ inlined@ during@ the@ first@ pass@ on@ the@ current@ \
-       continuation@ handler"
+       continuation@ handler@ with@ the@ following@ reason:@ @[<hov 2>%a@]"
+      report_reason t'
   | Begin_unrolling n ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@unroll %d]@ attribute" n
   | Continue_unrolling ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -34,7 +34,7 @@ type t =
         is_a_functor : bool
       }
   | Attribute_always
-  | Replay_history_says_must_inline
+  | Replay_history_says_must_inline of t
   | Begin_unrolling of int
   | Continue_unrolling
   | Definition_says_inline of { was_inline_always : bool }

--- a/testsuite/tests/flambda/match_in_match_inlining_depth.ml
+++ b/testsuite/tests/flambda/match_in_match_inlining_depth.ml
@@ -1,0 +1,23 @@
+(* TEST
+   flambda;
+   ocamlopt_flags = "-flambda2-inline-max-depth 1 -flambda2-expert-cont-lifting-budget 200 -flambda2-expert-cont-specialization-budget 20";
+   native;
+*)
+
+let[@inline] incr x = x + 1
+
+let[@inline] map f = function
+  | None -> None
+  | Some x -> Some (f x)
+
+let[@inline] id f x = f x
+
+let[@inline] _match = function
+  | None -> 0
+  | Some x -> x
+
+let[@inline] test t =
+  let f = id (id _match) in
+  let y = map incr t in
+  f y
+


### PR DESCRIPTION
This fixes a bug that can occur with match-in-match, where different inlining decisions can be made during the first downwards pass, and subsequent passes. This happens because the `Replay_say_must_inline` decision that was used when replaying inlining decisions did not have the same impact on the inlining depth, and therefore with enough inlining, the replayed passes could hit the threshold because the `Replay_says_must_inline` made the inlining depth increase more than e.g. `Definition_say_must_inline`.