### PR TITLE
Fix hidden dependency cache checking

### DIFF
--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -961,7 +961,19 @@ let find ~allow_hidden penv f name ~allow_excess_args =
 
 let check ~allow_hidden penv f ~loc name =
   let {persistent_structures; _} = penv in
-  if not (Hashtbl.mem persistent_structures name) then begin
+  let persistent_structure_visible =
+    match Hashtbl.find persistent_structures name with
+    | ps ->
+        begin
+          match
+            check_visibility ~allow_hidden ps.ps_name_info.pn_import
+          with
+        | () -> true
+        | exception Not_found -> false
+        end
+    | exception Not_found -> false
+  in
+  if not persistent_structure_visible then begin
     (* PR#6843: record the weak dependency ([add_import]) regardless of
        whether the check succeeds, to help make builds more
        deterministic. *)


### PR DESCRIPTION
Fix `Persistent_env.check` so cached hidden CMIs are still treated as hidden when checking whether a module is directly available.

Previously, `check` only tested whether a module was present in `persistent_structures`. If a hidden CMI had already been loaded through an allowed transitive lookup, later checks could incorrectly suppress warning 49 (`no-cmi-file`) even when the module was only available through `-H` and the current lookup did not allow hidden dependencies. This made the warning depend on cache state and lookup order.

The new check applies the existing visibility predicate to cached entries before deciding that the module is available. This keeps the behavior consistent with normal persistent-structure lookup and makes hidden dependency warnings independent of whether the CMI was already cached.
