### PR TITLE
Fix scannable axis printing to meet

### DIFF
--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -92,8 +92,7 @@ Line 2, characters 45-47:
 Error: Tuple element types must have layout value.
        The layout of "'a" is the abstract kind x
          because of the annotation on the universal variable 'a.
-       But the layout of "'a" must overlap with
-           value maybe_separable maybe_null
+       But the layout of "'a" must overlap with value_or_null
          because it's the type of a tuple element.
 |}]
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -162,6 +162,12 @@ type t16 : value non_pointer
 type t17 : value & value non_pointer
 |}]
 
+type ('a : value mod external_ stateless many unyielding non_float) t18 =
+  ('a : value mod immutable global aliased)
+[%%expect{|
+type ('a : value mod everything non_float) t18 = 'a
+|}]
+
 type t = #(int * float#)
 
 let f xs = match xs with

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,5 @@
-File "source_jane_street.ml", line 165, characters 0-24:
-165 | type t = #(int * float#)
+File "source_jane_street.ml", line 171, characters 0-24:
+171 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name "t".
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1276,7 +1276,7 @@ type ('a : bits32 mod aliased) t = ('a : any mod global)
 type ('a : value mod global) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
-type ('a : immediate non_float) t = 'a
+type ('a : value mod everything non_float) t = 'a
 type 'a t = 'a
 type 'a t = 'a
 type ('a : bits32 mod global) t = 'a
@@ -1820,9 +1820,9 @@ Error: Signature mismatch:
          type 'a t : value_or_null mod everything
        is not included in
          type 'a t : value_or_null mod everything separable
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 4, characters 2-42.
-       But the layout of the first must be a sublayout of value maybe_null
+       But the layout of the first must be a sublayout of value_maybe_null
          because of the definition of t at line 2, characters 2-52.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1276,7 +1276,7 @@ type ('a : bits32 mod aliased) t = ('a : any mod global)
 type ('a : value mod global) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
-type ('a : immediate non_float) t = 'a
+type ('a : value mod everything non_float) t = 'a
 type 'a t = 'a
 type 'a t = 'a
 type ('a : bits32 mod global) t = 'a
@@ -1820,9 +1820,9 @@ Error: Signature mismatch:
          type 'a t : value_or_null mod everything
        is not included in
          type 'a t : value_or_null mod everything separable
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 4, characters 2-42.
-       But the layout of the first must be a sublayout of value maybe_null
+       But the layout of the first must be a sublayout of value_maybe_null
          because of the definition of t at line 2, characters 2-52.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/bvar.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/bvar.ml
@@ -60,7 +60,7 @@ Line 14, characters 14-31:
 14 |   type 'a t = int M.contended_t data_t
                    ^^^^^^^^^^^^^^^^^
 Error: This type "int M.contended_t" should be an instance of type "('a : value)"
-       The layout of int M.contended_t is value maybe_separable maybe_null
+       The layout of int M.contended_t is value_or_null
          because of the definition of contended_t at line 2, characters 2-69.
        But the layout of int M.contended_t must be a sublayout of value
          because of the definition of data_t at line 9, characters 0-44.

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/bvar_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/bvar_ikinds.ml
@@ -60,7 +60,7 @@ Line 14, characters 14-31:
 14 |   type 'a t = int M.contended_t data_t
                    ^^^^^^^^^^^^^^^^^
 Error: This type "int M.contended_t" should be an instance of type "('a : value)"
-       The layout of int M.contended_t is value maybe_separable maybe_null
+       The layout of int M.contended_t is value_or_null
          because of the definition of contended_t at line 2, characters 2-69.
        But the layout of int M.contended_t must be a sublayout of value
          because of the definition of data_t at line 9, characters 0-44.

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -319,7 +319,9 @@ Line 2, characters 0-68:
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
-           immediate non_float with [< `A of string | `B of int ] t1
+           value mod everything
+             non_float
+             with [< `A of string | `B of int ] t1
          because of the annotation on the declaration of the type t2.
 |}]
 type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
@@ -337,7 +339,9 @@ Line 2, characters 0-68:
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
-           immediate non_float with [> `A of string | `B of int ] t1
+           value mod everything
+             non_float
+             with [> `A of string | `B of int ] t1
          because of the annotation on the declaration of the type t2.
 |}]
 type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
@@ -361,7 +365,7 @@ Line 7, characters 0-64:
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
-           immediate non_float with M1.t
+           value mod everything non_float with M1.t
          because of the annotation on the declaration of the type t2.
 |}]
 
@@ -389,7 +393,7 @@ Line 6, characters 4-68:
 Error: The kind of type "t4" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t4" must be a subkind of
-           immediate non_float with M1.t
+           value mod everything non_float with M1.t
          because of the annotation on the declaration of the type t4.
 |}]
 
@@ -409,7 +413,7 @@ Line 7, characters 0-64:
 Error: The kind of type "t2" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of
-           immediate non_float with M1.t
+           value mod everything non_float with M1.t
          because of the annotation on the declaration of the type t2.
 |}]
 
@@ -488,7 +492,7 @@ Line 3, characters 4-68:
 Error: The kind of type "t4" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t4" must be a subkind of
-           immediate non_float with M1.t
+           value mod everything non_float with M1.t
          because of the annotation on the declaration of the type t4.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -734,7 +734,7 @@ Lines 1-2, characters 0-28:
 1 | type 'a not_always_portable : any mod portable
 2 |   = #{ a : 'a t; u : unit# }
 Error: The kind of type "not_always_portable" is
-           immediate separable with 'a t & void mod everything with 'a t
+           value mod everything with 'a t & void mod everything with 'a t
          because it is an unboxed record.
        But the kind of type "not_always_portable" must be a subkind of
            value_or_null mod portable & void mod portable

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -694,7 +694,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        The layout of float is value
          because it is the primitive type float.
        But the layout of float must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -711,10 +711,10 @@ Line 3, characters 2-36:
 Error: This expression has type "('a array, 'a) idx_mut"
        but an expression was expected of type "('a array, non_sep) idx_mut"
        Type "'a" is not compatible with type "non_sep" = "float or_null"
-       The layout of non_sep is value maybe_separable maybe_null
+       The layout of non_sep is value_or_null
          because it is the primitive type or_null.
        But the layout of non_sep must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -733,7 +733,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        The layout of abstract is value
          because of the definition of abstract at line 1, characters 0-13.
        But the layout of abstract must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -749,7 +749,7 @@ Error: This expression has type "('a iarray, 'a) idx_imm"
        The layout of float is value
          because it is the primitive type float.
        But the layout of float must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -768,7 +768,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        The layout of float is value
          because it is the primitive type float.
        But the layout of float must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -785,10 +785,10 @@ Line 3, characters 2-37:
 Error: This expression has type "('a iarray, 'a) idx_imm"
        but an expression was expected of type "('a iarray, non_sep) idx_imm"
        Type "'a" is not compatible with type "non_sep" = "float or_null"
-       The layout of non_sep is value maybe_separable maybe_null
+       The layout of non_sep is value_or_null
          because it is the primitive type or_null.
        But the layout of non_sep must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -807,7 +807,7 @@ Error: This expression has type "('a iarray, 'a) idx_imm"
        The layout of abstract is value
          because of the definition of abstract at line 1, characters 0-13.
        But the layout of abstract must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -693,8 +693,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        but an expression was expected of type "(float array, 'b) idx_mut"
        The layout of float is value
          because it is the primitive type float.
-       But the layout of float must be a sublayout of
-           value_maybe_null non_float
+       But the layout of float must be a sublayout of value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -714,7 +713,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        The layout of non_sep is value_or_null
          because it is the primitive type or_null.
        But the layout of non_sep must be a sublayout of
-           value_maybe_null non_float
+           value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -733,7 +732,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        The layout of abstract is value
          because of the definition of abstract at line 1, characters 0-13.
        But the layout of abstract must be a sublayout of
-           value_maybe_null non_float
+           value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -748,8 +747,7 @@ Error: This expression has type "('a iarray, 'a) idx_imm"
        but an expression was expected of type "(float iarray, 'b) idx_imm"
        The layout of float is value
          because it is the primitive type float.
-       But the layout of float must be a sublayout of
-           value_maybe_null non_float
+       But the layout of float must be a sublayout of value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -767,8 +765,7 @@ Error: This expression has type "('a array, 'a) idx_mut"
        but an expression was expected of type "(float array, 'b) idx_mut"
        The layout of float is value
          because it is the primitive type float.
-       But the layout of float must be a sublayout of
-           value_maybe_null non_float
+       But the layout of float must be a sublayout of value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -788,7 +785,7 @@ Error: This expression has type "('a iarray, 'a) idx_imm"
        The layout of non_sep is value_or_null
          because it is the primitive type or_null.
        But the layout of non_sep must be a sublayout of
-           value_maybe_null non_float
+           value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
@@ -807,7 +804,7 @@ Error: This expression has type "('a iarray, 'a) idx_imm"
        The layout of abstract is value
          because of the definition of abstract at line 1, characters 0-13.
        But the layout of abstract must be a sublayout of
-           value_maybe_null non_float
+           value_or_null non_float
          because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -213,7 +213,7 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type "('a : value)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 3, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of id_value at line 4, characters 0-31.
@@ -231,7 +231,7 @@ Error: Signature mismatch:
        is not included in
          sig type t end
        Type declarations do not match: type t = X.t is not included in type t
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 1, characters 18-40.
        But the layout of the first must be a sublayout of value
          because of the definition of t at line 1, characters 52-66.
@@ -261,7 +261,7 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type
          "('a : any separable)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 3, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of any separable
          because of the definition of id_any_mod_separable at line 2, characters 0-55.
@@ -282,7 +282,7 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any separable
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 1, characters 18-40.
        But the layout of the first must be a sublayout of any separable
          because of the definition of t at line 1, characters 52-78.
@@ -447,7 +447,7 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type "('a : value)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 3, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of t1 at line 3, characters 0-71.

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -30,7 +30,7 @@ Line 3, characters 19-34:
                        ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type
          "('a : any separable)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -76,7 +76,7 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float or_null is value maybe_separable maybe_null
+       The layout of float or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float or_null must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -127,7 +127,7 @@ Line 3, characters 19-34:
                        ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type
          "('a : any separable)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -173,7 +173,7 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float or_null is value maybe_separable maybe_null
+       The layout of float or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float or_null must be a sublayout of any separable
          because it's the type argument to the array type.

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -116,7 +116,7 @@ Error: This type "float t" should be an instance of type
        The layout of float t is value_or_null
          because of the definition of t at lines 1-4, characters 0-11.
        But the layout of float t must be a sublayout of
-           value_maybe_null non_float
+           value_or_null non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -71,7 +71,7 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This expression has type "'a t" but an expression was expected of type
          "('b : value)"
-       The layout of 'a t is value maybe_separable maybe_null
+       The layout of 'a t is value_or_null
          because of the definition of t at lines 1-4, characters 0-11.
        But the layout of 'a t must be a sublayout of value
          because of the definition of t at lines 1-4, characters 0-11.
@@ -99,7 +99,7 @@ Line 1, characters 13-20:
 1 | type fails = float t accepts_sep
                  ^^^^^^^
 Error: This type "float t" should be an instance of type "('a : any separable)"
-       The layout of float t is value maybe_separable maybe_null
+       The layout of float t is value_or_null
          because of the definition of t at lines 1-4, characters 0-11.
        But the layout of float t must be a sublayout of any separable
          because of the definition of accepts_sep at line 2, characters 0-41.
@@ -113,10 +113,10 @@ Line 1, characters 13-20:
                  ^^^^^^^
 Error: This type "float t" should be an instance of type
          "('a : value_or_null non_float)"
-       The layout of float t is value maybe_separable maybe_null
+       The layout of float t is value_or_null
          because of the definition of t at lines 1-4, characters 0-11.
        But the layout of float t must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
 |}]
 
@@ -281,8 +281,7 @@ Lines 1-4, characters 0-11:
 2 |   | A
 3 |   | B of 'a
 4 | [@@or_null]
-Error: The layout of type "wrong_result_kind" is
-           value maybe_separable maybe_null
+Error: The layout of type "wrong_result_kind" is value_or_null
          because of the annotation on 'a in the declaration of the type
                                       wrong_result_kind.
        But the layout of type "wrong_result_kind" must be a sublayout of value
@@ -331,7 +330,7 @@ Error: Signature mismatch:
          type 'a t = Nope | Yep of 'a [@@or_null]
        is not included in
          type 'a t
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at lines 4-7, characters 2-13.
        But the layout of the first must be a sublayout of value
          because of the definition of t at line 2, characters 2-11.

--- a/testsuite/tests/typing-layouts-or-null/existential_kind_annotations.ml
+++ b/testsuite/tests/typing-layouts-or-null/existential_kind_annotations.ml
@@ -29,7 +29,7 @@ type packed = P : 'a -> packed
 Line 3, characters 20-25:
 3 | let f (P (type (a : value)) (x : a)) = ()
                         ^^^^^
-Error: The layout of a is value maybe_separable maybe_null
+Error: The layout of a is value_or_null
          because of the definition of packed at line 1, characters 0-52.
        But the layout of a must be a sublayout of value
          because of the annotation on the existential variable a.
@@ -44,7 +44,7 @@ let k (Packed (type a) (x : a)) = ()
 Line 1, characters 20-21:
 1 | let k (Packed (type a) (x : a)) = ()
                         ^
-Error: The layout of a is value maybe_separable maybe_null
+Error: The layout of a is value_or_null
          because of the definition of packed at line 1, characters 0-57.
        But the layout of a must be a sublayout of value
          because it's an unannotated existential type variable.
@@ -144,7 +144,7 @@ Line 3, characters 41-42:
                                              ^
 Error: This pattern matches values of type "a"
        but a pattern was expected which matches values of type "('a : value)"
-       The layout of a is value maybe_separable maybe_null
+       The layout of a is value_or_null
          because of the annotation on the existential variable a.
        But the layout of a must be a sublayout of value
          because of the definition of packed at line 1, characters 0-44.

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -40,7 +40,7 @@ Line 1, characters 19-38:
                        ^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate_or_null" should be an instance of type
          "('a : immediate)"
-       The layout of t_immediate_or_null is value non_pointer maybe_null
+       The layout of t_immediate_or_null is value_maybe_null non_pointer
          because of the definition of t_immediate_or_null at line 1, characters 0-44.
        But the layout of t_immediate_or_null must be a sublayout of
            value non_pointer
@@ -60,7 +60,7 @@ Line 1, characters 19-38:
                        ^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate_or_null" should be an instance of type
          "('a : value)"
-       The layout of t_immediate_or_null is value non_pointer maybe_null
+       The layout of t_immediate_or_null is value_maybe_null non_pointer
          because of the definition of t_immediate_or_null at line 1, characters 0-44.
        But the layout of t_immediate_or_null must be a sublayout of value
          because of the definition of accept_value at line 1, characters 0-30.
@@ -177,7 +177,7 @@ Line 1, characters 19-40:
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate64_or_null" should be an instance of type
          "('a : immediate64)"
-       The layout of t_immediate64_or_null is value non_pointer64 maybe_null
+       The layout of t_immediate64_or_null is value_maybe_null non_pointer64
          because of the definition of t_immediate64_or_null at line 1, characters 0-48.
        But the layout of t_immediate64_or_null must be a sublayout of
            value non_pointer64
@@ -192,7 +192,7 @@ Line 1, characters 19-40:
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate64_or_null" should be an instance of type
          "('a : immediate)"
-       The layout of t_immediate64_or_null is value non_pointer64 maybe_null
+       The layout of t_immediate64_or_null is value_maybe_null non_pointer64
          because of the definition of t_immediate64_or_null at line 1, characters 0-48.
        But the layout of t_immediate64_or_null must be a sublayout of
            value non_pointer
@@ -207,7 +207,7 @@ Line 1, characters 19-40:
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate64_or_null" should be an instance of type
          "('a : value)"
-       The layout of t_immediate64_or_null is value non_pointer64 maybe_null
+       The layout of t_immediate64_or_null is value_maybe_null non_pointer64
          because of the definition of t_immediate64_or_null at line 1, characters 0-48.
        But the layout of t_immediate64_or_null must be a sublayout of value
          because of the definition of accept_value at line 1, characters 0-30.
@@ -236,10 +236,10 @@ Line 1, characters 19-30:
                        ^^^^^^^^^^^
 Error: This type "exn or_null" should be an instance of type
          "('a : immediate64_or_null)"
-       The layout of exn or_null is value maybe_separable maybe_null
+       The layout of exn or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of exn or_null must be a sublayout of
-           value non_pointer64 maybe_null
+           value_maybe_null non_pointer64
          because of the definition of accept_immediate64_or_null at line 1, characters 0-58.
 |}]
 
@@ -273,9 +273,9 @@ Error: Signature mismatch:
          type t = string or_null
        is not included in
          type t : immediate64_or_null
-       The layout of the first is value non_float maybe_null
+       The layout of the first is value_maybe_null non_float
          because it is the primitive type or_null.
        But the layout of the first must be a sublayout of
-           value non_pointer64 maybe_null
+           value_maybe_null non_pointer64
          because of the definition of t at line 2, characters 2-30.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -40,7 +40,7 @@ Line 1, characters 19-38:
                        ^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate_or_null" should be an instance of type
          "('a : immediate)"
-       The layout of t_immediate_or_null is value_maybe_null non_pointer
+       The layout of t_immediate_or_null is value_or_null non_pointer
          because of the definition of t_immediate_or_null at line 1, characters 0-44.
        But the layout of t_immediate_or_null must be a sublayout of
            value non_pointer
@@ -60,7 +60,7 @@ Line 1, characters 19-38:
                        ^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate_or_null" should be an instance of type
          "('a : value)"
-       The layout of t_immediate_or_null is value_maybe_null non_pointer
+       The layout of t_immediate_or_null is value_or_null non_pointer
          because of the definition of t_immediate_or_null at line 1, characters 0-44.
        But the layout of t_immediate_or_null must be a sublayout of value
          because of the definition of accept_value at line 1, characters 0-30.
@@ -177,7 +177,7 @@ Line 1, characters 19-40:
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate64_or_null" should be an instance of type
          "('a : immediate64)"
-       The layout of t_immediate64_or_null is value_maybe_null non_pointer64
+       The layout of t_immediate64_or_null is value_or_null non_pointer64
          because of the definition of t_immediate64_or_null at line 1, characters 0-48.
        But the layout of t_immediate64_or_null must be a sublayout of
            value non_pointer64
@@ -192,7 +192,7 @@ Line 1, characters 19-40:
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate64_or_null" should be an instance of type
          "('a : immediate)"
-       The layout of t_immediate64_or_null is value_maybe_null non_pointer64
+       The layout of t_immediate64_or_null is value_or_null non_pointer64
          because of the definition of t_immediate64_or_null at line 1, characters 0-48.
        But the layout of t_immediate64_or_null must be a sublayout of
            value non_pointer
@@ -207,7 +207,7 @@ Line 1, characters 19-40:
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_immediate64_or_null" should be an instance of type
          "('a : value)"
-       The layout of t_immediate64_or_null is value_maybe_null non_pointer64
+       The layout of t_immediate64_or_null is value_or_null non_pointer64
          because of the definition of t_immediate64_or_null at line 1, characters 0-48.
        But the layout of t_immediate64_or_null must be a sublayout of value
          because of the definition of accept_value at line 1, characters 0-30.
@@ -239,7 +239,7 @@ Error: This type "exn or_null" should be an instance of type
        The layout of exn or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of exn or_null must be a sublayout of
-           value_maybe_null non_pointer64
+           value_or_null non_pointer64
          because of the definition of accept_immediate64_or_null at line 1, characters 0-58.
 |}]
 
@@ -273,9 +273,9 @@ Error: Signature mismatch:
          type t = string or_null
        is not included in
          type t : immediate64_or_null
-       The layout of the first is value_maybe_null non_float
+       The layout of the first is value_or_null non_float
          because it is the primitive type or_null.
        But the layout of the first must be a sublayout of
-           value_maybe_null non_pointer64
+           value_or_null non_pointer64
          because of the definition of t at line 2, characters 2-30.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/inclusions_aliases.ml
+++ b/testsuite/tests/typing-layouts-or-null/inclusions_aliases.ml
@@ -13,7 +13,7 @@ type t_vn : value_or_null
 Line 2, characters 0-23:
 2 | type q_v : value = t_vn
     ^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "t_vn" is value maybe_separable maybe_null
+Error: The layout of type "t_vn" is value_or_null
          because of the definition of t_vn at line 1, characters 0-25.
        But the layout of type "t_vn" must be a sublayout of value
          because of the definition of q_v at line 2, characters 0-23.
@@ -61,7 +61,7 @@ type t_vn2 : value_or_null
 Line 2, characters 0-39:
 2 | type q_sep2 : any mod separable = t_vn2
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "t_vn2" is value maybe_separable maybe_null
+Error: The layout of type "t_vn2" is value_or_null
          because of the definition of t_vn2 at line 1, characters 0-26.
        But the layout of type "t_vn2" must be a sublayout of any separable
          because of the definition of q_sep2 at line 2, characters 0-39.

--- a/testsuite/tests/typing-layouts-or-null/inclusions_aliases_ikinds.ml
+++ b/testsuite/tests/typing-layouts-or-null/inclusions_aliases_ikinds.ml
@@ -14,7 +14,7 @@ type t_vn : value_or_null
 Line 2, characters 0-23:
 2 | type q_v : value = t_vn
     ^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "t_vn" is value maybe_separable maybe_null
+Error: The layout of type "t_vn" is value_or_null
          because of the definition of t_vn at line 1, characters 0-25.
        But the layout of type "t_vn" must be a sublayout of value
          because of the definition of q_v at line 2, characters 0-23.
@@ -62,7 +62,7 @@ type t_vn2 : value_or_null
 Line 2, characters 0-39:
 2 | type q_sep2 : any mod separable = t_vn2
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "t_vn2" is value maybe_separable maybe_null
+Error: The layout of type "t_vn2" is value_or_null
          because of the definition of t_vn2 at line 1, characters 0-26.
        But the layout of type "t_vn2" must be a sublayout of any separable
          because of the definition of q_sep2 at line 2, characters 0-39.

--- a/testsuite/tests/typing-layouts-or-null/inclusions_modules.ml
+++ b/testsuite/tests/typing-layouts-or-null/inclusions_modules.ml
@@ -20,7 +20,7 @@ Error: Signature mismatch:
          type t : value_or_null
        is not included in
          type t
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 2, characters 2-24.
        But the layout of the first must be a sublayout of value
          because of the definition of t at line 1, characters 16-30.
@@ -63,7 +63,7 @@ Error: Signature mismatch:
        is not included in
          sig type t end
        Type declarations do not match: type t = X.t is not included in type t
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 1, characters 19-41.
        But the layout of the first must be a sublayout of value
          because of the definition of t at line 1, characters 53-67.

--- a/testsuite/tests/typing-layouts-or-null/inclusions_modules_ikinds.ml
+++ b/testsuite/tests/typing-layouts-or-null/inclusions_modules_ikinds.ml
@@ -21,7 +21,7 @@ Error: Signature mismatch:
          type t : value_or_null
        is not included in
          type t
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 2, characters 2-24.
        But the layout of the first must be a sublayout of value
          because of the definition of t at line 1, characters 16-30.
@@ -64,7 +64,7 @@ Error: Signature mismatch:
        is not included in
          sig type t end
        Type declarations do not match: type t = X.t is not included in type t
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because of the definition of t at line 1, characters 19-41.
        But the layout of the first must be a sublayout of value
          because of the definition of t at line 1, characters 53-67.

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -86,7 +86,7 @@ Line 1, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The layout of 'a Or_null.t is value maybe_separable maybe_null
+       The layout of 'a Or_null.t is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a Or_null.t must be a sublayout of value
          because of the definition of t at line 2, characters 2-79.
@@ -107,7 +107,7 @@ Line 4, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The layout of 'a Or_null.t is value maybe_separable maybe_null
+       The layout of 'a Or_null.t is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a Or_null.t must be a sublayout of value
          because of the definition of t at line 2, characters 2-45.
@@ -121,7 +121,7 @@ type 'a t : value = 'a or_null [@@or_null_reexport]
 Line 1, characters 0-51:
 1 | type 'a t : value = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "'a or_null" is value maybe_separable maybe_null
+Error: The layout of type "'a or_null" is value_or_null
          because it is the primitive type or_null.
        But the layout of type "'a or_null" must be a sublayout of value
          because of the definition of t at line 1, characters 0-51.
@@ -133,7 +133,7 @@ type 'a t : float64 = 'a or_null [@@or_null_reexport]
 Line 1, characters 0-53:
 1 | type 'a t : float64 = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "'a or_null" is value maybe_separable maybe_null
+Error: The layout of type "'a or_null" is value_or_null
          because it is the primitive type or_null.
        But the layout of type "'a or_null" must be a sublayout of float64
          because of the definition of t at line 1, characters 0-53.
@@ -171,10 +171,10 @@ Line 4, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value_maybe_separable)"
-       The layout of 'a Or_null.t is value maybe_separable maybe_null
+       The layout of 'a Or_null.t is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a Or_null.t must be a sublayout of
-           value maybe_separable
+           value_maybe_separable
          because of the definition of t at line 2, characters 2-63.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -109,7 +109,7 @@ Line 1, characters 13-18:
 1 | type fails = t_von accepts_sep
                  ^^^^^
 Error: This type "t_von" should be an instance of type "('a : any separable)"
-       The layout of t_von is value maybe_separable maybe_null
+       The layout of t_von is value_or_null
          because of the definition of t_von at line 1, characters 0-26.
        But the layout of t_von must be a sublayout of any separable
          because of the definition of accepts_sep at line 2, characters 0-41.
@@ -122,7 +122,7 @@ Line 1, characters 13-18:
 1 | type fails = t_von accepts_nonfloat
                  ^^^^^
 Error: This type "t_von" should be an instance of type "('a : any non_float)"
-       The layout of t_von is value maybe_separable maybe_null
+       The layout of t_von is value_or_null
          because of the definition of t_von at line 1, characters 0-26.
        But the layout of t_von must be a sublayout of any non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-46.
@@ -504,7 +504,7 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "t_val or_null" should be an instance of type
          "('a : any separable)"
-       The layout of t_val or_null is value maybe_separable maybe_null
+       The layout of t_val or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of t_val or_null must be a sublayout of any separable
          because of the definition of accepts_sep at line 2, characters 0-41.
@@ -559,7 +559,7 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float or_null is value maybe_separable maybe_null
+       The layout of float or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float or_null must be a sublayout of any separable
          because of the definition of accepts_sep at line 2, characters 0-41.
@@ -577,7 +577,7 @@ Line 1, characters 13-27:
                  ^^^^^^^^^^^^^^
 Error: This type "t_maybesep_val" should be an instance of type
          "('a : any separable)"
-       The layout of t_maybesep_val is value maybe_separable
+       The layout of t_maybesep_val is value_maybe_separable
          because of the definition of t_maybesep_val at line 1, characters 0-48.
        But the layout of t_maybesep_val must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -613,7 +613,7 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float or_null is value maybe_separable maybe_null
+       The layout of float or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float or_null must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -704,7 +704,7 @@ type a : value = #{ a : t_maybesep_val }
 Line 1, characters 0-40:
 1 | type a : value = #{ a : t_maybesep_val }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "a" is value maybe_separable
+Error: The layout of type "a" is value_maybe_separable
          because it is an unboxed record.
        But the layout of type "a" must be a sublayout of value
          because of the annotation on the declaration of the type a.
@@ -730,7 +730,7 @@ Line 3, characters 83-89:
                                                                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type "('b : value & value & float64)" is not compatible with type "b"
-       The layout of b is value non_pointer & value maybe_separable & float64
+       The layout of b is value non_pointer & value_maybe_separable & float64
          because of the definition of b at line 1, characters 0-51.
        But the layout of b must be a sublayout of value & value & float64
          because of the annotation on 'b in the declaration of the type fails.
@@ -749,7 +749,7 @@ Line 3, characters 83-89:
 Error: The type constraints are not consistent.
        Type "('c : value & value & float64)" is not compatible with type
          "c" = "#(float * float or_null * float#)"
-       The layout of c is value & value maybe_separable maybe_null & float64
+       The layout of c is value & value_or_null & float64
          because it is an unboxed tuple.
        But the layout of c must be a sublayout of value & value & float64
          because of the annotation on 'c in the declaration of the type fails.
@@ -809,8 +809,7 @@ Line 1, characters 13-37:
                  ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any non_float)"
-       The layout of float Or_null_reexport.t is
-           value maybe_separable maybe_null
+       The layout of float Or_null_reexport.t is value_or_null
          because it is the primitive type or_null.
        But the layout of float Or_null_reexport.t must be a sublayout of
            any non_float
@@ -825,8 +824,7 @@ Line 1, characters 13-37:
                  ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any separable)"
-       The layout of float Or_null_reexport.t is
-           value maybe_separable maybe_null
+       The layout of float Or_null_reexport.t is value_or_null
          because it is the primitive type or_null.
        But the layout of float Or_null_reexport.t must be a sublayout of
            any separable
@@ -857,7 +855,7 @@ Line 1, characters 13-31:
                  ^^^^^^^^^^^^^^^^^^
 Error: This type "float unbx or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float unbx or_null is value maybe_separable maybe_null
+       The layout of float unbx or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float unbx or_null must be a sublayout of
            any separable
@@ -939,10 +937,10 @@ Error: Signature mismatch:
          type 'a t = float or_null
        is not included in
          type ('a : value non_float) t : value_or_null non_float
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because it is the primitive type or_null.
        But the layout of the first must be a sublayout of
-           value non_float maybe_null
+           value_maybe_null non_float
          because of the definition of t at line 2, characters 2-65.
 |}]
 
@@ -996,9 +994,9 @@ Error: Signature mismatch:
          type t = float or_null
        is not included in
          type t : value_maybe_null
-       The layout of the first is value maybe_separable maybe_null
+       The layout of the first is value_or_null
          because it is the primitive type or_null.
-       But the layout of the first must be a sublayout of value maybe_null
+       But the layout of the first must be a sublayout of value_maybe_null
          because of the definition of t at line 2, characters 2-38.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -940,7 +940,7 @@ Error: Signature mismatch:
        The layout of the first is value_or_null
          because it is the primitive type or_null.
        But the layout of the first must be a sublayout of
-           value_maybe_null non_float
+           value_or_null non_float
          because of the definition of t at line 2, characters 2-65.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/separability_bug.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_bug.ml
@@ -105,9 +105,9 @@ Line 1, characters 17-27:
                      ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type
          "('b : value_maybe_separable)"
-       The layout of 'a or_null is value maybe_separable maybe_null
+       The layout of 'a or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a or_null must be a sublayout of
-           value maybe_separable
+           value_maybe_separable
          because the type argument of or_null has layout value.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -99,10 +99,10 @@ Line 1, characters 14-25:
                   ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : value_maybe_separable)"
-       The layout of int or_null is value maybe_separable maybe_null
+       The layout of int or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of int or_null must be a sublayout of
-           value maybe_separable
+           value_maybe_separable
          because the type argument of or_null has layout value.
 |}]
 
@@ -114,7 +114,7 @@ Line 1, characters 23-31:
                            ^^^^^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The layout of 'a t is value maybe_separable maybe_null
+       The layout of 'a t is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a t must be a sublayout of value
          because of the definition of t at line 1, characters 0-69.
@@ -128,7 +128,7 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The layout of 'a t is value maybe_separable maybe_null
+       The layout of 'a t is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a t must be a sublayout of value
          because of the definition of t at line 1, characters 0-69.
@@ -221,7 +221,7 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float or_null is value maybe_separable maybe_null
+       The layout of float or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float or_null must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -278,7 +278,7 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any separable)"
-       The layout of float or_null is value maybe_separable maybe_null
+       The layout of float or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of float or_null must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -292,7 +292,7 @@ Line 1, characters 26-42:
 1 | type object_with_null = < x : int or_null; .. >
                               ^^^^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of "int or_null" is value maybe_separable maybe_null
+       The layout of "int or_null" is value_or_null
          because it is the primitive type or_null.
        But the layout of "int or_null" must be a sublayout of value
          because it's the type of an object field.
@@ -309,7 +309,7 @@ Line 3, characters 8-9:
 3 |     val x = Null
             ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is value maybe_separable maybe_null
+       The layout of x is value_or_null
          because it is the primitive type or_null.
        But the layout of x must be a sublayout of value
          because it's the type of a class field.
@@ -372,7 +372,7 @@ Line 1, characters 45-55:
 1 | type (_, _) fail = Fail : 'a or_null -> ('a, 'a or_null) fail [@@unboxed]
                                                  ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type "('b : value)"
-       The layout of 'a or_null is value maybe_separable maybe_null
+       The layout of 'a or_null is value_or_null
          because it is the primitive type or_null.
        But the layout of 'a or_null must be a sublayout of value
          because it instantiates an unannotated type parameter of fail,
@@ -412,7 +412,7 @@ Line 1, characters 35-51:
                                        ^^^^^^^^^^^^^^^^
 Error: This expression has type "unboxed_rec"
        but an expression was expected of type "('a : value)"
-       The layout of unboxed_rec is value maybe_separable maybe_null
+       The layout of unboxed_rec is value_or_null
          because it is the primitive type or_null.
        But the layout of unboxed_rec must be a sublayout of value
          because of the definition of t at line 1, characters 0-69.
@@ -426,7 +426,7 @@ Line 1, characters 35-46:
                                        ^^^^^^^^^^^
 Error: This expression has type "unboxed_var"
        but an expression was expected of type "('a : value)"
-       The layout of unboxed_var is value maybe_separable maybe_null
+       The layout of unboxed_var is value_or_null
          because it is the primitive type or_null.
        But the layout of unboxed_var must be a sublayout of value
          because of the definition of t at line 1, characters 0-69.
@@ -440,8 +440,7 @@ Line 1, characters 36-47:
                                         ^^^^^^^^^^^
 Error: This expression has type "('a, 'a or_null) gadt"
        but an expression was expected of type "('b : value)"
-       The layout of ('a, 'a or_null) gadt is
-           value maybe_separable maybe_null
+       The layout of ('a, 'a or_null) gadt is value_or_null
          because it is the primitive type or_null.
        But the layout of ('a, 'a or_null) gadt must be a sublayout of value
          because of the definition of t at line 1, characters 0-69.
@@ -458,7 +457,7 @@ Line 1, characters 0-55:
 1 | type bad : immediate & immediate = #(int or_null * int)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "#(int or_null * int)" is
-           value maybe_separable maybe_null & value non_pointer
+           value_or_null & value non_pointer
          because it is an unboxed tuple.
        But the layout of type "#(int or_null * int)" must be a sublayout of
            value non_pointer & value non_pointer

--- a/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,7 +24,7 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type "('a : value)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of should_not_accept_or_null at line 1, characters 0-55.
@@ -63,7 +63,7 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : 'a -> unit
        The type "'a -> unit" is not compatible with the type "'b -> unit"
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of should_not_work at line 6, characters 2-57.
        But the layout of 'a must be a sublayout of value
          because of the definition of should_not_work at line 2, characters 2-34.
@@ -87,7 +87,7 @@ Error: Signature mismatch:
        is not included in
          type ('a : value_or_null) t
        The problem is in the kinds of a parameter:
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of t at line 1, characters 39-66.
        But the layout of 'a must be a sublayout of value
          because of the definition of t at line 1, characters 18-27.
@@ -106,7 +106,7 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type "('a : value)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of t at line 2, characters 2-16.
@@ -135,7 +135,7 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null" should be an instance of type "('a : value)"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of t at line 2, characters 2-25.
@@ -164,7 +164,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of f at line 2, characters 2-40.
        But the layout of 'a must be a sublayout of value
          because of the definition of f at line 4, characters 8-28.
@@ -191,7 +191,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of f at line 2, characters 2-40.
        But the layout of 'a must be a sublayout of value
          because of the definition of f at line 4, characters 6-7.
@@ -219,7 +219,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of f at line 2, characters 2-41.
        But the layout of 'a must be a sublayout of value
          because of the definition of f at line 4, characters 6-7.
@@ -247,7 +247,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of f at line 2, characters 2-41.
        But the layout of 'a must be a sublayout of value
          because of the definition of f at line 4, characters 6-7.
@@ -276,7 +276,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
-       The layout of 'a is value maybe_separable maybe_null
+       The layout of 'a is value_or_null
          because of the definition of f at line 2, characters 2-41.
        But the layout of 'a must be a sublayout of value
          because of the definition of f at line 4, characters 6-7.
@@ -346,7 +346,7 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null dummy" should be an instance of type "'a dummy"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of constrained at line 1, characters 0-49.
@@ -375,7 +375,7 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "t_value_or_null dummy" should be an instance of type "'a dummy"
-       The layout of t_value_or_null is value maybe_separable maybe_null
+       The layout of t_value_or_null is value_or_null
          because of the definition of t_value_or_null at line 1, characters 0-36.
        But the layout of t_value_or_null must be a sublayout of value
          because of the definition of constrained' at lines 1-2, characters 0-44.

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2074,7 +2074,8 @@ Line 1, characters 19-27:
 Error: This type "string t" = "#(string u * string u)"
        should be an instance of type "('a : any mod global)"
        The kind of string t is
-           immutable_data separable & immutable_data separable
+           value mod forkable unyielding many stateless immutable
+           & value mod forkable unyielding many stateless immutable
          because it is an unboxed tuple.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
@@ -2085,8 +2086,8 @@ Line 1, characters 19-27:
 Error: This type "string t" = "#(string u * string u)"
        should be an instance of type "('a : any mod global)"
        The kind of string t is
-           immediate separable mod dynamic with string u
-           & immediate separable mod dynamic with string u
+           value mod everything mod dynamic with string u
+           & value mod everything mod dynamic with string u
          because it is an unboxed tuple.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
@@ -2120,7 +2121,7 @@ Error: This type "#(int * string * int)" should be an instance of type
          "('a : any mod external_)"
        The kind of #(int * string * int) is
            immediate mod dynamic with int with string
-           & immediate non_float mod dynamic with int with string
+           & value mod everything non_float mod dynamic with int with string
            & immediate mod dynamic with int with string
          because it is an unboxed tuple.
        But the kind of #(int * string * int) must be a subkind of
@@ -2149,7 +2150,8 @@ Line 1, characters 19-27:
                        ^^^^^^^^
 Error: This type "string t" should be an instance of type "('a : any mod global)"
        The kind of string t is
-           immutable_data separable & immutable_data separable
+           value mod forkable unyielding many stateless immutable
+           & value mod forkable unyielding many stateless immutable
          because of the definition of t at line 2, characters 0-47.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
@@ -2159,8 +2161,8 @@ Line 1, characters 19-27:
                        ^^^^^^^^
 Error: This type "string t" should be an instance of type "('a : any mod global)"
        The kind of string t is
-           immediate separable mod dynamic with string u
-           & immediate separable mod dynamic with string u
+           value mod everything mod dynamic with string u
+           & value mod everything mod dynamic with string u
          because of the definition of t at line 2, characters 0-47.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
@@ -2576,8 +2578,7 @@ Line 3, characters 0-66:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "t" is value non_pointer & value & value non_float
          because it is an unboxed record.
-       But the layout of type "t" must be a sublayout of
-           value maybe_separable maybe_null & bits32
+       But the layout of type "t" must be a sublayout of value_or_null & bits32
          because of the annotation on the declaration of the type t.
        Note: The layout of immediate is value non_pointer.
        Note: The kinds mutable_data, immutable_data, and sync_data have
@@ -2612,8 +2613,7 @@ Lines 3-4, characters 0-34:
 4 |   #{ a : int; b : t s; c : int32 }
 Error: The layout of type "t" is value non_pointer & value & value non_float
          because it is an unboxed record.
-       But the layout of type "t" must be a sublayout of
-           value maybe_separable maybe_null & bits32
+       But the layout of type "t" must be a sublayout of value_or_null & bits32
          because of the annotation on the declaration of the type t.
        Note: The layout of immediate is value non_pointer.
        Note: The kinds mutable_data, immutable_data, and sync_data have
@@ -2632,8 +2632,7 @@ Lines 3-4, characters 0-34:
 4 |   #{ a : int; b : t s; c : int32 }
 Error: The layout of type "t" is value non_pointer & value & value non_float
          because it is an unboxed record.
-       But the layout of type "t" must be a sublayout of
-           value maybe_separable maybe_null & bits32
+       But the layout of type "t" must be a sublayout of value_or_null & bits32
          because of the annotation on the declaration of the type t.
        Note: The layout of immediate is value non_pointer.
        Note: The kinds mutable_data, immutable_data, and sync_data have

--- a/testsuite/tests/typing-layouts-products/recursive.ml
+++ b/testsuite/tests/typing-layouts-products/recursive.ml
@@ -497,7 +497,7 @@ Line 3, characters 0-26:
 Error: The layout of type "r" is value non_pointer & value non_pointer
          because it is an unboxed record.
        But the layout of type "r" must be a sublayout of
-           value maybe_separable maybe_null & float64
+           value_or_null & float64
          because it is an unboxed record.
        Note: The layout of immediate is value non_pointer.
 |}]

--- a/testsuite/tests/typing-layouts-products/recursive_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/recursive_implicit_unboxed_records.ml
@@ -433,7 +433,7 @@ Line 3, characters 0-25:
 Error: The layout of type "r#" is value non_pointer & value non_pointer
          because it is an unboxed record.
        But the layout of type "r#" must be a sublayout of
-           value maybe_separable maybe_null & float64
+           value_or_null & float64
          because it is an unboxed record.
        Note: The layout of immediate is value non_pointer.
 |}]

--- a/testsuite/tests/typing-layouts-scannable/mutual_recursion.ml
+++ b/testsuite/tests/typing-layouts-scannable/mutual_recursion.ml
@@ -19,9 +19,7 @@ and b = #{ i : t_nonptr_val; j : t_nonptr_val }
 Line 1, characters 0-59:
 1 | type a : value non_pointer & value non_pointer = #{ b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "a" is
-           value maybe_separable maybe_null
-           & value maybe_separable maybe_null
+Error: The layout of type "a" is value_or_null & value_or_null
          because it is an unboxed record.
        But the layout of type "a" must be a sublayout of
            value non_pointer & value non_pointer
@@ -46,9 +44,7 @@ Lines 1-3, characters 0-68:
 1 | type a : value non_pointer & value non_pointer
 2 |        (* BUT an annotation here does not change anything... *)
 3 |        = #{ b : (b as (_ : value non_pointer & value non_pointer)) }
-Error: The layout of type "a" is
-           value maybe_separable maybe_null
-           & value maybe_separable maybe_null
+Error: The layout of type "a" is value_or_null & value_or_null
          because it is an unboxed record.
        But the layout of type "a" must be a sublayout of
            value non_pointer & value non_pointer
@@ -115,8 +111,7 @@ Line 2, characters 0-33:
 Error: The layout of type "r" is value non_pointer & float64
          because it is an unboxed record.
        But the layout of type "r" must be a sublayout of
-           value maybe_separable maybe_null
-           & value maybe_separable maybe_null
+           value_or_null & value_or_null
          because it is an unboxed record.
        Note: The layout of immediate is value non_pointer.
 |}]
@@ -140,8 +135,7 @@ Line 2, characters 0-32:
 Error: The layout of type "r#" is value non_pointer & float64
          because it is an unboxed record.
        But the layout of type "r#" must be a sublayout of
-           value maybe_separable maybe_null
-           & value maybe_separable maybe_null
+           value_or_null & value_or_null
          because it is an unboxed record.
        Note: The layout of immediate is value non_pointer.
 |}]

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -94,7 +94,7 @@ Line 1, characters 13-27:
                  ^^^^^^^^^^^^^^
 Error: This type "t_maybeptr_val" should be an instance of type
          "('a : value non_pointer)"
-       The layout of t_maybeptr_val is value maybe_separable
+       The layout of t_maybeptr_val is value_maybe_separable
          because of the definition of t_maybeptr_val at line 1, characters 0-43.
        But the layout of t_maybeptr_val must be a sublayout of
            value non_pointer
@@ -164,7 +164,7 @@ Line 1, characters 13-27:
                  ^^^^^^^^^^^^^^
 Error: This type "t_maybeptr_val" should be an instance of type
          "('a : value non_pointer64)"
-       The layout of t_maybeptr_val is value maybe_separable
+       The layout of t_maybeptr_val is value_maybe_separable
          because of the definition of t_maybeptr_val at line 1, characters 0-43.
        But the layout of t_maybeptr_val must be a sublayout of
            value non_pointer64
@@ -241,7 +241,7 @@ Line 3, characters 13-27:
                  ^^^^^^^^^^^^^^
 Error: This type "t_maybeptr_val" should be an instance of type
          "('a : any separable)"
-       The layout of t_maybeptr_val is value maybe_separable
+       The layout of t_maybeptr_val is value_maybe_separable
          because of the definition of t_maybeptr_val at line 1, characters 0-43.
        But the layout of t_maybeptr_val must be a sublayout of any separable
          because it's the type argument to the array type.
@@ -261,7 +261,7 @@ type fails : value non_pointer = #{ a : t_maybeptr_val }
 Line 1, characters 0-56:
 1 | type fails : value non_pointer = #{ a : t_maybeptr_val }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "fails" is value maybe_separable
+Error: The layout of type "fails" is value_maybe_separable
          because it is an unboxed record.
        But the layout of type "fails" must be a sublayout of value non_pointer
          because of the annotation on the declaration of the type fails.
@@ -509,7 +509,7 @@ Error: Signature mismatch:
          type 'a t = t_maybeptr_val
        is not included in
          type ('a : value non_pointer) t : value non_pointer
-       The layout of the first is value maybe_separable
+       The layout of the first is value_maybe_separable
          because of the definition of t_maybeptr_val at line 1, characters 0-43.
        But the layout of the first must be a sublayout of value non_pointer
          because of the definition of t at line 2, characters 2-53.

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -496,7 +496,7 @@ Line 2, characters 0-23:
 Error: The layout of type "r#" is value non_pointer & value non_pointer
          because it is an unboxed record.
        But the layout of type "r#" must be a sublayout of
-           value maybe_separable maybe_null & float64
+           value_or_null & float64
          because it is an unboxed record.
        Note: The layout of immediate is value non_pointer.
 |}]
@@ -512,7 +512,7 @@ Line 2, characters 0-23:
 Error: The layout of type "r#" is value non_pointer & value non_pointer
          because it is an unboxed record.
        But the layout of type "r#" must be a sublayout of
-           value maybe_separable maybe_null & float64
+           value_or_null & float64
          because it is an unboxed record.
        Note: The layout of immediate is value non_pointer.
 |}]

--- a/testsuite/tests/typing-modal-kinds/everything.ml
+++ b/testsuite/tests/typing-modal-kinds/everything.ml
@@ -11,7 +11,7 @@ type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 [%%expect{|
 type t_value
-type t_value_mod_e : immediate separable
+type t_value_mod_e : value mod everything
 type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 |}]
@@ -254,7 +254,7 @@ type t : value_or_null mod everything
 Line 2, characters 0-20:
 2 | type bad : value = t
     ^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "t" is value maybe_separable maybe_null
+Error: The layout of type "t" is value_or_null
          because of the definition of t at line 1, characters 0-37.
        But the layout of type "t" must be a sublayout of value
          because of the definition of bad at line 2, characters 0-20.
@@ -287,13 +287,13 @@ type t : immediate & immediate
 
 type t : value & float64 mod everything
 [%%expect{|
-type t : immediate separable & float64 mod everything
+type t : value mod everything & float64 mod everything
 |}]
 
 type t : value & (immediate & bits64) & float32 mod everything
 [%%expect{|
 type t
-  : immediate separable
+  : value mod everything
     & (immediate & bits64 mod everything)
     & float32 mod everything
 |}]

--- a/testsuite/tests/typing-modal-kinds/unboxed.ml
+++ b/testsuite/tests/typing-modal-kinds/unboxed.ml
@@ -238,13 +238,11 @@ Lines 1-2, characters 0-43:
 1 | type 'a t : value & value mod portable =
 2 |   #{ x : 'a contended; y : 'a @@ portable }
 Error: The kind of type "t" is
-           immediate
-             separable
+           value mod everything
              mod dynamic
              with 'a @@ portable
              with 'a contended
-           & immediate
-               separable
+           & value mod everything
                mod dynamic
                with 'a @@ portable
                with 'a contended
@@ -265,9 +263,11 @@ Lines 1-2, characters 0-40:
 1 | type 'a t : value & value mod portable =
 2 |   #{ x : 'a contended; y : 'a portable }
 Error: The kind of type "t" is
-           immediate separable mod dynamic with 'a contended with 'a portable
-           & immediate
-               separable
+           value mod everything
+             mod dynamic
+             with 'a contended
+             with 'a portable
+           & value mod everything
                mod dynamic
                with 'a contended
                with 'a portable

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1374,6 +1374,14 @@ module Jkind0 = struct
           name = "value"
         }
 
+      let value_mod_everything =
+        { jkind =
+            mk_jkind (Base (Scannable, Scannable_axes.value_axes))
+              ~crossing:cross_all_except_staticity
+              ~externality:Mod_bounds.Externality.min;
+          name = "value mod everything"
+        }
+
       let immutable_data_mod_bounds =
         let open Mod_bounds in
         let crossing =
@@ -1816,6 +1824,7 @@ module Jkind0 = struct
 
       let additional_common_jkinds =
         [ any_mod_everything;
+          value_mod_everything;
           value_or_null_mod_everything;
           void_mod_everything;
           kind_of_untagged_int;

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -78,23 +78,29 @@ module Scannable_axes = struct
       separability = Separability.meet s1 s2
     }
 
+  (* A scannable axis annotation can only lower, so [base] is only a valid
+     prefix when [actual <= base] on every axis. If it's not, return [None]. *)
   let to_string_list_diff
       ~base:{ nullability = n_against; separability = s_against }
       { nullability; separability } =
-    let diff = [] in
-    let diff =
-      if Nullability.equal n_against nullability
-      then diff
-      else Nullability.to_string nullability :: diff
+    let nullability_diff =
+      match Nullability.less_or_equal nullability n_against with
+      | Equal -> Some []
+      | Less -> Some [Nullability.to_string nullability]
+      | Not_le -> None
     in
-    let diff =
-      if Separability.equal s_against separability
-      then diff
-      else Separability.to_string separability :: diff
+    let separability_diff =
+      match Separability.less_or_equal separability s_against with
+      | Equal -> Some []
+      | Less -> Some [Separability.to_string separability]
+      | Not_le -> None
     in
-    diff
+    Misc.Stdlib.List.some_if_all_elements_are_some
+      [separability_diff; nullability_diff]
+    |> Option.map List.concat
 
-  let to_string_list = to_string_list_diff ~base:max
+  let to_string_list sa =
+    Option.value (to_string_list_diff ~base:max sa) ~default:[]
 
   let debug_print ppf { nullability; separability } =
     Fmt.fprintf ppf "@[{ nullability = %a;@ separability = %a }@]"
@@ -169,17 +175,47 @@ module Layout = struct
       | Univar _ -> t
       | Genvar _ -> t
 
+    (* Compute how to print the layout [scannable sa] *)
+    let format_scannable_layout ~include_redundant_scannable_axes
+        (sa : Scannable_axes.t) =
+      let scannable_layout_abbrevs : (string * Scannable_axes.t) list =
+        (* CR-someday rtjoa: This somewhat-duplicative list exists because we
+           don't have a notion of layout abbreviations (and in general, conflate
+           layouts and kinds-with-max-crossing). *)
+        (* Listed from most-specific to least-specific so [find_map] yields the
+           tightest match. *)
+        [ "value", Scannable_axes.value_axes;
+          ( "value_maybe_null",
+            { nullability = Maybe_null; separability = Separable } );
+          ( "value_maybe_separable",
+            { nullability = Non_null; separability = Maybe_separable } );
+          ( "value_or_null",
+            { nullability = Maybe_null; separability = Maybe_separable } ) ]
+      in
+      let format_wrt (name, base) =
+        match Scannable_axes.to_string_list_diff ~base sa with
+        | None -> None
+        | Some diff ->
+          let axes =
+            if include_redundant_scannable_axes
+            then Scannable_axes.to_string_list sa
+            else diff
+          in
+          Some (name :: axes)
+      in
+      match List.find_map format_wrt scannable_layout_abbrevs with
+      | Some r -> r
+      | None ->
+        (* [value_or_null] is max on every axis, so at least it should work *)
+        Misc.fatal_error "Jkind.Layout.Const.format_scannable_layout"
+
     let to_string t ~include_redundant_scannable_axes =
       let rec to_string nested (t : t) =
         match t with
         | Any sa -> String.concat " " ("any" :: Scannable_axes.to_string_list sa)
         | Base (Scannable, sa) ->
-          let sa =
-            if include_redundant_scannable_axes
-            then Scannable_axes.to_string_list sa
-            else Scannable_axes.(to_string_list_diff ~base:value_axes) sa
-          in
-          String.concat " " ("value" :: sa)
+          String.concat " "
+            (format_scannable_layout ~include_redundant_scannable_axes sa)
         | Base (b, _) -> Sort.to_string_base b
         | Product ts ->
           String.concat ""
@@ -407,10 +443,9 @@ module Layout = struct
       | Sort (s, sa) -> (
         match Sort.get s with
         | Base Scannable ->
-          let value_axes_diff =
-            Scannable_axes.(to_string_list_diff ~base:value_axes sa)
-          in
-          pp_string_list ppf ("value" :: value_axes_diff)
+          pp_string_list ppf
+            (Const.format_scannable_layout
+               ~include_redundant_scannable_axes:false sa)
         | Var _ ->
           let sort_var_str = Fmt.asprintf "%a" Sort.format s in
           pp_string_list ppf (sort_var_str :: Scannable_axes.to_string_list sa)
@@ -1679,11 +1714,13 @@ module Const = struct
           |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s))
         bounds_to_print
 
+    (* Returns [None] if [actual] has any scannable axis strictly greater
+       than [base], and thus can't be printed in terms of [base] *)
     let get_scannable_axes_diff ~base actual =
       let base_sa = Layout.Const.get_root_scannable_axes base in
       let actual_sa = Layout.Const.get_root_scannable_axes actual in
       match base_sa, actual_sa with
-      | None, _ | _, None -> []
+      | None, _ | _, None -> Some []
       | Some base_sa, Some actual_sa ->
         Scannable_axes.to_string_list_diff ~base:base_sa actual_sa
 
@@ -1729,9 +1766,9 @@ module Const = struct
           then
             match base_jkind.base with
             | Layout base_l -> get_scannable_axes_diff ~base:base_l l
-            | Kconstr _ -> []
-          else []
-        | Kconstr _ -> []
+            | Kconstr _ -> Some []
+          else Some []
+        | Kconstr _ -> Some []
       in
       let modal_bounds =
         get_modal_bounds ~verbosity ~base:base_jkind.mod_bounds
@@ -1773,15 +1810,15 @@ module Const = struct
               out_type, modal @ nonmodal)
             with_bounds otys
       in
-      match matching_layouts, modal_bounds with
-      | true, Some modal_bounds ->
+      match matching_layouts, modal_bounds, scannable_axes with
+      | true, Some modal_bounds, Some scannable_axes ->
         Some
           { base = base.name;
             scannable_axes;
             modal_bounds;
             printable_with_bounds
           }
-      | false, _ | _, None -> None
+      | false, _, _ | _, None, _ | _, _, None -> None
 
     (** Select the out_jkind_const with the least number of modal bounds and
         scannable axes to print *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -182,30 +182,39 @@ module Layout = struct
         (* CR-someday rtjoa: This somewhat-duplicative list exists because we
            don't have a notion of layout abbreviations (and in general, conflate
            layouts and kinds-with-max-crossing). *)
-        (* Listed from most-specific to least-specific so [find_map] yields the
-           tightest match. *)
+        (* We pick the abbreviation requiring the fewest annotations, with ties
+           broken by order in this list. So when annotating separability anyway
+           we get [value_or_null non_float] rather than [value_maybe_null
+           non_float]. *)
         [ "value", Scannable_axes.value_axes;
-          ( "value_maybe_null",
-            { nullability = Maybe_null; separability = Separable } );
+          ( "value_or_null",
+            { nullability = Maybe_null; separability = Maybe_separable } );
           ( "value_maybe_separable",
             { nullability = Non_null; separability = Maybe_separable } );
-          ( "value_or_null",
-            { nullability = Maybe_null; separability = Maybe_separable } ) ]
+          ( "value_maybe_null",
+            { nullability = Maybe_null; separability = Separable } ) ]
       in
-      let format_wrt (name, base) =
-        match Scannable_axes.to_string_list_diff ~base sa with
-        | None -> None
-        | Some diff ->
-          let axes =
-            if include_redundant_scannable_axes
-            then Scannable_axes.to_string_list sa
-            else diff
-          in
-          Some (name :: axes)
+      let diff_against (_, base) =
+        Scannable_axes.to_string_list_diff ~base sa
       in
-      match List.find_map format_wrt scannable_layout_abbrevs with
-      | Some r -> r
-      | None ->
+      let shorter_diff (_, d1) (_, d2) =
+        Int.compare (List.length d1) (List.length d2)
+      in
+      let sorted =
+        List.filter_map
+          (fun abbrev -> Option.map (fun d -> abbrev, d) (diff_against abbrev))
+          scannable_layout_abbrevs
+        |> List.stable_sort shorter_diff
+      in
+      match sorted with
+      | ((name, _), diff) :: _ ->
+        let axes =
+          if include_redundant_scannable_axes
+          then Scannable_axes.to_string_list sa
+          else diff
+        in
+        name :: axes
+      | [] ->
         (* [value_or_null] is max on every axis, so at least it should work *)
         Misc.fatal_error "Jkind.Layout.Const.format_scannable_layout"
 


### PR DESCRIPTION
Fix scannable axis printing to adapt to https://github.com/oxcaml/oxcaml/pull/5921.

### For review
This also adds a builtin for `value mod everything` so we print e.g. `value mod everything non_float` where we would otherwise print `value_or_null mod everything non_float non_null`.