### PR TITLE
Fix hidden dependency cache checking

### DIFF
--- a/testsuite/tests/hidden_includes/alias_after_hidden_load.ocamlc.reference
+++ b/testsuite/tests/hidden_includes/alias_after_hidden_load.ocamlc.reference
@@ -1,0 +1,4 @@
+File "libc/c6.ml", line 3, characters 17-18:
+3 | module A_alias = A
+                     ^
+Warning 49 [no-cmi-file]: no cmi file was found in path for module A

--- a/testsuite/tests/hidden_includes/libc/c6.ml
+++ b/testsuite/tests/hidden_includes/libc/c6.ml
@@ -1,0 +1,6 @@
+let x = B.x + 1
+
+module A_alias = A
+
+(* Typing [x] loads [A.cmi] through [-H liba].  The alias must still report
+   warning 49 because direct references to [A] are not allowed. *)

--- a/testsuite/tests/hidden_includes/test.ml
+++ b/testsuite/tests/hidden_includes/test.ml
@@ -152,6 +152,18 @@ ocamlc.byte;
   check-ocamlc.byte-output;
 }
 
+(* Test that a hidden `A` doesn't become visible to -no-alias-deps checking
+   just because the typechecker loaded it earlier. *)
+{
+  flags = "-H liba -I libb -no-alias-deps -nocwd";
+  module = "libc/c6.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/alias_after_hidden_load.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
 (* Test that type-directed constructor disambiguation works through -H (at
    least, for now). *)
 {

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -961,7 +961,19 @@ let find ~allow_hidden penv f name ~allow_excess_args =
 
 let check ~allow_hidden penv f ~loc name =
   let {persistent_structures; _} = penv in
-  if not (Hashtbl.mem persistent_structures name) then begin
+  let persistent_structure_visible =
+    match Hashtbl.find persistent_structures name with
+    | ps ->
+        begin
+          match
+            check_visibility ~allow_hidden ps.ps_name_info.pn_import
+          with
+        | () -> true
+        | exception Not_found -> false
+        end
+    | exception Not_found -> false
+  in
+  if not persistent_structure_visible then begin
     (* PR#6843: record the weak dependency ([add_import]) regardless of
        whether the check succeeds, to help make builds more
        deterministic. *)


### PR DESCRIPTION
Fix `Persistent_env.check` so cached hidden CMIs are still treated as hidden when checking whether a module is directly available.

Previously, `check` only tested whether a module was present in `persistent_structures`. If a hidden CMI had already been loaded through an allowed transitive lookup, later checks could incorrectly suppress warning 49 (`no-cmi-file`) even when the module was only available through `-H` and the current lookup did not allow hidden dependencies. This made the warning depend on cache state and lookup order.

The new check applies the existing visibility predicate to cached entries before deciding that the module is available. This keeps the behavior consistent with normal persistent-structure lookup and makes hidden dependency warnings independent of whether the CMI was already cached.
