### PR TITLE
x86-64 RIP-relative instruction operands

### DIFF
--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -99,6 +99,7 @@ type local_reloc =
   | RelocCall of string
   | RelocShortJump of string * int (* loc *)
   | RelocLongJump of string
+  | RelocRipRelative of string * int64 (* symbol, addend *)
   | RelocConstant of C.t * data_size
 
 type result =
@@ -173,6 +174,9 @@ let str_int64L s pos v =
    [OPCODE] + [MODRM] + [SIB] + [IMM32] *)
 
 let local_relocs = ref []
+
+let record_local_reloc b ?(offset=0) local_reloc =
+  local_relocs := (Buffer.length b.buf + offset, local_reloc) :: !local_relocs
 
 let local_labels = String.Tbl.create 100
 
@@ -480,9 +484,14 @@ let emit_prefix_modrm b opcodes rm reg ~prefix =
       prefix b ~rex:0 ~rexr:(rexr_reg reg) ~rexb:0 ~rexx:0;
       buf_opcodes b opcodes;
       buf_int8 b (mod_rm_reg 0b00 0b101 reg);
-      record_reloc b (Buffer.length b.buf)
-        (Relocation.Kind.REL32 (symbol, Int64.of_int offset));
-      buf_int32L b 0L
+      if String.Tbl.mem local_labels symbol then (
+        record_local_reloc b
+          (RelocRipRelative (symbol, Int64.of_int offset));
+        buf_int32L b 0L)
+      else (
+        record_reloc b (Buffer.length b.buf)
+          (Relocation.Kind.REL32 (symbol, Int64.of_int offset));
+        buf_int32L b 0L)
   | Mem { arch; typ = _; idx; scale; base; sym; displ } -> (
       let offset =
         let displ = Int64.of_int displ in
@@ -1100,9 +1109,6 @@ let emit_SHR b dst src = emit_shift 5 b dst src
 
 let emit_SAR b dst src = emit_shift 7 b dst src
 
-let record_local_reloc b ?(offset=0) local_reloc =
-  local_relocs := (Buffer.length b.buf + offset, local_reloc) :: !local_relocs
-
 let emit_reloc_jump near_opcodes far_opcodes b loc symbol =
   if String.Tbl.mem local_labels symbol then
     (* local_reloc *)
@@ -1706,6 +1712,11 @@ and assemble_section0 arch section =
                 (Relocation.Kind.REL32 (lbl, Int64.add offset 4L))
           | Rrel _, _ -> assert false
           | Rabs _, _ -> assert false)
+      | RelocRipRelative (label, addend) ->
+          let source_pos = pos + 4 in
+          let target_pos = label_pos b label in
+          let n = target_pos - source_pos + Int64.to_int addend in
+          add_patch b pos B32 (Int64.of_int n)
     in
 
     ListLabels.iter !local_relocs ~f:(fun (pos, local_reloc) ->


### PR DESCRIPTION
This PR teaches the x86-64 binary emitter to resolve RIP-relative memory operands that target labels defined within the same assembled section. Instead of always producing a REL32 relocation for `symbol(%rip)`, the emitter records a local relocation for these operands and patches the disp32 once label positions are known, preserving any encoded addend.

A concrete win is switch code: the AMD64 backend emits an instruction like `lea .Ljump_table(%rip), %rax` to materialize the base of a jump table before indexing into it, and that jump-table label is in the same text section. The binary emitter can now encode the final displacement directly for that operand instead of leaving behind a relocation against the local label. This is intentionally separate from explicit `.reloc` directives, which still request relocation records and should continue to emit them even for locally-defined targets.

This does not add cross-section RIP-relative resolution or broaden the set of supported symbolic expressions in instruction operands. For example, a RIP-relative load from a label emitted in a different literal/data section, or an external/GOT/PLT-style reference such as `foo@GOTPCREL(%rip)`, still remains relocation-backed for the linker or JIT to resolve.
