### PR TITLE
[5.4] Fix effects typechecking

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2675,9 +2675,10 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
         let val_cases = transl_cases ~scopes return_sort val_caselist in
         let param, param_duid = Typecore.name_cases "param" val_caselist in
         let body =
-          Matching.for_function ~scopes
-            ~arg_sort:body_sort ~arg_layout:body_layout ~return_layout
-            e.exp_loc None (Lvar param) val_cases partial
+          maybe_region_layout return_layout
+            (Matching.for_function ~scopes
+              ~arg_sort:body_sort ~arg_layout:body_layout ~return_layout
+              e.exp_loc None (Lvar param) val_cases partial)
         in
         lfunction ~kind:(Curried {nlocal=0})
           ~params:[mk_param param param_duid body_layout]
@@ -2688,8 +2689,9 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
     let exn_cases = transl_cases ~scopes return_sort exn_caselist in
     let param, param_duid = Typecore.name_cases "exn" exn_caselist in
     let body =
-      Matching.for_trywith ~scopes ~return_layout e.exp_loc
-        (Lvar param) exn_cases
+      maybe_region_layout return_layout
+        (Matching.for_trywith ~scopes ~return_layout e.exp_loc
+          (Lvar param) exn_cases)
     in
     lfunction ~kind:(Curried {nlocal=0})
       ~params:[mk_param param param_duid layout_exception] ~return:return_layout
@@ -2702,8 +2704,9 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
     let cont_tail = Ident.create_local "ktail" in
     let eff_cases = transl_cases ~scopes ~cont return_sort eff_caselist in
     let body =
-      Matching.for_handler ~scopes ~return_layout e.exp_loc (Lvar param)
-        (Lvar cont) (Lvar cont_tail) eff_cases
+      maybe_region_layout return_layout
+        (Matching.for_handler ~scopes ~return_layout e.exp_loc (Lvar param)
+          (Lvar cont) (Lvar cont_tail) eff_cases)
     in
     lfunction ~kind:(Curried {nlocal=0})
       ~params:[mk_param param param_duid Lambda.layout_block;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2719,7 +2719,9 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
      the thunk. We always use the thunk path because we cannot verify that the
      arg has layout [value] from [Lapply]. *)
   let (body_fun, arg) =
-    let body = transl_exp ~scopes body_sort body in
+    let body =
+      maybe_region_layout body_layout (transl_exp ~scopes body_sort body)
+    in
     let param = Ident.create_local "param" in
     (lfunction ~kind:(Curried {nlocal=0})
        ~params:[mk_param param Lambda.debug_uid_none Lambda.layout_int]

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -173,6 +173,89 @@ Error: The value "r" is "local"
          because it is used in an expression (at lines 3-10, characters 2-19).
 |}]
 
+(* A [match] body currently inherits an enclosing local return expectation. *)
+let match_body_enclosing_local_return () =
+  exclave_
+  match
+    let (r @ local) = ref 0 in
+    r
+  with
+  | r -> r
+  | effect Need_ref, k -> continue k (ref 0)
+[%%expect {|
+val match_body_enclosing_local_return : unit -> int ref @ local = <fun>
+|}]
+
+(* A [match] value clause currently inherits an enclosing local return
+   expectation. *)
+let match_value_clause_enclosing_local_return () =
+  exclave_
+  match perform Need_ref with
+  | r ->
+      let (r @ local) = ref !r in
+      r
+  | effect Need_ref, k -> continue k (ref 1)
+[%%expect {|
+val match_value_clause_enclosing_local_return : unit -> int ref @ local =
+  <fun>
+|}]
+
+(* A [match] effect clause currently inherits an enclosing local return
+   expectation. *)
+let match_effect_clause_enclosing_local_return () =
+  exclave_
+  match perform Need_unit with
+  | () -> ref 2
+  | effect Need_unit, k ->
+      let (r @ local) = ref 2 in
+      r
+[%%expect {|
+val match_effect_clause_enclosing_local_return : unit -> int ref @ local =
+  <fun>
+|}]
+
+(* A [try] body currently inherits an enclosing local return expectation. *)
+let try_body_enclosing_local_return () =
+  exclave_
+  try
+    let (r @ local) = ref 3 in
+    r
+  with
+  | effect Need_ref, k -> continue k (ref 4)
+[%%expect {|
+val try_body_enclosing_local_return : unit -> int ref @ local = <fun>
+|}]
+
+(* A [try] exception clause currently inherits an enclosing local return
+   expectation. *)
+let try_exception_clause_enclosing_local_return () =
+  exclave_
+  try raise Exit with
+  | Exit ->
+      let (r @ local) = ref 5 in
+      r
+  | effect Need_ref, k -> continue k (ref 6)
+[%%expect {|
+val try_exception_clause_enclosing_local_return : unit -> int ref @ local =
+  <fun>
+|}]
+
+(* A [try] effect clause currently inherits an enclosing local return
+   expectation. *)
+let try_effect_clause_enclosing_local_return () =
+  exclave_
+  try
+    perform Need_unit;
+    ref 7
+  with
+  | effect Need_unit, k ->
+      let (r @ local) = ref 7 in
+      r
+[%%expect {|
+val try_effect_clause_enclosing_local_return : unit -> int ref @ local =
+  <fun>
+|}]
+
 (* Can allocate local values inside a [match] body. *)
 let match_body_internal_local () =
   match

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -34,9 +34,7 @@ let () =
 Line 3, characters 20-21:
 3 |   | r -> use_unique r
                         ^
-Error: This value is "aliased"
-         because it is used in a pattern match with effect cases (at lines 2-4, characters 2-44).
-       However, the highlighted expression is expected to be "unique".
+Error: This value is "aliased" but is expected to be "unique".
 |}]
 
 (* A continuation result cannot be a local reference escaping globally. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -49,6 +49,19 @@ Line 4, characters 37-53:
 Error: This value is "local" but is expected to be "global".
 |}]
 
+(* An effect payload passed to [perform] must be legacy. *)
+let () =
+  perform (Payload (stack_ (ref 0)))
+[%%expect {|
+Line 2, characters 19-35:
+2 |   perform (Payload (stack_ (ref 0)))
+                       ^^^^^^^^^^^^^^^^
+Error: This value is "local"
+       but is expected to be "global"
+         because it is contained (via constructor "Payload") in the value at line 2, characters 10-36
+         which is expected to be "global".
+|}]
+
 (* A payload captured by an effect pattern is aliased, not unique. *)
 let () =
   match perform (Payload (ref 0)) with

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -7,6 +7,8 @@ open Effect.Deep
 
 let use_unique : 'a @ unique -> unit = fun _ -> ()
 
+let use_portable : 'a @ portable -> unit = fun _ -> ()
+
 let use_portable_function : (unit -> unit) @ portable -> unit = fun _ -> ()
 
 type record = { a : int }
@@ -18,6 +20,7 @@ type _ eff += Need_unit : unit eff
 type _ eff += Payload : int ref -> unit eff
 [%%expect {|
 val use_unique : 'a @ unique -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
 val use_portable_function : (unit -> unit) @ portable -> unit = <fun>
 type record = { a : int; }
 type _ eff += Need_ref : int ref eff
@@ -37,6 +40,16 @@ Line 3, characters 20-21:
 Error: This value is "aliased" but is expected to be "unique".
 |}]
 
+(* A result returned by [perform] is aliased, not unique. *)
+let () =
+  use_unique (perform Need_ref)
+[%%expect {|
+Line 2, characters 13-31:
+2 |   use_unique (perform Need_ref)
+                 ^^^^^^^^^^^^^^^^^^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
 (* A continuation result cannot be a local reference escaping globally. *)
 let _ =
   match perform Need_ref with
@@ -47,6 +60,44 @@ Line 4, characters 37-53:
 4 |   | effect Need_ref, k -> continue k (stack_ (ref 0))
                                          ^^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
+|}]
+
+(* The continuation passed to [continue] must be legacy. *)
+let () =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k ->
+      let (k @ local) = k in
+      continue k ()
+[%%expect {|
+Line 6, characters 15-16:
+6 |       continue k ()
+                   ^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* A result returned by [continue] is aliased, not unique. *)
+let () =
+  match perform Need_ref with
+  | r -> ignore !r
+  | effect Need_ref, k -> use_unique (continue k (ref 0))
+[%%expect {|
+Line 4, characters 37-57:
+4 |   | effect Need_ref, k -> use_unique (continue k (ref 0))
+                                         ^^^^^^^^^^^^^^^^^^^^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+(* An effect continuation is legacy, not portable. *)
+let () =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k -> use_portable k
+[%%expect {|
+Line 4, characters 40-41:
+4 |   | effect Need_unit, k -> use_portable k
+                                            ^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 (* An effect payload passed to [perform] must be legacy. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -173,7 +173,8 @@ Error: The value "r" is "local"
          because it is used in an expression (at lines 3-10, characters 2-19).
 |}]
 
-(* A [match] body currently inherits an enclosing local return expectation. *)
+(* A [match] body uses legacy modes instead of inheriting an enclosing local
+   return expectation. *)
 let match_body_enclosing_local_return () =
   exclave_
   match
@@ -183,11 +184,14 @@ let match_body_enclosing_local_return () =
   | r -> r
   | effect Need_ref, k -> continue k (ref 0)
 [%%expect {|
-val match_body_enclosing_local_return : unit -> int ref @ local = <fun>
+Line 5, characters 4-5:
+5 |     r
+        ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* A [match] value clause currently inherits an enclosing local return
-   expectation. *)
+(* A [match] value clause uses legacy modes instead of inheriting an enclosing
+   local return expectation. *)
 let match_value_clause_enclosing_local_return () =
   exclave_
   match perform Need_ref with
@@ -196,12 +200,14 @@ let match_value_clause_enclosing_local_return () =
       r
   | effect Need_ref, k -> continue k (ref 1)
 [%%expect {|
-val match_value_clause_enclosing_local_return : unit -> int ref @ local =
-  <fun>
+Line 6, characters 6-7:
+6 |       r
+          ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* A [match] effect clause currently inherits an enclosing local return
-   expectation. *)
+(* A [match] effect clause uses legacy modes instead of inheriting an enclosing
+   local return expectation. *)
 let match_effect_clause_enclosing_local_return () =
   exclave_
   match perform Need_unit with
@@ -210,11 +216,14 @@ let match_effect_clause_enclosing_local_return () =
       let (r @ local) = ref 2 in
       r
 [%%expect {|
-val match_effect_clause_enclosing_local_return : unit -> int ref @ local =
-  <fun>
+Line 7, characters 6-7:
+7 |       r
+          ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* A [try] body currently inherits an enclosing local return expectation. *)
+(* A [try] body uses legacy modes instead of inheriting an enclosing local
+   return expectation. *)
 let try_body_enclosing_local_return () =
   exclave_
   try
@@ -223,11 +232,14 @@ let try_body_enclosing_local_return () =
   with
   | effect Need_ref, k -> continue k (ref 4)
 [%%expect {|
-val try_body_enclosing_local_return : unit -> int ref @ local = <fun>
+Line 5, characters 4-5:
+5 |     r
+        ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* A [try] exception clause currently inherits an enclosing local return
-   expectation. *)
+(* A [try] exception clause uses legacy modes instead of inheriting an
+   enclosing local return expectation. *)
 let try_exception_clause_enclosing_local_return () =
   exclave_
   try raise Exit with
@@ -236,12 +248,14 @@ let try_exception_clause_enclosing_local_return () =
       r
   | effect Need_ref, k -> continue k (ref 6)
 [%%expect {|
-val try_exception_clause_enclosing_local_return : unit -> int ref @ local =
-  <fun>
+Line 6, characters 6-7:
+6 |       r
+          ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* A [try] effect clause currently inherits an enclosing local return
-   expectation. *)
+(* A [try] effect clause uses legacy modes instead of inheriting an enclosing
+   local return expectation. *)
 let try_effect_clause_enclosing_local_return () =
   exclave_
   try
@@ -252,8 +266,10 @@ let try_effect_clause_enclosing_local_return () =
       let (r @ local) = ref 7 in
       r
 [%%expect {|
-val try_effect_clause_enclosing_local_return : unit -> int ref @ local =
-  <fun>
+Line 9, characters 6-7:
+9 |       r
+          ^
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Can allocate local values inside a [match] body. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -9,6 +9,8 @@ let use_unique : 'a @ unique -> unit = fun _ -> ()
 
 let use_portable_function : (unit -> unit) @ portable -> unit = fun _ -> ()
 
+type record = { a : int }
+
 type _ eff += Need_ref : int ref eff
 
 type _ eff += Need_unit : unit eff
@@ -17,6 +19,7 @@ type _ eff += Payload : int ref -> unit eff
 [%%expect {|
 val use_unique : 'a @ unique -> unit = <fun>
 val use_portable_function : (unit -> unit) @ portable -> unit = <fun>
+type record = { a : int; }
 type _ eff += Need_ref : int ref eff
 type _ eff += Need_unit : unit eff
 type _ eff += Payload : int ref -> unit eff
@@ -62,6 +65,38 @@ Line 5, characters 17-18:
 Error: This value is "aliased"
          because it is contained (via constructor "Payload") in the value at line 4, characters 11-22
          which is "aliased".
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+(* A scrutinee of [match] cannot capture a unique value from outside the
+   generated handler boundary. *)
+let () =
+  let r = { a = 42 } in
+  match use_unique r with
+  | () -> ()
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+Line 3, characters 19-20:
+3 |   match use_unique r with
+                       ^
+Error: This value is "aliased"
+         because it is used in a pattern match with effect cases (at lines 3-5, characters 2-40).
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+(* A value clause of [match] cannot capture a unique value from outside the
+   generated handler boundary. *)
+let () =
+  let r = { a = 42 } in
+  match () with
+  | n -> use_unique r
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+Line 4, characters 20-21:
+4 |   | n -> use_unique r
+                        ^
+Error: This value is "aliased"
+         because it is used in a pattern match with effect cases (at lines 3-5, characters 2-40).
        However, the highlighted expression is expected to be "unique".
 |}]
 

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -7,6 +7,8 @@ open Effect.Deep
 
 let use_unique : 'a @ unique -> unit = fun _ -> ()
 
+let use_portable_function : (unit -> unit) @ portable -> unit = fun _ -> ()
+
 type _ eff += Need_ref : int ref eff
 
 type _ eff += Need_unit : unit eff
@@ -14,6 +16,7 @@ type _ eff += Need_unit : unit eff
 type _ eff += Payload : int ref -> unit eff
 [%%expect {|
 val use_unique : 'a @ unique -> unit = <fun>
+val use_portable_function : (unit -> unit) @ portable -> unit = <fun>
 type _ eff += Need_ref : int ref eff
 type _ eff += Need_unit : unit eff
 type _ eff += Payload : int ref -> unit eff
@@ -270,6 +273,30 @@ Line 9, characters 6-7:
 9 |       r
           ^
 Error: This value is "local" but is expected to be "global".
+|}]
+
+(* A [match] result must preserve an enclosing portable expectation while using
+   legacy modes for the generated handler body. *)
+let () =
+  use_portable_function
+    (match () with
+     | () ->
+         let (f @ nonportable) () = () in
+         f
+     | effect Need_unit, _ -> fun () -> ())
+[%%expect {|
+|}]
+
+(* A [try] result must preserve an enclosing portable expectation while using
+   legacy modes for the generated handler body. *)
+let () =
+  use_portable_function
+    (try
+       let (f @ nonportable) () = () in
+       f
+     with
+     | effect Need_unit, _ -> fun () -> ())
+[%%expect {|
 |}]
 
 (* Can allocate local values inside a [match] body. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -31,7 +31,9 @@ let () =
 Line 3, characters 20-21:
 3 |   | r -> use_unique r
                         ^
-Error: This value is "aliased" but is expected to be "unique".
+Error: This value is "aliased"
+         because it is used in a pattern match with effect cases (at lines 2-4, characters 2-44).
+       However, the highlighted expression is expected to be "unique".
 |}]
 
 (* A continuation result cannot be a local reference escaping globally. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -76,7 +76,7 @@ Line 3, characters 9-10:
              ^
 Error: The value "r" is "local"
        but is expected to be "global"
-         because it is used in an expression (at lines 3-5, characters 2-40).
+         because it is used in a pattern match with effect cases (at lines 3-5, characters 2-40).
 |}]
 
 (* A value clause of [match] cannot capture a local from outside the generated
@@ -92,7 +92,7 @@ Line 4, characters 11-12:
                ^
 Error: The value "r" is "local"
        but is expected to be "global"
-         because it is used in an expression (at lines 3-5, characters 2-40).
+         because it is used in a pattern match with effect cases (at lines 3-5, characters 2-40).
 |}]
 
 (* An effect clause of [match] cannot capture a local from outside the generated
@@ -110,7 +110,7 @@ Line 6, characters 14-15:
                   ^
 Error: The value "r" is "local"
        but is expected to be "global"
-         because it is used in an expression (at lines 3-7, characters 2-19).
+         because it is used in a pattern match with effect cases (at lines 3-7, characters 2-19).
 |}]
 
 (* A [try] continuation result cannot be a local reference escaping globally. *)
@@ -136,7 +136,7 @@ Line 3, characters 7-8:
            ^
 Error: The value "r" is "local"
        but is expected to be "global"
-         because it is used in an expression (at lines 3-4, characters 2-40).
+         because it is used in a try-with with effect cases (at lines 3-4, characters 2-40).
 |}]
 
 (* An exception clause of [try] cannot capture a local from outside the
@@ -152,7 +152,7 @@ Line 4, characters 13-14:
                  ^
 Error: The value "r" is "local"
        but is expected to be "global"
-         because it is used in an expression (at lines 3-5, characters 2-40).
+         because it is used in a try-with with effect cases (at lines 3-5, characters 2-40).
 |}]
 
 (* An effect clause of [try] cannot capture a local from outside the generated
@@ -173,7 +173,7 @@ Line 9, characters 14-15:
                   ^
 Error: The value "r" is "local"
        but is expected to be "global"
-         because it is used in an expression (at lines 3-10, characters 2-19).
+         because it is used in a try-with with effect cases (at lines 3-10, characters 2-19).
 |}]
 
 (* A [match] body uses legacy modes instead of inheriting an enclosing local
@@ -285,6 +285,10 @@ let () =
          f
      | effect Need_unit, _ -> fun () -> ())
 [%%expect {|
+Line 6, characters 9-10:
+6 |          f
+             ^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 (* A [try] result must preserve an enclosing portable expectation while using
@@ -297,6 +301,10 @@ let () =
      with
      | effect Need_unit, _ -> fun () -> ())
 [%%expect {|
+Line 5, characters 7-8:
+5 |        f
+           ^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 (* Can allocate local values inside a [match] body. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -68,7 +68,12 @@ let _ =
   | n -> n
   | effect Need_unit, k -> continue k ()
 [%%expect {|
-- : int = 0
+Line 3, characters 9-10:
+3 |   match !r with
+             ^
+Error: The value "r" is "local"
+       but is expected to be "global"
+         because it is used in an expression (at lines 3-5, characters 2-40).
 |}]
 
 (* A value clause of [match] cannot capture a local from outside the generated
@@ -79,7 +84,12 @@ let _ =
   | () -> !r
   | effect Need_unit, k -> continue k ()
 [%%expect {|
-- : int = 0
+Line 4, characters 11-12:
+4 |   | () -> !r
+               ^
+Error: The value "r" is "local"
+       but is expected to be "global"
+         because it is used in an expression (at lines 3-5, characters 2-40).
 |}]
 
 (* An effect clause of [match] cannot capture a local from outside the generated
@@ -92,7 +102,12 @@ let _ =
       ignore !r;
       continue k ()
 [%%expect {|
-- : unit = ()
+Line 6, characters 14-15:
+6 |       ignore !r;
+                  ^
+Error: The value "r" is "local"
+       but is expected to be "global"
+         because it is used in an expression (at lines 3-7, characters 2-19).
 |}]
 
 (* A [try] continuation result cannot be a local reference escaping globally. *)
@@ -113,7 +128,12 @@ let _ =
   try !r with
   | effect Need_unit, k -> continue k ()
 [%%expect {|
-- : int = 0
+Line 3, characters 7-8:
+3 |   try !r with
+           ^
+Error: The value "r" is "local"
+       but is expected to be "global"
+         because it is used in an expression (at lines 3-4, characters 2-40).
 |}]
 
 (* An exception clause of [try] cannot capture a local from outside the
@@ -124,7 +144,12 @@ let _ =
   | Exit -> !r
   | effect Need_unit, k -> continue k ()
 [%%expect {|
-- : int = 0
+Line 4, characters 13-14:
+4 |   | Exit -> !r
+                 ^
+Error: The value "r" is "local"
+       but is expected to be "global"
+         because it is used in an expression (at lines 3-5, characters 2-40).
 |}]
 
 (* An effect clause of [try] cannot capture a local from outside the generated
@@ -140,7 +165,12 @@ let _ =
       ignore !r;
       continue k ()
 [%%expect {|
-- : int = 0
+Line 9, characters 14-15:
+9 |       ignore !r;
+                  ^
+Error: The value "r" is "local"
+       but is expected to be "global"
+         because it is used in an expression (at lines 3-10, characters 2-19).
 |}]
 
 (* Can allocate local values inside a [match] body. *)

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -1,0 +1,262 @@
+(* TEST
+  expect;
+*)
+
+open Effect
+open Effect.Deep
+
+let use_unique : 'a @ unique -> unit = fun _ -> ()
+
+type _ eff += Need_ref : int ref eff
+
+type _ eff += Need_unit : unit eff
+
+type _ eff += Payload : int ref -> unit eff
+[%%expect {|
+val use_unique : 'a @ unique -> unit = <fun>
+type _ eff += Need_ref : int ref eff
+type _ eff += Need_unit : unit eff
+type _ eff += Payload : int ref -> unit eff
+|}]
+
+(* A result returned by [perform] is aliased, not unique. *)
+let () =
+  match perform Need_ref with
+  | r -> use_unique r
+  | effect Need_ref, k -> continue k (ref 0)
+[%%expect {|
+Line 3, characters 20-21:
+3 |   | r -> use_unique r
+                        ^
+Error: This value is "aliased" but is expected to be "unique".
+|}]
+
+(* A continuation result cannot be a local reference escaping globally. *)
+let _ =
+  match perform Need_ref with
+  | r -> ignore !r
+  | effect Need_ref, k -> continue k (stack_ (ref 0))
+[%%expect {|
+Line 4, characters 37-53:
+4 |   | effect Need_ref, k -> continue k (stack_ (ref 0))
+                                         ^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* A payload captured by an effect pattern is aliased, not unique. *)
+let () =
+  match perform (Payload (ref 0)) with
+  | () -> ()
+  | effect (Payload x), k ->
+      use_unique x;
+      continue k ()
+[%%expect {|
+Line 5, characters 17-18:
+5 |       use_unique x;
+                     ^
+Error: This value is "aliased"
+         because it is contained (via constructor "Payload") in the value at line 4, characters 11-22
+         which is "aliased".
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+(* The handled expression of [match] cannot capture a local from outside the
+   generated handler boundary. *)
+let _ =
+  let (r @ local) = ref 0 in
+  match !r with
+  | n -> n
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+- : int = 0
+|}]
+
+(* A value clause of [match] cannot capture a local from outside the generated
+   handler boundary. *)
+let _ =
+  let (r @ local) = ref 0 in
+  match perform Need_unit with
+  | () -> !r
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+- : int = 0
+|}]
+
+(* An effect clause of [match] cannot capture a local from outside the generated
+   handler boundary. *)
+let _ =
+  let (r @ local) = ref 0 in
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k ->
+      ignore !r;
+      continue k ()
+[%%expect {|
+- : unit = ()
+|}]
+
+(* A [try] continuation result cannot be a local reference escaping globally. *)
+let _ =
+  try perform Need_ref with
+  | effect Need_ref, k -> continue k (stack_ (ref 0))
+[%%expect {|
+Line 3, characters 37-53:
+3 |   | effect Need_ref, k -> continue k (stack_ (ref 0))
+                                         ^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* The body of [try] cannot capture a local from outside the generated handler
+   boundary. *)
+let _ =
+  let (r @ local) = ref 0 in
+  try !r with
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+- : int = 0
+|}]
+
+(* An exception clause of [try] cannot capture a local from outside the
+   generated handler boundary. *)
+let _ =
+  let (r @ local) = ref 0 in
+  try raise Exit with
+  | Exit -> !r
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+- : int = 0
+|}]
+
+(* An effect clause of [try] cannot capture a local from outside the generated
+   handler boundary. *)
+let _ =
+  let (r @ local) = ref 0 in
+  try
+    perform Need_unit;
+    0
+  with
+  | Exit -> 0
+  | effect Need_unit, k ->
+      ignore !r;
+      continue k ()
+[%%expect {|
+- : int = 0
+|}]
+
+(* Can allocate local values inside a [match] body. *)
+let match_body_internal_local () =
+  match
+    let (r @ local) = ref 0 in
+    !r
+  with
+  | n -> n
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+val match_body_internal_local : unit -> int = <fun>
+|}]
+
+(* Can allocate local values inside a [try] body. *)
+let try_body_internal_local () =
+  try
+    let (r @ local) = ref 1 in
+    !r
+  with
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+val try_body_internal_local : unit -> int = <fun>
+|}]
+
+(* Can allocate local values inside a [match] value clause. *)
+let match_value_clause_internal_local () =
+  match 2 with
+  | n ->
+      let (r @ local) = ref n in
+      !r
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+val match_value_clause_internal_local : unit -> int = <fun>
+|}]
+
+(* Can allocate local values inside a [match] effect clause. *)
+let match_effect_clause_internal_local () =
+  match perform Need_unit with
+  | () -> 0
+  | effect Need_unit, k ->
+      let (r @ local) = ref 3 in
+      ignore !r;
+      continue k ()
+[%%expect {|
+val match_effect_clause_internal_local : unit -> int = <fun>
+|}]
+
+(* Can allocate local values inside a [try] exception clause. *)
+let try_exception_clause_internal_local () =
+  try raise Exit with
+  | Exit ->
+      let (r @ local) = ref 4 in
+      !r
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+val try_exception_clause_internal_local : unit -> int = <fun>
+|}]
+
+(* Can allocate local values inside a [try] effect clause. *)
+let try_effect_clause_internal_local () =
+  try
+    perform Need_unit;
+    0
+  with
+  | Exit -> 0
+  | effect Need_unit, k ->
+      let (r @ local) = ref 5 in
+      ignore !r;
+      continue k ()
+[%%expect {|
+val try_effect_clause_internal_local : unit -> int = <fun>
+|}]
+
+(* A global value may be used in a handled [match] body. *)
+let match_body_global_capture () =
+  let r = ref 6 in
+  match !r with
+  | n -> n
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+val match_body_global_capture : unit -> int = <fun>
+|}]
+
+(* A global value may be used in handled [match] clauses. *)
+let match_handler_global_capture () =
+  let r = ref 7 in
+  match perform Need_unit with
+  | () -> !r
+  | effect Need_unit, k ->
+      ignore !r;
+      continue k ()
+[%%expect {|
+val match_handler_global_capture : unit -> int = <fun>
+|}]
+
+(* A global value may be used in a handled [try] body. *)
+let try_body_global_capture () =
+  let r = ref 8 in
+  try !r with
+  | effect Need_unit, k -> continue k ()
+[%%expect {|
+val try_body_global_capture : unit -> int = <fun>
+|}]
+
+(* A global value may be used in handled [try] clauses. *)
+let try_handler_global_capture () =
+  let r = ref 9 in
+  try
+    perform Need_unit;
+    0
+  with
+  | Exit -> !r
+  | effect Need_unit, k ->
+      ignore !r;
+      continue k ()
+[%%expect {|
+val try_handler_global_capture : unit -> int = <fun>
+|}]

--- a/testsuite/tests/typing-local/effects.ml
+++ b/testsuite/tests/typing-local/effects.ml
@@ -205,10 +205,60 @@ let g1 () = assert (g1' () = 123)
 
 (* ------------------------------------------------------------------------ *)
 
+type _ Effect.t += Eff_syntax : int t
+exception Exn_syntax
+
+let[@inline never] effect_syntax_value_case () =
+  let result =
+    match perform Eff_syntax with
+    | x ->
+      let r = opaque (local_ ref x) in
+      !r
+    | effect Eff_syntax, k -> continue k 42
+  in
+  assert (result = 42)
+
+let[@inline never] effect_syntax_exception_case () =
+  let result =
+    try raise Exn_syntax with
+    | Exn_syntax ->
+      let r = opaque (local_ ref 42) in
+      !r
+    | effect Eff_syntax, _ -> 0
+  in
+  assert (result = 42)
+
+let[@inline never] effect_syntax_effect_case () =
+  let result =
+    match perform Eff_syntax with
+    | x -> x
+    | effect Eff_syntax, k ->
+      let r = opaque (local_ ref 41) in
+      continue k (!r + 1)
+  in
+  assert (result = 42)
+
+let[@inline never] effect_syntax_body () =
+  let result =
+    match
+      let r = opaque (local_ ref 1) in
+      perform Eff_syntax + !r
+    with
+    | x -> x
+    | effect Eff_syntax, _ -> 42
+  in
+  assert (result = 42)
+
+(* ------------------------------------------------------------------------ *)
+
 let () =
   print_endline "f1"; f1 ();
   print_endline "f2"; f2 ();
   print_endline "f3"; f3 ();
   print_endline "f4"; f4 ();
   print_endline "f5"; f5 ();
-  print_endline "g1"; g1 ()
+  print_endline "g1"; g1 ();
+  effect_syntax_value_case ();
+  effect_syntax_exception_case ();
+  effect_syntax_effect_case ();
+  effect_syntax_body ()

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2062,6 +2062,10 @@ module Report = struct
     | Functor -> Some (print_article_noun Consonant "functor")
     | Lazy -> Some (print_article_noun Consonant "lazy expression")
     | Expression -> Some (print_article_noun Vowel "expression")
+    | Effect_match ->
+      Some (print_article_noun Consonant "pattern match with effect cases")
+    | Effect_try ->
+      Some (print_article_noun Consonant "try-with with effect cases")
     | Allocation -> Some (print_article_noun Vowel "allocation")
     | Class -> Some (print_article_noun Consonant "class")
     | Object -> Some (print_article_noun Vowel "object")

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -35,6 +35,8 @@ type pinpoint_desc =
   | Lazy  (** A lazy expression *)
   | Allocation  (** An allocation *)
   | Expression  (** An arbitrary expression *)
+  | Effect_match  (** A pattern match with effect cases *)
+  | Effect_try  (** A try-with expression with effect cases *)
   | Class  (** A class declaration *)
   | Object  (** An object declaration *)
   | Loop  (** A loop *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6757,7 +6757,6 @@ and type_expect_
       in
       if val_caselist = [] && eff_caselist <> [] then
         raise (Error (loc, env, No_value_clauses));
-      let exp_env = env in
       let env, arg_pat_mode, arg_expected_mode, expected_mode =
         match eff_caselist with
         | [] ->
@@ -6800,8 +6799,8 @@ and type_expect_
         match eff_caselist with
         | [] -> []
         | eff_caselist ->
-            type_effect_cases Value env expected_mode ty_expected_explained
-              loc eff_caselist eff_conts
+            type_effect_cases Value env expected_mode ty_expected_explained loc
+              eff_caselist eff_conts
       in
       if
         List.for_all (fun c -> pattern_needs_partial_application_check c.c_lhs)
@@ -6812,7 +6811,7 @@ and type_expect_
         exp_loc = loc; exp_extra;
         exp_type = instance ty_expected;
         exp_attributes = sexp.pexp_attributes;
-        exp_env }
+        exp_env = env }
   | Pexp_try(sbody, caselist) ->
       check_dynamic (loc, Expression) (Always_dynamic Try_with) expected_mode;
       let arg_mode = simple_pat_mode Value.legacy in
@@ -6827,7 +6826,6 @@ and type_expect_
       let exn_caselist, eff_caselist, eff_conts =
         split_cases [] [] [] caselist
       in
-      let exp_env = env in
       let env, body_mode, expected_mode =
         match eff_caselist with
         | [] -> env, mode_trywith expected_mode, expected_mode
@@ -6850,15 +6848,15 @@ and type_expect_
         match eff_caselist with
         | [] -> []
         | eff_caselist ->
-            type_effect_cases Value env expected_mode ty_expected_explained
-              loc eff_caselist eff_conts
+            type_effect_cases Value env expected_mode ty_expected_explained loc
+              eff_caselist eff_conts
       in
       re {
         exp_desc = Texp_try(body, exn_cases, eff_cases);
         exp_loc = loc; exp_extra = [];
         exp_type = body.exp_type;
         exp_attributes = sexp.pexp_attributes;
-        exp_env }
+        exp_env = env }
   | Pexp_tuple sexpl ->
       type_tuple ~overwrite ~loc ~env ~expected_mode ~ty_expected ~explanation
         ~attributes:sexp.pexp_attributes sexpl

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -661,14 +661,25 @@ let mode_trywith expected_mode =
 
 (* Effect syntax lowers each handled computation and handler RHS into a
    generated function body wrapped with [maybe_region_layout]. Type those
-   expressions as tails of the generated handler functions' regions. *)
+   expressions as tails of the generated handler functions' regions, while
+   preserving outer expectations that are stricter than legacy modes. *)
 let mode_effect_handler_body expected_mode =
+  let expected_mode =
+    mode_coerce (Value.of_const Value.Const.legacy) expected_mode
+  in
   let mode = as_single_mode expected_mode in
   { expected_mode with
     position =
       RTail
         ( Regionality.disallow_left (Value.proj_comonadic Areality mode),
           FTail ) }
+
+let effect_handler_modes loc pinpoint env expected_mode =
+  let env =
+    Env.add_const_closure_lock (loc, pinpoint) Value.Comonadic.Const.legacy env
+  in
+  env, mode_effect_handler_body mode_legacy,
+  mode_effect_handler_body expected_mode
 
 let mode_tuple mode tuple_modes =
   let tuple_modes =
@@ -6741,7 +6752,8 @@ and type_expect_
       in
       if val_caselist = [] && eff_caselist <> [] then
         raise (Error (loc, env, No_value_clauses));
-      let handler_env, arg_pat_mode, arg_expected_mode, rhs_mode =
+      let exp_env = env in
+      let env, arg_pat_mode, arg_expected_mode, expected_mode =
         match eff_caselist with
         | [] ->
           let arg_pat_mode, arg_expected_mode =
@@ -6757,40 +6769,32 @@ and type_expect_
           in
           env, arg_pat_mode, arg_expected_mode, expected_mode
         | _ :: _ ->
-          (* In [match f () with | effect ...], [f ()] is the handled
-             computation. It is compiled into the generated handler body
-             function, so reject captures across the handler boundary here,
-             not just inside the effect arms. *)
-          let handler_env =
-            Env.add_const_closure_lock (loc, Expression)
-              Value.Comonadic.Const.legacy env
+          let env, body_mode, expected_mode =
+            effect_handler_modes loc Effect_match env expected_mode
           in
-          handler_env,
-          simple_pat_mode Value.legacy,
-          mode_effect_handler_body mode_legacy,
-          mode_effect_handler_body mode_legacy
+          env, simple_pat_mode Value.legacy, body_mode, expected_mode
       in
       let arg, sort =
         with_local_level_generalize begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect handler_env arg_expected_mode sarg
+            type_expect env arg_expected_mode sarg
               (mk_expected expected_ty)
           in
           arg, sort
         end ~before_generalize:(fun (arg, _) ->
-          may_lower_contravariant handler_env arg;
+          may_lower_contravariant env arg;
           generalize arg.exp_type)
       in
       let val_cases, partial =
-        type_cases Computation handler_env arg_pat_mode rhs_mode arg.exp_type
+        type_cases Computation env arg_pat_mode expected_mode arg.exp_type
           sort ty_expected_explained ~check_if_total:true loc val_caselist
       in
       let eff_cases =
         match eff_caselist with
         | [] -> []
         | eff_caselist ->
-            type_effect_cases Value handler_env rhs_mode ty_expected_explained
+            type_effect_cases Value env expected_mode ty_expected_explained
               loc eff_caselist eff_conts
       in
       if
@@ -6802,7 +6806,7 @@ and type_expect_
         exp_loc = loc; exp_extra;
         exp_type = instance ty_expected;
         exp_attributes = sexp.pexp_attributes;
-        exp_env = env }
+        exp_env }
   | Pexp_try(sbody, caselist) ->
       check_dynamic (loc, Expression) (Always_dynamic Try_with) expected_mode;
       let arg_mode = simple_pat_mode Value.legacy in
@@ -6817,23 +6821,21 @@ and type_expect_
       let exn_caselist, eff_caselist, eff_conts =
         split_cases [] [] [] caselist
       in
-      let handler_env, body_mode, rhs_mode =
+      let exp_env = env in
+      let env, body_mode, expected_mode =
         match eff_caselist with
         | [] -> env, mode_trywith expected_mode, expected_mode
         | _ :: _ ->
-          let handler_env =
-            Env.add_const_closure_lock (loc, Expression)
-              Value.Comonadic.Const.legacy env
+          let env, _, expected_mode =
+            effect_handler_modes loc Effect_try env expected_mode
           in
-          handler_env,
-          mode_effect_handler_body mode_legacy,
-          mode_effect_handler_body mode_legacy
+          env, expected_mode, expected_mode
       in
       let body =
-        type_expect handler_env body_mode sbody ty_expected_explained
+        type_expect env body_mode sbody ty_expected_explained
       in
       let exn_cases, _ =
-        type_cases Value handler_env arg_mode rhs_mode
+        type_cases Value env arg_mode expected_mode
           Predef.type_exn Jkind.Sort.(of_const Const.for_exception)
           ty_expected_explained
           ~check_if_total:false loc exn_caselist
@@ -6842,7 +6844,7 @@ and type_expect_
         match eff_caselist with
         | [] -> []
         | eff_caselist ->
-            type_effect_cases Value handler_env rhs_mode ty_expected_explained
+            type_effect_cases Value env expected_mode ty_expected_explained
               loc eff_caselist eff_conts
       in
       re {
@@ -6850,7 +6852,7 @@ and type_expect_
         exp_loc = loc; exp_extra = [];
         exp_type = body.exp_type;
         exp_attributes = sexp.pexp_attributes;
-        exp_env = env }
+        exp_env }
   | Pexp_tuple sexpl ->
       type_tuple ~overwrite ~loc ~env ~expected_mode ~ty_expected ~explanation
         ~attributes:sexp.pexp_attributes sexpl

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -744,11 +744,6 @@ type expected_pat_mode =
 let simple_pat_mode mode =
   { mode = Value.disallow_right mode; tuple_modes = None }
 
-let effect_handler_pat_mode loc pinpoint =
-  Value.of_const ~hint_monadic:(Is_used_in (loc, pinpoint))
-    Value.Const.legacy
-  |> simple_pat_mode
-
 let tuple_pat_mode mode tuple_modes =
   let mode = Value.disallow_right mode in
   let tuple_modes = Some (Value.List.disallow_right tuple_modes) in
@@ -6776,8 +6771,7 @@ and type_expect_
           let env, body_mode, expected_mode =
             effect_handler_modes loc Effect_match env expected_mode
           in
-          env, effect_handler_pat_mode loc Effect_match, body_mode,
-          expected_mode
+          env, simple_pat_mode Value.legacy, body_mode, expected_mode
       in
       let arg, sort =
         with_local_level_generalize begin fun () ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6741,20 +6741,21 @@ and type_expect_
       in
       if val_caselist = [] && eff_caselist <> [] then
         raise (Error (loc, env, No_value_clauses));
-      let arg_pat_mode, arg_expected_mode =
-        match cases_tuple_arity caselist with
-        | Not_local_tuple | Maybe_local_tuple ->
-          let mode = Value.newvar () in
-          simple_pat_mode mode, mode_default mode
-        | Local_tuple locs ->
-          let modes = List.map (fun loc -> Value.newvar (), loc) locs in
-          let modes_pat = List.map fst modes in
-          let mode = Value.newvar () in
-          tuple_pat_mode mode modes_pat, mode_tuple mode modes
-      in
-      let handler_env, arg_expected_mode, rhs_mode =
+      let handler_env, arg_pat_mode, arg_expected_mode, rhs_mode =
         match eff_caselist with
-        | [] -> env, arg_expected_mode, expected_mode
+        | [] ->
+          let arg_pat_mode, arg_expected_mode =
+            match cases_tuple_arity caselist with
+            | Not_local_tuple | Maybe_local_tuple ->
+              let mode = Value.newvar () in
+              simple_pat_mode mode, mode_default mode
+            | Local_tuple locs ->
+              let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+              let modes_pat = List.map fst modes in
+              let mode = Value.newvar () in
+              tuple_pat_mode mode modes_pat, mode_tuple mode modes
+          in
+          env, arg_pat_mode, arg_expected_mode, expected_mode
         | _ :: _ ->
           (* In [match f () with | effect ...], [f ()] is the handled
              computation. It is compiled into the generated handler body
@@ -6765,14 +6766,16 @@ and type_expect_
               Value.Comonadic.Const.legacy env
           in
           handler_env,
-          mode_effect_handler_body arg_expected_mode,
-          mode_effect_handler_body expected_mode
+          simple_pat_mode Value.legacy,
+          mode_effect_handler_body mode_legacy,
+          mode_effect_handler_body mode_legacy
       in
       let arg, sort =
         with_local_level_generalize begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect handler_env arg_expected_mode sarg (mk_expected expected_ty)
+            type_expect handler_env arg_expected_mode sarg
+              (mk_expected expected_ty)
           in
           arg, sort
         end ~before_generalize:(fun (arg, _) ->
@@ -6823,8 +6826,8 @@ and type_expect_
               Value.Comonadic.Const.legacy env
           in
           handler_env,
-          mode_effect_handler_body (mode_trywith expected_mode),
-          mode_effect_handler_body expected_mode
+          mode_effect_handler_body mode_legacy,
+          mode_effect_handler_body mode_legacy
       in
       let body =
         type_expect handler_env body_mode sbody ty_expected_explained

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -674,13 +674,6 @@ let mode_effect_handler_body expected_mode =
         ( Regionality.disallow_left (Value.proj_comonadic Areality mode),
           FTail ) }
 
-let effect_handler_modes loc pinpoint env expected_mode =
-  let env =
-    Env.add_const_closure_lock (loc, pinpoint) Value.Comonadic.Const.legacy env
-  in
-  env, mode_effect_handler_body mode_legacy,
-  mode_effect_handler_body expected_mode
-
 let mode_tuple mode tuple_modes =
   let tuple_modes =
     Some (List.map (fun (mode, loc) ->
@@ -748,6 +741,13 @@ let tuple_pat_mode mode tuple_modes =
   let mode = Value.disallow_right mode in
   let tuple_modes = Some (Value.List.disallow_right tuple_modes) in
   { mode; tuple_modes }
+
+let effect_handler_modes loc pinpoint env expected_mode =
+  let env =
+    Env.add_const_closure_lock (loc, pinpoint) Value.Comonadic.Const.legacy env
+  in
+  env, simple_pat_mode Value.legacy, mode_effect_handler_body mode_legacy,
+  mode_effect_handler_body expected_mode
 
 let global_pat_mode {mode; _}=
   let mode =
@@ -6768,10 +6768,7 @@ and type_expect_
           in
           env, arg_pat_mode, arg_expected_mode, expected_mode
         | _ :: _ ->
-          let env, body_mode, expected_mode =
-            effect_handler_modes loc Effect_match env expected_mode
-          in
-          env, simple_pat_mode Value.legacy, body_mode, expected_mode
+          effect_handler_modes loc Effect_match env expected_mode
       in
       let arg, sort =
         with_local_level_generalize begin fun () ->
@@ -6807,7 +6804,6 @@ and type_expect_
         exp_env = env }
   | Pexp_try(sbody, caselist) ->
       check_dynamic (loc, Expression) (Always_dynamic Try_with) expected_mode;
-      let arg_mode = simple_pat_mode Value.legacy in
       let rec split_cases exnc effc conts = function
         | [] -> List.rev exnc, List.rev effc, List.rev conts
         | {pc_lhs = {ppat_desc=Ppat_effect(p1, p2)}} as c :: rest ->
@@ -6819,14 +6815,16 @@ and type_expect_
       let exn_caselist, eff_caselist, eff_conts =
         split_cases [] [] [] caselist
       in
-      let env, body_mode, expected_mode =
+      let env, arg_mode, body_mode, expected_mode =
         match eff_caselist with
-        | [] -> env, mode_trywith expected_mode, expected_mode
+        | [] ->
+          env, simple_pat_mode Value.legacy, mode_trywith expected_mode,
+          expected_mode
         | _ :: _ ->
-          let env, _, expected_mode =
+          let env, arg_mode, _, expected_mode =
             effect_handler_modes loc Effect_try env expected_mode
           in
-          env, expected_mode, expected_mode
+          env, arg_mode, expected_mode, expected_mode
       in
       let body =
         type_expect env body_mode sbody ty_expected_explained

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -744,6 +744,11 @@ type expected_pat_mode =
 let simple_pat_mode mode =
   { mode = Value.disallow_right mode; tuple_modes = None }
 
+let effect_handler_pat_mode loc pinpoint =
+  Value.of_const ~hint_monadic:(Is_used_in (loc, pinpoint))
+    Value.Const.legacy
+  |> simple_pat_mode
+
 let tuple_pat_mode mode tuple_modes =
   let mode = Value.disallow_right mode in
   let tuple_modes = Some (Value.List.disallow_right tuple_modes) in
@@ -6772,7 +6777,8 @@ and type_expect_
           let env, body_mode, expected_mode =
             effect_handler_modes loc Effect_match env expected_mode
           in
-          env, simple_pat_mode Value.legacy, body_mode, expected_mode
+          env, effect_handler_pat_mode loc Effect_match, body_mode,
+          expected_mode
       in
       let arg, sort =
         with_local_level_generalize begin fun () ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6783,8 +6783,7 @@ and type_expect_
         with_local_level_generalize begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect env arg_expected_mode sarg
-              (mk_expected expected_ty)
+            type_expect env arg_expected_mode sarg (mk_expected expected_ty)
           in
           arg, sort
         end ~before_generalize:(fun (arg, _) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6772,8 +6772,7 @@ and type_expect_
         with_local_level_generalize begin fun () ->
           let expected_ty, sort = new_rep_var ~why:Match () in
           let arg =
-            type_expect handler_env arg_expected_mode sarg
-              (mk_expected expected_ty)
+            type_expect handler_env arg_expected_mode sarg (mk_expected expected_ty)
           in
           arg, sort
         end ~before_generalize:(fun (arg, _) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -659,6 +659,17 @@ let mode_partial_application expected_mode =
 let mode_trywith expected_mode =
   { expected_mode with position = RNontail }
 
+(* Effect syntax lowers each handled computation and handler RHS into a
+   generated function body wrapped with [maybe_region_layout]. Type those
+   expressions as tails of the generated handler functions' regions. *)
+let mode_effect_handler_body expected_mode =
+  let mode = as_single_mode expected_mode in
+  { expected_mode with
+    position =
+      RTail
+        ( Regionality.disallow_left (Value.proj_comonadic Areality mode),
+          FTail ) }
+
 let mode_tuple mode tuple_modes =
   let tuple_modes =
     Some (List.map (fun (mode, loc) ->
@@ -6717,28 +6728,6 @@ and type_expect_
       let env, expected_mode, exp_extra =
         enter_region_if is_bor ~region:(loc, Borrow) env expected_mode
       in
-      let arg_pat_mode, arg_expected_mode =
-        match cases_tuple_arity caselist with
-        | Not_local_tuple | Maybe_local_tuple ->
-          let mode = Value.newvar () in
-          simple_pat_mode mode, mode_default mode
-        | Local_tuple locs ->
-          let modes = List.map (fun loc -> Value.newvar (), loc) locs in
-          let modes_pat = List.map fst modes in
-          let mode = Value.newvar () in
-          tuple_pat_mode mode modes_pat, mode_tuple mode modes
-      in
-      let arg, sort =
-        with_local_level_generalize begin fun () ->
-          let expected_ty, sort = new_rep_var ~why:Match () in
-          let arg =
-            type_expect env arg_expected_mode sarg (mk_expected expected_ty)
-          in
-          arg, sort
-        end ~before_generalize:(fun (arg, _) ->
-          may_lower_contravariant env arg;
-          generalize arg.exp_type)
-      in
       let rec split_cases valc effc conts = function
         | [] -> List.rev valc, List.rev effc, List.rev conts
         | {pc_lhs = {ppat_desc=Ppat_effect(p1, p2)}} as c :: rest ->
@@ -6752,16 +6741,55 @@ and type_expect_
       in
       if val_caselist = [] && eff_caselist <> [] then
         raise (Error (loc, env, No_value_clauses));
+      let arg_pat_mode, arg_expected_mode =
+        match cases_tuple_arity caselist with
+        | Not_local_tuple | Maybe_local_tuple ->
+          let mode = Value.newvar () in
+          simple_pat_mode mode, mode_default mode
+        | Local_tuple locs ->
+          let modes = List.map (fun loc -> Value.newvar (), loc) locs in
+          let modes_pat = List.map fst modes in
+          let mode = Value.newvar () in
+          tuple_pat_mode mode modes_pat, mode_tuple mode modes
+      in
+      let handler_env, arg_expected_mode, rhs_mode =
+        match eff_caselist with
+        | [] -> env, arg_expected_mode, expected_mode
+        | _ :: _ ->
+          (* In [match f () with | effect ...], [f ()] is the handled
+             computation. It is compiled into the generated handler body
+             function, so reject captures across the handler boundary here,
+             not just inside the effect arms. *)
+          let handler_env =
+            Env.add_const_closure_lock (loc, Expression)
+              Value.Comonadic.Const.legacy env
+          in
+          handler_env,
+          mode_effect_handler_body arg_expected_mode,
+          mode_effect_handler_body expected_mode
+      in
+      let arg, sort =
+        with_local_level_generalize begin fun () ->
+          let expected_ty, sort = new_rep_var ~why:Match () in
+          let arg =
+            type_expect handler_env arg_expected_mode sarg
+              (mk_expected expected_ty)
+          in
+          arg, sort
+        end ~before_generalize:(fun (arg, _) ->
+          may_lower_contravariant handler_env arg;
+          generalize arg.exp_type)
+      in
       let val_cases, partial =
-        type_cases Computation env arg_pat_mode expected_mode arg.exp_type
+        type_cases Computation handler_env arg_pat_mode rhs_mode arg.exp_type
           sort ty_expected_explained ~check_if_total:true loc val_caselist
       in
       let eff_cases =
         match eff_caselist with
         | [] -> []
         | eff_caselist ->
-            type_effect_cases Value env expected_mode ty_expected_explained loc
-              eff_caselist eff_conts
+            type_effect_cases Value handler_env rhs_mode ty_expected_explained
+              loc eff_caselist eff_conts
       in
       if
         List.for_all (fun c -> pattern_needs_partial_application_check c.c_lhs)
@@ -6775,10 +6803,6 @@ and type_expect_
         exp_env = env }
   | Pexp_try(sbody, caselist) ->
       check_dynamic (loc, Expression) (Always_dynamic Try_with) expected_mode;
-      let body =
-        type_expect env (mode_trywith expected_mode)
-          sbody ty_expected_explained
-      in
       let arg_mode = simple_pat_mode Value.legacy in
       let rec split_cases exnc effc conts = function
         | [] -> List.rev exnc, List.rev effc, List.rev conts
@@ -6791,8 +6815,23 @@ and type_expect_
       let exn_caselist, eff_caselist, eff_conts =
         split_cases [] [] [] caselist
       in
+      let handler_env, body_mode, rhs_mode =
+        match eff_caselist with
+        | [] -> env, mode_trywith expected_mode, expected_mode
+        | _ :: _ ->
+          let handler_env =
+            Env.add_const_closure_lock (loc, Expression)
+              Value.Comonadic.Const.legacy env
+          in
+          handler_env,
+          mode_effect_handler_body (mode_trywith expected_mode),
+          mode_effect_handler_body expected_mode
+      in
+      let body =
+        type_expect handler_env body_mode sbody ty_expected_explained
+      in
       let exn_cases, _ =
-        type_cases Value env arg_mode expected_mode
+        type_cases Value handler_env arg_mode rhs_mode
           Predef.type_exn Jkind.Sort.(of_const Const.for_exception)
           ty_expected_explained
           ~check_if_total:false loc exn_caselist
@@ -6801,8 +6840,8 @@ and type_expect_
         match eff_caselist with
         | [] -> []
         | eff_caselist ->
-            type_effect_cases Value env expected_mode ty_expected_explained loc
-              eff_caselist eff_conts
+            type_effect_cases Value handler_env rhs_mode ty_expected_explained
+              loc eff_caselist eff_conts
       in
       re {
         exp_desc = Texp_try(body, exn_cases, eff_cases);

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2416,7 +2416,8 @@ let rec check_uniqueness_exp_desc ~borrows ~overwrite (ienv : Ienv.t) ~loc :
   | Texp_match (arg, _, cases, eff_cases, _) ->
     let value, uf_arg = check_uniqueness_exp_for_match ienv arg in
     let uf_cases = check_uniqueness_comp_cases ienv value cases in
-    let uf_eff_cases = check_uniqueness_cases ienv value eff_cases in
+    let effect_value = Match_single Paths.untracked in
+    let uf_eff_cases = check_uniqueness_cases ienv effect_value eff_cases in
     (* CR rtjoa for zqian: uncertain whether this is sound *)
     (* Effects can be run multiple times - for uniqueness, this is equivalent to
        twice - and can also be run when the non-effect case is run. *)
@@ -2426,7 +2427,8 @@ let rec check_uniqueness_exp_desc ~borrows ~overwrite (ienv : Ienv.t) ~loc :
     let uf_body = check_uniqueness_exp ~overwrite:None ienv body in
     let value = Match_single (Paths.fresh ()) in
     let uf_cases = check_uniqueness_cases ienv value cases in
-    let uf_eff_cases = check_uniqueness_cases ienv value eff_cases in
+    let effect_value = Match_single Paths.untracked in
+    let uf_eff_cases = check_uniqueness_cases ienv effect_value eff_cases in
     (* CR rtjoa for zqian: uncertain whether this is sound *)
     (* Effects can be run multiple times - for uniqueness, this is equivalent to
        twice - and can also be run when the non-effect case is run. *)


### PR DESCRIPTION
Fix typechecking of effects, based on https://github.com/oxcaml/oxcaml/pull/5880 and a discussion with Zesen. The last two commits add tests demonstrating issues and fix them.