### PR TITLE
Simple `open` in quotes

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -3889,7 +3889,7 @@ and quote_expression_desc ~scopes ~transl stage e : Exp_desc.t =
           },
           exp ) ->
       let exp = quote_expression ~scopes ~transl stage exp in
-      Exp_desc.let_open loc (module_for_path loc path) exp
+      Exp_desc.let_open loc (module_for_path loc env path) exp
     | Texp_open _ ->
       fatal_errorf "Translquote [at %a]: non-trivial Texp_open not implemented"
         Location.print_loc (to_location loc)

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2041,7 +2041,8 @@ and Exp_desc : sig
     Case.t ->
     t'
 
-  val let_open : Debuginfo.Scoped_location.t -> Identifier.Module.t -> Exp.t -> t'
+  val let_open :
+    Debuginfo.Scoped_location.t -> Identifier.Module.t -> Exp.t -> t'
 
   val exclave : Debuginfo.Scoped_location.t -> Exp.t -> t'
 
@@ -3883,8 +3884,10 @@ and quote_expression_desc ~scopes ~transl stage e : Exp_desc.t =
       let meth = quote_method loc meth in
       Exp_desc.send loc obj meth
     | Texp_open
-        ({ open_expr = { mod_desc = Tmod_ident (path, _) }; open_attributes = [] }, exp)
-      ->
+        ( { open_expr = { mod_desc = Tmod_ident (path, _) };
+            open_attributes = []
+          },
+          exp ) ->
       let exp = quote_expression ~scopes ~transl stage exp in
       Exp_desc.let_open loc (module_for_path loc path) exp
     | Texp_open _ ->

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2041,6 +2041,8 @@ and Exp_desc : sig
     Case.t ->
     t'
 
+  val let_open : Debuginfo.Scoped_location.t -> Identifier.Module.t -> Exp.t -> t'
+
   val exclave : Debuginfo.Scoped_location.t -> Exp.t -> t'
 
   val list_comprehension : Debuginfo.Scoped_location.t -> Comprehension.t -> t'
@@ -2197,6 +2199,9 @@ end = struct
       (mk_list ~loc (List.map extract a1))
       (mk_list ~loc (List.map extract a2))
       (extract a3)
+
+  let let_open loc a1 a2 =
+    apply2 "Exp_desc" "let_open" loc (extract a1) (extract a2)
 
   let exclave loc a1 = apply1 "Exp_desc" "exclave" loc (extract a1)
 
@@ -2898,9 +2903,7 @@ and quote_pat_extra ~env ~scopes loc pat_lam extra =
   | Tpat_type _ ->
     fatal_errorf "Translquote [at %a]: [#tconst] not implemented."
       Location.print_loc (to_location loc)
-  | Tpat_open _ ->
-    fatal_errorf "Translquote [at %a]: no support for open patterns."
-      Location.print_loc (to_location loc)
+  | Tpat_open _ -> pat_lam (* handled by path resolution  *)
   | Tpat_inspected_type (Label_disambiguation ambiguity) ->
     pat_lam
     |> maybe_constrain_pat_with_type loc
@@ -3646,7 +3649,7 @@ and update_env_without_extra ~loc extra =
   | Texp_ghost_region -> ()
   | Texp_borrowed -> ()
 
-and quote_expression_desc ~scopes ~transl stage e =
+and quote_expression_desc ~scopes ~transl stage e : Exp_desc.t =
   let env = e.exp_env in
   let loc' = e.exp_loc in
   let loc = of_location ~scopes loc' in
@@ -3879,8 +3882,13 @@ and quote_expression_desc ~scopes ~transl stage e =
       let obj = quote_expression ~scopes ~transl stage obj in
       let meth = quote_method loc meth in
       Exp_desc.send loc obj meth
+    | Texp_open
+        ({ open_expr = { mod_desc = Tmod_ident (path, _) }; open_attributes = [] }, exp)
+      ->
+      let exp = quote_expression ~scopes ~transl stage exp in
+      Exp_desc.let_open loc (module_for_path loc path) exp
     | Texp_open _ ->
-      fatal_errorf "Translquote [at %a]: Texp_open not implemented"
+      fatal_errorf "Translquote [at %a]: non-trivial Texp_open not implemented"
         Location.print_loc (to_location loc)
     | Texp_letmodule (ident, _, _, mod_exp, body) -> (
       let mod_exp = quote_module_exp ~transl stage loc env mod_exp in
@@ -4023,7 +4031,7 @@ and quote_expression_desc ~scopes ~transl stage e =
     (quote_expression_extra ~env ~scopes stage)
     e.exp_extra (Exp_desc.wrap body)
 
-and quote_expression ~scopes ~transl stage e =
+and quote_expression ~scopes ~transl stage e : Exp.t =
   let desc = quote_expression_desc ~scopes ~transl stage e
   and attributes = quote_attributes e
   and loc = of_location ~scopes e.exp_loc in

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -2078,7 +2078,7 @@ module Ast = struct
     | Let_exception (name, exp) ->
       pp fmt "@[<2>let@ exception@ %s@ in@ %a@]" name (print_exp env) exp
     | Let_open (id, exp) ->
-      pp fmt "@[<2>let@ open@ %a@ in@ %a@]"
+      pp fmt "@[<2>let@ open!@ %a@ in@ %a@]"
         (print_raw_ident_module env) id (print_exp env) exp
     | Extension_constructor name ->
       pp fmt "@[[%%extension_constructor@ %a]@]" Name.print name

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1359,6 +1359,7 @@ module Ast = struct
     | Unboxed_field of expression * record_field
     | Let_op of raw_ident_value_t list * expression list * case
     | Let_exception of Name.t * expression
+    | Let_open of raw_ident_module_t * expression
     | Extension_constructor of Name.t
     | List_comprehension of comprehension
     | Array_comprehension of comprehension
@@ -2076,6 +2077,9 @@ module Ast = struct
     | Borrow exp -> pp fmt "@[<2>borrow_@ %a@]" (print_exp_with_parens env) exp
     | Let_exception (name, exp) ->
       pp fmt "@[<2>let@ exception@ %s@ in@ %a@]" name (print_exp env) exp
+    | Let_open (id, exp) ->
+      pp fmt "@[<2>let@ open@ %a@ in@ %a@]"
+        (print_raw_ident_module env) id (print_exp env) exp
     | Extension_constructor name ->
       pp fmt "@[[%%extension_constructor@ %a]@]" Name.print name
     | Unboxed_unit -> pp fmt "#()"
@@ -3075,6 +3079,11 @@ module Exp_desc = struct
   let let_op idents defs case =
     let+ idents = all idents and+ defs = all defs and+ case = case in
     Ast.Let_op (idents, defs, case)
+
+  let let_open id exp =
+    let+ id = id
+    and+ exp = exp in
+    Ast.Let_open (id, exp)
 
   let stack exp =
     let+ exp = exp in

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -2104,10 +2104,15 @@ module Ast = struct
     | Src_pos -> pp fmt "[%%src_pos]"
 
   and print_exp env fmt exp =
-    if exp.attributes <> [] then pp fmt "(@[";
-    print_exp_desc env fmt exp;
-    List.iter (print_attribute fmt) exp.attributes;
-    if exp.attributes <> [] then pp fmt "@])"
+    match exp.attributes with
+    | [] ->
+      print_exp_desc env fmt exp
+    | (_ :: _) as attr ->
+      pp fmt "(@[(@[";
+      print_exp_desc env fmt exp;
+      pp fmt "@])";
+      List.iter (print_attribute fmt) attr;
+      pp fmt "@])"
 end
 
 module Label = struct

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -655,6 +655,8 @@ and Exp_desc : sig
 
   val let_op : Identifier.Value.t list -> Exp.t list -> Case.t -> t
 
+  val let_open : Identifier.Module.t -> Exp.t -> t
+
   val exclave : Exp.t -> t
 
   val list_comprehension : Comprehension.t -> t

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -7,10 +7,24 @@
 
 (* Preamble types for use in tests *)
 
+module M = struct
+  let ( + ) = ( +. )
+  let foo = 42
+  type 'a record = { record_field : 'a }
+  type 'a variant = Variant_tag of 'a
+end
+
 module E = struct
   type existential = Exists : 'a -> existential
 end
 [%%expect {|
+module M :
+  sig
+    val ( + ) : float -> float -> float
+    val foo : int
+    type 'a record = { record_field : 'a; }
+    type 'a variant = Variant_tag of 'a
+  end
 module E : sig type existential = Exists : 'a -> existential end
 |}];;
 
@@ -941,25 +955,24 @@ Error: Object definition using "object..end"
 
 <[ let open List in map ]>;;
 [%%expect {|
-Line 1, characters 3-23:
-1 | <[ let open List in map ]>;;
-       ^^^^^^^^^^^^^^^^^^^^
-Error: Opening modules is not supported inside quoted expressions,
-       as seen at line 1, characters 3-23.
+- : <[($('a) -> $('b)) -> $('a) list -> $('b) list]> expr =
+<[let open Stdlib.List in Stdlib.List.map]>
 |}];;
-
-module M = struct
-  let foo = 42
-end;;
 
 <[ let open M in M.foo ]>;;
 [%%expect {|
-module M : sig val foo : int end
-Line 5, characters 3-22:
-5 | <[ let open M in M.foo ]>;;
-       ^^^^^^^^^^^^^^^^^^^
-Error: Opening modules is not supported inside quoted expressions,
-       as seen at line 5, characters 3-22.
+- : <[int]> expr = <[let open M in M.foo]>
+|}]
+;;
+
+<[ let open struct let foo = 42 end in foo ]>;;
+[%%expect {|
+Line 1, characters 3-42:
+1 | <[ let open struct let foo = 42 end in foo ]>;;
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Opening non-trivial modules
+       is not supported inside quoted expressions,
+       as seen at line 1, characters 3-42.
 |}]
 ;;
 
@@ -1614,4 +1627,33 @@ exception E
 <[ raise Exc.E ]>;;
 [%%expect {|
 - : 'a expr = <[Stdlib.raise Exc.E]>
+|}];;
+
+(* Opening modules *)
+
+<[ let open List in map length [[1]; [2; 3]] ]>
+[%%expect {|
+- : <[int list]> expr =
+<[let open Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
+]>
+|}];;
+
+<[ List.(map length [[1]; [2; 3]]) ]>
+[%%expect {|
+- : <[int list]> expr =
+<[let open Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
+]>
+|}];;
+
+<[ M.(0.1 + 0.2) ]>
+[%%expect {|
+- : <[float]> expr = <[let open M in M.( + ) 0.1 0.2]>
+|}];;
+
+<[ M.{ record_field = "open" }, { M.record_field = "path" } ]>
+[%%expect {|
+- : <[string M.record * string M.record]> expr =
+<[
+  ((let open M in { M.record_field = "open"; }), { M.record_field = "path"; })
+]>
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1120,7 +1120,7 @@ let x = <[<[42]>]> in <[ fun () -> <[ $($x) ]> ]>;;
 <[ fun f x -> (f [@inlined]) x [@nontail] ]>
 [%%expect {|
 - : <[($('a) -> $('b)) -> $('a) -> $('b)]> expr =
-<[fun f x -> ((f [@inlined]) x [@nontail])]>
+<[fun f x -> ((((f) [@inlined]) x) [@nontail])]>
 |}];;
 
 <[ fun x -> [ x ; x + 1 ] ]>
@@ -1722,12 +1722,12 @@ Error: Identifier "foo" is used at line 1, characters 56-59,
 
 <[ let open [@inline] M in foo ]>
 [%%expect {|
-- : <[int]> expr = <[(let open! M in M.foo [@inline])]>
+- : <[int]> expr = <[((let open! M in M.foo) [@inline])]>
 |}];;
 
 <[ ((let open M in foo) [@inline]) ]>
 [%%expect {|
-- : <[int]> expr = <[(let open! M in M.foo [@inline])]>
+- : <[int]> expr = <[((let open! M in M.foo) [@inline])]>
 |}];;
 
 (** Opening modules in patterns **)

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -956,12 +956,12 @@ Error: Object definition using "object..end"
 <[ let open List in map ]>;;
 [%%expect {|
 - : <[($('a) -> $('b)) -> $('a) list -> $('b) list]> expr =
-<[let open Stdlib.List in Stdlib.List.map]>
+<[let open! Stdlib.List in Stdlib.List.map]>
 |}];;
 
 <[ let open M in M.foo ]>;;
 [%%expect {|
-- : <[int]> expr = <[let open M in M.foo]>
+- : <[int]> expr = <[let open! M in M.foo]>
 |}]
 ;;
 
@@ -1634,26 +1634,27 @@ exception E
 <[ let open List in map length [[1]; [2; 3]] ]>
 [%%expect {|
 - : <[int list]> expr =
-<[let open Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
+<[let open! Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
 ]>
 |}];;
 
 <[ List.(map length [[1]; [2; 3]]) ]>
 [%%expect {|
 - : <[int list]> expr =
-<[let open Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
+<[let open! Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
 ]>
 |}];;
 
 <[ M.(0.1 + 0.2) ]>
 [%%expect {|
-- : <[float]> expr = <[let open M in M.( + ) 0.1 0.2]>
+- : <[float]> expr = <[let open! M in M.( + ) 0.1 0.2]>
 |}];;
 
 <[ M.{ record_field = "open" }, { M.record_field = "path" } ]>
 [%%expect {|
 - : <[string M.record * string M.record]> expr =
 <[
-  ((let open M in { M.record_field = "open"; }), { M.record_field = "path"; })
+  ((let open! M in { M.record_field = "open"; }),
+   { M.record_field = "path"; })
 ]>
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -12,6 +12,7 @@ module M = struct
   let foo = 42
   type 'a record = { record_field : 'a }
   type 'a variant = Variant_tag of 'a
+  type 'a my_option = None | Some of 'a
 end
 [%%expect {|
 module M :
@@ -20,6 +21,7 @@ module M :
     val foo : int
     type 'a record = { record_field : 'a; }
     type 'a variant = Variant_tag of 'a
+    type 'a my_option = None | Some of 'a
   end
 |}];;
 
@@ -979,7 +981,7 @@ Error: Object definition using "object..end"
 Line 1, characters 3-42:
 1 | <[ let open struct let foo = 42 end in foo ]>;;
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Opening non-trivial modules
+Error: Opening modules otherwise than by name
        is not supported inside quoted expressions,
        as seen at line 1, characters 3-42.
 |}]
@@ -1638,7 +1640,7 @@ exception E
 - : 'a expr = <[Stdlib.raise Exc.E]>
 |}];;
 
-(* Opening modules *)
+(** Opening modules in expressions **)
 
 <[ let open List in map length [[1]; [2; 3]] ]>
 [%%expect {|
@@ -1668,11 +1670,27 @@ exception E
 ]>
 |}];;
 
+<[ M.(Variant_tag "open"), M.Variant_tag "path" ]>
+[%%expect {|
+- : <[string M.variant * string M.variant]> expr =
+<[((let open! M in M.Variant_tag "open"), (M.Variant_tag "path"))]>
+|}];;
+
+(* Opening packed module *)
+
+<[ fun (module M : T) -> let open M in foo + 1 ]>
+[%%expect {|
+- : <[(module T) -> int]> expr =
+<[fun (module M : T) -> let open! M in M.foo + 1]>
+|}];;
+
 (* Cross-stage open *)
+
 <[ let open List in $(hd [ <[ 0 ]>; <[ 1 ]> ]) ]>
 [%%expect {|
 - : <[int]> expr = <[let open! Stdlib.List in 0]>
 |}];;
+
 let open List in <[ length [1; 2; 3] ]>
 [%%expect {|
 - : <[int]> expr = <[Stdlib.List.length ([1; 2; 3])]>
@@ -1690,12 +1708,6 @@ Error: Identifier "foo1" is used at line 2, characters 18-22,
        it is introduced at line 1, characters 23-27, outside any quotations.
 |}];;
 
-(* Opening packed module *)
-<[ fun (module M : T) -> let open M in foo + 1 ]>
-[%%expect {|
-- : <[(module T) -> int]> expr =
-<[fun (module M : T) -> let open! M in M.foo + 1]>
-|}];;
 <[ fun (module M : T) -> let open M in $(Quote.Expr.int foo) ]>
 [%%expect {|
 Line 1, characters 56-59:
@@ -1704,4 +1716,30 @@ Line 1, characters 56-59:
 Error: Identifier "foo" is used at line 1, characters 56-59,
        outside any quotations; it is introduced at line 2, characters 2-15,
        inside a quotation (<[ ... ]>).
+|}];;
+
+(* Attributes on let-open *)
+
+<[ let open [@inline] M in foo ]>
+[%%expect {|
+- : <[int]> expr = <[(let open! M in M.foo [@inline])]>
+|}];;
+
+<[ ((let open M in foo) [@inline]) ]>
+[%%expect {|
+- : <[int]> expr = <[(let open! M in M.foo [@inline])]>
+|}];;
+
+(** Opening modules in patterns **)
+
+<[ function M.(Variant_tag 0) -> 1 | M.Variant_tag _ -> 0 ]>
+[%%expect {|
+- : <[int M.variant -> int]> expr =
+<[function | M.Variant_tag (0) -> 1 | M.Variant_tag (_) -> 0]>
+|}];;
+
+<[ function M.(Some x) -> x | M.(None) -> 0 ]>
+[%%expect {|
+- : <[int M.my_option -> int]> expr =
+<[function | M.Some (x) -> x | M.None -> 0]>
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -981,7 +981,7 @@ Error: Object definition using "object..end"
 Line 1, characters 3-42:
 1 | <[ let open struct let foo = 42 end in foo ]>;;
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Opening modules otherwise than by name
+Error: Opening a non-identifier module expression
        is not supported inside quoted expressions,
        as seen at line 1, characters 3-42.
 |}]

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -13,10 +13,6 @@ module M = struct
   type 'a record = { record_field : 'a }
   type 'a variant = Variant_tag of 'a
 end
-
-module E = struct
-  type existential = Exists : 'a -> existential
-end
 [%%expect {|
 module M :
   sig
@@ -25,6 +21,19 @@ module M :
     type 'a record = { record_field : 'a; }
     type 'a variant = Variant_tag of 'a
   end
+|}];;
+
+module type T = sig
+  val foo : int
+end
+[%%expect {|
+module type T = sig val foo : int end
+|}];;
+
+module E = struct
+  type existential = Exists : 'a -> existential
+end
+[%%expect {|
 module E : sig type existential = Exists : 'a -> existential end
 |}];;
 
@@ -1657,4 +1666,42 @@ exception E
   ((let open! M in { M.record_field = "open"; }),
    { M.record_field = "path"; })
 ]>
+|}];;
+
+(* Cross-stage open *)
+<[ let open List in $(hd [ <[ 0 ]>; <[ 1 ]> ]) ]>
+[%%expect {|
+- : <[int]> expr = <[let open! Stdlib.List in 0]>
+|}];;
+let open List in <[ length [1; 2; 3] ]>
+[%%expect {|
+- : <[int]> expr = <[Stdlib.List.length ([1; 2; 3])]>
+|}];;
+
+module M1 = struct let foo1 = 42 end;;
+let open M1 in <[ foo1 ]>
+[%%expect {|
+module M1 : sig val foo1 : int end
+Line 2, characters 18-22:
+2 | let open M1 in <[ foo1 ]>
+                      ^^^^
+Error: Identifier "foo1" is used at line 2, characters 18-22,
+       inside a quotation (<[ ... ]>);
+       it is introduced at line 1, characters 23-27, outside any quotations.
+|}];;
+
+(* Opening packed module *)
+<[ fun (module M : T) -> let open M in foo + 1 ]>
+[%%expect {|
+- : <[(module T) -> int]> expr =
+<[fun (module M : T) -> let open! M in M.foo + 1]>
+|}];;
+<[ fun (module M : T) -> let open M in $(Quote.Expr.int foo) ]>
+[%%expect {|
+Line 1, characters 56-59:
+1 | <[ fun (module M : T) -> let open M in $(Quote.Expr.int foo) ]>
+                                                            ^^^
+Error: Identifier "foo" is used at line 1, characters 56-59,
+       outside any quotations; it is introduced at line 2, characters 2-15,
+       inside a quotation (<[ ... ]>).
 |}];;

--- a/testsuite/tests/quotation/eval/open_warnings.ml
+++ b/testsuite/tests/quotation/eval/open_warnings.ml
@@ -1,0 +1,25 @@
+(* TEST
+  include eval;
+  flags = "-extension runtime_metaprogramming";
+  native;
+*)
+
+#syntax quotations on
+
+let () =
+  print_string "shadowing open: ";
+  Eval.eval <[
+    let tl x = x in ignore tl;
+    let open List in [0; 42; 1] |> tl |> hd
+  ]> |> print_int;
+  print_newline ()
+;;
+
+let () =
+  print_string "unused open: ";
+  Eval.eval <[
+    let my_hd = function x :: _ -> x | _ -> 0 in
+    let open List in [42; 0; 1] |> my_hd
+  ]> |> print_int;
+  print_newline ()
+;;

--- a/testsuite/tests/quotation/eval/open_warnings.ml
+++ b/testsuite/tests/quotation/eval/open_warnings.ml
@@ -6,6 +6,11 @@
 
 #syntax quotations on
 
+(* As of 2026-05-19, we silence all warnings.
+   This test ensures that, should we ever propagate warnings from compiling
+   the generated program, then local opens don't cause any.
+   Any legitimate warnings will be reported when compiling the metaprogram. *)
+
 let () =
   print_string "shadowing open: ";
   Eval.eval <[
@@ -19,7 +24,7 @@ let () =
   print_string "unused open: ";
   Eval.eval <[
     let my_hd = function x :: _ -> x | _ -> 0 in
-    let open List in [42; 0; 1] |> my_hd
+    let open Option in [42; 0; 1] |> my_hd
   ]> |> print_int;
   print_newline ()
 ;;

--- a/testsuite/tests/quotation/eval/open_warnings.reference
+++ b/testsuite/tests/quotation/eval/open_warnings.reference
@@ -1,0 +1,2 @@
+shadowing open: 42
+unused open: 42

--- a/testsuite/tests/quotation/typing/magic_staged_modes.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes.ml
@@ -87,5 +87,5 @@ Error: The value "x" is "local" to the parent region
 <[ fun x -> (<[ ($x [@magic_staged_modes]) ]> [@magic_staged_modes]) ]>
 [%%expect{|
 - : <[$('a) expr -> $('a) expr @ once]> expr =
-<[fun x -> (<[($x [@magic_staged_modes])]> [@magic_staged_modes])]>
+<[fun x -> ((<[(($x) [@magic_staged_modes])]>) [@magic_staged_modes])]>
 |}];;

--- a/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
+++ b/testsuite/tests/quotation/typing/magic_staged_modes_eval.reference
@@ -1,5 +1,5 @@
 generated program:
-(42 [@magic_staged_modes])
+((42) [@magic_staged_modes])
 
 generated program:
 stack_ (Some 42)
@@ -13,9 +13,9 @@ Error: The expression is "local" because it is "stack_"-allocated.
 eval failed.
 
 generated program:
-((Stdlib.ref 0 : _ @ unique) [@magic_staged_modes])
+(((Stdlib.ref 0 : _ @ unique)) [@magic_staged_modes])
 
-File "//eval//", line 1, characters 14-26:
+File "//eval//", line 1, characters 15-27:
 Error: This value is "aliased" but is expected to be "unique".
 eval failed.
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -5011,7 +5011,7 @@ let print_unsupported_quotation ppf =
       fprintf ppf "Module type definition using %a"
         (Style.inline_code) "sig..end"
   | Open_qt ->
-      fprintf ppf "Opening non-trivial modules"
+      fprintf ppf "Opening modules otherwise than by name"
   | Object_field_with_attribute_qt ->
       fprintf ppf "Adding attributes on fields in object types"
   | Variant_tag_with_attribute_qt ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -5011,7 +5011,7 @@ let print_unsupported_quotation ppf =
       fprintf ppf "Module type definition using %a"
         (Style.inline_code) "sig..end"
   | Open_qt ->
-      fprintf ppf "Opening modules"
+      fprintf ppf "Opening non-trivial modules"
   | Object_field_with_attribute_qt ->
       fprintf ppf "Adding attributes on fields in object types"
   | Variant_tag_with_attribute_qt ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -5011,7 +5011,7 @@ let print_unsupported_quotation ppf =
       fprintf ppf "Module type definition using %a"
         (Style.inline_code) "sig..end"
   | Open_qt ->
-      fprintf ppf "Opening modules otherwise than by name"
+      fprintf ppf "Opening a non-identifier module expression"
   | Object_field_with_attribute_qt ->
       fprintf ppf "Adding attributes on fields in object types"
   | Variant_tag_with_attribute_qt ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3542,7 +3542,6 @@ and type_pat_aux
         { p with pat_extra = (Tpat_type (path, lid), loc, sp.ppat_attributes)
         :: p.pat_extra }
   | Ppat_open (lid,p) ->
-      Env.check_no_open_quotations sp.ppat_loc !!penv Env.Open_qt;
       let path, new_env =
         !type_open Asttypes.Fresh !!penv sp.ppat_loc lid in
       Pattern_env.set_env penv new_env;
@@ -7683,7 +7682,10 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_open (od, e) ->
-      Env.check_no_open_quotations loc env Open_qt;
+      begin match od with
+      | { popen_expr = { pmod_desc = Pmod_ident _ } } -> ()
+      | _ -> Env.check_no_open_quotations loc env Open_qt
+      end;
       let tv = newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
       let (od, newenv) = !type_open_decl env od in
       let exp = type_expect newenv expected_mode e ty_expected_explained in


### PR DESCRIPTION
Implement `let open` (and other variations that sugar into `*exp_open`) in quotes.

See tests for examples, e.g.:

```ocaml
<[ let open List in map length [[1]; [2; 3]] ]>
[%%expect {|
- : <[int list]> expr =
<[let open Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
]>
|}];;

<[ List.(map length [[1]; [2; 3]]) ]>
[%%expect {|
- : <[int list]> expr =
<[let open Stdlib.List in Stdlib.List.map Stdlib.List.length ([[1]; [2; 3]])
]>
|}];;

<[ M.(0.1 + 0.2) ]>
[%%expect {|
- : <[float]> expr = <[let open M in M.( + ) 0.1 0.2]>
|}];;
```