### PR TITLE
[5.4] lib-unix/common/sigwait.ml test needs `multicore`

### DIFF
--- a/testsuite/tests/lib-unix/common/sigwait.ml
+++ b/testsuite/tests/lib-unix/common/sigwait.ml
@@ -1,4 +1,5 @@
 (* TEST
+ multicore;
  include unix;
  hasunix;
  not-target-windows;


### PR DESCRIPTION
Some PRs are bigger than others. This tests spawns a Domain...