### PR TITLE
Fix modes bug in untypeast/pprintast roundtrip

### DIFF
--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -15,6 +15,19 @@ let run s =
 val run : string -> unit = <fun>
 |}];;
 
+let run_structure s =
+  let structure = Parse.implementation (Lexing.from_string s) in
+  let typed_structure, _, _, _, _, _ =
+    Typemod.type_structure (Lazy.force Env.initial) structure
+  in
+  let structure = Untypeast.untype_structure typed_structure in
+  Format.printf "%a@." Pprintast.structure structure
+;;
+
+[%%expect{|
+val run_structure : string -> unit = <fun>
+|}];;
+
 run {| match None with Some (Some _) -> () | _ -> () |};;
 
 [%%expect{|
@@ -95,8 +108,6 @@ foo
 - : unit = ()
 |}];;
 
-(* CR: untypeast/pprintast are totally busted on programs with modes in value
-   bindings. Fix this. *)
 run {| let foo : ('a -> 'a) @ portable = fun x -> x in foo |}
 
 [%%expect{|
@@ -130,3 +141,28 @@ run {| let foo : 'a -> 'a = fun x -> x in foo |}
 let (foo : 'a -> 'a) = (fun x -> x : 'a -> 'a) in foo
 - : unit = ()
 |}];;
+
+(***********************************)
+(* Untypeast/pprintast correctly handle declaration modalities. *)
+
+run_structure {|
+  module State = struct
+    type t = int
+    external next : t -> t @@ portable = "%identity"
+  end |};;
+
+[%%expect{|
+module State = struct type t = int
+                      external next : t -> t = "%identity" end
+- : unit = ()
+|}];;
+
+run_structure {|
+  module type S = sig
+    val x : int -> int @@ portable
+  end |};;
+
+[%%expect{|
+module type S  = sig val x : int -> int end
+- : unit = ()
+|}]

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -152,8 +152,9 @@ run_structure {|
   end |};;
 
 [%%expect{|
-module State = struct type t = int
-                      external next : t -> t = "%identity" end
+module State =
+  struct type t = int
+         external next : t -> t @@ portable = "%identity" end
 - : unit = ()
 |}];;
 
@@ -163,6 +164,6 @@ run_structure {|
   end |};;
 
 [%%expect{|
-module type S  = sig val x : int -> int end
+module type S  = sig val x : int -> int @@ portable end
 - : unit = ()
 |}]

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -215,11 +215,21 @@ let structure_item sub item =
   in
   Str.mk ~loc desc
 
+let modalities_of_val_modal_info = function
+  | Valmi_sig_value modalities -> Typemode.untransl_modalities modalities
+  | Valmi_str_primitive modes ->
+      let modality_of_mode { txt = Mode mode; loc } =
+        { txt = Modality mode; loc }
+      in
+      List.map modality_of_mode (Typemode.untransl_mode modes)
+
 let value_description sub v =
   let loc = sub.location sub v.val_loc in
   let attrs = sub.attributes sub v.val_attributes in
+  let modalities = modalities_of_val_modal_info v.val_modal_info in
   Val.mk ~loc ~attrs
     ~prim:v.val_prim
+    ~modalities
     (map_loc sub v.val_name)
     (sub.typ sub v.val_desc)
 


### PR DESCRIPTION
#5218 arranged for the typed tree to record information about the modalities on `val` and `external` signature/structure items. However, that information was not being restored to the parsetree in `untypeast`, resulting in files that fail to typecheck after the untypeast/pprintast roundtrip. This fixes that.

There are two commits, one that adds examples to the untypeast test showing the sad output, and one that fixes it.