### PR TITLE
Add reviewing skill

### DIFF
--- a/.claude/skills/oxcaml-pr-review/SKILL.md
+++ b/.claude/skills/oxcaml-pr-review/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: oxcaml-pr-review
+description: Review an oxcaml GitHub PR by posting line-anchored comments to a pending review, without submitting it.
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(python3 .claude/skills/oxcaml-pr-review/scripts/find-or-create-pending-review.py:*), Bash(python3 .claude/skills/oxcaml-pr-review/scripts/post-pending-comment.py:*), Bash(python3 .claude/skills/oxcaml-pr-review/scripts/list-review-comments.py:*), AskUserQuestion(*)
+argument-hint: [PR number]
+---
+
+# OxCaml PR Review Skill
+
+This skill walks through reviewing a pull request on `oxcaml/oxcaml`. The output is a set of line-anchored comments attached to a **pending** review on GitHub. The user reads those comments in place on GitHub and decides what to keep, edit, or submit.
+
+The repository is `oxcaml/oxcaml` unless the user says otherwise.
+
+The skill uses three helper scripts under `.claude/skills/oxcaml-pr-review/scripts/`. They are the only way this skill writes to GitHub — direct `gh api` calls are not allowed by this skill's permissions, so use the scripts.
+
+## Step 1: Identify the PR
+
+The PR number may be clear from conversation context, explicitly provided as an argument, or unknown. If unknown, use `AskUserQuestion` to ask for it.
+
+## Step 2: Gather
+
+Fetch the PR metadata and diff. If the diff is large, write it locally (using a distinctive filename like `pr-NNNN.diff`) so it stays out of your context window.
+
+```bash
+gh pr view NNNN --repo oxcaml/oxcaml
+gh pr diff NNNN --repo oxcaml/oxcaml          # or redirect to claude-ws if large
+```
+
+## Step 3: Read source at HEAD
+
+For each location you plan to comment on, read the affected file at HEAD so you have correct line numbers and surrounding context. The diff alone is not enough — line numbers shift, and you need to see what's actually around the change. Check that the local repo is checked out to the PR branch, ensuring that HEAD lines up with the PR.
+
+## Step 4: Compose
+
+Draft the review as a list of **line-anchored** comments rather than a wall of prose. Each comment should be:
+
+- Tied to a specific file and line that appears in the PR diff
+- Specific enough that the user can act on it without re-reading the diff
+- Focused on a single point — split unrelated observations into separate comments
+
+It's fine to have few comments, or none, if the diff is clean. Quality over quantity.
+
+## Step 5: Post as pending
+
+### Find or create the pending review
+
+```bash
+python3 .claude/skills/oxcaml-pr-review/scripts/find-or-create-pending-review.py \
+  --pr NNNN
+```
+
+Output is a JSON object `{"node_id": "...", "rest_id": ...}`. The script reuses an existing PENDING review if one exists, or creates a fresh one in PENDING state. It never submits.
+
+### Append each comment
+
+Use `post-pending-comment.py` once per comment. The script enforces that every body starts with `**Claude:**` (the convention that lets the user tell your comments apart from theirs) and that `--line` is positive and `--side` is `RIGHT` or `LEFT`.
+
+```bash
+python3 .claude/skills/oxcaml-pr-review/scripts/post-pending-comment.py \
+  --review-id "<node_id>" \
+  --path "<file>" \
+  --line <line> \
+  --side RIGHT \
+  --body '**Claude:** <comment>'
+```
+
+Notes:
+- `--line` must be a line that's part of the PR diff. Use `--side RIGHT` for additions and context lines; use `--side LEFT` for deleted lines. Lines outside the diff hunks are rejected by the GitHub API.
+- Independent comment posts can run in parallel — issue them in one batch of tool calls.
+
+### Verify
+
+```bash
+python3 .claude/skills/oxcaml-pr-review/scripts/list-review-comments.py \
+  --pr NNNN --review-id <rest_id>
+```
+
+Read-only; confirms that the comments you posted are all attached to the same pending review.
+
+## Step 6: Do NOT submit
+
+**Leave the review in PENDING state.** This skill provides no way to submit, approve, or request changes on a review, and it should not. The user reads the comments in place on GitHub and submits — or edits/deletes them — themselves.
+
+When you finish, tell the user how many comments you posted and the URL of the PR. Do not write a long prose summary of the review; the comments themselves are the deliverable.

--- a/.claude/skills/oxcaml-pr-review/scripts/find-or-create-pending-review.py
+++ b/.claude/skills/oxcaml-pr-review/scripts/find-or-create-pending-review.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Find or create a PENDING review on a PR.
+
+Usage:
+    find-or-create-pending-review.py --pr N [--repo OWNER/REPO]
+
+Arguments:
+    --pr     PR number (required, positive integer).
+    --repo   GitHub repo in OWNER/REPO form. Defaults to oxcaml/oxcaml.
+
+Output:
+    A single JSON object on stdout with two fields:
+      node_id   GraphQL node id of the pending review
+                (pass to post-pending-comment.py --review-id).
+      rest_id   REST numeric id of the pending review
+                (pass to list-review-comments.py --review-id).
+
+If a PENDING review already exists on the PR, its ids are returned. Otherwise
+a new review is created with no `event` field, which leaves it in PENDING
+state. The script never submits a review.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def gh(*args):
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+        sys.exit(result.returncode)
+    return result.stdout
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--repo", default="oxcaml/oxcaml")
+    args = parser.parse_args()
+
+    if not REPO_RE.match(args.repo):
+        sys.stderr.write(f"Refusing suspicious --repo value: {args.repo!r}\n")
+        sys.exit(2)
+    if args.pr <= 0:
+        sys.stderr.write(f"Refusing non-positive --pr value: {args.pr}\n")
+        sys.exit(2)
+
+    endpoint = f"repos/{args.repo}/pulls/{args.pr}/reviews"
+
+    reviews = json.loads(gh("api", endpoint))
+    for r in reviews:
+        if r.get("state") == "PENDING":
+            print(json.dumps({"node_id": r["node_id"], "rest_id": r["id"]}))
+            return
+
+    created = json.loads(
+        gh("api", endpoint, "--method", "POST", "-f", "body=")
+    )
+    print(json.dumps({"node_id": created["node_id"], "rest_id": created["id"]}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/oxcaml-pr-review/scripts/list-review-comments.py
+++ b/.claude/skills/oxcaml-pr-review/scripts/list-review-comments.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""List comments on a specific review of a PR (read-only).
+
+Usage:
+    list-review-comments.py --pr N --review-id REST_ID [--repo OWNER/REPO]
+
+Arguments:
+    --pr         PR number (positive integer).
+    --review-id  REST numeric id of the review (from find-or-create-pending-review.py).
+    --repo       GitHub repo in OWNER/REPO form. Defaults to oxcaml/oxcaml.
+
+Output:
+    JSON list (as returned by GitHub) of comments belonging to the review,
+    forwarded to stdout. Use to verify that comments posted by
+    post-pending-comment.py landed on the expected pending review.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--review-id", type=int, required=True)
+    parser.add_argument("--repo", default="oxcaml/oxcaml")
+    args = parser.parse_args()
+
+    if not REPO_RE.match(args.repo):
+        sys.stderr.write(f"Refusing suspicious --repo value: {args.repo!r}\n")
+        sys.exit(2)
+    if args.pr <= 0:
+        sys.stderr.write(f"Refusing non-positive --pr value: {args.pr}\n")
+        sys.exit(2)
+    if args.review_id <= 0:
+        sys.stderr.write(
+            f"Refusing non-positive --review-id value: {args.review_id}\n"
+        )
+        sys.exit(2)
+
+    endpoint = f"repos/{args.repo}/pulls/{args.pr}/reviews/{args.review_id}/comments"
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+        sys.exit(result.returncode)
+    sys.stdout.write(result.stdout.decode("utf-8", errors="replace"))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/oxcaml-pr-review/scripts/post-pending-comment.py
+++ b/.claude/skills/oxcaml-pr-review/scripts/post-pending-comment.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Append a single line-anchored comment to a PENDING review.
+
+Usage:
+    post-pending-comment.py
+        --review-id  <GraphQL node id of the pending review>
+        --path       <path to a file in the PR>
+        --line       <line number, must be part of the PR diff>
+        --side       RIGHT | LEFT
+        --body       <comment body; must start with "**Claude:**">
+
+The body must start with `**Claude:**` so review comments authored by Claude
+are visually distinct from human comments. Use `side: RIGHT` for additions
+and context lines; use `side: LEFT` for deleted lines. Lines outside the PR's
+diff hunks are rejected by the GitHub API.
+
+Calls the GraphQL `addPullRequestReviewThread` mutation. Does nothing that
+could submit, approve, or request changes on a review.
+"""
+
+import argparse
+import subprocess
+import sys
+
+MUTATION = """
+mutation($reviewId: ID!, $path: String!, $body: String!, $line: Int!, $side: DiffSide!) {
+  addPullRequestReviewThread(input: {
+    pullRequestReviewId: $reviewId,
+    path: $path,
+    body: $body,
+    line: $line,
+    side: $side
+  }) {
+    thread { id }
+  }
+}
+"""
+
+REQUIRED_BODY_PREFIX = "**Claude:**"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--review-id", required=True)
+    parser.add_argument("--path", required=True)
+    parser.add_argument("--line", type=int, required=True)
+    parser.add_argument("--side", choices=["RIGHT", "LEFT"], required=True)
+    parser.add_argument("--body", required=True)
+    args = parser.parse_args()
+
+    if not args.body.startswith(REQUIRED_BODY_PREFIX):
+        sys.stderr.write(
+            f"Refusing: --body must start with {REQUIRED_BODY_PREFIX!r}.\n"
+        )
+        sys.exit(2)
+    if args.line <= 0:
+        sys.stderr.write(f"Refusing non-positive --line value: {args.line}\n")
+        sys.exit(2)
+
+    result = subprocess.run(
+        [
+            "gh", "api", "graphql",
+            "-f", f"query={MUTATION}",
+            "-f", f"reviewId={args.review_id}",
+            "-f", f"path={args.path}",
+            "-F", f"line={args.line}",
+            "-f", f"side={args.side}",
+            "-f", f"body={args.body}",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+        sys.exit(result.returncode)
+    sys.stdout.write(result.stdout.decode("utf-8", errors="replace"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have figured out how to get Claude to review for me... and now everyone else can have Claude review for them, too!

Of course, let's please all continue to use discretion when using this skill. It should _not_ be a replacement for actual human review, but an accelerant.

Testing: I removed my local capabilities to do Claude-based review and was able to successfully review a PR with this skill. My prompt: `Please review PR 1234`. Claude asked me whether to enable the skill (good! it changes permissions and I'm glad for this question), and then that's it. Hooray!

For best results, have your repo checked out to the branch of the PR.