### PR TITLE
Fix compiler panic around with [@@unboxed] and existentials

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/regression-tests/unboxed_gadt_existential_array.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/unboxed_gadt_existential_array.ml
@@ -1,0 +1,58 @@
+(* TEST
+ expect;
+*)
+
+(* Regression test for COMPILERS-7227.
+
+   An [@@unboxed] GADT constructor that opens an existential storage type
+   whose kind is constrained by [immutable_data] used to produce a [t]
+   whose kind "depends on the existential". When the layout of [_ t array]
+   was requested -- via a layout-poly array primitive ([%array_length],
+   [%array_unsafe_get]) or via [Translcore.layout_exp] / [Typeopt.value_kind]
+   on a function parameter or higher-order argument -- the type was scraped
+   to [Tof_kind], which fell into the [assert false] arm of
+   [Typeopt.classify], producing a fatal ICE. *)
+
+type ('a, 'b : immutable_data) unpacked : immutable_data with 'b =
+  { node : 'b }
+[@@unboxed]
+
+type +'a t = Node : ('a, _) unpacked -> 'a t
+[@@unboxed] [@@warning "-unused-constructor"]
+
+[%%expect{|
+type ('a, 'b : immutable_data) unpacked = { node : 'b; } [@@unboxed]
+type +'a t = Node : 'a ('b : immutable_data). ('a, 'b) unpacked -> 'a t [@@unboxed]
+|}]
+
+(* (1) %array_length -> Translprim.specialize_primitive (Parraylength). *)
+let _01_array_length (children : 'a t array) = Array.length children
+[%%expect{|
+Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
+
+|}]
+
+(* (2) %array_unsafe_get -> Translprim.specialize_primitive (Parrayrefu). *)
+let _02_array_get (children : 'a t array) = children.(0)
+[%%expect{|
+Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
+
+|}]
+
+(* (3) Just naming the array as a parameter -> Translcore.transl_curried_function
+       computing the parameter's layout via Typeopt.value_kind ->
+       array_kind_of_elt -> classify. *)
+let _03_param_layout (children : 'a t array) = ignore children
+[%%expect{|
+Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
+
+|}]
+
+(* (4) Passing the array to a higher-order function -> Translcore.layout_exp
+       on the array argument, same value_kind -> array_kind_of_elt ->
+       classify path as (3). *)
+let _04_array_arg_layout (children : 'a t array) = Array.iter ignore children
+[%%expect{|
+Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
+
+|}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/unboxed_gadt_existential_array.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/unboxed_gadt_existential_array.ml
@@ -28,15 +28,13 @@ type +'a t = Node : 'a ('b : immutable_data). ('a, 'b) unpacked -> 'a t [@@unbox
 (* (1) %array_length -> Translprim.specialize_primitive (Parraylength). *)
 let _01_array_length (children : 'a t array) = Array.length children
 [%%expect{|
-Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
-
+val _01_array_length : 'a t array -> int = <fun>
 |}]
 
 (* (2) %array_unsafe_get -> Translprim.specialize_primitive (Parrayrefu). *)
 let _02_array_get (children : 'a t array) = children.(0)
 [%%expect{|
-Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
-
+val _02_array_get : 'a t array -> 'a t = <fun>
 |}]
 
 (* (3) Just naming the array as a parameter -> Translcore.transl_curried_function
@@ -44,8 +42,7 @@ Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Asserti
        array_kind_of_elt -> classify. *)
 let _03_param_layout (children : 'a t array) = ignore children
 [%%expect{|
-Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
-
+val _03_param_layout : 'a t array -> unit = <fun>
 |}]
 
 (* (4) Passing the array to a higher-order function -> Translcore.layout_exp
@@ -53,6 +50,5 @@ Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Asserti
        classify path as (3). *)
 let _04_array_arg_layout (children : 'a t array) = Array.iter ignore children
 [%%expect{|
-Uncaught exception: File "typing/typeopt.ml", line 265, characters 6-12: Assertion failed
-
+val _04_array_arg_layout : 'a t array -> unit = <fun>
 |}]

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -204,7 +204,7 @@ let classify ~classify_product env ty layout : _ classification =
     if Ctype.check_type_nullability env ty Non_null
     then Immediate else Immediate_or_null
   else match get_desc ty with
-  | Tvar _ | Tunivar _ ->
+  | Tvar _ | Tunivar _ | Tof_kind _ ->
       Any
   | Tconstr (p, _args, _abbrev) ->
       if Path.same p Predef.path_float then Float
@@ -261,7 +261,7 @@ let classify ~classify_product env ty layout : _ classification =
   | Tquote _ | Tsplice _ | Tquote_eval _ ->
       Any
   | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _
-  | Tof_kind _ | Trepr _ ->
+  | Trepr _ ->
       assert false
   end
   | Base (Float64, _) -> Unboxed_float Unboxed_float64


### PR DESCRIPTION
See first commit for the failing test and the second commit for the fix.

Logic: the `Tof_kind` case is a type that we don't really know what it is -- just like a variable. So let's treat it like one. The previous implementation was based on a mistaken assumption that a `Tof_kind` couldn't ever get to the relevant... but the test here shows that it can, and there's nothing wrong with that. So let's just treat it like other unknown types.