### PR TITLE
Printing "poly_" in value descriptions

### DIFF
--- a/testsuite/tests/layout_poly/apply_layout.ml
+++ b/testsuite/tests/layout_poly/apply_layout.ml
@@ -7,8 +7,7 @@ module type S = sig
   val f : layout_ x y. ('a : x) ('b : y). 'a -> 'b -> unit
 end
 [%%expect{|
-module type S =
-  sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit end
+module type S = sig val poly_ f : 'a 'b. 'a -> 'b -> unit end
 |}]
 
 (* layout instantiation requires static *)
@@ -72,11 +71,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit end
+         sig val poly_ g : 'a 'b. 'a -> 'b -> unit end
        is not included in
          sig val g : int end
        Values do not match:
-         val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit
+         val poly_ g : 'a 'b. 'a -> 'b -> unit
        is not included in
          val g : int
        The type "'a -> 'b -> unit" is not compatible with the type "int"
@@ -136,11 +135,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val g : '_weak1 -> unit end
        is not included in
-         sig val g : layout_ l. ('b : l). 'b -> unit end
+         sig val poly_ g : 'b. 'b -> unit end
        Values do not match:
          val g : '_weak1 -> unit
        is not included in
-         val g : layout_ l. ('b : l). 'b -> unit
+         val poly_ g : 'b. 'b -> unit
        The type "'_weak1 -> unit" is not compatible with the type "'a -> unit"
        Type "'_weak1" is not compatible with type "'a"
 |}]

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -29,11 +29,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val id : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ id : 'a. 'a -> 'a end
        is not included in
          sig val id : int end
        Values do not match:
-         val id : layout_ l. ('a : l). 'a -> 'a
+         val poly_ id : 'a. 'a -> 'a
        is not included in
          val id : int
        The type "'a -> 'a" is not compatible with the type "int"
@@ -66,11 +66,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val id : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ id : 'a. 'a -> 'a end
        is not included in
          sig val id : int end
        Values do not match:
-         val id : layout_ l. ('a : l). 'a -> 'a
+         val poly_ id : 'a. 'a -> 'a
        is not included in
          val id : int
        The type "'a -> 'a" is not compatible with the type "int"
@@ -94,14 +94,13 @@ Lines 4-7, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val const : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
-           val apply :
-             layout_ l l0. ('a : l) ('b : l0). ('a -> 'b) -> 'a -> 'b
+           val poly_ const : 'a 'b. 'a -> 'b -> 'a
+           val poly_ apply : 'a 'b. ('a -> 'b) -> 'a -> 'b
          end
        is not included in
          sig val const : int val apply : int end
        Values do not match:
-         val const : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+         val poly_ const : 'a 'b. 'a -> 'b -> 'a
        is not included in
          val const : int
        The type "'a -> 'b -> 'a" is not compatible with the type "int"
@@ -122,13 +121,13 @@ Lines 4-6, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
-           val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'b
+           val poly_ f : 'a 'b. 'a -> 'b -> 'a
+           val poly_ g : 'a 'b. 'a -> 'b -> 'b
          end
        is not included in
          sig val f : int val g : int end
        Values do not match:
-         val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+         val poly_ f : 'a 'b. 'a -> 'b -> 'a
        is not included in
          val f : int
        The type "'a -> 'b -> 'a" is not compatible with the type "int"
@@ -149,11 +148,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val regular_id : 'a -> 'a end
        is not included in
-         sig val regular_id : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ regular_id : 'a. 'a -> 'a end
        Values do not match:
          val regular_id : 'a -> 'a
        is not included in
-         val regular_id : layout_ l. ('a : l). 'a -> 'a
+         val poly_ regular_id : 'a. 'a -> 'a
        the second has 1 more layout parameter that is not used,
        which is not supported yet.
 |}]
@@ -215,11 +214,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val id : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ id : 'a. 'a -> 'a end
        is not included in
          sig val id : 'a -> 'a end
        Values do not match:
-         val id : layout_ l. ('a : l). 'a -> 'a
+         val poly_ id : 'a. 'a -> 'a
        is not included in
          val id : 'a -> 'a
        the first has 1 more layout parameter that is not used,
@@ -386,16 +385,13 @@ Lines 3-5, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val f :
-             layout_ l.
-               ('a : l) ('b : value_or_null). 'a -> 'b -> #('a * ('b * 'b))
+           val poly_ f :
+             'a ('b : value_or_null). 'a -> 'b -> #('a * ('b * 'b))
          end
        is not included in
          sig val f : int end
        Values do not match:
-         val f :
-           layout_ l.
-             ('a : l) ('b : value_or_null). 'a -> 'b -> #('a * ('b * 'b))
+         val poly_ f : 'a ('b : value_or_null). 'a -> 'b -> #('a * ('b * 'b))
        is not included in
          val f : int
        The type "'a -> 'b -> #('a * ('b * 'b))" is not compatible with the type
@@ -415,11 +411,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a. 'a -> 'a end
        is not included in
          sig val f : int end
        Values do not match:
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a. 'a -> 'a
        is not included in
          val f : int
        The type "'a -> 'a" is not compatible with the type "int"
@@ -463,11 +459,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l. ('a : l). unit -> 'a end
+         sig val poly_ f : 'a. unit -> 'a end
        is not included in
          sig val f : int end
        Values do not match:
-         val f : layout_ l. ('a : l). unit -> 'a
+         val poly_ f : 'a. unit -> 'a
        is not included in
          val f : int
        The type "unit -> 'a" is not compatible with the type "int"
@@ -528,11 +524,11 @@ Lines 3-9, characters 6-3:
 9 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val foo : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit end
+         sig val poly_ foo : 'a 'b. 'a -> 'b -> unit end
        is not included in
          sig val foo : int end
        Values do not match:
-         val foo : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit
+         val poly_ foo : 'a 'b. 'a -> 'b -> unit
        is not included in
          val foo : int
        The type "'a -> 'b -> unit" is not compatible with the type "int"

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -386,12 +386,16 @@ Lines 3-5, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val f : layout_ l. ('a : l) 'b. 'a -> 'b -> #('a * ('b * 'b))
+           val f :
+             layout_ l.
+               ('a : l) ('b : value_or_null). 'a -> 'b -> #('a * ('b * 'b))
          end
        is not included in
          sig val f : int end
        Values do not match:
-         val f : layout_ l. ('a : l) 'b. 'a -> 'b -> #('a * ('b * 'b))
+         val f :
+           layout_ l.
+             ('a : l) ('b : value_or_null). 'a -> 'b -> #('a * ('b * 'b))
        is not included in
          val f : int
        The type "'a -> 'b -> #('a * ('b * 'b))" is not compatible with the type

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -8,7 +8,7 @@ module type S = sig
   val foo : layout_ x y. ('a : x) ('b : y). 'a -> 'b
 end
 [%%expect{|
-module type S = sig val foo : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+module type S = sig val poly_ foo : 'a 'b. 'a -> 'b end
 |}]
 
 (* The following is error, because the module type goes through inclusion check
@@ -116,11 +116,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : layout_ l l0. ('a : l). 'a -> 'a end
        is not included in
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a. 'a -> 'a end
        Values do not match:
          val f : layout_ l l0. ('a : l). 'a -> 'a
        is not included in
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a. 'a -> 'a
        the first has 1 more layout parameter that is not used,
        which is not supported yet.
 |}]
@@ -137,11 +137,11 @@ Line 5, characters 6-7:
           ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a. 'a -> 'a end
        is not included in
          sig val f : layout_ l l0. ('a : l). 'a -> 'a end
        Values do not match:
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a. 'a -> 'a
        is not included in
          val f : layout_ l l0. ('a : l). 'a -> 'a
        the second has 1 more layout parameter that is not used,
@@ -203,8 +203,8 @@ end) : sig
 end = M
 [%%expect{|
 module F1 :
-  functor (M : sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end) ->
-    sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+  functor (M : sig val poly_ f : 'a 'b. 'a -> 'b end) ->
+    sig val poly_ f : 'a 'b. 'a -> 'b end
 |}]
 
 (* layout-poly is not included in non-poly functions, even tho the former can be instantiate to the latter. *)
@@ -219,11 +219,11 @@ Line 5, characters 6-7:
           ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a. 'a -> 'a end
        is not included in
          sig val f : 'a -> 'a end
        Values do not match:
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a. 'a -> 'a
        is not included in
          val f : 'a -> 'a
        the first has 1 more layout parameter that is not used,
@@ -286,8 +286,8 @@ end) : sig
 end = M
 [%%expect{|
 module FO3 :
-  functor (M : sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end) ->
-    sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+  functor (M : sig val poly_ f : 'a 'b. 'a -> 'b end) ->
+    sig val poly_ f : 'a 'b. 'a -> 'b end
 |}]
 
 (* Ordering: sorts swapped between sides - should fail *)
@@ -302,13 +302,13 @@ Line 5, characters 6-7:
           ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+         sig val poly_ f : 'a 'b. 'a -> 'b end
        is not included in
-         sig val f : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b end
+         sig val poly_ f : 'a 'b. 'a -> 'b end
        Values do not match:
-         val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b
+         val poly_ f : 'a 'b. 'a -> 'b
        is not included in
-         val f : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b
+         val poly_ f : 'a 'b. 'a -> 'b
        The layout parameter at position 1 in the first
        corresponds to the parameter at position 2 in the second,
        which is not supported yet.
@@ -478,8 +478,7 @@ module type S = sig
   val poly_ foo1 : 'a -> 'b -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo1 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+module type S = sig val poly_ foo1 : 'a 'b. 'a -> 'b -> #('a * 'b) end
 |}]
 
 (* Fresh layout variables assigned as kinds for type variables specifically
@@ -488,8 +487,7 @@ module type S = sig
   val poly_ foo2 : 'a 'b. 'a -> 'b -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo2 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+module type S = sig val poly_ foo2 : 'a 'b. 'a -> 'b -> #('a * 'b) end
 |}]
 
 (* The ordering of the explicitly-quantified type variables matters most in
@@ -509,16 +507,14 @@ module type S = sig
   val poly_ foo3 : 'a. 'a -> 'b -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo3 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+module type S = sig val poly_ foo3 : 'a 'b. 'a -> 'b -> #('a * 'b) end
 |}]
 
 module type S = sig
   val poly_ foo4 : 'a. 'a -> 'b -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo4 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+module type S = sig val poly_ foo4 : 'a 'b. 'a -> 'b -> #('a * 'b) end
 |}]
 
 (* Interaction between "val poly_" and "layout_". Currently errors.
@@ -542,10 +538,8 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz1 :
-      layout_ l l0.
-        ('a : l) ('b : immediate) ('c : l0).
-          'a -> #('b * 'c) -> #('a * 'b * 'c)
+    val poly_ baz1 :
+      'a ('b : immediate) 'c. 'a -> #('b * 'c) -> #('a * 'b * 'c)
   end
 |}]
 
@@ -555,10 +549,8 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz2 :
-      layout_ l l0.
-        ('a : immediate) ('b : l) ('c : l0).
-          'a -> #('b * 'c) -> #('a * 'b * 'c)
+    val poly_ baz2 :
+      ('a : immediate) 'b 'c. 'a -> #('b * 'c) -> #('a * 'b * 'c)
   end
 |}]
 
@@ -568,10 +560,8 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz3 :
-      layout_ l l0.
-        ('b : l) ('a : immediate) ('c : l0).
-          'b -> #('a * 'c) -> #('b * 'a * 'c)
+    val poly_ baz3 :
+      'b ('a : immediate) 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -581,10 +571,8 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz4 :
-      layout_ l l0.
-        ('b : l) ('a : immediate) ('c : l0).
-          'b -> #('a * 'c) -> #('b * 'a * 'c)
+    val poly_ baz4 :
+      'b ('a : immediate) 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -594,10 +582,8 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz5 :
-      layout_ l l0.
-        ('b : l) ('a : immediate) ('c : l0).
-          'b -> #('a * 'c) -> #('b * 'a * 'c)
+    val poly_ baz5 :
+      'b ('a : immediate) 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -608,10 +594,7 @@ module type S = sig
 end
 [%%expect {|
 module type S =
-  sig
-    val baz6 :
-      layout_ l. ('a : value) ('b : l). 'a -> #('a * 'b) -> #('a * 'b)
-  end
+  sig val poly_ baz6 : ('a : value) 'b. 'a -> #('a * 'b) -> #('a * 'b) end
 |}]
 
 (* "value_or_null" should be printed *)
@@ -621,9 +604,7 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz7 :
-      layout_ l.
-        ('a : value_or_null) ('b : l). 'a -> #('a * 'b) -> #('a * 'b)
+    val poly_ baz7 : ('a : value_or_null) 'b. 'a -> #('a * 'b) -> #('a * 'b)
   end
 |}]
 
@@ -634,9 +615,20 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz8 :
-      layout_ l l0.
-        ('a : l) ('b : l0) ('c : value).
-          'a -> 'b -> 'c list -> #('a * 'b * 'c)
+    val poly_ baz8 :
+      'a 'b ('c : value). 'a -> 'b -> 'c list -> #('a * 'b * 'c)
   end
 |}]
+
+(* CR-soon layouts aivaskovic: uncomment this test once layout variables can
+   appear in products *)
+(* module type S = sig
+ *   val lpoly_prod : layout_ l. ('a : value & l) 'b. 'a -> 'b -> #('a * 'b)
+ * end
+ * [%%expect {|
+ * module type S =
+ *   sig
+ *     val lpoly_prod :
+ *       layout_ l. ('a : value & l) 'b. 'a -> 'b -> #('a * 'b)
+ *   end
+ * |}] *)

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -304,11 +304,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val poly_ f : 'a 'b. 'a -> 'b end
        is not included in
-         sig val poly_ f : 'a 'b. 'a -> 'b end
+         sig val poly_ f : 'b 'a. 'a -> 'b end
        Values do not match:
          val poly_ f : 'a 'b. 'a -> 'b
        is not included in
-         val poly_ f : 'a 'b. 'a -> 'b
+         val poly_ f : 'b 'a. 'a -> 'b
        The layout parameter at position 1 in the first
        corresponds to the parameter at position 2 in the second,
        which is not supported yet.
@@ -496,8 +496,7 @@ module type S = sig
   val poly_ ordering : 'a 'b. 'b -> 'a
 end
 [%%expect {|
-module type S =
-  sig val ordering : layout_ l l0. ('b : l0) ('a : l). 'b -> 'a end
+module type S = sig val poly_ ordering : 'a 'b. 'b -> 'a end
 |}]
 
 
@@ -539,7 +538,7 @@ end
 module type S =
   sig
     val poly_ baz1 :
-      'a ('b : immediate) 'c. 'a -> #('b * 'c) -> #('a * 'b * 'c)
+      'a 'c ('b : immediate). 'a -> #('b * 'c) -> #('a * 'b * 'c)
   end
 |}]
 
@@ -550,7 +549,7 @@ end
 module type S =
   sig
     val poly_ baz2 :
-      ('a : immediate) 'b 'c. 'a -> #('b * 'c) -> #('a * 'b * 'c)
+      'b 'c ('a : immediate). 'a -> #('b * 'c) -> #('a * 'b * 'c)
   end
 |}]
 
@@ -561,7 +560,7 @@ end
 module type S =
   sig
     val poly_ baz3 :
-      'b ('a : immediate) 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
+      'b 'c ('a : immediate). 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -572,7 +571,7 @@ end
 module type S =
   sig
     val poly_ baz4 :
-      'b ('a : immediate) 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
+      'b 'c ('a : immediate). 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -583,7 +582,7 @@ end
 module type S =
   sig
     val poly_ baz5 :
-      'b ('a : immediate) 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
+      'b 'c ('a : immediate). 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -594,7 +593,7 @@ module type S = sig
 end
 [%%expect {|
 module type S =
-  sig val poly_ baz6 : ('a : value) 'b. 'a -> #('a * 'b) -> #('a * 'b) end
+  sig val poly_ baz6 : 'b ('a : value). 'a -> #('a * 'b) -> #('a * 'b) end
 |}]
 
 (* "value_or_null" should be printed *)
@@ -604,7 +603,7 @@ end
 [%%expect {|
 module type S =
   sig
-    val poly_ baz7 : ('a : value_or_null) 'b. 'a -> #('a * 'b) -> #('a * 'b)
+    val poly_ baz7 : 'b ('a : value_or_null). 'a -> #('a * 'b) -> #('a * 'b)
   end
 |}]
 

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -492,6 +492,17 @@ module type S =
   sig val foo2 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
 |}]
 
+(* The ordering of the explicitly-quantified type variables matters most in
+   determining the order of layouts. *)
+module type S = sig
+  val poly_ ordering : 'a 'b. 'b -> 'a
+end
+[%%expect {|
+module type S =
+  sig val ordering : layout_ l l0. ('b : l0) ('a : l). 'b -> 'a end
+|}]
+
+
 (* Type scheme with a subset of polymorphic type variables that are explicitly
    forall-bound *)
 module type S = sig

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -22,19 +22,21 @@ end
 [%%expect{|
 Line 1:
 Error: Module type declarations do not match:
-         module type S = sig val foo : layout_ l. 'a -> 'b end
+         module type S =
+           sig val foo : layout_ l. ('a : value) ('b : value). 'a -> 'b end
        does not match
-         module type S = sig val foo : layout_ l. 'a -> 'b end
+         module type S =
+           sig val foo : layout_ l. ('a : value) ('b : value). 'a -> 'b end
        At position "module type S = <here>"
        Module types do not match:
-         sig val foo : layout_ l. 'a -> 'b end
+         sig val foo : layout_ l. ('a : value) ('b : value). 'a -> 'b end
        is not equal to
-         sig val foo : layout_ l. 'a -> 'b end
+         sig val foo : layout_ l. ('a : value) ('b : value). 'a -> 'b end
        At position "module type S = <here>"
        Values do not match:
-         val foo : layout_ l. 'a -> 'b
+         val foo : layout_ l. ('a : value) ('b : value). 'a -> 'b
        is not included in
-         val foo : layout_ l. 'a -> 'b
+         val foo : layout_ l. ('a : value) ('b : value). 'a -> 'b
        The layout parameter at position 1 in the first
        is instantiated with an unconstrained layout variable,
        which is not supported yet.
@@ -266,11 +268,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : layout_ l. ('a : l) ('b : l). 'a -> 'b end
        is not included in
-         sig val f : layout_ l. 'a -> 'b end
+         sig val f : layout_ l. ('a : value) ('b : value). 'a -> 'b end
        Values do not match:
          val f : layout_ l. ('a : l) ('b : l). 'a -> 'b
        is not included in
-         val f : layout_ l. 'a -> 'b
+         val f : layout_ l. ('a : value) ('b : value). 'a -> 'b
        The layout parameter at position 1 in the first
        is instantiated with layout "value",
        which is not supported yet.
@@ -467,4 +469,149 @@ module F :
       val bar :
         layout_ l. ('a : l mod contended) ('b : l mod contended). 'a -> 'b
     end
+|}]
+
+(* "val poly_" syntax tests *)
+
+(* Layout variables generated corresponding to free type variables *)
+module type S = sig
+  val poly_ foo1 : 'a -> 'b -> #('a * 'b)
+end
+[%%expect {|
+module type S =
+  sig val foo1 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+|}]
+
+(* Fresh layout variables assigned as kinds for type variables specifically
+   introduced in the type scheme *)
+module type S = sig
+  val poly_ foo2 : 'a 'b. 'a -> 'b -> #('a * 'b)
+end
+[%%expect {|
+module type S =
+  sig val foo2 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+|}]
+
+(* Type scheme with a subset of polymorphic type variables that are explicitly
+   forall-bound *)
+module type S = sig
+  val poly_ foo3 : 'a. 'a -> 'b -> #('a * 'b)
+end
+[%%expect {|
+module type S =
+  sig val foo3 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+|}]
+
+module type S = sig
+  val poly_ foo4 : 'a. 'a -> 'b -> #('a * 'b)
+end
+[%%expect {|
+module type S =
+  sig val foo4 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+|}]
+
+(* Interaction between "val poly_" and "layout_". Currently errors.
+   CR-soon aivaskovic: allow combining them after deciding what order layout
+   variables should have inside "layout_". *)
+module type S = sig
+  val poly_ bar : layout_ x. ('b : x). 'a -> 'b -> #('a * 'b)
+end
+[%%expect {|
+Line 2, characters 18-61:
+2 |   val poly_ bar : layout_ x. ('b : x). 'a -> 'b -> #('a * 'b)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The "layout_" keyword is not support inside layout-polymorphic
+       value descriptions introduced using "val poly_".
+|}]
+
+(* Interaction with type variables that are constrained. *)
+module type S = sig
+  val poly_ baz1 : 'a ('b : immediate). 'a -> #('b * 'c) -> #('a * 'b * 'c)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz1 :
+      layout_ l l0.
+        ('a : l) ('b : immediate) ('c : l0).
+          'a -> #('b * 'c) -> #('a * 'b * 'c)
+  end
+|}]
+
+module type S = sig
+  val poly_ baz2 : ('a : immediate) 'b. 'a -> #('b * 'c) -> #('a * 'b * 'c)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz2 :
+      layout_ l l0.
+        ('a : immediate) ('b : l) ('c : l0).
+          'a -> #('b * 'c) -> #('a * 'b * 'c)
+  end
+|}]
+
+module type S = sig
+  val poly_ baz3 : ('a : immediate) 'b. 'b -> #('a * 'c) -> #('b * 'a * 'c)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz3 :
+      layout_ l l0.
+        ('b : l) ('a : immediate) ('c : l0).
+          'b -> #('a * 'c) -> #('b * 'a * 'c)
+  end
+|}]
+
+module type S = sig
+  val poly_ baz4 : ('a : immediate) 'b 'c. 'b -> #('a * 'c) -> #('b * 'a * 'c)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz4 :
+      layout_ l l0.
+        ('b : l) ('a : immediate) ('c : l0).
+          'b -> #('a * 'c) -> #('b * 'a * 'c)
+  end
+|}]
+
+module type S = sig
+  val poly_ baz5 : ('a : immediate). 'b -> #('a * 'c) -> #('b * 'a * 'c)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz5 :
+      layout_ l l0.
+        ('b : l) ('a : immediate) ('c : l0).
+          'b -> #('a * 'c) -> #('b * 'a * 'c)
+  end
+|}]
+
+(* "value" is special and usually a default.
+   It is not a default inside "val poly_". *)
+module type S = sig
+  val poly_ baz5 : ('a : value) 'b. 'a -> #('a * 'b) -> #('a * 'b)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz5 :
+      layout_ l. ('a : value) ('b : l). 'a -> #('a * 'b) -> #('a * 'b)
+  end
+|}]
+
+(* "value_or_null" should be printed *)
+module type S = sig
+  val poly_ baz6 : ('a : value_or_null) 'b. 'a -> #('a * 'b) -> #('a * 'b)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz6 :
+      layout_ l.
+        ('a : value_or_null) ('b : l). 'a -> #('a * 'b) -> #('a * 'b)
+  end
 |}]

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -520,7 +520,7 @@ end
 Line 2, characters 18-61:
 2 |   val poly_ bar : layout_ x. ('b : x). 'a -> 'b -> #('a * 'b)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The "layout_" keyword is not support inside layout-polymorphic
+Error: The "layout_" keyword is not supported inside layout-polymorphic
        value descriptions introduced using "val poly_".
 |}]
 

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -593,25 +593,39 @@ module type S =
 (* "value" is special and usually a default.
    It is not a default inside "val poly_". *)
 module type S = sig
-  val poly_ baz5 : ('a : value) 'b. 'a -> #('a * 'b) -> #('a * 'b)
+  val poly_ baz6 : ('a : value) 'b. 'a -> #('a * 'b) -> #('a * 'b)
 end
 [%%expect {|
 module type S =
   sig
-    val baz5 :
+    val baz6 :
       layout_ l. ('a : value) ('b : l). 'a -> #('a * 'b) -> #('a * 'b)
   end
 |}]
 
 (* "value_or_null" should be printed *)
 module type S = sig
-  val poly_ baz6 : ('a : value_or_null) 'b. 'a -> #('a * 'b) -> #('a * 'b)
+  val poly_ baz7 : ('a : value_or_null) 'b. 'a -> #('a * 'b) -> #('a * 'b)
 end
 [%%expect {|
 module type S =
   sig
-    val baz6 :
+    val baz7 :
       layout_ l.
         ('a : value_or_null) ('b : l). 'a -> #('a * 'b) -> #('a * 'b)
+  end
+|}]
+
+(* "'c is a value and not layout-polymorphic" *)
+module type S = sig
+  val poly_ baz8 : 'a -> 'b -> 'c list -> #('a * 'b * 'c)
+end
+[%%expect {|
+module type S =
+  sig
+    val baz8 :
+      layout_ l l0.
+        ('a : l) ('b : l0) ('c : value).
+          'a -> 'b -> 'c list -> #('a * 'b * 'c)
   end
 |}]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1719,10 +1719,7 @@ module type S_poly = sig
 end
 [%%expect{|
 module type S_poly =
-  sig
-    val f : layout_ l. ('a : l). 'a -> 'a
-    val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
-  end
+  sig val poly_ f : 'a. 'a -> 'a val poly_ g : 'a 'b. 'a -> 'b -> 'a end
 |}]
 
 let poly_ f : 'a. 'a -> 'a = fun x -> x
@@ -1775,5 +1772,5 @@ module type S = sig
   val f : layout_ x y. ('a : x) ('b : y). 'a -> 'b
 end
 [%%expect{|
-module type S = sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+module type S = sig val poly_ f : 'a 'b. 'a -> 'b end
 |}]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1718,10 +1718,11 @@ module type S_poly = sig
   val poly_ g : 'a 'b. 'a -> 'b -> 'a
 end
 [%%expect{|
-Line 2, characters 2-28:
-2 |   val poly_ f : 'a. 'a -> 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The "val poly_" annotation is not yet implemented.
+module type S_poly =
+  sig
+    val f : layout_ l. ('a : l). 'a -> 'a
+    val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+  end
 |}]
 
 let poly_ f : 'a. 'a -> 'a = fun x -> x

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -692,6 +692,30 @@ let remove_mode_and_jkind_variables ty =
     end
   in go ty
 
+(* Generalize layout variables, return a list of fresh layouts *)
+let generalize_layout_variables ty =
+  let visited = ref TypeSet.empty in
+  let layouts = ref ([] : Jkind.Sort.var list) in
+  let rec go ty =
+    if TypeSet.mem ty !visited then () else begin
+      visited := TypeSet.add ty !visited;
+      match get_desc ty with
+      | Tvar { name; jkind } ->
+        let vars, base = Jkind.default_to_fresh_layout jkind in
+        layouts := vars @ !layouts;
+        let jkind = { jkind with jkind = { jkind.jkind with base = base } } in
+        set_type_desc ty (Tvar { name; jkind })
+      | Tunivar { name; jkind } ->
+        let vars, base = Jkind.default_to_fresh_layout jkind in
+        layouts := vars @ !layouts;
+        let jkind = { jkind with jkind = { jkind.jkind with base = base } } in
+        set_type_desc ty (Tunivar { name; jkind })
+      | _ -> iter_type_expr go ty
+    end
+  in
+  go ty;
+  List.rev !layouts
+
                     (**************************************)
                     (*  Check genericity of type schemes  *)
                     (**************************************)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -553,6 +553,8 @@ val normalize_type: type_expr -> unit
 val remove_mode_and_jkind_variables: type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
+val generalize_layout_variables: type_expr -> Jkind_types.Sort.var list
+
 val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
         (* Return any non-generic variables in the type scheme.  Also ensures
            mode variables are fully determined. *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1889,7 +1889,12 @@ module Const = struct
                layout matches and the modal bounds are all max *)
             Option.get out_jkind_verbose)
       in
-      let base = Outcometree.Ojkind_const_abbreviation (base, scannable_axes) in
+      let base =
+        match jkind.base with
+        | Layout (Genvar _) -> Outcometree.Ojkind_const_genvar base
+        | Layout _ | Kconstr _ ->
+          Outcometree.Ojkind_const_abbreviation (base, scannable_axes)
+      in
       (* Add on [mod] bounds, if there are any *)
       let base =
         if modal_bounds = []

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -396,6 +396,21 @@ module Layout = struct
       Const.of_sort_const (Sort.default_to_scannable_and_get s) sa
     | Product p -> Product (List.map default_to_scannable_and_get p)
 
+  let rec default_to_fresh_layouts_and_get :
+      Sort.var list -> _ Layout.t -> Sort.var list * _ Layout.t =
+   fun vars layout ->
+    match layout with
+    | Any sa -> vars, Any sa
+    | Sort (s, sa) ->
+      let vars', s = Sort.default_to_fresh_layouts_and_get s in
+      vars' @ vars, Sort (s, sa)
+    | Product p ->
+      let vars', p = List.fold_left_map default_to_fresh_layouts_and_get [] p in
+      vars' @ vars, Product p
+
+  let default_to_fresh_layouts_and_get layout =
+    default_to_fresh_layouts_and_get [] layout
+
   let format ppf layout =
     let pp_string_list ppf lst =
       Fmt.pp_print_list
@@ -2465,6 +2480,13 @@ let default_to_scannable t =
   match t.jkind.base with
   | Kconstr _ -> ()
   | Layout l -> ignore (Layout.default_to_scannable_and_get l)
+
+let default_to_fresh_layout t =
+  match t.jkind.base with
+  | Kconstr _ as b -> [], b
+  | Layout l ->
+    let vars, l = Layout.default_to_fresh_layouts_and_get l in
+    vars, Layout l
 
 let generalize ~current_level t =
   (* Expanding unnecessary in the case of a Kconstr, which is constant. *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -561,6 +561,10 @@ val default_to_scannable : 'd Types.jkind -> unit
    these three functions to default to void - it's the most efficient thing
    when we have a choice. *)
 
+(** Generate a fresh sort variable when the type has no kind constraint. *)
+val default_to_fresh_layout :
+  'd Types.jkind -> Sort.var list * sort Layout.t Types.jkind_base
+
 (** Generalize the sorts in a jkind when in sort generalization context. Only
     has an effect when called within {!Sort.generalize_with}. *)
 val generalize : current_level:int -> 'd Types.jkind -> unit

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -222,6 +222,7 @@ module type Sort = sig
       variable, it is set to [scannable] first. *)
   val default_to_scannable_and_get : t -> Const.t
 
+  val default_to_fresh_layouts_and_get : t -> var list * t
   (* CR layouts v12: Default this to void. *)
 
   (** [default_for_transl_and_get] extracts the sort as a `const`. If it's a

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -757,6 +757,33 @@ module Sort = struct
       (* path compression *)
       result
 
+  let rec default_to_fresh_layouts_and_get : var list -> t -> var list * t =
+   fun vars -> function
+    | Base b -> vars, Base b
+    | Product ts ->
+      let vars, ts =
+        List.fold_left_map default_to_fresh_layouts_and_get vars ts
+      in
+      vars, Product ts
+    | Univar uv -> vars, Univar uv
+    | Var r -> (
+      match r.contents with
+      | None when is_genvar r -> vars, Var r
+      | None ->
+        let v = new_genvar () in
+        let v' = of_var v in
+        r.level <- v.level;
+        r.contents <- Some v';
+        v :: vars, v'
+      | Some s ->
+        let vars, result = default_to_fresh_layouts_and_get vars s in
+        set r (Some result);
+        (* path compression *)
+        vars, result)
+
+  let default_to_fresh_layouts_and_get : t -> var list * t =
+   fun t -> default_to_fresh_layouts_and_get [] t
+
   (* CR layouts v12: Default to void instead. *)
   let default_for_transl_and_get s = default_to_scannable_and_get s
 

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -777,7 +777,7 @@ module Sort = struct
         v :: vars, v'
       | Some s ->
         let vars, result = default_to_fresh_layouts_and_get vars s in
-        set r (Some result);
+        set_to_compress r (Some result);
         (* path compression *)
         vars, result)
 

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -638,6 +638,7 @@ and print_out_jkind_const ppf ojkind =
     | Ojkind_const_default -> fprintf ppf "_"
     | Ojkind_const_abbreviation (abbrev, sa) ->
       (pp_print_list ~pp_sep:pp_print_space pp_print_string) ppf (abbrev :: sa)
+    | Ojkind_const_genvar var -> pp_print_string ppf var
     | Ojkind_const_mod (base, modes) ->
       let pp_base ppf base =
         match base with
@@ -959,8 +960,9 @@ and print_out_sig_item ppf =
            | Orec_next  -> "and")
           ppf td
   | Osig_value { oval_name; oval_type; oval_modalities;
-                 oval_prims; oval_attributes } ->
+                 oval_prims; oval_attributes; oval_poly } ->
       let kwd = if oval_prims = [] then "val" else "external" in
+      let poly = if oval_poly then "poly_ " else "" in
       let pr_prims ppf =
         function
           [] -> ()
@@ -968,7 +970,7 @@ and print_out_sig_item ppf =
             fprintf ppf "@ = \"%s\"" s;
             List.iter (fun s -> fprintf ppf "@ \"%s\"" s) sl
       in
-      fprintf ppf "@[<2>%s %a :@ %a%a%a%a@]" kwd value_ident oval_name
+      fprintf ppf "@[<2>%s %s%a :@ %a%a%a%a@]" kwd poly value_ident oval_name
         !out_type oval_type
         print_out_modalities oval_modalities
         pr_prims oval_prims

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -100,6 +100,7 @@ type out_ret_mode =
 type out_jkind_const =
   | Ojkind_const_default
   | Ojkind_const_abbreviation of string * string list
+  | Ojkind_const_genvar of string
   (** The base of [Ojkind_const_mod] is optional to enable printing individual axes *)
   | Ojkind_const_mod of out_jkind_const option * string list
   | Ojkind_const_with of out_jkind_const * out_type * out_modality list
@@ -232,6 +233,7 @@ and out_type_extension =
 and out_val_decl =
   { oval_name: string;
     oval_type: out_type;
+    oval_poly: bool;
     oval_modalities : out_modality list;
     (* Modalities on value descriptions are always new, even for [global_] *)
     oval_prims: string list;

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2478,9 +2478,71 @@ let tree_of_value_description id decl =
              ]
        }]
   in
+  (* We print [val poly_] in when the following conditions are met:
+     1. each layout var in [qsvs] appears exactly once in [qtvs] kinds
+     2. no kind in [qtvs] contains a layout var from [qsvs] in a non-immediate
+     way (say, in a product).
+     If these conditions are met, we output an [Otyp_poly] with all generic
+     type variable explicitly printed as a type scheme, where
+     jkind-unconstrained variables are layout-polymorphic. Consequently, we need
+     to print all other jkind annotations, including [value].
+     Otherwise, we output the [layout_] representation.
+     CR-soon layouts aivaskovic:
+     We aspire to eventually remove the layout-polymorphic type variables which
+     currently appear unconstrained. This means that, instead of:
+       [val poly_ : 'a 'b ('c : value). 'a -> 'b -> 'c -> #('a * 'b * 'c)]
+     we would print:
+       [val poly_ : ('c : value). 'a -> 'b -> 'c -> #('a * 'b * 'c)]
+  *)
+  let rec out_jkind_const_has_genvar = function
+    | Ojkind_const_genvar _ -> true
+    | Ojkind_const_product ks -> List.exists out_jkind_const_has_genvar ks
+    | Ojkind_const_mod (Some k, _) -> out_jkind_const_has_genvar k
+    | Ojkind_const_mod (None, _) -> false
+    | Ojkind_const_with (k, _, _) -> out_jkind_const_has_genvar k
+    | Ojkind_const_default
+    | Ojkind_const_abbreviation _
+    | Ojkind_const_kind_of _ -> false
+  in
+  let rec out_jkind_has_genvar = function
+    | Ojkind_const k -> out_jkind_const_has_genvar k
+    | Ojkind_var _ -> false
+    | Ojkind_product ks -> List.exists out_jkind_has_genvar ks
+  in
+  let qtvs_top_genvars =
+    List.filter_map
+      (fun (_, jkind) -> match jkind with
+         | Some (Ojkind_const (Ojkind_const_genvar v)) -> Some v
+         | Some _ | None -> None)
+      qtvs
+  in
+  let oval_poly =
+    in_layout_poly &&
+    List.sort String.compare qtvs_top_genvars = List.sort String.compare qsvs &&
+    List.for_all
+      (fun (_, jkind) ->
+         match jkind with
+         | None -> true
+         | Some (Ojkind_const (Ojkind_const_genvar _)) -> true
+         | Some jk -> not (out_jkind_has_genvar jk))
+      qtvs
+  in
+  let oval_type =
+    if oval_poly then
+      let qtvs =
+        List.map
+          (fun ((v, jkind) as qtv) -> match jkind with
+             | Some (Ojkind_const (Ojkind_const_genvar _)) ->
+               (v, None)
+             | Some _ | None -> qtv)
+          qtvs
+      in Otyp_poly(qtvs, ty)
+    else Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty))
+  in
   let vd =
     { oval_name = id;
-      oval_type = Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty));
+      oval_type;
+      oval_poly;
       oval_modalities = tree_of_modalities Immutable moda;
       oval_prims = [];
       oval_attributes = attrs

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2420,6 +2420,82 @@ let extension_only_constructor id ppf ext =
       ocstr_return_type = ret;
     }
 
+(* We print [val poly_] when the following conditions are met:
+   1. each layout var in [qsvs] appears exactly once in [qtvs] kinds
+   2. no kind in [qtvs] contains a layout var from [qsvs] in a non-immediate
+   way (say, in a product).
+   If these conditions are met, we output an [Otyp_poly] with all generic
+   type variable explicitly printed as a type scheme, where
+   jkind-unconstrained variables are layout-polymorphic. Consequently, we need
+   to print all other jkind annotations, including [value].
+   Otherwise, we output the [layout_] representation.
+   CR-soon layouts aivaskovic:
+   We aspire to eventually remove the layout-polymorphic type variables which
+   currently appear unconstrained. This means that, instead of:
+     [val poly_ : 'a 'b ('c : value). 'a -> 'b -> 'c -> #('a * 'b * 'c)]
+   we would print:
+     [val poly_ : ('c : value). 'a -> 'b -> 'c -> #('a * 'b * 'c)]
+*)
+let val_poly_and_type in_layout_poly qsvs qtvs ty =
+  let rec out_jkind_const_has_genvar = function
+    | Ojkind_const_genvar _ -> true
+    | Ojkind_const_product ks -> List.exists out_jkind_const_has_genvar ks
+    | Ojkind_const_mod (Some k, _) -> out_jkind_const_has_genvar k
+    | Ojkind_const_mod (None, _) -> false
+    | Ojkind_const_with (k, _, _) -> out_jkind_const_has_genvar k
+    | Ojkind_const_default
+    | Ojkind_const_abbreviation _
+    | Ojkind_const_kind_of _ -> false
+  in
+  let rec out_jkind_has_genvar = function
+    | Ojkind_const k -> out_jkind_const_has_genvar k
+    | Ojkind_var _ -> false
+    | Ojkind_product ks -> List.exists out_jkind_has_genvar ks
+  in
+  let (genvar_qtvs, non_genvar_qtvs) =
+    List.partition
+      (fun (_, jkind) -> match jkind with
+         | Some (Ojkind_const (Ojkind_const_genvar _)) -> true
+         | _ -> false)
+      qtvs
+  in
+  let qtvs_top_genvars =
+    List.filter_map
+      (fun (_, jkind) -> match jkind with
+         | Some (Ojkind_const (Ojkind_const_genvar v)) -> Some v
+         | _ -> None)
+      genvar_qtvs
+  in
+  let oval_poly =
+    in_layout_poly &&
+    List.sort String.compare qtvs_top_genvars = List.sort String.compare qsvs &&
+    List.for_all
+      (fun (_, jkind) ->
+         match jkind with
+         | None -> true
+         | Some jk -> not (out_jkind_has_genvar jk))
+      non_genvar_qtvs
+  in
+  let oval_type =
+    if oval_poly then
+      let ordered_genvar_qtvs =
+        List.filter_map
+          (fun v ->
+             match List.find_opt
+                     (fun (_, jkind) -> match jkind with
+                        | Some (Ojkind_const (Ojkind_const_genvar v')) -> v = v'
+                        | _ -> false)
+                     genvar_qtvs
+             with
+             | Some (name, _) -> Some (name, None)
+             | None -> None)
+          qsvs
+      in
+      Otyp_poly(ordered_genvar_qtvs @ non_genvar_qtvs, ty)
+    else Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty))
+  in
+  oval_poly, oval_type
+
 (* Print a value declaration *)
 
 let tree_of_value_description id decl =
@@ -2478,67 +2554,7 @@ let tree_of_value_description id decl =
              ]
        }]
   in
-  (* We print [val poly_] in when the following conditions are met:
-     1. each layout var in [qsvs] appears exactly once in [qtvs] kinds
-     2. no kind in [qtvs] contains a layout var from [qsvs] in a non-immediate
-     way (say, in a product).
-     If these conditions are met, we output an [Otyp_poly] with all generic
-     type variable explicitly printed as a type scheme, where
-     jkind-unconstrained variables are layout-polymorphic. Consequently, we need
-     to print all other jkind annotations, including [value].
-     Otherwise, we output the [layout_] representation.
-     CR-soon layouts aivaskovic:
-     We aspire to eventually remove the layout-polymorphic type variables which
-     currently appear unconstrained. This means that, instead of:
-       [val poly_ : 'a 'b ('c : value). 'a -> 'b -> 'c -> #('a * 'b * 'c)]
-     we would print:
-       [val poly_ : ('c : value). 'a -> 'b -> 'c -> #('a * 'b * 'c)]
-  *)
-  let rec out_jkind_const_has_genvar = function
-    | Ojkind_const_genvar _ -> true
-    | Ojkind_const_product ks -> List.exists out_jkind_const_has_genvar ks
-    | Ojkind_const_mod (Some k, _) -> out_jkind_const_has_genvar k
-    | Ojkind_const_mod (None, _) -> false
-    | Ojkind_const_with (k, _, _) -> out_jkind_const_has_genvar k
-    | Ojkind_const_default
-    | Ojkind_const_abbreviation _
-    | Ojkind_const_kind_of _ -> false
-  in
-  let rec out_jkind_has_genvar = function
-    | Ojkind_const k -> out_jkind_const_has_genvar k
-    | Ojkind_var _ -> false
-    | Ojkind_product ks -> List.exists out_jkind_has_genvar ks
-  in
-  let qtvs_top_genvars =
-    List.filter_map
-      (fun (_, jkind) -> match jkind with
-         | Some (Ojkind_const (Ojkind_const_genvar v)) -> Some v
-         | Some _ | None -> None)
-      qtvs
-  in
-  let oval_poly =
-    in_layout_poly &&
-    List.sort String.compare qtvs_top_genvars = List.sort String.compare qsvs &&
-    List.for_all
-      (fun (_, jkind) ->
-         match jkind with
-         | None -> true
-         | Some (Ojkind_const (Ojkind_const_genvar _)) -> true
-         | Some jk -> not (out_jkind_has_genvar jk))
-      qtvs
-  in
-  let oval_type =
-    if oval_poly then
-      let qtvs =
-        List.map
-          (fun ((v, jkind) as qtv) -> match jkind with
-             | Some (Ojkind_const (Ojkind_const_genvar _)) ->
-               (v, None)
-             | Some _ | None -> qtv)
-          qtvs
-      in Otyp_poly(qtvs, ty)
-    else Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty))
-  in
+  let oval_poly, oval_type = val_poly_and_type in_layout_poly qsvs qtvs ty in
   let vd =
     { oval_name = id;
       oval_type;

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1420,13 +1420,14 @@ let rec out_jkind_of_desc env (desc : 'd Jkind.Desc.t) =
 (* CR layouts v2.8: This should use the annotation in the jkind, if there
    is one. But first that annotation needs to be in Typedtree, not in
    Parsetree. Internal ticket 4435. *)
-let out_jkind_option_of_jkind ~ignore_null env jkind =
+let out_jkind_option_of_jkind ~ignore_null ~in_layout_poly env jkind =
   let desc = Jkind.get jkind in
   let elide =
-    Jkind.is_value_for_printing ~ignore_null env jkind (* C2.1 *)
-    || (match desc.base with
-        | Layout (Sort (Var _, _)) -> not !Clflags.verbose_types (* X1 *)
-        | _ -> false)
+    not in_layout_poly
+    && (Jkind.is_value_for_printing ~ignore_null env jkind (* C2.1 *)
+        || (match desc.base with
+          | Layout (Sort (Var _, _)) -> not !Clflags.verbose_types (* X1 *)
+          | _ -> false))
   in
   if elide then None else Some (out_jkind_of_desc env desc)
 
@@ -1673,7 +1674,7 @@ let rec tree_of_modal_typexp mode modal ty =
         (* Make the names delayed, so that the real type is
            printed once when used as proxy *)
         List.iter add_delayed tyl;
-        let tl = tree_of_qtvs tyl in
+        let tl = tree_of_qtvs ~in_layout_poly:false tyl in
         let tr = Otyp_poly (tl, tree_of_typexp mode alloc_mode ty) in
         (* Forget names when we leave scope *)
         Names.remove_names tyl;
@@ -1757,16 +1758,19 @@ and tree_of_typexp mode alloc_mode ty =
   tree_of_modal_typexp mode (Other alloc_mode) ty
 
 (* qtvs = quantified type variables *)
-(* this silently drops any arguments that are not generic Tvar or Tunivar *)
-and tree_of_qtvs qtvs =
+(* this silently drops any arguments that are not generic Tvar or Tunivar, *)
+(* unless we're printing a layout-polymorphic value description *)
+and tree_of_qtvs ~in_layout_poly qtvs =
   let tree_of_qtv v : (string * out_jkind option) option =
-    (* CR layouts: We ignore nullability here to avoid needlessly printing
-       ['a : value_or_null] when it's not relevant (most cases).
+    (* CR layouts: We possibly ignore nullability here to avoid needlessly
+       printing ['a : value_or_null] when it's not relevant (most cases);
+       a notable exception is "val poly_".
        Unfortunately, this makes error messages really confusing, because
        we don't consider jkind annotations. *)
     let tree jkind =
       Some (Names.name_of_type Names.new_name v,
-            out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind)
+            out_jkind_option_of_jkind ~ignore_null:true ~in_layout_poly
+              !printing_env jkind)
     in
     match v.desc with
     | Tvar { jkind } when v.level = generic_level -> tree jkind
@@ -2004,20 +2008,21 @@ let zap_qtvs_if_boring qtvs =
 (* get the free variables with their jkinds; do this *after* converting the
    type itself, so that the type names are available.
    This implements Case (C3) from Note [When to print jkind annotations]. *)
-let extract_qtvs tyl =
+let extract_qtvs ~in_layout_poly tyl =
   let fvs = Ctype.free_non_row_variables_of_list tyl in
   (* The [Ctype.free*variables] family of functions returns the free
      variables in reverse order they were encountered in the list of types.
   *)
   let fvs = List.rev fvs in
   let tfvs = List.map Transient_expr.repr fvs in
-  let vars_jkinds = tree_of_qtvs tfvs in
+  let vars_jkinds = tree_of_qtvs ~in_layout_poly tfvs in
   zap_qtvs_if_boring vars_jkinds
 
 let param_jkind ty =
   match get_desc ty with
   | Tvar { jkind; _ } | Tunivar { jkind; _ } ->
-     out_jkind_option_of_jkind ~ignore_null:false !printing_env jkind
+      out_jkind_option_of_jkind ~ignore_null:false ~in_layout_poly:false
+        !printing_env jkind
   | _ -> None (* this is (C2.2) from Note [When to print jkind annotations] *)
 
 let tree_of_label l =
@@ -2051,7 +2056,9 @@ let tree_of_constructor_args_and_ret_type args ret_type =
   | Some res ->
       let out_ret = tree_of_typexp Type res in
       let out_args = tree_of_constructor_arguments args in
-      let qtvs = extract_qtvs (res :: tys_of_constr_args args) in
+      let qtvs =
+        extract_qtvs ~in_layout_poly:false (res :: tys_of_constr_args args)
+      in
       (out_args, Some (qtvs, out_ret))
 
 let tree_of_single_constructor cd =
@@ -2429,12 +2436,13 @@ let tree_of_value_description id decl =
       Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha
         decl.val_modalities
   in
+  let in_layout_poly = not (List.is_empty (Lpoly.get_exn decl.val_lpoly)) in
   let qsvs, qtvs =
     (* Important: process the fvs *after* the type; tree_of_type_scheme
        resets the naming context. Both must be inside print_with_genvars
        so that sort poly var names are registered when jkinds are printed. *)
     Jkind_types.Sort.print_with_genvars (Lpoly.get_exn decl.val_lpoly)
-      (fun names -> names, extract_qtvs [decl.val_type])
+      (fun names -> names, extract_qtvs ~in_layout_poly [decl.val_type])
   in
   let apparent_arity =
     let rec count n typ =
@@ -2503,7 +2511,7 @@ let tree_of_method mode (lab, priv, virt, ty) =
   let (ty, tyl) = method_type priv ty in
   let tty = tree_of_typexp mode ty in
   let tyl = List.map Transient_expr.repr tyl in
-  let qtvs = tree_of_qtvs tyl in
+  let qtvs = tree_of_qtvs ~in_layout_poly:false tyl in
   let qtvs = zap_qtvs_if_boring qtvs in
   Names.remove_names tyl;
   let priv = priv <> Mpublic in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4236,8 +4236,11 @@ let transl_value_decl env loc ~modal ~why valdecl =
         in
         md_mode, modalities, Valmi_sig_value raw_modalities
   in
+  let lpoly_flag =
+    if valdecl.pval_poly then Typetexp.Lpoly else Typetexp.Lmono
+  in
   let lpoly, cty =
-    Typetexp.transl_type_scheme env valdecl.pval_poly valdecl.pval_type
+    Typetexp.transl_type_scheme env valdecl.pval_type lpoly_flag
   in
   let sort =
     match Ctype.type_sort ~why ~fixed:false env cty.ctyp_type with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4226,7 +4226,6 @@ let transl_value_decl env loc ~modal ~why valdecl =
         if valdecl.pval_poly then begin
           Language_extension.assert_enabled ~loc Layout_poly
             Language_extension.Alpha;
-          raise (Error (loc, Poly_not_yet_implemented))
         end;
         let raw_modalities =
           Typemode.transl_modalities_with_default
@@ -4237,7 +4236,9 @@ let transl_value_decl env loc ~modal ~why valdecl =
         in
         md_mode, modalities, Valmi_sig_value raw_modalities
   in
-  let lpoly, cty = Typetexp.transl_type_scheme env valdecl.pval_type in
+  let lpoly, cty =
+    Typetexp.transl_type_scheme env valdecl.pval_poly valdecl.pval_type
+  in
   let sort =
     match Ctype.type_sort ~why ~fixed:false env cty.ctyp_type with
     | Ok sort -> sort

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -55,6 +55,14 @@ type cannot_quantify_reason =
   | Univar
   | Scope_escape
 
+type valdecl_lpoly_flag =
+  | Lpoly
+  | Lmono
+
+let is_poly_valdecl = function
+  | Lpoly -> true
+  | Lmono -> false
+
 (* a description of the jkind on an explicitly quantified universal
    variable, containing whether the jkind was a default
    (e.g. [let f : 'a. 'a -> 'a = ...]) or explicit
@@ -1733,17 +1741,18 @@ let transl_type_scheme_newlayout env attrs loc vars inner_type =
     ident_var_pairs |> List.map snd |> List.rev, ctyp
   end
 
-let transl_type_scheme env poly_valdecl styp =
+let transl_type_scheme env styp valdecl_flag =
+  let is_val_poly = is_poly_valdecl valdecl_flag in
   match styp.ptyp_desc with
   | Ptyp_newlayout (vars, st) ->
     Language_extension.assert_enabled ~loc:styp.ptyp_loc Layout_poly
       Language_extension.Alpha;
-    if poly_valdecl then
+    if is_val_poly then
       raise (Error (styp.ptyp_loc, env, Val_poly_and_layout));
     transl_type_scheme_newlayout env styp.ptyp_attributes
       styp.ptyp_loc vars st
   | _ ->
-    if poly_valdecl then transl_type_scheme_poly_val env styp
+    if is_val_poly then transl_type_scheme_poly_val env styp
     else [], transl_type_scheme_lmono env styp
 
 (* Error report *)

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1656,28 +1656,43 @@ let transl_type_scheme_poly_val env styp =
     | Ptyp_poly (vars, styp) -> vars, styp
     | _ -> [], styp
   in
-  let cty =
-    with_local_level begin fun () ->
-      TyVarEnv.reset ();
-      List.iter
-        (fun (name_loc, jkind_opt) ->
-           let name = name_loc.txt in
-           if Option.is_some jkind_opt then
-             let jkind =
-               jkind_of_annotation env
-                 (Type_variable ("'" ^ name)) [] (Option.get jkind_opt)
-             in
-             let var = newvar ~name jkind in
-             TyVarEnv.add name var jkind (Env.stage env))
-        vars;
-      transl_simple_type ~new_var_jkind:Sort env ~closed:false
-        Alloc.Const.legacy styp
-    end
-    ~post:generalize_ctyp
+  let cty, preregistered =
+    with_local_level
+      begin fun () ->
+        TyVarEnv.reset ();
+        let preregistered =
+          List.map
+            (fun (name_loc, jkind_opt) ->
+              let name = name_loc.txt in
+              let jkind =
+                match jkind_opt with
+                | Some jkind_annot ->
+                  jkind_of_annotation env
+                    (Type_variable ("'" ^ name)) [] jkind_annot
+                | None ->
+                  let level = get_current_level () in
+                  Jkind.of_new_legacy_sort ~why:Unification_var ~level
+              in
+              let var = newvar ~name jkind in
+              TyVarEnv.add name var jkind (Env.stage env);
+              var)
+            vars
+        in
+        let cty =
+          transl_simple_type ~new_var_jkind:Sort env ~closed:false
+            Alloc.Const.legacy styp
+        in
+        cty, preregistered
+      end
+      ~post:(fun (cty, _) -> generalize_ctyp cty)
   in
   let ty = cty.ctyp_type in
+  let declared_sort_vars =
+    List.concat_map generalize_layout_variables preregistered
+  in
   let ety = Subst.type_expr Subst.identity ty in
-  let sort_vars = generalize_layout_variables ety in
+  let body_sort_vars = generalize_layout_variables ety in
+  let sort_vars = declared_sort_vars @ body_sort_vars in
   let vars_names_loc =
     List.map (fun v -> mknoloc (Jkind_types.Sort.Var.name v)) sort_vars
   in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1971,7 +1971,7 @@ let report_error_doc env ppf =
          annotations@]"
   | Val_poly_and_layout ->
       fprintf ppf
-        "@[The %a keyword is not support inside layout-polymorphic@ \
+        "@[The %a keyword is not supported inside layout-polymorphic@ \
          value descriptions introduced using %a.@]"
         Style.inline_code "layout_"
         Style.inline_code "val poly_"

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -106,6 +106,7 @@ type error =
   | Mismatched_jkind_annotation of
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
+  | Val_poly_and_layout
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -1641,7 +1642,41 @@ let transl_type_scheme_lmono env styp =
   | _ ->
     transl_type_scheme_mono env styp
 
-let transl_type_scheme_lpoly env attrs loc vars inner_type =
+let transl_type_scheme_poly_val env styp =
+  let vars, styp =
+    match styp.ptyp_desc with
+    | Ptyp_poly (vars, styp) -> vars, styp
+    | _ -> [], styp
+  in
+  let cty =
+    with_local_level begin fun () ->
+      TyVarEnv.reset ();
+      List.iter
+        (fun (name_loc, jkind_opt) ->
+           let name = name_loc.txt in
+           if Option.is_some jkind_opt then
+             let jkind =
+               jkind_of_annotation env
+                 (Type_variable ("'" ^ name)) [] (Option.get jkind_opt)
+             in
+             let var = newvar ~name jkind in
+             TyVarEnv.add name var jkind (Env.stage env))
+        vars;
+      transl_simple_type ~new_var_jkind:Sort env ~closed:false
+        Alloc.Const.legacy styp
+    end
+    ~post:generalize_ctyp
+  in
+  let ty = cty.ctyp_type in
+  let ety = Subst.type_expr Subst.identity ty in
+  let sort_vars = generalize_layout_variables ety in
+  let vars_names_loc =
+    List.map (fun v -> mknoloc (Jkind_types.Sort.Var.name v)) sort_vars
+  in
+  let ctyp = { cty with ctyp_desc = Ttyp_newlayout (vars_names_loc, cty) } in
+  sort_vars, ctyp
+
+let transl_type_scheme_newlayout env attrs loc vars inner_type =
   (* Use [with_local_level] just for scoping *)
   with_local_level begin fun () ->
     let env', ident_var_pairs =
@@ -1698,15 +1733,18 @@ let transl_type_scheme_lpoly env attrs loc vars inner_type =
     ident_var_pairs |> List.map snd |> List.rev, ctyp
   end
 
-let transl_type_scheme env styp =
+let transl_type_scheme env poly_valdecl styp =
   match styp.ptyp_desc with
   | Ptyp_newlayout (vars, st) ->
     Language_extension.assert_enabled ~loc:styp.ptyp_loc Layout_poly
       Language_extension.Alpha;
-    transl_type_scheme_lpoly env styp.ptyp_attributes
+    if poly_valdecl then
+      raise (Error (styp.ptyp_loc, env, Val_poly_and_layout));
+    transl_type_scheme_newlayout env styp.ptyp_attributes
       styp.ptyp_loc vars st
   | _ ->
-    [], transl_type_scheme_lmono env styp
+    if poly_valdecl then transl_type_scheme_poly_val env styp
+    else [], transl_type_scheme_lmono env styp
 
 (* Error report *)
 
@@ -1922,6 +1960,12 @@ let report_error_doc env ppf =
       fprintf ppf
         "@[Layout polymorphism is not supported in term-level type \
          annotations@]"
+  | Val_poly_and_layout ->
+      fprintf ppf
+        "@[The %a keyword is not support inside layout-polymorphic@ \
+         value descriptions introduced using %a.@]"
+        Style.inline_code "layout_"
+        Style.inline_code "val poly_"
 
 let () =
   Location.register_error_of_exn

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -20,6 +20,8 @@ open Mode
 
 type jkind_initialization_choice = Sort | Any
 
+type valdecl_lpoly_flag = Lpoly | Lmono
+
 module TyVarEnv : sig
   (* this is just the subset of [TyVarEnv] that is needed outside
      of [Typetexp]. See the ml file for more. *)
@@ -130,7 +132,7 @@ val transl_simple_type_delayed
            Returns the type, an instance of the corresponding type_expr, and a
            function that binds the type variable. *)
 val transl_type_scheme:
-        Env.t -> bool -> Parsetree.core_type ->
+        Env.t -> Parsetree.core_type -> valdecl_lpoly_flag ->
         Jkind_types.Sort.var list * Typedtree.core_type
 val transl_type_param:
   Env.t -> Path.t -> jkind_lr -> Parsetree.core_type -> Typedtree.core_type

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -130,7 +130,7 @@ val transl_simple_type_delayed
            Returns the type, an instance of the corresponding type_expr, and a
            function that binds the type variable. *)
 val transl_type_scheme:
-        Env.t -> Parsetree.core_type ->
+        Env.t -> bool -> Parsetree.core_type ->
         Jkind_types.Sort.var list * Typedtree.core_type
 val transl_type_param:
   Env.t -> Path.t -> jkind_lr -> Parsetree.core_type -> Typedtree.core_type
@@ -196,6 +196,7 @@ type error =
   | Mismatched_jkind_annotation of
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
+  | Val_poly_and_layout
 
 exception Error of Location.t * Env.t * error
 


### PR DESCRIPTION
Following PR #5755, this pull request introduces `poly_` in value descriptions that get printed.
**Status quo:** `layout_` bindings are always printed.

# Main changes
- The outcome tree's representation of value descriptions in a signature uses its `oval_poly` field and the type being printed to decide whether or not to print `layout_`.
- New logic is added to decide whether and how jkind annotations are printed in layout-polymorphic polymorphic value descriptions. Layout-polymorphic value descriptions that have non-trivial uses of the layouts are printed with `layout_` and without `poly_`; value descriptions with `poly_` are not 

# Testing
- Diffs appear throughout the `layout_poly/val_poly.ml` test file, so that the expected outputs contain `val poly_`.
- Test are added to demonstrate when `poly_` cannot be used and when `value` is printed.