### PR TITLE
[5.4] Testsuite resolutions and fixes for minus37

### DIFF
--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -1650,7 +1650,7 @@ L379:
   %124 = load i64, ptr %30
   store i64 %124, ptr %4
   %125 = load i64, ptr %ds
-  %126 = add i64 %125, 240
+  %126 = add i64 %125, 272
   %127 = inttoptr i64 %126 to ptr
   store i64 0, ptr %127
   %128 = load i64, ptr %4

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -1536,87 +1536,6 @@ L396:
   %55 = icmp eq i64 %54, 0
   br i1 %55, label %L397, label %L355
 L397:
-<<<<<<< HEAD
-  %111 = load i64, ptr %26
-  %112 = load i64, ptr %7
-  %113 = icmp sgt i64 %111, %112
-  br i1 %113, label %L377, label %L384
-L377:
-  %114 = ptrtoint ptr @camlExn_part2__Pmakeblock195 to i64
-  store i64 %114, ptr %27
-  %115 = load i64, ptr %27
-  store i64 %115, ptr %4
-  %116 = load i64, ptr %ds
-  %117 = add i64 %116, 272
-  %118 = inttoptr i64 %117 to ptr
-  store i64 0, ptr %118
-  %119 = load i64, ptr %4
-  %120 = load i64, ptr %ds
-  %121 = load i64, ptr %alloc
-  %122 = call oxcamlcc { { i64, i64 }, {  } } @caml_raise_exn(i64 %120, i64 %121, i64 %119) "statepoint-id"="0"
-  %123 = extractvalue { { i64, i64 }, {  } } %122, 0, 0
-  %124 = extractvalue { { i64, i64 }, {  } } %122, 0, 1
-  store i64 %123, ptr %ds
-  store i64 %124, ptr %alloc
-  unreachable
-L380:
-  %125 = load ptr addrspace(1), ptr %12
-  %126 = ptrtoint ptr addrspace(1) %125 to i64
-  store i64 %126, ptr %4
-  %127 = load i64, ptr %4
-  %128 = load i64, ptr %ds
-  %129 = load i64, ptr %alloc
-  %130 = call oxcamlcc { { i64, i64 }, {  } } @caml_reraise_exn(i64 %128, i64 %129, i64 %127) "statepoint-id"="0"
-  %131 = extractvalue { { i64, i64 }, {  } } %130, 0, 0
-  %132 = extractvalue { { i64, i64 }, {  } } %130, 0, 1
-  store i64 %131, ptr %ds
-  store i64 %132, ptr %alloc
-  unreachable
-L384:
-  %133 = load i64, ptr %7
-  %134 = icmp slt i64 %133, 2001
-  br i1 %134, label %L386, label %L398
-||||||| 5.2.0minus-31
-  %111 = load i64, ptr %26
-  %112 = load i64, ptr %7
-  %113 = icmp sgt i64 %111, %112
-  br i1 %113, label %L377, label %L384
-L377:
-  %114 = ptrtoint ptr @camlExn_part2__Pmakeblock195 to i64
-  store i64 %114, ptr %27
-  %115 = load i64, ptr %27
-  store i64 %115, ptr %4
-  %116 = load i64, ptr %ds
-  %117 = add i64 %116, 240
-  %118 = inttoptr i64 %117 to ptr
-  store i64 0, ptr %118
-  %119 = load i64, ptr %4
-  %120 = load i64, ptr %ds
-  %121 = load i64, ptr %alloc
-  %122 = call oxcamlcc { { i64, i64 }, {  } } @caml_raise_exn(i64 %120, i64 %121, i64 %119) "statepoint-id"="0"
-  %123 = extractvalue { { i64, i64 }, {  } } %122, 0, 0
-  %124 = extractvalue { { i64, i64 }, {  } } %122, 0, 1
-  store i64 %123, ptr %ds
-  store i64 %124, ptr %alloc
-  unreachable
-L380:
-  %125 = load ptr addrspace(1), ptr %12
-  %126 = ptrtoint ptr addrspace(1) %125 to i64
-  store i64 %126, ptr %4
-  %127 = load i64, ptr %4
-  %128 = load i64, ptr %ds
-  %129 = load i64, ptr %alloc
-  %130 = call oxcamlcc { { i64, i64 }, {  } } @caml_reraise_exn(i64 %128, i64 %129, i64 %127) "statepoint-id"="0"
-  %131 = extractvalue { { i64, i64 }, {  } } %130, 0, 0
-  %132 = extractvalue { { i64, i64 }, {  } } %130, 0, 1
-  store i64 %131, ptr %ds
-  store i64 %132, ptr %alloc
-  unreachable
-L384:
-  %133 = load i64, ptr %7
-  %134 = icmp slt i64 %133, 2001
-  br i1 %134, label %L386, label %L398
-=======
   store ptr blockaddress(@camlExn_part2__raise_in_loop_7_16_code, %L396), ptr @camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_var.L396
   %56 = call  ptr @llvm.stacksave()
   %57 = alloca { i64, i64, i64, i64 }
@@ -1704,7 +1623,6 @@ L355:
   %108 = load i64, ptr %26
   %109 = icmp slt i64 %107, %108
   br i1 %109, label %L382, label %L398
->>>>>>> 5.2.0minus-37
 L398:
   %110 = load i64, ptr %27
   %111 = load i64, ptr %26

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -14,7 +14,7 @@ let immutable_load l = (List.hd l) + (List.hd l)
 immutable_load:
   testb $1, %al
   je    .L105
-  movq  camlStdlib__List__Pmakeblock2305@GOTPCREL(%rip), %rax
+  movq  camlStdlib__List__Pmakeblock2453@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -100,7 +100,7 @@ loop_with_non_dominating_load:
 .L108:
   testb $1, %bl
   je    .L112
-  movq  camlStdlib__List__Pmakeblock2305@GOTPCREL(%rip), %rax
+  movq  camlStdlib__List__Pmakeblock2453@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/dash-Ix/wrong_include_order.ocamlc.reference
+++ b/testsuite/tests/dash-Ix/wrong_include_order.ocamlc.reference
@@ -1,3 +1,3 @@
 File "libc/c1.ml", line 1:
-Error: The files "libb/b.cmi" and "liba_alt/a.cmi" make inconsistent assumptions
-       over interface "A"
+Error: The files libb/b.cmi and liba_alt/a.cmi make inconsistent assumptions
+       over interface A

--- a/testsuite/tests/flambda2/examples/array_kind.compilers.reference
+++ b/testsuite/tests/flambda2/examples/array_kind.compilers.reference
@@ -1,9 +1,9 @@
 (let
-  (f/275 =
-     (function {nlocal = 0} a/277[value<addrarray>]
+  (f/279 =
+     (function {nlocal = 0} a/281[value<addrarray>]
        : (consts (0)) (non_consts ([0: ?]))
-       (array.get[gen indexed by int] a/277 0)))
-  (makeblock 0 f/275))
+       (array.get[gen indexed by int] a/281 0)))
+  (makeblock 0 f/279))
 (data global "camlArray_kind__gc_roots": int 0)
 (data int 1792 global "camlArray_kind": addr G:"camlArray_kind__f_1")
 (data
@@ -23,14 +23,14 @@
  skip 4
  byte 4)
 (function{array_kind.ml:27,6-59} camlArray_kind__f_0_1_code
-     (a/342: val) : val
+     (a/348: val) : val
  (catch
-   (if (<u 1 (>>u (<< (load_mut int (+a a/342 -8)) 8) 17))
-     (load_mut val a/342) (exit 3))
- with(3)(cold)
+   (if (<u 1 (>>u (<< (load_mut int (+a a/348 -8)) 8) 17))
+     (load_mut val a/348) (exit 5))
+ with(5)(cold)
    (raise_notrace{array_kind.ml:28,14-19} L:"camlArray_kind__block13")) )
 
 (function no_cse reduce_code_size linscan camlArray_kind__entry () : val
- (catch (exit 2 G:"camlArray_kind") with(2 *ret*/340: val) 1) )
+ (catch (exit 4 G:"camlArray_kind") with(4 *ret*/346: val) 1) )
 
 (data)

--- a/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
+++ b/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
@@ -22,42 +22,42 @@ let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
      where k6 =
        (cont k6 (0)
           where rec k6
-                      (path_285_unboxed0 :
+                      (path_289_unboxed0 :
                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-            let path_285_unboxed0_1 = path_285_unboxed0 in
+            let path_289_unboxed0_1 = path_289_unboxed0 in
             (apply direct(input_line_0_1)
                ($camlExn_extra_args__input_line_2 : _ -> val)
                  (0)
-                 -> k7 * k5 (path_285_unboxed0 val)
+                 -> k7 * k5 (path_289_unboxed0 val)
                where k7 (return_val0 : val) =
                  let Pmakeblock =
-                   %block.[`0`] (return_val0, path_285_unboxed0)
+                   %block.[`0`] (return_val0, path_289_unboxed0)
                  in
                  cont k6 (Pmakeblock)))
-     where k5 exn (`exn` : val, path_285_unboxed0) =
-       let path_285_unboxed0_1 = path_285_unboxed0 in
+     where k5 exn (`exn` : val, path_289_unboxed0) =
+       let path_289_unboxed0_1 = path_289_unboxed0 in
        let `unit` = %end_try_region (try_region_1) in
        let unit_1 = %end_try_ghost_region (try_ghost_region_1) in
        let prim = %phys_eq (`exn`, $`*predef*`.caml_exn_End_of_file) in
        switch prim
-         | 0 -> k3 (path_285_unboxed0, `exn`)
-         | 1 -> k4 (path_285_unboxed0))
-    where k4 (path_285_unboxed0) =
-      let path_285_unboxed0_1 = path_285_unboxed0 in
-      cont k2 (path_285_unboxed0)
-    where k3 (path_285_unboxed0, `exn`) =
+         | 0 -> k3 (path_289_unboxed0, `exn`)
+         | 1 -> k4 (path_289_unboxed0))
+    where k4 (path_289_unboxed0) =
+      let path_289_unboxed0_1 = path_289_unboxed0 in
+      cont k2 (path_289_unboxed0)
+    where k3 (path_289_unboxed0, `exn`) =
       let exn_1 = `exn` in
-      let path_285_unboxed0_1 = path_285_unboxed0 in
+      let path_289_unboxed0_1 = path_289_unboxed0 in
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       let Pfield = %block_load.[`0`] (exn_1) in
       let prim = %phys_eq (Pfield, $`*predef*`.caml_exn_Sys_error) in
       switch prim
         | 0 -> k1 pop(reraise k1) (exn_1)
-        | 1 -> k2 (path_285_unboxed0)
-    where k2 (path_285_unboxed0) =
-      let path_285_unboxed0_1 = path_285_unboxed0 in
-      cont k (path_285_unboxed0_1)
+        | 1 -> k2 (path_289_unboxed0)
+    where k2 (path_289_unboxed0) =
+      let path_289_unboxed0_1 = path_289_unboxed0 in
+      cont k (path_289_unboxed0_1)
 in
 let $camlExn_extra_args__ld_conf_contents_3 =
   closure ld_conf_contents_1_1 @ld_conf_contents

--- a/testsuite/tests/flambda2/examples/extra_args_and_staticraise.compilers.reference
+++ b/testsuite/tests/flambda2/examples/extra_args_and_staticraise.compilers.reference
@@ -1,11 +1,11 @@
 (let
-  (f/282 =
-     (function {nlocal = 0} x/284[value<int>] init/285[value<int>] : int
-       (let (m/286 =mut[value<int>] init/285)
+  (f/286 =
+     (function {nlocal = 0} x/288[value<int>] init/289[value<int>] : int
+       (let (m/290 =mut[value<int>] init/289)
          (catch
            (try
-             (exit 1
-               (for i/287 0 to x/284 (assign m/286 (%int_add *m/286 i/287))))
-            with exn/296 0)
-          with (1 val/295[value<int>]) *m/286))))
-  (makeblock 0 f/282))
+             (exit 2
+               (for i/291 0 to x/288 (assign m/290 (%int_add *m/290 i/291))))
+            with exn/300 0)
+          with (2 val/299[value<int>]) *m/290))))
+  (makeblock 0 f/286))

--- a/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
+++ b/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
@@ -13,10 +13,10 @@ let code loopify(never) size(31) newer_version_of(f_0)
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, init)
          where rec k2
-                     (for_counter_naked : int64, m_286_unboxed0 : imm tagged) =
+                     (for_counter_naked : int64, m_290_unboxed0 : imm tagged) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
-           let int_add = %int_barith.add (m_286_unboxed0, i) in
+           let int_add = %int_barith.add (m_290_unboxed0, i) in
            let for_next_naked =
              %int_barith.`int64`.add (for_counter_naked, 1L)
            in

--- a/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
@@ -30,8 +30,8 @@ let code loopify(never) size(44) newer_version_of(f_0)
              | 0 -> k2 (float_add)
              | 1 -> k3 (for_next_naked, prim_2))
     where k2 (float_add) =
-      let r_277_unboxed0 = float_add in
-      cont k (r_277_unboxed0)
+      let r_281_unboxed0 = float_add in
+      cont k (r_281_unboxed0)
 in
 let $camlFloat_unboxing__f_1 = closure f_0_1 @f in
 let $camlFloat_unboxing__Pmakeblock120 = Block 0 ($camlFloat_unboxing__f_1)

--- a/testsuite/tests/flambda2/examples/invalid.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.compilers.reference
@@ -39,35 +39,35 @@
 (data int 768 "camlInvalid__empty_array41":)
 (data int 2044 "camlInvalid__immstring17": string "lengths" skip 0 byte 0)
 (function{invalid.ml:15,25-96} camlInvalid__check_0_3_code
-     (t1/360: val t2/361: val) : int
+     (t1/366: val t2/367: val) : int
  (if
-   (!= (or (>>u (<< (load_mut int (+a t1/360 -8)) 8) 17) 1)
-     (or (>>u (<< (load_mut int (+a t2/361 -8)) 8) 17) 1))
+   (!= (or (>>u (<< (load_mut int (+a t1/366 -8)) 8) 17) 1)
+     (or (>>u (<< (load_mut int (+a t2/367 -8)) 8) 17) 1))
    (raise_notrace{invalid.ml:16,45-63;stdlib.ml:39,17-33}
      L:"camlInvalid__Pmakeblock71")
    1) )
 
 (function{invalid.ml:18,17-68} camlInvalid__bar_1_4_code
-     (t1/365: val t2/366: val) : int
+     (t1/371: val t2/372: val) : int
  (let
-   param/367
-     (app{invalid.ml:19,2-13} G:"camlInvalid__check_0_3_code" t1/365 t2/366
+   param/373
+     (app{invalid.ml:19,2-13} G:"camlInvalid__check_0_3_code" t1/371 t2/372
        int)
-   (+ (<< (==f (load_mut float64 t2/366) 0.) 1) 1)) )
+   (+ (<< (==f (load_mut float64 t2/372) 0.) 1) 1)) )
 
 (function{invalid.ml:22,8-30} camlInvalid__foo_2_5_code
-     (param/371: int) : int
+     (param/377: int) : int
  (let
-   (Pmakearray/372 (alloc{invalid.ml:22,17-25} 1278 1.)
-    param/373
+   (Pmakearray/378 (alloc{invalid.ml:22,17-25} 1278 1.)
+    param/379
       (app{invalid.ml:22,13-30;invalid.ml:19,2-13}
-        G:"camlInvalid__check_0_3_code" Pmakearray/372
+        G:"camlInvalid__check_0_3_code" Pmakearray/378
         L:"camlInvalid__empty_array41" int))
    (invalid
      "(Defining_expr_of_let (bound_pattern prim/110N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)\n   invalid.ml:20,2--23)))"
      L:"camlInvalid__invalid177")) )
 
 (function no_cse reduce_code_size linscan camlInvalid__entry () : val
- (catch (exit 2 G:"camlInvalid") with(2 *ret*/358: val) 1) )
+ (catch (exit 7 G:"camlInvalid") with(7 *ret*/364: val) 1) )
 
 (data)

--- a/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
+++ b/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
@@ -14,7 +14,7 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim) in
       (cont k2 (0L, 0)
          where rec k2
-                     (for_counter_naked : int64, n_289_unboxed0 : imm tagged) =
+                     (for_counter_naked : int64, n_293_unboxed0 : imm tagged) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let prim_3 = %num_conv.[`tagged_imm`].[`nativeint`] (i) in
@@ -27,17 +27,17 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
                where k5 =
                  let prim_6 = %num_conv.[`tagged_imm`].[`int8`] (c) in
                  let prim_7 =
-                   %num_conv.[`tagged_imm`].[`nativeint`] (n_289_unboxed0)
+                   %num_conv.[`tagged_imm`].[`nativeint`] (n_293_unboxed0)
                  in
                  let Pbytessetu =
                    %bytes_or_bigstring_set.bytes.[`8`] (s', prim_7, prim_6)
                  in
-                 cont k3 (n_289_unboxed0)
+                 cont k3 (n_293_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (n_289_unboxed0, 1) in
+                 let int_add = %int_barith.add (n_293_unboxed0, 1) in
                  cont k3 (int_add))
-              where k3 (n_289_unboxed0_1 : imm tagged) =
-                let int_add = %int_barith.add (n_289_unboxed0_1, 1) in
+              where k3 (n_293_unboxed0_1 : imm tagged) =
+                let int_add = %int_barith.add (n_293_unboxed0_1, 1) in
                 let for_next_naked =
                   %int_barith.`int64`.add (for_counter_naked, 1L)
                 in

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
@@ -26,16 +26,16 @@ let code loopify(never) size(20) newer_version_of(stuff_1)
    let try_ghost_region = %begin_try_ghost_region (ghost_region) in
    cont k4 push(k3)
      where k4 =
-       let r_281_unboxed0 = 0 in
+       let r_285_unboxed0 = 0 in
        let Popaque = %opaque ($camlData_flow_exception_bug__do_stuff_2) in
        (apply Popaque (env) -> k4 * k3
           where k4 (return_val0 : [ 0 | 0 of val ]) =
             cont k2 pop(k3) (return_val0))
      where k3 exn (`exn` : val) =
-       let r_281_unboxed0 = 0 in
+       let r_285_unboxed0 = 0 in
        let `unit` = %end_try_region (try_region) in
        let unit_1 = %end_try_ghost_region (try_ghost_region) in
-       let Popaque = %opaque (r_281_unboxed0) in
+       let Popaque = %opaque (r_285_unboxed0) in
        cont k2 (Popaque))
     where k2 (region_return : [ 0 | 0 of val ]) =
       let `unit` = %end_region (`region`) in

--- a/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
@@ -27,7 +27,7 @@
    cont k1 (Pmakeblock)
  in
  let code size(1)
-       fn_2 (param_298_unboxed0, param_298_unboxed1)
+       fn_2 (param_302_unboxed0, param_302_unboxed1)
          my_closure _region _ghost_region my_depth
          -> k1 * k2
          : imm tagged =

--- a/testsuite/tests/flambda2/examples/unknown/lazy_invalid.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/lazy_invalid.simplify.reference
@@ -27,11 +27,12 @@ apply ccall noalloc
             where k1 =
               let Popaque = %opaque ($camlLazy_invalid__immstring10) in
               apply direct(force_lazy_block_4) inlined(never)
-                $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_9
+                $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_11
                   (Popaque)
                   -> k * error))
   where k (region_return : val) =
-    (apply ccall ($`*extern*`.caml_alloc_dummy : val -> val) (1) -> k * error
+    (apply ccall
+       ($`*extern*`.caml_alloc_dummy_lazy : val -> val) (0) -> k * error
        where k (t) =
          let code loopify(never) size(1) newer_version_of(foo_0)
                foo_0_1 (x : imm tagged)
@@ -69,7 +70,7 @@ apply ccall noalloc
                        where k2 =
                          let Popaque = %opaque ($camlLazy_invalid__foo_2) in
                          apply direct(force_lazy_block_4) inlined(never)
-                           $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_9
+                           $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_11
                              (Popaque)
                              -> k * k1))
          in
@@ -81,7 +82,7 @@ apply ccall noalloc
            %lazy ($`camlLazy_invalid__fn[lazy_invalid.ml:13,13--29]_3`)
          in
          (apply ccall
-            ($`*extern*`.caml_update_dummy : val * val -> val)
+            ($`*extern*`.caml_update_dummy_lazy : val * val -> val)
               (t, Pmakelazyblock)
               -> k1 * error
             where k1 (param) =

--- a/testsuite/tests/flambda2/examples/unknown/let_symbol_var_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/let_symbol_var_inlining.simplify.reference
@@ -20,9 +20,9 @@ let code loopify(never) size(5) newer_version_of(g_1)
 in
 let $camlLet_symbol_var_inlining__g_3 = closure g_1_1 @g in
 let $camlLet_symbol_var_inlining =
-  Block 0 ($Stdlib__List.camlStdlib__List__length_99,
+  Block 0 ($Stdlib__List.camlStdlib__List__length_109,
            b,
-           $Stdlib__List.camlStdlib__List__map_113,
+           $Stdlib__List.camlStdlib__List__map_124,
            $camlLet_symbol_var_inlining__f_2,
            $camlLet_symbol_var_inlining__g_3)
 in

--- a/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
@@ -45,28 +45,28 @@ let code loopify(never) size(18) newer_version_of(f_3)
   let try_region = %begin_try_region () in
   let try_ghost_region = %begin_try_ghost_region () in
   cont k3 (x)
-    where rec k3 (c_295_unboxed0 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+    where rec k3 (c_299_unboxed0 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       (cont k6 push(k5)
          where k6 =
            (apply direct(p_2_1) inlining_state(depth(10))
               ($camlTest_exn_handler_inlining__p_6
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                (c_295_unboxed0)
+                (c_299_unboxed0)
                 -> k6 * k5
               where k6
                       (wrapper_return :
                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                 cont k4 pop(k5) (wrapper_return))
          where k5 exn (`exn`) =
-           cont k2 (c_295_unboxed0)
+           cont k2 (c_299_unboxed0)
          where k4 (wrapper_return) =
            let return_val0 = wrapper_return in
            cont k3 (return_val0))
-    where k2 (c_295_unboxed0) =
-      let c_295_unboxed0_1 = c_295_unboxed0 in
+    where k2 (c_299_unboxed0) =
+      let c_299_unboxed0_1 = c_299_unboxed0 in
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
-      cont k (c_295_unboxed0_1)
+      cont k (c_299_unboxed0_1)
 in
 let $camlTest_exn_handler_inlining__f_7 = closure f_3_1 @f in
 let $camlTest_exn_handler_inlining =

--- a/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
@@ -21,13 +21,13 @@ apply ccall noalloc
       cont k3 push(k2)
         where k3 =
           (cont k3 (x)
-             where rec k3 (r_290_unboxed0 : imm tagged) =
-               let prim = %int_comp.lt (r_290_unboxed0, 42) in
+             where rec k3 (r_294_unboxed0 : imm tagged) =
+               let prim = %int_comp.lt (r_294_unboxed0, 42) in
                (switch prim
                   | 0 -> k pop(k2) (0)
                   | 1 -> k4
                   where k4 =
-                    (apply g (r_290_unboxed0) -> k6 * k2
+                    (apply g (r_294_unboxed0) -> k6 * k2
                        where k6 (param : imm tagged) =
                          let unboxed_field = %untag_imm (param) in
                          cont k5 (unboxed_field)
@@ -39,7 +39,7 @@ apply ccall noalloc
                                     pop(regular k2)
                                     ($camlLocal_exns_to_jumps__Exit209)
                        where k4 =
-                         let int_add = %int_barith.add (r_290_unboxed0, 1) in
+                         let int_add = %int_barith.add (r_294_unboxed0, 1) in
                          cont k3 (int_add))))
         where k2 exn (`exn` : val) =
           let `unit` = %end_try_region (try_region) in
@@ -58,8 +58,8 @@ apply ccall noalloc
       let try_region = %begin_try_region () in
       let try_ghost_region = %begin_try_ghost_region () in
       cont k3 (x)
-        where rec k3 (r_295_unboxed0 : imm tagged) =
-          let prim = %int_comp.lt (r_295_unboxed0, 42) in
+        where rec k3 (r_299_unboxed0 : imm tagged) =
+          let prim = %int_comp.lt (r_299_unboxed0, 42) in
           (switch prim
              | 0 -> k (0)
              | 1 -> k4
@@ -68,8 +68,8 @@ apply ccall noalloc
                  let try_ghost_region_1 = %begin_try_ghost_region () in
                  cont k7 push(k6)
                    where k7 =
-                     let r_295_unboxed0_1 = r_295_unboxed0 in
-                     (apply g (r_295_unboxed0) -> k8 * k6
+                     let r_299_unboxed0_1 = r_299_unboxed0 in
+                     (apply g (r_299_unboxed0) -> k8 * k6
                         where k8 (param : imm tagged) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
@@ -77,19 +77,19 @@ apply ccall noalloc
                           let naked_immediate = unboxed_field in
                           cont k5 pop(k6) (naked_immediate))
                    where k6 exn (`exn` : val) =
-                     let r_295_unboxed0_1 = r_295_unboxed0 in
+                     let r_299_unboxed0_1 = r_299_unboxed0 in
                      let `unit` = %end_try_region (try_region_1) in
                      let unit_1 = %end_try_ghost_region (try_ghost_region_1)
                      in
                      cont k5 (0i)
                    where k5 (naked_immediate : imm) =
-                     let r_295_unboxed0_1 = r_295_unboxed0 in
+                     let r_299_unboxed0_1 = r_299_unboxed0 in
                      switch naked_immediate
                        | 0 -> k4
                        | 1 -> k2)
                   where k4 =
-                    let r_295_unboxed0_1 = r_295_unboxed0 in
-                    let int_add = %int_barith.add (r_295_unboxed0_1, 1) in
+                    let r_299_unboxed0_1 = r_299_unboxed0 in
+                    let int_add = %int_barith.add (r_299_unboxed0_1, 1) in
                     cont k3 (int_add)))
         where k2 =
           let `unit` = %end_try_region (try_region) in
@@ -105,8 +105,8 @@ apply ccall noalloc
       let try_region = %begin_try_region () in
       let try_ghost_region = %begin_try_ghost_region () in
       cont k3 (x)
-        where rec k3 (r_300_unboxed0 : imm tagged) =
-          let prim = %int_comp.lt (r_300_unboxed0, 42) in
+        where rec k3 (r_304_unboxed0 : imm tagged) =
+          let prim = %int_comp.lt (r_304_unboxed0, 42) in
           (switch prim
              | 0 -> k (0)
              | 1 -> k4
@@ -115,8 +115,8 @@ apply ccall noalloc
                  let try_ghost_region_1 = %begin_try_ghost_region () in
                  cont k7 push(k6)
                    where k7 =
-                     let r_300_unboxed0_1 = r_300_unboxed0 in
-                     (apply g (r_300_unboxed0) -> k8 * k6
+                     let r_304_unboxed0_1 = r_304_unboxed0 in
+                     (apply g (r_304_unboxed0) -> k8 * k6
                         where k8 (param : imm tagged) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
@@ -124,19 +124,19 @@ apply ccall noalloc
                           let naked_immediate = unboxed_field in
                           cont k5 pop(k6) (naked_immediate))
                    where k6 exn (`exn` : val) =
-                     let r_300_unboxed0_1 = r_300_unboxed0 in
+                     let r_304_unboxed0_1 = r_304_unboxed0 in
                      let `unit` = %end_try_region (try_region_1) in
                      let unit_1 = %end_try_ghost_region (try_ghost_region_1)
                      in
                      cont k5 (0i)
                    where k5 (naked_immediate : imm) =
-                     let r_300_unboxed0_1 = r_300_unboxed0 in
+                     let r_304_unboxed0_1 = r_304_unboxed0 in
                      switch naked_immediate
                        | 0 -> k4
                        | 1 -> k2)
                   where k4 =
-                    let r_300_unboxed0_1 = r_300_unboxed0 in
-                    let int_add = %int_barith.add (r_300_unboxed0_1, 1) in
+                    let r_304_unboxed0_1 = r_304_unboxed0 in
+                    let int_add = %int_barith.add (r_304_unboxed0_1, 1) in
                     cont k3 (int_add)))
         where k2 =
           let `unit` = %end_try_region (try_region) in
@@ -159,8 +159,8 @@ apply ccall noalloc
            let try_region = %begin_try_region () in
            let try_ghost_region = %begin_try_ghost_region () in
            cont k3 (x)
-             where rec k3 (r_306_unboxed0 : imm tagged) =
-               let prim = %int_comp.lt (r_306_unboxed0, 42) in
+             where rec k3 (r_310_unboxed0 : imm tagged) =
+               let prim = %int_comp.lt (r_310_unboxed0, 42) in
                (switch prim
                   | 0 -> k (0)
                   | 1 -> k4
@@ -169,8 +169,8 @@ apply ccall noalloc
                       let try_ghost_region_1 = %begin_try_ghost_region () in
                       cont k7 push(k6)
                         where k7 =
-                          let r_306_unboxed0_1 = r_306_unboxed0 in
-                          (apply g (r_306_unboxed0) -> k8 * k6
+                          let r_310_unboxed0_1 = r_310_unboxed0 in
+                          (apply g (r_310_unboxed0) -> k8 * k6
                              where k8 (param : imm tagged) =
                                let unboxed_field = %untag_imm (param) in
                                cont k7 (unboxed_field)
@@ -178,28 +178,28 @@ apply ccall noalloc
                                let naked_immediate = unboxed_field in
                                cont k5 pop(k6) (naked_immediate))
                         where k6 exn (`exn` : val) =
-                          let r_306_unboxed0_1 = r_306_unboxed0 in
+                          let r_310_unboxed0_1 = r_310_unboxed0 in
                           let `unit` = %end_try_region (try_region_1) in
                           let unit_1 =
                             %end_try_ghost_region (try_ghost_region_1)
                           in
                           cont k5 (0i)
                         where k5 (naked_immediate : imm) =
-                          let r_306_unboxed0_1 = r_306_unboxed0 in
+                          let r_310_unboxed0_1 = r_310_unboxed0 in
                           (switch naked_immediate
                              | 0 -> k4
                              | 1 -> k5
                              where k5 =
                                let int_add =
-                                 %int_barith.add (r_306_unboxed0_1, 3)
+                                 %int_barith.add (r_310_unboxed0_1, 3)
                                in
                                let int_add_1 =
-                                 %int_barith.add (r_306_unboxed0_1, 2)
+                                 %int_barith.add (r_310_unboxed0_1, 2)
                                in
                                cont k2 (int_add_1, int_add)))
                        where k4 =
-                         let r_306_unboxed0_1 = r_306_unboxed0 in
-                         let int_add = %int_barith.add (r_306_unboxed0_1, 1)
+                         let r_310_unboxed0_1 = r_310_unboxed0 in
+                         let int_add = %int_barith.add (r_310_unboxed0_1, 1)
                          in
                          cont k3 (int_add)))
              where k2 (int_add, int_add_1) =

--- a/testsuite/tests/implicit-types/implicit_kinds_upstream_compatible.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds_upstream_compatible.ml
@@ -23,21 +23,5 @@ module type S2 = sig
   val g : 'elt array -> int
 end
 [%%expect{|
-<<<<<<< HEAD
-Line 4, characters 2-27:
-4 |   val g : 'elt array -> int
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in g
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 4, characters 2-27:
-4 |   val g : 'elt array -> int
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in g
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S2 = sig val g : ('elt : immediate). 'elt array -> int end
 |}]

--- a/testsuite/tests/layout_poly/apply_layout.ml
+++ b/testsuite/tests/layout_poly/apply_layout.ml
@@ -172,7 +172,7 @@ end
 Line 6, characters 12-13:
 6 |   let poly_ g = M.f 42
                 ^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 
 Lines 5-7, characters 6-3:
 5 | ......struct
@@ -205,7 +205,7 @@ end
 Line 7, characters 9-11:
 7 |     (x', y')
              ^^
-Error: This expression has type "float#" but an expression was expected of type
+Error: The value "y'" has type "float#" but an expression was expected of type
          "('a : value_or_null)"
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -208,7 +208,7 @@ end
 Line 2, characters 12-13:
 2 |   let poly_ f = 42
                 ^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 >> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
 Uncaught exception: Misc.Fatal_error
 
@@ -321,7 +321,7 @@ end
 Line 4, characters 12-13:
 4 |   let poly_ f x = (x : (_ : value))
                 ^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 
 Lines 3-5, characters 6-3:
 3 | ......struct
@@ -435,7 +435,7 @@ end
 Line 4, characters 16-17:
 4 |   let rec poly_ f x = x
                     ^
-Warning 218: "poly_" has no effect in recursive bindings, which do not support layout polymorphism. Consider using a regular "let rec" instead.
+Warning 218: poly_ has no effect in recursive bindings, which do not support layout polymorphism. Consider using a regular let rec instead.
 >> Fatal error: Translcore.transl_let
 Uncaught exception: Misc.Fatal_error
 

--- a/testsuite/tests/lib-array/test_iarray.ml
+++ b/testsuite/tests/lib-array/test_iarray.ml
@@ -444,7 +444,7 @@ let n, strs =
 in
 n, Iarray.map_local_input ~f:globalize_string strs;;
 [%%expect{|
-- : int * string iarray = (5, [:"1"; "2"; "3"; "4"; "5":])
+- : int * string iarray = (15, [:"1"; "2"; "3"; "4"; "5":])
 |}];;
 
 Iarray.fold_left_map_local_input ~f:(fun acc x -> acc + x, string_of_int x) ~init:0 iarray;;
@@ -458,7 +458,7 @@ let n, strs =
 in
 n, Iarray.map_local_input ~f:globalize_string strs;;
 [%%expect{|
-- : int * string iarray = (5, [:"1"; "2"; "3"; "4"; "5":])
+- : int * string iarray = (15, [:"1"; "2"; "3"; "4"; "5":])
 |}];;
 
 (* Confirm the function isn't called on the empty immutable array *)

--- a/testsuite/tests/parallel/domain_alert.compilers.reference
+++ b/testsuite/tests/parallel/domain_alert.compilers.reference
@@ -1,5 +1,5 @@
-File "domain_alert.ml", line 9, characters 8-25:
-9 | let _ = Domain.Safe.spawn (fun () -> ())
+File "domain_alert.ml", line 8, characters 8-25:
+8 | let _ = Domain.Safe.spawn (fun () -> ())
             ^^^^^^^^^^^^^^^^^
 Alert do_not_spawn_domains: Stdlib.Domain.Safe.spawn
 User programs should never spawn domains. To execute a function on a domain, use [Multicore] from the threading library. This is because spawning more than [recommended_domain_count] domains (the CPU core count) will significantly degrade GC performance. Using both [Domain.spawn] and [Multicore] can cause [Multicore] to abort.

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1689,7 +1689,7 @@ let poly_ id : 'a. 'a -> 'a = fun x -> x
 Line 1, characters 10-12:
 1 | let poly_ id : 'a. 'a -> 'a = fun x -> x
               ^^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 >> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
 Uncaught exception: Misc.Fatal_error
 
@@ -1707,7 +1707,7 @@ let poly_ const : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
 Line 1, characters 10-15:
 1 | let poly_ const : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
               ^^^^^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 >> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
 Uncaught exception: Misc.Fatal_error
 
@@ -1730,12 +1730,12 @@ and poly_ g : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
 Line 2, characters 10-11:
 2 | and poly_ g : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
               ^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 
 Line 1, characters 10-11:
 1 | let poly_ f : 'a. 'a -> 'a = fun x -> x
               ^
-Warning 217: This binding has no layout variables, so "poly_" has no effect. Consider using a regular "let" instead.
+Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
 >> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
 Uncaught exception: Misc.Fatal_error
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -433,30 +433,6 @@ let g () = exclave_ local_
   local_ (() : @ unique once);;
 
 [%%expect{|
-<<<<<<< HEAD
-Line 2, characters 6-7:
-2 |   let f = (() : _ @ unique once) in
-          ^
-Warning 26 [unused-var]: unused variable "f".
-
-Line 3, characters 6-7:
-3 |   let f x y @ local unique = exclave_ local_ (x + y : _ @ once unique) in
-          ^
-Warning 26 [unused-var]: unused variable "f".
-
-||||||| 5.2.0minus-31
-Line 2, characters 6-7:
-2 |   let f = (() : _ @ unique once) in
-          ^
-Warning 26 [unused-var]: unused variable f.
-
-Line 3, characters 6-7:
-3 |   let f x y @ local unique = exclave_ local_ (x + y : _ @ once unique) in
-          ^
-Warning 26 [unused-var]: unused variable f.
-
-=======
->>>>>>> 5.2.0minus-37
 val g : unit -> unit @ local once = <fun>
 |}]
 
@@ -1591,14 +1567,8 @@ Line 2, characters 19-43:
 2 |     (a, b) as t -> overwrite_ t with (b, _)
                        ^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -2,35 +2,35 @@
   (empty_cases_returning_string/280 =
      (function {nlocal = 0} param/282?
        (raise
-         (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 28 50])))
+         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 28 50])))
    empty_cases_returning_float64/283 =
      (function {nlocal = 0} param/285? : unboxed_float
        (raise
-         (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 29 50])))
+         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 29 50])))
    empty_cases_accepting_string/286 =
      (function {nlocal = 0} param/288?
        (raise
-         (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 30 50])))
+         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 30 50])))
    empty_cases_accepting_float64/289 =
      (function {nlocal = 0} param/291[float]
        (raise
-         (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 31 50])))
+         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 31 50])))
    non_empty_cases_returning_string/292 =
      (function {nlocal = 0} param/294
        (raise
-         (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 32 68])))
+         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 32 68])))
    non_empty_cases_returning_float64/295 =
      (function {nlocal = 0} param/297 : unboxed_float
        (raise
-         (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 33 68])))
+         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 33 68])))
    non_empty_cases_accepting_string/298 =
      (function {nlocal = 0} param/300
        (raise
-         (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 34 68])))
+         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 34 68])))
    non_empty_cases_accepting_float64/301 =
      (function {nlocal = 0} param/303[float]
        (raise
-         (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 35 68]))))
+         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 35 68]))))
   (makeblock 0 empty_cases_returning_string/280
     empty_cases_returning_float64/283 empty_cases_accepting_string/286
     empty_cases_accepting_float64/289 non_empty_cases_returning_string/292

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -2,105 +2,34 @@
   (empty_cases_returning_string/280 =
      (function {nlocal = 0} param/282?
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 28 50])))
    empty_cases_returning_float64/283 =
      (function {nlocal = 0} param/285? : unboxed_float
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Match_failure/49!!) [0: "test.ml" 28 50])))
-   empty_cases_returning_float64/279 =
-     (function {nlocal = 0} param/281? : unboxed_float
-=======
-         (makeblock 0 (getpredef Match_failure/50!!) [0: "test.ml" 28 50])))
-   empty_cases_returning_float64/279 =
-     (function {nlocal = 0} param/281? : unboxed_float
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 29 50])))
    empty_cases_accepting_string/286 =
      (function {nlocal = 0} param/288?
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Match_failure/49!!) [0: "test.ml" 29 50])))
-   empty_cases_accepting_string/282 =
-     (function {nlocal = 0} param/284?
-=======
-         (makeblock 0 (getpredef Match_failure/50!!) [0: "test.ml" 29 50])))
-   empty_cases_accepting_string/282 =
-     (function {nlocal = 0} param/284?
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 30 50])))
    empty_cases_accepting_float64/289 =
      (function {nlocal = 0} param/291[float]
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Match_failure/49!!) [0: "test.ml" 30 50])))
-   empty_cases_accepting_float64/285 =
-     (function {nlocal = 0} param/287[float]
-=======
-         (makeblock 0 (getpredef Match_failure/50!!) [0: "test.ml" 30 50])))
-   empty_cases_accepting_float64/285 =
-     (function {nlocal = 0} param/287[float]
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Match_failure/51!!) [0: "test.ml" 31 50])))
    non_empty_cases_returning_string/292 =
      (function {nlocal = 0} param/294
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Match_failure/49!!) [0: "test.ml" 31 50])))
-   non_empty_cases_returning_string/288 =
-     (function {nlocal = 0} param/290
-=======
-         (makeblock 0 (getpredef Match_failure/50!!) [0: "test.ml" 31 50])))
-   non_empty_cases_returning_string/288 =
-     (function {nlocal = 0} param/290
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 32 68])))
    non_empty_cases_returning_float64/295 =
      (function {nlocal = 0} param/297 : unboxed_float
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Assert_failure/60!!) [0: "test.ml" 32 68])))
-   non_empty_cases_returning_float64/291 =
-     (function {nlocal = 0} param/293 : unboxed_float
-=======
-         (makeblock 0 (getpredef Assert_failure/61!!) [0: "test.ml" 32 68])))
-   non_empty_cases_returning_float64/291 =
-     (function {nlocal = 0} param/293 : unboxed_float
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 33 68])))
    non_empty_cases_accepting_string/298 =
      (function {nlocal = 0} param/300
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Assert_failure/60!!) [0: "test.ml" 33 68])))
-   non_empty_cases_accepting_string/294 =
-     (function {nlocal = 0} param/296
-=======
-         (makeblock 0 (getpredef Assert_failure/61!!) [0: "test.ml" 33 68])))
-   non_empty_cases_accepting_string/294 =
-     (function {nlocal = 0} param/296
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 34 68])))
    non_empty_cases_accepting_float64/301 =
      (function {nlocal = 0} param/303[float]
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Assert_failure/60!!) [0: "test.ml" 34 68])))
-   non_empty_cases_accepting_float64/297 =
-     (function {nlocal = 0} param/299[float]
-=======
-         (makeblock 0 (getpredef Assert_failure/61!!) [0: "test.ml" 34 68])))
-   non_empty_cases_accepting_float64/297 =
-     (function {nlocal = 0} param/299[float]
->>>>>>> 5.2.0minus-37
        (raise
-<<<<<<< HEAD
          (makeblock 0 (getpredef Assert_failure/62!!) [0: "test.ml" 35 68]))))
   (makeblock 0 empty_cases_returning_string/280
     empty_cases_returning_float64/283 empty_cases_accepting_string/286
@@ -108,20 +37,3 @@
     non_empty_cases_returning_float64/295
     non_empty_cases_accepting_string/298
     non_empty_cases_accepting_float64/301))
-||||||| 5.2.0minus-31
-         (makeblock 0 (getpredef Assert_failure/60!!) [0: "test.ml" 35 68]))))
-  (makeblock 0 empty_cases_returning_string/276
-    empty_cases_returning_float64/279 empty_cases_accepting_string/282
-    empty_cases_accepting_float64/285 non_empty_cases_returning_string/288
-    non_empty_cases_returning_float64/291
-    non_empty_cases_accepting_string/294
-    non_empty_cases_accepting_float64/297))
-=======
-         (makeblock 0 (getpredef Assert_failure/61!!) [0: "test.ml" 35 68]))))
-  (makeblock 0 empty_cases_returning_string/276
-    empty_cases_returning_float64/279 empty_cases_accepting_string/282
-    empty_cases_accepting_float64/285 non_empty_cases_returning_string/288
-    non_empty_cases_returning_float64/291
-    non_empty_cases_accepting_string/294
-    non_empty_cases_accepting_float64/297))
->>>>>>> 5.2.0minus-37

--- a/testsuite/tests/quotation/mark_toplevel.ml
+++ b/testsuite/tests/quotation/mark_toplevel.ml
@@ -57,10 +57,10 @@ module M : sig type t val x : t end
 |}];;
 let id (x : <[M.t]> expr) = x
 [%%expect {|
-Line 1, characters 14-17:
+Line 1, characters 14-15:
 1 | let id (x : <[M.t]> expr) = x
-                  ^^^
-Error: Identifier "M" is used at line 1, characters 14-17,
+                  ^
+Error: Identifier "M" is used at line 1, characters 14-15,
        inside a quotation (<[ ... ]>);
        it is introduced at file "_none_", line 1, outside any quotations.
 |}];;

--- a/testsuite/tests/quotation/typing/eval/override.ml
+++ b/testsuite/tests/quotation/typing/eval/override.ml
@@ -43,6 +43,6 @@ let f (x : <[int]> eval) : int = x
 Line 1, characters 33-34:
 1 | let f (x : <[int]> eval) : int = x
                                      ^
-Error: This expression has type "<[int]> eval"
+Error: The value "x" has type "<[int]> eval"
        but an expression was expected of type "int"
 |}]

--- a/testsuite/tests/quotation/typing/eval/reductions.ml
+++ b/testsuite/tests/quotation/typing/eval/reductions.ml
@@ -26,7 +26,7 @@ let f (x : <[int]> eval) : string = x
 Line 1, characters 36-37:
 1 | let f (x : <[int]> eval) : string = x
                                         ^
-Error: This expression has type "<[int]> eval" = "int"
+Error: The value "x" has type "<[int]> eval" = "int"
        but an expression was expected of type "string"
 |}]
 
@@ -148,7 +148,7 @@ let f (x : <[#($('a) * $('b) * $('c))]> expr)
 Line 2, characters 44-45:
 2 |     : #('a eval * 'b eval * 'c eval) = eval x
                                                 ^
-Error: This expression has type "<[#($('a) * $('b) * $('c))]> expr"
+Error: The value "x" has type "<[#($('a) * $('b) * $('c))]> expr"
        but an expression was expected of type "'d expr"
        The layout of <[#($('a) * $('b) * $('c))]> is any & any & any
          because it is an unboxed tuple.
@@ -422,7 +422,7 @@ let f (x : <[ $('a) eval ]> expr) : 'a eval expr = x
 Line 4, characters 51-52:
 4 | let f (x : <[ $('a) eval ]> expr) : 'a eval expr = x
                                                        ^
-Error: This expression has type "<[$('a) eval]> expr"
+Error: The value "x" has type "<[$('a) eval]> expr"
        but an expression was expected of type "'a eval expr"
        Type "<[$('a) eval]>" is not compatible with type "'a eval"
 |}]
@@ -433,16 +433,17 @@ let f (x : <[ <[int]> ]> eval expr) : <[int]> expr = x
 Line 1, characters 53-54:
 1 | let f (x : <[ <[int]> ]> eval expr) : <[int]> expr = x
                                                          ^
-Error: This expression has type "<[<[int]>]> eval expr"
+Error: The value "x" has type "<[<[int]>]> eval expr"
        but an expression was expected of type "<[int]> expr"
-       Type "<[<[int]>]> eval" is not compatible with type "<[int]>"
+       Type "<[<[int]>]> eval" = "<$(<[int]>)>" is not compatible with type
+         "<[int]>"
 |}]
 let f (x : <[<[int]>]> eval eval) : int = x
 [%%expect {|
 Line 1, characters 42-43:
 1 | let f (x : <[<[int]>]> eval eval) : int = x
                                               ^
-Error: This expression has type "<[<[int]>]> eval eval"
+Error: The value "x" has type "<[<[int]>]> eval eval"
        but an expression was expected of type "int"
 |}]
 let f (x : <[ <[ <[int]> ]> ]> eval eval eval) : int = x
@@ -450,7 +451,7 @@ let f (x : <[ <[ <[int]> ]> ]> eval eval eval) : int = x
 Line 1, characters 55-56:
 1 | let f (x : <[ <[ <[int]> ]> ]> eval eval eval) : int = x
                                                            ^
-Error: This expression has type "<[<[<[int]>]>]> eval eval eval"
+Error: The value "x" has type "<[<[<[int]>]>]> eval eval eval"
        but an expression was expected of type "int"
 |}]
 let f (x : <[ <[ <[int]> ]> ]> eval eval expr) : <[int]> expr = x
@@ -458,7 +459,7 @@ let f (x : <[ <[ <[int]> ]> ]> eval eval expr) : <[int]> expr = x
 Line 1, characters 64-65:
 1 | let f (x : <[ <[ <[int]> ]> ]> eval eval expr) : <[int]> expr = x
                                                                     ^
-Error: This expression has type "<[<[<[int]>]>]> eval eval expr"
+Error: The value "x" has type "<[<[<[int]>]>]> eval eval expr"
        but an expression was expected of type "<[int]> expr"
        Type "<[<[<[int]>]>]> eval eval" is not compatible with type "<[int]>"
 |}]
@@ -529,7 +530,7 @@ let f (x : <['a eval]> eval) : <['a]> eval eval = x
 Line 1, characters 50-51:
 1 | let f (x : <['a eval]> eval) : <['a]> eval eval = x
                                                       ^
-Error: This expression has type "<['a eval]> eval"
+Error: The value "x" has type "<['a eval]> eval"
        but an expression was expected of type "<['a]> eval eval"
        Type "'a eval" is not compatible with type "$(<['a]> eval)"
 |}]
@@ -543,7 +544,7 @@ let f (x : <[<[int]> eval]> eval) : <[<[int]>]> eval eval = x
 Line 1, characters 60-61:
 1 | let f (x : <[<[int]> eval]> eval) : <[<[int]>]> eval eval = x
                                                                 ^
-Error: This expression has type "<[<[int]> eval]> eval" = "int"
+Error: The value "x" has type "<[<[int]> eval]> eval" = "int"
        but an expression was expected of type "<[<[int]>]> eval eval"
 |}]
 (* This one should definitely succeed *)

--- a/testsuite/tests/quotation/typing/quotes_splices/gadt.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/gadt.ml
@@ -322,8 +322,7 @@ let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
 Line 2, characters 25-26:
 2 |             (x : M.t) -> x + 1
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 
 (* 1 ~~> 2 ~~> 1  @  1 <=> 0 *)
@@ -333,8 +332,7 @@ let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) (x : M.t) ->
 Line 2, characters 25-26:
 2 |     <[ $(Quote.Expr.int (x + 1)) * 2 ]> ]>
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 1 ~~> 2 ~~> 1  @  0 <=> 1 *)
 let _ = <[ fun (Equal : (M.t, int) Type.eq) (x : <[M.t]> expr) ->
@@ -343,7 +341,7 @@ let _ = <[ fun (Equal : (M.t, int) Type.eq) (x : <[M.t]> expr) ->
 Line 2, characters 8-9:
 2 |     <[ $x + 1 ]> ]>
             ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" = "int" is not compatible with type "int"
 |}]
@@ -355,8 +353,7 @@ let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
 Line 2, characters 25-26:
 2 |             (x : M.t) -> x + 1
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 0 ~~> 0  @  1 <=> 2 *)
 let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
@@ -365,7 +362,7 @@ let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
 Line 2, characters 50-51:
 2 |             (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]>
                                                       ^
-Error: This expression has type "<[<[M.t]> expr]> expr"
+Error: The value "x" has type "<[<[M.t]> expr]> expr"
        but an expression was expected of type "<[<[int]> expr]> expr"
        Type "<[M.t]>" = "<[int]>" is not compatible with type "<[int]>"
        Type "M.t" is not compatible with type "int"
@@ -377,7 +374,7 @@ let _ = <[ fun (Equal : (M.t, int) Type.eq)
 Line 2, characters 40-41:
 2 |                (x : <[M.t]> expr) -> <[$x + 1]> ]>
                                             ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" = "int" is not compatible with type "int"
 |}]
@@ -388,8 +385,7 @@ let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
 Line 2, characters 25-26:
 2 |             (x : M.t) -> x + 1
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 0 ~~> 0  @  2 <=> 1 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
@@ -398,7 +394,7 @@ let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
 Line 2, characters 37-38:
 2 |             (x : <[M.t]> expr) -> <[$x + 1]>
                                          ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" is not compatible with type "int"
 |}]
@@ -409,7 +405,7 @@ let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq)
 Line 2, characters 63-64:
 2 |             (x : <[<[<[M.t]> expr]> expr]> expr) -> <[<[<[$($($x)) + 1]>]>]>
                                                                    ^
-Error: This expression has type "<[<[<[M.t]> expr]> expr]> expr"
+Error: The value "x" has type "<[<[<[M.t]> expr]> expr]> expr"
        but an expression was expected of type "<[<[<[int]> expr]> expr]> expr"
        Type "M.t" is not compatible with type "int"
 |}]
@@ -420,8 +416,7 @@ let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
 Line 2, characters 28-29:
 2 |                (x : M.t) -> x + 1 ]>
                                 ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 1 ~~> 1  @  2 <=> 3 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
@@ -430,7 +425,7 @@ let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq)
 Line 2, characters 53-54:
 2 |                (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]> ]>
                                                          ^
-Error: This expression has type "<[<[M.t]> expr]> expr"
+Error: The value "x" has type "<[<[M.t]> expr]> expr"
        but an expression was expected of type "<[<[int]> expr]> expr"
        Type "<[M.t]>" = "<[int]>" is not compatible with type "<[int]>"
        Type "M.t" is not compatible with type "int"
@@ -526,7 +521,7 @@ let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
 Line 2, characters 37-38:
 2 |      <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]>
                                          ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" = "int" is not compatible with type "int"
 |}]
@@ -537,8 +532,7 @@ let _ = fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
 Line 2, characters 25-26:
 2 |   <[ <[ fun (x : M.t) -> x + 1 ]> ]>
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 1 ~~> 2  @  1 <=> 2 *)
 let _ = <[ fun (Equal : (M.t, int) Type.eq) ->
@@ -547,8 +541,7 @@ let _ = <[ fun (Equal : (M.t, int) Type.eq) ->
 Line 2, characters 28-29:
 2 |         <[ fun (x : M.t) -> x + 1 ]> ]>
                                 ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 0 ~~> 1  @  2 <=> 1 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
@@ -557,8 +550,7 @@ let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
 Line 2, characters 25-26:
 2 |      <[ fun (x : M.t) -> x + 1 ]>
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 0 ~~> 1  @  2 <=> 3 *)
 let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
@@ -567,7 +559,7 @@ let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
 Line 2, characters 50-51:
 2 |      <[ fun (x : <[<[M.t]> expr]> expr) -> <[<[$($x) + 1]>]> ]>
                                                       ^
-Error: This expression has type "<[<[M.t]> expr]> expr"
+Error: The value "x" has type "<[<[M.t]> expr]> expr"
        but an expression was expected of type "<[<[int]> expr]> expr"
        Type "<[M.t]>" = "<[int]>" is not compatible with type "<[int]>"
        Type "M.t" is not compatible with type "int"
@@ -579,7 +571,7 @@ let _ = fun (Equal : (<[<[M.t]> expr]> expr, <[<[int]> expr]> expr) Type.eq) ->
 Line 2, characters 37-38:
 2 |   <[ <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]> ]>
                                          ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" = "int" is not compatible with type "int"
 |}]
@@ -591,8 +583,7 @@ let _ = fun (Equal : (<[<[<[M.t]> expr]> expr]> expr,
 Line 3, characters 25-26:
 3 |   <[ <[ fun (x : M.t) -> x + 1 ]> ]>
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 (* 1 ~~> 2  @  2 <=> 3 *)
 let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
@@ -601,7 +592,7 @@ let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
 Line 2, characters 40-41:
 2 |         <[ fun (x : <[M.t]> expr) -> <[$x + 1]> ]> ]>
                                             ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" = "int" is not compatible with type "int"
 |}]
@@ -612,8 +603,7 @@ let _ = <[ fun (Equal : (<[M.t]> expr, <[int]> expr) Type.eq) ->
 Line 2, characters 28-29:
 2 |      <[ <[ fun (x : M.t) -> x + 1 ]> ]> ]>
                                 ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 
 (* 0 ~~> 1  @  0 <=> 1 *)
@@ -626,8 +616,7 @@ let _ = <[
 Line 4, characters 8-9:
 4 |       <[x + 1]>)
             ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 
 (* Evidence travels to the right stage in the past -- should always fail:
@@ -682,7 +671,7 @@ let _ = fun (type t) (x : t expr) -> <[
 Line 3, characters 7-8:
 3 |       $x + 1)
            ^
-Error: This expression has type "t expr" but an expression was expected of type
+Error: The value "x" has type "t expr" but an expression was expected of type
          "<[int]> expr"
        Type "t" is not compatible with type "<[int]>"
 |}]
@@ -694,8 +683,7 @@ let _ = fun (type t) (x : t expr) -> <[
 Line 3, characters 21-22:
 3 |       let y = $x in (y : int) + 1)
                          ^
-Error: This expression has type "$(t)" but an expression was expected of type
-         "int"
+Error: The value "y" has type "$(t)" but an expression was expected of type "int"
 |}]
 (* 2 ~~> 1  @  1 <=> 1 *)
 let _ = <[ fun (type t) (x : t expr) -> <[
@@ -706,7 +694,7 @@ let _ = <[ fun (type t) (x : t expr) -> <[
 Line 3, characters 7-8:
 3 |       $x + 1)
            ^
-Error: This expression has type "t expr" but an expression was expected of type
+Error: The value "x" has type "t expr" but an expression was expected of type
          "<[int]> expr"
        Type "t" is not compatible with type "<[int]>"
 |}]
@@ -723,8 +711,7 @@ let _ = fun (x : M.t) ->
 Line 3, characters 25-26:
 3 |         $(Quote.Expr.int x) + 1 ]>
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 
 (* 2 ~~> 0  @  2 <=> 1 *)
@@ -735,7 +722,7 @@ let _ = fun (x : <[M.t]> expr) ->
 Line 3, characters 26-27:
 3 |         $(Quote.Expr.int $x) + 1 ]> ]>
                               ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[int]> expr"
        Type "M.t" is not compatible with type "int"
 |}]
@@ -749,8 +736,7 @@ let _ =
 Line 4, characters 25-26:
 4 |         $(Quote.Expr.int x) + 1 ]> ]>
                              ^
-Error: This expression has type "M.t" but an expression was expected of type
-         "int"
+Error: The value "x" has type "M.t" but an expression was expected of type "int"
 |}]
 
 (* Repeated equations at different stages *)
@@ -783,7 +769,7 @@ let _ = fun (Equal : (M.t, string) Type.eq) ->
 Line 3, characters 38-39:
 3 |         fun (x : <[M.t]> expr) -> <[ $x ^ "" ]>
                                           ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[string]> expr"
        Type "<[M.t]>" = "<[int]>" is not compatible with type "<[string]>"
        Type "int" is not compatible with type "string"
@@ -796,7 +782,7 @@ let _ = fun (Equal : (M.t, string) Type.eq) ->
 Line 3, characters 25-26:
 3 |         fun (x : M.t) -> x + 0
                              ^
-Error: This expression has type "M.t" = "string"
+Error: The value "x" has type "M.t" = "string"
        but an expression was expected of type "int"
 |}]
 
@@ -826,8 +812,8 @@ let _ = fun (Equal : (M.t, string) Type.eq) ->
 Line 3, characters 25-26:
 3 |         fun (x : M.t) -> x ^ "" ]>
                              ^
-Error: This expression has type "M.t" = "int"
-       but an expression was expected of type "string"
+Error: The value "x" has type "M.t" = "int" but an expression was expected of type
+         "string"
 |}]
 (* fails, because we only instantiate stage 0 *)
 let _ = fun (Equal : (M.t, string) Type.eq) ->
@@ -837,7 +823,7 @@ let _ = fun (Equal : (M.t, string) Type.eq) ->
 Line 3, characters 45-46:
 3 |         fun (Equal : (M.t, int) Type.eq) -> $x ^ "" ]>
                                                  ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[string]> expr"
        Type "<[M.t]>" = "<[int]>" is not compatible with type "<[string]>"
        Type "int" is not compatible with type "string"
@@ -905,7 +891,7 @@ let _ =
 Line 4, characters 38-39:
 4 |         fun (x : <[M.t]> expr) -> <[ $x ^ "" ]> ]>
                                           ^
-Error: This expression has type "<[M.t]> expr"
+Error: The value "x" has type "<[M.t]> expr"
        but an expression was expected of type "<[string]> expr"
        Type "<[M.t]>" = "<[int]>" is not compatible with type "<[string]>"
        Type "int" is not compatible with type "string"
@@ -919,7 +905,7 @@ let _ =
 Line 4, characters 25-26:
 4 |         fun (x : M.t) -> x + 0 ]>
                              ^
-Error: This expression has type "M.t" = "string"
+Error: The value "x" has type "M.t" = "string"
        but an expression was expected of type "int"
 |}]
 
@@ -967,7 +953,7 @@ let magic_with_time_travel_and_past_types (type a b) (x : a) : b =
 Line 4, characters 22-23:
 4 |      $(result := Some x; <[()]>) ]> |> ignore;
                           ^
-Error: This expression has type "a" but an expression was expected of type "b"
+Error: The value "x" has type "a" but an expression was expected of type "b"
 |}]
 (* Splices are not instantiable *)
 let foo (type a) (c : a expr) = <[
@@ -978,7 +964,7 @@ let bad = foo <["abc"]>
 Line 3, characters 5-6:
 3 |     $c + 42 ]>
          ^
-Error: This expression has type "a expr" but an expression was expected of type
+Error: The value "c" has type "a expr" but an expression was expected of type
          "<[int]> expr"
        Type "a" is not compatible with type "<[int]>"
 |}]

--- a/testsuite/tests/quotation/typing/quotes_splices/unify.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/unify.ml
@@ -119,7 +119,7 @@ let _ = <[ fun (Equal : ($Inst1.t, int NonInst0.t) Type.eq)
 Line 8, characters 38-39:
 8 |                (x : Inst1.t expr) -> (x : <[int NonInst0.t]> expr) ]>
                                           ^
-Error: This expression has type "Inst1.t expr"
+Error: The value "x" has type "Inst1.t expr"
        but an expression was expected of type "<[int NonInst0.t]> expr"
        Type "Inst1.t" is not compatible with type "<[int NonInst0.t]>"
 |}]
@@ -130,7 +130,7 @@ let _ = <[ fun (Equal : (int NonInst0.t, $Inst1.t) Type.eq)
 Line 2, characters 38-39:
 2 |                (x : Inst1.t expr) -> (x : <[int NonInst0.t]> expr) ]>
                                           ^
-Error: This expression has type "Inst1.t expr"
+Error: The value "x" has type "Inst1.t expr"
        but an expression was expected of type "<[int NonInst0.t]> expr"
        Type "Inst1.t" is not compatible with type "<[int NonInst0.t]>"
 |}]
@@ -233,7 +233,7 @@ let _ = <[ fun (Equal : ($Inst1.t, $Inst1.t') Type.eq) ->
 Line 2, characters 39-40:
 2 |         $( (fun (x : Inst1.t expr) -> (x : Inst1.t' expr))
                                            ^
-Error: This expression has type "Inst1.t expr"
+Error: The value "x" has type "Inst1.t expr"
        but an expression was expected of type "Inst1.t' expr"
        Type "Inst1.t" is not compatible with type "Inst1.t'"
 |}]

--- a/testsuite/tests/slambda/modules.ml
+++ b/testsuite/tests/slambda/modules.ml
@@ -137,7 +137,7 @@ M.a
 Line 18, characters 2-9:
 18 |   kind_ l
        ^^^^^^^
-Warning 191 [unused-kind-declaration]: unused kind l.
+Warning 191 [unused-kind-declaration]: unused kind "l".
 { c = (let
         (two =
            { c = (missing);
@@ -170,9 +170,8 @@ Warning 191 [unused-kind-declaration]: unused kind l.
                         r = ⟪ (let
                                 (j_tables =o (opaque (makemutable 0 0 0 0))
                                  j_init =
-                                   (function {nlocal = 0} class
-                                     (function {nlocal = 0} env
-                                       self[value<genarray>]
+                                   (function {nlocal = 0} class?
+                                     (function {nlocal = 0} env self?
                                        (opaque
                                          (apply
                                            (field_imm 23
@@ -206,9 +205,8 @@ Warning 191 [unused-kind-declaration]: unused kind l.
                               (let
                                 (j_tables =o (opaque (makemutable 0 0 0 0))
                                  j_init =
-                                   (function {nlocal = 0} class
-                                     (function {nlocal = 0} env
-                                       self[value<genarray>]
+                                   (function {nlocal = 0} class?
+                                     (function {nlocal = 0} env self?
                                        (opaque
                                          (apply
                                            (field_imm 23
@@ -247,9 +245,8 @@ Warning 191 [unused-kind-declaration]: unused kind l.
                         (let
                           (j_tables =o (opaque (makemutable 0 0 0 0))
                            j_init =
-                             (function {nlocal = 0} class
-                               (function {nlocal = 0} env
-                                 self[value<genarray>]
+                             (function {nlocal = 0} class?
+                               (function {nlocal = 0} env self?
                                  (opaque
                                    (apply
                                      (field_imm 23 (global CamlinternalOO!))

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1261,8 +1261,7 @@ Lines 13-14, characters 24-19:
 13 | ........................match x with
 14 |   | M1.Int -> "int"
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-K
+  Here is an example of a case that is not matched: "K"
 
 val f1 : int M1.t -> string = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -652,7 +652,7 @@ let f { field } = field "hello"
 Line 1, characters 24-31:
 1 | let f { field } = field "hello"
                             ^^^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "('a : immediate)"
        The layout of string is value non_float
          because it is the primitive type string.
@@ -669,7 +669,7 @@ let f { fieldg } = fieldg "hello"
 Line 1, characters 26-33:
 1 | let f { fieldg } = fieldg "hello"
                               ^^^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "('a : value mod global)"
        The kind of string is immutable_data
          because it is the primitive type string.
@@ -683,7 +683,7 @@ let f { fieldc } = fieldc "hello"
 Line 1, characters 26-33:
 1 | let f { fieldc } = fieldc "hello"
                               ^^^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "('a : word mod many aliased)"
        The layout of string is value non_float
          because it is the primitive type string.
@@ -1069,7 +1069,7 @@ let f (x : ('a : immediate). 'a -> 'a) = x "string"
 Line 1, characters 43-51:
 1 | let f (x : ('a : immediate). 'a -> 'a) = x "string"
                                                ^^^^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "('a : immediate)"
        The layout of string is value non_float
          because it is the primitive type string.
@@ -1086,7 +1086,7 @@ let f (x : ('a : value mod global). 'a -> 'a) = x "string"
 Line 1, characters 50-58:
 1 | let f (x : ('a : value mod global). 'a -> 'a) = x "string"
                                                       ^^^^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "('a : value mod global)"
        The kind of string is immutable_data
          because it is the primitive type string.
@@ -1749,7 +1749,7 @@ let bad p =
 Line 3, characters 43-44:
 3 |   | T (type (a : float64)) (x : a) -> Some x
                                                ^
-Error: This expression has type "a" but an expression was expected of type
+Error: The value "x" has type "a" but an expression was expected of type
          "('a : value_or_null)"
        The layout of a is float64
          because of the annotation on the existential variable a.

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -503,7 +503,7 @@ type ('a : value mod aliased) t = { aliased_field : 'a; }
 Line 2, characters 26-34:
 2 | let x = { aliased_field = "string" }
                               ^^^^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "('a : value mod aliased)"
        The kind of string is immutable_data
          because it is the primitive type string.
@@ -525,7 +525,7 @@ type t : value mod many
 Line 2, characters 42-43:
 2 | let g (x : t) : ('a : value mod global) = x
                                               ^
-Error: This expression has type "t" but an expression was expected of type
+Error: The value "x" has type "t" but an expression was expected of type
          "('a : value mod global)"
        The kind of t is value mod many
          because of the definition of t at line 1, characters 0-23.
@@ -551,7 +551,7 @@ val f : ('a : value mod aliased). 'a -> unit = <fun>
 Line 3, characters 18-19:
 3 | let g (x : t) = f x
                       ^
-Error: This expression has type "t" but an expression was expected of type
+Error: The value "x" has type "t" but an expression was expected of type
          "('a : value mod aliased)"
        The kind of t is value mod external64
          because of the definition of t at line 1, characters 0-29.
@@ -1392,7 +1392,7 @@ type _ t =
 Line 17, characters 6-7:
 17 |     f y
            ^
-Error: This expression has type "a" but an expression was expected of type
+Error: The value "y" has type "a" but an expression was expected of type
          "('a : immediate)"
        The layout of a is value
          because of the annotation on the abstract type declaration for a.

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -70,7 +70,7 @@ let bar (x : q) =
 Line 2, characters 23-24:
 2 |   takes_only_immutable x
                            ^
-Error: This expression has type "q" but an expression was expected of type
+Error: The value "x" has type "q" but an expression was expected of type
          "('a : immutable_data)"
        The kind of q is immutable_data with M.t
          because of the definition of q at line 1, characters 0-32.

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -71,7 +71,7 @@ let bar (x : q) =
 Line 2, characters 23-24:
 2 |   takes_only_immutable x
                            ^
-Error: This expression has type "q" but an expression was expected of type
+Error: The value "x" has type "q" but an expression was expected of type
          "('a : immutable_data)"
        The kind of q is immutable_data with M.t
          because of the definition of q at line 1, characters 0-32.

--- a/testsuite/tests/typing-jkind-bounds/misc.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc.ml
@@ -62,7 +62,7 @@ external f : unit -> t @ contended = "%identity"
 Line 3, characters 20-21:
 3 | let _ : unit -> t = f
                         ^
-Error: This expression has type "unit -> t @ contended"
+Error: The value "f" has type "unit -> t @ contended"
        but an expression was expected of type "unit -> t"
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
@@ -63,7 +63,7 @@ external f : unit -> t @ contended = "%identity"
 Line 3, characters 20-21:
 3 | let _ : unit -> t = f
                         ^
-Error: This expression has type "unit -> t @ contended"
+Error: The value "f" has type "unit -> t @ contended"
        but an expression was expected of type "unit -> t"
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -609,7 +609,7 @@ let () = cross_global t
 Line 1, characters 22-23:
 1 | let () = cross_global t
                           ^
-Error: This expression has type "t" but an expression was expected of type
+Error: The value "t" has type "t" but an expression was expected of type
          "('a : value mod global)"
        The kind of t is immutable_data
          because of the definition of t at line 1, characters 0-32.
@@ -641,7 +641,7 @@ let () =
 Line 2, characters 13-16:
 2 |   cross_many int;
                  ^^^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "int" has type "int t" but an expression was expected of type
          "('a : value mod many)"
        The kind of int t is immutable_data with int
          because of the definition of t at line 1, characters 0-22.
@@ -654,7 +654,7 @@ let () = cross_aliased int
 Line 1, characters 23-26:
 1 | let () = cross_aliased int
                            ^^^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "int" has type "int t" but an expression was expected of type
          "('a : value mod aliased)"
        The kind of int t is immutable_data
          because of the definition of t at line 1, characters 0-22.
@@ -664,7 +664,7 @@ Error: This expression has type "int t" but an expression was expected of type
 Line 1, characters 23-26:
 1 | let () = cross_aliased int
                            ^^^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "int" has type "int t" but an expression was expected of type
          "('a : value mod aliased)"
        The kind of int t is immutable_data with int
          because of the definition of t at line 1, characters 0-22.
@@ -677,7 +677,7 @@ let () = cross_portable func
 Line 1, characters 24-28:
 1 | let () = cross_portable func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
        The kind of (unit -> unit) t is value non_float mod immutable
          because of the definition of t at line 1, characters 0-22.
@@ -688,7 +688,7 @@ Error: This expression has type "(unit -> unit) t"
 Line 1, characters 24-28:
 1 | let () = cross_portable func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
        The kind of (unit -> unit) t is immutable_data with unit -> unit
          because of the definition of t at line 1, characters 0-22.
@@ -702,7 +702,7 @@ let () = cross_external func
 Line 1, characters 24-28:
 1 | let () = cross_external func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
        The kind of (unit -> unit) t is value non_float mod immutable
          because of the definition of t at line 1, characters 0-22.
@@ -713,7 +713,7 @@ Error: This expression has type "(unit -> unit) t"
 Line 1, characters 24-28:
 1 | let () = cross_external func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
        The kind of (unit -> unit) t is immutable_data with unit -> unit
          because of the definition of t at line 1, characters 0-22.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
@@ -362,7 +362,7 @@ end
 Line 4, characters 40-48:
 4 |   type 'a t : immutable_data with 'a @@ portable contended portable
                                             ^^^^^^^^
-Warning 213: This portability is overriden by portable later.
+Warning 213: This portability is overridden by portable later.
 
 module M : sig type 'a t : immutable_data with 'a @@ portable end
 |}]

--- a/testsuite/tests/typing-jkind-bounds/universal_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/universal_ikinds.ml
@@ -45,7 +45,7 @@ val v : 'a t = {f = <cycle>}
 Line 2, characters 32-33:
 2 | let () = require_immutable_data v
                                     ^
-Error: This expression has type "'a t" but an expression was expected of type
+Error: The value "v" has type "'a t" but an expression was expected of type
          "('b : immutable_data)"
        The kind of 'a t is immutable_data with 'b. 'b t
          because of the definition of t at line 1, characters 0-28.

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -610,7 +610,7 @@ let () = cross_global t
 Line 1, characters 22-23:
 1 | let () = cross_global t
                           ^
-Error: This expression has type "t" but an expression was expected of type
+Error: The value "t" has type "t" but an expression was expected of type
          "('a : value mod global)"
        The kind of t is immutable_data
          because of the definition of t at line 1, characters 0-35.
@@ -642,7 +642,7 @@ let () =
 Line 2, characters 13-16:
 2 |   cross_many int;
                  ^^^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "int" has type "int t" but an expression was expected of type
          "('a : value mod many)"
        The kind of int t is immutable_data with int
          because of the definition of t at line 1, characters 0-21.
@@ -655,7 +655,7 @@ let () = cross_aliased int
 Line 1, characters 23-26:
 1 | let () = cross_aliased int
                            ^^^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "int" has type "int t" but an expression was expected of type
          "('a : value mod aliased)"
        The kind of int t is immutable_data
          because of the definition of t at line 1, characters 0-21.
@@ -665,7 +665,7 @@ Error: This expression has type "int t" but an expression was expected of type
 Line 1, characters 23-26:
 1 | let () = cross_aliased int
                            ^^^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "int" has type "int t" but an expression was expected of type
          "('a : value mod aliased)"
        The kind of int t is immutable_data with int
          because of the definition of t at line 1, characters 0-21.
@@ -678,7 +678,7 @@ let () = cross_portable func
 Line 1, characters 24-28:
 1 | let () = cross_portable func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
        The kind of (unit -> unit) t is value non_float mod immutable
          because of the definition of t at line 1, characters 0-21.
@@ -689,7 +689,7 @@ Error: This expression has type "(unit -> unit) t"
 Line 1, characters 24-28:
 1 | let () = cross_portable func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
        The kind of (unit -> unit) t is immutable_data with unit -> unit
          because of the definition of t at line 1, characters 0-21.
@@ -703,7 +703,7 @@ let () = cross_external func
 Line 1, characters 24-28:
 1 | let () = cross_external func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
        The kind of (unit -> unit) t is value non_float mod immutable
          because of the definition of t at line 1, characters 0-21.
@@ -714,7 +714,7 @@ Error: This expression has type "(unit -> unit) t"
 Line 1, characters 24-28:
 1 | let () = cross_external func
                             ^^^^
-Error: This expression has type "(unit -> unit) t"
+Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
        The kind of (unit -> unit) t is immutable_data with unit -> unit
          because of the definition of t at line 1, characters 0-21.
@@ -1038,7 +1038,7 @@ type 'a t = Degen of ('a * 'a) t | Leaf
 Line 2, characters 35-36:
 2 | let f (x : int t) = cross_portable x
                                        ^
-Error: This expression has type "int t" but an expression was expected of type
+Error: The value "x" has type "int t" but an expression was expected of type
          "('a : value mod portable)"
        The kind of int t is immutable_data with (int * int) t
          because of the definition of t at line 1, characters 0-39.

--- a/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -244,16 +244,8 @@ end
 Line 11, characters 79-82:
 11 |   let _ =  assert (Stdlib_upstream_compatible.Int64_u.equal #42L (get_third [| #0L; #1L; #42L |]))
                                                                                     ^^^
-<<<<<<< HEAD
 Error: This constant has type "int64#" but an expression was expected of type
-         "('a : bits32 mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int64#" but an expression was expected of type
-         "('a : bits32 mod separable)"
-=======
-Error: This expression has type "int64#" but an expression was expected of type
          "('a : bits32)"
->>>>>>> 5.2.0minus-37
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a sublayout of bits32
@@ -295,16 +287,8 @@ let _ =
 Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
                                            ^^^^^
-<<<<<<< HEAD
 Error: This constant has type "float#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "float#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "float#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -319,16 +303,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42l in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "int32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "int32#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of int32# is bits32
          because it is the unboxed version of the primitive type int32.
        But the layout of int32# must be a value layout
@@ -343,16 +319,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42L in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "int64#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int64#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "int64#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a value layout
@@ -367,18 +335,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42n in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "nativeint#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "nativeint#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "nativeint#"
        but an expression was expected of type "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of nativeint# is word
          because it is the unboxed version of the primitive type nativeint.
        But the layout of nativeint# must be a value layout
@@ -393,17 +351,8 @@ let _ =
 Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0s in
                                            ^^^^^^
-<<<<<<< HEAD
 Error: This constant has type "float32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "float32#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "float32#"
-       but an expression was expected of type "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
+         "('a : value maybe_null)"
        The layout of float32# is float32
          because it is the unboxed version of the primitive type float32.
        But the layout of float32# must be a value layout

--- a/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -241,16 +241,8 @@ end
 Line 11, characters 79-82:
 11 |   let _ =  assert (Stdlib_upstream_compatible.Int64_u.equal #42L (get_third [| #0L; #1L; #42L |]))
                                                                                     ^^^
-<<<<<<< HEAD
 Error: This constant has type "int64#" but an expression was expected of type
-         "('a : bits32 mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int64#" but an expression was expected of type
-         "('a : bits32 mod separable)"
-=======
-Error: This expression has type "int64#" but an expression was expected of type
          "('a : bits32)"
->>>>>>> 5.2.0minus-37
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a sublayout of bits32
@@ -292,16 +284,8 @@ let _ =
 Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
                                            ^^^^^
-<<<<<<< HEAD
 Error: This constant has type "float#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "float#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "float#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -316,16 +300,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42l in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "int32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "int32#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of int32# is bits32
          because it is the unboxed version of the primitive type int32.
        But the layout of int32# must be a value layout
@@ -340,16 +316,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42L in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "int64#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int64#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "int64#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a value layout
@@ -364,18 +332,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42n in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "nativeint#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "nativeint#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "nativeint#"
        but an expression was expected of type "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of nativeint# is word
          because it is the unboxed version of the primitive type nativeint.
        But the layout of nativeint# must be a value layout
@@ -390,17 +348,8 @@ let _ =
 Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0s in
                                            ^^^^^^
-<<<<<<< HEAD
 Error: This constant has type "float32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "float32#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "float32#"
-       but an expression was expected of type "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
+         "('a : value maybe_null)"
        The layout of float32# is float32
          because it is the unboxed version of the primitive type float32.
        But the layout of float32# must be a value layout

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -387,28 +387,6 @@ type t1 = { a : string; }
 val b : unit -> (t1# iarray, string) idx_imm = <fun>
 |}]
 
-<<<<<<< HEAD
-let bad_index_type = (.("test"))
-[%%expect{|
-Line 1, characters 24-30:
-1 | let bad_index_type = (.("test"))
-                            ^^^^^^
-Error: This constant has type "string" but an expression was expected of type
-         "int"
-|}]
-
-||||||| 5.2.0minus-31
-let bad_index_type = (.("test"))
-[%%expect{|
-Line 1, characters 24-30:
-1 | let bad_index_type = (.("test"))
-                            ^^^^^^
-Error: This expression has type "string" but an expression was expected of type
-         "int"
-|}]
-
-=======
->>>>>>> 5.2.0minus-37
 (****************)
 (* Illegal gaps *)
 
@@ -781,22 +759,10 @@ let bad (x : float array) =
   let y = Idx_mut.unsafe_create_into_array 42 in
   Idx_mut.get x y
 [%%expect{|
-<<<<<<< HEAD
 Line 3, characters 23-24:
-3 |   Idx_mut.unsafe_get x y
+3 |   Idx_mut.get x y
                            ^
 Error: The value "y" has type "('a array, 'a) idx_mut"
-||||||| 5.2.0minus-31
-Line 3, characters 23-24:
-3 |   Idx_mut.unsafe_get x y
-                           ^
-Error: This expression has type "('a array, 'a) idx_mut"
-=======
-Line 3, characters 16-17:
-3 |   Idx_mut.get x y
-                    ^
-Error: This expression has type "('a array, 'a) idx_mut"
->>>>>>> 5.2.0minus-37
        but an expression was expected of type "(float array, 'b) idx_mut"
        The layout of float is value
          because it is the primitive type float.
@@ -941,23 +907,11 @@ let f c =
 [%%expect{|
 val f : bool -> (u array, int) idx_mut = <fun>
 |}, Principal{|
-<<<<<<< HEAD
-Line 5, characters 11-12:
-5 |     (.(1).#x)
-               ^
-Warning 18 [not-principal]: this type-based unboxed record field disambiguation
-  is not principal.
-||||||| 5.2.0minus-31
-Line 5, characters 11-12:
-5 |     (.(1).#x)
-               ^
-Warning 18 [not-principal]: this type-based unboxed record field disambiguation is not principal.
-=======
 Line 6, characters 51-52:
 6 |     (.idx_mut(Idx_mut.unsafe_create_into_array 1).#x)
                                                        ^
-Warning 18 [not-principal]: this type-based unboxed record field disambiguation is not principal.
->>>>>>> 5.2.0minus-37
+Warning 18 [not-principal]: this type-based unboxed record field disambiguation
+  is not principal.
 
 val f : bool -> (u array, int) idx_mut = <fun>
 |}]
@@ -973,23 +927,11 @@ let f c =
 [%%expect{|
 val f : bool -> (u t# array, int) idx_mut = <fun>
 |}, Principal{|
-<<<<<<< HEAD
-Line 5, characters 14-15:
-5 |     (.(1).#a.#x)
-                  ^
-Warning 18 [not-principal]: this type-based unboxed record field disambiguation
-  is not principal.
-||||||| 5.2.0minus-31
-Line 5, characters 14-15:
-5 |     (.(1).#a.#x)
-                  ^
-Warning 18 [not-principal]: this type-based unboxed record field disambiguation is not principal.
-=======
 Line 6, characters 54-55:
 6 |     (.idx_mut(Idx_mut.unsafe_create_into_array 1).#a.#x)
                                                           ^
-Warning 18 [not-principal]: this type-based unboxed record field disambiguation is not principal.
->>>>>>> 5.2.0minus-37
+Warning 18 [not-principal]: this type-based unboxed record field disambiguation
+  is not principal.
 
 val f : bool -> (u t# array, int) idx_mut = <fun>
 |}]

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -759,9 +759,9 @@ let bad (x : float array) =
   let y = Idx_mut.unsafe_create_into_array 42 in
   Idx_mut.get x y
 [%%expect{|
-Line 3, characters 23-24:
+Line 3, characters 16-17:
 3 |   Idx_mut.get x y
-                           ^
+                    ^
 Error: The value "y" has type "('a array, 'a) idx_mut"
        but an expression was expected of type "(float array, 'b) idx_mut"
        The layout of float is value

--- a/testsuite/tests/typing-layouts-block-indices/parsing_idx_bad_ident.compilers.reference
+++ b/testsuite/tests/typing-layouts-block-indices/parsing_idx_bad_ident.compilers.reference
@@ -1,14 +1,4 @@
 File "parsing_idx_bad_ident.ml", line 8, characters 13-14:
 8 | let _ = (.foo(0))
                  ^
-<<<<<<< HEAD
-Error: Syntax error: A parenthesis here can only follow one of:
-  ., .L, .l, .S, .s, .n, .:, .:L, .:l, .:S, .:s, .:n,
-  .idx_imm, .idx_mut.
-||||||| 5.2.0minus-31
-Error: Syntax error: A parenthesis here can only follow one of:
-  ".", ".L", ".l", ".S", ".s", ".n", ".:", ".:L", ".:l", ".:S", ".:s", ".:n",
-  ".idx_imm", ".idx_mut".
-=======
-Error: Syntax error: A parenthesis here can only follow ".idx_imm" or ".idx_mut".
->>>>>>> 5.2.0minus-37
+Error: Syntax error: A parenthesis here can only follow .idx_imm or .idx_mut.

--- a/testsuite/tests/typing-layouts-err-msg/immediate.ml
+++ b/testsuite/tests/typing-layouts-err-msg/immediate.ml
@@ -26,19 +26,9 @@ type v = unit
 Line 3, characters 21-22:
 3 | let f (x: v): 'a t = x
                          ^
-<<<<<<< HEAD
 Error: The value "x" has type "v" = "unit" but an expression was expected of type
          "'a t" = "('a : void)"
-       The layout of unit is value
-||||||| 5.2.0minus-31
-Error: This expression has type "v" = "unit"
-       but an expression was expected of type "'a t" = "('a : void)"
-       The layout of unit is value
-=======
-Error: This expression has type "v" = "unit"
-       but an expression was expected of type "'a t" = "('a : void)"
        The layout of unit is value non_pointer
->>>>>>> 5.2.0minus-37
          because it is the primitive type unit.
        But the layout of unit must be a sublayout of void
          because of the definition of t at line 1, characters 0-22.

--- a/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -232,19 +232,9 @@ type ('a : void) t = 'a
 Line 2, characters 31-32:
 2 | let f (x : int -> int): 'a t = x
                                    ^
-<<<<<<< HEAD
 Error: The value "x" has type "int -> int" but an expression was expected of type
          "'a t" = "('a : void)"
-       The layout of int -> int is value
-||||||| 5.2.0minus-31
-Error: This expression has type "int -> int"
-       but an expression was expected of type "'a t" = "('a : void)"
-       The layout of int -> int is value
-=======
-Error: This expression has type "int -> int"
-       but an expression was expected of type "'a t" = "('a : void)"
        The layout of int -> int is value non_float
->>>>>>> 5.2.0minus-37
          because it's a function type.
        But the layout of int -> int must be a sublayout of void
          because of the definition of t at line 1, characters 0-22.

--- a/testsuite/tests/typing-layouts-iarrays/basics.ml
+++ b/testsuite/tests/typing-layouts-iarrays/basics.ml
@@ -223,16 +223,8 @@ end
 Line 13, characters 39-42:
 13 |                     #42L (get_third [: #0L; #1L; #42L :]))
                                             ^^^
-<<<<<<< HEAD
 Error: This constant has type "int64#" but an expression was expected of type
-         "('a : bits32 mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int64#" but an expression was expected of type
-         "('a : bits32 mod separable)"
-=======
-Error: This expression has type "int64#" but an expression was expected of type
          "('a : bits32)"
->>>>>>> 5.2.0minus-37
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a sublayout of bits32
@@ -275,16 +267,8 @@ let _ =
 Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [: x :]; #42.0 in
                                            ^^^^^
-<<<<<<< HEAD
 Error: This constant has type "float#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "float#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "float#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
        But the layout of float# must be a value layout
@@ -299,16 +283,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [: x :]; #42l in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "int32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "int32#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of int32# is bits32
          because it is the unboxed version of the primitive type int32.
        But the layout of int32# must be a value layout
@@ -323,16 +299,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [: x :]; #42L in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "int64#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "int64#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "int64#" but an expression was expected of type
          "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of int64# is bits64
          because it is the unboxed version of the primitive type int64.
        But the layout of int64# must be a value layout
@@ -347,18 +315,8 @@ let _ =
 Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [: x :]; #42n in
                                            ^^^^
-<<<<<<< HEAD
 Error: This constant has type "nativeint#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "nativeint#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "nativeint#"
        but an expression was expected of type "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
        The layout of nativeint# is word
          because it is the unboxed version of the primitive type nativeint.
        But the layout of nativeint# must be a value layout
@@ -373,17 +331,8 @@ let _ =
 Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [: x :]; #42.0s in
                                            ^^^^^^
-<<<<<<< HEAD
 Error: This constant has type "float32#" but an expression was expected of type
-         "('a : value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "float32#"
-       but an expression was expected of type
-         "('a : value_or_null mod separable)"
-=======
-Error: This expression has type "float32#"
-       but an expression was expected of type "('a : value maybe_null)"
->>>>>>> 5.2.0minus-37
+         "('a : value maybe_null)"
        The layout of float32# is float32
          because it is the unboxed version of the primitive type float32.
        But the layout of float32# must be a value layout

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -90,21 +90,9 @@ let should_fail = [| Null; This 3.4 |]
 Line 1, characters 32-35:
 1 | let should_fail = [| Null; This 3.4 |]
                                     ^^^
-<<<<<<< HEAD
 Error: The constant "3.4" has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-||||||| 5.2.0minus-31
-Error: This expression has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-=======
-Error: This expression has type "float" but an expression was expected of type
          "('a : value non_float)"
        The layout of float is value
->>>>>>> 5.2.0minus-37
          because it is the primitive type float.
        But the layout of float must be a sublayout of value non_float
          because it's the type of an array element.
@@ -198,21 +186,9 @@ let should_fail_iarray = [: Null; This 3.4 :]
 Line 1, characters 39-42:
 1 | let should_fail_iarray = [: Null; This 3.4 :]
                                            ^^^
-<<<<<<< HEAD
 Error: The constant "3.4" has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-||||||| 5.2.0minus-31
-Error: This expression has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-=======
-Error: This expression has type "float" but an expression was expected of type
          "('a : value non_float)"
        The layout of float is value
->>>>>>> 5.2.0minus-37
          because it is the primitive type float.
        But the layout of float must be a sublayout of value non_float
          because it's the type of an array element.

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -69,7 +69,7 @@ let bad = Yep (Yep 5)
 Line 1, characters 14-21:
 1 | let bad = Yep (Yep 5)
                   ^^^^^^^
-Error: This expression has type "'a t" but an expression was expected of type
+Error: This constructor has type "'a t" but an expression was expected of type
          "('b : value)"
        The layout of 'a t is value maybe_separable maybe_null
          because of the definition of t at lines 1-4, characters 0-11.

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -170,8 +170,7 @@ Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
 Error: This constructor has type "'a Or_null.t" = "'a or_null"
-       but an expression was expected of type
-         "('b : value maybe_separable)"
+       but an expression was expected of type "('b : value maybe_separable)"
        The layout of 'a Or_null.t is value maybe_separable maybe_null
          because it is the primitive type or_null.
        But the layout of 'a Or_null.t must be a sublayout of

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -169,21 +169,10 @@ module Or_null :
 Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
 Error: This constructor has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type
-         "('b : value_or_null mod non_null)"
-       The kind of 'a Or_null.t is value_or_null mod everything with 'a
-||||||| 5.2.0minus-31
-Error: This expression has type "'a Or_null.t" = "'a or_null"
-       but an expression was expected of type
-         "('b : value_or_null mod non_null)"
-       The kind of 'a Or_null.t is value_or_null mod everything with 'a
-=======
-Error: This expression has type "'a Or_null.t" = "'a or_null"
-       but an expression was expected of type "('b : value maybe_separable)"
+         "('b : value maybe_separable)"
        The layout of 'a Or_null.t is value maybe_separable maybe_null
->>>>>>> 5.2.0minus-37
          because it is the primitive type or_null.
        But the layout of 'a Or_null.t must be a sublayout of
            value maybe_separable

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -885,21 +885,9 @@ let fails = make_vect 3 (This 5.)
 Line 1, characters 30-32:
 1 | let fails = make_vect 3 (This 5.)
                                   ^^
-<<<<<<< HEAD
 Error: The constant "5." has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-||||||| 5.2.0minus-31
-Error: This expression has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-=======
-Error: This expression has type "float" but an expression was expected of type
          "('a : value non_float)"
        The layout of float is value
->>>>>>> 5.2.0minus-37
          because it is the primitive type float.
        But the layout of float must be a sublayout of value non_float
          because it's the layout polymorphic type in an external declaration

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -197,21 +197,9 @@ let should_fail = [| This 5.; Null |]
 Line 1, characters 26-28:
 1 | let should_fail = [| This 5.; Null |]
                               ^^
-<<<<<<< HEAD
 Error: The constant "5." has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-||||||| 5.2.0minus-31
-Error: This expression has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-=======
-Error: This expression has type "float" but an expression was expected of type
          "('a : value non_float)"
        The layout of float is value
->>>>>>> 5.2.0minus-37
          because it is the primitive type float.
        But the layout of float must be a sublayout of value non_float
          because it's the type of an array element.
@@ -266,21 +254,9 @@ let should_fail = [: Null; This 5. :]
 Line 1, characters 32-34:
 1 | let should_fail = [: Null; This 5. :]
                                     ^^
-<<<<<<< HEAD
 Error: The constant "5." has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-||||||| 5.2.0minus-31
-Error: This expression has type "float" but an expression was expected of type
-         "('a : value mod non_float)"
-       The kind of float is
-           value mod forkable unyielding many stateless immutable
-=======
-Error: This expression has type "float" but an expression was expected of type
          "('a : value non_float)"
        The layout of float is value
->>>>>>> 5.2.0minus-37
          because it is the primitive type float.
        But the layout of float must be a sublayout of value non_float
          because it's the type of an array element.

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2194,16 +2194,8 @@ val f : ('a : any separable & value). unit -> 'a -> 'a = <fun>
 Line 3, characters 30-31:
 3 | let g (type a) (x : a) = f () x
                                   ^
-<<<<<<< HEAD
 Error: The value "x" has type "a" but an expression was expected of type
-         "('a : '_representable_layout_21 & value_or_null mod separable)"
-||||||| 5.2.0minus-31
-Error: This expression has type "a" but an expression was expected of type
-         "('a : '_representable_layout_21 & value_or_null mod separable)"
-=======
-Error: This expression has type "a" but an expression was expected of type
          "('a : '_representable_layout_21 separable & value)"
->>>>>>> 5.2.0minus-37
        The layout of a is value
          because it is or unifies with an unannotated universal variable.
        But the layout of a must be representable

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -354,7 +354,7 @@ let f (type a1 : value non_pointer) (type a2 : value) (a1 : a1) (a2 : a2) =
 Line 5, characters 19-20:
 5 |   cant_promote_snd v
                        ^
-Error: This expression has type "a2" but an expression was expected of type
+Error: The value "v" has type "a2" but an expression was expected of type
          "('a : value non_pointer)"
        The layout of a2 is value
          because of the annotation on the abstract type declaration for a2.
@@ -400,8 +400,8 @@ let outer (type a : value non_float) (nf : a or_null) =
 Line 8, characters 4-6:
 8 |   f nf
         ^^
-Error: This expression has type "a or_null"
-       but an expression was expected of type "'a or_null"
+Error: The value "nf" has type "a or_null" but an expression was expected of type
+         "'a or_null"
        The layout of a is value non_float
          because of the annotation on the abstract type declaration for a.
        But the layout of a must be a sublayout of value non_pointer

--- a/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -18,22 +18,6 @@ module type S = sig
   val f_immediate : ('a : immediate). 'a -> 'a -> 'a
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-52:
-2 |   val f_immediate : ('a : immediate). 'a -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-52:
-2 |   val f_immediate : ('a : immediate). 'a -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig val f_immediate : ('a : immediate). 'a -> 'a -> 'a end
 |}];;
 
@@ -41,22 +25,6 @@ module type S = sig
   val f_immediate : ('a : immediate) -> 'a -> 'a
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-48:
-2 |   val f_immediate : ('a : immediate) -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-48:
-2 |   val f_immediate : ('a : immediate) -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig val f_immediate : ('a : immediate). 'a -> 'a -> 'a end
 |}];;
 
@@ -64,22 +32,6 @@ module type S = sig
   type ('a : immediate) t
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-25:
-2 |   type ('a : immediate) t
-      ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-25:
-2 |   type ('a : immediate) t
-      ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig type ('a : immediate) t end
 |}];;
 
@@ -87,85 +39,21 @@ module type S = sig
   type _ g = | MkG : ('a : immediate). 'a g
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-43:
-2 |   type _ g = | MkG : ('a : immediate). 'a g
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in g
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-43:
-2 |   type _ g = | MkG : ('a : immediate). 'a g
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in g
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig type _ g = MkG : ('a : immediate). 'a g end
 |}];;
 
 let f (type a : immediate): a -> a = fun x -> x
 [%%expect {|
-<<<<<<< HEAD
-Line 1, characters 4-5:
-1 | let f (type a : immediate): a -> a = fun x -> x
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 1, characters 4-5:
-1 | let f (type a : immediate): a -> a = fun x -> x
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}];;
 
 let f x = (x : (_ : immediate))
 [%%expect {|
-<<<<<<< HEAD
-Line 1, characters 4-5:
-1 | let f x = (x : (_ : immediate))
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 1, characters 4-5:
-1 | let f x = (x : (_ : immediate))
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}];;
 
 let f v: ((_ : immediate)[@error_message "Custom message"]) = v
 [%%expect {|
-<<<<<<< HEAD
-Line 1, characters 4-5:
-1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 1, characters 4-5:
-1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}];;
 
@@ -174,22 +62,6 @@ module type S = sig
   val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-56:
-2 |   val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate64
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-56:
-2 |   val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate64
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S =
   sig val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a end
 |}];;
@@ -198,22 +70,6 @@ module type S = sig
   val f_immediate64 : ('a : immediate64) -> 'a -> 'a
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-52:
-2 |   val f_immediate64 : ('a : immediate64) -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate64
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-52:
-2 |   val f_immediate64 : ('a : immediate64) -> 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f_immediate64
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S =
   sig val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a end
 |}];;
@@ -222,22 +78,6 @@ module type S = sig
   type ('a : immediate64) t
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-27:
-2 |   type ('a : immediate64) t
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-27:
-2 |   type ('a : immediate64) t
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig type ('a : immediate64) t end
 |}];;
 
@@ -245,85 +85,21 @@ module type S = sig
   type _ g = | MkG : ('a : immediate64). 'a g
 end;;
 [%%expect {|
-<<<<<<< HEAD
-Line 2, characters 2-45:
-2 |   type _ g = | MkG : ('a : immediate64). 'a g
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in g
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 2, characters 2-45:
-2 |   type _ g = | MkG : ('a : immediate64). 'a g
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in g
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig type _ g = MkG : ('a : immediate64). 'a g end
 |}];;
 
 let f (type a : immediate64): a -> a = fun x -> x
 [%%expect {|
-<<<<<<< HEAD
-Line 1, characters 4-5:
-1 | let f (type a : immediate64): a -> a = fun x -> x
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 1, characters 4-5:
-1 | let f (type a : immediate64): a -> a = fun x -> x
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate64). 'a -> 'a = <fun>
 |}];;
 
 let f x = (x : (_ : immediate64))
 [%%expect {|
-<<<<<<< HEAD
-Line 1, characters 4-5:
-1 | let f x = (x : (_ : immediate64))
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 1, characters 4-5:
-1 | let f x = (x : (_ : immediate64))
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate64). 'a -> 'a = <fun>
 |}];;
 
 let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
 [%%expect {|
-<<<<<<< HEAD
-Line 1, characters 4-5:
-1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 1, characters 4-5:
-1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate64). 'a -> 'a = <fun>
 |}];;
 
@@ -337,22 +113,6 @@ end
 
 [%%expect {|
 module type S = sig type t : immediate64 end
-<<<<<<< HEAD
-Line 6, characters 2-49:
-6 |   val f : 'a -> (module S with type t = 'a) -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 6, characters 2-49:
-6 |   val f : 'a -> (module S with type t = 'a) -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type K =
   sig val f : ('a : immediate64). 'a -> (module S with type t = 'a) -> 'a end
 |}];;
@@ -374,22 +134,6 @@ module type S = sig
 end
 
 [%%expect {|
-<<<<<<< HEAD
-Line 3, characters 2-42:
-3 |   val f : ('a id as (_ : immediate)) -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 3, characters 2-42:
-3 |   val f : ('a id as (_ : immediate)) -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 module type S = sig type 'b id = 'b val f : ('a : immediate). 'a id -> 'a end
 |}];;
 
@@ -403,22 +147,6 @@ let f (module _ : S with type t = 'a) (x : 'a) = x
 
 [%%expect{|
 module type S = sig type t : immediate end
-<<<<<<< HEAD
-Line 5, characters 4-5:
-5 | let f (module _ : S with type t = 'a) (x : 'a) = x
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-  can't be erased for compatibility with upstream OCaml.
-
-||||||| 5.2.0minus-31
-Line 5, characters 4-5:
-5 | let f (module _ : S with type t = 'a) (x : 'a) = x
-        ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-=======
->>>>>>> 5.2.0minus-37
 val f : ('a : immediate). (module S with type t = 'a) -> 'a -> 'a = <fun>
 |}]
 
@@ -747,169 +475,7 @@ module M3 : sig type t = private float# end
 external f_4 : M3.t -> M3.t = "%identity" [@@unboxed]
 |}];;
 
-<<<<<<< HEAD
-(* Disabling warnings *)
-
-module M4 : sig
-  [@@@warning "-187"]
-  type ('a : immediate) t = Something of 'a
-
-  val f : ('a : immediate). 'a t -> 'a
-end = struct
-  [@@@warning "-187"]
-
-  type ('a : immediate) t = Something of 'a
-
-  let f (Something x) = x
-end;;
-
-[%%expect{|
-module M4 :
-  sig
-    type ('a : immediate) t = Something of 'a
-    val f : ('a : immediate). 'a t -> 'a
-  end
-|}]
-
-module[@warning "-187"] M5 = struct
-  let f (type a : immediate): a -> a = fun x -> x
-end;;
-
-[%%expect{|
-module M5 : sig val f : ('a : immediate). 'a -> 'a end
-|}]
-
-(* Just disabling the warning on the expression level doesn't work
-   if the declaration has a type variable annotation. *)
-
-let[@warning "-187"] fails (type a : immediate): a -> a = fun x -> x
-;;
-
-[%%expect{|
-Line 1, characters 21-26:
-1 | let[@warning "-187"] fails (type a : immediate): a -> a = fun x -> x
-                         ^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in fails
-  can't be erased for compatibility with upstream OCaml.
-
-val fails : ('a : immediate). 'a -> 'a = <fun>
-|}]
-
-module type S1 = sig
-  type ('a : immediate) fails = int [@@warning "-187"]
-end;;
-
-[%%expect{|
-Line 2, characters 2-54:
-2 |   type ('a : immediate) fails = int [@@warning "-187"]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in fails
-  can't be erased for compatibility with upstream OCaml.
-
-module type S1 = sig type ('a : immediate) fails = int end
-|}]
-
-(* Disabling the warning just in the signature isn't sufficient. *)
-module M6 : sig
-  [@@@warning "-187"]
-  type ('a : immediate) t = 'a * 'a
-end = struct
-  type ('a : immediate) t = 'a * 'a
-end;;
-[%%expect{|
-Line 5, characters 2-35:
-5 |   type ('a : immediate) t = 'a * 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-  can't be erased for compatibility with upstream OCaml.
-
-module M6 : sig type ('a : immediate) t = 'a * 'a end
-|}]
-
-(* More disabled warnings. *)
-||||||| 5.2.0minus-31
-(* Disabling warnings *)
-
-module M4 : sig
-  [@@@warning "-187"]
-  type ('a : immediate) t = Something of 'a
-
-  val f : ('a : immediate). 'a t -> 'a
-end = struct
-  [@@@warning "-187"]
-
-  type ('a : immediate) t = Something of 'a
-
-  let f (Something x) = x
-end;;
-
-[%%expect{|
-module M4 :
-  sig
-    type ('a : immediate) t = Something of 'a
-    val f : ('a : immediate). 'a t -> 'a
-  end
-|}]
-
-module[@warning "-187"] M5 = struct
-  let f (type a : immediate): a -> a = fun x -> x
-end;;
-
-[%%expect{|
-module M5 : sig val f : ('a : immediate). 'a -> 'a end
-|}]
-
-(* Just disabling the warning on the expression level doesn't work
-   if the declaration has a type variable annotation. *)
-
-let[@warning "-187"] fails (type a : immediate): a -> a = fun x -> x
-;;
-
-[%%expect{|
-Line 1, characters 21-26:
-1 | let[@warning "-187"] fails (type a : immediate): a -> a = fun x -> x
-                         ^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in fails
-can't be erased for compatibility with upstream OCaml.
-
-val fails : ('a : immediate). 'a -> 'a = <fun>
-|}]
-
-module type S1 = sig
-  type ('a : immediate) fails = int [@@warning "-187"]
-end;;
-
-[%%expect{|
-Line 2, characters 2-54:
-2 |   type ('a : immediate) fails = int [@@warning "-187"]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in fails
-can't be erased for compatibility with upstream OCaml.
-
-module type S1 = sig type ('a : immediate) fails = int end
-|}]
-
-(* Disabling the warning just in the signature isn't sufficient. *)
-module M6 : sig
-  [@@@warning "-187"]
-  type ('a : immediate) t = 'a * 'a
-end = struct
-  type ('a : immediate) t = 'a * 'a
-end;;
-[%%expect{|
-Line 5, characters 2-35:
-5 |   type ('a : immediate) t = 'a * 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-can't be erased for compatibility with upstream OCaml.
-
-module M6 : sig type ('a : immediate) t = 'a * 'a end
-|}]
-
-(* More disabled warnings. *)
-=======
 (* Disabled warnings. *)
->>>>>>> 5.2.0minus-37
 external[@warning "-187"] f_ok : int -> bool -> int64# = "foo" "bar";;
 
 [%%expect{|

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1464,14 +1464,6 @@ let foo y =
   mut
 [%%expect{|
 val foo : 'a -> 'a = <fun>
-<<<<<<< HEAD
-|}, Principal{|
-val foo : 'a -> 'a = <fun>
-||||||| 5.2.0minus-31
-|}, Principal{|
-val foo : '_weak1 -> '_weak1 = <fun>
-=======
->>>>>>> 5.2.0minus-37
 |}]
 let foo (local_ #{ gbl }) = gbl
 [%%expect{|
@@ -1482,14 +1474,6 @@ let foo y =
   gbl
 [%%expect{|
 val foo : 'a -> 'a = <fun>
-<<<<<<< HEAD
-|}, Principal{|
-val foo : 'a -> 'a = <fun>
-||||||| 5.2.0minus-31
-|}, Principal{|
-val foo : '_weak2 -> '_weak2 = <fun>
-=======
->>>>>>> 5.2.0minus-37
 |}]
 
 let foo (local_ imm) =
@@ -1578,14 +1562,6 @@ let foo y =
   gbl
 [%%expect{|
 val foo : 'a -> 'a = <fun>
-<<<<<<< HEAD
-|}, Principal{|
-val foo : 'a -> 'a = <fun>
-||||||| 5.2.0minus-31
-|}, Principal{|
-val foo : '_weak3 -> '_weak3 = <fun>
-=======
->>>>>>> 5.2.0minus-37
 |}]
 let foo (local_ gbl) =
   let _ = #{ gbl } in

--- a/testsuite/tests/typing-unboxed-types/test_flat_upstream.ml
+++ b/testsuite/tests/typing-unboxed-types/test_flat_upstream.ml
@@ -24,22 +24,10 @@ type t18 = A : _ list abs -> t18 [@@ocaml.unboxed];;
 Line 1, characters 0-50:
 1 | type t18 = A : _ list abs -> t18 [@@ocaml.unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-  and would not be accepted by upstream OCaml.
-
-type t18 = A : 'a list abs -> t18 [@@unboxed]
-||||||| 5.2.0minus-31
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-and would not be accepted by upstream OCaml.
-
-type t18 = A : 'a list abs -> t18 [@@unboxed]
-=======
 Error: This type cannot be unboxed because
        it might contain both float and non-float values,
        depending on the instantiation of an unnamed existential variable.
        You should annotate it with "[@@ocaml.boxed]".
->>>>>>> 5.2.0minus-37
 |}];;
 
 (* regression test for PR#7511 (wrong determination of unboxability for GADTs)
@@ -90,22 +78,10 @@ type t = T : (unit -> _) M.r -> t [@@unboxed];;
 Line 1, characters 0-45:
 1 | type t = T : (unit -> _) M.r -> t [@@unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-  and would not be accepted by upstream OCaml.
-
-type t = T : (unit -> 'a) M.r -> t [@@unboxed]
-||||||| 5.2.0minus-31
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-and would not be accepted by upstream OCaml.
-
-type t = T : (unit -> 'a) M.r -> t [@@unboxed]
-=======
 Error: This type cannot be unboxed because
        it might contain both float and non-float values,
        depending on the instantiation of an unnamed existential variable.
        You should annotate it with "[@@ocaml.boxed]".
->>>>>>> 5.2.0minus-37
 |}];;
 
 (* accept *)
@@ -152,22 +128,10 @@ type t = T : (unit -> _) N.r -> t [@@unboxed];;
 Line 1, characters 0-45:
 1 | type t = T : (unit -> _) N.r -> t [@@unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-  and would not be accepted by upstream OCaml.
-
-type t = T : (unit -> 'a) N.r -> t [@@unboxed]
-||||||| 5.2.0minus-31
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-and would not be accepted by upstream OCaml.
-
-type t = T : (unit -> 'a) N.r -> t [@@unboxed]
-=======
 Error: This type cannot be unboxed because
        it might contain both float and non-float values,
        depending on the instantiation of an unnamed existential variable.
        You should annotate it with "[@@ocaml.boxed]".
->>>>>>> 5.2.0minus-37
 |}];;
 
 (* accept *)
@@ -233,22 +197,10 @@ type t = T : (unit -> _) M.r -> t [@@unboxed];;
 Line 1, characters 0-45:
 1 | type t = T : (unit -> _) M.r -> t [@@unboxed];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-  and would not be accepted by upstream OCaml.
-
-type t = T : (unit -> 'a) M.r -> t [@@unboxed]
-||||||| 5.2.0minus-31
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-and would not be accepted by upstream OCaml.
-
-type t = T : (unit -> 'a) M.r -> t [@@unboxed]
-=======
 Error: This type cannot be unboxed because
        it might contain both float and non-float values,
        depending on the instantiation of an unnamed existential variable.
        You should annotate it with "[@@ocaml.boxed]".
->>>>>>> 5.2.0minus-37
 |}];;
 
 type 'a s = S : (unit -> 'a) M.r -> 'a option s [@@unboxed];;

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -16,14 +16,8 @@ Line 2, characters 10-41:
 2 |   let x = overwrite_ r with { x = "foo" } in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -35,14 +29,8 @@ Line 2, characters 10-59:
 2 |   let x = overwrite_ r with ({ x = "foo" } : record_update) in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -144,14 +132,8 @@ Line 2, characters 11-34:
 2 |   exclave_ overwrite_ r with { x }
                ^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -165,14 +147,8 @@ Line 2, characters 2-25:
 2 |   overwrite_ r with { x }
       ^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -198,14 +174,8 @@ Line 4, characters 4-27:
 4 |     overwrite_ r with { x }
         ^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -237,14 +207,8 @@ Line 2, characters 11-34:
 2 |   exclave_ overwrite_ r with { x }
                ^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -255,14 +219,8 @@ Line 2, characters 2-25:
 2 |   overwrite_ r with { x }
       ^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -283,14 +241,8 @@ Line 2, characters 2-36:
 2 |   overwrite_ eq with { eq0 = "foo" }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -336,14 +288,8 @@ Line 3, characters 2-41:
 3 |   overwrite_ eq with { eq0 = 1; eq1 = 2 }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -354,14 +300,8 @@ Line 2, characters 2-31:
 2 |   overwrite_ eq with ("foo", _)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -394,14 +334,8 @@ Line 3, characters 2-27:
 3 |   overwrite_ eq with (1, 2)
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -422,14 +356,8 @@ Line 4, characters 4-49:
 4 |     overwrite_ mr with { a = None; b = many_fun }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -487,14 +415,8 @@ Line 4, characters 4-53:
 4 |     overwrite_ mr with { a = None; b = portable_fun }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -538,14 +460,8 @@ Line 3, characters 4-42:
 3 |     overwrite_ mr with { a = None; b = _ }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -558,14 +474,8 @@ Line 3, characters 4-35:
 3 |     overwrite_ mr with { a = None }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -643,14 +553,8 @@ Line 5, characters 17-53:
 5 |   | Constr1 _ -> overwrite_ c with Constr1 { x = "" }
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -713,14 +617,8 @@ Line 2, characters 22-49:
 2 |   | OptionA s as v -> overwrite_ v with OptionA s
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -733,14 +631,8 @@ Line 3, characters 17-44:
 3 |   | OptionA s -> overwrite_ v with OptionA s
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -756,14 +648,8 @@ Line 5, characters 20-47:
 5 |      | OptionA s -> overwrite_ v with OptionA s
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -779,14 +665,8 @@ Line 5, characters 20-47:
 5 |      | OptionA _ -> overwrite_ v with OptionA s
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -836,14 +716,8 @@ Line 2, characters 44-75:
 2 |   | (OptionA "foo" | OptionA "bar") as v -> overwrite_ v with OptionA "baz"
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -855,14 +729,8 @@ Line 2, characters 53-84:
 2 |   | ((OptionA "foo" as v) | (OptionA "bar" as v)) -> overwrite_ v with OptionA "baz"
                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -923,14 +791,8 @@ Line 8, characters 30-59:
 8 |     | Some s when is_option_a (overwrite_ v with OptionA s) -> true
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -957,14 +819,8 @@ Line 3, characters 25-54:
 3 |   | { x = OptionA s } -> overwrite_ r.x with OptionA s
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1217,14 +1073,8 @@ Line 2, characters 10-34:
 2 |   let x = overwrite_ r with (_, _) in
               ^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1236,14 +1086,8 @@ Line 2, characters 10-38:
 2 |   let x = overwrite_ r with ("foo", _) in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1255,14 +1099,8 @@ Line 2, characters 10-42:
 2 |   let x = overwrite_ r with ("foo", "bar") in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1305,14 +1143,8 @@ Line 2, characters 10-44:
 2 |   let x = overwrite_ r with (~x:(_), ~y:(_)) in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1324,14 +1156,8 @@ Line 2, characters 10-46:
 2 |   let x = overwrite_ r with (~x:"foo", ~y:(_)) in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1343,14 +1169,8 @@ Line 2, characters 10-48:
 2 |   let x = overwrite_ r with (~x:"foo", ~y:"bar") in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1394,14 +1214,8 @@ Line 3, characters 12-47:
 3 |     let x = overwrite_ c with Con { x = "foo" } in
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1414,14 +1228,8 @@ Line 3, characters 12-55:
 3 |     let x = overwrite_ c with Con { c1 with x = "foo" } in
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1456,14 +1264,8 @@ Line 3, characters 16-49:
 3 |     let x = Con (overwrite_ c with { x = "foo" }) in
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -1476,13 +1278,7 @@ Line 3, characters 16-56:
 3 |     let x = Con (overwrite_ c with { c with x = "foo" }) in
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]

--- a/testsuite/tests/typing-unique/overwriting_lift_constants.ml
+++ b/testsuite/tests/typing-unique/overwriting_lift_constants.ml
@@ -78,13 +78,7 @@ Line 9, characters 10-66:
 9 |   let p = overwrite_ p with { dim = 4; x = 1.0; y = 2.0; z = 3.0 } in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]

--- a/testsuite/tests/typing-unique/overwriting_lift_constants_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_lift_constants_bug.ml
@@ -65,13 +65,7 @@ Line 5, characters 19-48:
 5 |   if b then p else overwrite_ p with { x = 2.0 }
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]

--- a/testsuite/tests/typing-unique/overwriting_map.ml
+++ b/testsuite/tests/typing-unique/overwriting_map.ml
@@ -35,13 +35,7 @@ Line 3, characters 22-57:
 3 |   | hd :: tl as xs -> overwrite_ xs with f hd :: map f tl
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -469,14 +469,8 @@ Line 2, characters 2-35:
 2 |   overwrite_ r with { x = Some "" }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -487,14 +481,8 @@ Line 2, characters 2-35:
 2 |   overwrite_ r with { x = Some "" }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -515,14 +503,8 @@ Line 2, characters 10-41:
 2 |   let x = overwrite_ r with { x = "foo" } in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -534,13 +516,7 @@ Line 2, characters 10-41:
 2 |   let x = overwrite_ r with { y = "foo" } in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]

--- a/testsuite/tests/typing-unique/overwriting_syntax.ml
+++ b/testsuite/tests/typing-unique/overwriting_syntax.ml
@@ -21,14 +21,8 @@ Line 2, characters 17-41:
 2 |   (a, b) as t -> overwrite_ t with (b, _)
                      ^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -42,14 +36,8 @@ Line 4, characters 19-53:
 4 |   { a; b } as t -> overwrite_ t with { b = a; a = _ }
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -66,14 +54,8 @@ Line 2, characters 21-48:
 2 |     { a; b } as t -> overwrite_ t with { b = a }
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -87,14 +69,8 @@ Line 4, characters 21-57:
 4 |   C { a; b } as t -> overwrite_ t with C { b = a; a = _ }
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -105,14 +81,8 @@ Line 2, characters 23-52:
 2 |     C { a; b } as t -> overwrite_ t with C { b = a }
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 
@@ -134,14 +104,8 @@ Line 3, characters 10-46:
 3 |     match overwrite_ t with C { b = a; a = _ } with
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]
 

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -510,13 +510,7 @@ Line 110, characters 16-52:
 110 |     | Node _ -> overwrite_ t with Node { color = c }
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert Translcore: Overwrite not implemented.
-<<<<<<< HEAD
-Uncaught exception: File "parsing/location.ml", line 1168, characters 2-8: Assertion failed
-||||||| 5.2.0minus-31
-Uncaught exception: File "parsing/location.ml", line 1136, characters 2-8: Assertion failed
-=======
 >> Fatal error: Location.todo_overwrite_not_implemented
 Uncaught exception: Misc.Fatal_error
->>>>>>> 5.2.0minus-37
 
 |}]

--- a/testsuite/tests/warnings/w55_classic.compilers.reference
+++ b/testsuite/tests/warnings/w55_classic.compilers.reference
@@ -1,13 +1,15 @@
 File "w55_classic.ml", line 7, characters 26-48:
 7 | let[@inline always] g x = (f[@inlined always]) x
                               ^^^^^^^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: 
+Warning 55 [inlining-impossible]: Cannot inline:
+  
   the optimizer did not know what function was being applied (is it marked [@inline never]?)
   (the full inlining stack was: w55_classic.ml:7,26--48)
 
 File "w55_classic.ml", line 7, characters 26-48:
 7 | let[@inline always] g x = (f[@inlined always]) x
                               ^^^^^^^^^^^^^^^^^^^^^^
-Warning 55 [inlining-impossible]: Cannot inline: 
+Warning 55 [inlining-impossible]: Cannot inline:
+  
   the optimizer did not know what function was being applied (is it marked [@inline never]?)
   (the full inlining stack was: w55_classic.ml:9,10--13;w55_classic.ml:7,26--48)


### PR DESCRIPTION
This PR is in two commits which are worth reviewing separately:
- The first resolves all the conflicts:
  - The llvmize test is resolved in favour of incoming (the second commit then updates the offset which is causing the issue)
  - In typing-local/local.ml we had some churn over the display of some types meaning that the fix in #5592 wasn't applying cleanly
  - ppx-empty-cases split into two - the change is the `Match_failure` exception index changing, which is resolved in the second commit
  - In all other cases, the hunks don't apply because of either formatting differences from the new messages or source code location differences, and the diff is obvious
- The second commit fixes actual errors in the testsuite using a Claude-written resolution of the type checker from #5958 which, when combined with #5880 and #5972, brings us back to a fully passing testsuite. I have reviewed all of the resolutions in the second commit (i.e. Opus 4.7 "fixed" the type-checker, but was not permitted to update tests) - it is certainly reviewable at this stage and, looking at the actual changes suggested, probably mergeable. Some notes:
  - lib-array/test_iarray.ml changes because we've now pulled in #5683 (the test was temporarily regressed in #5882, knowing - at least, I hope knowing - that we would take #5683 before the final merge!)
  - parallel/domain_alert.ml had a message change and for some reason with the various bits of churn the merge driver reverted our line-number change in the reference file
  - ppx-empty-cases/test.ml I split into two as noted above
  - slambda/modules.ml note that the changes here are because of the layout alterations in #5883
  - The change in w55_classic.compilers.reference is whitespace. Incoming has a stray space after the "Cannot inline:" and then the new formatter (I think correctly) puts an extra line in.