### PR TITLE
Canonicalize reg-reg movl/movq encodings

### DIFF
--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -643,10 +643,10 @@ let emit_MOV b dst src =
       buf_int8 b 0x66;
       emit_mod_rm_reg b no_rex [ 0x8B ] rm (rd_of_reg64 reg)
   (* movl *)
-  | Reg32 reg32, ((Reg32 _ | Mem _ | Mem64_RIP _) as rm) ->
+  | Reg32 reg32, ((Mem _ | Mem64_RIP _) as rm) ->
       let reg = rd_of_reg64 reg32 in
       emit_mod_rm_reg b 0 [ 0x8B ] rm reg
-  | ((Mem _ | Mem64_RIP _) as rm), Reg32 reg32 ->
+  | ((Reg32 _ | Mem _ | Mem64_RIP _) as rm), Reg32 reg32 ->
       let reg = rd_of_reg64 reg32 in
       emit_mod_rm_reg b 0 [ 0x89 ] rm reg
   | (Mem { typ = DWORD } as rm), ((Imm _ | Sym _) as n) ->
@@ -669,9 +669,9 @@ let emit_MOV b dst src =
       buf_int8 b (0xB8 lor reg7 reg);
       buf_int32_imm b n
   (* movq *)
-  | Reg64 reg, ((Reg64 _ | Mem _ | Mem64_RIP _) as rm) ->
+  | Reg64 reg, ((Mem _ | Mem64_RIP _) as rm) ->
       emit_mod_rm_reg b rexw [ 0x8B ] rm (rd_of_reg64 reg)
-  | ((Mem _ | Mem64_RIP _) as rm), Reg64 reg ->
+  | ((Reg64 _ | Mem _ | Mem64_RIP _) as rm), Reg64 reg ->
       emit_mod_rm_reg b rexw [ 0x89 ] rm (rd_of_reg64 reg)
   | Reg64 r64, Imm n when not (is_imm32L n) ->
       (* MOVNoneQ *)


### PR DESCRIPTION
For register-to-register `movl` and `movq`, two valid x86 encodings exist:

- `0x89 /r` — `MOV r/m, r` (store form): destination in ModR/M's r/m field, source in the reg field.
- `0x8B /r` — `MOV r, r/m` (load form): destination in the reg field, source in r/m.

For two register operands, both encode the same architectural operation. The binary emitter previously used the load form (`0x8B`) for reg-reg moves, which differs from what other assemblers emit for the same instruction—they canonicalize to `0x89`.

**llvm-mc**
```
$ printf 'movl %%eax, %%ebx\nmovq %%rax, %%rbx\n' | llvm-mc --triple=x86_64 --show-encoding
	movl	%eax, %ebx                      # encoding: [0x89,0xc3]
	movq	%rax, %rbx                      # encoding: [0x48,0x89,0xc3]
```

**GNU as**
```
$ cat mov_demo.s
	.text
	movl %eax, %ebx
	movq %rax, %rbx

$ as --64 -o mov_demo.o mov_demo.s && objdump -d mov_demo.o
0000000000000000 <.text>:
   0:	89 c3                	mov    %eax,%ebx
   2:	48 89 c3             	mov    %rax,%rbx
```