### PR TITLE
[5.4] Fix `templates/basic/test.ml`

### DIFF
--- a/testsuite/tests/templates/basic/main.reference
+++ b/testsuite/tests/templates/basic/main.reference
@@ -16,16 +16,15 @@ val concat_chain_semi :
   ('a, 'b) Chain[Category:Category_of_monoid[Monoid:Monoid_of_semigroup]].t ->
   ('a, 'b) Category_of_monoid[Monoid:Monoid_of_semigroup].t
 val append3_semi :
-  ('a, 'b) Category_of_monoid[Monoid:Monoid_of_semigroup].t ->
-  ('b, 'c) Category_of_monoid[Monoid:Monoid_of_semigroup].t ->
-  ('c, 'd) Category_of_monoid[Monoid:Monoid_of_semigroup].t ->
-  ('a, 'd) Category_of_monoid[Monoid:Monoid_of_semigroup].t
+  Monoid_of_semigroup.t ->
+  Monoid_of_semigroup.t ->
+  Monoid_of_semigroup.t ->
+  ('a, 'b) Category_of_monoid[Monoid:Monoid_of_semigroup].t
 val concat_lists : 'a list list -> 'a list
 val concat_chain_lists :
   ('a, 'b) Chain[Category:Category_of_monoid[Monoid:List_monoid]].t ->
   ('a, 'b) Category_of_monoid[Monoid:List_monoid].t
 val append3_lists :
-  ('a, 'b) Category_of_monoid[Monoid:List_monoid].t ->
-  ('b, 'c) Category_of_monoid[Monoid:List_monoid].t ->
-  ('c, 'd) Category_of_monoid[Monoid:List_monoid].t ->
-  ('a, 'd) Category_of_monoid[Monoid:List_monoid].t
+  List_monoid.t ->
+  List_monoid.t ->
+  List_monoid.t -> ('a, 'b) Category_of_monoid[Monoid:List_monoid].t


### PR DESCRIPTION
First, fix `summarize.awk` so the error gets reported correctly for sub-tests.

Next, promote the output in `testsuite/tests/templates/basic/main.reference` due to a short paths improvement from upstream. The test already has cases like `val concat_semi : Monoid_utils_of_semigroup.ts -> Monoid_of_semigroup.t`, so it's fine to replace the square-bracket-substitution paths with shorter definitions.