### PR TITLE
Remove jump distance heuristic from x86 binary emitter

### DIFF
--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1143,8 +1143,14 @@ let emit_reloc_jump near_opcodes far_opcodes b loc symbol =
       (* Have we detected previously that this jump instruction needs
          to be a long one?  If not, optimistically emit a short jump and
          let the retry mechanism upgrade it on a later pass if the actual
-         offset turns out to exceed the 8-bit range. *)
-      let force_far = IntSet.mem loc !forced_long_jumps in
+         offset turns out to exceed the 8-bit range.
+
+         If the range is more than 127 instructions, we know it has to
+         become a long jump, since every instruction is at least one byte. *)
+      let force_far =
+        (target_loc - loc > 127)
+        || IntSet.mem loc !forced_long_jumps
+      in
       if force_far then (
         buf_opcodes b far_opcodes;
         record_local_reloc b (RelocLongJump symbol);

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -163,22 +163,16 @@ let str_int64L s pos v =
   str_int32L s pos v;
   str_int32L s (pos + 4) (Int64.shift_right_logical v 32)
 
-(* When a jump has to be generated, we compare the offset between the
-   source instruction and the target instruction, in number of
-   instructions.
-
-   If the offset is less than [short_jump_threshold] instructions,
-   we generate a short jump during the first pass. 16 is a "safe"
-   value, as most instructions are shorter than 8 bytes: [REX] +
-   [OPCODE] + [MODRM] + [SIB] + [IMM32] *)
+(* Forward local jumps are sized by fixed-point iteration. We first emit the
+   short form for code size. During relocation resolution, any jump whose 8-bit
+   displacement does not fit is recorded in [forced_long_jumps], and the
+   section is reassembled with that jump in long form. *)
 
 let local_relocs = ref []
 
 let local_labels = String.Tbl.create 100
 
 let forced_long_jumps = ref IntSet.empty
-
-let instr_size = ref 4
 
 let new_buffer sec =
   {
@@ -1146,25 +1140,11 @@ let emit_reloc_jump near_opcodes far_opcodes b loc symbol =
           (Int64.sub togo (Int64.of_int (4 + List.length far_opcodes)))))
     else
       (* forward *)
-      (* Is the target too far forward (in term of instruction count)
-         or have we detected previously that this jump instruction needs
-         to be a long one?
-
-         The str_size constant (see below) is chosen to avoid a second
-         pass most oftenm while not being overly pessimistic. *)
-
-      (*
-      if Int64.of_int ((target_loc - loc) * !instr_size) >= 120L then
-        Printf.printf "%s/%i: probably too far (%i)\n%!" symbol loc target_loc
-      else if IntSet.mem loc !forced_long_jumps then
-        Printf.printf "%s/%i: forced long jump\n%!" symbol loc
-      else
-        Printf.printf "%s/%i: short\n%!" symbol loc;
-*)
-      let force_far =
-        Int64.compare (Int64.of_int ((target_loc - loc) * !instr_size)) 120L >= 0
-        || IntSet.mem loc !forced_long_jumps
-      in
+      (* Have we detected previously that this jump instruction needs
+         to be a long one?  If not, optimistically emit a short jump and
+         let the retry mechanism upgrade it on a later pass if the actual
+         offset turns out to exceed the 8-bit range. *)
+      let force_far = IntSet.mem loc !forced_long_jumps in
       if force_far then (
         buf_opcodes b far_opcodes;
         record_local_reloc b (RelocLongJump symbol);
@@ -1679,8 +1659,7 @@ let rec assemble_section arch section =
     X86_gas.generate_asm Out_channel.stderr dll;
     Printexc.raise_with_backtrace Misc.Fatal_error bt
 
-and assemble_section0 arch section =
-  (match arch with X86 -> instr_size := 5 | X64 -> instr_size := 6);
+and assemble_section0 _arch section =
   forced_long_jumps := IntSet.empty;
   String.Tbl.clear local_labels;
 


### PR DESCRIPTION
The forward-jump emitter in `backend/x86_binary_emitter.ml` used to force a long (32-bit displacement) jump whenever the target was more than `120 / instr_size` *instructions* ahead. With `instr_size = 6` on x64, that triggered at more than 20 instructions of distance, leading to suboptimal code gen.

This PR replaces the heuristic with a more conservative check: every jump that is longer than 127 instructions must be long. All other forward jumps now optimistically emit a short form, and the existing fixed-point retry mechanism upgrades any that actually overflow.

**Correctness** The retry loop in `assemble_section0` is monotone: once a location is added to `forced_long_jumps`, it stays. Each pass either succeeds or strictly grows the forced set, so the algorithm still converges in `O(#jumps)` passes per section.

**Performance implications** Code size decreases (every jump that flips from forced-long back to short saves
  3 bytes or 4 bytes), improving runtime performance. Assembly time increases due to potentially more iterations. The previous heuristic converged almost always in one iteration. For the new version, the number of required passes for convergence increases but it seems to remain small in practice. See [this comment](https://github.com/oxcaml/oxcaml/pull/6024#issuecomment-4534338693) below.