### PR TITLE
Use `Global_module.Name.t` in `Shape.Uid.t`

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -1467,8 +1467,9 @@ module With_cms_reduce = Shape_reduce.Make (struct
       | _, Some cmt_infos -> Some cmt_infos.cmt_impl_shape
       | _ -> Some None)
 
-  let read_unit_shape ~diagnostics ~unit_name =
-    match String.Tbl.find_opt cms_file_cache unit_name with
+  let read_unit_shape ~diagnostics ~(unit_name : Global_module.Name.t) =
+    let base_name = unit_name.head in
+    match String.Tbl.find_opt cms_file_cache base_name with
     | Some shape ->
       Shape_reduce.Diagnostics.count_cms_file_cached diagnostics;
       shape
@@ -1479,7 +1480,7 @@ module With_cms_reduce = Shape_reduce.Make (struct
       if MB.is_out_of_bounds !cms_files_read_counter max_cms_files
       then None
       else
-        let filename = String.uncapitalize_ascii unit_name in
+        let filename = String.uncapitalize_ascii base_name in
         let cms_file = filename ^ ".cms" in
         let cmt_file = filename ^ ".cmt" in
         let shape_opt_opt =
@@ -1499,7 +1500,7 @@ module With_cms_reduce = Shape_reduce.Make (struct
         in
         (* Note: [shape_opt] is an option, and we are also caching the [None]
            case. *)
-        String.Tbl.add cms_file_cache unit_name shape_opt;
+        String.Tbl.add cms_file_cache base_name shape_opt;
         shape_opt
 end)
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1807,7 +1807,7 @@ let find_shape env (ns : Shape.Sig_component_kind.t) id =
   | Module ->
       begin match IdTbl.find_same_without_locks id env.modules with
       | Mod_local ({ mda_shape; _ }, _) -> mda_shape
-      | Mod_persistent -> Shape.for_persistent_unit (Ident.name id)
+      | Mod_persistent -> Shape.for_persistent_unit (Ident.to_global_exn id)
       | Mod_unbound _ ->
           (* Only present temporarily while approximating the environment for
              recursive modules.
@@ -1816,7 +1816,7 @@ let find_shape env (ns : Shape.Sig_component_kind.t) id =
           assert false
       | exception Not_found
         when Ident.is_global id && not (Current_unit_name.is_ident id) ->
-          Shape.for_persistent_unit (Ident.name id)
+          Shape.for_persistent_unit (Ident.to_global_exn id)
       end
   | Module_type ->
       let modtype =  IdTbl.find_same_without_locks id env.modtypes in

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -822,7 +822,9 @@ let acknowledge_new_pers_struct penv modname pers_name val_of_pers_sig =
   in
   let shape =
     match import.imp_impl, import.imp_params with
-    | Some unit, [] -> Shape.for_persistent_unit (CU.full_path_as_string unit)
+    | Some unit, [] ->
+        Shape.for_persistent_unit
+          (CU.to_global_name_without_prefix unit)
     | _, _ ->
         (* TODO Implement shapes for parameters and parameterised modules *)
         Shape.error ~uid "parameter or parameterised module"

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -18,8 +18,9 @@ type base_layout = Jkind_types.Sort.base
 
 module Uid = struct
   type t =
-    | Compilation_unit of string
-    | Item of { comp_unit: string; id: int; from: Unit_info.intf_or_impl }
+    | Compilation_unit of Global_module.Name.t
+    | Item of { comp_unit: Global_module.Name.t; id: int;
+                from: Unit_info.intf_or_impl }
     | Internal
     | Predef of string
     | Unboxed_version of t
@@ -29,11 +30,13 @@ module Uid = struct
 
     let rec compare (x : t) y =
       match x, y with
-      | Compilation_unit s1, Compilation_unit s2 -> String.compare s1 s2
+      | Compilation_unit s1, Compilation_unit s2 ->
+        Global_module.Name.compare s1 s2
       | Item c1, Item c2 ->
         let c = Int.compare c1.id c2.id in
         let c =
-          if c <> 0 then c else String.compare c1.comp_unit c2.comp_unit
+          if c <> 0 then c
+          else Global_module.Name.compare c1.comp_unit c2.comp_unit
         in
         if c <> 0 then c else Stdlib.compare c1.from c2.from
       | Internal, Internal -> 0
@@ -63,9 +66,11 @@ module Uid = struct
     let rec print fmt = function
       | Internal -> Format.pp_print_string fmt "<internal>"
       | Predef name -> Format.fprintf fmt "<predef:%s>" name
-      | Compilation_unit s -> Format.pp_print_string fmt s
+      | Compilation_unit s ->
+        Format.fprintf fmt "%a" (Format_doc.compat Global_module.Name.print) s
       | Item { comp_unit; id; from } ->
-          Format.fprintf fmt "%a%s.%d" pp_intf_or_impl from comp_unit id
+          Format.fprintf fmt "%a%a.%d" pp_intf_or_impl from
+            (Format_doc.compat Global_module.Name.print) comp_unit id
       | Unboxed_version t -> Format.fprintf fmt "%a#" print t
 
     let output oc t =
@@ -81,18 +86,20 @@ module Uid = struct
       let comp_unit, from =
         let open Unit_info in
         match current_unit with
-        | None -> "", Impl
+        | None ->
+          Global_module.Name.create_no_args "", Impl
         | Some ui ->
-          Compilation_unit.full_path_as_string (modname ui), kind ui
+          Compilation_unit.to_global_name_without_prefix (modname ui),
+          kind ui
       in
       incr id;
       Item { comp_unit; id = !id; from }
 
   let of_compilation_unit_id id =
-    Compilation_unit (id |> Compilation_unit.full_path_as_string)
+    Compilation_unit (Compilation_unit.to_global_name_without_prefix id)
 
   let of_compilation_unit_name name =
-    Compilation_unit (name |> Compilation_unit.Name.to_string)
+    Compilation_unit (Compilation_unit.Name.to_global_name name)
 
   let of_predef_id id =
     if not (Ident.is_predef id) then
@@ -517,7 +524,7 @@ and desc =
   | Alias of t
   | Leaf
   | Proj of t * Item.t
-  | Comp_unit of string
+  | Comp_unit of Global_module.Name.t
   | Error of string
 
   (* constructors for types  *)
@@ -631,7 +638,7 @@ let rec equal_desc0 d1 d2 =
   | Proj (t1, i1), Proj (t2, i2) ->
     if Item.compare i1 i2 <> 0 then false
     else equal t1 t2
-  | Comp_unit c1, Comp_unit c2 -> String.equal c1 c2
+  | Comp_unit c1, Comp_unit c2 -> Global_module.Name.equal c1 c2
   | Constr (c1, ts1), Constr (c2, ts2) ->
     Ident.equal c1 c2
     && List.equal equal ts1 ts2
@@ -759,7 +766,9 @@ let rec print fmt t =
               Item.print item
               Uid.print uid
         end
-    | Comp_unit name -> Format.fprintf fmt "CU %s" name
+    | Comp_unit name ->
+      Format.fprintf fmt "CU %a"
+        (Format_doc.compat Global_module.Name.print) name
     | Struct map ->
         let print_map fmt =
           Item.Map.iter (fun item t ->
@@ -1149,8 +1158,8 @@ let of_path ~find_shape ~namespace path =
   in
   aux namespace path
 
-let for_persistent_unit s =
-  comp_unit ~uid:(Compilation_unit s) s
+let for_persistent_unit name =
+  comp_unit ~uid:(Compilation_unit name) name
 
 let leaf_for_unpack = leaf' None
 

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -59,9 +59,9 @@ type base_layout = Jkind_types.Sort.base
     stored to that effect in the [uid_to_decl] table of cmt files. *)
 module Uid : sig
   type t = private
-    | Compilation_unit of string
+    | Compilation_unit of Global_module.Name.t
     | Item of {
-        comp_unit: string;
+        comp_unit: Global_module.Name.t;
         id: int;
         from: Unit_info.intf_or_impl }
     | Internal
@@ -239,7 +239,7 @@ and desc =
   | Alias of t
   | Leaf
   | Proj of t * Item.t
-  | Comp_unit of string
+  | Comp_unit of Global_module.Name.t
   | Error of string
 
   (* constructors for types *)
@@ -363,7 +363,7 @@ val error : ?uid:Uid.t -> string -> t
 val proj : ?uid:Uid.t -> t -> Item.t -> t
 val leaf : Uid.t -> t
 val leaf' : Uid.t option -> t
-val comp_unit : ?uid:Uid.t -> string -> t
+val comp_unit : ?uid:Uid.t -> Global_module.Name.t -> t
 
 (* constructors for types  *)
 val constr : ?uid:Uid.t -> Ident.t -> t list -> t
@@ -396,8 +396,7 @@ val abs_list : t -> Ident.t list -> t
 
 val decompose_abs : t -> (var * t) option
 
-(* CR lmaurer: Should really take a [Compilation_unit.t] *)
-val for_persistent_unit : string -> t
+val for_persistent_unit : Global_module.Name.t -> t
 val leaf_for_unpack : t
 
 val poly_variant_constructors_map :

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -125,7 +125,7 @@ module Make(Params : sig
   val max_shape_reduce_steps_per_variable : unit -> MB.t
   val max_compilation_unit_depth : unit -> MB.t
   val read_unit_shape :
-    diagnostics:Diagnostics.t -> unit_name:string -> t option
+    diagnostics:Diagnostics.t -> unit_name:Global_module.Name.t -> t option
 end) = struct
   (* We implement a strong call-by-need reduction, following an
      evaluator from Nathanaelle Courant. *)
@@ -139,7 +139,7 @@ end) = struct
     | NAlias of delayed_nf
     | NProj of nf * Item.t
     | NLeaf
-    | NComp_unit of string
+    | NComp_unit of Global_module.Name.t
     | NError of string
     | NMu of nf
     | NRec_var of Shape.DeBruijn_index.t
@@ -224,7 +224,7 @@ end) = struct
     | NProj (t1, i1), NProj (t2, i2) ->
       if Item.compare i1 i2 <> 0 then false
       else equal_nf t1 t2
-    | NComp_unit c1, NComp_unit c2 -> String.equal c1 c2
+    | NComp_unit c1, NComp_unit c2 -> Global_module.Name.equal c1 c2
     | NAlias a1, NAlias a2 -> equal_delayed_nf a1 a2
     | NError e1, NError e2 -> String.equal e1 e2
     | NMu (nf1), NMu (nf2) -> equal_nf nf1 nf2

--- a/typing/shape_reduce.mli
+++ b/typing/shape_reduce.mli
@@ -84,7 +84,9 @@ module Make(_ : sig
     val max_compilation_unit_depth : unit -> Misc.Maybe_bounded.t
 
     val read_unit_shape :
-      diagnostics:Diagnostics.t -> unit_name:string -> Shape.t option
+      diagnostics:Diagnostics.t ->
+      unit_name:Global_module.Name.t ->
+      Shape.t option
   end) : sig
   val reduce : ?diagnostics: Diagnostics.t -> Env.t -> Shape.t -> Shape.t
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -4681,9 +4681,10 @@ let package_units initial_env objfiles target_cmi modulename =
   let pack_uid = Uid.of_compilation_unit_id modulename in
   let shape =
     List.fold_left (fun map (name, _sg) ->
-      let name = Compilation_unit.Name.to_string name in
-      let id = Ident.create_persistent name in
-      Shape.Map.add_module map id (Shape.for_persistent_unit name)
+      let id = Ident.create_persistent (Compilation_unit.Name.to_string name) in
+      Shape.Map.add_module map id
+        (Shape.for_persistent_unit
+           (Compilation_unit.Name.to_global_name name))
     ) Shape.Map.empty units
     |> Shape.str ~uid:pack_uid
   in


### PR DESCRIPTION
This PR changes the `Compilation_unit` variant of `Shape.Uid.t` to carry a `Global_module.Name.t` instead of a `string`, thus completing this CR in `shape.mli`:
```
(* lmaurer: Should really take a [Compilation_unit.t] *)
val for_persistent_unit : string -> t
```

The motivation is to fix a Merlin bug where it refused to go to the definition of an identifier because of a parameterized library usage. The `Compilation_unit` in the shape was `Foo[Bar]`, resulting in Merlin's `read_unit_shape` function (that it passes into `Shape_reduce.Make`) receiving `Foo[Bar]`, which it fails to handle correctly. This PR causes `read_unit_shape` to receive a `Global_module.Name.t` instead of a `string`, causing Merlin to receive more structured information about the module, which it can then use to find `foo.ml`.