### PR TITLE
Fix for arm64 binary emitter ordering problem

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -681,6 +681,14 @@ let slot_offset loc ~stack_class ~stack_offset ~fun_contains_calls
 let assemble_file infile outfile =
   X86_proc.assemble_file infile outfile
 
+(* On amd64 the deferred-JIT-hook mechanism is implemented inside [X86_proc]
+   via the [binary_content] ref written by the registered internal assembler.
+   These entry points exist only so that the cross-architecture interface in
+   [proc.mli] is uniform. *)
+let set_pending_jit_run _ = ()
+
+let clear_pending_jit_run () = ()
+
 (* Precolored_regs is not always the same as [all_phys_regs], as some physical registers
    may not be allocatable (e.g. rbp when frame pointers are enabled). *)
 let precolored_regs () =

--- a/backend/arm64/binary_emitter_helpers.ml
+++ b/backend/arm64/binary_emitter_helpers.ml
@@ -196,5 +196,5 @@ let end_emission () =
     | Some hook ->
       Proc.set_pending_jit_run (fun () ->
           (* The hook returns a file writer we don't use for JIT. *)
-          let _file_writer = hook sections_for_jit in
+          let _file_writer : string -> unit = hook sections_for_jit in
           ()))

--- a/backend/arm64/binary_emitter_helpers.ml
+++ b/backend/arm64/binary_emitter_helpers.ml
@@ -41,6 +41,11 @@ let should_save_binary_sections () = !Oxcaml_flags.verify_binary_emitter
 let begin_emission () =
   if should_use_binary_emitter ()
   then (
+    (* If a previous compilation aborted between [end_emission] and
+       [Proc.flush_pending_jit_run] (e.g. an exception inside [gen ()] after
+       [end_assembly] had already stashed the hook), drop the stale thunk so it
+       does not run later against a different compilation's state. *)
+    Proc.clear_pending_jit_run ();
     (* When saving binary sections (for verification), emit relocations for all
        symbol references to match assembler behavior *)
     if should_save_binary_sections ()
@@ -183,12 +188,13 @@ let end_emission () =
     (* Save sections to files if needed for verification or explicit saving *)
     if should_save_binary_sections ()
     then save_sections_to_files sections section_tbl;
-    (* Call the JIT hook if registered *)
+    (* Defer the JIT hook invocation until [Proc.assemble_file] time so that any
+       recursive compilation triggered by the loaded code does not interfere
+       with the outer compilation's [Compilenv]/zero-alloc bookkeeping. *)
     match BE.For_jit.Internal_assembler.get () with
     | None -> ()
     | Some hook ->
-      (* The hook expects (string * assembled_section) list and returns a file
-         writer function. We ignore the file writer for JIT. Use the aggregated
-         sections where all .text.* are merged into .text. *)
-      let _file_writer = hook sections_for_jit in
-      ())
+      Proc.set_pending_jit_run (fun () ->
+          (* The hook returns a file writer we don't use for JIT. *)
+          let _file_writer = hook sections_for_jit in
+          ()))

--- a/backend/arm64/binary_emitter_helpers.mli
+++ b/backend/arm64/binary_emitter_helpers.mli
@@ -40,6 +40,9 @@ val should_use_binary_emitter : unit -> bool
 val begin_emission : unit -> Asm_targets.Asm_directives.Directive.t -> unit
 
 (** Finalize the binary emitter if it was enabled. This handles section
-    aggregation, file saving for verification, and JIT hook invocation. Call
-    this at the end of assembly. *)
+    aggregation and file saving for verification. If a JIT hook is registered, a
+    thunk to invoke it is stashed via [Proc.set_pending_jit_run] (so that
+    [Proc.assemble_file] runs it after [Zero_alloc_checker.record_unit_info] has
+    finished) rather than being invoked inline. Call this at the end of
+    assembly. *)
 val end_emission : unit -> unit

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -445,17 +445,50 @@ let slot_offset (loc : Reg.stack_location) ~stack_class ~stack_offset
 
 (* Calling the assembler *)
 
+(* Deferred JIT hook invocation. The hook (registered by [Jit_backend] via
+   [Arm64_binary_emitter.Binary_emitter.For_jit.Internal_assembler]) loads the
+   in-memory assembled sections and runs the entry function, which may
+   recursively re-enter the compiler (e.g. via [Eval.eval] in Opttoploop).
+   Running it inline from [end_emission] would do this in the middle of
+   [Asmgen.gen ()], before [Zero_alloc_checker.record_unit_info] has copied
+   function summaries from the local table into the current [Compilenv]
+   unit's [ui_zero_alloc_info]. A nested compile would replace [current_unit]
+   and refill the table, so the outer [record_unit_info] would write the
+   nested unit's symbols a second time and trip the "is already set" check
+   in [Zero_alloc_info.set_value]. To match the x86 path (where the hook is
+   captured during emit but invoked from [X86_proc.assemble_file], after
+   [record_unit_info]), [end_emission] stashes a thunk here and
+   [assemble_file] flushes it. *)
+let pending_jit_run : (unit -> unit) option ref = ref None
+
+let set_pending_jit_run run =
+  if Option.is_some !pending_jit_run
+  then Misc.fatal_error "Arm64 Proc.set_pending_jit_run: already set";
+  pending_jit_run := Some run
+
+let clear_pending_jit_run () = pending_jit_run := None
+
 let assemble_file infile outfile =
-  let dwarf_flag =
-    if !Clflags.native_code && !Clflags.debug then
-      Dwarf_flags.get_dwarf_as_toolchain_flag ()
-    else
-      ""
-  in
-  Ccomp.command (Config.asm ^ " " ^
-                 (String.concat " " (Misc.debug_prefix_map_flags ())) ^
-                 dwarf_flag ^
-                 " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
+  match !pending_jit_run with
+  | Some run ->
+    (* JIT mode: the binary emitter has already produced sections in memory.
+       Run the deferred JIT hook (which loads them and executes the entry
+       function) and skip the system assembler. *)
+    pending_jit_run := None;
+    run ();
+    0
+  | None ->
+    let dwarf_flag =
+      if !Clflags.native_code && !Clflags.debug then
+        Dwarf_flags.get_dwarf_as_toolchain_flag ()
+      else
+        ""
+    in
+    Ccomp.command (Config.asm ^ " " ^
+                   (String.concat " " (Misc.debug_prefix_map_flags ())) ^
+                   dwarf_flag ^
+                   " -o " ^ Filename.quote outfile ^
+                   " " ^ Filename.quote infile)
 
 let has_three_operand_float_ops () = false
 

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -115,6 +115,19 @@ val domainstate_ptr_dwarf_register_number : int
 (* Calling the assembler *)
 val assemble_file : string -> string -> int
 
+(** Stash a thunk to be invoked the next time [assemble_file] is called, in
+    place of shelling out to the system assembler. Used by the ARM64 binary
+    emitter to defer JIT hook invocation until after
+    [Zero_alloc_checker.record_unit_info] has run. Fails if a thunk is already
+    pending. No-op on architectures without an in-process binary emitter
+    (currently amd64). *)
+val set_pending_jit_run : (unit -> unit) -> unit
+
+(** Drop any pending thunk previously stashed by [set_pending_jit_run] without
+    running it. Used to recover from compilations that aborted between stashing
+    and the corresponding [assemble_file] call. *)
+val clear_pending_jit_run : unit -> unit
+
 (** [operation_supported op] returns true when [op] can be implemented directly
     with a hardware instruction. Used in Cmmgen when converting [@@builtin]
     external calls to primitive operations. *)


### PR DESCRIPTION
There are some problems with ordering of various operations when using the arm64 binary emitter and the JIT; code generated by the latter can end up re-entering compilerlibs, and in one case triggering an exception from the zero alloc checking infrastructure.  This patch solves the problem and will probably suffice for now (mdx on arm64 now works), but I'm planning a follow-up PR to clean up this area further and harmonise the x86 and arm64 binary emitter interfaces.