### PR TITLE
Add `-open-cmi`, a strict cmi-based variant of `-open`

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -330,7 +330,13 @@ let read_one_param ppf position name v =
   | "runtime-variant" -> runtime_variant := v
   | "with-runtime" -> set "with-runtime" [ with_runtime ] v
   | "open" ->
-      open_modules := List.rev_append (String.split_on_char ',' v) !open_modules
+      let names = String.split_on_char ',' v in
+      open_args :=
+        List.rev_append (List.map (fun n -> Open n) names) !open_args
+  | "open-cmi" ->
+      let names = String.split_on_char ',' v in
+      open_args :=
+        List.rev_append (List.map (fun n -> Open_cmi n) names) !open_args
   | "cc" -> c_compiler := Some v
 
   | "clambda-checks" -> set "clambda-checks" [ clambda_checks ] v

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -97,7 +97,7 @@ let initial_env () =
   Typemod.initial_env
     ~loc:(Location.in_file "command line")
     ~initially_opened_module
-    ~open_implicit_modules:(List.rev !Clflags.open_modules)
+    ~open_implicit_args:(List.rev !Clflags.open_args)
 
 let set_from_env flag Clflags.{ parse; usage; env_var } =
   try

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -499,6 +499,11 @@ let mk_o f =
 let mk_open f =
   "-open", Arg.String f, "<module>  Opens the module <module> before typing"
 
+let mk_open_cmi f =
+  "-open-cmi", Arg.String f,
+  "<file.cmi>  Same as -open, but reads the signature from <file.cmi>\n\
+  \    rather than looking up a module on the include path"
+
 let mk_output_obj f =
   "-output-obj", Arg.Unit f, " Output an object file instead of an executable"
 
@@ -1160,6 +1165,7 @@ module type Common_options = sig
   val _no_auto_include_otherlibs : unit -> unit
   val _nocwd : unit -> unit
   val _open : string -> unit
+  val _open_cmi : string -> unit
   val _ppx : string -> unit
   val _keywords: string -> unit
   val _principal : unit -> unit
@@ -1546,6 +1552,7 @@ struct
     mk_o F._o;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_open_cmi F._open_cmi;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
     mk_output_complete_exe F._output_complete_exe;
@@ -1669,6 +1676,7 @@ struct
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
     mk_open F._open;
+    mk_open_cmi F._open_cmi;
     mk_ppx F._ppx;
     mk_keywords F._keywords;
     mk_principal F._principal;
@@ -1834,6 +1842,7 @@ struct
     mk_o4 F._o4;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_open_cmi F._open_cmi;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
     mk_p F._p;
@@ -2012,6 +2021,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_o3 F._o3;
     mk_o4 F._o4;
     mk_open F._open;
+    mk_open_cmi F._open_cmi;
     mk_ppx F._ppx;
     mk_principal F._principal;
     mk_no_principal F._no_principal;
@@ -2156,6 +2166,7 @@ struct
     mk_o4 F._o4;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_open_cmi F._open_cmi;
     mk_output_obj F._output_obj;
     mk_pack_byt F._pack;
     mk_parameter F._parameter;
@@ -2285,6 +2296,7 @@ struct
     mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
     mk_nocwd F._nocwd;
     mk_open F._open;
+    mk_open_cmi F._open_cmi;
     mk_pp F._pp;
     mk_ppx F._ppx;
     mk_principal F._principal;
@@ -2403,7 +2415,8 @@ module Default = struct
     let _nostdlib = set no_std_include
     let _no_auto_include_otherlibs = set no_auto_include_otherlibs
     let _nocwd = set no_cwd
-    let _open s = open_modules := (s :: (!open_modules))
+    let _open s = open_args := Open s :: !open_args
+    let _open_cmi s = open_args := Open_cmi s :: !open_args
     let _principal = set principal
     let _rectypes = set recursive_types
     let _safer_matching = set safer_matching

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -47,6 +47,7 @@ module type Common_options = sig
   val _no_auto_include_otherlibs : unit -> unit
   val _nocwd : unit -> unit
   val _open : string -> unit
+  val _open_cmi : string -> unit
   val _ppx : string -> unit
   val _keywords: string -> unit
   val _principal : unit -> unit

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -332,14 +332,22 @@ let read_parse_and_extract parse_function extract_function def ast_kind
       let ast = Pparse.file ~tool_name input_file parse_function ast_kind in
       let bound_vars =
         List.fold_left
-          (fun bv modname ->
-             let lid =
-               let lexbuf = Lexing.from_string modname in
-               Location.init lexbuf
-                 (Printf.sprintf "command line argument: -open %S" modname);
-               Parse.simple_module_path lexbuf in
-             Depend.open_module bv lid)
-          !module_map ((* PR#7248 *) List.rev !Clflags.open_modules)
+          (fun bv (arg : Clflags.open_arg) ->
+             match arg with
+             | Open modname ->
+                 let lid =
+                   let lexbuf = Lexing.from_string modname in
+                   Location.init lexbuf
+                     (Printf.sprintf "command line argument: -open %S" modname);
+                   Parse.simple_module_path lexbuf in
+                 Depend.open_module bv lid
+             | Open_cmi _ ->
+                 (* ocamldep does not accept the [-open-cmi] flag and does
+                    not load cmis, so there is nothing to do.  An
+                    [Open_cmi] could still reach this list via [OCAMLPARAM],
+                    in which case we just skip it. *)
+                 bv)
+          !module_map ((* PR#7248 *) List.rev !Clflags.open_args)
       in
       let r = extract_function bound_vars ast in
       (!Depend.free_structure_names, r)
@@ -655,7 +663,9 @@ let run_main argv =
         "<file> Output to <file> rather than stdout";
       "-one-line", Arg.Set one_line,
         " Output one line per file, regardless of the length";
-      "-open", Arg.String (prepend_to_list Clflags.open_modules),
+      "-open", Arg.String
+        (fun s ->
+           Clflags.open_args := Clflags.Open s :: !Clflags.open_args),
         "<module>  Opens the module <module> before typing";
       "-plugin", Arg.String(fun _p -> Clflags.plugin := true),
         "<plugin>  (no longer supported)";

--- a/extract_externals/extract_externals.ml
+++ b/extract_externals/extract_externals.ml
@@ -155,7 +155,8 @@ let extract_shapes_from_file ~verbose file =
 
 let extract_shapes_from_files ~verbose files =
   Clflags.include_dirs := !include_dirs @ !Clflags.include_dirs;
-  Clflags.open_modules := !open_modules @ !Clflags.open_modules;
+  Clflags.open_args
+    := List.map (fun s -> Clflags.Open s) !open_modules @ !Clflags.open_args;
   Clflags.hidden_include_dirs
     := !hidden_include_dirs @ !Clflags.hidden_include_dirs;
   Clflags.include_manifests := !include_manifests @ !Clflags.include_manifests;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1907,7 +1907,7 @@ let transl_prim modname field =
   match Env.open_pers_signature modname env with
   | exception Not_found ->
       fatal_errorf "Module %s unavailable." modname
-    | _path, _mode, env -> (
+    | _path, env -> (
       match Env.find_value_by_name_lazy (Longident.Lident field) env with
       | exception Not_found ->
           fatal_errorf "Primitive %s.%s not found." modname field

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -41,7 +41,7 @@ let camlinternalQuote =
      with
     | exception Not_found ->
       fatal_errorf "Module CamlinternalQuote unavailable."
-    | path, _, env -> path, env)
+    | path, env -> path, env)
 
 let use modname field =
   lazy

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -36,13 +36,14 @@ let initial_env () =
     else
       Some initial
   in
-  let open_implicit_modules =
+  let open_implicit_args =
     let ln = !Odoc_global.library_namespace in
     let ln = if current = ln || ln = initial || ln = "" then [] else [ln] in
-    ln @ List.rev !Clflags.open_modules in
+    List.map (fun s -> Clflags.Open s) ln @ List.rev !Clflags.open_args
+  in
   Typemod.initial_env
     ~loc:(Location.in_file "ocamldoc command line")
-    ~open_implicit_modules
+    ~open_implicit_args
     ~initially_opened_module
 
 (** Optionally preprocess a source file *)

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -1125,6 +1125,11 @@ module PpxContext = struct
     | Some x -> Exp.construct (lid "Some") (Some (f x))
     | None   -> Exp.construct (lid "None") None
 
+  let make_open_arg (arg : Clflags.open_arg) =
+    match arg with
+    | Open s -> Exp.construct (lid "Open") (Some (make_string s))
+    | Open_cmi s -> Exp.construct (lid "Open_cmi") (Some (make_string s))
+
   let get_cookies () =
     lid "cookies",
     make_list (make_pair make_string (fun x -> x))
@@ -1159,7 +1164,8 @@ module PpxContext = struct
             (make_list (make_pair make_string make_bool))
             (make_list make_string)
             (visible_load_dir_pairs visible, hidden);
-        lid "open_modules", make_list make_string !Clflags.open_modules;
+        lid "open_args",
+          make_list make_open_arg !Clflags.open_args;
         lid "for_package",  make_option make_string !Clflags.for_package;
         lid "debug",        make_bool !Clflags.debug;
         lid "use_threads",  make_bool !Clflags.use_threads;
@@ -1225,6 +1231,16 @@ module PpxContext = struct
             None
         | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
                              { %s }] option syntax" name
+      and get_open_arg = function
+        | { pexp_desc =
+              Pexp_construct ({ txt = Longident.Lident "Open" }, Some exp) } ->
+            Clflags.Open (get_string exp)
+        | { pexp_desc =
+              Pexp_construct
+                ({ txt = Longident.Lident "Open_cmi" }, Some exp) } ->
+            Clflags.Open_cmi (get_string exp)
+        | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
+                             { %s }] open_arg syntax" name
       in
       match name with
       | "tool_name" ->
@@ -1259,8 +1275,8 @@ module PpxContext = struct
               visible
           in
           Load_path.init ~auto_include ~visible ~hidden
-      | "open_modules" ->
-          Clflags.open_modules := get_list get_string payload
+      | "open_args" ->
+          Clflags.open_args := get_list get_open_arg payload
       | "for_package" ->
           Clflags.for_package := get_option get_string payload
       | "debug" ->

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -139,7 +139,7 @@ val tool_name: unit -> string
     ["ocaml"], ...  Some global variables that reflect command-line
     options are automatically synchronized between the calling tool
     and the ppx preprocessor: {!Clflags.include_dirs},
-    {!Clflags.hidden_include_dirs}, {!Load_path}, {!Clflags.open_modules},
+    {!Clflags.hidden_include_dirs}, {!Load_path}, {!Clflags.open_args},
     {!Clflags.for_package}, {!Clflags.debug}. *)
 
 

--- a/testsuite/tests/hidden_includes/libb/b_open.ml
+++ b/testsuite/tests/hidden_includes/libb/b_open.ml
@@ -1,0 +1,3 @@
+(* Compiled with [-open-cmi liba/a.cmi]: bare [t] and [x] should resolve
+   to [A.t] / [A.x] without [A] being on the include path. *)
+let y : t = x

--- a/testsuite/tests/hidden_includes/libb/uses_float.ml
+++ b/testsuite/tests/hidden_includes/libb/uses_float.ml
@@ -1,0 +1,3 @@
+(* Compiled with [-open A] after [-open-cmi libb/with_sub.cmi]: bare [x]
+   resolves to the [float] [x] inside [with_sub.A]. *)
+let y : float = x

--- a/testsuite/tests/hidden_includes/libb/uses_int.ml
+++ b/testsuite/tests/hidden_includes/libb/uses_int.ml
@@ -1,0 +1,4 @@
+(* Compiled with [-open-cmi libb/with_sub.cmi -open-cmi liba/a.cmi]: bare
+   [x] resolves to [liba/a.cmi]'s [int] [x], not to the [A] sub-module that
+   [with_sub.cmi] brought into scope. *)
+let y : int = x

--- a/testsuite/tests/hidden_includes/libb/uses_string.ml
+++ b/testsuite/tests/hidden_includes/libb/uses_string.ml
@@ -1,0 +1,5 @@
+(* Compiled with [-I liba -open A -open-cmi libb/with_sub.cmi]: the
+   trailing [-open-cmi] should shadow the earlier [-open A], so [x]
+   resolves to [With_sub]'s top-level [string] [x] rather than to
+   [liba/a.cmi]'s [int] [x]. *)
+let y : string = x

--- a/testsuite/tests/hidden_includes/libb/with_sub.ml
+++ b/testsuite/tests/hidden_includes/libb/with_sub.ml
@@ -1,0 +1,12 @@
+(* Used by [-open-cmi] tests:
+   - [A] is a sub-module whose [x] is a [float], distinguishing it from
+     [liba/a.cmi]'s [int] [x] (used to test ordering and shadowing).
+   - The top-level [x : string] lets the same cmi be used to test command-line
+     order against an [-open A] without a cmi name collision. *)
+module A = struct
+  type t = float
+
+  let x = 3.14
+end
+
+let x = "from With_sub"

--- a/testsuite/tests/hidden_includes/test.ml
+++ b/testsuite/tests/hidden_includes/test.ml
@@ -34,6 +34,10 @@ ocamlc.byte;
 flags = "-I liba -I libb -nocwd";
 module = "libb/b.ml";
 ocamlc.byte;
+
+flags = "-nocwd";
+module = "libb/with_sub.ml";
+ocamlc.byte;
 {
   (* Test hiding A completely. You can't do much with types from it because
      their layouts are unknown. *)
@@ -169,6 +173,65 @@ ocamlc.byte;
 {
   flags = "-H liba -I libb -nocwd";
   module = "libc/c5.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+}
+
+(* Test that [-open-cmi] reads the cmi from the given path without
+   consulting the include path. *)
+{
+  flags = "-nocwd -open-cmi liba/a.cmi";
+  module = "libb/b_open.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+}
+
+(* Test that [-open-cmi] works alongside -H. *)
+{
+  flags = "-H liba -I libb -nocwd -open-cmi liba/a.cmi";
+  module = "libb/b_open.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+}
+
+(* Test that [-open-cmi] of a hidden module does not make user-code
+   references to that module legal. *)
+{
+  flags = "-H liba -I libb -nocwd -open-cmi liba/a.cmi";
+  module = "libc/c3.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc_byte_exit_status = "2";
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/cant_reference_hidden.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Test that an [-open] following an earlier [-open-cmi] can refer to a
+   module brought into scope by it: command-line order is preserved. *)
+{
+  flags = "-nocwd -open-cmi libb/with_sub.cmi -open A";
+  module = "libb/uses_float.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+}
+
+(* Test that [-open-cmi] loads the cmi at the given path and ignores any
+   in-scope module of the same name: the sub-module [A] brought into scope
+   by [-open-cmi libb/with_sub.cmi] does not shadow the subsequent
+   [-open-cmi liba/a.cmi]. *)
+{
+  flags = "-nocwd -open-cmi libb/with_sub.cmi -open-cmi liba/a.cmi";
+  module = "libb/uses_int.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+}
+
+(* Test that a trailing [-open-cmi] overrides an earlier [-open]:
+   command-line order is preserved across the two flag kinds. *)
+{
+  flags = "-I liba -nocwd -open A -open-cmi libb/with_sub.cmi";
+  module = "libb/uses_string.ml";
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
 }

--- a/testsuite/tests/ppx-contexts/myppx.ml
+++ b/testsuite/tests/ppx-contexts/myppx.ml
@@ -3,8 +3,6 @@
 open Ast_mapper
 
 let () =
-  let quote_strings li =
-    List.map (Printf.sprintf "%S") li |> String.concat " " in
   let quote_option = function
     | None -> "None"
     | Some s -> Printf.sprintf "Some(%S)" s in
@@ -20,8 +18,12 @@ let () =
       Printf.eprintf "load_path: [%s]\n"
         (quote_strings !Config.load_path);
       *)
-      Printf.eprintf "open_modules: [%s]\n"
-        (quote_strings !Clflags.open_modules);
+      let quote_open_arg : Clflags.open_arg -> string = function
+        | Open s -> Printf.sprintf "Open(%S)" s
+        | Open_cmi s -> Printf.sprintf "Open_cmi(%S)" s
+      in
+      Printf.eprintf "open_args: [%s]\n"
+        (List.map quote_open_arg !Clflags.open_args |> String.concat " ");
       Printf.eprintf "for_package: %S\n"
         (quote_option !Clflags.for_package);
       Printf.eprintf "use_debug: %B\n"

--- a/testsuite/tests/ppx-contexts/test.compilers.reference
+++ b/testsuite/tests/ppx-contexts/test.compilers.reference
@@ -1,6 +1,6 @@
 <ppx-context>
 tool_name: "ocamlc"
-open_modules: ["List"]
+open_args: [Open("List")]
 for_package: "None"
 use_debug: false
 use_threads: true
@@ -11,7 +11,7 @@ unboxed_types: true
 </ppx-context>
 <ppx-context>
 tool_name: "ocamlc"
-open_modules: []
+open_args: []
 for_package: "None"
 use_debug: true
 use_threads: false

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3490,6 +3490,15 @@ let assert_does_not_cross_quotation ~loc_use ~loc_def env path locks =
         (Location.Doc.loc ~capitalize_first:false) loc_def
         (Location.Doc.loc ~capitalize_first:false) loc_use
 
+let locks_for_pers_mod ~loc_use ~loc_def env path =
+  let stage_locks, locks =
+    partition_locks (IdTbl.get_all_locks env.modules)
+  in
+  (* Tripwire: persistent paths are toplevel-scoped, so this should never
+     fire. *)
+  assert_does_not_cross_quotation env ~loc_use ~loc_def path stage_locks;
+  locks
+
 let report_module_unbound ~errors ~loc env reason =
   match reason with
   | Mod_unbound_illegal_recursion { container; unbound } ->
@@ -4278,7 +4287,27 @@ let remove_last_open root env0 =
 (* Open a signature from a file *)
 
 let open_pers_signature name env =
-  open_signature ~errors:false None (Location.mknoloc (Lident name)) env
+  let path, _, env =
+    open_signature ~errors:false None (Location.mknoloc (Lident name)) env
+  in
+  path, env
+
+let open_pers_signature_cmi filename env =
+  let global_name, _sign =
+    Persistent_env.read_cmi_file !persistent_env filename
+  in
+  let mda =
+    find_pers_mod ~allow_hidden:true global_name ~allow_excess_args:false
+  in
+  let path = Pident (Ident.create_global global_name) in
+  use_module ~use:true ~loc:Location.none path mda;
+  let comps = find_structure_components path env in
+  let locks =
+    locks_for_pers_mod ~loc_use:Location.none
+      ~loc_def:Location.none env path
+  in
+  let env = add_components None path env comps locks in
+  path, env
 
 let open_signature
     ~used_slot
@@ -4356,7 +4385,6 @@ let lookup_module_path ~errors ~use ~loc ~load lid env =
 let lookup_module_instance_path ~errors ~use ~loc ~load name env =
   (* The locks are whatever locks we would find if we went through
      [lookup_module_path] on a module not found in the environment *)
-  let locks = IdTbl.get_all_locks env.modules in
   let path, loc_def, mode =
     if !Clflags.no_alias_deps && not load then
       let path, () =
@@ -4373,8 +4401,9 @@ let lookup_module_instance_path ~errors ~use ~loc ~load name env =
       in
       path, mda.mda_declaration.md_loc, mda.mda_mode
   in
-  let stage_locks, locks = partition_locks locks in
-  assert_does_not_cross_quotation env ~loc_use:loc ~loc_def path stage_locks;
+  let locks =
+    locks_for_pers_mod ~loc_use:loc ~loc_def env path
+  in
   path, (mode, locks)
 
 let lookup_value_lazy ~errors ~use ~loc lid env =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -503,7 +503,13 @@ val add_signature_lazy: Subst.Lazy.signature_item list -> t -> t
 
 (* Insertion of all fields of a signature, relative to the given path.
    Used to implement open. Returns None if the path refers to a functor,
-   not a structure. *)
+   not a structure.
+
+   Soundness of type checking does not depend on the returned
+   [mode_with_locks]: the locks crossed to reach the opened module have
+   already been threaded into the resulting environment so that later
+   lookups of items brought into scope walk them. The value is returned
+   only so callers can record it on the typedtree's [mod_mode]. *)
 val open_signature:
     used_slot:bool ref ->
     loc:Location.t -> toplevel:bool ->
@@ -512,7 +518,12 @@ val open_signature:
 
 val open_signature_by_path: Path.t -> t -> t
 
-val open_pers_signature: string -> t -> Path.t * mode_with_locks * t
+val open_pers_signature: string -> t -> Path.t * t
+
+(* Like [open_pers_signature], but takes a [.cmi] file path and loads it
+   directly (bypassing the include path) and ignores any in-scope module of
+   the same name. Used to implement [-open-cmi]. *)
+val open_pers_signature_cmi: string -> t -> Path.t * t
 
 val remove_last_open: Path.t -> t -> t option
 

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -959,6 +959,22 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
 let read penv modname a =
   read_pers_struct penv true modname a
 
+let read_cmi_file penv filename =
+  let cmi = read_cmi_lazy filename in
+  let unit_name = cmi.cmi_name in
+  let modname = CU.Name.to_global_name unit_name in
+  add_import penv unit_name;
+  (* Register as hidden so that direct user-code references to the module
+     are still reported as unbound; only transitive lookups can reach it. *)
+  let pers_sig =
+    { Persistent_signature.filename; cmi; visibility = Load_path.Hidden }
+  in
+  let import = acknowledge_import penv ~check:true unit_name pers_sig in
+  let pers_name =
+    acknowledge_pers_name penv true modname import ~allow_excess_args:false
+  in
+  modname, pers_name.pn_sign
+
 let find ~allow_hidden penv f name ~allow_excess_args =
   (find_pers_struct ~allow_hidden ~allow_excess_args penv f ~check:true
      name).ps_val

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -106,6 +106,15 @@ type 'a sig_reader =
 
 val read : 'a t -> Global_module.Name.t -> Unit_info.Artifact.t
   -> Subst.Lazy.persistent_signature
+
+(** [read_cmi_file] is a variant of [read] that takes the path of a cmi
+    file directly: it reads the cmi and registers it as a hidden import
+    under the module name stored inside the cmi (rather than one inferred
+    from the filename or supplied by the caller). Returns the resulting
+    global name and signature. *)
+val read_cmi_file :
+     'a t -> string
+  -> Global_module.Name.t * Subst.Lazy.persistent_signature
 val find : allow_hidden:bool -> 'a t -> 'a sig_reader
   -> Global_module.Name.t -> allow_excess_args:bool -> 'a
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -317,8 +317,7 @@ let extract_sig_functor_open funct_body env loc mty sig_acc md_mode =
 let type_open_ ?(used_slot=ref false) ?(toplevel=false) ovf env loc lid =
   Env.open_signature ~loc ~used_slot ~toplevel ovf lid env
 
-let initial_env ~loc ~initially_opened_module
-    ~open_implicit_modules =
+let initial_env ~loc ~initially_opened_module ~open_implicit_args =
   let env = Lazy.force Env.initial in
   let open_module env m =
     let open Asttypes in
@@ -329,6 +328,13 @@ let initial_env ~loc ~initially_opened_module
     in
     let _, _, env = type_open_ Override env loc {txt;loc} in
     env
+  in
+  let process_open_arg env (arg : Clflags.open_arg) =
+    match arg with
+    | Open m -> open_module env m
+    | Open_cmi cmi ->
+        let _, env = Env.open_pers_signature_cmi cmi env in
+        env
   in
   let add_units env units =
     String.Set.fold
@@ -373,7 +379,10 @@ let initial_env ~loc ~initially_opened_module
   let units_from_filenames =
     Env.persistent_structures_of_basenames basenames in
   let env = add_units env units_from_filenames in
-  List.fold_left open_module env open_implicit_modules
+  (* Process [-open] and [-open-cmi] in command-line order, so an [-open]
+     can refer to a module brought into scope by an earlier [-open-cmi]
+     (and vice-versa: a later [-open-cmi] shadows an earlier [-open]). *)
+  List.fold_left process_open_arg env open_implicit_args
 
 let type_open_descr ?used_slot ?toplevel env sod =
   let (path, _, newenv) =

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -82,7 +82,7 @@ val package_units:
 val initial_env:
   loc:Location.t ->
   initially_opened_module:string option ->
-  open_implicit_modules:string list -> Env.t
+  open_implicit_args:Clflags.open_arg list -> Env.t
 
 module Sig_component_kind : sig
   type t =

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -38,6 +38,10 @@ module Float_arg_helper = Arg_helper.Make (struct
   end
 end)
 
+type open_arg =
+  | Open of string
+  | Open_cmi of string
+
 let objfiles = ref ([] : string list)   (* .cmo and .cma files *)
 and ccobjs = ref ([] : string list)     (* .o, .a, .so and -cclib -lxxx *)
 and dllibs = ref ([] : string list)     (* .so and -dllib -lxxx *)
@@ -150,7 +154,7 @@ and noprompt = ref false                (* -noprompt *)
 and nopromptcont = ref false            (* -nopromptcont *)
 and init_file = ref (None : string option)   (* -init *)
 and noinit = ref false                  (* -noinit *)
-and open_modules = ref []               (* -open *)
+and open_args = ref ([] : open_arg list) (* -open / -open-cmi *)
 and use_prims = ref ""                  (* -use-prims ... *)
 and use_runtime = ref ""                (* -use-runtime ... *)
 and plugin = ref false                  (* -plugin ... *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -122,7 +122,11 @@ val classic : bool ref
 val nopervasives : bool ref
 val match_context_rows : int ref
 val safer_matching : bool ref
-val open_modules : string list ref
+type open_arg =
+  | Open of string
+  | Open_cmi of string
+
+val open_args : open_arg list ref
 val preprocessor : string option ref
 val all_ppx : string list ref
 val absname : bool ref


### PR DESCRIPTION
`-open-cmi <file.cmi>` opens a module signature directly from the given `.cmi` file. The file is taken verbatim (no `-I` / `-H` lookup, similar to `-cmi-file`). The flag is processed before `-open`, so a subsequent `-open` can refer to a module brought into scope by `-open-cmi`.

Useful for build systems that want to `open M` without putting `M` or its sibling modules on the include path.