### PR TITLE
Avoid lifting switch tables with local coercions

### DIFF
--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -298,11 +298,19 @@ let recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
     then None
     else
       let single_kind array_kind array_load_kind =
-        let element_kind = ALK.kind_of_loaded_value array_load_kind in
-        Some
-          ( dest,
-            Static_arguments_of_single_kind
-              { array_kind; array_load_kind; element_kind; simples = args } )
+        (* The lookup table is lifted as a static constant. Symbols are OK, but
+           any coercion attached to them must not mention local variables. *)
+        if
+          List.exists
+            (fun arg -> not (NO.no_variables (Simple.free_names arg)))
+            args
+        then None
+        else
+          let element_kind = ALK.kind_of_loaded_value array_load_kind in
+          Some
+            ( dest,
+              Static_arguments_of_single_kind
+                { array_kind; array_load_kind; element_kind; simples = args } )
       in
       let try_tagged_immediates () =
         (* If no arm is a symbol and all [Const]s are tagged immediates, return

--- a/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
+++ b/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
@@ -189,3 +189,22 @@ match_symbol_tagged_or_null:
   movq  -4(%rbx,%rax,4), %rax
   ret
 |}]
+
+(* This should not be turned into a static lookup table: the returned closures
+   carry coercions mentioning the recursive group's local depth variable. *)
+
+let rec recursive_symbol x =
+  if x = 0 then 0 else recursive_symbol_from_switch A (x - 1)
+and recursive_symbol' x =
+  if x = 0 then 1 else recursive_symbol (x - 1)
+and recursive_symbol_from_switch (t : t) =
+  match t with
+  | A -> recursive_symbol
+  | B -> recursive_symbol
+  | C -> recursive_symbol'
+  | D -> recursive_symbol'
+[%%expect{|
+val recursive_symbol : int -> int = <fun>
+val recursive_symbol' : int -> int = <fun>
+val recursive_symbol_from_switch : t -> int -> int = <fun>
+|}]


### PR DESCRIPTION
https://github.com/oxcaml/oxcaml/pull/3242 extended the Flambda 2 switch lookup-table optimization to value-kind symbols, but symbol simples can carry coercions. In recursive groups, those coercions may mention local depth variables, so lifting them into a static lookup table can make a local variable free in the whole compilation unit. This caused failures like `my_depth/... not expected to be free in whole-compilation-unit term`.

This change makes the lookup-table recognizer reject non-fully-static simples: symbols are still allowed, but any attached coercion must not contain free variables. Switches with such local coercions fall back to the normal switch representation instead of building an invalid lifted constant.

A regression case was added to `switch_lookup_table_kinds.ml` using a recursive group that returns functions from a switch, matching the escaping-depth-variable shape from the failure.