### PR TITLE
Implement support for jitdump files

### DIFF
--- a/JIT_GDB_PLAN.md
+++ b/JIT_GDB_PLAN.md
@@ -77,8 +77,8 @@ single-threaded so this is free.
 
 A new submodule on `Binary_emitter_intf.S` named `Gdb_jit_symfile` lets
 ocaml-jit stay backend-agnostic: it calls `For_jit.Gdb_jit_symfile.build`
-without knowing the concrete section type. X86 implements it via
-`internal_assembler`; arm64 returns `None` for now.
+without knowing the concrete section type. Both x86 and arm64 implement it
+by delegating to a shared, generic ELF builder.
 
 ```
 module type Gdb_jit_symfile = sig
@@ -86,19 +86,23 @@ module type Gdb_jit_symfile = sig
   val build :
     sections:(string * assembled_section) list ->
     section_address:(string -> int64 option) ->
+    section_runtime_size:(string -> int option) ->
     Compiler_owee.Owee_buf.t option
 end
 ```
 
-`internal_assembler` gains a new public entry point that:
+The generic builder lives in a new tiny library `backend/jit_symfile/` so
+both `x86_binary_emitter` (in the main library) and `arm64_binary_emitter`
+(a separate library) can depend on it without circularity. Its only inputs
+are an `Assembled_section` first-class module (taking
+`size`/`contents_mut`/`iter_labels_and_symbols`), the `e_machine` value, and
+the per-section address/runtime-size callbacks. It allocates a
+`Bigarray.Array1` of the right size, zero-fills it, and writes a complete
+ET_REL ELF: ELF header, section bodies, symtab, strtab, shstrtab, section
+header table. No `.rela*`, no DWARF.
 
-- Takes already-assembled `X86_binary_emitter.section`s (no DWARF callback).
-- Takes a `section_address : Section_name.t -> int64 option`.
-- Skips `create_relocation_tables` / `make_relocation_section`.
-- Sets `sh_addr` for `SHF_ALLOC` sections from `section_address`.
-- Allocates a `Bigarray.Array1` of the right size and writes into it
-  instead of mmap'ing a file.
-- Returns the `Owee_buf.t`.
+The existing `Internal_assembler.assemble` (the on-disk path used by the
+normal `.o`-emitting compiler driver) is unchanged.
 
 A new module `external/ocaml-jit/lib/gdb_jit.{ml,mli}` owns the protocol.
 The `Owee_buf.t` (Bigarray) is held in OCaml so it stays live; the
@@ -112,60 +116,89 @@ compilation phrase.
 
 ## File-level changes
 
-1. `backend/binary_emitter_intf/binary_emitter_intf.ml`
+1. `backend/binary_emitter_intf/binary_emitter_intf.ml` (+ dune)
    - Add `module type Gdb_jit_symfile`.
    - Add `module Gdb_jit_symfile : Gdb_jit_symfile with type assembled_section = Assembled_section.t` to `module type S`.
+   - Dune now depends on `compiler_owee` (because the signature mentions
+     `Compiler_owee.Owee_buf.t`).
 
-2. `backend/internal_assembler/internal_assembler.{ml,mli}`
-   - Factor the inner ELF-writing logic so it can run on pre-assembled
-     sections (skipping `get_sections`'s assemble + DWARF passes).
-   - Add `val assemble_in_memory :
-       sections:(X86_proc.Section_name.t * X86_binary_emitter.section) list ->
-       section_address:(X86_proc.Section_name.t -> int64 option) ->
-       Compiler_owee.Owee_buf.t`.
-   - Internally allocate a Bigarray of computed total size and write into it.
-   - In the SHF_ALLOC section creators, look up `section_address name` and
-     use it for `sh_addr` (default `0L`).
-   - Skip relocation table creation entirely on this path.
+2. `backend/jit_symfile/` — new library.
+   - `Jit_symfile.build` takes a `(module Binary_emitter_intf.Assembled_section)`,
+     `e_machine`, sections, address/runtime-size callbacks; returns an
+     in-memory `Owee_buf.t`.
+   - Skips DWARF and relocation tables.
+   - Symbols come from `iter_labels_and_symbols`; names starting `.L` are
+     stripped (standard ELF convention). All emitted symbols are
+     `STB_GLOBAL` with type heuristically `STT_FUNC` for text-like
+     sections, `STT_OBJECT` for data-like, else `STT_NOTYPE`. (See
+     "Caveats" below — this is a deliberate fidelity loss versus the
+     existing `internal_assembler` path.)
 
-3. `backend/x86_binary_emitter.{ml,mli}`
-   - In `For_jit`, add `module Gdb_jit_symfile` that converts the input
-     list to the form `internal_assembler.assemble_in_memory` wants and
-     calls it; returns `Some buf`.
-   - The public `.mli` doesn't need extra signature work because `For_jit
-     : Binary_emitter_intf.S` propagates the new submodule automatically.
+3. `backend/x86_binary_emitter.ml`
+   - In `For_jit`, add `module Gdb_jit_symfile` that calls
+     `Jit_symfile.build (module Assembled_section) ~e_machine:0x3E …`.
+   - The public `.mli` doesn't need extra signature work because
+     `For_jit : Binary_emitter_intf.S` propagates the new submodule
+     automatically.
+   - `Internal_assembler` (the on-disk x86 ELF writer) is untouched.
 
-4. `backend/arm64/binary_emitter/for_jit.ml`
-   - Add a `Gdb_jit_symfile` stub returning `None`.
+4. `backend/arm64/binary_emitter/for_jit.ml` (+ dune)
+   - Add `module Gdb_jit_symfile` calling
+     `Jit_symfile.build (module Assembled_section) ~e_machine:0xB7 …`.
+   - Dune depends on `jit_symfile`.
 
-5. `external/ocaml-jit/lib/jit_stubs.c`
-   - Add `__jit_debug_descriptor` (version=1) and `__jit_debug_register_code`.
+5. `dune` (top-level main library) — add `jit_symfile` dependency so
+   `x86_binary_emitter` (which is in the main library) can use it.
+
+6. `external/ocaml-jit/lib/jit_stubs.c`
+   - Add `__jit_debug_descriptor` (version=1) and `__jit_debug_register_code`
+     (`noinline` + memory-clobber asm).
    - Add `caml_jit_gdb_register` taking a Bigarray; mallocs an entry,
-     splices it in, sets action_flag, calls the trampoline. Returns the
-     entry pointer as a nativeint.
-   - Add `caml_jit_gdb_unregister` for completeness (may not call it in
-     v1).
+     splices it in at the head of the doubly-linked list, sets
+     `action_flag = JIT_REGISTER`, calls the trampoline. Returns the entry
+     pointer as a nativeint.
+   - Add `caml_jit_gdb_unregister` for completeness.
 
-6. `external/ocaml-jit/lib/gdb_jit.{ml,mli}` (new)
-   - `type handle` — record holding `bigarray : Owee_buf.t` (root) and
-     `entry_ptr : nativeint`.
+7. `external/ocaml-jit/lib/gdb_jit.{ml,mli}` (new)
+   - `type handle = { symfile : Owee_buf.t; entry : nativeint }` — keeps
+     the Bigarray header live so the underlying off-heap data is not
+     freed.
    - `val register : Owee_buf.t -> handle`.
    - `val unregister : handle -> unit`.
 
-7. `external/ocaml-jit/lib/jit.ml`
-   - In `jit_load`, after `load_text`/`load_sections`, call the emitter's
-     `For_jit.Gdb_jit_symfile.build`, passing:
-     - `sections`: the binary-section map flattened to `(string,
-       assembled_section) list` (just `.text` plus the other sections;
-       relocations have already been applied).
-     - `section_address`: lookup against the `addressed_text` and
-       `addressed_sections` maps.
-   - If `Some buf`, call `Gdb_jit.register buf`, store the handle in
-     `Globals`.
+8. `external/ocaml-jit/lib/jit.ml`
+   - New `register_with_gdb` runs after `load_text`/`load_sections`. Builds
+     a per-section address table from `text.address` and
+     `addressed_sections`, plus a single runtime-size override for `.text`
+     equal to `Jit_text_section.in_memory_size` so the section spans the
+     GOT and PLT padding. Calls `E.Gdb_jit_symfile.build`; if `Some buf`,
+     calls `Gdb_jit.register` and stores the handle in `Globals`.
 
-8. `external/ocaml-jit/lib/globals.{ml,mli}`
-   - Add a `gdb_handles : Gdb_jit.handle list ref` (or a Stack) so
-     handles stay reachable.
+9. `external/ocaml-jit/lib/jit_text_section.{ml,mli}` — exposes
+   `binary_section : ('a, _) t -> 'a` so jit.ml can pull out the underlying
+   assembled section to feed to `Gdb_jit_symfile.build`.
+
+10. `external/ocaml-jit/lib/globals.{ml,mli}`
+    - Add `val gdb_jit_handles : Gdb_jit.handle list ref` so handles stay
+      reachable for the process lifetime.
+
+## Caveats (known loss-of-fidelity / leak)
+
+- **Symbols emitted as global only.** `Jit_symfile` infers symbol type
+  from the containing section's name and emits everything as
+  `STB_GLOBAL`. The previous on-disk x86 path used the rich
+  `X86_binary_emitter.symbol` metadata (`Sy_local`/`Sy_global`/`Sy_weak`,
+  `Function`/`Object`/`None`, `sy_protected`). For OCaml code most
+  user-visible symbols are global, so this is a cosmetic loss — GDB still
+  finds everything by name.
+- **`Globals.gdb_jit_handles` never pruned.** Every JIT phrase appends a
+  handle that stays alive for the process. For a long-running JIT
+  toplevel this is a slow leak. Pruning would require also tracking which
+  handles correspond to which phrases, which we don't currently.
+- **`Owee_elf.write_elf` writes section names into shstrtab at the
+  computed `sh_name` offsets**, and `Jit_symfile` then writes the entire
+  shstrtab linearly over the same region. Both produce the same bytes by
+  construction; just an unimportant duplication of effort.
 
 ## Risks / unknowns
 

--- a/JIT_GDB_PLAN.md
+++ b/JIT_GDB_PLAN.md
@@ -1,0 +1,216 @@
+# GDB JIT Interface for OxCaml's in-process JIT (x86-64 ELF)
+
+## Goal
+
+Make code produced by `external/ocaml-jit` visible to GDB via the GDB
+JIT-Interface protocol, on x86-64 Linux. Cannot test on this Mach-O box;
+implementation is by inspection only.
+
+Scope of this first cut:
+- x86-64 only.
+- ELF symfile only (the format GDB's JIT loader consumes).
+- **No DWARF.** GDB will get function names, addresses, and disassembly via
+  the symtab; no source-level stepping. DWARF can be added later.
+- Symfile bytes are taken to be already post-relocation (the JIT applies
+  relocations to the in-memory section bytes before we hand them off).
+
+## Protocol summary (verified against `binutils-gdb/gdb/jit.{c,h}`)
+
+GDB looks up two well-known globals in the inferior:
+
+- `__jit_debug_descriptor` — a `{ uint32_t version; uint32_t action_flag;
+  jit_code_entry *relevant_entry; jit_code_entry *first_entry; }`. Initialised
+  to `{ 1, 0, 0, 0 }`.
+- `__jit_debug_register_code` — empty `noinline` function. GDB sets a
+  breakpoint here.
+
+To register a symfile: build a `jit_code_entry { next, prev, symfile_addr,
+symfile_size }`, splice into the doubly-linked list rooted at
+`first_entry`, set `relevant_entry`, set `action_flag = JIT_REGISTER (1)`,
+call `__jit_debug_register_code()`. GDB:
+
+1. Reads the entry from inferior memory.
+2. `gdb_bfd_open_from_target_memory` reads `symfile_size` bytes at
+   `symfile_addr` and parses them as a BFD object.
+3. Walks `nbfd->sections`, takes `bfd_section_vma (sec)` (= ELF `sh_addr`)
+   for each `SEC_ALLOC|SEC_LOAD` section, and treats those as **absolute**
+   addresses. (`gdb/jit.c:786-798`.)
+4. Calls `symbol_file_add_from_bfd` with `OBJF_SHARED|OBJF_NOT_FILENAME`.
+
+GDB does not patch inferior memory. `.rela*` sections are not consulted.
+Therefore for a JIT that has already applied its own relocations, we just
+need to:
+
+- Set `sh_addr` for each `SHF_ALLOC` section to the runtime address.
+- Provide a symtab so symbols resolve to `sh_addr + st_value`.
+- Optionally include or omit `.rela*` (we omit, since they describe
+  relocations already applied to live code and are not used by GDB).
+
+Unregister: same dance with `JIT_UNREGISTER (2)` and the entry removed from
+the list.
+
+The descriptor must be serialised across registrations; the JIT toplevel is
+single-threaded so this is free.
+
+## What we already have
+
+- `backend/internal_assembler/` — full ELF-64 x86-64 writer (ET_REL, EM_X86_64,
+  symtab/strtab/shstrtab, `.rela*` for `R_X86_64_{64,PLT32,GOTPCREL}`).
+  Currently writes to disk via `Compiler_owee.Owee_buf.map_binary_write`.
+- `Compiler_owee.Owee_buf.t` is a `Bigarray.Array1` of `int8_unsigned` —
+  contiguous memory we can hand to GDB without copying. We can construct
+  one directly with `Bigarray.Array1.create` (no need to add anything to
+  Owee).
+- `external/ocaml-jit/lib/jit.ml` already lays out sections at runtime
+  addresses (`alloc_all`), applies relocations (`relocate_text`,
+  `relocate_other`), and copies + mprotects pages (`load_text`,
+  `load_sections`). At the moment `load_*` runs, every section we care about
+  has a runtime address available in the `addressed` records.
+- `backend/binary_emitter_intf/` — abstraction layer that lets ocaml-jit
+  stay backend-agnostic. Both X86 and arm64 implement `For_jit :
+  Binary_emitter_intf.S`.
+- `backend/jit_backend.ml` — architecture dispatch that packs assembled
+  sections into a `Packed { emitter; sections }` existential and hands them
+  to ocaml-jit's callback.
+
+## Design
+
+A new submodule on `Binary_emitter_intf.S` named `Gdb_jit_symfile` lets
+ocaml-jit stay backend-agnostic: it calls `For_jit.Gdb_jit_symfile.build`
+without knowing the concrete section type. X86 implements it via
+`internal_assembler`; arm64 returns `None` for now.
+
+```
+module type Gdb_jit_symfile = sig
+  type assembled_section
+  val build :
+    sections:(string * assembled_section) list ->
+    section_address:(string -> int64 option) ->
+    Compiler_owee.Owee_buf.t option
+end
+```
+
+`internal_assembler` gains a new public entry point that:
+
+- Takes already-assembled `X86_binary_emitter.section`s (no DWARF callback).
+- Takes a `section_address : Section_name.t -> int64 option`.
+- Skips `create_relocation_tables` / `make_relocation_section`.
+- Sets `sh_addr` for `SHF_ALLOC` sections from `section_address`.
+- Allocates a `Bigarray.Array1` of the right size and writes into it
+  instead of mmap'ing a file.
+- Returns the `Owee_buf.t`.
+
+A new module `external/ocaml-jit/lib/gdb_jit.{ml,mli}` owns the protocol.
+The `Owee_buf.t` (Bigarray) is held in OCaml so it stays live; the
+`jit_code_entry` itself is `malloc`'d by the C stubs (so it has a stable
+address GDB can read). C side defines `__jit_debug_descriptor` and
+`__jit_debug_register_code`.
+
+`external/ocaml-jit/lib/jit.ml` calls the new path after `load_text` /
+`load_sections` and stashes handles in `Globals` so they outlive the
+compilation phrase.
+
+## File-level changes
+
+1. `backend/binary_emitter_intf/binary_emitter_intf.ml`
+   - Add `module type Gdb_jit_symfile`.
+   - Add `module Gdb_jit_symfile : Gdb_jit_symfile with type assembled_section = Assembled_section.t` to `module type S`.
+
+2. `backend/internal_assembler/internal_assembler.{ml,mli}`
+   - Factor the inner ELF-writing logic so it can run on pre-assembled
+     sections (skipping `get_sections`'s assemble + DWARF passes).
+   - Add `val assemble_in_memory :
+       sections:(X86_proc.Section_name.t * X86_binary_emitter.section) list ->
+       section_address:(X86_proc.Section_name.t -> int64 option) ->
+       Compiler_owee.Owee_buf.t`.
+   - Internally allocate a Bigarray of computed total size and write into it.
+   - In the SHF_ALLOC section creators, look up `section_address name` and
+     use it for `sh_addr` (default `0L`).
+   - Skip relocation table creation entirely on this path.
+
+3. `backend/x86_binary_emitter.{ml,mli}`
+   - In `For_jit`, add `module Gdb_jit_symfile` that converts the input
+     list to the form `internal_assembler.assemble_in_memory` wants and
+     calls it; returns `Some buf`.
+   - The public `.mli` doesn't need extra signature work because `For_jit
+     : Binary_emitter_intf.S` propagates the new submodule automatically.
+
+4. `backend/arm64/binary_emitter/for_jit.ml`
+   - Add a `Gdb_jit_symfile` stub returning `None`.
+
+5. `external/ocaml-jit/lib/jit_stubs.c`
+   - Add `__jit_debug_descriptor` (version=1) and `__jit_debug_register_code`.
+   - Add `caml_jit_gdb_register` taking a Bigarray; mallocs an entry,
+     splices it in, sets action_flag, calls the trampoline. Returns the
+     entry pointer as a nativeint.
+   - Add `caml_jit_gdb_unregister` for completeness (may not call it in
+     v1).
+
+6. `external/ocaml-jit/lib/gdb_jit.{ml,mli}` (new)
+   - `type handle` — record holding `bigarray : Owee_buf.t` (root) and
+     `entry_ptr : nativeint`.
+   - `val register : Owee_buf.t -> handle`.
+   - `val unregister : handle -> unit`.
+
+7. `external/ocaml-jit/lib/jit.ml`
+   - In `jit_load`, after `load_text`/`load_sections`, call the emitter's
+     `For_jit.Gdb_jit_symfile.build`, passing:
+     - `sections`: the binary-section map flattened to `(string,
+       assembled_section) list` (just `.text` plus the other sections;
+       relocations have already been applied).
+     - `section_address`: lookup against the `addressed_text` and
+       `addressed_sections` maps.
+   - If `Some buf`, call `Gdb_jit.register buf`, store the handle in
+     `Globals`.
+
+8. `external/ocaml-jit/lib/globals.{ml,mli}`
+   - Add a `gdb_handles : Gdb_jit.handle list ref` (or a Stack) so
+     handles stay reachable.
+
+## Risks / unknowns
+
+- Whether `bfd_check_format` accepts an ELF where some sections have
+  `sh_addr != 0` and others (the non-loadable ones like `.symtab`,
+  `.strtab`, `.shstrtab`) have `sh_addr = 0`. This is the normal case for
+  ELF objects; it should be fine. Worth checking by running `objdump -h`
+  on a sample symfile once we can build one.
+- Whether the `e_machine` check at `gdb/jit.c:778-784` against the
+  inferior's gdbarch needs `EM_X86_64` exactly (it does — already what
+  `internal_assembler` emits).
+- We hold the Bigarray live in OCaml, but the `jit_code_entry` is in C
+  malloc. If OCaml's GC moves the Bigarray's underlying memory, GDB sees
+  stale `symfile_addr`. Bigarrays are off-heap (`malloc`'d), so this is
+  fine — but the Bigarray *header* in OCaml must stay live.
+
+## Out of scope (later)
+
+- DWARF (`.debug_*`).
+- Source-level breakpoints.
+- Mach-O symfile output (would need a Mach-O writer; not present today, and
+  not necessary — see the lldb note below).
+
+## Status update (after implementation)
+
+- **x86-64 ELF**: implemented. `Jit_symfile.build` produces an in-memory ELF
+  with sh_addr set; `register_with_gdb` in `external/ocaml-jit/lib/jit.ml`
+  registers it with the GDB JIT protocol via `Gdb_jit.register`.
+- **arm64 ELF**: implemented. Same pipeline; arm64 backend's
+  `For_jit.Gdb_jit_symfile.build` calls `Jit_symfile.build` with
+  `e_machine = EM_AARCH64` (0xB7).
+- **lldb on macOS**: should work without further changes. Verified by reading
+  `llvm-project/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp` and
+  `Plugins/ObjectFile/ELF/ObjectFileELF.cpp`. Key facts:
+  - `JITLoaderGDB` looks up `__jit_debug_descriptor` and
+    `__jit_debug_register_code` exactly as GDB does. The plugin is registered
+    via `PluginManager` and runs on any host (including Darwin).
+  - `Process::ReadModuleFromMemory` constructs a `Module` with empty
+    `ArchSpec()`, then `GetMemoryObjectFile` content-sniffs the bytes.
+    `ObjectFileELF::CreateMemoryInstance` matches the ELF magic and parses
+    the header, regardless of host platform.
+  - In `JITLoaderGDB::ReadJITDescriptorImpl` (~L349), when the symfile is not
+    Mach-O, lldb does `module_sp->SetLoadAddress(target, 0, true, changed)`,
+    which makes sections appear at their `sh_addr` as-is. That's exactly what
+    our symfile assumes.
+- The `e_machine` value is taken from the symfile, not derived from the host
+  triple. For an arm64-apple-darwin process, our `EM_AARCH64` ELF is what
+  lldb expects to see.

--- a/PERF_JIT_PLAN.md
+++ b/PERF_JIT_PLAN.md
@@ -1,0 +1,185 @@
+# Linux `perf` jitdump support for OxCaml's in-process JIT
+
+## Goal
+
+Make code produced by `external/ocaml-jit` visible to `perf record` /
+`perf inject --jit` / `perf report`, on Linux x86-64 and arm64. Independent
+of the GDB JIT support already in place; the two run side by side.
+
+## Scope of v1
+
+- Emit the **jitdump** stream (the modern format, supported by `perf inject
+  --jit`). Skip the older `/tmp/perf-PID.map` text format entirely.
+- Emit one `JIT_CODE_LOAD` record per JIT'd phrase. Function name +
+  address + native bytes; enough for `perf report` to attribute samples to
+  named OCaml functions.
+- No `JIT_CODE_DEBUG_INFO`. No `JIT_CODE_UNWINDING_INFO`. (See "Deferred"
+  below.)
+- Linux only; on macOS the writer is a no-op (the format is Linux-perf-
+  specific).
+
+## How `perf inject --jit` discovers the dump
+
+`perf record` captures every `mmap(2)` as a `PERF_RECORD_MMAP` event.
+`perf inject --jit` later scans `perf.data` for executable mmaps of paths
+matching `jit-<pid>.dump` and pulls debug info out of those files. So the
+JIT must:
+
+1. Open `$JITDUMP_DIR/jit-<pid>.dump` (defaulting to `~/.debug/jit/`),
+   creating directories as needed.
+2. Write the 48-byte file header.
+3. `mmap(fd, header_size, PROT_READ | PROT_EXEC, MAP_PRIVATE, ...)` once,
+   **before** the first JIT'd function executes. Never unmap (the mapping is
+   the marker; if it goes away `perf inject` won't find the dump).
+4. Append records for each JIT'd phrase as they are produced.
+
+Steps 1–3 happen once at JIT startup; step 4 runs per-phrase.
+
+## File format (per the in-tree linux/tools/perf/Documentation/jitdump-specification.txt)
+
+### File header (48 bytes)
+
+| Offset | Field        | Type     | Value                                 |
+| ------ | ------------ | -------- | ------------------------------------- |
+| 0      | `magic`      | u32      | `0x4A695444` (`"JiTD"`, native endian) |
+| 4      | `version`    | u32      | `1`                                   |
+| 8      | `total_size` | u32      | `48`                                  |
+| 12     | `elf_mach`   | u32      | `EM_X86_64` (62) or `EM_AARCH64` (183) |
+| 16     | `pad1`       | u32      | `0`                                   |
+| 20     | `pid`        | u32      | `getpid()`                            |
+| 24     | `timestamp`  | u64      | `clock_gettime(CLOCK_MONOTONIC)` ns   |
+| 32     | `flags`      | u64      | `0`                                   |
+
+### Per-record common prefix (16 bytes)
+
+| Offset | Field        | Type | Notes                                              |
+| ------ | ------------ | ---- | -------------------------------------------------- |
+| 0      | `id`         | u32  | Record type (0 = LOAD, 2 = DEBUG_INFO, 4 = UNWIND) |
+| 4      | `total_size` | u32  | Record size, including this prefix                 |
+| 8      | `timestamp`  | u64  | `CLOCK_MONOTONIC` ns                               |
+
+### `JIT_CODE_LOAD` (id=0) body
+
+```
+pid: u32        // == file-header pid
+tid: u32        // we use pid (single-threaded JIT)
+vma: u64        // runtime address (== code_addr for us)
+code_addr: u64
+code_size: u64
+code_index: u64 // monotonic counter in Globals
+name: char[N]   // null-terminated, e.g. caml<phrase>__entry
+native_code: u8[code_size]  // raw relocated bytes
+```
+
+`total_size` = 16 + 40 + len(name)+1 + code_size.
+
+### Ordering rule
+
+`JIT_CODE_DEBUG_INFO` for a function (when we add it) **must precede** the
+function's `JIT_CODE_LOAD`. v1 emits no DEBUG_INFO so this doesn't bite,
+but the writer should be designed so debug records are emitted first.
+
+## Mapping to existing code
+
+Almost everything is already at hand inside `external/ocaml-jit/lib/jit.ml`'s
+`jit_load`, at the same point where we register the GDB symfile:
+
+| jitdump field      | Source                                                |
+| ------------------ | ----------------------------------------------------- |
+| `vma` / `code_addr` | `Address.to_int64 text.address`                      |
+| `code_size`        | `Jit_text_section.in_memory_size (module E) text.value` (covers GOT/PLT, like the GDB symfile's `.text`) |
+| `name`             | the phrase entry symbol (we already compute this for `entry_points`) |
+| `native_code`      | `Jit_text_section.content (module E) text.value` — the relocated `.text` plus GOT+PLT |
+| `code_index`       | a fresh counter held in `Globals`                     |
+| `pid` / `tid`      | `Unix.getpid ()`                                      |
+| `timestamp`        | `clock_gettime(CLOCK_MONOTONIC)` via a tiny C stub    |
+| `elf_mach`         | dispatched on `Target_system.architecture ()`         |
+
+We have neither EH frame nor DWARF line info handy in the JIT path today —
+hence the v1 scope.
+
+## File-level changes
+
+1. `external/ocaml-jit/lib/perf_jitdump.{ml,mli}` (new)
+   - `val init : unit -> handle option`
+     - On non-Linux: returns `None` (whole feature disabled).
+     - On Linux: opens `~/.debug/jit/jit-<pid>.dump` (or
+       `$JITDUMP_DIR/...`), writes the header, mmaps it `PROT_EXEC`,
+       returns a handle wrapping the `fd` and a counter ref.
+   - `val emit_code_load : handle -> name:string -> code_addr:int64 ->
+        code_size:int -> code:bytes -> unit`
+     - Builds and appends a `JIT_CODE_LOAD` record.
+   - Records and the `mmap` use a single mutex so concurrent emission is
+     race-free (defensive — current JIT is single-threaded).
+   - Closes the fd at exit; the mmap is left intact for the kernel to
+     reclaim, so the file is still discoverable from saved perf.data after
+     the process dies.
+
+2. `external/ocaml-jit/lib/perf_jitdump_stubs.c` (new)
+   - C stubs the OCaml side calls:
+     - `caml_perf_jitdump_open` — opens the path with `O_CREAT|O_TRUNC|O_RDWR`.
+     - `caml_perf_jitdump_mmap_marker` — `mmap` with `PROT_EXEC`.
+     - `caml_perf_jitdump_clock_monotonic` — `clock_gettime(CLOCK_MONOTONIC)` ns.
+     - `caml_perf_jitdump_getpid` (could just use OCaml's, but C is simpler).
+   - Wrapped in `#ifdef __linux__` so the compile is a no-op on macOS;
+     OCaml side checks `Sys.os_type` / `Target_system` and never calls
+     them on non-Linux.
+
+3. `external/ocaml-jit/lib/globals.{ml,mli}`
+   - `val perf_jitdump : Perf_jitdump.handle option ref` — created lazily
+     on first use; `None` on non-Linux.
+
+4. `external/ocaml-jit/lib/jit.ml`
+   - In `register_with_gdb`'s sibling location (right after
+     `load_text` / `load_sections`, before `jit_run`), call a new
+     `register_with_perf` that:
+     1. Lazily inits `Globals.perf_jitdump`.
+     2. For each phrase entry symbol it found, emits a `JIT_CODE_LOAD`
+        with `code_addr = text.address`, `code_size =
+        Jit_text_section.in_memory_size`, `code = Jit_text_section.content`,
+        and a fresh `code_index`.
+   - Independent of the GDB-symfile path; both run in `jit_load`.
+
+5. `external/ocaml-jit/lib/dune`
+   - `(foreign_stubs ... (names jit_stubs perf_jitdump_stubs))`.
+
+## Out of scope (v1) — both deferred to a follow-up that needs DWARF
+
+We will NOT emit these in v1 because both depend on DWARF the JIT
+pipeline does not currently produce:
+
+- **`JIT_CODE_DEBUG_INFO` (id=2) — source-line annotation.**
+  Needs a per-function table mapping `code_addr → (file, line, discrim)`.
+  The compiler's DWARF emission produces `.debug_line` for the on-disk
+  path; the JIT pipeline currently calls neither
+  `Emitaux.Dwarf_helpers.emit_delayed_dwarf` nor anything that materialises
+  a line table for in-memory sections. Without this, `perf annotate` on
+  JIT'd code shows assembly only — same as today's no-DWARF GDB symfile.
+
+- **`JIT_CODE_UNWINDING_INFO` (id=4) — backtraces through JIT'd frames.**
+  Needs an `.eh_frame` (FDE/CIE blob) and a `.eh_frame_hdr` for the JIT'd
+  region. Same root cause: the JIT path doesn't emit `.eh_frame`. Without
+  this, `perf record -g` stops unwinding at the first JIT'd frame; samples
+  inside JIT code still attribute correctly (the LOAD records suffice for
+  that), but parents in the call stack are missing.
+
+Both will land together when the JIT path starts producing DWARF — at
+which point the GDB symfile path can also gain `.debug_*` sections,
+giving source-level stepping in addition to function-level symbols.
+
+## Caveats / known gaps for v1
+
+- **Embedding raw native bytes inflates the dump file**: roughly the same
+  size as the JIT'd code itself. Acceptable for normal use; could be
+  staggering for code-heavy workloads. There is no streaming alternative
+  in the format.
+- **`mmap` marker leaks**: the `PROT_EXEC` mapping is intentionally never
+  unmapped (it's the persistence cue for `perf inject --jit` after the
+  process dies). Cost: one VMA per JIT process, size = header_size.
+- **`$HOME/.debug/jit/` directory**: created lazily. If `$HOME` is unset
+  or unwritable, fall back to `$TMPDIR` or `/tmp`. Best-effort.
+- **`perf record` clock**: must run with `-k mono` (or `--clockid
+  monotonic`) for our timestamps to line up. Worth documenting in the JIT
+  README later.
+- **Tests**: cannot exercise on the current Mach-O dev box. v1 must be
+  reviewed by inspection; runtime verification needs a Linux host.

--- a/PERF_JIT_PLAN.md
+++ b/PERF_JIT_PLAN.md
@@ -10,9 +10,11 @@ of the GDB JIT support already in place; the two run side by side.
 
 - Emit the **jitdump** stream (the modern format, supported by `perf inject
   --jit`). Skip the older `/tmp/perf-PID.map` text format entirely.
-- Emit one `JIT_CODE_LOAD` record per JIT'd phrase. Function name +
-  address + native bytes; enough for `perf report` to attribute samples to
-  named OCaml functions.
+- Emit one `JIT_CODE_LOAD` record **per non-label symbol** in the JIT'd
+  phrase, with `code_size` set to the byte distance to the next symbol (or
+  end of the assembled section for the last). This gives `perf report`
+  per-OCaml-function attribution rather than collapsing the whole phrase
+  under one name.
 - No `JIT_CODE_DEBUG_INFO`. No `JIT_CODE_UNWINDING_INFO`. (See "Deferred"
   below.)
 - Linux only; on macOS the writer is a no-op (the format is Linux-perf-
@@ -27,23 +29,28 @@ JIT must:
 
 1. Open `$JITDUMP_DIR/jit-<pid>.dump` (defaulting to `~/.debug/jit/`),
    creating directories as needed.
-2. Write the 48-byte file header.
+2. Write the 40-byte file header.
 3. `mmap(fd, header_size, PROT_READ | PROT_EXEC, MAP_PRIVATE, ...)` once,
-   **before** the first JIT'd function executes. Never unmap (the mapping is
-   the marker; if it goes away `perf inject` won't find the dump).
+   **before** the first JIT'd function executes, then `munmap` immediately.
+   The kernel emits the `PERF_RECORD_MMAP` event at the moment of the
+   `mmap(2)` syscall (it's not tied to the mapping's lifetime), so as long
+   as `perf record` is already running we can release the VMA right away.
+   Per the source article's footnote: *"You can unmap the JIT dump file
+   immediately if you want."*
 4. Append records for each JIT'd phrase as they are produced.
 
-Steps 1–3 happen once at JIT startup; step 4 runs per-phrase.
+Steps 1–3 happen once at first phrase load (lazy init); step 4 runs
+per-phrase.
 
-## File format (per the in-tree linux/tools/perf/Documentation/jitdump-specification.txt)
+## File format (per the in-tree linux/tools/perf/Documentation/jitdump-specification.txt and linux/tools/perf/util/jitdump.h)
 
-### File header (48 bytes)
+### File header (40 bytes)
 
 | Offset | Field        | Type     | Value                                 |
 | ------ | ------------ | -------- | ------------------------------------- |
 | 0      | `magic`      | u32      | `0x4A695444` (`"JiTD"`, native endian) |
 | 4      | `version`    | u32      | `1`                                   |
-| 8      | `total_size` | u32      | `48`                                  |
+| 8      | `total_size` | u32      | `40`                                  |
 | 12     | `elf_mach`   | u32      | `EM_X86_64` (62) or `EM_AARCH64` (183) |
 | 16     | `pad1`       | u32      | `0`                                   |
 | 20     | `pid`        | u32      | `getpid()`                            |
@@ -82,18 +89,19 @@ but the writer should be designed so debug records are emitted first.
 ## Mapping to existing code
 
 Almost everything is already at hand inside `external/ocaml-jit/lib/jit.ml`'s
-`jit_load`, at the same point where we register the GDB symfile:
+`jit_load`, at the same point where we register the GDB symfile. We emit
+one record per non-label symbol:
 
 | jitdump field      | Source                                                |
 | ------------------ | ----------------------------------------------------- |
-| `vma` / `code_addr` | `Address.to_int64 text.address`                      |
-| `code_size`        | `Jit_text_section.in_memory_size (module E) text.value` (covers GOT/PLT, like the GDB symfile's `.text`) |
-| `name`             | the phrase entry symbol (we already compute this for `entry_points`) |
-| `native_code`      | `Jit_text_section.content (module E) text.value` — the relocated `.text` plus GOT+PLT |
-| `code_index`       | a fresh counter held in `Globals`                     |
-| `pid` / `tid`      | `Unix.getpid ()`                                      |
+| `vma` / `code_addr` | `Address.to_int64 text.address + offset` of the symbol |
+| `code_size`        | distance to the next symbol's offset, or `E.Assembled_section.size raw - offset` for the last symbol |
+| `name`             | `Asm_symbol.encode` / `Asm_label.encode` of each non-label `iter_labels_and_symbols` target |
+| `native_code`      | `String.sub (E.Assembled_section.contents raw) offset code_size` (assembled bytes only — GOT/PLT padding is *not* covered by any record) |
+| `code_index`       | a fresh counter held inside the `Perf_jitdump.handle` |
+| `pid` / `tid`      | `Unix.getpid ()` (single-threaded JIT)                |
 | `timestamp`        | `clock_gettime(CLOCK_MONOTONIC)` via a tiny C stub    |
-| `elf_mach`         | dispatched on `Target_system.architecture ()`         |
+| `elf_mach`         | dispatched on `Target_system.architecture ()` by `jit.ml`, then passed to `Perf_jitdump.init` |
 
 We have neither EH frame nor DWARF line info handy in the JIT path today —
 hence the v1 scope.
@@ -101,43 +109,65 @@ hence the v1 scope.
 ## File-level changes
 
 1. `external/ocaml-jit/lib/perf_jitdump.{ml,mli}` (new)
-   - `val init : unit -> handle option`
-     - On non-Linux: returns `None` (whole feature disabled).
+   - `val init : elf_mach:int -> handle option`
+     - On non-Linux or when `elf_mach = 0` (architecture not supported),
+       returns `None`.
      - On Linux: opens `~/.debug/jit/jit-<pid>.dump` (or
-       `$JITDUMP_DIR/...`), writes the header, mmaps it `PROT_EXEC`,
-       returns a handle wrapping the `fd` and a counter ref.
+       `$JITDUMP_DIR/...`), writes the 40-byte header, briefly `mmap`s
+       it `PROT_EXEC` and immediately `munmap`s, returns an opaque
+       `handle` wrapping the fd and a `code_index` counter.
+     - Best-effort: any error during setup yields `None`; the function
+       never raises.
    - `val emit_code_load : handle -> name:string -> code_addr:int64 ->
-        code_size:int -> code:bytes -> unit`
-     - Builds and appends a `JIT_CODE_LOAD` record.
-   - Records and the `mmap` use a single mutex so concurrent emission is
-     race-free (defensive — current JIT is single-threaded).
-   - Closes the fd at exit; the mmap is left intact for the kernel to
-     reclaim, so the file is still discoverable from saved perf.data after
-     the process dies.
+        code_size:int -> code:string -> unit`
+     - Builds and appends a `JIT_CODE_LOAD` record. (We pass the bytes
+       as a `string` because `Jit_text_section.content` /
+       `E.Assembled_section.contents` already return strings.)
+     - On any write failure, latches a `disabled` flag in the handle so
+       subsequent calls become no-ops; this avoids appending to a
+       now-truncated and unparseable dump.
+   - No mutex; ocaml-jit is single-threaded and we don't link against
+     `threads`.
+   - The fd is left open for the process lifetime; the kernel closes it at
+     exit. `Unix.write` is unbuffered, so each record is flushed
+     immediately.
 
 2. `external/ocaml-jit/lib/perf_jitdump_stubs.c` (new)
-   - C stubs the OCaml side calls:
-     - `caml_perf_jitdump_open` — opens the path with `O_CREAT|O_TRUNC|O_RDWR`.
-     - `caml_perf_jitdump_mmap_marker` — `mmap` with `PROT_EXEC`.
-     - `caml_perf_jitdump_clock_monotonic` — `clock_gettime(CLOCK_MONOTONIC)` ns.
-     - `caml_perf_jitdump_getpid` (could just use OCaml's, but C is simpler).
-   - Wrapped in `#ifdef __linux__` so the compile is a no-op on macOS;
-     OCaml side checks `Sys.os_type` / `Target_system` and never calls
-     them on non-Linux.
+   - Three C stubs the OCaml side calls:
+     - `caml_perf_jitdump_is_linux` — runtime check used by the OCaml side
+       to bail out on non-Linux without conditionalising the externals.
+     - `caml_perf_jitdump_clock_monotonic` —
+       `clock_gettime(CLOCK_MONOTONIC)` returning ns as int64.
+     - `caml_perf_jitdump_mmap_marker` — `mmap(fd, size, PROT_READ |
+       PROT_EXEC, MAP_PRIVATE, 0)` followed by an immediate `munmap` so
+       the only effect is a single `PERF_RECORD_MMAP` event in the
+       perf ring buffer.
+   - File open and getpid are done from OCaml via `Unix.openfile` /
+     `Unix.getpid`.
+   - Linux-specific code is wrapped in `#ifdef __linux__`; non-Linux
+     builds compile but never call into those branches.
 
 3. `external/ocaml-jit/lib/globals.{ml,mli}`
-   - `val perf_jitdump : Perf_jitdump.handle option ref` — created lazily
-     on first use; `None` on non-Linux.
+   - `val perf_jitdump : Perf_jitdump.handle option option ref` — the
+     outer `option` distinguishes "not yet initialised" from "init was
+     attempted". This caches init failure so we don't retry on every
+     phrase. `None None` is the initial state; `None (Some _)` is success;
+     `None None` after init means init failed and we stop trying.
 
 4. `external/ocaml-jit/lib/jit.ml`
-   - In `register_with_gdb`'s sibling location (right after
-     `load_text` / `load_sections`, before `jit_run`), call a new
-     `register_with_perf` that:
-     1. Lazily inits `Globals.perf_jitdump`.
-     2. For each phrase entry symbol it found, emits a `JIT_CODE_LOAD`
-        with `code_addr = text.address`, `code_size =
-        Jit_text_section.in_memory_size`, `code = Jit_text_section.content`,
-        and a fresh `code_index`.
+   - In `register_with_gdb`'s sibling location (right after `load_text` /
+     `load_sections`, before `jit_run`), call a new `register_with_perf`
+     that:
+     1. Lazily initialises `Globals.perf_jitdump`, dispatching `elf_mach`
+        from `Target_system.architecture ()` (`X86_64 -> 0x3E`,
+        `AArch64 -> 0xB7`, otherwise `0`).
+     2. Iterates `E.Assembled_section.iter_labels_and_symbols` over the
+        phrase's text section, drops names beginning with `.L`, sorts by
+        offset, and emits one `JIT_CODE_LOAD` per symbol with
+        `code_size = next_offset - this_offset` (or
+        `assembled_size - offset` for the last symbol),
+        `code_addr = text.address + offset`, and `code` sliced from
+        `E.Assembled_section.contents`.
    - Independent of the GDB-symfile path; both run in `jit_load`.
 
 5. `external/ocaml-jit/lib/dune`
@@ -173,9 +203,13 @@ giving source-level stepping in addition to function-level symbols.
   size as the JIT'd code itself. Acceptable for normal use; could be
   staggering for code-heavy workloads. There is no streaming alternative
   in the format.
-- **`mmap` marker leaks**: the `PROT_EXEC` mapping is intentionally never
-  unmapped (it's the persistence cue for `perf inject --jit` after the
-  process dies). Cost: one VMA per JIT process, size = header_size.
+- **`perf record` must be running before the JIT starts.** The marker is
+  a one-shot `mmap`/`munmap` pair, so the `PERF_RECORD_MMAP` event is
+  emitted exactly once and then gone. Attaching `perf record` to an
+  already-running JIT process won't see the marker; only the dump file
+  itself remains on disk. (If we ever care about attach-to-running, we'd
+  switch to keeping the mapping alive so `perf` can synthesize an MMAP
+  event from `/proc/<pid>/maps` on attach.)
 - **`$HOME/.debug/jit/` directory**: created lazily. If `$HOME` is unset
   or unwritable, fall back to `$TMPDIR` or `/tmp`. Best-effort.
 - **`perf record` clock**: must run with `-k mono` (or `--clockid
@@ -183,3 +217,11 @@ giving source-level stepping in addition to function-level symbols.
   README later.
 - **Tests**: cannot exercise on the current Mach-O dev box. v1 must be
   reviewed by inspection; runtime verification needs a Linux host.
+- **GOT/PLT regions are not covered by any `JIT_CODE_LOAD`.** Per-symbol
+  emission stops at the assembled section boundary; the GOT and PLT bytes
+  appended afterwards by `Jit_text_section.in_memory_size` are excluded.
+  Samples that land inside a PLT stub will be unattributed in `perf
+  report`. This contrasts with the GDB symfile path, where `.text`'s
+  `sh_size` deliberately spans the GOT/PLT padding so backtraces don't
+  fall into a "no module" hole. Acceptable for a profiler in v1; revisit
+  if it bites.

--- a/backend/arm64/binary_emitter/dune
+++ b/backend/arm64/binary_emitter/dune
@@ -6,4 +6,4 @@
  (ocamlopt_flags
   (:standard -w +4
    (:include %{project_root}/ocamlopt_flags.sexp)))
- (libraries ocamlcommon asm_targets arm64_ast binary_emitter_intf))
+ (libraries ocamlcommon asm_targets arm64_ast binary_emitter_intf jit_symfile))

--- a/backend/arm64/binary_emitter/for_jit.ml
+++ b/backend/arm64/binary_emitter/for_jit.ml
@@ -183,6 +183,5 @@ module Gdb_jit_symfile = struct
     Some
       (Jit_symfile.build
          (module Assembled_section)
-         ~e_machine:em_aarch64 ~sections ~section_address
-         ~section_runtime_size)
+         ~e_machine:em_aarch64 ~sections ~section_address ~section_runtime_size)
 end

--- a/backend/arm64/binary_emitter/for_jit.ml
+++ b/backend/arm64/binary_emitter/for_jit.ml
@@ -172,3 +172,17 @@ module Internal_assembler = struct
 
   let get () = !current_hook
 end
+
+module Gdb_jit_symfile = struct
+  type assembled_section = Assembled_section.t
+
+  (* EM_AARCH64 in [e_machine]. *)
+  let em_aarch64 = 0xB7
+
+  let build ~sections ~section_address ~section_runtime_size =
+    Some
+      (Jit_symfile.build
+         (module Assembled_section)
+         ~e_machine:em_aarch64 ~sections ~section_address
+         ~section_runtime_size)
+end

--- a/backend/binary_emitter_intf/binary_emitter_intf.ml
+++ b/backend/binary_emitter_intf/binary_emitter_intf.ml
@@ -143,10 +143,10 @@ module type Gdb_jit_symfile = sig
       [sections] and are assumed to be post-relocation.
 
       [section_runtime_size] returns an override for [sh_size] when the
-      section's runtime extent is larger than the assembled bytes (e.g. the
-      JIT appends GOT/PLT padding after [.text]). The trailing bytes inside
-      the symfile are zero-padded. Returning [None] uses the natural assembled
-      size. *)
+      section's runtime extent is larger than the assembled bytes (e.g. the JIT
+      appends GOT/PLT padding after [.text]). The trailing bytes inside the
+      symfile are zero-padded. Returning [None] uses the natural assembled size.
+  *)
   val build :
     sections:(string * assembled_section) list ->
     section_address:(string -> int64 option) ->

--- a/backend/binary_emitter_intf/binary_emitter_intf.ml
+++ b/backend/binary_emitter_intf/binary_emitter_intf.ml
@@ -128,6 +128,32 @@ module type Internal_assembler_hook = sig
   val get : unit -> hook option
 end
 
+(** GDB JIT symfile production. Produces an in-memory ELF object file describing
+    the JIT'd code, suitable for registration via GDB's JIT-Interface protocol.
+
+    The returned buffer is a contiguous byte array whose address can be passed
+    directly to GDB as [symfile_addr]. The implementation is allowed to return
+    [None] on architectures where it is not yet supported. *)
+module type Gdb_jit_symfile = sig
+  type assembled_section
+
+  (** [build ~sections ~section_address ~section_runtime_size] returns an ELF
+      object whose loadable sections have [sh_addr] set to the runtime address
+      reported by [section_address]. Section bytes are taken verbatim from
+      [sections] and are assumed to be post-relocation.
+
+      [section_runtime_size] returns an override for [sh_size] when the
+      section's runtime extent is larger than the assembled bytes (e.g. the
+      JIT appends GOT/PLT padding after [.text]). The trailing bytes inside
+      the symfile are zero-padded. Returning [None] uses the natural assembled
+      size. *)
+  val build :
+    sections:(string * assembled_section) list ->
+    section_address:(string -> int64 option) ->
+    section_runtime_size:(string -> int option) ->
+    Compiler_owee.Owee_buf.t option
+end
+
 (** Combined signature that each architecture's binary emitter provides. *)
 module type S = sig
   module Relocation : Relocation
@@ -149,4 +175,8 @@ module type S = sig
   (** Internal assembler hook for JIT support *)
   module Internal_assembler :
     Internal_assembler_hook with type assembled_section = Assembled_section.t
+
+  (** GDB JIT symfile builder *)
+  module Gdb_jit_symfile :
+    Gdb_jit_symfile with type assembled_section = Assembled_section.t
 end

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -63,7 +63,7 @@ let make_header identification shnum e_shoff : Compiler_owee.Owee_elf.header =
   }
 
 let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
-    ?sh_info shstrtab =
+    ?sh_info ?(sh_addr = 0L) shstrtab =
   let sh_addralign = Option.value ~default:1L align in
   let sh_entsize = Option.value ~default:0L entsize in
   let sh_flags = Option.value ~default:0L flags in
@@ -74,7 +74,7 @@ let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
     { sh_name = String_table.current_length shstrtab;
       sh_type;
       sh_flags;
-      sh_addr = 0L;
+      sh_addr;
       sh_offset = offset;
       sh_size = size;
       sh_link;
@@ -88,24 +88,37 @@ let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
   section
 
 let make_section sections name ~sh_type ~size ?align ?entsize ?flags ?sh_link
-    ?sh_info ?body shstrtab =
+    ?sh_info ?body ?sh_addr shstrtab =
   let section : Compiler_owee.Owee_elf.section =
     create_section name ~sh_type ~size
       ~offset:(Section_table.current_offset sections)
-      ?align ?entsize ?flags ?sh_link ?sh_info shstrtab
+      ?align ?entsize ?flags ?sh_link ?sh_info ?sh_addr shstrtab
   in
   Section_table.add_section sections name ?body section
 
-let make_text sections name raw_section ~align sh_string_table =
+let pick_size raw_section runtime_size =
+  let body_size = X86_binary_emitter.size raw_section in
+  match runtime_size with
+  | None -> Int64.of_int body_size
+  | Some n when n < body_size ->
+    failwith
+      (Printf.sprintf
+         "Internal_assembler: runtime_size (%d) smaller than body size (%d)"
+         n body_size)
+  | Some n -> Int64.of_int n
+
+let make_text sections name raw_section ~align ?sh_addr ?runtime_size
+    sh_string_table =
   make_section sections name ~sh_type:1
-    ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
-    ~flags:0x6L sh_string_table ~align
+    ~size:(pick_size raw_section runtime_size)
+    ~flags:0x6L sh_string_table ~align ?sh_addr
     ~body:(X86_binary_emitter.contents_mut raw_section)
 
-let make_data sections name raw_section ~align sh_string_table =
+let make_data sections name raw_section ~align ?sh_addr ?runtime_size
+    sh_string_table =
   make_section sections name ~sh_type:1
-    ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
-    ~flags:0x3L sh_string_table ~align
+    ~size:(pick_size raw_section runtime_size)
+    ~flags:0x3L sh_string_table ~align ?sh_addr
     ~body:(X86_binary_emitter.contents_mut raw_section)
 
 let make_shstrtab sections sh_string_table =
@@ -141,12 +154,13 @@ let parse_flags flags =
   in
   inner 0L (String.to_seq flags ())
 
-let make_custom_section sections name raw_section sh_string_table =
+let make_custom_section sections name raw_section ?sh_addr ?runtime_size
+    sh_string_table =
   let flags = parse_flags (X86_proc.Section_name.flags name) in
   let align = X86_proc.Section_name.alignment name in
   make_section sections name
-    ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
-    ~align ~flags
+    ~size:(pick_size raw_section runtime_size)
+    ~align ~flags ?sh_addr
     ~body:(X86_binary_emitter.contents_mut raw_section)
     sh_string_table
 
@@ -196,26 +210,34 @@ let get_sections ~delayed sections =
   Emitaux.Dwarf_helpers.emit_delayed_dwarf ();
   get acc (delayed ())
 
-let make_compiler_sections section_table compiler_sections symbol_table
-    sh_string_table =
+let make_compiler_sections ?section_address ?section_runtime_size section_table
+    compiler_sections symbol_table sh_string_table =
   let section_symbols = Section_name.Tbl.create 100 in
+  let addr_for name =
+    match section_address with None -> None | Some f -> f name
+  in
+  let runtime_size_for name =
+    match section_runtime_size with None -> None | Some f -> f name
+  in
   Section_name.Map.iter
     (fun name (align, raw_section) ->
+      let sh_addr = addr_for name in
+      let runtime_size = runtime_size_for name in
       if Section_name.is_text_like name
       then
         make_text section_table name raw_section ~align:(Int64.of_int align)
-          sh_string_table
+          ?sh_addr ?runtime_size sh_string_table
       else if Section_name.is_data_like name
       then
         make_data section_table name raw_section ~align:(Int64.of_int align)
-          sh_string_table
+          ?sh_addr ?runtime_size sh_string_table
       else if Section_name.is_note_like name
       then
         make_custom_section section_table name raw_section ~sh_type:7
-          (* SHT_NOTE *) sh_string_table
+          (* SHT_NOTE *) ?sh_addr ?runtime_size sh_string_table
       else
         make_custom_section section_table name raw_section ~sh_type:1
-          (* SHT_PROGBITS *) sh_string_table;
+          (* SHT_PROGBITS *) ?sh_addr ?runtime_size sh_string_table;
       Section_name.Tbl.add section_symbols name
         (Symbol_table.make_section_symbol symbol_table
            (Section_table.num_sections section_table - 1)
@@ -321,3 +343,4 @@ let assemble unix ~delayed asm output_file =
       + (header.e_shnum * header.e_shentsize))
   in
   write elf header sections symbol_table relocation_tables string_table
+

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -63,7 +63,7 @@ let make_header identification shnum e_shoff : Compiler_owee.Owee_elf.header =
   }
 
 let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
-    ?sh_info ?(sh_addr = 0L) shstrtab =
+    ?sh_info shstrtab =
   let sh_addralign = Option.value ~default:1L align in
   let sh_entsize = Option.value ~default:0L entsize in
   let sh_flags = Option.value ~default:0L flags in
@@ -74,7 +74,7 @@ let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
     { sh_name = String_table.current_length shstrtab;
       sh_type;
       sh_flags;
-      sh_addr;
+      sh_addr = 0L;
       sh_offset = offset;
       sh_size = size;
       sh_link;
@@ -88,37 +88,24 @@ let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
   section
 
 let make_section sections name ~sh_type ~size ?align ?entsize ?flags ?sh_link
-    ?sh_info ?body ?sh_addr shstrtab =
+    ?sh_info ?body shstrtab =
   let section : Compiler_owee.Owee_elf.section =
     create_section name ~sh_type ~size
       ~offset:(Section_table.current_offset sections)
-      ?align ?entsize ?flags ?sh_link ?sh_info ?sh_addr shstrtab
+      ?align ?entsize ?flags ?sh_link ?sh_info shstrtab
   in
   Section_table.add_section sections name ?body section
 
-let pick_size raw_section runtime_size =
-  let body_size = X86_binary_emitter.size raw_section in
-  match runtime_size with
-  | None -> Int64.of_int body_size
-  | Some n when n < body_size ->
-    failwith
-      (Printf.sprintf
-         "Internal_assembler: runtime_size (%d) smaller than body size (%d)"
-         n body_size)
-  | Some n -> Int64.of_int n
-
-let make_text sections name raw_section ~align ?sh_addr ?runtime_size
-    sh_string_table =
+let make_text sections name raw_section ~align sh_string_table =
   make_section sections name ~sh_type:1
-    ~size:(pick_size raw_section runtime_size)
-    ~flags:0x6L sh_string_table ~align ?sh_addr
+    ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
+    ~flags:0x6L sh_string_table ~align
     ~body:(X86_binary_emitter.contents_mut raw_section)
 
-let make_data sections name raw_section ~align ?sh_addr ?runtime_size
-    sh_string_table =
+let make_data sections name raw_section ~align sh_string_table =
   make_section sections name ~sh_type:1
-    ~size:(pick_size raw_section runtime_size)
-    ~flags:0x3L sh_string_table ~align ?sh_addr
+    ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
+    ~flags:0x3L sh_string_table ~align
     ~body:(X86_binary_emitter.contents_mut raw_section)
 
 let make_shstrtab sections sh_string_table =
@@ -154,13 +141,12 @@ let parse_flags flags =
   in
   inner 0L (String.to_seq flags ())
 
-let make_custom_section sections name raw_section ?sh_addr ?runtime_size
-    sh_string_table =
+let make_custom_section sections name raw_section sh_string_table =
   let flags = parse_flags (X86_proc.Section_name.flags name) in
   let align = X86_proc.Section_name.alignment name in
   make_section sections name
-    ~size:(pick_size raw_section runtime_size)
-    ~align ~flags ?sh_addr
+    ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
+    ~align ~flags
     ~body:(X86_binary_emitter.contents_mut raw_section)
     sh_string_table
 
@@ -210,34 +196,26 @@ let get_sections ~delayed sections =
   Emitaux.Dwarf_helpers.emit_delayed_dwarf ();
   get acc (delayed ())
 
-let make_compiler_sections ?section_address ?section_runtime_size section_table
-    compiler_sections symbol_table sh_string_table =
+let make_compiler_sections section_table compiler_sections symbol_table
+    sh_string_table =
   let section_symbols = Section_name.Tbl.create 100 in
-  let addr_for name =
-    match section_address with None -> None | Some f -> f name
-  in
-  let runtime_size_for name =
-    match section_runtime_size with None -> None | Some f -> f name
-  in
   Section_name.Map.iter
     (fun name (align, raw_section) ->
-      let sh_addr = addr_for name in
-      let runtime_size = runtime_size_for name in
       if Section_name.is_text_like name
       then
         make_text section_table name raw_section ~align:(Int64.of_int align)
-          ?sh_addr ?runtime_size sh_string_table
+          sh_string_table
       else if Section_name.is_data_like name
       then
         make_data section_table name raw_section ~align:(Int64.of_int align)
-          ?sh_addr ?runtime_size sh_string_table
+          sh_string_table
       else if Section_name.is_note_like name
       then
         make_custom_section section_table name raw_section ~sh_type:7
-          (* SHT_NOTE *) ?sh_addr ?runtime_size sh_string_table
+          (* SHT_NOTE *) sh_string_table
       else
         make_custom_section section_table name raw_section ~sh_type:1
-          (* SHT_PROGBITS *) ?sh_addr ?runtime_size sh_string_table;
+          (* SHT_PROGBITS *) sh_string_table;
       Section_name.Tbl.add section_symbols name
         (Symbol_table.make_section_symbol symbol_table
            (Section_table.num_sections section_table - 1)

--- a/backend/internal_assembler/internal_assembler.mli
+++ b/backend/internal_assembler/internal_assembler.mli
@@ -27,3 +27,4 @@ val assemble :
   (X86_proc.Section_name.t * X86_ast.asm_program) list ->
   string ->
   unit
+

--- a/backend/jit_symfile/dune
+++ b/backend/jit_symfile/dune
@@ -1,7 +1,7 @@
 (library
- (name binary_emitter_intf)
+ (name jit_symfile)
  (wrapped false)
- (libraries asm_targets compiler_owee)
+ (libraries asm_targets binary_emitter_intf compiler_owee)
  (ocamlopt_flags
   (:standard -w +4
    (:include %{project_root}/ocamlopt_flags.sexp))))

--- a/backend/jit_symfile/jit_symfile.ml
+++ b/backend/jit_symfile/jit_symfile.ml
@@ -1,0 +1,344 @@
+(** Generic in-memory ELF symfile builder. See .mli for overview. *)
+
+module Buf = Compiler_owee.Owee_buf
+module Elf = Compiler_owee.Owee_elf
+
+(* ELF constants *)
+let elf_header_size = 64
+
+let section_header_size = 64
+
+let symbol_entry_size = 24
+
+let sht_null = 0
+
+let sht_progbits = 1
+
+let sht_symtab = 2
+
+let sht_strtab = 3
+
+let shf_write = 0x1
+
+let shf_alloc = 0x2
+
+let shf_execinstr = 0x4
+
+let stb_global = 1
+
+let stt_notype = 0
+
+let stt_object = 1
+
+let stt_func = 2
+
+(* Append-only byte string accumulator with offset tracking; index 0 is
+   reserved for the empty string. *)
+module Strtab : sig
+  type t
+
+  val create : unit -> t
+
+  (** [add t s] appends [s] (zero-terminated) and returns its offset. *)
+  val add : t -> string -> int
+
+  val size : t -> int
+
+  val write : t -> Buf.cursor -> unit
+end = struct
+  type t =
+    { mutable rev_entries : string list;
+      mutable size : int
+    }
+
+  let create () = { rev_entries = [ "" ]; size = 1 }
+
+  let add t s =
+    let off = t.size in
+    t.rev_entries <- s :: t.rev_entries;
+    t.size <- off + String.length s + 1;
+    off
+
+  let size t = t.size
+
+  let write t cursor =
+    List.iter
+      (Buf.Write.zero_terminated_string cursor)
+      (List.rev t.rev_entries)
+end
+
+let is_local_label name =
+  String.length name >= 2 && Char.equal name.[0] '.' && Char.equal name.[1] 'L'
+
+let starts_with ~prefix s =
+  let pl = String.length prefix in
+  String.length s >= pl && String.equal (String.sub s 0 pl) prefix
+
+let is_text_like name =
+  String.equal name ".text" || starts_with ~prefix:".text." name
+
+let is_data_like name =
+  String.equal name ".data"
+  || starts_with ~prefix:".data." name
+  || String.equal name ".bss"
+  || String.equal name ".rodata"
+  || starts_with ~prefix:".rodata." name
+
+let section_flags name =
+  if is_text_like name then Int64.of_int (shf_alloc lor shf_execinstr)
+  else if is_data_like name then Int64.of_int (shf_alloc lor shf_write)
+  else Int64.of_int shf_alloc
+
+let section_alignment name = if is_text_like name then 16L else 8L
+
+let default_symbol_type name =
+  if is_text_like name then stt_func
+  else if is_data_like name then stt_object
+  else stt_notype
+
+let st_info ~bind ~ty = (bind lsl 4) lor ty
+
+let target_to_name (target : Binary_emitter_intf.target) =
+  match target with
+  | Binary_emitter_intf.Symbol s -> Asm_targets.Asm_symbol.encode s
+  | Binary_emitter_intf.Label l -> Asm_targets.Asm_label.encode l
+
+(* A symbol with its string-table offset already resolved. *)
+type symbol =
+  { st_name : int;
+    st_value : int64;
+    st_size : int64;
+    st_info : int;
+    st_other : int;
+    st_shndx : int
+  }
+
+let collect_symbols (type a r)
+    (module S : Binary_emitter_intf.Assembled_section
+      with type t = a
+       and type relocation = r) ~strtab sections =
+  let acc = ref [] in
+  List.iteri
+    (fun i (name, raw) ->
+      let shndx = i + 1 in
+      let ty = default_symbol_type name in
+      S.iter_labels_and_symbols raw ~f:(fun target ~offset ->
+          let sym_name = target_to_name target in
+          if not (is_local_label sym_name)
+          then
+            let st_name = Strtab.add strtab sym_name in
+            acc
+              := { st_name;
+                   st_value = Int64.of_int offset;
+                   st_size = 0L;
+                   st_info = st_info ~bind:stb_global ~ty;
+                   st_other = 0;
+                   st_shndx = shndx
+                 }
+                 :: !acc))
+    sections;
+  List.rev !acc
+
+let write_symbol cursor s =
+  Buf.Write.u32 cursor s.st_name;
+  Buf.Write.u8 cursor s.st_info;
+  Buf.Write.u8 cursor s.st_other;
+  Buf.Write.u16 cursor s.st_shndx;
+  Buf.Write.u64 cursor s.st_value;
+  Buf.Write.u64 cursor s.st_size
+
+(* Build a section header. *)
+let make_section_header ~sh_name ~sh_type ~sh_flags ~sh_addr ~sh_offset
+    ~sh_size ~sh_link ~sh_info ~sh_addralign ~sh_entsize ~sh_name_str :
+    Elf.section =
+  { sh_name;
+    sh_type;
+    sh_flags;
+    sh_addr;
+    sh_offset;
+    sh_size;
+    sh_link;
+    sh_info;
+    sh_addralign;
+    sh_entsize;
+    sh_name_str
+  }
+
+let null_section_header () =
+  make_section_header ~sh_name:0 ~sh_type:sht_null ~sh_flags:0L ~sh_addr:0L
+    ~sh_offset:0L ~sh_size:0L ~sh_link:0 ~sh_info:0 ~sh_addralign:0L
+    ~sh_entsize:0L ~sh_name_str:""
+
+(* Compute body sizes in the file. For each input section, sh_size is the
+   body's footprint in the file (= max of body_size and runtime_size). *)
+let resolve_sh_size raw runtime_size body_size_fn =
+  let body_size = body_size_fn raw in
+  let sh_size =
+    match runtime_size with
+    | None -> body_size
+    | Some n when n >= body_size -> n
+    | Some n ->
+      failwith
+        (Printf.sprintf
+           "Jit_symfile.build: section_runtime_size (%d) < body size (%d)"
+           n body_size)
+  in
+  body_size, sh_size
+
+let build (type a r)
+    (module S : Binary_emitter_intf.Assembled_section
+      with type t = a
+       and type relocation = r)
+    ~e_machine ~sections ~section_address ~section_runtime_size =
+  let n_input = List.length sections in
+  let symtab_shndx = n_input + 1 in
+  let strtab_shndx = n_input + 2 in
+  let shstrtab_shndx = n_input + 3 in
+  let total_shnum = n_input + 4 in
+  let shstrtab = Strtab.create () in
+  let strtab = Strtab.create () in
+  (* Compute layout offsets for input section bodies. We register section
+     names in shstrtab in the same order as the section header table to keep
+     order deterministic. *)
+  let layout =
+    Array.make n_input (0, 0, 0L, 0L, 0L, 0, 0L, 0L)
+    (* (sh_name, body_size, sh_size_64, sh_offset, sh_addr, _shndx, sh_flags,
+       sh_addralign) *)
+  in
+  let cur_offset = ref (Int64.of_int elf_header_size) in
+  List.iteri
+    (fun i (name, raw) ->
+      let body_size, sh_size =
+        resolve_sh_size raw (section_runtime_size name) S.size
+      in
+      let sh_addr =
+        match section_address name with None -> 0L | Some a -> a
+      in
+      let sh_name = Strtab.add shstrtab name in
+      layout.(i)
+        <- ( sh_name,
+             body_size,
+             Int64.of_int sh_size,
+             !cur_offset,
+             sh_addr,
+             i + 1,
+             section_flags name,
+             section_alignment name );
+      cur_offset := Int64.add !cur_offset (Int64.of_int sh_size))
+    sections;
+  (* Collect symbols. This populates strtab for symbol names. *)
+  let symbols = collect_symbols (module S) ~strtab sections in
+  let n_symbols_with_null = List.length symbols + 1 in
+  let symtab_size = symbol_entry_size * n_symbols_with_null in
+  let symtab_offset = !cur_offset in
+  cur_offset := Int64.add !cur_offset (Int64.of_int symtab_size);
+  let symtab_sh_name = Strtab.add shstrtab ".symtab" in
+  let strtab_offset = !cur_offset in
+  cur_offset := Int64.add !cur_offset (Int64.of_int (Strtab.size strtab));
+  let strtab_sh_name = Strtab.add shstrtab ".strtab" in
+  let shstrtab_offset = !cur_offset in
+  let shstrtab_sh_name = Strtab.add shstrtab ".shstrtab" in
+  cur_offset := Int64.add !cur_offset (Int64.of_int (Strtab.size shstrtab));
+  let sh_table_offset = !cur_offset in
+  let total_size =
+    Int64.to_int sh_table_offset
+    + (total_shnum * section_header_size)
+  in
+  (* Build the section header array. *)
+  let headers = Array.make total_shnum (null_section_header ()) in
+  Array.iteri
+    (fun i
+         ( sh_name,
+           _body_size,
+           sh_size,
+           sh_offset,
+           sh_addr,
+           _shndx,
+           sh_flags,
+           sh_addralign ) ->
+      let name, _ = List.nth sections i in
+      headers.(i + 1)
+        <- make_section_header ~sh_name ~sh_type:sht_progbits ~sh_flags
+             ~sh_addr ~sh_offset ~sh_size ~sh_link:0 ~sh_info:0 ~sh_addralign
+             ~sh_entsize:0L ~sh_name_str:name)
+    layout;
+  (* Symbol table header. sh_info = number of local symbols (= 1 because the
+     NULL entry is the only local; everything else we emit is GLOBAL). *)
+  headers.(symtab_shndx)
+    <- make_section_header ~sh_name:symtab_sh_name ~sh_type:sht_symtab
+         ~sh_flags:0L ~sh_addr:0L ~sh_offset:symtab_offset
+         ~sh_size:(Int64.of_int symtab_size) ~sh_link:strtab_shndx ~sh_info:1
+         ~sh_addralign:8L
+         ~sh_entsize:(Int64.of_int symbol_entry_size)
+         ~sh_name_str:".symtab";
+  headers.(strtab_shndx)
+    <- make_section_header ~sh_name:strtab_sh_name ~sh_type:sht_strtab
+         ~sh_flags:0L ~sh_addr:0L ~sh_offset:strtab_offset
+         ~sh_size:(Int64.of_int (Strtab.size strtab))
+         ~sh_link:0 ~sh_info:0 ~sh_addralign:1L ~sh_entsize:0L
+         ~sh_name_str:".strtab";
+  headers.(shstrtab_shndx)
+    <- make_section_header ~sh_name:shstrtab_sh_name ~sh_type:sht_strtab
+         ~sh_flags:0L ~sh_addr:0L ~sh_offset:shstrtab_offset
+         ~sh_size:(Int64.of_int (Strtab.size shstrtab))
+         ~sh_link:0 ~sh_info:0 ~sh_addralign:1L ~sh_entsize:0L
+         ~sh_name_str:".shstrtab";
+  let header : Elf.header =
+    { e_ident =
+        { elf_class = 2;
+          (* ELFCLASS64 *)
+          elf_data = 1;
+          (* ELFDATA2LSB *)
+          elf_version = 1;
+          elf_osabi = 0;
+          elf_abiversion = 0
+        };
+      e_type = 1;
+      (* ET_REL *)
+      e_machine;
+      e_version = 1;
+      e_entry = 0L;
+      e_phoff = 0L;
+      e_shoff = sh_table_offset;
+      e_flags = 0;
+      e_ehsize = elf_header_size;
+      e_phentsize = 0;
+      e_phnum = 0;
+      e_shentsize = section_header_size;
+      e_shnum = total_shnum;
+      e_shstrndx = shstrtab_shndx
+    }
+  in
+  let buf =
+    Bigarray.Array1.create Bigarray.int8_unsigned Bigarray.c_layout total_size
+  in
+  (* Trailing padding (where a section's sh_size exceeds its body) must be
+     zero. *)
+  Bigarray.Array1.fill buf 0;
+  (* Write ELF header + section header table. *)
+  Elf.write_elf buf header headers;
+  (* Write section bodies. *)
+  List.iteri
+    (fun i (_, raw) ->
+      let _, body_size, _, sh_offset, _, _, _, _ = layout.(i) in
+      let body = S.contents_mut raw in
+      let cursor = Buf.cursor buf ~at:(Int64.to_int sh_offset) in
+      Buf.Write.fixed_bytes cursor body_size body)
+    sections;
+  (* Write symtab. *)
+  let cursor = Buf.cursor buf ~at:(Int64.to_int symtab_offset) in
+  (* NULL entry (24 zero bytes — already zeroed by Array1.fill, just advance
+     the cursor by writing a zero entry explicitly so that subsequent entries
+     are positioned correctly). *)
+  Buf.Write.u32 cursor 0;
+  Buf.Write.u8 cursor 0;
+  Buf.Write.u8 cursor 0;
+  Buf.Write.u16 cursor 0;
+  Buf.Write.u64 cursor 0L;
+  Buf.Write.u64 cursor 0L;
+  List.iter (write_symbol cursor) symbols;
+  (* Write strtab and shstrtab. *)
+  Strtab.write strtab (Buf.cursor buf ~at:(Int64.to_int strtab_offset));
+  Strtab.write shstrtab
+    (Buf.cursor buf ~at:(Int64.to_int shstrtab_offset));
+  buf

--- a/backend/jit_symfile/jit_symfile.mli
+++ b/backend/jit_symfile/jit_symfile.mli
@@ -1,0 +1,22 @@
+(** Generic in-memory ELF symfile builder for the GDB/lldb JIT interface.
+
+    Produces an ET_REL ELF-64 object with sections placed at the runtime
+    addresses provided by [section_address]. Used by the JIT to publish
+    just-in-time-compiled code so debuggers can resolve symbols and addresses.
+
+    Section bytes are taken verbatim from [sections] and assumed to be
+    post-relocation. No [.rela*] sections are emitted: the JIT has already
+    applied relocations to the live code, and GDB's JIT loader does not patch
+    inferior memory. No DWARF is emitted in this minimal build; symbol names
+    and addresses are sufficient for [info functions], backtraces by name,
+    breakpoints by symbol, and disassembly. *)
+
+val build :
+  (module Binary_emitter_intf.Assembled_section
+     with type t = 'a
+      and type relocation = 'r) ->
+  e_machine:int ->
+  sections:(string * 'a) list ->
+  section_address:(string -> int64 option) ->
+  section_runtime_size:(string -> int option) ->
+  Compiler_owee.Owee_buf.t

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1974,4 +1974,18 @@ module For_jit = struct
 
     let get () = !current_hook
   end
+
+  module Gdb_jit_symfile = struct
+    type assembled_section = Assembled_section.t
+
+    (* EM_X86_64 in [e_machine]. *)
+    let em_x86_64 = 0x3E
+
+    let build ~sections ~section_address ~section_runtime_size =
+      Some
+        (Jit_symfile.build
+           (module Assembled_section)
+           ~e_machine:em_x86_64 ~sections ~section_address
+           ~section_runtime_size)
+  end
 end

--- a/dune
+++ b/dune
@@ -743,7 +743,8 @@
   arm64_ast
   dwarf_low
   dwarf_high
-  binary_emitter_intf))
+  binary_emitter_intf
+  jit_symfile))
 
 (library
  (name oxcaml_common)

--- a/external/ocaml-jit/lib/dune
+++ b/external/ocaml-jit/lib/dune
@@ -3,7 +3,7 @@
  (libraries ocamlcommon ocamloptcomp ocamlopttoplevel flambda2 unix)
  (foreign_stubs
   (language c)
-  (names jit_stubs)))
+  (names jit_stubs perf_jitdump_stubs)))
 
 (install
  (files

--- a/external/ocaml-jit/lib/gdb_jit.ml
+++ b/external/ocaml-jit/lib/gdb_jit.ml
@@ -1,0 +1,25 @@
+type handle =
+  { (* The underlying ELF buffer. GDB reads from this memory directly via the
+       symfile_addr in the C-side jit_code_entry, so the Bigarray header must
+       stay live so the off-heap data is not freed. *)
+    symfile : Compiler_owee.Owee_buf.t;
+    (* Address of the C-allocated jit_code_entry, returned by the register
+       stub. Used as a token for unregistration. *)
+    entry : nativeint
+  }
+
+external register_c : Compiler_owee.Owee_buf.t -> nativeint
+  = "caml_jit_gdb_register"
+
+external unregister_c : nativeint -> unit = "caml_jit_gdb_unregister"
+
+let register symfile =
+  let entry = register_c symfile in
+  { symfile; entry }
+
+let unregister h =
+  unregister_c h.entry;
+  (* Keep [h.symfile] reachable until after the C call. Reading the field
+     here prevents an over-eager GC from freeing the buffer between the C
+     call's read of [symfile_addr] and the unregister notification. *)
+  ignore (Bigarray.Array1.dim h.symfile : int)

--- a/external/ocaml-jit/lib/gdb_jit.mli
+++ b/external/ocaml-jit/lib/gdb_jit.mli
@@ -1,0 +1,20 @@
+(** GDB JIT interface registration.
+
+    Publishes an in-memory ELF symfile to GDB via the protocol described at
+    https://sourceware.org/gdb/current/onlinedocs/gdb.html/JIT-Interface.html.
+
+    The implementation uses globals [__jit_debug_descriptor] and
+    [__jit_debug_register_code] in [jit_stubs.c]; GDB looks these up by name
+    in the inferior. *)
+
+type handle
+
+(** Register an ELF symfile contained in the given buffer with GDB. The
+    underlying bytes of [symfile] must remain valid for the lifetime of the
+    returned handle; this is achieved by keeping a reference to the buffer
+    inside the handle. *)
+val register : Compiler_owee.Owee_buf.t -> handle
+
+(** Unregister a previously registered symfile. After this returns, the
+    handle's buffer can be collected. *)
+val unregister : handle -> unit

--- a/external/ocaml-jit/lib/globals.ml
+++ b/external/ocaml-jit/lib/globals.ml
@@ -19,3 +19,8 @@ open! Import
 let symbols = ref Symbols.empty
 
 let debug = ref false
+
+(* Handles for in-memory ELF symfiles registered with GDB. Kept alive here
+   so the underlying buffers and C-allocated jit_code_entry records are not
+   freed for the duration of the process. *)
+let gdb_jit_handles : Gdb_jit.handle list ref = ref []

--- a/external/ocaml-jit/lib/globals.ml
+++ b/external/ocaml-jit/lib/globals.ml
@@ -24,3 +24,8 @@ let debug = ref false
    so the underlying buffers and C-allocated jit_code_entry records are not
    freed for the duration of the process. *)
 let gdb_jit_handles : Gdb_jit.handle list ref = ref []
+
+(* Lazily-initialised perf jitdump writer. [None] on non-Linux or before
+   the first JIT phrase is loaded; [Some] once initialised, even if init
+   subsequently failed (in which case it stays [None] permanently). *)
+let perf_jitdump : Perf_jitdump.handle option option ref = ref None

--- a/external/ocaml-jit/lib/globals.mli
+++ b/external/ocaml-jit/lib/globals.mli
@@ -19,3 +19,5 @@ open! Import
 val symbols : Symbols.t ref
 
 val debug : bool ref
+
+val gdb_jit_handles : Gdb_jit.handle list ref

--- a/external/ocaml-jit/lib/globals.mli
+++ b/external/ocaml-jit/lib/globals.mli
@@ -21,3 +21,5 @@ val symbols : Symbols.t ref
 val debug : bool ref
 
 val gdb_jit_handles : Gdb_jit.handle list ref
+
+val perf_jitdump : Perf_jitdump.handle option option ref

--- a/external/ocaml-jit/lib/jit.ml
+++ b/external/ocaml-jit/lib/jit.ml
@@ -206,6 +206,46 @@ let jit_run entry_points =
       | Ok x -> Result x
       | Err s -> failwithf "Jit.run: %s" s)
 
+(** Build an in-memory ELF symfile describing the just-loaded JIT'd code and
+    register it with GDB via the JIT-Interface protocol. On architectures
+    where the emitter does not implement [Gdb_jit_symfile.build] (currently
+    arm64), this is a no-op.
+
+    The [.text] entry's [sh_size] is set to [Jit_text_section.in_memory_size],
+    which covers the assembled text plus the GOT and PLT tables that follow
+    in memory. The trailing bytes in the symfile are zero-padded; GDB reads
+    actual instructions from inferior memory, not the symfile. *)
+let register_with_gdb (type a r)
+    (module E : Binary_emitter_intf.S
+      with type Assembled_section.t = a
+       and type Relocation.t = r) ~text ~sections =
+  let address_table = Hashtbl.create 16 in
+  let runtime_size_table = Hashtbl.create 16 in
+  Hashtbl.add address_table Jit_text_section.name
+    (Address.to_int64 text.address);
+  Hashtbl.add runtime_size_table Jit_text_section.name
+    (Jit_text_section.in_memory_size (module E) text.value);
+  String.Map.iter sections ~f:(fun ~key:name ~data:{ address; value = _ } ->
+      Hashtbl.add address_table name (Address.to_int64 address));
+  let section_address name = Hashtbl.find_opt address_table name in
+  let section_runtime_size name = Hashtbl.find_opt runtime_size_table name in
+  let sections_list =
+    let init =
+      [ Jit_text_section.name, Jit_text_section.binary_section text.value ]
+    in
+    String.Map.fold sections ~init
+      ~f:(fun ~key:name ~data:{ address = _; value } acc ->
+        (name, value) :: acc)
+  in
+  match
+    E.Gdb_jit_symfile.build ~sections:sections_list ~section_address
+      ~section_runtime_size
+  with
+  | None -> ()
+  | Some symfile ->
+    let handle = Gdb_jit.register symfile in
+    Globals.gdb_jit_handles := handle :: !Globals.gdb_jit_handles
+
 (** Load and run assembled binary sections. This is the main generic JIT entry
     point that works with any architecture. *)
 let jit_load (type a r)
@@ -260,6 +300,7 @@ let jit_load (type a r)
   Debug.save_text_section (module E) ~phrase_name relocated_text;
   load_text (module E) relocated_text;
   load_sections (module E) addressed_sections;
+  register_with_gdb (module E) ~text:relocated_text ~sections:addressed_sections;
   let entry_points = entry_points ~phrase_name symbols in
   let result = jit_run entry_points in
   outcome_ref := Some result

--- a/external/ocaml-jit/lib/jit.ml
+++ b/external/ocaml-jit/lib/jit.ml
@@ -206,6 +206,87 @@ let jit_run entry_points =
       | Ok x -> Result x
       | Err s -> failwithf "Jit.run: %s" s)
 
+let elf_mach_for_arch () =
+  match Target_system.architecture () with
+  | X86_64 -> 0x3E (* EM_X86_64 *)
+  | AArch64 -> 0xB7 (* EM_AARCH64 *)
+  | _ -> 0
+
+(* Lazily initialise the perf jitdump writer the first time we have a JIT
+   phrase to record. The result (including failure) is cached so we don't
+   retry on every phrase. *)
+let perf_handle () =
+  match !Globals.perf_jitdump with
+  | Some h -> h
+  | None ->
+    let h = Perf_jitdump.init ~elf_mach:(elf_mach_for_arch ()) in
+    Globals.perf_jitdump := Some h;
+    h
+
+let is_local_label name =
+  String.length name >= 2
+  && Char.equal name.[0] '.'
+  && Char.equal name.[1] 'L'
+
+(** Append [JIT_CODE_LOAD] records to the perf jitdump for each user-visible
+    symbol in the just-loaded text section. Each record covers the bytes
+    from one symbol's offset to the next symbol's offset (or the end of the
+    assembled section for the last one); this gives [perf report]
+    per-function attribution rather than collapsing the whole phrase under
+    one name.
+
+    The dump file is the cue [perf inject --jit] uses to symbolicate samples
+    after the fact. On non-Linux this is a no-op (the writer's [init] returns
+    [None]). *)
+let register_with_perf (type a r)
+    (module E : Binary_emitter_intf.S
+      with type Assembled_section.t = a
+       and type Relocation.t = r) ~text =
+  match perf_handle () with
+  | None -> ()
+  | Some h ->
+    let raw = Jit_text_section.binary_section text.value in
+    let assembled_size = E.Assembled_section.size raw in
+    let contents = E.Assembled_section.contents raw in
+    let base_addr = Address.to_int64 text.address in
+    (* Collect non-label symbols. *)
+    let symbols = ref [] in
+    E.Assembled_section.iter_labels_and_symbols raw
+      ~f:(fun target ~offset ->
+        let name =
+          match target with
+          | Binary_emitter_intf.Symbol s -> Asm_targets.Asm_symbol.encode s
+          | Binary_emitter_intf.Label l -> Asm_targets.Asm_label.encode l
+        in
+        if not (is_local_label name)
+        then symbols := (offset, name) :: !symbols);
+    (* Sort by offset so we can compute end-of-function as the next entry's
+       offset. *)
+    let sorted =
+      List.sort (fun (a, _) (b, _) -> compare a b) !symbols
+    in
+    let rec emit = function
+      | [] -> ()
+      | [ (off, name) ] ->
+        let size = assembled_size - off in
+        if size > 0
+        then
+          Perf_jitdump.emit_code_load h ~name
+            ~code_addr:(Int64.add base_addr (Int64.of_int off))
+            ~code_size:size
+            ~code:(String.sub contents off size)
+      | (off, name) :: ((next_off, _) :: _ as rest) ->
+        let size = next_off - off in
+        if size > 0
+        then
+          Perf_jitdump.emit_code_load h ~name
+            ~code_addr:(Int64.add base_addr (Int64.of_int off))
+            ~code_size:size
+            ~code:(String.sub contents off size);
+        emit rest
+    in
+    emit sorted
+
 (** Build an in-memory ELF symfile describing the just-loaded JIT'd code and
     register it with GDB via the JIT-Interface protocol. On architectures
     where the emitter does not implement [Gdb_jit_symfile.build] (currently
@@ -301,6 +382,7 @@ let jit_load (type a r)
   load_text (module E) relocated_text;
   load_sections (module E) addressed_sections;
   register_with_gdb (module E) ~text:relocated_text ~sections:addressed_sections;
+  register_with_perf (module E) ~text:relocated_text;
   let entry_points = entry_points ~phrase_name symbols in
   let result = jit_run entry_points in
   outcome_ref := Some result

--- a/external/ocaml-jit/lib/jit_stubs.c
+++ b/external/ocaml-jit/lib/jit_stubs.c
@@ -29,9 +29,12 @@
 #include "caml/alloc.h"
 #include "caml/osdeps.h"
 #include "caml/codefrag.h"
+#include "caml/bigarray.h"
+#include "caml/fail.h"
 
 #include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -323,4 +326,117 @@ CAMLprim value jit_addr_to_obj(value address) {
 CAMLprim value jit_obj_to_addr(value obj) {
   CAMLparam1(obj);
   CAMLreturn(caml_copy_nativeint((intnat) obj));
+}
+
+/* ===========================================================================
+   GDB JIT Interface
+   ---------------------------------------------------------------------------
+   Protocol per https://sourceware.org/gdb/current/onlinedocs/gdb.html/JIT-Interface.html
+   and binutils-gdb/gdb/jit.{c,h}.
+
+   The inferior publishes generated code to GDB via two well-known symbols:
+
+     __jit_debug_descriptor    -- a singleton struct read by GDB
+     __jit_debug_register_code -- a no-op function GDB sets a breakpoint on
+
+   Each registration: malloc a jit_code_entry, splice into the doubly-linked
+   list, set descriptor->relevant_entry / action_flag, call the trampoline.
+
+   This box is Mach-O so GDB JIT is not testable here; the symfile produced
+   is ELF and intended for x86-64 Linux GDB.
+   =========================================================================== */
+
+typedef enum {
+  JIT_NOACTION = 0,
+  JIT_REGISTER = 1,
+  JIT_UNREGISTER = 2
+} jit_actions_t;
+
+struct jit_code_entry {
+  struct jit_code_entry *next_entry;
+  struct jit_code_entry *prev_entry;
+  const char *symfile_addr;
+  uint64_t symfile_size;
+};
+
+struct jit_descriptor {
+  uint32_t version;
+  uint32_t action_flag;
+  struct jit_code_entry *relevant_entry;
+  struct jit_code_entry *first_entry;
+};
+
+/* GDB looks up these symbols by name in the inferior. They must have
+   external linkage and the descriptor must be initialised to {1, 0, 0, 0}. */
+struct jit_descriptor __jit_debug_descriptor = { 1, 0, 0, 0 };
+
+/* GDB places a breakpoint at the entry of this function. The body is a
+   memory-clobber asm so the compiler cannot optimise the call site away
+   even after inlining/LTO. The noinline attribute keeps a real call site. */
+void __attribute__((noinline)) __jit_debug_register_code(void) {
+  __asm__ volatile("" ::: "memory");
+}
+
+/* Splice [entry] at the head of the descriptor's linked list, set
+   relevant_entry/action_flag, and notify GDB. */
+static void caml_jit_gdb_notify(struct jit_code_entry *entry,
+                                jit_actions_t action) {
+  __jit_debug_descriptor.relevant_entry = entry;
+  __jit_debug_descriptor.action_flag = action;
+  __jit_debug_register_code();
+}
+
+/* Register an in-memory ELF symfile with GDB.
+
+   [symfile] is an Owee_buf.t (a 1-D int8_unsigned Bigarray). Its underlying
+   bytes are off-heap so GDB sees a stable address. The OCaml caller is
+   responsible for keeping the Bigarray alive (see Gdb_jit.handle).
+
+   Returns the malloc'd jit_code_entry pointer as a nativeint, used later for
+   unregistration. */
+CAMLprim value caml_jit_gdb_register(value symfile) {
+  CAMLparam1(symfile);
+  CAMLlocal1(result);
+
+  void *data = Caml_ba_data_val(symfile);
+  intnat size = Caml_ba_array_val(symfile)->dim[0];
+
+  struct jit_code_entry *entry =
+    (struct jit_code_entry *)malloc(sizeof(struct jit_code_entry));
+  if (entry == NULL)
+    caml_failwith("Gdb_jit.register: malloc failed");
+
+  entry->symfile_addr = (const char *)data;
+  entry->symfile_size = (uint64_t)size;
+  entry->prev_entry = NULL;
+  entry->next_entry = __jit_debug_descriptor.first_entry;
+  if (entry->next_entry != NULL)
+    entry->next_entry->prev_entry = entry;
+  __jit_debug_descriptor.first_entry = entry;
+
+  caml_jit_gdb_notify(entry, JIT_REGISTER);
+
+  result = caml_copy_nativeint((intnat)entry);
+  CAMLreturn(result);
+}
+
+/* Unregister a previously registered entry. [entry_addr] is the nativeint
+   returned by [caml_jit_gdb_register]. */
+CAMLprim value caml_jit_gdb_unregister(value entry_addr) {
+  CAMLparam1(entry_addr);
+
+  struct jit_code_entry *entry =
+    (struct jit_code_entry *)Nativeint_val(entry_addr);
+
+  if (entry->prev_entry != NULL)
+    entry->prev_entry->next_entry = entry->next_entry;
+  else
+    __jit_debug_descriptor.first_entry = entry->next_entry;
+  if (entry->next_entry != NULL)
+    entry->next_entry->prev_entry = entry->prev_entry;
+
+  caml_jit_gdb_notify(entry, JIT_UNREGISTER);
+
+  free(entry);
+  CAMLreturn(Val_unit);
 }

--- a/external/ocaml-jit/lib/jit_text_section.ml
+++ b/external/ocaml-jit/lib/jit_text_section.ml
@@ -112,3 +112,5 @@ let symbols (type a r)
        and type Relocation.t = r)
     { address; value = t } =
   Symbols.from_binary_section (module E) { address; value = t.binary_section }
+
+let binary_section t = t.binary_section

--- a/external/ocaml-jit/lib/jit_text_section.mli
+++ b/external/ocaml-jit/lib/jit_text_section.mli
@@ -70,3 +70,6 @@ val symbols :
   Symbols.t
 (** Return a mapping from symbols to absolute address for the symbols defined in the given
     text section. *)
+
+val binary_section : ('a, _) t -> 'a
+(** The underlying assembled binary section (without the GOT/PLT tables). *)

--- a/external/ocaml-jit/lib/perf_jitdump.ml
+++ b/external/ocaml-jit/lib/perf_jitdump.ml
@@ -8,10 +8,14 @@ external is_linux : unit -> bool = "caml_perf_jitdump_is_linux" [@@noalloc]
 external clock_monotonic_ns : unit -> int64
   = "caml_perf_jitdump_clock_monotonic"
 
+(* Generates a single PROT_EXEC mmap event then unmaps. The kernel records
+   the event at mmap-time, so the mapping itself does not need to persist. *)
 external mmap_exec_marker : Unix.file_descr -> int -> unit
   = "caml_perf_jitdump_mmap_marker"
 
-let header_size = 48
+(* Six u32s (magic, version, total_size, elf_mach, pad1, pid) plus two u64s
+   (timestamp, flags) = 24 + 16 = 40 bytes. *)
+let header_size = 40
 
 let record_prefix_size = 16
 

--- a/external/ocaml-jit/lib/perf_jitdump.ml
+++ b/external/ocaml-jit/lib/perf_jitdump.ml
@@ -1,0 +1,151 @@
+(* Linux [perf] jitdump writer. See .mli for protocol overview.
+
+   Format reference:
+   linux/tools/perf/Documentation/jitdump-specification.txt *)
+
+external is_linux : unit -> bool = "caml_perf_jitdump_is_linux" [@@noalloc]
+
+external clock_monotonic_ns : unit -> int64
+  = "caml_perf_jitdump_clock_monotonic"
+
+external mmap_exec_marker : Unix.file_descr -> int -> unit
+  = "caml_perf_jitdump_mmap_marker"
+
+let header_size = 48
+
+let record_prefix_size = 16
+
+let code_load_fixed_body_size = 40
+
+let id_jit_code_load = 0
+
+let magic = 0x4A695444 (* "JiTD" in native endian *)
+
+let version = 1
+
+type handle =
+  { fd : Unix.file_descr;
+    pid : int;
+    mutable code_index : int;
+    mutable disabled : bool
+  }
+
+(* Little-endian byte writers. The jitdump format is "native endian" with
+   readers detecting via the magic; on Linux x86-64 and arm64 native is
+   little-endian, which is what we emit. *)
+
+let buf_u32 buf v =
+  Buffer.add_char buf (Char.chr (v land 0xff));
+  Buffer.add_char buf (Char.chr ((v lsr 8) land 0xff));
+  Buffer.add_char buf (Char.chr ((v lsr 16) land 0xff));
+  Buffer.add_char buf (Char.chr ((v lsr 24) land 0xff))
+
+let buf_u64_int64 buf v =
+  for i = 0 to 7 do
+    let b =
+      Int64.logand (Int64.shift_right_logical v (i * 8)) 0xffL |> Int64.to_int
+    in
+    Buffer.add_char buf (Char.chr b)
+  done
+
+let buf_u64_int buf v = buf_u64_int64 buf (Int64.of_int v)
+
+(* Write all of [bytes] to [fd], retrying short writes and EINTR. *)
+let rec write_all fd buf off len =
+  if len = 0
+  then ()
+  else
+    match Unix.write fd buf off len with
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all fd buf off len
+    | 0 -> failwith "perf_jitdump: write returned 0"
+    | n -> write_all fd buf (off + n) (len - n)
+
+let dump_dir () =
+  match Sys.getenv_opt "JITDUMP_DIR" with
+  | Some d -> d
+  | None -> (
+    match Sys.getenv_opt "HOME" with
+    | Some h -> Filename.concat (Filename.concat h ".debug") "jit"
+    | None -> (
+      match Sys.getenv_opt "TMPDIR" with Some t -> t | None -> "/tmp"))
+
+let mkdir_p dir =
+  let rec go dir =
+    if Sys.file_exists dir
+    then ()
+    else (
+      go (Filename.dirname dir);
+      try Unix.mkdir dir 0o755
+      with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  go dir
+
+let build_header ~elf_mach ~pid =
+  let buf = Buffer.create header_size in
+  buf_u32 buf magic;
+  buf_u32 buf version;
+  buf_u32 buf header_size;
+  buf_u32 buf elf_mach;
+  buf_u32 buf 0 (* pad1 *);
+  buf_u32 buf pid;
+  buf_u64_int64 buf (clock_monotonic_ns ()) (* timestamp *);
+  buf_u64_int64 buf 0L (* flags *);
+  assert (Buffer.length buf = header_size);
+  Buffer.to_bytes buf
+
+let init ~elf_mach =
+  if not (is_linux ())
+  then None
+  else if elf_mach = 0
+  then None
+  else
+    try
+      let dir = dump_dir () in
+      mkdir_p dir;
+      let pid = Unix.getpid () in
+      let path = Filename.concat dir (Printf.sprintf "jit-%d.dump" pid) in
+      let fd =
+        Unix.openfile path [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_RDWR ] 0o644
+      in
+      let header = build_header ~elf_mach ~pid in
+      write_all fd header 0 header_size;
+      mmap_exec_marker fd header_size;
+      Some { fd; pid; code_index = 0; disabled = false }
+    with _ -> None
+
+let emit_code_load h ~name ~code_addr ~code_size ~code =
+  if h.disabled
+  then ()
+  else if String.length code <> code_size
+  then h.disabled <- true (* mismatch — refuse to emit corrupt records *)
+  else
+    let idx = h.code_index in
+    h.code_index <- idx + 1;
+    let name_len_with_nul = String.length name + 1 in
+    let total =
+      record_prefix_size + code_load_fixed_body_size + name_len_with_nul
+      + code_size
+    in
+    let buf = Buffer.create total in
+    (* Record prefix *)
+    buf_u32 buf id_jit_code_load;
+    buf_u32 buf total;
+    buf_u64_int64 buf (clock_monotonic_ns ());
+    (* JIT_CODE_LOAD body *)
+    buf_u32 buf h.pid;
+    buf_u32 buf h.pid (* tid; ocaml-jit is single-threaded *);
+    buf_u64_int64 buf code_addr (* vma *);
+    buf_u64_int64 buf code_addr (* code_addr *);
+    buf_u64_int buf code_size;
+    buf_u64_int buf idx;
+    Buffer.add_string buf name;
+    Buffer.add_char buf '\x00';
+    Buffer.add_string buf code;
+    let bytes = Buffer.to_bytes buf in
+    let len = Bytes.length bytes in
+    assert (len = total);
+    try write_all h.fd bytes 0 len
+    with _ ->
+      (* If a write fails the dump is now truncated and unparseable; stop
+         emitting further records to avoid making it worse. *)
+      h.disabled <- true

--- a/external/ocaml-jit/lib/perf_jitdump.mli
+++ b/external/ocaml-jit/lib/perf_jitdump.mli
@@ -1,0 +1,32 @@
+(** Linux [perf] jitdump support.
+
+    Writes the streaming format consumed by [perf inject --jit] (see
+    linux/tools/perf/Documentation/jitdump-specification.txt). The dump file
+    lives under [$JITDUMP_DIR] (default [~/.debug/jit/]) as
+    [jit-<pid>.dump]; a [PROT_EXEC] [mmap] of the file's header is
+    established so [perf record] captures it as a [PERF_RECORD_MMAP] event,
+    which is the cue [perf inject --jit] uses to find the dump after the
+    fact.
+
+    On non-Linux platforms [init] returns [None]; the rest of the API is
+    a no-op. *)
+
+type handle
+
+(** [init ~elf_mach] opens the jitdump file for the current process, writes
+    the header, and establishes the [PROT_EXEC] mmap marker. [elf_mach] is
+    the [EM_*] value (e.g. [0x3E] for x86-64, [0xB7] for arm64) that goes in
+    the header. Returns [None] on non-Linux, on unsupported [elf_mach], or on
+    any error during setup. Best-effort — never raises. *)
+val init : elf_mach:int -> handle option
+
+(** Append a [JIT_CODE_LOAD] record describing one JIT'd function. [code] is
+    the relocated machine code at runtime address [code_addr]; its length
+    must equal [code_size]. Best-effort: errors are swallowed. *)
+val emit_code_load :
+  handle ->
+  name:string ->
+  code_addr:int64 ->
+  code_size:int ->
+  code:string ->
+  unit

--- a/external/ocaml-jit/lib/perf_jitdump.mli
+++ b/external/ocaml-jit/lib/perf_jitdump.mli
@@ -3,10 +3,11 @@
     Writes the streaming format consumed by [perf inject --jit] (see
     linux/tools/perf/Documentation/jitdump-specification.txt). The dump file
     lives under [$JITDUMP_DIR] (default [~/.debug/jit/]) as
-    [jit-<pid>.dump]; a [PROT_EXEC] [mmap] of the file's header is
-    established so [perf record] captures it as a [PERF_RECORD_MMAP] event,
-    which is the cue [perf inject --jit] uses to find the dump after the
-    fact.
+    [jit-<pid>.dump]. At [init] time we briefly [mmap] the file's header
+    with [PROT_READ | PROT_EXEC] and immediately [munmap]; the kernel emits
+    a [PERF_RECORD_MMAP] event at the moment of the [mmap] syscall, which
+    is the cue [perf inject --jit] uses to associate the dump with this
+    process.
 
     On non-Linux platforms [init] returns [None]; the rest of the API is
     a no-op. *)

--- a/external/ocaml-jit/lib/perf_jitdump_stubs.c
+++ b/external/ocaml-jit/lib/perf_jitdump_stubs.c
@@ -50,21 +50,27 @@ CAMLprim value caml_perf_jitdump_clock_monotonic(value unit) {
 #endif
 }
 
-/* mmap [size] bytes of [fd] at offset 0 with PROT_READ | PROT_EXEC. The
-   resulting mapping is the "marker" `perf record` captures as a
-   PERF_RECORD_MMAP, letting `perf inject --jit` later locate the dump file
-   by path. The mapping is intentionally never unmapped — the kernel reaps it
-   at process exit, and saved perf.data must remain replayable.
+/* Generate a single PROT_EXEC mmap event for [fd]. This is the marker
+   `perf record` captures as PERF_RECORD_MMAP; `perf inject --jit` later
+   scans for executable mmaps of paths matching jit-<pid>.dump to locate the
+   dump file by name.
 
-   Best-effort: if mmap fails, we silently continue. The dump still gets
-   written to disk; only the marker is missing, so `perf inject` will not
-   find it automatically. */
+   The kernel records the mmap event at mmap(2) time, so the mapping itself
+   only has to live long enough for that event to be emitted into the kernel
+   ring buffer — i.e. not at all from a userspace point of view. We munmap
+   immediately to avoid leaking a VMA for the process lifetime.
+
+   Best-effort: if either call fails, we silently continue. The dump still
+   gets written to disk; only the marker is missing, so `perf inject` will
+   not find it automatically. */
 CAMLprim value caml_perf_jitdump_mmap_marker(value v_fd, value v_size) {
 #ifdef __linux__
   int fd = Int_val(v_fd);
   size_t size = (size_t)Long_val(v_size);
   void *p = mmap(NULL, size, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0);
-  (void)p; /* leak intentional */
+  if (p != MAP_FAILED) {
+    munmap(p, size);
+  }
 #else
   (void)v_fd;
   (void)v_size;

--- a/external/ocaml-jit/lib/perf_jitdump_stubs.c
+++ b/external/ocaml-jit/lib/perf_jitdump_stubs.c
@@ -1,0 +1,73 @@
+/* C stubs for the Linux `perf` jitdump format.
+
+   On non-Linux platforms the entire feature is disabled at runtime via
+   [caml_perf_jitdump_is_linux] returning [false]; the other stubs are
+   compiled in but should never be called. They are still safe to call
+   (returning failure / no-op) so the OCaml side does not need conditional
+   externals. */
+
+#define CAML_INTERNALS
+
+#include "caml/mlvalues.h"
+#include "caml/memory.h"
+#include "caml/alloc.h"
+#include "caml/fail.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __linux__
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+#endif
+
+CAMLprim value caml_perf_jitdump_is_linux(value unit) {
+  (void)unit;
+#ifdef __linux__
+  return Val_true;
+#else
+  return Val_false;
+#endif
+}
+
+/* Returns nanoseconds since CLOCK_MONOTONIC origin, the timestamp source
+   recommended by the jitdump spec. Must match `perf record -k mono`. */
+CAMLprim value caml_perf_jitdump_clock_monotonic(value unit) {
+  (void)unit;
+#ifdef __linux__
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    caml_failwith("perf_jitdump: clock_gettime(CLOCK_MONOTONIC) failed");
+  }
+  uint64_t ns = (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+  return caml_copy_int64((int64_t)ns);
+#else
+  return caml_copy_int64(0);
+#endif
+}
+
+/* mmap [size] bytes of [fd] at offset 0 with PROT_READ | PROT_EXEC. The
+   resulting mapping is the "marker" `perf record` captures as a
+   PERF_RECORD_MMAP, letting `perf inject --jit` later locate the dump file
+   by path. The mapping is intentionally never unmapped — the kernel reaps it
+   at process exit, and saved perf.data must remain replayable.
+
+   Best-effort: if mmap fails, we silently continue. The dump still gets
+   written to disk; only the marker is missing, so `perf inject` will not
+   find it automatically. */
+CAMLprim value caml_perf_jitdump_mmap_marker(value v_fd, value v_size) {
+#ifdef __linux__
+  int fd = Int_val(v_fd);
+  size_t size = (size_t)Long_val(v_size);
+  void *p = mmap(NULL, size, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0);
+  (void)p; /* leak intentional */
+#else
+  (void)v_fd;
+  (void)v_size;
+#endif
+  return Val_unit;
+}


### PR DESCRIPTION
This aims to implement support for "jitdump" files, which can be used with `perf inject`.  This should allow `perf` to work for metaprogramming quotes.

Credits: https://theunixzoo.co.uk/blog/2025-09-14-linux-perf-jit.html

Based on #6017 