### PR TITLE
Refactor record representation recomputation

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2425,6 +2425,8 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
             Lprim (Pmixedfield ([lbl.lbl_pos], shape, sem), [ arg ], loc),
             lbl.lbl_sort, lbl_layout
         | Record_inlined (_, _, Variant_with_null) -> assert false
+        | Record_dummy _ ->
+          fatal_error "get_expr_args_record: unexpected dummy representation"
       in
       let str = if Types.is_mutable lbl.lbl_mut then StrictOpt else Alias in
       let str = add_barrier_to_let_kind ubr str in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -320,6 +320,7 @@ let record_rep ppf r = match r with
   | Record_float -> fprintf ppf "float"
   | Record_ufloat -> fprintf ppf "ufloat"
   | Record_mixed _ -> fprintf ppf "mixed"
+  | Record_dummy _ -> fprintf ppf "dummy"
 
 let rec mixed_block_element
   : 'a. (_ -> 'a -> _) -> _ -> 'a mixed_block_element -> _ =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -68,6 +68,8 @@ let field_offset_for_label lbl =
   | Record_inlined (_, Constructor_mixed _, Variant_with_null)
   | Record_mixed _ ->
       lbl.lbl_pos
+  | Record_dummy _ ->
+      fatal_error "field_offset_for_label: dummy record representation"
 
 (* Forward declaration -- to be filled in by Translmod.transl_module *)
 let transl_module =
@@ -758,6 +760,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           in
           Some (Pmixedfield ([lbl.lbl_pos], shape, sem), [targ])
         | Record_inlined (_, _, Variant_with_null) -> assert false
+        | Record_dummy _ ->
+          fatal_error "transl_exp0: dummy record representation"
       in
       begin match prim_and_args with
       | None -> targ
@@ -840,6 +844,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           Psetmixedfield([lbl.lbl_pos], shape, mode),
           [arg_lambda; newval_lambda]
         | Record_inlined (_, _, Variant_with_null) -> assert false
+        | Record_dummy _ ->
+            fatal_error "transl_exp0: unexpected dummy representation"
       in
       Lprim(prim, args, of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
@@ -2133,6 +2139,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                 Psetmixedfield
                   ([lbl.lbl_pos], shape, Assignment modify_heap)
             | Record_inlined (_, _, Variant_with_null) -> assert false
+            | Record_dummy _ ->
+              fatal_error "transl_record: unexpected dummy representation"
           in
           Lsequence(Lprim(upd, [Lvar copy_id;
                                 transl_exp ~scopes lbl.lbl_sort expr],
@@ -2213,6 +2221,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                    in
                    Pmixedfield ([i], shape, sem)
                  | Record_inlined (_, _, Variant_with_null) -> assert false
+                 | Record_dummy _ ->
+                   fatal_error "transl_record: unexpected dummy representation"
                in
                Lprim(access, [Lvar init_id],
                      of_location ~scopes loc),
@@ -2272,6 +2282,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         | Record_inlined (_, _, (Variant_extensible | Variant_with_null))
         | Record_inlined ((Extension _ | Null), _, _) ->
             raise Not_constant
+        | Record_dummy _ ->
+          fatal_error "transl_record: unexpected dummy representation"
       with Not_constant ->
         let loc = of_location ~scopes loc in
         match repres with
@@ -2323,6 +2335,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                    ll, loc)
         | Record_inlined (_, _, Variant_with_null) -> assert false
         | Record_inlined (Null, _, _) -> assert false
+        | Record_dummy _ ->
+          fatal_error "transl_record: unexpected dummy representation"
     in
     begin match opt_init_expr with
       None -> lam
@@ -2338,7 +2352,7 @@ and transl_atomic_loc ~scopes arg arg_sort lbl =
   let arg = transl_exp ~scopes arg_sort arg in
   begin match lbl.lbl_repres with
   | Record_unboxed | Record_inlined (_, _, Variant_unboxed) | Record_mixed _
-  | Record_float | Record_ufloat
+  | Record_float | Record_ufloat | Record_dummy _
     ->
       (* Atomic fields not allowed here *)
       Misc.fatal_error "Bad lbl_repres for label of atomic_loc"
@@ -2382,7 +2396,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
       | [l] -> l (* erase singleton unboxed records before lambda *)
       | _ -> Lprim(Pmake_unboxed_product shape, ll, of_location ~scopes loc)
     in
-    match opt_init_expr with
+    begin match opt_init_expr with
     | None -> lam
     | Some (init_expr, init_expr_sort) ->
       let init_expr_sort =
@@ -2391,6 +2405,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
       let layout = layout_exp init_expr_sort init_expr in
       let exp = transl_exp ~scopes init_expr_sort init_expr in
       Llet(Strict, layout, init_id, init_id_duid, exp, lam)
+    end
 
 (* See [jane/doc/extensions/_03-unboxed-types/03-block-indices.md]. *)
 and transl_idx ~scopes loc env ba uas =
@@ -2447,6 +2462,8 @@ and transl_idx ~scopes loc env ba uas =
         raise (Error (loc, Block_index_gap_overflow_possible));
       Lprim (Pmake_idx_mixed_field (shape, lbl.lbl_pos, uas_path), [],
              (of_location ~scopes loc))
+    | Record_dummy _ ->
+      fatal_error "transl_idx: unexpected dummy representation"
     end
   end
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2351,8 +2351,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
 and transl_atomic_loc ~scopes arg arg_sort lbl =
   let arg = transl_exp ~scopes arg_sort arg in
   begin match lbl.lbl_repres with
+  | Record_dummy _ ->
+    Misc.fatal_error "transl_atomic_loc: unexpected dummy representation"
   | Record_unboxed | Record_inlined (_, _, Variant_unboxed) | Record_mixed _
-  | Record_float | Record_ufloat | Record_dummy _
+  | Record_float | Record_ufloat
     ->
       (* Atomic fields not allowed here *)
       Misc.fatal_error "Bad lbl_repres for label of atomic_loc"

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -261,6 +261,9 @@ let compute_static_size lam =
         | Record_unboxed | Record_ufloat
         | Record_inlined (_, _, (Variant_unboxed | Variant_with_null)) ->
             Misc.fatal_error "size_of_primitive"
+        | Record_dummy _ ->
+            Misc.fatal_error
+              "size_of_primitive: unexpected dummy representation"
         end
     | Pmakeblock (_, _, shape, _) ->
         (* The block shape is unfortunately an option, so we rely on the

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2143,6 +2143,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Record_inlined (Null, _, _) ->
         Misc.fatal_errorf "Cannot handle record kind for Pduprecord: %a"
           Printlambda.primitive prim
+      | Record_dummy _ ->
+        Misc.fatal_error "convert_lprim: Pduprecord: dummy representation"
     in
     [Unary (Duplicate_block { kind }, arg)]
   | Pnot, [[arg]] -> [Unary (Boolean_not, arg)]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2144,7 +2144,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         Misc.fatal_errorf "Cannot handle record kind for Pduprecord: %a"
           Printlambda.primitive prim
       | Record_dummy _ ->
-        Misc.fatal_error "convert_lprim: Pduprecord: dummy representation"
+        Misc.fatal_errorf "convert_lprim: Pduprecord: dummy representation: %a"
+          Printlambda.primitive prim
     in
     [Unary (Duplicate_block { kind }, arg)]
   | Pnot, [[arg]] -> [Unary (Boolean_not, arg)]

--- a/testsuite/tests/typing-layouts/represent_as_float_array.ml
+++ b/testsuite/tests/typing-layouts/represent_as_float_array.ml
@@ -124,3 +124,12 @@ Error: Signature mismatch:
        Their internal representations differ:
        the first declaration uses float# representation.
 |}]
+
+(* The below test requires that [type_unboxed_default] was computed correctly
+   https://github.com/oxcaml/oxcaml/pull/6035#discussion_r3253683496 *)
+type r = { f : float# } [@@represent_as_float_array]
+external id : r -> r = "%identity"
+[%%expect{|
+type r = { f : float#; }
+external id : r -> r = "%identity"
+|}]

--- a/testsuite/tests/typing-layouts/represent_as_float_array.ml
+++ b/testsuite/tests/typing-layouts/represent_as_float_array.ml
@@ -23,6 +23,17 @@ Lines 1-2, characters 0-28:
 Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
 |}]
 
+type ('a : float64) t = { i : 'a }
+[@@unboxed]
+[@@represent_as_float_array]
+[%%expect{|
+Lines 1-3, characters 0-28:
+1 | type ('a : float64) t = { i : 'a }
+2 | [@@unboxed]
+3 | [@@represent_as_float_array]
+Error: "[@@represent_as_float_array]" can only be used on records whose fields are all float64.
+|}]
+
 type t [@@represent_as_float_array]
 [%%expect{|
 Line 1, characters 0-35:

--- a/testsuite/tests/typing-layouts/represent_as_float_array.ml
+++ b/testsuite/tests/typing-layouts/represent_as_float_array.ml
@@ -125,8 +125,9 @@ Error: Signature mismatch:
        the first declaration uses float# representation.
 |}]
 
-(* The below test requires that [type_unboxed_default] was computed correctly
-   https://github.com/oxcaml/oxcaml/pull/6035#discussion_r3253683496 *)
+(* Regression test: [type_unboxed_default] must be [false] when
+   [@@represent_as_float_array] is used, so that this declaration does not
+   trigger the [unboxable-type-in-prim-decl] warning. *)
 type r = { f : float# } [@@represent_as_float_array]
 external id : r -> r = "%identity"
 [%%expect{|

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -575,6 +575,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                                 if !Clflags.native_code
                                 then Outval_record_mixed_block mixed
                                 else Outval_record_boxed
+                          | Record_dummy _ ->
+                              Misc.fatal_error "dummy record representation"
                         in
                         tree_of_record_fields depth
                           env path decl.type_params ty_list

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1025,6 +1025,10 @@ module Record_diffing = struct
            Some (Record_mismatch (Mixed_representation Second))
 
         | Record_boxed, Record_boxed -> None
+
+        | Record_dummy _, _ | _, Record_dummy _ ->
+          Misc.fatal_error
+            "compare_with_representation: dummy record representation"
         end
       | Unboxed_product ->
         begin match rep1, rep2 with

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -252,6 +252,11 @@ let record_representation i ppf = let open Types in function
   | Record_mixed shape ->
     line i ppf "Record_mixed\n";
     array (i+1) mixed_block_element ppf shape
+  | Record_dummy { represent_as_float_array = true } ->
+    line i ppf "Record_dummy [@@represent_as_float_array]\n"
+  | Record_dummy { represent_as_float_array = false } ->
+    line i ppf "Record_dummy\n"
+
 
 let record_unboxed_product_representation i ppf = let open Types in function
   | Record_unboxed_product ->

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -257,7 +257,6 @@ let record_representation i ppf = let open Types in function
   | Record_dummy { represent_as_float_array = false } ->
     line i ppf "Record_dummy\n"
 
-
 let record_unboxed_product_representation i ppf = let open Types in function
   | Record_unboxed_product ->
     line i ppf "Record_unboxed_product\n"

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -596,7 +596,9 @@ module Type_decl_shape = struct
                  inside of a match. For example, if [Foo] is the constructor \
                  [Foo { a : int; b : int }], then [r] is an inline record in \
                  [match e with Foo r -> ...]."
-            else unknown_shape ())
+            else unknown_shape ()
+          | Record_dummy _ -> Misc.fatal_error "unexpected dummy representation"
+          )
         | Type_abstract _ -> unknown_shape ()
         | Type_open -> unknown_shape ()
         | Type_record_unboxed_product (lbl_list, _, _) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2520,7 +2520,7 @@ module Label = NameChoice (struct
   let in_env lbl =
     match lbl.lbl_repres with
     | Record_boxed | Record_float | Record_ufloat | Record_unboxed
-    | Record_mixed _ -> true
+    | Record_mixed _ | Record_dummy _ -> true
     | Record_inlined _ -> false
 end)
 
@@ -6171,6 +6171,8 @@ and type_expect_
           | Record_boxed | Record_float | Record_ufloat | Record_mixed _
           | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
             -> true
+          | Record_dummy _ ->
+            Misc.fatal_error "type_expect: dummy record representation"
         end
         | Unboxed_product -> begin match rep with
           | Record_unboxed_product -> false
@@ -8107,7 +8109,9 @@ and type_block_access env expected_base_ty principal
      | Record_ufloat -> bad_record_error "[@@represent_as_float_array]"
      | Record_unboxed -> bad_record_error "[@@unboxed]"
      | Record_inlined _ ->
-       Misc.fatal_error "Typecore.type_block_access: inlined record");
+       Misc.fatal_error "Typecore.type_block_access: inlined record"
+     | Record_dummy _ ->
+       Misc.fatal_error "Typecore.type_block_access: dummy representation");
     (match label.lbl_private with
      | Public -> ()
      | Private -> bad_record_error "private");

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -937,7 +937,7 @@ let transl_declaration env sdecl (id, uid) =
     | Ptype_record [{pld_mutable=Immutable; _}] ->
       Option.value unboxed_attr
         ~default:(!Clflags.unboxed_types && not represent_as_float_array),
-      Option.is_none unboxed_attr
+      Option.is_none unboxed_attr && not represent_as_float_array
     | Ptype_record_unboxed_product _ -> false, false
     | _ -> false, false (* Not unboxable, mark as boxed *)
   in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1121,6 +1121,7 @@ let transl_declaration env sdecl (id, uid) =
               Jkind.of_new_sort ~why:Old_style_unboxed_type
                 ~level:(Ctype.get_current_level ())
             else
+              (* See Note [Record_dummy] in [typing/types.mli] *)
               Record_dummy { represent_as_float_array },
               Jkind.for_non_float ~why:Boxed_record
           in
@@ -1256,8 +1257,8 @@ let transl_declaration env sdecl (id, uid) =
    1. In the temporary environment computed by [enter_type], all types get an
       unboxed version.
 
-   2. After translating declarations, [derive_unboxed_versions] gives the
-      all [Record_dummy { represent_as_float_array = false }] records unboxed
+   2. After translating declarations, [derive_unboxed_versions] gives all
+      [Record_dummy { represent_as_float_array = false }] records unboxed
       versions.
 
    3. But not all of these [Record_dummy]s will end up with unboxed versions:

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -931,6 +931,8 @@ let transl_declaration env sdecl (id, uid) =
     Builtin_attributes.has_represent_as_float_array sdecl.ptype_attributes
   in
   let unbox, unboxed_default =
+    (* [unboxed_default] is [true] iff the user did not specify an explicit
+       representation attribute ([@@unboxed] or [@@represent_as_float_array]) *)
     match sdecl.ptype_kind with
     | Ptype_variant [{pcd_args = Pcstr_tuple [_]; _}]
     | Ptype_variant [{pcd_args = Pcstr_record [{pld_mutable=Immutable; _}]; _}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2101,6 +2101,98 @@ let compute_record_repr
     [@warning "+9"] ->
     Misc.fatal_error "Typedecl.compute_record_repr: empty record"
 
+(* For tracking what types appear in record blocks. All product layouts
+   count only as a [non_float64_unboxed_field], even if it's a
+   [float64 & float64] or [void & void].
+*)
+type element_repr_summary =
+  {  mutable values : bool; (* includes immediates. *)
+     mutable floats: bool;
+     (* For purposes of this record, [floats] tracks whether any field
+        has layout value and is known to be a float.
+     *)
+     mutable atomic_floats : bool;
+     mutable atomic_fields : bool;
+     mutable float64s : bool;
+     mutable non_float64_unboxed_fields : bool;
+     (* Includes product containing void *)
+     mutable voids : bool;
+  }
+
+let compute_repr_summary env lbls jkinds =
+  let reprs =
+    List.map2
+      (fun lbl jkind ->
+          Element_repr.classify env lbl.Types.ld_type jkind,
+          lbl.Types.ld_type )
+      lbls jkinds
+  in
+  let repr_summary =
+    { values = false; floats = false; atomic_floats = false;
+      atomic_fields = false; float64s = false;
+      non_float64_unboxed_fields = false; voids = false;
+    }
+  in
+  List.iter2
+    (fun ((repr : Element_repr.t), _) lbl ->
+        if Types.is_atomic lbl.Types.ld_mutable
+        then repr_summary.atomic_fields <- true;
+        match repr with
+        | Float_element ->
+            repr_summary.floats <- true;
+            (* Check if this float field is atomic *)
+            if Types.is_atomic lbl.Types.ld_mutable
+            then repr_summary.atomic_floats <- true;
+        | Unboxed_element Float64 -> repr_summary.float64s <- true
+        | Unboxed_element ( Float32 | Bits8 | Bits16 | Bits32 | Bits64
+                          | Vec128 | Vec256 | Vec512 | Word
+                          | Untagged_immediate | Product _ ) ->
+            repr_summary.non_float64_unboxed_fields <- true
+        | Value_element _ -> repr_summary.values <- true
+        | Void ->
+            repr_summary.voids <- true)
+    reprs lbls;
+  reprs, repr_summary
+
+(* Given a record with a temporary representation from [transl_declaration]
+   computes the updated labels and updated rep *)
+let compute_record_kind env loc lbls rep =
+  match lbls, rep with
+  | [Types.{ld_type} as lbl], Record_unboxed ->
+    let jkind =
+      Ctype.type_jkind env ld_type |>
+      Jkind.apply_modality_l lbl.ld_modalities
+    in
+    (* This next line is guaranteed to be OK because of a call to
+        [check_representable] *)
+    let sort = Jkind.sort_of_jkind env jkind in
+    let ld_sort = Jkind.Sort.default_to_scannable_and_get sort in
+    [{lbl with ld_sort}], Record_unboxed, jkind
+  | _, Record_dummy { represent_as_float_array } ->
+    let lbls, jkinds = update_label_sorts env loc lbls in
+    let reprs, repr_summary = compute_repr_summary env lbls jkinds in
+    let jkind = Jkind.for_boxed_record lbls in
+    let { values; floats; atomic_floats; float64s;
+          non_float64_unboxed_fields; atomic_fields; voids } =
+      repr_summary
+    in
+    let rep =
+      compute_record_repr
+        loc reprs lbls
+        ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
+        ~atomic_fields ~voids
+        ~represent_as_float_array
+    in
+    if represent_as_float_array && rep <> Record_ufloat then
+      raise (Error (loc, Bad_represent_as_float_array_attribute));
+    lbls, rep, jkind
+  | _, ( Record_boxed | Record_inlined _ | Record_float | Record_ufloat
+        | Record_mixed _)
+  | ([] | (_ :: _)), Record_unboxed ->
+    (* These are never created by [transl_declaration]. *)
+    Misc.fatal_error
+      "Typedecl.compute_record_kind: unexpected record representation"
+
 (* This function updates jkind stored in kinds with more accurate jkinds.
    It is called after the circularity checks and the delayed jkind checks
    have happened, so we can fully compute jkinds of types.
@@ -2118,94 +2210,6 @@ let rec update_decl_jkind env dpath decl =
       decl.type_unboxed_version
   in
   let decl = { decl with type_unboxed_version } in
-  let open struct
-    (* For tracking what types appear in record blocks. All product layouts
-       count only as a [non_float64_unboxed_field], even if it's a
-       [float64 & float64] or [void & void].
-    *)
-    type element_repr_summary =
-      {  mutable values : bool; (* includes immediates. *)
-         mutable floats: bool;
-         (* For purposes of this record, [floats] tracks whether any field
-            has layout value and is known to be a float.
-         *)
-         mutable atomic_floats : bool;
-         mutable atomic_fields : bool;
-         mutable float64s : bool;
-         mutable non_float64_unboxed_fields : bool;
-         (* Includes product containing void *)
-         mutable voids : bool;
-      }
-  end in
-  (* returns updated labels, updated rep, and updated jkind *)
-  let update_record_kind loc lbls rep =
-    match lbls, rep with
-    | [Types.{ld_type} as lbl], Record_unboxed ->
-      let jkind =
-        Ctype.type_jkind env ld_type |>
-        Jkind.apply_modality_l lbl.ld_modalities
-      in
-      (* This next line is guaranteed to be OK because of a call to
-         [check_representable] *)
-      let sort = Jkind.sort_of_jkind env jkind in
-      let ld_sort = Jkind.Sort.default_to_scannable_and_get sort in
-      [{lbl with ld_sort}], Record_unboxed, jkind
-    | _, Record_dummy { represent_as_float_array } ->
-      let lbls, jkinds = update_label_sorts env loc lbls in
-      let jkind = Jkind.for_boxed_record lbls in
-      let reprs =
-        List.map2
-          (fun lbl jkind ->
-             Element_repr.classify env lbl.Types.ld_type jkind,
-             lbl.Types.ld_type )
-          lbls jkinds
-      in
-      let repr_summary =
-        { values = false; floats = false; atomic_floats = false;
-          atomic_fields = false; float64s = false;
-          non_float64_unboxed_fields = false; voids = false;
-        }
-      in
-      List.iter2
-        (fun ((repr : Element_repr.t), _) lbl ->
-           if Types.is_atomic lbl.Types.ld_mutable
-           then repr_summary.atomic_fields <- true;
-           match repr with
-           | Float_element ->
-               repr_summary.floats <- true;
-               (* Check if this float field is atomic *)
-               if Types.is_atomic lbl.Types.ld_mutable
-               then repr_summary.atomic_floats <- true;
-           | Unboxed_element Float64 -> repr_summary.float64s <- true
-           | Unboxed_element ( Float32 | Bits8 | Bits16 | Bits32 | Bits64
-                             | Vec128 | Vec256 | Vec512 | Word
-                             | Untagged_immediate | Product _ ) ->
-               repr_summary.non_float64_unboxed_fields <- true
-           | Value_element _ -> repr_summary.values <- true
-           | Void ->
-               repr_summary.voids <- true)
-        reprs lbls;
-      let { values; floats; atomic_floats; float64s;
-            non_float64_unboxed_fields; atomic_fields; voids } =
-        repr_summary
-      in
-      let rep =
-        compute_record_repr
-          loc reprs lbls
-          ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
-          ~atomic_fields ~voids
-          ~represent_as_float_array
-      in
-      if represent_as_float_array && rep <> Record_ufloat then
-        raise (Error (loc, Bad_represent_as_float_array_attribute));
-      lbls, rep, jkind
-    | _, ( Record_boxed | Record_inlined _ | Record_float | Record_ufloat
-         | Record_mixed _)
-    | ([] | (_ :: _)), Record_unboxed ->
-      (* These are never created by [transl_declaration]. *)
-      Misc.fatal_error
-        "Typedecl.update_record_kind: unexpected record representation"
-  in
   (* returns updated constructors, updated rep, and updated jkind *)
   let update_variant_kind loc cstrs rep =
     (* CR layouts: factor out duplication *)
@@ -2333,7 +2337,9 @@ let rec update_decl_jkind env dpath decl =
         type_ikind = Types.ikinds_todo reason
       }
     | Type_record (lbls, rep, umc) ->
-      let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in
+      let lbls, rep, type_jkind =
+        compute_record_kind env decl.type_loc lbls rep
+      in
       (* See Note [Quality of jkinds during inference] for more information about when we
          mark jkinds as best *)
       let type_jkind = Jkind.mark_best type_jkind in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -927,16 +927,26 @@ let transl_declaration env sdecl (id, uid) =
     sdecl.ptype_cstrs
   in
   let unboxed_attr = get_unboxed_from_attributes sdecl in
+  let represent_as_float_array =
+    Builtin_attributes.has_represent_as_float_array sdecl.ptype_attributes
+  in
   let unbox, unboxed_default =
     match sdecl.ptype_kind with
     | Ptype_variant [{pcd_args = Pcstr_tuple [_]; _}]
     | Ptype_variant [{pcd_args = Pcstr_record [{pld_mutable=Immutable; _}]; _}]
     | Ptype_record [{pld_mutable=Immutable; _}] ->
-      Option.value unboxed_attr ~default:!Clflags.unboxed_types,
+      Option.value unboxed_attr
+        ~default:(!Clflags.unboxed_types && not represent_as_float_array),
       Option.is_none unboxed_attr
     | Ptype_record_unboxed_product _ -> false, false
     | _ -> false, false (* Not unboxable, mark as boxed *)
   in
+  if represent_as_float_array then begin
+    match sdecl.ptype_kind with
+    | Ptype_record _ when not unbox -> ()
+    | _ ->
+      raise (Error (sdecl.ptype_loc, Bad_represent_as_float_array_attribute))
+  end;
   verify_unboxed_attr unboxed_attr sdecl;
   let transl_type sty =
     let cty =
@@ -1111,11 +1121,7 @@ let transl_declaration env sdecl (id, uid) =
               Jkind.of_new_sort ~why:Old_style_unboxed_type
                 ~level:(Ctype.get_current_level ())
             else
-            (* Note this is inaccurate, using `Record_boxed` in cases where the
-               correct representation is [Record_float], [Record_ufloat], or
-               [Record_mixed].  Those cases are fixed up after we can get
-               accurate sorts for the fields, in [update_decl_jkind]. *)
-              Record_boxed,
+              Record_dummy { represent_as_float_array },
               Jkind.for_non_float ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
@@ -1251,20 +1257,20 @@ let transl_declaration env sdecl (id, uid) =
       unboxed version.
 
    2. After translating declarations, [derive_unboxed_versions] gives the
-      [Record_boxed] records unboxed versions.
+      all [Record_dummy { represent_as_float_array = false }] records unboxed
+      versions.
 
-   3. But some of these [Record_boxed]s are a lie, and become
-      [Record_float]/[Record_ufloat]/[Record_mixed] after [update_decls_jkind].
-      As float records should not end up with unboxed versions, we then remove
-      theirs in [remove_unboxed_versions].
+   3. But not all of these [Record_dummy]s will end up with unboxed versions:
+      they become [Record_float]/[Record_boxed]/[Record_mixed], and float
+      records don't have unboxed versions. These unboxed versions are removed in
+      [remove_unboxed_versions].
 
    After steps 2 and 3, the set of unboxed versions decreases, so we check for
    newly-unbound unboxed paths with [check_unboxed_paths].
 *)
 
-(* Record declarations with representation [Record_boxed] get an implicit
-   unboxed record stored in [type_unboxed_version]. If that record is also an
-   alias, so is its stored unboxed version. E.g. [type t = r = { i : int }]'s
+(* If a record with an unboxed version is also an alias, so is its unboxed
+   version stored in [type_unboxed_version]. E.g. [type t = r = { i : int }]'s
    unboxed version gets kind [#{ i : int}] and manifest [r#].
 
    Note that all aliases of types with unboxed versions, with an abstract kind,
@@ -1283,10 +1289,14 @@ let record_has_float_boxed = function
   | Record_mixed shape -> shape_has_float_boxed shape
   | Record_unboxed | Record_inlined _ | Record_boxed
   | Record_float | Record_ufloat -> false
+  | Record_dummy _ ->
+    fatal_error "record_has_float_boxed: unexpected dummy representation"
 
 let record_gets_unboxed_version = function
   | Record_unboxed | Record_inlined _ | Record_float | Record_ufloat -> false
   | Record_boxed -> true
+  | Record_dummy { represent_as_float_array } ->
+    not represent_as_float_array
   | Record_mixed shape -> not (shape_has_float_boxed shape)
 let gets_unboxed_version decl =
   (* This must be kept in sync with the match in [derive_unboxed_version] *)
@@ -1309,14 +1319,6 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
          if both have unboxed versions (because the unboxed version is a second
          alias). *)
       not (Builtin_attributes.attr_equals_builtin a "deprecated_mutable")
-    in
-    let keep_decl_attribute a =
-      (* [@@represent_as_float_array] records don't have unboxed versions, but
-         we still produce one for the phase of typechecking where every record
-         has an unboxed version (see Note [Typechecking unboxed versions of
-         types]). For those unboxed versions, we don't keep the attribute, since
-         it's not valid on an unboxed record. *)
-      not (Builtin_attributes.attr_equals_builtin a "represent_as_float_array")
     in
     let lbls_unboxed =
       List.map
@@ -1386,7 +1388,7 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
         type_is_newtype = false;
         type_expansion_scope = Btype.lowest_level;
         type_loc = decl.type_loc;
-        type_attributes = List.filter keep_decl_attribute decl.type_attributes;
+        type_attributes = decl.type_attributes;
         type_unboxed_default = false;
         type_uid = Uid.unboxed_version decl.type_uid;
         type_unboxed_version = None;
@@ -1977,6 +1979,128 @@ let add_types_to_env ~shapes decls env =
       add_type ~check:true ~shape id decl env)
     decls shapes env
 
+let compute_record_repr
+    loc reprs lbls
+    ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
+    ~atomic_fields ~voids
+    ~represent_as_float_array
+  =
+  let mixed_record () =
+    let shape =
+      Element_repr.mixed_product_shape loc reprs Record
+    in
+    let shape =
+      match shape with
+      | Some x -> x
+      | None -> Misc.fatal_error "expected mixed block"
+    in
+    Record_mixed shape
+  in
+  match
+    ( ~values, ~floats, ~atomic_floats, ~float64s, ~non_float64_unboxed_fields,
+      ~atomic_fields, ~voids )
+  with
+  (* We store floats flatly in mixed records if all fields are
+      float/float64/void. *)
+  | ~values:false, ~floats:true,
+      ~atomic_floats:false, ~float64s:true,
+      ~non_float64_unboxed_fields:false, ~atomic_fields:false,
+      .. ->
+      let shape =
+        List.map
+          (fun ((repr : Element_repr.t), _lbl) ->
+            match repr with
+            | Float_element -> Float_boxed
+            | Unboxed_element Float64 -> Float64
+            | Void -> Void
+            | Unboxed_element (Float32 | Bits8 | Bits16 | Bits32 | Bits64
+                              | Vec128 | Vec256 | Vec512 | Word
+                              | Untagged_immediate | Product _)
+            | Value_element _ ->
+                Misc.fatal_error "Expected only floats and float64s")
+          reprs
+        |> Array.of_list
+      in
+      assert_mixed_product_support loc Record ~value_prefix_len:0;
+      Record_mixed shape
+  (* Forbid atomic fields in mixed blocks *)
+  | ~values:true, ~voids:true, ~atomic_fields:true, ..
+  | ~floats:true, ~voids:true, ~atomic_fields:true, ..
+  | ~float64s:true, ~voids:true, ~atomic_fields:true, ..
+  | ~values:true, ~float64s:true, ~atomic_fields:true, ..
+  | ~non_float64_unboxed_fields:true, ~atomic_fields:true, .. ->
+    let error =
+      (* Print a different error if an atomic field itself is
+          non-value *)
+      match
+        List.find_map
+          (fun ((repr : Element_repr.t), lbl) ->
+              match repr with
+              | Value_element _ | Float_element -> None
+              | _ ->
+                if Types.is_atomic lbl.Types.ld_mutable
+                then Some lbl
+                else None)
+          (List.map2 (fun (repr, _) lbl -> repr, lbl) reprs lbls)
+      with
+      | Some lbl ->
+        Error(lbl.Types.ld_loc, Non_value_atomic_field)
+      | None ->
+        (* Find the first atomic field, to get a better location for the
+            error *)
+        let lbl =
+          List.find (fun lbl -> Types.is_atomic lbl.Types.ld_mutable)
+            lbls
+        in
+        Error(lbl.Types.ld_loc, Atomic_field_in_mixed_block)
+    in
+    raise error
+  (* For other mixed blocks, float fields are stored as flat
+      only when they're unboxed.
+  *)
+  | ~values:true, ~voids:true, ~atomic_fields:false, ..
+  | ~floats:true, ~voids:true, ~atomic_fields:false, ..
+  | ~float64s:true, ~voids:true, ~atomic_fields:false, ..
+  | ~values:true, ~float64s:true, ~atomic_fields:false, ..
+  | ~non_float64_unboxed_fields:true, ~atomic_fields:false, .. ->
+    mixed_record ()
+  (* value-only records are stored as boxed records *)
+  | ~values:true, ~float64s:false, ~non_float64_unboxed_fields:false,
+      ~voids:false, ..
+    ->
+    Record_boxed
+  (* All-nonatomic-float and all-nonatomic-float64 records are stored as
+      flat float records.
+  *)
+  | ~values:false, ~floats:true, ~atomic_floats:false,
+      ~float64s:false, ~non_float64_unboxed_fields:false,
+      ~voids:false, ..
+    ->
+    Record_float
+  | ~values:false, ~floats:false, ~atomic_floats:false,
+      ~float64s:true, ~non_float64_unboxed_fields:false,
+      ~voids:false, ..
+    ->
+    if represent_as_float_array then
+      Record_ufloat
+    else
+      mixed_record ()
+  (* Records with atomic float fields cannot use flat representation *)
+  | ~atomic_floats:true, .. ->
+    if floats && not values
+    then Location.prerr_warning loc Warnings.Atomic_float_record_boxed;
+    Record_boxed
+  | ~voids:false, ~values:false, ~floats:true, ~atomic_floats:false,
+      ~atomic_fields:true, ~float64s:true,
+      ~non_float64_unboxed_fields:false ->
+    Misc.fatal_error
+      "Typedecl.compute_record_repr: invariant broken in repr_summary \
+        (only floats, some atomic fields, no atomic floats?)"
+  | ~values:false, ~floats:false, ~atomic_floats:false,
+      ~float64s:false, ~non_float64_unboxed_fields:false, ..
+    [@warning "+9"] ->
+    Misc.fatal_error "Typedecl.compute_record_repr: empty record"
+
 (* This function updates jkind stored in kinds with more accurate jkinds.
    It is called after the circularity checks and the delayed jkind checks
    have happened, so we can fully compute jkinds of types.
@@ -2013,27 +2137,6 @@ let rec update_decl_jkind env dpath decl =
          mutable voids : bool;
       }
   end in
-  (* The compiler does not like matching on records with mutable fields, so we
-     create an immutable copy for the match below. *)
-  let module Imm_element_rep = struct
-    type element_repr_summary =
-      {  values : bool;
-         floats: bool;
-         atomic_floats : bool;
-         atomic_fields : bool;
-         float64s : bool;
-         non_float64_unboxed_fields : bool;
-         voids : bool;
-    }
-  end in
-  let represent_as_float_array =
-    Builtin_attributes.has_represent_as_float_array decl.type_attributes
-  in
-  if represent_as_float_array then begin
-    match decl.type_kind with
-    | Type_record _ -> ()
-    | _ -> raise (Error (decl.type_loc, Bad_represent_as_float_array_attribute))
-  end;
   (* returns updated labels, updated rep, and updated jkind *)
   let update_record_kind loc lbls rep =
     match lbls, rep with
@@ -2047,7 +2150,7 @@ let rec update_decl_jkind env dpath decl =
       let sort = Jkind.sort_of_jkind env jkind in
       let ld_sort = Jkind.Sort.default_to_scannable_and_get sort in
       [{lbl with ld_sort}], Record_unboxed, jkind
-    | _, Record_boxed ->
+    | _, Record_dummy { represent_as_float_array } ->
       let lbls, jkinds = update_label_sorts env loc lbls in
       let jkind = Jkind.for_boxed_record lbls in
       let reprs =
@@ -2082,136 +2185,27 @@ let rec update_decl_jkind env dpath decl =
            | Void ->
                repr_summary.voids <- true)
         reprs lbls;
-      let rep =
-        (* CR layouts: improve the readability of this match *)
-        let { values; floats; atomic_floats; float64s;
-               non_float64_unboxed_fields; atomic_fields; voids} = repr_summary
-        in
-        let summary : Imm_element_rep.element_repr_summary =
-          { values; floats; atomic_floats; float64s;
-            non_float64_unboxed_fields; atomic_fields; voids }
-        in
-        let mixed_record () =
-          let shape =
-            Element_repr.mixed_product_shape loc reprs Record
-          in
-          let shape =
-            match shape with
-            | Some x -> x
-            | None -> Misc.fatal_error "expected mixed block"
-          in
-          Record_mixed shape
-        in
-        match summary with
-        (* We store floats flatly in mixed records if all fields are
-           float/float64/void. *)
-        | { values = false; floats = true; atomic_floats = false;
-            float64s = true; non_float64_unboxed_fields = false;
-            atomic_fields = false }
-           ->
-            let shape =
-              List.map
-                (fun ((repr : Element_repr.t), _lbl) ->
-                  match repr with
-                  | Float_element -> Float_boxed
-                  | Unboxed_element Float64 -> Float64
-                  | Void -> Void
-                  | Unboxed_element (Float32 | Bits8 | Bits16 | Bits32 | Bits64
-                                    | Vec128 | Vec256 | Vec512 | Word
-                                    | Untagged_immediate | Product _)
-                  | Value_element _ ->
-                      Misc.fatal_error "Expected only floats and float64s")
-                reprs
-              |> Array.of_list
-            in
-            assert_mixed_product_support loc Record ~value_prefix_len:0;
-            Record_mixed shape
-        (* Forbid atomic fields in mixed blocks *)
-        | { values = true; voids = true; atomic_fields = true }
-        | { floats = true; voids = true; atomic_fields = true }
-        | { float64s = true; voids = true; atomic_fields = true }
-        | { values = true; float64s = true; atomic_fields = true }
-        | { non_float64_unboxed_fields = true; atomic_fields = true } -> begin
-            let error =
-              (* Print a different error if an atomic field itself is
-                 non-value *)
-              match
-                List.find_map
-                  (fun ((repr : Element_repr.t), lbl) ->
-                     match repr with
-                     | Value_element _ | Float_element -> None
-                     | _ ->
-                       if Types.is_atomic lbl.Types.ld_mutable
-                       then Some lbl
-                       else None)
-                  (List.map2 (fun (repr, _) lbl -> repr, lbl) reprs lbls)
-              with
-              | Some lbl ->
-                Error(lbl.ld_loc, Non_value_atomic_field)
-              | None ->
-                (* Find the first atomic field, to get a better location for the
-                   error *)
-                let lbl =
-                  List.find (fun lbl -> Types.is_atomic lbl.Types.ld_mutable)
-                    lbls
-                in
-                Error(lbl.ld_loc, Atomic_field_in_mixed_block)
-            in
-            raise error
-          end
-        (* For other mixed blocks, float fields are stored as flat
-           only when they're unboxed.
-        *)
-        | { values = true; voids = true; atomic_fields = false }
-        | { floats = true; voids = true; atomic_fields = false }
-        | { float64s = true; voids = true; atomic_fields = false }
-        | { values = true; float64s = true; atomic_fields = false }
-        | { non_float64_unboxed_fields = true; atomic_fields = false } ->
-            mixed_record ()
-        (* value-only records are stored as boxed records *)
-        | { values = true; float64s = false; non_float64_unboxed_fields = false;
-            voids = false }
-          -> rep
-        (* All-nonatomic-float and all-nonatomic-float64 records are stored as
-           flat float records.
-        *)
-        | { values = false; floats = true ; atomic_floats = false;
-            float64s = false; non_float64_unboxed_fields = false;
-            voids = false } ->
-          Record_float
-        | { values = false; floats = false; atomic_floats = false;
-            float64s = true; non_float64_unboxed_fields = false;
-            voids = false } ->
-          if represent_as_float_array then
-            Record_ufloat
-          else
-            mixed_record ()
-        (* Records with atomic float fields cannot use flat representation *)
-        | { atomic_floats = true; floats; values; _ } ->
-          if floats && not values
-          then Location.prerr_warning loc Warnings.Atomic_float_record_boxed;
-          rep
-        | { voids=false; values=false; floats=true; atomic_floats=false;
-            atomic_fields=true; float64s=true; non_float64_unboxed_fields=false
-          } ->
-          Misc.fatal_error
-            "Typedecl.update_record_kind: invariant broken in repr_summary \
-             (only floats, some atomic fields, no atomic floats?)"
-        | { values = false; floats = false; atomic_floats = false;
-            float64s = false; non_float64_unboxed_fields = false;
-            voids = _; atomic_fields = _ }
-          [@warning "+9"] ->
-          Misc.fatal_error "Typedecl.update_record_kind: empty record"
+      let { values; floats; atomic_floats; float64s;
+            non_float64_unboxed_fields; atomic_fields; voids } =
+        repr_summary
       in
+      let rep =
+        compute_record_repr
+          loc reprs lbls
+          ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
+          ~atomic_fields ~voids
+          ~represent_as_float_array
+      in
+      if represent_as_float_array && rep <> Record_ufloat then
+        raise (Error (loc, Bad_represent_as_float_array_attribute));
       lbls, rep, jkind
-    | _, ( Record_inlined _ | Record_float | Record_ufloat
+    | _, ( Record_boxed | Record_inlined _ | Record_float | Record_ufloat
          | Record_mixed _)
     | ([] | (_ :: _)), Record_unboxed ->
       (* These are never created by [transl_declaration]. *)
       Misc.fatal_error
         "Typedecl.update_record_kind: unexpected record representation"
   in
-
   (* returns updated constructors, updated rep, and updated jkind *)
   let update_variant_kind loc cstrs rep =
     (* CR layouts: factor out duplication *)
@@ -2340,8 +2334,6 @@ let rec update_decl_jkind env dpath decl =
       }
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in
-      if represent_as_float_array && rep <> Record_ufloat then
-        raise (Error (decl.type_loc, Bad_represent_as_float_array_attribute));
       (* See Note [Quality of jkinds during inference] for more information about when we
          mark jkinds as best *)
       let type_jkind = Jkind.mark_best type_jkind in

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1017,6 +1017,9 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ld_type
       | [] | _ :: _ :: _ -> assert false
     end
+  | Record_dummy _ ->
+    Misc.fatal_error
+      "Typeopt.value_kind_record: unexpected dummy representation"
   | Record_inlined (_, _, Variant_with_null) -> assert false
   | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
   | Record_boxed | Record_float | Record_ufloat | Record_mixed _ -> begin
@@ -1029,7 +1032,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
       else
         let num_nodes_visited, fields =
           match rep with
-          | Record_unboxed ->
+          | Record_unboxed | Record_dummy _ ->
               (* The outer match guards against this *)
               assert false
           | Record_inlined (_, Constructor_uniform_value, _)
@@ -1050,7 +1053,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
                       | Record_inlined _ | Record_boxed ->
                           value_kind env ~loc ~visited ~depth ~num_nodes_visited
                             label.ld_type
-                      | Record_mixed _ | Record_unboxed ->
+                      | Record_mixed _ | Record_unboxed | Record_dummy _ ->
                           (* The outer match guards against this *)
                           assert false
                     in
@@ -1078,6 +1081,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
             [0, fields]
           | Record_unboxed -> assert false
           | Record_inlined (Null, _, _) -> assert false
+          | Record_dummy _ -> assert false
         in
         (num_nodes_visited,
          non_nullable (Pvariant { consts = []; non_consts }))

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -506,6 +506,7 @@ and record_representation =
   | Record_float
   | Record_ufloat
   | Record_mixed of mixed_product_shape
+  | Record_dummy of { represent_as_float_array : bool }
 
 and record_unboxed_product_representation =
   | Record_unboxed_product
@@ -971,8 +972,11 @@ let equal_record_representation_up_to_scannable_axes r1 r2 = match r1, r2 with
       true
   | Record_mixed mx1, Record_mixed mx2 ->
       equal_mixed_product_shape_up_to_scannable_axes mx1 mx2
+  | Record_dummy { represent_as_float_array = a },
+    Record_dummy { represent_as_float_array = b } ->
+      Bool.equal a b
   | (Record_unboxed | Record_inlined _ | Record_boxed | Record_float
-    | Record_ufloat | Record_mixed _), _ ->
+    | Record_ufloat | Record_mixed _ | Record_dummy _), _ ->
       false
 
 let equal_record_unboxed_product_representation_up_to_scannable_axes r1 r2 =
@@ -1058,7 +1062,7 @@ let find_unboxed_type decl =
     Some (arg, ms)
   | Type_record (_, ( Record_inlined _ | Record_unboxed
                     | Record_boxed | Record_float | Record_ufloat
-                    | Record_mixed _), _)
+                    | Record_mixed _ | Record_dummy _), _)
   | Type_record_unboxed_product (_, Record_unboxed_product, _)
   | Type_variant (_, ( Variant_boxed _ | Variant_unboxed
                      | Variant_extensible | Variant_with_null), _)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -843,7 +843,9 @@ type type_declaration =
     type_loc: Location.t;
     type_attributes: Parsetree.attributes;
     type_unboxed_default: bool;
-    (* true if the unboxed-ness of this type was chosen by a compiler flag *)
+    (* true if the user did not specify an explicit representation attribute
+       ([@@unboxed] or [@@represent_as_float_array]), so the representation may
+       have been chosen by a compiler flag. *)
     type_uid: Uid.t;
     type_unboxed_version : type_declaration option;
     (* stores the unboxed version of that this type introduces: this is [Some]

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -940,7 +940,8 @@ and record_representation =
      is tagged such that polymorphic operations will not work.
   *)
   | Record_dummy of { represent_as_float_array : bool }
-  (* We typecheck type declarations before updating their kinds, yet some record
+  (* Note [Record_dummy]:
+     We typecheck type declarations before updating their kinds, yet some record
      representations are kind-dependent. In particular, we don't choose between
      [Record_boxed], [Record_float], [Record_ufloat], and [Record_mixed] until
      type declaration jkinds are updated in [update_decls_jkind].

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -939,6 +939,18 @@ and record_representation =
   (* The record contains a mix of values and unboxed elements. The block
      is tagged such that polymorphic operations will not work.
   *)
+  | Record_dummy of { represent_as_float_array : bool }
+  (* We typecheck type declarations before updating their kinds, yet some record
+     representations are kind-dependent. In particular, we don't choose between
+     [Record_boxed], [Record_float], [Record_ufloat], and [Record_mixed] until
+     type declaration jkinds are updated in [update_decls_jkind].
+
+     Until then, we use [Record_dummy], which also tracks whether the
+     declaration has the attribute [@@represent_as_float_array], as we can't
+     check whether the attribute is valid until we know the kinds of the fields
+     (which must all be [float64]).
+
+     After [update_decls_jkind], no record should have this representation. *)
 
 and record_unboxed_product_representation =
   | Record_unboxed_product

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -817,6 +817,8 @@ let rec expression : Typedtree.expression -> term_judg =
              | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate
              | Void | Product _ ->
                Dereference)
+          | Record_dummy _ ->
+            Misc.fatal_error "value_rec_check: unexpected dummy representation"
         in
         let field (label, field_def) =
           let env =

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -394,6 +394,7 @@ and value_kind_record env subst ~visited ~depth
              (Other "Record_unboxed should have been handled above"))
       | Record_mixed _ -> raise (Vicuna_unsupported Mixed_records)
       | Record_ufloat -> FloatArray
+      | Record_dummy _ -> Misc.fatal_error "unexpected dummy representation"
     in
     non_consts
 


### PR DESCRIPTION
Three related changes ahead of https://github.com/oxcaml/oxcaml/pull/5461.

**1. Add `Record_dummy`.**

This record representation is a placeholder value for records declarations that are currently being typechecked, as we don't know their representation until `update_decls_jkind`. See the note added in `typing/types.mli`.

**2. Change where we handle `[@@represent_as_float_array]`.**

We move this to be the same place as where we handle `[@@unboxed]`. Before, we delayed this until `update_decls_jkind` (associated code smell: we filtered out the attribute in the typedtree with the function `keep_decl_attribute` in `typedecl.ml`, which this PR deletes), but now, we can store this info in `Record_dummy`.

At the same time, this fixes a bug where we allowed both `[@@unboxed]` and `[@@represent_as_float_array]` on the same declaration. (Added a regression test to `testsuite/tests/typing-layouts/represent_as_float_array.ml`.)

**3. Move code from `update_decls_jkind`.**

We do this partially for readability, and partially to split out `compute_record_repr` and `compute_repr_summary`, which will be used in multiple places with #5461.

## Stack
1. https://github.com/oxcaml/oxcaml/pull/6002
2. https://github.com/oxcaml/oxcaml/pull/6035
3. https://github.com/oxcaml/oxcaml/pull/5461