### PR TITLE
Use total structural order for solver morph map keys

### DIFF
--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -183,8 +183,11 @@ module Per_axis = struct
     let print : type a. a t -> Fmt.formatter -> a -> unit = function
       | Externality -> Externality.print
 
-    let compare_obj : type a b. a t -> b t -> (a, b) Misc.comparison =
-     fun a b -> match a, b with Externality, Externality -> Equal
+    let compare_obj : type a b. a t -> b t -> int =
+     fun a b -> match a, b with Externality, Externality -> 0
+
+    let equal_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
+     fun a b -> match a, b with Externality, Externality -> Some Refl
   end
 
   let min : type a. a t -> a = function[@inline available]
@@ -223,13 +226,21 @@ module Per_axis = struct
     | Modal ax -> Mode.Crossing.Per_axis.print ax
     | Nonmodal ax -> Nonmodal.print ax
 
-  let compare_obj : type a b. a t -> b t -> (a, b) Misc.comparison =
+  let compare_obj : type a b. a t -> b t -> int =
    fun a b ->
     match a, b with
     | Modal ax0, Modal ax1 -> Mode.Crossing.Per_axis.compare_obj ax0 ax1
-    | Modal _, _ -> Less_than
-    | _, Modal _ -> Greater_than
+    | Modal _, _ -> -1
+    | _, Modal _ -> 1
     | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.compare_obj ax0 ax1
+
+  let equal_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
+   fun a b ->
+    match a, b with
+    | Modal ax0, Modal ax1 -> Mode.Crossing.Per_axis.equal_obj ax0 ax1
+    | Modal _, _ -> None
+    | _, Modal _ -> None
+    | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.equal_obj ax0 ax1
 
   let print_obj : type a. Fmt.formatter -> a t -> unit =
    fun ppf ax -> Fmt.pp_print_string ppf (name ax)

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -186,8 +186,8 @@ module Per_axis = struct
     let compare_obj : type a b. a t -> b t -> int =
      fun a b -> match a, b with Externality, Externality -> 0
 
-    let equal_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
-     fun a b -> match a, b with Externality, Externality -> Some Refl
+    let equal_obj : type a b. a t -> b t -> (a, b) Misc.is_eq =
+     fun a b -> match a, b with Externality, Externality -> Misc.Is_eq
   end
 
   let min : type a. a t -> a = function[@inline available]
@@ -234,12 +234,12 @@ module Per_axis = struct
     | _, Modal _ -> 1
     | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.compare_obj ax0 ax1
 
-  let equal_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
+  let equal_obj : type a b. a t -> b t -> (a, b) Misc.is_eq =
    fun a b ->
     match a, b with
     | Modal ax0, Modal ax1 -> Mode.Crossing.Per_axis.equal_obj ax0 ax1
-    | Modal _, _ -> None
-    | _, Modal _ -> None
+    | Modal _, _ -> Misc.Is_not_eq
+    | _, Modal _ -> Misc.Is_not_eq
     | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.equal_obj ax0 ax1
 
   let print_obj : type a. Fmt.formatter -> a t -> unit =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1258,29 +1258,29 @@ module Lattices = struct
     | _, Comonadic_with_regionality -> 1
     | Comonadic_with_locality, Comonadic_with_locality -> 0
 
-  let equal_obj : type a b. a obj -> b obj -> (a, b) Misc.eq option =
+  let equal_obj : type a b. a obj -> b obj -> (a, b) Misc.is_eq =
    fun a b ->
     match a, b with
-    | Locality, Locality -> Some Refl
-    | Regionality, Regionality -> Some Refl
-    | Uniqueness_op, Uniqueness_op -> Some Refl
-    | Linearity, Linearity -> Some Refl
-    | Portability, Portability -> Some Refl
-    | Forkable, Forkable -> Some Refl
-    | Yielding, Yielding -> Some Refl
-    | Statefulness, Statefulness -> Some Refl
-    | Contention_op, Contention_op -> Some Refl
-    | Visibility_op, Visibility_op -> Some Refl
-    | Staticity_op, Staticity_op -> Some Refl
-    | Monadic_op, Monadic_op -> Some Refl
-    | Comonadic_with_regionality, Comonadic_with_regionality -> Some Refl
-    | Comonadic_with_locality, Comonadic_with_locality -> Some Refl
+    | Locality, Locality -> Misc.Is_eq
+    | Regionality, Regionality -> Misc.Is_eq
+    | Uniqueness_op, Uniqueness_op -> Misc.Is_eq
+    | Linearity, Linearity -> Misc.Is_eq
+    | Portability, Portability -> Misc.Is_eq
+    | Forkable, Forkable -> Misc.Is_eq
+    | Yielding, Yielding -> Misc.Is_eq
+    | Statefulness, Statefulness -> Misc.Is_eq
+    | Contention_op, Contention_op -> Misc.Is_eq
+    | Visibility_op, Visibility_op -> Misc.Is_eq
+    | Staticity_op, Staticity_op -> Misc.Is_eq
+    | Monadic_op, Monadic_op -> Misc.Is_eq
+    | Comonadic_with_regionality, Comonadic_with_regionality -> Misc.Is_eq
+    | Comonadic_with_locality, Comonadic_with_locality -> Misc.Is_eq
     | ( ( Locality | Regionality | Uniqueness_op | Linearity | Portability
         | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
         | Staticity_op | Monadic_op | Comonadic_with_regionality
         | Comonadic_with_locality ),
         _ ) ->
-      None
+      Misc.Is_not_eq
 end
 
 module Lattices_mono = struct
@@ -1602,6 +1602,13 @@ module Lattices_mono = struct
       let src0 = src dst0 f in
       comonadic_with_obj src0
 
+  let axis_is_eq : type p r1 r2.
+      (p, r1) Axis.t -> (p, r2) Axis.t -> (r1, r2) Misc.is_eq =
+   fun ax1 ax2 ->
+    match Axis.compare ax1 ax2 with
+    | Equal -> Misc.Is_eq
+    | Less_than | Greater_than -> Misc.Is_not_eq
+
   let rec compare_morph : type a1 l1 r1 a2 b l2 r2.
       b obj -> (a1, b, l1 * r1) morph -> (a2, b, l2 * r2) morph -> int =
    fun dst f1 f2 ->
@@ -1615,8 +1622,8 @@ module Lattices_mono = struct
       then c
       else
         match equal_obj src1 src2 with
-        | Some Refl -> Misc.comparison_result (Axis.compare ax1 ax2)
-        | None ->
+        | Misc.Is_eq -> Misc.comparison_result (Axis.compare ax1 ax2)
+        | Misc.Is_not_eq ->
           Misc.fatal_error
             "Mode.Lattices_mono.compare_morph: inconsistent object equality")
     | Proj _, _ -> -1
@@ -1670,8 +1677,8 @@ module Lattices_mono = struct
       then c
       else
         match equal_morph dst f1 f2 with
-        | Some Refl -> compare_morph (src dst f1) g1 g2
-        | None ->
+        | Misc.Is_eq -> compare_morph (src dst f1) g1 g2
+        | Misc.Is_not_eq ->
           Misc.fatal_error
             "Mode.Lattices_mono.compare_morph: inconsistent equality")
     | Compose _, _ -> -1
@@ -1683,42 +1690,42 @@ module Lattices_mono = struct
       b obj ->
       (a1, b, l1 * r1) morph ->
       (a2, b, l2 * r2) morph ->
-      (a1, a2) Misc.eq option =
+      (a1, a2) Misc.is_eq =
    fun dst f1 f2 ->
     match f1, f2 with
-    | Id, Id -> Some Refl
+    | Id, Id -> Misc.Is_eq
     | Proj (src1, ax1), Proj (src2, ax2) -> (
       match equal_obj src1 src2 with
-      | None -> None
-      | Some Refl -> (
-        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl))
-    | Max_with ax1, Max_with ax2 -> (
-      match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
-    | Min_with ax1, Min_with ax2 -> (
-      match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> (
+        match Axis.compare ax1 ax2 with
+        | Equal -> Misc.Is_eq
+        | Less_than | Greater_than -> Misc.Is_not_eq))
+    | Max_with ax1, Max_with ax2 -> axis_is_eq ax1 ax2
+    | Min_with ax1, Min_with ax2 -> axis_is_eq ax1 ax2
     | Meet_const c1, Meet_const c2 ->
-      if equal dst c1 c2 then Some Refl else None
+      if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
     | Imply_const c1, Imply_const c2 ->
-      if equal dst c1 c2 then Some Refl else None
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Some Refl
+      if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
+    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Misc.Is_eq
     | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
       equal_obj a1 a2
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Some Refl
+    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Misc.Is_eq
     | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
       equal_obj a1 a2
-    | Local_to_regional, Local_to_regional -> Some Refl
-    | Locality_as_regionality, Locality_as_regionality -> Some Refl
-    | Global_to_regional, Global_to_regional -> Some Refl
-    | Regional_to_local, Regional_to_local -> Some Refl
-    | Regional_to_global, Regional_to_global -> Some Refl
+    | Local_to_regional, Local_to_regional -> Misc.Is_eq
+    | Locality_as_regionality, Locality_as_regionality -> Misc.Is_eq
+    | Global_to_regional, Global_to_regional -> Misc.Is_eq
+    | Regional_to_local, Regional_to_local -> Misc.Is_eq
+    | Regional_to_global, Regional_to_global -> Misc.Is_eq
     | Compose (f1, g1), Compose (f2, g2) -> (
       match equal_morph dst f1 f2 with
-      | None -> None
-      | Some Refl -> equal_morph (src dst f1) g1 g2)
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> equal_morph (src dst f1) g1 g2)
     | Map_comonadic f, Map_comonadic g ->
       begin match equal_morph (proj_obj Areality dst) f g with
-      | None -> None
-      | Some Refl -> Some Refl
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> Misc.Is_eq
       end
     | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_const _ | Imply_const _
         | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
@@ -1727,7 +1734,7 @@ module Lattices_mono = struct
         | Regional_to_local | Regional_to_global | Compose _ | Map_comonadic _
           ),
         _ ) ->
-      None
+      Misc.Is_not_eq
 
   let rec print_morph : type a b l r.
       b obj -> Fmt.formatter -> (a, b, l * r) morph -> unit =
@@ -2819,8 +2826,8 @@ module Report = struct
   let equal_mode : type a b. a C.obj -> b C.obj -> a -> b -> bool =
    fun a_obj b_obj a b ->
     match C.equal_obj a_obj b_obj with
-    | Some Refl -> Misc.Le_result.equal ~le:(C.le a_obj) a b
-    | None -> false
+    | Misc.Is_eq -> Misc.Le_result.equal ~le:(C.le a_obj) a b
+    | Misc.Is_not_eq -> false
 
   let rec print_ahint : type a l r.
       ?sub:bool ->
@@ -5350,16 +5357,6 @@ module Crossing = struct
         | Greater_than -> Greater_than
         end
 
-    let equal : type a b. a t -> b t -> (a, b) Misc.eq option =
-     fun ax1 ax2 ->
-      match ax1, ax2 with
-      | Monadic ax1, Monadic ax2 -> (
-        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
-      | Monadic _, _ -> None
-      | _, Monadic _ -> None
-      | Comonadic ax1, Comonadic ax2 -> (
-        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
-
     let print : type a. Fmt.formatter -> a t -> unit =
      fun ppf -> function
       | Monadic ax -> Axis.print ppf ax
@@ -5409,7 +5406,11 @@ module Crossing = struct
 
     let compare_obj ax1 ax2 = Misc.comparison_result (Axis.compare ax1 ax2)
 
-    let equal_obj = Axis.equal
+    let equal_obj : type a b. a Axis.t -> b Axis.t -> (a, b) Misc.is_eq =
+     fun ax1 ax2 ->
+      match Axis.compare ax1 ax2 with
+      | Equal -> Misc.Is_eq
+      | Less_than | Greater_than -> Misc.Is_not_eq
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -22,6 +22,11 @@ open Mode_intf
 module Hint = Mode_hint
 module Fmt = Format_doc
 
+let int_of_comparison : type a b. (a, b) Misc.comparison -> int = function
+  | Less_than -> -1
+  | Equal -> 0
+  | Greater_than -> 1
+
 module Hint_for_solver (* : Solver_intf.Hint *) = struct
   module Pinpoint = struct
     type t = Hint.pinpoint
@@ -1622,18 +1627,16 @@ module Lattices_mono = struct
       then c
       else
         match equal_obj src1 src2 with
-        | Misc.Is_eq -> Misc.comparison_result (Axis.compare ax1 ax2)
+        | Misc.Is_eq -> int_of_comparison (Axis.compare ax1 ax2)
         | Misc.Is_not_eq ->
           Misc.fatal_error
             "Mode.Lattices_mono.compare_morph: inconsistent object equality")
     | Proj _, _ -> -1
     | _, Proj _ -> 1
-    | Max_with ax1, Max_with ax2 ->
-      Misc.comparison_result (Axis.compare ax1 ax2)
+    | Max_with ax1, Max_with ax2 -> int_of_comparison (Axis.compare ax1 ax2)
     | Max_with _, _ -> -1
     | _, Max_with _ -> 1
-    | Min_with ax1, Min_with ax2 ->
-      Misc.comparison_result (Axis.compare ax1 ax2)
+    | Min_with ax1, Min_with ax2 -> int_of_comparison (Axis.compare ax1 ax2)
     | Min_with _, _ -> -1
     | _, Min_with _ -> 1
     | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
@@ -3559,8 +3562,7 @@ module Comonadic_with (Areality : Areality) = struct
         P Forkable;
         P Yielding;
         P Statefulness ]
-      |> List.sort (fun (P ax1) (P ax2) ->
-          Misc.comparison_result (compare ax1 ax2))
+      |> List.sort (fun (P ax1) (P ax2) -> int_of_comparison (compare ax1 ax2))
   end
 
   let proj_obj ax = (C.proj_obj [@inlined hint]) ax Obj.obj
@@ -3703,8 +3705,7 @@ module Monadic = struct
 
     let all =
       [P Uniqueness; P Contention; P Visibility; P Staticity]
-      |> List.sort (fun (P ax1) (P ax2) ->
-          Misc.comparison_result (compare ax1 ax2))
+      |> List.sort (fun (P ax1) (P ax2) -> int_of_comparison (compare ax1 ax2))
   end
 
   let proj_obj ax = (C.proj_obj [@inlined hint]) ax Obj.obj
@@ -3864,8 +3865,7 @@ module Value_with (Areality : Areality) = struct
       @ List.map
           (fun (Comonadic.Axis.P ax) -> P (Comonadic ax))
           Comonadic.Axis.all
-      |> List.sort (fun (P ax1) (P ax2) ->
-          Misc.comparison_result (compare ax1 ax2))
+      |> List.sort (fun (P ax1) (P ax2) -> int_of_comparison (compare ax1 ax2))
   end
 
   let proj_obj : type a. a Axis.t -> a C.obj = function
@@ -5404,7 +5404,8 @@ module Crossing = struct
 
     let print_obj = Axis.print
 
-    let compare_obj ax1 ax2 = Misc.comparison_result (Axis.compare ax1 ax2)
+    let compare_obj : type a b. a Axis.t -> b Axis.t -> int =
+     fun ax1 ax2 -> int_of_comparison (Axis.compare ax1 ax2)
 
     let equal_obj : type a b. a Axis.t -> b Axis.t -> (a, b) Misc.is_eq =
      fun ax1 ax2 ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5376,10 +5376,9 @@ module Crossing = struct
 
     let print_obj = Axis.print
 
-    let compare_obj : type a b. a Axis.t -> b Axis.t -> int = Axis.compare
+    let compare_obj = Axis.compare
 
-    let equal_obj : type a b. a Axis.t -> b Axis.t -> (a, b) Misc.is_eq =
-      Axis.equal
+    let equal_obj = Axis.equal
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -22,11 +22,6 @@ open Mode_intf
 module Hint = Mode_hint
 module Fmt = Format_doc
 
-let int_of_comparison : type a b. (a, b) Misc.comparison -> int = function
-  | Less_than -> -1
-  | Equal -> 0
-  | Greater_than -> 1
-
 module Hint_for_solver (* : Solver_intf.Hint *) = struct
   module Pinpoint = struct
     type t = Hint.pinpoint
@@ -1323,59 +1318,38 @@ module Lattices_mono = struct
       | Visibility -> Fmt.fprintf ppf "visibility"
       | Staticity -> Fmt.fprintf ppf "staticity"
 
-    let equal : type p r1 r2. (p, r1) t -> (p, r2) t -> (r1, r2) Misc.eq option
-        =
+    let equal : type p r1 r2. (p, r1) t -> (p, r2) t -> (r1, r2) Misc.is_eq =
      fun ax1 ax2 ->
       match ax1, ax2 with
-      | Areality, Areality -> Some Refl
-      | Linearity, Linearity -> Some Refl
-      | Portability, Portability -> Some Refl
-      | Uniqueness, Uniqueness -> Some Refl
-      | Contention, Contention -> Some Refl
-      | Forkable, Forkable -> Some Refl
-      | Yielding, Yielding -> Some Refl
-      | Statefulness, Statefulness -> Some Refl
-      | Visibility, Visibility -> Some Refl
-      | Staticity, Staticity -> Some Refl
+      | Areality, Areality -> Is_eq
+      | Linearity, Linearity -> Is_eq
+      | Portability, Portability -> Is_eq
+      | Uniqueness, Uniqueness -> Is_eq
+      | Contention, Contention -> Is_eq
+      | Forkable, Forkable -> Is_eq
+      | Yielding, Yielding -> Is_eq
+      | Statefulness, Statefulness -> Is_eq
+      | Visibility, Visibility -> Is_eq
+      | Staticity, Staticity -> Is_eq
       | ( ( Areality | Linearity | Uniqueness | Portability | Contention
           | Forkable | Yielding | Statefulness | Visibility | Staticity ),
           _ ) ->
-        None
+        Is_not_eq
 
-    let compare : type p r1 r2.
-        (p, r1) t -> (p, r2) t -> (r1, r2) Misc.comparison =
-     fun ax1 ax2 ->
-      match ax1, ax2 with
-      | Areality, Areality -> Equal
-      | Areality, _ -> Less_than
-      | _, Areality -> Greater_than
-      | Forkable, Forkable -> Equal
-      | Forkable, _ -> Less_than
-      | _, Forkable -> Greater_than
-      | Yielding, Yielding -> Equal
-      | Yielding, _ -> Less_than
-      | _, Yielding -> Greater_than
-      | Linearity, Linearity -> Equal
-      | Linearity, _ -> Less_than
-      | _, Linearity -> Greater_than
-      | Statefulness, Statefulness -> Equal
-      | Statefulness, _ -> Less_than
-      | _, Statefulness -> Greater_than
-      | Portability, Portability -> Equal
-      | Portability, _ -> .
-      | _, Portability -> .
-      | Uniqueness, Uniqueness -> Equal
-      | Uniqueness, _ -> Less_than
-      | _, Uniqueness -> Greater_than
-      | Visibility, Visibility -> Equal
-      | Visibility, _ -> Less_than
-      | _, Visibility -> Greater_than
-      | Contention, Contention -> Equal
-      | Contention, _ -> Less_than
-      | _, Contention -> Greater_than
-      | Staticity, Staticity -> Equal
-      | Staticity, _ -> .
-      | _, Staticity -> .
+    let ord : type p r. (p, r) t -> int = function
+      | Areality -> 0
+      | Forkable -> 1
+      | Yielding -> 2
+      | Linearity -> 3
+      | Statefulness -> 4
+      | Portability -> 5
+      | Uniqueness -> 6
+      | Visibility -> 7
+      | Contention -> 8
+      | Staticity -> 9
+
+    let compare : type p r1 r2. (p, r1) t -> (p, r2) t -> int =
+     fun ax1 ax2 -> Int.compare (ord ax1) (ord ax2)
 
     let proj : type p r. (p, r) t -> p -> r =
      fun ax t ->
@@ -1613,13 +1587,6 @@ module Lattices_mono = struct
       let src0 = src dst0 f in
       comonadic_with_obj src0
 
-  let axis_is_eq : type p r1 r2.
-      (p, r1) Axis.t -> (p, r2) Axis.t -> (r1, r2) Misc.is_eq =
-   fun ax1 ax2 ->
-    match Axis.compare ax1 ax2 with
-    | Equal -> Misc.Is_eq
-    | Less_than | Greater_than -> Misc.Is_not_eq
-
   let rec compare_morph : type a1 l1 r1 a2 b l2 r2.
       b obj -> (a1, b, l1 * r1) morph -> (a2, b, l2 * r2) morph -> int =
    fun dst f1 f2 ->
@@ -1633,16 +1600,16 @@ module Lattices_mono = struct
       then c
       else
         match equal_obj src1 src2 with
-        | Misc.Is_eq -> int_of_comparison (Axis.compare ax1 ax2)
+        | Misc.Is_eq -> Axis.compare ax1 ax2
         | Misc.Is_not_eq ->
           Misc.fatal_error
             "Mode.Lattices_mono.compare_morph: inconsistent object equality")
     | Proj _, _ -> -1
     | _, Proj _ -> 1
-    | Max_with ax1, Max_with ax2 -> int_of_comparison (Axis.compare ax1 ax2)
+    | Max_with ax1, Max_with ax2 -> Axis.compare ax1 ax2
     | Max_with _, _ -> -1
     | _, Max_with _ -> 1
-    | Min_with ax1, Min_with ax2 -> int_of_comparison (Axis.compare ax1 ax2)
+    | Min_with ax1, Min_with ax2 -> Axis.compare ax1 ax2
     | Min_with _, _ -> -1
     | _, Min_with _ -> 1
     | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
@@ -1707,11 +1674,11 @@ module Lattices_mono = struct
       match equal_obj src1 src2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
       | Misc.Is_eq -> (
-        match Axis.compare ax1 ax2 with
-        | Equal -> Misc.Is_eq
-        | Less_than | Greater_than -> Misc.Is_not_eq))
-    | Max_with ax1, Max_with ax2 -> axis_is_eq ax1 ax2
-    | Min_with ax1, Min_with ax2 -> axis_is_eq ax1 ax2
+        match Axis.equal ax1 ax2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq))
+    | Max_with ax1, Max_with ax2 -> Axis.equal ax1 ax2
+    | Min_with ax1, Min_with ax2 -> Axis.equal ax1 ax2
     | Meet_const c1, Meet_const c2 ->
       if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
     | Imply_const c1, Imply_const c2 ->
@@ -1997,8 +1964,8 @@ module Lattices_mono = struct
         | Portability -> Axis Portability)
       | Max_with m_ax, ax | Min_with m_ax, ax -> (
         match Axis.equal m_ax ax with
-        | None -> NoneResponsible
-        | Some Refl -> SourceIsSingle)
+        | Is_not_eq -> NoneResponsible
+        | Is_eq -> SourceIsSingle)
       | Monadic_to_comonadic_min, ax -> handle_monadic_to_comonadic ax
       | Monadic_to_comonadic_max, ax -> handle_monadic_to_comonadic ax
       | Comonadic_to_monadic_min _, ax -> handle_comonadic_to_monadic ax
@@ -2048,9 +2015,9 @@ module Lattices_mono = struct
     | Proj (mid, ax), Meet_const c ->
       Some (compose dst (Meet_const (Axis.proj ax c)) (Proj (mid, ax)))
     | Proj (_, ax1), Max_with ax2 -> (
-      match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Id)
+      match Axis.equal ax1 ax2 with Is_not_eq -> None | Is_eq -> Some Id)
     | Proj (_, ax1), Min_with ax2 -> (
-      match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Id)
+      match Axis.equal ax1 ax2 with Is_not_eq -> None | Is_eq -> Some Id)
     | Proj (mid, ax), Map_comonadic f -> (
       let src' = src mid m2 in
       match ax with
@@ -3568,7 +3535,7 @@ module Comonadic_with (Areality : Areality) = struct
         P Forkable;
         P Yielding;
         P Statefulness ]
-      |> List.sort (fun (P ax1) (P ax2) -> int_of_comparison (compare ax1 ax2))
+      |> List.sort (fun (P ax1) (P ax2) -> compare ax1 ax2)
   end
 
   let proj_obj ax = (C.proj_obj [@inlined hint]) ax Obj.obj
@@ -3711,7 +3678,7 @@ module Monadic = struct
 
     let all =
       [P Uniqueness; P Contention; P Visibility; P Staticity]
-      |> List.sort (fun (P ax1) (P ax2) -> int_of_comparison (compare ax1 ax2))
+      |> List.sort (fun (P ax1) (P ax2) -> compare ax1 ax2)
   end
 
   let proj_obj ax = (C.proj_obj [@inlined hint]) ax Obj.obj
@@ -3851,12 +3818,12 @@ module Value_with (Areality : Areality) = struct
       | Comonadic : 'a Comonadic.Axis.t -> 'a t
       | Monadic : 'a Monadic.Axis.t -> 'a t
 
-    let compare : type a b. a t -> b t -> (a, b) Misc.comparison =
+    let compare : type a b. a t -> b t -> int =
      fun t1 t2 ->
       match t1, t2 with
       | Comonadic t1, Comonadic t2 -> Axis.compare t1 t2
-      | Comonadic _, _ -> Less_than
-      | _, Comonadic _ -> Greater_than
+      | Comonadic _, _ -> -1
+      | _, Comonadic _ -> 1
       | Monadic t1, Monadic t2 -> Axis.compare t1 t2
 
     type packed = P : 'a t -> packed
@@ -3871,7 +3838,7 @@ module Value_with (Areality : Areality) = struct
       @ List.map
           (fun (Comonadic.Axis.P ax) -> P (Comonadic ax))
           Comonadic.Axis.all
-      |> List.sort (fun (P ax1) (P ax2) -> int_of_comparison (compare ax1 ax2))
+      |> List.sort (fun (P ax1) (P ax2) -> compare ax1 ax2)
   end
 
   let proj_obj : type a. a Axis.t -> a C.obj = function
@@ -5345,23 +5312,22 @@ module Crossing = struct
       | P (Monadic ax) -> P (Monadic ax)
       | P (Comonadic ax) -> P (Comonadic ax)
 
-    let compare : type a b. a t -> b t -> (a, b) Misc.comparison =
+    let compare : type a b. a t -> b t -> int =
      fun ax1 ax2 ->
       match ax1, ax2 with
-      | Monadic ax1, Monadic ax2 ->
-        begin match Axis.compare ax1 ax2 with
-        | Less_than -> Less_than
-        | Equal -> Equal
-        | Greater_than -> Greater_than
-        end
-      | Monadic _, _ -> Less_than
-      | _, Monadic _ -> Greater_than
-      | Comonadic ax1, Comonadic ax2 ->
-        begin match Axis.compare ax1 ax2 with
-        | Less_than -> Less_than
-        | Equal -> Equal
-        | Greater_than -> Greater_than
-        end
+      | Monadic ax1, Monadic ax2 -> Axis.compare ax1 ax2
+      | Monadic _, _ -> -1
+      | _, Monadic _ -> 1
+      | Comonadic ax1, Comonadic ax2 -> Axis.compare ax1 ax2
+
+    let equal : type a b. a t -> b t -> (a, b) Misc.is_eq =
+     fun ax1 ax2 ->
+      match ax1, ax2 with
+      | Monadic ax1, Monadic ax2 -> (
+        match Axis.equal ax1 ax2 with Is_eq -> Is_eq | Is_not_eq -> Is_not_eq)
+      | Comonadic ax1, Comonadic ax2 -> (
+        match Axis.equal ax1 ax2 with Is_eq -> Is_eq | Is_not_eq -> Is_not_eq)
+      | (Monadic _ | Comonadic _), _ -> Is_not_eq
 
     let print : type a. Fmt.formatter -> a t -> unit =
      fun ppf -> function
@@ -5410,14 +5376,10 @@ module Crossing = struct
 
     let print_obj = Axis.print
 
-    let compare_obj : type a b. a Axis.t -> b Axis.t -> int =
-     fun ax1 ax2 -> int_of_comparison (Axis.compare ax1 ax2)
+    let compare_obj : type a b. a Axis.t -> b Axis.t -> int = Axis.compare
 
     let equal_obj : type a b. a Axis.t -> b Axis.t -> (a, b) Misc.is_eq =
-     fun ax1 ax2 ->
-      match Axis.compare ax1 ax2 with
-      | Equal -> Misc.Is_eq
-      | Less_than | Greater_than -> Misc.Is_not_eq
+      Axis.equal
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -276,6 +276,8 @@ module type Heyting = sig
 
   include Lattice
 
+  val compare_total : t -> t -> int
+
   (** [imply c] is the right adjoint of [meet c]; That is, for any [a] and [b],
       [meet c a <= b] iff [a <= imply c b] *)
   val imply : t -> t -> t
@@ -285,6 +287,8 @@ module type CoHeyting = sig
   (** Extend the [Lattice] interface with operations of co-Heyting algebras *)
 
   include Lattice
+
+  val compare_total : t -> t -> int
 
   (** [subtract _ c] is the left adjoint of [join c]. That is, for any [a] and
       [b], [subtract a c <= b] iff [a <= join c b] *)
@@ -302,6 +306,8 @@ module Lattices = struct
     let le a b = L.ord a <= L.ord b
 
     let equal a b = L.ord a = L.ord b
+
+    let compare_total a b = Int.compare (L.ord a) (L.ord b)
 
     let join a b = if L.ord a > L.ord b then a else b
 
@@ -381,6 +387,8 @@ module Lattices = struct
     let max = L.max
 
     let equal a b = a = b
+
+    let compare_total a b = Int.compare (l_to_int a) (l_to_int b)
 
     let join a b = l_of_int (l_to_int a lor l_to_int b)
 
@@ -763,6 +771,20 @@ module Lattices = struct
       && Visibility.equal visibility1 visibility2
       && Staticity.equal staticity1 staticity2
 
+    let compare_total m1 m2 =
+      let c = Uniqueness.compare_total m1.uniqueness m2.uniqueness in
+      if c <> 0
+      then c
+      else
+        let c = Contention.compare_total m1.contention m2.contention in
+        if c <> 0
+        then c
+        else
+          let c = Visibility.compare_total m1.visibility m2.visibility in
+          if c <> 0
+          then c
+          else Staticity.compare_total m1.staticity m2.staticity
+
     let join m1 m2 =
       let uniqueness = Uniqueness.join m1.uniqueness m2.uniqueness in
       let contention = Contention.join m1.contention m2.contention in
@@ -881,6 +903,28 @@ module Lattices = struct
       && Yielding.equal yielding1 yielding2
       && Statefulness.equal statefulness1 statefulness2
 
+    let compare_total m1 m2 =
+      let c = Areality.compare_total m1.areality m2.areality in
+      if c <> 0
+      then c
+      else
+        let c = Linearity.compare_total m1.linearity m2.linearity in
+        if c <> 0
+        then c
+        else
+          let c = Portability.compare_total m1.portability m2.portability in
+          if c <> 0
+          then c
+          else
+            let c = Forkable.compare_total m1.forkable m2.forkable in
+            if c <> 0
+            then c
+            else
+              let c = Yielding.compare_total m1.yielding m2.yielding in
+              if c <> 0
+              then c
+              else Statefulness.compare_total m1.statefulness m2.statefulness
+
     let join m1 m2 =
       let areality = Areality.join m1.areality m2.areality in
       let linearity = Linearity.join m1.linearity m2.linearity in
@@ -926,6 +970,8 @@ module Lattices = struct
     let[@inline] le a b = L.le b a
 
     let equal = L.equal
+
+    let compare_total = L.compare_total
 
     let join = L.meet
 
@@ -1061,13 +1107,27 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.le a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.le a b
 
-  let compare : type a. a obj -> a -> a -> (a, a) Misc.comparison =
-   fun obj c1 c2 ->
-    if le obj c1 c2
-    then
-      begin if le obj c2 c1 then Equal else Less_than
-      end
-    else Greater_than
+  let compare_total : type a. a obj -> a -> a -> (a, a) Misc.comparison =
+   fun obj a b ->
+    let c =
+      match obj with
+      | Locality -> Locality.compare_total a b
+      | Regionality -> Regionality.compare_total a b
+      | Uniqueness_op -> Uniqueness_op.compare_total a b
+      | Contention_op -> Contention_op.compare_total a b
+      | Visibility_op -> Visibility_op.compare_total a b
+      | Linearity -> Linearity.compare_total a b
+      | Portability -> Portability.compare_total a b
+      | Forkable -> Forkable.compare_total a b
+      | Yielding -> Yielding.compare_total a b
+      | Statefulness -> Statefulness.compare_total a b
+      | Staticity_op -> Staticity_op.compare_total a b
+      | Monadic_op -> Monadic_op.compare_total a b
+      | Comonadic_with_locality -> Comonadic_with_locality.compare_total a b
+      | Comonadic_with_regionality ->
+        Comonadic_with_regionality.compare_total a b
+    in
+    if c < 0 then Less_than else if c > 0 then Greater_than else Equal
 
   let equal : type a. a obj -> a -> a -> bool =
    fun obj a b ->
@@ -1557,10 +1617,10 @@ module Lattices_mono = struct
       | Equal -> Equal)
     | Min_with _, _ -> Less_than
     | _, Min_with _ -> Greater_than
-    | Meet_const c1, Meet_const c2 -> compare dst c1 c2
+    | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
     | Meet_const _, _ -> Less_than
     | _, Meet_const _ -> Greater_than
-    | Imply_const c1, Imply_const c2 -> compare dst c1 c2
+    | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
     | Imply_const _, _ -> Less_than
     | _, Imply_const _ -> Greater_than
     | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Equal

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1107,27 +1107,23 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.le a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.le a b
 
-  let compare_total : type a. a obj -> a -> a -> (a, a) Misc.comparison =
+  let compare_total : type a. a obj -> a -> a -> int =
    fun obj a b ->
-    let c =
-      match obj with
-      | Locality -> Locality.compare_total a b
-      | Regionality -> Regionality.compare_total a b
-      | Uniqueness_op -> Uniqueness_op.compare_total a b
-      | Contention_op -> Contention_op.compare_total a b
-      | Visibility_op -> Visibility_op.compare_total a b
-      | Linearity -> Linearity.compare_total a b
-      | Portability -> Portability.compare_total a b
-      | Forkable -> Forkable.compare_total a b
-      | Yielding -> Yielding.compare_total a b
-      | Statefulness -> Statefulness.compare_total a b
-      | Staticity_op -> Staticity_op.compare_total a b
-      | Monadic_op -> Monadic_op.compare_total a b
-      | Comonadic_with_locality -> Comonadic_with_locality.compare_total a b
-      | Comonadic_with_regionality ->
-        Comonadic_with_regionality.compare_total a b
-    in
-    if c < 0 then Less_than else if c > 0 then Greater_than else Equal
+    match obj with
+    | Locality -> Locality.compare_total a b
+    | Regionality -> Regionality.compare_total a b
+    | Uniqueness_op -> Uniqueness_op.compare_total a b
+    | Contention_op -> Contention_op.compare_total a b
+    | Visibility_op -> Visibility_op.compare_total a b
+    | Linearity -> Linearity.compare_total a b
+    | Portability -> Portability.compare_total a b
+    | Forkable -> Forkable.compare_total a b
+    | Yielding -> Yielding.compare_total a b
+    | Statefulness -> Statefulness.compare_total a b
+    | Staticity_op -> Staticity_op.compare_total a b
+    | Monadic_op -> Monadic_op.compare_total a b
+    | Comonadic_with_locality -> Comonadic_with_locality.compare_total a b
+    | Comonadic_with_regionality -> Comonadic_with_regionality.compare_total a b
 
   let equal : type a. a obj -> a -> a -> bool =
    fun obj a b ->
@@ -1218,49 +1214,73 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.print
     | Comonadic_with_regionality -> Comonadic_with_regionality.print
 
-  let compare_obj : type a b. a obj -> b obj -> (a, b) Misc.comparison =
+  let compare_obj : type a b. a obj -> b obj -> int =
    fun a b ->
     match a, b with
-    | Locality, Locality -> Equal
-    | Locality, _ -> Less_than
-    | _, Locality -> Greater_than
-    | Regionality, Regionality -> Equal
-    | Regionality, _ -> Less_than
-    | _, Regionality -> Greater_than
-    | Uniqueness_op, Uniqueness_op -> Equal
-    | Uniqueness_op, _ -> Less_than
-    | _, Uniqueness_op -> Greater_than
-    | Linearity, Linearity -> Equal
-    | Linearity, _ -> Less_than
-    | _, Linearity -> Greater_than
-    | Portability, Portability -> Equal
-    | Portability, _ -> Less_than
-    | _, Portability -> Greater_than
-    | Forkable, Forkable -> Equal
-    | Forkable, _ -> Less_than
-    | _, Forkable -> Greater_than
-    | Yielding, Yielding -> Equal
-    | Yielding, _ -> Less_than
-    | _, Yielding -> Greater_than
-    | Statefulness, Statefulness -> Equal
-    | Statefulness, _ -> Less_than
-    | _, Statefulness -> Greater_than
-    | Contention_op, Contention_op -> Equal
-    | Contention_op, _ -> Less_than
-    | _, Contention_op -> Greater_than
-    | Visibility_op, Visibility_op -> Equal
-    | Visibility_op, _ -> Less_than
-    | _, Visibility_op -> Greater_than
-    | Staticity_op, Staticity_op -> Equal
-    | Staticity_op, _ -> Less_than
-    | _, Staticity_op -> Greater_than
-    | Monadic_op, Monadic_op -> Equal
-    | Monadic_op, _ -> Less_than
-    | _, Monadic_op -> Greater_than
-    | Comonadic_with_regionality, Comonadic_with_regionality -> Equal
-    | Comonadic_with_regionality, _ -> Less_than
-    | _, Comonadic_with_regionality -> Greater_than
-    | Comonadic_with_locality, Comonadic_with_locality -> Equal
+    | Locality, Locality -> 0
+    | Locality, _ -> -1
+    | _, Locality -> 1
+    | Regionality, Regionality -> 0
+    | Regionality, _ -> -1
+    | _, Regionality -> 1
+    | Uniqueness_op, Uniqueness_op -> 0
+    | Uniqueness_op, _ -> -1
+    | _, Uniqueness_op -> 1
+    | Linearity, Linearity -> 0
+    | Linearity, _ -> -1
+    | _, Linearity -> 1
+    | Portability, Portability -> 0
+    | Portability, _ -> -1
+    | _, Portability -> 1
+    | Forkable, Forkable -> 0
+    | Forkable, _ -> -1
+    | _, Forkable -> 1
+    | Yielding, Yielding -> 0
+    | Yielding, _ -> -1
+    | _, Yielding -> 1
+    | Statefulness, Statefulness -> 0
+    | Statefulness, _ -> -1
+    | _, Statefulness -> 1
+    | Contention_op, Contention_op -> 0
+    | Contention_op, _ -> -1
+    | _, Contention_op -> 1
+    | Visibility_op, Visibility_op -> 0
+    | Visibility_op, _ -> -1
+    | _, Visibility_op -> 1
+    | Staticity_op, Staticity_op -> 0
+    | Staticity_op, _ -> -1
+    | _, Staticity_op -> 1
+    | Monadic_op, Monadic_op -> 0
+    | Monadic_op, _ -> -1
+    | _, Monadic_op -> 1
+    | Comonadic_with_regionality, Comonadic_with_regionality -> 0
+    | Comonadic_with_regionality, _ -> -1
+    | _, Comonadic_with_regionality -> 1
+    | Comonadic_with_locality, Comonadic_with_locality -> 0
+
+  let equal_obj : type a b. a obj -> b obj -> (a, b) Misc.eq option =
+   fun a b ->
+    match a, b with
+    | Locality, Locality -> Some Refl
+    | Regionality, Regionality -> Some Refl
+    | Uniqueness_op, Uniqueness_op -> Some Refl
+    | Linearity, Linearity -> Some Refl
+    | Portability, Portability -> Some Refl
+    | Forkable, Forkable -> Some Refl
+    | Yielding, Yielding -> Some Refl
+    | Statefulness, Statefulness -> Some Refl
+    | Contention_op, Contention_op -> Some Refl
+    | Visibility_op, Visibility_op -> Some Refl
+    | Staticity_op, Staticity_op -> Some Refl
+    | Monadic_op, Monadic_op -> Some Refl
+    | Comonadic_with_regionality, Comonadic_with_regionality -> Some Refl
+    | Comonadic_with_locality, Comonadic_with_locality -> Some Refl
+    | ( ( Locality | Regionality | Uniqueness_op | Linearity | Portability
+        | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
+        | Staticity_op | Monadic_op | Comonadic_with_regionality
+        | Comonadic_with_locality ),
+        _ ) ->
+      None
 end
 
 module Lattices_mono = struct
@@ -1583,97 +1603,131 @@ module Lattices_mono = struct
       comonadic_with_obj src0
 
   let rec compare_morph : type a1 l1 r1 a2 b l2 r2.
+      b obj -> (a1, b, l1 * r1) morph -> (a2, b, l2 * r2) morph -> int =
+   fun dst f1 f2 ->
+    match f1, f2 with
+    | Id, Id -> 0
+    | Id, _ -> -1
+    | _, Id -> 1
+    | Proj (src1, ax1), Proj (src2, ax2) -> (
+      let c = compare_obj src1 src2 in
+      if c <> 0
+      then c
+      else
+        match equal_obj src1 src2 with
+        | Some Refl -> Misc.comparison_result (Axis.compare ax1 ax2)
+        | None ->
+          Misc.fatal_error
+            "Mode.Lattices_mono.compare_morph: inconsistent object equality")
+    | Proj _, _ -> -1
+    | _, Proj _ -> 1
+    | Max_with ax1, Max_with ax2 ->
+      Misc.comparison_result (Axis.compare ax1 ax2)
+    | Max_with _, _ -> -1
+    | _, Max_with _ -> 1
+    | Min_with ax1, Min_with ax2 ->
+      Misc.comparison_result (Axis.compare ax1 ax2)
+    | Min_with _, _ -> -1
+    | _, Min_with _ -> 1
+    | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
+    | Meet_const _, _ -> -1
+    | _, Meet_const _ -> 1
+    | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
+    | Imply_const _, _ -> -1
+    | _, Imply_const _ -> 1
+    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> 0
+    | Monadic_to_comonadic_min, _ -> -1
+    | _, Monadic_to_comonadic_min -> 1
+    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
+      compare_obj a1 a2
+    | Comonadic_to_monadic_min _, _ -> -1
+    | _, Comonadic_to_monadic_min _ -> 1
+    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> 0
+    | Monadic_to_comonadic_max, _ -> -1
+    | _, Monadic_to_comonadic_max -> 1
+    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
+      compare_obj a1 a2
+    | Comonadic_to_monadic_max _, _ -> -1
+    | _, Comonadic_to_monadic_max _ -> 1
+    | Local_to_regional, Local_to_regional -> 0
+    | Local_to_regional, _ -> -1
+    | _, Local_to_regional -> 1
+    | Locality_as_regionality, Locality_as_regionality -> 0
+    | Locality_as_regionality, _ -> -1
+    | _, Locality_as_regionality -> 1
+    | Global_to_regional, Global_to_regional -> 0
+    | Global_to_regional, _ -> -1
+    | _, Global_to_regional -> 1
+    | Regional_to_local, Regional_to_local -> 0
+    | Regional_to_local, _ -> -1
+    | _, Regional_to_local -> 1
+    | Regional_to_global, Regional_to_global -> 0
+    | Regional_to_global, _ -> -1
+    | _, Regional_to_global -> 1
+    | Compose (f1, g1), Compose (f2, g2) -> (
+      let c = compare_morph dst f1 f2 in
+      if c <> 0
+      then c
+      else
+        match equal_morph dst f1 f2 with
+        | Some Refl -> compare_morph (src dst f1) g1 g2
+        | None ->
+          Misc.fatal_error
+            "Mode.Lattices_mono.compare_morph: inconsistent equality")
+    | Compose _, _ -> -1
+    | _, Compose _ -> 1
+    | Map_comonadic f, Map_comonadic g ->
+      compare_morph (proj_obj Areality dst) f g
+
+  and equal_morph : type a1 l1 r1 a2 b l2 r2.
       b obj ->
       (a1, b, l1 * r1) morph ->
       (a2, b, l2 * r2) morph ->
-      (a1, a2) Misc.comparison =
+      (a1, a2) Misc.eq option =
    fun dst f1 f2 ->
     match f1, f2 with
-    | Id, Id -> Equal
-    | Id, _ -> Less_than
-    | _, Id -> Greater_than
+    | Id, Id -> Some Refl
     | Proj (src1, ax1), Proj (src2, ax2) -> (
-      match compare_obj src1 src2 with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> (
-        match Axis.compare ax1 ax2 with
-        | Less_than -> Less_than
-        | Greater_than -> Greater_than
-        | Equal -> Equal))
-    | Proj _, _ -> Less_than
-    | _, Proj _ -> Greater_than
+      match equal_obj src1 src2 with
+      | None -> None
+      | Some Refl -> (
+        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl))
     | Max_with ax1, Max_with ax2 -> (
-      match Axis.compare ax1 ax2 with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> Equal)
-    | Max_with _, _ -> Less_than
-    | _, Max_with _ -> Greater_than
+      match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
     | Min_with ax1, Min_with ax2 -> (
-      match Axis.compare ax1 ax2 with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> Equal)
-    | Min_with _, _ -> Less_than
-    | _, Min_with _ -> Greater_than
-    | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
-    | Meet_const _, _ -> Less_than
-    | _, Meet_const _ -> Greater_than
-    | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
-    | Imply_const _, _ -> Less_than
-    | _, Imply_const _ -> Greater_than
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Equal
-    | Monadic_to_comonadic_min, _ -> Less_than
-    | _, Monadic_to_comonadic_min -> Greater_than
-    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 -> (
-      match compare_obj a1 a2 with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> Equal)
-    | Comonadic_to_monadic_min _, _ -> Less_than
-    | _, Comonadic_to_monadic_min _ -> Greater_than
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Equal
-    | Monadic_to_comonadic_max, _ -> Less_than
-    | _, Monadic_to_comonadic_max -> Greater_than
-    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 -> (
-      match compare_obj a1 a2 with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> Equal)
-    | Comonadic_to_monadic_max _, _ -> Less_than
-    | _, Comonadic_to_monadic_max _ -> Greater_than
-    | Local_to_regional, Local_to_regional -> Equal
-    | Local_to_regional, _ -> Less_than
-    | _, Local_to_regional -> Greater_than
-    | Locality_as_regionality, Locality_as_regionality -> Equal
-    | Locality_as_regionality, _ -> Less_than
-    | _, Locality_as_regionality -> Greater_than
-    | Global_to_regional, Global_to_regional -> Equal
-    | Global_to_regional, _ -> Less_than
-    | _, Global_to_regional -> Greater_than
-    | Regional_to_local, Regional_to_local -> Equal
-    | Regional_to_local, _ -> Less_than
-    | _, Regional_to_local -> Greater_than
-    | Regional_to_global, Regional_to_global -> Equal
-    | Regional_to_global, _ -> Less_than
-    | _, Regional_to_global -> Greater_than
+      match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
+    | Meet_const c1, Meet_const c2 ->
+      if equal dst c1 c2 then Some Refl else None
+    | Imply_const c1, Imply_const c2 ->
+      if equal dst c1 c2 then Some Refl else None
+    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Some Refl
+    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
+      equal_obj a1 a2
+    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Some Refl
+    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
+      equal_obj a1 a2
+    | Local_to_regional, Local_to_regional -> Some Refl
+    | Locality_as_regionality, Locality_as_regionality -> Some Refl
+    | Global_to_regional, Global_to_regional -> Some Refl
+    | Regional_to_local, Regional_to_local -> Some Refl
+    | Regional_to_global, Regional_to_global -> Some Refl
     | Compose (f1, g1), Compose (f2, g2) -> (
-      match compare_morph dst f1 f2 with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> (
-        match compare_morph (src dst f1) g1 g2 with
-        | Less_than -> Less_than
-        | Greater_than -> Greater_than
-        | Equal -> Equal))
-    | Compose _, _ -> Less_than
-    | _, Compose _ -> Greater_than
-    | Map_comonadic f, Map_comonadic g -> (
-      match compare_morph (proj_obj Areality dst) f g with
-      | Less_than -> Less_than
-      | Greater_than -> Greater_than
-      | Equal -> Equal)
+      match equal_morph dst f1 f2 with
+      | None -> None
+      | Some Refl -> equal_morph (src dst f1) g1 g2)
+    | Map_comonadic f, Map_comonadic g ->
+      begin match equal_morph (proj_obj Areality dst) f g with
+      | None -> None
+      | Some Refl -> Some Refl
+      end
+    | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_const _ | Imply_const _
+        | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
+        | Monadic_to_comonadic_max | Comonadic_to_monadic_max _
+        | Local_to_regional | Locality_as_regionality | Global_to_regional
+        | Regional_to_local | Regional_to_global | Compose _ | Map_comonadic _
+          ),
+        _ ) ->
+      None
 
   let rec print_morph : type a b l r.
       b obj -> Fmt.formatter -> (a, b, l * r) morph -> unit =
@@ -2764,9 +2818,9 @@ module Report = struct
 
   let equal_mode : type a b. a C.obj -> b C.obj -> a -> b -> bool =
    fun a_obj b_obj a b ->
-    match C.compare_obj a_obj b_obj with
-    | Equal -> Misc.Le_result.equal ~le:(C.le a_obj) a b
-    | Less_than | Greater_than -> false
+    match C.equal_obj a_obj b_obj with
+    | Some Refl -> Misc.Le_result.equal ~le:(C.le a_obj) a b
+    | None -> false
 
   let rec print_ahint : type a l r.
       ?sub:bool ->
@@ -3544,6 +3598,11 @@ module Comonadic_with (Areality : Areality) = struct
         let obj2 = proj_obj ax2 in
         C.compare_obj obj1 obj2
 
+      let equal_obj ax1 ax2 =
+        let obj1 = proj_obj ax1 in
+        let obj2 = proj_obj ax2 in
+        C.equal_obj obj1 obj2
+
       let print_obj ppf ax =
         let obj = proj_obj ax in
         C.print_obj ppf obj
@@ -3684,6 +3743,11 @@ module Monadic = struct
         let obj1 = proj_obj ax1 in
         let obj2 = proj_obj ax2 in
         C.compare_obj obj1 obj2
+
+      let equal_obj ax1 ax2 =
+        let obj1 = proj_obj ax1 in
+        let obj2 = proj_obj ax2 in
+        C.equal_obj obj1 obj2
 
       let print_obj ppf ax =
         let obj = proj_obj ax in
@@ -5286,6 +5350,16 @@ module Crossing = struct
         | Greater_than -> Greater_than
         end
 
+    let equal : type a b. a t -> b t -> (a, b) Misc.eq option =
+     fun ax1 ax2 ->
+      match ax1, ax2 with
+      | Monadic ax1, Monadic ax2 -> (
+        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
+      | Monadic _, _ -> None
+      | _, Monadic _ -> None
+      | Comonadic ax1, Comonadic ax2 -> (
+        match Axis.equal ax1 ax2 with None -> None | Some Refl -> Some Refl)
+
     let print : type a. Fmt.formatter -> a t -> unit =
      fun ppf -> function
       | Monadic ax -> Axis.print ppf ax
@@ -5333,7 +5407,9 @@ module Crossing = struct
 
     let print_obj = Axis.print
 
-    let compare_obj = Axis.compare
+    let compare_obj ax1 ax2 = Misc.comparison_result (Axis.compare ax1 ax2)
+
+    let equal_obj = Axis.equal
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -281,6 +281,9 @@ module type Heyting = sig
 
   include Lattice
 
+  (** A total structural order used for map keys. This is not lattice order:
+      [compare_total a b = 0] must agree with semantic equality of [a] and [b].
+  *)
   val compare_total : t -> t -> int
 
   (** [imply c] is the right adjoint of [meet c]; That is, for any [a] and [b],
@@ -293,6 +296,9 @@ module type CoHeyting = sig
 
   include Lattice
 
+  (** A total structural order used for map keys. This is not lattice order:
+      [compare_total a b = 0] must agree with semantic equality of [a] and [b].
+  *)
   val compare_total : t -> t -> int
 
   (** [subtract _ c] is the left adjoint of [join c]. That is, for any [a] and

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -211,7 +211,7 @@ module type Axis = sig
 
   (** Compare two axes in implication order. If A implies B, then A is before B.
   *)
-  val compare : 'a t -> 'b t -> ('a, 'b) Misc.comparison
+  val compare : 'a t -> 'b t -> int
 
   type packed = P : 'a t -> packed
 
@@ -573,7 +573,7 @@ module type S = sig
 
     val print : Fmt.formatter -> ('p, 'r) t -> unit
 
-    val equal : ('p, 'r0) t -> ('p, 'r1) t -> ('r0, 'r1) Misc.eq option
+    val equal : ('p, 'r0) t -> ('p, 'r1) t -> ('r0, 'r1) Misc.is_eq
   end
 
   module type Mode := sig

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -774,7 +774,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
 
   let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =
-    if eq_morphvar dst mv mu || C.le dst (mupper dst mv) (mlower dst mu)
+    if C.le dst (mupper dst mv) (mlower dst mu)
+    then Ok ()
+    else if eq_morphvar dst mv mu
     then Ok ()
     else
       let muupper = mupper dst mu in

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -252,8 +252,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         then c
         else
           match C.equal_obj obj1 obj2 with
-          | Some Refl -> C.compare_morph obj1 m1 m2
-          | None ->
+          | Misc.Is_eq -> C.compare_morph obj1 m1 m2
+          | Misc.Is_not_eq ->
             Misc.fatal_error
               "Solver.VarMap.compare: compare_obj inconsistent with equal_obj"
   end)
@@ -772,7 +772,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         disallow_left (disallow_right mv0) == disallow_left (disallow_right mv1))
     then true
     else
-      match C.equal_morph dst f0 f1 with None -> false | Some Refl -> v0 == v1
+      match C.equal_morph dst f0 f1 with
+      | Misc.Is_not_eq -> false
+      | Misc.Is_eq -> v0 == v1
 
   let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -247,15 +247,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       if c <> 0
       then c
       else
-        let c = C.compare_obj obj1 obj2 in
-        if c <> 0
-        then c
-        else
-          match C.equal_obj obj1 obj2 with
-          | Misc.Is_eq -> C.compare_morph obj1 m1 m2
-          | Misc.Is_not_eq ->
-            Misc.fatal_error
-              "Solver.VarMap.compare: compare_obj inconsistent with equal_obj"
+        match C.equal_obj obj1 obj2 with
+        | Misc.Is_eq -> C.compare_morph obj1 m1 m2
+        | Misc.Is_not_eq ->
+          Misc.fatal_error
+            "Solver.VarMap.compare: inconsistent destination objects"
   end)
 
   (** Map the function to the list, and returns the first [Error] found; Returns

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -760,18 +760,20 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        (Amorphvar (v1, f1, _f1_hint) as mv1) ->
     (* To align l0/l1, r0/r1; The existing disallow_left/right] is for [mode],
        not [morphvar]. *)
-    Morphvar.(
-      disallow_left (disallow_right mv0) == disallow_left (disallow_right mv1))
-    ||
-    match C.compare_morph dst f0 f1 with
-    | Less_than | Greater_than -> false
-    | Equal -> v0 == v1
+    if v0.id <> v1.id
+    then false
+    else if
+      Morphvar.(
+        disallow_left (disallow_right mv0) == disallow_left (disallow_right mv1))
+    then true
+    else
+      match C.compare_morph dst f0 f1 with
+      | Less_than | Greater_than -> false
+      | Equal -> true
 
   let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =
-    if C.le dst (mupper dst mv) (mlower dst mu)
-    then Ok ()
-    else if eq_morphvar dst mv mu
+    if eq_morphvar dst mv mu || C.le dst (mupper dst mv) (mlower dst mu)
     then Ok ()
     else
       let muupper = mupper dst mu in

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -237,10 +237,10 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           a, Branch (Meet, ahint1, ahint2))
   end
 
-  (* The variable id determines the destination object for all keys that may
-     coexist in a map.  If two equal ids have different destination objects, the
-     comparator below rejects the malformed keys rather than inventing an order
-     that could not be used to compare their morphisms. *)
+  (* All keys in a particular [VarMap] should have the same destination object,
+     but the key type does not encode that invariant.  The comparator orders by
+     variable id first, only checking object equality when equal ids force it to
+     compare morphisms. *)
   type key = Key : 'b C.obj * int * ('a, 'b, 'd) C.morph -> key
 
   module VarMap = Map.Make (struct
@@ -774,7 +774,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     else
       match C.equal_morph dst f0 f1 with
       | Misc.Is_not_eq -> false
-      | Misc.Is_eq -> v0 == v1
+      | Misc.Is_eq -> true
 
   let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -237,6 +237,10 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           a, Branch (Meet, ahint1, ahint2))
   end
 
+  (* The variable id determines the destination object for all keys that may
+     coexist in a map.  If two equal ids have different destination objects, the
+     comparator below rejects the malformed keys rather than inventing an order
+     that could not be used to compare their morphisms. *)
   type key = Key : 'b C.obj * int * ('a, 'b, 'd) C.morph -> key
 
   module VarMap = Map.Make (struct

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -247,10 +247,15 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       if c <> 0
       then c
       else
-        match C.compare_obj obj1 obj2 with
-        | Less_than -> 1
-        | Greater_than -> -1
-        | Equal -> Misc.comparison_result (C.compare_morph obj1 m1 m2)
+        let c = C.compare_obj obj1 obj2 in
+        if c <> 0
+        then c
+        else
+          match C.equal_obj obj1 obj2 with
+          | Some Refl -> C.compare_morph obj1 m1 m2
+          | None ->
+            Misc.fatal_error
+              "Solver.VarMap.compare: compare_obj inconsistent with equal_obj"
   end)
 
   (** Map the function to the list, and returns the first [Error] found; Returns
@@ -767,9 +772,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         disallow_left (disallow_right mv0) == disallow_left (disallow_right mv1))
     then true
     else
-      match C.compare_morph dst f0 f1 with
-      | Less_than | Greater_than -> false
-      | Equal -> true
+      match C.equal_morph dst f0 f1 with None -> false | Some Refl -> v0 == v1
 
   let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -49,12 +49,12 @@ module type Lattices = sig
 
   (** Total ordering on objects, used for internal map keys. This is not a
       lattice ordering or semantic equality check. If this returns [0], then
-      [equal_obj] must return [Some Refl]. *)
+      [equal_obj] must return [Misc.Is_eq]. *)
   val compare_obj : 'a obj -> 'b obj -> int
 
   (** Equality on objects recognized by the solver. This is the only object
       comparison that carries type equality evidence. *)
-  val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.eq option
+  val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.is_eq
 
   val print_obj : Fmt.formatter -> 'a obj -> unit
 end
@@ -158,7 +158,7 @@ module type Lattices_mono = sig
 
   (** Total ordering on morphisms with a shared target object, used for internal
       map keys. This is not a lattice ordering or semantic equality check. If
-      this returns [0], then [equal_morph] must return [Some Refl]. *)
+      this returns [0], then [equal_morph] must return [Misc.Is_eq]. *)
   val compare_morph :
     'b obj -> ('a0, 'b, 'd0) morph -> ('a1, 'b, 'd1) morph -> int
 
@@ -169,7 +169,7 @@ module type Lattices_mono = sig
     'b obj ->
     ('a0, 'b, 'd0) morph ->
     ('a1, 'b, 'd1) morph ->
-    ('a0, 'a1) Misc.eq option
+    ('a0, 'a1) Misc.is_eq
 
   (** Print morphism *)
   val print_morph : 'b obj -> Fmt.formatter -> ('a, 'b, 'd) morph -> unit

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -47,9 +47,14 @@ module type Lattices = sig
 
   val print : 'a obj -> Fmt.formatter -> 'a elt -> unit
 
-  (** Compares two objects. Used for deduplication only; it is sound (but not
-      recommended) to return a nonzero value for equal objects. *)
-  val compare_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.comparison
+  (** Total ordering on objects, used for internal map keys. This is not a
+      lattice ordering or semantic equality check. If this returns [0], then
+      [equal_obj] must return [Some Refl]. *)
+  val compare_obj : 'a obj -> 'b obj -> int
+
+  (** Equality on objects recognized by the solver. This is the only object
+      comparison that carries type equality evidence. *)
+  val equal_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.eq option
 
   val print_obj : Fmt.formatter -> 'a obj -> unit
 end
@@ -151,13 +156,20 @@ module type Lattices_mono = sig
   (** Apply morphism on constant *)
   val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
 
-  (** Compares two morphisms. Used for deduplication only; it is fine (but not
-      recommended) to return a nonzero value for equal morphisms. *)
+  (** Total ordering on morphisms with a shared target object, used for internal
+      map keys. This is not a lattice ordering or semantic equality check. If
+      this returns [0], then [equal_morph] must return [Some Refl]. *)
   val compare_morph :
+    'b obj -> ('a0, 'b, 'd0) morph -> ('a1, 'b, 'd1) morph -> int
+
+  (** Equality on morphisms with a shared target object recognized by the
+      solver. This is the only morphism comparison that carries source type
+      equality evidence. *)
+  val equal_morph :
     'b obj ->
     ('a0, 'b, 'd0) morph ->
     ('a1, 'b, 'd1) morph ->
-    ('a0, 'a1) Misc.comparison
+    ('a0, 'a1) Misc.eq option
 
   (** Print morphism *)
   val print_morph : 'b obj -> Fmt.formatter -> ('a, 'b, 'd) morph -> unit

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -630,7 +630,10 @@ let sort_dedup_modalities ~warn l =
       =
     let (P ax0) = Axis.to_value (P ax0) in
     let (P ax1) = Axis.to_value (P ax1) in
-    Misc.comparison_result (Mode.Value.Axis.compare ax0 ax1)
+    match Mode.Value.Axis.compare ax0 ax1 with
+    | Less_than -> -1
+    | Equal -> 0
+    | Greater_than -> 1
   in
   let dedup ~on_dup =
     let rec loop x = function

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -630,10 +630,7 @@ let sort_dedup_modalities ~warn l =
       =
     let (P ax0) = Axis.to_value (P ax0) in
     let (P ax1) = Axis.to_value (P ax1) in
-    match Mode.Value.Axis.compare ax0 ax1 with
-    | Less_than -> -1
-    | Equal -> 0
-    | Greater_than -> 1
+    Mode.Value.Axis.compare ax0 ax1
   in
   let dedup ~on_dup =
     let rec loop x = function

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1926,6 +1926,10 @@ end
 
 type (_, _) eq = Refl : ('a, 'a) eq
 
+type (_, _) is_eq =
+  | Is_eq : ('a, 'a) is_eq
+  | Is_not_eq : ('a, 'b) is_eq
+
 type ('a, 'b) comparison =
   | Less_than : ('a, 'b) comparison
   | Equal : ('a, 'a) comparison

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1935,11 +1935,6 @@ type ('a, 'b) comparison =
   | Equal : ('a, 'a) comparison
   | Greater_than : ('a, 'b) comparison
 
-let comparison_result : type a b. (a, b) comparison -> int = function
-  | Less_than -> -1
-  | Equal -> 0
-  | Greater_than -> 1
-
 (*********************************************)
 (* Fancy modules *)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1930,11 +1930,6 @@ type (_, _) is_eq =
   | Is_eq : ('a, 'a) is_eq
   | Is_not_eq : ('a, 'b) is_eq
 
-type ('a, 'b) comparison =
-  | Less_than : ('a, 'b) comparison
-  | Equal : ('a, 'a) comparison
-  | Greater_than : ('a, 'b) comparison
-
 (*********************************************)
 (* Fancy modules *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -1123,12 +1123,6 @@ type (_, _) is_eq =
   | Is_eq : ('a, 'a) is_eq
   | Is_not_eq : ('a, 'b) is_eq
 
-(** Propositional comparison *)
-type ('a, 'b) comparison =
-  | Less_than : ('a, 'b) comparison
-  | Equal : ('a, 'a) comparison
-  | Greater_than : ('a, 'b) comparison
-
 (** Utilities for module-level programming *)
 module type T = sig
   type t

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -1129,8 +1129,6 @@ type ('a, 'b) comparison =
   | Equal : ('a, 'a) comparison
   | Greater_than : ('a, 'b) comparison
 
-val comparison_result : ('a, 'b) comparison -> int
-
 (** Utilities for module-level programming *)
 module type T = sig
   type t

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -1118,6 +1118,11 @@ end
 (** Propositional equality *)
 type (_, _) eq = Refl : ('a, 'a) eq
 
+(** Propositional equality test *)
+type (_, _) is_eq =
+  | Is_eq : ('a, 'a) is_eq
+  | Is_not_eq : ('a, 'b) is_eq
+
 (** Propositional comparison *)
 type ('a, 'b) comparison =
   | Less_than : ('a, 'b) comparison


### PR DESCRIPTION
`Solver_mono.VarMap` keys include morphs. The existing morph ordering compared `Meet_const` and `Imply_const` payloads using the lattice order on mode constants. That order is not total: two incomparable constants can compare as `Greater_than` in both directions, which violates the ordering contract required by `Map`.

This changes morph key comparison to use a separate structural total order for constants. The lattice operations and lattice ordering predicates are unchanged. The total order is only used to order map keys:

- total axes compare by their existing `ord` encoding
- diamond axes compare by their immediate-constructor encoding
- product constants compare lexicographically by field
- opposite lattices use the same structural order as their underlying representation

The PR also does some `eq_morphvar` and `submode_mvmv` optimizations.