### PR TITLE
Update Merlin import script

### DIFF
--- a/external/merlin/import-added-ocaml-source-files.sh
+++ b/external/merlin/import-added-ocaml-source-files.sh
@@ -60,7 +60,7 @@ fi
 function new_files() {
   comm -13 \
     <(sorted_files_at_committish "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")" "$old_subdirectory") \
-    <(sorted_files_at_committish "$rev" "$subdirectory")
+    <(sorted_files_at_committish "$1" "$subdirectory")
 }
 
 function directories_from_previous_import() {
@@ -73,7 +73,7 @@ function directories_from_previous_import() {
   | xargs -n 1 printf "^%s\n"
 }
 
-files=$(new_files | grep -f <(directories_from_previous_import))
+files=$(new_files "$rev" | grep -f <(directories_from_previous_import))
 
 echo "The script will attempt to import these files added to directories that had previously been imported:"
 echo "$files"

--- a/external/merlin/import-added-ocaml-source-files.sh
+++ b/external/merlin/import-added-ocaml-source-files.sh
@@ -73,22 +73,24 @@ function directories_from_previous_import() {
   | xargs -n 1 printf "^%s\n"
 }
 
-files=$(new_files "$rev" | grep -f <(directories_from_previous_import))
+files=$(new_files "$rev" | grep -f <(directories_from_previous_import) || test "$?" = 1)
 
-echo "The script will attempt to import these files added to directories that had previously been imported:"
-echo "$files"
+if [ -n "$files" ]; then
+  echo "The script will attempt to import these files added to directories that had previously been imported:"
+  echo "$files"
 
-for file in $files; do
-  read -p "Import new file $file? [Y/n] " answer
-  case ${answer} in
-    y|Y|"" )
-      echo "Importing $file"
-      ocaml_flambda_file="${subtree_prefix}upstream/ocaml_flambda/${file}"
-      git show "$rev:$file" > "$ocaml_flambda_file"
-      cp "$ocaml_flambda_file" "${subtree_prefix}src/ocaml/$file"
-      ;;
-    * )
-      echo "Skipping $file; run '$0' again in order to make a different decision"
-      ;;
-  esac
-done
+  for file in $files; do
+    read -p "Import new file $file? [Y/n] " answer
+    case ${answer} in
+      y|Y|"" )
+        echo "Importing $file"
+        ocaml_flambda_file="${subtree_prefix}upstream/ocaml_flambda/${file}"
+        git show "$rev:$file" > "$ocaml_flambda_file"
+        cp "$ocaml_flambda_file" "${subtree_prefix}src/ocaml/$file"
+        ;;
+      * )
+        echo "Skipping $file; run '$0' again in order to make a different decision"
+        ;;
+    esac
+  done
+fi

--- a/external/merlin/import-added-ocaml-source-files.sh
+++ b/external/merlin/import-added-ocaml-source-files.sh
@@ -7,8 +7,8 @@ subtree_prefix="$(git rev-parse --show-prefix)"
 cd "$(git rev-parse --show-toplevel)"
 
 # Script arguments with their default values
-commitish=main
-repository=https://github.com/ocaml-flambda/flambda-backend
+commitish=HEAD
+repository=.
 subdirectory=.
 old_subdirectory=.
 
@@ -49,14 +49,18 @@ function sorted_files_at_committish() {
   git ls-tree -r --name-only "$1" "$2" | sed "s#^$2/##" | sort
 }
 
-git fetch "$repository" "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")"
-git fetch "$repository" "$commitish"
-rev=$(git rev-parse FETCH_HEAD)
+if [ "$repository" != "." ]; then
+  git fetch "$repository" "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")"
+  git fetch "$repository" "$commitish"
+  rev=$(git rev-parse FETCH_HEAD)
+else
+  rev=$(git rev-parse "$commitish")
+fi
 
-function files_new_at_fetch_head() {
+function new_files() {
   comm -13 \
     <(sorted_files_at_committish "$(cat "${subtree_prefix}upstream/ocaml_flambda/base-rev.txt")" "$old_subdirectory") \
-    <(sorted_files_at_committish FETCH_HEAD "$subdirectory")
+    <(sorted_files_at_committish "$rev" "$subdirectory")
 }
 
 function directories_from_previous_import() {
@@ -69,7 +73,7 @@ function directories_from_previous_import() {
   | xargs -n 1 printf "^%s\n"
 }
 
-files=$(files_new_at_fetch_head | grep -f <(directories_from_previous_import))
+files=$(new_files | grep -f <(directories_from_previous_import))
 
 echo "The script will attempt to import these files added to directories that had previously been imported:"
 echo "$files"
@@ -80,7 +84,7 @@ for file in $files; do
     y|Y|"" )
       echo "Importing $file"
       ocaml_flambda_file="${subtree_prefix}upstream/ocaml_flambda/${file}"
-      git show "FETCH_HEAD:$file" > "$ocaml_flambda_file"
+      git show "$rev:$file" > "$ocaml_flambda_file"
       cp "$ocaml_flambda_file" "${subtree_prefix}src/ocaml/$file"
       ;;
     * )

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 subtree_prefix="$(git rev-parse --show-prefix)"
 
@@ -43,7 +44,7 @@ function repository-commit () {
   fi
 }
 
-case "$1" in
+case "${1-unused}" in
   -h|-help|--help|-\?)
     usage
     exit 0

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -95,7 +95,6 @@ for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
   fi
   git show "$rev:$git_file" > "$file"
 done
-git add --intent-to-add .
 cd ../..
 
 # Annotations for diff3 regions; "@" would be more natural than ":" but confuses

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -140,7 +140,6 @@ for file in $(git diff --no-ext-diff --name-only); do
   esac
   tgt=src/ocaml/$tgt
 
-  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file))
   # ignore patch output if it worked
   if ! patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file) > $tgt.out; then
     sed -i \

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -151,8 +151,6 @@ for file in $(git diff --no-ext-diff --name-only); do
         -e 's!^|||||||$!& '"$parent_marker"'!' \
         -e 's!^>>>>>>>$!& '"$new_marker"'!'    \
         $tgt
-    echo "$err"
-  fi
     cat $tgt.out
   fi
   rm -f $tgt.orig $tgt.out

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -16,10 +16,10 @@ Usage: $0 [COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]]
 
 Fetch the new compiler sources and patch Merlin to keep Merlin's local copies of
 things in sync. By default, this will pull in compiler changes from the local
-repo at the current revision. But you may pass an arbitrary commitish (branch,
-tag, full (not abbreviated!) commit hash, etc.) to important changes from. You
+repo at the current revision. But you may pass an arbitrary committish (branch,
+tag, full (not abbreviated!) commit hash, etc.) to import changes from. You
 may also fetch from a remote repository by specifying a REPO, and the
-subdirectory of the repo that the compiler is located in can be overriden by any
+subdirectory of the repo that the compiler is located in can be overridden by any
 path (including ".").
 
 This attempts to import new files from the compiler by running the
@@ -63,7 +63,7 @@ else
   exit 1
 fi
 
-if ! [ -z "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain)" ]; then
   echo "Working directory must be clean before using this script,"
   echo "but currently has the following changes:"
   git status

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -132,12 +132,6 @@ for file in $(git diff --no-ext-diff --name-only); do
     lambda/mixed_product_bytes.ml*)
       tgt=${base/#lambda/typing};;
 
-    # We have to inspect these files by hand, we only care about a subset of the
-    # changes
-    utils/clflags.ml*|utils/config.ml*)
-      printf '\e[7mIgnoring changes to %s, inspect it manually.\e[0m\n' "$base"
-      continue;;
-
     base-rev.txt)
       continue;;
 

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -4,20 +4,22 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 subtree_prefix="$(git rev-parse --show-prefix)"
 
 # Script arguments with their default values
-repository=https://github.com/oxcaml/oxcaml
+commitish=HEAD
+repository=.
 subdirectory=.
 old_subdirectory=.
 
 function usage () {
   cat <<USAGE
-Usage: $0 COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]
+Usage: $0 [COMMITISH [REPO [SUBDIRECTORY [OLD_SUBDIRECTORY]]]]
 
 Fetch the new compiler sources and patch Merlin to keep Merlin's local copies of
-things in sync.  By default, this will pull the COMMITISH branch from
-<$repository> and look in "$subdirectory/" for the compiler source, but the
-branch can be overridden by any commitish (branch, tag, full (not abbreviated!)
-commit hash, etc.), the repository can be overridden by any URL, and the
-subdirectory can be overriden by any path (including ".").
+things in sync. By default, this will pull in compiler changes from the local
+repo at the current revision. But you may pass an arbitrary commitish (branch,
+tag, full (not abbreviated!) commit hash, etc.) to important changes from. You
+may also fetch from a remote repository by specifying a REPO, and the
+subdirectory of the repo that the compiler is located in can be overriden by any
+path (including ".").
 
 This attempts to import new files from the compiler by running the
 "import_added_ocaml_source_files.sh" script. If that doesn't work, you can also
@@ -48,14 +50,8 @@ case "$1" in
     ;;
 esac
 
-if [[ $# -gt 0 ]]; then
-  commitish="$1"
-else
-  usage >&2
-  exit 1
-fi
-
 if [[ $# -le 4 ]]; then
+  commitish="${1-$commitish}"
   repository="${2-$repository}"
   # Although the subdirectory arguments are probably no longer useful, it doesn't hurt
   # to keep them around in case they ever are of use.
@@ -66,10 +62,10 @@ else
   exit 1
 fi
 
-if ! git diff --quiet; then
+if ! [ -z "$(git status --porcelain)" ]; then
   echo "Working directory must be clean before using this script,"
   echo "but currently has the following changes:"
-  git diff --stat
+  git status
   exit 1
 fi
 
@@ -81,10 +77,13 @@ current_head="$(git symbolic-ref --short HEAD)"
 # First, add any files that have been added since the last import.
 ./import-added-ocaml-source-files.sh "$commitish" "$repository" "$subdirectory" "$old_subdirectory"
 
-# Then, fetch the new oxcaml sources (which include ocaml-jst) and
-# copy into upstream/ocaml_flambda
-git fetch "$repository" "$commitish"
-rev=$(git rev-parse FETCH_HEAD)
+# Then, get the new oxcaml sources and copy into upstream/ocaml_flambda
+if [ "$repository" != "." ]; then
+  git fetch "$repository" "$commitish"
+  rev=$(git rev-parse FETCH_HEAD)
+else
+  rev=$(git rev-parse "$commitish")
+fi
 cd upstream/ocaml_flambda
 echo $rev > base-rev.txt
 for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
@@ -93,21 +92,19 @@ for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
   else
     git_file="$subdirectory/$file"
   fi
-  git show "FETCH_HEAD:$git_file" > "$file"
+  git show "$rev:$git_file" > "$file"
 done
-git add -u .
+git add --intent-to-add .
 cd ../..
-git commit -m "Import ocaml sources for $(repository-commit "$(git describe --always $rev)")"
 
 # Annotations for diff3 regions; "@" would be more natural than ":" but confuses
 # smerge-mode's highlighting
-short_ocaml_repo="${repository#https://github.com/}"
-old_marker="janestreet/merlin-jst:$current_head"
-parent_marker="$short_ocaml_repo:$old_base_rev"
-new_marker="$short_ocaml_repo:$commitish"
+old_marker="Merlin:$current_head"
+parent_marker="Compiler:$old_base_rev"
+new_marker="Compiler:$commitish"
 
 # Then patch src/ocaml using the changes you just imported
-for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
+for file in $(git diff --no-ext-diff --name-only); do
   file=${file#${subtree_prefix}}
   base=${file#upstream/ocaml_flambda/}
   case $base in
@@ -149,11 +146,9 @@ for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
   # Not all files are necessary
   if [ ! -e $tgt ]; then continue; fi
 
-  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff HEAD^ HEAD -- $file))
+  err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file))
   # ignore patch output if it worked
-  if [ $? = 0 ]; then
-    git add -u $tgt
-  else
+  if [ $? != 0 ]; then
     sed -i \
         -e 's!^<<<<<<<$!& '"$old_marker"'!'    \
         -e 's!^|||||||$!& '"$parent_marker"'!' \
@@ -163,3 +158,6 @@ for file in $(git diff --no-ext-diff --name-only HEAD^ HEAD); do
   fi
   rm -f $tgt.orig
 done
+
+git add .
+git commit -m "Automated commit: Import compiler changes from $old_base_rev to $rev"

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -153,4 +153,7 @@ for file in $(git diff --no-ext-diff --name-only); do
 done
 
 git add .
+# Also add any .rej files that were created by patch, even though they're
+# ignored.
+git add "*.rej" --force &> /dev/null || true
 git commit -m "Automated commit: Import compiler changes from $old_base_rev to $rev"

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -159,7 +159,9 @@ for file in $(git diff --no-ext-diff --name-only); do
         $tgt
     echo "$err"
   fi
-  rm -f $tgt.orig
+    cat $tgt.out
+  fi
+  rm -f $tgt.orig $tgt.out
 done
 
 git add .

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -138,6 +138,9 @@ for file in $(git diff --no-ext-diff --name-only); do
       printf '\e[7mIgnoring changes to %s, inspect it manually.\e[0m\n' "$base"
       continue;;
 
+    base-rev.txt)
+      continue;;
+
     # Most cases are simple
     *) tgt=$base;;
   esac

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -140,9 +140,6 @@ for file in $(git diff --no-ext-diff --name-only); do
   esac
   tgt=src/ocaml/$tgt
 
-  # Not all files are necessary
-  if [ ! -e $tgt ]; then continue; fi
-
   err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file))
   # ignore patch output if it worked
   if ! patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file) > $tgt.out; then

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -93,7 +93,12 @@ for file in $(git ls-tree --name-only -r HEAD | grep -v base-rev.txt); do
   else
     git_file="$subdirectory/$file"
   fi
-  git show "$rev:$git_file" > "$file"
+  if git cat-file -e "$rev:$git_file" 2> /dev/null; then
+    git show "$rev:$git_file" > "$file"
+  else
+    # The file was deleted from the compiler
+    rm "$file"
+  fi
 done
 cd ../..
 
@@ -140,16 +145,32 @@ for file in $(git diff --no-ext-diff --name-only); do
   esac
   tgt=src/ocaml/$tgt
 
-  # ignore patch output if it worked
-  if ! patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file) > $tgt.out; then
-    sed -i \
-        -e 's!^<<<<<<<$!& '"$old_marker"'!'    \
-        -e 's!^|||||||$!& '"$parent_marker"'!' \
-        -e 's!^>>>>>>>$!& '"$new_marker"'!'    \
-        $tgt
-    cat $tgt.out
+  if [ -e "$file" ]; then
+    # ignore patch output if it worked
+    if ! patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file) > $tgt.out; then
+      sed -i \
+          -e 's!^<<<<<<<$!& '"$old_marker"'!'    \
+          -e 's!^|||||||$!& '"$parent_marker"'!' \
+          -e 's!^>>>>>>>$!& '"$new_marker"'!'    \
+          $tgt
+      cat $tgt.out
+    fi
+    rm -f $tgt.orig $tgt.out
+  else
+    # The file was deleted from the compiler, so delete Merlin's copy too. If
+    # Merlin had local changes relative to the previously imported copy, record
+    # them in a .rej file so they aren't silently lost.
+    if git show "HEAD:${subtree_prefix}${file}" \
+        | diff -u --label "$parent_marker" --label "$old_marker" - "$tgt" > "$tgt.rej"
+    then
+      rm "$tgt.rej"
+      echo "Deleted $tgt (deleted from the compiler)"
+    else
+      echo "Deleted $tgt (deleted from the compiler);"
+      echo "local Merlin changes recorded in $tgt.rej"
+    fi
+    rm "$tgt"
   fi
-  rm -f $tgt.orig $tgt.out
 done
 
 git add .

--- a/external/merlin/import-ocaml-source.sh
+++ b/external/merlin/import-ocaml-source.sh
@@ -151,7 +151,7 @@ for file in $(git diff --no-ext-diff --name-only); do
 
   err=$(patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file))
   # ignore patch output if it worked
-  if [ $? != 0 ]; then
+  if ! patch --merge=diff3 $tgt <(git diff --no-ext-diff -- $file) > $tgt.out; then
     sed -i \
         -e 's!^<<<<<<<$!& '"$old_marker"'!'    \
         -e 's!^|||||||$!& '"$parent_marker"'!' \


### PR DESCRIPTION
Update Merlin's `import-ocaml-source.sh` script to pull in changes from the local workspace by default.

## Testing
Testing this was a tad annoying. First, I created the branch [liam-test-import-script](https://github.com/oxcaml/oxcaml/tree/liam-test-import-script). To create it, I:
1. Created the branch, with its head set to the head of this PR.
2. Made commit [78fc8837e9](https://github.com/oxcaml/oxcaml/commit/78fc8837e96d9e1088f835a06cf98e92cf4cd338), which commits some dummy changes for us to import.

Then from the liam-test-import-script branch, I performed the following tests, checking that the changes made to the repo match expectations:
```
$ external/merlin/import-ocaml-source.sh 
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler)
[liam-test-import-script aafbeff4b9] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 78fc8837e96d9e1088f835a06cf98e92cf4cd338
 9 files changed, 18 insertions(+), 376 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```
```
# Reject the new file
$ external/merlin/import-ocaml-source.sh 
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] n
Skipping typing/foo.ml; run './import-added-ocaml-source-files.sh' again in order to make a different decision
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler)
[liam-test-import-script 3a853c2f5a] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 78fc8837e96d9e1088f835a06cf98e92cf4cd338
 7 files changed, 18 insertions(+), 376 deletions(-)
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```
```
# Specify a commit
$ external/merlin/import-ocaml-source.sh 78fc8837e96d9e1088f835a06cf98e92cf4cd338
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler)
[liam-test-import-script 9f2d754192] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 78fc8837e96d9e1088f835a06cf98e92cf4cd338
 9 files changed, 18 insertions(+), 376 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```
```
# Fetch the commit from a remote
$ external/merlin/import-ocaml-source.sh 78fc8837e96d9e1088f835a06cf98e92cf4cd338 https://github.com/oxcaml/oxcaml.git
From https://github.com/oxcaml/oxcaml
 * branch                  083478d04f754234ed2e90d32bcbf79266739c0f -> FETCH_HEAD
From https://github.com/oxcaml/oxcaml
 * branch                  78fc8837e96d9e1088f835a06cf98e92cf4cd338 -> FETCH_HEAD
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
From https://github.com/oxcaml/oxcaml
 * branch                  78fc8837e96d9e1088f835a06cf98e92cf4cd338 -> FETCH_HEAD
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler)
[liam-test-import-script bef4a99dd8] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 78fc8837e96d9e1088f835a06cf98e92cf4cd338
 9 files changed, 18 insertions(+), 376 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```
```
# Run from a different directory
$ cd external/merlin
$ ./import-ocaml-source.sh 
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler)
[liam-test-import-script 25157fbcba] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 78fc8837e96d9e1088f835a06cf98e92cf4cd338
 9 files changed, 18 insertions(+), 376 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```
```
# Remove the new file before importing so that there's no new files
$ git rm typing/foo.ml 
rm 'typing/foo.ml'
$ git commit -m "Delete foo.ml"
[liam-test-import-script 8b42d4277d] Delete foo.ml
 1 file changed, 0 insertions(+), 0 deletions(-)
 delete mode 100644 typing/foo.ml
$ external/merlin/import-ocaml-source.sh 
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler)
[liam-test-import-script 8c9810e8f0] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 8b42d4277d6690407f04cc550c841e6cda030bf4
 7 files changed, 18 insertions(+), 376 deletions(-)
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```
```
# Fail when the workspace isn't clean
$ touch foo
$ external/merlin/import-ocaml-source.sh 
Working directory must be clean before using this script,
but currently has the following changes:
On branch liam-test-import-script
Your branch is up to date with 'origin/liam-test-import-script'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        ../../foo

nothing added to commit but untracked files present (use "git add" to track)
```
```
# Try to import the compiler revision that's already been imported
$ external/merlin/import-ocaml-source.sh $(cat external/merlin/upstream/ocaml_flambda/base-rev.txt)
On branch liam-test-import-script
Your branch is up to date with 'origin/liam-test-import-script'.

nothing to commit, working tree clean
```
```
# Import a compiler that has no diff with the previously imported revision, but has a different hash
$ external/merlin/import-ocaml-source.sh HEAD~
[liam-test-import-script 4d6c804bb5] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to 9004562a4c7da749fab6b56052cee69ac4f18357
 1 file changed, 1 insertion(+), 1 deletion(-)
```
```
# Delete a file that has Merlin-specific diff
$ echo "Hello world" >> external/merlin/src/ocaml/utils/zero_alloc_utils.mli
$ git add .
$ git commit -m "Modify zero_alloc_utils.mli"
[liam-test-import-script d52edc97eb] Modify zero_alloc_utils.mli
 1 file changed, 1 insertion(+)
$ external/merlin/import-ocaml-source.sh
The script will attempt to import these files added to directories that had previously been imported:
typing/foo.ml
Import new file typing/foo.ml? [Y/n] Y
Importing typing/foo.ml
patching file src/ocaml/typing/typecore.ml
Hunk #1 NOT MERGED at 21-44.
Deleted src/ocaml/utils/zero_alloc_utils.mli (deleted from the compiler);
local Merlin changes recorded in src/ocaml/utils/zero_alloc_utils.mli.rej
[liam-test-import-script ed2a5310fe] Automated commit: Import compiler changes from 083478d04f754234ed2e90d32bcbf79266739c0f to d52edc97eb47d7b6dae30271e2aa3564483fde86
 10 files changed, 25 insertions(+), 377 deletions(-)
 create mode 100644 external/merlin/src/ocaml/typing/foo.ml
 delete mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli
 create mode 100644 external/merlin/src/ocaml/utils/zero_alloc_utils.mli.rej
 create mode 100644 external/merlin/upstream/ocaml_flambda/typing/foo.ml
 delete mode 100644 external/merlin/upstream/ocaml_flambda/utils/zero_alloc_utils.mli
```