### PR TITLE
Fixing the issue on `let..in` binding on signature help

### DIFF
--- a/external/merlin/src/analysis/signature_help.ml
+++ b/external/merlin/src/analysis/signature_help.ml
@@ -174,7 +174,8 @@ let is_arrow t =
   | Tarrow _ -> true
   | _ -> false
 
-let application_signature ~prefix ~cursor = function
+let application_signature ~prefix ~cursor node =
+  match node with
   | (_, Browse_raw.Expression arg)
     :: ( _,
          Expression
@@ -207,7 +208,54 @@ let application_signature ~prefix ~cursor = function
     let result = separate_function_signature e ~args:[] in
     let active_param = active_parameter_by_prefix ~prefix result.parameters in
     Some { result with active_param }
-  | _ -> None
+  | _ ->
+    let rec find_smallest_arrow_before_pos (e : Typedtree.expression) pos
+        ~(acc : Typedtree.expression) =
+      if Lexing.compare_pos e.exp_loc.loc_start pos = 1 then
+        match acc.exp_desc with
+        | Texp_let (_, vlist, _) ->
+          let v =
+            List.find_opt
+              ~f:(fun (value_binding : Typedtree.value_binding) ->
+                match Types.get_desc value_binding.vb_expr.exp_type with
+                | Tarrow _ -> true
+                | _ -> false)
+              vlist
+          in
+          Option.map ~f:(fun (v : Typedtree.value_binding) -> v.vb_expr) v
+        | _ -> None
+      else
+        match e.exp_desc with
+        | Texp_let (_, _, next) ->
+          find_smallest_arrow_before_pos next pos ~acc:e
+        | _ -> None
+    in
+    let f node cursor =
+      match node with
+      | _, Browse_raw.Expression e ->
+        find_smallest_arrow_before_pos e cursor ~acc:e
+      | _ -> assert false
+    in
+    let expressions =
+      List.filter
+        ~f:(fun n ->
+          match n with
+          | _, Browse_raw.Expression _ -> true
+          | _ -> false)
+        node
+    in
+    if expressions = [] then None
+    else
+      let last_node = List.hd (List.rev expressions) in
+      let smallest_frag_opt = f last_node cursor in
+      Option.map
+        ~f:(fun frag ->
+          let result = separate_function_signature frag ~args:[] in
+          let active_param =
+            active_parameter_by_prefix ~prefix result.parameters
+          in
+          { result with active_param })
+        smallest_frag_opt
 
 let prefix_of_position ~short_path source position =
   match Msource.text source with

--- a/external/merlin/src/analysis/signature_help.ml
+++ b/external/merlin/src/analysis/signature_help.ml
@@ -210,8 +210,8 @@ let application_signature ~prefix ~cursor node =
     Some { result with active_param }
   | _ ->
     let rec find_smallest_arrow_before_pos (e : Typedtree.expression) pos
-        ~(acc : Typedtree.expression) =
-      if Lexing.compare_pos e.exp_loc.loc_start pos = 1 then
+        (acc : Typedtree.expression) =
+      if Lexing.compare_pos e.exp_loc.loc_start pos > 0 then
         match acc.exp_desc with
         | Texp_let (_, vlist, _) ->
           let v =
@@ -226,28 +226,23 @@ let application_signature ~prefix ~cursor node =
         | _ -> None
       else
         match e.exp_desc with
-        | Texp_let (_, _, next) ->
-          find_smallest_arrow_before_pos next pos ~acc:e
+        | Texp_let (_, _, next) -> find_smallest_arrow_before_pos next pos e
         | _ -> None
     in
-    let f node cursor =
-      match node with
-      | _, Browse_raw.Expression e ->
-        find_smallest_arrow_before_pos e cursor ~acc:e
-      | _ -> assert false
-    in
     let expressions =
-      List.filter
+      List.filter_map
         ~f:(fun n ->
           match n with
-          | _, Browse_raw.Expression _ -> true
-          | _ -> false)
+          | _, Browse_raw.Expression e -> Some e
+          | _ -> None)
         node
     in
     if expressions = [] then None
     else
       let last_node = List.hd (List.rev expressions) in
-      let smallest_frag_opt = f last_node cursor in
+      let smallest_frag_opt =
+        find_smallest_arrow_before_pos last_node cursor last_node
+      in
       Option.map
         ~f:(fun frag ->
           let result = separate_function_signature frag ~args:[] in

--- a/external/merlin/tests/test-dirs/signature-help/issue_let_in_binding.t
+++ b/external/merlin/tests/test-dirs/signature-help/issue_let_in_binding.t
@@ -1,3 +1,4 @@
+The cursor is between 'map' and 'in' and behaves correctly as the in is written.
   $ cat > test1.ml <<'EOF'
   > let _ =
   > let f = List.map   in
@@ -8,7 +9,7 @@
   $ $MERLIN single signature-help -position 2:17 -filename test1 < test1.ml | jq '.value.signatures[0].label'
   "List.map : ('a -> 'b) -> 'a list -> 'b list"
 
-FIXME: Signature-help does not trigger on unfinished let ... in bindings.
+FIXME: The cursor is after the map, but without the 'in', signature help is not triggered.
   $ cat > test2.ml <<'EOF'
   > let _ =
   > let f = List.map  
@@ -18,3 +19,191 @@ FIXME: Signature-help does not trigger on unfinished let ... in bindings.
 
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml | jq '.value.signatures[0].label'
   null
+
+FIXME: The cursor is after 'map' and should trigger signature help for the function 'map'.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+The cursor is after the 'ends_with' function and triggers the signature help.
+FIXME: The active parameter should be 0.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map ~f:(fun x -> String.ends_with ) in
+  > let n = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:47 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "String.ends_with : suffix:string -> string -> bool",
+          "parameters": [
+            {
+              "label": [
+                19,
+                32
+              ]
+            },
+            {
+              "label": [
+                36,
+                42
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is between 'map' and 'in' and triggers correctly the 'map' even if the unfinished 'iter'
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map  in
+  > let s = List.iter
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "List.map : ('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+FIXME: The cursor is after 'map' and should trigger the 'map'
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter
+  > let n = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+FIXME: The cursor is after the '()' of the 'iter' function. It should trigger the 'iter' with active parameter set to 1.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter () 
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 3:21 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+FIXME: The cursor is after the 'iter' and should trigger the 'iter'.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter 
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 3:18 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+The cursor is between the '()' and 'in' and triggers correctly the 'iter' signature help.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter ()  in
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 3:21 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "List.iter : ('a -> unit) -> 'a list -> unit",
+          "parameters": [
+            {
+              "label": [
+                12,
+                24
+              ]
+            },
+            {
+              "label": [
+                28,
+                35
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after the 'in' of the 'let n = 5 in' and triggers nothing.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.hd in
+  > let s = List.iter  in
+  > let n = 5 in
+  > 9
+  > EOF
+
+  $ $MERLIN single signature-help -position 4:18 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }

--- a/external/merlin/tests/test-dirs/signature-help/issue_let_in_binding.t
+++ b/external/merlin/tests/test-dirs/signature-help/issue_let_in_binding.t
@@ -9,7 +9,7 @@ The cursor is between 'map' and 'in' and behaves correctly as the in is written.
   $ $MERLIN single signature-help -position 2:17 -filename test1 < test1.ml | jq '.value.signatures[0].label'
   "List.map : ('a -> 'b) -> 'a list -> 'b list"
 
-FIXME: The cursor is after the map, but without the 'in', signature help is not triggered.
+The cursor is after the map and triggers the 'map' signature help.
   $ cat > test2.ml <<'EOF'
   > let _ =
   > let f = List.map  
@@ -18,9 +18,9 @@ FIXME: The cursor is after the map, but without the 'in', signature help is not 
   > EOF
 
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml | jq '.value.signatures[0].label'
-  null
+  "List.map : ('a -> 'b) -> 'a list -> 'b list"
 
-FIXME: The cursor is after 'map' and should trigger signature help for the function 'map'.
+The cursor is after 'map' and triggers correctly signature help for the function 'map'.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -30,7 +30,29 @@ FIXME: The cursor is after 'map' and should trigger signature help for the funct
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "List.map : ('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
@@ -109,7 +131,7 @@ The cursor is between 'map' and 'in' and triggers correctly the 'map' even if th
     "notifications": []
   }
 
-FIXME: The cursor is after 'map' and should trigger the 'map'
+The cursor is after 'map' and triggers correctly the 'map'.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -121,11 +143,33 @@ FIXME: The cursor is after 'map' and should trigger the 'map'
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "List.map : ('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
-FIXME: The cursor is after the '()' of the 'iter' function. It should trigger the 'iter' with active parameter set to 1.
+FIXME: The cursor is after the '()' of the 'iter' function. It triggers the function from the parenthesis but should trigger the 'iter' with active parameter set to 1.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -136,11 +180,27 @@ FIXME: The cursor is after the '()' of the 'iter' function. It should trigger th
   $ $MERLIN single signature-help -position 3:21 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "_ : 'a list -> unit",
+          "parameters": [
+            {
+              "label": [
+                4,
+                11
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
-FIXME: The cursor is after the 'iter' and should trigger the 'iter'.
+The cursor is after the 'iter' and trigger correcly the 'iter'.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -151,7 +211,29 @@ FIXME: The cursor is after the 'iter' and should trigger the 'iter'.
   $ $MERLIN single signature-help -position 3:18 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "List.iter : ('a -> unit) -> 'a list -> unit",
+          "parameters": [
+            {
+              "label": [
+                12,
+                24
+              ]
+            },
+            {
+              "label": [
+                28,
+                35
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
@@ -192,7 +274,7 @@ The cursor is between the '()' and 'in' and triggers correctly the 'iter' signat
     "notifications": []
   }
 
-The cursor is after the 'in' of the 'let n = 5 in' and triggers nothing.
+The cursor is after the 'in' of the 'let n = 5 in' and triggers correctly nothing.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.hd in


### PR DESCRIPTION
I am opening this PR on behalf of @Lucccyo. She originally opened this PR on [oxcaml/merlin](https://github.com/oxcaml/merlin) - I am simply migrating the PR over to this repo since Merlin has migrated over.

[Original PR: https://github.com/oxcaml/merlin/pull/205](https://github.com/oxcaml/merlin/pull/223)

Migrating this PR over required me to do some merging. As a result, I did my best to faithfully merge this PR. To do so, I cherry picked commits 044f88562164698b1bc547008c23372ada2ba591 and 896c7501ddd5c686fdebfb725bd8f70bb27bf08f, but I dropped commits f5bbddd1969b90f7a883ef7887f57a945b681fa7, 1adb8341c8a8277f14229915be8a23c4f7cfdf64, and 0f9399fe2720c28098d5757cc5a80d669563d591, which seemed to be mostly a duplication of commits that were merged in https://github.com/oxcaml/merlin/pull/216. I did, however, keep some changes that were mixed in with 1adb8341c8a8277f14229915be8a23c4f7cfdf64 that were not included in 216.