### PR TITLE
[5.4] Resolve conflicts and update tests relating to the `multicore` ocamltest action

### DIFF
--- a/testsuite/tests/callback/callback_effects_domains_gc.ml
+++ b/testsuite/tests/callback/callback_effects_domains_gc.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags += "-alert -do_not_spawn_domains";
  multicore;
  native;
 *)

--- a/testsuite/tests/compaction/test_compact_manydomains.ml
+++ b/testsuite/tests/compaction/test_compact_manydomains.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/compaction/test_compact_multi.ml
+++ b/testsuite/tests/compaction/test_compact_multi.ml
@@ -1,30 +1,7 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
  { bytecode; }
  { native; }
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- {
-   runtime4;
-   skip;
- }{
-   runtime5;
-   multidomain;
-   { bytecode; }
-   { native; }
- }
-=======
- {
-   runtime4;
-   skip;
- }{
-   runtime5;
-   multidomain;
-   { bytecode; }
-   { native; }
- }
->>>>>>> 5.2.0minus-37
 *)
 
 let num_domains = 2

--- a/testsuite/tests/effects/test_lazy.ml
+++ b/testsuite/tests/effects/test_lazy.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
    multicore;
-||||||| 5.2.0minus-31
-  flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-   runtime5;
-   multidomain;
-=======
-   runtime5;
-   multidomain;
->>>>>>> 5.2.0minus-37
    { bytecode; }
    { native; }
 *)

--- a/testsuite/tests/lib-atomic/test_atomic_domain.ml
+++ b/testsuite/tests/lib-atomic/test_atomic_domain.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
    multicore;
-||||||| 5.2.0minus-31
-   flags = "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-   runtime5;
-   multidomain;
-=======
-   runtime5;
-   multidomain;
->>>>>>> 5.2.0minus-37
    native;
    bytecode;
 *)

--- a/testsuite/tests/lib-channels/refcounting.ml
+++ b/testsuite/tests/lib-channels/refcounting.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  expect;
 *)
 

--- a/testsuite/tests/lib-domain/tick_fork.ml
+++ b/testsuite/tests/lib-domain/tick_fork.ml
@@ -4,7 +4,6 @@
    hasunix;
    not-windows;
    runtime5;
-   flags = "-alert -unsafe_multidomain";
    { native; }
 *)
 

--- a/testsuite/tests/lib-domain/tick_interval.ml
+++ b/testsuite/tests/lib-domain/tick_interval.ml
@@ -1,7 +1,5 @@
 (* TEST
-   runtime5;
-   flags = "-alert -unsafe_multidomain -alert -do_not_spawn_domains";
-   multidomain;
+   multicore;
    { native; }
    { bytecode; }
 *)

--- a/testsuite/tests/lib-domain/tick_without_threads.ml
+++ b/testsuite/tests/lib-domain/tick_without_threads.ml
@@ -1,7 +1,6 @@
 (* TEST
    modules = "tick_stubs.c";
    runtime5;
-   flags = "-alert -unsafe_multidomain";
    { native; }
 *)
 

--- a/testsuite/tests/lib-format/domains.ml
+++ b/testsuite/tests/lib-format/domains.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-format/mc_pr586_par.ml
+++ b/testsuite/tests/lib-format/mc_pr586_par.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-format/mc_pr586_par2.ml
+++ b/testsuite/tests/lib-format/mc_pr586_par2.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
@@ -4,16 +4,7 @@
    skip;
  }{
    include runtime_events;
-<<<<<<< HEAD
    multicore;
-||||||| 5.2.0minus-31
-   runtime5;
-   multidomain;
-   flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-=======
-   runtime5;
-   multidomain;
->>>>>>> 5.2.0minus-37
    { bytecode; }
    { native; }
  }

--- a/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
@@ -4,16 +4,7 @@
    skip;
  }{
    include runtime_events;
-<<<<<<< HEAD
    multicore;
-||||||| 5.2.0minus-31
-   runtime5;
-   multidomain;
-   flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-=======
-   runtime5;
-   multidomain;
->>>>>>> 5.2.0minus-37
    { bytecode; }
    { native; }
  }

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -6,16 +6,7 @@
    reason = "flaky test: sporadically failing on both arm64 and amd64 (#5669)";
    skip;
    include runtime_events;
-<<<<<<< HEAD
    multicore;
-||||||| 5.2.0minus-31
-   runtime5;
-   multidomain;
-   flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-=======
-   runtime5;
-   multidomain;
->>>>>>> 5.2.0minus-37
    include unix;
    ocamlrunparam += ",e=6";
    hasunix;

--- a/testsuite/tests/lib-str/parallel.ml
+++ b/testsuite/tests/lib-str/parallel.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include str;
  hasstr;
  {

--- a/testsuite/tests/lib-sync/prodcons.ml
+++ b/testsuite/tests/lib-sync/prodcons.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  hasunix;
  not-target-windows;

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  hasunix;
  not-target-windows;

--- a/testsuite/tests/lib-unix/kill/unix_kill.ml
+++ b/testsuite/tests/lib-unix/kill/unix_kill.ml
@@ -1,6 +1,5 @@
 (* TEST
  include unix;
-<<<<<<< HEAD
  hasunix;
  not-target-windows;
  (*
@@ -9,12 +8,6 @@
    see https://github.com/llvm/llvm-project/issues/63824
  *)
  not_macos_amd64_tsan;
-||||||| 5.2.0minus-31
- flags = "-alert -unsafe_multidomain";
- libunix;
-=======
- libunix;
->>>>>>> 5.2.0minus-37
  {
    bytecode;
  }{

--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/backup_thread.ml
+++ b/testsuite/tests/parallel/backup_thread.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/backup_thread_pipe.ml
+++ b/testsuite/tests/parallel/backup_thread_pipe.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/churn.ml
+++ b/testsuite/tests/parallel/churn.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/constpromote.ml
+++ b/testsuite/tests/parallel/constpromote.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/deadcont.ml
+++ b/testsuite/tests/parallel/deadcont.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_alert.ml
+++ b/testsuite/tests/parallel/domain_alert.ml
@@ -1,14 +1,6 @@
 (* TEST
  flags += "-alert +do_not_spawn_domains";
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_dls.ml
+++ b/testsuite/tests/parallel/domain_dls.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_dls2.ml
+++ b/testsuite/tests/parallel/domain_dls2.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -1,21 +1,8 @@
 (* TEST
-<<<<<<< HEAD
   multicore;
   include unix;
   hasunix;
   { bytecode; } { native; }
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
- { bytecode; }
- { native; }
-=======
- runtime5;
- multidomain;
- { bytecode; }
- { native; }
->>>>>>> 5.2.0minus-37
 *)
 
 open Domain

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
@@ -1,21 +1,8 @@
 (* TEST
-<<<<<<< HEAD
   multicore;
   include unix;
   hasunix;
   { bytecode; } { native; }
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
- { bytecode; }
- { native; }
-=======
- runtime5;
- multidomain;
- { bytecode; }
- { native; }
->>>>>>> 5.2.0minus-37
 *)
 
 open Domain

--- a/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/fib_threads.ml
+++ b/testsuite/tests/parallel/fib_threads.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include systhreads;
  hassysthreads;
  {

--- a/testsuite/tests/parallel/fiber_migration.ml
+++ b/testsuite/tests/parallel/fiber_migration.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  {
    bytecode;
  }{

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include unix;
  multicore;
  hasunix;

--- a/testsuite/tests/parallel/multicore_systhreads.ml
+++ b/testsuite/tests/parallel/multicore_systhreads.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  include systhreads;
  hassysthreads;
  {

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -1,10 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-=======
->>>>>>> 5.2.0minus-37
  no-tsan; (* TSan detects the intentional data race *)
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/prodcons_domains.ml
+++ b/testsuite/tests/parallel/prodcons_domains.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/tak.ml
+++ b/testsuite/tests/parallel/tak.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/test_issue_11094.ml
+++ b/testsuite/tests/parallel/test_issue_11094.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  stack-checks;
  {
    bytecode;

--- a/testsuite/tests/parallel/tls_multi_domain_single_thread.ml
+++ b/testsuite/tests/parallel/tls_multi_domain_single_thread.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/unsafe_alert.ml
+++ b/testsuite/tests/parallel/unsafe_alert.ml
@@ -1,15 +1,6 @@
 (* TEST
  flags += "-alert +unsafe_multidomain";
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/ephetest_par.ml
+++ b/testsuite/tests/weak-ephe-final/ephetest_par.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/finaliser_handover.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser_handover.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/weak_array_par.ml
+++ b/testsuite/tests/weak-ephe-final/weak_array_par.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
    multicore;
-||||||| 5.2.0minus-31
-   flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
-   runtime5;
-   multidomain;
-=======
-   runtime5;
-   multidomain;
->>>>>>> 5.2.0minus-37
    { bytecode; }
    { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,14 +1,5 @@
 (* TEST
-<<<<<<< HEAD
  multicore;
-||||||| 5.2.0minus-31
- flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
- runtime5;
- multidomain;
-=======
- runtime5;
- multidomain;
->>>>>>> 5.2.0minus-37
  { bytecode; }
  { native; }
 *)


### PR DESCRIPTION
We got a lot of conflicts from #5694. This PR resolves those conflicts in favour of 5.4 to use the newly co-opted `multicore` ocamltest action. It also updates various new tests which brought in uses of `multidomain` (which we no longer have) and picked up one unnecessary suppressing of the `do_not_spawn_domains` alert (unnecessary because the testsuite no longer enables that alert by default).