### PR TITLE
Allow forks to use GitHub Actions default runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,56 +22,56 @@ jobs:
         include:
           - name: runtime5 (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_debug: true
 
           - name: runtime5 dissector-assembler (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             oxcaml_llvm_tag: oxcaml-llvmize-16.0.6-minus3
             oxcaml_llvm_source_branch: llvmize-oxcaml
             dissector_assembler: true
 
           - name: runtime5 stack-checks (x86_64-linux)
             config: --enable-runtime5 --enable-stack-checks
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
 
           - name: runtime5 poll-insertion (x86_64-linux)
             config: --enable-runtime5 --enable-poll-insertion
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
 
           - name: runtime5 multidomain (x86_64-linux)
             config: --enable-runtime5 --enable-stack-checks --enable-poll-insertion --enable-multidomain
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
 
           - name: runtime4 dev (x86_64-linux)
             config: --disable-runtime5 --enable-dev
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
 
           # We use a custom install prefix for this workflow.
           # Consider renaming it to indicate as such when convenient.
           - name: runtime5 dev (x86_64-linux)
             config: --enable-runtime5 --enable-dev
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             install_path: _custom_install
 
           - name: runtime5 debug stack-checks (x86_64-linux)
             config: --enable-runtime5 --enable-stack-checks
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: ''
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
           - name: runtime5 debug (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: ''
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
           - name: runtime4 O3 (x86_64-linux)
             config: --disable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: ''
             ocamlparam: '_,O3=1'
             disable_testcases: 'testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
@@ -79,7 +79,7 @@ jobs:
 
           - name: runtime4 O3 metrics (x86_64-linux)
             config: --disable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: '_'
             ocamlparam: '_,O3=1'
             collect_metrics: true
@@ -87,25 +87,25 @@ jobs:
 
           - name: runtime4 Oclassic frame-pointers poll-insertion flambda-invariants (x86_64-linux)
             config: --disable-runtime5 --enable-frame-pointers --enable-poll-insertion --enable-flambda-invariants
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: ''
             ocamlparam: '_,Oclassic=1'
             disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/array_element_kind_meet.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/gadt_simplified_switch.ml'
 
           - name: runtime4 (aarch64-darwin)
             config: --disable-runtime5 --disable-warn-error
-            os: warp-macos-15-arm64-6x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-macos-15-arm64-6x' || 'macos-15' }}
 
           - name: runtime5 regalloc (aarch64-darwin)
             config: --enable-runtime5 --disable-warn-error
-            os: warp-macos-15-arm64-6x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-macos-15-arm64-6x' || 'macos-15' }}
             build_ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
             ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
             run_regalloc_tool: true
 
           - name: runtime5 debug regalloc (aarch64-darwin)
             config: --enable-runtime5 --disable-warn-error
-            os: warp-macos-15-arm64-6x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-macos-15-arm64-6x' || 'macos-15' }}
             build_ocamlparam: '_,w=-46,save-ir-before=register_allocation'
             ocamlparam: '_,w=-46,save-ir-before=register_allocation'
             use_runtime: d
@@ -114,21 +114,21 @@ jobs:
 
           - name: runtime5 regalloc (aarch64-linux)
             config: --enable-runtime5 --disable-warn-error
-            os: warp-ubuntu-latest-arm64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-arm64-8x' || 'ubuntu-24.04-arm' }}
             build_ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
             ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
             run_regalloc_tool: true
 
           - name: runtime5 regalloc multidomain (aarch64-linux)
             config: --enable-runtime5 --enable-poll-insertion --enable-multidomain --disable-warn-error
-            os: warp-ubuntu-latest-arm64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-arm64-8x' || 'ubuntu-24.04-arm' }}
             build_ocamlparam: '_,w=-46,save-ir-before=register_allocation'
             ocamlparam: '_,w=-46,save-ir-before=register_allocation'
             run_regalloc_tool: true
 
           - name: runtime4 regalloc (x86_64-linux)
             config: --disable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: '_,w=-46,save-ir-before=register_allocation'
             ocamlparam: '_,w=-46,save-ir-before=register_allocation'
             check_arch: true
@@ -136,47 +136,47 @@ jobs:
 
           - name: runtime5 frame-pointers irc (x86_64-linux)
             config: --enable-runtime5 --enable-frame-pointers
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: '_,w=-46,regalloc=irc'
             ocamlparam: '_,w=-46,regalloc=irc'
             check_arch: true
 
           - name: runtime5 cfg-invariants (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: '_,w=-46,regalloc=cfg,cfg-invariants=1,cfg-eliminate-dead-trap-handlers=1'
             ocamlparam: '_,w=-46,regalloc=cfg,cfg-invariants=1,cfg-eliminate-dead-trap-handlers=1'
             check_arch: true
 
           - name: runtime5 cfg-invariants (aarch64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-arm64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-arm64-8x' || 'ubuntu-24.04-arm' }}
             build_ocamlparam: "_,w=-46,regalloc=cfg,cfg-invariants=1,cfg-eliminate-dead-trap-handlers=1"
             ocamlparam: "_,w=-46,regalloc=cfg,cfg-invariants=1,cfg-eliminate-dead-trap-handlers=1"
             check_arch: true
 
           - name: runtime5 vectorizer (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: '_,w=-46,regalloc=cfg,vectorize=1'
             ocamlparam: '_,w=-46,regalloc=cfg,vectorize=1'
             check_arch: true
 
           - name: runtime5 x86-peephole (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: '_,w=-46,x86-peephole-optimize=1'
             ocamlparam: '_,w=-46,x86-peephole-optimize=1'
             check_arch: true
 
           - name: runtime4 address-sanitizer (x86_64-linux)
             config: --disable-runtime5 --enable-address-sanitizer
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             cc: clang
 
           - name: runtime5 address-sanitizer (x86_64-linux)
             config: --enable-runtime5 --enable-address-sanitizer
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             cc: clang
 
           # CR sspies: The DWARF tests unconditionally pass -function-sections
@@ -188,21 +188,21 @@ jobs:
           # with DWARF enabled under function sections.
           - name: runtime5 dwarf-tests (x86_64-linux)
             config: --enable-runtime5 --enable-function-sections
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             dwarf_tests_only: true
             oxcaml_llvm_tag: oxcaml-lldb-16.0.6-minus1
             oxcaml_llvm_source_branch: lldb
 
           - name: runtime5 frame-pointers llvmize-tests (x86_64-linux)
             config: --enable-runtime5 --enable-frame-pointers
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             llvmize_tests_only: true
             oxcaml_llvm_tag: oxcaml-llvmize-16.0.6-minus3
             oxcaml_llvm_source_branch: llvmize-oxcaml
 
           - name: runtime5 musl (x86_64-linux)
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             cc: musl-gcc
 
           # Here and below, we put 'reaper=1,_' instead of '_,reaper=1', as
@@ -210,14 +210,14 @@ jobs:
           # enabled.
           - name: runtime5 reaper
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: 'reaper=1,_'
             ocamlparam: 'reaper=1,_'
             disable_testcases: 'testsuite/tests/flambda2/examples/array_kind.ml testsuite/tests/flambda2/examples/code_id_join_b.ml testsuite/tests/flambda2/examples/functor_call.ml testsuite/tests/flambda2/examples/invalid.ml testsuite/tests/flambda2/examples/value_slot_c.ml testsuite/tests/flambda2/examples/value_slot_use_b.ml'
 
           - name: runtime5 reaper with local value slots
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: 'reaper=1,reaper-local-fields=1,_'
             ocamlparam: 'reaper=1,reaper-local-fields=1,_'
             disable_testcases: 'testsuite/tests/tool-ocamlobjinfo/question.ml testsuite/tests/flambda2/examples/array_kind.ml testsuite/tests/flambda2/examples/code_id_join_b.ml testsuite/tests/flambda2/examples/functor_call.ml testsuite/tests/flambda2/examples/invalid.ml testsuite/tests/flambda2/examples/value_slot_c.ml testsuite/tests/flambda2/examples/value_slot_use_b.ml testsuite/tests/flambda2/examples/unknown/bigarrays.ml testsuite/tests/flambda2/examples/unknown/test_cmx_offsets2.ml'
@@ -226,7 +226,7 @@ jobs:
           # lifting and specialization
           - name: runtime5 match-in-match
             config: --enable-runtime5
-            os: warp-ubuntu-latest-x64-8x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
             build_ocamlparam: 'flambda2-expert-cont-lifting-budget=1000,flambda2-expert-cont-spec-budget=100,_'
             ocamlparam: 'flambda2-expert-cont-lifting-budget=1000,flambda2-expert-cont-spec-budget=100,_'
             disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/array_element_kind_meet.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   nix-matrix:
-    runs-on: warp-ubuntu-latest-arm64-8x
+    runs-on: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-arm64-8x' || 'ubuntu-24.04-arm' }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -29,8 +29,18 @@ jobs:
         name: Generate Nix Matrix
         run: |
           set -Eeuo pipefail
+          if [ "${{ github.repository }}" = 'oxcaml/oxcaml' ]; then
+            filter='.'
+          else
+            filter='walk(if type == "string" then ({
+              "warp-ubuntu-latest-x64-8x":   "ubuntu-latest",
+              "warp-ubuntu-latest-x64-32x":  "ubuntu-latest",
+              "warp-ubuntu-latest-arm64-8x": "ubuntu-24.04-arm",
+              "warp-macos-15-arm64-6x":      "macos-15"
+            }[.] // .) else . end)'
+          fi
           echo -n 'matrix=' >> "$GITHUB_OUTPUT"
-          nix eval --json '.#githubActions.matrix' | tee -a "$GITHUB_OUTPUT"
+          nix eval --json '.#githubActions.matrix' | jq -c "$filter" | tee -a "$GITHUB_OUTPUT"
 
   nix-build:
     name: ${{ matrix.name }} (${{ matrix.system }})

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - system: x86_64-linux
-            os: warp-ubuntu-latest-x64-32x
+            os: ${{ github.repository == 'oxcaml/oxcaml' && 'warp-ubuntu-latest-x64-32x' || 'ubuntu-latest' }}
     steps:
       - name: Checkout the OxCaml repo
         uses: actions/checkout@master


### PR DESCRIPTION
I like to use "self-PRs" (i.e. PRs opened one's own fork) as part of my workflow. It has a benefit of freeing up resource on upstream repo's CI time (I've even [pontificated about this in the past](https://www.dra27.uk/blog/platform/2017/09/27/ocaml-github-ci.html)), and I use it to park ideas occasionally as well.

At the moment, OxCaml's is a bit awkward to do that with because of our WarpBuild runners, as I don't have any :sob:

This PR adds the appropriate fu so that PRs on oxcaml/oxcaml use WarpBuild and ones elsewhere use the standard GHA runners. You can see it running on my fork in https://github.com/dra27/oxcaml/pull/25/checks.

I have tested it and hope not to be embarrassed by this PR failing to use WarpBuild, but don't laugh too loudly after I hit "Create pull request" and it tries to use GHA runners...

Three notes:
- We could put the names of our runners in Settings and refer to them, then we'd have changes more like `${{ vars.RUNNER_LINUX_X64 || 'ubuntu-latest' }}`, since oxcaml/oxcaml would have the build variable set and forks wouldn't (well, but then they could if someone was really keen...)
- GitHub Actions doesn't run on forks by default anyway, so this change doesn't affect anyone who isn't already trying to use it
- The triggers for our workflows means that this wouldn't suddenly cause pushes to branches on forks to start building either (even on forks which have already enabled GitHub Actions)