### PR TITLE
[5.4] Two little runtime fixes

### DIFF
--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -1409,7 +1409,7 @@ G(caml_system__code_end):
 /* Uses the same naming convention as ocamlopt generated modules. */
 OBJECT(CAMLSEP(system,frametable))
         .quad   2                   /* two descriptors */
-        .quad  L(caml_retaddr) - .  /* return address into callback */
+        .4byte  L(caml_retaddr) - . /* return address into callback */
         .short  -1                  /* negative frame size => use callback link */
         .short  0                   /* no roots */
         .align  3

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -395,7 +395,8 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
 
     /* Don't copy, but do darken, custom blocks #7279 */
     if (Tag_val(val) == Custom_tag) {
-      caml_darken (Caml_state, val, 0);
+      if (caml_marking_started())
+        caml_darken (Caml_state, val, 0);
       copy = val;
       goto some;
     }


### PR DESCRIPTION
The first commit cherry-picks part of #13580 from OCaml 5.5, which fixes two tests when running in the debug runtime. The second commit fixes 10 tests on arm64 (macOS and Linux)