### PR TITLE
[5.4] Remove runtime4 from Nix testing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
   multidomain ? false,
   ocamltest ? true,
   pollInsertion ? false,
-  runtime5 ? false,
+  runtime5 ? true,
   stackChecks ? false,
   warnError ? true,
   oxcamlClang ? false,

--- a/flake.nix
+++ b/flake.nix
@@ -28,16 +28,7 @@
         packages = {
           inherit oxcaml;
           oxcaml-fp = oxcaml.override { framePointers = true; };
-          oxcaml-r5 = oxcaml.override { runtime5 = true; };
-          oxcaml-fp-r5 = oxcaml.override {
-            framePointers = true;
-            runtime5 = true;
-          };
           oxcaml-asan = oxcaml.override { addressSanitizer = true; };
-          oxcaml-asan-r5 = oxcaml.override {
-            addressSanitizer = true;
-            runtime5 = true;
-          };
           default = oxcaml;
         };
 
@@ -45,10 +36,7 @@
           inherit (self.packages.${system})
             oxcaml
             oxcaml-fp
-            oxcaml-r5
-            oxcaml-fp-r5
             oxcaml-asan
-            oxcaml-asan-r5
             ;
         };
 


### PR DESCRIPTION
#5915 dealt with the normal builds, but didn't update the Nix workflows, which this PR does.