### PR TITLE
Remove sorts from Record_boxed

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2390,7 +2390,7 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
       let sem = add_barrier_to_read ubr sem in
       let access, sort, layout =
         match lbl.lbl_repres with
-        | Record_boxed _
+        | Record_boxed
         | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
             Lprim (Pfield (lbl.lbl_pos, ptr, sem), [ arg ], loc),
             lbl.lbl_sort, lbl_layout

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -315,7 +315,7 @@ let print_bigarray name unsafe kind ppf layout =
 
 let record_rep ppf r = match r with
   | Record_unboxed -> fprintf ppf "unboxed"
-  | Record_boxed _ -> fprintf ppf "boxed"
+  | Record_boxed -> fprintf ppf "boxed"
   | Record_inlined _ -> fprintf ppf "inlined"
   | Record_float -> fprintf ppf "float"
   | Record_ufloat -> fprintf ppf "ufloat"

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -48,7 +48,7 @@ let layout_pat sort p = layout p.pat_env p.pat_loc sort p.pat_type
 
 let field_offset_for_label lbl =
   match lbl.lbl_repres with
-  | Record_boxed _
+  | Record_boxed
   | Record_inlined (_, Constructor_uniform_value, Variant_boxed _)
   | Record_inlined (_, Constructor_uniform_value, Variant_with_null) ->
       lbl.lbl_pos
@@ -696,7 +696,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let sem = add_barrier_to_read (transl_unique_barrier ubr) sem in
       let prim_and_args =
         match lbl.lbl_repres with
-          Record_boxed _
+          Record_boxed
         | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
           let immediate_or_pointer, _ = maybe_pointer e in
           if Types.is_atomic lbl.lbl_mut
@@ -796,7 +796,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let newval_lambda = transl_exp ~scopes lbl.lbl_sort newval in
       let prim, args =
         match lbl.lbl_repres with
-          Record_boxed _
+          Record_boxed
         | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
           let immediate_or_pointer, _ = maybe_pointer newval in
           if Types.is_atomic lbl.lbl_mut
@@ -2100,7 +2100,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       | Overridden (_lid, expr) ->
           let upd =
             match repres with
-              Record_boxed _
+              Record_boxed
             | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
                 let ptr, _ = maybe_pointer expr in
                 Psetfield(lbl.lbl_pos, ptr, Assignment modify_heap)
@@ -2170,7 +2170,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                let sem = add_barrier_to_read unique_barrier sem in
                let access =
                  match repres with
-                   Record_boxed _
+                   Record_boxed
                  | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
                    let ptr, _ = maybe_pointer_type env typ in
                    Pfield (i, ptr, sem)
@@ -2232,7 +2232,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         if mut = Mutable then raise Not_constant;
         let cl = List.map extract_constant ll in
         match repres with
-        | Record_boxed _ -> Lconst(Const_block(0, cl))
+        | Record_boxed -> Lconst(Const_block(0, cl))
         | Record_inlined (Ordinary {runtime_tag},
                           Constructor_uniform_value, Variant_boxed _) ->
             Lconst(Const_block(runtime_tag, cl))
@@ -2275,7 +2275,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       with Not_constant ->
         let loc = of_location ~scopes loc in
         match repres with
-          Record_boxed _ ->
+          Record_boxed ->
             let shape = List.map must_be_value shape in
             Lprim(Pmakeblock(0, mut,
                              Lambda.block_shape_of_value_kinds (Some shape),
@@ -2342,7 +2342,7 @@ and transl_atomic_loc ~scopes arg arg_sort lbl =
     ->
       (* Atomic fields not allowed here *)
       Misc.fatal_error "Bad lbl_repres for label of atomic_loc"
-  | Record_boxed _
+  | Record_boxed
   | Record_inlined (_, _, ( Variant_boxed _
                           | Variant_extensible
                           | Variant_with_null))
@@ -2422,7 +2422,7 @@ and transl_idx ~scopes loc env ba uas =
     end
   | Baccess_field (_id, lbl) ->
     begin match lbl.lbl_repres with
-    | Record_boxed _
+    | Record_boxed
     | Record_float | Record_ufloat ->
       (* Assert that all unboxed fields are of singleton records *)
       List.iter

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -243,7 +243,7 @@ let compute_static_size lam =
 
     | Pduprecord (repres, size) ->
         begin match repres with
-        | Record_boxed _
+        | Record_boxed
         | Record_inlined (_, Constructor_uniform_value,
                           (Variant_boxed _ | Variant_extensible)) ->
             Block (Regular_block size)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2092,7 +2092,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Pduprecord (repr, num_fields), [[arg]] ->
     let kind : P.Duplicate_block_kind.t =
       match repr with
-      | Record_boxed _ ->
+      | Record_boxed ->
         Values
           { tag = Tag.Scannable.zero;
             length = Target_ocaml_int.of_int machine_width num_fields

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -561,7 +561,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                                             Variant_unboxed)
                           | Record_unboxed
                               -> Outval_record_unboxed
-                          | Record_boxed _ | Record_float | Record_ufloat
+                          | Record_boxed | Record_float | Record_ufloat
                           | Record_inlined (_, Constructor_uniform_value, _)
                               -> Outval_record_boxed
                           | Record_inlined (_, Constructor_mixed mixed, _)

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1024,7 +1024,7 @@ module Record_diffing = struct
         | _, Record_mixed _ ->
            Some (Record_mismatch (Mixed_representation Second))
 
-        | Record_boxed _, Record_boxed _ -> None
+        | Record_boxed, Record_boxed -> None
         end
       | Unboxed_product ->
         begin match rep1, rep2 with

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -717,11 +717,7 @@ let build_initial_env add_type add_extension add_jkind empty_env =
            ("pos_bol", type_int);
            ("pos_cnum", type_int) ]
          in
-         Type_record (
-           labels,
-           (Record_boxed (List.map (fun label -> label.ld_sort) labels |> Array.of_list)),
-           None
-         )
+         Type_record (labels, Record_boxed, None)
        )
        (* Fields are [int] and [string], so [immutable_data] already captures
           their direct contribution. Encoding this directly avoids predef-time

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -243,8 +243,8 @@ let mixed_block_element i ppf mixed_block_element =
 let record_representation i ppf = let open Types in function
   | Record_unboxed ->
     line i ppf "Record_unboxed\n"
-  | Record_boxed sorts ->
-    line i ppf "Record_boxed %a\n" (sort_array i) sorts
+  | Record_boxed ->
+    line i ppf "Record_boxed\n"
   | Record_inlined (t, _c, v) ->
     line i ppf "Record_inlined (%a, %a)\n" tag t (variant_representation i) v
   | Record_float -> line i ppf "Record_float\n"

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -563,7 +563,7 @@ module Type_decl_shape = struct
           (* CR sspies: These variants are not yet supported. *)
         | Type_record (lbl_list, record_repr, _unsafe_mode_crossing) -> (
           match record_repr with
-          | Record_boxed _ ->
+          | Record_boxed ->
             record_of_labels ~shape_for_constr ~type_subst Record_boxed lbl_list
           | Record_mixed fields ->
             record_of_labels ~shape_for_constr ~type_subst

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2489,7 +2489,7 @@ module Label = NameChoice (struct
     Env.lookup_all_labels_from_type ~record_form:Legacy ~loc usage path env
   let in_env lbl =
     match lbl.lbl_repres with
-    | Record_boxed _ | Record_float | Record_ufloat | Record_unboxed
+    | Record_boxed | Record_float | Record_ufloat | Record_unboxed
     | Record_mixed _ -> true
     | Record_inlined _ -> false
 end)
@@ -6138,7 +6138,7 @@ and type_expect_
           | Record_unboxed
           | Record_inlined (_, _, (Variant_unboxed | Variant_with_null))
             -> false
-          | Record_boxed _ | Record_float | Record_ufloat | Record_mixed _
+          | Record_boxed | Record_float | Record_ufloat | Record_mixed _
           | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
             -> true
         end
@@ -8069,7 +8069,7 @@ and type_block_access env expected_base_ty principal
           to [float#] here because it could be a singleton unboxed record
           containing a float, and thus be followed by an unboxed access *)
       match label.lbl_repres with
-      | Record_boxed _ -> false
+      | Record_boxed -> false
       | Record_mixed mixed ->
         begin match mixed.(label.lbl_pos) with
         | Float_boxed -> true

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1115,7 +1115,7 @@ let transl_declaration env sdecl (id, uid) =
                correct representation is [Record_float], [Record_ufloat], or
                [Record_mixed].  Those cases are fixed up after we can get
                accurate sorts for the fields, in [update_decl_jkind]. *)
-              Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
+              Record_boxed,
               Jkind.for_non_float ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
@@ -1283,12 +1283,12 @@ let rec shape_has_float_boxed shape =
 
 let record_has_float_boxed = function
   | Record_mixed shape -> shape_has_float_boxed shape
-  | Record_unboxed | Record_inlined _ | Record_boxed _
+  | Record_unboxed | Record_inlined _ | Record_boxed
   | Record_float | Record_ufloat -> false
 
 let record_gets_unboxed_version = function
   | Record_unboxed | Record_inlined _ | Record_float | Record_ufloat -> false
-  | Record_boxed _ -> true
+  | Record_boxed -> true
   | Record_mixed shape -> not (shape_has_float_boxed shape)
 let gets_unboxed_version decl =
   (* This must be kept in sync with the match in [derive_unboxed_version] *)
@@ -1749,23 +1749,15 @@ let check_abbrev env sdecl (id, decl) =
 (* [update_label_sorts] additionally returns whether all the jkinds
    were void, and the jkinds of the labels *)
 (* CR reisenberg: remove all_void return *)
-let update_label_sorts env loc lbls named =
-  (* [named] is [Some sorts] for top-level records (we will update the
-     sorts) and [None] for inlined records. *)
+let update_label_sorts env loc lbls =
   (* CR layouts v5: it wouldn't be too hard to support records that are all
      void.  just needs a bit of refactoring in translcore *)
-  let update =
-    match named with
-    | None -> fun _ _ -> ()
-    | Some sorts -> fun idx sort -> sorts.(idx) <- sort
-  in
   let lbls_and_jkinds =
-    List.mapi (fun idx (Types.{ld_type} as lbl) ->
+    List.map (fun (Types.{ld_type} as lbl) ->
       let jkind = Ctype.type_jkind env ld_type in
       (* Next line guaranteed to be safe because of [check_representable] *)
       let sort = Jkind.sort_of_jkind env jkind in
       let ld_sort = Jkind.Sort.default_to_scannable_and_get sort in
-      update idx ld_sort;
       {lbl with ld_sort}, jkind
     ) lbls
   in
@@ -1802,9 +1794,7 @@ let update_constructor_arguments_sorts env loc cd_args sorts =
       (fun { ca_sort } -> Jkind_types.Sort.Const.(all_void ca_sort)) args,
     jkinds
   | Types.Cstr_record lbls ->
-    let lbls, all_void, jkinds =
-      update_label_sorts env loc lbls None
-    in
+    let lbls, all_void, jkinds = update_label_sorts env loc lbls in
     update 0 Jkind.Sort.Const.scannable;
     Types.Cstr_record lbls, all_void, jkinds
 
@@ -2062,10 +2052,8 @@ let rec update_decl_jkind env dpath decl =
       let sort = Jkind.sort_of_jkind env jkind in
       let ld_sort = Jkind.Sort.default_to_scannable_and_get sort in
       [{lbl with ld_sort}], Record_unboxed, jkind
-    | _, Record_boxed sorts ->
-      let lbls, _all_void, jkinds =
-        update_label_sorts env loc lbls (Some sorts)
-      in
+    | _, Record_boxed ->
+      let lbls, _all_void, jkinds = update_label_sorts env loc lbls in
       let jkind = Jkind.for_boxed_record lbls in
       let reprs =
         List.map2

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1746,9 +1746,7 @@ let check_abbrev env sdecl (id, decl) =
    including which fields of a record are void.  This would be hard to do during
    [transl_declaration] due to mutually recursive types.
 *)
-(* [update_label_sorts] additionally returns whether all the jkinds
-   were void, and the jkinds of the labels *)
-(* CR reisenberg: remove all_void return *)
+(* [update_label_sorts] additionally returns the jkinds of the labels *)
 let update_label_sorts env loc lbls =
   (* CR layouts v5: it wouldn't be too hard to support records that are all
      void.  just needs a bit of refactoring in translcore *)
@@ -1764,8 +1762,7 @@ let update_label_sorts env loc lbls =
   let lbls, jkinds = List.split lbls_and_jkinds in
   if List.for_all (fun l -> Jkind.Sort.Const.all_void l.ld_sort) lbls then
     raise (Error (loc, Jkind_empty_record))
-  else lbls, false, jkinds
-(* CR layouts v5: return true for a record with all voids *)
+  else lbls, jkinds
 
 (* In addition to updated constructor arguments, returns whether
    all arguments are void, useful for detecting enumerations that
@@ -1794,9 +1791,9 @@ let update_constructor_arguments_sorts env loc cd_args sorts =
       (fun { ca_sort } -> Jkind_types.Sort.Const.(all_void ca_sort)) args,
     jkinds
   | Types.Cstr_record lbls ->
-    let lbls, all_void, jkinds = update_label_sorts env loc lbls in
+    let lbls, jkinds = update_label_sorts env loc lbls in
     update 0 Jkind.Sort.Const.scannable;
-    Types.Cstr_record lbls, all_void, jkinds
+    Types.Cstr_record lbls, false, jkinds
 
 let assert_mixed_product_support =
   let required_reserved_header_bits = 8 in
@@ -2053,7 +2050,7 @@ let rec update_decl_jkind env dpath decl =
       let ld_sort = Jkind.Sort.default_to_scannable_and_get sort in
       [{lbl with ld_sort}], Record_unboxed, jkind
     | _, Record_boxed ->
-      let lbls, _all_void, jkinds = update_label_sorts env loc lbls in
+      let lbls, jkinds = update_label_sorts env loc lbls in
       let jkind = Jkind.for_boxed_record lbls in
       let reprs =
         List.map2

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1019,7 +1019,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
     end
   | Record_inlined (_, _, Variant_with_null) -> assert false
   | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
-  | Record_boxed _ | Record_float | Record_ufloat | Record_mixed _ -> begin
+  | Record_boxed | Record_float | Record_ufloat | Record_mixed _ -> begin
       let is_mutable =
         List.exists (fun label -> Types.is_mutable label.Types.ld_mutable)
           labels
@@ -1033,7 +1033,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
               (* The outer match guards against this *)
               assert false
           | Record_inlined (_, Constructor_uniform_value, _)
-          | Record_boxed _ | Record_float | Record_ufloat ->
+          | Record_boxed | Record_float | Record_ufloat ->
               let num_nodes_visited, fields =
                 List.fold_left_map
                   (fun num_nodes_visited (label:Types.label_declaration) ->
@@ -1047,7 +1047,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
                       | Record_float | Record_ufloat ->
                         num_nodes_visited,
                         non_nullable (Pboxedfloatval Boxed_float64)
-                      | Record_inlined _ | Record_boxed _ ->
+                      | Record_inlined _ | Record_boxed ->
                           value_kind env ~loc ~visited ~depth ~num_nodes_visited
                             label.ld_type
                       | Record_mixed _ | Record_unboxed ->
@@ -1070,7 +1070,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
             [runtime_tag, fields]
           | Record_float | Record_ufloat ->
             [ Obj.double_array_tag, fields ]
-          | Record_boxed _ ->
+          | Record_boxed ->
             [0, fields]
           | Record_inlined (Extension _, _, _) ->
             [0, fields]

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -502,7 +502,7 @@ and module_representation = Jkind_types.Sort.t array
 and record_representation =
   | Record_unboxed
   | Record_inlined of tag * constructor_representation * variant_representation
-  | Record_boxed of Jkind_types.Sort.Const.t array
+  | Record_boxed
   | Record_float
   | Record_ufloat
   | Record_mixed of mixed_product_shape
@@ -961,15 +961,15 @@ let equal_record_representation_up_to_scannable_axes r1 r2 = match r1, r2 with
       ignore (cr2 : constructor_representation);
       equal_tag tag1 tag2 &&
         equal_variant_representation_up_to_scannable_axes vr1 vr2
-  | Record_boxed sorts1, Record_boxed sorts2 ->
-      Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal sorts1 sorts2
+  | Record_boxed, Record_boxed ->
+      true
   | Record_float, Record_float ->
       true
   | Record_ufloat, Record_ufloat ->
       true
   | Record_mixed mx1, Record_mixed mx2 ->
       equal_mixed_product_shape_up_to_scannable_axes mx1 mx2
-  | (Record_unboxed | Record_inlined _ | Record_boxed _ | Record_float
+  | (Record_unboxed | Record_inlined _ | Record_boxed | Record_float
     | Record_ufloat | Record_mixed _), _ ->
       false
 
@@ -1055,7 +1055,7 @@ let find_unboxed_type decl =
   | Type_variant ([{cd_args = Cstr_record [{ld_type = arg; ld_modalities = ms; _}]; _}], Variant_unboxed, _) ->
     Some (arg, ms)
   | Type_record (_, ( Record_inlined _ | Record_unboxed
-                    | Record_boxed _ | Record_float | Record_ufloat
+                    | Record_boxed | Record_float | Record_ufloat
                     | Record_mixed _), _)
   | Type_record_unboxed_product (_, Record_unboxed_product, _)
   | Type_variant (_, ( Variant_boxed _ | Variant_unboxed

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -929,7 +929,7 @@ and record_representation =
   (* For an inlined record, we record the representation of the variant that
      contains it and the tag/representation of the relevant constructor of that
      variant. *)
-  | Record_boxed of Jkind_types.Sort.Const.t array
+  | Record_boxed
   | Record_float (* All fields are floats *)
   | Record_ufloat
   (* All fields are [float#]s.  Same runtime representation as [Record_float],

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -807,7 +807,7 @@ let rec expression : Typedtree.expression -> term_judg =
         let field_mode i = match rep with
           | Record_float | Record_ufloat -> Dereference
           | Record_unboxed | Record_inlined (_, _, Variant_unboxed) -> Return
-          | Record_boxed _ | Record_inlined (_, Constructor_uniform_value, _) ->
+          | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) ->
               Guard
           | Record_inlined (_, Constructor_mixed mixed_shape, _)
           | Record_mixed mixed_shape ->

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -384,7 +384,7 @@ and value_kind_record env subst ~visited ~depth
       | Record_inlined (Ordinary { runtime_tag; _ }, _, _) ->
         Block (Some (runtime_tag, fields))
       | Record_float -> FloatArray
-      | Record_boxed _ -> Block (Some (0, fields))
+      | Record_boxed -> Block (Some (0, fields))
       | Record_inlined (Extension _, _, _) -> Block (Some (0, fields))
       | Record_inlined (Null, _, _) ->
         raise (Vicuna_unsupported With_null_variants)


### PR DESCRIPTION
Record_boxed stores an array of sorts corresponding to the sorts of its labels. This is now dead info.


## Stack
1. https://github.com/oxcaml/oxcaml/pull/6002
2. https://github.com/oxcaml/oxcaml/pull/6035
3. https://github.com/oxcaml/oxcaml/pull/5461