### PR TITLE
merlin: add support for injected parsetrees to mpipeline

### DIFF
--- a/external/merlin/src/kernel/mpipeline.ml
+++ b/external/merlin/src/kernel/mpipeline.ml
@@ -301,8 +301,8 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
     ?(ppx_cache_hit = ref false) ?(reader_cache_hit = ref false)
     ?(document_overrides_cache_hit = ref false)
     ?(locate_overrides_cache_hit = ref false)
-    ?(typer_cache_stats = ref Mtyper.Miss) ?for_completion
-    ?inject_parsetree config raw_source =
+    ?(typer_cache_stats = ref Mtyper.Miss) ?for_completion ?inject_parsetree
+    config raw_source =
   let state =
     match state with
     | None -> Cache.get config
@@ -313,7 +313,7 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
       (lazy
         (match inject_parsetree with
         | Some parsetree -> (raw_source, Some parsetree)
-        | None ->
+        | None -> (
           match Mconfig.(config.ocaml.pp) with
           | None -> (raw_source, None)
           | Some { workdir; workval } -> (
@@ -324,7 +324,8 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
                 ~source ~pp:workval
             with
             | `Source source -> (Msource.make source, None)
-            | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast))))
+            | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast)
+            ))))
   in
   let reader =
     timed_lazy reader_time
@@ -451,17 +452,13 @@ let make_with_parsetree ~state config raw_source parsetree =
      The parsetree is injected via the source tuple (raw_source, Some parsetree),
      which causes the reader to skip parsing. With ppx=[], the ppx phase is a no-op. *)
   let config =
-    Mconfig.{ config with
-      ocaml = { config.ocaml with ppx = []; pp = None }
-    }
+    Mconfig.{ config with ocaml = { config.ocaml with ppx = []; pp = None } }
   in
   let config = Mconfig.normalize config in
   (* Pass the parsetree through the pp mechanism: when source has Some parsetree,
      the reader uses it directly instead of parsing. *)
   let source_with_tree = Msource.make (Msource.text raw_source) in
-  process config source_with_tree
-    ~state
-    ~inject_parsetree:parsetree
+  process config source_with_tree ~state ~inject_parsetree:parsetree
 
 let for_completion position
     { config;

--- a/external/merlin/src/kernel/mpipeline.ml
+++ b/external/merlin/src/kernel/mpipeline.ml
@@ -236,6 +236,7 @@ type t =
   { config : Mconfig.t;
     state : Mocaml.typer_state;
     raw_source : Msource.t;
+    inject_parsetree : Mreader.parsetree option;
     source : (Msource.t * Mreader.parsetree option) lazy_t;
     reader : Reader.t lazy_t;
     ppx : Ppx.t lazy_t;
@@ -255,6 +256,7 @@ type t =
   }
 
 let raw_source t = t.raw_source
+let typer_state t = t.state
 
 let input_config t = t.config
 let input_source t = fst (Lazy.force t.source)
@@ -299,7 +301,8 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
     ?(ppx_cache_hit = ref false) ?(reader_cache_hit = ref false)
     ?(document_overrides_cache_hit = ref false)
     ?(locate_overrides_cache_hit = ref false)
-    ?(typer_cache_stats = ref Mtyper.Miss) ?for_completion config raw_source =
+    ?(typer_cache_stats = ref Mtyper.Miss) ?for_completion
+    ?inject_parsetree config raw_source =
   let state =
     match state with
     | None -> Cache.get config
@@ -308,17 +311,20 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
   let source =
     timed_lazy pp_time
       (lazy
-        (match Mconfig.(config.ocaml.pp) with
-        | None -> (raw_source, None)
-        | Some { workdir; workval } -> (
-          let source = Msource.text raw_source in
-          match
-            Pparse.apply_pp ~workdir
-              ~filename:Mconfig.(config.query.filename)
-              ~source ~pp:workval
-          with
-          | `Source source -> (Msource.make source, None)
-          | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast))))
+        (match inject_parsetree with
+        | Some parsetree -> (raw_source, Some parsetree)
+        | None ->
+          match Mconfig.(config.ocaml.pp) with
+          | None -> (raw_source, None)
+          | Some { workdir; workval } -> (
+            let source = Msource.text raw_source in
+            match
+              Pparse.apply_pp ~workdir
+                ~filename:Mconfig.(config.query.filename)
+                ~source ~pp:workval
+            with
+            | `Source source -> (Msource.make source, None)
+            | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast))))
   in
   let reader =
     timed_lazy reader_time
@@ -419,6 +425,7 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
   { config;
     state;
     raw_source;
+    inject_parsetree;
     source;
     reader;
     ppx;
@@ -439,10 +446,28 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
 
 let make config source = process (Mconfig.normalize config) source
 
+let make_with_parsetree ~state config raw_source parsetree =
+  (* Clear ppx to avoid re-running them on the already-ppx'd parsetree.
+     The parsetree is injected via the source tuple (raw_source, Some parsetree),
+     which causes the reader to skip parsing. With ppx=[], the ppx phase is a no-op. *)
+  let config =
+    Mconfig.{ config with
+      ocaml = { config.ocaml with ppx = []; pp = None }
+    }
+  in
+  let config = Mconfig.normalize config in
+  (* Pass the parsetree through the pp mechanism: when source has Some parsetree,
+     the reader uses it directly instead of parsing. *)
+  let source_with_tree = Msource.make (Msource.text raw_source) in
+  process config source_with_tree
+    ~state
+    ~inject_parsetree:parsetree
+
 let for_completion position
     { config;
       state;
       raw_source;
+      inject_parsetree;
       pp_time;
       reader_time;
       ppx_time;
@@ -451,7 +476,7 @@ let for_completion position
       _
     } =
   process config raw_source ~for_completion:position ~state ~pp_time
-    ~reader_time ~ppx_time ~typer_time ~error_time
+    ~reader_time ~ppx_time ~typer_time ~error_time ?inject_parsetree
 
 let timing_information t =
   [ ("pp", !(t.pp_time));

--- a/external/merlin/src/kernel/mpipeline.mli
+++ b/external/merlin/src/kernel/mpipeline.mli
@@ -17,7 +17,8 @@ val make : Mconfig.t -> Msource.t -> t
     which is necessary when called from within [with_pipeline] (where [Local_store] is
     already bound and creating a new state would fail). Use the state from the normal
     pipeline that provided the parsetree. *)
-val make_with_parsetree : state:Mocaml.typer_state -> Mconfig.t -> Msource.t -> Mreader.parsetree -> t
+val make_with_parsetree :
+  state:Mocaml.typer_state -> Mconfig.t -> Msource.t -> Mreader.parsetree -> t
 
 val with_pipeline : t -> (unit -> 'a) -> 'a
 val for_completion : Msource.position -> t -> t

--- a/external/merlin/src/kernel/mpipeline.mli
+++ b/external/merlin/src/kernel/mpipeline.mli
@@ -1,9 +1,29 @@
 type t
 val make : Mconfig.t -> Msource.t -> t
+
+(** Create a pipeline with a pre-provided parsetree, bypassing reader and ppx phases.
+
+    The parsetree is used directly for type checking. The source is still needed for
+    position resolution (e.g., [get_lexing_pos]).
+
+    This is used for fast-path completion: the caller gets the ppx parsetree from a normal
+    pipeline, strips uninteresting parts, then creates a new pipeline with the stripped
+    parsetree for cheaper type checking.
+
+    The config should have a modified filename (e.g., append ["__for_completion"]) to avoid
+    cache collisions with the normal pipeline.
+
+    The [state] parameter allows reusing the typer state from an existing pipeline,
+    which is necessary when called from within [with_pipeline] (where [Local_store] is
+    already bound and creating a new state would fail). Use the state from the normal
+    pipeline that provided the parsetree. *)
+val make_with_parsetree : state:Mocaml.typer_state -> Mconfig.t -> Msource.t -> Mreader.parsetree -> t
+
 val with_pipeline : t -> (unit -> 'a) -> 'a
 val for_completion : Msource.position -> t -> t
 
 val raw_source : t -> Msource.t
+val typer_state : t -> Mocaml.typer_state
 
 val input_config : t -> Mconfig.t
 val input_source : t -> Msource.t


### PR DESCRIPTION
This change is useful for an alternative implementation of completion functionality, which - for performance purposes - operates on a reduced parsetree. The whole flow is like this:
1. parse the buffer, get an original parsetree
2. replace certain bits of the original parsetree with placeholders (like bodies of top-level definitions, which don't contain the cursor), get a reduced parsetree
3. type this new reduced parsetree, get a reduced typedtree
4. perform completion on the reduced typedtree

Because reduced parsetree << original parsetree, we get faster typing.