### PR TITLE
Remove ikinds flag

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -547,7 +547,6 @@ let read_one_param ppf position name v =
     |> Option.iter (fun path -> Clflags.profile_output_name := Some path)
 
   | "extension" -> Language_extension.enable_of_string_exn v
-  | "ikinds" -> set "ikinds" [ Clflags.ikinds ] v
   | "ikinds-debug" -> set "ikinds-debug" [ Clflags.ikinds_debug ] v
   | "disable-all-extensions" ->
     if check_bool ppf name v then

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -806,9 +806,6 @@ let mk_dump_into_file f =
 let mk_dump_into_csv f =
   "-dump-into-csv", Arg.Unit f, " Dump profile information to profile.csv"
 
-let mk_ikinds f =
-  "-ikinds", Arg.Unit f, " Enable ikinds-based kind checker (experimental)"
-
 let mk_ikinds_debug f =
   "-ikinds-debug", Arg.Unit f, " Enable ikinds debug logging"
 
@@ -1111,7 +1108,6 @@ module type Common_options = sig
   val _locs : unit -> unit
   val _no_locs : unit -> unit
   val _alert : string -> unit
-  val _ikinds : unit -> unit
   val _ikinds_debug : unit -> unit
   val _I : string -> unit
   val _Ix : string -> unit
@@ -1461,7 +1457,6 @@ struct
     mk_config_var F._config_var;
     mk_custom F._custom;
     mk_disable_all_extensions F._disable_all_extensions;
-    mk_ikinds F._ikinds;
     mk_ikinds_debug F._ikinds_debug;
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_dllib F._dllib;
@@ -1614,7 +1609,6 @@ struct
     mk_no_app_funct F._no_app_funct;
     mk_directory F._directory;
     mk_disable_all_extensions F._disable_all_extensions;
-    mk_ikinds F._ikinds;
     mk_ikinds_debug F._ikinds_debug;
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
@@ -1718,7 +1712,6 @@ struct
     mk_config_var F._config_var;
     mk_dtypes F._annot;
     mk_disable_all_extensions F._disable_all_extensions;
-    mk_ikinds F._ikinds;
     mk_ikinds_debug F._ikinds_debug;
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
@@ -1938,7 +1931,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_no_app_funct F._no_app_funct;
     mk_directory F._directory;
     mk_disable_all_extensions F._disable_all_extensions;
-    mk_ikinds F._ikinds;
     mk_ikinds_debug F._ikinds_debug;
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
@@ -2312,7 +2304,6 @@ module Default = struct
     let _absname = set Clflags.absname
     let _locs = set Clflags.locs
     let _alert = Warnings.parse_alert_option
-    let _ikinds = set Clflags.ikinds
     let _ikinds_debug = set Clflags.ikinds_debug
     let _alias_deps = clear transparent_modules
     let _app_funct = set applicative_functors

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -22,7 +22,6 @@ module type Common_options = sig
   val _locs : unit -> unit
   val _no_locs : unit -> unit
   val _alert : string -> unit
-  val _ikinds : unit -> unit
   val _ikinds_debug : unit -> unit
   val _I : string -> unit
   val _Ix : string -> unit

--- a/testsuite/tests/tool-ocamldep-abstract-kinds/test_ikinds.ml
+++ b/testsuite/tests/tool-ocamldep-abstract-kinds/test_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-ikinds";
  readonly_files = "a1.ml a2.ml b.ml";
  setup-ocamlc.byte-build-env;
  commandline = "-depend b.ml -o b.deps";

--- a/testsuite/tests/typing-abstract-kinds-missing-cmi/test_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds-missing-cmi/test_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
  readonly_files = "a1.ml a2.ml b.ml c_sub1.ml c_sub2.ml c_inter.ml";
  setup-ocamlc.byte-build-env;
  module = "a1.ml";

--- a/testsuite/tests/typing-abstract-kinds/alerts_ikinds.compilers.reference
+++ b/testsuite/tests/typing-abstract-kinds/alerts_ikinds.compilers.reference
@@ -1,17 +1,17 @@
-File "alerts_ikinds.ml", line 12, characters 12-29:
-12 |   kind_ k = Kind_with_alert.k
+File "alerts_ikinds.ml", line 11, characters 12-29:
+11 |   kind_ k = Kind_with_alert.k
                  ^^^^^^^^^^^^^^^^^
 Alert kind_alert: Kind_with_alert.k
 foo
 
-File "alerts_ikinds.ml", line 16, characters 11-28:
-16 |   type t : Kind_with_alert.k
+File "alerts_ikinds.ml", line 15, characters 11-28:
+15 |   type t : Kind_with_alert.k
                 ^^^^^^^^^^^^^^^^^
 Alert kind_alert: Kind_with_alert.k
 foo
 
-File "alerts_ikinds.ml", line 20, characters 13-30:
-20 |   type ('a : Kind_with_alert.k) t
+File "alerts_ikinds.ml", line 19, characters 13-30:
+19 |   type ('a : Kind_with_alert.k) t
                   ^^^^^^^^^^^^^^^^^
 Alert kind_alert: Kind_with_alert.k
 foo

--- a/testsuite/tests/typing-abstract-kinds/alerts_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/alerts_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
 *)
 
 module Kind_with_alert = struct

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 
@@ -1386,8 +1385,8 @@ type t2 : k2
 type ('a : k1) require_k1
 |}]
 
-(* In the [-ikinds] variant this is accepted: [t1]'s kind is [k1], so the
-   with bound does not change the required kind. *)
+(* This is accepted because [t1]'s kind is [k1], so the with bound does not
+   change the required kind. *)
 type a : k1 with t1
 type b = a require_k1
 [%%expect{|

--- a/testsuite/tests/typing-abstract-kinds/warnings_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/warnings_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w +191 -ikinds";
+   flags = "-w +191";
 *)
 
 (* The unused kind decl warning exists *)

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1,10 +1,9 @@
 (* TEST
  include stdlib_upstream_compatible;
  {
-   flags = "-ikinds";
    expect;
  }{
-   flags = "-extension layouts_beta -ikinds";
+   flags = "-extension layouts_beta";
    expect;
  }
 *)

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers -ikinds";
+ flags = "-extension small_numbers";
  expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/inclusion/test_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/inclusion/test_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    readonly_files = "inclusion.mli inclusion.ml";
    setup-ocamlc.byte-build-env;
    module = "inclusion.mli";

--- a/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()

--- a/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/poly-variant-limit/test_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/poly-variant-limit/test_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-ikinds";
  readonly_files = "gen_types.sh types.ml";
  setup-ocamlc.byte-build-env;
 

--- a/testsuite/tests/typing-jkind-bounds/predef_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/predefs_are_best.ml
+++ b/testsuite/tests/typing-jkind-bounds/predefs_are_best.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/predefs_are_best_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/predefs_are_best_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/bvar_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/bvar_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers -ikinds";
+ flags = "-extension small_numbers";
  expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/no_annot_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/no_annot_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers -ikinds";
+ flags = "-extension small_numbers";
  expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/regex_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/regex_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers -ikinds";
+ flags = "-extension small_numbers";
  expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/right_kinds_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/right_kinds_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 
@@ -327,7 +326,7 @@ Error: The layout of type "t2" is value non_float
 |}]
 type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
 (* CR layouts v2.8: This should be accepted, but still fails in principal mode.
-   ikinds regression vs non-ikinds.
+   ikinds regression.
    Internal ticket 6481. *)
 [%%expect{|
 Line 1, characters 0-78:
@@ -356,7 +355,7 @@ Error: The layout of type "t2" is value non_float
 |}]
 type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
 (* CR layouts v2.8: This should be accepted, but still fails in principal mode.
-   ikinds regression vs non-ikinds.
+   ikinds regression.
    Internal ticket 6481. *)
 [%%expect{|
 Line 1, characters 0-96:

--- a/testsuite/tests/typing-jkind-bounds/subsumption/abstracts_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/abstracts_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/fuel_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/fuel_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -ikinds";
+    flags = "-extension layouts_alpha";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/universal_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/universal_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 (* Tests for universally quantified types *)

--- a/testsuite/tests/typing-jkind-bounds/unsafe-across-files/test_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/unsafe-across-files/test_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    readonly_files = "unsafe_across_files.mli unsafe_across_files.ml";
    setup-ocamlc.byte-build-env;
    module = "unsafe_across_files.mli";

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-    flags = "-ikinds";
     expect;
 *)
 

--- a/testsuite/tests/typing-layouts-or-null/inclusions_aliases_ikinds.ml
+++ b/testsuite/tests/typing-layouts-or-null/inclusions_aliases_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/testsuite/tests/typing-layouts-or-null/inclusions_modules_ikinds.ml
+++ b/testsuite/tests/typing-layouts-or-null/inclusions_modules_ikinds.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-ikinds";
    expect;
 *)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5926,25 +5926,21 @@ let crossing_of_ty env ?modalities ty =
         let jkind = type_jkind_purely env ty in
         crossing_of_jkind env jkind
       in
-      if !Clflags.ikinds
-      then (
-        let ikind_crossing = Ikind.crossing_of_type env ty in
-        if debug_ikind_crossing_mismatch then (
-          let old_jkind_crossing = jkind_crossing () in
-          if not (Crossing.equal ikind_crossing old_jkind_crossing)
-          then
-            Format.eprintf
-              "@[<v>[ikind-crossing-mismatch]@ \
-               type=%a@ \
-               ikind=%a@ \
-               jkind=%a@]@."
-              !Btype.print_raw ty
-              (Format_doc.compat Crossing.print) ikind_crossing
-              (Format_doc.compat Crossing.print) old_jkind_crossing
-        );
-        ikind_crossing)
-      else
-        jkind_crossing ()
+      let ikind_crossing = Ikind.crossing_of_type env ty in
+      if debug_ikind_crossing_mismatch then (
+        let old_jkind_crossing = jkind_crossing () in
+        if not (Crossing.equal ikind_crossing old_jkind_crossing)
+        then
+          Format.eprintf
+            "@[<v>[ikind-crossing-mismatch]@ \
+             type=%a@ \
+             ikind=%a@ \
+             jkind=%a@]@."
+            !Btype.print_raw ty
+            (Format_doc.compat Crossing.print) ikind_crossing
+            (Format_doc.compat Crossing.print) old_jkind_crossing
+      );
+      ikind_crossing
   in
   match modalities with
   | None -> crossing
@@ -8338,8 +8334,7 @@ let constrain_decl_jkind env decl jkind =
     let type_equal = type_equal env in
     let context = mk_jkind_context_always_principal env in
     match
-      (* Use Ikind when enabled so axis constraints are checked; it falls
-         back to [Jkind.sub_or_error] when ikinds are disabled. *)
+      (* Use Ikind so axis constraints are checked. *)
       Ikind.sub_or_error ~type_equal ~context env
         decl.type_jkind jkind
     with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -16,8 +16,6 @@
    These are intended to be easy to flip while iterating on
    performance or correctness. *)
 (* CR jujacobs: remove toggles in the final version. *)
-let () = Clflags.ikinds := true
-
 let enable_crossing = true
 
 let enable_sub_jkind_l = true
@@ -529,12 +527,6 @@ let constructor_ikind ~base ~coeffs : Types.constructor_ikind =
 let pp_coeffs (coeffs : Ldd.node array) : string =
   coeffs |> Array.map Ldd.pp |> Array.to_list |> String.concat "; "
 
-let with_ikinds_enabled (f : unit -> Types.constructor_ikind) :
-    Types.type_ikind =
-  if not !Clflags.ikinds
-  then Types.ikinds_todo "ikinds disabled"
-  else Types.Constructor_ikind (f ())
-
 let origin_suffix_of = function None -> "" | Some o -> " origin=" ^ o
 
 let pp_axes (axes : Jkind_axis.Axis.packed list) : string =
@@ -878,15 +870,13 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) :
         *)
         )
     in
-    (* Prefer a stored constructor ikind if one is present and enabled. *)
+    (* Prefer a stored constructor ikind if one is present. *)
     let ikind =
       match type_decl.type_ikind with
-      | Types.Constructor_ikind { base; coeffs } when !Clflags.ikinds ->
+      | Types.Constructor_ikind { base; coeffs } ->
         Solver.Poly (base, coeffs)
       | Types.No_constructor_ikind reason ->
         if !Clflags.ikinds_debug then Format.eprintf "[ikind-miss] %s@." reason;
-        fallback ()
-      | Types.Constructor_ikind _ ->
         fallback ()
     in
     (if !Clflags.ikinds_debug
@@ -922,7 +912,7 @@ let type_declaration_ikind ~(env : Env.t option)
   let base, coeffs = Solver.constr_kind_poly ctx path in
   constructor_ikind ~base ~coeffs
 
-let type_declaration_ikind_gated ~(env : Env.t option)
+let type_declaration_type_ikind ~(env : Env.t option)
     ~(path : Path.t) : Types.type_ikind =
   (* This function gets called separately for each
     type definition of a mutually recursive group. This is
@@ -931,43 +921,41 @@ let type_declaration_ikind_gated ~(env : Env.t option)
     ikind for all of them at once. Alternatively, keep the cache
     between calls to this function from the same mutually recursive
     group. *)
-  with_ikinds_enabled (fun () ->
-    let ikind = type_declaration_ikind ~env ~path in
-    (if !Clflags.ikinds_debug
-    then
-      let stored_jkind =
-        match env with
-        | None -> "?"
-        | Some env -> (
-          match Env.find_type path env with
-          | exception Not_found -> "?"
-          | _decl -> "<stored-jkind>")
-      in
-      Format.eprintf "[ikind] %a: stored=%s, base=%s, coeffs=[%s]@."
-        (Format_doc.compat Path.print) path stored_jkind
-        (Ldd.pp ikind.base)
-        (pp_coeffs ikind.coeffs));
-    ikind)
+  let ikind = type_declaration_ikind ~env ~path in
+  (if !Clflags.ikinds_debug
+  then
+    let stored_jkind =
+      match env with
+      | None -> "?"
+      | Some env -> (
+        match Env.find_type path env with
+        | exception Not_found -> "?"
+        | _decl -> "<stored-jkind>")
+    in
+    Format.eprintf "[ikind] %a: stored=%s, base=%s, coeffs=[%s]@."
+      (Format_doc.compat Path.print) path stored_jkind
+      (Ldd.pp ikind.base)
+      (pp_coeffs ikind.coeffs));
+  Types.Constructor_ikind ikind
 
 let type_declaration_ikind_of_jkind ~(env : Env.t option)
     ~(params : Types.type_expr list) (type_jkind : Types.jkind_l) :
     Types.type_ikind =
-  with_ikinds_enabled (fun () ->
-    let poly = normalize ~env type_jkind in
-    let rigid_vars =
-      List.map (fun ty -> Ldd.rigid (Ldd.Name.param (Types.get_id ty))) params
-    in
-    let base, coeffs =
-      Ldd.decompose_into_linear_terms ~universe:rigid_vars poly
-    in
-    let coeffs = Array.of_list coeffs in
-    let payload = constructor_ikind ~base ~coeffs in
-    if !Clflags.ikinds_debug
-    then
-      Format.eprintf "[ikind] from jkind: base=%s; coeffs=[%s]@."
-        (Ldd.pp payload.base)
-        (pp_coeffs payload.coeffs);
-    payload)
+  let poly = normalize ~env type_jkind in
+  let rigid_vars =
+    List.map (fun ty -> Ldd.rigid (Ldd.Name.param (Types.get_id ty))) params
+  in
+  let base, coeffs =
+    Ldd.decompose_into_linear_terms ~universe:rigid_vars poly
+  in
+  let coeffs = Array.of_list coeffs in
+  let payload = constructor_ikind ~base ~coeffs in
+  if !Clflags.ikinds_debug
+  then
+    Format.eprintf "[ikind] from jkind: base=%s; coeffs=[%s]@."
+      (Ldd.pp payload.base)
+      (pp_coeffs payload.coeffs);
+  Types.Constructor_ikind payload
 
 let predef_ikind_of_jkind ~params type_jkind =
   type_declaration_ikind_of_jkind ~env:None ~params type_jkind
@@ -1045,7 +1033,7 @@ let sub_jkind_l ?allow_any_crossing ?origin
     ~(context : Jkind.jkind_context) env (sub : Types.jkind_l)
     (super : Types.jkind_l) : (unit, Jkind.Violation.t) result =
   let open Misc.Stdlib.Monad.Result.Syntax in
-  if not (enable_sub_jkind_l && !Clflags.ikinds)
+  if not enable_sub_jkind_l
   then
     Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env
       sub super
@@ -1114,7 +1102,7 @@ let sub_jkind_l ?allow_any_crossing ?origin
 
 let crossing_of_jkind ~(context : Jkind.jkind_context)
     env (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =
-  if not (enable_crossing && !Clflags.ikinds)
+  if not enable_crossing
   then Jkind.get_mode_crossing ~context env jkind
   else
     let with_bounds_is_empty :
@@ -1298,7 +1286,7 @@ let sub_or_intersect ?origin
         in
         Jkind.May_have_intersection reasons
   in
-  if not (enable_sub_or_intersect && !Clflags.ikinds)
+  if not enable_sub_or_intersect
   then Jkind.sub_or_intersect ~type_equal ~context env t1 t2
   else if fast_sub ~context env t1 t2
   then (
@@ -1317,7 +1305,7 @@ let sub_or_error ?origin:_origin
     (t1 : (Allowance.allowed * 'r1) Types.jkind)
     (t2 : ('l2 * Allowance.allowed) Types.jkind) :
     (unit, Jkind.Violation.t) result =
-  if not (enable_sub_or_error && !Clflags.ikinds)
+  if not enable_sub_or_error
   then Jkind.sub_or_error ~type_equal ~context env t1 t2
   else
     let { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; _ } =

--- a/typing/ikind.mli
+++ b/typing/ikind.mli
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val type_declaration_ikind_gated :
+val type_declaration_type_ikind :
   env:Env.t option ->
   path:Path.t ->
   Types.type_ikind

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1637,10 +1637,10 @@ let narrow_to_manifest_jkind env loc path decl =
           Format.eprintf
             "[ikind-narrow] path=%a branch=ikind_sub_jkind_l@."
             (Format_doc.compat Path.print) path;
-        (* Under -ikinds we keep [decl.type_jkind] in left/Best form, so
-           [try_allow_r] returns [None] and we route through Ikind. We also
-           fall back here when [decl.type_jkind] cannot allow-right
-           (e.g. due to with-bounds/Best). *)
+        (* Ikinds keep [decl.type_jkind] in left/Best form, so [try_allow_r]
+           returns [None] and we route through Ikind. We also fall back here
+           when [decl.type_jkind] cannot allow-right (e.g. due to
+           with-bounds/Best). *)
         let type_equal = Ctype.type_equal env in
         let context = Ctype.mk_jkind_context_always_principal env in
         (match
@@ -1666,8 +1666,8 @@ let narrow_to_manifest_jkind env loc path decl =
           Format.eprintf
             "[ikind-narrow] path=%a branch=constrain_type_jkind@."
             (Format_doc.compat Path.print) path;
-        (* Legacy path: refine via [constrain_type_jkind] when ikinds disabled
-           and we can allow-right. *)
+        (* Legacy path: refine via [constrain_type_jkind] when we can
+           allow-right. *)
         (match Ctype.constrain_type_jkind env ty type_jkind with
          | Ok () -> ()
          | Error v ->
@@ -1678,7 +1678,7 @@ let narrow_to_manifest_jkind env loc path decl =
              raise (Error (loc, Jkind_mismatch_of_type (env, ty, v))))
     end;
     let type_ikind =
-      Ikind.type_declaration_ikind_gated ~env:(Some env) ~path
+      Ikind.type_declaration_type_ikind ~env:(Some env) ~path
     in
     { decl with type_jkind = manifest_jkind; type_ikind }
 
@@ -3129,7 +3129,7 @@ let normalize_decl_jkinds env decls =
       { decl with
         type_jkind = normalized_jkind;
         type_ikind =
-          Ikind.type_declaration_ikind_gated ~env:(Some env) ~path;
+          Ikind.type_declaration_type_ikind ~env:(Some env) ~path;
         type_unboxed_version
       }
     in

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -831,7 +831,7 @@ type type_declaration =
 
     type_ikind: constructor_ikind_entry;
     (* Cached constructor ikind polynomial (opaque) populated when jkinds are
-       normalized under [-ikinds]; carries a reason when absent. *)
+       normalized; carries a reason when absent. *)
 
     type_private: private_flag;
     type_manifest: type_expr option;

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -204,7 +204,6 @@ let dump_linear = ref false             (* -dlinear *)
 let keep_startup_file = ref false       (* -dstartup *)
 let debug_ocaml = ref false             (* -debug-ocaml *)
 let llvm_backend = ref false            (* -llvm-backend *)
-let ikinds = ref false                  (* -ikinds *)
 let ikinds_debug = ref false            (* -ikinds-debug *)
 let default_timings_precision  = 3
 let timings_precision = ref default_timings_precision (* -dtimings-precision *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -260,8 +260,6 @@ val supports_optimized_probes : bool
 
 val llvm_backend : bool ref
 
-(* Dedicated flag to enable the ikinds kind checker. *)
-val ikinds : bool ref
 val ikinds_debug : bool ref
 
 val all_passes : string list ref


### PR DESCRIPTION
This is a pure refactor PR stacked on the PR that hardcoded ikinds on.
It removes the `-ikinds` flag now that it is always on, and cleans up code paths that branched on that flag.
This PR is supposed to not change behavior.