### PR TITLE
Allow empty objects to be immutable_data

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2494,6 +2494,8 @@ let rec estimate_type_jkind ~expand_component ~ignore_mod_bounds env ty =
        a [Missing_cmi]. Internal ticket 5109. *)
     | Cannot_subst | Not_found -> Jkind.Builtin.any ~why:(Missing_cmi p)
     end
+  | Tobject (fi, nm) when get_desc fi = Tnil && !nm = None ->
+     Jkind.for_empty_object
   | Tobject _ -> Jkind.for_object
   | Tfield _ -> Jkind.Builtin.value ~why:Tfield
   | Tquote _ -> Jkind.Builtin.value ~why:Tquote

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2365,6 +2365,8 @@ let for_object =
     }
     ~annotation:None ~why:(Value_creation Object)
 
+let for_empty_object = Builtin.immutable_data ~why:Object
+
 let for_array_element_sort ~level =
   let jkind_desc, sort =
     Jkind_desc.of_new_sort_var ~level Maybe_null Separable

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -493,6 +493,9 @@ val for_arrow : Types.jkind_l
 (** The jkind of an object type. *)
 val for_object : Types.jkind_l
 
+(** The jkind of an object type with no methods. *)
+val for_empty_object : Types.jkind_l
+
 (** The jkind for values that are not floats. *)
 val for_non_float : why:History.value_creation_reason -> 'd Types.jkind
 


### PR DESCRIPTION
I think this is fine, if not particularly exciting:
```ocaml
type t : immutable_data = <  >
```
since empty object types are basically just `unit`. Allowing this makes it easier to typecheck a weird hack in the 5.4 stdlib.