### PR TITLE
simplify: Avoid loading cmx files for non-inlinable apply exprs

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -521,6 +521,23 @@ let check_simple_is_bound t (simple : Simple.t) =
 let mem_code t id =
   Code_id.Map.mem id t.all_code || Exported_code.mem id (t.get_imported_code ())
 
+let find_code_metadata_exn t id =
+  match Code_id.Map.find id t.all_code with
+  | code -> Code.code_metadata code
+  | exception Not_found -> (
+    (* We don't care which unit the metadata is coming from, so if we have
+       already loaded the metadata in imported code, return it. *)
+    match Exported_code.find_exn (t.get_imported_code ()) id with
+    | code_or_metadata -> Code_or_metadata.code_metadata code_or_metadata
+    | exception Not_found ->
+      (* Sometimes the metadata is not properly reexported; try to force loading
+         it. *)
+      let (_ : TE.Serializable.t option) =
+        TE.resolver t.typing_env (Code_id.get_compilation_unit id)
+      in
+      Code_or_metadata.code_metadata
+        (Exported_code.find_exn (t.get_imported_code ()) id))
+
 let find_code_exn t id =
   match Code_id.Map.find id t.all_code with
   | code -> Code_or_metadata.create code

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -138,6 +138,9 @@ val mem_code : t -> Code_id.t -> bool
 (** This function raises if the code ID is unbound. *)
 val find_code_exn : t -> Code_id.t -> Code_or_metadata.t
 
+(** This function raises if the code ID is unbound. *)
+val find_code_metadata_exn : t -> Code_id.t -> Code_metadata.t
+
 val set_inlined_debuginfo : t -> from:t -> t
 
 val merge_inlined_debuginfo : t -> from_apply_expr:Inlined_debuginfo.t -> t

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -157,21 +157,23 @@ let argument_types_useful dacc apply =
           ~const:(fun _ -> true))
       (Apply.args apply)
 
-let inlining_does_decrease_code_size ~code_or_metadata cost_metrics =
+let inlining_does_decrease_code_size ~code_metadata cost_metrics =
   let[@ocamlformat "break-infix=fit-or-vertical"] original_code_size =
-    code_or_metadata
-    |> Code_or_metadata.code_metadata
-    |> Code_metadata.cost_metrics
-    |> Cost_metrics.size
+    code_metadata |> Code_metadata.cost_metrics |> Cost_metrics.size
   in
   let inlined_code_size = Cost_metrics.size cost_metrics in
   not (Code_size.( <= ) original_code_size inlined_code_size)
 
-let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
+let might_inline dacc ~apply ~code_metadata ~function_type ~simplify_expr
     ~return_arity : Call_site_inlining_decision_type.t =
+  let code_present () =
+    let code_or_metadata =
+      DE.find_code_exn (DA.denv dacc) (Code_metadata.code_id code_metadata)
+    in
+    Code_or_metadata.code_present code_or_metadata
+  in
   let denv = DA.denv dacc in
   let disable_inlining = DE.disable_inlining denv in
-  let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
   let decision = Code_metadata.inlining_decision code_metadata in
   let is_a_functor = Code_metadata.is_a_functor code_metadata in
   let in_a_stub, doing_speculative_inlining =
@@ -184,10 +186,13 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
   then In_a_stub
   else if Function_decl_inlining_decision_type.must_be_inlined decision
   then
-    Definition_says_inline
-      { was_inline_always =
-          Function_decl_inlining_decision_type.has_attribute_inline decision
-      }
+    if code_present ()
+    then
+      Definition_says_inline
+        { was_inline_always =
+            Function_decl_inlining_decision_type.has_attribute_inline decision
+        }
+    else Missing_code
   else if Function_decl_inlining_decision_type.cannot_be_inlined decision
   then Definition_says_not_to_inline
   else if doing_speculative_inlining
@@ -203,7 +208,7 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
           let counters =
             Profile.Counters.incr "speculatively_inline" counters
           in
-          if inlining_does_decrease_code_size ~code_or_metadata cost_metrics
+          if inlining_does_decrease_code_size ~code_metadata cost_metrics
           then counters
           else Profile.Counters.incr "same_code_size" counters
         | Speculatively_not_inline _ ->
@@ -224,6 +229,8 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
       (fun () : Call_site_inlining_decision_type.t ->
         if not (argument_types_useful dacc apply)
         then Argument_types_not_useful
+        else if not (code_present ())
+        then Missing_code
         else
           let cost_metrics =
             speculative_inlining ~apply dacc ~simplify_expr ~return_arity
@@ -267,22 +274,35 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
         Replay_history.print
         (DE.replay_history (DA.denv dacc))
   in
+  let[@local] do_not_inline (decision : Call_site_inlining_decision_type.t) =
+    fail_if_must_inline ();
+    decision
+  in
   let rec_info = get_rec_info dacc ~function_type in
   let inlined = Apply.inlined apply in
   match inlined with
-  | Never_inlined ->
-    fail_if_must_inline ();
-    Never_inlined_attribute
+  | Never_inlined -> do_not_inline Never_inlined_attribute
   | Default_inlined | Unroll _ | Always_inlined _ | Hint_inlined -> (
-    match DE.find_code_exn (DA.denv dacc) (FT.code_id function_type) with
-    | exception Not_found ->
-      fail_if_must_inline ();
-      Missing_code
-    | code_or_metadata when not (Code_or_metadata.code_present code_or_metadata)
-      ->
-      fail_if_must_inline ();
-      Missing_code
-    | code_or_metadata -> (
+    match
+      DE.find_code_metadata_exn (DA.denv dacc) (FT.code_id function_type)
+    with
+    | exception Not_found -> do_not_inline Missing_code
+    | code_metadata -> (
+      let code_present () =
+        match
+          DE.find_code_exn (DA.denv dacc) (Code_metadata.code_id code_metadata)
+        with
+        | code_or_metadata -> Code_or_metadata.code_present code_or_metadata
+        | exception Not_found ->
+          Misc.fatal_errorf
+            "[DE.find_code_metadata_exn] found a code metadata, but \
+             [DE.find_code_exn] returns Not_found for code_id %a"
+            Code_id.print
+            (Code_metadata.code_id code_metadata)
+      in
+      let[@local] inline_if_code_present decision =
+        if code_present () then decision else do_not_inline Missing_code
+      in
       (* The unrolling process is rather subtle, but it boils down to two steps:
 
          1. We see an [@unrolled n] annotation (with n > 0) on an apply
@@ -301,10 +321,8 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
         Simplify_rec_info_expr.known_remaining_unrolling_depth dacc rec_info
       in
       match unrolling_depth with
-      | Some 0 ->
-        fail_if_must_inline ();
-        Unrolling_depth_exceeded
-      | Some _ -> Continue_unrolling
+      | Some 0 -> do_not_inline Unrolling_depth_exceeded
+      | Some _ -> inline_if_code_present Continue_unrolling
       | None -> (
         (* lmaurer: This seems semantically dodgy: If we really think of a free
            depth variable as [Unknown], then we shouldn't be considering
@@ -320,14 +338,9 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
            ramifications of treating unknown-ness as an observable property this
            way. Are we relying on monotonicity somewhere? *)
         let apply_inlining_state = Apply.inlining_state apply in
-        let recursive =
-          Code_metadata.recursive
-            (Code_or_metadata.code_metadata code_or_metadata)
-        in
+        let recursive = Code_metadata.recursive code_metadata in
         if Inlining_state.is_depth_exceeded apply_inlining_state
-        then (
-          fail_if_must_inline ();
-          Max_inlining_depth_exceeded)
+        then do_not_inline Max_inlining_depth_exceeded
         else
           let policy =
             match inlined with
@@ -353,9 +366,7 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
             if
               Simplify_rec_info_expr.depth_may_exceed dacc rec_info
                 max_rec_depth
-            then (
-              fail_if_must_inline ();
-              Recursion_depth_exceeded)
+            then do_not_inline Recursion_depth_exceeded
             else if must_inline
             then
               match
@@ -367,9 +378,17 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
                   "Internal assumption broken: DE.says must_inline\n\
                   \                  (presumably because of the replay \
                    history), but the replay history is still recoding."
-              | Replayed decision -> Replay_history_says_must_inline decision
+              | Replayed decision ->
+                if code_present ()
+                then Replay_history_says_must_inline decision
+                else
+                  Misc.fatal_errorf
+                    "Replay history says we should inline %a, but its code is \
+                     not present"
+                    Code_id.print
+                    (Code_metadata.code_id code_metadata)
             else
-              might_inline dacc ~apply ~code_or_metadata ~function_type
+              might_inline dacc ~apply ~code_metadata ~function_type
                 ~simplify_expr ~return_arity
           | `Unroll unroll_to ->
             if Simplify_rec_info_expr.can_unroll dacc rec_info
@@ -377,11 +396,9 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
               (* This sets off step 1 in the comment above; see
                  [Inlining_transforms] for how [unroll_to] is ultimately
                  handled. *)
-              Begin_unrolling unroll_to
-            else (
-              fail_if_must_inline ();
-              Unrolling_depth_exceeded)
-          | `Always -> Attribute_always)))
+              inline_if_code_present (Begin_unrolling unroll_to)
+            else do_not_inline Unrolling_depth_exceeded
+          | `Always -> inline_if_code_present Attribute_always)))
 
 let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
     Call_site_inlining_decision_type.t =

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -868,7 +868,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       match Code_id.Set.get_singleton callee's_code_ids with
       | None -> callee's_code_id_from_type, callee's_code_metadata_from_type
       | Some callee's_code_id -> (
-        match DE.find_code_exn (DA.denv dacc) callee's_code_id with
+        match DE.find_code_metadata_exn (DA.denv dacc) callee's_code_id with
         | exception Not_found ->
           (* This can happen if we have a more precise code id from the call
              kind, but we don't have the metadata for it. This should be rare
@@ -876,9 +876,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
              this code id); in that case, we use the metadata that we do have
              available for the code id from the type. *)
           callee's_code_id_from_type, callee's_code_metadata_from_type
-        | callee's_code_or_metadata ->
-          ( callee's_code_id,
-            Code_or_metadata.code_metadata callee's_code_or_metadata ))
+        | callee's_code_metadata -> callee's_code_id, callee's_code_metadata)
     in
     let call_kind = Call_kind.direct_function_call callee's_code_id in
     let apply = Apply.with_call_kind apply call_kind in
@@ -1103,12 +1101,9 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
   | None -> (
     match call with
     | Direct callee's_code_id -> (
-      match DE.find_code_exn denv callee's_code_id with
+      match DE.find_code_metadata_exn denv callee's_code_id with
       | exception Not_found -> type_unavailable ()
-      | callee's_code_or_metadata ->
-        let callee's_code_metadata =
-          Code_or_metadata.code_metadata callee's_code_or_metadata
-        in
+      | callee's_code_metadata ->
         simplify_direct_full_application ~simplify_expr dacc apply None
           ~params_arity:(Code_metadata.params_arity callee's_code_metadata)
           ~result_arity:(Code_metadata.result_arity callee's_code_metadata)
@@ -1137,12 +1132,9 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         | Indirect_known_arity _ | Indirect_unknown_arity -> true
       in
       let callee's_code_id_from_type = T.Function_type.code_id func_decl_type in
-      match DE.find_code_exn denv callee's_code_id_from_type with
+      match DE.find_code_metadata_exn denv callee's_code_id_from_type with
       | exception Not_found -> type_unavailable ()
-      | callee's_code_or_metadata ->
-        let callee's_code_metadata_from_type =
-          Code_or_metadata.code_metadata callee's_code_or_metadata
-        in
+      | callee's_code_metadata_from_type ->
         let must_be_detupled =
           call_must_be_detupled
             (Code_metadata.is_tupled callee's_code_metadata_from_type)


### PR DESCRIPTION
This tries to avoid loading cmx files when we only have the code metadata for a function and don't need to look at the code for inlining (because the function is not inlinable, or the argument_types_useful check does not pass, etc).

In `downwards_env.ml`, we could put a fatal error instead of trying to force loading the cmx. In that case, the code metadata reexporting would need to be fixed.