### PR TITLE
fix: Include static constants in the code size

### DIFF
--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -228,13 +228,23 @@ let create_raw_let_symbol uacc bound_static static_consts ~body =
       (Bound_static.everything_being_defined bound_static)
       name_occurrences
   in
+  let cost_metrics_of_static_consts =
+    if Flambda_features.Inlining.speculative_inlining_track_lifted_constants ()
+    then Rebuilt_static_const.Group.cost_metrics static_consts
+    else
+      (* Static consts used to always have zero cost metrics. That is now
+         considered to be a bug, but it can have unexpected consequences on
+         speculative inlining -- the flag above is used to control a progressive
+         rollout of the fix and will be removed in due time. *)
+      Cost_metrics.zero
+  in
   let uacc =
     UA.with_name_occurrences uacc ~name_occurrences:free_names_of_let
     |> UA.add_cost_metrics
          (Cost_metrics.increase_due_to_let_expr
             ~is_phantom:false
               (* Static consts always have zero cost metrics at present. *)
-            ~cost_metrics_of_defining_expr:Cost_metrics.zero)
+            ~cost_metrics_of_defining_expr:cost_metrics_of_static_consts)
   in
   if Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
   then RE.term_not_rebuilt, uacc

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -126,7 +126,26 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   let cost_metrics_of_lifted_constants =
     if Flambda_features.Inlining.speculative_inlining_track_lifted_constants ()
     then
+      (* If we are not at toplevel, there might still be lifted constants to be
+         placed in the accumulator whose size must be taken into account for
+         speculative inlining. *)
       let lifted_constants = UA.lifted_constants uacc in
+      (* CR-someday bclement: Ideally we would simply call
+         [place_lifted_constants] in [after_rebuild] above so that we can share
+         the code with the non-speculative inlining code path; however, that
+         function expects to be called at toplevel and there could be unintended
+         consequences -- notably regarding the validity of the used value slots.
+
+         At the time of writing, this means that we incorrectly:
+
+         - Ignore the size of the symbol projections created during speculative
+         inlining;
+
+         - Count the size of unused value slots of lifted sets of closures
+         created during speculative inlining (but again, it is not clear that it
+         is always possible to compute a correct set of "used value slots" at
+         the time we are doing speculative inlining, because some value slots
+         could be used later in the compilation unit). *)
       Lifted_constant_state.fold lifted_constants ~init:Cost_metrics.zero
         ~f:(fun cost_metrics lifted_constant ->
           List.fold_left

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -437,6 +437,11 @@ module Group = struct
       t.free_names <- Known free_names;
       free_names
 
+  let cost_metrics t =
+    List.fold_left
+      (fun cm const -> Cost_metrics.( + ) cm (cost_metrics const))
+      Cost_metrics.zero t.consts
+
   let to_named t =
     ListLabels.map t.consts ~f:(fun (const : rebuilt_static_const) ->
         match const with

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -191,6 +191,8 @@ module Group : sig
 
   val free_names : t -> Name_occurrences.t
 
+  val cost_metrics : t -> Cost_metrics.t
+
   (** This function may only be used when rebuilding terms (a fatal error will
       be produced otherwise). *)
   val to_named : t -> Named.t

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.ml
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.ml
@@ -1,0 +1,36 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0";
+   ocamlopt_flags += " -flambda2-inline-threshold 0";
+   ocamlopt_flags += " -flambda2-speculative-inlining-track-lifted-constants";
+   ocamlopt_flags += " -no-flambda2-speculative-inlining-only-if-arguments-useful";
+
+   setup-ocamlopt.byte-build-env;
+   ocamlopt.byte with dump-raw, dump-simplify;
+   check-fexpr-dump;
+ *)
+
+[@@@ocaml.flambda_o3]
+
+(* With the small function size and inlining threshold both at [0], we expect
+   that none of the calls to [f] below should be inlined, because there is
+   really nothing we can do except for avoiding the allocation of the pair,
+   which should not be enough benefit.
+
+   We used to have a bug where the size of lifted constants was not taken into
+   account when doing speculative inlining, which would compute a code size of
+   [1] (the cost of loading from the precomputed constant) for each of the
+   calls to [f], causing them to be inlined (see oxcaml/oxcaml#5917 and
+   commit 09f54a649f35fe5c572caf1485674672a14d75ff). *)
+
+let f x = (x, x)
+
+let zero = Sys.opaque_identity 0
+
+let v0 = f zero
+
+let one = Sys.opaque_identity 1
+
+let v1 () = f one

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
@@ -14,8 +14,8 @@ let $camlSpeculative_inlining_lifted_constants__first_const = Block 0 () in
          -> k1 * k2
          : [ 0 of imm tagged * imm tagged ] =
    let next_depth = rec_info (succ my_depth) in
-   let one = %project_value_slot.[`v1`].[`one`] (my_closure) in
-   let f = %project_value_slot.[`v1`].[`f`] (my_closure) in
+   let one = %project_value_slot.[v1].[one] (my_closure) in
+   let f = %project_value_slot.[v1].[f] (my_closure) in
    apply direct(f_0)
      (f : _ -> [ 0 of imm tagged * imm tagged ]) (one) -> k1 * k2
  in

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
@@ -1,0 +1,40 @@
+let $camlSpeculative_inlining_lifted_constants__first_const = Block 0 () in
+(let code size(8)
+       f_0 (x)
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : [ 0 of val * val ] =
+   let next_depth = rec_info (succ my_depth) in
+   let Pmakeblock = %block.[`0`] (x, x) in
+   cont k1 (Pmakeblock)
+ in
+ let code size(6)
+       v1_1 (param : imm tagged)
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : [ 0 of imm tagged * imm tagged ] =
+   let next_depth = rec_info (succ my_depth) in
+   let one = %project_value_slot.[`v1`].[`one`] (my_closure) in
+   let f = %project_value_slot.[`v1`].[`f`] (my_closure) in
+   apply direct(f_0)
+     (f : _ -> [ 0 of imm tagged * imm tagged ]) (one) -> k1 * k2
+ in
+ let f = closure f_0 @f in
+ let zero = %opaque (0) in
+ apply direct(f_0)
+   (f : _ -> [ 0 of imm tagged * imm tagged ]) (zero) -> k1 * error
+   where k1 (v0 : [ 0 of imm tagged * imm tagged ]) =
+     let one = %opaque (1) in
+     let v1 = closure v1_1 @v1 with { f = f; one = one } in
+     let Pmakeblock = %block.[`0`] (f, zero, v0, one, v1) in
+     cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`5`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`5`].[`2`] (module_block) in
+    let field_3 = %block_load.tag[`0`].`size`[`5`].[`3`] (module_block) in
+    let field_4 = %block_load.tag[`0`].`size`[`5`].[`4`] (module_block) in
+    let $camlSpeculative_inlining_lifted_constants =
+      Block 0 (field_0, field_1, field_2, field_3, field_4)
+    in
+    cont done ($camlSpeculative_inlining_lifted_constants)

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
@@ -14,8 +14,8 @@ let $camlSpeculative_inlining_lifted_constants__first_const = Block 0 () in
          -> k1 * k2
          : [ 0 of imm tagged * imm tagged ] =
    let next_depth = rec_info (succ my_depth) in
-   let one = %project_value_slot.[v1].[one] (my_closure) in
    let f = %project_value_slot.[v1].[f] (my_closure) in
+   let one = %project_value_slot.[v1].[one] (my_closure) in
    apply direct(f_0)
      (f : _ -> [ 0 of imm tagged * imm tagged ]) (one) -> k1 * k2
  in

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
@@ -25,7 +25,7 @@ apply direct(f_0_1)
             -> k * k1
             : [ 0 of imm tagged * imm tagged ] =
       let one_1 =
-        %project_value_slot.[`v1`].[`one`]
+        %project_value_slot.[v1].[one]
           ($camlSpeculative_inlining_lifted_constants__v1_3)
       in
       apply direct(f_0_1)

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
@@ -1,0 +1,42 @@
+let code f_0 deleted in
+let code v1_1 deleted in
+let code loopify(never) size(8) newer_version_of(f_0)
+      f_0_1 (x)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : [ 0 of val * val ] =
+  let Pmakeblock = %block.[`0`] (x, x) in
+  cont k (Pmakeblock)
+in
+let $camlSpeculative_inlining_lifted_constants__f_2 = closure f_0_1 @f in
+let zero = %opaque (0) in
+let $camlSpeculative_inlining_lifted_constants__Pmakeblock94 =
+  Block 0 (zero, zero)
+in
+let one = %opaque (1) in
+let $camlSpeculative_inlining_lifted_constants__v1_3 =
+  closure v1_1_1 @v1
+and code loopify(never) size(5) newer_version_of(v1_1)
+      v1_1_1 (param : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : [ 0 of imm tagged * imm tagged ] =
+  let one_1 =
+    %project_value_slot.[`v1`].[`one`]
+      ($camlSpeculative_inlining_lifted_constants__v1_3)
+  in
+  apply direct(f_0_1)
+    ($camlSpeculative_inlining_lifted_constants__f_2
+     : _ -> [ 0 of imm tagged * imm tagged ])
+      (one_1)
+      -> k * k1
+  with { one = one }
+in
+let $camlSpeculative_inlining_lifted_constants =
+  Block 0 ($camlSpeculative_inlining_lifted_constants__f_2,
+           zero,
+           $camlSpeculative_inlining_lifted_constants__Pmakeblock94,
+           one,
+           $camlSpeculative_inlining_lifted_constants__v1_3)
+in
+cont done ($camlSpeculative_inlining_lifted_constants)

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
@@ -10,33 +10,36 @@ let code loopify(never) size(8) newer_version_of(f_0)
 in
 let $camlSpeculative_inlining_lifted_constants__f_2 = closure f_0_1 @f in
 let zero = %opaque (0) in
-let $camlSpeculative_inlining_lifted_constants__Pmakeblock94 =
-  Block 0 (zero, zero)
-in
-let one = %opaque (1) in
-let $camlSpeculative_inlining_lifted_constants__v1_3 =
-  closure v1_1_1 @v1
-and code loopify(never) size(5) newer_version_of(v1_1)
-      v1_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
-        -> k * k1
-        : [ 0 of imm tagged * imm tagged ] =
-  let one_1 =
-    %project_value_slot.[`v1`].[`one`]
-      ($camlSpeculative_inlining_lifted_constants__v1_3)
-  in
-  apply direct(f_0_1)
-    ($camlSpeculative_inlining_lifted_constants__f_2
-     : _ -> [ 0 of imm tagged * imm tagged ])
-      (one_1)
-      -> k * k1
-  with { one = one }
-in
-let $camlSpeculative_inlining_lifted_constants =
-  Block 0 ($camlSpeculative_inlining_lifted_constants__f_2,
-           zero,
-           $camlSpeculative_inlining_lifted_constants__Pmakeblock94,
-           one,
-           $camlSpeculative_inlining_lifted_constants__v1_3)
-in
-cont done ($camlSpeculative_inlining_lifted_constants)
+apply direct(f_0_1)
+  ($camlSpeculative_inlining_lifted_constants__f_2
+   : _ -> [ 0 of imm tagged * imm tagged ])
+    (zero)
+    -> k * error
+  where k (v0 : [ 0 of imm tagged * imm tagged ]) =
+    let one = %opaque (1) in
+    let $camlSpeculative_inlining_lifted_constants__v1_3 =
+      closure v1_1_1 @v1
+    and code loopify(never) size(5) newer_version_of(v1_1)
+          v1_1_1 (param : imm tagged)
+            my_closure _region _ghost_region my_depth
+            -> k * k1
+            : [ 0 of imm tagged * imm tagged ] =
+      let one_1 =
+        %project_value_slot.[`v1`].[`one`]
+          ($camlSpeculative_inlining_lifted_constants__v1_3)
+      in
+      apply direct(f_0_1)
+        ($camlSpeculative_inlining_lifted_constants__f_2
+         : _ -> [ 0 of imm tagged * imm tagged ])
+          (one_1)
+          -> k * k1
+      with { one = one }
+    in
+    let $camlSpeculative_inlining_lifted_constants =
+      Block 0 ($camlSpeculative_inlining_lifted_constants__f_2,
+               zero,
+               v0,
+               one,
+               $camlSpeculative_inlining_lifted_constants__v1_3)
+    in
+    cont done ($camlSpeculative_inlining_lifted_constants)


### PR DESCRIPTION
Since https://github.com/oxcaml/oxcaml/pull/5917 we compute the code size of static constants in order to
take into account the size of the constants lifted during speculative
inlining.

When performing speculative inlining at toplevel, this doesn't work
because the lifted constants get placed into the toplevel expression
with a code size of `0` during the speculative inlining, making https://github.com/oxcaml/oxcaml/pull/5917
useless in particular for (toplevel) functor applications.

This patch includes the size of the lifted constants in the code size of
the toplevel expression, making the code size computation during
speculative inlining at toplevel correct.