### PR TITLE
Better error messages for `Invalid_native_repr_for_primitive`

### DIFF
--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1163,8 +1163,8 @@ Line 4, characters 25-45:
                              ^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 external ext_tuple_arg_with_attr_u : (#(int * bool) [@unboxed]) -> int = "foo"
@@ -1193,8 +1193,8 @@ Line 1, characters 27-43:
                                ^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 external ext_product_arg_3 : t_product_3 -> int = "foo" "bar"
@@ -1204,8 +1204,8 @@ Line 1, characters 29-47:
                                  ^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 external ext_product_arg_with_attr_u : (t_product [@unboxed]) -> int = "foo"
@@ -1239,6 +1239,7 @@ Line 1, characters 29-58:
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: Unboxed products in C stub returns must be a pair of non-products.
 |}]
 
 external ext_nested_tuple_return : int -> #(int * #(int * bool)) = "foo" "bar"
@@ -1248,6 +1249,7 @@ Line 1, characters 35-64:
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: Unboxed products in C stub returns must be a pair of non-products.
 |}]
 
 external ext_tuple_return_with_attr_u :
@@ -1284,6 +1286,7 @@ Line 1, characters 32-50:
                                     ^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: Unboxed products in C stub returns must be a pair of non-products.
 |}]
 
 external ext_product_return_with_attr_u : int -> (t_product [@unboxed]) = "foo"
@@ -1333,8 +1336,8 @@ Line 2, characters 26-54:
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 type ext_record_arg_record_3 = #{ i : int; b : bool; s : string }
@@ -1346,8 +1349,8 @@ Line 2, characters 28-58:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 type ext_record_arg_attr_record = #{ i : int; b : bool }
@@ -1389,6 +1392,7 @@ Line 2, characters 31-41:
                                    ^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: Unboxed products in C stub returns must be a pair of non-products.
 |}]
 
 type ext_record_nested = #{ x : int; y : ext_record_arg_record }
@@ -1400,6 +1404,7 @@ Line 2, characters 30-54:
                                   ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: Unboxed products in C stub returns must be a pair of non-products.
 |}]
 
 type t = #{ i : int; b : bool }
@@ -1487,8 +1492,8 @@ Line 2, characters 2-22:
       ^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 (* @unpacked allows product types as arguments to C stubs *)
@@ -1538,6 +1543,7 @@ Line 2, characters 2-36:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: The "[@unpacked]" attribute is not allowed on C stub returns.
 |}]
 
 (* @unpacked combined with @unboxed should error *)
@@ -1731,8 +1737,8 @@ Line 1, characters 16-60:
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [caml_array_make] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 external[@layout_poly] make : ('a : any mod separable) . int -> 'a -> 'a array =

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1407,6 +1407,20 @@ Error: The primitive [foo] is used in an invalid declaration.
 Hint: Unboxed products in C stub returns must be a pair of non-products.
 |}]
 
+external error_with_multiple_hints
+  : #(int * int) -> #(int * int) -> #(int * int * int)
+  = "foo" "bar"
+[%%expect{|
+Line 2, characters 4-54:
+2 |   : #(int * int) -> #(int * int) -> #(int * int * int)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [foo] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
+Hint: Unboxed products in C stub returns must be a pair of non-products.
+|}]
+
 type t = #{ i : int; b : bool }
 external ext_record_return_with_attr_u : int -> (t [@unboxed]) = "foo"
 [%%expect{|

--- a/testsuite/tests/typing-layouts-void/void_stubs.ml
+++ b/testsuite/tests/typing-layouts-void/void_stubs.ml
@@ -30,8 +30,8 @@ Line 1, characters 35-59:
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 
 external ext_void_in_product_return : unit -> #(string * void) = "foo" "bar"
@@ -46,8 +46,8 @@ Line 1, characters 28-37:
                                 ^^^^^^^^^
 Error: The primitive [foo] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-       Hint: Types with product layouts in C stub arguments
-       require the "[@unpacked]" attribute.
+Hint: Types with product layouts in C stub arguments require the
+      "[@unpacked]" attribute.
 |}]
 external ext_all_void_return : unit -> r = "foo" "bar"
 [%%expect{|

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2542,6 +2542,8 @@ Line 1, characters 13-33:
                  ^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [%send] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: This was expected to be a value-only primitive. You might've
+      misspelled the primitive name.
 |}]
 
 external f : int -> int -> float# = "%sendself";;
@@ -2551,6 +2553,8 @@ Line 1, characters 13-33:
                  ^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [%sendself] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: This was expected to be a value-only primitive. You might've
+      misspelled the primitive name.
 |}]
 
 external f : int -> float# -> int -> int -> int = "%sendcache";;
@@ -2560,6 +2564,8 @@ Line 1, characters 13-47:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [%sendcache] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: This was expected to be a value-only primitive. You might've
+      misspelled the primitive name.
 |}]
 
 (*********************************************************)

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -681,6 +681,8 @@ Line 1, characters 29-49:
                                  ^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [%obj_dup] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: This was expected to be a value-only primitive. You might've
+      misspelled the primitive name.
 |}]
 
 external dup : float# -> float# = "%obj_dup"
@@ -690,6 +692,8 @@ Line 1, characters 15-31:
                    ^^^^^^^^^^^^^^^^
 Error: The primitive [%obj_dup] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+Hint: This was expected to be a value-only primitive. You might've
+      misspelled the primitive name.
 |}]
 
 (*************************************************************)

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -65,6 +65,17 @@ type 'repr description_gen =
 
 type description = native_repr description_gen
 
+type wrong_repr_error =
+  | Product_arg
+  | Expected_value_prim
+  | Product_return
+  | Unpacked_product_return
+  | Repr_mismatch
+
+(* [wrong_repr_error] is immediate, so poly-compare is ok *)
+let compare_wrong_repr_error (a : wrong_repr_error) (b : wrong_repr_error) =
+  Stdlib.compare a b
+
 type error =
   | Old_style_float_with_native_repr_attribute
   | Old_style_float_with_non_value
@@ -75,7 +86,7 @@ type error =
   | Inconsistent_noalloc_attributes_for_effects
   | Invalid_representation_polymorphic_attribute
   | Invalid_native_repr_for_primitive of
-      { prim_name : string; has_product_arg : bool }
+      { prim_name : string; errors : wrong_repr_error list }
 
 exception Error of Location.t * error
 
@@ -471,16 +482,19 @@ module Repr_check = struct
 
   type result =
     | Wrong_arity
-    | Wrong_repr
+    | Wrong_repr of wrong_repr_error list (* non-empty list *)
     | Success
 
   let args_res_reprs prim =
     (prim.prim_native_repr_args @ [prim.prim_native_repr_res])
     |> List.map snd
 
-  let is repr = equal_native_repr repr
+  let is expected_repr repr =
+    if equal_native_repr expected_repr repr
+    then []
+    else [Repr_mismatch]
 
-  let any = fun _ -> true
+  let any = fun _ -> []
 
   let value_or_unboxed_or_untagged = function
     | Same_as_ocaml_repr (Base Scannable)
@@ -493,34 +507,40 @@ module Repr_check = struct
     | Univar _ -> Misc.fatal_error "sort_is_product: univar"
     | Genvar _ -> Misc.fatal_error "sort_is_product: genvar"
 
-  let valid_c_stub_arg = function
+  let c_stub_arg_errors = function
     | Same_as_ocaml_repr s ->
-      not (sort_is_product s)
+      if sort_is_product s then [Product_arg] else []
     | Unboxed_float _ | Unboxed_or_untagged_integer _ | Unboxed_vector _
-    | Unpacked_product _ | Repr_poly -> true
+    | Unpacked_product _ | Repr_poly -> []
 
-  let valid_c_stub_return = function
+  let c_stub_return_errors = function
     | Same_as_ocaml_repr (Base _)
     | Unboxed_float _ | Unboxed_or_untagged_integer _ | Unboxed_vector _
-    | Repr_poly -> true
-    | Unpacked_product _ -> false
+    | Repr_poly -> []
+    | Unpacked_product _ -> [Unpacked_product_return]
     | Same_as_ocaml_repr (Product [s1; s2]) ->
-      not (sort_is_product s1) &&
-      not (sort_is_product s2)
-    | Same_as_ocaml_repr (Product _) -> false
+      if (sort_is_product s1) ||
+         (sort_is_product s2)
+      then [Product_return]
+      else []
+    | Same_as_ocaml_repr (Product _) -> [Product_return]
     | Same_as_ocaml_repr (Univar _) ->
-      Misc.fatal_error "valid_c_stub_return: univar"
+      Misc.fatal_error "c_stub_return_errors: univar"
     | Same_as_ocaml_repr (Genvar _) ->
-      Misc.fatal_error "valid_c_stub_return: genvar"
+      Misc.fatal_error "c_stub_return_errors: genvar"
 
   let check checks prim =
     let reprs = args_res_reprs prim in
     if List.length reprs <> List.length checks
     then Wrong_arity
-    else
-    if not (List.for_all2 (fun f x -> f x) checks reprs)
-    then Wrong_repr
-    else Success
+    else begin
+      let repr_errors =
+        List.concat (List.map2 (fun f x -> f x) checks reprs)
+      in
+      if List.is_empty repr_errors
+      then Success
+      else Wrong_repr repr_errors
+    end
 
   let exactly required =
     check (List.map is required)
@@ -534,7 +554,11 @@ module Repr_check = struct
   let no_non_value_repr prim =
     let arity = List.length prim.prim_native_repr_args in
     check
-      (List.init (arity+1) (fun _ -> value_or_unboxed_or_untagged))
+      (List.init (arity+1)
+         (fun _ repr ->
+            if value_or_unboxed_or_untagged repr
+            then []
+            else [Expected_value_prim]))
       prim
 
   let check_c_stub prim =
@@ -542,7 +566,8 @@ module Repr_check = struct
        arguments or return products with more than two elements. *)
     let arity = List.length prim.prim_native_repr_args in
     let checks =
-      (List.init arity (fun _ -> valid_c_stub_arg)) @ [valid_c_stub_return]
+      (List.init arity (fun _ -> c_stub_arg_errors))
+      @ [c_stub_return_errors]
     in
     check checks prim
 end
@@ -1044,18 +1069,10 @@ let prim_has_valid_reprs ~loc prim =
        primitives here but not all, and it would be weird to raise different
        errors dependent on the [prim_name]. *)
     ()
-  | Wrong_repr ->
-    let has_product_arg =
-      not (is_builtin_prim_name prim.prim_name)
-      && List.exists (fun (_, repr) ->
-           match repr with
-           | Same_as_ocaml_repr (Product _) -> true
-           | _ -> false)
-           prim.prim_native_repr_args
-    in
+  | Wrong_repr errors ->
     raise (Error (loc,
             Invalid_native_repr_for_primitive
-              { prim_name = prim.prim_name; has_product_arg }))
+              { prim_name = prim.prim_name; errors }))
 
 let prim_can_contain_layout_any prim =
   match prim.prim_name with
@@ -1118,17 +1135,39 @@ let report_error ppf err =
     Format_doc.fprintf ppf "Attribute %a can only be used \
                         on built-in primitives."
       Style.inline_code "[@layout_poly]"
-  | Invalid_native_repr_for_primitive { prim_name; has_product_arg } ->
+  | Invalid_native_repr_for_primitive { prim_name; errors } ->
     Format_doc.fprintf ppf
       "The primitive [%s] is used in an invalid declaration.@ \
        The declaration contains argument/return types with the@ \
        wrong layout."
       prim_name;
-    if has_product_arg then
-      Format_doc.fprintf ppf
-        "@ Hint: Types with product layouts in C stub arguments@ \
-         require the %a attribute."
-        Style.inline_code "[@unpacked]"
+    let errors = List.sort_uniq compare_wrong_repr_error errors in
+    List.iter
+      (function
+      | Product_arg ->
+        Format_doc.fprintf ppf
+          "@.@{<hint>Hint@}: @[<v>\
+           Types with product layouts in C stub arguments require the@ \
+           %a attribute.@]"
+          Style.inline_code "[@unpacked]"
+      | Expected_value_prim ->
+        Format_doc.fprintf ppf
+          "@.@{<hint>Hint@}: @[<v>\
+           This was expected to be a value-only primitive. You might've@ \
+           misspelled the primitive name.@]"
+      | Product_return ->
+        Format_doc.fprintf ppf
+          "@.@{<hint>Hint@}: @[<v>\
+           Unboxed products in C stub returns must be a pair of non-products.@]"
+      | Unpacked_product_return ->
+        Format_doc.fprintf ppf
+          "@.@{<hint>Hint@}: @[<v>\
+           The %a attribute is not allowed on C stub returns.@]"
+          Style.inline_code "[@unpacked]"
+      | Repr_mismatch -> ()
+        (* The error message already says "wrong layout", so a hint here would
+           be redundant. *))
+      errors
 
 let () =
   Location.register_error_of_exn

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -65,14 +65,17 @@ type 'repr description_gen =
 
 type description = native_repr description_gen
 
+(* Is [[@@immediate]], so poly-compare can be used to de-dup errors. If a [loc]
+   is added, then errors will always be unique and de-duping will no longer be
+   necessary. *)
 type wrong_repr_error =
   | Product_arg
   | Expected_value_prim
   | Product_return
   | Unpacked_product_return
   | Repr_mismatch
+[@@immediate]
 
-(* [wrong_repr_error] is immediate, so poly-compare is ok *)
 let compare_wrong_repr_error (a : wrong_repr_error) (b : wrong_repr_error) =
   Stdlib.compare a b
 
@@ -489,7 +492,7 @@ module Repr_check = struct
     (prim.prim_native_repr_args @ [prim.prim_native_repr_res])
     |> List.map snd
 
-  let is expected_repr repr =
+  let is expected_repr repr : wrong_repr_error list =
     if equal_native_repr expected_repr repr
     then []
     else [Repr_mismatch]
@@ -529,6 +532,12 @@ module Repr_check = struct
     | Same_as_ocaml_repr (Genvar _) ->
       Misc.fatal_error "c_stub_return_errors: genvar"
 
+  (* [checks = [check_arg1; check_arg2; ..; check_argn; check_ret]], where for
+     each check, [check (repr : native_repr)] returns a [wrong_repr_error list].
+     If the returned list is empty, then the check succeeded. For example,
+     [check [any; is (Same_as_ocaml_repr C.scannable)] prim_desc] checks that
+     [prim_desc] accepts a single argument of any layout and returns a
+     scannable value. *)
   let check checks prim =
     let reprs = args_res_reprs prim in
     if List.length reprs <> List.length checks

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -151,6 +151,13 @@ val prim_has_valid_reprs : loc:Location.t -> description -> unit
     the layout of type parameters ([%array_length] for example). *)
 val prim_can_contain_layout_any : description -> bool
 
+type wrong_repr_error =
+  | Product_arg
+  | Expected_value_prim
+  | Product_return
+  | Unpacked_product_return
+  | Repr_mismatch
+
 type error =
   | Old_style_float_with_native_repr_attribute
   | Old_style_float_with_non_value
@@ -161,6 +168,6 @@ type error =
   | Inconsistent_noalloc_attributes_for_effects
   | Invalid_representation_polymorphic_attribute
   | Invalid_native_repr_for_primitive of
-      { prim_name : string; has_product_arg : bool }
+      { prim_name : string; errors : wrong_repr_error list }
 
 exception Error of Location.t * error


### PR DESCRIPTION
We have a few options for aligning the hint text.

What Ryan originally wrote:
```
Error: The primitive ...
       Hint: Types with product layouts in C stub arguments
       require the "[@unpacked]" attribute.
```

The style in other parts of the compiler:
```
Error: The primitive ...
Hint: Types with product layouts in C stub arguments require the
"[@unpacked]" attribute.
```

Align with "Hint":
```
Error: The primitive ...
Hint: Types with product layouts in C stub arguments require the
      "[@unpacked]" attribute.
```

Align with "Error":
```
Error: The primitive ...
Hint:  Types with product layouts in C stub arguments require the
       "[@unpacked]" attribute.
```
Currently, align with hint is implemented.
