### PR TITLE
Make fatal errors related to array primitives more verbose

### DIFF
--- a/lambda/printlambda.mli
+++ b/lambda/printlambda.mli
@@ -38,6 +38,7 @@ val zero_alloc_attribute : formatter -> zero_alloc_attribute -> unit
 val locality_mode : formatter -> locality_mode -> unit
 val array_kind : array_kind -> string
 val array_set_kind : formatter -> array_set_kind -> unit
+val array_ref_kind : formatter -> array_ref_kind -> unit
 
 val tag_and_constructor_shape :
   (formatter -> value_kind -> unit) ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1291,7 +1291,12 @@ and glb_scannable_kind kind1 kind2 =
    probably trigger it. For other layouts, we raise an error.
 *)
 let glb_array_type loc t1 t2 =
-
+  let unexpected ?(what="unexpected array kind") () =
+    Misc.fatal_errorf "%a: %s in glb: %s, %s"
+      Location.print_loc loc
+      what
+      (Printlambda.array_kind t1) (Printlambda.array_kind t2)
+  in
   match t1, t2 with
   (* Handle unboxed array kinds which should only match with themselves.
 
@@ -1309,7 +1314,7 @@ let glb_array_type loc t1 t2 =
   | (Pgenarray | Punboxedfloatarray Unboxed_float32), Punboxedfloatarray Unboxed_float32 ->
     Punboxedfloatarray Unboxed_float32
   | Punboxedfloatarray _, _ | _, Punboxedfloatarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
   | (Pgenarray | Punboxedoruntaggedintarray Untagged_int),
     Punboxedoruntaggedintarray Untagged_int ->
     Punboxedoruntaggedintarray Untagged_int
@@ -1329,7 +1334,7 @@ let glb_array_type loc t1 t2 =
     Punboxedoruntaggedintarray Unboxed_nativeint ->
     Punboxedoruntaggedintarray Unboxed_nativeint
   | Punboxedoruntaggedintarray _, _ | _, Punboxedoruntaggedintarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
   | (Pgenarray | Punboxedvectorarray Unboxed_vec128),
     Punboxedvectorarray Unboxed_vec128 ->
     Punboxedvectorarray Unboxed_vec128
@@ -1340,7 +1345,7 @@ let glb_array_type loc t1 t2 =
     Punboxedvectorarray Unboxed_vec512 ->
     Punboxedvectorarray Unboxed_vec512
   | Punboxedvectorarray _, _ | _, Punboxedvectorarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
 
   (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
   | Pgenarray,
@@ -1348,16 +1353,16 @@ let glb_array_type loc t1 t2 =
   | (Pgcignorableproductarray kinds1) as k, Pgcignorableproductarray kinds2 ->
     if List.equal equal_ignorable_product_element_kind kinds1 kinds2
     then k
-    else Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+    else unexpected () ~what:"mismatched ignorableproductarray kinds"
   | Pgcscannableproductarray kinds1, Pgcscannableproductarray kinds2 ->
     begin match glb_scannable_kinds kinds1 kinds2 with
     | Some kinds -> Pgcscannableproductarray kinds
-    | None -> Misc.fatal_error "mismatched scannableproductarray kinds in glb"
+    | None -> unexpected () ~what:"mismatched scannableproductarray kinds"
     end
   | Pgcignorableproductarray _, _ | _, Pgcignorableproductarray _ ->
-    Misc.fatal_error "unexpected Pgcignorableproductarray kind in glb"
+    unexpected () ~what:"unexpected Pgcignorableproductarray kind"
   | Pgcscannableproductarray _, _ | _, Pgcscannableproductarray _ ->
-    Misc.fatal_error "unexpected Pgcscannableproductarray kind in glb"
+    unexpected () ~what:"unexpected Pgcscannableproductarray kind"
 
   (* No GLB; only used in the [Obj.magic] case *)
   | Pfloatarray, (Paddrarray | Pgcignorableaddrarray | Pintarray)
@@ -1380,6 +1385,12 @@ let glb_array_type loc t1 t2 =
   | Pfloatarray, Pfloatarray -> Pfloatarray
 
 let glb_array_ref_type loc t1 t2 =
+  let unexpected ?(what="unexpected array kind") () =
+    Misc.fatal_errorf "%a: %s in glb: %a, %s"
+      Location.print_loc loc
+      what
+      Printlambda.array_ref_kind t1 (Printlambda.array_kind t2)
+  in
   match t1, t2 with
   (* Handle unboxed array kinds which should only match with themselves.
 
@@ -1398,7 +1409,7 @@ let glb_array_ref_type loc t1 t2 =
     Punboxedfloatarray_ref Unboxed_float32
   | Punboxedfloatarray_ref _, _
   | _, Punboxedfloatarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
   | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Untagged_int),
     Punboxedoruntaggedintarray Untagged_int ->
     Punboxedoruntaggedintarray_ref Untagged_int
@@ -1418,7 +1429,7 @@ let glb_array_ref_type loc t1 t2 =
     Punboxedoruntaggedintarray Unboxed_nativeint ->
     Punboxedoruntaggedintarray_ref Unboxed_nativeint
   | Punboxedoruntaggedintarray_ref _, _ | _, Punboxedoruntaggedintarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
   | (Pgenarray_ref _ | Punboxedvectorarray_ref Unboxed_vec128),
     Punboxedvectorarray Unboxed_vec128 ->
     Punboxedvectorarray_ref Unboxed_vec128
@@ -1429,7 +1440,7 @@ let glb_array_ref_type loc t1 t2 =
     Punboxedvectorarray Unboxed_vec512 ->
     Punboxedvectorarray_ref Unboxed_vec512
   | Punboxedvectorarray_ref _, _ | _, Punboxedvectorarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
 
   (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
   | Pgenarray_ref _, Pgcignorableproductarray kinds ->
@@ -1438,17 +1449,17 @@ let glb_array_ref_type loc t1 t2 =
     Pgcscannableproductarray_ref kinds
   | (Pgcignorableproductarray_ref kinds1) as k,
     Pgcignorableproductarray kinds2 ->
-    if kinds1 = kinds2 then k else
-      Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+    if kinds1 = kinds2 then k
+    else unexpected () ~what:"mismatched ignorableproductarray kinds"
   | Pgcscannableproductarray_ref kinds1, Pgcscannableproductarray kinds2 ->
     begin match glb_scannable_kinds kinds1 kinds2 with
     | Some kinds -> Pgcscannableproductarray_ref kinds
-    | None -> Misc.fatal_error "mismatched scannableproductarray kinds in glb"
+    | None -> unexpected () ~what:"mismatched scannableproductarray kinds"
     end
   | Pgcignorableproductarray_ref _, _ | _, Pgcignorableproductarray _ ->
-    Misc.fatal_error "unexpected Pgcignorableproductarray kind in glb"
+    unexpected () ~what:"unexpected Pgcignorableproductarray kind"
   | Pgcscannableproductarray_ref _, _ | _, Pgcscannableproductarray _ ->
-    Misc.fatal_error "unexpected Pgcscannableproductarray kind in glb"
+    unexpected () ~what:"unexpected Pgcscannableproductarray kind"
 
   (* No GLB; only used in the [Obj.magic] case *)
   | Pfloatarray_ref _, (Paddrarray | Pgcignorableaddrarray | Pintarray)
@@ -1484,6 +1495,12 @@ let glb_array_ref_type loc t1 t2 =
   | (Pfloatarray_ref _ as x), Pfloatarray -> x
 
 let glb_array_set_type loc t1 t2 =
+  let unexpected ?(what="unexpected array kind") () =
+    Misc.fatal_errorf "%a: %s in glb: %a, %s"
+      Location.print_loc loc
+      what
+      Printlambda.array_set_kind t1 (Printlambda.array_kind t2)
+  in
   match t1, t2 with
   (* Handle unboxed array kinds which can only match with themselves.
 
@@ -1502,7 +1519,7 @@ let glb_array_set_type loc t1 t2 =
     Punboxedfloatarray_set Unboxed_float32
   | Punboxedfloatarray_set _, _
   | _, Punboxedfloatarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
   | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Untagged_int),
     Punboxedoruntaggedintarray Untagged_int ->
     Punboxedoruntaggedintarray_set Untagged_int
@@ -1522,7 +1539,7 @@ let glb_array_set_type loc t1 t2 =
     Punboxedoruntaggedintarray Unboxed_nativeint ->
     Punboxedoruntaggedintarray_set Unboxed_nativeint
   | Punboxedoruntaggedintarray_set _, _ | _, Punboxedoruntaggedintarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
   | (Pgenarray_set _ | Punboxedvectorarray_set Unboxed_vec128),
     Punboxedvectorarray Unboxed_vec128 ->
     Punboxedvectorarray_set Unboxed_vec128
@@ -1533,7 +1550,7 @@ let glb_array_set_type loc t1 t2 =
     Punboxedvectorarray Unboxed_vec512 ->
     Punboxedvectorarray_set Unboxed_vec512
   | Punboxedvectorarray_set _, _ | _, Punboxedvectorarray _ ->
-    Misc.fatal_error "unexpected array kind in glb"
+    unexpected ()
 
   (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
   | Pgenarray_set _, Pgcignorableproductarray kinds ->
@@ -1542,18 +1559,18 @@ let glb_array_set_type loc t1 t2 =
     Pgcscannableproductarray_set (m, kinds)
   | (Pgcignorableproductarray_set kinds1) as k,
     Pgcignorableproductarray kinds2 ->
-    if kinds1 = kinds2 then k else
-      Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+    if kinds1 = kinds2 then k
+    else unexpected () ~what:"mismatched ignorableproductarray kinds"
   | Pgcscannableproductarray_set (mode, kinds1),
     Pgcscannableproductarray kinds2 ->
     begin match glb_scannable_kinds kinds1 kinds2 with
     | Some kinds -> Pgcscannableproductarray_set (mode, kinds)
-    | None -> Misc.fatal_error "mismatched scannableproductarray kinds in glb"
+    | None -> unexpected () ~what:"mismatched scannableproductarray kinds"
     end
   | Pgcignorableproductarray_set _, _ | _, Pgcignorableproductarray _ ->
-    Misc.fatal_error "unexpected Pgcignorableproductarray_set kind in glb"
+    unexpected () ~what:"unexpected Pgcignorableproductarray_set kind"
   | Pgcscannableproductarray_set _, _ | _, Pgcscannableproductarray _ ->
-    Misc.fatal_error "unexpected Pgcscannableproductarray_set kind in glb"
+    unexpected () ~what:"unexpected Pgcscannableproductarray_set kind"
 
   (* No GLB; only used in the [Obj.magic] case *)
   | Pfloatarray_set, (Paddrarray | Pgcignorableaddrarray | Pintarray)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -144,21 +144,21 @@ let convert_block_shape ~machine_width (shape : L.block_shape) ~num_fields =
         num_fields fields_length;
     fields
 
-let check_float_array_optimisation_enabled name =
+let check_float_array_optimisation_enabled dbg name =
   if not (Flambda_features.flat_float_array ())
   then
     Misc.fatal_errorf
-      "[%s] is not expected when the float array optimisation is disabled" name
-      ()
+      "%a: [%s] is not expected when the float array optimisation is disabled"
+      Debuginfo.print_compact dbg name ()
 
 type converted_array_kind =
   | Array_kind of P.Array_kind.t
   | Float_array_opt_dynamic
 
-let convert_array_kind (kind : L.array_kind) : converted_array_kind =
+let convert_array_kind dbg (kind : L.array_kind) : converted_array_kind =
   match kind with
   | Pgenarray ->
-    check_float_array_optimisation_enabled "Pgenarray";
+    check_float_array_optimisation_enabled dbg "Pgenarray";
     Float_array_opt_dynamic
   | Paddrarray -> Array_kind Values
   | Pgcignorableaddrarray -> Array_kind Gc_ignorable_values
@@ -205,8 +205,8 @@ let convert_array_kind (kind : L.array_kind) : converted_array_kind =
     in
     Array_kind (Unboxed_product (List.map convert_kind kinds))
 
-let convert_array_kind_for_length kind : P.Array_kind_for_length.t =
-  match convert_array_kind kind with
+let convert_array_kind_for_length dbg kind : P.Array_kind_for_length.t =
+  match convert_array_kind dbg kind with
   | Array_kind array_kind -> Array_kind array_kind
   | Float_array_opt_dynamic -> Float_array_opt_dynamic
 
@@ -239,8 +239,8 @@ type converted_array_ref_kind =
   | Array_ref_kind of Array_ref_kind.t
   | Float_array_opt_dynamic_ref of L.locality_mode
 
-let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
-    =
+let convert_array_ref_kind _dbg (kind : L.array_ref_kind) :
+    converted_array_ref_kind =
   match kind with
   | Pgenarray_ref mode ->
     (* CR mshinwell: We can't check this because of the translations of
@@ -354,9 +354,9 @@ let convert_array_ref_kind_to_array_kind (array_ref_kind : Array_ref_kind.t) :
     | Unboxed_product kinds ->
       Unboxed_product (List.map convert_unboxed_product_array_ref_kind kinds))
 
-let convert_array_ref_kind_for_length array_ref_kind : P.Array_kind_for_length.t
-    =
-  match convert_array_ref_kind array_ref_kind with
+let convert_array_ref_kind_for_length dbg array_ref_kind :
+    P.Array_kind_for_length.t =
+  match convert_array_ref_kind dbg array_ref_kind with
   | Float_array_opt_dynamic_ref _ -> Float_array_opt_dynamic
   | Array_ref_kind array_ref_kind -> (
     match array_ref_kind with
@@ -409,8 +409,8 @@ type converted_array_set_kind =
   | Array_set_kind of Array_set_kind.t
   | Float_array_opt_dynamic_set of Alloc_mode.For_assignments.t
 
-let convert_array_set_kind (kind : L.array_set_kind) : converted_array_set_kind
-    =
+let convert_array_set_kind _dbg (kind : L.array_set_kind) :
+    converted_array_set_kind =
   match kind with
   | Pgenarray_set mode ->
     (* CR mshinwell: see CR in [convert_array_ref_kind] above
@@ -524,9 +524,9 @@ let convert_array_set_kind_to_array_kind (array_set_kind : Array_set_kind.t) :
     | Unboxed_product kinds ->
       Unboxed_product (List.map convert_unboxed_product_array_set_kind kinds))
 
-let convert_array_set_kind_for_length array_set_kind : P.Array_kind_for_length.t
-    =
-  match convert_array_set_kind array_set_kind with
+let convert_array_set_kind_for_length dbg array_set_kind :
+    P.Array_kind_for_length.t =
+  match convert_array_set_kind dbg array_set_kind with
   | Float_array_opt_dynamic_set _ -> Float_array_opt_dynamic
   | Array_set_kind Naked_floats_to_be_unboxed -> Array_kind Naked_floats
   | Array_set_kind (No_float_array_opt nfo) -> (
@@ -554,11 +554,11 @@ type converted_duplicate_array_kind =
   | Duplicate_array_kind of P.Duplicate_array_kind.t
   | Float_array_opt_dynamic
 
-let convert_array_kind_to_duplicate_array_kind (kind : L.array_kind) :
+let convert_array_kind_to_duplicate_array_kind dbg (kind : L.array_kind) :
     converted_duplicate_array_kind =
   match kind with
   | Pgenarray ->
-    check_float_array_optimisation_enabled "Pgenarray";
+    check_float_array_optimisation_enabled dbg "Pgenarray";
     Float_array_opt_dynamic
   | Paddrarray -> Duplicate_array_kind Values
   | Pgcignorableaddrarray -> Duplicate_array_kind Values
@@ -1490,9 +1490,9 @@ let array_set_unsafe ~machine_width dbg ~array ~index array_kind array_set_kind
     ~new_values
   |> H.maybe_create_unboxed_product
 
-let[@inline always] match_on_array_ref_kind ~array array_ref_kind f :
+let[@inline always] match_on_array_ref_kind dbg ~array array_ref_kind f :
     H.expr_primitive =
-  match convert_array_ref_kind array_ref_kind with
+  match convert_array_ref_kind dbg array_ref_kind with
   | Array_ref_kind array_ref_kind ->
     let array_kind = convert_array_ref_kind_to_array_kind array_ref_kind in
     f array_kind array_ref_kind
@@ -1509,9 +1509,9 @@ let[@inline always] match_on_array_ref_kind ~array array_ref_kind f :
            a singleton. *)
         [K.With_subkind.any_value] )
 
-let[@inline always] match_on_array_set_kind ~array array_set_kind f :
+let[@inline always] match_on_array_set_kind dbg ~array array_set_kind f :
     H.expr_primitive =
-  match convert_array_set_kind array_set_kind with
+  match convert_array_set_kind dbg array_set_kind with
   | Array_set_kind array_set_kind ->
     let array_kind = convert_array_set_kind_to_array_kind array_set_kind in
     f array_kind array_set_kind
@@ -2042,7 +2042,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Pmakearray (lambda_array_kind, mutability, mode), _ -> (
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
-    let array_kind = convert_array_kind lambda_array_kind in
+    let array_kind = convert_array_kind dbg lambda_array_kind in
     let mutability = Mutability.from_lambda mutability in
     match array_kind with
     | Array_kind array_kind ->
@@ -2373,7 +2373,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     in
     [Ternary (Array_set (array_kind, array_set_kind), Prim obj, field, value)]
   | Parraylength kind, [[arg]] -> (
-    let array_kind = convert_array_kind_for_length kind in
+    let array_kind = convert_array_kind_for_length dbg kind in
     let prim : H.expr_primitive = Unary (Array_length array_kind, arg) in
     match array_kind with
     | Array_kind
@@ -2394,7 +2394,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [Binary (Int_arith (Tagged_immediate, Div), Prim prim, Simple divisor)])
   | Pduparray (kind, mutability), [[arg]] -> (
     let duplicate_array_kind =
-      convert_array_kind_to_duplicate_array_kind kind
+      convert_array_kind_to_duplicate_array_kind dbg kind
     in
     let source_mutability = Mutability.Immutable in
     let destination_mutability = Mutability.from_lambda mutability in
@@ -2715,28 +2715,32 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     (* For this and the following cases we will end up relying on the backend to
        CSE the two accesses to the array's header word in the [Pgenarray]
        case. *)
-    [ match_on_array_ref_kind ~array array_ref_kind
+    [ match_on_array_ref_kind dbg ~array array_ref_kind
         (array_load_unsafe ~machine_width ~array ~mut
            ~index:(convert_index_to_tagged_int ~index ~index_kind)
            ~current_region) ]
   | Parrayrefs (array_ref_kind, index_kind, mut), [[array]; [index]] ->
-    let array_length_kind = convert_array_ref_kind_for_length array_ref_kind in
+    let array_length_kind =
+      convert_array_ref_kind_for_length dbg array_ref_kind
+    in
     [ check_array_access ~dbg ~array array_length_kind ~index ~index_kind
         ~machine_width
-        (match_on_array_ref_kind ~array array_ref_kind
+        (match_on_array_ref_kind dbg ~array array_ref_kind
            (array_load_unsafe ~machine_width ~array ~mut
               ~index:(convert_index_to_tagged_int ~index ~index_kind)
               ~current_region)) ]
   | Parraysetu (array_set_kind, index_kind), [[array]; [index]; new_values] ->
-    [ match_on_array_set_kind ~array array_set_kind
+    [ match_on_array_set_kind dbg ~array array_set_kind
         (array_set_unsafe ~machine_width dbg ~array
            ~index:(convert_index_to_tagged_int ~index ~index_kind)
            ~new_values) ]
   | Parraysets (array_set_kind, index_kind), [[array]; [index]; new_values] ->
-    let array_length_kind = convert_array_set_kind_for_length array_set_kind in
+    let array_length_kind =
+      convert_array_set_kind_for_length dbg array_set_kind
+    in
     [ check_array_access ~dbg ~array array_length_kind ~index ~index_kind
         ~machine_width
-        (match_on_array_set_kind ~array array_set_kind
+        (match_on_array_set_kind dbg ~array array_set_kind
            (array_set_unsafe ~machine_width dbg ~array
               ~index:(convert_index_to_tagged_int ~index ~index_kind)
               ~new_values)) ]
@@ -2987,7 +2991,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ~boxed_or_tagged:boxed bigstring ~index_kind index new_value ]
   | ( Pfloat_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    check_float_array_optimisation_enabled "Pfloat_array_load_vec";
+    check_float_array_optimisation_enabled dbg "Pfloat_array_load_vec";
     [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
         ~boxed ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
   | ( Pfloatarray_load_vec { size; unsafe; index_kind; mode; boxed },
@@ -3037,7 +3041,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ~boxed ~vec_kind:(vec_kind size) Naked_int16s array ~index_kind index ]
   | ( Pfloat_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    check_float_array_optimisation_enabled "Pfloat_array_set_vec";
+    check_float_array_optimisation_enabled dbg "Pfloat_array_set_vec";
     [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
         ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index new_value
     ]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -17,7 +17,7 @@
 module Acc = Closure_conversion_aux.Acc
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-val check_float_array_optimisation_enabled : string -> unit
+val check_float_array_optimisation_enabled : Debuginfo.t -> string -> unit
 
 val convert_and_bind :
   Acc.t ->


### PR DESCRIPTION
This PR makes a few fatal errors more verbose so that they are easier to debug. These errors are fatal errros, so normally the user cannot see them as they correspond to a programming errors in the compiler. But they can occur when working on the compiler itself and the extra information, such as the location, is very useful for debugging the issue.

Concretely, this PR:

- add location to fatal errors related to seeing an unexpected `Pgenarray` when `flat_float_array = false` in `lambda_to_flambda_primitives.ml`
- add location to fatal errors in the various `glb_array*_type` functions, as well as a pretty-print of the arguments

