### PR TITLE
Regalloc validation testing

### DIFF
--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -470,7 +470,8 @@ end = struct
     t
 
   let create cfg =
-    match !Oxcaml_flags.regalloc_validate with
+    let regalloc_validate = false in
+    match regalloc_validate with
     | false -> None
     | true -> Some (do_create cfg)
 

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -19,7 +19,7 @@ let regalloc = ref Clflags.Register_allocator.Cfg (* -regalloc *)
 let default_regalloc_linscan_threshold = 100_000
 let regalloc_linscan_threshold = ref max_int (* -regalloc-linscan-threshold *)
 let regalloc_params = ref ([] : string list)  (* -regalloc-param *)
-let regalloc_validate = ref true        (* -[no-]regalloc-validate *)
+let regalloc_validate = ref false       (* -[no-]regalloc-validate *)
 
 let vectorize = ref false                (* -[no-]vectorize *)
 let dump_vectorize = ref false          (* -dvectorize *)


### PR DESCRIPTION
[The purpose of this is to measure how much time regalloc validation takes]

Regalloc validation currently runs by default during native compilation. On representative compiler inputs, this adds measurable compile-time overhead. This PR is to internally benchmark how much enabling/disabling this costs/saves.