### PR TITLE
[5.4] Fix linkage of ocamlFDO symbols

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -113,14 +113,10 @@ let make_startup_file linkenv unix ~ppf_dump ~sourcefile_for_dwarf genfns units
     (Cmm_helpers.data_segment_table (startup_comp_unit :: name_list));
   (* CR mshinwell: We should have a separate notion of "backend compilation
      unit" really, since the units here don't correspond to .ml source files. *)
-  let hot_comp_unit = CU.create CU.Prefix.empty (CU.Name.of_string "_hot") in
   let system_comp_unit =
     CU.create CU.Prefix.empty (CU.Name.of_string "_system")
   in
-  let code_comp_units =
-    if !Clflags.function_sections
-    then hot_comp_unit :: startup_comp_unit :: name_list
-    else startup_comp_unit :: name_list
+  let code_comp_units = startup_comp_unit :: name_list
   in
   let code_comp_units =
     if !Oxcaml_flags.use_cached_generic_functions

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -471,13 +471,18 @@ X(16) X(17) X(18) X(19) X(20) X(21) X(22) X(23) X(24) X(25) X(26) X(27) X(27) X(
         .text
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(CAMLSEP(hot,code_begin))
-        .globl  G(CAMLSEP(hot,code_begin))
-G(CAMLSEP(hot,code_begin)):
+/* The section names, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end are used by OCamlFDO. They need to match each
+   other, have C linkage names, and match the hard-wired names in OCamlFDO.
+*/
 
-        TEXT_SECTION(CAMLSEP(hot,code_end))
-        .globl  G(CAMLSEP(hot,code_end))
-G(CAMLSEP(hot,code_end)):
+        TEXT_SECTION(caml_hot__code_begin)
+        .globl  G(caml_hot__code_begin)
+G(caml_hot__code_begin):
+
+        TEXT_SECTION(caml_hot__code_end)
+        .globl  G(caml_hot__code_end)
+G(caml_hot__code_end):
 #endif
 
 /******************************************************************************/

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -106,13 +106,18 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-        TEXT_SECTION(CAMLSEP(hot,code_begin))
-        .globl  G(CAMLSEP(hot,code_begin))
-G(CAMLSEP(hot,code_begin)):
+/* The section names, and matching symbols, caml_hot__code_begin and
+   caml_hot__code_end are used by OCamlFDO. They need to match each
+   other, have C linkage names, and match the hard-wired names in OCamlFDO.
+*/
 
-        TEXT_SECTION(CAMLSEP(hot,code_end))
-        .globl  G(CAMLSEP(hot,code_end))
-G(CAMLSEP(hot,code_end)):
+        TEXT_SECTION(caml_hot__code_begin)
+        .globl  G(caml_hot__code_begin)
+G(caml_hot__code_begin):
+
+        TEXT_SECTION(caml_hot__code_end)
+        .globl  G(caml_hot__code_end)
+G(caml_hot__code_end):
 #endif
 
 #if defined(SYS_macosx)

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -82,6 +82,14 @@ static void init_segments(void)
   caml_register_code_fragment(&caml_system__code_begin,
                               &caml_system__code_end,
                               DIGEST_IGNORE, NULL);
+#ifdef FUNCTION_SECTIONS
+  /* And the "hot" code for OCamlFDO */
+  extern char caml_hot__code_begin, caml_hot__code_end;
+  caml_register_code_fragment(&caml_hot__code_begin,
+                              &caml_hot__code_end,
+                              DIGEST_IGNORE, NULL);
+#endif /* FUNCTION_SECTIONS */
+
 }
 
 extern value caml_start_program (caml_domain_state*);


### PR DESCRIPTION
OCamlFDO has two symbol names hardwired, `caml_hot__code_begin` and `caml_hot__code_end`. The earlier #5598 had this wrong, and #5812 was confusingly different. So fixed upstream in ocaml/ocaml#14778, and now this PR corresponds to that.