### PR TITLE
Place frametables in the `.rodata` section by default

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3128,10 +3128,15 @@ let end_assembly () =
   (* PR#6329 *)
   emit_global_label ~section:Data "data_end";
   D.int64 0L;
-  D.text ();
-  D.align ~fill:Nop ~bytes:8;
+  let frametable_section : Asm_targets.Asm_section.t =
+    if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Text
+  in
+  D.switch_to_section frametable_section;
+  D.align
+    ~fill:(if !Oxcaml_flags.frametables_in_rodata then Zero else Nop)
+    ~bytes:8;
   (* PR#7591 *)
-  emit_global_label ~section:Text "frametable";
+  emit_global_label ~section:frametable_section "frametable";
   (* CR sspies: Share the [emit_frames] code with the Arm backend. *)
   emit_frames
     { efa_code_label =
@@ -3152,13 +3157,13 @@ let end_assembly () =
       efa_align = (fun n -> D.align ~fill:Nop ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
-          let lbl = label_to_asm_label ~section:Text lbl in
+          let lbl = label_to_asm_label ~section:frametable_section lbl in
           let ofs = Targetint.of_int32 ofs in
           D.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:ofs);
       efa_def_label =
         (fun l ->
-          let lbl = label_to_asm_label ~section:Text l in
+          let lbl = label_to_asm_label ~section:frametable_section l in
           D.define_label lbl);
       efa_string = (fun s -> D.string (s ^ "\000"))
     };

--- a/backend/arm64/binary_emitter/encode_directive.ml
+++ b/backend/arm64/binary_emitter/encode_directive.ml
@@ -96,10 +96,11 @@ let rec eval_constant state ~all_sections const =
   C.eval ~this ~lookup_label ~lookup_symbol ~lookup_variable const
 
 (* Handle cross-section (Label - This) + offset pattern. This occurs in
-   frametable entries where a DATA section location references a TEXT section
-   label (return address), or when DATA references read-only data sections like
-   .rodata.cst8. On ELF with function sections, we emit R_AARCH64_PREL32 with
-   section name and addend. On macOS, we emit PREL32_PAIR using symbol pairs. *)
+   frametable entries where a DATA or Read_only_data section location references
+   a TEXT section label (return address), or when DATA references read-only data
+   sections like .rodata.cst8. On ELF with function sections, we emit
+   R_AARCH64_PREL32 with section name and addend. On macOS, we emit PREL32_PAIR
+   using symbol pairs. *)
 let is_cross_section_relative_reference state ~all_sections ~current_section c =
   match extract_target_this_offset c with
   | None -> None
@@ -110,6 +111,10 @@ let is_cross_section_relative_reference state ~all_sections ~current_section c =
     | None -> (
       let macosx = String.equal Config.system "macosx" in
       let for_jit = All_section_states.for_jit all_sections in
+      let current_section_supports_cross_section_reference =
+        Asm_section.equal current_section Asm_section.Data
+        || Asm_section.equal current_section Asm_section.Read_only_data
+      in
       (* On ELF (not JIT) with function sections, check individual sections
          first. The assembler emits R_AARCH64_PREL32 with section symbol and
          addend. For JIT mode, we aggregate sections so can't use section
@@ -122,11 +127,11 @@ let is_cross_section_relative_reference state ~all_sections ~current_section c =
             all_sections target
         with
         | Some (target_offset, section, _target_state) ->
-          if not (Asm_section.equal current_section Asm_section.Data)
+          if not current_section_supports_cross_section_reference
           then
             Misc.fatal_errorf
-              "Cross-section (Label - This) from non-DATA section %s to %s not \
-               supported"
+              "Cross-section (Label - This) from unsupported source section %s \
+               to %s not supported"
               (Asm_section.to_string current_section)
               (Asm_section.to_string section)
           else
@@ -150,11 +155,11 @@ let is_cross_section_relative_reference state ~all_sections ~current_section c =
         | Some (target_offset, label_section, _target_state) -> (
           if Asm_section.equal label_section current_section
           then None (* Same section after all *)
-          else if not (Asm_section.equal current_section Asm_section.Data)
+          else if not current_section_supports_cross_section_reference
           then
             Misc.fatal_errorf
-              "Cross-section (Label - This) from non-DATA section %s to %s not \
-               supported"
+              "Cross-section (Label - This) from unsupported source section %s \
+               to %s not supported"
               (Asm_section.to_string current_section)
               (Asm_section.to_string label_section)
           else if (not macosx) && not for_jit
@@ -171,11 +176,12 @@ let is_cross_section_relative_reference state ~all_sections ~current_section c =
                linker computes: plus_sym - minus_sym + addend So: addend =
                (target - plus_sym) - (current - minus_sym) *)
             let current_pos = SS.offset_in_bytes state in
-            (* Find nearest symbol in DATA for SUBTRACTOR *)
+            (* Find nearest symbol in the current source section for
+               SUBTRACTOR *)
             match SS.find_nearest_symbol_before state current_pos with
             | None ->
               Misc.fatal_error
-                "No symbol in DATA section for cross-section relocation"
+                "No symbol in source section for cross-section relocation"
             | Some (minus_symbol, minus_sym_offset) -> (
               (* Find nearest symbol in target section for UNSIGNED. Note: when
                  using find_in_any_section_with_state, we get the target offset

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2182,12 +2182,16 @@ let end_assembly () =
   global_maybe_protected data_end_sym;
   D.define_symbol_label ~section:Data data_end_sym;
   D.int64 0L;
+  let frametable_section : Asm_targets.Asm_section.t =
+    if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Data
+  in
+  D.switch_to_section frametable_section;
   D.align ~fill:Zero ~bytes:8;
   (* #7887 *)
   let frametable = Cmm_helpers.make_symbol "frametable" in
   let frametable_sym = S.create_global frametable in
   global_maybe_protected frametable_sym;
-  D.define_symbol_label ~section:Data frametable_sym;
+  D.define_symbol_label ~section:frametable_section frametable_sym;
   (* CR sspies: Share the [emit_frames] code with the x86 backend. *)
   emit_frames
     { efa_code_label =
@@ -2210,15 +2214,12 @@ let end_assembly () =
       efa_align = (fun n -> D.align ~fill:Zero ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
-          let lbl = label_to_asm_label ~section:Data lbl in
+          let lbl = label_to_asm_label ~section:frametable_section lbl in
           D.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:(Targetint.of_int32 ofs));
       efa_def_label =
         (fun lbl ->
-          (* CR sspies: The frametable lives in the [.data] section on Arm, but
-             in the [.text] section on x86. The frametable should move to the
-             text section on Arm as well. *)
-          let lbl = label_to_asm_label ~section:Data lbl in
+          let lbl = label_to_asm_label ~section:frametable_section lbl in
           D.define_label lbl);
       efa_string = (fun s -> D.string (s ^ "\000"))
     };

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2183,6 +2183,9 @@ let end_assembly () =
   D.define_symbol_label ~section:Data data_end_sym;
   D.int64 0L;
   let frametable_section : Asm_targets.Asm_section.t =
+    (* This is inconsistent with x86, where the non-rodata section is [Text]
+       instead of [Data]. Now that [frametables_in_rodata] is the default, it's
+       unclear how much this matters. *)
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Data
   in
   D.switch_to_section frametable_section;

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -243,6 +243,7 @@ let details t first_occurrence =
     | Jump_tables, _, (MacOS_like | Win64) ->
       text () (* with LLVM/OS X and MASM, use the text segment *)
     | Jump_tables, _, _ -> [".rodata"], None, []
+    | Read_only_data, _, MacOS_like -> ["__DATA"; "__const"], None, ["regular"]
     | Read_only_data, _, (MinGW_32 | Win32) -> data ()
     | Read_only_data, _, (MinGW_64 | Cygwin) -> [".rdata"], Some "dr", []
     | Read_only_data, _, _ -> rodata ()
@@ -293,6 +294,7 @@ let of_names names =
   (* macOS *)
   | ["__TEXT"; "__text"] -> Some Text
   | ["__DATA"; "__data"] -> Some Data
+  | ["__DATA"; "__const"] -> Some Read_only_data
   | ["__TEXT"; "__literal8"] -> Some Eight_byte_literals
   | ["__TEXT"; "__literal16"] -> Some Sixteen_byte_literals
   | ["__TEXT"; "__probes"] -> Some Probes

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -141,9 +141,10 @@ let parse_flags flags =
   in
   inner 0L (String.to_seq flags ())
 
-let make_custom_section sections name raw_section sh_string_table =
+let make_custom_section sections name raw_section ~align sh_string_table =
   let flags = parse_flags (X86_proc.Section_name.flags name) in
-  let align = X86_proc.Section_name.alignment name in
+  let args_align = X86_proc.Section_name.alignment name in
+  let align = Int64.max args_align align in
   make_section sections name
     ~size:(Int64.of_int (X86_binary_emitter.size raw_section))
     ~align ~flags
@@ -211,11 +212,12 @@ let make_compiler_sections section_table compiler_sections symbol_table
           sh_string_table
       else if Section_name.is_note_like name
       then
-        make_custom_section section_table name raw_section ~sh_type:7
-          (* SHT_NOTE *) sh_string_table
+        make_custom_section section_table name raw_section
+          ~align:(Int64.of_int align) ~sh_type:7 (* SHT_NOTE *) sh_string_table
       else
-        make_custom_section section_table name raw_section ~sh_type:1
-          (* SHT_PROGBITS *) sh_string_table;
+        make_custom_section section_table name raw_section
+          ~align:(Int64.of_int align) ~sh_type:1 (* SHT_PROGBITS *)
+          sh_string_table;
       Section_name.Tbl.add section_symbols name
         (Symbol_table.make_section_symbol symbol_table
            (Section_table.num_sections section_table - 1)

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -271,7 +271,7 @@ let mk_dno_asm_comments f =
 let mk_frametables_in_rodata f =
   ( "-frametables-in-rodata",
     Arg.Unit f,
-    " Emit GC frametables into the .rodata section" )
+    " Emit GC frametables into the .rodata section (default)" )
 
 let mk_no_frametables_in_rodata f =
   ( "-no-frametables-in-rodata",

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -268,6 +268,16 @@ let mk_dasm_comments f =
 let mk_dno_asm_comments f =
   ("-dno-asm-comments", Arg.Unit f, " Do not add comments in .s files")
 
+let mk_frametables_in_rodata f =
+  ( "-frametables-in-rodata",
+    Arg.Unit f,
+    " Emit GC frametables into the .rodata section" )
+
+let mk_no_frametables_in_rodata f =
+  ( "-no-frametables-in-rodata",
+    Arg.Unit f,
+    " Do not emit GC frametables into the .rodata section" )
+
 let mk_heap_reduction_threshold f =
   ( "-heap-reduction-threshold",
     Arg.Int f,
@@ -1285,6 +1295,8 @@ module type Oxcaml_options = sig
   val module_entry_functions_section : unit -> unit
   val dasm_comments : unit -> unit
   val dno_asm_comments : unit -> unit
+  val frametables_in_rodata : unit -> unit
+  val no_frametables_in_rodata : unit -> unit
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : string -> unit
   val zero_alloc_assert : string -> unit
@@ -1467,6 +1479,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_module_entry_functions_section F.module_entry_functions_section;
       mk_dasm_comments F.dasm_comments;
       mk_dno_asm_comments F.dno_asm_comments;
+      mk_frametables_in_rodata F.frametables_in_rodata;
+      mk_no_frametables_in_rodata F.no_frametables_in_rodata;
       mk_heap_reduction_threshold F.heap_reduction_threshold;
       mk_zero_alloc_check F.zero_alloc_check;
       mk_zero_alloc_assert F.zero_alloc_assert;
@@ -1807,6 +1821,8 @@ module Oxcaml_options_impl = struct
 
   let dasm_comments = set' Oxcaml_flags.dasm_comments
   let dno_asm_comments = clear' Oxcaml_flags.dasm_comments
+  let frametables_in_rodata = set' Oxcaml_flags.frametables_in_rodata
+  let no_frametables_in_rodata = clear' Oxcaml_flags.frametables_in_rodata
   let dump_inlining_paths = set' Oxcaml_flags.dump_inlining_paths
   let davail = set' Oxcaml_flags.davail
   let dranges = set' Oxcaml_flags.dranges

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -71,6 +71,8 @@ module type Oxcaml_options = sig
   val module_entry_functions_section : unit -> unit
   val dasm_comments : unit -> unit
   val dno_asm_comments : unit -> unit
+  val frametables_in_rodata : unit -> unit
+  val no_frametables_in_rodata : unit -> unit
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : string -> unit
   val zero_alloc_assert : string -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -59,6 +59,8 @@ let module_entry_functions_section = ref false
 
 let dasm_comments = ref false (* -dasm-comments *)
 
+let frametables_in_rodata = ref false (* -frametables-in-rodata *)
+
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 let dump_zero_alloc = ref false          (* -dzero-alloc *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -59,7 +59,7 @@ let module_entry_functions_section = ref false
 
 let dasm_comments = ref false (* -dasm-comments *)
 
-let frametables_in_rodata = ref false (* -frametables-in-rodata *)
+let frametables_in_rodata = ref true (* -frametables-in-rodata *)
 
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -57,6 +57,8 @@ val module_entry_functions_section : bool ref
 
 val dasm_comments : bool ref
 
+val frametables_in_rodata : bool ref
+
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 val dump_zero_alloc : bool ref

--- a/oxcaml/testsuite/tests/asmcomp/frametables_in_rodata.ml
+++ b/oxcaml/testsuite/tests/asmcomp/frametables_in_rodata.ml
@@ -1,8 +1,123 @@
 (* TEST
- ocamlopt_flags = "-S -frametables-in-rodata";
+ ocamlopt_flags = "-S -g -frametables-in-rodata";
  native;
 *)
 
+(* Exercises runtime features that depend on the GC frametable, with
+   [-frametables-in-rodata] active.  The frametable is consulted by the
+   runtime to:
+     - locate live stack roots during GC;
+     - resolve return addresses to source locations for backtraces;
+     - dispatch user finalisation callbacks during a collection. *)
+
 let[@cold] f x = x +. 1.
 
-let () = ignore (f 27.)
+let () = assert (f 27. = 28.)
+
+(* -- GC root scanning ---------------------------------------------------- *)
+
+(* Each frame keeps [pair] live across an explicit minor collection, the
+   recursive call (which itself allocates and may collect), and an
+   occasional major collection.  If the frametable describes the layout
+   incorrectly, [pair] will be corrupted by GC and [check_pair] will see
+   stale data. *)
+
+let[@inline never] check_pair n (a, b) =
+  assert (a = n);
+  assert (b = n * 2)
+
+let rec gc_roots_recursive n =
+  if n = 0
+  then []
+  else
+    let pair = n, n * 2 in
+    Gc.minor ();
+    let rest = gc_roots_recursive (n - 1) in
+    if n mod 10 = 0 then Gc.full_major ();
+    check_pair n pair;
+    pair :: rest
+
+let () =
+  let pairs = gc_roots_recursive 200 in
+  assert (List.length pairs = 200);
+  List.iteri
+    (fun i (a, b) ->
+      let expected = 200 - i in
+      assert (a = expected);
+      assert (b = expected * 2))
+    pairs
+
+(* -- Exception handling -------------------------------------------------- *)
+
+exception Test_exn of int
+
+let rec deep_raise n =
+  if n = 0 then raise (Test_exn 42) else 1 + deep_raise (n - 1)
+
+let () =
+  match deep_raise 200 with
+  | _ -> assert false
+  | exception Test_exn n -> assert (n = 42)
+
+(* Catch and re-raise an exception at every level of the stack, allocating
+   in between to interleave the exception machinery with the GC. *)
+
+let rec rethrow n =
+  if n = 0
+  then raise (Test_exn 0)
+  else
+    try rethrow (n - 1) with
+    | Test_exn k ->
+      Gc.minor ();
+      raise (Test_exn (k + 1))
+
+let () =
+  match rethrow 50 with
+  | _ -> assert false
+  | exception Test_exn n -> assert (n = 50)
+
+(* -- Backtraces ---------------------------------------------------------- *)
+
+let () = Printexc.record_backtrace true
+
+let contains_substring s sub =
+  let n = String.length s and m = String.length sub in
+  let rec loop i =
+    if i + m > n
+    then false
+    else if String.equal sub (String.sub s i m)
+    then true
+    else loop (i + 1)
+  in
+  m = 0 || loop 0
+
+let rec frame_with_backtrace n =
+  if n = 0 then raise (Test_exn 0) else 1 + frame_with_backtrace (n - 1)
+
+let () =
+  match frame_with_backtrace 20 with
+  | _ -> assert false
+  | exception Test_exn _ ->
+    let bt = Printexc.get_backtrace () in
+    (* With [-g], frametable debuginfo should resolve return addresses back
+       to this source file. *)
+    assert (contains_substring bt "frametables_in_rodata.ml")
+
+(* -- Finalizers ---------------------------------------------------------- *)
+
+(* Finalisation callbacks execute OCaml code from inside the GC; the runtime
+   must walk and resume each stack via its frametable. *)
+
+let finalizer_runs = ref 0
+
+let[@inline never] register_finalizer () =
+  let buf = Bytes.create 16 in
+  Gc.finalise (fun _ -> incr finalizer_runs) buf
+
+let () =
+  for _ = 1 to 200 do
+    register_finalizer ()
+  done;
+  Gc.full_major ();
+  Gc.full_major ();
+  assert (!finalizer_runs = 200)

--- a/oxcaml/testsuite/tests/asmcomp/frametables_in_rodata.ml
+++ b/oxcaml/testsuite/tests/asmcomp/frametables_in_rodata.ml
@@ -1,0 +1,8 @@
+(* TEST
+ ocamlopt_flags = "-S -frametables-in-rodata";
+ native;
+*)
+
+let[@cold] f x = x +. 1.
+
+let () = ignore (f 27.)

--- a/oxcaml/testsuite/tests/asmcomp/no_frametables_in_rodata.ml
+++ b/oxcaml/testsuite/tests/asmcomp/no_frametables_in_rodata.ml
@@ -1,10 +1,10 @@
 (* TEST
- ocamlopt_flags = "-S -g -frametables-in-rodata";
+ ocamlopt_flags = "-S -g -no-frametables-in-rodata";
  native;
 *)
 
 (* Exercises runtime features that depend on the GC frametable, with
-   [-frametables-in-rodata] active.  The frametable is consulted by the
+   [-no-frametables-in-rodata] active.  The frametable is consulted by the
    runtime to:
      - locate live stack roots during GC;
      - resolve return addresses to source locations for backtraces;


### PR DESCRIPTION
Frametables were previously placed in the `.text` section on x86. Putting them in the `.rodata` section avoids polluting the iTLB with contents that aren't instructions, and heed's the [Intel x86 optimization manual's advice](https://cdrdv2.intel.com/v1/dl/getContent/821612?fileName=248966-Optimization-Reference-Manual-V1-050.pdf&view=true#page=146):
> Assembly/Compiler Coding Rule 50. (H impact, L generality) Always put code and data on separate pages. 

Internal experiments demonstrate that this has no measurable impact on link times.