### PR TITLE
Add a C interop section to small number docs

### DIFF
--- a/jane/doc/extensions/_11-miscellaneous-extensions/small-numbers.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/small-numbers.md
@@ -124,6 +124,40 @@ other context. For example, an `int8# array` of length 30 takes up 4 words of
 space, plus the header word, but a `#(int8# * int8#)` takes up 2 words of space
 and requires 2 registers to pass around.
 
+### C ABI
+
+Both tagged and untagged `int8`s and `int16`s may be passed to C stubs.
+
+```ocaml
+external int16_stub : (int16[@unboxed]) -> (int16[@unboxed]) =
+  "tagged_int16_stub" "untagged_int16_stub"
+
+external int16_hash_stub : int16# -> int16# =
+  "tagged_int16_stub" "untagged_int16_stub"
+
+external int8_stub : (int8[@unboxed]) -> (int8[@unboxed]) =
+  "tagged_int8_stub" "untagged_int8_stub"
+
+external int8_hash_stub : int8# -> int8# =
+  "tagged_int8_stub" "untagged_int8_stub"
+```
+
+The following is also valid, but discouraged:
+```ocaml
+external int16_stub_untagged : (int16[@untagged]) -> (int16[@untagged]) =
+  "tagged_int16_stub" "untagged_int16_stub"
+```
+`[@untagged]` can be applied to any `immediate` type, and it doesn't sign
+extend the stub return value, which is usually zero-extended. On the other
+hand, the behavior of `[@unboxed]` depends on the particular type,
+so the proper sign extensions are applied to the return value.
+
+For example, the following implementation makes `int16_stub` and
+`int16_hash_stub` valid, but `int16_stub_untagged` invalid:
+```c
+signed short untagged_int16_stub (short x) { return -2; }
+```
+
 ## Untagged Char
 
 When small numbers are enabled, the types `char#` and `char# array`
@@ -154,3 +188,14 @@ library.
 
 Untagged chars have the same layout as `int8#`, and `char# array`s are packed
 like `int8# array`s.
+
+### C ABI
+
+Untagged chars may be passed to C stubs:
+```ocaml
+external char_hash_stub : char# -> char# =
+  "tagged_char_stub" "untagged_char_stub"
+```
+
+`char[@unboxed]` is not allowed in external declarations. As a reminder, you may
+use upstream OCaml's `char[@untagged]` in correspondence with `intnat` in C.

--- a/testsuite/tests/typing-layouts-bits16/basics.ml
+++ b/testsuite/tests/typing-layouts-bits16/basics.ml
@@ -440,7 +440,7 @@ external f10_9 : (int16#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int16#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -449,7 +449,7 @@ external f10_10 : string -> (int16#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int16#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -446,7 +446,7 @@ external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -455,7 +455,7 @@ external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -439,7 +439,7 @@ external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -448,7 +448,7 @@ external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -446,7 +446,7 @@ external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -455,7 +455,7 @@ external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -439,7 +439,7 @@ external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -448,7 +448,7 @@ external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits8/basics.ml
+++ b/testsuite/tests/typing-layouts-bits8/basics.ml
@@ -440,7 +440,7 @@ external f10_9 : (int8#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-23:
 1 | external f10_9 : (int8#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -449,7 +449,7 @@ external f10_10 : string -> (int8#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-34:
 1 | external f10_10 : string -> (int8#[@untagged])  = "foo" "bar";;
                                  ^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/testsuite/tests/typing-layouts-float32/basics.ml
@@ -498,7 +498,7 @@ external f10_9 : (float32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-26:
 1 | external f10_9 : (float32#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -507,7 +507,7 @@ external f10_10 : string -> (float32#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-37:
 1 | external f10_10 : string -> (float32#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/testsuite/tests/typing-layouts-float64/basics.ml
@@ -503,7 +503,7 @@ external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -512,7 +512,7 @@ external f10_10 : string -> (float#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (float#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-or-null/untagged.compilers.reference
+++ b/testsuite/tests/typing-layouts-or-null/untagged.compilers.reference
@@ -1,5 +1,5 @@
 File "untagged.ml", line 15, characters 8-19:
 15 |     :  (int_or_null [@untagged])
              ^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1173,7 +1173,7 @@ Line 1, characters 38-51:
 1 | external ext_tuple_arg_with_attr_u : (#(int * bool) [@unboxed]) -> int = "foo"
                                           ^^^^^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -1182,7 +1182,7 @@ external ext_tuple_arg_with_attr_t : (#(int * bool) [@untagged]) -> int = "foo"
 Line 1, characters 38-51:
 1 | external ext_tuple_arg_with_attr_t : (#(int * bool) [@untagged]) -> int = "foo"
                                           ^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 
@@ -1214,7 +1214,7 @@ Line 1, characters 40-49:
 1 | external ext_product_arg_with_attr_u : (t_product [@unboxed]) -> int = "foo"
                                             ^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -1223,7 +1223,7 @@ external ext_product_arg_with_attr_t : (t_product [@untagged]) -> int = "foo"
 Line 1, characters 40-49:
 1 | external ext_product_arg_with_attr_t : (t_product [@untagged]) -> int = "foo"
                                             ^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 
@@ -1259,7 +1259,7 @@ Line 2, characters 10-23:
 2 |   int -> (#(int * bool) [@unboxed]) = "foo"
               ^^^^^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -1269,7 +1269,7 @@ external ext_tuple_return_with_attr_t :
 Line 2, characters 10-23:
 2 |   int -> (#(int * bool) [@untagged]) = "foo"
               ^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 
@@ -1295,7 +1295,7 @@ Line 1, characters 50-59:
 1 | external ext_product_return_with_attr_u : int -> (t_product [@unboxed]) = "foo"
                                                       ^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -1304,7 +1304,7 @@ external ext_product_return_with_attr_t : int -> (t_product [@untagged]) = "foo"
 Line 1, characters 50-59:
 1 | external ext_product_return_with_attr_t : int -> (t_product [@untagged]) = "foo"
                                                       ^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 
@@ -1362,7 +1362,7 @@ Line 3, characters 3-29:
 3 |   (ext_record_arg_attr_record [@unboxed]) -> int = "foo"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -1372,7 +1372,7 @@ external ext_record_arg_with_attr_t :
 Line 2, characters 3-29:
 2 |   (ext_record_arg_attr_record [@untagged]) -> int = "foo"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 
@@ -1429,7 +1429,7 @@ Line 2, characters 49-50:
 2 | external ext_record_return_with_attr_u : int -> (t [@unboxed]) = "foo"
                                                      ^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -1438,7 +1438,7 @@ external ext_record_return_with_attr_t : int -> (t [@untagged]) = "foo"
 Line 1, characters 49-50:
 1 | external ext_record_return_with_attr_t : int -> (t [@untagged]) = "foo"
                                                      ^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 

--- a/testsuite/tests/typing-layouts-untagged-immediate/basics.ml
+++ b/testsuite/tests/typing-layouts-untagged-immediate/basics.ml
@@ -448,7 +448,7 @@ Line 1, characters 17-20:
 1 | external f10_8 : int -> int#  = "foo" "bar" [@@unboxed];;
                      ^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}];;
 
@@ -457,7 +457,7 @@ external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-22:
 1 | external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -466,7 +466,7 @@ external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-33:
 1 | external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
                                  ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-untagged-immediate/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-untagged-immediate/basics_alpha.ml
@@ -443,7 +443,7 @@ Line 1, characters 17-20:
 1 | external f10_8 : int -> int#  = "foo" "bar" [@@unboxed];;
                      ^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}];;
 
@@ -452,7 +452,7 @@ external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-22:
 1 | external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -461,7 +461,7 @@ external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-33:
 1 | external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
                                  ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-vec128/basics.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics.ml
@@ -442,7 +442,7 @@ external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-26:
 1 | external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -451,7 +451,7 @@ external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-37:
 1 | external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
@@ -437,7 +437,7 @@ external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-26:
 1 | external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -446,7 +446,7 @@ external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-37:
 1 | external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-void/void_upstream_compatible.ml
+++ b/testsuite/tests/typing-layouts-void/void_upstream_compatible.ml
@@ -17,7 +17,7 @@ Line 1, characters 19-20:
 1 | external void_id : t -> t = "%identity" [@@unboxed]
                        ^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 

--- a/testsuite/tests/typing-layouts-word/basics.ml
+++ b/testsuite/tests/typing-layouts-word/basics.ml
@@ -444,7 +444,7 @@ external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-28:
 1 | external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -453,7 +453,7 @@ external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-39:
 1 | external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -437,7 +437,7 @@ external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-28:
 1 | external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -446,7 +446,7 @@ external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-39:
 1 | external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -276,7 +276,7 @@ external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 16-22:
 1 | external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
                     ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -285,7 +285,7 @@ external f_7 : string -> (int64#[@untagged])  = "foo" "bar";;
 Line 1, characters 26-32:
 1 | external f_7 : string -> (int64#[@untagged])  = "foo" "bar";;
                               ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -356,7 +356,7 @@ external f_6 : (int32'[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 16-22:
 1 | external f_6 : (int32'[@untagged]) -> bool -> string  = "foo" "bar";;
                     ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -365,7 +365,7 @@ external f_7 : string -> (int64# int64'#[@untagged])  = "foo" "bar";;
 Line 1, characters 26-40:
 1 | external f_7 : string -> (int64# int64'#[@untagged])  = "foo" "bar";;
                               ^^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}];;
 
@@ -383,7 +383,7 @@ Line 1, characters 40-42:
 1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@unboxed]
                                             ^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}];;
 
@@ -394,7 +394,7 @@ Line 1, characters 41-43:
 1 | external[@layout_poly] id : ('a : any). ('a[@unboxed]) -> 'a = "%identity"
                                              ^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}];;
 

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -560,7 +560,7 @@ Line 1, characters 40-42:
 1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@unboxed]
                                             ^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -570,7 +570,7 @@ external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@untagged]
 Line 1, characters 40-42:
 1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@untagged]
                                             ^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -636,7 +636,7 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int" and
        other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;
@@ -645,7 +645,7 @@ Line 1, characters 14-17:
 1 | external h : (int [@unboxed]) -> float = "h" "h_nat";;
                   ^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 
@@ -656,7 +656,7 @@ Line 1, characters 13-25:
 1 | external i : int -> float [@unboxed] = "i" "i_nat";;
                  ^^^^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only "float", "int32", "int64", "nativeint", vector primitives, and
+       Only "float", "int8", "int16", "int32", "int64", "nativeint", vector primitives, and
        the corresponding unboxed types can be marked unboxed.
 |}]
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -5178,17 +5178,17 @@ let report_error_doc ppf = function
         Style.inline_code "[@@unpacked]"
   | Cannot_unbox_or_untag_type Unboxed ->
       fprintf ppf "@[Don't know how to unbox this type.@ \
-                   Only %a, %a, %a, %a, vector primitives, and@ \
+                   Only %a, %a, %a, %a, %a, %a, vector primitives, and@ \
                    the corresponding unboxed types can be marked unboxed.@]"
         Style.inline_code "float"
+        Style.inline_code "int8"
+        Style.inline_code "int16"
         Style.inline_code "int32"
         Style.inline_code "int64"
         Style.inline_code "nativeint"
   | Cannot_unbox_or_untag_type Untagged ->
-      fprintf ppf "@[Don't know how to untag this type. Only %a, %a, %a, \
+      fprintf ppf "@[Don't know how to untag this type. Only %a \
                    and@ other immediate types can be untagged.@]"
-        Style.inline_code "int8"
-        Style.inline_code "int16"
         Style.inline_code "int"
   | Cannot_unbox_or_untag_type Unpacked ->
       fprintf ppf "@[Don't know how to unpack this type.@ \


### PR DESCRIPTION
Also change error messages to discourage `(int8[@untagged])` and `(int16[@untagged])` in external declarations.

If desired, I can split this into 2 PRs: one for updating the docs and one for updating error messages.