### PR TITLE
Support for more cross-section constant expressions in the x86 binary emitter

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -637,8 +637,13 @@ let compile_unit unix ~output_prefix ~asm_filename ~keep_asm ~obj_filename
   if !Oxcaml_flags.verify_binary_emitter
   then
     let binary_sections_dir = output_prefix ^ ".binary-sections" in
+    let comparison_mode : Binary_emitter_verify.comparison_mode =
+      match Target_system.architecture () with
+      | X86_64 -> Disassembly
+      | _ -> Exact
+    in
     match
-      Binary_emitter_verify.compare unix ~obj_file:obj_filename
+      Binary_emitter_verify.compare ~comparison_mode unix ~obj_file:obj_filename
         ~binary_sections_dir
     with
     | Match { text_size; data_size } ->
@@ -653,7 +658,7 @@ let compile_unit unix ~output_prefix ~asm_filename ~keep_asm ~obj_filename
       then
         Format.eprintf
           "Binary emitter verification skipped (no binary sections)@."
-    | (Mismatch _ | Object_file_error _) as result ->
+    | (Mismatch _ | Object_file_error _ | Error _) as result ->
       Binary_emitter_verify.print_result Format.err_formatter result;
       Format.eprintf "Binary sections saved to: %s@." binary_sections_dir;
       raise (Error (Binary_emitter_mismatch obj_filename))

--- a/asmcomp/binary_emitter_verify.ml
+++ b/asmcomp/binary_emitter_verify.ml
@@ -26,7 +26,7 @@
  ******************************************************************************)
 
 (* Binary emitter verification: compare binary emitter output against system
-   assembler output to ensure they produce identical machine code. *)
+   assembler output according to the selected comparison mode. *)
 
 module Owee_buf = Compiler_owee.Owee_buf
 module Owee_object = Compiler_owee.Owee_object
@@ -58,6 +58,17 @@ type mismatch =
         actual : int
       }
   | Relocation of relocation_mismatch
+  | Instruction of
+      { section_name : string;
+        index : int;
+        assembler : string;
+        binary_emitter : string
+      }
+  | Instruction_count of
+      { section_name : string;
+        assembler : int;
+        binary_emitter : int
+      }
   | Missing_section of string
   | Missing_binary_sections_dir of string
 
@@ -68,6 +79,7 @@ type result =
       }
   | Mismatch of mismatch
   | Object_file_error of string
+  | Error of string
 
 (* Text sections: either a single .text section or per-function sections *)
 type text_sections =
@@ -203,38 +215,216 @@ let read_text_relocations dir ~include_main_text =
 
 (* Section comparison *)
 
-let compare_section ~section_name ~expected ~actual =
+type comparison_mode =
+  | Exact
+  | Disassembly
+
+(* Disassembly-based comparison: disassemble both binary emitter output and
+   assembler output using objdump in raw binary mode, then compare the textual
+   instruction representations (mnemonic + operands). Since both byte streams go
+   through the same disassembler, any difference that changes the decoded
+   instruction text is caught. This is intentionally not a byte-exact check:
+   different encodings with the same decoded text are accepted, and details that
+   objdump omits (for example branch/call targets when [--no-addresses] is used)
+   are not compared. *)
+module Disassembly = struct
+  type classified_line =
+    | Skip
+    | Instr of string
+    | Parse_error of string
+
+  (* Classify a single line of objdump output. With --no-addresses, instruction
+     lines start with a tab followed by the instruction text. The text runs up
+     to an optional '#' comment, which we strip so that RIP-relative comment
+     targets don't cause spurious mismatches. Expected non-instruction lines
+     (file header, section headers, blanks) are skipped. Anything else is a
+     parse error; we'd rather fail loudly than silently drop lines and report a
+     false match. *)
+  let classify_line line =
+    let trimmed = String.trim line in
+    if
+      trimmed = ""
+      || String.starts_with ~prefix:"Disassembly of section" trimmed
+      || String.starts_with ~prefix:"<" trimmed
+      ||
+      (* e.g. "foo.bin: file format binary" *)
+      Misc.Stdlib.String.is_substring trimmed ~substring:"file format"
+    then Skip
+    else if String.starts_with ~prefix:"\t" line
+    then
+      let mnemonic_end =
+        match String.index_opt line '#' with
+        | Some i -> i
+        | None -> String.length line
+      in
+      (* Skip the leading tab (index 0), take up to the comment or end. *)
+      Instr (String.trim (String.sub line 1 (mnemonic_end - 1)))
+    else Parse_error line
+
+  let extract_instructions output =
+    let rec loop acc = function
+      | [] -> Result.Ok (List.rev acc)
+      | line :: rest -> (
+        match classify_line line with
+        | Skip -> loop acc rest
+        | Instr s -> loop (s :: acc) rest
+        | Parse_error l ->
+          Result.Error (Printf.sprintf "unexpected objdump line: %S" l))
+    in
+    loop [] (String.split_on_char '\n' output)
+
+  type redirect =
+    | Null
+    | File of string
+    | Pipe
+
+  let run ~command ?(stdout = Pipe) ?(stderr = Pipe) args =
+    let stdout_str =
+      match stdout with
+      | Pipe -> ""
+      | Null -> " > /dev/null"
+      | File path -> Printf.sprintf " > %s" (Filename.quote path)
+    in
+    let stderr_str =
+      match stderr with
+      | Pipe -> ""
+      | Null -> " 2> /dev/null"
+      | File path -> Printf.sprintf " 2> %s" (Filename.quote path)
+    in
+    let cmd =
+      String.concat " " (Filename.quote command :: List.map Filename.quote args)
+      ^ stdout_str ^ stderr_str
+    in
+    Ccomp.command cmd
+
+  let disassemble bin_path =
+    let out_file = Filename.temp_file "caml_objdump" ".txt" in
+    let machine =
+      match Target_system.architecture () with
+      | X86_64 -> "i386:x86-64"
+      | AArch64 -> "aarch64"
+      | _ -> "i386:x86-64"
+    in
+    let rc =
+      run ~command:"objdump" ~stdout:(File out_file)
+        [ "-D";
+          "-b";
+          "binary";
+          "-m";
+          machine;
+          "--no-show-raw-insn";
+          "--no-addresses";
+          "-z";
+          bin_path ]
+    in
+    if rc <> 0
+    then (
+      (try Sys.remove out_file with Sys_error _ -> ());
+      Result.Error (Printf.sprintf "objdump failed (exit %d)" rc))
+    else
+      let output = read_file out_file in
+      (try Sys.remove out_file with Sys_error _ -> ());
+      extract_instructions output
+
+  let compare_instruction_lists ~section_name ~assembler ~binary_emitter =
+    let rec loop i asm be =
+      match asm, be with
+      | [], [] -> None
+      | [], _ :: _ ->
+        Some
+          (Instruction_count
+             { section_name;
+               assembler = i;
+               binary_emitter = i + List.length be
+             })
+      | _ :: _, [] ->
+        Some
+          (Instruction_count
+             { section_name;
+               assembler = i + List.length asm;
+               binary_emitter = i
+             })
+      | a :: asm_rest, b :: be_rest ->
+        if String.equal a b
+        then loop (i + 1) asm_rest be_rest
+        else
+          Some
+            (Instruction
+               { section_name; index = i; assembler = a; binary_emitter = b })
+    in
+    loop 0 assembler binary_emitter
+
+  let write_temp_bin contents =
+    let path = Filename.temp_file "caml_verify" ".bin" in
+    let oc = open_out_bin path in
+    output_string oc contents;
+    close_out oc;
+    path
+
+  let disassemble_contents contents =
+    (* [objdump -D -b binary] exits with status 1 on a zero-byte file. Empty
+       sections are legitimate (e.g. [.note.GNU-stack], or [code_end]/empty
+       jump-tables under [-function-sections]), so short-circuit instead of
+       invoking objdump. *)
+    if String.length contents = 0
+    then Result.Ok []
+    else
+      let bin_path = write_temp_bin contents in
+      let result = disassemble bin_path in
+      (try Sys.remove bin_path with Sys_error _ -> ());
+      result
+
+  let compare_sections ~section_name ~expected ~actual =
+    match disassemble_contents expected, disassemble_contents actual with
+    | Result.Error e, _ | _, Result.Error e -> Some (Error e)
+    | Result.Ok be_instrs, Result.Ok asm_instrs ->
+      Option.map
+        (fun m -> Mismatch m)
+        (compare_instruction_lists ~section_name ~assembler:asm_instrs
+           ~binary_emitter:be_instrs)
+end
+
+let byte_mismatch ~section_name ~expected ~actual byte_offset =
+  let instruction_offset =
+    if is_text_section section_name
+    then Some (align_to_instruction byte_offset)
+    else None
+  in
+  let display_offset = Option.value instruction_offset ~default:byte_offset in
+  Section_content
+    { section_name;
+      byte_offset;
+      instruction_offset;
+      expected = hex_dump expected display_offset;
+      actual = hex_dump actual display_offset;
+      expected_size = String.length expected;
+      actual_size = String.length actual
+    }
+
+(* Returns [result option]: [None] means match, [Some r] means mismatch or
+   error. *)
+let compare_section ~comparison_mode ~section_name ~expected ~actual =
   let expected_size = String.length expected in
   let actual_size = String.length actual in
   if expected_size <> actual_size
   then
     Some
-      (Section_size
-         { section_name; expected = expected_size; actual = actual_size })
+      (Mismatch
+         (Section_size
+            { section_name; expected = expected_size; actual = actual_size }))
   else
-    match find_first_difference expected actual with
-    | None -> None
-    | Some byte_offset ->
-      let instruction_offset =
-        if is_text_section section_name
-        then Some (align_to_instruction byte_offset)
-        else None
-      in
-      let display_offset =
-        Option.value instruction_offset ~default:byte_offset
-      in
-      Some
-        (Section_content
-           { section_name;
-             byte_offset;
-             instruction_offset;
-             expected = hex_dump expected display_offset;
-             actual = hex_dump actual display_offset;
-             expected_size;
-             actual_size
-           })
+    match comparison_mode with
+    | Disassembly when is_text_section section_name ->
+      Disassembly.compare_sections ~section_name ~expected ~actual
+    | Exact | Disassembly -> (
+      match find_first_difference expected actual with
+      | None -> None
+      | Some byte_offset ->
+        Some
+          (Mismatch (byte_mismatch ~section_name ~expected ~actual byte_offset))
+      )
 
-let compare_sections ~expected ~actual =
+let compare_sections ~comparison_mode ~expected ~actual =
   let actual_map = Hashtbl.create (List.length actual) in
   List.iter (fun (name, content) -> Hashtbl.add actual_map name content) actual;
   let expected_map = Hashtbl.create (List.length expected) in
@@ -244,14 +434,16 @@ let compare_sections ~expected ~actual =
     | [] -> None
     | (name, expected) :: rest -> (
       match Hashtbl.find_opt actual_map name with
-      | None -> Some (Missing_section (name ^ " (in object file)"))
+      | None -> Some (Mismatch (Missing_section (name ^ " (in object file)")))
       | Some actual -> (
-        match compare_section ~section_name:name ~expected ~actual with
-        | Some mismatch -> Some mismatch
+        match
+          compare_section ~comparison_mode ~section_name:name ~expected ~actual
+        with
+        | Some _ as r -> r
         | None -> check_expected rest))
   in
   match check_expected expected with
-  | Some _ as mismatch -> mismatch
+  | Some _ as r -> r
   | None -> (
     (* Check for sections in actual that are missing from expected *)
     let extra_in_actual =
@@ -261,7 +453,7 @@ let compare_sections ~expected ~actual =
     in
     match extra_in_actual with
     | Some (name, _) ->
-      Some (Missing_section (name ^ " (in binary emitter output)"))
+      Some (Mismatch (Missing_section (name ^ " (in binary emitter output)")))
     | None -> None)
 
 (* Relocation comparison *)
@@ -374,7 +566,7 @@ let compare_section_relocations ~expected ~actual =
 
 (* Main comparison *)
 
-let compare unix ~obj_file ~binary_sections_dir =
+let compare ~comparison_mode unix ~obj_file ~binary_sections_dir =
   if not (Sys.file_exists binary_sections_dir)
   then Mismatch (Missing_binary_sections_dir binary_sections_dir)
   else if not (Sys.is_directory binary_sections_dir)
@@ -399,64 +591,74 @@ let compare unix ~obj_file ~binary_sections_dir =
         ( (match be_opt with Some s -> [".text", s] | None -> []),
           match asm_opt with Some s -> [".text", s] | None -> [] ))
     in
-    (* Normalize text relocations to (name, relocs) list *)
-    let be_text_relocs, asm_text_relocs =
-      match be_text with
-      | Function_sections _ ->
-        ( read_text_relocations binary_sections_dir ~include_main_text:true,
-          Owee_object.extract_individual_text_relocations buf )
-      | No_function_sections _ ->
-        ( [".text", read_relocations binary_sections_dir "text"],
-          [".text", Owee_object.extract_text_relocations buf] )
-    in
     (* Compare text sections *)
     let text_result =
-      compare_sections ~expected:be_text_list ~actual:asm_text_list
+      compare_sections ~comparison_mode ~expected:be_text_list
+        ~actual:asm_text_list
     in
     match text_result with
-    | Some m -> Mismatch m
+    | Some r -> r
     | None -> (
       (* Compare data section *)
       let data_result =
         match be_data, asm_data with
         | Some expected, Some actual ->
-          compare_section ~section_name:"data" ~expected ~actual
+          compare_section ~comparison_mode ~section_name:"data" ~expected
+            ~actual
         | None, None -> None
-        | Some _, None -> Some (Missing_section "data (in object file)")
+        | Some _, None ->
+          Some (Mismatch (Missing_section "data (in object file)"))
         | None, Some _ ->
-          Some (Missing_section "data (in binary emitter output)")
+          Some (Mismatch (Missing_section "data (in binary emitter output)"))
       in
       match data_result with
-      | Some m -> Mismatch m
+      | Some r -> r
       | None -> (
-        (* Compare text relocations *)
-        let text_reloc_result =
-          compare_section_relocations ~expected:be_text_relocs
-            ~actual:asm_text_relocs
+        let text_size =
+          List.fold_left
+            (fun acc (_, c) -> acc + String.length c)
+            0 be_text_list
         in
-        match text_reloc_result with
-        | Some m -> Mismatch m
-        | None -> (
-          (* Compare data relocations *)
-          let be_data_relocs =
-            [".data", read_relocations binary_sections_dir "data"]
+        let data_size = Option.fold ~none:0 ~some:String.length be_data in
+        match comparison_mode with
+        | Disassembly ->
+          (* Disassembly mode is instruction-stream-only for text sections. It
+             intentionally skips relocation checks, including data relocations,
+             because relocation differences are not represented in raw-binary
+             objdump output. *)
+          Match { text_size; data_size }
+        | Exact -> (
+          (* Normalize text relocations to (name, relocs) list *)
+          let be_text_relocs, asm_text_relocs =
+            match be_text with
+            | Function_sections _ ->
+              ( read_text_relocations binary_sections_dir ~include_main_text:true,
+                Owee_object.extract_individual_text_relocations buf )
+            | No_function_sections _ ->
+              ( [".text", read_relocations binary_sections_dir "text"],
+                [".text", Owee_object.extract_text_relocations buf] )
           in
-          let asm_data_relocs =
-            [".data", Owee_object.extract_data_relocations buf]
+          (* Compare text relocations *)
+          let text_reloc_result =
+            compare_section_relocations ~expected:be_text_relocs
+              ~actual:asm_text_relocs
           in
-          match
-            compare_section_relocations ~expected:be_data_relocs
-              ~actual:asm_data_relocs
-          with
+          match text_reloc_result with
           | Some m -> Mismatch m
-          | None ->
-            let text_size =
-              List.fold_left
-                (fun acc (_, c) -> acc + String.length c)
-                0 be_text_list
+          | None -> (
+            (* Compare data relocations *)
+            let be_data_relocs =
+              [".data", read_relocations binary_sections_dir "data"]
             in
-            let data_size = Option.fold ~none:0 ~some:String.length be_data in
-            Match { text_size; data_size })))
+            let asm_data_relocs =
+              [".data", Owee_object.extract_data_relocations buf]
+            in
+            match
+              compare_section_relocations ~expected:be_data_relocs
+                ~actual:asm_data_relocs
+            with
+            | Some m -> Mismatch m
+            | None -> Match { text_size; data_size }))))
 
 let print_result ppf = function
   | Match { text_size; data_size } ->
@@ -501,6 +703,24 @@ let print_result ppf = function
        Assembler:      %s@,\
        Binary emitter: %s@]@."
       r.section_name r.offset r.actual r.expected
+  | Mismatch (Instruction m) ->
+    Format.fprintf ppf
+      "@[<v>Binary emitter verification FAILED@,\
+       @,\
+       Section: %s@,\
+       Instruction #%d:@,\
+      \  Assembler:      %s@,\
+      \  Binary emitter: %s@]@."
+      m.section_name m.index m.assembler m.binary_emitter
+  | Mismatch (Instruction_count m) ->
+    Format.fprintf ppf
+      "@[<v>Binary emitter verification FAILED@,\
+       @,\
+       Section: %s@,\
+       Instruction count mismatch:@,\
+      \  Assembler:      %d instructions@,\
+      \  Binary emitter: %d instructions@]@."
+      m.section_name m.assembler m.binary_emitter
   | Mismatch (Missing_section name) ->
     Format.fprintf ppf
       "@[<v>Binary emitter verification FAILED@,@,Missing section: %s@]@." name
@@ -517,6 +737,9 @@ let print_result ppf = function
        @,\
        Error reading object file: %s@]@."
       msg
+  | Error msg ->
+    Format.fprintf ppf
+      "@[<v>Binary emitter verification FAILED@,@,Error: %s@]@." msg
 
 module For_testing = struct
   let extract_text_sections buf =
@@ -551,30 +774,30 @@ module For_testing = struct
     let actual_text_relocs = extract_text_relocs actual_buf in
     (* Compare text sections *)
     match
-      compare_sections ~expected:expected_text_list ~actual:actual_text_list
+      compare_sections ~comparison_mode:Exact ~expected:expected_text_list
+        ~actual:actual_text_list
     with
-    | Some m -> Mismatch m
+    | Some r -> r
     | None -> (
       (* Compare data section *)
       let data_result =
         match expected_data, actual_data with
         | Some expected, Some actual ->
-          compare_section ~section_name:"data" ~expected ~actual
+          compare_section ~comparison_mode:Exact ~section_name:"data" ~expected
+            ~actual
         | None, None -> None
-        | Some _, None -> Some (Missing_section "data (in actual)")
-        | None, Some _ -> Some (Missing_section "data (in expected)")
+        | Some _, None -> Some (Mismatch (Missing_section "data (in actual)"))
+        | None, Some _ -> Some (Mismatch (Missing_section "data (in expected)"))
       in
       match data_result with
-      | Some m -> Mismatch m
+      | Some r -> r
       | None -> (
-        (* Compare text relocations *)
         match
           compare_section_relocations ~expected:expected_text_relocs
             ~actual:actual_text_relocs
         with
         | Some m -> Mismatch m
         | None -> (
-          (* Compare data relocations *)
           let expected_data_relocs =
             [".data", Owee_object.extract_data_relocations expected_buf]
           in

--- a/asmcomp/binary_emitter_verify.mli
+++ b/asmcomp/binary_emitter_verify.mli
@@ -27,9 +27,10 @@
 
 (** Verification of binary emitter output against system assembler output.
 
-    This module compares the section contents produced by the binary emitter
-    (saved in .binary-sections/ directories) against the corresponding sections
-    extracted from object files produced by the system assembler. *)
+    This module compares the sections produced by the binary emitter (saved in
+    .binary-sections/ directories) against the corresponding sections extracted
+    from object files produced by the system assembler. The exact comparison
+    depends on [comparison_mode]. *)
 
 type section_mismatch =
   { section_name : string;
@@ -56,8 +57,28 @@ type mismatch =
         actual : int
       }
   | Relocation of relocation_mismatch
+  | Instruction of
+      { section_name : string;
+        index : int;
+        assembler : string;
+        binary_emitter : string
+      }
+  | Instruction_count of
+      { section_name : string;
+        assembler : int;
+        binary_emitter : int
+      }
   | Missing_section of string
   | Missing_binary_sections_dir of string
+
+type comparison_mode =
+  | Exact  (** Byte-exact section comparison, including relocations. *)
+  | Disassembly
+      (** Disassemble text sections using objdump and compare instruction text.
+          The [.data] section is still compared byte-for-byte, but other
+          non-text sections are not compared. This tolerates text encoding
+          differences that produce the same decoded instructions, and relocation
+          checks are skipped in this mode. *)
 
 type result =
   | Match of
@@ -66,14 +87,21 @@ type result =
       }
   | Mismatch of mismatch
   | Object_file_error of string
+  | Error of string
 
 (** Compare binary emitter output against assembled object file.
 
+    @param comparison_mode
+      Controls how sections are compared. [Exact] reports any byte or relocation
+      difference. [Disassembly] compares text sections through objdump-based
+      instruction text, while still requiring equal text sizes and exact
+      non-text bytes.
     @param unix The Unix module (as first-class module)
     @param obj_file Path to the .o file produced by the system assembler
     @param binary_sections_dir Path to the .binary-sections/ directory
     @return Comparison result *)
 val compare :
+  comparison_mode:comparison_mode ->
   (module Compiler_owee.Unix_intf.S) ->
   obj_file:string ->
   binary_sections_dir:string ->

--- a/asmcomp/dissector/iplt.ml
+++ b/asmcomp/dissector/iplt.ml
@@ -82,7 +82,9 @@ let plt_entry_template =
         |]
     }
   in
-  let buffer = X86_binary_emitter.assemble_section X86_ast.X64 section in
+  let buffer =
+    X86_binary_emitter.assemble_singleton_section X86_ast.X64 section
+  in
   let bytes = X86_binary_emitter.contents buffer in
   assert (String.length bytes = 8);
   bytes

--- a/backend/amd64/binary_emitter_helpers.ml
+++ b/backend/amd64/binary_emitter_helpers.ml
@@ -25,11 +25,40 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(** CR mshinwell: Implement binary sections saving for x86 to match ARM64.
-    Currently this module provides stub implementations. *)
+(* CR sspies: More of this module could be shared with the arm64 counterpart
+   (e.g. the section-name normalization and the on-disk layout used when saving
+   binary sections for verification). The two backends currently differ because
+   the x86 emitter assembles sections post-hoc via [X86_proc.iter_sections]
+   while the arm64 emitter is wired in via callbacks during emission. *)
 
 let should_use_binary_emitter () = false
 
 let begin_emission () = fun _ -> ()
 
-let end_emission () = ()
+let should_save_binary_sections () =
+  !Oxcaml_flags.verify_binary_emitter && not !Oxcaml_flags.internal_assembler
+
+let save_binary_sections () =
+  let dir = !Emitaux.output_prefix ^ ".binary-sections" in
+  (try Sys.mkdir dir 0o755 with Sys_error _ -> ());
+  X86_proc.iter_sections (fun name instructions ->
+      let buf =
+        X86_binary_emitter.assemble_section X64
+          { X86_binary_emitter.sec_name = name;
+            sec_instrs = Oxcaml_utils.Doubly_linked_list.to_array instructions
+          }
+      in
+      let sec_name = X86_proc.Section_name.to_string name in
+      let bare_name =
+        if String.length sec_name > 0 && Char.equal (String.get sec_name 0) '.'
+        then String.sub sec_name 1 (String.length sec_name - 1)
+        else sec_name
+      in
+      let safe_name = "section_" ^ bare_name in
+      let bin_path = Filename.concat dir (safe_name ^ ".bin") in
+      let oc = open_out_bin bin_path in
+      output_string oc (X86_binary_emitter.contents buf);
+      close_out oc)
+
+let end_emission () =
+  if should_save_binary_sections () then save_binary_sections ()

--- a/backend/amd64/binary_emitter_helpers.ml
+++ b/backend/amd64/binary_emitter_helpers.ml
@@ -41,6 +41,10 @@ let should_save_binary_sections () =
 let save_binary_sections () =
   let dir = !Emitaux.output_prefix ^ ".binary-sections" in
   (try Sys.mkdir dir 0o755 with Sys_error _ -> ());
+  (* Assemble every section first; defer writing until after
+     [resolve_global_patches] has resolved cross-section data-directive
+     references using a global view over all buffers' labels. *)
+  let unresolved = ref [] in
   X86_proc.iter_sections (fun name instructions ->
       let buf =
         X86_binary_emitter.assemble_section X64
@@ -55,10 +59,17 @@ let save_binary_sections () =
         else sec_name
       in
       let safe_name = "section_" ^ bare_name in
+      unresolved := (safe_name, buf) :: !unresolved);
+  let resolved =
+    X86_binary_emitter.resolve_global_patches (List.map snd !unresolved)
+  in
+  List.iter2
+    (fun (safe_name, _) buf ->
       let bin_path = Filename.concat dir (safe_name ^ ".bin") in
       let oc = open_out_bin bin_path in
       output_string oc (X86_binary_emitter.contents buf);
       close_out oc)
+    !unresolved resolved
 
 let end_emission () =
   if should_save_binary_sections () then save_binary_sections ()

--- a/backend/amd64/binary_emitter_helpers.mli
+++ b/backend/amd64/binary_emitter_helpers.mli
@@ -25,10 +25,7 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(** Hooks for connecting the x86 binary emitter to the emit process.
-
-    CR mshinwell: Implement binary sections saving for x86 to match ARM64.
-    Currently this module provides stub implementations. *)
+(** Hooks for connecting the x86 binary emitter to the emit process. *)
 
 (** Returns true if the binary emitter should be enabled for this compilation.
     Currently always returns false on x86. *)

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3191,5 +3191,6 @@ let end_assembly () =
   then Emitaux.Dwarf_helpers.emit_dwarf ();
   invoke_expect_asm_callbacks ();
   X86_proc.generate_code asm;
+  Binary_emitter_helpers.end_emission ();
   (* The internal assembler does not work if reset_all is called here *)
   if not !Oxcaml_flags.internal_assembler then reset_all ()

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -272,7 +272,23 @@ let write buf header section_table symbol_table relocation_tables string_table =
   String_table.write string_table strtab.sh_offset buf
 
 let assemble unix ~delayed asm output_file =
-  let compiler_sections = get_sections ~delayed asm in
+  let unresolved_sections = get_sections ~delayed asm in
+  (* Resolve data-directive references that need a global view across all
+     assembled sections, e.g. cross-section [s1 - s2] expressions:
+     - if both s1 and s2 are in the same section, fold to a literal;
+     - if s2 is in the current section, encode as REL32 against s1.
+     Rebuild the section map with resolved buffers, preserving alignment. *)
+  let bindings = Section_name.Map.bindings unresolved_sections in
+  let resolved_bufs =
+    X86_binary_emitter.resolve_global_patches
+      (List.map (fun (_, (_align, buf)) -> buf) bindings)
+  in
+  let compiler_sections =
+    List.fold_left2
+      (fun acc (name, (align, _)) buf ->
+        Section_name.Map.add name (align, buf) acc)
+      Section_name.Map.empty bindings resolved_bufs
+  in
   let string_table = String_table.create () in
   let sh_string_table = String_table.create () in
   let sections = Section_table.create () in

--- a/backend/jit_backend.ml
+++ b/backend/jit_backend.ml
@@ -58,23 +58,37 @@ let register callback =
     (* Save old x86 internal assembler and register our hook *)
     saved_x86_internal_assembler := !X86_proc.internal_assembler;
     X86_proc.register_internal_assembler (fun ~delayed:_ sections _filename ->
-        (* Assemble each section *)
-        let sections_map =
-          List.fold_left
-            (fun map (name, instrs) ->
+        (* Assemble each section. Empty-section filtering happens after
+           resolution because [size] is only available on resolved buffers. *)
+        let named_unresolved =
+          List.map
+            (fun (name, instrs) ->
               let name_str = X86_proc.Section_name.to_string name in
               let section =
                 { X86_binary_emitter.sec_name = name;
                   sec_instrs = DLL.to_array instrs
                 }
               in
-              let binary_section =
-                X86_binary_emitter.assemble_section X86_ast.X64 section
-              in
-              if X86_binary_emitter.size binary_section = 0
+              name_str, X86_binary_emitter.assemble_section X86_ast.X64 section)
+            sections
+        in
+        (* Resolve data-directive references that need a global view across all
+           assembled sections, e.g. cross-section [s1 - s2] expressions:
+
+           - if both s1 and s2 are in the same section, fold to a literal;
+
+           - if s2 is in the current section, encode as REL32 against s1. *)
+        let resolved =
+          X86_binary_emitter.resolve_global_patches
+            (List.map snd named_unresolved)
+        in
+        let sections_map =
+          List.fold_left2
+            (fun map (name_str, _) buf ->
+              if X86_binary_emitter.size buf = 0
               then map
-              else String_map.add name_str binary_section map)
-            String_map.empty sections
+              else String_map.add name_str buf map)
+            String_map.empty named_unresolved resolved
         in
         let packed =
           Packed

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -197,7 +197,7 @@ let label_pos b lbl =
 (* Try to compute some statically computable arithmetic expressions
    in labels, or to simplify them to a form that is encodable by
    relocations. *)
-let eval_const b current_pos cst =
+let eval_with_lookup ~lookup ~current_pos cst =
   let rec eval = function
     | C.Signed_int n -> Rint n
     | C.Unsigned_int n -> Rint (Numbers.Uint64.to_int64 n)
@@ -213,41 +213,40 @@ let eval_const b current_pos cst =
         | Rrel (s, n1), Rint n2 -> Rrel (s, Int64.sub n1 n2)
         | Rabs ("", n1), Rabs ("", n2) -> Rint (Int64.sub n1 n2)
         | Rabs ("", n1), Rabs (s2, n2) -> (
-            try
-              let sy2 = String.Tbl.find b.labels s2 in
-              match sy2.sy_pos with
-              | Some pos2 ->
-                  let pos2 = Int64.of_int pos2 in
-                  Rint
-                    (Int64.sub
-                       (Int64.add n1 (Int64.of_int current_pos))
-                       (Int64.add pos2 n2))
-              | _ -> assert false
-            with Not_found -> assert false)
+            match lookup s2 with
+            | Some sy2 -> (
+                match sy2.sy_pos with
+                | Some pos2 ->
+                    let pos2 = Int64.of_int pos2 in
+                    Rint
+                      (Int64.sub
+                         (Int64.add n1 (Int64.of_int current_pos))
+                         (Int64.add pos2 n2))
+                | _ -> assert false)
+            | None -> assert false)
         | Rabs (s, n1), Rabs ("", n2) -> (
-            try
-              let sy = String.Tbl.find b.labels s in
-              match sy.sy_pos with
-              | Some pos ->
-                  let pos = Int64.of_int pos in
-                  Rint
-                    (Int64.sub (Int64.add pos n1)
-                       (Int64.add n2 (Int64.of_int current_pos)))
-              | _ -> assert false
-            with Not_found -> Rrel (s, Int64.sub n1 n2))
+            match lookup s with
+            | Some sy -> (
+                match sy.sy_pos with
+                | Some pos ->
+                    let pos = Int64.of_int pos in
+                    Rint
+                      (Int64.sub (Int64.add pos n1)
+                         (Int64.add n2 (Int64.of_int current_pos)))
+                | _ -> assert false)
+            | None -> Rrel (s, Int64.sub n1 n2))
         | Rabs (s1, n1), Rabs (s2, n2) -> (
-            try
-              let sy2 = String.Tbl.find b.labels s2 in
-              try
-                let sy1 = String.Tbl.find b.labels s1 in
+            match lookup s1, lookup s2 with
+            | Some sy1, Some sy2 -> (
                 assert (sy1.sy_sec == sy2.sy_sec);
-                match (sy1.sy_pos, sy2.sy_pos) with
+                match sy1.sy_pos, sy2.sy_pos with
                 | Some pos1, Some pos2 ->
                     let pos1 = Int64.of_int pos1 in
                     let pos2 = Int64.of_int pos2 in
-                    Rint (Int64.sub (Int64.add pos1 n1) (Int64.add pos2 n2))
-                | _ -> assert false
-              with Not_found -> (
+                    Rint
+                      (Int64.sub (Int64.add pos1 n1) (Int64.add pos2 n2))
+                | _ -> assert false)
+            | None, Some sy2 -> (
                 match sy2.sy_pos with
                 | Some pos2 ->
                     let pos2 = Int64.of_int pos2 in
@@ -257,7 +256,7 @@ let eval_const b current_pos cst =
                           (Int64.add n1 (Int64.of_int current_pos))
                           (Int64.add pos2 n2) )
                 | _ -> assert false)
-            with Not_found -> assert false)
+            | Some _, None | None, None -> assert false)
         | _ -> assert false)
     | C.Add (c1, c2) -> (
         let c1 = eval c1 and c2 = eval c2 in
@@ -273,8 +272,12 @@ let eval_const b current_pos cst =
         | Rrel (s, n1), Rabs ("", n2) -> Rabs (s, Int64.add n1 n2)
         | _ -> assert false)
   in
+  eval cst
+
+let eval_const b current_pos cst =
+  let lookup name = String.Tbl.find_opt b.labels name in
   try
-    let r = eval cst in
+    let r = eval_with_lookup ~lookup ~current_pos cst in
     (*
     if debug then
       Printf.eprintf "eval_const (%s) = %s at @%d\n%!"
@@ -1663,6 +1666,27 @@ let assemble_line b loc ins =
 
 let add_patch b pos size v = b.patches <- (pos, size, v) :: b.patches
 
+let resolve_reloc_result b pos result data_size =
+  match result, data_size with
+  | Rint n, _ -> add_patch b pos data_size n
+  | Rabs (lbl, offset), B32 ->
+      record_reloc b pos (Relocation.Kind.DIR32 (lbl, offset))
+  | Rabs (lbl, offset), B64 ->
+      record_reloc b pos (Relocation.Kind.DIR64 (lbl, offset))
+  (* Relative relocation in data segment. We add an offset of 4 because
+     REL32 relocations are computed with a PC at the end, while here, it
+     is at the beginning. *)
+  | Rrel (lbl, offset), B32 ->
+      record_reloc b pos (Relocation.Kind.REL32 (lbl, Int64.add offset 4L))
+  | Rrel _, _ -> assert false
+  | Rabs _, _ -> assert false
+
+let resolve_reloc_constant b pos cst data_size =
+  (* Printf.eprintf "RelocConstant (%s, %s)\n%!"
+     (X86_gas.string_of_constant cst)
+     (string_of_data_size data_size); *)
+  resolve_reloc_result b pos (eval_const b pos cst) data_size
+
 let rec assemble_section arch section =
   try assemble_section0 arch section
   with Misc.Fatal_error ->
@@ -1726,25 +1750,8 @@ and assemble_section0 arch section =
          allow one external symbol per expression. We could tolerate more complex
          expressions if we delay resolution later, i.e. after all sections have
          been generated and all symbol positions are known. *)
-      | RelocConstant (cst, data_size) -> (
-          (* Printf.eprintf "RelocConstant (%s, %s)\n%!"
-             (X86_gas.string_of_constant cst)
-             (string_of_data_size data_size); *)
-          let v = eval_const b pos cst in
-          match (v, data_size) with
-          | Rint n, _ -> add_patch b pos data_size n
-          | Rabs (lbl, offset), B32 ->
-              record_reloc b pos (Relocation.Kind.DIR32 (lbl, offset))
-          | Rabs (lbl, offset), B64 ->
-              record_reloc b pos (Relocation.Kind.DIR64 (lbl, offset))
-          (* Relative relocation in data segment. We add an offset of 4 because
-              REL32 relocations are computed with a PC at the end, while here, it
-              is at the beginning. *)
-          | Rrel (lbl, offset), B32 ->
-              record_reloc b pos
-                (Relocation.Kind.REL32 (lbl, Int64.add offset 4L))
-          | Rrel _, _ -> assert false
-          | Rabs _, _ -> assert false)
+      | RelocConstant (cst, data_size) ->
+          resolve_reloc_constant b pos cst data_size
     in
 
     ListLabels.iter !local_relocs ~f:(fun (pos, local_reloc) ->

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -87,13 +87,26 @@ type symbol = {
   mutable sy_num : int option; (* position in .symtab *)
 }
 
+type global_patch = {
+  gp_pos : int;
+  gp_size : data_size;
+  gp_cst : C.t;
+}
+
 type buffer = {
   sec : section;
   buf : Buffer.t;
   labels : symbol String.Tbl.t;
   mutable patches : (int * data_size * int64) list;
   mutable relocations : Relocation.t list;
+  mutable global_patches : global_patch list;
 }
+
+(* At the implementation level, [unresolved_buffer] and [buffer] are the
+   same record; [resolve_global_patches] acts as the identity on values
+   while refining the type at the interface boundary to prevent callers
+   from consuming unresolved buffers via [contents]/[relocations]. *)
+type unresolved_buffer = buffer
 
 type local_reloc =
   | RelocCall of string
@@ -187,6 +200,7 @@ let new_buffer sec =
     labels = String.Tbl.create 100;
     relocations = [];
     patches = [];
+    global_patches = [];
   }
 
 let label_pos b lbl =
@@ -194,10 +208,18 @@ let label_pos b lbl =
   | None -> raise Not_found
   | Some pos -> pos
 
+(* Result of a symbol lookup: which section the symbol is in, and its byte
+   offset within that section. *)
+type lookup_result = { lu_sec_id : Section_name.t; lu_pos : int }
+
 (* Try to compute some statically computable arithmetic expressions
    in labels, or to simplify them to a form that is encodable by
-   relocations. *)
-let eval_with_lookup ~lookup ~current_pos cst =
+   relocations. [lookup] resolves a symbol name to its section-id and
+   byte-offset; [current_sec_id] names the section the expression is
+   being emitted into, so that same-section subtractions can be folded
+   to literals, and current-section-anchored differences can become
+   PC-relative relocations. *)
+let eval ~lookup ~current_sec_id ~current_pos cst =
   let rec eval = function
     | C.Signed_int n -> Rint n
     | C.Unsigned_int n -> Rint (Numbers.Uint64.to_int64 n)
@@ -213,51 +235,96 @@ let eval_with_lookup ~lookup ~current_pos cst =
         | Rrel (s, n1), Rint n2 -> Rrel (s, Int64.sub n1 n2)
         | Rabs ("", n1), Rabs ("", n2) -> Rint (Int64.sub n1 n2)
         | Rabs ("", n1), Rabs (s2, n2) -> (
+            (* [. - s2] *)
             match lookup s2 with
-            | Some sy2 -> (
-                match sy2.sy_pos with
-                | Some pos2 ->
-                    let pos2 = Int64.of_int pos2 in
-                    Rint
-                      (Int64.sub
-                         (Int64.add n1 (Int64.of_int current_pos))
-                         (Int64.add pos2 n2))
-                | _ -> assert false)
-            | None -> assert false)
+            | Some { lu_sec_id; lu_pos }
+              when Section_name.equal lu_sec_id current_sec_id ->
+                let pos2 = Int64.of_int lu_pos in
+                Rint
+                  (Int64.sub
+                     (Int64.add n1 (Int64.of_int current_pos))
+                     (Int64.add pos2 n2))
+            | Some _ ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter: cannot compute . - %s: target in \
+                   different section"
+                  s2
+            | None ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter: cannot compute . - %s: symbol not \
+                   found"
+                  s2)
         | Rabs (s, n1), Rabs ("", n2) -> (
+            (* [s - .] *)
             match lookup s with
-            | Some sy -> (
-                match sy.sy_pos with
-                | Some pos ->
-                    let pos = Int64.of_int pos in
-                    Rint
-                      (Int64.sub (Int64.add pos n1)
-                         (Int64.add n2 (Int64.of_int current_pos)))
-                | _ -> assert false)
-            | None -> Rrel (s, Int64.sub n1 n2))
+            | Some { lu_sec_id; lu_pos }
+              when Section_name.equal lu_sec_id current_sec_id ->
+                (* Same section: fold to literal. *)
+                let pos = Int64.of_int lu_pos in
+                Rint
+                  (Int64.sub (Int64.add pos n1)
+                     (Int64.add n2 (Int64.of_int current_pos)))
+            | _ ->
+                (* Different section or external: PC-relative relocation. *)
+                Rrel (s, Int64.sub n1 n2))
         | Rabs (s1, n1), Rabs (s2, n2) -> (
-            match lookup s1, lookup s2 with
-            | Some sy1, Some sy2 -> (
-                assert (sy1.sy_sec == sy2.sy_sec);
-                match sy1.sy_pos, sy2.sy_pos with
-                | Some pos1, Some pos2 ->
-                    let pos1 = Int64.of_int pos1 in
-                    let pos2 = Int64.of_int pos2 in
-                    Rint
-                      (Int64.sub (Int64.add pos1 n1) (Int64.add pos2 n2))
-                | _ -> assert false)
-            | None, Some sy2 -> (
-                match sy2.sy_pos with
-                | Some pos2 ->
-                    let pos2 = Int64.of_int pos2 in
-                    Rrel
-                      ( s1,
-                        Int64.sub
-                          (Int64.add n1 (Int64.of_int current_pos))
-                          (Int64.add pos2 n2) )
-                | _ -> assert false)
-            | Some _, None | None, None -> assert false)
-        | _ -> assert false)
+            (* [s1 - s2] *)
+            match (lookup s1, lookup s2) with
+            | ( Some { lu_sec_id = sec1; lu_pos = pos1 },
+                Some { lu_sec_id = sec2; lu_pos = pos2 } ) ->
+                if Section_name.equal sec1 sec2
+                then
+                  let pos1 = Int64.of_int pos1 in
+                  let pos2 = Int64.of_int pos2 in
+                  Rint
+                    (Int64.sub (Int64.add pos1 n1) (Int64.add pos2 n2))
+                else if Section_name.equal sec2 current_sec_id
+                then
+                  (* s2 is in the current section, so [pos2 - current_pos] is
+                     a known constant. Encode [s1 - s2] as a PC-relative
+                     relocation against s1. This is the case for jump tables
+                     emitted in a separate section from the code they index
+                     (e.g. with [-function-sections]). *)
+                  let pos2 = Int64.of_int pos2 in
+                  Rrel
+                    ( s1,
+                      Int64.sub
+                        (Int64.add n1 (Int64.of_int current_pos))
+                        (Int64.add pos2 n2) )
+                else
+                  Misc.fatal_errorf
+                    "x86_binary_emitter: true cross-section subtraction \
+                     %s - %s (%s vs %s) is unsupported"
+                    s1 s2 (Section_name.to_string sec1)
+                    (Section_name.to_string sec2)
+            | None, Some { lu_sec_id = sec2; lu_pos = pos2 }
+              when Section_name.equal sec2 current_sec_id ->
+                (* s1 external, s2 local: PC-relative to s1 with addend
+                   derived from s2's known offset. *)
+                let pos2 = Int64.of_int pos2 in
+                Rrel
+                  ( s1,
+                    Int64.sub
+                      (Int64.add n1 (Int64.of_int current_pos))
+                      (Int64.add pos2 n2) )
+            | None, Some { lu_sec_id = sec2; _ } ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter: subtraction of symbol %s in section %s \
+                   from external symbol %s is unsupported"
+                  s2 (Section_name.to_string sec2) s1
+            | Some _, None ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter: subtraction of external symbol %s \
+                   from local symbol %s is unsupported"
+                  s2 s1
+            | None, None ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter: subtraction of two external \
+                   symbols %s - %s is unsupported"
+                  s1 s2)
+        | _ ->
+            Misc.fatal_error
+              "x86_binary_emitter: unsupported form in Sub")
     | C.Add (c1, c2) -> (
         let c1 = eval c1 and c2 = eval c2 in
         match (c1, c2) with
@@ -269,25 +336,28 @@ let eval_with_lookup ~lookup ~current_pos cst =
         (* TODO: we could add another case, easy to solve: adding a
            Rrel to a Rabs where the symbol is local, in which case it
            can be computed. *)
-        | Rrel (s, n1), Rabs ("", n2) -> Rabs (s, Int64.add n1 n2)
-        | _ -> assert false)
+        | Rrel (s, n1), Rabs ("", n2) | Rabs ("", n2), Rrel (s, n1) ->
+            Rabs (s, Int64.add n1 n2)
+        | _ ->
+            Misc.fatal_error
+              "x86_binary_emitter: unsupported form in Add")
   in
   eval cst
 
 let eval_const b current_pos cst =
-  let lookup name = String.Tbl.find_opt b.labels name in
+  let lookup name =
+    match String.Tbl.find_opt b.labels name with
+    | Some sym -> (
+        match sym.sy_pos with
+        | Some pos -> Some { lu_sec_id = b.sec.sec_name; lu_pos = pos }
+        | None -> None)
+    | None -> None
+  in
   try
-    let r = eval_with_lookup ~lookup ~current_pos cst in
-    (*
-    if debug then
-      Printf.eprintf "eval_const (%s) = %s at @%d\n%!"
-        (X86_gas.string_of_constant cst)
-        (string_of_result r) current_pos;
-*)
-    r
+    eval ~lookup ~current_sec_id:b.sec.sec_name ~current_pos cst
   with e ->
     Printf.eprintf "Error in eval_const: exception %S\n%!"
-      (*(X86_gas.string_of_constant cst)*) (Printexc.to_string e);
+      (Printexc.to_string e);
     raise e
 
 let is_imm32L n = Int64.compare n 0x8000_0000L < 0 && Int64.compare n (-0x8000_0000L) >= 0
@@ -1648,9 +1718,17 @@ let assemble_line b loc ins =
       when String.Tbl.mem local_labels (Asm_symbol.encode target_symbol) ->
       let sym = Asm_symbol.encode target_symbol in
       record_local_reloc b ~offset:(-4) (RelocCall sym)
-    | Directive (D.Reloc _)
-    | Directive (D.Sleb128 _)
-    | Directive (D.Uleb128 _) ->
+    | Directive (D.Uleb128 { constant; _ }) -> (
+      match eval_const b (Buffer.length b.buf) constant with
+      | Rint n -> D.emit_uleb128 b.buf n
+      | Rabs _ | Rrel _ ->
+        Misc.fatal_error "x86_binary_emitter: non-integer uleb128")
+    | Directive (D.Sleb128 { constant; _ }) -> (
+      match eval_const b (Buffer.length b.buf) constant with
+      | Rint n -> D.emit_sleb128 b.buf n
+      | Rabs _ | Rrel _ ->
+        Misc.fatal_error "x86_binary_emitter: non-integer sleb128")
+    | Directive (D.Reloc _) ->
       let dll = Oxcaml_utils.Doubly_linked_list.make_single ins in
       X86_gas.generate_asm Out_channel.stderr dll;
       Misc.fatal_errorf "x86_binary_emitter: unsupported instruction"
@@ -1673,19 +1751,60 @@ let resolve_reloc_result b pos result data_size =
       record_reloc b pos (Relocation.Kind.DIR32 (lbl, offset))
   | Rabs (lbl, offset), B64 ->
       record_reloc b pos (Relocation.Kind.DIR64 (lbl, offset))
-  (* Relative relocation in data segment. We add an offset of 4 because
-     REL32 relocations are computed with a PC at the end, while here, it
-     is at the beginning. *)
   | Rrel (lbl, offset), B32 ->
+      (* Add 4 to compensate for the [-4] adjustment applied uniformly by
+         [Relocation_entry.create_relocation] (which is needed for
+         instruction RIP-relative operands but unwanted here, where the
+         literal bytes should encode [target - pos]). *)
       record_reloc b pos (Relocation.Kind.REL32 (lbl, Int64.add offset 4L))
-  | Rrel _, _ -> assert false
-  | Rabs _, _ -> assert false
+  | Rrel _, _ | Rabs _, _ ->
+      Misc.fatal_errorf
+        "x86_binary_emitter.resolve_reloc_result: unsupported combination of \
+         result and data size in section %s at offset %d"
+        (Section_name.to_string b.sec.sec_name) pos
 
-let resolve_reloc_constant b pos cst data_size =
-  (* Printf.eprintf "RelocConstant (%s, %s)\n%!"
-     (X86_gas.string_of_constant cst)
-     (string_of_data_size data_size); *)
-  resolve_reloc_result b pos (eval_const b pos cst) data_size
+(* Resolve every buffer's [global_patches] using a global symbol table
+   built from all buffers' labels. Each patch is converted into either
+   a literal (via [add_patch]) or an ELF relocation (via [record_reloc]),
+   depending on whether the constant expression evaluates to an integer,
+   an absolute symbol reference, or a PC-relative expression. *)
+let resolve_global_patches buffers =
+  let symbols : lookup_result String.Tbl.t = String.Tbl.create 256 in
+  ListLabels.iter buffers ~f:(fun b ->
+      let sec_id = b.sec.sec_name in
+      String.Tbl.iter
+        (fun name sym ->
+          match sym.sy_pos with
+          | None -> ()
+          | Some pos -> (
+              let entry = { lu_sec_id = sec_id; lu_pos = pos } in
+              match String.Tbl.find_opt symbols name with
+              | None -> String.Tbl.add symbols name entry
+              | Some existing ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter.resolve_global_patches: symbol %s \
+                   defined twice (%s@%d vs %s@%d)"
+                  name
+                  (Section_name.to_string existing.lu_sec_id)
+                  existing.lu_pos
+                  (Section_name.to_string entry.lu_sec_id)
+                  entry.lu_pos))
+        b.labels);
+  let lookup name = String.Tbl.find_opt symbols name in
+  ListLabels.iter buffers ~f:(fun b ->
+      let current_sec_id = b.sec.sec_name in
+      ListLabels.iter b.global_patches
+        ~f:(fun { gp_pos = pos; gp_size; gp_cst = cst } ->
+          let v =
+            eval ~lookup ~current_sec_id ~current_pos:pos cst
+          in
+          resolve_reloc_result b pos v gp_size);
+      b.global_patches <- []);
+  (* Identity at the value level; the signature refines the type from
+     [unresolved_buffer list] to [buffer list], enforcing the invariant
+     that [contents]/[relocations] are only called after resolution. *)
+  buffers
+
 
 let rec assemble_section arch section =
   try assemble_section0 arch section
@@ -1746,12 +1865,13 @@ and assemble_section0 arch section =
           let target_pos = label_pos b label in
           let n = target_pos - source_pos in
           add_patch b pos B32 (Int64.of_int n)
-      (* TODO: here, we resolve all computations in each section, i.e. we can only
-         allow one external symbol per expression. We could tolerate more complex
-         expressions if we delay resolution later, i.e. after all sections have
-         been generated and all symbol positions are known. *)
       | RelocConstant (cst, data_size) ->
-          resolve_reloc_constant b pos cst data_size
+          (* Defer to the post-pass [resolve_global_patches], which sees all
+             sections' label offsets and can fold same-section differences or
+             emit supported PC-relative relocations. *)
+          b.global_patches <-
+            { gp_pos = pos; gp_size = data_size; gp_cst = cst }
+            :: b.global_patches
     in
 
     ListLabels.iter !local_relocs ~f:(fun (pos, local_reloc) ->
@@ -1767,6 +1887,11 @@ and assemble_section0 arch section =
    labels should be replaced by a relative computation. The goal is to make
    all computations either absolute, or relative to the current offset.
 *)
+
+let assemble_singleton_section arch section =
+  match resolve_global_patches [assemble_section arch section] with
+  | [b] -> b
+  | _ -> assert false
 
 let size b = Buffer.length b.buf
 

--- a/backend/x86_binary_emitter.mli
+++ b/backend/x86_binary_emitter.mli
@@ -51,13 +51,38 @@ end
 
 module StringMap : Map.S with type key = string
 
+(** Output of [assemble_section]. Cannot be consumed directly; must be
+    passed through [resolve_global_patches] first. This type-level
+    distinction ensures callers cannot forget the global-resolution
+    pass, which folds same-section symbol differences to literals and
+    emits ELF relocations for external references and supported
+    cross-section PC-relative references. *)
+type unresolved_buffer
+
+(** Fully resolved buffer. Once [resolve_global_patches] has run, the
+    bytes and relocation list are in their final form and can be
+    consumed via [contents]/[relocations]. *)
 type buffer
 
 val size : buffer -> int
 
 val relocations : buffer -> Relocation.t list
 
-val assemble_section : arch -> section -> buffer
+val assemble_section : arch -> section -> unresolved_buffer
+
+
+(** Resolve every buffer's deferred data-directive patches using a
+    global symbol table built from all the buffers' labels. Same-section
+    symbol differences fold to literal bytes; external absolute
+    references and supported current-section-anchored PC-relative
+    references produce ELF relocations. Unsupported cross-section
+    subtractions are rejected with a fatal error. Returns the same
+    buffers with their type refined to [buffer]. *)
+val resolve_global_patches : unresolved_buffer list -> buffer list
+
+(** Assemble and resolve a single self-contained section in one step. Use this
+    only when the section definitely has no cross-section references. *)
+val assemble_singleton_section : arch -> section -> buffer
 
 val get_symbol : buffer -> StringMap.key -> symbol
 

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -412,6 +412,10 @@ let peephole_optimize_from pos =
     in
     X86_peephole_optimize.optimize_from_cell start
 
+let iter_sections f =
+  Section_name.Tbl.iter f asm_code_by_section;
+  Section_name.Tbl.iter f delayed_sections
+
 let generate_code asm =
   (match asm with
   | Some f -> Profile.record ~accumulate:true "write_asm" f asm_code

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -86,6 +86,14 @@ val peephole_optimize_from : output_pos -> unit
     (if registered through [register_internal_assembler]). *)
 val generate_code : (X86_ast.asm_program -> unit) option -> unit
 
+(** Iterate over all sections (both regular and delayed), calling [f] with the
+    section name and the instruction stream for each. *)
+val iter_sections :
+  (X86_section.Section_name.t ->
+  X86_ast.asm_line Oxcaml_utils.Doubly_linked_list.t ->
+  unit) ->
+  unit
+
 (** Generate an object file corresponding to the last call to [generate_code].
     An internal assembler is used if available (and the input file is ignored).
     Otherwise, the source asm file with an external assembler. *)


### PR DESCRIPTION
This PR extends the x86 binary emitter/internal assembler to handle cross-section constant expressions emitted by the compiler, especially for DWARF data and function-section layouts. These expressions can refer to labels or symbols defined in other sections, and the binary emitter now resolves the supported cases consistently.

In particular, the emitter now supports section-aware constant evaluation across all assembled sections, including valid PC-relative forms where the expression is anchored at the current section location. Unsupported true cross-section subtractions are still rejected explicitly.

The newly supported cross-section expression cases are:
- Differences between two labels or symbols in the same _non-current_ section
- PC-relative expressions of the form `target - .`
- PC-relative expressions of the form `target - anchor`, where `anchor` is in
  the current section

The PR also adds `.sleb128` and `.uleb128` directive emission for integer-valued expressions, which is needed for DWARF output through the binary emitter.

**Review** This PR builds on #5990 (first commit). To simplify review, it then splits the actual changes into two separate commits, preparation (same functionality as before) and then the actual implementation of the changes described above.
