### PR TITLE
Fix stage-tracking fatal error when reporting inclusion error

### DIFF
--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -3779,7 +3779,7 @@ let expand_type env ty =
   (* If the type contains top-level splices, then we enter some far-away future
      stage where all splices are valid. *)
   (* CR metaprogramming jbachurski: Remove [contains_toplevel_splice] and
-     track the stage in errors so we don't need this. *)
+     track the stage in errors so we don't need this. See ticket 6726. *)
   let env =
     if contains_toplevel_splice (Env.stage env :> int) ty
     then Env.enter_future env

--- a/testsuite/tests/quotation/typing/quotes_splices/moregen.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/moregen.ml
@@ -158,3 +158,52 @@ Error: Signature mismatch:
        Type "int * int" is not compatible with type "int * string"
        Type "int" is not compatible with type "string"
 |}]
+
+(* Some obvious cases with misplaced quotes/splices *)
+
+(* error -- quote missing on expr's argument in signature *)
+module M : sig
+  val e : ('a -> unit) expr
+end = struct
+  let e = <[ fun x -> () ]>
+end
+[%%expect{|
+>> Fatal error: Ctype.decr_stage: Stage decreased below the meta stage
+Uncaught exception: Typemod.Error(_, _, _)
+
+|}]
+
+(* error -- quote missing on expr's argument in structure (analogous) *)
+module M : sig
+  val e : <[$'a -> unit]> expr
+end = struct
+  let e : (_ -> _) expr = Obj.magic <[ fun x -> () ]>
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let e : (_ -> _) expr = Obj.magic <[ fun x -> () ]>
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val e : ('a : any) ('b : any). ('a -> 'b) expr end
+       is not included in
+         sig val e : <[$('a) -> unit]> expr end
+       Values do not match:
+         val e : ('a : any) ('b : any). ('a -> 'b) expr
+       is not included in
+         val e : <[$('a) -> unit]> expr
+       The type "('a -> 'b) expr" is not compatible with the type
+         "<[$('c) -> unit]> expr"
+       Type "'a -> 'b" is not compatible with type "<[$('c) -> unit]>"
+|}]
+
+(* the correct version of the above *)
+module M : sig
+  val e : <[$'a -> unit]> expr
+end = struct
+  let e = <[ fun x -> () ]>
+end
+[%%expect{|
+module M : sig val e : <[$('a) -> unit]> expr end
+|}]

--- a/testsuite/tests/quotation/typing/quotes_splices/moregen.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/moregen.ml
@@ -168,9 +168,22 @@ end = struct
   let e = <[ fun x -> () ]>
 end
 [%%expect{|
->> Fatal error: Ctype.decr_stage: Stage decreased below the meta stage
-Uncaught exception: Typemod.Error(_, _, _)
-
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let e = <[ fun x -> () ]>
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val e : <[$('a) -> unit]> expr end
+       is not included in
+         sig val e : ('a -> unit) expr end
+       Values do not match:
+         val e : <[$('a) -> unit]> expr
+       is not included in
+         val e : ('a -> unit) expr
+       The type "<[$('a) -> unit]> expr" is not compatible with the type
+         "('b -> unit) expr"
+       Type "$('a) -> unit" is not compatible with type "$('b -> unit)"
 |}]
 
 (* error -- quote missing on expr's argument in structure (analogous) *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -3223,6 +3223,13 @@ let is_unit_arg env ty =
   let ty, vars = tpoly_get_poly ty in
   if vars <> [] then false
   else begin
+    (* CR metaprogramming jbachurski: Remove [contains_toplevel_splice] and
+       track the stage in errors so we don't need this. See ticket 6726. *)
+    let env =
+      if Ctype.contains_toplevel_splice (Env.stage env :> int) ty
+      then Env.enter_future env
+      else env
+    in
     match get_desc (Ctype.expand_head env ty) with
     | Tconstr (p, _, _) -> Path.same p Predef.path_unit
     | _ -> false


### PR DESCRIPTION
## Summary

This PR fixes a compiler fatal error caused by insufficient stage tracking. It can be attributed to the lack of stages in errors, tracked by ticket 6726. Until errors are tracked in stages, we use the same `if contains_toplevel_splice then enter_future` hack as first done in the initial part of #5641 (environment stage tracking).

## Explanation

This crash is triggered by `Printtyp.is_unit_arg`, which is only ever called to improve a `Errortrace.Diff` error. In this case, it happens when attempting to report `$'a` is not equal to some type, but since that contains a top-level splice, we need to make sure the environment is at a high enough stage to allow it.
`enter_future` instead of an accurate stage might hide an equation that some type is `unit`. This might (though unlikely) cause an explanation not to appear in the error message.

## Motivation

This is a trivial fix that improves user experience, stopping a compiler crash from hiding a nice type error. 
