### PR TITLE
Expect asm: Normalize labels

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -69,7 +69,7 @@ let invoke_expect_asm_callbacks () =
   asm_collected_for_expect_asm := [];
   List.iter (fun f -> f output) callbacks
 
-let record_for_expect_asm ~name ~debug_info ~asm_start ~fun_body_end =
+let record_for_expect_asm ~name ~debug_info ~fun_body_start ~fun_body_end =
   if
     (not (List.is_empty !expect_asm_callbacks))
     && (not (String.ends_with ~suffix:"__entry" name))
@@ -89,7 +89,8 @@ let record_for_expect_asm ~name ~debug_info ~asm_start ~fun_body_end =
     in
     let output =
       X86_gas.format_asm_for_expect_asm ~name
-        ~body:(X86_proc.output_range ~from_pos:asm_start ~to_pos:fun_body_end)
+        ~body:
+          (X86_proc.output_range ~from_pos:fun_body_start ~to_pos:fun_body_end)
         ~hidden:(X86_proc.output_from fun_body_end)
     in
     asm_collected_for_expect_asm := output :: !asm_collected_for_expect_asm
@@ -2687,7 +2688,7 @@ let fundecl fundecl =
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
-    ~asm_start:fun_body_start ~fun_body_end;
+    ~fun_body_start ~fun_body_end;
   emit_call_safety_errors ();
   emit_stack_realloc ();
   (if !frame_required

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -69,7 +69,8 @@ let invoke_expect_asm_callbacks () =
   asm_collected_for_expect_asm := [];
   List.iter (fun f -> f output) callbacks
 
-let record_for_expect_asm ~name ~debug_info ~fun_body_start ~fun_body_end =
+let record_for_expect_asm ~name ~debug_info ~fun_body_start ~fun_body_end
+    ~gc_jump_pads_start ~gc_jump_pads_end =
   if
     (not (List.is_empty !expect_asm_callbacks))
     && (not (String.ends_with ~suffix:"__entry" name))
@@ -91,7 +92,9 @@ let record_for_expect_asm ~name ~debug_info ~fun_body_start ~fun_body_end =
       X86_gas.format_asm_for_expect_asm ~name
         ~body:
           (X86_proc.output_range ~from_pos:fun_body_start ~to_pos:fun_body_end)
-        ~hidden:(X86_proc.output_from fun_body_end)
+        ~hidden_gc_jump_pads:
+          (X86_proc.output_range ~from_pos:gc_jump_pads_start
+             ~to_pos:gc_jump_pads_end)
     in
     asm_collected_for_expect_asm := output :: !asm_collected_for_expect_asm
 
@@ -2688,7 +2691,8 @@ let fundecl fundecl =
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
-    ~fun_body_start ~fun_body_end;
+    ~fun_body_start ~fun_body_end ~gc_jump_pads_start:fun_body_end
+    ~gc_jump_pads_end:(current_output_pos ());
   emit_call_safety_errors ();
   emit_stack_realloc ();
   (if !frame_required

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -69,7 +69,7 @@ let invoke_expect_asm_callbacks () =
   asm_collected_for_expect_asm := [];
   List.iter (fun f -> f output) callbacks
 
-let record_for_expect_asm ~name ~debug_info ~asm_start =
+let record_for_expect_asm ~name ~debug_info ~asm_start ~fun_body_end =
   if
     (not (List.is_empty !expect_asm_callbacks))
     && (not (String.ends_with ~suffix:"__entry" name))
@@ -89,7 +89,8 @@ let record_for_expect_asm ~name ~debug_info ~asm_start =
     in
     let output =
       X86_gas.format_asm_for_expect_asm ~name
-        ~body:(X86_proc.output_from asm_start)
+        ~body:(X86_proc.output_range ~from_pos:asm_start ~to_pos:fun_body_end)
+        ~hidden:(X86_proc.output_from fun_body_end)
     in
     asm_collected_for_expect_asm := output :: !asm_collected_for_expect_asm
 
@@ -2682,10 +2683,11 @@ let fundecl fundecl =
   let fun_body_start = current_output_pos () in
   emit_all ~first:true ~fallthrough:true fundecl.fun_body;
   X86_proc.peephole_optimize_from fun_body_start;
+  let fun_body_end = current_output_pos () in
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
-    ~asm_start:fun_body_start;
+    ~asm_start:fun_body_start ~fun_body_end;
   emit_call_safety_errors ();
   emit_stack_realloc ();
   (if !frame_required

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2682,10 +2682,10 @@ let fundecl fundecl =
   let fun_body_start = current_output_pos () in
   emit_all ~first:true ~fallthrough:true fundecl.fun_body;
   X86_proc.peephole_optimize_from fun_body_start;
-  record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
-    ~asm_start:fun_body_start;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
+  record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
+    ~asm_start:fun_body_start;
   emit_call_safety_errors ();
   emit_stack_realloc ();
   (if !frame_required

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -671,6 +671,10 @@ module Directive = struct
     | Private_extern _ | Section _ | Size _ | Type _ | Protected _ | Hidden _
     | Weak _ | External _ | Reloc _ ->
       offset_in_bytes
+
+  let map_new_label f = function[@warning "-4"]
+    | New_label (Label l, c) -> New_label (Label (f l), c)
+    | d -> d
 end
 
 (* A higher-level version of [Constant.t] which contains some more abstractions

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -499,6 +499,10 @@ module Directive : sig
 
   (** Emit a little-endian integer value of the given width to a buffer. *)
   val emit_int_le : Buffer.t -> width_bytes:int -> int64 -> unit
+
+  (** Replace the [Asm_label.t] inside a [New_label (Label _, _)] directive
+      using the given function. Other directives are returned unchanged. *)
+  val map_new_label : (Asm_label.t -> Asm_label.t) -> t -> t
 end
 
 (** To be called by the emitter at the very start of code generation.

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -331,7 +331,7 @@ let format_asm_for_expect_asm ~name ~body ~hidden_gc_jump_pads =
     (fun line ->
       match[@warning "-4"] line with
       | Directive (D.New_label (D.Label l, _)) ->
-        Hashtbl.add hidden_labels (L.encode l) ();
+        Hashtbl.add hidden_labels (L.encode l) ()
       | Ins _ | Directive _ -> ())
     hidden_gc_jump_pads;
   let rewrite_str s =

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -289,7 +289,7 @@ let generate_asm oc lines =
       Buffer.add_char b '\n';
       Buffer.output_buffer oc b)
 
-let format_asm_for_expect_asm ~name ~body ~hidden =
+let format_asm_for_expect_asm ~name ~body ~hidden_gc_jump_pads =
   let module D = Asm_targets.Asm_directives.Directive in
   let module L = Asm_targets.Asm_label in
   let tab_stops = [| 2; 8 |] in
@@ -325,10 +325,19 @@ let format_asm_for_expect_asm ~name ~body ~hidden =
         Hashtbl.add label_map old_str new_label;
         incr next_id
       | Ins _ | Directive _ -> ())
-    (body @ hidden);
+    body;
+  let hidden_labels : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun line ->
+      match[@warning "-4"] line with
+      | Directive (D.New_label (D.Label l, _)) ->
+        Hashtbl.add hidden_labels (L.encode l) ();
+        incr next_id
+      | Ins _ | Directive _ -> ())
+    hidden_gc_jump_pads;
   let rewrite_str s =
     match Hashtbl.find_opt label_map s with
-    | None -> s
+    | None -> if Hashtbl.mem hidden_labels s then "<hidden GC jump pad>" else s
     | Some new_label -> L.encode new_label
   in
   let rewrite_label l =

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -332,7 +332,6 @@ let format_asm_for_expect_asm ~name ~body ~hidden_gc_jump_pads =
       match[@warning "-4"] line with
       | Directive (D.New_label (D.Label l, _)) ->
         Hashtbl.add hidden_labels (L.encode l) ();
-        incr next_id
       | Ins _ | Directive _ -> ())
     hidden_gc_jump_pads;
   let rewrite_str s =

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -289,7 +289,7 @@ let generate_asm oc lines =
       Buffer.add_char b '\n';
       Buffer.output_buffer oc b)
 
-let format_asm_for_expect_asm ~name ~body =
+let format_asm_for_expect_asm ~name ~body ~hidden =
   let module D = Asm_targets.Asm_directives.Directive in
   let module L = Asm_targets.Asm_label in
   let tab_stops = [| 2; 8 |] in
@@ -321,13 +321,11 @@ let format_asm_for_expect_asm ~name ~body =
       match[@warning "-4"] line with
       | Directive (D.New_label (D.Label l, _)) ->
         let old_str = L.encode l in
-        if not (Hashtbl.mem label_map old_str)
-        then (
-          let new_label = L.create_int (L.section l) !next_id in
-          Hashtbl.add label_map old_str new_label;
-          incr next_id)
+        let new_label = L.create_int (L.section l) !next_id in
+        Hashtbl.add label_map old_str new_label;
+        incr next_id
       | Ins _ | Directive _ -> ())
-    body;
+    (body @ hidden);
   let rewrite_str s =
     match Hashtbl.find_opt label_map s with
     | None -> s

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -220,6 +220,65 @@ let print_line b i =
   | Ins i -> print_instr b i
   | Directive d -> Asm_targets.Asm_directives.Directive.print b d
 
+let map_arg (f : arg -> arg) (instr : instruction) : instruction =
+  match instr with
+  | ADD (a, b) -> ADD (f a, f b)
+  | ADC (a, b) -> ADC (f a, f b)
+  | AND (a, b) -> AND (f a, f b)
+  | BSF (a, b) -> BSF (f a, f b)
+  | BSR (a, b) -> BSR (f a, f b)
+  | BSWAP a -> BSWAP (f a)
+  | CALL a -> CALL (f a)
+  | CDQ -> CDQ
+  | CLDEMOTE a -> CLDEMOTE (f a)
+  | CMOV (c, a, b) -> CMOV (c, f a, f b)
+  | CMP (a, b) -> CMP (f a, f b)
+  | CQO -> CQO
+  | DEC a -> DEC (f a)
+  | HLT -> HLT
+  | IDIV a -> IDIV (f a)
+  | IMUL (a, b) -> IMUL (f a, Option.map f b)
+  | MUL a -> MUL (f a)
+  | INC a -> INC (f a)
+  | J (c, a) -> J (c, f a)
+  | JMP a -> JMP (f a)
+  | LEA (a, b) -> LEA (f a, f b)
+  | LOCK_CMPXCHG (a, b) -> LOCK_CMPXCHG (f a, f b)
+  | LOCK_XADD (a, b) -> LOCK_XADD (f a, f b)
+  | LOCK_ADD (a, b) -> LOCK_ADD (f a, f b)
+  | LOCK_SUB (a, b) -> LOCK_SUB (f a, f b)
+  | LOCK_AND (a, b) -> LOCK_AND (f a, f b)
+  | LOCK_OR (a, b) -> LOCK_OR (f a, f b)
+  | LOCK_XOR (a, b) -> LOCK_XOR (f a, f b)
+  | LEAVE -> LEAVE
+  | MOV (a, b) -> MOV (f a, f b)
+  | MOVSX (a, b) -> MOVSX (f a, f b)
+  | MOVSXD (a, b) -> MOVSXD (f a, f b)
+  | MOVZX (a, b) -> MOVZX (f a, f b)
+  | NEG a -> NEG (f a)
+  | NOP -> NOP
+  | OR (a, b) -> OR (f a, f b)
+  | PAUSE -> PAUSE
+  | POP a -> POP (f a)
+  | PREFETCH (w, h, a) -> PREFETCH (w, h, f a)
+  | PUSH a -> PUSH (f a)
+  | RDTSC -> RDTSC
+  | RDPMC -> RDPMC
+  | LFENCE -> LFENCE
+  | SFENCE -> SFENCE
+  | MFENCE -> MFENCE
+  | RET -> RET
+  | SAL (a, b) -> SAL (f a, f b)
+  | SAR (a, b) -> SAR (f a, f b)
+  | SET (c, a) -> SET (c, f a)
+  | SHR (a, b) -> SHR (f a, f b)
+  | SUB (a, b) -> SUB (f a, f b)
+  | SBB (a, b) -> SBB (f a, f b)
+  | TEST (a, b) -> TEST (f a, f b)
+  | XCHG (a, b) -> XCHG (f a, f b)
+  | XOR (a, b) -> XOR (f a, f b)
+  | SIMD (simd_instr, args) -> SIMD (simd_instr, Array.map f args)
+
 let generate_asm oc lines =
   let b = Buffer.create 10000 in
   output_string oc "\t.file \"\"\n";
@@ -231,6 +290,8 @@ let generate_asm oc lines =
       Buffer.output_buffer oc b)
 
 let format_asm_for_expect_asm ~name ~body =
+  let module D = Asm_targets.Asm_directives.Directive in
+  let module L = Asm_targets.Asm_label in
   let tab_stops = [| 2; 8 |] in
   let tabs_to_spaces s =
     let result = Buffer.create (String.length s) in
@@ -252,6 +313,48 @@ let format_asm_for_expect_asm ~name ~body =
           incr col))
       s;
     Buffer.contents result
+  in
+  let label_map : (string, L.t) Hashtbl.t = Hashtbl.create 16 in
+  let next_id = ref 0 in
+  List.iter
+    (fun line ->
+      match[@warning "-4"] line with
+      | Directive (D.New_label (D.Label l, _)) ->
+        let old_str = L.encode l in
+        if not (Hashtbl.mem label_map old_str)
+        then (
+          let new_label = L.create_int (L.section l) !next_id in
+          Hashtbl.add label_map old_str new_label;
+          incr next_id)
+      | Ins _ | Directive _ -> ())
+    body;
+  let rewrite_str s =
+    match Hashtbl.find_opt label_map s with
+    | None -> s
+    | Some new_label -> L.encode new_label
+  in
+  let rewrite_label l =
+    match Hashtbl.find_opt label_map (L.encode l) with
+    | None -> l
+    | Some new_label -> new_label
+  in
+  let rewrite_arg (a : arg) : arg =
+    match a with
+    | Sym s -> Sym (rewrite_str s)
+    | Mem ({ sym; _ } as addr) ->
+      Mem { addr with sym = Option.map rewrite_str sym }
+    | Mem64_RIP (typ, s, displ) -> Mem64_RIP (typ, rewrite_str s, displ)
+    | (Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Reg32 _ | Reg64 _ | Regf _) as a
+      ->
+      a
+  in
+  let body =
+    List.map
+      (fun line ->
+        match line with
+        | Ins instr -> Ins (map_arg rewrite_arg instr)
+        | Directive d -> Directive (D.map_new_label rewrite_label d))
+      body
   in
   let buf = Buffer.create 1024 in
   bprintf buf "%s:\n" name;

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -344,8 +344,7 @@ let format_asm_for_expect_asm ~name ~body =
     | Mem ({ sym; _ } as addr) ->
       Mem { addr with sym = Option.map rewrite_str sym }
     | Mem64_RIP (typ, s, displ) -> Mem64_RIP (typ, rewrite_str s, displ)
-    | (Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Reg32 _ | Reg64 _ | Regf _) as a
-      ->
+    | (Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Reg32 _ | Reg64 _ | Regf _) as a ->
       a
   in
   let body =

--- a/backend/x86_gas.mli
+++ b/backend/x86_gas.mli
@@ -22,5 +22,5 @@ val generate_asm : out_channel -> X86_ast.asm_program -> unit
 val format_asm_for_expect_asm :
   name:string ->
   body:X86_ast.asm_line list ->
-  hidden:X86_ast.asm_line list ->
+  hidden_gc_jump_pads:X86_ast.asm_line list ->
   string

--- a/backend/x86_gas.mli
+++ b/backend/x86_gas.mli
@@ -20,4 +20,7 @@
 val generate_asm : out_channel -> X86_ast.asm_program -> unit
 
 val format_asm_for_expect_asm :
-  name:string -> body:X86_ast.asm_line list -> string
+  name:string ->
+  body:X86_ast.asm_line list ->
+  hidden:X86_ast.asm_line list ->
+  string

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -399,10 +399,11 @@ let current_output_pos () = DLL.last_cell asm_code
 let next_pos pos =
   match pos with None -> DLL.hd_cell asm_code | Some cell -> DLL.next cell
 
-let output_from pos = DLL.range_to_list ~from_incl:(next_pos pos) ~to_excl:None
+let output_from pos =
+  DLL.range_to_list ~left_incl:(next_pos pos) ~right_excl:None
 
 let output_range ~from_pos ~to_pos =
-  DLL.range_to_list ~from_incl:(next_pos from_pos) ~to_excl:(next_pos to_pos)
+  DLL.range_to_list ~left_incl:(next_pos from_pos) ~right_excl:(next_pos to_pos)
 
 let peephole_optimize_from pos =
   if !Oxcaml_flags.x86_peephole_optimize

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -399,9 +399,6 @@ let current_output_pos () = DLL.last_cell asm_code
 let next_pos pos =
   match pos with None -> DLL.hd_cell asm_code | Some cell -> DLL.next cell
 
-let output_from pos =
-  DLL.range_to_list ~left_incl:(next_pos pos) ~right_excl:None
-
 let output_range ~from_pos ~to_pos =
   DLL.range_to_list ~left_incl:(next_pos from_pos) ~right_excl:(next_pos to_pos)
 

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -396,10 +396,13 @@ type output_pos = asm_line DLL.cell option (* None means the beginning *)
 
 let current_output_pos () = DLL.last_cell asm_code
 
-let output_from pos =
-  match pos with
-  | None -> DLL.to_list asm_code
-  | Some start_excl -> DLL.suffix start_excl
+let next_pos pos =
+  match pos with None -> DLL.hd_cell asm_code | Some cell -> DLL.next cell
+
+let output_from pos = DLL.range_to_list ~from_incl:(next_pos pos) ~to_excl:None
+
+let output_range ~from_pos ~to_pos =
+  DLL.range_to_list ~from_incl:(next_pos from_pos) ~to_excl:(next_pos to_pos)
 
 let peephole_optimize_from pos =
   if !Oxcaml_flags.x86_peephole_optimize

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -77,6 +77,8 @@ val current_output_pos : unit -> output_pos
 
 val output_from : output_pos -> asm_line list
 
+val output_range : from_pos:output_pos -> to_pos:output_pos -> asm_line list
+
 val peephole_optimize_from : output_pos -> unit
 
 (** Code emission *)

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -75,8 +75,6 @@ type output_pos
 
 val current_output_pos : unit -> output_pos
 
-val output_from : output_pos -> asm_line list
-
 val output_range : from_pos:output_pos -> to_pos:output_pos -> asm_line list
 
 val peephole_optimize_from : output_pos -> unit

--- a/testsuite/tests/codegen/allocation.ml
+++ b/testsuite/tests/codegen/allocation.ml
@@ -40,14 +40,6 @@ one_or_two_element_list:
   movq  %rdi, 8(%rax)
   addq  $8, %rsp
   ret
-.L3:
-  call  .Lcaml_call_gc_
-.L4:
-  jmp   .L2
-.L5:
-  call  .Lcaml_call_gc_
-.L6:
-  jmp   .L0
 |}]
 
 
@@ -94,10 +86,6 @@ spill_slot_lifetime:
   vmovsd %xmm0, 24(%rax)
   addq  $24, %rsp
   ret
-.L5:
-  call  .Lcaml_call_gc_sse_
-.L6:
-  jmp   .L4
 
 spill_slot_lifetime.get_one:
   vmovsd .L122(%rip), %xmm0

--- a/testsuite/tests/codegen/allocation.ml
+++ b/testsuite/tests/codegen/allocation.ml
@@ -18,7 +18,7 @@ one_or_two_element_list:
   subq  $8, %rsp
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L5
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rdi
   movq  $2048, -8(%rdi)
@@ -32,7 +32,7 @@ one_or_two_element_list:
 .L1:
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L3
+  jb    <hidden GC jump pad>
 .L2:
   leaq  8(%r15), %rax
   movq  $2048, -8(%rax)
@@ -72,7 +72,7 @@ spill_slot_lifetime:
 .L3:
   subq  $40, %r15
   cmpq  (%r14), %r15
-  jb    .L5
+  jb    <hidden GC jump pad>
 .L4:
   leaq  8(%r15), %rax
   movabsq $72057594037932032, %rbx

--- a/testsuite/tests/codegen/allocation.ml
+++ b/testsuite/tests/codegen/allocation.ml
@@ -19,21 +19,21 @@ one_or_two_element_list:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L110
-.L112:
+.L0:
   leaq  8(%r15), %rdi
   movq  $2048, -8(%rdi)
   movq  %rbx, (%rdi)
   movq  $1, 8(%rdi)
   cmpq  $1, %rax
-  jne   .L106
+  jne   .L1
   movq  %rdi, %rax
   addq  $8, %rsp
   ret
-.L106:
+.L1:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L113
-.L115:
+.L2:
   leaq  8(%r15), %rax
   movq  $2048, -8(%rax)
   movq  %rbx, (%rax)
@@ -57,23 +57,23 @@ spill_slot_lifetime:
   subq  $24, %rsp
   movl  $1, %eax
   call  camlTOP3__get_one_3_5_code@PLT
-.L112:
+.L0:
   vmovsd %xmm0, (%rsp)
   movl  $1, %eax
   call  camlTOP3__get_one_3_5_code@PLT
-.L113:
+.L1:
   vmovsd %xmm0, 8(%rsp)
   movl  $1, %eax
   call  camlTOP3__get_one_3_5_code@PLT
-.L114:
+.L2:
   vmovsd %xmm0, 16(%rsp)
   movl  $1, %eax
   call  camlTOP3__get_one_3_5_code@PLT
-.L115:
+.L3:
   subq  $40, %r15
   cmpq  (%r14), %r15
   jb    .L116
-.L118:
+.L4:
   leaq  8(%r15), %rax
   movabsq $72057594037932032, %rbx
   movq  %rbx, -8(%rax)

--- a/testsuite/tests/codegen/allocation.ml
+++ b/testsuite/tests/codegen/allocation.ml
@@ -18,7 +18,7 @@ one_or_two_element_list:
   subq  $8, %rsp
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L110
+  jb    .L5
 .L0:
   leaq  8(%r15), %rdi
   movq  $2048, -8(%rdi)
@@ -32,7 +32,7 @@ one_or_two_element_list:
 .L1:
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L113
+  jb    .L3
 .L2:
   leaq  8(%r15), %rax
   movq  $2048, -8(%rax)
@@ -40,6 +40,14 @@ one_or_two_element_list:
   movq  %rdi, 8(%rax)
   addq  $8, %rsp
   ret
+.L3:
+  call  .Lcaml_call_gc_
+.L4:
+  jmp   .L2
+.L5:
+  call  .Lcaml_call_gc_
+.L6:
+  jmp   .L0
 |}]
 
 
@@ -72,7 +80,7 @@ spill_slot_lifetime:
 .L3:
   subq  $40, %r15
   cmpq  (%r14), %r15
-  jb    .L116
+  jb    .L5
 .L4:
   leaq  8(%r15), %rax
   movabsq $72057594037932032, %rbx
@@ -86,6 +94,10 @@ spill_slot_lifetime:
   vmovsd %xmm0, 24(%rax)
   addq  $24, %rsp
   ret
+.L5:
+  call  .Lcaml_call_gc_sse_
+.L6:
+  jmp   .L4
 
 spill_slot_lifetime.get_one:
   vmovsd .L122(%rip), %xmm0

--- a/testsuite/tests/codegen/arrays.ml
+++ b/testsuite/tests/codegen/arrays.ml
@@ -130,7 +130,7 @@ poly_unsafe_get:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L2
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -485,7 +485,7 @@ poly_safe_get:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L3
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)

--- a/testsuite/tests/codegen/arrays.ml
+++ b/testsuite/tests/codegen/arrays.ml
@@ -141,10 +141,6 @@ poly_unsafe_get:
 .L1:
   movq  -4(%rdi,%rbx,4), %rax
   ret
-.L2:
-  call  .Lcaml_call_gc_
-.L3:
-  jmp   .L0
 |}]
 
 let poly_unsafe_set (a : 'a array) (i : int) (v : 'a) =
@@ -507,10 +503,6 @@ poly_safe_get:
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-.L3:
-  call  .Lcaml_call_gc_
-.L4:
-  jmp   .L0
 |}]
 
 let poly_safe_set (a : 'a array) (i : int) (v : 'a) =

--- a/testsuite/tests/codegen/arrays.ml
+++ b/testsuite/tests/codegen/arrays.ml
@@ -130,7 +130,7 @@ poly_unsafe_get:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L112
+  jb    .L2
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -141,6 +141,10 @@ poly_unsafe_get:
 .L1:
   movq  -4(%rdi,%rbx,4), %rax
   ret
+.L2:
+  call  .Lcaml_call_gc_
+.L3:
+  jmp   .L0
 |}]
 
 let poly_unsafe_set (a : 'a array) (i : int) (v : 'a) =
@@ -485,7 +489,7 @@ poly_safe_get:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L126
+  jb    .L3
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -503,6 +507,10 @@ poly_safe_get:
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
+.L3:
+  call  .Lcaml_call_gc_
+.L4:
+  jmp   .L0
 |}]
 
 let poly_safe_set (a : 'a array) (i : int) (v : 'a) =

--- a/testsuite/tests/codegen/arrays.ml
+++ b/testsuite/tests/codegen/arrays.ml
@@ -42,13 +42,13 @@ push:
   salq  $8, %rax
   shrq  $17, %rax
   cmpq  %rax, %r12
-  jae   .L117
+  jae   .L0
   leaq  -4(%rbx,%r12,4), %rdi
   call  caml_modify@PLT
   leaq  2(%r12), %rax
   addq  $8, %rsp
   ret
-.L117:
+.L0:
   movq  camlTOP3__block33@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -126,19 +126,19 @@ poly_unsafe_get:
   movq  %rax, %rdi
   movzbq -8(%rdi), %rax
   cmpq  $254, %rax
-  jne   .L108
+  jne   .L1
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L112
-.L114:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovsd -4(%rdi,%rbx,4), %xmm0
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L108:
+.L1:
   movq  -4(%rdi,%rbx,4), %rax
   ret
 |}]
@@ -150,12 +150,12 @@ poly_unsafe_set:
   movq  %rdi, %rsi
   movzbq -8(%rax), %rdi
   cmpq  $254, %rdi
-  jne   .L108
+  jne   .L0
   vmovsd (%rsi), %xmm0
   vmovsd %xmm0, -4(%rax,%rbx,4)
   movl  $1, %eax
   ret
-.L108:
+.L0:
   subq  $8, %rsp
   leaq  -4(%rax,%rbx,4), %rdi
   call  caml_modify@PLT
@@ -430,10 +430,10 @@ int_safe_get:
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
-  jae   .L115
+  jae   .L0
   movq  -4(%rax,%rbx,4), %rax
   ret
-.L115:
+.L0:
   movq  camlTOP38__block1142@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -451,13 +451,13 @@ ref_safe_set:
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
-  jae   .L116
+  jae   .L0
   leaq  -4(%rax,%rbx,4), %rdi
   call  caml_modify@PLT
   movl  $1, %eax
   addq  $8, %rsp
   ret
-.L116:
+.L0:
   movq  camlTOP39__block1184@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -478,25 +478,25 @@ poly_safe_get:
   salq  $8, %rax
   shrq  $17, %rax
   cmpq  %rax, %rbx
-  jae   .L123
+  jae   .L2
   movzbq -8(%rdi), %rax
   cmpq  $254, %rax
-  jne   .L116
+  jne   .L1
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L126
-.L128:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovsd -4(%rdi,%rbx,4), %xmm0
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L116:
+.L1:
   movq  -4(%rdi,%rbx,4), %rax
   ret
-.L123:
+.L2:
   subq  $8, %rsp
   movq  camlTOP40__block1227@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
@@ -514,22 +514,22 @@ poly_safe_set:
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
-  jae   .L124
+  jae   .L1
   movzbq -8(%rax), %rdi
   cmpq  $254, %rdi
-  jne   .L116
+  jne   .L0
   vmovsd (%rsi), %xmm0
   vmovsd %xmm0, -4(%rax,%rbx,4)
   movl  $1, %eax
   ret
-.L116:
+.L0:
   subq  $8, %rsp
   leaq  -4(%rax,%rbx,4), %rdi
   call  caml_modify@PLT
   movl  $1, %eax
   addq  $8, %rsp
   ret
-.L124:
+.L1:
   subq  $8, %rsp
   movq  camlTOP41__block1282@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
@@ -548,10 +548,10 @@ int64_safe_get:
   shrq  $18, %rdi
   salq  $1, %rdi
   cmpq  %rdi, %rbx
-  jae   .L116
+  jae   .L0
   movq  -4(%rax,%rbx,4), %rax
   ret
-.L116:
+.L0:
   movq  camlTOP42__block1339@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -567,10 +567,10 @@ float_safe_get:
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
-  jae   .L115
+  jae   .L0
   vmovsd -4(%rax,%rbx,4), %xmm0
   ret
-.L115:
+.L0:
   movq  camlTOP43__block1380@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -586,10 +586,10 @@ float_safe_get_plain:
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
-  jae   .L115
+  jae   .L0
   vmovsd -4(%rax,%rbx,4), %xmm0
   ret
-.L115:
+.L0:
   movq  camlTOP44__block1421@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -610,10 +610,10 @@ int32_safe_get:
   subq  %rdi, %rsi
   salq  $1, %rsi
   cmpq  %rsi, %rbx
-  jae   .L120
+  jae   .L0
   movslq -2(%rax,%rbx,2), %rax
   ret
-.L120:
+.L0:
   movq  camlTOP45__block1466@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)

--- a/testsuite/tests/codegen/bytes.ml
+++ b/testsuite/tests/codegen/bytes.ml
@@ -198,10 +198,10 @@ bytes_safe_get_int32:
   xorq  $-1, %rsi
   andq  %rdi, %rsi
   cmpq  %rsi, %rbx
-  jae   .L123
+  jae   .L0
   movslq (%rax,%rbx), %rax
   ret
-.L123:
+.L0:
   movq  camlTOP18__block602@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)

--- a/testsuite/tests/codegen/check_elimination.ml
+++ b/testsuite/tests/codegen/check_elimination.ml
@@ -15,21 +15,21 @@ let unwrap_twice o = Option.value ~default:7 o + Option.value ~default:7 o
 [%%expect_asm X86_64{|
 unwrap_twice:
   testb $1, %al
-  je    .L108
+  je    .L0
   movl  $15, %ebx
   testb $1, %al
-  je    .L119
-  jmp   .L117
-.L108:
+  je    .L2
+  jmp   .L1
+.L0:
   movq  (%rax), %rbx
   testb $1, %al
-  je    .L119
-.L117:
+  je    .L2
+.L1:
   movl  $15, %eax
-  jmp   .L123
-.L119:
+  jmp   .L3
+.L2:
   movq  (%rax), %rax
-.L123:
+.L3:
   leaq  -1(%rax,%rbx), %rax
   ret
 |}]
@@ -52,27 +52,27 @@ arr_sum:
   orq   $1, %rdi
   leaq  -2(%rdi), %rsi
   cmpq  $1, %rsi
-  jl    .L137
+  jl    .L2
   sarq  $1, %rsi
   movl  $1, %eax
   xorl  %edx, %edx
-.L114:
+.L0:
   leaq  1(%rdx,%rdx), %rcx
   cmpq  %rdi, %rcx
-  jae   .L133
+  jae   .L1
   movq  -4(%rbx,%rcx,4), %rcx
   leaq  -1(%rax,%rcx), %rax
   incq  %rdx
   cmpq  %rsi, %rdx
-  jle   .L114
+  jle   .L0
   ret
-.L133:
+.L1:
   movq  camlTOP2__block101@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-.L137:
+.L2:
   movl  $1, %eax
   ret
 |}]
@@ -96,32 +96,32 @@ let search ~target (start : int list) =
 search:
   movq  %rax, %rdi
   testb $1, %bl
-  je    .L116
-.L114:
+  je    .L1
+.L0:
   xorl  %esi, %esi
   movq  %rbx, %rax
-  jmp   .L131
-.L116:
+  jmp   .L4
+.L1:
   movq  (%rbx), %rax
   xorl  %esi, %esi
   cmpq  %rax, %rdi
   setl  %sil
   testq %rsi, %rsi
-  je    .L123
+  je    .L2
   movq  8(%rbx), %rax
   testq %rsi, %rsi
-  jne   .L129
-  jmp   .L131
-.L123:
+  jne   .L3
+  jmp   .L4
+.L2:
   movq  %rbx, %rax
   testq %rsi, %rsi
-  je    .L131
-.L129:
+  je    .L4
+.L3:
   movq  %rax, %rbx
   testb $1, %bl
-  je    .L116
-  jmp   .L114
-.L131:
+  je    .L1
+  jmp   .L0
+.L4:
   ret
 |}]
 
@@ -130,12 +130,12 @@ let redundant_compare (x: int) = if x > 0 && x > 5 then 100 else 200
 [%%expect_asm X86_64{|
 redundant_compare:
   cmpq  $1, %rax
-  jle   .L110
+  jle   .L0
   cmpq  $11, %rax
-  jle   .L110
+  jle   .L0
   movl  $201, %eax
   ret
-.L110:
+.L0:
   movl  $401, %eax
   ret
 |}]
@@ -148,10 +148,10 @@ let learn_from_branch (x : int) : int =
 [%%expect_asm X86_64{|
 learn_from_branch:
   cmpq  $7, %rax
-  je    .L105
+  je    .L0
   movl  $201, %eax
   ret
-.L105:
+.L0:
   leaq  -1(%rax,%rax), %rax
   ret
 |}]

--- a/testsuite/tests/codegen/fields.ml
+++ b/testsuite/tests/codegen/fields.ml
@@ -102,10 +102,6 @@ header:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 (* int_as_pointer *)
@@ -149,10 +145,6 @@ make_ref:
   movq  %rbx, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let deref r = !r

--- a/testsuite/tests/codegen/fields.ml
+++ b/testsuite/tests/codegen/fields.ml
@@ -92,7 +92,7 @@ header:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -138,7 +138,7 @@ make_ref:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1024, -8(%rax)

--- a/testsuite/tests/codegen/fields.ml
+++ b/testsuite/tests/codegen/fields.ml
@@ -92,7 +92,7 @@ header:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -102,6 +102,10 @@ header:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 (* int_as_pointer *)
@@ -138,13 +142,17 @@ make_ref:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1024, -8(%rax)
   movq  %rbx, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let deref r = !r

--- a/testsuite/tests/codegen/fields.ml
+++ b/testsuite/tests/codegen/fields.ml
@@ -93,7 +93,7 @@ header:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_nativeint_ops@GOTPCREL(%rip), %rdi
@@ -139,7 +139,7 @@ make_ref:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $1024, -8(%rax)
   movq  %rbx, (%rax)

--- a/testsuite/tests/codegen/float32_u.ml
+++ b/testsuite/tests/codegen/float32_u.ml
@@ -83,7 +83,7 @@ to_float:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)

--- a/testsuite/tests/codegen/float32_u.ml
+++ b/testsuite/tests/codegen/float32_u.ml
@@ -91,10 +91,6 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_sse_
-.L2:
-  jmp   .L0
 |}]
 
 let of_int x = Float32_u.of_int x

--- a/testsuite/tests/codegen/float32_u.ml
+++ b/testsuite/tests/codegen/float32_u.ml
@@ -83,7 +83,7 @@ to_float:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -91,6 +91,10 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_sse_
+.L2:
+  jmp   .L0
 |}]
 
 let of_int x = Float32_u.of_int x

--- a/testsuite/tests/codegen/float32_u.ml
+++ b/testsuite/tests/codegen/float32_u.ml
@@ -84,7 +84,7 @@ to_float:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vcvtss2sd %xmm0, %xmm0, %xmm0

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -110,7 +110,7 @@ to_float:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -117,10 +117,6 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_sse_
-.L2:
-  jmp   .L0
 |}]
 
 

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -110,13 +110,17 @@ to_float:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_sse_
+.L2:
+  jmp   .L0
 |}]
 
 

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -111,7 +111,7 @@ to_float:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovsd %xmm0, (%rax)
@@ -147,29 +147,29 @@ min:
   vmovsd 8(%rsp), %xmm0
   vmovsd (%rsp), %xmm1
   vcomisd %xmm1, %xmm0
-  ja    .L134
+  ja    .L1
   vmovsd 8(%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L126
+  jne   .L0
   vmovsd (%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L134
-.L126:
+  jne   .L1
+.L0:
   vmovsd (%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jp    .L138
-  jmp   .L136
-.L134:
+  jp    .L3
+  jmp   .L2
+.L1:
   vmovsd 8(%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jnp   .L138
-.L136:
+  jnp   .L3
+.L2:
   vmovsd 8(%rsp), %xmm0
   addq  $24, %rsp
   ret
-.L138:
+.L3:
   vmovsd (%rsp), %xmm0
   addq  $24, %rsp
   ret
@@ -186,29 +186,29 @@ max:
   vmovsd 8(%rsp), %xmm0
   vmovsd (%rsp), %xmm1
   vcomisd %xmm1, %xmm0
-  ja    .L134
+  ja    .L1
   vmovsd 8(%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L126
+  jne   .L0
   vmovsd (%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L134
-.L126:
+  jne   .L1
+.L0:
   vmovsd 8(%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jp    .L138
-  jmp   .L136
-.L134:
+  jp    .L3
+  jmp   .L2
+.L1:
   vmovsd (%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jnp   .L138
-.L136:
+  jnp   .L3
+.L2:
   vmovsd (%rsp), %xmm0
   addq  $24, %rsp
   ret
-.L138:
+.L3:
   vmovsd 8(%rsp), %xmm0
   addq  $24, %rsp
   ret
@@ -225,29 +225,29 @@ min_num:
   vmovsd 8(%rsp), %xmm0
   vmovsd (%rsp), %xmm1
   vcomisd %xmm1, %xmm0
-  ja    .L134
+  ja    .L1
   vmovsd 8(%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L126
+  jne   .L0
   vmovsd (%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L134
-.L126:
+  jne   .L1
+.L0:
   vmovsd 8(%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jp    .L138
-  jmp   .L136
-.L134:
+  jp    .L3
+  jmp   .L2
+.L1:
   vmovsd (%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jnp   .L138
-.L136:
+  jnp   .L3
+.L2:
   vmovsd 8(%rsp), %xmm0
   addq  $24, %rsp
   ret
-.L138:
+.L3:
   vmovsd (%rsp), %xmm0
   addq  $24, %rsp
   ret
@@ -264,29 +264,29 @@ max_num:
   vmovsd 8(%rsp), %xmm0
   vmovsd (%rsp), %xmm1
   vcomisd %xmm1, %xmm0
-  ja    .L134
+  ja    .L1
   vmovsd 8(%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L126
+  jne   .L0
   vmovsd (%rsp), %xmm0
   call  caml_signbit@PLT
   cmpq  $1, %rax
-  jne   .L134
-.L126:
+  jne   .L1
+.L0:
   vmovsd (%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jp    .L138
-  jmp   .L136
-.L134:
+  jp    .L3
+  jmp   .L2
+.L1:
   vmovsd 8(%rsp), %xmm0
   vucomisd %xmm0, %xmm0
-  jnp   .L138
-.L136:
+  jnp   .L3
+.L2:
   vmovsd (%rsp), %xmm0
   addq  $24, %rsp
   ret
-.L138:
+.L3:
   vmovsd 8(%rsp), %xmm0
   addq  $24, %rsp
   ret
@@ -302,10 +302,10 @@ min_unchecked:
   vmovapd %xmm0, %xmm2
   vmovapd %xmm1, %xmm0
   vcomisd %xmm2, %xmm0
-  jbe   .L105
+  jbe   .L0
   vmovapd %xmm2, %xmm0
   ret
-.L105:
+.L0:
   ret
 |}]
 

--- a/testsuite/tests/codegen/functions.ml
+++ b/testsuite/tests/codegen/functions.ml
@@ -55,10 +55,6 @@ mutual_recursion:
   leaq  24(%rdi), %rbx
   addq  $8, %rsp
   jmp   camlTOP3__f_5_8_code@PLT
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 
 mutual_recursion.f:
   movq  %rbx, %rdi
@@ -128,14 +124,6 @@ f:
   movq  (%rbx), %rdi
   addq  $8, %rsp
   jmp   *%rdi
-.L4:
-  call  .Lcaml_call_gc_
-.L5:
-  jmp   .L2
-.L6:
-  call  .Lcaml_call_gc_
-.L7:
-  jmp   .L0
 |}]
 
 

--- a/testsuite/tests/codegen/functions.ml
+++ b/testsuite/tests/codegen/functions.ml
@@ -38,7 +38,7 @@ mutual_recursion:
   subq  $8, %rsp
   subq  $56, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rdi
   movq  $6391, -8(%rdi)
@@ -97,7 +97,7 @@ f:
   jge   .L1
   subq  $32, %r15
   cmpq  (%r14), %r15
-  jb    .L6
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
@@ -110,7 +110,7 @@ f:
 .L1:
   subq  $32, %r15
   cmpq  (%r14), %r15
-  jb    .L4
+  jb    <hidden GC jump pad>
 .L2:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)

--- a/testsuite/tests/codegen/functions.ml
+++ b/testsuite/tests/codegen/functions.ml
@@ -38,7 +38,7 @@ mutual_recursion:
   subq  $8, %rsp
   subq  $56, %r15
   cmpq  (%r14), %r15
-  jb    .L106
+  jb    .L1
 .L0:
   leaq  8(%r15), %rdi
   movq  $6391, -8(%rdi)
@@ -55,6 +55,10 @@ mutual_recursion:
   leaq  24(%rdi), %rbx
   addq  $8, %rsp
   jmp   camlTOP3__f_5_8_code@PLT
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 
 mutual_recursion.f:
   movq  %rbx, %rdi
@@ -97,7 +101,7 @@ f:
   jge   .L1
   subq  $32, %r15
   cmpq  (%r14), %r15
-  jb    .L128
+  jb    .L6
 .L0:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
@@ -110,7 +114,7 @@ f:
 .L1:
   subq  $32, %r15
   cmpq  (%r14), %r15
-  jb    .L131
+  jb    .L4
 .L2:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
@@ -124,6 +128,14 @@ f:
   movq  (%rbx), %rdi
   addq  $8, %rsp
   jmp   *%rdi
+.L4:
+  call  .Lcaml_call_gc_
+.L5:
+  jmp   .L2
+.L6:
+  call  .Lcaml_call_gc_
+.L7:
+  jmp   .L0
 |}]
 
 

--- a/testsuite/tests/codegen/functions.ml
+++ b/testsuite/tests/codegen/functions.ml
@@ -21,7 +21,7 @@ f_unboxed_unit:
   movl  $1, %eax
   movq  (%rbx), %rdi
   call  *%rdi
-.L107:
+.L0:
   addq  $8, %rsp
   ret
 |}]
@@ -39,7 +39,7 @@ mutual_recursion:
   subq  $56, %r15
   cmpq  (%r14), %r15
   jb    .L106
-.L108:
+.L0:
   leaq  8(%r15), %rdi
   movq  $6391, -8(%rdi)
   movq  camlTOP3__g_6_9_code@GOTPCREL(%rip), %rsi
@@ -59,9 +59,9 @@ mutual_recursion:
 mutual_recursion.f:
   movq  %rbx, %rdi
   cmpq  $1, %rax
-  jge   .L114
+  jge   .L0
   ret
-.L114:
+.L0:
   leaq  -24(%rdi), %rbx
   movq  16(%rdi), %rdi
   subq  %rdi, %rax
@@ -70,9 +70,9 @@ mutual_recursion.f:
 
 mutual_recursion.g:
   cmpq  $1, %rax
-  jge   .L127
+  jge   .L0
   ret
-.L127:
+.L0:
   addq  $24, %rbx
   addq  $-60, %rax
   jmp   camlTOP3__f_5_8_code@PLT
@@ -94,11 +94,11 @@ f.(fun):
 f:
   subq  $8, %rsp
   cmpq  $1, %rax
-  jge   .L119
+  jge   .L1
   subq  $32, %r15
   cmpq  (%r14), %r15
   jb    .L128
-.L130:
+.L0:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
   leaq  .LcamlTOP4__fn$5b$3a1$2c29$2d$2d50$5d_10_15_code(%rip), %rdi
@@ -106,12 +106,12 @@ f:
   movabsq $108086391056891911, %rdi
   movq  %rdi, 8(%rbx)
   movq  %rax, 16(%rbx)
-  jmp   .L123
-.L119:
+  jmp   .L3
+.L1:
   subq  $32, %r15
   cmpq  (%r14), %r15
   jb    .L131
-.L133:
+.L2:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
   leaq  .LcamlTOP4__fn$5b$3a1$2c56$2d$2d69$5d_9_14_code(%rip), %rdi
@@ -119,7 +119,7 @@ f:
   movabsq $108086391056891911, %rdi
   movq  %rdi, 8(%rbx)
   movq  %rax, 16(%rbx)
-.L123:
+.L3:
   movl  $1, %eax
   movq  (%rbx), %rdi
   addq  $8, %rsp
@@ -134,10 +134,10 @@ let inline_identical x =
 [%%expect_asm X86_64{|
 inline_identical:
   cmpq  $1, %rax
-  jle   .L106
+  jle   .L0
   addq  $2, %rax
   ret
-.L106:
+.L0:
   addq  $2, %rax
   ret
 |}]

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -172,7 +172,7 @@ two_element_list:
   movq  %rax, %rbx
   subq  $48, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rdi
   addq  $24, %rdi
@@ -267,7 +267,7 @@ pause:
   subq  $8, %rsp
   pause
   cmpq  (%r14), %r15
-  jbe   .L1
+  jbe   <hidden GC jump pad>
 .L0:
   movl  $1, %eax
   addq  $8, %rsp

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -185,10 +185,6 @@ two_element_list:
   movq  %rdi, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 
@@ -276,10 +272,6 @@ pause:
   movl  $1, %eax
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 (* Cross-type conversions between unboxed types *)

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -66,10 +66,10 @@ let do_intersect t1 t2 =
 do_intersect:
   andq  %rbx, %rax
   testq %rax, %rax
-  jne   .L106
+  jne   .L0
   movl  $100, %eax
   ret
-.L106:
+.L0:
   movl  $200, %eax
   ret
 |}]
@@ -82,11 +82,11 @@ logand_branch:
   movq  %rdi, %rbx
   andl  $33, %eax
   cmpq  $1, %rax
-  je    .L108
+  je    .L0
   movl  $1, %eax
   movq  (%rbx), %rdi
   jmp   *%rdi
-.L108:
+.L0:
   movl  $1, %eax
   ret
 |}]
@@ -107,12 +107,12 @@ combine_comparisons:
   cmpq  $41, %rbx
   setl  %al
   cmpq  $11, %rbx
-  jle   .L114
+  jle   .L0
   testq %rax, %rax
-  je    .L114
+  je    .L0
   movq  %rbx, %rax
   ret
-.L114:
+.L0:
   movl  $1, %eax
   ret
 |}]
@@ -130,12 +130,12 @@ repeat_comparisons:
   cmpq  $11, %rbx
   setg  %al
   cmpq  $11, %rbx
-  jle   .L113
+  jle   .L0
   testq %rax, %rax
-  je    .L113
+  je    .L0
   movl  $3, %eax
   ret
-.L113:
+.L0:
   movl  $5, %eax
   ret
 |}]
@@ -154,10 +154,10 @@ branch_and_return:
   setne %al
   leaq  1(%rax,%rax), %rax
   cmpq  $3, %rax
-  jne   .L107
+  jne   .L0
   movq  %rbx, %rax
   ret
-.L107:
+.L0:
   movl  $15, %eax
   ret
 |}]
@@ -173,7 +173,7 @@ two_element_list:
   subq  $48, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rdi
   addq  $24, %rdi
   movq  $2048, -8(%rdi)
@@ -196,15 +196,15 @@ let constant_folding (x : int) =
 [%%expect_asm X86_64{|
 constant_folding:
   cmpq  %rax, %rax
-  jl    .L109
+  jl    .L0
   subq  %rax, %rax
   incq  %rax
   cmpq  $1, %rax
-  jne   .L111
-.L109:
+  jne   .L1
+.L0:
   movl  $7, %eax
   ret
-.L111:
+.L1:
   movl  $9, %eax
   ret
 |}]
@@ -268,7 +268,7 @@ pause:
   pause
   cmpq  (%r14), %r15
   jbe   .L105
-.L106:
+.L0:
   movl  $1, %eax
   addq  $8, %rsp
   ret
@@ -339,11 +339,11 @@ let is_int_branch (x : 'a) f = if Obj.is_int(Obj.repr x) then f()
 [%%expect_asm X86_64{|
 is_int_branch:
   testb $1, %al
-  je    .L107
+  je    .L0
   movl  $1, %eax
   movq  (%rbx), %rdi
   jmp   *%rdi
-.L107:
+.L0:
   movl  $1, %eax
   ret
 |}]
@@ -354,10 +354,10 @@ let is_block_branch (x : 'a) f = if not(Obj.is_int(Obj.repr x)) then f()
 [%%expect_asm X86_64{|
 is_block_branch:
   testb $1, %al
-  je    .L105
+  je    .L0
   movl  $1, %eax
   ret
-.L105:
+.L0:
   movl  $1, %eax
   movq  (%rbx), %rdi
   jmp   *%rdi
@@ -375,13 +375,13 @@ let branch_or_tailcall x =
 [%%expect_asm X86_64{|
 branch_or_tailcall:
   cmpq  $5, %rax
-  jbe   .L105
+  jbe   .L0
   movq  camlTOP28__Pmakeblock918@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-.L105:
+.L0:
   movq  camlTOP28__switch_block919@GOTPCREL(%rip), %rbx
   movq  -4(%rbx,%rax,4), %rax
   ret

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -172,7 +172,7 @@ two_element_list:
   movq  %rax, %rbx
   subq  $48, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rdi
   addq  $24, %rdi
@@ -185,6 +185,10 @@ two_element_list:
   movq  %rdi, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 
@@ -267,11 +271,15 @@ pause:
   subq  $8, %rsp
   pause
   cmpq  (%r14), %r15
-  jbe   .L105
+  jbe   .L1
 .L0:
   movl  $1, %eax
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 (* Cross-type conversions between unboxed types *)

--- a/testsuite/tests/codegen/int.ml
+++ b/testsuite/tests/codegen/int.ml
@@ -57,14 +57,14 @@ let div x y = x / y
 div:
   movq  %rbx, %rcx
   cmpq  $1, %rcx
-  je    .L115
+  je    .L0
   sarq  $1, %rcx
   sarq  $1, %rax
   cqto
   idivq %rcx
   leaq  1(%rax,%rax), %rax
   ret
-.L115:
+.L0:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -110,14 +110,14 @@ let rem x y = x mod y
 rem:
   movq  %rbx, %rcx
   cmpq  $1, %rcx
-  je    .L115
+  je    .L0
   sarq  $1, %rcx
   sarq  $1, %rax
   cqto
   idivq %rcx
   leaq  1(%rdx,%rdx), %rax
   ret
-.L115:
+.L0:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -189,10 +189,10 @@ let abs x = abs x
 abs:
   movq  %rax, %rbx
   cmpq  $1, %rbx
-  jl    .L105
+  jl    .L0
   movq  %rbx, %rax
   ret
-.L105:
+.L0:
   movl  $2, %eax
   subq  %rbx, %rax
   ret
@@ -321,10 +321,10 @@ min:
   movq  %rax, %rdi
   movq  %rbx, %rax
   cmpq  %rax, %rdi
-  jg    .L105
+  jg    .L0
   movq  %rdi, %rax
   ret
-.L105:
+.L0:
   ret
 |}]
 
@@ -335,10 +335,10 @@ max:
   movq  %rax, %rdi
   movq  %rbx, %rax
   cmpq  %rax, %rdi
-  jl    .L105
+  jl    .L0
   movq  %rdi, %rax
   ret
-.L105:
+.L0:
   ret
 |}]
 
@@ -369,10 +369,10 @@ collatz:
   movq  %rax, %rbx
   movl  $1, %eax
   cmpq  $3, %rbx
-  jg    .L110
-.L108:
+  jg    .L1
+.L0:
   ret
-.L110:
+.L1:
   addq  $2, %rax
   movq  %rbx, %rdi
   sarq  $1, %rdi
@@ -385,15 +385,15 @@ collatz:
   subq  %rsi, %rdi
   leaq  1(%rdi,%rdi), %rdi
   cmpq  $1, %rdi
-  jne   .L126
+  jne   .L2
   sarq  $1, %rdx
   leaq  1(%rdx,%rdx), %rbx
   cmpq  $3, %rbx
-  jg    .L110
-  jmp   .L108
-.L126:
+  jg    .L1
+  jmp   .L0
+.L2:
   leaq  (%rbx,%rbx,2), %rbx
   cmpq  $3, %rbx
-  jg    .L110
-  jmp   .L108
+  jg    .L1
+  jmp   .L0
 |}]

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -483,10 +483,6 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_float_u x = Int16_u.to_float_u x
@@ -513,10 +509,6 @@ to_float32:
   vmovss %xmm0, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_float32_u x = Int16_u.to_float32_u x
@@ -563,10 +555,6 @@ to_int32:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_int32_u x = Int16_u.to_int32_u x
@@ -591,10 +579,6 @@ to_int64:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_int64_u x = Int16_u.to_int64_u x
@@ -636,10 +620,6 @@ to_nativeint:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_nativeint_u x = Int16_u.to_nativeint_u x

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -475,7 +475,7 @@ to_float:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -499,7 +499,7 @@ to_float32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -545,7 +545,7 @@ to_int32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -570,7 +570,7 @@ to_int64:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -611,7 +611,7 @@ to_nativeint:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -178,13 +178,13 @@ let div x y = Int16_u.div x y
 div:
   movq  %rbx, %rcx
   testq %rcx, %rcx
-  je    .L114
+  je    .L0
   cqto
   idivq %rcx
   salq  $48, %rax
   sarq  $48, %rax
   ret
-.L114:
+.L0:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -197,14 +197,14 @@ let rem x y = Int16_u.rem x y
 rem:
   movq  %rbx, %rcx
   testq %rcx, %rcx
-  je    .L114
+  je    .L0
   cqto
   idivq %rcx
   movq  %rdx, %rax
   salq  $48, %rax
   sarq  $48, %rax
   ret
-.L114:
+.L0:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -476,7 +476,7 @@ to_float:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vcvtsi2sdq %rbx, %xmm0, %xmm0
@@ -500,7 +500,7 @@ to_float32:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_float32_ops@GOTPCREL(%rip), %rdi
@@ -546,7 +546,7 @@ to_int32:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_int32_ops@GOTPCREL(%rip), %rdi
@@ -571,7 +571,7 @@ to_int64:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_int64_ops@GOTPCREL(%rip), %rdi
@@ -612,7 +612,7 @@ to_nativeint:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_nativeint_ops@GOTPCREL(%rip), %rdi

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -475,7 +475,7 @@ to_float:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -483,6 +483,10 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_float_u x = Int16_u.to_float_u x
@@ -499,7 +503,7 @@ to_float32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -509,6 +513,10 @@ to_float32:
   vmovss %xmm0, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_float32_u x = Int16_u.to_float32_u x
@@ -545,7 +553,7 @@ to_int32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -555,6 +563,10 @@ to_int32:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_int32_u x = Int16_u.to_int32_u x
@@ -570,7 +582,7 @@ to_int64:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -579,6 +591,10 @@ to_int64:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_int64_u x = Int16_u.to_int64_u x
@@ -611,7 +627,7 @@ to_nativeint:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -620,6 +636,10 @@ to_nativeint:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_nativeint_u x = Int16_u.to_nativeint_u x

--- a/testsuite/tests/codegen/int32_u.ml
+++ b/testsuite/tests/codegen/int32_u.ml
@@ -35,10 +35,10 @@ min:
   movq  %rax, %rdi
   movq  %rbx, %rax
   cmpq  %rax, %rdi
-  jg    .L105
+  jg    .L0
   movq  %rdi, %rax
   ret
-.L105:
+.L0:
   ret
 |}]
 

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -381,7 +381,7 @@ unsigned_to_int:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L2
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1024, -8(%rax)
@@ -409,7 +409,7 @@ to_float:
   vcvtsi2sdq %rax, %xmm0, %xmm0
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -432,7 +432,7 @@ to_int32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -458,7 +458,7 @@ to_nativeint:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -509,7 +509,7 @@ float_of_bits:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -613,7 +613,7 @@ to_int64:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -392,10 +392,6 @@ unsigned_to_int:
 .L1:
   movl  $1, %eax
   ret
-.L2:
-  call  .Lcaml_call_gc_
-.L3:
-  jmp   .L0
 |}]
 
 let of_float x = Int64_u.of_float x
@@ -420,10 +416,6 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_sse_
-.L2:
-  jmp   .L0
 |}]
 
 let of_int32 x = Int64_u.of_int32 x
@@ -450,10 +442,6 @@ to_int32:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let of_nativeint x = Int64_u.of_nativeint x
@@ -479,10 +467,6 @@ to_nativeint:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let of_int32_u x = Int64_u.of_int32_u x
@@ -533,10 +517,6 @@ float_of_bits:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 (* CR ttebbi: Subtraction should be done on byte registers. *)
@@ -642,10 +622,6 @@ to_int64:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let of_int64 x = Int64_u.of_int64 x

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -381,7 +381,7 @@ unsigned_to_int:
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L115
+  jb    .L2
 .L0:
   leaq  8(%r15), %rax
   movq  $1024, -8(%rax)
@@ -392,6 +392,10 @@ unsigned_to_int:
 .L1:
   movl  $1, %eax
   ret
+.L2:
+  call  .Lcaml_call_gc_
+.L3:
+  jmp   .L0
 |}]
 
 let of_float x = Int64_u.of_float x
@@ -409,13 +413,17 @@ to_float:
   vcvtsi2sdq %rax, %xmm0, %xmm0
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_sse_
+.L2:
+  jmp   .L0
 |}]
 
 let of_int32 x = Int64_u.of_int32 x
@@ -432,7 +440,7 @@ to_int32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L106
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -442,6 +450,10 @@ to_int32:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let of_nativeint x = Int64_u.of_nativeint x
@@ -458,7 +470,7 @@ to_nativeint:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -467,6 +479,10 @@ to_nativeint:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let of_int32_u x = Int64_u.of_int32_u x
@@ -509,7 +525,7 @@ float_of_bits:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -517,6 +533,10 @@ float_of_bits:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 (* CR ttebbi: Subtraction should be done on byte registers. *)
@@ -613,7 +633,7 @@ to_int64:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -622,6 +642,10 @@ to_int64:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let of_int64 x = Int64_u.of_int64 x

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -64,18 +64,18 @@ div:
   movq  %rax, %rdi
   movq  %rbx, %rcx
   testq %rcx, %rcx
-  je    .L118
+  je    .L1
   cmpq  $-1, %rcx
-  je    .L111
+  je    .L0
   movq  %rdi, %rax
   cqto
   idivq %rcx
   ret
-.L111:
+.L0:
   xorl  %eax, %eax
   subq  %rdi, %rax
   ret
-.L118:
+.L1:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -102,33 +102,33 @@ unsigned_div:
   movq  %rax, %rdi
   movq  %rbx, %rcx
   cmpq  $0, %rcx
-  jge   .L115
+  jge   .L1
   movabsq $-9223372036854775808, %rax
   subq  %rax, %rcx
   movabsq $-9223372036854775808, %rax
   subq  %rax, %rdi
   cmpq  %rcx, %rdi
-  jge   .L109
+  jge   .L0
   xorl  %eax, %eax
   ret
-.L109:
+.L0:
   movl  $1, %eax
   ret
-.L115:
+.L1:
   testq %rcx, %rcx
-  je    .L141
+  je    .L5
   movq  %rdi, %rbx
   shrq  $1, %rbx
   cmpq  $-1, %rcx
-  je    .L123
+  je    .L2
   movq  %rbx, %rax
   cqto
   idivq %rcx
-  jmp   .L126
-.L123:
+  jmp   .L3
+.L2:
   xorl  %eax, %eax
   subq  %rbx, %rax
-.L126:
+.L3:
   salq  $1, %rax
   movabsq $-9223372036854775808, %rsi
   movq  %rcx, %rbx
@@ -139,12 +139,12 @@ unsigned_div:
   subq  %rsi, %rdi
   subq  %rdx, %rdi
   cmpq  %rbx, %rdi
-  jge   .L134
+  jge   .L4
   ret
-.L134:
+.L4:
   incq  %rax
   ret
-.L141:
+.L5:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -157,17 +157,17 @@ let rem x y = Int64_u.rem x y
 rem:
   movq  %rbx, %rcx
   testq %rcx, %rcx
-  je    .L117
+  je    .L1
   cmpq  $-1, %rcx
-  je    .L111
+  je    .L0
   cqto
   idivq %rcx
   movq  %rdx, %rax
   ret
-.L111:
+.L0:
   xorl  %eax, %eax
   ret
-.L117:
+.L1:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -182,7 +182,7 @@ unsigned_rem:
   movq  %rax, %rdi
   movq  %rbx, %rcx
   cmpq  $0, %rcx
-  jge   .L118
+  jge   .L1
   movabsq $-9223372036854775808, %rbx
   movq  %rcx, %rax
   subq  %rbx, %rax
@@ -190,27 +190,27 @@ unsigned_rem:
   movq  %rdi, %rbx
   subq  %rsi, %rbx
   cmpq  %rax, %rbx
-  jge   .L112
+  jge   .L0
   xorl  %ebx, %ebx
-  jmp   .L148
-.L112:
+  jmp   .L5
+.L0:
   movl  $1, %ebx
-  jmp   .L148
-.L118:
+  jmp   .L5
+.L1:
   testq %rcx, %rcx
-  je    .L144
+  je    .L4
   movq  %rdi, %rax
   shrq  $1, %rax
   cmpq  $-1, %rcx
-  je    .L126
+  je    .L2
   cqto
   idivq %rcx
   movq  %rax, %rbx
-  jmp   .L129
-.L126:
+  jmp   .L3
+.L2:
   xorl  %ebx, %ebx
   subq  %rax, %rbx
-.L129:
+.L3:
   salq  $1, %rbx
   movabsq $-9223372036854775808, %rsi
   movq  %rcx, %rax
@@ -222,16 +222,16 @@ unsigned_rem:
   subq  %rsi, %rdx
   subq  %r8, %rdx
   cmpq  %rax, %rdx
-  jl    .L148
+  jl    .L5
   incq  %rbx
-  jmp   .L148
-.L144:
+  jmp   .L5
+.L4:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-.L148:
+.L5:
   imulq %rcx, %rbx
   movq  %rdi, %rax
   subq  %rbx, %rax
@@ -257,9 +257,9 @@ unsigned_rem_2:
   subq  %rdi, %rsi
   subq  %rcx, %rsi
   cmpq  %rdx, %rsi
-  jl    .L120
+  jl    .L0
   incq  %rbx
-.L120:
+.L0:
   salq  $1, %rbx
   subq  %rbx, %rax
   ret
@@ -285,10 +285,10 @@ let abs x = Int64_u.abs x
 abs:
   movq  %rax, %rbx
   cmpq  $0, %rbx
-  jl    .L105
+  jl    .L0
   movq  %rbx, %rax
   ret
-.L105:
+.L0:
   xorl  %eax, %eax
   subq  %rbx, %rax
   ret
@@ -374,22 +374,22 @@ let unsigned_to_int x = Int64_u.unsigned_to_int x
 unsigned_to_int:
   movq  %rax, %rbx
   cmpq  $0, %rbx
-  jl    .L112
+  jl    .L1
   movabsq $4611686018427387903, %rax
   cmpq  %rax, %rbx
-  jg    .L112
+  jg    .L1
   subq  $8, %rsp
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L115
-.L117:
+.L0:
   leaq  8(%r15), %rax
   movq  $1024, -8(%rax)
   leaq  1(%rbx,%rbx), %rbx
   movq  %rbx, (%rax)
   addq  $8, %rsp
   ret
-.L112:
+.L1:
   movl  $1, %eax
   ret
 |}]
@@ -410,7 +410,7 @@ to_float:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovsd %xmm0, (%rax)
@@ -433,7 +433,7 @@ to_int32:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L106
-.L108:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_int32_ops@GOTPCREL(%rip), %rdi
@@ -459,7 +459,7 @@ to_nativeint:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_nativeint_ops@GOTPCREL(%rip), %rdi
@@ -510,7 +510,7 @@ float_of_bits:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vmovq %rbx, %xmm0
@@ -585,10 +585,10 @@ min:
   movq  %rax, %rdi
   movq  %rbx, %rax
   cmpq  %rax, %rdi
-  jg    .L105
+  jg    .L0
   movq  %rdi, %rax
   ret
-.L105:
+.L0:
   ret
 |}]
 
@@ -599,10 +599,10 @@ max:
   movq  %rax, %rdi
   movq  %rbx, %rax
   cmpq  %rax, %rdi
-  jl    .L105
+  jl    .L0
   movq  %rdi, %rax
   ret
-.L105:
+.L0:
   ret
 |}]
 
@@ -614,7 +614,7 @@ to_int64:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_int64_ops@GOTPCREL(%rip), %rdi

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -464,7 +464,7 @@ to_float:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -488,7 +488,7 @@ to_float32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -540,7 +540,7 @@ to_int32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -565,7 +565,7 @@ to_int64:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -596,7 +596,7 @@ to_nativeint:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -472,10 +472,6 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_float_u x = Int8_u.to_float_u x
@@ -502,10 +498,6 @@ to_float32:
   vmovss %xmm0, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_float32_u x = Int8_u.to_float32_u x
@@ -558,10 +550,6 @@ to_int32:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_int32_u x = Int8_u.to_int32_u x
@@ -586,10 +574,6 @@ to_int64:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_int64_u x = Int8_u.to_int64_u x
@@ -621,10 +605,6 @@ to_nativeint:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 |}]
 
 let to_nativeint_u x = Int8_u.to_nativeint_u x

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -165,13 +165,13 @@ let div x y = Int8_u.div x y
 div:
   movq  %rbx, %rcx
   testq %rcx, %rcx
-  je    .L114
+  je    .L0
   cqto
   idivq %rcx
   salq  $56, %rax
   sarq  $56, %rax
   ret
-.L114:
+.L0:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -184,14 +184,14 @@ let rem x y = Int8_u.rem x y
 rem:
   movq  %rbx, %rcx
   testq %rcx, %rcx
-  je    .L114
+  je    .L0
   cqto
   idivq %rcx
   movq  %rdx, %rax
   salq  $56, %rax
   sarq  $56, %rax
   ret
-.L114:
+.L0:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -465,7 +465,7 @@ to_float:
   subq  $16, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
   vcvtsi2sdq %rbx, %xmm0, %xmm0
@@ -489,7 +489,7 @@ to_float32:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_float32_ops@GOTPCREL(%rip), %rdi
@@ -541,7 +541,7 @@ to_int32:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_int32_ops@GOTPCREL(%rip), %rdi
@@ -566,7 +566,7 @@ to_int64:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_int64_ops@GOTPCREL(%rip), %rdi
@@ -597,7 +597,7 @@ to_nativeint:
   subq  $24, %r15
   cmpq  (%r14), %r15
   jb    .L104
-.L106:
+.L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
   movq  caml_nativeint_ops@GOTPCREL(%rip), %rdi

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -464,7 +464,7 @@ to_float:
   movq  %rax, %rbx
   subq  $16, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $1277, -8(%rax)
@@ -472,6 +472,10 @@ to_float:
   vmovsd %xmm0, (%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_float_u x = Int8_u.to_float_u x
@@ -488,7 +492,7 @@ to_float32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -498,6 +502,10 @@ to_float32:
   vmovss %xmm0, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_float32_u x = Int8_u.to_float32_u x
@@ -540,7 +548,7 @@ to_int32:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -550,6 +558,10 @@ to_int32:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_int32_u x = Int8_u.to_int32_u x
@@ -565,7 +577,7 @@ to_int64:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -574,6 +586,10 @@ to_int64:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_int64_u x = Int8_u.to_int64_u x
@@ -596,7 +612,7 @@ to_nativeint:
   movq  %rax, %rbx
   subq  $24, %r15
   cmpq  (%r14), %r15
-  jb    .L104
+  jb    .L1
 .L0:
   leaq  8(%r15), %rax
   movq  $2303, -8(%rax)
@@ -605,6 +621,10 @@ to_nativeint:
   movq  %rbx, 8(%rax)
   addq  $8, %rsp
   ret
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 |}]
 
 let to_nativeint_u x = Int8_u.to_nativeint_u x

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -13,13 +13,13 @@ let immutable_load l = (List.hd l) + (List.hd l)
 [%%expect_asm X86_64{|
 immutable_load:
   testb $1, %al
-  je    .L105
+  je    .L0
   movq  camlStdlib__List__Pmakeblock2305@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-.L105:
+.L0:
   movq  (%rax), %rax
   leaq  -1(%rax,%rax), %rax
   ret
@@ -50,12 +50,12 @@ let mutable_load_branch r b =
 mutable_load_branch:
   movq  (%rax), %rax
   cmpq  $1, %rbx
-  jne   .L109
+  jne   .L0
   movl  $15, %ebx
-  jmp   .L113
-.L109:
+  jmp   .L1
+.L0:
   movq  %rax, %rbx
-.L113:
+.L1:
   leaq  -1(%rax,%rbx), %rax
   ret
 |}]
@@ -73,15 +73,15 @@ immutable_load_loop:
   movq  (%rax), %rbx
   movl  $21, %edi
   movq  %rbx, %rax
-  jmp   .L111
-.L109:
+  jmp   .L1
+.L0:
   ret
-.L111:
+.L1:
   leaq  -1(%rax,%rbx), %rax
   addq  $-2, %rdi
   cmpq  $1, %rdi
-  jne   .L111
-  jmp   .L109
+  jne   .L1
+  jmp   .L0
 |}]
 
 (* CR ttebbi: Load elimination inside the loop is not working. *)
@@ -93,16 +93,16 @@ mutable_load_loop:
   movq  %rax, %rbx
   movq  (%rbx), %rax
   movl  $21, %edi
-  jmp   .L111
-.L109:
+  jmp   .L1
+.L0:
   ret
-.L111:
+.L1:
   movq  (%rbx), %rsi
   leaq  -1(%rax,%rsi), %rax
   addq  $-2, %rdi
   cmpq  $1, %rdi
-  jne   .L111
-  jmp   .L109
+  jne   .L1
+  jmp   .L0
 |}]
 
 (* CR ttebbi: We should figure out that the store and the load cannot alias. *)

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -131,7 +131,7 @@ f:
   subq  $8, %rsp
   subq  $32, %r15
   cmpq  (%r14), %r15
-  jb    .L1
+  jb    <hidden GC jump pad>
 .L0:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -143,10 +143,6 @@ f:
   movl  $1, %eax
   addq  $8, %rsp
   jmp   camlTOP5__do_work_11_15_code@PLT
-.L1:
-  call  .Lcaml_call_gc_
-.L2:
-  jmp   .L0
 
 f.do_work:
   movq  16(%rbx), %rax

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -131,7 +131,7 @@ f:
   subq  $8, %rsp
   subq  $32, %r15
   cmpq  (%r14), %r15
-  jb    .L105
+  jb    .L1
 .L0:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
@@ -143,6 +143,10 @@ f:
   movl  $1, %eax
   addq  $8, %rsp
   jmp   camlTOP5__do_work_11_15_code@PLT
+.L1:
+  call  .Lcaml_call_gc_
+.L2:
+  jmp   .L0
 
 f.do_work:
   movq  16(%rbx), %rax

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -33,20 +33,20 @@ let loop_code_layout n =
 loop_code_layout:
   subq  $8, %rsp
   movl  $1, %ebx
-.L106:
+.L0:
   leaq  -1(%rbx,%rax), %rbx
   cmpq  $1, %rax
-  jne   .L112
+  jne   .L2
   movq  %rbx, (%rsp)
   movl  $1, %eax
   call  camlTOP2__cold_1_4_code@PLT
-.L118:
+.L1:
   movq  (%rsp), %rax
   addq  $8, %rsp
   ret
-.L112:
+.L2:
   addq  $-2, %rax
-  jmp   .L106
+  jmp   .L0
 
 loop_code_layout.cold:
   movl  $1, %eax
@@ -60,28 +60,28 @@ let for_loop_layout n f =
 [%%expect_asm X86_64{|
 for_loop_layout:
   cmpq  $1, %rax
-  jl    .L120
+  jl    .L2
   subq  $24, %rsp
   movq  %rbx, (%rsp)
   sarq  $1, %rax
   movq  %rax, 8(%rsp)
   xorl  %eax, %eax
-.L109:
+.L0:
   movq  %rax, 16(%rsp)
   movl  $1, %eax
   movq  (%rbx), %rdi
   call  *%rdi
-.L124:
+.L1:
   movq  16(%rsp), %rax
   incq  %rax
   movq  (%rsp), %rbx
   movq  8(%rsp), %rdi
   cmpq  %rdi, %rax
-  jle   .L109
+  jle   .L0
   movl  $1, %eax
   addq  $24, %rsp
   ret
-.L120:
+.L2:
   movl  $1, %eax
   ret
 |}]
@@ -97,20 +97,20 @@ let loop_with_non_dominating_load x l =
 loop_with_non_dominating_load:
   movl  $1, %eax
   movl  $201, %edi
-.L108:
+.L0:
   testb $1, %bl
-  je    .L112
+  je    .L1
   movq  camlStdlib__List__Pmakeblock2305@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-.L112:
+.L1:
   movq  (%rbx), %rsi
   leaq  -1(%rax,%rsi), %rax
   addq  $-2, %rdi
   cmpq  $1, %rdi
-  jg    .L108
+  jg    .L0
   ret
 |}]
 
@@ -132,7 +132,7 @@ f:
   subq  $32, %r15
   cmpq  (%r14), %r15
   jb    .L105
-.L107:
+.L0:
   leaq  8(%r15), %rbx
   movq  $3319, -8(%rbx)
   movq  camlTOP5__do_work_11_15_code@GOTPCREL(%rip), %rdi
@@ -148,12 +148,12 @@ f.do_work:
   movq  16(%rbx), %rax
   leaq  -1(%rax,%rax), %rax
   movl  $1, %edi
-.L120:
+.L0:
   movq  16(%rbx), %rsi
   leaq  -1(%rax,%rsi), %rax
   incq  %rdi
   cmpq  $100, %rdi
-  jle   .L120
+  jle   .L0
   ret
 |}]
 
@@ -164,14 +164,14 @@ let noop_loop lo hi = for i = lo to hi do () done
 [%%expect_asm X86_64{|
 noop_loop:
   cmpq  %rbx, %rax
-  jg    .L119
+  jg    .L1
   sarq  $1, %rax
   sarq  $1, %rbx
-.L110:
+.L0:
   incq  %rax
   cmpq  %rbx, %rax
-  jle   .L110
-.L119:
+  jle   .L0
+.L1:
   movl  $1, %eax
   ret
 |}]
@@ -192,19 +192,19 @@ let f n =
 f:
   movq  %rax, %rbx
   cmpq  $1, %rbx
-  jl    .L121
+  jl    .L1
   sarq  $1, %rbx
   movl  $1, %eax
   xorl  %edi, %edi
-.L109:
+.L0:
   movq  %rdi, %rsi
   imulq $6, %rsi
   addq  %rsi, %rax
   incq  %rdi
   cmpq  %rbx, %rdi
-  jle   .L109
+  jle   .L0
   ret
-.L121:
+.L1:
   movl  $1, %eax
   ret
 |}]
@@ -242,11 +242,11 @@ M.f:
   leaq  (%rdx,%rdi), %rax
   leaq  -1(%rax,%rax), %rax
   cmpq  $1, %rax
-  jl    .L132
+  jl    .L1
   sarq  $1, %rax
   vxorpd %xmm0, %xmm0, %xmm0
   xorl  %edi, %edi
-.L116:
+.L0:
   movq  %rdi, %rsi
   imulq $6, %rsi
   incq  %rsi
@@ -256,9 +256,9 @@ M.f:
   vaddsd %xmm1, %xmm0, %xmm0
   incq  %rdi
   cmpq  %rax, %rdi
-  jle   .L116
+  jle   .L0
   ret
-.L132:
+.L1:
   vxorpd %xmm0, %xmm0, %xmm0
   ret
 |}]
@@ -276,24 +276,24 @@ loop_invariant_code:
   movq  %rbx, 8(%rsp)
   xorl  %edi, %edi
   cmpq  $1, %rax
-  je    .L118
-  jmp   .L113
-.L109:
+  je    .L3
+  jmp   .L1
+.L0:
   cmpq  $1, %rax
-  je    .L118
-.L113:
+  je    .L3
+.L1:
   movq  %rdi, 16(%rsp)
   movl  $1, %eax
   movq  (%rbx), %rdi
   call  *%rdi
-.L130:
+.L2:
   movq  (%rsp), %rax
   movq  8(%rsp), %rbx
   movq  16(%rsp), %rdi
-.L118:
+.L3:
   incq  %rdi
   cmpq  $9, %rdi
-  jle   .L109
+  jle   .L0
   movl  $1, %eax
   addq  $24, %rsp
   ret

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -400,9 +400,6 @@ double_loop_no_definition_at_beginning:
   movl  $1, %eax
   addq  $72, %rsp
   ret
-.L6:
-  call  caml_call_local_realloc@PLT
-  jmp   .L1
 
 double_loop_no_definition_at_beginning.f:
   movq  24(%rbx), %rsi

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -357,7 +357,7 @@ double_loop_no_definition_at_beginning:
   subq  $40, %rbx
   movq  %rbx, 64(%r14)
   cmpq  80(%r14), %rbx
-  jl    .L6
+  jl    <hidden GC jump pad>
 .L1:
   addq  72(%r14), %rbx
   addq  $8, %rbx

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -357,7 +357,7 @@ double_loop_no_definition_at_beginning:
   subq  $40, %rbx
   movq  %rbx, 64(%r14)
   cmpq  80(%r14), %rbx
-  jl    .L156
+  jl    .L6
 .L1:
   addq  72(%r14), %rbx
   addq  $8, %rbx
@@ -400,6 +400,9 @@ double_loop_no_definition_at_beginning:
   movl  $1, %eax
   addq  $72, %rsp
   ret
+.L6:
+  call  caml_call_local_realloc@PLT
+  jmp   .L1
 
 double_loop_no_definition_at_beginning.f:
   movq  24(%rbx), %rsi

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -32,13 +32,13 @@ spill_cold_path:
   subq  $8, %rsp
   addq  $2, %rax
   cmpq  $201, %rax
-  jne   .L113
+  jne   .L1
   movq  %rax, (%rsp)
   movl  $1, %eax
   call  camlTOP2__cold_1_3_code@PLT
-.L119:
+.L0:
   movq  (%rsp), %rax
-.L113:
+.L1:
   addq  $4, %rax
   addq  $8, %rsp
   ret
@@ -107,11 +107,11 @@ f:
   subq  $24, %rsp
   movq  %rax, (%rsp)
   call  camlTOP7__g_11_13_code@PLT
-.L108:
+.L0:
   movq  %rax, 8(%rsp)
   movq  (%rsp), %rax
   call  camlTOP7__g_11_13_code@PLT
-.L109:
+.L1:
   movq  8(%rsp), %rbx
   leaq  -1(%rax,%rbx), %rax
   addq  $24, %rsp
@@ -136,18 +136,18 @@ loop_readonly_use_spilled_var:
   movq  %rax, %rbx
   movq  %rbx, (%rsp)
   cmpq  $1, %rax
-  jge   .L111
-.L108:
+  jge   .L1
+.L0:
   leaq  -1(%rbx,%rax), %rax
   addq  $8, %rsp
   ret
-.L111:
+.L1:
   call  camlTOP8__g_15_18_code@PLT
-.L117:
+.L2:
   movq  (%rsp), %rbx
   cmpq  $1, %rax
-  jge   .L111
-  jmp   .L108
+  jge   .L1
+  jmp   .L0
 
 loop_readonly_use_spilled_var.g:
   addq  $-2, %rax
@@ -169,17 +169,17 @@ spill_unspill_loop_movement:
   movq  %rax, %rdi
   movq  %rbx, %rax
   cmpq  $3, %rax
-  jl    .L135
+  jl    .L4
   movq  %rdi, 24(%rsp)
   movq  %rax, %rbx
   movq  %rax, (%rsp)
   sarq  $1, %rbx
   movq  %rbx, 8(%rsp)
   movl  $1, %edi
-.L112:
+.L0:
   movq  %rdi, 16(%rsp)
   call  camlTOP9__f_20_23_code@PLT
-.L145:
+.L1:
   movq  %rax, %rsi
   movq  16(%rsp), %rdi
   movq  %rdi, %rdx
@@ -187,24 +187,24 @@ spill_unspill_loop_movement:
   movq  (%rsp), %rax
   movq  8(%rsp), %rbx
   cmpq  $11, %rdx
-  jle   .L125
+  jle   .L3
   movq  %rsi, 32(%rsp)
   movq  %rdi, 16(%rsp)
   call  camlTOP9__f_20_23_code@PLT
-.L146:
+.L2:
   movq  (%rsp), %rax
   movq  8(%rsp), %rbx
   movq  16(%rsp), %rdi
   movq  32(%rsp), %rsi
-.L125:
+.L3:
   incq  %rdi
   cmpq  %rbx, %rdi
-  jle   .L112
+  jle   .L0
   movq  24(%rsp), %rdi
-  jmp   .L138
-.L135:
+  jmp   .L5
+.L4:
   movl  $1, %esi
-.L138:
+.L5:
   leaq  -1(%rdi,%rsi), %rax
   addq  $40, %rsp
   ret
@@ -217,11 +217,11 @@ let f a b c = if a > 10 then b - c else a - b
 [%%expect_asm X86_64{|
 f:
   cmpq  $21, %rax
-  jle   .L107
+  jle   .L0
   subq  %rdi, %rbx
   leaq  1(%rbx), %rax
   ret
-.L107:
+.L0:
   subq  %rbx, %rax
   incq  %rax
   ret
@@ -280,22 +280,22 @@ unnecessary_moves:
   movq  %rdx, %rbx
   leaq  -1(%rcx,%r8), %rax
   cmpq  %r8, %rcx
-  jge   .L106
+  jge   .L0
   movq  %rcx, %rax
   ret
-.L106:
+.L0:
   cmpq  %rsi, %rdi
-  jge   .L112
+  jge   .L2
   subq  $8, %rsp
   movq  %rax, (%rsp)
   movq  (%rbx), %rdi
   movq  %r8, %rax
   call  *%rdi
-.L117:
+.L1:
   movq  (%rsp), %rax
   addq  $8, %rsp
   ret
-.L112:
+.L2:
   ret
 |}]
 
@@ -315,7 +315,7 @@ spill_one_or_two:
   movl  $1, %eax
   movq  (%rbx), %rdi
   call  *%rdi
-.L107:
+.L0:
   movq  (%rsp), %rax
   movq  8(%rsp), %rbx
   leaq  -1(%rax,%rbx), %rax
@@ -343,14 +343,14 @@ double_loop_no_definition_at_beginning:
   movq  %rbx, %rsi
   movq  64(%r14), %rbx
   cmpq  $1, %rsi
-  jl    .L149
+  jl    .L5
   movq  %rbx, 16(%rsp)
   movq  %rdi, 32(%rsp)
   movq  %rax, 24(%rsp)
   sarq  $1, %rsi
   movq  %rsi, 40(%rsp)
   xorl  %edx, %edx
-.L113:
+.L0:
   movq  64(%r14), %rbx
   movq  %rbx, 8(%rsp)
   movq  64(%r14), %rbx
@@ -358,7 +358,7 @@ double_loop_no_definition_at_beginning:
   movq  %rbx, 64(%r14)
   cmpq  80(%r14), %rbx
   jl    .L156
-.L157:
+.L1:
   addq  72(%r14), %rbx
   addq  $8, %rbx
   movq  $5111, -8(%rbx)
@@ -373,12 +373,12 @@ double_loop_no_definition_at_beginning:
   movq  %rbx, 48(%rsp)
   movq  %rdi, %rdx
   testb $1, %dl
-  jne   .L135
-.L128:
+  jne   .L4
+.L2:
   movq  (%rdx), %rax
   movq  %rdx, 56(%rsp)
   call  camlTOP15__f_33_37_code@PLT
-.L158:
+.L3:
   movq  56(%rsp), %rdx
   movq  8(%rdx), %rdx
   movq  24(%rsp), %rax
@@ -386,16 +386,16 @@ double_loop_no_definition_at_beginning:
   movq  40(%rsp), %rsi
   movq  48(%rsp), %rbx
   testb $1, %dl
-  je    .L128
-.L135:
+  je    .L2
+.L4:
   movq  8(%rsp), %rbx
   movq  %rbx, 64(%r14)
   movq  (%rsp), %rdx
   incq  %rdx
   cmpq  %rsi, %rdx
-  jle   .L113
+  jle   .L0
   movq  16(%rsp), %rbx
-.L149:
+.L5:
   movq  %rbx, 64(%r14)
   movl  $1, %eax
   addq  $72, %rsp
@@ -407,12 +407,12 @@ double_loop_no_definition_at_beginning.f:
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rax
-  jae   .L177
+  jae   .L0
   movq  16(%rbx), %rbx
   movq  %rbx, -4(%rsi,%rax,4)
   movl  $1, %eax
   ret
-.L177:
+.L0:
   movq  camlTOP15__block741@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -441,7 +441,7 @@ spilled_phi_merge:
   call  caml_sys_time_unboxed@PLT
   movq  8(%rsp), %rax
   cmpq  $1, %rax
-  je    .L114
+  je    .L1
   movq  %r13, 40(%rsp)
   movq  %r12, 32(%rsp)
   movq  24(%rsp), %rax
@@ -453,7 +453,7 @@ spilled_phi_merge:
   movq  (%rbx), %rdi
   movq  48(%rsp), %rbx
   call  *%rdi
-.L120:
+.L0:
   movq  (%rsp), %rax
   movq  8(%rsp), %rbp
   movq  16(%rsp), %rbx
@@ -464,7 +464,7 @@ spilled_phi_merge:
   movq  %rdi, 24(%rsp)
   movq  %r8, %r12
   movq  %r9, %r13
-.L114:
+.L1:
   movq  %rbp, %rax
   movq  24(%rsp), %rdi
   movq  %r12, %rsi
@@ -501,35 +501,35 @@ spill_slot_lifetime:
   subq  $56, %rsp
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L127:
+.L0:
   vmovsd %xmm0, (%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L128:
+.L1:
   vmovsd %xmm0, 8(%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L129:
+.L2:
   vmovsd %xmm0, 16(%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L130:
+.L3:
   vmovsd %xmm0, 24(%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L131:
+.L4:
   vmovsd %xmm0, 32(%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L132:
+.L5:
   vmovsd %xmm0, 40(%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L133:
+.L6:
   vmovsd %xmm0, 48(%rsp)
   movl  $1, %eax
   call  camlTOP17__get_one_39_43_code@PLT
-.L134:
+.L7:
   vxorpd %xmm1, %xmm1, %xmm1
   vmovsd (%rsp), %xmm2
   vaddsd %xmm2, %xmm1, %xmm1

--- a/testsuite/tests/codegen/variants.ml
+++ b/testsuite/tests/codegen/variants.ml
@@ -306,13 +306,4 @@ double_match:
   movq  %rsi, 64(%r14)
   addq  $8, %rsp
   ret
-.L6:
-  call  caml_call_local_realloc@PLT
-  jmp   .L4
-.L7:
-  call  caml_call_local_realloc@PLT
-  jmp   .L2
-.L8:
-  call  caml_call_local_realloc@PLT
-  jmp   .L0
 |}]

--- a/testsuite/tests/codegen/variants.ml
+++ b/testsuite/tests/codegen/variants.ml
@@ -270,7 +270,7 @@ double_match:
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
-  jl    .L8
+  jl    <hidden GC jump pad>
 .L0:
   addq  72(%r14), %rax
   addq  $8, %rax
@@ -282,7 +282,7 @@ double_match:
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
-  jl    .L7
+  jl    <hidden GC jump pad>
 .L2:
   addq  72(%r14), %rax
   addq  $8, %rax
@@ -294,7 +294,7 @@ double_match:
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
-  jl    .L6
+  jl    <hidden GC jump pad>
 .L4:
   addq  72(%r14), %rax
   addq  $8, %rax

--- a/testsuite/tests/codegen/variants.ml
+++ b/testsuite/tests/codegen/variants.ml
@@ -28,10 +28,10 @@ end
 [%%expect_asm X86_64{|
 Variant_as_index.get:
   cmpq  $1, %rbx
-  jne   .L106
+  jne   .L0
   movq  (%rax), %rax
   ret
-.L106:
+.L0:
   movq  8(%rax), %rax
   ret
 |}]
@@ -57,10 +57,10 @@ end
 Variant_with_uneven_mutability.get:
   movzbq -8(%rax), %rbx
   cmpq  $1, %rbx
-  jne   .L113
+  jne   .L0
   movq  (%rax), %rax
   ret
-.L113:
+.L0:
   movq  (%rax), %rax
   ret
 |}]
@@ -110,14 +110,14 @@ let even_variant (t : t) : bool =
 [%%expect_asm X86_64{|
 even_variant:
   cmpq  $3, %rax
-  je    .L108
+  je    .L0
   cmpq  $7, %rax
   setge %al
   movzbq %al, %rax
   leaq  1(%rax,%rax), %rax
   xorq  $2, %rax
   ret
-.L108:
+.L0:
   movl  $1, %eax
   ret
 |}]
@@ -177,10 +177,10 @@ let map_to_constants_two (t : t) : int =
 [%%expect_asm X86_64{|
 map_to_constants_two:
   cmpq  $1, %rax
-  jne   .L105
+  jne   .L0
   movq  $-1, %rax
   ret
-.L105:
+.L0:
   movl  $3, %eax
   ret
 |}]
@@ -209,25 +209,25 @@ unnecessary_match:
   movslq (%rdx,%rax,4), %rax
   addq  %rax, %rdx
   jmp   *%rdx
-.L104:
+.L0:
   movq  camlTOP15__unnecessary_match_21@GOTPCREL(%rip), %rax
   movq  16(%rax), %rbx
   movl  $1, %eax
   movq  (%rbx), %rdi
   jmp   *%rdi
-.L109:
+.L1:
   movq  camlTOP15__unnecessary_match_21@GOTPCREL(%rip), %rax
   movq  16(%rax), %rbx
   movl  $3, %eax
   movq  (%rbx), %rdi
   jmp   *%rdi
-.L114:
+.L2:
   movq  camlTOP15__unnecessary_match_21@GOTPCREL(%rip), %rax
   movq  16(%rax), %rbx
   movl  $5, %eax
   movq  (%rbx), %rdi
   jmp   *%rdi
-.L119:
+.L3:
   movq  camlTOP15__unnecessary_match_21@GOTPCREL(%rip), %rax
   movq  16(%rax), %rbx
   movl  $7, %eax
@@ -264,44 +264,44 @@ double_match:
   movq  64(%r14), %rsi
   sarq  $1, %rax
   cmpq  $1, %rax
-  je    .L111
-  ja    .L114
+  je    .L1
+  ja    .L3
   movq  64(%r14), %rax
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
   jl    .L124
-.L125:
+.L0:
   addq  72(%r14), %rax
   addq  $8, %rax
   movq  $1792, -8(%rax)
   movq  %rbx, (%rax)
-  jmp   .L119
-.L111:
+  jmp   .L5
+.L1:
   movq  64(%r14), %rax
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
   jl    .L126
-.L127:
+.L2:
   addq  72(%r14), %rax
   addq  $8, %rax
   movq  $1793, -8(%rax)
   movq  %rdi, (%rax)
-  jmp   .L119
-.L114:
+  jmp   .L5
+.L3:
   movq  64(%r14), %rax
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
   jl    .L128
-.L129:
+.L4:
   addq  72(%r14), %rax
   addq  $8, %rax
   movq  $1793, -8(%rax)
   leaq  2(%rdi), %rbx
   movq  %rbx, (%rax)
-.L119:
+.L5:
   movq  (%rax), %rax
   movq  %rsi, 64(%r14)
   addq  $8, %rsp

--- a/testsuite/tests/codegen/variants.ml
+++ b/testsuite/tests/codegen/variants.ml
@@ -270,7 +270,7 @@ double_match:
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
-  jl    .L124
+  jl    .L8
 .L0:
   addq  72(%r14), %rax
   addq  $8, %rax
@@ -282,7 +282,7 @@ double_match:
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
-  jl    .L126
+  jl    .L7
 .L2:
   addq  72(%r14), %rax
   addq  $8, %rax
@@ -294,7 +294,7 @@ double_match:
   subq  $16, %rax
   movq  %rax, 64(%r14)
   cmpq  80(%r14), %rax
-  jl    .L128
+  jl    .L6
 .L4:
   addq  72(%r14), %rax
   addq  $8, %rax
@@ -306,4 +306,13 @@ double_match:
   movq  %rsi, 64(%r14)
   addq  $8, %rsp
   ret
+.L6:
+  call  caml_call_local_realloc@PLT
+  jmp   .L4
+.L7:
+  call  caml_call_local_realloc@PLT
+  jmp   .L2
+.L8:
+  call  caml_call_local_realloc@PLT
+  jmp   .L0
 |}]

--- a/testsuite/tests/flambda2/for_loop_structure.ml
+++ b/testsuite/tests/flambda2/for_loop_structure.ml
@@ -11,19 +11,19 @@ let f bound r t =
 [%%expect_asm X86_64{|
 f:
   cmpq  $1, %rax
-  jl    .L121
+  jl    .L1
   sarq  $1, %rax
   xorl  %ebx, %ebx
-.L109:
+.L0:
   movq  (%rdi), %rsi
   leaq  (%rsi,%rbx,2), %rsi
   movq  %rsi, (%rdi)
   incq  %rbx
   cmpq  %rax, %rbx
-  jle   .L109
+  jle   .L0
   movl  $1, %eax
   ret
-.L121:
+.L1:
   movl  $1, %eax
   ret
 |}]

--- a/testsuite/tests/tool-expect-test/expect_assembly.ml
+++ b/testsuite/tests/tool-expect-test/expect_assembly.ml
@@ -14,10 +14,10 @@ val helper2 : int -> int = <fun>
 [%%expect_asm X86_64{|
 helper2:
   cmpq  $7, %rax
-  jle   .L106
+  jle   .L0
   addq  $14, %rax
   ret
-.L106:
+.L0:
   imulq $7, %rax
   addq  $-6, %rax
   ret
@@ -27,10 +27,10 @@ let helper x = if x > 3 then x + 7 else x * 7
 [%%expect_asm X86_64{|
 helper:
   cmpq  $7, %rax
-  jle   .L106
+  jle   .L0
   addq  $14, %rax
   ret
-.L106:
+.L0:
   imulq $7, %rax
   addq  $-6, %rax
   ret
@@ -56,7 +56,7 @@ f:
   movq  %rax, %rbx
   movq  camlTOP4__fn$5b$3a1$2c19$2d$2d45$5d_10@GOTPCREL(%rip), %rax
   call  camlStdlib__List__map_15_113_code@PLT
-.L113:
+.L0:
   movq  %rax, %rbx
   movq  camlTOP4__fn$5b$3a1$2c60$2d$2d86$5d_11@GOTPCREL(%rip), %rax
   addq  $8, %rsp

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -367,24 +367,29 @@ let for_alli t ~f =
   in
   aux f 0 t.first
 
+let to_list t = fold_right t ~f:(fun hd tl -> hd :: tl) ~init:[]
+
 let range_to_list ~from_incl ~to_excl =
   match from_incl, to_excl with
   | None, _ -> []
   | Some from_incl, None ->
-    let[@tail_mod_cons] rec suffix pos =
-      match next pos with None -> [] | Some cell -> value cell :: suffix cell
+    let[@tail_mod_cons] rec loop node =
+      match node with
+      | Empty -> []
+      | Node { value; next; _ } -> value :: loop next
     in
-    value from_incl :: suffix from_incl
+    loop from_incl.node
   | Some from_incl, Some to_excl ->
-    let[@tail_mod_cons] rec loop pos =
-      if pos.node == to_excl.node
+    let to_excl_node = to_excl.node in
+    let[@tail_mod_cons] rec loop node =
+      if node == to_excl_node
       then []
       else
-        value pos :: (match next pos with None -> [] | Some cell -> loop cell)
+        match node with
+        | Empty -> []
+        | Node { value; next; _ } -> value :: loop next
     in
-    loop from_incl
-
-let to_list t = range_to_list ~from_incl:(hd_cell t) ~to_excl:None
+    loop from_incl.node
 
 let to_array t =
   let len = length t in

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -326,6 +326,23 @@ let fold_right t ~f ~init =
   in
   aux f t.last init
 
+let fold_right_range ~right_incl ~left_excl ~f ~init =
+  match right_incl with
+  | None -> init
+  | Some { node = start; t } ->
+    let rec aux f curr ~stop acc =
+      if curr == stop
+      then acc
+      else
+        match curr with
+        | Empty -> acc
+        | Node node -> aux f node.prev ~stop (f node.value acc)
+    in
+    aux f start
+      ~stop:
+        (match left_excl with None -> Empty | Some { node = stop; _ } -> stop)
+      init
+
 let find_cell_opt t ~f =
   let rec aux t f curr =
     match curr with
@@ -369,27 +386,18 @@ let for_alli t ~f =
 
 let to_list t = fold_right t ~f:(fun hd tl -> hd :: tl) ~init:[]
 
-let range_to_list ~from_incl ~to_excl =
-  match from_incl, to_excl with
-  | None, _ -> []
-  | Some from_incl, None ->
-    let[@tail_mod_cons] rec loop node =
-      match node with
-      | Empty -> []
-      | Node { value; next; _ } -> value :: loop next
-    in
-    loop from_incl.node
-  | Some from_incl, Some to_excl ->
-    let to_excl_node = to_excl.node in
-    let[@tail_mod_cons] rec loop node =
-      if node == to_excl_node
-      then []
-      else
-        match node with
-        | Empty -> []
-        | Node { value; next; _ } -> value :: loop next
-    in
-    loop from_incl.node
+let range_to_list ~left_incl ~right_excl =
+  match left_incl with
+  | None -> []
+  | Some left_incl ->
+    fold_right_range
+      ~right_incl:
+        (match right_excl with
+        | None -> last_cell left_incl.t
+        | Some right_excl -> prev right_excl)
+      ~left_excl:(prev left_incl)
+      ~f:(fun hd tl -> hd :: tl)
+      ~init:[]
 
 let to_array t =
   let len = length t in

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -367,10 +367,24 @@ let for_alli t ~f =
   in
   aux f 0 t.first
 
-let to_list t = fold_right t ~f:(fun hd tl -> hd :: tl) ~init:[]
+let range_to_list ~from_incl ~to_excl =
+  match from_incl, to_excl with
+  | None, _ -> []
+  | Some from_incl, None ->
+    let[@tail_mod_cons] rec suffix pos =
+      match next pos with None -> [] | Some cell -> value cell :: suffix cell
+    in
+    value from_incl :: suffix from_incl
+  | Some from_incl, Some to_excl ->
+    let[@tail_mod_cons] rec loop pos =
+      if pos.node == to_excl.node
+      then []
+      else
+        value pos :: (match next pos with None -> [] | Some cell -> loop cell)
+    in
+    loop from_incl
 
-let[@tail_mod_cons] rec suffix pos =
-  match next pos with None -> [] | Some cell -> value cell :: suffix cell
+let to_list t = range_to_list ~from_incl:(hd_cell t) ~to_excl:None
 
 let to_array t =
   let len = length t in

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -77,6 +77,16 @@ val fold_left : 'a t -> f:('b -> 'a -> 'b) -> init:'b -> 'b
 
 val fold_right : 'a t -> f:('a -> 'b -> 'b) -> init:'b -> 'b
 
+(** Folding the range of cells from [right_incl] to [left_excl]. If [right_incl]
+    is [None], then the effective range is empty. Otherwise, if [left_excl] is
+    [None], then the range extends to the beginning of the list. *)
+val fold_right_range :
+  right_incl:'a cell option ->
+  left_excl:'a cell option ->
+  f:('a -> 'b -> 'b) ->
+  init:'b ->
+  'b
+
 val find_cell_opt : 'a t -> f:('a -> bool) -> 'a cell option
 
 val find_opt : 'a t -> f:('a -> bool) -> 'a option
@@ -87,11 +97,11 @@ val for_all : 'a t -> f:('a -> bool) -> bool
 
 val for_alli : 'a t -> f:(int -> 'a -> bool) -> bool
 
-(** The range of cells from [from_incl] to [to_excl]. If [from_incl] is [None],
-    then the result is the empty list. Otherwise, if [to_excl] is [None], then
-    the reange extends to the end of the list.*)
+(** The range of cells from [left_incl] to [right_excl]. If [left_incl] is
+    [None], then the result is the empty list. Otherwise, if [right_excl] is
+    [None], then the range extends to the end of the list.*)
 val range_to_list :
-  from_incl:'a cell option -> to_excl:'a cell option -> 'a list
+  left_incl:'a cell option -> right_excl:'a cell option -> 'a list
 
 val to_list : 'a t -> 'a list
 

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -87,10 +87,13 @@ val for_all : 'a t -> f:('a -> bool) -> bool
 
 val for_alli : 'a t -> f:(int -> 'a -> bool) -> bool
 
-val to_list : 'a t -> 'a list
+(** The range of cells from [from_incl] to [to_excl]. If [from_incl] is [None],
+    then the result is the empty list. Otherwise, if [to_excl] is [None], then
+    the reange extends to the end of the list.*)
+val range_to_list :
+  from_incl:'a cell option -> to_excl:'a cell option -> 'a list
 
-(** the list suffix from the provided cell (exclusive) *)
-val suffix : 'a cell -> 'a list
+val to_list : 'a t -> 'a list
 
 val to_array : 'a t -> 'a array
 


### PR DESCRIPTION
Currently, the labels output with [%%expect_asm] are based on CFG block ids. Instead, this PR normalizes them per function when producing expect_asm output while leaving everything unchanged for the actual pipeline.

This also expands expect_asm to include GC callsites, as this includes the corresponding labels in the normalization.