### PR TITLE
Define the %obj_xxx primitives in a similar way to array primitives

### DIFF
--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -896,11 +896,14 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%array_element_size_in_bytes" ->
       (* The array kind will be filled in later *)
       Primitive (Parray_element_size_in_bytes Pgenarray, 1)
-    | "%obj_size" -> Primitive ((Parraylength Pgenarray), 1)
-    | "%obj_field" -> Primitive ((Parrayrefu (Pgenarray_ref mode, Ptagged_int_index, Mutable)), 2)
+    | "%obj_size" -> Primitive ((Parraylength gen_array_kind), 1)
+    | "%obj_field" ->
+      Primitive
+        ((Parrayrefu (gen_array_ref_kind mode, Ptagged_int_index, Mutable)), 2)
     | "%obj_set_field" ->
       Primitive
-        ((Parraysetu (Pgenarray_set (get_first_arg_mode ()), Ptagged_int_index)), 3)
+        ((Parraysetu
+            (gen_array_set_kind (get_first_arg_mode ()),Ptagged_int_index)), 3)
     | "%floatarray_length" -> Primitive ((Parraylength Pfloatarray), 1)
     | "%floatarray_safe_get" ->
       Primitive ((Parrayrefs (Pfloatarray_ref mode, Ptagged_int_index, Mutable)), 2)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -239,17 +239,11 @@ type converted_array_ref_kind =
   | Array_ref_kind of Array_ref_kind.t
   | Float_array_opt_dynamic_ref of L.locality_mode
 
-let convert_array_ref_kind _dbg (kind : L.array_ref_kind) :
+let convert_array_ref_kind dbg (kind : L.array_ref_kind) :
     converted_array_ref_kind =
   match kind with
   | Pgenarray_ref mode ->
-    (* CR mshinwell: We can't check this because of the translations of
-       primitives for Obj.size, Obj.field and Obj.set_field, which can be used
-       both on arrays and blocks. We should probably propagate the "%obj_..."
-       primitives which these functions use all the way to the middle end. Then
-       this check could be reinstated for all normal cases.
-
-       check_float_array_optimisation_enabled (); *)
+    check_float_array_optimisation_enabled dbg "Pgenarray_ref";
     Float_array_opt_dynamic_ref mode
   | Paddrarray_ref -> Array_ref_kind (No_float_array_opt Values)
   | Pgcignorableaddrarray_ref ->
@@ -409,13 +403,11 @@ type converted_array_set_kind =
   | Array_set_kind of Array_set_kind.t
   | Float_array_opt_dynamic_set of Alloc_mode.For_assignments.t
 
-let convert_array_set_kind _dbg (kind : L.array_set_kind) :
+let convert_array_set_kind dbg (kind : L.array_set_kind) :
     converted_array_set_kind =
   match kind with
   | Pgenarray_set mode ->
-    (* CR mshinwell: see CR in [convert_array_ref_kind] above
-
-       check_float_array_optimisation_enabled (); *)
+    check_float_array_optimisation_enabled dbg "Pgenarray_set";
     Float_array_opt_dynamic_set (Alloc_mode.For_assignments.from_lambda mode)
   | Paddrarray_set mode ->
     Array_set_kind


### PR DESCRIPTION
At the moment, the various array primitives such `%array_unsafe_set` are translated using the array kind `Pgenarray` when the flat float array optimization is enabled and `Paddrarray` when it is disabled. This is because `Pgenarray` means "either an addr array or a flat float array", so is not expected when the optimization is disabled.

While all array primitives are defined this way, the `%obj_size`, `%obj_field` and `%obj_set_field` primitives currently differ: they always use `Pgenarray` even when the flat float array optimization is disabled. This is causing `Pgenarray` kinds to appear at unexpected places when the optimization is disabled. It is worth noting that this particular question was discussed upstream when the flat float array option was introduced and it was decided to make these primitives generate `Paddrarray` when the optimization is disabled (ocaml/ocaml#1294). However, it was changed back to always using `Pgenarray` in OxCaml in #1420, but the reason was not stated.

Given that the current behavior is causing issues, and it is not clear why this change was introduced, I propose that we revert it.

Concretely, what does this mean?

Well, for float arrays, it makes no difference, both before and after this PR, whether the flat float optimization is enabled or not, the following always holds:

```ocaml
Obj.field (Obj.repr [|0.0|]) 0 = Obj.repr 0.0
```

This is because when the optimization is disabled, then float arrays are always boxed and so the direct field access without the conditional on the tag will work as expected. The only difference introduced by this PR is when doing something like `Obj.field (Obj.repr x) 0` and `x` is a value of type `float# array`:
- before this PR, the above code would return the first element of `x` as a (boxed) float
- after this PR, it is undefined and could cause a segfault

That being said, when `x` is a value of type `<anything else than float># array`, `Obj.field (Obj.repr x) 0` is also undefined. Given that unboxed arrays are quite new and that disabling the flat float array optimization is not widely used, I don't think such a change in behavior will cause any problem. What is more, this change actually aligns with upstream OCaml.
