### PR TITLE
Disable CFG prologue validation by default

### DIFF
--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -623,7 +623,8 @@ end
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
   let cfg = Cfg_with_infos.cfg cfg_with_infos in
-  if !Oxcaml_flags.cfg_prologue_validate then validate_no_prologue cfg;
+  let cfg_prologue_validate = false in
+  if cfg_prologue_validate then validate_no_prologue cfg;
   (match !Oxcaml_flags.cfg_prologue_shrink_wrap with
   | true
     when Label.Tbl.length cfg.blocks
@@ -639,7 +640,8 @@ let validate : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
   let cfg = Cfg_with_infos.cfg cfg_with_infos in
   let fun_name = Cfg.fun_name cfg in
-  match !Oxcaml_flags.cfg_prologue_validate with
+  let cfg_prologue_validate = false in
+  match cfg_prologue_validate with
   | true -> (
     match
       Validator.run cfg

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -40,7 +40,7 @@ let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-handlers *)
 
-let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
+let cfg_prologue_validate = ref false    (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)
 let cfg_prologue_shrink_wrap_threshold = ref 16384
                                        (* -cfg-prologue-shrink-wrap-threshold *)


### PR DESCRIPTION
Disable CFG prologue validation by default, while keeping the existing `-cfg-prologue-validate` flag available for explicit validation runs. PR for internal benchmarking purposes to see if this is a speedup.