### PR TITLE
Add To_cmm_env.find_pure_bound_cmm_expr

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -999,6 +999,23 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
         let env = remove_binding env var in
         will_inline_simple env res binding))
 
+let find_pure_bound_cmm_expr env var =
+  let var = resolve_alias env var in
+  match Variable.Map.find var env.bindings with
+  | exception Not_found -> None
+  | Binding binding -> (
+    match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
+    | Effect | Coeffect_only | Generative_immutable -> None
+    | Pure ->
+      let cmm_expr_of_bound_expr (type a) (b : a bound_expr) =
+        match b with
+        | Simple { cmm_expr; free_vars = _ } | Split { cmm_expr; free_vars = _ }
+          ->
+          Some cmm_expr
+        | Splittable_prim _ -> None
+      in
+      cmm_expr_of_bound_expr binding.bound_expr)
+
 (* Handling of aliases between variables *)
 
 (* Situation: [alias_of] is a `must_inline_once` and [var] is used exactly once

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -300,7 +300,10 @@ val inline_variable :
     has been flushed, or is bound to a splittable primitive that has not yet
     been materialised as a single Cmm expression), or if the bound defining
     expression is not pure (i.e. has any effects or coeffects). Aliases (as
-    recorded by [add_alias]) are resolved before the lookup. *)
+    recorded by [add_alias]) are resolved before the lookup.
+
+    Note that using this function can throw off other assumptions made in
+    To_cmm, so should be used with caution. *)
 val find_pure_bound_cmm_expr : t -> Variable.t -> Cmm.expression option
 
 type flush_mode =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -294,6 +294,15 @@ val inline_variable :
   Variable.t ->
   translation_result
 
+(** Look up the Cmm expression associated with a given Flambda variable in the
+    delayed let-bindings, if any. Returns [None] if the variable is not present
+    in the bindings map (for instance because it is a continuation parameter,
+    has been flushed, or is bound to a splittable primitive that has not yet
+    been materialised as a single Cmm expression), or if the bound defining
+    expression is not pure (i.e. has any effects or coeffects). Aliases (as
+    recorded by [add_alias]) are resolved before the lookup. *)
+val find_pure_bound_cmm_expr : t -> Variable.t -> Cmm.expression option
+
 type flush_mode =
   | Entering_loop
   | Branching_point


### PR DESCRIPTION
One of the nice properties of the new IR in #5810 is the ability to match directly on patterns of instruction inputs, even where they comprise several operations, potentially in different basic blocks.  We need something similar during `To_cmm` in order to produce good code for block indices, and indeed array access (at the moment, the latter easily produces x86 instructions which do not make sufficiently good use of the addressing modes available).  This PR adds a function which does a best-effort lookup in the environment to discover the defining expressions associated with a given variable, meaning that similar matching to that just described can be performed.  In the cases for block indices (#6040) and array access (no PR yet) this lookup should be completely reliable, as far as I know.