### PR TITLE
Add `[@magic_staged_modes]` to delay mode checks til program generation

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -590,6 +590,8 @@ module Exp_attribute : sig
   val loop : t'
 
   val tail_mod_cons : t'
+
+  val magic_staged_modes : t'
 end = struct
   type s = lambda
 
@@ -618,6 +620,8 @@ end = struct
   let loop = use "Exp_attribute" "loop"
 
   let tail_mod_cons = use "Exp_attribute" "tail_mod_cons"
+
+  let magic_staged_modes = use "Exp_attribute" "magic_staged_modes"
 end
 
 module Vb_attribute : sig
@@ -2311,6 +2315,7 @@ let quote_attributes e =
       | "poll" -> Exp_attribute.poll
       | "loop" -> Exp_attribute.loop
       | "tail_mod_cons" -> Exp_attribute.tail_mod_cons
+      | "magic_staged_modes" -> Exp_attribute.magic_staged_modes
       | s ->
         fatal_errorf "Translquote (at %a): unknown attribute %s"
           Location.print_loc attr.attr_name.loc s)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -700,6 +700,9 @@ let has_or_null attrs =
 let has_or_null_reexport attrs =
   has_attribute "or_null_reexport" attrs
 
+let has_magic_staged_modes attrs =
+  has_attribute "magic_staged_modes" attrs
+
 let curry_attr loc =
   Ast_helper.Attr.mk ~loc:Location.none (Location.mkloc curry_attr_name loc) (PStr [])
 ;;

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -219,6 +219,7 @@ val has_layout_poly: Parsetree.attributes -> bool
 val has_curry: Parsetree.attributes -> bool
 val has_or_null : Parsetree.attributes -> bool
 val has_or_null_reexport : Parsetree.attributes -> bool
+val has_magic_staged_modes : Parsetree.attributes -> bool
 
 val tailcall : Parsetree.attributes ->
     ([`Tail|`Nontail|`Tail_if_possible] option, [`Conflict]) result

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1273,6 +1273,7 @@ module Ast = struct
     | Poll
     | Loop
     | Tail_mod_cons
+    | Magic_staged_modes
 
   let attribute_as_string = function
     | Inline -> "inline"
@@ -1285,6 +1286,7 @@ module Ast = struct
     | Poll -> "poll"
     | Loop -> "loop"
     | Tail_mod_cons -> "tail_mod_cons"
+    | Magic_staged_modes -> "magic_staged_modes"
 
   type vb_attribute =
     { vb_attr_name : string;
@@ -2362,6 +2364,8 @@ module Exp_attribute = struct
   let loop = Ast.Loop
 
   let tail_mod_cons = Ast.Tail_mod_cons
+
+  let magic_staged_modes = Ast.Magic_staged_modes
 end
 
 module Vb_attribute = struct

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -480,6 +480,8 @@ module Exp_attribute : sig
   val loop : t
 
   val tail_mod_cons : t
+
+  val magic_staged_modes : t
 end
 
 module Vb_attribute : sig

--- a/testsuite/tests/quotation/typing/magic_staged_modes.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes.ml
@@ -1,0 +1,91 @@
+(* TEST
+ flags = "-extension runtime_metaprogramming";
+ expect;
+*)
+
+#syntax quotations on
+
+module M : sig
+  val free : 'a @ unique -> unit
+  val of_local : 'a expr @ local -> <[unit]> expr
+  val of_global : 'a expr @ global -> <[unit]> expr
+end = struct
+  let free _ = ()
+  let of_local _ = <[()]>
+  let of_global _ = <[()]>
+end
+#mark_toplevel_in_quotations
+[%%expect{|
+module M :
+  sig
+    val free : 'a @ unique -> unit
+    val of_local : 'a expr @ local -> <[unit]> expr
+    val of_global : 'a expr -> <[unit]> expr
+  end
+|}];;
+
+(* We cannot normally quote an expression at local *)
+<[ stack_ (Some 42) ]>
+[%%expect{|
+Line 1, characters 3-19:
+1 | <[ stack_ (Some 42) ]>
+       ^^^^^^^^^^^^^^^^
+Error: This value is "local" because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global"
+         because it is a quoted expression's result and thus always at the legacy modes.
+|}];;
+(* but we can delay the mode checks until generation *)
+(<[ stack_ (Some 42) ]> [@magic_staged_modes])
+[%%expect{|
+- : <[int option]> expr = <[stack_ (Some 42)]>
+|}];;
+
+(* We cannot expect a spliced expression to be non-legacy *)
+fun x -> <[ M.free $x ]>
+[%%expect{|
+Line 1, characters 19-21:
+1 | fun x -> <[ M.free $x ]>
+                       ^^
+Error: This value is "aliased"
+         because it is a quoted expression's result and thus always at the legacy modes.
+       However, the highlighted expression is expected to be "unique".
+|}];;
+(* but we can delay the mode checks until generation *)
+fun x -> <[ M.free ($x [@magic_staged_modes]) ]>
+[%%expect{|
+- : 'a expr -> <[unit]> expr @ once = <fun>
+|}];;
+
+(* We can capture a local, but not quote it as it is not legacy *)
+<[ fun (x @ local) -> $(M.of_local <[ x ]>) ]>
+[%%expect{|
+Line 1, characters 38-39:
+1 | <[ fun (x @ local) -> $(M.of_local <[ x ]>) ]>
+                                          ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is a quoted expression's result and thus always at the legacy modes.
+|}];;
+(* but we can delay the mode checks on [x] until generation *)
+<[ fun (x @ local) -> $(M.of_local (<[ x ]> [@magic_staged_modes])) ]>
+[%%expect{|
+- : <[$('a) @ local -> unit]> expr = <[fun (x : _ @ local) -> ()]>
+|}];;
+(* however, the mode checks on the capture of [x] remain *)
+<[ fun (x @ local) -> $(M.of_global (<[ x ]> [@magic_staged_modes])) ]>
+[%%expect{|
+Line 1, characters 40-41:
+1 | <[ fun (x @ local) -> $(M.of_global (<[ x ]> [@magic_staged_modes])) ]>
+                                            ^
+Error: The value "x" is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 36-67
+         which is expected to be "global".
+|}];;
+
+(* The attribute is quoted appropriately *)
+<[ fun x -> (<[ ($x [@magic_staged_modes]) ]> [@magic_staged_modes]) ]>
+[%%expect{|
+- : <[$('a) expr -> $('a) expr @ once]> expr =
+<[fun x -> (<[($x [@magic_staged_modes])]> [@magic_staged_modes])]>
+|}];;

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
@@ -13,9 +13,7 @@ let test e =
   try
     ignore (Eval.eval e)
   with e ->
-    (* Print the backtrace if eval fails *)
-    print_endline "eval failed with:";
-    Printexc.print_backtrace stdout; print_newline ()
+    print_endline "eval failed.\n"
 
 (* This is fine -- and the attribute should be printed  *)
 let () = test <[ ($(<[42]>) [@magic_staged_modes]) ]>

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
@@ -8,7 +8,27 @@
 
 let test e =
   let e = Obj.magic_many e in
+  print_endline "generated program:";
   print_endline (Quote.string_of_expr e); print_newline ();
-  ignore (Eval.eval e)
+  try
+    ignore (Eval.eval e)
+  with e ->
+    (* Print the backtrace if eval fails *)
+    print_endline "eval failed with:";
+    Printexc.print_backtrace stdout; print_newline ()
 
+(* This is fine -- and the attribute should be printed  *)
 let () = test <[ ($(<[42]>) [@magic_staged_modes]) ]>
+
+(* The following two examples show unsound uses of [@magic_staged_modes]
+   that cause program generation failures. *)
+
+(* This causes an eval error -- we ignored that the quote is non-legacy (local),
+   and then spliced it as legacy (global). *)
+let () = test <[ ($(<[stack_ (Some 42)]> [@magic_staged_modes])) ]>
+
+(* This causes an eval error -- we quoted something legacy (aliased),
+   and then spliced it as non-legacy (unique). *)
+let () =
+  let x = <[ref 0]> in
+  test <[ (($x [@magic_staged_modes]) : _ @ unique) ]>

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
@@ -1,0 +1,14 @@
+(* TEST
+ include eval;
+ flags = "-extension runtime_metaprogramming -uses-metaprogramming";
+ native;
+*)
+
+#syntax quotations on
+
+let test e =
+  let e = Obj.magic_many e in
+  print_endline (Quote.string_of_expr e); print_newline ();
+  ignore (Eval.eval e)
+
+let () = test <[ ($(<[42]>) [@magic_staged_modes]) ]>

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.ml
@@ -13,7 +13,7 @@ let test e =
   try
     ignore (Eval.eval e)
   with e ->
-    print_endline "eval failed.\n"
+    print_endline "eval failed."; print_newline ()
 
 (* This is fine -- and the attribute should be printed  *)
 let () = test <[ ($(<[42]>) [@magic_staged_modes]) ]>

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
@@ -1,0 +1,2 @@
+(42 [@magic_staged_modes])
+

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
@@ -10,74 +10,12 @@ Error: The expression is "local" because it is "stack_"-allocated.
          because it is the value "eval" in the structure at file "//eval//", line 1, characters 0-29
          which is expected to be "global"
          because modules always need to be allocated on the heap.
-eval failed with:
-Raised at Mode.Comonadic_with.submode_err in file "typing/mode.ml", line 3549, characters 6-73
-Called from Typemod.infer_modalities in file "typing/typemod.ml", line 181, characters 4-65
-Called from Typemod.type_structure.type_str_item.(fun) in file "typing/typemod.ml", line 3715, characters 16-70
-Called from Stdlib__List.fold_left in file "list.ml" (inlined), line 128, characters 24-34
-Called from Typemod.type_structure.type_str_item in file "typing/typemod.ml", lines 3692-3726, characters 10-1688
-Called from Typemod.type_structure.type_struct in file "typing/typemod.ml", line 4070, characters 10-66
-Called from Typemod.type_structure.run in file "typing/typemod.ml", line 4082, characters 6-61
-Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
-Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
-Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
-Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
-Called from Typemod.type_implementation.(fun) in file "typing/typemod.ml", line 4407, characters 8-78
-Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
-Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
-Called from Eval.eval in file "otherlibs/eval/eval.ml", line 182, characters 4-66
-Called from Stdlib__Fun.protect in file "fun.ml", line 39, characters 8-15
-Re-raised at Stdlib__Fun.protect in file "fun.ml", line 44, characters 6-52
-Called from Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 240, characters 10-57
-Re-raised at Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 244, characters 8-51
-Called from Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 30, characters 8-12
-Re-raised at Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 36, characters 10-21
-Called from Magic_staged_modes_eval.test in file "magic_staged_modes_eval.ml", line 14, characters 11-24
+eval failed.
 
 generated program:
 ((Stdlib.ref 0 : _ @ unique) [@magic_staged_modes])
 
 File "//eval//", line 1, characters 14-26:
 Error: This value is "aliased" but is expected to be "unique".
-eval failed with:
-Raised at Typecore.submode in file "typing/typecore.ml", line 704, characters 6-36
-Called from Typecore.type_expect_ in file "typing/typecore.ml", line 6736, characters 6-75
-Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
-Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
-Called from Typecore.type_expect in file "typing/typecore.ml", lines 6036-6039, characters 4-168
-Called from Typecore.type_argument in file "typing/typecore.ml", lines 9433-9434, characters 17-109
-Called from Typecore.type_expect_ in file "typing/typecore.ml", line 7294, characters 16-93
-Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
-Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
-Called from Typecore.type_expect in file "typing/typecore.ml", lines 6036-6039, characters 4-168
-Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
-Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
-Called from Typecore.type_let.(fun) in file "typing/typecore.ml", lines 10570-10571, characters 18-153
-Called from Stdlib__List.map2 in file "list.ml", line 139, characters 15-22
-Called from Typecore.type_let_def_wrap_warnings in file "typing/typecore.ml", lines 10806-10810, characters 4-197
-Called from Typecore.type_let.(fun) in file "typing/typecore.ml", lines 10551-10573, characters 8-1082
-Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
-Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
-Called from Ctype.wrap_end_def in file "typing/ctype.ml" (inlined), line 178, characters 21-55
-Called from Ctype.with_local_level in file "typing/ctype.ml", line 188, characters 15-29
-Called from Typecore.type_let in file "typing/typecore.ml", lines 10448-10648, characters 4-8704
-Called from Typecore.type_binding in file "typing/typecore.ml", lines 11446-11451, characters 4-247
-Called from Typemod.type_structure.type_str_item in file "typing/typemod.ml", line 3684, characters 10-76
-Called from Typemod.type_structure.type_struct in file "typing/typemod.ml", line 4070, characters 10-66
-Called from Typemod.type_structure.run in file "typing/typemod.ml", line 4082, characters 6-61
-Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
-Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
-Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
-Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
-Called from Typemod.type_implementation.(fun) in file "typing/typemod.ml", line 4407, characters 8-78
-Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
-Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
-Called from Eval.eval in file "otherlibs/eval/eval.ml", line 182, characters 4-66
-Called from Stdlib__Fun.protect in file "fun.ml", line 39, characters 8-15
-Re-raised at Stdlib__Fun.protect in file "fun.ml", line 44, characters 6-52
-Called from Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 240, characters 10-57
-Re-raised at Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 244, characters 8-51
-Called from Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 30, characters 8-12
-Re-raised at Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 36, characters 10-21
-Called from Magic_staged_modes_eval.test in file "magic_staged_modes_eval.ml", line 14, characters 11-24
+eval failed.
 

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
@@ -1,2 +1,83 @@
+generated program:
 (42 [@magic_staged_modes])
+
+generated program:
+stack_ (Some 42)
+
+File "//eval//", line 1, characters 4-8:
+Error: The expression is "local" because it is "stack_"-allocated.
+       However, the expression highlighted is expected to be "global"
+         because it is the value "eval" in the structure at file "//eval//", line 1, characters 0-29
+         which is expected to be "global"
+         because modules always need to be allocated on the heap.
+eval failed with:
+Raised at Mode.Comonadic_with.submode_err in file "typing/mode.ml", line 3549, characters 6-73
+Called from Typemod.infer_modalities in file "typing/typemod.ml", line 181, characters 4-65
+Called from Typemod.type_structure.type_str_item.(fun) in file "typing/typemod.ml", line 3715, characters 16-70
+Called from Stdlib__List.fold_left in file "list.ml" (inlined), line 128, characters 24-34
+Called from Typemod.type_structure.type_str_item in file "typing/typemod.ml", lines 3692-3726, characters 10-1688
+Called from Typemod.type_structure.type_struct in file "typing/typemod.ml", line 4070, characters 10-66
+Called from Typemod.type_structure.run in file "typing/typemod.ml", line 4082, characters 6-61
+Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
+Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
+Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
+Called from Typemod.type_implementation.(fun) in file "typing/typemod.ml", line 4407, characters 8-78
+Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
+Called from Eval.eval in file "otherlibs/eval/eval.ml", line 182, characters 4-66
+Called from Stdlib__Fun.protect in file "fun.ml", line 39, characters 8-15
+Re-raised at Stdlib__Fun.protect in file "fun.ml", line 44, characters 6-52
+Called from Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 240, characters 10-57
+Re-raised at Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 244, characters 8-51
+Called from Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 30, characters 8-12
+Re-raised at Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 36, characters 10-21
+Called from Magic_staged_modes_eval.test in file "magic_staged_modes_eval.ml", line 14, characters 11-24
+
+generated program:
+((Stdlib.ref 0 : _ @ unique) [@magic_staged_modes])
+
+File "//eval//", line 1, characters 14-26:
+Error: This value is "aliased" but is expected to be "unique".
+eval failed with:
+Raised at Typecore.submode in file "typing/typecore.ml", line 704, characters 6-36
+Called from Typecore.type_expect_ in file "typing/typecore.ml", line 6736, characters 6-75
+Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
+Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
+Called from Typecore.type_expect in file "typing/typecore.ml", lines 6036-6039, characters 4-168
+Called from Typecore.type_argument in file "typing/typecore.ml", lines 9433-9434, characters 17-109
+Called from Typecore.type_expect_ in file "typing/typecore.ml", line 7294, characters 16-93
+Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
+Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
+Called from Typecore.type_expect in file "typing/typecore.ml", lines 6036-6039, characters 4-168
+Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
+Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
+Called from Typecore.type_let.(fun) in file "typing/typecore.ml", lines 10570-10571, characters 18-153
+Called from Stdlib__List.map2 in file "list.ml", line 139, characters 15-22
+Called from Typecore.type_let_def_wrap_warnings in file "typing/typecore.ml", lines 10806-10810, characters 4-197
+Called from Typecore.type_let.(fun) in file "typing/typecore.ml", lines 10551-10573, characters 8-1082
+Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
+Called from Ctype.wrap_end_def in file "typing/ctype.ml" (inlined), line 178, characters 21-55
+Called from Ctype.with_local_level in file "typing/ctype.ml", line 188, characters 15-29
+Called from Typecore.type_let in file "typing/typecore.ml", lines 10448-10648, characters 4-8704
+Called from Typecore.type_binding in file "typing/typecore.ml", lines 11446-11451, characters 4-247
+Called from Typemod.type_structure.type_str_item in file "typing/typemod.ml", line 3684, characters 10-76
+Called from Typemod.type_structure.type_struct in file "typing/typemod.ml", line 4070, characters 10-66
+Called from Typemod.type_structure.run in file "typing/typemod.ml", line 4082, characters 6-61
+Called from Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 433, characters 14-18
+Re-raised at Builtin_attributes.warning_scope in file "parsing/builtin_attributes.ml", line 438, characters 4-13
+Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
+Called from Typemod.type_implementation.(fun) in file "typing/typemod.ml", line 4407, characters 8-78
+Called from Misc.try_finally in file "utils/misc.ml", line 36, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 50, characters 10-56
+Called from Eval.eval in file "otherlibs/eval/eval.ml", line 182, characters 4-66
+Called from Stdlib__Fun.protect in file "fun.ml", line 39, characters 8-15
+Re-raised at Stdlib__Fun.protect in file "fun.ml", line 44, characters 6-52
+Called from Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 240, characters 10-57
+Re-raised at Eval.eval.(fun) in file "otherlibs/eval/eval.ml", line 244, characters 8-51
+Called from Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 30, characters 8-12
+Re-raised at Stdlib__Mutex.protect in file "stdlib/mutex.ml", line 36, characters 10-21
+Called from Magic_staged_modes_eval.test in file "magic_staged_modes_eval.ml", line 14, characters 11-24
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8002,6 +8002,11 @@ and type_expect_
       let expr_ty = Predef.type_code (newgenty (Tquote ty)) in
       with_explanation (fun () ->
         unify_exp_types loc env expr_ty (generic_instance ty_expected));
+      let mode_quoted =
+        match Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes with
+        | true -> mode_default Value.max
+        | false -> mode_quoted
+      in
       let arg = type_expect new_env mode_quoted exp (mk_expected ty) in
       if maybe_computation arg then
         submode ~loc ~env ~reason:Other mode_computation_quoted expected_mode;
@@ -8015,7 +8020,8 @@ and type_expect_
       if not (Language_extension.is_enabled Runtime_metaprogramming) then
         raise (Typetexp.Error (loc, env,
                                Unsupported_extension Runtime_metaprogramming));
-      submode ~loc ~env ~reason:Other mode_splice expected_mode;
+      if not (Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes) then
+        submode ~loc ~env ~reason:Other mode_splice expected_mode;
       let new_env = Env.enter_splice ~loc env in
       let ty = Predef.type_code (newgenty (Tquote ty_expected)) in
       let arg = type_expect new_env mode_spliced exp (mk_expected ty) in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8002,10 +8002,14 @@ and type_expect_
       let expr_ty = Predef.type_code (newgenty (Tquote ty)) in
       with_explanation (fun () ->
         unify_exp_types loc env expr_ty (generic_instance ty_expected));
+      (* If we are checking staged modes in the metaprogram,
+         we need to assume the expression in quotes is at legacy.
+         Otherwise, we are delaying checking modes until program generation
+         (with magic_staged_modes), and we do not constrain the mode. *)
       let mode_quoted =
-        match Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes with
-        | true -> mode_default Value.max
-        | false -> mode_quoted
+        if Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes
+        then mode_default Value.max
+        else mode_quoted
       in
       let arg = type_expect new_env mode_quoted exp (mk_expected ty) in
       if maybe_computation arg then
@@ -8020,7 +8024,14 @@ and type_expect_
       if not (Language_extension.is_enabled Runtime_metaprogramming) then
         raise (Typetexp.Error (loc, env,
                                Unsupported_extension Runtime_metaprogramming));
-      if not (Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes) then
+      (* If we are checking staged modes in the metaprogram,
+         we need to assume the splice is at legacy.
+         Otherwise, if we are delaying checking modes until program generation
+         (with magic_staged_modes), and we do not constrain the mode. *)
+      let magic_staged_modes =
+        Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes
+      in
+      if not magic_staged_modes then
         submode ~loc ~env ~reason:Other mode_splice expected_mode;
       let new_env = Env.enter_splice ~loc env in
       let ty = Predef.type_code (newgenty (Tquote ty_expected)) in


### PR DESCRIPTION
## Motivation

Runtime metaprogramming is very conservative with modes right now. This means that this simple expression cannot mode-check:
```ocaml
<[ fun (x @ local) -> $(f <[ x ]>) ]>
```

While `<[ x ]>` is `local` as expected (it captures a `local` thing), we cannot have `x` in quotes as it is itself local. 

## Feature

This PR adds a `[@magic_staged_modes]` argument that ignores the modes on quotes/splices in the metaprogram, delaying their checking until program generation.

## Examples

For instance, we can quote a non-legacy (e.g. local) expression: 
```ocaml
<[ fun (x @ local) -> ($(f <[ x ]>) [@magic_staged_modes]) ]>
```
Similarly, it's possible to splice an expression expected to be non-legacy like so (here, `of_unique : _ @ unique -> _`):
```ocaml
fun x -> <[ M.of_unique ($x [@magic_staged_modes]) ]>
```

## Safety

This feature is inherently unsafe -- it can cause errors when evaluating (specifically, mode-checking) the generated program. This happens when there is a mismatch between the mode of the expression in quotes and that of a splice (which, without the attribute, are always assumed to be `legacy`). However, sticking to the safe mode-checking is too conservative, as seen in the motivating example, so we want to expose delaying mode-checking to users.