### PR TITLE
Add support for rematerialization (register allocators)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,6 +514,10 @@ jobs:
             ./_build/main/tools/regalloc/regalloc.exe _build \
               -validate -param AFFINITY:on -regalloc $allocator || exit 1; \
           done
+          for allocator in irc ls gi; do \
+            ./_build/main/tools/regalloc/regalloc.exe _build \
+              -validate -param SPLIT_REMATERIALIZE:on -regalloc $allocator || exit 1; \
+          done
 
       - name: Collect and push metrics
         if: matrix.collect_metrics == true && github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -268,7 +268,8 @@ let count_duplicate_spills_reloads_in_block (block : Cfg.basic_block) =
 type spills_reloads_moves =
   { spills : int;
     reloads : int;
-    moves : int
+    moves : int;
+    loads : int
   }
 
 let count_spills_reloads_moves (block : Cfg.basic_block) =
@@ -277,15 +278,18 @@ let count_spills_reloads_moves (block : Cfg.basic_block) =
     | Op Spill -> { acc with spills = acc.spills + 1 }
     | Op Reload -> { acc with reloads = acc.reloads + 1 }
     | Op Move -> { acc with moves = acc.moves + 1 }
+    | Op (Load _) -> { acc with loads = acc.loads + 1 }
     | _ -> acc
   in
-  DLL.fold_left ~f ~init:{ spills = 0; reloads = 0; moves = 0 } block.body
+  DLL.fold_left ~f
+    ~init:{ spills = 0; reloads = 0; moves = 0; loads = 0 }
+    block.body
 
 (** Returns all CFG counters that work on a single block and are summative over
     the blocks. *)
 let cfg_block_counters (block : Cfg.basic_block) =
   let dup_spills, dup_reloads = count_duplicate_spills_reloads_in_block block in
-  let { spills; reloads; moves } = count_spills_reloads_moves block in
+  let { spills; reloads; moves; loads } = count_spills_reloads_moves block in
   let instructions = DLL.length block.body + 1 in
   Profile.Counters.create ()
   |> Profile.Counters.set "block_duplicate_spill" dup_spills
@@ -295,6 +299,7 @@ let cfg_block_counters (block : Cfg.basic_block) =
   |> Profile.Counters.set "instruction" instructions
   |> Profile.Counters.set "block" 1
   |> Profile.Counters.set "move" moves
+  |> Profile.Counters.set "load" loads
 
 (** Returns all CFG counters that require the whole CFG to produce a count. *)
 let whole_cfg_counters (cfg : Cfg.t) =

--- a/backend/printreg.ml
+++ b/backend/printreg.ml
@@ -79,6 +79,17 @@ let regset ppf s =
       else fprintf ppf "@ %a" reg r)
     s
 
+let regmap ppf s =
+  let first = ref true in
+  Map.iter
+    (fun r _ ->
+      if !first
+      then (
+        first := false;
+        fprintf ppf "%a" reg r)
+      else fprintf ppf "@ %a" reg r)
+    s
+
 let regsetaddr' ?(print_reg = reg) ppf s =
   let reg = print_reg in
   let first = ref true in

--- a/backend/printreg.mli
+++ b/backend/printreg.mli
@@ -37,6 +37,8 @@ val regs : Format.formatter -> Reg.t array -> unit
 
 val regset : Format.formatter -> Reg.Set.t -> unit
 
+val regmap : Format.formatter -> _ Reg.Map.t -> unit
+
 val reglist : Format.formatter -> Reg.t list -> unit
 
 val regsetaddr' :

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -346,9 +346,21 @@ let make_reload : type a. (a, definition_kind) make_operation =
     then
       log "remat %a -> %a (from %a)" Printreg.reg old_reg Printreg.regs res
         Printreg.regs arg;
-    Cfg.make_instruction_from_copy copy ~desc:source.desc
-      ~id:(InstructionId.get_and_incr instr_id)
-      ~arg ~res ()
+    let id = InstructionId.get_and_incr instr_id in
+    (* Record the pre-split (description-style) shape of this rematerialized
+       instruction with the validator, so that its equation transfer uses the
+       same abstract register stamps as the description-based equations in the
+       equation set. For single-result sources we record [old_reg] as the result
+       (which is the consumer being rematerialized — possibly different from
+       [source.res.(0)] when [try_rematerialize] followed a [Move] chain); for
+       multi-result sources, [reg] is directly in [source.res] (cf.
+       [RewriteAsRematerialize]) so we record [source.res] as-is. *)
+    let recorded_res =
+      if Array.length source.res = 1 then [| old_reg |] else source.res
+    in
+    Regalloc_validate.record_rematerialization ~id ~desc:source.desc
+      ~arg:source.arg ~res:recorded_res;
+    Cfg.make_instruction_from_copy copy ~desc:source.desc ~id ~arg ~res ()
 
 (* Inserts the reloads in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. Rematerialized loads are

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -390,13 +390,29 @@ let insert_reloads_in_block :
     | None -> dummy_instr_of_terminator block.terminator
     | Some hd -> hd
   in
-  (* A multi-result rematerialization source (today only multi-result loads;
-     constants and [Intop_imm] are single-result) that is rematerialized at this
-     block appears in [remats] once per result register, all sharing the same
-     source instruction [id]. We must emit only one copy per distinct source:
-     that single rematerialized instruction defines all of the result registers
-     (with their substituted names) in one go. Tracking the set of
-     already-emitted source ids makes the deduplication explicit. *)
+  (* Deduplication policy.
+
+     Multi-result rematerialization sources (today only multi-result immutable
+     loads; constants and [Intop_imm] are single-result) appear in [remats] once
+     per result register, all sharing the same source instruction [id]. We emit
+     a single copy per distinct multi-result source: that one instruction
+     defines all of its result registers (with their substituted names) in one
+     go, as set up by [make_reload]'s multi-result branch.
+
+     Single-result sources, however, MUST be emitted once per [old_reg], not
+     once per source [id]. When [try_rematerialize] follows a [Move] chain (e.g.
+     [a := Load ...; b := a; c := b]), several distinct description-stamps along
+     the chain can independently land in [definitions_at_beginning] at the same
+     block, each routed to its own fresh [new_reg] by
+     [compute_substitution_tree]. They all share the same source instruction
+     (the Load at the head of the chain), and a single-result [make_reload]
+     emits with [res = [|new_reg|]] for its [old_reg]. Deduplicating by
+     [source.id] would emit the source ONCE — defining only ONE of those fresh
+     [new_reg]s and leaving the others undefined, so any consumer reading the
+     un-emitted [new_reg] would read garbage. Emitting per [old_reg] gives each
+     renamed copy its own materializing instruction; downstream coalescing in
+     the register allocator can then often merge them back if they end up in the
+     same physical register. *)
   let already_emitted = ref Instruction.IdSet.empty in
   Reg.Map.iter
     (fun old_reg kind ->
@@ -406,9 +422,14 @@ let insert_reloads_in_block :
         (* [remats] only contains [Rematerialize] entries by construction. *)
         | Reload -> assert false
       in
-      if not (Instruction.IdSet.mem source.id !already_emitted)
+      let single_result = Array.length source.res = 1 in
+      let should_emit =
+        single_result || not (Instruction.IdSet.mem source.id !already_emitted)
+      in
+      if should_emit
       then (
-        already_emitted := Instruction.IdSet.add source.id !already_emitted;
+        if not single_result
+        then already_emitted := Instruction.IdSet.add source.id !already_emitted;
         let new_reg = Substitution.apply_reg block_subst old_reg in
         let remat =
           make_reload state ~instr_id ~stack_subst ~block_subst ~old_reg

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -15,17 +15,16 @@ let[@inline] remove_from_bindings :
     State.t ->
     Label.t ->
     field:(State.t -> 'a Label.Map.t) ->
-    extract:('a -> Reg.Set.t) ->
+    mem:(Reg.t -> 'a -> bool) ->
     Reg.t Reg.Map.t ->
     Reg.t Reg.Map.t =
- fun state label ~field ~extract bindings ->
+ fun state label ~field ~mem bindings ->
   match Label.Map.find_opt label (field state) with
   | None -> bindings
   | Some data ->
-    let regs = extract data in
     Reg.Map.filter
       (fun reg _ ->
-        let remove = Reg.Set.mem reg regs in
+        let remove = mem reg data in
         if debug then if remove then log "removing %a" Printreg.reg reg;
         not remove)
       bindings
@@ -51,7 +50,7 @@ let rec compute_substitution_tree :
   if debug then log "removing from phis";
   let bindings =
     remove_from_bindings state label ~field:State.phi_at_beginning
-      ~extract:Fun.id bindings
+      ~mem:Reg.Set.mem bindings
   in
   if debug then log "removing from definitions";
   (* note: it is possible to have two definitions in a row (i.e. without any
@@ -59,7 +58,7 @@ let rec compute_substitution_tree :
      destructions of constant values. *)
   let bindings =
     remove_from_bindings state label ~field:State.definitions_at_beginning
-      ~extract:Fun.id bindings
+      ~mem:Reg.Map.mem bindings
   in
   let subst = Reg.Tbl.create 17 in
   Label.Tbl.replace substs label subst;
@@ -83,8 +82,8 @@ let rec compute_substitution_tree :
     match Label.Map.find_opt label (State.definitions_at_beginning state) with
     | None -> bindings
     | Some renames ->
-      Reg.Set.fold
-        (fun old_reg bindings ->
+      Reg.Map.fold
+        (fun old_reg Reload bindings ->
           let slots = State.stack_slots state in
           let (_ : int) = Regalloc_stack_slots.get_or_create slots old_reg in
           let new_reg = Reg.create_with_typ_and_name old_reg in
@@ -103,7 +102,8 @@ let rec compute_substitution_tree :
     log "removing from destructions");
   let bindings =
     remove_from_bindings state label ~field:State.destructions_at_end
-      ~extract:snd bindings
+      ~mem:(fun reg (_destr_kind, regs) -> Reg.Set.mem reg regs)
+      bindings
   in
   (* Finally, propagate the bindings to the children. *)
   List.iter tree.children ~f:(fun child ->
@@ -132,21 +132,22 @@ let apply_substitutions : Cfg_with_infos.t -> Substitution.map -> unit =
  fun cfg_with_infos substs ->
   Substitution.apply_cfg_in_place substs (Cfg_with_infos.cfg cfg_with_infos)
 
-type 'a make_operation =
+type ('a, 'b) make_operation =
   State.t ->
   instr_id:InstructionId.sequence ->
   stack_subst:Substitution.t ->
   old_reg:Reg.t ->
   new_reg:Reg.t ->
   copy:'a Cfg.instruction ->
+  kind:'b ->
   Instruction.t
 
 (* Creates a spill instruction for the register named `old_reg` before
    substitution and `new_reg` after substitution, copying debug and FDO
    information from `copy`, and populating `stack_subst` with a mapping from
    `old_reg` to its stack slot. *)
-let make_spill : type a. a make_operation =
- fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ->
+let make_spill : type a. (a, unit) make_operation =
+ fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ~kind:() ->
   let stack_reg =
     match Reg.Tbl.find_opt stack_subst old_reg with
     | Some stack_reg -> stack_reg
@@ -176,11 +177,15 @@ let dummy_instr_of_terminator : Cfg.terminator Cfg.instruction -> Instruction.t
     stack_offset = terminator.stack_offset
   }
 
+let occur_check : Instruction.t -> Reg.t -> bool =
+ fun instr reg ->
+  occurs_array instr.arg reg || occurs_array instr.res reg
+  || occurs_array (Proc.destroyed_at_basic instr.desc) reg
+
 let rec insert_spills_or_reloads_in_block :
     State.t ->
     instr_id:InstructionId.sequence ->
-    make_spill_or_reload:'a make_operation ->
-    occur_check:(Instruction.t -> Reg.t -> bool) ->
+    make_spill_or_reload:('a, 'b) make_operation ->
     insert:(Instruction.t DLL.cell -> Instruction.t -> Reg.t -> unit) ->
     copy_default:Instruction.t ->
     add_default:(Instruction.t DLL.t -> Instruction.t -> Reg.t -> unit) ->
@@ -189,29 +194,29 @@ let rec insert_spills_or_reloads_in_block :
     stack_subst:Substitution.t ->
     Cfg.basic_block ->
     Instruction.t DLL.cell option ->
-    Reg.Set.t ->
+    (Reg.t * 'b) Seq.t ->
     unit =
- fun state ~instr_id ~make_spill_or_reload ~occur_check ~insert ~copy_default
-     ~add_default ~move_cell ~block_subst ~stack_subst block cell
+ fun state ~instr_id ~make_spill_or_reload ~insert ~copy_default ~add_default
+     ~move_cell ~block_subst ~stack_subst block cell
      live_at_interesting_point ->
-  match Reg.Set.is_empty live_at_interesting_point with
+  match Seq.is_empty live_at_interesting_point with
   | true -> ()
   | false -> (
     match cell with
     | None ->
-      Reg.Set.iter
-        (fun old_reg ->
+      Seq.iter
+        (fun (old_reg, kind) ->
           let new_reg = Substitution.apply_reg block_subst old_reg in
           let spill_or_reload =
             make_spill_or_reload state ~instr_id ~stack_subst ~old_reg ~new_reg
               ~copy:copy_default
           in
-          add_default block.body spill_or_reload new_reg)
+          add_default block.body (spill_or_reload ~kind) new_reg)
         live_at_interesting_point
     | Some cell ->
       let live_at_interesting_point =
-        Reg.Set.filter
-          (fun old_reg ->
+        Seq.filter
+          (fun (old_reg, kind) ->
             let new_reg = Substitution.apply_reg block_subst old_reg in
             let instr = DLL.value cell in
             if occur_check instr new_reg
@@ -220,20 +225,15 @@ let rec insert_spills_or_reloads_in_block :
                 make_spill_or_reload state ~instr_id ~stack_subst ~old_reg
                   ~new_reg ~copy:instr
               in
-              insert cell spill_or_reload new_reg;
+              insert cell (spill_or_reload ~kind) new_reg;
               false)
             else true)
           live_at_interesting_point
       in
       let cell = move_cell cell in
       insert_spills_or_reloads_in_block state ~instr_id ~make_spill_or_reload
-        ~occur_check ~insert ~copy_default ~add_default ~move_cell ~block_subst
-        ~stack_subst block cell live_at_interesting_point)
-
-let occur_check : Instruction.t -> Reg.t -> bool =
- fun instr reg ->
-  occurs_array instr.arg reg || occurs_array instr.res reg
-  || occurs_array (Proc.destroyed_at_basic instr.desc) reg
+        ~insert ~copy_default ~add_default ~move_cell ~block_subst ~stack_subst
+        block cell live_at_interesting_point)
 
 (* Inserts the spills in a block, as early as possible (i.e. immediately after
    the register is last set), to reduce live ranges. *)
@@ -249,7 +249,7 @@ let insert_spills_in_block :
  fun state ~instr_id ~block_subst ~stack_subst block cell
      live_at_destruction_point ->
   insert_spills_or_reloads_in_block state ~instr_id
-    ~make_spill_or_reload:make_spill ~occur_check
+    ~make_spill_or_reload:make_spill
     ~insert:(fun cell instr reg ->
       (* See comment before Insert_skipping_name_for_debugger *)
       Insert_skipping_name_for_debugger.insert_after cell instr ~reg)
@@ -261,7 +261,7 @@ let insert_spills_in_block :
       (* See comment before Insert_skipping_name_for_debugger *)
       Insert_skipping_name_for_debugger.add_begin list instr ~reg)
     ~move_cell:DLL.prev ~block_subst ~stack_subst block cell
-    live_at_destruction_point
+    (Seq.map (fun reg -> reg, ()) (Reg.Set.to_seq live_at_destruction_point))
 
 (* Inserts spills in all blocks. *)
 let insert_spills :
@@ -289,8 +289,8 @@ let insert_spills :
    substitution and `new_reg` after substitution, copying debug and FDO
    information from `copy`, and getting the stack slot from `stack_subst` if
    `old_reg` is mapped. *)
-let make_reload : type a. a make_operation =
- fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ->
+let make_reload : type a. (a, definition_kind) make_operation =
+ fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ~kind:Reload ->
   let stack_reg : Reg.t =
     match Reg.Tbl.find_opt stack_subst old_reg with
     | Some stack_reg -> stack_reg
@@ -318,12 +318,12 @@ let insert_reloads_in_block :
     stack_subst:Substitution.t ->
     Cfg.basic_block ->
     Instruction.t DLL.cell option ->
-    Reg.Set.t ->
+    definition_kind Reg.Map.t ->
     unit =
  fun state ~instr_id ~block_subst ~stack_subst block cell
      live_at_definition_point ->
   insert_spills_or_reloads_in_block state ~instr_id
-    ~make_spill_or_reload:make_reload ~occur_check
+    ~make_spill_or_reload:make_reload
     ~insert:(fun cell instr _reg ->
       (* We don't need special handling here, because we wouldn't expect a new
          Name_for_debugger operation anyway (that should have occurred when the
@@ -337,7 +337,7 @@ let insert_reloads_in_block :
       (* Same reasoning as for insert above *)
       DLL.add_end list instr)
     ~move_cell:DLL.next ~block_subst ~stack_subst block cell
-    live_at_definition_point
+    (Reg.Map.to_seq live_at_definition_point)
 
 (* Inserts reloads in all blocks. *)
 let insert_reloads :

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -319,22 +319,24 @@ let make_reload : type a. (a, definition_kind) make_operation =
     Move.make_instr Move.Load
       ~id:(InstructionId.get_and_incr instr_id)
       ~copy ~from:stack_reg ~to_:new_reg
-  | Rematerialize load ->
-    (* Use the post-substitution names of the load's arguments and results. For
-       a multi-result load, all of the result registers are defined by this
-       single rematerialized instruction; their substitution mappings were
-       established by [compute_substitution_tree] (since
+  | Rematerialize source ->
+    (* The rematerialization source can be a [Load], [Const], or [Intop_imm]
+       (cf. [Regalloc_split_utils.Uses.source]); its [desc] is preserved
+       verbatim. We use the post-substitution names of the source's arguments
+       and results. For a multi-result source, all of the result registers are
+       defined by this single rematerialized instruction; their substitution
+       mappings were established by [compute_substitution_tree] (since
        [RewriteAsRematerialize] only emits [Rematerialize] when all of the
-       load's result registers need to be redefined at this block). The
+       source's result registers need to be redefined at this block). The
        [old_reg]/[new_reg] pair is just one of those, used here for the log
        message. *)
-    let arg = Substitution.apply_array block_subst load.arg in
-    let res = Substitution.apply_array block_subst load.res in
+    let arg = Substitution.apply_array block_subst source.arg in
+    let res = Substitution.apply_array block_subst source.res in
     if debug
     then
       log "remat %a -> %a (from %a)" Printreg.reg old_reg Printreg.regs res
         Printreg.regs arg;
-    Cfg.make_instruction_from_copy copy ~desc:load.desc
+    Cfg.make_instruction_from_copy copy ~desc:source.desc
       ~id:(InstructionId.get_and_incr instr_id)
       ~arg ~res ()
 
@@ -366,24 +368,25 @@ let insert_reloads_in_block :
     | None -> dummy_instr_of_terminator block.terminator
     | Some hd -> hd
   in
-  (* A multi-result load that is rematerialized at this block appears in
-     [remats] once per result register, all sharing the same load instruction
-     [id]. We must emit only one copy per distinct source load: that single
-     rematerialized instruction defines all of the result registers (with their
-     substituted names) in one go. Tracking the set of already-emitted
-     source-load ids makes the deduplication explicit. *)
+  (* A multi-result rematerialization source (today only multi-result loads;
+     constants and [Intop_imm] are single-result) that is rematerialized at this
+     block appears in [remats] once per result register, all sharing the same
+     source instruction [id]. We must emit only one copy per distinct source:
+     that single rematerialized instruction defines all of the result registers
+     (with their substituted names) in one go. Tracking the set of
+     already-emitted source ids makes the deduplication explicit. *)
   let already_emitted = ref Instruction.IdSet.empty in
   Reg.Map.iter
     (fun old_reg kind ->
-      let load =
+      let source =
         match (kind : definition_kind) with
-        | Rematerialize load -> load
+        | Rematerialize source -> source
         (* [remats] only contains [Rematerialize] entries by construction. *)
         | Reload -> assert false
       in
-      if not (Instruction.IdSet.mem load.id !already_emitted)
+      if not (Instruction.IdSet.mem source.id !already_emitted)
       then (
-        already_emitted := Instruction.IdSet.add load.id !already_emitted;
+        already_emitted := Instruction.IdSet.add source.id !already_emitted;
         let new_reg = Substitution.apply_reg block_subst old_reg in
         let remat =
           make_reload state ~instr_id ~stack_subst ~block_subst ~old_reg

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -322,16 +322,26 @@ let make_reload : type a. (a, definition_kind) make_operation =
   | Rematerialize source ->
     (* The rematerialization source can be a [Load], [Const], or [Intop_imm]
        (cf. [Regalloc_split_utils.Uses.source]); its [desc] is preserved
-       verbatim. We use the post-substitution names of the source's arguments
-       and results. For a multi-result source, all of the result registers are
-       defined by this single rematerialized instruction; their substitution
-       mappings were established by [compute_substitution_tree] (since
-       [RewriteAsRematerialize] only emits [Rematerialize] when all of the
-       source's result registers need to be redefined at this block). The
-       [old_reg]/[new_reg] pair is just one of those, used here for the log
-       message. *)
+       verbatim. The result handling depends on arity:
+
+       - Single-result source: emit with [res = [|new_reg|]]. This directly
+       assigns the source's value to the consumer's renamed register and
+       transparently bypasses any [Move] chain that [try_rematerialize] followed
+       (sound because [Move] preserves bits, and the chain's intermediate moves
+       have matching machtypes by construction in [Uses.classify_source]).
+
+       - Multi-result source: emit with [res = apply_array block_subst
+       source.res]. All of the result registers are defined by this single
+       rematerialized instruction; their substitution mappings were established
+       by [compute_substitution_tree] (since [RewriteAsRematerialize] only emits
+       a multi-result [Rematerialize] when all of [source.res] need to be
+       redefined at this block, and [reg] is directly in [source.res]). *)
     let arg = Substitution.apply_array block_subst source.arg in
-    let res = Substitution.apply_array block_subst source.res in
+    let res =
+      if Array.length source.res = 1
+      then [| new_reg |]
+      else Substitution.apply_array block_subst source.res
+    in
     if debug
     then
       log "remat %a -> %a (from %a)" Printreg.reg old_reg Printreg.regs res

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -330,18 +330,42 @@ let make_reload : type a. (a, definition_kind) make_operation =
       ~arg ~res:[| new_reg |] ()
 
 (* Inserts the reloads in a block, as late as possible (i.e. immediately before
-   the register is first read), to reduce live ranges. *)
+   the register is first read), to reduce live ranges. Rematerialized loads are
+   pre-inserted at the head of the block; the regular first-use iteration then
+   runs for the [Reload] entries, and naturally places the reload of any
+   register used as an argument by a rematerialized load before its consumer.
+   This ordering relies on [RewriteAsRematerialize] forbidding
+   Rematerialize-on-Rematerialize within a single block, so the relative order
+   of pre-inserted rematerialized instructions does not matter. *)
 let insert_reloads_in_block :
     State.t ->
     instr_id:InstructionId.sequence ->
     block_subst:Substitution.t ->
     stack_subst:Substitution.t ->
     Cfg.basic_block ->
-    Instruction.t DLL.cell option ->
     definition_kind Reg.Map.t ->
     unit =
- fun state ~instr_id ~block_subst ~stack_subst block cell
-     live_at_definition_point ->
+ fun state ~instr_id ~block_subst ~stack_subst block live_at_definition_point ->
+  let remats, reloads =
+    Reg.Map.partition
+      (fun _reg (kind : definition_kind) ->
+        match kind with Rematerialize _ -> true | Reload -> false)
+      live_at_definition_point
+  in
+  let copy_for_remat =
+    match DLL.hd block.body with
+    | None -> dummy_instr_of_terminator block.terminator
+    | Some hd -> hd
+  in
+  Reg.Map.iter
+    (fun old_reg kind ->
+      let new_reg = Substitution.apply_reg block_subst old_reg in
+      let remat =
+        make_reload state ~instr_id ~stack_subst ~block_subst ~old_reg ~new_reg
+          ~copy:copy_for_remat ~kind
+      in
+      DLL.add_begin block.body remat)
+    remats;
   insert_spills_or_reloads_in_block state ~instr_id
     ~make_spill_or_reload:make_reload
     ~insert:(fun cell instr _reg ->
@@ -356,8 +380,8 @@ let insert_reloads_in_block :
     ~add_default:(fun list instr _reg ->
       (* Same reasoning as for insert above *)
       DLL.add_end list instr)
-    ~move_cell:DLL.next ~block_subst ~stack_subst block cell
-    (Reg.Map.to_seq live_at_definition_point)
+    ~move_cell:DLL.next ~block_subst ~stack_subst block (DLL.hd_cell block.body)
+    (Reg.Map.to_seq reloads)
 
 (* Inserts reloads in all blocks. *)
 let insert_reloads :
@@ -374,7 +398,7 @@ let insert_reloads :
       let instr_id = (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id in
       let block_subst = Substitution.for_label substs label in
       insert_reloads_in_block state ~instr_id ~block_subst ~stack_subst block
-        (DLL.hd_cell block.body) live_at_definition_point)
+        live_at_definition_point)
     (State.definitions_at_beginning state);
   if debug then dedent ()
 

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -320,14 +320,23 @@ let make_reload : type a. (a, definition_kind) make_operation =
       ~id:(InstructionId.get_and_incr instr_id)
       ~copy ~from:stack_reg ~to_:new_reg
   | Rematerialize load ->
+    (* Use the post-substitution names of the load's arguments and results. For
+       a multi-result load, all of the result registers are defined by this
+       single rematerialized instruction; their substitution mappings were
+       established by [compute_substitution_tree] (since
+       [RewriteAsRematerialize] only emits [Rematerialize] when all of the
+       load's result registers need to be redefined at this block). The
+       [old_reg]/[new_reg] pair is just one of those, used here for the log
+       message. *)
     let arg = Substitution.apply_array block_subst load.arg in
+    let res = Substitution.apply_array block_subst load.res in
     if debug
     then
-      log "remat %a -> %a (from %a)" Printreg.reg old_reg Printreg.reg new_reg
+      log "remat %a -> %a (from %a)" Printreg.reg old_reg Printreg.regs res
         Printreg.regs arg;
     Cfg.make_instruction_from_copy copy ~desc:load.desc
       ~id:(InstructionId.get_and_incr instr_id)
-      ~arg ~res:[| new_reg |] ()
+      ~arg ~res ()
 
 (* Inserts the reloads in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. Rematerialized loads are
@@ -357,14 +366,30 @@ let insert_reloads_in_block :
     | None -> dummy_instr_of_terminator block.terminator
     | Some hd -> hd
   in
+  (* A multi-result load that is rematerialized at this block appears in
+     [remats] once per result register, all sharing the same load instruction
+     [id]. We must emit only one copy per distinct source load: that single
+     rematerialized instruction defines all of the result registers (with their
+     substituted names) in one go. Tracking the set of already-emitted
+     source-load ids makes the deduplication explicit. *)
+  let already_emitted = ref Instruction.IdSet.empty in
   Reg.Map.iter
     (fun old_reg kind ->
-      let new_reg = Substitution.apply_reg block_subst old_reg in
-      let remat =
-        make_reload state ~instr_id ~stack_subst ~block_subst ~old_reg ~new_reg
-          ~copy:copy_for_remat ~kind
+      let load =
+        match (kind : definition_kind) with
+        | Rematerialize load -> load
+        (* [remats] only contains [Rematerialize] entries by construction. *)
+        | Reload -> assert false
       in
-      DLL.add_begin block.body remat)
+      if not (Instruction.IdSet.mem load.id !already_emitted)
+      then (
+        already_emitted := Instruction.IdSet.add load.id !already_emitted;
+        let new_reg = Substitution.apply_reg block_subst old_reg in
+        let remat =
+          make_reload state ~instr_id ~stack_subst ~block_subst ~old_reg
+            ~new_reg ~copy:copy_for_remat ~kind
+        in
+        DLL.add_begin block.body remat))
     remats;
   insert_spills_or_reloads_in_block state ~instr_id
     ~make_spill_or_reload:make_reload

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -83,12 +83,15 @@ let rec compute_substitution_tree :
     | None -> bindings
     | Some renames ->
       Reg.Map.fold
-        (fun old_reg Reload bindings ->
-          let slots = State.stack_slots state in
-          let (_ : int) = Regalloc_stack_slots.get_or_create slots old_reg in
+        (fun old_reg kind bindings ->
           let new_reg = Reg.create_with_typ_and_name old_reg in
-          Regalloc_stack_slots.use_same_slot_or_fatal slots new_reg
-            ~existing:old_reg;
+          (match kind with
+          | Reload ->
+            let slots = State.stack_slots state in
+            let (_ : int) = Regalloc_stack_slots.get_or_create slots old_reg in
+            Regalloc_stack_slots.use_same_slot_or_fatal slots new_reg
+              ~existing:old_reg
+          | Rematerialize _ -> ());
           if debug
           then log "renaming %a to %a" Printreg.reg old_reg Printreg.reg new_reg;
           Reg.Tbl.replace subst old_reg new_reg;
@@ -136,6 +139,7 @@ type ('a, 'b) make_operation =
   State.t ->
   instr_id:InstructionId.sequence ->
   stack_subst:Substitution.t ->
+  block_subst:Substitution.t ->
   old_reg:Reg.t ->
   new_reg:Reg.t ->
   copy:'a Cfg.instruction ->
@@ -147,7 +151,8 @@ type ('a, 'b) make_operation =
    information from `copy`, and populating `stack_subst` with a mapping from
    `old_reg` to its stack slot. *)
 let make_spill : type a. (a, unit) make_operation =
- fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ~kind:() ->
+ fun state ~instr_id ~stack_subst ~block_subst:_ ~old_reg ~new_reg ~copy
+     ~kind:() ->
   let stack_reg =
     match Reg.Tbl.find_opt stack_subst old_reg with
     | Some stack_reg -> stack_reg
@@ -208,8 +213,8 @@ let rec insert_spills_or_reloads_in_block :
         (fun (old_reg, kind) ->
           let new_reg = Substitution.apply_reg block_subst old_reg in
           let spill_or_reload =
-            make_spill_or_reload state ~instr_id ~stack_subst ~old_reg ~new_reg
-              ~copy:copy_default
+            make_spill_or_reload state ~instr_id ~stack_subst ~block_subst
+              ~old_reg ~new_reg ~copy:copy_default
           in
           add_default block.body (spill_or_reload ~kind) new_reg)
         live_at_interesting_point
@@ -222,8 +227,8 @@ let rec insert_spills_or_reloads_in_block :
             if occur_check instr new_reg
             then (
               let spill_or_reload =
-                make_spill_or_reload state ~instr_id ~stack_subst ~old_reg
-                  ~new_reg ~copy:instr
+                make_spill_or_reload state ~instr_id ~stack_subst ~block_subst
+                  ~old_reg ~new_reg ~copy:instr
               in
               insert cell (spill_or_reload ~kind) new_reg;
               false)
@@ -290,24 +295,39 @@ let insert_spills :
    information from `copy`, and getting the stack slot from `stack_subst` if
    `old_reg` is mapped. *)
 let make_reload : type a. (a, definition_kind) make_operation =
- fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ~kind:Reload ->
-  let stack_reg : Reg.t =
-    match Reg.Tbl.find_opt stack_subst old_reg with
-    | Some stack_reg -> stack_reg
-    | None ->
-      let slots = State.stack_slots state in
-      let slot = Regalloc_stack_slots.get_or_create slots old_reg in
-      let stack = Reg.create_with_typ_and_name ~prefix_if_var:"stack" old_reg in
-      Regalloc_stack_slots.use_same_slot_or_fatal slots stack ~existing:old_reg;
-      Regalloc_stack_slots.use_same_slot_or_fatal slots stack ~existing:new_reg;
-      Reg.set_loc stack Reg.(Stack (Local slot));
-      stack
-  in
-  if debug
-  then log "reload %a -> %a" Printreg.reg stack_reg Printreg.reg new_reg;
-  Move.make_instr Move.Load
-    ~id:(InstructionId.get_and_incr instr_id)
-    ~copy ~from:stack_reg ~to_:new_reg
+ fun state ~instr_id ~stack_subst ~block_subst ~old_reg ~new_reg ~copy ~kind ->
+  match kind with
+  | Reload ->
+    let stack_reg : Reg.t =
+      match Reg.Tbl.find_opt stack_subst old_reg with
+      | Some stack_reg -> stack_reg
+      | None ->
+        let slots = State.stack_slots state in
+        let slot = Regalloc_stack_slots.get_or_create slots old_reg in
+        let stack =
+          Reg.create_with_typ_and_name ~prefix_if_var:"stack" old_reg
+        in
+        Regalloc_stack_slots.use_same_slot_or_fatal slots stack
+          ~existing:old_reg;
+        Regalloc_stack_slots.use_same_slot_or_fatal slots stack
+          ~existing:new_reg;
+        Reg.set_loc stack Reg.(Stack (Local slot));
+        stack
+    in
+    if debug
+    then log "reload %a -> %a" Printreg.reg stack_reg Printreg.reg new_reg;
+    Move.make_instr Move.Load
+      ~id:(InstructionId.get_and_incr instr_id)
+      ~copy ~from:stack_reg ~to_:new_reg
+  | Rematerialize load ->
+    let arg = Substitution.apply_array block_subst load.arg in
+    if debug
+    then
+      log "remat %a -> %a (from %a)" Printreg.reg old_reg Printreg.reg new_reg
+        Printreg.regs arg;
+    Cfg.make_instruction_from_copy copy ~desc:load.desc
+      ~id:(InstructionId.get_and_incr instr_id)
+      ~arg ~res:[| new_reg |] ()
 
 (* Inserts the reloads in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. *)

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -494,24 +494,17 @@ module RemoveDominatedSpillsForConstants : sig
   val optimize :
     Cfg_with_infos.t ->
     destructions_at_end:destructions_at_end ->
+    uses:Uses.t ->
     destructions_at_end
 end = struct
-  type set =
-    | At_most_once
-    | Maybe_more_than_once
-
-  let string_of_set = function
-    | At_most_once -> "at most once"
-    | Maybe_more_than_once -> "maybe more than once"
-
   let rec remove_dominated_spills :
       Cfg_dominators.t ->
       Cfg_dominators.dominator_tree ->
-      num_sets:set Reg.Tbl.t ->
+      uses:Uses.t ->
       already_spilled:Label.t Reg.Map.t ->
       destructions_at_end:destructions_at_end ->
       destructions_at_end =
-   fun doms tree ~num_sets ~already_spilled ~destructions_at_end ->
+   fun doms tree ~uses ~already_spilled ~destructions_at_end ->
     if debug
     then (
       log "remove_dominated_spills %a" Label.format tree.label;
@@ -526,9 +519,9 @@ end = struct
                 (fun (reg : Reg.t) ->
                   if debug then log "register %a" Printreg.reg reg;
                   let keep =
-                    match Reg.Tbl.find_opt num_sets reg with
+                    match Reg.Tbl.find_opt uses reg with
                     | None | Some Maybe_more_than_once -> true
-                    | Some At_most_once -> (
+                    | Some (At_most_once _) -> (
                       match Reg.Map.find_opt reg !already_spilled with
                       | None ->
                         if debug
@@ -594,53 +587,29 @@ end = struct
       List.fold_left tree.children ~init:destructions_at_end
         ~f:(fun destructions_at_end (child : Cfg_dominators.dominator_tree) ->
           if debug then log "child %a" Label.format child.label;
-          remove_dominated_spills doms child ~num_sets
+          remove_dominated_spills doms child ~uses
             ~already_spilled:!already_spilled ~destructions_at_end)
     in
     if debug then dedent ();
     res
 
-  let optimize cfg_with_infos ~destructions_at_end =
+  let optimize cfg_with_infos ~destructions_at_end ~uses =
     if debug
     then (
       log "RemoveDominatedSpillsForConstants.optimize";
       indent ());
-    let loops = Cfg_with_infos.loop_infos cfg_with_infos in
-    let incr_set (tbl : set Reg.Tbl.t) (arr : Reg.t array) ~(in_loop : bool) :
-        unit =
-      Array.iter arr ~f:(fun (reg : Reg.t) ->
-          match Reg.Tbl.find_opt tbl reg with
-          | None ->
-            Reg.Tbl.replace tbl reg
-              (if in_loop then Maybe_more_than_once else At_most_once)
-          | Some At_most_once -> Reg.Tbl.replace tbl reg Maybe_more_than_once
-          | Some Maybe_more_than_once -> ())
-    in
-    let num_sets =
-      Cfg_with_infos.fold_blocks cfg_with_infos ~init:(Reg.Tbl.create 123)
-        ~f:(fun label block acc ->
-          let in_loop : bool = Cfg_loop_infos.is_in_loop loops label in
-          if debug then log "block %a in_loop? %B" Label.format label in_loop;
-          incr_set acc block.terminator.res ~in_loop;
-          DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
-              incr_set acc instr.res ~in_loop);
-          acc)
-    in
     if debug
     then (
-      log "num_sets:";
+      log "uses:";
       indent ();
-      Reg.Tbl.iter
-        (fun reg num_set ->
-          log "%a ~> %s" Printreg.reg reg (string_of_set num_set))
-        num_sets;
+      log "%a" Uses.format uses;
       dedent ());
     let doms = Cfg_with_infos.dominators cfg_with_infos in
     let forest = Cfg_dominators.dominator_forest doms in
     let res =
       List.fold_left forest ~init:destructions_at_end
         ~f:(fun destructions_at_end dominator_tree ->
-          remove_dominated_spills doms dominator_tree ~num_sets
+          remove_dominated_spills doms dominator_tree ~uses
             ~already_spilled:Reg.Map.empty ~destructions_at_end)
     in
     dedent ();
@@ -870,9 +839,10 @@ let make cfg_with_infos =
     RemoveReloadSpillInSameBlock.optimize cfg_with_infos ~destructions_at_end
       ~definitions_at_beginning
   in
+  let uses = Uses.compute cfg_with_infos in
   let destructions_at_end =
     RemoveDominatedSpillsForConstants.optimize cfg_with_infos
-      ~destructions_at_end
+      ~destructions_at_end ~uses
   in
   let definitions_at_beginning =
     remove_empty_sets definitions_at_beginning ~f:Fun.id

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -7,7 +7,9 @@ module DLL = Oxcaml_utils.Doubly_linked_list
 
 type destructions_at_end = (destruction_kind * Reg.Set.t) Label.Map.t
 
-type definitions_at_beginning = Reg.Set.t Label.Map.t
+type unqualified_definitions_at_beginning = Reg.Set.t Label.Map.t
+
+type definitions_at_beginning = definition_kind Reg.Map.t Label.Map.t
 
 type phi_at_beginning = Reg.Set.t Label.Map.t
 
@@ -36,9 +38,9 @@ let log_renaming_info : t -> unit =
   log "definitions:";
   indent ();
   Label.Map.iter
-    (fun label regset ->
-      log " - beginning of block %a (%a)" Label.format label Printreg.regset
-        regset)
+    (fun label regs ->
+      log " - beginning of block %a (reloads: %a)" Label.format label
+        Printreg.regmap regs)
     state.definitions_at_beginning;
   dedent ();
   log "phi:";
@@ -62,8 +64,8 @@ module ExtractSpillsAndReloadsFromLoops : sig
   val optimize :
     Cfg_with_infos.t ->
     destructions_at_end:destructions_at_end ->
-    definitions_at_beginning:definitions_at_beginning ->
-    destructions_at_end * definitions_at_beginning
+    definitions_at_beginning:unqualified_definitions_at_beginning ->
+    destructions_at_end * unqualified_definitions_at_beginning
 end = struct
   type loop_sets =
     { destroyed : Reg.Set.t;
@@ -135,7 +137,7 @@ end = struct
       (* Remove destructions for not-written and definitions for not-occurring
          registers from inside the loop. *)
       let (destructions_at_end, definitions_at_beginning) :
-          destructions_at_end * definitions_at_beginning =
+          destructions_at_end * unqualified_definitions_at_beginning =
         Label.Set.fold
           (fun label (destructions_at_end, definitions_at_beginning) ->
             let destructions_at_end =
@@ -187,7 +189,7 @@ end = struct
              loop Label.Set.empty)
           loop
       in
-      let definitions_at_beginning : definitions_at_beginning =
+      let definitions_at_beginning : unqualified_definitions_at_beginning =
         Label.Set.fold
           (fun label acc ->
             if debug then log "definitions now happen at %a" Label.print label;
@@ -233,8 +235,8 @@ module MoveSpillsAndReloads : sig
   val optimize :
     Cfg_with_infos.t ->
     destructions_at_end:destructions_at_end ->
-    definitions_at_beginning:definitions_at_beginning ->
-    destructions_at_end * definitions_at_beginning
+    definitions_at_beginning:unqualified_definitions_at_beginning ->
+    destructions_at_end * unqualified_definitions_at_beginning
 end = struct
   (** A definition at the begin of a block can be moved down if:
 
@@ -245,8 +247,8 @@ end = struct
       - the defined register has no occurrences in the block. *)
   let move_definitions_at_beginning_down :
       Cfg_with_infos.t ->
-      definitions_at_beginning:definitions_at_beginning ->
-      definitions_at_beginning * Label.t Stack.t =
+      definitions_at_beginning:unqualified_definitions_at_beginning ->
+      unqualified_definitions_at_beginning * Label.t Stack.t =
    fun cfg_with_infos ~definitions_at_beginning ->
     if debug
     then (
@@ -324,7 +326,7 @@ end = struct
   let move_destructions_at_end_up :
       Cfg_with_infos.t ->
       Label.t Stack.t ->
-      definitions_at_beginning:definitions_at_beginning ->
+      definitions_at_beginning:unqualified_definitions_at_beginning ->
       destructions_at_end:destructions_at_end ->
       destructions_at_end =
    fun cfg_with_infos stack ~definitions_at_beginning ~destructions_at_end ->
@@ -419,8 +421,8 @@ module RemoveReloadSpillInSameBlock : sig
   val optimize :
     Cfg_with_infos.t ->
     destructions_at_end:destructions_at_end ->
-    definitions_at_beginning:definitions_at_beginning ->
-    destructions_at_end * definitions_at_beginning
+    definitions_at_beginning:unqualified_definitions_at_beginning ->
+    destructions_at_end * unqualified_definitions_at_beginning
 end = struct
   let optimize cfg_with_infos ~destructions_at_end ~definitions_at_beginning =
     if debug
@@ -690,7 +692,7 @@ let compute_destructions : Cfg_with_infos.t -> destructions_at_end =
 let compute_definitions :
     Cfg_with_infos.t ->
     destructions_at_end:destructions_at_end ->
-    definitions_at_beginning =
+    unqualified_definitions_at_beginning =
  fun cfg_with_infos ~destructions_at_end ->
   let definitions_at_beginning = Label.Map.empty in
   let definitions_at_beginning =
@@ -820,7 +822,7 @@ let rec fix_point_phi : Cfg_with_infos.t -> phi_at_beginning -> phi_at_beginning
 let compute_phis :
     Cfg_with_infos.t ->
     destructions_at_end:destructions_at_end ->
-    definitions_at_beginning:definitions_at_beginning ->
+    definitions_at_beginning:unqualified_definitions_at_beginning ->
     phi_at_beginning =
  fun cfg_with_infos ~destructions_at_end ~definitions_at_beginning ->
   let phi_at_beginning = Label.Map.empty in
@@ -880,6 +882,14 @@ let make cfg_with_infos =
     compute_phis cfg_with_infos ~destructions_at_end ~definitions_at_beginning
   in
   let stack_slots = Regalloc_stack_slots.make () in
+  let definitions_at_beginning =
+    Label.Map.map
+      (fun regs ->
+        Reg.Set.fold
+          (fun reg acc -> Reg.Map.add reg Reload acc)
+          regs Reg.Map.empty)
+      definitions_at_beginning
+  in
   { destructions_at_end;
     definitions_at_beginning;
     phi_at_beginning;

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -651,18 +651,37 @@ end = struct
                    (fun reg acc ->
                      match try_rematerialize uses ~is_arg_ok reg with
                      | None -> acc
-                     | Some load ->
-                       (* Only rematerialize a (potentially multi-result) load
-                          when all of its result registers also need to be
-                          redefined at this block. Otherwise the rematerialized
-                          load would assign fresh registers to the unwanted
-                          result slots, growing the register count without
-                          buying anything. *)
-                       if
-                         Array.for_all load.res ~f:(fun (r : Reg.t) ->
-                             Reg.Set.mem r regs)
-                       then Reg.Map.add reg load acc
-                       else acc)
+                     | Some source ->
+                       let single_result = Array.length source.res = 1 in
+                       let ok =
+                         if single_result
+                         then
+                           (* Single-result source: always safe. Note that [reg]
+                              might not equal [source.res.(0)] when
+                              [try_rematerialize] followed a [Move] chain, but
+                              the rematerialized instruction is emitted with
+                              [res = [|new_reg|]] (cf. [make_reload]), so the
+                              load's original result register is never
+                              materialized at this site and therefore does not
+                              need to be in [regs]. *)
+                           true
+                         else
+                           (* Multi-result source: the rematerialized
+                              instruction will redefine *all* of its result
+                              registers (with [apply_array block_subst
+                              source.res]). To avoid wasting fresh registers on
+                              dead result slots we require every result to be in
+                              [regs]. We also forbid [Move]-chain entry ([reg]
+                              not directly in [source.res]) because in that case
+                              [reg]'s renamed register is not among the emitted
+                              result names, and we would have to additionally
+                              emit a move from one of the result names to
+                              [new_reg]. *)
+                           Array.exists source.res ~f:(Reg.same reg)
+                           && Array.for_all source.res ~f:(fun (r : Reg.t) ->
+                               Reg.Set.mem r regs)
+                       in
+                       if ok then Reg.Map.add reg source acc else acc)
                    regs Reg.Map.empty)
           in
           let changed = ref true in

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -616,6 +616,82 @@ end = struct
     res
 end
 
+(* Converts the unqualified `definitions_at_beginning` (a set of registers) to a
+   qualified one (a map from register to `definition_kind`), turning entries
+   into `Rematerialize` when possible and `Reload` otherwise. A register can be
+   rematerialized as a copy of an immutable load (cf. [try_rematerialize]). To
+   avoid having to topologically order the inserted rematerialized instructions,
+   we forbid Rematerialize-on-Rematerialize within a single block: a candidate
+   is demoted to `Reload` if any of its load arguments is itself a candidate at
+   the same block. *)
+module RewriteAsRematerialize : sig
+  val optimize :
+    Cfg_with_infos.t ->
+    uses:Uses.t ->
+    definitions_at_beginning:unqualified_definitions_at_beginning ->
+    definition_kind Reg.Map.t Label.Map.t
+end = struct
+  let optimize cfg_with_infos ~uses ~definitions_at_beginning =
+    if debug
+    then (
+      log "RewriteAsRematerialize.optimize";
+      indent ());
+    let enabled = Lazy.force split_rematerialize in
+    let result =
+      Label.Map.mapi
+        (fun (label : Label.t) (regs : Reg.Set.t) ->
+          let candidates =
+            ref
+              (if not enabled
+               then Reg.Map.empty
+               else
+                 let available = live_at_block_beginning cfg_with_infos label in
+                 Reg.Set.fold
+                   (fun reg acc ->
+                     match try_rematerialize uses ~available reg with
+                     | None -> acc
+                     | Some load -> Reg.Map.add reg load acc)
+                   regs Reg.Map.empty)
+          in
+          let changed = ref true in
+          while !changed do
+            changed := false;
+            candidates
+              := Reg.Map.filter
+                   (fun _reg (load : Instruction.t) ->
+                     let keep =
+                       Array.for_all load.arg ~f:(fun (arg : Reg.t) ->
+                           not (Reg.Map.mem arg !candidates))
+                     in
+                     if not keep then changed := true;
+                     keep)
+                   !candidates
+          done;
+          if debug
+          then (
+            log "block %a" Label.format label;
+            indent ();
+            Reg.Map.iter
+              (fun reg (load : Instruction.t) ->
+                log "remat %a from instruction %a" Printreg.reg reg
+                  InstructionId.format load.id)
+              !candidates;
+            dedent ());
+          Reg.Set.fold
+            (fun (reg : Reg.t) acc ->
+              let kind : definition_kind =
+                match Reg.Map.find_opt reg !candidates with
+                | Some load -> Rematerialize load
+                | None -> Reload
+              in
+              Reg.Map.add reg kind acc)
+            regs Reg.Map.empty)
+        definitions_at_beginning
+    in
+    if debug then dedent ();
+    result
+end
+
 let add_destruction_point_at_end :
     Cfg_with_infos.t ->
     Cfg.basic_block ->
@@ -853,12 +929,8 @@ let make cfg_with_infos =
   in
   let stack_slots = Regalloc_stack_slots.make () in
   let definitions_at_beginning =
-    Label.Map.map
-      (fun regs ->
-        Reg.Set.fold
-          (fun reg acc -> Reg.Map.add reg Reload acc)
-          regs Reg.Map.empty)
-      definitions_at_beginning
+    RewriteAsRematerialize.optimize cfg_with_infos ~uses
+      ~definitions_at_beginning
   in
   { destructions_at_end;
     definitions_at_beginning;

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -651,7 +651,18 @@ end = struct
                    (fun reg acc ->
                      match try_rematerialize uses ~is_arg_ok reg with
                      | None -> acc
-                     | Some load -> Reg.Map.add reg load acc)
+                     | Some load ->
+                       (* Only rematerialize a (potentially multi-result) load
+                          when all of its result registers also need to be
+                          redefined at this block. Otherwise the rematerialized
+                          load would assign fresh registers to the unwanted
+                          result slots, growing the register count without
+                          buying anything. *)
+                       if
+                         Array.for_all load.res ~f:(fun (r : Reg.t) ->
+                             Reg.Set.mem r regs)
+                       then Reg.Map.add reg load acc
+                       else acc)
                    regs Reg.Map.empty)
           in
           let changed = ref true in

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -646,9 +646,10 @@ end = struct
                then Reg.Map.empty
                else
                  let available = live_at_block_beginning cfg_with_infos label in
+                 let is_arg_ok = at_most_once_in uses available in
                  Reg.Set.fold
                    (fun reg acc ->
-                     match try_rematerialize uses ~available reg with
+                     match try_rematerialize uses ~is_arg_ok reg with
                      | None -> acc
                      | Some load -> Reg.Map.add reg load acc)
                    regs Reg.Map.empty)

--- a/backend/regalloc/regalloc_split_state.mli
+++ b/backend/regalloc/regalloc_split_state.mli
@@ -4,7 +4,7 @@ open Regalloc_split_utils
 
 type destructions_at_end = (destruction_kind * Reg.Set.t) Label.Map.t
 
-type definitions_at_beginning = Reg.Set.t Label.Map.t
+type definitions_at_beginning = definition_kind Reg.Map.t Label.Map.t
 
 type phi_at_beginning = Reg.Set.t Label.Map.t
 

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -196,20 +196,33 @@ module Uses = struct
      [Load]/[Const]/[Intop_imm] mirror [is_rematerializable_shape] (which is
      re-used by the validator). [Move] is classified separately because it is
      not itself a rematerialization source, but rather a step on the chain that
-     [try_rematerialize] follows back to the actual source. *)
+     [try_rematerialize] follows back to the actual source.
+
+     For rematerialization sources we duplicate the [arg] and [res] arrays of
+     the captured instruction. The split pass later mutates the original arrays
+     in-place (cf. [Regalloc_substitution.apply_array_in_place]) when it renames
+     registers across destruction points; without these copies, downstream
+     consumers (notably the validator-side recording in
+     [Regalloc_validate.record_rematerialization]) would observe
+     post-substitution names and disagree with the description-based equations,
+     which use the pre-split (description) names. *)
+  let snapshot_arrays (instr : Cfg.basic Cfg.instruction) : Instruction.t =
+    { instr with arg = Array.copy instr.arg; res = Array.copy instr.res }
+
   let classify_source (instr : Cfg.basic Cfg.instruction) : source =
     match[@ocaml.warning "-fragile-match"] instr.desc with
-    | Op (Load { mutability = Immutable; is_atomic = false; _ }) -> Load instr
+    | Op (Load { mutability = Immutable; is_atomic = false; _ }) ->
+      Load (snapshot_arrays instr)
     | Op
         ( Const_int _ | Const_float _ | Const_float32 _ | Const_symbol _
         | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ) ->
-      Const instr
+      Const (snapshot_arrays instr)
     | Op
         (Intop_imm
            ( ( Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
              | Ipopcnt | Iclz | Ictz ),
              _ )) ->
-      Intop_imm instr
+      Intop_imm (snapshot_arrays instr)
     | Op Move
       when Cmm.equal_machtype_component instr.arg.(0).typ instr.res.(0).typ ->
       Move instr.arg.(0)

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -126,9 +126,39 @@ type definition_kind =
   | Reload
   | Rematerialize of Instruction.t
 
+(* Centralized predicate: an instruction is a legitimate rematerialization
+   source iff it is pure, cheap, doesn't read mutable state, and doesn't destroy
+   hardware registers in ways that change the surrounding allocation. This
+   predicate is shared between [Uses.compute] (which classifies sources) and the
+   regalloc validator (which recognizes the rematerialized instruction in the
+   post-allocation CFG). *)
+let is_rematerializable_shape : Cfg.basic -> bool =
+ fun desc ->
+  match[@ocaml.warning "-fragile-match"] desc with
+  | Op (Load { mutability = Immutable; is_atomic = false; _ })
+  (* Multi-result loads are accepted: [RewriteAsRematerialize] only emits a copy
+     when *all* of the load's result registers need to be redefined at the same
+     site. *)
+  | Op
+      ( Const_int _ | Const_float _ | Const_float32 _ | Const_symbol _
+      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ )
+  (* CR-soon xclerc for xclerc: also handle [Stackoffset]. *)
+  | Op
+      (Intop_imm
+         ( ( Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
+           | Ipopcnt | Iclz | Ictz ),
+           _ )) ->
+    (* Excluded [Intop_imm] cases: - [Idiv]/[Imod]: trap on zero divisor and
+       destroy [%rax]/[%rdx]; - [Imulh _]: destroys [%rax]; - [Icomp _]:
+       destroys [%rax]. *)
+    true
+  | _ -> false
+
 module Uses = struct
   type source =
     | Load of Instruction.t
+    | Const of Instruction.t
+    | Intop_imm of Instruction.t
     | Move of Reg.t
     | Other
 
@@ -136,6 +166,9 @@ module Uses = struct
    fun fmt source ->
     match source with
     | Load instr -> Format.fprintf fmt "Load %a" Printreg.regs instr.arg
+    | Const _ -> Format.fprintf fmt "Const"
+    | Intop_imm instr ->
+      Format.fprintf fmt "Intop_imm %a" Printreg.regs instr.arg
     | Move arg -> Format.fprintf fmt "Move %a" Printreg.reg arg
     | Other -> Format.fprintf fmt "Other"
 
@@ -158,6 +191,29 @@ module Uses = struct
       (fun reg num_set ->
         Format.fprintf fmt "%a ~> %a" Printreg.reg reg format_set num_set)
       t
+
+  (* Classify [instr] as a rematerialization source. The accepted shapes for
+     [Load]/[Const]/[Intop_imm] mirror [is_rematerializable_shape] (which is
+     re-used by the validator). [Move] is classified separately because it is
+     not itself a rematerialization source, but rather a step on the chain that
+     [try_rematerialize] follows back to the actual source. *)
+  let classify_source (instr : Cfg.basic Cfg.instruction) : source =
+    match[@ocaml.warning "-fragile-match"] instr.desc with
+    | Op (Load { mutability = Immutable; is_atomic = false; _ }) -> Load instr
+    | Op
+        ( Const_int _ | Const_float _ | Const_float32 _ | Const_symbol _
+        | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ) ->
+      Const instr
+    | Op
+        (Intop_imm
+           ( ( Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
+             | Ipopcnt | Iclz | Ictz ),
+             _ )) ->
+      Intop_imm instr
+    | Op Move
+      when Cmm.equal_machtype_component instr.arg.(0).typ instr.res.(0).typ ->
+      Move instr.arg.(0)
+    | _ -> Other
 
   let compute : Cfg_with_infos.t -> t =
    fun cfg_with_infos ->
@@ -183,28 +239,7 @@ module Uses = struct
         let in_loop : bool = Cfg_loop_infos.is_in_loop loops label in
         incr_set acc block.terminator.res ~in_loop ~source:Other;
         DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
-            let source =
-              match[@ocaml.warning "-fragile-match"] instr.desc with
-              | Op
-                  (Load
-                     { memory_chunk = _;
-                       addressing_mode = _;
-                       mutability = Immutable;
-                       (* CR-soon xclerc for xclerc: check whether an atomic
-                          load could be rematerialized. *)
-                       is_atomic = false
-                     }) ->
-                (* Multi-result loads are accepted: the rematerialization
-                   analysis (cf. [RewriteAsRematerialize]) will only emit a copy
-                   when *all* of the load's result registers need to be
-                   redefined at the same site, so no result slot is wasted. *)
-                Load instr
-              | Op Move
-                when Cmm.equal_machtype_component instr.arg.(0).typ
-                       instr.res.(0).typ ->
-                Move instr.arg.(0)
-              | _ -> Other
-            in
+            let source = classify_source instr in
             incr_set acc instr.res ~in_loop ~source);
         acc)
 end
@@ -221,10 +256,14 @@ let try_rematerialize :
     Uses.t -> is_arg_ok:(Reg.t -> bool) -> Reg.t -> Instruction.t option =
  fun uses ~is_arg_ok reg ->
   (* Walk the at-most-once-set-by chain of [reg]: through any number of moves,
-     stopping at the load that ultimately produces the value. The chain is
-     guaranteed to be acyclic and finite because every visited register is
-     [At_most_once] (set exactly once, outside any loop), so no register can
-     appear twice as a target in the chain. *)
+     stopping at the rematerialization source ([Load], [Const], or [Intop_imm])
+     that ultimately produces the value. The chain is guaranteed to be acyclic
+     and finite because every visited register is [At_most_once] (set exactly
+     once, outside any loop), so no register can appear twice as a target in the
+     chain. *)
+  let accept (instr : Instruction.t) =
+    if Array.for_all instr.arg ~f:is_arg_ok then Some instr else None
+  in
   let rec chase reg =
     match Reg.Tbl.find_opt uses reg with
     | None
@@ -232,7 +271,9 @@ let try_rematerialize :
     | Some (Uses.At_most_once { source = Other }) ->
       None
     | Some (Uses.At_most_once { source = Move arg }) -> chase arg
-    | Some (Uses.At_most_once { source = Load load }) ->
-      if Array.for_all load.arg ~f:is_arg_ok then Some load else None
+    | Some (Uses.At_most_once { source = Load instr })
+    | Some (Uses.At_most_once { source = Const instr })
+    | Some (Uses.At_most_once { source = Intop_imm instr }) ->
+      accept instr
   in
   chase reg

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -13,16 +13,11 @@ let split_more_destruction_points : bool Lazy.t =
 let split_around_loops : bool Lazy.t =
   bool_of_param "SPLIT_AROUND_LOOPS" ~default:true
 
-(* CR-soon xclerc for xclerc: this flag is off by default until the regalloc
-   validator is taught about rematerialized immutable loads. Today
-   `Regalloc_validate.verify_basic` only accepts a newly-inserted basic
-   instruction if it is `Op Move` (phi moves) or one of `Op (Spill | Reload)`,
-   and the equation-transfer in `Regalloc_validate.basic` only handles those
-   shapes (via `rename_location`/`rename_register`). To enable rematerialization
-   in production both call sites need to recognize a copy of an immutable,
-   non-atomic, single-result load and thread the appropriate equations through,
-   so the validator can confirm that the rematerialized result holds the same
-   value as the original load's result. *)
+(* CR-soon xclerc for xclerc: this flag is off by default while we gain
+   confidence in the rematerialization analysis (heuristics, code-size impact,
+   benchmarks). The regalloc validator already accepts rematerialized immutable
+   loads (cf. [is_rematerialized_immutable_load_shape] in
+   `Regalloc_validate`). *)
 let split_rematerialize : bool Lazy.t =
   bool_of_param "SPLIT_REMATERIALIZE" ~default:false
 

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -13,6 +13,19 @@ let split_more_destruction_points : bool Lazy.t =
 let split_around_loops : bool Lazy.t =
   bool_of_param "SPLIT_AROUND_LOOPS" ~default:true
 
+(* CR-soon xclerc for xclerc: this flag is off by default until the regalloc
+   validator is taught about rematerialized immutable loads. Today
+   `Regalloc_validate.verify_basic` only accepts a newly-inserted basic
+   instruction if it is `Op Move` (phi moves) or one of `Op (Spill | Reload)`,
+   and the equation-transfer in `Regalloc_validate.basic` only handles those
+   shapes (via `rename_location`/`rename_register`). To enable rematerialization
+   in production both call sites need to recognize a copy of an immutable,
+   non-atomic, single-result load and thread the appropriate equations through,
+   so the validator can confirm that the rematerialized result holds the same
+   value as the original load's result. *)
+let split_rematerialize : bool Lazy.t =
+  bool_of_param "SPLIT_REMATERIALIZE" ~default:false
+
 let log_function = lazy (make_log_function ~label:"split")
 
 let indent () = (Lazy.force log_function).indent ()
@@ -199,3 +212,33 @@ module Uses = struct
             incr_set acc instr.res ~in_loop ~source);
         acc)
 end
+
+let all_at_most_once_in : Uses.t -> Reg.Set.t -> Reg.t array -> bool =
+ fun uses available regs ->
+  Array.for_all regs ~f:(fun (reg : Reg.t) ->
+      Reg.Set.mem reg available
+      &&
+      match Reg.Tbl.find_opt uses reg with
+      | None | Some Uses.Maybe_more_than_once -> false
+      | Some (Uses.At_most_once _) -> true)
+
+(* CR-soon xclerc for xclerc: this function would benefit from some refactoring
+   once the design has settled (e.g. share the move-chasing logic, generalize
+   the arg-availability check, lift the depth-1 cap on the move chain, etc.). *)
+let try_rematerialize :
+    Uses.t -> available:Reg.Set.t -> Reg.t -> Instruction.t option =
+ fun uses ~available reg ->
+  match Reg.Tbl.find_opt uses reg with
+  | None | Some Uses.Maybe_more_than_once -> None
+  | Some (Uses.At_most_once { source = Other }) -> None
+  | Some (Uses.At_most_once { source = Load load }) ->
+    if all_at_most_once_in uses available load.arg then Some load else None
+  | Some (Uses.At_most_once { source = Move arg }) -> (
+    match Reg.Tbl.find_opt uses arg with
+    | None
+    | Some Uses.Maybe_more_than_once
+    | Some (Uses.At_most_once { source = Other })
+    | Some (Uses.At_most_once { source = Move _ }) ->
+      None
+    | Some (Uses.At_most_once { source = Load load }) ->
+      if all_at_most_once_in uses available load.arg then Some load else None)

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -115,3 +115,85 @@ let destruction_point_at_end : Cfg.basic_block -> destruction_kind option =
     else Some Destruction_only_on_exceptional_path)
 
 type definition_kind = Reload
+
+module Uses = struct
+  type source =
+    | Load of Cfg.basic Cfg.instruction
+    | Move of Reg.t
+    | Other
+
+  let format_source : Format.formatter -> source -> unit =
+   fun fmt source ->
+    match source with
+    | Load instr -> Format.fprintf fmt "Load %a" Printreg.regs instr.arg
+    | Move arg -> Format.fprintf fmt "Move %a" Printreg.reg arg
+    | Other -> Format.fprintf fmt "Other"
+
+  type set =
+    | At_most_once of { source : source }
+    | Maybe_more_than_once
+
+  let format_set : Format.formatter -> set -> unit =
+   fun fmt set ->
+    match set with
+    | At_most_once { source } ->
+      Format.fprintf fmt "At_most_once %a" format_source source
+    | Maybe_more_than_once -> Format.fprintf fmt "Maybe_more_than_once"
+
+  type t = set Reg.Tbl.t
+
+  let format : Format.formatter -> t -> unit =
+   fun fmt t ->
+    Reg.Tbl.iter
+      (fun reg num_set ->
+        Format.fprintf fmt "%a ~> %a" Printreg.reg reg format_set num_set)
+      t
+
+  let compute : Cfg_with_infos.t -> t =
+   fun cfg_with_infos ->
+    let loops = Cfg_with_infos.loop_infos cfg_with_infos in
+    let incr_set (tbl : set Reg.Tbl.t) (regs : Reg.t array) ~(in_loop : bool)
+        ~(source : source) : unit =
+      Array.iter regs ~f:(fun (reg : Reg.t) ->
+          if Reg.is_unknown reg
+          then
+            begin match Reg.Tbl.find_opt tbl reg with
+            | None ->
+              Reg.Tbl.replace tbl reg
+                (if in_loop
+                 then Maybe_more_than_once
+                 else At_most_once { source })
+            | Some (At_most_once _) ->
+              Reg.Tbl.replace tbl reg Maybe_more_than_once
+            | Some Maybe_more_than_once -> ()
+            end)
+    in
+    Cfg_with_infos.fold_blocks cfg_with_infos ~init:(Reg.Tbl.create 123)
+      ~f:(fun label block acc ->
+        let in_loop : bool = Cfg_loop_infos.is_in_loop loops label in
+        incr_set acc block.terminator.res ~in_loop ~source:Other;
+        DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+            let source =
+              match[@ocaml.warning "-fragile-match"] instr.desc with
+              | Op
+                  (Load
+                     { memory_chunk = _;
+                       addressing_mode = _;
+                       mutability = Immutable;
+                       (* CR-soon xclerc for xclerc: check whether an aotmic
+                          load could be rematerialized. *)
+                       is_atomic = false
+                     })
+              (* CR-soon xclerc for xclerc: lift the condition on the length of
+                 `instr.res`. *)
+                when Array.length instr.res = 1 ->
+                Load instr
+              | Op Move
+                when Cmm.equal_machtype_component instr.arg.(0).typ
+                       instr.res.(0).typ ->
+                Move instr.arg.(0)
+              | _ -> Other
+            in
+            incr_set acc instr.res ~in_loop ~source);
+        acc)
+end

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -133,7 +133,7 @@ type definition_kind =
 
 module Uses = struct
   type source =
-    | Load of Cfg.basic Cfg.instruction
+    | Load of Instruction.t
     | Move of Reg.t
     | Other
 

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -208,32 +208,30 @@ module Uses = struct
         acc)
 end
 
-let all_at_most_once_in : Uses.t -> Reg.Set.t -> Reg.t array -> bool =
- fun uses available regs ->
-  Array.for_all regs ~f:(fun (reg : Reg.t) ->
-      Reg.Set.mem reg available
-      &&
-      match Reg.Tbl.find_opt uses reg with
-      | None | Some Uses.Maybe_more_than_once -> false
-      | Some (Uses.At_most_once _) -> true)
-
-(* CR-soon xclerc for xclerc: this function would benefit from some refactoring
-   once the design has settled (e.g. share the move-chasing logic, generalize
-   the arg-availability check, lift the depth-1 cap on the move chain, etc.). *)
-let try_rematerialize :
-    Uses.t -> available:Reg.Set.t -> Reg.t -> Instruction.t option =
- fun uses ~available reg ->
+let at_most_once_in : Uses.t -> Reg.Set.t -> Reg.t -> bool =
+ fun uses available reg ->
+  Reg.Set.mem reg available
+  &&
   match Reg.Tbl.find_opt uses reg with
-  | None | Some Uses.Maybe_more_than_once -> None
-  | Some (Uses.At_most_once { source = Other }) -> None
-  | Some (Uses.At_most_once { source = Load load }) ->
-    if all_at_most_once_in uses available load.arg then Some load else None
-  | Some (Uses.At_most_once { source = Move arg }) -> (
-    match Reg.Tbl.find_opt uses arg with
+  | None | Some Uses.Maybe_more_than_once -> false
+  | Some (Uses.At_most_once _) -> true
+
+let try_rematerialize :
+    Uses.t -> is_arg_ok:(Reg.t -> bool) -> Reg.t -> Instruction.t option =
+ fun uses ~is_arg_ok reg ->
+  (* Walk the at-most-once-set-by chain of [reg]: through any number of moves,
+     stopping at the load that ultimately produces the value. The chain is
+     guaranteed to be acyclic and finite because every visited register is
+     [At_most_once] (set exactly once, outside any loop), so no register can
+     appear twice as a target in the chain. *)
+  let rec chase reg =
+    match Reg.Tbl.find_opt uses reg with
     | None
     | Some Uses.Maybe_more_than_once
-    | Some (Uses.At_most_once { source = Other })
-    | Some (Uses.At_most_once { source = Move _ }) ->
+    | Some (Uses.At_most_once { source = Other }) ->
       None
+    | Some (Uses.At_most_once { source = Move arg }) -> chase arg
     | Some (Uses.At_most_once { source = Load load }) ->
-      if all_at_most_once_in uses available load.arg then Some load else None)
+      if Array.for_all load.arg ~f:is_arg_ok then Some load else None
+  in
+  chase reg

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -190,13 +190,14 @@ module Uses = struct
                      { memory_chunk = _;
                        addressing_mode = _;
                        mutability = Immutable;
-                       (* CR-soon xclerc for xclerc: check whether an aotmic
+                       (* CR-soon xclerc for xclerc: check whether an atomic
                           load could be rematerialized. *)
                        is_atomic = false
-                     })
-              (* CR-soon xclerc for xclerc: lift the condition on the length of
-                 `instr.res`. *)
-                when Array.length instr.res = 1 ->
+                     }) ->
+                (* Multi-result loads are accepted: the rematerialization
+                   analysis (cf. [RewriteAsRematerialize]) will only emit a copy
+                   when *all* of the load's result registers need to be
+                   redefined at the same site, so no result slot is wasted. *)
                 Load instr
               | Op Move
                 when Cmm.equal_machtype_component instr.arg.(0).typ

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -114,7 +114,9 @@ let destruction_point_at_end : Cfg.basic_block -> destruction_kind option =
     then Some Destruction_on_all_paths
     else Some Destruction_only_on_exceptional_path)
 
-type definition_kind = Reload
+type definition_kind =
+  | Reload
+  | Rematerialize of Instruction.t
 
 module Uses = struct
   type source =

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -113,3 +113,5 @@ let destruction_point_at_end : Cfg.basic_block -> destruction_kind option =
     if Label.Set.is_empty (Cfg.successor_labels block ~normal:true ~exn:false)
     then Some Destruction_on_all_paths
     else Some Destruction_only_on_exceptional_path)
+
+type definition_kind = Reload

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -34,7 +34,9 @@ val equal_destruction_kind : destruction_kind -> destruction_kind -> bool
 
 val destruction_point_at_end : Cfg.basic_block -> destruction_kind option
 
-type definition_kind = Reload
+type definition_kind =
+  | Reload
+  | Rematerialize of Regalloc_utils.Instruction.t
 
 module Uses : sig
   type source =

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -35,3 +35,24 @@ val equal_destruction_kind : destruction_kind -> destruction_kind -> bool
 val destruction_point_at_end : Cfg.basic_block -> destruction_kind option
 
 type definition_kind = Reload
+
+module Uses : sig
+  type source =
+    | Load of Cfg.basic Cfg.instruction
+    | Move of Reg.t
+    | Other
+
+  val format_source : Format.formatter -> source -> unit
+
+  type set =
+    | At_most_once of { source : source }
+    | Maybe_more_than_once
+
+  val format_set : Format.formatter -> set -> unit
+
+  type t = set Reg.Tbl.t
+
+  val format : Format.formatter -> t -> unit
+
+  val compute : Cfg_with_infos.t -> set Reg.Tbl.t
+end

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -40,9 +40,26 @@ type definition_kind =
   | Reload
   | Rematerialize of Regalloc_utils.Instruction.t
 
+(** [is_rematerializable_shape desc] is [true] iff a basic instruction with that
+    [desc] is a legitimate rematerialization source: it must be pure (no side
+    effects, no observable memory write or fence), cheap enough to be worth
+    duplicating, and must not destroy hardware registers in ways that change the
+    surrounding allocation. The set of accepted shapes is shared between the
+    analysis (cf. {!Uses.compute}) that classifies rematerialization sources and
+    the validator (cf. [Regalloc_validate]) that recognizes the rematerialized
+    instructions in the post-allocation CFG. *)
+val is_rematerializable_shape : Cfg.basic -> bool
+
 module Uses : sig
   type source =
-    | Load of Regalloc_utils.Instruction.t
+    | Load of Regalloc_utils.Instruction.t  (** Immutable, non-atomic load. *)
+    | Const of Regalloc_utils.Instruction.t
+        (** Integer / float / vector / symbol constant. Always rematerializable
+            (zero arguments). *)
+    | Intop_imm of Regalloc_utils.Instruction.t
+        (** Integer-with-immediate operation, restricted to the safe subset (see
+            [is_rematerializable_shape]). One register argument plus an
+            immediate. *)
     | Move of Reg.t
     | Other
 
@@ -65,11 +82,13 @@ end
     and is a member of [available]. *)
 val at_most_once_in : Uses.t -> Reg.Set.t -> Reg.t -> bool
 
-(** [try_rematerialize uses ~is_arg_ok reg] returns [Some ld] if [reg] can be
-    rematerialized as a copy of the immutable load [ld]. The chain
-    [reg <- move ... <- move <- load] is followed of arbitrary length; every
-    register on the chain must be set at most once. The load is accepted iff
-    [is_arg_ok] holds for every one of its arguments. *)
+(** [try_rematerialize uses ~is_arg_ok reg] returns [Some instr] if [reg] can be
+    rematerialized as a copy of the rematerializable instruction [instr]. The
+    chain [reg <- move <- ... <- move <- source] is followed of arbitrary
+    length; every register on the chain must be set at most once. [source] is a
+    [Load], [Const], or [Intop_imm] (cf. {!Uses.source}). The source is accepted
+    iff [is_arg_ok] holds for every one of its register arguments (which is
+    vacuously true for zero-arg constants). *)
 val try_rematerialize :
   Uses.t ->
   is_arg_ok:(Reg.t -> bool) ->

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -61,11 +61,17 @@ module Uses : sig
   val compute : Cfg_with_infos.t -> set Reg.Tbl.t
 end
 
-(** [try_rematerialize uses ~available reg] returns [Some ld] if [reg] can be
-    rematerialized as a copy of the immutable load [ld]: [reg] must be set at
-    most once, that single set must be the load (possibly via a move chain of
-    length one), and all of the load's arguments must themselves be set at most
-    once and be members of [available]. The [available] set is the set of
-    registers expected to hold a usable value at the rematerialization point. *)
+(** [at_most_once_in uses available reg] is [true] iff [reg] is set at most once
+    and is a member of [available]. *)
+val at_most_once_in : Uses.t -> Reg.Set.t -> Reg.t -> bool
+
+(** [try_rematerialize uses ~is_arg_ok reg] returns [Some ld] if [reg] can be
+    rematerialized as a copy of the immutable load [ld]. The chain
+    [reg <- move ... <- move <- load] is followed of arbitrary length; every
+    register on the chain must be set at most once. The load is accepted iff
+    [is_arg_ok] holds for every one of its arguments. *)
 val try_rematerialize :
-  Uses.t -> available:Reg.Set.t -> Reg.t -> Regalloc_utils.Instruction.t option
+  Uses.t ->
+  is_arg_ok:(Reg.t -> bool) ->
+  Reg.t ->
+  Regalloc_utils.Instruction.t option

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -42,7 +42,7 @@ type definition_kind =
 
 module Uses : sig
   type source =
-    | Load of Cfg.basic Cfg.instruction
+    | Load of Regalloc_utils.Instruction.t
     | Move of Reg.t
     | Other
 

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -33,3 +33,5 @@ type destruction_kind =
 val equal_destruction_kind : destruction_kind -> destruction_kind -> bool
 
 val destruction_point_at_end : Cfg.basic_block -> destruction_kind option
+
+type definition_kind = Reload

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -6,6 +6,8 @@ val split_more_destruction_points : bool Lazy.t
 
 val split_around_loops : bool Lazy.t
 
+val split_rematerialize : bool Lazy.t
+
 val indent : unit -> unit
 
 val dedent : unit -> unit
@@ -58,3 +60,12 @@ module Uses : sig
 
   val compute : Cfg_with_infos.t -> set Reg.Tbl.t
 end
+
+(** [try_rematerialize uses ~available reg] returns [Some ld] if [reg] can be
+    rematerialized as a copy of the immutable load [ld]: [reg] must be set at
+    most once, that single set must be the load (possibly via a move chain of
+    length one), and all of the load's arguments must themselves be set at most
+    once and be members of [available]. The [available] set is the set of
+    registers expected to hold a usable value at the rematerialization point. *)
+val try_rematerialize :
+  Uses.t -> available:Reg.Set.t -> Reg.t -> Regalloc_utils.Instruction.t option

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -121,6 +121,8 @@ module Interval : sig
       mutable end_ : Point.t (* inclusive *)
     }
 
+  val is_dummy : t -> bool
+
   val overlap : t -> t -> bool
 
   val print : Format.formatter -> t -> unit
@@ -129,6 +131,8 @@ end = struct
     { mutable start : Point.t;
       mutable end_ : Point.t
     }
+
+  let is_dummy t = t.start == Point.dummy
 
   let overlap left right =
     Point.compare left.start right.end_ <= 0
@@ -246,16 +250,25 @@ with type slots := t = struct
     in
     Stack_class.Tbl.iter intervals ~f:(fun stack_class intervals ->
         Array.iteri intervals ~f:(fun slot_index interval ->
-            let buckets = Stack_class.Tbl.find buckets stack_class in
-            let bucket_index = ref 0 in
-            while
-              !bucket_index < Array.length buckets
-              && does_not_fit buckets.(!bucket_index) interval
-            do
-              incr bucket_index
-            done;
-            assert (!bucket_index < Array.length buckets);
-            Int.Tbl.replace buckets.(!bucket_index) slot_index interval));
+            (* Skip slots whose interval is still dummy: no CFG instruction
+               references them (typically the slot of a spill that
+               [Cfg_deadcode] removed once rematerialization replaced every
+               reload that would have read it). Bucketing them would inflate
+               [max_bucket_indices] in [optimize] and leave [num_stack_slots]
+               higher than the count of slots actually used. Orphan [Reg.t]s
+               pointing at such slots are skipped by [optimize]'s remap loop. *)
+            if not (Interval.is_dummy interval)
+            then (
+              let buckets = Stack_class.Tbl.find buckets stack_class in
+              let bucket_index = ref 0 in
+              while
+                !bucket_index < Array.length buckets
+                && does_not_fit buckets.(!bucket_index) interval
+              do
+                incr bucket_index
+              done;
+              assert (!bucket_index < Array.length buckets);
+              Int.Tbl.replace buckets.(!bucket_index) slot_index interval)));
     buckets
 
   let contains_empty t =
@@ -327,8 +340,14 @@ let optimize (t : t) (cfg_with_infos : Cfg_with_infos.t) : unit =
               let stack_class = Stack_class.of_machtype reg.typ in
               match Buckets.find_bucket buckets ~stack_class ~slot_index with
               | None ->
-                fatal "slot %d (stack_class=%a) is not in any of the buckets"
-                  slot_index Stack_class.print stack_class
+                (* The slot's interval was [Point.dummy] in
+                   [Intervals.build_from_cfg] and was therefore skipped by
+                   [Buckets.build_from_intervals]: no CFG instruction references
+                   this slot. The [Reg.t] is an orphan from a now-deleted spill
+                   (cf. [Cfg_deadcode] eliminating spills made dead by
+                   rematerialization on every reload path); its dangling [Stack
+                   (Local _)] location is harmless because nothing reads it. *)
+                ()
               | Some bucket_index ->
                 if debug
                 then

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -327,6 +327,25 @@ end
 let is_rematerialized_shape (instr : basic Cfg.instruction) =
   Regalloc_split_utils.is_rematerializable_shape instr.desc
 
+(* Side-table populated by [Regalloc_split] for each rematerialized basic
+   instruction it emits. The validator's equation transfer uses the pre-split
+   (description-style) abstract registers stored here so its [reg_instr] matches
+   the abstract registers used by the description-based equations in the
+   equation set; without this, the transfer would use the fresh post-split
+   stamps from the post-allocation CFG and the "0-or-2 sides" invariant of
+   [remove_result] would trip on equations keyed by the description's stamps. *)
+let rematerializations : (InstructionId.t, basic Instruction.t) Hashtbl.t =
+  Hashtbl.create 64
+
+let clear_rematerializations () = Hashtbl.clear rematerializations
+
+let record_rematerialization ~id ~desc ~arg ~res =
+  Hashtbl.replace rematerializations id
+    { Instruction.desc;
+      arg = Array.map Register.create arg;
+      res = Array.map Register.create res
+    }
+
 module Description : sig
   (** A snapshot of the [desc], [arg] and [res] fields of all instructions in
       the CFG and [fun_args] of the CFG. It is used by the validator to record
@@ -481,6 +500,9 @@ end = struct
     t
 
   let create cfg =
+    (* Discard any rematerialization records left from a previous function;
+       split will repopulate the table for this one. *)
+    clear_rematerializations ();
     match !Oxcaml_flags.regalloc_validate with
     | false -> None
     | true -> Some (do_create cfg)
@@ -1238,23 +1260,26 @@ module Transfer (Desc_val : Description_value) :
            constant, safe [Intop_imm], ...). Unlike [Op (Spill | Reload | Move)]
            (which transport an existing value between locations and are handled
            by [rename_location]), this instruction recomputes a fresh value
-           (memory read, constant materialization, or pure arithmetic). However,
-           its [arg]/[res] arrays still carry the abstract registers that were
-           assigned during split (only the [loc] field gets overwritten by the
-           allocator), so we can synthesize a [reg_instr] directly from the
-           post-allocation instruction and reuse the generic equation transfer.
-           The result registers are fresh — created by
-           [compute_substitution_tree] for this rematerialization — so they do
-           not collide with any abstract register from the pre-allocation
-           description, and the equations stay self-consistent for all
-           downstream uses, which refer to the same fresh registers. The
-           instruction's [desc] is preserved verbatim, so [destroyed_at_basic]
-           returns the same destroyed locations as for the original. *)
-        let reg_instr : basic Instruction.t =
-          { Instruction.desc = instr.desc;
-            arg = Array.map Register.create instr.arg;
-            res = Array.map Register.create instr.res
-          }
+           (memory read, constant materialization, or pure arithmetic). The
+           split pass calls [record_rematerialization] to register the pre-split
+           (description-style) [reg_instr] for this instruction; we look it up
+           here so the equation transfer uses the same abstract register stamps
+           as the description-based equations already in the equation set.
+           Synthesizing [reg_instr] from the post-allocation instruction's
+           [Reg.t] values directly would use the *fresh* post-split stamps from
+           [compute_substitution_tree], not the description's stamps, and
+           [remove_result]'s "0-or-2 sides" invariant would trip on equations
+           keyed by the description's stamps. The instruction's [desc] is
+           preserved verbatim by split, so [destroyed_at_basic] returns the same
+           destroyed locations as for the original. *)
+        let reg_instr =
+          match Hashtbl.find_opt rematerializations instr.id with
+          | Some reg_instr -> reg_instr
+          | None ->
+            Regalloc_utils.fatal
+              "Rematerialized instruction no. %a was not registered with \
+               [Regalloc_validate.record_rematerialization]"
+              InstructionId.format instr.id
         in
         append_equations t ~instr_kind:Instruction.Kind.Basic ~exn:None
           ~reg_instr ~loc_instr:instr

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -544,6 +544,21 @@ end = struct
            (InstructionId.to_string id))
       ~reg_arr:old_instr.res ~loc_arr:instr.res
 
+  (* Follow the description's successor chain starting at [old_successor_id],
+     skipping ids whose corresponding description-instruction was validly
+     deleted by [Cfg_deadcode] (i.e. not present in [seen_ids] and with a pure
+     [desc]). The returned id is the first one that is either still present in
+     the post-allocation CFG, or that is not in the description at all (e.g. the
+     block's terminator). *)
+  let rec effective_successor_id ~seen_ids t old_successor_id =
+    if Hashtbl.mem seen_ids old_successor_id
+    then old_successor_id
+    else
+      match Hashtbl.find_opt t.instructions old_successor_id with
+      | Some info when Cfg.is_pure_basic info.instr.Instruction.desc ->
+        effective_successor_id ~seen_ids t info.successor_id
+      | _ -> old_successor_id
+
   let verify_basic ~seen_ids ~successor_id t instr =
     let id = instr.id in
     add_instr_id ~seen_ids
@@ -553,14 +568,17 @@ end = struct
     with
     (* The instruction was present before. *)
     | Some { instr = old_instr; successor_id = old_successor_id }, false ->
-      if not (InstructionId.equal old_successor_id successor_id)
+      let effective_old_successor_id =
+        effective_successor_id ~seen_ids t old_successor_id
+      in
+      if not (InstructionId.equal effective_old_successor_id successor_id)
       then
         Regalloc_utils.fatal
           "The instruction's no. %a successor id has changed. Before \
            allocation: %a. After allocation (ignoring instructions added by \
            allocation): %a."
-          InstructionId.format id InstructionId.format old_successor_id
-          InstructionId.format successor_id;
+          InstructionId.format id InstructionId.format
+          effective_old_successor_id InstructionId.format successor_id;
       (match instr.desc, old_instr.desc with
       | Op (Name_for_debugger _), Op (Name_for_debugger _) ->
         (* IRC uses `Reg.interf` to represent the adjacency lists for the
@@ -781,12 +799,25 @@ end = struct
         ignore (first_instruction_id : InstructionId.t))
       (Cfg_with_layout.cfg cfg).Cfg.blocks;
     Hashtbl.iter
-      (fun id _ ->
+      (fun id (info : basic_info) ->
         if not (Hashtbl.mem seen_ids id)
         then
-          Regalloc_utils.fatal
-            "Instruction no. %a was deleted by register allocator"
-            InstructionId.format id)
+          (* [Cfg_deadcode] runs at the end of the split pass and removes any
+             pure basic instruction whose result becomes dead (e.g. because a
+             rematerialization rerouted all of its uses, possibly cascading to
+             upstream pure instructions whose results were only consumed by the
+             deleted ones). We mirror its rule here: deletion is accepted iff
+             the description's [desc] is [Cfg.is_pure_basic], matching the
+             predicate [Cfg_deadcode] itself uses (cf.
+             [Cfg_deadcode.remove_deadcode]). The equation system stays
+             consistent because no surviving instruction in the post-allocation
+             CFG references the deleted instruction's result registers, so no
+             equation involving them is ever added or expected to be removed. *)
+          if not (Cfg.is_pure_basic info.instr.Instruction.desc)
+          then
+            Regalloc_utils.fatal
+              "Instruction no. %a was deleted by register allocator"
+              InstructionId.format id)
       t.instructions;
     Hashtbl.iter
       (fun id _ ->

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -857,6 +857,25 @@ module Equation_set : sig
     t ->
     (t, string) Result.t
 
+  (** Like {!remove_result}, but tolerating that the same description-stamp can
+      be live at multiple locations simultaneously. Only the "two distinct
+      registers at the same location" half of the compatibility check is
+      enforced; the symmetric "same register at two locations" half is skipped.
+      Used for the result equation of rematerialized basic instructions added by
+      the split pass: the rematerialization creates a fresh physical copy of the
+      value at the result location, but other physical copies of the same value
+      (typically the pre-destruction spill slot used by a sibling
+      post-destruction path that reloads instead of rematerializing) can
+      legitimately co-exist in the equation set. Those residual equations
+      propagate back to the original definition site through the existing
+      spill/move chain, where the strict {!remove_result} catches any real
+      inconsistency. *)
+  val remove_result_lenient :
+    reg_res:Register.t array ->
+    loc_res:Location.t array ->
+    t ->
+    (t, string) Result.t
+
   val verify_destroyed_locations :
     destroyed:Location.t array -> t -> (t, string) Result.t
 
@@ -1018,6 +1037,40 @@ end = struct
   let remove_result ~reg_res ~loc_res t =
     try
       Array.iter2 (fun reg loc -> compatible_one ~reg ~loc t) reg_res loc_res;
+      let t =
+        array_fold2 (fun t reg loc -> remove (reg, loc) t) t reg_res loc_res
+      in
+      Ok t
+    with Verification_failed message -> Error message
+
+  let compatible_one_lenient ~reg ~loc t =
+    (* Only enforce the "two distinct registers at the same location" half of
+       the compatibility check; intentionally skip the symmetric "same register
+       at two locations" half (cf. [compatible_one]). See the
+       [remove_result_lenient] interface comment for the soundness argument. *)
+    match Location.Map.find_opt loc t.for_loc with
+    | None -> ()
+    | Some regs ->
+      Register.Set.iter
+        (fun eq_reg ->
+          if not (Register.equal eq_reg reg)
+          then (
+            Format.fprintf Format.str_formatter
+              "Unsatisfiable equations when removing a rematerialized result \
+               equation.\n\
+               Two distinct registers cannot be live at the same location.\n\
+               Existing equation %a.\n\
+               Removed equation: %a."
+              Equation.print (eq_reg, loc) Equation.print (reg, loc);
+            let message = Format.flush_str_formatter () in
+            raise (Verification_failed message)))
+        regs
+
+  let remove_result_lenient ~reg_res ~loc_res t =
+    try
+      Array.iter2
+        (fun reg loc -> compatible_one_lenient ~reg ~loc t)
+        reg_res loc_res;
       let t =
         array_fold2 (fun t reg loc -> remove (reg, loc) t) t reg_res loc_res
       in
@@ -1224,10 +1277,18 @@ module Transfer (Desc_val : Description_value) :
       all other cases not handled by [rename_location] or [rename_register]. We
       have an additional parameter which is the equations for the exceptional
       path successor which is not present in the paper [1] because exceptions
-      are not considered there. *)
-  let append_equations (type a) equations ~(instr_kind : a Instruction.Kind.t)
-      ~exn ~(reg_instr : a Instruction.t) ~(loc_instr : a instruction)
-      ~destroyed =
+      are not considered there.
+
+      [remove_result_kind] selects whether the result equations are removed
+      using the strict {!Equation_set.remove_result} or the lenient
+      {!Equation_set.remove_result_lenient}; the lenient variant is used for
+      rematerialized basic instructions (cf. [is_rematerialized_shape] in
+      [basic] below), which can legitimately leave behind other equations for
+      the same description-stamp at different locations. *)
+  let append_equations (type a) equations
+      ~(remove_result_kind : [`Strict | `Lenient])
+      ~(instr_kind : a Instruction.Kind.t) ~exn ~(reg_instr : a Instruction.t)
+      ~(loc_instr : a instruction) ~destroyed =
     let bind f res = Result.bind res f in
     let wrap_error res =
       Result.map_error
@@ -1235,6 +1296,11 @@ module Transfer (Desc_val : Description_value) :
           Transfer_error.create equations ~instr_kind ~exn ~reg_instr ~loc_instr
             message)
         res
+    in
+    let remove_result =
+      match remove_result_kind with
+      | `Strict -> Equation_set.remove_result
+      | `Lenient -> Equation_set.remove_result_lenient
     in
     let exn =
       exn
@@ -1262,7 +1328,7 @@ module Transfer (Desc_val : Description_value) :
     equations
     |>
     (* First remove the result equations. *)
-    Equation_set.remove_result ~reg_res:reg_instr.Instruction.res
+    remove_result ~reg_res:reg_instr.Instruction.res
       ~loc_res:(Location.of_regs_exn loc_instr.res)
     |> wrap_error
     |> bind (fun equations ->
@@ -1312,8 +1378,12 @@ module Transfer (Desc_val : Description_value) :
                [Regalloc_validate.record_rematerialization]"
               InstructionId.format instr.id
         in
-        append_equations t ~instr_kind:Instruction.Kind.Basic ~exn:None
-          ~reg_instr ~loc_instr:instr
+        (* See [remove_result_lenient]: the rematerialized result equation is
+           removed leniently because the same description-stamp can persist at
+           another location (the spill slot used by a sibling path). *)
+        append_equations t ~remove_result_kind:`Lenient
+          ~instr_kind:Instruction.Kind.Basic ~exn:None ~reg_instr
+          ~loc_instr:instr
           ~destroyed:(Proc.destroyed_at_basic instr.desc |> Location.of_regs_exn)
       | _ -> assert false)
     | Some instr_before -> (
@@ -1326,8 +1396,9 @@ module Transfer (Desc_val : Description_value) :
            have the same locations. *)
         Result.ok @@ rename_register t ~reg_instr:instr_before
       | _ ->
-        append_equations t ~instr_kind:Instruction.Kind.Basic ~exn:None
-          ~reg_instr:instr_before ~loc_instr:instr
+        append_equations t ~remove_result_kind:`Strict
+          ~instr_kind:Instruction.Kind.Basic ~exn:None ~reg_instr:instr_before
+          ~loc_instr:instr
           ~destroyed:(Proc.destroyed_at_basic instr.desc |> Location.of_regs_exn)
       )
 
@@ -1340,8 +1411,9 @@ module Transfer (Desc_val : Description_value) :
       let exn =
         if Cfg.can_raise_terminator instr.desc then Some exn else None
       in
-      append_equations t ~instr_kind:Instruction.Kind.Terminator ~exn
-        ~reg_instr:instr_before ~loc_instr:instr
+      append_equations t ~remove_result_kind:`Strict
+        ~instr_kind:Instruction.Kind.Terminator ~exn ~reg_instr:instr_before
+        ~loc_instr:instr
         ~destroyed:
           (Proc.destroyed_at_terminator instr.desc |> Location.of_regs_exn)
     | None -> (

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -337,14 +337,51 @@ let is_rematerialized_shape (instr : basic Cfg.instruction) =
 let rematerializations : (InstructionId.t, basic Instruction.t) Hashtbl.t =
   Hashtbl.create 64
 
-let clear_rematerializations () = Hashtbl.clear rematerializations
+(* Pre-split (description-style) registers whose value is rematerialized
+   somewhere in this function. Populated alongside [rematerializations] by
+   [record_rematerialization] from the result registers of each emitted
+   rematerialized instruction, then queried by [Equation_set.compatible_one] to
+   relax the "same description-stamp, different location" half of the
+   compatibility check for these registers.
+
+   Why this is needed: in a non-rematerialized split, the value flowing across a
+   destruction point lives at exactly one location at any program point — either
+   in a register or, post-spill, on a stack slot — because every downstream path
+   goes through the same spill/reload pair and the [rename_location] transitions
+   through the slot keep all paths converging on one (stamp, location) pair.
+   With rematerialization the same logical value can simultaneously sit at a
+   register location (where the rematerialized copy was just produced) AND on
+   the spill slot used by a sibling post-destruction path that reloads instead
+   of rematerializing. The resulting equation set legitimately has the same
+   description-stamp at two distinct locations.
+
+   The relaxation is targeted (only stamps recorded as remat results) so that
+   for any stamp the split pass did NOT rematerialize, the strict
+   one-location-per-stamp invariant is still enforced and any genuine regalloc
+   bug for those stamps is still caught. The complementary "two registers at one
+   location" half stays unconditional — that is the genuine aliasing-bug check.
+   Residual same-stamp/different-location equations accumulated through the
+   relaxed pass propagate backward and are eventually cleaned up either at the
+   spill that wrote the slot (via [rename_location]) or at the original
+   definition site, where the same-location check still fires for any actual
+   inconsistency. *)
+let rematerialized_res : Register.Set.t ref = ref Register.Set.empty
+
+let clear_rematerializations () =
+  Hashtbl.clear rematerializations;
+  rematerialized_res := Register.Set.empty
+
+let is_rematerialized_res (reg : Register.t) : bool =
+  Register.Set.mem reg !rematerialized_res
 
 let record_rematerialization ~id ~desc ~arg ~res =
-  Hashtbl.replace rematerializations id
-    { Instruction.desc;
-      arg = Array.map Register.create arg;
-      res = Array.map Register.create res
-    }
+  let arg = Array.map Register.create arg in
+  let res = Array.map Register.create res in
+  Hashtbl.replace rematerializations id { Instruction.desc; arg; res };
+  Array.iter
+    (fun (r : Register.t) ->
+      rematerialized_res := Register.Set.add r !rematerialized_res)
+    res
 
 module Description : sig
   (** A snapshot of the [desc], [arg] and [res] fields of all instructions in
@@ -850,27 +887,19 @@ module Equation_set : sig
   (** Calling [remove_result], [verify_destoyed_locations] and [add_argument] in
       this order corresponds to case (7) in Fig. 1 of the paper [1]. This
       implementation is also generalized for all cases not handled by
-      [rename_loc] or [rename_reg]. *)
-  val remove_result :
-    reg_res:Register.t array ->
-    loc_res:Location.t array ->
-    t ->
-    (t, string) Result.t
+      [rename_loc] or [rename_reg].
 
-  (** Like {!remove_result}, but tolerating that the same description-stamp can
-      be live at multiple locations simultaneously. Only the "two distinct
-      registers at the same location" half of the compatibility check is
-      enforced; the symmetric "same register at two locations" half is skipped.
-      Used for the result equation of rematerialized basic instructions added by
-      the split pass: the rematerialization creates a fresh physical copy of the
-      value at the result location, but other physical copies of the same value
-      (typically the pre-destruction spill slot used by a sibling
-      post-destruction path that reloads instead of rematerializing) can
-      legitimately co-exist in the equation set. Those residual equations
-      propagate back to the original definition site through the existing
-      spill/move chain, where the strict {!remove_result} catches any real
-      inconsistency. *)
-  val remove_result_lenient :
+      The compatibility check has two halves (see [compatible_one] below for
+      details and the soundness argument): the "two registers at one location"
+      half is unconditional (it would always represent a regalloc aliasing bug);
+      the "one register at two locations" half is automatically relaxed for the
+      description-stamps that the split pass has flagged as rematerialized (cf.
+      [is_rematerialized_res] above). Rematerialization legitimately creates a
+      fresh physical copy of the value at the result location while a sibling
+      post-destruction path may still carry the same description-stamp at the
+      spill slot used by its own reload, so the equation set can legitimately
+      hold the same stamp at multiple locations at the same program point. *)
+  val remove_result :
     reg_res:Register.t array ->
     loc_res:Location.t array ->
     t ->
@@ -1020,57 +1049,45 @@ end = struct
         let message = Format.flush_str_formatter () in
         raise (Verification_failed message))
     in
-    (* Check equations that have the location the same. *)
+    (* "Same-location" half: a second register sharing [loc] would mean two
+       distinct values live at the same physical location at the same program
+       point — always a regalloc bug (aliasing). This half is unconditional and
+       is the load-bearing soundness check even under rematerialization. *)
     (match Location.Map.find_opt loc t.for_loc with
     | None -> ()
     | Some regs ->
       let eq_loc = loc in
       Register.Set.iter (fun eq_reg -> check_equation eq_reg eq_loc) regs);
-    (* Check equations that have the register the same. *)
-    (match Register.Map.find_opt reg t.for_reg with
-    | None -> ()
-    | Some locs ->
-      let eq_reg = reg in
-      Location.Set.iter (fun eq_loc -> check_equation eq_reg eq_loc) locs);
+    (* "Same-register" half: under the original Rideau/Leroy semantics each
+       description-stamp lives at exactly one location at any program point,
+       which makes this check the symmetric companion of the same-location half.
+       That assumption is broken by the split pass when rematerialization is on
+       (cf. [rematerialized_res] above for the full argument): a stamp can
+       simultaneously be in a register (from a rematerialized copy on one path)
+       and on a spill slot (from a sibling post-destruction path that reloads).
+       Skip this half exactly for the stamps the split pass recorded as
+       rematerialization results. For every other stamp it is still enforced, so
+       a regalloc that puts a non-rematerialized value at two locations is still
+       caught here. Residual same-stamp/different-location equations from this
+       relaxation get cleaned up downstream: at the spill writing the slot,
+       [rename_location] folds the [= s[i:N]] equation back to the source
+       register; at the original definition the result equation removal does the
+       rest. If those clean-ups don't actually unify the equations (a real bug),
+       the same-location half above will fire at one of the upstream
+       instructions (or [verify_destroyed_locations] at a destroyed location)
+       once the location finally collides. *)
+    (if not (is_rematerialized_res reg)
+     then
+       match Register.Map.find_opt reg t.for_reg with
+       | None -> ()
+       | Some locs ->
+         let eq_reg = reg in
+         Location.Set.iter (fun eq_loc -> check_equation eq_reg eq_loc) locs);
     ()
 
   let remove_result ~reg_res ~loc_res t =
     try
       Array.iter2 (fun reg loc -> compatible_one ~reg ~loc t) reg_res loc_res;
-      let t =
-        array_fold2 (fun t reg loc -> remove (reg, loc) t) t reg_res loc_res
-      in
-      Ok t
-    with Verification_failed message -> Error message
-
-  let compatible_one_lenient ~reg ~loc t =
-    (* Only enforce the "two distinct registers at the same location" half of
-       the compatibility check; intentionally skip the symmetric "same register
-       at two locations" half (cf. [compatible_one]). See the
-       [remove_result_lenient] interface comment for the soundness argument. *)
-    match Location.Map.find_opt loc t.for_loc with
-    | None -> ()
-    | Some regs ->
-      Register.Set.iter
-        (fun eq_reg ->
-          if not (Register.equal eq_reg reg)
-          then (
-            Format.fprintf Format.str_formatter
-              "Unsatisfiable equations when removing a rematerialized result \
-               equation.\n\
-               Two distinct registers cannot be live at the same location.\n\
-               Existing equation %a.\n\
-               Removed equation: %a."
-              Equation.print (eq_reg, loc) Equation.print (reg, loc);
-            let message = Format.flush_str_formatter () in
-            raise (Verification_failed message)))
-        regs
-
-  let remove_result_lenient ~reg_res ~loc_res t =
-    try
-      Array.iter2
-        (fun reg loc -> compatible_one_lenient ~reg ~loc t)
-        reg_res loc_res;
       let t =
         array_fold2 (fun t reg loc -> remove (reg, loc) t) t reg_res loc_res
       in
@@ -1277,18 +1294,10 @@ module Transfer (Desc_val : Description_value) :
       all other cases not handled by [rename_location] or [rename_register]. We
       have an additional parameter which is the equations for the exceptional
       path successor which is not present in the paper [1] because exceptions
-      are not considered there.
-
-      [remove_result_kind] selects whether the result equations are removed
-      using the strict {!Equation_set.remove_result} or the lenient
-      {!Equation_set.remove_result_lenient}; the lenient variant is used for
-      rematerialized basic instructions (cf. [is_rematerialized_shape] in
-      [basic] below), which can legitimately leave behind other equations for
-      the same description-stamp at different locations. *)
-  let append_equations (type a) equations
-      ~(remove_result_kind : [`Strict | `Lenient])
-      ~(instr_kind : a Instruction.Kind.t) ~exn ~(reg_instr : a Instruction.t)
-      ~(loc_instr : a instruction) ~destroyed =
+      are not considered there. *)
+  let append_equations (type a) equations ~(instr_kind : a Instruction.Kind.t)
+      ~exn ~(reg_instr : a Instruction.t) ~(loc_instr : a instruction)
+      ~destroyed =
     let bind f res = Result.bind res f in
     let wrap_error res =
       Result.map_error
@@ -1296,11 +1305,6 @@ module Transfer (Desc_val : Description_value) :
           Transfer_error.create equations ~instr_kind ~exn ~reg_instr ~loc_instr
             message)
         res
-    in
-    let remove_result =
-      match remove_result_kind with
-      | `Strict -> Equation_set.remove_result
-      | `Lenient -> Equation_set.remove_result_lenient
     in
     let exn =
       exn
@@ -1328,7 +1332,7 @@ module Transfer (Desc_val : Description_value) :
     equations
     |>
     (* First remove the result equations. *)
-    remove_result ~reg_res:reg_instr.Instruction.res
+    Equation_set.remove_result ~reg_res:reg_instr.Instruction.res
       ~loc_res:(Location.of_regs_exn loc_instr.res)
     |> wrap_error
     |> bind (fun equations ->
@@ -1378,12 +1382,8 @@ module Transfer (Desc_val : Description_value) :
                [Regalloc_validate.record_rematerialization]"
               InstructionId.format instr.id
         in
-        (* See [remove_result_lenient]: the rematerialized result equation is
-           removed leniently because the same description-stamp can persist at
-           another location (the spill slot used by a sibling path). *)
-        append_equations t ~remove_result_kind:`Lenient
-          ~instr_kind:Instruction.Kind.Basic ~exn:None ~reg_instr
-          ~loc_instr:instr
+        append_equations t ~instr_kind:Instruction.Kind.Basic ~exn:None
+          ~reg_instr ~loc_instr:instr
           ~destroyed:(Proc.destroyed_at_basic instr.desc |> Location.of_regs_exn)
       | _ -> assert false)
     | Some instr_before -> (
@@ -1396,9 +1396,8 @@ module Transfer (Desc_val : Description_value) :
            have the same locations. *)
         Result.ok @@ rename_register t ~reg_instr:instr_before
       | _ ->
-        append_equations t ~remove_result_kind:`Strict
-          ~instr_kind:Instruction.Kind.Basic ~exn:None ~reg_instr:instr_before
-          ~loc_instr:instr
+        append_equations t ~instr_kind:Instruction.Kind.Basic ~exn:None
+          ~reg_instr:instr_before ~loc_instr:instr
           ~destroyed:(Proc.destroyed_at_basic instr.desc |> Location.of_regs_exn)
       )
 
@@ -1411,9 +1410,8 @@ module Transfer (Desc_val : Description_value) :
       let exn =
         if Cfg.can_raise_terminator instr.desc then Some exn else None
       in
-      append_equations t ~remove_result_kind:`Strict
-        ~instr_kind:Instruction.Kind.Terminator ~exn ~reg_instr:instr_before
-        ~loc_instr:instr
+      append_equations t ~instr_kind:Instruction.Kind.Terminator ~exn
+        ~reg_instr:instr_before ~loc_instr:instr
         ~destroyed:
           (Proc.destroyed_at_terminator instr.desc |> Location.of_regs_exn)
     | None -> (

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -316,20 +316,16 @@ module Instruction = struct
     }
 end
 
-(* The split pass may rematerialize a register by inserting a copy of the
-   immutable, non-atomic load that originally produced its value. Such an
+(* The split pass may rematerialize a register by inserting a copy of a pure,
+   side-effect-free instruction (an immutable load, a constant, an [Intop_imm]
+   from a safe subset, ...) that originally produced its value. Such an
    instruction is a legitimate addition during register allocation even though
-   its [desc] is not [Op (Spill | Reload | Move)]. We recognize it by shape: [Op
-   (Load _)] with [Immutable] mutability, [is_atomic = false], and a single
-   result register; this matches the predicate used by
-   [Regalloc_split_utils.Uses.compute] when classifying rematerialization
-   sources. *)
-let is_rematerialized_immutable_load_shape (instr : basic Cfg.instruction) =
-  match[@ocaml.warning "-4"] instr.desc with
-  | Op (Load { mutability = Immutable; is_atomic = false; _ })
-    when Array.length instr.res = 1 ->
-    true
-  | _ -> false
+   its [desc] is not [Op (Spill | Reload | Move)]. The exact set of accepted
+   shapes is defined by [Regalloc_split_utils.is_rematerializable_shape] and
+   shared with the classification side ([Regalloc_split_utils.Uses.compute]) so
+   the two ends stay in lock-step. *)
+let is_rematerialized_shape (instr : basic Cfg.instruction) =
+  Regalloc_split_utils.is_rematerializable_shape instr.desc
 
 module Description : sig
   (** A snapshot of the [desc], [arg] and [res] fields of all instructions in
@@ -572,14 +568,15 @@ end = struct
         (* A move instruction, while no regalloc-specific, can be inserted
            because of phi moves in split/rename. *)
         successor_id
-      | _ when is_rematerialized_immutable_load_shape instr ->
-        (* The split pass may rematerialize a register by emitting a copy of the
-           immutable load that produced its value (cf.
-           [Regalloc_split.RewriteAsRematerialize]). The shape check above
-           guards us against accepting arbitrary new loads: only loads that the
-           rematerialization analysis would itself emit can pass it. Like [Op
-           Move] additions, this instruction does not advance the pre-allocation
-           successor chain, so we keep [successor_id] as-is. *)
+      | _ when is_rematerialized_shape instr ->
+        (* The split pass may rematerialize a register by emitting a copy of a
+           pure source instruction (immutable load, constant, safe [Intop_imm],
+           ...; cf. [Regalloc_split.RewriteAsRematerialize]). The shape check
+           above is the same one used at classification time, so only
+           instructions the rematerialization analysis would itself emit can
+           pass it. Like [Op Move] additions, this instruction does not advance
+           the pre-allocation successor chain, so we keep [successor_id]
+           as-is. *)
         successor_id
       | _ ->
         Regalloc_utils.fatal
@@ -1236,22 +1233,23 @@ module Transfer (Desc_val : Description_value) :
       match instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
-      | _ when is_rematerialized_immutable_load_shape instr ->
-        (* Rematerialized immutable load added by the split pass. Unlike [Op
-           (Spill | Reload | Move)] (which transport an existing value between
-           locations and are handled by [rename_location]), this instruction
-           computes a fresh value: [loc_res := mem[loc_arg]]. However, its
-           [arg]/[res] arrays still carry the abstract registers that were
+      | _ when is_rematerialized_shape instr ->
+        (* Rematerialized pure source added by the split pass (immutable load,
+           constant, safe [Intop_imm], ...). Unlike [Op (Spill | Reload | Move)]
+           (which transport an existing value between locations and are handled
+           by [rename_location]), this instruction recomputes a fresh value
+           (memory read, constant materialization, or pure arithmetic). However,
+           its [arg]/[res] arrays still carry the abstract registers that were
            assigned during split (only the [loc] field gets overwritten by the
            allocator), so we can synthesize a [reg_instr] directly from the
            post-allocation instruction and reuse the generic equation transfer.
-           The result register is fresh — created by [compute_substitution_tree]
-           for this rematerialization — so it does not collide with any abstract
-           register from the pre-allocation description, and the equations stay
-           self-consistent for all downstream uses, which refer to the same
-           fresh register. The instruction's [desc] is preserved verbatim, so
-           [destroyed_at_basic] returns the same destroyed locations as for the
-           original load. *)
+           The result registers are fresh — created by
+           [compute_substitution_tree] for this rematerialization — so they do
+           not collide with any abstract register from the pre-allocation
+           description, and the equations stay self-consistent for all
+           downstream uses, which refer to the same fresh registers. The
+           instruction's [desc] is preserved verbatim, so [destroyed_at_basic]
+           returns the same destroyed locations as for the original. *)
         let reg_instr : basic Instruction.t =
           { Instruction.desc = instr.desc;
             arg = Array.map Register.create instr.arg;

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -316,6 +316,21 @@ module Instruction = struct
     }
 end
 
+(* The split pass may rematerialize a register by inserting a copy of the
+   immutable, non-atomic load that originally produced its value. Such an
+   instruction is a legitimate addition during register allocation even though
+   its [desc] is not [Op (Spill | Reload | Move)]. We recognize it by shape: [Op
+   (Load _)] with [Immutable] mutability, [is_atomic = false], and a single
+   result register; this matches the predicate used by
+   [Regalloc_split_utils.Uses.compute] when classifying rematerialization
+   sources. *)
+let is_rematerialized_immutable_load_shape (instr : basic Cfg.instruction) =
+  match[@ocaml.warning "-4"] instr.desc with
+  | Op (Load { mutability = Immutable; is_atomic = false; _ })
+    when Array.length instr.res = 1 ->
+    true
+  | _ -> false
+
 module Description : sig
   (** A snapshot of the [desc], [arg] and [res] fields of all instructions in
       the CFG and [fun_args] of the CFG. It is used by the validator to record
@@ -556,6 +571,15 @@ end = struct
       | Op Move ->
         (* A move instruction, while no regalloc-specific, can be inserted
            because of phi moves in split/rename. *)
+        successor_id
+      | _ when is_rematerialized_immutable_load_shape instr ->
+        (* The split pass may rematerialize a register by emitting a copy of the
+           immutable load that produced its value (cf.
+           [Regalloc_split.RewriteAsRematerialize]). The shape check above
+           guards us against accepting arbitrary new loads: only loads that the
+           rematerialization analysis would itself emit can pass it. Like [Op
+           Move] additions, this instruction does not advance the pre-allocation
+           successor chain, so we keep [successor_id] as-is. *)
         successor_id
       | _ ->
         Regalloc_utils.fatal
@@ -1212,6 +1236,31 @@ module Transfer (Desc_val : Description_value) :
       match instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
+      | _ when is_rematerialized_immutable_load_shape instr ->
+        (* Rematerialized immutable load added by the split pass. Unlike [Op
+           (Spill | Reload | Move)] (which transport an existing value between
+           locations and are handled by [rename_location]), this instruction
+           computes a fresh value: [loc_res := mem[loc_arg]]. However, its
+           [arg]/[res] arrays still carry the abstract registers that were
+           assigned during split (only the [loc] field gets overwritten by the
+           allocator), so we can synthesize a [reg_instr] directly from the
+           post-allocation instruction and reuse the generic equation transfer.
+           The result register is fresh — created by [compute_substitution_tree]
+           for this rematerialization — so it does not collide with any abstract
+           register from the pre-allocation description, and the equations stay
+           self-consistent for all downstream uses, which refer to the same
+           fresh register. The instruction's [desc] is preserved verbatim, so
+           [destroyed_at_basic] returns the same destroyed locations as for the
+           original load. *)
+        let reg_instr : basic Instruction.t =
+          { Instruction.desc = instr.desc;
+            arg = Array.map Register.create instr.arg;
+            res = Array.map Register.create instr.res
+          }
+        in
+        append_equations t ~instr_kind:Instruction.Kind.Basic ~exn:None
+          ~reg_instr ~loc_instr:instr
+          ~destroyed:(Proc.destroyed_at_basic instr.desc |> Location.of_regs_exn)
       | _ -> assert false)
     | Some instr_before -> (
       match instr.desc with

--- a/backend/regalloc/regalloc_validate.mli
+++ b/backend/regalloc/regalloc_validate.mli
@@ -16,3 +16,26 @@ val test :
   Description.t -> Cfg_with_layout.t -> (Cfg_with_layout.t, Error.t) Result.t
 
 val run : Description.t option -> Cfg_with_infos.t -> Cfg_with_infos.t
+
+(** Record the pre-allocation shape (description-style abstract registers and
+    desc) of a rematerialized basic instruction added by the split pass. The
+    validator looks this up when processing the instruction in the
+    post-allocation CFG, so that the equation transfer uses the same abstract
+    register stamps as the existing description-based equations rather than the
+    fresh post-split stamps. Should be called for every basic instruction that
+    [Regalloc_split.RewriteAsRematerialize] inserts.
+
+    Argument [desc] is preserved verbatim. [arg]/[res] must be the pre-split
+    (description-style) abstract registers — i.e. without locations on Named
+    registers. *)
+val record_rematerialization :
+  id:InstructionId.t ->
+  desc:Cfg_intf.S.basic ->
+  arg:Reg.t array ->
+  res:Reg.t array ->
+  unit
+
+(** Reset the rematerialization side-table. [Description.create] calls this
+    automatically; the call is also exposed in case a caller wants to discard
+    stale state explicitly (e.g. between unrelated compilation units). *)
+val clear_rematerializations : unit -> unit

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -563,9 +563,9 @@ let () =
       cfg1, cfg2)
     ~exp_std:"fatal exception raised when validating description"
     ~exp_err:
-      ">> Fatal error: The instruction's no. 12 successor id has changed. \
-       Before allocation: 11. After allocation (ignoring instructions added by \
-       allocation): 9."
+      ">> Fatal error: The instruction's no. 11 successor id has changed. \
+       Before allocation: 9. After allocation (ignoring instructions added by \
+       allocation): 12."
 
 let () =
   check "Regalloc added a loop"
@@ -622,16 +622,24 @@ let () =
        return, after: raise."
 
 let () =
+  (* Delete the [Prologue] in [entry_label] rather than a pure instruction so
+     the deletion is rejected by the validator. After
+     "Validator: accept Cfg_deadcode-style deletions" (ef8cd0e0e2), the
+     validator silently accepts the removal of any [Cfg.is_pure_basic]
+     instruction (matching what [Cfg_deadcode.remove_deadcode] does); deleting
+     a pure instruction therefore reaches the [cfg = after] polymorphic
+     equality below, which loops on cycles in [Reg.t.interf]. The deletion
+     check remains exercised by removing a non-pure instruction. *)
   check "Deleted instruction"
     (fun () ->
       let templ, _ = base_templ () in
       let cfg1 = Cfg_desc.make_pre_regalloc templ in
-      templ.&(add_label).body <- List.tl templ.&(add_label).body;
+      templ.&(entry_label).body <- List.tl templ.&(entry_label).body;
       let cfg2 = Cfg_desc.make_post_regalloc templ in
       cfg1, cfg2)
     ~exp_std:"fatal exception raised when validating description"
     ~exp_err:
-      ">> Fatal error: Instruction no. 8 was deleted by register allocator"
+      ">> Fatal error: Instruction no. 25 was deleted by register allocator"
 
 let make_loop ~loop_loc_first n =
   let make_id =

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -623,13 +623,13 @@ let () =
 
 let () =
   (* Delete the [Prologue] in [entry_label] rather than a pure instruction so
-     the deletion is rejected by the validator. After
-     "Validator: accept Cfg_deadcode-style deletions" (ef8cd0e0e2), the
-     validator silently accepts the removal of any [Cfg.is_pure_basic]
-     instruction (matching what [Cfg_deadcode.remove_deadcode] does); deleting
-     a pure instruction therefore reaches the [cfg = after] polymorphic
-     equality below, which loops on cycles in [Reg.t.interf]. The deletion
-     check remains exercised by removing a non-pure instruction. *)
+     the deletion is rejected by the validator. After "Validator: accept
+     Cfg_deadcode-style deletions" (ef8cd0e0e2), the validator silently accepts
+     the removal of any [Cfg.is_pure_basic] instruction (matching what
+     [Cfg_deadcode.remove_deadcode] does); deleting a pure instruction therefore
+     reaches the [cfg = after] polymorphic equality below, which loops on cycles
+     in [Reg.t.interf]. The deletion check remains exercised by removing a
+     non-pure instruction. *)
   check "Deleted instruction"
     (fun () ->
       let templ, _ = base_templ () in


### PR DESCRIPTION
This pull request is a first stab at rematerialization,
implemented as part of the split pre-processing pass of
register allocation. It is implemented there so that we
do not rematerialize a value that would be moved and/or
optimized away by the split pass.

This work is riskier than most register-allocation work,
because the validator needs to be updated to support
rematerialization.

Rematerialization currently applies only to `Const_xyz`,
`Int_imm`, and `Load` operations, the latter providing
the vast majority of hits.

The results are encouraging (tl;dr: -5% stack slots):

|              |       off |        on | ratio / percentage |
| ------------ | --------- | --------- | ------------------ |
| blocks       |   748,011 |   748,272 |             100.03 |
| instructions | 3,843,502 | 3,840,897 |              99.93 |
| moves        |   317,666 |   318,852 |             100.37 |
| reloads      |   353,895 |   345,299 |              97.57 |
| spills       |   249,315 |   236,590 |              94.90 |
| loads        |   549,694 |   566,701 |             103.09 |
| stack slots  |   144,643 |   136,378 |              94.29 |

In absolute numbers, we add fewer loads than
we remove spills and reloads. The size of artifacts
is also a bit improvement, but by far less than 1%.

(Still a draft because, among other things, the diff should
probably be split.)
