### PR TITLE
Allow implicit kind redeclaration

### DIFF
--- a/jane/doc/extensions/_06-kinds/05-implicit.md
+++ b/jane/doc/extensions/_06-kinds/05-implicit.md
@@ -71,7 +71,7 @@ module type Outer = sig
 end
 ```
 
-Trying to re-declare an implicit kind will fail too:
+You can re-declare implicit kinds:
 
 ```ocaml
 module type Outer = sig
@@ -85,15 +85,7 @@ module type Outer = sig
     val inner : 't -> 't
   end
 end
-
-[%%expect{|
-Line 7, characters 29-38:
-7 |     [@@@implicit_kind: ('t : immediate)]
-                                 ^^^^^^^^^
-Error: The implicit kind for "t" is already defined at Line 2, characters 27-33.
-|}]
 ```
-
 
 Implicit kinds can't be declared in structures, though we plan to support that.
 

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -235,16 +235,20 @@ module type S11 =
 
 module type S12 = sig
   [@@@implicit_kind: ('a : immediate)]
+
+  val before : 'a -> 'a
+
   [@@@implicit_kind: ('a : bits64)]
 
-  val f : 'a -> 'a
+  val after : 'a -> 'a
 end
 
 [%%expect{|
-Line 3, characters 27-33:
-3 |   [@@@implicit_kind: ('a : bits64)]
-                               ^^^^^^
-Error: The implicit kind for "a" is already defined at line 2, characters 27-36.
+module type S12 =
+  sig
+    val before : ('a : immediate). 'a -> 'a
+    val after : ('a : bits64). 'a -> 'a
+  end
 |}]
 
 (* No override when variable names don't match. *)
@@ -271,10 +275,8 @@ module type S14 = sig
 end
 
 [%%expect{|
-Line 3, characters 27-36:
-3 |   [@@@implicit_kind: ('b : immediate)]
-                               ^^^^^^^^^
-Error: The implicit kind for "b" is already defined at line 2, characters 44-50.
+module type S14 =
+  sig val f : ('a : float32) ('b : immediate). 'a -> 'b -> 'b list end
 |}]
 
 (* Override in nested modules. *)
@@ -289,13 +291,17 @@ module type S15 = sig
 
     val inner : 't -> 't
   end
+
+  val outer_after : 't -> 't
 end
 
 [%%expect{|
-Line 7, characters 29-38:
-7 |     [@@@implicit_kind: ('t : immediate)]
-                                 ^^^^^^^^^
-Error: The implicit kind for "t" is already defined at line 2, characters 27-33.
+module type S15 =
+  sig
+    val outer : ('t : bits64). 't -> 't
+    module Inner : sig val inner : ('t : immediate). 't -> 't end
+    val outer_after : ('t : bits64). 't -> 't
+  end
 |}]
 
 (* Multiple overrides with different variables. *)
@@ -310,10 +316,12 @@ module type S16 = sig
 end
 
 [%%expect{|
-Line 4, characters 27-31:
-4 |   [@@@implicit_kind: ('a : word) * ('c : immediate)]
-                               ^^^^
-Error: The implicit kind for "a" is already defined at line 2, characters 27-36.
+module type S16 =
+  sig
+    val f :
+      ('a : word) ('b : bits64) ('c : immediate). 'a -> 'b -> 'c -> 'b array
+    val g : ('a : word) ('c : immediate). 'a -> 'c list
+  end
 |}]
 
 (* Annotations narrowing the jkind fail.*)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -894,11 +894,6 @@ type lookup_error =
 type error =
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
-  | Implicit_jkind_already_defined of {
-      loc : Location.t;
-      name : string;
-      defined_at : Location.t;
-    }
   | Lookup_error of Location.t * t * lookup_error
   | Incomplete_instantiation of { unset_param : Global_module.Parameter_name.t }
   | Toplevel_splice of Location.t
@@ -2958,14 +2953,9 @@ let add_local_constraint ~stage path info env =
       StagedPath.Map.add { stage; path } info env.local_constraints }
 
 let add_implicit_jkind ~loc name jkind env =
-  match String.Map.find_opt name env.implicit_jkinds with
-  | Some { loc = defined_loc; txt = _ } ->
-      error
-        (Implicit_jkind_already_defined { loc; name; defined_at = defined_loc })
-  | None ->
-      { env with
-        implicit_jkinds =
-          String.Map.add name { txt = jkind; loc } env.implicit_jkinds }
+  { env with
+    implicit_jkinds =
+      String.Map.add name { txt = jkind; loc } env.implicit_jkinds }
 
 let clear_implicit_jkinds env =
   { env with implicit_jkinds = String.Map.empty }
@@ -5301,11 +5291,6 @@ let report_error_doc ppf = function
   | Illegal_value_name(_loc, name) ->
       fprintf ppf "%a is not a valid value identifier."
        Style.inline_code name
-  | Implicit_jkind_already_defined { name; defined_at; loc = _ } ->
-      fprintf ppf
-        "@[<hov>The implicit kind for %a is already defined at %a.@]"
-        Style.inline_code name
-        (Location.Doc.loc ~capitalize_first:false) defined_at
   | Lookup_error(loc, t, err) -> report_lookup_error_doc loc t ppf err
   | Incomplete_instantiation { unset_param } ->
       fprintf ppf "@[<hov>Not enough instance arguments: the parameter@ %a@ is \
@@ -5332,7 +5317,6 @@ let () =
             match err with
             | Missing_module (loc, _, _)
             | Illegal_value_name (loc, _)
-            | Implicit_jkind_already_defined { loc; _ }
             | Toplevel_splice loc
             | Unsupported_inside_quotation (loc, _)
             | Lookup_error(loc, _, _) -> loc

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -663,11 +663,6 @@ val env_of_only_summary : (summary -> Subst.t -> t) -> t -> t
 type error =
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
-  | Implicit_jkind_already_defined of {
-      loc : Location.t;
-      name : string;
-      defined_at : Location.t;
-    }
   | Lookup_error of Location.t * t * lookup_error
   | Incomplete_instantiation of { unset_param : Global_module.Parameter_name.t; }
   | Toplevel_splice of Location.t


### PR DESCRIPTION
Allow redeclaring implicit kinds. We originally forbade that to be conservative, but users want it and it doesn't seem to have downsides. Example:

```ocaml
module type Outer = sig
  [@@@implicit_kind: ('t : bits64)]

  val outer : 't -> 't

  module Inner : sig
    [@@@implicit_kind: ('t : immediate)]

    val inner : 't -> 't
  end
end
```

