### PR TITLE
[5.4] Update native-debugger tests

### DIFF
--- a/testsuite/tests/native-debugger/linux-gdb-amd64.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.ml
@@ -1,6 +1,7 @@
 (* TEST
    native-compiler;
    no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   no-address-sanitizer; (* Same reason *)
    linux;
    arch_amd64;
    script = "sh ${test_source_directory}/has_gdb.sh";

--- a/testsuite/tests/native-debugger/linux-gdb-amd64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64.reference
@@ -23,8 +23,8 @@ Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
 frame 1: caml_c_call
-frame 2: camlMeander.omain
-frame 3: camlMeander.entry
+frame 2: camlMeander__omain_1_code
+frame 3: camlMeander__entry
 frame 4: caml_program
 frame 5: caml_start_program
 frame 6: caml_startup_common
@@ -33,16 +33,16 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
+Breakpoint 4, camlMeander__c_to_ocaml_2_code () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander.c_to_ocaml
+frame 0: camlMeander__c_to_ocaml_code
 frame 1: caml_start_program
-frame 2: caml_callback_exn
+frame 2: callback
 frame 3: caml_callback
 frame 4: ocaml_to_c
 frame 5: caml_c_call
-frame 6: camlMeander.omain
-frame 7: camlMeander.entry
+frame 6: camlMeander__omain_1_code
+frame 7: camlMeander__entry
 frame 8: caml_program
 frame 9: caml_start_program
 frame 10: caml_startup_common

--- a/testsuite/tests/native-debugger/linux-gdb-arm64.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64.reference
@@ -23,8 +23,8 @@ Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
 5	    caml_callback(*caml_named_value
 frame 0: ocaml_to_c
 frame 1: caml_c_call
-frame 2: camlMeander.omain
-frame 3: camlMeander.entry
+frame 2: camlMeander__omain_1_code
+frame 3: camlMeander__entry
 frame 4: caml_program
 frame 5: caml_start_program
 frame 6: caml_startup_common
@@ -33,16 +33,16 @@ frame 8: caml_startup_exn
 frame 9: caml_startup
 frame 10: caml_main
 frame 11: main
-Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
+Breakpoint 4, camlMeander__c_to_ocaml_2_code () at meander.ml:5
 5	let c_to_ocaml () = raise E1
-frame 0: camlMeander.c_to_ocaml
+frame 0: camlMeander__c_to_ocaml_code
 frame 1: caml_start_program
-frame 2: caml_callback_exn
+frame 2: callback
 frame 3: caml_callback
 frame 4: ocaml_to_c
 frame 5: caml_c_call
-frame 6: camlMeander.omain
-frame 7: camlMeander.entry
+frame 6: camlMeander__omain_1_code
+frame 7: camlMeander__entry
 frame 8: caml_program
 frame 9: caml_start_program
 frame 10: caml_startup_common

--- a/testsuite/tests/native-debugger/lldb-script
+++ b/testsuite/tests/native-debugger/lldb-script
@@ -3,7 +3,7 @@ settings set stop-disassembly-display never
 command script import ./lldb_test.py
 create caml_start_program
 create caml_program
-create camlMeander[.$]c_to_ocaml*
+create camlMeander__c_to_ocaml*
 create ocaml_to_c
 run
 backtrace

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -9,8 +9,8 @@ Executing commands in 'XXXX'.
 Breakpoint created for regex caml_start_program.
 (lldb) create caml_program
 Breakpoint created for regex caml_program.
-(lldb) create camlMeander[.$]c_to_ocaml*
-Breakpoint created for regex camlMeander[.$]c_to_ocaml*.
+(lldb) create camlMeander__c_to_ocaml*
+Breakpoint created for regex camlMeander__c_to_ocaml*.
 (lldb) create ocaml_to_c
 Breakpoint created for regex ocaml_to_c.
 (lldb) run
@@ -59,37 +59,35 @@ Target 0: (meander) stopped.
 (lldb) backtrace
 frame 0: meander`ocaml_to_c
 frame 1: meander`caml_c_call
-frame 2: meander`camlMeander$omain
-frame 3: meander`camlMeander$entry
+frame 2: meander`camlMeander__omain_1_code
+frame 3: meander`camlMeander__entry
 frame 4: meander`caml_program
 frame 5: meander`caml_start_program
-frame 6: meander`caml_startup_common
-frame 7: meander`caml_startup_exn
-frame 8: meander`caml_startup
-frame 9: meander`caml_main
-frame 10: meander`main
-frame 11: dyld`start
+frame 6: meander`caml_program
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
 * thread #1, queue = 'XXXX', stop reason = breakpoint 3.1
-    frame #0: 0x00000000000000 meander`camlMeander$c_to_ocaml
+    frame #0: 0x00000000000000 meander`camlMeander__c_to_ocaml_2_code at meander.ml:5:20
+   2   	         : unit -> int = "ocaml_to_c"
+   3   	exception E1
+   4   	exception E2
+-> 5   	let c_to_ocaml () = raise E1
+    	                   ^
+   6   	let _ = Callback.register
+   7   	          "c_to_ocaml" c_to_ocaml
+   8   	let omain () =
 Target 0: (meander) stopped.
 (lldb) backtrace
-frame 0: meander`camlMeander$c_to_ocaml
+frame 0: meander`camlMeander__c_to_ocaml_code
 frame 1: meander`caml_start_program
-frame 2: meander`caml_callback_exn
+frame 2: meander`callback
 frame 3: meander`caml_callback
 frame 4: meander`ocaml_to_c
 frame 5: meander`caml_c_call
-frame 6: meander`camlMeander$omain
-frame 7: meander`camlMeander$entry
+frame 6: meander`camlMeander__omain_1_code
+frame 7: meander`camlMeander__entry
 frame 8: meander`caml_program
 frame 9: meander`caml_start_program
-frame 10: meander`caml_startup_common
-frame 11: meander`caml_startup_exn
-frame 12: meander`caml_startup
-frame 13: meander`caml_main
-frame 14: meander`main
-frame 15: dyld`start
+frame 10: meander`caml_program
 (lldb) quit

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -52,7 +52,7 @@
     gsub(/__libc_start_main@@GLIBC_[0-9]+.[0-9]+$/, "__libc_start_mainXXXX")
 
     gsub("warning: This version of LLDB", "This version of LLDB")
-    gsub("This version of LLDB has no plugin for the language \"assembler\". Inspection of frame variables will be limited.", "")
+    gsub("This version of LLDB has no plugin for the language \"ocaml\". Inspection of frame variables will be limited.", "")
     # Replace printed match results
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
 


### PR DESCRIPTION
I was expecting we'd just end up disabling these tests, but in fact it doesn't appear to need much to adapt them to OxCaml. I've only done the macOS lldb one as it's the only one which shows up in CI at the moment.

cc @tmcgilchrist 