### PR TITLE
Add name mangling ocamlopt flag

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -37,7 +37,7 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
     | [] | _ :: _ -> fun_name
   in
   let linkage_name =
-    match Config.name_mangling_scheme with
+    match Compilation_unit.name_mangling_scheme () with
     | Flat -> Some (linkage_name_from_debug ())
     | Structured -> None
     (* When structured mangling is used, there is no need for additional linkage

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -37,7 +37,7 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
     | [] | _ :: _ -> fun_name
   in
   let linkage_name =
-    match Compilation_unit.name_mangling_scheme () with
+    match Compilation_unit.name_mangling_scheme_for_current_unit () with
     | Flat -> Some (linkage_name_from_debug ())
     | Structured -> None
     (* When structured mangling is used, there is no need for additional linkage

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -348,6 +348,11 @@ let mk_function_layout f =
     Printf.sprintf " Order of functions in the generated assembly (default: %s)"
       default )
 
+let mk_name_mangling_scheme f =
+  ( "-name-mangling-scheme",
+    Arg.Symbol ([ "flat"; "structured" ], f),
+    " Override the default name mangling scheme set at configure time" )
+
 let mk_disable_builtin_check f =
   ( "-disable-builtin-check",
     Arg.Unit f,
@@ -1269,6 +1274,7 @@ module type Oxcaml_options = sig
   val no_zero_alloc_checker_details_extra : unit -> unit
   val zero_alloc_checker_join : int -> unit
   val function_layout : string -> unit
+  val name_mangling_scheme : string -> unit
   val disable_builtin_check : unit -> unit
   val disable_poll_insertion : unit -> unit
   val enable_poll_insertion : unit -> unit
@@ -1448,6 +1454,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_zero_alloc_checker_details_extra;
       mk_zero_alloc_checker_join F.zero_alloc_checker_join;
       mk_function_layout F.function_layout;
+      mk_name_mangling_scheme F.name_mangling_scheme;
       mk_disable_builtin_check F.disable_builtin_check;
       mk_disable_poll_insertion F.disable_poll_insertion;
       mk_enable_poll_insertion F.enable_poll_insertion;
@@ -1726,6 +1733,17 @@ module Oxcaml_options_impl = struct
     match Oxcaml_flags.Function_layout.of_string s with
     | None -> () (* this should not occur as we use Arg.Symbol *)
     | Some layout -> Oxcaml_flags.function_layout := layout
+
+  let name_mangling_scheme s =
+    let scheme : Config.name_mangling_scheme option =
+      match s with
+      | "flat" -> Some Flat
+      | "structured" -> Some Structured
+      | _ -> None (* this should not occur as we use Arg.Symbol *)
+    in
+    match scheme with
+    | Some scheme -> Compilation_unit.set_name_mangling_scheme_override scheme
+    | None -> ()
 
   let disable_builtin_check = set' Oxcaml_flags.disable_builtin_check
   let disable_poll_insertion = set' Oxcaml_flags.disable_poll_insertion
@@ -2252,6 +2270,20 @@ module Extra_params = struct
         match Oxcaml_flags.Function_layout.of_string v with
         | Some layout ->
             Oxcaml_flags.function_layout := layout;
+            true
+        | None ->
+            raise (Arg.Bad (Printf.sprintf "Unexpected value %s for %s" v name))
+        )
+    | "name-mangling-scheme" -> (
+        let scheme : Config.name_mangling_scheme option =
+          match v with
+          | "flat" -> Some Flat
+          | "structured" -> Some Structured
+          | _ -> None
+        in
+        match scheme with
+        | Some scheme ->
+            Compilation_unit.set_name_mangling_scheme_override scheme;
             true
         | None ->
             raise (Arg.Bad (Printf.sprintf "Unexpected value %s for %s" v name))

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -82,6 +82,7 @@ module type Oxcaml_options = sig
   val no_zero_alloc_checker_details_extra : unit -> unit
   val zero_alloc_checker_join : int -> unit
   val function_layout : string -> unit
+  val name_mangling_scheme : string -> unit
   val disable_builtin_check : unit -> unit
   val disable_poll_insertion : unit -> unit
   val enable_poll_insertion : unit -> unit

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -49,7 +49,7 @@ let name_for_function (func : Lambda.lfunction) =
   (* Name anonymous functions by their source location, if known, when using the
      Flat name-mangling scheme. *)
   let mangling_scheme_locates_anonymous_functions =
-    match Compilation_unit.name_mangling_scheme () with
+    match Compilation_unit.name_mangling_scheme_for_current_unit () with
     | Flat -> false
     | Structured -> true
   in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -49,7 +49,9 @@ let name_for_function (func : Lambda.lfunction) =
   (* Name anonymous functions by their source location, if known, when using the
      Flat name-mangling scheme. *)
   let mangling_scheme_locates_anonymous_functions =
-    match Config.name_mangling_scheme with Flat -> false | Structured -> true
+    match Compilation_unit.name_mangling_scheme () with
+    | Flat -> false
+    | Structured -> true
   in
   match func.loc with
   | Loc_unknown -> "fn"

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -834,7 +834,7 @@ module Code_id = struct
       !previous_name_stamp
     in
     let linkage_name =
-      match Config.name_mangling_scheme with
+      match Compilation_unit.name_mangling_scheme () with
       | Flat ->
         let name =
           if Flambda_features.Expert.shorten_symbol_names ()

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -834,7 +834,7 @@ module Code_id = struct
       !previous_name_stamp
     in
     let linkage_name =
-      match Compilation_unit.name_mangling_scheme () with
+      match Compilation_unit.name_mangling_scheme_for_current_unit () with
       | Flat ->
         let name =
           if Flambda_features.Expert.shorten_symbol_names ()

--- a/utils/compilation_unit.ml
+++ b/utils/compilation_unit.ml
@@ -714,6 +714,17 @@ let get_current_exn () =
 let is_current t =
   match get_current () with None -> false | Some t' -> equal t t'
 
+let name_mangling_scheme_override : Config.name_mangling_scheme option ref =
+  ref None
+
+let set_name_mangling_scheme_override scheme =
+  name_mangling_scheme_override := Some scheme
+
+let name_mangling_scheme () =
+  match !name_mangling_scheme_override with
+  | Some scheme -> scheme
+  | None -> Config.name_mangling_scheme
+
 module Private = struct
   let fwd_get_current = fwd_get_current
 end

--- a/utils/compilation_unit.ml
+++ b/utils/compilation_unit.ml
@@ -720,7 +720,7 @@ let name_mangling_scheme_override : Config.name_mangling_scheme option ref =
 let set_name_mangling_scheme_override scheme =
   name_mangling_scheme_override := Some scheme
 
-let name_mangling_scheme () =
+let name_mangling_scheme_for_current_unit () =
   match !name_mangling_scheme_override with
   | Some scheme -> scheme
   | None -> Config.name_mangling_scheme

--- a/utils/compilation_unit.mli
+++ b/utils/compilation_unit.mli
@@ -305,15 +305,20 @@ val get_current_exn : unit -> t
 
 val is_current : t -> bool
 
-(** Set an override for the compile-time name mangling scheme. This is typically
-    called by the driver when the [-name-mangling-scheme] command-line option is
-    used. *)
+(** Set an override for the name mangling scheme used while compiling the
+    current unit. Typically called by the driver when the
+    [-name-mangling-scheme] command-line option is used. The override applies
+    for the lifetime of the [ocamlopt] invocation. *)
 val set_name_mangling_scheme_override : Config.name_mangling_scheme -> unit
 
-(** Returns the name mangling scheme to use for the current compilation. If
-    [set_name_mangling_scheme_override] has been called, that value is returned;
-    otherwise [Config.name_mangling_scheme] is returned. *)
-val name_mangling_scheme : unit -> Config.name_mangling_scheme
+(** Returns the name mangling scheme to use for the unit currently being
+    compiled. If [set_name_mangling_scheme_override] has been called, that value
+    is returned; otherwise [Config.name_mangling_scheme] is returned.
+
+    There is no per-[t] equivalent: linkage names are baked in when each unit is
+    compiled and serialised with its [.cmx], so when reading another unit we
+    never need to know which scheme it was compiled under. *)
+val name_mangling_scheme_for_current_unit : unit -> Config.name_mangling_scheme
 
 module Private : sig
   val fwd_get_current : (unit -> t option) ref

--- a/utils/compilation_unit.mli
+++ b/utils/compilation_unit.mli
@@ -305,6 +305,16 @@ val get_current_exn : unit -> t
 
 val is_current : t -> bool
 
+(** Set an override for the compile-time name mangling scheme. This is typically
+    called by the driver when the [-name-mangling-scheme] command-line option is
+    used. *)
+val set_name_mangling_scheme_override : Config.name_mangling_scheme -> unit
+
+(** Returns the name mangling scheme to use for the current compilation. If
+    [set_name_mangling_scheme_override] has been called, that value is returned;
+    otherwise [Config.name_mangling_scheme] is returned. *)
+val name_mangling_scheme : unit -> Config.name_mangling_scheme
+
 module Private : sig
   val fwd_get_current : (unit -> t option) ref
 end


### PR DESCRIPTION
This attempts to add a flag to allow specified compilation units to use a particular name mangling convention, overriding that specified by `configure`.  If this can be got to work, it will make testing the new structured name mangling scheme much easier.