### PR TITLE
Fix missing-cmx kind fallback in flambda typing env

### DIFF
--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -433,6 +433,19 @@ let test_meet_bottom_after_alias () =
   Format.eprintf "@[<hov 2>after meet:@ %a@]@." T.print meet_ty;
   assert (T.is_bottom env meet_ty)
 
+let test_missing_cmx_find_respects_requested_kind () =
+  let env = create_env () in
+  let previous_unit_info = Env.get_unit_name () in
+  let missing_comp_unit = "Missing_cmx" |> Compilation_unit.of_string in
+  let missing_unit_info =
+    Unit_info.make_dummy ~input_name:"missing_cmx" missing_comp_unit
+  in
+  Env.set_unit_name (Some missing_unit_info);
+  let var_from_missing_cmx = Variable.create "missing" K.value in
+  Env.set_unit_name previous_unit_info;
+  let ty = TE.find env (Name.var var_from_missing_cmx) (Some K.naked_float32) in
+  assert (K.equal (T.kind ty) K.naked_float32)
+
 let () =
   let comp_unit = "Meet_test" |> Compilation_unit.of_string in
   let unit_info = Unit_info.make_dummy ~input_name:"meet_test" comp_unit in
@@ -452,4 +465,5 @@ let () =
   Format.eprintf "@.JOIN WITH EXTENSIONS@\n@.";
   test_join_with_extensions ();
   Format.eprintf "@.JOIN WITH COMPLEX EXTENSIONS@\n@.";
-  test_join_with_complex_extensions ()
+  test_join_with_complex_extensions ();
+  test_missing_cmx_find_respects_requested_kind ()

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -444,8 +444,10 @@ let find_with_binding_time_and_mode' t name kind =
             check_optional_kind_matches name (fst initial_symbol_type) kind;
             initial_symbol_type)
           ~var:(fun var ->
-            let ty = MTC.unknown (Variable.kind var) in
-            check_optional_kind_matches name ty kind;
+            let kind =
+              match kind with Some kind -> kind | None -> Variable.kind var
+            in
+            let ty = MTC.unknown kind in
             ty, Binding_time.With_name_mode.imported_variables)
       | Some t -> (
         match

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -132,9 +132,9 @@ val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
 val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
 
-(** If the kind of the name is known, it should be specified, otherwise it can
-    be omitted. Such omission will cause an error if the name satisfies
-    [variable_is_from_missing_cmx_file]. *)
+(** If the kind of the name is known, it should be specified. If it is omitted
+    for a variable from a missing .cmx file, the kind recorded on the variable
+    will be used. *)
 val find : t -> Name.t -> Flambda_kind.t option -> Type_grammar.t
 
 val find_params : t -> Bound_parameters.t -> Type_grammar.t list


### PR DESCRIPTION
https://github.com/oxcaml/oxcaml/pull/5886 removed imported-name tracking and made missing-CMX variable lookups synthesize unknown types from `Variable.kind`. This exposed a case where an imported variable recorded as `Value` was looked up with expected `Naked_float32`, causing a kind mismatch during meet.

This changes missing-CMX lookup to honor the caller-provided expected kind when present, falling back to `Variable.kind` only when no kind is supplied. It also adds a Flambda `meet_test` regression.