### PR TITLE
Forward `[@inlined]` attribute on stubs

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -754,8 +754,18 @@ let mk_no_simplify_stubs f =
   ( "-flambda2-no-simplify-stubs",
     Arg.Unit f,
     Printf.sprintf
-      " Prevent the simplification of stub functions%s (Flambda2 only)"
-      (format_not_default Flambda2.Default.simplify_stubs) )
+      " Prevent the simplification of stub functions (Flambda2 only)" )
+
+let mk_stubs_forward_inlining f =
+  ( "-stubs-forward-inlining",
+    Arg.Unit f,
+    Printf.sprintf " Forward inlining information on stubs (Flambda2 only)" )
+
+let mk_no_stubs_forward_inlining f =
+  ( "-no-stubs-forward-inlining",
+    Arg.Unit f,
+    Printf.sprintf
+      " Do not forward inlining information on stubs (Flambda2 only)" )
 
 let mk_flambda2_expert_fallback_inlining_heuristic f =
   ( "-flambda2-expert-fallback-inlining-heuristic",
@@ -1419,6 +1429,8 @@ module type Oxcaml_options = sig
   val no_flambda2_match_in_match : unit -> unit
   val simplify_stubs : unit -> unit
   val no_simplify_stubs : unit -> unit
+  val stubs_forward_inlining : unit -> unit
+  val no_stubs_forward_inlining : unit -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val flambda2_expert_inline_effects_in_cmm : unit -> unit
@@ -1620,6 +1632,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_flambda2_match_in_match F.no_flambda2_match_in_match;
       mk_simplify_stubs F.simplify_stubs;
       mk_no_simplify_stubs F.no_simplify_stubs;
+      mk_stubs_forward_inlining F.stubs_forward_inlining;
+      mk_no_stubs_forward_inlining F.no_stubs_forward_inlining;
       mk_flambda2_expert_fallback_inlining_heuristic
         F.flambda2_expert_fallback_inlining_heuristic;
       mk_no_flambda2_expert_fallback_inlining_heuristic
@@ -2107,6 +2121,8 @@ module Oxcaml_options_impl = struct
 
   let simplify_stubs = set Flambda2.simplify_stubs
   let no_simplify_stubs = clear Flambda2.simplify_stubs
+  let stubs_forward_inlining = set' Clflags.stubs_forward_inlining
+  let no_stubs_forward_inlining = clear' Clflags.stubs_forward_inlining
 
   let flambda2_expert_fallback_inlining_heuristic =
     set Flambda2.Expert.fallback_inlining_heuristic
@@ -2748,6 +2764,7 @@ module Extra_params = struct
     | "reaper-change-calling-conventions" ->
         set Flambda2.reaper_change_calling_conventions
     | "flambda2-simplify-stubs" -> set Flambda2.simplify_stubs
+    | "stubs-forward-inlining" -> set' Clflags.stubs_forward_inlining
     | "dissector" -> set' Clflags.dissector
     | "dissector-partition-size" -> (
         match float_of_string_opt v with

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -147,6 +147,8 @@ module type Oxcaml_options = sig
   val no_flambda2_match_in_match : unit -> unit
   val simplify_stubs : unit -> unit
   val no_simplify_stubs : unit -> unit
+  val stubs_forward_inlining : unit -> unit
+  val no_stubs_forward_inlining : unit -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val flambda2_expert_inline_effects_in_cmm : unit -> unit

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -915,6 +915,7 @@ type inlined_attribute =
   | Always_inlined (* [@inlined] or [@inlined always] *)
   | Never_inlined (* [@inlined never] *)
   | Hint_inlined (* [@inlined hint] *)
+  | Forward_inlined (* [@inlined forward] *)
   | Unroll of int (* [@unroll x] *)
   | Default_inlined (* no [@inlined] attribute *)
 
@@ -937,13 +938,14 @@ let equal_inlined_attribute (x : inlined_attribute) (y : inlined_attribute) =
   | Always_inlined, Always_inlined
   | Never_inlined, Never_inlined
   | Hint_inlined, Hint_inlined
+  | Forward_inlined, Forward_inlined
   | Default_inlined, Default_inlined
     ->
     true
   | Unroll u, Unroll v ->
     u = v
   | (Always_inlined | Never_inlined
-    | Hint_inlined | Unroll _ | Default_inlined), _ ->
+    | Hint_inlined | Forward_inlined | Unroll _ | Default_inlined), _ ->
     false
 
 type probe_desc = { name: string; enabled_at_init: bool; }

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -744,6 +744,7 @@ type inlined_attribute =
   | Always_inlined (* [@inlined] or [@inlined always] *)
   | Never_inlined (* [@inlined never] *)
   | Hint_inlined (* [@inlined hint] *)
+  | Forward_inlined (* [@inlined forward] *)
   | Unroll of int (* [@unroll x] *)
   | Default_inlined (* no [@inlined] attribute *)
 

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -1204,6 +1204,7 @@ let apply_inlined_attribute ppf = function
   | Always_inlined -> fprintf ppf " always_inline"
   | Never_inlined -> fprintf ppf " never_inline"
   | Hint_inlined -> fprintf ppf " hint_inline"
+  | Forward_inlined -> fprintf ppf " forward_inline"
   | Unroll i -> fprintf ppf " never_inline(%i)" i
 
 let apply_specialised_attribute ppf = function

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -911,7 +911,9 @@ let split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind ~params ~return
                which ignores [ap_yielding]. *)
             ap_yielding = May_yield;
             ap_tailcall = Default_tailcall;
-            ap_inlined = Default_inlined;
+            ap_inlined =
+              if !Clflags.stubs_forward_inlining
+              then Forward_inlined else Default_inlined;
             ap_specialised = Default_specialise;
             ap_probe=None;
           }

--- a/lambda/translattribute.ml
+++ b/lambda/translattribute.ml
@@ -131,6 +131,7 @@ let parse_inlined_attribute attr : inlined_attribute =
           "never", Never_inlined;
           "always", Always_inlined;
           "hint", Hint_inlined;
+          "forward", Forward_inlined;
         ]
         payload
 
@@ -550,7 +551,8 @@ let get_inlined_attribute_on_module e =
       | Tmod_constraint (me, _, _, _) ->
         let inner_attr = get me in
         begin match attr with
-        | Always_inlined | Hint_inlined | Never_inlined | Unroll _ -> attr
+        | Always_inlined | Hint_inlined | Forward_inlined | Never_inlined
+        | Unroll _ -> attr
         | Default_inlined -> inner_attr
         end
       | _ -> attr

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1647,7 +1647,7 @@ and transl_apply ~scopes
       ~result_layout
       lam sargs loc
   =
-  let lapply funct args loc pos mode result_layout =
+  let lapply ?(inlined = inlined) funct args loc pos mode result_layout =
     match funct, pos with
     | Lsend((Self | Public) as k, lmet, lobj, [], _, _, _, _, sy), _ ->
         Lsend(k, lmet, lobj, args, pos, mode, loc, result_layout,
@@ -1717,7 +1717,7 @@ and transl_apply ~scopes
        will occur exactly when all the arguments up to this parameter
        have been received.
   *)
-  let rec build_apply lam args loc pos ap_mode result_layout = function
+  let rec build_apply ~inlined lam args loc pos ap_mode result_layout = function
     | Omitted { mode_closure; mode_arg; mode_ret; sort_arg; sort_ret } :: l ->
         (* Out-of-order partial application; we will need to build a closure *)
         assert (pos = Rc_normal);
@@ -1759,8 +1759,14 @@ and transl_apply ~scopes
           let sort_arg = Jkind.Sort.default_for_transl_and_get sort_arg in
           let sort_ret = Jkind.Sort.default_for_transl_and_get sort_ret in
           let result_layout = layout_of_sort (to_location loc) sort_ret in
+          let inlined =
+            match inlined with
+            | Default_inlined when !Clflags.stubs_forward_inlining ->
+              Forward_inlined
+            | _ -> inlined
+          in
           let body =
-            build_apply handle [Lvar id_arg] loc Rc_normal ret_mode
+            build_apply ~inlined handle [Lvar id_arg] loc Rc_normal ret_mode
               result_layout l
           in
           let nlocal =
@@ -1787,9 +1793,9 @@ and transl_apply ~scopes
           Llet(Strict, layout, id, Lambda.debug_uid_none, lam, body))
           !defs body
     | Arg (arg, _) :: l ->
-        build_apply lam (arg :: args) loc pos ap_mode result_layout l
+        build_apply ~inlined lam (arg :: args) loc pos ap_mode result_layout l
     | [] ->
-        lapply lam (List.rev args) loc pos ap_mode result_layout
+        lapply ~inlined lam (List.rev args) loc pos ap_mode result_layout
   in
   let args =
     List.map
@@ -1802,7 +1808,7 @@ and transl_apply ~scopes
            Arg (transl_exp ~scopes layout exp, layout))
       sargs
   in
-  build_apply lam [] loc position mode result_layout args
+  build_apply ~inlined lam [] loc position mode result_layout args
 
 (* There are two cases in function translation:
     - [Tupled]. It takes a tupled argument, and we can flatten it.

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -204,7 +204,9 @@ and apply_coercion_result loc strict funct params args yielding cc_res =
                       ap_yielding=
                         Translmode.transl_yielding_mode_l yielding;
                       ap_tailcall=Default_tailcall;
-                      ap_inlined=Default_inlined;
+                      ap_inlined=
+                        if !Clflags.stubs_forward_inlining
+                        then Forward_inlined else Default_inlined;
                       ap_specialised=Default_specialise;
                       ap_probe=None;
                     })))

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -621,7 +621,9 @@ let rec split_static_function lfun block_var local_idents lam :
         ap_args = List.map (fun p -> Lvar (p.name)) params;
         ap_loc = no_loc;
         ap_tailcall = Default_tailcall;
-        ap_inlined = Default_inlined;
+        ap_inlined =
+          if !Clflags.stubs_forward_inlining
+          then Forward_inlined else Default_inlined;
         ap_specialised = Default_specialise;
         ap_result_layout = lfun.return;
         ap_region_close = Rc_normal;

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -415,7 +415,7 @@ module Inlining = struct
               Not_inlinable )
           | Always_inlined _ | Hint_inlined ->
             Call_site_inlining_decision_type.Attribute_always, Inlinable code
-          | Default_inlined | Unroll _ ->
+          | Default_inlined | Forward_inlined | Unroll _ ->
             (* Closure ignores completely [@unrolled] attributes, so it seems
                safe to do the same. *)
             ( Call_site_inlining_decision_type.Definition_says_inline
@@ -428,10 +428,11 @@ module Inlining = struct
           ~are_rebuilding_terms decision;
         res
 
-  let make_inlined_body acc ~callee ~called_code_id ~region_inlined_into ~params
-      ~args ~my_closure ~my_alloc_mode ~my_depth ~body ~free_names_of_body
-      ~exn_continuation ~return_continuation ~apply_exn_continuation
-      ~apply_return_continuation ~apply_depth ~apply_dbg =
+  let make_inlined_body acc ~callee ~called_code_id ~region_inlined_into
+      ~inlined_attribute ~params ~args ~my_closure ~my_alloc_mode ~my_depth
+      ~body ~free_names_of_body ~exn_continuation ~return_continuation
+      ~apply_exn_continuation ~apply_return_continuation ~apply_depth ~apply_dbg
+      =
     let my_depth_duid = Flambda_debug_uid.none in
     let my_closure_duid = Flambda_debug_uid.none in
     let rec_info =
@@ -481,7 +482,8 @@ module Inlining = struct
       (Bound_pattern.singleton
          (VB.create inlined_dbg_var inlined_dbg_var_duid Name_mode.normal))
       (Named.create_prim
-         (Nullary (Enter_inlined_apply { dbg = inlined_debuginfo }))
+         (Nullary
+            (Enter_inlined_apply { dbg = inlined_debuginfo; inlined_attribute }))
          Debuginfo.none)
       ~body
 
@@ -515,6 +517,7 @@ module Inlining = struct
            function call."
     in
     let region_inlined_into = Apply.alloc_mode apply in
+    let inlined_attribute = Apply.inlined apply in
     let args = Apply.args apply in
     let apply_return_continuation = Apply.continuation apply in
     let apply_exn_continuation = Apply.exn_continuation apply in
@@ -541,7 +544,7 @@ module Inlining = struct
         in
         let make_inlined_body =
           make_inlined_body ~callee ~called_code_id:(Code.code_id code)
-            ~region_inlined_into
+            ~region_inlined_into ~inlined_attribute
             ~params:(Bound_parameters.vars_and_uids params)
             ~args ~my_closure ~my_alloc_mode ~my_depth ~body ~free_names_of_body
             ~exn_continuation ~return_continuation ~apply_depth ~apply_dbg
@@ -3803,7 +3806,7 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
           (Warnings.Inlining_impossible
              Inlining_helpers.(
                inlined_attribute_on_partial_application_msg Inlined))
-      | Never_inlined | Hint_inlined | Default_inlined -> ());
+      | Never_inlined | Hint_inlined | Forward_inlined | Default_inlined -> ());
       wrap_partial_application acc env apply.continuation apply approx ~provided
         ~provided_arity ~missing_arity ~missing_param_modes ~result_arity
         ~arity:params_arity ~first_complex_local_param ~result_mode

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2386,6 +2386,11 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
              args_arity) ]
   in
   let make_body cont =
+    let inlined : Inlined_attribute.t =
+      if !Clflags.stubs_forward_inlining
+      then Forward_inlined
+      else Default_inlined
+    in
     let main_application =
       Apply_expr.create
         ~callee:(Some (Simple.var main_closure))
@@ -2398,7 +2403,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
              (Function_decl.result_mode decl)
              ~current_alloc_region:my_alloc_region ~current_region:my_region
              ~current_ghost_region:my_ghost_region)
-        Debuginfo.none ~inlined:Inlined_attribute.Default_inlined
+        Debuginfo.none ~inlined
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe:None ~position:Normal
         ~relative_history:(Env.relative_history_from_scoped ~loc external_env)
@@ -3453,7 +3458,10 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
         args_arity = arity;
         continuation = return_continuation;
         exn_continuation;
-        inlined = Lambda.Default_inlined;
+        inlined =
+          (if !Clflags.stubs_forward_inlining
+           then Lambda.Forward_inlined
+           else Lambda.Default_inlined);
         mode = result_mode;
         return_arity = result_arity;
         region = my_region;

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -281,6 +281,7 @@ type inline_attribute = Inline_attribute.t =
 type inlined_attribute =
   | Always_inlined
   | Hint_inlined
+  | Forward_inlined
   | Never_inlined
   | Unroll of int
   | Default_inlined

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -729,7 +729,8 @@ let probe_is_enabled =
 let enter_inlined_apply =
   D.(
     nullary "%inlined_apply" ~params:param0 (fun _env () ->
-        P.Enter_inlined_apply { dbg = Inlined_debuginfo.none }))
+        P.Enter_inlined_apply
+          { dbg = Inlined_debuginfo.none; inlined_attribute = Default_inlined }))
 
 let domain_index =
   D.(nullary "%domain_index" ~params:param0 (fun _env () -> P.Domain_index))
@@ -1323,7 +1324,8 @@ module OfFlambda = struct
     | Optimised_out kind -> optimised_out env kind
     | Probe_is_enabled { name; enabled_at_init } ->
       probe_is_enabled env (wrap_loc name, enabled_at_init)
-    | Enter_inlined_apply { dbg = _ } -> enter_inlined_apply env ()
+    | Enter_inlined_apply { dbg = _; inlined_attribute = _ } ->
+      enter_inlined_apply env ()
     | Domain_index -> domain_index env ()
     | Dls_get -> dls_get env ()
     | Tls_get -> tls_get env ()

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -919,6 +919,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
       match inlined with
       | None | Some Default_inlined -> Default_inlined
       | Some Hint_inlined -> Hint_inlined
+      | Some Forward_inlined -> Forward_inlined
       | Some Always_inlined -> Always_inlined Expected_to_be_used
       | Some (Unroll n) -> Unroll (n, Expected_to_be_used)
       | Some Never_inlined -> Never_inlined

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -692,6 +692,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       match Apply_expr.inlined app with
       | Default_inlined -> Some Default_inlined
       | Hint_inlined -> Some Hint_inlined
+      | Forward_inlined -> Some Forward_inlined
       | Always_inlined _ -> Some Always_inlined
       | Unroll (n, _) -> Some (Unroll n)
       | Never_inlined -> Some Never_inlined

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -633,6 +633,7 @@ let inlined_attribute ~space ppf (i : Fexpr.inlined_attribute) =
     match i with
     | Always_inlined -> Some "inlined(always)"
     | Hint_inlined -> Some "inlined(hint)"
+    | Forward_inlined -> Some "inlined(forward)"
     | Never_inlined -> Some "inlined(never)"
     | Unroll i -> Some (Format.sprintf "unroll(%d)" i)
     | Default_inlined -> None

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -55,6 +55,7 @@ type t =
     inlined_debuginfo : Inlined_debuginfo.t;
     disable_inlining : Disable_inlining.t;
     disable_partial_application_stub_generation : bool;
+    forward_inlined : Inlined_attribute.t option;
     inlining_state : Inlining_state.t;
     propagating_float_consts : bool;
     at_unit_toplevel : bool;
@@ -106,7 +107,7 @@ type t =
 
 let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
                 inlined_debuginfo; disable_inlining;
-                disable_partial_application_stub_generation;
+                disable_partial_application_stub_generation; forward_inlined;
                 inlining_state; propagating_float_consts;
                 at_unit_toplevel; unit_toplevel_exn_continuation;
                 variables_defined_at_toplevel; cse; comparison_results;
@@ -124,6 +125,7 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
       @[<hov 1>(inlined_debuginfo@ %a)@]@ \
       @[<hov 1>(disable_inlining@ %a)@]@ \
       @[<hov 1>(disable_partial_application_stub_generation@ %b)@]@ \
+      %a\
       @[<hov 1>(inlining_state@ %a)@]@ \
       @[<hov 1>(propagating_float_consts@ %b)@]@ \
       @[<hov 1>(at_unit_toplevel@ %b)@]@ \
@@ -150,6 +152,10 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
     Inlined_debuginfo.print inlined_debuginfo
     Disable_inlining.print disable_inlining
     disable_partial_application_stub_generation
+    (Format.pp_print_option (fun ppf attribute ->
+      Format.fprintf ppf "@[<hov 1>(forward_inlined@ %a)@]@ "
+        Inlined_attribute.print attribute))
+    forward_inlined
     Inlining_state.print inlining_state
     propagating_float_consts
     at_unit_toplevel
@@ -233,6 +239,7 @@ let create ~round ~machine_width ~(resolver : resolver)
       inlined_debuginfo = Inlined_debuginfo.none;
       disable_inlining = Do_not_disable_inlining;
       disable_partial_application_stub_generation = false;
+      forward_inlined = None;
       inlining_state = Inlining_state.default ~round;
       propagating_float_consts;
       at_unit_toplevel = true;
@@ -285,6 +292,8 @@ let disable_inlining t = t.disable_inlining
 let disable_partial_application_stub_generation t =
   t.disable_partial_application_stub_generation
 
+let forward_inlined t = t.forward_inlined
+
 let propagating_float_consts t = t.propagating_float_consts
 
 let unit_toplevel_exn_continuation t = t.unit_toplevel_exn_continuation
@@ -335,6 +344,7 @@ let enter_set_of_closures
       inlined_debuginfo = _;
       disable_inlining;
       disable_partial_application_stub_generation;
+      forward_inlined = _;
       inlining_state;
       propagating_float_consts;
       at_unit_toplevel = _;
@@ -364,6 +374,7 @@ let enter_set_of_closures
     inlined_debuginfo = Inlined_debuginfo.none;
     disable_inlining;
     disable_partial_application_stub_generation;
+    forward_inlined = None;
     inlining_state;
     propagating_float_consts;
     at_unit_toplevel = false;
@@ -640,8 +651,18 @@ let set_inlining_arguments arguments t =
 let set_inlined_debuginfo t ~from =
   { t with inlined_debuginfo = from.inlined_debuginfo }
 
-let merge_inlined_debuginfo t ~from_apply_expr =
+let merge_inlined_debuginfo_and_forward_inlined_attribute t ~from_apply_expr
+    ~inlined_attribute =
+  let forward_inlined =
+    match (inlined_attribute : Inlined_attribute.t) with
+    | Forward_inlined -> t.forward_inlined
+    | ( Always_inlined _ | Hint_inlined | Never_inlined
+      | Unroll (_, _)
+      | Default_inlined ) as inlined ->
+      Some inlined
+  in
   { t with
+    forward_inlined;
     inlined_debuginfo =
       Inlined_debuginfo.merge t.inlined_debuginfo ~from_apply_expr
   }
@@ -683,8 +704,17 @@ let enter_inlined_apply ~called_code ~apply ~was_inline_always t =
     Inlined_debuginfo.create ~called_code_id:(Code.code_id called_code)
       ~apply_dbg:(Apply.dbg apply)
   in
+  let forward_inlined =
+    match Apply.inlined apply with
+    | Forward_inlined -> t.forward_inlined
+    | ( Always_inlined _ | Hint_inlined | Never_inlined
+      | Unroll (_, _)
+      | Default_inlined ) as inlined ->
+      Some inlined
+  in
   { t with
     inlined_debuginfo;
+    forward_inlined;
     inlining_state;
     inlining_history_tracker =
       Inlining_history.Tracker.enter_inlined_apply
@@ -801,6 +831,7 @@ let denv_for_lifted_continuation ~denv_for_join ~denv =
     disable_inlining = denv.disable_inlining;
     disable_partial_application_stub_generation =
       denv.disable_partial_application_stub_generation;
+    forward_inlined = denv.forward_inlined;
     inlining_state = denv.inlining_state;
     inlining_history_tracker = denv.inlining_history_tracker;
     (* denv_for_join *)

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -143,7 +143,11 @@ val find_code_exn : t -> Code_id.t -> Code_or_metadata.t
 
 val set_inlined_debuginfo : t -> from:t -> t
 
-val merge_inlined_debuginfo : t -> from_apply_expr:Inlined_debuginfo.t -> t
+val merge_inlined_debuginfo_and_forward_inlined_attribute :
+  t ->
+  from_apply_expr:Inlined_debuginfo.t ->
+  inlined_attribute:Inlined_attribute.t ->
+  t
 
 val add_inlined_debuginfo : t -> Debuginfo.t -> Debuginfo.t
 
@@ -190,6 +194,8 @@ end
 val disable_inlining : t -> Disable_inlining.t
 
 val disable_partial_application_stub_generation : t -> bool
+
+val forward_inlined : t -> Inlined_attribute.t option
 
 val enter_set_of_closures : t -> t
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -230,7 +230,8 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
         | Missing_code | Definition_says_not_to_inline | In_a_stub
         | Doing_speculative_inlining | Unrolling_depth_exceeded
         | Max_inlining_depth_exceeded | Recursion_depth_exceeded
-        | Never_inlined_attribute | Attribute_always
+        | Never_inlined_attribute
+        | Forward_inlined_attribute_but_nothing_to_forward | Attribute_always
         | Replay_history_says_must_inline _ | Begin_unrolling _
         | Continue_unrolling | Definition_says_inline _ | Jsir_inlining_disabled
           ->
@@ -293,6 +294,9 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
   | Never_inlined ->
     fail_if_must_inline ();
     Never_inlined_attribute
+  | Forward_inlined ->
+    fail_if_must_inline ();
+    Forward_inlined_attribute_but_nothing_to_forward
   | Default_inlined | Unroll _ | Always_inlined _ | Hint_inlined -> (
     match DE.find_code_exn (DA.denv dacc) (FT.code_id function_type) with
     | exception Not_found ->
@@ -351,7 +355,7 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
         else
           let policy =
             match inlined with
-            | Never_inlined -> assert false
+            | Never_inlined | Forward_inlined -> assert false
             | Default_inlined -> `Heuristic
             | Unroll (to_, _) -> `Unroll to_
             | Always_inlined _ | Hint_inlined -> (

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -224,6 +224,8 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
     match function_type with
     | None ->
       (* No rec info available, prevent inlining to avoid problems *)
+      if Flambda_features.debug_flambda2 ()
+      then Format.eprintf "no rec info :( @.";
       Do_not_inline { erase_attribute = false }
     | Some function_type -> (
       let decision =
@@ -447,7 +449,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       (Warnings.Inlining_impossible
          Inlining_helpers.(
            inlined_attribute_on_partial_application_msg Unrolled))
-  | Default_inlined | Hint_inlined -> ());
+  | Default_inlined | Hint_inlined | Forward_inlined -> ());
   let num_non_unarized_params = Flambda_arity.num_params param_arity in
   let num_non_unarized_args = Flambda_arity.num_params args_arity in
   assert (num_non_unarized_params > num_non_unarized_args);
@@ -952,7 +954,9 @@ let simplify_direct_function_call ~simplify_expr dacc apply
     ~call =
   (match Apply.probe apply, Apply.inlined apply with
   | None, _ | Some _, Never_inlined -> ()
-  | Some _, (Hint_inlined | Unroll _ | Default_inlined | Always_inlined _) ->
+  | ( Some _,
+      ( Hint_inlined | Forward_inlined | Unroll _ | Default_inlined
+      | Always_inlined _ ) ) ->
     Misc.fatal_errorf
       "[Apply] terms with a [probe] (i.e. that call a tracing probe) must \
        always be marked as [Never_inline]:@ %a"
@@ -1247,6 +1251,17 @@ let simplify_apply_shared dacc apply : _ simplify_apply_shared_result =
         ~from_env:(DE.get_inlining_state (DA.denv dacc))
         ~from_metadata:(Apply.inlining_state apply)
     in
+    let inlined =
+      let[@local] inlined_from_apply () = Apply.inlined apply in
+      match Apply.inlined apply with
+      | Never_inlined | Default_inlined | Unroll _ | Always_inlined _
+      | Hint_inlined ->
+        inlined_from_apply ()
+      | Forward_inlined -> (
+        match DE.forward_inlined (DA.denv dacc) with
+        | None -> inlined_from_apply ()
+        | Some inlined_from_env -> inlined_from_env)
+    in
     let apply =
       Apply.create ~callee:simplified_callee
         ~continuation:(Apply.continuation apply)
@@ -1255,8 +1270,8 @@ let simplify_apply_shared dacc apply : _ simplify_apply_shared_result =
         ~return_arity:(Apply.return_arity apply)
         ~call_kind:(Apply.call_kind apply) ~alloc_mode:(Apply.alloc_mode apply)
         (DE.add_inlined_debuginfo (DA.denv dacc) (Apply.dbg apply))
-        ~inlined:(Apply.inlined apply) ~inlining_state
-        ~probe:(Apply.probe apply) ~position:(Apply.position apply)
+        ~inlined ~inlining_state ~probe:(Apply.probe apply)
+        ~position:(Apply.position apply)
         ~relative_history:
           (Inlining_history.Relative.concat
              ~earlier:(DE.relative_history (DA.denv dacc))

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -638,11 +638,16 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
             List.map arg applied_unarized_args
             @ Bound_parameters.simples remaining_params
           in
+          let inlined : Inlined_attribute.t =
+            if !Clflags.stubs_forward_inlining
+            then Forward_inlined
+            else Default_inlined
+          in
           let full_application =
             Apply.create ~callee ~continuation:(Return return_continuation)
               exn_continuation ~args ~args_arity:param_arity
               ~return_arity:result_arity ~call_kind ~alloc_mode:my_alloc_mode
-              dbg ~inlined:Default_inlined
+              dbg ~inlined
               ~inlining_state:(Apply.inlining_state apply)
               ~position:Normal ~probe:None
               ~relative_history:Inlining_history.Relative.empty

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -37,10 +37,11 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
-  | Enter_inlined_apply { dbg } ->
+  | Enter_inlined_apply { dbg; inlined_attribute } ->
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->
-          DE.merge_inlined_debuginfo denv ~from_apply_expr:dbg)
+          DE.merge_inlined_debuginfo_and_forward_inlined_attribute denv
+            ~from_apply_expr:dbg ~inlined_attribute)
     in
     let machine_width = DE.machine_width (DA.denv dacc) in
     let named = Named.create_simple (Simple.const_unit machine_width) in

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -34,6 +34,7 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
+  | Forward_inlined_attribute_but_nothing_to_forward
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
@@ -71,6 +72,8 @@ let [@ocamlformat "disable"] rec print ppf t =
     Format.fprintf ppf "Recursion_depth_exceeded"
   | Never_inlined_attribute ->
     Format.fprintf ppf "Never_inlined_attribute"
+  | Forward_inlined_attribute_but_nothing_to_forward ->
+    Format.fprintf ppf "Forward_inlined_attribute_but_nothing_to_forward"
   | Attribute_always ->
     Format.fprintf ppf "Attribute_always"
   | Replay_history_says_must_inline t' ->
@@ -139,6 +142,8 @@ let rec can_inline (t : t) : can_inline =
     (* If there's an [@unrolled] attribute on this, then we'll ignore the
        attribute when we stop unrolling, which is fine *)
     Do_not_inline { erase_attribute_if_ignored = true }
+  | Forward_inlined_attribute_but_nothing_to_forward ->
+    Do_not_inline { erase_attribute_if_ignored = false }
   | Begin_unrolling unroll_to ->
     Inline { unroll_to = Some unroll_to; was_inline_always = false }
   | Continue_unrolling ->
@@ -186,6 +191,10 @@ let rec report_reason fmt t =
     Format.fprintf fmt "the@ maximum@ recursion@ depth@ has@ been@ exceeded"
   | Never_inlined_attribute ->
     Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
+  | Forward_inlined_attribute_but_nothing_to_forward ->
+    Format.pp_print_text fmt
+      "the call has an attribute requesting the same inlining decision as the \
+       parent function, which was not inlined"
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
   | Replay_history_says_must_inline t' ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -27,6 +27,7 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
+  | Forward_inlined_attribute_but_nothing_to_forward
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1083,7 +1083,10 @@ type nullary_primitive =
       { name : string;
         enabled_at_init : bool option
       }
-  | Enter_inlined_apply of { dbg : Inlined_debuginfo.t }
+  | Enter_inlined_apply of
+      { dbg : Inlined_debuginfo.t;
+        inlined_attribute : Inlined_attribute.t
+      }
   | Dls_get
   | Tls_get
   | Domain_index
@@ -1117,8 +1120,13 @@ let compare_nullary_primitive p1 p2 =
     if c <> 0
     then c
     else Option.compare Bool.compare enabled_at_init1 enabled_at_init2
-  | Enter_inlined_apply { dbg = dbg1 }, Enter_inlined_apply { dbg = dbg2 } ->
-    Inlined_debuginfo.compare dbg1 dbg2
+  | ( Enter_inlined_apply { dbg = dbg1; inlined_attribute = inlined_attribute1 },
+      Enter_inlined_apply { dbg = dbg2; inlined_attribute = inlined_attribute2 }
+    ) ->
+    let c = Inlined_debuginfo.compare dbg1 dbg2 in
+    if c <> 0
+    then c
+    else Inlined_attribute.compare inlined_attribute1 inlined_attribute2
   | Dls_get, Dls_get -> 0
   | Tls_get, Tls_get -> 0
   | Domain_index, Domain_index -> 0
@@ -1146,9 +1154,9 @@ let print_nullary_primitive ppf p =
       (match enabled_at_init with
       | None | Some false -> ""
       | Some true -> " enabled_at_init")
-  | Enter_inlined_apply { dbg } ->
-    Format.fprintf ppf "@[<hov 1>(Enter_inlined_apply@ %a)@]"
-      Inlined_debuginfo.print dbg
+  | Enter_inlined_apply { dbg; inlined_attribute } ->
+    Format.fprintf ppf "@[<hov 1>(Enter_inlined_apply@ %a@ %a)@]"
+      Inlined_debuginfo.print dbg Inlined_attribute.print inlined_attribute
   | Dls_get -> Format.pp_print_string ppf "Dls_get"
   | Tls_get -> Format.pp_print_string ppf "Tls_get"
   | Domain_index -> Format.pp_print_string ppf "Domain_index"

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -372,7 +372,10 @@ type nullary_primitive =
           Semaphore initialization code may be emitted as a consequence of
           seeing this instruction, but the emitter checks that all occurrences
           of [enabled_at_init] are consistent for a given probe [name]. *)
-  | Enter_inlined_apply of { dbg : Inlined_debuginfo.t }
+  | Enter_inlined_apply of
+      { dbg : Inlined_debuginfo.t;
+        inlined_attribute : Inlined_attribute.t
+      }
       (** Used in classic mode to denote the start of an inlined function body.
           This is then used in to_cmm to correctly add inlined debuginfo. *)
   | Dls_get  (** Obtain the domain-local state block. *)

--- a/middle_end/flambda2/terms/inlined_attribute.ml
+++ b/middle_end/flambda2/terms/inlined_attribute.ml
@@ -33,6 +33,15 @@ module Use_info = struct
         _ ) ->
       false
 
+  let compare t1 t2 =
+    let use_info_numbering = function
+      | Expected_to_be_used -> 0
+      | Unused_because_of_call_site_decision -> 1
+      | Unused_because_function_unknown -> 2
+      | Jsir_inlining_disabled -> 3
+    in
+    Int.compare (use_info_numbering t1) (use_info_numbering t2)
+
   let explanation t =
     match t with
     | Expected_to_be_used -> None
@@ -54,6 +63,7 @@ end
 type t =
   | Always_inlined of Use_info.t
   | Hint_inlined
+  | Forward_inlined
   | Never_inlined
   | Unroll of int * Use_info.t
   | Default_inlined
@@ -63,6 +73,7 @@ let print ppf t =
   match t with
   | Always_inlined _ -> fprintf ppf "Always_inlined"
   | Hint_inlined -> fprintf ppf "Hint_inlined"
+  | Forward_inlined -> fprintf ppf "Forward_inlined"
   | Never_inlined -> fprintf ppf "Never_inlined"
   | Unroll (n, _) -> fprintf ppf "@[(Unroll %d)@]" n
   | Default_inlined -> fprintf ppf "Default_inlined"
@@ -73,25 +84,56 @@ let equal t1 t2 =
     Use_info.equal use_info1 use_info2
   | Hint_inlined, Hint_inlined
   | Never_inlined, Never_inlined
+  | Forward_inlined, Forward_inlined
   | Default_inlined, Default_inlined ->
     true
   | Unroll (n1, use_info1), Unroll (n2, use_info2) ->
     n1 = n2 && Use_info.equal use_info1 use_info2
-  | ( ( Always_inlined _ | Hint_inlined | Never_inlined | Unroll _
-      | Default_inlined ),
+  | ( ( Always_inlined _ | Hint_inlined | Forward_inlined | Never_inlined
+      | Unroll _ | Default_inlined ),
       _ ) ->
     false
+
+let compare t1 t2 =
+  let inlined_attribute_numbering = function
+    | Always_inlined _ -> 0
+    | Hint_inlined -> 1
+    | Forward_inlined -> 2
+    | Never_inlined -> 3
+    | Unroll _ -> 4
+    | Default_inlined -> 5
+  in
+  match t1, t2 with
+  | Always_inlined use_info1, Always_inlined use_info2 ->
+    Use_info.compare use_info1 use_info2
+  | Hint_inlined, Hint_inlined
+  | Never_inlined, Never_inlined
+  | Forward_inlined, Forward_inlined
+  | Default_inlined, Default_inlined ->
+    0
+  | Unroll (n1, use_info1), Unroll (n2, use_info2) ->
+    let c = Int.compare n1 n2 in
+    if c <> 0 then c else Use_info.compare use_info1 use_info2
+  | ( ( Always_inlined _ | Hint_inlined | Forward_inlined | Never_inlined
+      | Unroll _ | Default_inlined ),
+      _ ) ->
+    Int.compare
+      (inlined_attribute_numbering t1)
+      (inlined_attribute_numbering t2)
 
 let is_default t =
   match t with
   | Default_inlined -> true
-  | Always_inlined _ | Hint_inlined | Never_inlined | Unroll _ -> false
+  | Always_inlined _ | Hint_inlined | Forward_inlined | Never_inlined | Unroll _
+    ->
+    false
 
 let from_lambda (attr : Lambda.inlined_attribute) =
   match attr with
   | Always_inlined -> Always_inlined Expected_to_be_used
   | Never_inlined -> Never_inlined
   | Hint_inlined -> Hint_inlined
+  | Forward_inlined -> Forward_inlined
   | Unroll i -> Unroll (i, Expected_to_be_used)
   | Default_inlined -> Default_inlined
 
@@ -99,9 +141,9 @@ let with_use_info t use_info =
   match t with
   | Always_inlined _ -> Always_inlined use_info
   | Unroll (n, _) -> Unroll (n, use_info)
-  | Never_inlined | Hint_inlined | Default_inlined -> t
+  | Never_inlined | Hint_inlined | Forward_inlined | Default_inlined -> t
 
 let use_info t =
   match t with
   | Always_inlined use_info | Unroll (_, use_info) -> Some use_info
-  | Never_inlined | Hint_inlined | Default_inlined -> None
+  | Never_inlined | Hint_inlined | Forward_inlined | Default_inlined -> None

--- a/middle_end/flambda2/terms/inlined_attribute.mli
+++ b/middle_end/flambda2/terms/inlined_attribute.mli
@@ -29,6 +29,7 @@ end
 type t =
   | Always_inlined of Use_info.t
   | Hint_inlined
+  | Forward_inlined
   | Never_inlined
   | Unroll of int * Use_info.t
   | Default_inlined
@@ -36,6 +37,8 @@ type t =
 val print : Format.formatter -> t -> unit
 
 val equal : t -> t -> bool
+
+val compare : t -> t -> int
 
 val is_default : t -> bool
 

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -778,7 +778,9 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     when (not (Flambda_features.stack_allocation_enabled ()))
          && Flambda_primitive.is_begin_or_end_region p ->
     expr env res body
-  | Singleton _, Prim (Nullary (Enter_inlined_apply { dbg }), _) ->
+  | ( Singleton _,
+      Prim (Nullary (Enter_inlined_apply { dbg; inlined_attribute = _ }), _) )
+    ->
     let env = Env.enter_inlined_apply env dbg in
     expr env res body
   | Singleton v, Prim ((Unary (End_region _, _) as p), dbg) ->

--- a/testsuite/tests/flambda2/simplify/forward_inlined_always_inline.ml
+++ b/testsuite/tests/flambda2/simplify/forward_inlined_always_inline.ml
@@ -1,0 +1,39 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt.byte with dump-raw, dump-simplify;
+   check-fexpr-dump;
+ *)
+
+let[@inline always] f x =
+  x
+
+let[@inline always] g x =
+  (* Expected behaviour: [f] is not inlined.
+
+     In the code of [g] itself, [f] should not be inlined (because there is no
+     inlining of [g] to forward). *)
+  (f [@inlined forward]) x
+
+let call_g_with_default_inlined x =
+  (* Expected behaviour: [g] and [f] are inlined.
+
+     [g] should be inlined due to its [@inline always] attribute, and the call
+     to [f] within [g] should use the default inlining logic, which is to
+     inline due to the [@inline always] attribute on [f]. *)
+  g x
+
+let call_g_with_always_inlined x =
+  (* Expected behaviour: [g] and [f] are inlined.
+
+     [g] should be inlined due to its [@inline always] attribute, and the
+     [@inlined always] annotation propagated to the call to [f] within [g],
+     which should inline [f]. *)
+  (g [@inlined always]) x
+
+let call_g_with_never_inlined x =
+  (* Expected behaviour: [g] is not inlined.
+
+     The [@inlined never] attribute applies to [g]. *)
+  (g [@inlined never]) x

--- a/testsuite/tests/flambda2/simplify/forward_inlined_always_inline.raw.reference
+++ b/testsuite/tests/flambda2/simplify/forward_inlined_always_inline.raw.reference
@@ -1,0 +1,76 @@
+let $camlForward_inlined_always_inline__first_const = Block 0 () in
+(let code inline(always) size(1)
+       f_0 (x) my_closure &my_alloc_region my_depth -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (x)
+ in
+ let code inline(always) size(5)
+       g_1 (x) my_closure &my_alloc_region my_depth -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let f = %project_value_slot.[g].[f] (my_closure) in
+   apply direct(f_0 &my_alloc_region) inlined(forward) f (x) -> k1 * k2
+ in
+ let code size(5)
+       call_g_with_default_inlined_2 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let g = %project_value_slot.[call_g_with_default_inlined].[g] (my_closure)
+   in
+   apply direct(g_1 &my_alloc_region) g (x) -> k1 * k2
+ in
+ let code size(5)
+       call_g_with_always_inlined_3 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let g =
+     %project_value_slot.[call_g_with_always_inlined].[g_1] (my_closure)
+   in
+   apply direct(g_1 &my_alloc_region) inlined(always) g (x) -> k1 * k2
+ in
+ let code size(5)
+       call_g_with_never_inlined_4 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let g = %project_value_slot.[call_g_with_never_inlined].[g_2] (my_closure)
+   in
+   apply direct(g_1 &my_alloc_region) inlined(never) g (x) -> k1 * k2
+ in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let g = closure g_1 @g &toplevel.alloc_region with { f = f } in
+ let call_g_with_default_inlined =
+   closure call_g_with_default_inlined_2 @call_g_with_default_inlined
+     &toplevel.alloc_region
+ with { g = g }
+ in
+ let call_g_with_always_inlined =
+   closure call_g_with_always_inlined_3 @call_g_with_always_inlined
+     &toplevel.alloc_region
+ with { g_1 = g }
+ in
+ let call_g_with_never_inlined =
+   closure call_g_with_never_inlined_4 @call_g_with_never_inlined
+     &toplevel.alloc_region
+ with { g_2 = g }
+ in
+ let Pmakeblock =
+   %block.[`0`].`toplevel`
+     (f,
+      g,
+      call_g_with_default_inlined,
+      call_g_with_always_inlined,
+      call_g_with_never_inlined)
+ in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`5`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`5`].[`2`] (module_block) in
+    let field_3 = %block_load.tag[`0`].`size`[`5`].[`3`] (module_block) in
+    let field_4 = %block_load.tag[`0`].`size`[`5`].[`4`] (module_block) in
+    let $camlForward_inlined_always_inline =
+      Block 0 (field_0, field_1, field_2, field_3, field_4)
+    in
+    cont done ($camlForward_inlined_always_inline)

--- a/testsuite/tests/flambda2/simplify/forward_inlined_always_inline.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/forward_inlined_always_inline.simplify.reference
@@ -1,0 +1,59 @@
+let code f_0 deleted in
+let code g_1 deleted in
+let code call_g_with_default_inlined_2 deleted in
+let code call_g_with_always_inlined_3 deleted in
+let code call_g_with_never_inlined_4 deleted in
+let code inline(always) loopify(never) size(1) newer_version_of(f_0)
+      f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k (x)
+in
+let $camlForward_inlined_always_inline__f_5 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let code inline(always) loopify(never) size(4) newer_version_of(g_1)
+      g_1_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
+  apply direct(f_0_1 &my_alloc_region) inlined(forward)
+    $camlForward_inlined_always_inline__f_5 (x) -> k * k1
+in
+let $camlForward_inlined_always_inline__g_6 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
+let code loopify(never) size(1) newer_version_of(call_g_with_default_inlined_2)
+      call_g_with_default_inlined_2_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1 =
+  cont k (x)
+in
+let $camlForward_inlined_always_inline__call_g_with_default_inlined_7 =
+  closure call_g_with_default_inlined_2_1 @call_g_with_default_inlined
+    &toplevel.alloc_region
+in
+let code loopify(never) size(1) newer_version_of(call_g_with_always_inlined_3)
+      call_g_with_always_inlined_3_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1 =
+  cont k (x)
+in
+let $camlForward_inlined_always_inline__call_g_with_always_inlined_8 =
+  closure call_g_with_always_inlined_3_1 @call_g_with_always_inlined
+    &toplevel.alloc_region
+in
+let code loopify(never) size(4) newer_version_of(call_g_with_never_inlined_4)
+      call_g_with_never_inlined_4_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1 =
+  apply direct(g_1_1 &my_alloc_region) inlined(never)
+    $camlForward_inlined_always_inline__g_6 (x) -> k * k1
+in
+let $camlForward_inlined_always_inline__call_g_with_never_inlined_9 =
+  closure call_g_with_never_inlined_4_1 @call_g_with_never_inlined
+    &toplevel.alloc_region
+in
+let $camlForward_inlined_always_inline =
+  Block 0 ($camlForward_inlined_always_inline__f_5,
+           $camlForward_inlined_always_inline__g_6,
+           $camlForward_inlined_always_inline__call_g_with_default_inlined_7,
+           $camlForward_inlined_always_inline__call_g_with_always_inlined_8,
+           $camlForward_inlined_always_inline__call_g_with_never_inlined_9)
+in
+cont done ($camlForward_inlined_always_inline)

--- a/testsuite/tests/flambda2/simplify/forward_inlined_never_inline.ml
+++ b/testsuite/tests/flambda2/simplify/forward_inlined_never_inline.ml
@@ -1,0 +1,39 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt.byte with dump-raw, dump-simplify;
+   check-fexpr-dump;
+ *)
+
+let[@inline never] f x =
+  x
+
+let[@inline always] g x =
+  (* Expected behaviour: [f] is not inlined.
+
+     In the code of [g] itself, [f] should not be inlined (because there is no
+     inlining of [g] to forward). *)
+  (f [@inlined forward]) x
+
+let call_g_with_default_inlined x =
+  (* Expected behaviour: [g] is inlined, [f] is not inlined. 
+     
+     [g] should be inlined due to its [@inline always] attribute, but the call
+     to [f] within [g] uses the default inlining logic, which is to prevent
+     inlining due to the [@inline never] attribute on [f]. *)
+  g x
+
+let call_g_with_always_inlined x =
+  (* Expected behaviour: [g] and [f] are inlined.
+
+     [g] should be inlined due to its [@inline always] attribute, and the
+     [@inlined always] annotation propagated to the call to [f] within [g],
+     which should inline [f]. *)
+  (g [@inlined always]) x
+
+let call_g_with_never_inlined x =
+  (* Expected behaviour: [g] is not inlined.
+
+     The [@inlined never] attribute applies to [g]. *)
+  (g [@inlined never]) x

--- a/testsuite/tests/flambda2/simplify/forward_inlined_never_inline.raw.reference
+++ b/testsuite/tests/flambda2/simplify/forward_inlined_never_inline.raw.reference
@@ -1,0 +1,76 @@
+let $camlForward_inlined_never_inline__first_const = Block 0 () in
+(let code inline(never) size(1)
+       f_0 (x) my_closure &my_alloc_region my_depth -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (x)
+ in
+ let code inline(always) size(5)
+       g_1 (x) my_closure &my_alloc_region my_depth -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let f = %project_value_slot.[g].[f] (my_closure) in
+   apply direct(f_0 &my_alloc_region) inlined(forward) f (x) -> k1 * k2
+ in
+ let code size(5)
+       call_g_with_default_inlined_2 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let g = %project_value_slot.[call_g_with_default_inlined].[g] (my_closure)
+   in
+   apply direct(g_1 &my_alloc_region) g (x) -> k1 * k2
+ in
+ let code size(5)
+       call_g_with_always_inlined_3 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let g =
+     %project_value_slot.[call_g_with_always_inlined].[g_1] (my_closure)
+   in
+   apply direct(g_1 &my_alloc_region) inlined(always) g (x) -> k1 * k2
+ in
+ let code size(5)
+       call_g_with_never_inlined_4 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2 =
+   let next_depth = rec_info (succ my_depth) in
+   let g = %project_value_slot.[call_g_with_never_inlined].[g_2] (my_closure)
+   in
+   apply direct(g_1 &my_alloc_region) inlined(never) g (x) -> k1 * k2
+ in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let g = closure g_1 @g &toplevel.alloc_region with { f = f } in
+ let call_g_with_default_inlined =
+   closure call_g_with_default_inlined_2 @call_g_with_default_inlined
+     &toplevel.alloc_region
+ with { g = g }
+ in
+ let call_g_with_always_inlined =
+   closure call_g_with_always_inlined_3 @call_g_with_always_inlined
+     &toplevel.alloc_region
+ with { g_1 = g }
+ in
+ let call_g_with_never_inlined =
+   closure call_g_with_never_inlined_4 @call_g_with_never_inlined
+     &toplevel.alloc_region
+ with { g_2 = g }
+ in
+ let Pmakeblock =
+   %block.[`0`].`toplevel`
+     (f,
+      g,
+      call_g_with_default_inlined,
+      call_g_with_always_inlined,
+      call_g_with_never_inlined)
+ in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`5`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`5`].[`2`] (module_block) in
+    let field_3 = %block_load.tag[`0`].`size`[`5`].[`3`] (module_block) in
+    let field_4 = %block_load.tag[`0`].`size`[`5`].[`4`] (module_block) in
+    let $camlForward_inlined_never_inline =
+      Block 0 (field_0, field_1, field_2, field_3, field_4)
+    in
+    cont done ($camlForward_inlined_never_inline)

--- a/testsuite/tests/flambda2/simplify/forward_inlined_never_inline.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/forward_inlined_never_inline.simplify.reference
@@ -1,0 +1,60 @@
+let code f_0 deleted in
+let code g_1 deleted in
+let code call_g_with_default_inlined_2 deleted in
+let code call_g_with_always_inlined_3 deleted in
+let code call_g_with_never_inlined_4 deleted in
+let code inline(never) loopify(never) size(1) newer_version_of(f_0)
+      f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k (x)
+in
+let $camlForward_inlined_never_inline__f_5 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let code inline(always) loopify(never) size(4) newer_version_of(g_1)
+      g_1_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
+  apply direct(f_0_1 &my_alloc_region) inlined(forward)
+    $camlForward_inlined_never_inline__f_5 (x) -> k * k1
+in
+let $camlForward_inlined_never_inline__g_6 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
+let code loopify(never) size(4) newer_version_of(call_g_with_default_inlined_2)
+      call_g_with_default_inlined_2_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1 =
+  apply direct(f_0_1 &my_alloc_region) inlining_state(depth(1))
+    $camlForward_inlined_never_inline__f_5 (x) -> k * k1
+in
+let $camlForward_inlined_never_inline__call_g_with_default_inlined_7 =
+  closure call_g_with_default_inlined_2_1 @call_g_with_default_inlined
+    &toplevel.alloc_region
+in
+let code loopify(never) size(1) newer_version_of(call_g_with_always_inlined_3)
+      call_g_with_always_inlined_3_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1 =
+  cont k (x)
+in
+let $camlForward_inlined_never_inline__call_g_with_always_inlined_8 =
+  closure call_g_with_always_inlined_3_1 @call_g_with_always_inlined
+    &toplevel.alloc_region
+in
+let code loopify(never) size(4) newer_version_of(call_g_with_never_inlined_4)
+      call_g_with_never_inlined_4_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1 =
+  apply direct(g_1_1 &my_alloc_region) inlined(never)
+    $camlForward_inlined_never_inline__g_6 (x) -> k * k1
+in
+let $camlForward_inlined_never_inline__call_g_with_never_inlined_9 =
+  closure call_g_with_never_inlined_4_1 @call_g_with_never_inlined
+    &toplevel.alloc_region
+in
+let $camlForward_inlined_never_inline =
+  Block 0 ($camlForward_inlined_never_inline__f_5,
+           $camlForward_inlined_never_inline__g_6,
+           $camlForward_inlined_never_inline__call_g_with_default_inlined_7,
+           $camlForward_inlined_never_inline__call_g_with_always_inlined_8,
+           $camlForward_inlined_never_inline__call_g_with_never_inlined_9)
+in
+cont done ($camlForward_inlined_never_inline)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_erased_optional_application.ml
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_erased_optional_application.ml
@@ -1,0 +1,35 @@
+(* TEST
+   flambda;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0 -flambda2-inline-threshold -100";
+   { ocamlopt_flags += " -stubs-forward-inlining";
+     fexpr_reference_suffix = "stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+   { ocamlopt_flags += " -no-stubs-forward-inlining";
+     fexpr_reference_suffix = "no-stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+ *)
+
+let default x = x
+
+let f ?(x = default 0) y z = x + y + z
+
+(* [g] is a partial application stub:
+
+   ```
+   let[@stub] g z = f ?x:None 0 z
+   ```
+ *)
+let g = f 0
+
+(* The [@inlined] attribute gets placed on the partial application stub.
+
+   When stubs forward inlining, the call to [f] inside the stub is marked with
+   [@inlined forward], ensuring that the user-provided attribute gets forwarded
+   to [f].
+
+   Note that the call to [default] in the optional default argument of [f]
+   should *NOT* be inlined. *)
+let h = (g [@inlined]) 0

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_erased_optional_application.simplify.no-stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_erased_optional_application.simplify.no-stubs-forward-inlining.reference
@@ -1,0 +1,85 @@
+let code default_0 deleted in
+let code f_inner_2 deleted in
+let code loopify(never) size(27) stub
+      f_1 (`*opt*x` : [ 0 | 0 of val ], y : imm tagged, z : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `default` = %project_value_slot.[f].[`default`] (my_closure) in
+  let f_inner = %project_value_slot.[f].[f_inner] (my_closure) in
+  (let prim = %is_int (`*opt*x`) in
+   switch prim
+     | 0 -> k3
+     | 1 -> k4
+     where k4 =
+       apply &my_alloc_region
+         (`default` : imm tagged -> imm tagged) (0) -> k2 * k1
+     where k3 =
+       let Pfield = %block_load.[`0`] (`*opt*x`) in
+       cont k2 (Pfield))
+    where k2 (x : imm tagged) =
+      apply &my_alloc_region
+        (f_inner : imm tagged * imm tagged * imm tagged -> imm tagged)
+          (x, y, z)
+          -> k * k1
+in
+let code loopify(never) size(5) stub
+      partial_f_3 (param2 : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let f = %project_value_slot.[partial_f].[f] (my_closure) in
+  apply direct(f_1 &my_alloc_region)
+    (f : _ -> imm tagged) (0, 0, param2) -> k * k1
+in
+let code loopify(never) size(1) newer_version_of(default_0)
+      default_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k (x)
+in
+let $camlInlined_attribute_on_erased_optional_application__default_4 =
+  closure default_0_1 @`default` &toplevel.alloc_region
+in
+let code loopify(never) size(5) newer_version_of(f_inner_2)
+      f_inner_2_1 (x, y : imm tagged, z : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  let int_add_1 = %int_barith.add (int_add, z) in
+  cont k (int_add_1)
+in
+let $camlInlined_attribute_on_erased_optional_application__f_inner_5 =
+  closure f_inner_2_1 @f_inner &toplevel.alloc_region
+in
+let $camlInlined_attribute_on_erased_optional_application__f_6 =
+  closure f_1 @f &toplevel.alloc_region
+  with {
+    `default` =
+      $camlInlined_attribute_on_erased_optional_application__default_4;
+    f_inner =
+      $camlInlined_attribute_on_erased_optional_application__f_inner_5
+  }
+in
+let $camlInlined_attribute_on_erased_optional_application__partial_f_7 =
+  closure partial_f_3 @partial_f &toplevel.alloc_region
+  with { f = $camlInlined_attribute_on_erased_optional_application__f_6 }
+in
+apply direct(default_0_1 &toplevel.alloc_region)
+  ($camlInlined_attribute_on_erased_optional_application__default_4
+   : _ -> imm tagged)
+    (0)
+    -> k1 * error
+  where k1 (x : imm tagged) =
+    apply direct(f_inner_2_1 &toplevel.alloc_region)
+      ($camlInlined_attribute_on_erased_optional_application__f_inner_5
+       : _ -> imm tagged)
+        (x, 0, 0)
+        -> k * error
+  where k (h : imm tagged) =
+    let $camlInlined_attribute_on_erased_optional_application =
+      Block 0 ($camlInlined_attribute_on_erased_optional_application__default_4,
+               $camlInlined_attribute_on_erased_optional_application__f_6,
+               $camlInlined_attribute_on_erased_optional_application__partial_f_7,
+               h)
+    in
+    cont done ($camlInlined_attribute_on_erased_optional_application)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_erased_optional_application.simplify.stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_erased_optional_application.simplify.stubs-forward-inlining.reference
@@ -1,0 +1,79 @@
+let code default_0 deleted in
+let code f_inner_2 deleted in
+let code loopify(never) size(27) stub
+      f_1 (`*opt*x` : [ 0 | 0 of val ], y : imm tagged, z : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `default` = %project_value_slot.[f].[`default`] (my_closure) in
+  let f_inner = %project_value_slot.[f].[f_inner] (my_closure) in
+  (let prim = %is_int (`*opt*x`) in
+   switch prim
+     | 0 -> k3
+     | 1 -> k4
+     where k4 =
+       apply &my_alloc_region
+         (`default` : imm tagged -> imm tagged) (0) -> k2 * k1
+     where k3 =
+       let Pfield = %block_load.[`0`] (`*opt*x`) in
+       cont k2 (Pfield))
+    where k2 (x : imm tagged) =
+      apply &my_alloc_region inlined(forward)
+        (f_inner : imm tagged * imm tagged * imm tagged -> imm tagged)
+          (x, y, z)
+          -> k * k1
+in
+let code loopify(never) size(5) stub
+      partial_f_3 (param2 : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let f = %project_value_slot.[partial_f].[f] (my_closure) in
+  apply direct(f_1 &my_alloc_region) inlined(forward)
+    (f : _ -> imm tagged) (0, 0, param2) -> k * k1
+in
+let code loopify(never) size(1) newer_version_of(default_0)
+      default_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k (x)
+in
+let $camlInlined_attribute_on_erased_optional_application__default_4 =
+  closure default_0_1 @`default` &toplevel.alloc_region
+in
+let code loopify(never) size(5) newer_version_of(f_inner_2)
+      f_inner_2_1 (x, y : imm tagged, z : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  let int_add_1 = %int_barith.add (int_add, z) in
+  cont k (int_add_1)
+in
+let $camlInlined_attribute_on_erased_optional_application__f_inner_5 =
+  closure f_inner_2_1 @f_inner &toplevel.alloc_region
+in
+let $camlInlined_attribute_on_erased_optional_application__f_6 =
+  closure f_1 @f &toplevel.alloc_region
+  with {
+    `default` =
+      $camlInlined_attribute_on_erased_optional_application__default_4;
+    f_inner =
+      $camlInlined_attribute_on_erased_optional_application__f_inner_5
+  }
+in
+let $camlInlined_attribute_on_erased_optional_application__partial_f_7 =
+  closure partial_f_3 @partial_f &toplevel.alloc_region
+  with { f = $camlInlined_attribute_on_erased_optional_application__f_6 }
+in
+apply direct(default_0_1 &toplevel.alloc_region)
+  ($camlInlined_attribute_on_erased_optional_application__default_4
+   : _ -> imm tagged)
+    (0)
+    -> k * error
+  where k (x : imm tagged) =
+    let $camlInlined_attribute_on_erased_optional_application =
+      Block 0 ($camlInlined_attribute_on_erased_optional_application__default_4,
+               $camlInlined_attribute_on_erased_optional_application__f_6,
+               $camlInlined_attribute_on_erased_optional_application__partial_f_7,
+               x)
+    in
+    cont done ($camlInlined_attribute_on_erased_optional_application)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_functors.ml
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_functors.ml
@@ -1,0 +1,35 @@
+(* TEST
+   flambda;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt_flags += " -flambda2-inline-small-functor-size 0 -flambda2-inline-threshold -100 -no-flambda2-result-types";
+   { ocamlopt_flags += " -stubs-forward-inlining";
+     fexpr_reference_suffix = "stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+   { ocamlopt_flags += " -no-stubs-forward-inlining";
+     fexpr_reference_suffix = "no-stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+ *)
+
+module type S = sig val x : int end
+
+module F : sig
+  module Make (X : S) : S
+end = struct
+  (* No signature here to force a coercion to the signature of [F].
+
+     [F.Make] will be a stub that calls [Make] and rearranges the result into a
+     block with a single field. *)
+  module Make(X : S) = struct
+    let _dummy = ()
+    let x = X.x
+  end
+end
+
+(* The [@inlined] attribute gets placed on the coercion stub. 
+
+   When stubs forward inlining, the call to [Make] inside the stub is marked
+   with [@inlined forward], ensuring that the user-provided attribute gets
+   forwarded to [Make]. *)
+module M = (F.Make [@inlined])(struct let x = 0 end)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_functors.simplify.no-stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_functors.simplify.no-stubs-forward-inlining.reference
@@ -1,0 +1,47 @@
+let code Make_0 deleted in
+let code loopify(never) size(15) stub
+      `fn[inlined_attribute_on_functors.ml:19,6--272]_1` (funarg : val)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : val =
+  let Make =
+    %project_value_slot.[`fn[inlined_attribute_on_functors.ml:19,6--272]`].[Make]
+      (my_closure)
+  in
+  apply &my_alloc_region (Make : val -> val) (funarg) -> k2 * k1
+    where k2 (`let` : val) =
+      let Pfield = %block_load.[`1`] (`let`) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (Pfield) in
+      cont k (Pmakeblock)
+in
+let $camlInlined_attribute_on_functors__Pmakeblock29 = Block 0 (0) in
+let code loopify(never) size(9) newer_version_of(Make_0)
+      Make_0_1 (X : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
+  let x = %block_load.[`0`] (X) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (0, x) in
+  cont k (Pmakeblock)
+in
+let $camlInlined_attribute_on_functors__Make_2 =
+  closure Make_0_1 @Make &toplevel.alloc_region
+in
+let $`camlInlined_attribute_on_functors__fn[inlined_attribute_on_functors.ml:19,6--272]_3` =
+  closure `fn[inlined_attribute_on_functors.ml:19,6--272]_1`
+    @`fn[inlined_attribute_on_functors.ml:19,6--272]` &toplevel.alloc_region
+  with { Make = $camlInlined_attribute_on_functors__Make_2 }
+in
+let $camlInlined_attribute_on_functors__Pmakeblock56 =
+  Block 0 ($`camlInlined_attribute_on_functors__fn[inlined_attribute_on_functors.ml:19,6--272]_3`)
+in
+apply direct(Make_0_1 &toplevel.alloc_region)
+  ($camlInlined_attribute_on_functors__Make_2 : _ -> val)
+    ($camlInlined_attribute_on_functors__Pmakeblock29)
+    -> k * error
+  where k (`let` : val) =
+    let Pfield = %block_load.[`1`] (`let`) in
+    let $camlInlined_attribute_on_functors__Pmakeblock78 = Block 0 (Pfield)
+    in
+    let $camlInlined_attribute_on_functors =
+      Block 0 ($camlInlined_attribute_on_functors__Pmakeblock56,
+               $camlInlined_attribute_on_functors__Pmakeblock78)
+    in
+    cont done ($camlInlined_attribute_on_functors)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_functors.simplify.stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_functors.simplify.stubs-forward-inlining.reference
@@ -1,0 +1,40 @@
+let code Make_0 deleted in
+let code loopify(never) size(15) stub
+      `fn[inlined_attribute_on_functors.ml:19,6--272]_1` (funarg : val)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : val =
+  let Make =
+    %project_value_slot.[`fn[inlined_attribute_on_functors.ml:19,6--272]`].[Make]
+      (my_closure)
+  in
+  apply &my_alloc_region inlined(forward)
+    (Make : val -> val) (funarg) -> k2 * k1
+    where k2 (`let` : val) =
+      let Pfield = %block_load.[`1`] (`let`) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (Pfield) in
+      cont k (Pmakeblock)
+in
+let code loopify(never) size(9) newer_version_of(Make_0)
+      Make_0_1 (X : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
+  let x = %block_load.[`0`] (X) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (0, x) in
+  cont k (Pmakeblock)
+in
+let $camlInlined_attribute_on_functors__Make_2 =
+  closure Make_0_1 @Make &toplevel.alloc_region
+in
+let $`camlInlined_attribute_on_functors__fn[inlined_attribute_on_functors.ml:19,6--272]_3` =
+  closure `fn[inlined_attribute_on_functors.ml:19,6--272]_1`
+    @`fn[inlined_attribute_on_functors.ml:19,6--272]` &toplevel.alloc_region
+  with { Make = $camlInlined_attribute_on_functors__Make_2 }
+in
+let $camlInlined_attribute_on_functors__Pmakeblock56 =
+  Block 0 ($`camlInlined_attribute_on_functors__fn[inlined_attribute_on_functors.ml:19,6--272]_3`)
+in
+let $camlInlined_attribute_on_functors__Pmakeblock78 = Block 0 (0) in
+let $camlInlined_attribute_on_functors =
+  Block 0 ($camlInlined_attribute_on_functors__Pmakeblock56,
+           $camlInlined_attribute_on_functors__Pmakeblock78)
+in
+cont done ($camlInlined_attribute_on_functors)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_out_of_order_partial_application.ml
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_out_of_order_partial_application.ml
@@ -1,0 +1,31 @@
+(* TEST
+   flambda;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0 -flambda2-inline-threshold -100";
+   { ocamlopt_flags += " -stubs-forward-inlining";
+     fexpr_reference_suffix = "stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+   { ocamlopt_flags += " -no-stubs-forward-inlining";
+     fexpr_reference_suffix = "no-stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+ *)
+
+let f x ~y = x + y
+
+(* [g] is a partial application stub:
+
+   ```
+   let[@stub] g x = f x ~y:0
+   ```
+ *)
+let g = f ~y:0
+
+(* The [@inlined] attribute gets placed on the partial application stub.
+
+   When stubs forward inlining, the call to [f] inside the stub is marked with
+   [@inlined forward], ensuring that the user-provided attribute gets forwarded
+   to [f]. *)
+let h = (g [@inlined]) 0
+

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_out_of_order_partial_application.simplify.no-stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_out_of_order_partial_application.simplify.no-stubs-forward-inlining.reference
@@ -1,0 +1,34 @@
+let code f_0 deleted in
+let code loopify(never) size(7) stub
+      g_1 (param) my_closure &my_alloc_region my_depth -> k * k1 =
+  let f = %project_value_slot.[g].[f] (my_closure) in
+  apply &my_alloc_region (f : val * imm tagged -> val) (param, 0) -> k * k1
+in
+let code loopify(never) size(3) newer_version_of(f_0)
+      f_0_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let $camlInlined_attribute_on_out_of_order_partial_application__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlInlined_attribute_on_out_of_order_partial_application__g_3 =
+  closure g_1 @g &toplevel.alloc_region
+  with {
+    f = $camlInlined_attribute_on_out_of_order_partial_application__f_2
+  }
+in
+apply direct(f_0_1 &toplevel.alloc_region)
+  $camlInlined_attribute_on_out_of_order_partial_application__f_2
+    (0, 0)
+    -> k * error
+  where k (h : imm tagged) =
+    let $camlInlined_attribute_on_out_of_order_partial_application =
+      Block 0 ($camlInlined_attribute_on_out_of_order_partial_application__f_2,
+               $camlInlined_attribute_on_out_of_order_partial_application__g_3,
+               h)
+    in
+    cont done ($camlInlined_attribute_on_out_of_order_partial_application)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_out_of_order_partial_application.simplify.stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_out_of_order_partial_application.simplify.stubs-forward-inlining.reference
@@ -1,0 +1,30 @@
+let code f_0 deleted in
+let code loopify(never) size(7) stub
+      g_1 (param) my_closure &my_alloc_region my_depth -> k * k1 =
+  let f = %project_value_slot.[g].[f] (my_closure) in
+  apply &my_alloc_region inlined(forward)
+    (f : val * imm tagged -> val) (param, 0) -> k * k1
+in
+let code loopify(never) size(3) newer_version_of(f_0)
+      f_0_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let $camlInlined_attribute_on_out_of_order_partial_application__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlInlined_attribute_on_out_of_order_partial_application__g_3 =
+  closure g_1 @g &toplevel.alloc_region
+  with {
+    f = $camlInlined_attribute_on_out_of_order_partial_application__f_2
+  }
+in
+let $camlInlined_attribute_on_out_of_order_partial_application =
+  Block 0 ($camlInlined_attribute_on_out_of_order_partial_application__f_2,
+           $camlInlined_attribute_on_out_of_order_partial_application__g_3,
+           0)
+in
+cont done ($camlInlined_attribute_on_out_of_order_partial_application)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_partial_application.ml
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_partial_application.ml
@@ -1,0 +1,30 @@
+(* TEST
+   flambda;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0 -flambda2-inline-threshold -100";
+   { ocamlopt_flags += " -stubs-forward-inlining";
+     fexpr_reference_suffix = "stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+   { ocamlopt_flags += " -no-stubs-forward-inlining";
+     fexpr_reference_suffix = "no-stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+ *)
+
+let f x y = x + y
+
+(* [g] is a partial application stub:
+
+   ```
+   let[@stub] g y = f 0 y
+   ```
+ *)
+let g = f 0
+
+(* The [@inlined] attribute gets placed on the partial application stub.
+
+   When stubs forward inlining, the call to [f] inside the stub is marked with
+   [@inlined forward], ensuring that the user-provided attribute gets forwarded
+   to [f]. *)
+let h = (g [@inlined]) 0

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_partial_application.simplify.no-stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_partial_application.simplify.no-stubs-forward-inlining.reference
@@ -1,0 +1,36 @@
+let code f_0 deleted in
+let code loopify(never) size(7) stub
+      partial_f_1 (param1 : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let f = %project_value_slot.[partial_f].[f] (my_closure) in
+  apply &my_alloc_region
+    (f : imm tagged * imm tagged -> imm tagged) (0, param1) -> k * k1
+in
+let code loopify(never) size(3) newer_version_of(f_0)
+      f_0_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let $camlInlined_attribute_on_partial_application__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlInlined_attribute_on_partial_application__partial_f_3 =
+  closure partial_f_1 @partial_f &toplevel.alloc_region
+  with { f = $camlInlined_attribute_on_partial_application__f_2 }
+in
+apply direct(f_0_1 &toplevel.alloc_region)
+  ($camlInlined_attribute_on_partial_application__f_2 : _ -> imm tagged)
+    (0, 0)
+    -> k * error
+  where k (h : imm tagged) =
+    let $camlInlined_attribute_on_partial_application =
+      Block 0 ($camlInlined_attribute_on_partial_application__f_2,
+               $camlInlined_attribute_on_partial_application__partial_f_3,
+               h)
+    in
+    cont done ($camlInlined_attribute_on_partial_application)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_partial_application.simplify.stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_partial_application.simplify.stubs-forward-inlining.reference
@@ -1,0 +1,31 @@
+let code f_0 deleted in
+let code loopify(never) size(7) stub
+      partial_f_1 (param1 : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let f = %project_value_slot.[partial_f].[f] (my_closure) in
+  apply &my_alloc_region inlined(forward)
+    (f : imm tagged * imm tagged -> imm tagged) (0, param1) -> k * k1
+in
+let code loopify(never) size(3) newer_version_of(f_0)
+      f_0_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let $camlInlined_attribute_on_partial_application__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlInlined_attribute_on_partial_application__partial_f_3 =
+  closure partial_f_1 @partial_f &toplevel.alloc_region
+  with { f = $camlInlined_attribute_on_partial_application__f_2 }
+in
+let $camlInlined_attribute_on_partial_application =
+  Block 0 ($camlInlined_attribute_on_partial_application__f_2,
+           $camlInlined_attribute_on_partial_application__partial_f_3,
+           0)
+in
+cont done ($camlInlined_attribute_on_partial_application)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_unboxable_function.ml
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_unboxable_function.ml
@@ -1,0 +1,30 @@
+(* TEST
+   flambda;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0 -flambda2-inline-threshold -100";
+   { ocamlopt_flags += " -stubs-forward-inlining";
+     fexpr_reference_suffix = "stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+   { ocamlopt_flags += " -no-stubs-forward-inlining";
+     fexpr_reference_suffix = "no-stubs-forward-inlining.reference";
+     ocamlopt.byte with dump-simplify;
+     check-fexpr-dump; }
+ *)
+
+let helper x y = x + y
+
+(* [f] becomes a stub that calls its unboxed version [f_unboxed]. *)
+let f x y = (x, helper x y)
+[@@unboxable]
+
+(* The [@inlined] attribute gets placed on the unboxed stub.
+
+   When stubs forward inlining, the call to the unboxed function inside the
+   stub gets marked with [@inlined forward], ensuring that the user-provided
+   attribute gets forwarded to the unboxed function.
+
+   Note that the call to [helper] in [f] should *NOT* be inlined. *)
+let h =
+  let a, b = (f [@inlined]) 0 0 in
+  a + b

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_unboxable_function.simplify.no-stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_unboxable_function.simplify.no-stubs-forward-inlining.reference
@@ -1,0 +1,60 @@
+let code helper_0 deleted in
+let code f_2 deleted in
+let code loopify(never) size(15) stub
+      f_2_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 of imm tagged * imm tagged ] =
+  (let f_unboxed = %project_function_slot.[f].[f_unboxed] (my_closure) in
+   apply &my_alloc_region
+     (f_unboxed : imm tagged * imm tagged -> imm tagged * imm tagged)
+       (x, y)
+       -> k2 * k1)
+    where k2 (unboxed_return : imm tagged, unboxed_return_1 : imm tagged) =
+      let boxed_return =
+        %block.[`0`].my_alloc_region (unboxed_return, unboxed_return_1)
+      in
+      cont k (boxed_return)
+in
+let code loopify(never) size(3) newer_version_of(helper_0)
+      helper_0_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let $camlInlined_attribute_on_unboxable_function__helper_3 =
+  closure helper_0_1 @helper &toplevel.alloc_region
+in
+let code loopify(never) size(5) newer_version_of(f_2)
+      f_2_2 (x : imm tagged, y : imm tagged)
+        my_unboxed_closure &my_alloc_region my_depth
+        -> unboxed_return * k
+        : imm tagged * imm tagged =
+  apply direct(helper_0_1 &my_alloc_region)
+    ($camlInlined_attribute_on_unboxable_function__helper_3 : _ -> imm tagged
+     )
+      (x, y)
+      -> k1 * k
+    where k1 (apply_result : imm tagged) =
+      cont unboxed_return (x, apply_result)
+in
+let $camlInlined_attribute_on_unboxable_function__f_4 =
+  closure f_2_1 @f &toplevel.alloc_region
+and $camlInlined_attribute_on_unboxable_function__f_unboxed_5 =
+  closure f_2_2 @f_unboxed &toplevel.alloc_region
+in
+apply direct(f_2_2 &toplevel.alloc_region)
+  ($camlInlined_attribute_on_unboxable_function__f_unboxed_5
+   : _ -> imm tagged * imm tagged)
+    (0, 0)
+    -> k * error
+  where k (unboxed_return : imm tagged, unboxed_return_1 : imm tagged) =
+    let int_add = %int_barith.add (unboxed_return, unboxed_return_1) in
+    let $camlInlined_attribute_on_unboxable_function =
+      Block 0 ($camlInlined_attribute_on_unboxable_function__helper_3,
+               $camlInlined_attribute_on_unboxable_function__f_4,
+               int_add)
+    in
+    cont done ($camlInlined_attribute_on_unboxable_function)

--- a/testsuite/tests/flambda2/simplify/inlined_attribute_on_unboxable_function.simplify.stubs-forward-inlining.reference
+++ b/testsuite/tests/flambda2/simplify/inlined_attribute_on_unboxable_function.simplify.stubs-forward-inlining.reference
@@ -1,0 +1,58 @@
+let code helper_0 deleted in
+let code f_2 deleted in
+let code loopify(never) size(15) stub
+      f_2_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 of imm tagged * imm tagged ] =
+  (let f_unboxed = %project_function_slot.[f].[f_unboxed] (my_closure) in
+   apply &my_alloc_region inlined(forward)
+     (f_unboxed : imm tagged * imm tagged -> imm tagged * imm tagged)
+       (x, y)
+       -> k2 * k1)
+    where k2 (unboxed_return : imm tagged, unboxed_return_1 : imm tagged) =
+      let boxed_return =
+        %block.[`0`].my_alloc_region (unboxed_return, unboxed_return_1)
+      in
+      cont k (boxed_return)
+in
+let code loopify(never) size(3) newer_version_of(helper_0)
+      helper_0_1 (x : imm tagged, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let $camlInlined_attribute_on_unboxable_function__helper_3 =
+  closure helper_0_1 @helper &toplevel.alloc_region
+in
+let code loopify(never) size(5) newer_version_of(f_2)
+      f_2_2 (x : imm tagged, y : imm tagged)
+        my_unboxed_closure &my_alloc_region my_depth
+        -> unboxed_return * k
+        : imm tagged * imm tagged =
+  apply direct(helper_0_1 &my_alloc_region)
+    ($camlInlined_attribute_on_unboxable_function__helper_3 : _ -> imm tagged
+     )
+      (x, y)
+      -> k1 * k
+    where k1 (apply_result : imm tagged) =
+      cont unboxed_return (x, apply_result)
+in
+let $camlInlined_attribute_on_unboxable_function__f_4 =
+  closure f_2_1 @f &toplevel.alloc_region
+and $camlInlined_attribute_on_unboxable_function__f_unboxed_5 =
+  closure f_2_2 @f_unboxed &toplevel.alloc_region
+in
+apply direct(helper_0_1 &toplevel.alloc_region) inlining_state(depth(1))
+  ($camlInlined_attribute_on_unboxable_function__helper_3 : _ -> imm tagged)
+    (0, 0)
+    -> k * error
+  where k (apply_result : imm tagged) =
+    let $camlInlined_attribute_on_unboxable_function =
+      Block 0 ($camlInlined_attribute_on_unboxable_function__helper_3,
+               $camlInlined_attribute_on_unboxable_function__f_4,
+               apply_result)
+    in
+    cont done ($camlInlined_attribute_on_unboxable_function)

--- a/testsuite/tests/warnings/w47_inline.compilers.reference
+++ b/testsuite/tests/warnings/w47_inline.compilers.reference
@@ -36,7 +36,7 @@ File "w47_inline.ml", line 23, characters 15-22:
 23 | let k x = (a [@inlined malformed]) x (* rejected *)
                     ^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute inlined.
-  It must be either 'never', 'always', 'hint' or empty
+  It must be either 'never', 'always', 'hint', 'forward' or empty
 
 File "w47_inline.ml", line 31, characters 7-12:
 31 |   let[@local malformed] f3 x = x (* bad payload *) in

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -1093,6 +1093,9 @@ let ddissector_verbose = ref false             (* -ddissector-verbose *)
 let ddissector_partitions = ref false          (* -ddissector-partitions *)
 let ddissector_inputs = ref None               (* -ddissector-inputs <file> *)
 
+(* CR bclement: should be changed to [true] after proper testing *)
+let stubs_forward_inlining = ref false         (* -stubs-forward-inlining *)
+
 let prepend_directory file_name =
   match !directory with
   | Some directory -> Filename.concat directory file_name

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -431,4 +431,6 @@ val ddissector_verbose : bool ref
 val ddissector_partitions : bool ref
 val ddissector_inputs : string option ref
 
+val stubs_forward_inlining : bool ref
+
 val prepend_directory : string -> string


### PR DESCRIPTION
This patch fixes the use of `[@inlined]` on stubs (in particular functor coercions, but also other stubs such as `[@unboxable]` functions and different kinds of partial applications).

Currently `[@inlined]` attributes on functors does not really work, because most functors (except when defined in the current module without an explicit signature) tend to actually be stubs to return a module block of the expected shape. This happens as soon as fields are hidden or reordered by a signature (other than a signature directly on the functor definition itself, i.e. `module F ( ... ) : S = struct ... end`). This means that the following code (included in the PR as a test) does not behave as expected:

```ocaml
module type S = sig val x : int end

module F : sig
  module Make (X : S) : S
end = struct
  (* No signature here to force a coercion to the signature of [F].

     [F.Make] will be a stub that calls [Make] and rearranges the result into a
     block with a single field:

    ```
    let[@stub] F.Make X =
      let { _dummy ; x } = apply direct(Make) X in
      return { x }
    ``` *)
  module Make(X : S) = struct
    let _dummy = ()
    let x = X.x
  end
end

(* The [@inlined] attribute gets placed on the coercion stub, not the actual functor.

    We go through the usual code size heuristic and speculative inlining, effectively
    ignoring the user intent. *)
module M = (F.Make [@inlined])(struct let x = 0 end)
```

This PR fixes the issue by introducing a new inlining attribute, `[@inlined forward]`. By default, `[@inlined forward]` behaves as `[@inlined never]`; however, if an application with the `[@inlined forward]` attribute is encountered while we are inlining another function, then it behaves as if it had whatever `[@inlined]` attribute the current function had. In classic mode, we cannot honor this behaviour (because we don't look at the code of inlined functions) — instead, the `[@inlined forward]` attribute is ignored.

When creating a stub that wraps an application, such as a functor coercion stub (but also an `[@unboxable]` wrapper or any of the partial application stubs), if the `-stubs-foward-inlining` flag is enabled, we mark the call to the wrapped application with the `[@inlined forward]` attribute. This ensures that if an `[@inlined]` attribute is provided on a stub, it gets forwarded to the actual application wrapped by the stub (note that using an attribute to denote the "main" application wrapped by a stub is necessary, because those stubs can sometimes contain *other* unrelated applications that should be left untouched).

The PR is split in two parts: the first part introduces the `[@inlined forward]` attribute, and the second part introduces the `-stubs-forward-inlining` flag to add `[@inlined forward]` on the application wrapped by stubs. I suggest reviewing the two commits independently (the commits messages also contain some more explanations).

Some details worth mentioning:

 - The current PR leaves the `[@inlined forward]` attribute available on the surface syntax. I think it is useful for testing and also useful for users wishing to write their own "calling convention change" stubs (there is an example in the commit message), but we might want to forbid it.

 - The main motivation for the change is specifically functors, but the PR implements the behaviour for all application-wrapping stubs. I think it is better to have a consistent behaviour across all these stubs, but if there are arguments for *not* doing this for some of these other types of stubs, we could disable it. I do think that the behaviour as implemented in the PR is the right one for all of them.