### PR TITLE
Require `CAML_INTERNALS` to be defined consistently when using headers

### DIFF
--- a/external/owee/owee_stubs.c
+++ b/external/owee/owee_stubs.c
@@ -6,7 +6,6 @@
 #if OCAML_VERSION >= 41200
 #define CAML_INTERNALS
 #include <caml/codefrag.h>
-#undef CAML_INTERNALS
 #endif
 #include <caml/alloc.h>
 #include <caml/memory.h>
@@ -89,9 +88,9 @@ CAMLprim value ml_owee_code_pointer_symbol(value cp)
   return caml_copy_string(result);
 }
 
-static inline char * get_bstr(value v_bstr, value v_pos) 
-{ 
-  return (char *) Caml_ba_data_val(v_bstr) + Long_val(v_pos); 
+static inline char * get_bstr(value v_bstr, value v_pos)
+{
+  return (char *) Caml_ba_data_val(v_bstr) + Long_val(v_pos);
 }
 
 CAMLprim value owee_blit_string_bigstring_stub(
@@ -111,4 +110,3 @@ CAMLprim value owee_blit_bytes_bigstring_stub(
   memcpy(bstr, str, Long_val(v_len));
   return Val_unit;
 }
-

--- a/otherlibs/unix/access.c
+++ b/otherlibs/unix/access.c
@@ -13,11 +13,11 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
-#define CAML_INTERNALS
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -14,10 +14,10 @@
 /**************************************************************************/
 
 #define _GNU_SOURCE  /* helps to find execvpe() */
+#define CAML_INTERNALS
 #include <string.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
-#define CAML_INTERNALS
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 #include "errno.h"

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_BACKTRACE_H
 #define CAML_BACKTRACE_H
+#include "guard.h"
 
 #include "mlvalues.h"
 

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_BACKTRACE_PRIM_H
 #define CAML_BACKTRACE_PRIM_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -120,12 +120,6 @@ CAMLextern value caml_ba_alloc_dims(int flags, int num_dims, void * data,
 CAMLextern uintnat caml_ba_byte_size(struct caml_ba_array * b);
 CAMLextern uintnat caml_ba_num_elts(struct caml_ba_array * b);
 
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef CAML_INTERNALS
-
 CAMLextern int caml_ba_element_size[];
 CAMLextern void caml_ba_finalize(value v);
 CAMLextern int caml_ba_compare(value v1, value v2);
@@ -133,6 +127,8 @@ CAMLextern intnat caml_ba_hash(value v);
 CAMLextern void caml_ba_serialize(value, uintnat *, uintnat *);
 CAMLextern uintnat caml_ba_deserialize(void * dst);
 
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* CAML_BIGARRAY_H */

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_BIGARRAY_H
 #define CAML_BIGARRAY_H
+#include "guard.h"
 
 #include "config.h"
 #include "mlvalues.h"

--- a/runtime/caml/blake2.h
+++ b/runtime/caml/blake2.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_BLAKE2_H
 #define CAML_BLAKE2_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -15,6 +15,7 @@
 /**************************************************************************/
 #ifndef CAML_ATOMIC_H
 #define CAML_ATOMIC_H
+#include "guard.h"
 
 #include "config.h"
 #include "misc.h"

--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_CODEFRAG_H
 #define CAML_CODEFRAG_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/compare.h
+++ b/runtime/caml/compare.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include "misc.h"
+
 CAMLextern int caml_compare_unordered;
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_CONFIG_H
 #define CAML_CONFIG_H
+#include "guard.h"
 
 /* CR ocaml 5 all-runtime5: remove this and all uses of it */
 #define CAML_RUNTIME_5

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_CUSTOM_H
 #define CAML_CUSTOM_H
+#include "guard.h"
 
 
 #include "mlvalues.h"

--- a/runtime/caml/debugger.h
+++ b/runtime/caml/debugger.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_DEBUGGER_H
 #define CAML_DEBUGGER_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -16,6 +16,7 @@
 
 #ifndef CAML_DOMAIN_H
 #define CAML_DOMAIN_H
+#include "guard.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/dune
+++ b/runtime/caml/dune
@@ -35,7 +35,15 @@
   ../../Makefile.config_if_required
   ../../Makefile.best_binaries)
  (action
-  (run make -s -f Makefile.upstream -C ../.. COMPUTE_DEPS=false runtime/caml/opnames.h)))
+  (run
+   make
+   -s
+   -f
+   Makefile.upstream
+   -C
+   ../..
+   COMPUTE_DEPS=false
+   runtime/caml/opnames.h)))
 
 (rule
  (targets version.h)
@@ -74,6 +82,7 @@
   (gc_ctrl.h as caml/gc_ctrl.h)
   (gc_stats.h as caml/gc_stats.h)
   (gc.h as caml/gc.h)
+  (guard.h as caml/guard.h)
   (globroots.h as caml/globroots.h)
   (hash.h as caml/hash.h)
   (hooks.h as caml/hooks.h)

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_DYNLINK_H
 #define CAML_DYNLINK_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_FAIL_H
 #define CAML_FAIL_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 #include <setjmp.h>

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -18,6 +18,7 @@
 
 #ifndef CAML_FIBER_H
 #define CAML_FIBER_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_FINALISE_H
 #define CAML_FINALISE_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/fix_code.h
+++ b/runtime/caml/fix_code.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_FIX_CODE_H
 #define CAML_FIX_CODE_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -18,6 +18,7 @@
 
 #ifndef CAML_FRAME_DESCRIPTORS_H
 #define CAML_FRAME_DESCRIPTORS_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/gc.h
+++ b/runtime/caml/gc.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_GC_H
 #define CAML_GC_H
+#include "guard.h"
 
 
 #include "mlvalues.h"

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_GC_CTRL_H
 #define CAML_GC_CTRL_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_GC_STATS_H
 #define CAML_GC_STATS_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_GLOBROOTS_H
 #define CAML_GLOBROOTS_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/guard.h
+++ b/runtime/caml/guard.h
@@ -2,10 +2,9 @@
 /*                                                                        */
 /*                                 OCaml                                  */
 /*                                                                        */
-/*           Damien Doligez, Projet Moscova, INRIA Rocquencourt           */
+/*                   David Allsopp, Jane Street Europe                    */
 /*                                                                        */
-/*   Copyright 2003 Institut National de Recherche en Informatique et     */
-/*     en Automatique.                                                    */
+/*   Copyright 2026 Jane Street Group LLC                                 */
 /*                                                                        */
 /*   All rights reserved.  This file is distributed under the terms of    */
 /*   the GNU Lesser General Public License version 2.1, with the          */
@@ -13,16 +12,11 @@
 /*                                                                        */
 /**************************************************************************/
 
-#ifndef CAML_COMPARE_H
-#define CAML_COMPARE_H
-#include "guard.h"
-
-#ifdef CAML_INTERNALS
-
-#include "misc.h"
-
-CAMLextern int caml_compare_unordered;
-
-#endif /* CAML_INTERNALS */
-
-#endif /* CAML_COMPARE_H */
+#if defined(CAML_INTERNALS) && defined(CAML_NO_INTERNALS) || \
+    !defined(CAML_INTERNALS) && defined(CAML_WITH_INTERNALS)
+#error "Inconsistent use of CAML_INTERNALS"
+#elif defined(CAML_INTERNALS) && !defined(CAML_WITH_INTERNALS)
+#define CAML_WITH_INTERNALS
+#elif !defined(CAML_INTERNALS) && !defined(CAML_NO_INTERNALS)
+#define CAML_NO_INTERNALS
+#endif

--- a/runtime/caml/hooks.h
+++ b/runtime/caml/hooks.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_HOOKS_H
 #define CAML_HOOKS_H
+#include "guard.h"
 
 #include "misc.h"
 #include "memory.h"

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -17,6 +17,7 @@
 
 #ifndef _instrtrace_
 #define _instrtrace_
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/instruct.h
+++ b/runtime/caml/instruct.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_INSTRUCT_H
 #define CAML_INSTRUCT_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/interp.h
+++ b/runtime/caml/interp.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_INTERP_H
 #define CAML_INTERP_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_INTEXT_H
 #define CAML_INTEXT_H
+#include "guard.h"
 
 #include "misc.h"
 #include "mlvalues.h"

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_IO_H
 #define CAML_IO_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/lf_skiplist.h
+++ b/runtime/caml/lf_skiplist.h
@@ -24,6 +24,7 @@
 
 #ifndef CAML_SKIPLIST_H
 #define CAML_SKIPLIST_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include "misc.h"
+
 typedef enum {
   Phase_sweep_main,
   Phase_sweep_and_mark_main,

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_MAJOR_GC_H
 #define CAML_MAJOR_GC_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/md5.h
+++ b/runtime/caml/md5.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_MD5_H
 #define CAML_MD5_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_MEMORY_H
 #define CAML_MEMORY_H
+#include "guard.h"
 
 #include "config.h"
 #ifdef CAML_INTERNALS

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_MEMPROF_H
 #define CAML_MEMPROF_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_MINOR_GC_H
 #define CAML_MINOR_GC_H
+#include "guard.h"
 
 #include "address_class.h"
 #include "misc.h"

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_MISC_H
 #define CAML_MISC_H
+#include "guard.h"
 
 #include "config.h"
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_MLVALUES_H
 #define CAML_MLVALUES_H
+#include "guard.h"
 
 #include "config.h"
 #include "misc.h"

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_OSDEPS_H
 #define CAML_OSDEPS_H
+#include "guard.h"
 
 #ifdef _WIN32
 #include <time.h>

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -16,6 +16,7 @@
 
 #ifndef CAML_PLAT_THREADS_H
 #define CAML_PLAT_THREADS_H
+#include "guard.h"
 /* Platform-specific concurrency and memory primitives */
 
 #ifdef CAML_INTERNALS

--- a/runtime/caml/prims.h
+++ b/runtime/caml/prims.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_PRIMS_H
 #define CAML_PRIMS_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/printexc.h
+++ b/runtime/caml/printexc.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_PRINTEXC_H
 #define CAML_PRINTEXC_H
+#include "guard.h"
 
 
 #include "misc.h"

--- a/runtime/caml/reverse.h
+++ b/runtime/caml/reverse.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_REVERSE_H
 #define CAML_REVERSE_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_ROOTS_H
 #define CAML_ROOTS_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -27,6 +27,7 @@
 
 #ifndef CAML_RUNTIME_EVENTS_H
 #define CAML_RUNTIME_EVENTS_H
+#include "guard.h"
 
 #include "mlvalues.h"
 #include <stdint.h>

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -15,6 +15,7 @@
 /**************************************************************************/
 #ifndef CAML_SHARED_HEAP_H
 #define CAML_SHARED_HEAP_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_SIGNALS_H
 #define CAML_SIGNALS_H
+#include "guard.h"
 
 #if defined(CAML_INTERNALS)
 #include <signal.h>

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -20,6 +20,7 @@
 
 #ifndef CAML_SKIPLIST_H
 #define CAML_SKIPLIST_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_STACK_H
 #define CAML_STACK_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_STARTUP_H
 #define CAML_STARTUP_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_STARTUP_AUX_H
 #define CAML_STARTUP_AUX_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_SYNC_H
 #define CAML_SYNC_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -15,6 +15,7 @@
 
 #ifndef CAML_SYS_H
 #define CAML_SYS_H
+#include "guard.h"
 
 #ifdef CAML_INTERNALS
 

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -14,6 +14,7 @@
 
 #ifndef CAML_TSAN_H
 #define CAML_TSAN_H
+#include "guard.h"
 
 /* Macro used to deactivate thread sanitizer on some functions. */
 #define CAMLno_tsan

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -17,6 +17,7 @@
 
 #ifndef CAML_WEAK_H
 #define CAML_WEAK_H
+#include "guard.h"
 
 #include "mlvalues.h"
 #include "memory.h"

--- a/runtime/caml/winsupport.h
+++ b/runtime/caml/winsupport.h
@@ -16,6 +16,7 @@
 
 #ifndef CAML_WINSUPPORT_H
 #define CAML_WINSUPPORT_H
+#include "guard.h"
 
 #if defined(_WIN32) && defined(CAML_INTERNALS)
 

--- a/runtime4/caml/bigarray.h
+++ b/runtime4/caml/bigarray.h
@@ -123,12 +123,6 @@ CAMLextern value caml_ba_alloc_dims(int flags, int num_dims, void * data,
 CAMLextern uintnat caml_ba_byte_size(struct caml_ba_array * b);
 CAMLextern uintnat caml_ba_num_elts(struct caml_ba_array * b);
 
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef CAML_INTERNALS
-
 CAMLextern int caml_ba_element_size[];
 CAMLextern void caml_ba_finalize(value v);
 CAMLextern int caml_ba_compare(value v1, value v2);
@@ -136,6 +130,8 @@ CAMLextern intnat caml_ba_hash(value v);
 CAMLextern void caml_ba_serialize(value, uintnat *, uintnat *);
 CAMLextern uintnat caml_ba_deserialize(void * dst);
 
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* CAML_BIGARRAY_H */

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
+#define CAML_INTERNALS
 #include "caml/alloc.h"
 #include "caml/memory.h"
-#define CAML_INTERNALS
 #include "caml/gc_ctrl.h"
 
 

--- a/testsuite/tests/lib-digest/blake2b_self_test_stubs.c
+++ b/testsuite/tests/lib-digest/blake2b_self_test_stubs.c
@@ -3,11 +3,10 @@
 
 #define CAML_NAME_SPACE
 
+#define CAML_INTERNALS
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
-#define CAML_INTERNALS
 #include "caml/blake2.h"
-#undef CAML_INTERNALS
 
 #include <stdio.h>
 #include <stdint.h>

--- a/utils/dune
+++ b/utils/dune
@@ -30,7 +30,7 @@
   (:tbl
    ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml/domain_state.tbl)
   (glob_files
-   ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml/{config,m,s}.h))
+   ../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}/caml/{guard,config,m,s}.h))
  (action
   (with-stdout-to
    %{targets}


### PR DESCRIPTION
This is a possible idea to ban patterns such as:

```c
#include <caml/mlvalues.h>
#define CAML_INTERNALS
#include <caml/codefrag.h>
#undef CAML_INTERNALS
#include <caml/domain.h>
```

The problem is that included with `CAML_INTERNALS` defined may include other headers and require internal definitions from them, but if they have been previously included with `CAML_INTERNALS` not defined things break weirdly.

Just an experiment at this stage - I want to see the impact (it definitely breaks upstream packages).