### PR TITLE
Fix infix operator logic inside quotations

### DIFF
--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1864,7 +1864,7 @@ module Ast = struct
   and print_for_iterator env fmt = function
     | Range (var, exp_start, exp_stop, dir) ->
       pp fmt "@[%a = %a@]@ %a@ %a"
-        (Var.Value.print env) var (print_exp env) exp_start
+        (print_value_var env) var (print_exp env) exp_start
         (print_dir) dir (print_exp env) exp_stop
     | In (pat, exp) ->
       pp fmt "%a@ in@ %a" (print_pat env) pat (print_exp env) exp

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1425,7 +1425,8 @@ module Ast = struct
 
   let view_fixity_of_exp = function
     | { desc = Ident (VVar _ as l); attributes = [] }
-    | { desc = Ident (VDot (Global_module "Stdlib", _) as l); attributes = [] } ->
+    | { desc = Ident (VDot (Global_module "Stdlib", _) as l);
+        attributes = [] } ->
       fixity_of_string (suffix_string_of_ident_value l)
     | _ -> `Normal
 

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -901,6 +901,17 @@ let print_op fmt s =
   then Format.fprintf fmt "( %s )" s
   else Format.fprintf fmt "%s" s
 
+let needs_value_parens s =
+  s <> ""
+  && (List.mem s special_infix_strings
+      || List.mem s.[0] special_symbols
+      || s.[0] = '.')
+
+let print_value_var env fmt v =
+  if needs_value_parens (Var.Value.name v)
+  then Format.fprintf fmt "( %a )" (Var.Value.print env) v
+  else Var.Value.print env fmt v
+
 let rec print_raw_ident_module env fmt = function
   | Global_module s -> Format.fprintf fmt "%s" s
   | MDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
@@ -909,7 +920,7 @@ let rec print_raw_ident_module env fmt = function
 let print_raw_ident_value env fmt = function
   | VDot (m, s) ->
     Format.fprintf fmt "%a.%a" (print_raw_ident_module env) m print_op s
-  | VVar (v, _) -> Var.Value.print env fmt v
+  | VVar (v, _) -> print_value_var env fmt v
 
 let print_raw_ident_type env fmt = function
   | TDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
@@ -1527,9 +1538,9 @@ module Ast = struct
   and print_pat ?(with_parens = true) env fmt pat =
     match pat with
     | PatAny -> pp fmt "_"
-    | PatVar v -> Var.Value.print env fmt v
+    | PatVar v -> print_value_var env fmt v
     | PatAlias (pat, v) ->
-      pp fmt "%a@ as@ %a" (print_pat env) pat (Var.Value.print env) v
+      pp fmt "%a@ as@ %a" (print_pat env) pat (print_value_var env) v
     | PatConstant c -> print_const fmt c
     | PatUnboxedUnit -> pp fmt "#()"
     | PatUnboxedBool b -> pp fmt "#%a" print_bool b

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1413,9 +1413,8 @@ module Ast = struct
     | _ -> `Normal
 
   let view_fixity_of_exp = function
-    (* FIXME: properly check that it is safe to treat the operator as infix
-       within the quotation context *)
-    | { desc = Ident l; attributes = [] } ->
+    | { desc = Ident (VVar _ as l); attributes = [] }
+    | { desc = Ident (VDot (Global_module "Stdlib", _) as l); attributes = [] } ->
       fixity_of_string (suffix_string_of_ident_value l)
     | _ -> `Normal
 

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1579,3 +1579,15 @@ let open Op in
 - : <[int]> expr =
 <[let ( + ) = (fun x y -> x) in let f = (fun g -> g 1 2) in f ( + )]>
 |}];;
+
+(* Infix operators are correctly named when used in comprehensions. *)
+<[ [2 + 3 for ( + ) in [( + ); ( * )]] ]>;;
+[%%expect {|
+- : <[int list]> expr = <[[ 2 + 3 for ( + ) in [Stdlib.( + ); Stdlib.( * )] ]
+]>
+|}];;
+
+<[ [( + ) for ( + ) = 1 to 3] ]>;;
+[%%expect {|
+- : <[int list]> expr = <[[ ( + ) for ( + ) = 1 to 3 ]]>
+|}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1567,3 +1567,15 @@ let open Op in
 [%%expect {|
 - : <[string]> expr = <[Op.( + ) "abc" "def"]>
 |}];;
+
+(* Infix operators are correctly parenthesised when defined in quotations. *)
+<[ let (+) x y = x ^ y in "foo" + "bar" ]>;;
+[%%expect {|
+- : <[string]> expr = <[let ( + ) = (fun x y -> x ^ y) in "foo" + "bar"]>
+|}];;
+
+<[ let (+) x y = x in let f g = g 1 2 in f (+) ]>;;
+[%%expect {|
+- : <[int]> expr =
+<[let ( + ) = (fun x y -> x) in let f = (fun g -> g 1 2) in f ( + )]>
+|}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -24,6 +24,13 @@ class cls = object method meth () = 42 end;;
 class cls : object method meth : unit -> int end
 |}];;
 
+module Op = struct
+  let (+) x y = x ^ y
+end
+[%%expect {|
+module Op : sig val ( + ) : string -> string -> string end
+|}];;
+
 #mark_toplevel_in_quotations;;
 
 (* Tests *)
@@ -1552,4 +1559,11 @@ Line 1, characters 31-40:
 Error: Annotating types with kinds
        is not supported inside quoted expressions,
        as seen at line 1, characters 31-40.
+|}];;
+
+(* Correct disambiguation of infix operators. *)
+let open Op in
+<[ "abc" + "def" ]>;;
+[%%expect {|
+- : <[string]> expr = <[Op.( + ) "abc" "def"]>
 |}];;


### PR DESCRIPTION
This PR addresses issues regarding syntax and typing errors during evaluation of quoted expressions that contain infix operators.

If an infix operator is being applied, the typing error can be triggered. If this operator shadows an infix operator from Stdlib, after this PR this operator is used as a fully-qualified prefix operator e.g. if `+` refers to a `M.(+)`, we use the latter inside a quotation in a prefix position.

Likewise, parentheses are now correctly inserted for locally-defined infix operators inside quotations. Prior to this PR, parentheses were not inserted outside of operator application:
```
# <[let (+) x y = x in let f g = g 1 2 in f (+)]>;;
- : <[int]> expr =
<[let + = (fun x y -> x) in let f = (fun g -> g 1 2) in f +]>
```
