### PR TITLE
amd64: align with nops, not zeros, in the text section

### DIFF
--- a/asmcomp/dissector/iplt.ml
+++ b/asmcomp/dissector/iplt.ml
@@ -73,7 +73,7 @@ let iplt_symbol_name ~prefix ~symbol =
    NOP instructions (90 90) for padding to reach 8 bytes. *)
 let plt_entry_template =
   let section =
-    { X86_binary_emitter.sec_name = ".text.iplt";
+    { X86_binary_emitter.sec_name = X86_proc.Section_name.of_string ".text.iplt";
       sec_instrs =
         [| X86_ast.Ins
              (X86_ast.JMP (X86_ast.Mem64_RIP (X86_ast.QWORD, "dummy", 0)));

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -784,7 +784,7 @@ let emit_jump_table t =
   done
 
 let emit_jump_tables () =
-  D.align ~fill:Zero ~bytes:4;
+  D.align ~fill:Nop ~bytes:4;
   List.iter emit_jump_table !jump_tables;
   jump_tables := []
 
@@ -3129,15 +3129,7 @@ let end_assembly () =
   emit_global_label ~section:Data "data_end";
   D.int64 0L;
   D.text ();
-  (* We align to 8 bytes before the frame table. Perhaps somewhat
-     counterintuitively, we use [~fill:Zero] even though we are now in the text
-     section. The reason is that the additional padding will never be executed,
-     so there is no need to pad it with nops in the X86 binary emitter. *)
-  (* CR sspies: We should just determine the filling based on the current
-     section for the binary emitter and then remove the argument [fill]. This is
-     the only place, where it does not seem to match the current section, and it
-     seems it does not matter whether we pad with zeros or nops here. *)
-  D.align ~fill:Zero ~bytes:8;
+  D.align ~fill:Nop ~bytes:8;
   (* PR#7591 *)
   emit_global_label ~section:Text "frametable";
   (* CR sspies: Share the [emit_frames] code with the Arm backend. *)
@@ -3157,7 +3149,7 @@ let end_assembly () =
       efa_u16 = (fun n -> D.uint16 n);
       efa_u32 = (fun n -> D.uint32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
-      efa_align = (fun n -> D.align ~fill:Zero ~bytes:n);
+      efa_align = (fun n -> D.align ~fill:Nop ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
           let lbl = label_to_asm_label ~section:Text lbl in

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -175,7 +175,7 @@ let assemble_one_section ~name instructions =
   in
   align,
   X86_binary_emitter.assemble_section X64
-    { X86_binary_emitter.sec_name = X86_proc.Section_name.to_string name;
+    { X86_binary_emitter.sec_name = name;
       sec_instrs = DLL.to_array instructions
     }
 

--- a/backend/internal_assembler/symbol_entry.ml
+++ b/backend/internal_assembler/symbol_entry.ml
@@ -98,10 +98,7 @@ let create_symbol (symbol : X86_binary_emitter.symbol) symbol_table sections
     { st_name = String_table.current_length string_table;
       st_info = (st_binding lsl 4) lor st_type;
       st_other = if symbol.sy_protected then 3 else 0;
-      st_shndx =
-        Section_table.get_sec_idx sections
-          (X86_proc.Section_name.of_string symbol.sy_sec.sec_name);
-      (* st_shname_str = symbol.sy_sec.sec_name; *)
+      st_shndx = Section_table.get_sec_idx sections symbol.sy_sec.sec_name;
       st_value = Int64.of_int value;
       st_size = Int64.of_int size;
       st_name_str = symbol.sy_name

--- a/backend/jit_backend.ml
+++ b/backend/jit_backend.ml
@@ -64,7 +64,7 @@ let register callback =
             (fun map (name, instrs) ->
               let name_str = X86_proc.Section_name.to_string name in
               let section =
-                { X86_binary_emitter.sec_name = name_str;
+                { X86_binary_emitter.sec_name = name;
                   sec_instrs = DLL.to_array instrs
                 }
               in

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -29,7 +29,7 @@ module Asm_symbol = Asm_targets.Asm_symbol
 
 
 type section = {
-  sec_name : string;
+  sec_name : Section_name.t;
   mutable sec_instrs : asm_line array;
 }
 
@@ -1531,6 +1531,45 @@ let[@warning "+4"] constant b cst
     record_local_reloc b (RelocConstant (cst, B64));
     buf_int64L b 0L
 
+let emit_single_nop b n =
+  match n with
+  | 0 -> ()
+  | 1 -> buf_int8 b 0x90
+  | 2 -> buf_opcodes b [ 0x66; 0x90 ]
+  | 3 -> buf_opcodes b [ 0x0f; 0x1f; 0x00 ]
+  | 4 -> buf_opcodes b [ 0x0f; 0x1f; 0x40; 0x00 ]
+  | 5 -> buf_opcodes b [ 0x0f; 0x1f; 0x44; 0x00; 0x00 ]
+  | 6 ->
+      buf_opcodes b [ 0x66; 0x0f; 0x1f; 0x44 ];
+      buf_int16L b 0L
+  | 7 ->
+      buf_opcodes b [ 0x0f; 0x1f; 0x80 ];
+      buf_int32L b 0L
+  | 8 ->
+      buf_opcodes b [ 0x0f; 0x1f; 0x84; 0x00 ];
+      buf_int32L b 0L
+  | 9 ->
+      buf_int8 b 0x66;
+      buf_opcodes b [ 0x0f; 0x1f; 0x84; 0x00 ];
+      buf_int32L b 0L
+  | n when n >= 10 && n <= 15 ->
+      for _ = 10 to n do
+        buf_int8 b 0x66
+      done;
+      buf_int8 b 0x2e;
+      buf_opcodes b [ 0x0f; 0x1f; 0x84; 0x00 ];
+      buf_int32L b 0L
+  | _ ->
+      invalid_arg
+        (Printf.sprintf "emit_single_nop: unsupported length %d" n)
+
+let emit_nop b n =
+  if n < 0 then invalid_arg (Printf.sprintf "emit_nop: negative length %d" n);
+  for _ = 1 to n / 15 do
+    emit_single_nop b 15
+  done;
+  emit_single_nop b (n mod 15)
+
 let assemble_line b loc ins =
   try
     match ins with
@@ -1589,31 +1628,14 @@ let assemble_line b loc ins =
             for _ = 1 to n do
               buf_int8 b 0x00
             done
-          | Asm_targets.Asm_directives.Nop ->
-            match n with
-            | 0 -> ()
-            | 1 -> buf_int8 b 0x90
-            | 2 -> buf_opcodes b [ 0x66; 0x90 ]
-            | 3 -> buf_opcodes b [ 0x0f; 0x1f; 0x00 ]
-            | 4 -> buf_opcodes b [ 0x0f; 0x1f; 0x40; 0x00 ]
-            | 5 -> buf_opcodes b [ 0x0f; 0x1f; 0x44; 0x00; 0x00 ]
-            | 6 ->
-                buf_opcodes b [ 0x66; 0x0f; 0x1f; 0x44 ];
-                buf_int16L b 0L
-            | 7 ->
-                buf_opcodes b [ 0x0f; 0x1f; 0x80 ];
-                buf_int32L b 0L
-            | _ ->
-                for _ = 9 to n do
-                  buf_int8 b 0x66
-                done;
-                buf_opcodes b [ 0x0f; 0x1f; 0x84; 0x00 ];
-                buf_int32L b 0L)
+          | Asm_targets.Asm_directives.Nop -> emit_nop b n)
     | Directive (D.Space { bytes = n }) ->
-        (* TODO: in text section, should be NOP *)
-        for _ = 1 to n do
-          buf_int8 b 0
-        done
+        if Section_name.is_text_like b.sec.sec_name then
+          emit_nop b n
+        else
+          for _ = 1 to n do
+            buf_int8 b 0
+          done
     | Directive (D.Hidden _) | Directive D.New_line -> ()
     | Directive
         (D.Reloc
@@ -1649,7 +1671,7 @@ let rec assemble_section arch section =
     let bt = Printexc.get_raw_backtrace () in
     Format.eprintf
       "\nContext is: x86 binary emission of section %s:\n%!"
-      section.sec_name;
+      (Section_name.to_string section.sec_name);
     let dll =
       Oxcaml_utils.Doubly_linked_list.of_list
         (Array.to_list section.sec_instrs)

--- a/backend/x86_binary_emitter.mli
+++ b/backend/x86_binary_emitter.mli
@@ -17,7 +17,10 @@
 open X86_ast
 module String = Misc.Stdlib.String
 
-type section = { sec_name : string; mutable sec_instrs : asm_line array }
+type section =
+  { sec_name : X86_proc.Section_name.t;
+    mutable sec_instrs : asm_line array
+  }
 
 type data_size = B8 | B16 | B32 | B64
 


### PR DESCRIPTION
Following #6028, this PR switches the `D.align` calls in `backend/amd64/emit.ml` to `~fill:Nop` for the three alignments that land in the text section: jump tables, the 8-byte pad before the frame table, and `efa_align` in the frame-emission record.