### PR TITLE
Remove float record indices

### DIFF
--- a/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
+++ b/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
@@ -135,7 +135,9 @@ let drop_last_to_y_axis (s : line Stack.t) =
 
 1. For block indices to arrays, the array type parameter must be `mod
    non_float`.
-2. Indices cannot be taken to `[@@unboxed]` records, `[@@represent_as_float_array]` records, records that store `float`s flatly, or `private` records.
+2. Indices cannot be taken to `[@@unboxed]` records,
+   `[@@represent_as_float_array]` records, records that store `float`s flatly,
+   or `private` records.
 3. Indices to some records containing both values and non-values, and occupying
    over 2^12 bytes, cannot be created. See [Representation of block
    indices](#representation-of-block-indices) for details.

--- a/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
+++ b/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
@@ -135,7 +135,7 @@ let drop_last_to_y_axis (s : line Stack.t) =
 
 1. For block indices to arrays, the array type parameter must be `mod
    non_float`.
-2. Indices cannot be taken to `[@@unboxed]` records, `[@@represent_as_float_array]` records, `float` records, or `private` records.
+2. Indices cannot be taken to `[@@unboxed]` records, `[@@represent_as_float_array]` records, records that store `float`s flatly, or `private` records.
 3. Indices to some records containing both values and non-values, and occupying
    over 2^12 bytes, cannot be created. See [Representation of block
    indices](#representation-of-block-indices) for details.

--- a/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
+++ b/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
@@ -135,13 +135,11 @@ let drop_last_to_y_axis (s : line Stack.t) =
 
 1. For block indices to arrays, the array type parameter must be `mod
    non_float`.
-2. Indices to `[@@unboxed]` records cannot be taken.
-3. An index to a `float` in a flattened float record has an element type
-   `float#`.
-4. Indices to some records containing both values and non-values, and occupying
+2. Indices cannot be taken to `[@@unboxed]` records, `[@@represent_as_float_array]` records, `float` records, or `private` records.
+3. Indices to some records containing both values and non-values, and occupying
    over 2^12 bytes, cannot be created. See [Representation of block
    indices](#representation-of-block-indices) for details.
-5. Indices to structures with non-default modalities are not supported.
+4. Indices to structures with non-default modalities are not supported.
    Specifically, the composition of modalities of the accesses of an `idx_imm`
    must have the identity modality, while the composition of modalities of the
    accesses of an `idx_mut` must the the modality

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_bytecode_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_bytecode_test.ml
@@ -738,16 +738,11 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a23 = 100. } in
   (* .a23 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a23 = next_r.a23 } in
-  Idx_mut.set r ((.a23) : (t23, _) idx_mut) (Float_u.of_float next_r.a23);
-  mark_test_run 87;
-  let test = eq r expected in
-  if not test then failwithf "test 87 failed";
-  mark_test_run 88;
-  let test = sub_eq (Idx_mut.get r ((.a23) : (t23, _) idx_mut)) (Float_u.of_float next_r.a23) in
-  if not test then failwithf "test 88 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (****************************)
   (*   t24 = { float; int }   *)
   (****************************)
@@ -759,12 +754,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a24 = next_r.a24 } in
   Idx_mut.set r ((.a24) : (t24, _) idx_mut) next_r.a24;
-  mark_test_run 89;
+  mark_test_run 87;
   let test = eq r expected in
-  if not test then failwithf "test 89 failed";
-  mark_test_run 90;
+  if not test then failwithf "test 87 failed";
+  mark_test_run 88;
   let test = sub_eq (Idx_mut.get r ((.a24) : (t24, _) idx_mut)) next_r.a24 in
-  if not test then failwithf "test 90 failed";
+  if not test then failwithf "test 88 failed";
   let r = { a24 = 0.; b24 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a24 = 100.; b24 = 101 } in
@@ -772,12 +767,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b24 = next_r.b24 } in
   Idx_mut.set r ((.b24) : (t24, _) idx_mut) next_r.b24;
-  mark_test_run 91;
+  mark_test_run 89;
   let test = eq r expected in
-  if not test then failwithf "test 91 failed";
-  mark_test_run 92;
+  if not test then failwithf "test 89 failed";
+  mark_test_run 90;
   let test = sub_eq (Idx_mut.get r ((.b24) : (t24, _) idx_mut)) next_r.b24 in
-  if not test then failwithf "test 92 failed";
+  if not test then failwithf "test 90 failed";
   (*********************************)
   (*   t25 = { float; int; int }   *)
   (*********************************)
@@ -789,12 +784,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a25 = next_r.a25 } in
   Idx_mut.set r ((.a25) : (t25, _) idx_mut) next_r.a25;
-  mark_test_run 93;
+  mark_test_run 91;
   let test = eq r expected in
-  if not test then failwithf "test 93 failed";
-  mark_test_run 94;
+  if not test then failwithf "test 91 failed";
+  mark_test_run 92;
   let test = sub_eq (Idx_mut.get r ((.a25) : (t25, _) idx_mut)) next_r.a25 in
-  if not test then failwithf "test 94 failed";
+  if not test then failwithf "test 92 failed";
   let r = { a25 = 0.; b25 = 1; c25 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a25 = 100.; b25 = 101; c25 = 102 } in
@@ -802,12 +797,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b25 = next_r.b25 } in
   Idx_mut.set r ((.b25) : (t25, _) idx_mut) next_r.b25;
-  mark_test_run 95;
+  mark_test_run 93;
   let test = eq r expected in
-  if not test then failwithf "test 95 failed";
-  mark_test_run 96;
+  if not test then failwithf "test 93 failed";
+  mark_test_run 94;
   let test = sub_eq (Idx_mut.get r ((.b25) : (t25, _) idx_mut)) next_r.b25 in
-  if not test then failwithf "test 96 failed";
+  if not test then failwithf "test 94 failed";
   let r = { a25 = 0.; b25 = 1; c25 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a25 = 100.; b25 = 101; c25 = 102 } in
@@ -815,12 +810,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with c25 = next_r.c25 } in
   Idx_mut.set r ((.c25) : (t25, _) idx_mut) next_r.c25;
-  mark_test_run 97;
+  mark_test_run 95;
   let test = eq r expected in
-  if not test then failwithf "test 97 failed";
-  mark_test_run 98;
+  if not test then failwithf "test 95 failed";
+  mark_test_run 96;
   let test = sub_eq (Idx_mut.get r ((.c25) : (t25, _) idx_mut)) next_r.c25 in
-  if not test then failwithf "test 98 failed";
+  if not test then failwithf "test 96 failed";
   (******************************)
   (*   t26 = { float; int64 }   *)
   (******************************)
@@ -832,12 +827,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a26 = next_r.a26 } in
   Idx_mut.set r ((.a26) : (t26, _) idx_mut) next_r.a26;
-  mark_test_run 99;
+  mark_test_run 97;
   let test = eq r expected in
-  if not test then failwithf "test 99 failed";
-  mark_test_run 100;
+  if not test then failwithf "test 97 failed";
+  mark_test_run 98;
   let test = sub_eq (Idx_mut.get r ((.a26) : (t26, _) idx_mut)) next_r.a26 in
-  if not test then failwithf "test 100 failed";
+  if not test then failwithf "test 98 failed";
   let r = { a26 = 0.; b26 = 1L } in
   (* Paths of depth 1 *)
   let next_r = { a26 = 100.; b26 = 101L } in
@@ -845,12 +840,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64.equal (globalize a) (globalize b)) in
   let expected = { r with b26 = next_r.b26 } in
   Idx_mut.set r ((.b26) : (t26, _) idx_mut) next_r.b26;
-  mark_test_run 101;
+  mark_test_run 99;
   let test = eq r expected in
-  if not test then failwithf "test 101 failed";
-  mark_test_run 102;
+  if not test then failwithf "test 99 failed";
+  mark_test_run 100;
   let test = sub_eq (Idx_mut.get r ((.b26) : (t26, _) idx_mut)) next_r.b26 in
-  if not test then failwithf "test 102 failed";
+  if not test then failwithf "test 100 failed";
   (**************************************)
   (*   t27 = { float; float; float# }   *)
   (**************************************)
@@ -859,43 +854,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101.; c27 = #102. } in
   (* .a27 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a27 = next_r.a27 } in
-  Idx_mut.set r ((.a27) : (t27, _) idx_mut) (Float_u.of_float next_r.a27);
-  mark_test_run 103;
-  let test = eq r expected in
-  if not test then failwithf "test 103 failed";
-  mark_test_run 104;
-  let test = sub_eq (Idx_mut.get r ((.a27) : (t27, _) idx_mut)) (Float_u.of_float next_r.a27) in
-  if not test then failwithf "test 104 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a27 = 0.; b27 = 1.; c27 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101.; c27 = #102. } in
   (* .b27 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b27 = next_r.b27 } in
-  Idx_mut.set r ((.b27) : (t27, _) idx_mut) (Float_u.of_float next_r.b27);
-  mark_test_run 105;
-  let test = eq r expected in
-  if not test then failwithf "test 105 failed";
-  mark_test_run 106;
-  let test = sub_eq (Idx_mut.get r ((.b27) : (t27, _) idx_mut)) (Float_u.of_float next_r.b27) in
-  if not test then failwithf "test 106 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a27 = 0.; b27 = 1.; c27 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101.; c27 = #102. } in
   (* .c27 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c27 = next_r.c27 } in
-  Idx_mut.set r ((.c27) : (t27, _) idx_mut) next_r.c27;
-  mark_test_run 107;
-  let test = eq r expected in
-  if not test then failwithf "test 107 failed";
-  mark_test_run 108;
-  let test = sub_eq (Idx_mut.get r ((.c27) : (t27, _) idx_mut)) next_r.c27 in
-  if not test then failwithf "test 108 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (**************************************)
   (*   t28 = { float; #{ int; int } }   *)
   (**************************************)
@@ -907,12 +888,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a28 = next_r.a28 } in
   Idx_mut.set r ((.a28) : (t28, _) idx_mut) next_r.a28;
-  mark_test_run 109;
+  mark_test_run 101;
   let test = eq r expected in
-  if not test then failwithf "test 109 failed";
-  mark_test_run 110;
+  if not test then failwithf "test 101 failed";
+  mark_test_run 102;
   let test = sub_eq (Idx_mut.get r ((.a28) : (t28, _) idx_mut)) next_r.a28 in
-  if not test then failwithf "test 110 failed";
+  if not test then failwithf "test 102 failed";
   let r = { a28 = 0.; b28 = #{ a5 = 1; b5 = 2 } } in
   (* Paths of depth 1 *)
   let next_r = { a28 = 100.; b28 = #{ a5 = 101; b5 = 102 } } in
@@ -920,34 +901,34 @@ let to_run () =
   let sub_eq = (fun #{ a5 = a51; b5 = b51 } #{ a5 = a52; b5 = b52 } -> (fun a b -> Int.equal a b) a51 a52 && (fun a b -> Int.equal a b) b51 b52) in
   let expected = { r with b28 = next_r.b28 } in
   Idx_mut.set r ((.b28) : (t28, _) idx_mut) next_r.b28;
-  mark_test_run 111;
+  mark_test_run 103;
   let test = eq r expected in
-  if not test then failwithf "test 111 failed";
-  mark_test_run 112;
+  if not test then failwithf "test 103 failed";
+  mark_test_run 104;
   let test = sub_eq (Idx_mut.get r ((.b28) : (t28, _) idx_mut)) next_r.b28 in
-  if not test then failwithf "test 112 failed";
+  if not test then failwithf "test 104 failed";
   (* Paths of depth 2 *)
   let next_r = { a28 = 200.; b28 = #{ a5 = 201; b5 = 202 } } in
   (* .b28.#a5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b28 = #{ r.b28 with a5 = next_r.b28.#a5 } } in
   Idx_mut.set r ((.b28.#a5) : (t28, _) idx_mut) next_r.b28.#a5;
-  mark_test_run 113;
+  mark_test_run 105;
   let test = eq r expected in
-  if not test then failwithf "test 113 failed";
-  mark_test_run 114;
+  if not test then failwithf "test 105 failed";
+  mark_test_run 106;
   let test = sub_eq (Idx_mut.get r ((.b28.#a5) : (t28, _) idx_mut)) next_r.b28.#a5 in
-  if not test then failwithf "test 114 failed";
+  if not test then failwithf "test 106 failed";
   (* .b28.#b5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b28 = #{ r.b28 with b5 = next_r.b28.#b5 } } in
   Idx_mut.set r ((.b28.#b5) : (t28, _) idx_mut) next_r.b28.#b5;
-  mark_test_run 115;
+  mark_test_run 107;
   let test = eq r expected in
-  if not test then failwithf "test 115 failed";
-  mark_test_run 116;
+  if not test then failwithf "test 107 failed";
+  mark_test_run 108;
   let test = sub_eq (Idx_mut.get r ((.b28.#b5) : (t28, _) idx_mut)) next_r.b28.#b5 in
-  if not test then failwithf "test 116 failed";
+  if not test then failwithf "test 108 failed";
   (***********************************)
   (*   t29 = { float; #{ float } }   *)
   (***********************************)
@@ -956,36 +937,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = #{ a7 = 101. } } in
   (* .a29 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a29 = next_r.a29 } in
-  Idx_mut.set r ((.a29) : (t29, _) idx_mut) (Float_u.of_float next_r.a29);
-  mark_test_run 117;
-  let test = eq r expected in
-  if not test then failwithf "test 117 failed";
-  mark_test_run 118;
-  let test = sub_eq (Idx_mut.get r ((.a29) : (t29, _) idx_mut)) (Float_u.of_float next_r.a29) in
-  if not test then failwithf "test 118 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a29 = 0.; b29 = #{ a7 = 1. } } in
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = #{ a7 = 101. } } in
   (* .b29 *)
   (* Note: skipping test as this is not a valid block index,
      due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
   let _ = next_r in
   (* Paths of depth 2 *)
   let next_r = { a29 = 200.; b29 = #{ a7 = 201. } } in
   (* .b29.#a7 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b29 = #{ r.b29 with a7 = next_r.b29.#a7 } } in
-  Idx_mut.set r ((.b29.#a7) : (t29, _) idx_mut) (Float_u.of_float next_r.b29.#a7);
-  mark_test_run 119;
-  let test = eq r expected in
-  if not test then failwithf "test 119 failed";
-  mark_test_run 120;
-  let test = sub_eq (Idx_mut.get r ((.b29.#a7) : (t29, _) idx_mut)) (Float_u.of_float next_r.b29.#a7) in
-  if not test then failwithf "test 120 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (****************************************)
   (*   t31 = { float; #{ float; int } }   *)
   (****************************************)
@@ -997,12 +970,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a31 = next_r.a31 } in
   Idx_mut.set r ((.a31) : (t31, _) idx_mut) next_r.a31;
-  mark_test_run 121;
+  mark_test_run 109;
   let test = eq r expected in
-  if not test then failwithf "test 121 failed";
-  mark_test_run 122;
+  if not test then failwithf "test 109 failed";
+  mark_test_run 110;
   let test = sub_eq (Idx_mut.get r ((.a31) : (t31, _) idx_mut)) next_r.a31 in
-  if not test then failwithf "test 122 failed";
+  if not test then failwithf "test 110 failed";
   let r = { a31 = 0.; b31 = #{ a30 = 1.; b30 = 2 } } in
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = #{ a30 = 101.; b30 = 102 } } in
@@ -1010,34 +983,34 @@ let to_run () =
   let sub_eq = (fun #{ a30 = a301; b30 = b301 } #{ a30 = a302; b30 = b302 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a301 a302 && (fun a b -> Int.equal a b) b301 b302) in
   let expected = { r with b31 = next_r.b31 } in
   Idx_mut.set r ((.b31) : (t31, _) idx_mut) next_r.b31;
-  mark_test_run 123;
+  mark_test_run 111;
   let test = eq r expected in
-  if not test then failwithf "test 123 failed";
-  mark_test_run 124;
+  if not test then failwithf "test 111 failed";
+  mark_test_run 112;
   let test = sub_eq (Idx_mut.get r ((.b31) : (t31, _) idx_mut)) next_r.b31 in
-  if not test then failwithf "test 124 failed";
+  if not test then failwithf "test 112 failed";
   (* Paths of depth 2 *)
   let next_r = { a31 = 200.; b31 = #{ a30 = 201.; b30 = 202 } } in
   (* .b31.#a30 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b31 = #{ r.b31 with a30 = next_r.b31.#a30 } } in
   Idx_mut.set r ((.b31.#a30) : (t31, _) idx_mut) next_r.b31.#a30;
-  mark_test_run 125;
+  mark_test_run 113;
   let test = eq r expected in
-  if not test then failwithf "test 125 failed";
-  mark_test_run 126;
+  if not test then failwithf "test 113 failed";
+  mark_test_run 114;
   let test = sub_eq (Idx_mut.get r ((.b31.#a30) : (t31, _) idx_mut)) next_r.b31.#a30 in
-  if not test then failwithf "test 126 failed";
+  if not test then failwithf "test 114 failed";
   (* .b31.#b30 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b31 = #{ r.b31 with b30 = next_r.b31.#b30 } } in
   Idx_mut.set r ((.b31.#b30) : (t31, _) idx_mut) next_r.b31.#b30;
-  mark_test_run 127;
+  mark_test_run 115;
   let test = eq r expected in
-  if not test then failwithf "test 127 failed";
-  mark_test_run 128;
+  if not test then failwithf "test 115 failed";
+  mark_test_run 116;
   let test = sub_eq (Idx_mut.get r ((.b31.#b30) : (t31, _) idx_mut)) next_r.b31.#b30 in
-  if not test then failwithf "test 128 failed";
+  if not test then failwithf "test 116 failed";
   (*******************************************)
   (*   t33 = { float; #{ float#; float } }   *)
   (*******************************************)
@@ -1049,12 +1022,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a33 = next_r.a33 } in
   Idx_mut.set r ((.a33) : (t33, _) idx_mut) next_r.a33;
-  mark_test_run 129;
+  mark_test_run 117;
   let test = eq r expected in
-  if not test then failwithf "test 129 failed";
-  mark_test_run 130;
+  if not test then failwithf "test 117 failed";
+  mark_test_run 118;
   let test = sub_eq (Idx_mut.get r ((.a33) : (t33, _) idx_mut)) next_r.a33 in
-  if not test then failwithf "test 130 failed";
+  if not test then failwithf "test 118 failed";
   let r = { a33 = 0.; b33 = #{ a32 = #1.; b32 = 2. } } in
   (* Paths of depth 1 *)
   let next_r = { a33 = 100.; b33 = #{ a32 = #101.; b32 = 102. } } in
@@ -1062,34 +1035,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a321 a322 && (fun a b -> Float.equal (globalize a) (globalize b)) b321 b322) in
   let expected = { r with b33 = next_r.b33 } in
   Idx_mut.set r ((.b33) : (t33, _) idx_mut) next_r.b33;
-  mark_test_run 131;
+  mark_test_run 119;
   let test = eq r expected in
-  if not test then failwithf "test 131 failed";
-  mark_test_run 132;
+  if not test then failwithf "test 119 failed";
+  mark_test_run 120;
   let test = sub_eq (Idx_mut.get r ((.b33) : (t33, _) idx_mut)) next_r.b33 in
-  if not test then failwithf "test 132 failed";
+  if not test then failwithf "test 120 failed";
   (* Paths of depth 2 *)
   let next_r = { a33 = 200.; b33 = #{ a32 = #201.; b32 = 202. } } in
   (* .b33.#a32 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b33 = #{ r.b33 with a32 = next_r.b33.#a32 } } in
   Idx_mut.set r ((.b33.#a32) : (t33, _) idx_mut) next_r.b33.#a32;
-  mark_test_run 133;
+  mark_test_run 121;
   let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
+  if not test then failwithf "test 121 failed";
+  mark_test_run 122;
   let test = sub_eq (Idx_mut.get r ((.b33.#a32) : (t33, _) idx_mut)) next_r.b33.#a32 in
-  if not test then failwithf "test 134 failed";
+  if not test then failwithf "test 122 failed";
   (* .b33.#b32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b33 = #{ r.b33 with b32 = next_r.b33.#b32 } } in
   Idx_mut.set r ((.b33.#b32) : (t33, _) idx_mut) next_r.b33.#b32;
-  mark_test_run 135;
+  mark_test_run 123;
   let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
+  if not test then failwithf "test 123 failed";
+  mark_test_run 124;
   let test = sub_eq (Idx_mut.get r ((.b33.#b32) : (t33, _) idx_mut)) next_r.b33.#b32 in
-  if not test then failwithf "test 136 failed";
+  if not test then failwithf "test 124 failed";
   (********************************************)
   (*   t35 = { float; #{ float#; float# } }   *)
   (********************************************)
@@ -1101,12 +1074,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a35 = next_r.a35 } in
   Idx_mut.set r ((.a35) : (t35, _) idx_mut) next_r.a35;
-  mark_test_run 137;
+  mark_test_run 125;
   let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
+  if not test then failwithf "test 125 failed";
+  mark_test_run 126;
   let test = sub_eq (Idx_mut.get r ((.a35) : (t35, _) idx_mut)) next_r.a35 in
-  if not test then failwithf "test 138 failed";
+  if not test then failwithf "test 126 failed";
   let r = { a35 = 0.; b35 = #{ a34 = #1.; b34 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a35 = 100.; b35 = #{ a34 = #101.; b34 = #102. } } in
@@ -1114,34 +1087,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b341 b342) in
   let expected = { r with b35 = next_r.b35 } in
   Idx_mut.set r ((.b35) : (t35, _) idx_mut) next_r.b35;
-  mark_test_run 139;
+  mark_test_run 127;
   let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
+  if not test then failwithf "test 127 failed";
+  mark_test_run 128;
   let test = sub_eq (Idx_mut.get r ((.b35) : (t35, _) idx_mut)) next_r.b35 in
-  if not test then failwithf "test 140 failed";
+  if not test then failwithf "test 128 failed";
   (* Paths of depth 2 *)
   let next_r = { a35 = 200.; b35 = #{ a34 = #201.; b34 = #202. } } in
   (* .b35.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with a34 = next_r.b35.#a34 } } in
   Idx_mut.set r ((.b35.#a34) : (t35, _) idx_mut) next_r.b35.#a34;
-  mark_test_run 141;
+  mark_test_run 129;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 129 failed";
+  mark_test_run 130;
   let test = sub_eq (Idx_mut.get r ((.b35.#a34) : (t35, _) idx_mut)) next_r.b35.#a34 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 130 failed";
   (* .b35.#b34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with b34 = next_r.b35.#b34 } } in
   Idx_mut.set r ((.b35.#b34) : (t35, _) idx_mut) next_r.b35.#b34;
-  mark_test_run 143;
+  mark_test_run 131;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 131 failed";
+  mark_test_run 132;
   let test = sub_eq (Idx_mut.get r ((.b35.#b34) : (t35, _) idx_mut)) next_r.b35.#b34 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 132 failed";
   (***************************************)
   (*   t36 = { float#; float; float# }   *)
   (***************************************)
@@ -1150,42 +1123,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a36 = #100.; b36 = 101.; c36 = #102. } in
   (* .a36 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a36 = next_r.a36 } in
-  Idx_mut.set r ((.a36) : (t36, _) idx_mut) next_r.a36;
-  mark_test_run 145;
-  let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
-  let test = sub_eq (Idx_mut.get r ((.a36) : (t36, _) idx_mut)) next_r.a36 in
-  if not test then failwithf "test 146 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a36 = #0.; b36 = 1.; c36 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a36 = #100.; b36 = 101.; c36 = #102. } in
   (* .b36 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b36 = next_r.b36 } in
-  Idx_mut.set r ((.b36) : (t36, _) idx_mut) (Float_u.of_float next_r.b36);
-  mark_test_run 147;
-  let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
-  let test = sub_eq (Idx_mut.get r ((.b36) : (t36, _) idx_mut)) (Float_u.of_float next_r.b36) in
-  if not test then failwithf "test 148 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a36 = #0.; b36 = 1.; c36 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a36 = #100.; b36 = 101.; c36 = #102. } in
   (* .c36 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c36 = next_r.c36 } in
-  Idx_mut.set r ((.c36) : (t36, _) idx_mut) next_r.c36;
-  mark_test_run 149;
-  let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
-  let test = sub_eq (Idx_mut.get r ((.c36) : (t36, _) idx_mut)) next_r.c36 in
-  if not test then failwithf "test 150 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (********************************)
   (*   t37 = { float#; float# }   *)
   (********************************)
@@ -1194,28 +1154,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = #101. } in
   (* .a37 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a37 = next_r.a37 } in
-  Idx_mut.set r ((.a37) : (t37, _) idx_mut) next_r.a37;
-  mark_test_run 151;
-  let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
-  let test = sub_eq (Idx_mut.get r ((.a37) : (t37, _) idx_mut)) next_r.a37 in
-  if not test then failwithf "test 152 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a37 = #0.; b37 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = #101. } in
   (* .b37 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b37 = next_r.b37 } in
-  Idx_mut.set r ((.b37) : (t37, _) idx_mut) next_r.b37;
-  mark_test_run 153;
-  let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
-  let test = sub_eq (Idx_mut.get r ((.b37) : (t37, _) idx_mut)) next_r.b37 in
-  if not test then failwithf "test 154 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (***************************************)
   (*   t38 = { float#; float#; float }   *)
   (***************************************)
@@ -1224,42 +1176,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101.; c38 = 102. } in
   (* .a38 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a38 = next_r.a38 } in
-  Idx_mut.set r ((.a38) : (t38, _) idx_mut) next_r.a38;
-  mark_test_run 155;
-  let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
-  let test = sub_eq (Idx_mut.get r ((.a38) : (t38, _) idx_mut)) next_r.a38 in
-  if not test then failwithf "test 156 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a38 = #0.; b38 = #1.; c38 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101.; c38 = 102. } in
   (* .b38 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b38 = next_r.b38 } in
-  Idx_mut.set r ((.b38) : (t38, _) idx_mut) next_r.b38;
-  mark_test_run 157;
-  let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
-  let test = sub_eq (Idx_mut.get r ((.b38) : (t38, _) idx_mut)) next_r.b38 in
-  if not test then failwithf "test 158 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a38 = #0.; b38 = #1.; c38 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101.; c38 = 102. } in
   (* .c38 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c38 = next_r.c38 } in
-  Idx_mut.set r ((.c38) : (t38, _) idx_mut) (Float_u.of_float next_r.c38);
-  mark_test_run 159;
-  let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
-  let test = sub_eq (Idx_mut.get r ((.c38) : (t38, _) idx_mut)) (Float_u.of_float next_r.c38) in
-  if not test then failwithf "test 160 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*************************************)
   (*   t40 = { float#; #{ float# } }   *)
   (*************************************)
@@ -1268,40 +1207,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #{ a39 = #101. } } in
   (* .a40 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a40 = next_r.a40 } in
-  Idx_mut.set r ((.a40) : (t40, _) idx_mut) next_r.a40;
-  mark_test_run 161;
-  let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
-  let test = sub_eq (Idx_mut.get r ((.a40) : (t40, _) idx_mut)) next_r.a40 in
-  if not test then failwithf "test 162 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a40 = #0.; b40 = #{ a39 = #1. } } in
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #{ a39 = #101. } } in
   (* .b40 *)
-  let sub_eq = (fun #{ a39 = a391 } #{ a39 = a392 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a391 a392) in
-  let expected = { r with b40 = next_r.b40 } in
-  Idx_mut.set r ((.b40) : (t40, _) idx_mut) next_r.b40;
-  mark_test_run 163;
-  let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
-  let test = sub_eq (Idx_mut.get r ((.b40) : (t40, _) idx_mut)) next_r.b40 in
-  if not test then failwithf "test 164 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (* Paths of depth 2 *)
   let next_r = { a40 = #200.; b40 = #{ a39 = #201. } } in
   (* .b40.#a39 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b40 = #{ r.b40 with a39 = next_r.b40.#a39 } } in
-  Idx_mut.set r ((.b40.#a39) : (t40, _) idx_mut) next_r.b40.#a39;
-  mark_test_run 165;
-  let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
-  let test = sub_eq (Idx_mut.get r ((.b40.#a39) : (t40, _) idx_mut)) next_r.b40.#a39 in
-  if not test then failwithf "test 166 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*********************************************)
   (*   t41 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1313,12 +1240,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a41 = next_r.a41 } in
   Idx_mut.set r ((.a41) : (t41, _) idx_mut) next_r.a41;
-  mark_test_run 167;
+  mark_test_run 133;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
   let test = sub_eq (Idx_mut.get r ((.a41) : (t41, _) idx_mut)) next_r.a41 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 134 failed";
   let r = { a41 = #0.; b41 = #{ a34 = #1.; b34 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a41 = #100.; b41 = #{ a34 = #101.; b34 = #102. } } in
@@ -1326,34 +1253,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b341 b342) in
   let expected = { r with b41 = next_r.b41 } in
   Idx_mut.set r ((.b41) : (t41, _) idx_mut) next_r.b41;
-  mark_test_run 169;
+  mark_test_run 135;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
   let test = sub_eq (Idx_mut.get r ((.b41) : (t41, _) idx_mut)) next_r.b41 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 136 failed";
   (* Paths of depth 2 *)
   let next_r = { a41 = #200.; b41 = #{ a34 = #201.; b34 = #202. } } in
   (* .b41.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b41 = #{ r.b41 with a34 = next_r.b41.#a34 } } in
   Idx_mut.set r ((.b41.#a34) : (t41, _) idx_mut) next_r.b41.#a34;
-  mark_test_run 171;
+  mark_test_run 137;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
   let test = sub_eq (Idx_mut.get r ((.b41.#a34) : (t41, _) idx_mut)) next_r.b41.#a34 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 138 failed";
   (* .b41.#b34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b41 = #{ r.b41 with b34 = next_r.b41.#b34 } } in
   Idx_mut.set r ((.b41.#b34) : (t41, _) idx_mut) next_r.b41.#b34;
-  mark_test_run 173;
+  mark_test_run 139;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
   let test = sub_eq (Idx_mut.get r ((.b41.#b34) : (t41, _) idx_mut)) next_r.b41.#b34 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 140 failed";
   (************************)
   (*   t42 = { string }   *)
   (************************)
@@ -1365,12 +1292,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a42 = next_r.a42 } in
   Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 175;
+  mark_test_run 141;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
   let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 142 failed";
   (****************************)
   (*   t44 = { (| unit_u) }   *)
   (****************************)
@@ -1382,12 +1309,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C43_0(a0), C43_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a44 = next_r.a44 } in
   Idx_mut.set r ((.a44) : (t44, _) idx_mut) next_r.a44;
-  mark_test_run 177;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.a44) : (t44, _) idx_mut)) next_r.a44 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 144 failed";
   (***********************************)
   (*   t45 = { (| unit_u); int64 }   *)
   (***********************************)
@@ -1399,12 +1326,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C43_0(a0), C43_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 179;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 146 failed";
   let r = { a45 = (C43_0 (unbox_unit ())); b45 = 0L } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (C43_0 (unbox_unit ())); b45 = 100L } in
@@ -1412,12 +1339,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64.equal (globalize a) (globalize b)) in
   let expected = { r with b45 = next_r.b45 } in
   Idx_mut.set r ((.b45) : (t45, _) idx_mut) next_r.b45;
-  mark_test_run 181;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.b45) : (t45, _) idx_mut)) next_r.b45 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 148 failed";
   (************************************)
   (*   t46 = { (| unit_u); int64# }   *)
   (************************************)
@@ -1429,12 +1356,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C43_0(a0), C43_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a46 = next_r.a46 } in
   Idx_mut.set r ((.a46) : (t46, _) idx_mut) next_r.a46;
-  mark_test_run 183;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.a46) : (t46, _) idx_mut)) next_r.a46 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 150 failed";
   let r = { a46 = (C43_0 (unbox_unit ())); b46 = #0L } in
   (* Paths of depth 1 *)
   let next_r = { a46 = (C43_0 (unbox_unit ())); b46 = #100L } in
@@ -1442,12 +1369,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b46 = next_r.b46 } in
   Idx_mut.set r ((.b46) : (t46, _) idx_mut) next_r.b46;
-  mark_test_run 185;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.b46) : (t46, _) idx_mut)) next_r.b46 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 152 failed";
   (**************************)
   (*   t47 = { #{ int } }   *)
   (**************************)
@@ -1459,24 +1386,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 187;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 154 failed";
   (* Paths of depth 2 *)
   let next_r = { a47 = #{ a3 = 200 } } in
   (* .a47.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a47 = #{ r.a47 with a3 = next_r.a47.#a3 } } in
   Idx_mut.set r ((.a47.#a3) : (t47, _) idx_mut) next_r.a47.#a3;
-  mark_test_run 189;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.a47.#a3) : (t47, _) idx_mut)) next_r.a47.#a3 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 156 failed";
   (*******************************)
   (*   t48 = { #{ int }; int }   *)
   (*******************************)
@@ -1488,24 +1415,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a48 = next_r.a48 } in
   Idx_mut.set r ((.a48) : (t48, _) idx_mut) next_r.a48;
-  mark_test_run 191;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.a48) : (t48, _) idx_mut)) next_r.a48 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 158 failed";
   (* Paths of depth 2 *)
   let next_r = { a48 = #{ a3 = 200 }; b48 = 201 } in
   (* .a48.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a48 = #{ r.a48 with a3 = next_r.a48.#a3 } } in
   Idx_mut.set r ((.a48.#a3) : (t48, _) idx_mut) next_r.a48.#a3;
-  mark_test_run 193;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.a48.#a3) : (t48, _) idx_mut)) next_r.a48.#a3 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 160 failed";
   let r = { a48 = #{ a3 = 0 }; b48 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a48 = #{ a3 = 100 }; b48 = 101 } in
@@ -1513,12 +1440,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b48 = next_r.b48 } in
   Idx_mut.set r ((.b48) : (t48, _) idx_mut) next_r.b48;
-  mark_test_run 195;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.b48) : (t48, _) idx_mut)) next_r.b48 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 162 failed";
   (***************************************)
   (*   t49 = { #{ int; int }; int32# }   *)
   (***************************************)
@@ -1530,34 +1457,34 @@ let to_run () =
   let sub_eq = (fun #{ a5 = a51; b5 = b51 } #{ a5 = a52; b5 = b52 } -> (fun a b -> Int.equal a b) a51 a52 && (fun a b -> Int.equal a b) b51 b52) in
   let expected = { r with a49 = next_r.a49 } in
   Idx_mut.set r ((.a49) : (t49, _) idx_mut) next_r.a49;
-  mark_test_run 197;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.a49) : (t49, _) idx_mut)) next_r.a49 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 164 failed";
   (* Paths of depth 2 *)
   let next_r = { a49 = #{ a5 = 200; b5 = 201 }; b49 = #202l } in
   (* .a49.#a5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a49 = #{ r.a49 with a5 = next_r.a49.#a5 } } in
   Idx_mut.set r ((.a49.#a5) : (t49, _) idx_mut) next_r.a49.#a5;
-  mark_test_run 199;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.a49.#a5) : (t49, _) idx_mut)) next_r.a49.#a5 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 166 failed";
   (* .a49.#b5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a49 = #{ r.a49 with b5 = next_r.a49.#b5 } } in
   Idx_mut.set r ((.a49.#b5) : (t49, _) idx_mut) next_r.a49.#b5;
-  mark_test_run 201;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.a49.#b5) : (t49, _) idx_mut)) next_r.a49.#b5 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 168 failed";
   let r = { a49 = #{ a5 = 0; b5 = 1 }; b49 = #2l } in
   (* Paths of depth 1 *)
   let next_r = { a49 = #{ a5 = 100; b5 = 101 }; b49 = #102l } in
@@ -1565,12 +1492,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b49 = next_r.b49 } in
   Idx_mut.set r ((.b49) : (t49, _) idx_mut) next_r.b49;
-  mark_test_run 203;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.b49) : (t49, _) idx_mut)) next_r.b49 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 170 failed";
   (***************************************)
   (*   t51 = { #{ int; int32# }; int }   *)
   (***************************************)
@@ -1582,34 +1509,34 @@ let to_run () =
   let sub_eq = (fun #{ a50 = a501; b50 = b501 } #{ a50 = a502; b50 = b502 } -> (fun a b -> Int.equal a b) a501 a502 && (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) b501 b502) in
   let expected = { r with a51 = next_r.a51 } in
   Idx_mut.set r ((.a51) : (t51, _) idx_mut) next_r.a51;
-  mark_test_run 205;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.a51) : (t51, _) idx_mut)) next_r.a51 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 172 failed";
   (* Paths of depth 2 *)
   let next_r = { a51 = #{ a50 = 200; b50 = #201l }; b51 = 202 } in
   (* .a51.#a50 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a51 = #{ r.a51 with a50 = next_r.a51.#a50 } } in
   Idx_mut.set r ((.a51.#a50) : (t51, _) idx_mut) next_r.a51.#a50;
-  mark_test_run 207;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.a51.#a50) : (t51, _) idx_mut)) next_r.a51.#a50 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 174 failed";
   (* .a51.#b50 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a51 = #{ r.a51 with b50 = next_r.a51.#b50 } } in
   Idx_mut.set r ((.a51.#b50) : (t51, _) idx_mut) next_r.a51.#b50;
-  mark_test_run 209;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.a51.#b50) : (t51, _) idx_mut)) next_r.a51.#b50 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 176 failed";
   let r = { a51 = #{ a50 = 0; b50 = #1l }; b51 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a51 = #{ a50 = 100; b50 = #101l }; b51 = 102 } in
@@ -1617,12 +1544,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b51 = next_r.b51 } in
   Idx_mut.set r ((.b51) : (t51, _) idx_mut) next_r.b51;
-  mark_test_run 211;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.b51) : (t51, _) idx_mut)) next_r.b51 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 178 failed";
   (**************************************)
   (*   t53 = { #{ int; float }; int }   *)
   (**************************************)
@@ -1634,34 +1561,34 @@ let to_run () =
   let sub_eq = (fun #{ a52 = a521; b52 = b521 } #{ a52 = a522; b52 = b522 } -> (fun a b -> Int.equal a b) a521 a522 && (fun a b -> Float.equal (globalize a) (globalize b)) b521 b522) in
   let expected = { r with a53 = next_r.a53 } in
   Idx_mut.set r ((.a53) : (t53, _) idx_mut) next_r.a53;
-  mark_test_run 213;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.a53) : (t53, _) idx_mut)) next_r.a53 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 180 failed";
   (* Paths of depth 2 *)
   let next_r = { a53 = #{ a52 = 200; b52 = 201. }; b53 = 202 } in
   (* .a53.#a52 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a53 = #{ r.a53 with a52 = next_r.a53.#a52 } } in
   Idx_mut.set r ((.a53.#a52) : (t53, _) idx_mut) next_r.a53.#a52;
-  mark_test_run 215;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.a53.#a52) : (t53, _) idx_mut)) next_r.a53.#a52 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 182 failed";
   (* .a53.#b52 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a53 = #{ r.a53 with b52 = next_r.a53.#b52 } } in
   Idx_mut.set r ((.a53.#b52) : (t53, _) idx_mut) next_r.a53.#b52;
-  mark_test_run 217;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a53.#b52) : (t53, _) idx_mut)) next_r.a53.#b52 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 184 failed";
   let r = { a53 = #{ a52 = 0; b52 = 1. }; b53 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a53 = #{ a52 = 100; b52 = 101. }; b53 = 102 } in
@@ -1669,12 +1596,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b53 = next_r.b53 } in
   Idx_mut.set r ((.b53) : (t53, _) idx_mut) next_r.b53;
-  mark_test_run 219;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.b53) : (t53, _) idx_mut)) next_r.b53 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 186 failed";
   (*************************************)
   (*   t55 = { #{ unit_u }; string }   *)
   (*************************************)
@@ -1686,24 +1613,24 @@ let to_run () =
   let sub_eq = (fun #{ a54 = a541 } #{ a54 = a542 } -> (fun _ _ -> true) a541 a542) in
   let expected = { r with a55 = next_r.a55 } in
   Idx_mut.set r ((.a55) : (t55, _) idx_mut) next_r.a55;
-  mark_test_run 221;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.a55) : (t55, _) idx_mut)) next_r.a55 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 188 failed";
   (* Paths of depth 2 *)
   let next_r = { a55 = #{ a54 = (unbox_unit ()) }; b55 = "200" } in
   (* .a55.#a54 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a55 = #{ r.a55 with a54 = next_r.a55.#a54 } } in
   Idx_mut.set r ((.a55.#a54) : (t55, _) idx_mut) next_r.a55.#a54;
-  mark_test_run 223;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.a55.#a54) : (t55, _) idx_mut)) next_r.a55.#a54 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 190 failed";
   let r = { a55 = #{ a54 = (unbox_unit ()) }; b55 = "0" } in
   (* Paths of depth 1 *)
   let next_r = { a55 = #{ a54 = (unbox_unit ()) }; b55 = "100" } in
@@ -1711,12 +1638,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b55 = next_r.b55 } in
   Idx_mut.set r ((.b55) : (t55, _) idx_mut) next_r.b55;
-  mark_test_run 225;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.b55) : (t55, _) idx_mut)) next_r.b55 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 192 failed";
   (*************************************)
   (*   t57 = { #{ unit_u; string } }   *)
   (*************************************)
@@ -1728,34 +1655,34 @@ let to_run () =
   let sub_eq = (fun #{ a56 = a561; b56 = b561 } #{ a56 = a562; b56 = b562 } -> (fun _ _ -> true) a561 a562 && (fun a b -> String.equal (globalize a) (globalize b)) b561 b562) in
   let expected = { r with a57 = next_r.a57 } in
   Idx_mut.set r ((.a57) : (t57, _) idx_mut) next_r.a57;
-  mark_test_run 227;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a57) : (t57, _) idx_mut)) next_r.a57 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 194 failed";
   (* Paths of depth 2 *)
   let next_r = { a57 = #{ a56 = (unbox_unit ()); b56 = "200" } } in
   (* .a57.#a56 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a57 = #{ r.a57 with a56 = next_r.a57.#a56 } } in
   Idx_mut.set r ((.a57.#a56) : (t57, _) idx_mut) next_r.a57.#a56;
-  mark_test_run 229;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.a57.#a56) : (t57, _) idx_mut)) next_r.a57.#a56 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 196 failed";
   (* .a57.#b56 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a57 = #{ r.a57 with b56 = next_r.a57.#b56 } } in
   Idx_mut.set r ((.a57.#b56) : (t57, _) idx_mut) next_r.a57.#b56;
-  mark_test_run 231;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.a57.#b56) : (t57, _) idx_mut)) next_r.a57.#b56 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 198 failed";
   (***********************************)
   (*   t59 = { #{ float; float } }   *)
   (***********************************)
@@ -1767,34 +1694,34 @@ let to_run () =
   let sub_eq = (fun #{ a58 = a581; b58 = b581 } #{ a58 = a582; b58 = b582 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a581 a582 && (fun a b -> Float.equal (globalize a) (globalize b)) b581 b582) in
   let expected = { r with a59 = next_r.a59 } in
   Idx_mut.set r ((.a59) : (t59, _) idx_mut) next_r.a59;
-  mark_test_run 233;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 233 failed";
-  mark_test_run 234;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a59) : (t59, _) idx_mut)) next_r.a59 in
-  if not test then failwithf "test 234 failed";
+  if not test then failwithf "test 200 failed";
   (* Paths of depth 2 *)
   let next_r = { a59 = #{ a58 = 200.; b58 = 201. } } in
   (* .a59.#a58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with a58 = next_r.a59.#a58 } } in
   Idx_mut.set r ((.a59.#a58) : (t59, _) idx_mut) next_r.a59.#a58;
-  mark_test_run 235;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 235 failed";
-  mark_test_run 236;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.a59.#a58) : (t59, _) idx_mut)) next_r.a59.#a58 in
-  if not test then failwithf "test 236 failed";
+  if not test then failwithf "test 202 failed";
   (* .a59.#b58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with b58 = next_r.a59.#b58 } } in
   Idx_mut.set r ((.a59.#b58) : (t59, _) idx_mut) next_r.a59.#b58;
-  mark_test_run 237;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 237 failed";
-  mark_test_run 238;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a59.#b58) : (t59, _) idx_mut)) next_r.a59.#b58 in
-  if not test then failwithf "test 238 failed";
+  if not test then failwithf "test 204 failed";
   (****************************************)
   (*   t60 = { #{ float; float }; int }   *)
   (****************************************)
@@ -1806,34 +1733,34 @@ let to_run () =
   let sub_eq = (fun #{ a58 = a581; b58 = b581 } #{ a58 = a582; b58 = b582 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a581 a582 && (fun a b -> Float.equal (globalize a) (globalize b)) b581 b582) in
   let expected = { r with a60 = next_r.a60 } in
   Idx_mut.set r ((.a60) : (t60, _) idx_mut) next_r.a60;
-  mark_test_run 239;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 239 failed";
-  mark_test_run 240;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a60) : (t60, _) idx_mut)) next_r.a60 in
-  if not test then failwithf "test 240 failed";
+  if not test then failwithf "test 206 failed";
   (* Paths of depth 2 *)
   let next_r = { a60 = #{ a58 = 200.; b58 = 201. }; b60 = 202 } in
   (* .a60.#a58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with a58 = next_r.a60.#a58 } } in
   Idx_mut.set r ((.a60.#a58) : (t60, _) idx_mut) next_r.a60.#a58;
-  mark_test_run 241;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 241 failed";
-  mark_test_run 242;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.a60.#a58) : (t60, _) idx_mut)) next_r.a60.#a58 in
-  if not test then failwithf "test 242 failed";
+  if not test then failwithf "test 208 failed";
   (* .a60.#b58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with b58 = next_r.a60.#b58 } } in
   Idx_mut.set r ((.a60.#b58) : (t60, _) idx_mut) next_r.a60.#b58;
-  mark_test_run 243;
+  mark_test_run 209;
   let test = eq r expected in
-  if not test then failwithf "test 243 failed";
-  mark_test_run 244;
+  if not test then failwithf "test 209 failed";
+  mark_test_run 210;
   let test = sub_eq (Idx_mut.get r ((.a60.#b58) : (t60, _) idx_mut)) next_r.a60.#b58 in
-  if not test then failwithf "test 244 failed";
+  if not test then failwithf "test 210 failed";
   let r = { a60 = #{ a58 = 0.; b58 = 1. }; b60 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a60 = #{ a58 = 100.; b58 = 101. }; b60 = 102 } in
@@ -1841,12 +1768,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b60 = next_r.b60 } in
   Idx_mut.set r ((.b60) : (t60, _) idx_mut) next_r.b60;
-  mark_test_run 245;
+  mark_test_run 211;
   let test = eq r expected in
-  if not test then failwithf "test 245 failed";
-  mark_test_run 246;
+  if not test then failwithf "test 211 failed";
+  mark_test_run 212;
   let test = sub_eq (Idx_mut.get r ((.b60) : (t60, _) idx_mut)) next_r.b60 in
-  if not test then failwithf "test 246 failed";
+  if not test then failwithf "test 212 failed";
   (*************************************)
   (*   t62 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -1858,24 +1785,24 @@ let to_run () =
   let sub_eq = (fun #{ a61 = a611 } #{ a61 = a612 } -> (fun a b -> String.equal (globalize a) (globalize b)) a611 a612) in
   let expected = { r with a62 = next_r.a62 } in
   Idx_mut.set r ((.a62) : (t62, _) idx_mut) next_r.a62;
-  mark_test_run 247;
+  mark_test_run 213;
   let test = eq r expected in
-  if not test then failwithf "test 247 failed";
-  mark_test_run 248;
+  if not test then failwithf "test 213 failed";
+  mark_test_run 214;
   let test = sub_eq (Idx_mut.get r ((.a62) : (t62, _) idx_mut)) next_r.a62 in
-  if not test then failwithf "test 248 failed";
+  if not test then failwithf "test 214 failed";
   (* Paths of depth 2 *)
   let next_r = { a62 = #{ a61 = "200" }; b62 = (unbox_unit ()) } in
   (* .a62.#a61 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a62 = #{ r.a62 with a61 = next_r.a62.#a61 } } in
   Idx_mut.set r ((.a62.#a61) : (t62, _) idx_mut) next_r.a62.#a61;
-  mark_test_run 249;
+  mark_test_run 215;
   let test = eq r expected in
-  if not test then failwithf "test 249 failed";
-  mark_test_run 250;
+  if not test then failwithf "test 215 failed";
+  mark_test_run 216;
   let test = sub_eq (Idx_mut.get r ((.a62.#a61) : (t62, _) idx_mut)) next_r.a62.#a61 in
-  if not test then failwithf "test 250 failed";
+  if not test then failwithf "test 216 failed";
   let r = { a62 = #{ a61 = "0" }; b62 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a62 = #{ a61 = "100" }; b62 = (unbox_unit ()) } in
@@ -1883,12 +1810,12 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b62 = next_r.b62 } in
   Idx_mut.set r ((.b62) : (t62, _) idx_mut) next_r.b62;
-  mark_test_run 251;
+  mark_test_run 217;
   let test = eq r expected in
-  if not test then failwithf "test 251 failed";
-  mark_test_run 252;
+  if not test then failwithf "test 217 failed";
+  mark_test_run 218;
   let test = sub_eq (Idx_mut.get r ((.b62) : (t62, _) idx_mut)) next_r.b62 in
-  if not test then failwithf "test 252 failed";
+  if not test then failwithf "test 218 failed";
   (*************************************)
   (*   t63 = { #{ string }; string }   *)
   (*************************************)
@@ -1900,24 +1827,24 @@ let to_run () =
   let sub_eq = (fun #{ a61 = a611 } #{ a61 = a612 } -> (fun a b -> String.equal (globalize a) (globalize b)) a611 a612) in
   let expected = { r with a63 = next_r.a63 } in
   Idx_mut.set r ((.a63) : (t63, _) idx_mut) next_r.a63;
-  mark_test_run 253;
+  mark_test_run 219;
   let test = eq r expected in
-  if not test then failwithf "test 253 failed";
-  mark_test_run 254;
+  if not test then failwithf "test 219 failed";
+  mark_test_run 220;
   let test = sub_eq (Idx_mut.get r ((.a63) : (t63, _) idx_mut)) next_r.a63 in
-  if not test then failwithf "test 254 failed";
+  if not test then failwithf "test 220 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a61 = "200" }; b63 = "201" } in
   (* .a63.#a61 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a63 = #{ r.a63 with a61 = next_r.a63.#a61 } } in
   Idx_mut.set r ((.a63.#a61) : (t63, _) idx_mut) next_r.a63.#a61;
-  mark_test_run 255;
+  mark_test_run 221;
   let test = eq r expected in
-  if not test then failwithf "test 255 failed";
-  mark_test_run 256;
+  if not test then failwithf "test 221 failed";
+  mark_test_run 222;
   let test = sub_eq (Idx_mut.get r ((.a63.#a61) : (t63, _) idx_mut)) next_r.a63.#a61 in
-  if not test then failwithf "test 256 failed";
+  if not test then failwithf "test 222 failed";
   let r = { a63 = #{ a61 = "0" }; b63 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a63 = #{ a61 = "100" }; b63 = "101" } in
@@ -1925,12 +1852,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b63 = next_r.b63 } in
   Idx_mut.set r ((.b63) : (t63, _) idx_mut) next_r.b63;
-  mark_test_run 257;
+  mark_test_run 223;
   let test = eq r expected in
-  if not test then failwithf "test 257 failed";
-  mark_test_run 258;
+  if not test then failwithf "test 223 failed";
+  mark_test_run 224;
   let test = sub_eq (Idx_mut.get r ((.b63) : (t63, _) idx_mut)) next_r.b63 in
-  if not test then failwithf "test 258 failed";
+  if not test then failwithf "test 224 failed";
   (*********************************************)
   (*   t65 = { #{ string; unit_u }; string }   *)
   (*********************************************)
@@ -1942,34 +1869,34 @@ let to_run () =
   let sub_eq = (fun #{ a64 = a641; b64 = b641 } #{ a64 = a642; b64 = b642 } -> (fun a b -> String.equal (globalize a) (globalize b)) a641 a642 && (fun _ _ -> true) b641 b642) in
   let expected = { r with a65 = next_r.a65 } in
   Idx_mut.set r ((.a65) : (t65, _) idx_mut) next_r.a65;
-  mark_test_run 259;
+  mark_test_run 225;
   let test = eq r expected in
-  if not test then failwithf "test 259 failed";
-  mark_test_run 260;
+  if not test then failwithf "test 225 failed";
+  mark_test_run 226;
   let test = sub_eq (Idx_mut.get r ((.a65) : (t65, _) idx_mut)) next_r.a65 in
-  if not test then failwithf "test 260 failed";
+  if not test then failwithf "test 226 failed";
   (* Paths of depth 2 *)
   let next_r = { a65 = #{ a64 = "200"; b64 = (unbox_unit ()) }; b65 = "201" } in
   (* .a65.#a64 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a65 = #{ r.a65 with a64 = next_r.a65.#a64 } } in
   Idx_mut.set r ((.a65.#a64) : (t65, _) idx_mut) next_r.a65.#a64;
-  mark_test_run 261;
+  mark_test_run 227;
   let test = eq r expected in
-  if not test then failwithf "test 261 failed";
-  mark_test_run 262;
+  if not test then failwithf "test 227 failed";
+  mark_test_run 228;
   let test = sub_eq (Idx_mut.get r ((.a65.#a64) : (t65, _) idx_mut)) next_r.a65.#a64 in
-  if not test then failwithf "test 262 failed";
+  if not test then failwithf "test 228 failed";
   (* .a65.#b64 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a65 = #{ r.a65 with b64 = next_r.a65.#b64 } } in
   Idx_mut.set r ((.a65.#b64) : (t65, _) idx_mut) next_r.a65.#b64;
-  mark_test_run 263;
+  mark_test_run 229;
   let test = eq r expected in
-  if not test then failwithf "test 263 failed";
-  mark_test_run 264;
+  if not test then failwithf "test 229 failed";
+  mark_test_run 230;
   let test = sub_eq (Idx_mut.get r ((.a65.#b64) : (t65, _) idx_mut)) next_r.a65.#b64 in
-  if not test then failwithf "test 264 failed";
+  if not test then failwithf "test 230 failed";
   let r = { a65 = #{ a64 = "0"; b64 = (unbox_unit ()) }; b65 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a65 = #{ a64 = "100"; b64 = (unbox_unit ()) }; b65 = "101" } in
@@ -1977,17 +1904,17 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b65 = next_r.b65 } in
   Idx_mut.set r ((.b65) : (t65, _) idx_mut) next_r.b65;
-  mark_test_run 265;
+  mark_test_run 231;
   let test = eq r expected in
-  if not test then failwithf "test 265 failed";
-  mark_test_run 266;
+  if not test then failwithf "test 231 failed";
+  mark_test_run 232;
   let test = sub_eq (Idx_mut.get r ((.b65) : (t65, _) idx_mut)) next_r.b65 in
-  if not test then failwithf "test 266 failed";
+  if not test then failwithf "test 232 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 266 do
+for i = 1 to 232 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_bytecode_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_bytecode_test.ml
@@ -1154,20 +1154,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = #101. } in
   (* .a37 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with a37 = next_r.a37 } in
+  Idx_mut.set r ((.a37) : (t37, _) idx_mut) next_r.a37;
+  mark_test_run 133;
+  let test = eq r expected in
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
+  let test = sub_eq (Idx_mut.get r ((.a37) : (t37, _) idx_mut)) next_r.a37 in
+  if not test then failwithf "test 134 failed";
   let r = { a37 = #0.; b37 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = #101. } in
   (* .b37 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with b37 = next_r.b37 } in
+  Idx_mut.set r ((.b37) : (t37, _) idx_mut) next_r.b37;
+  mark_test_run 135;
+  let test = eq r expected in
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
+  let test = sub_eq (Idx_mut.get r ((.b37) : (t37, _) idx_mut)) next_r.b37 in
+  if not test then failwithf "test 136 failed";
   (***************************************)
   (*   t38 = { float#; float#; float }   *)
   (***************************************)
@@ -1207,28 +1215,40 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #{ a39 = #101. } } in
   (* .a40 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with a40 = next_r.a40 } in
+  Idx_mut.set r ((.a40) : (t40, _) idx_mut) next_r.a40;
+  mark_test_run 137;
+  let test = eq r expected in
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
+  let test = sub_eq (Idx_mut.get r ((.a40) : (t40, _) idx_mut)) next_r.a40 in
+  if not test then failwithf "test 138 failed";
   let r = { a40 = #0.; b40 = #{ a39 = #1. } } in
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #{ a39 = #101. } } in
   (* .b40 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun #{ a39 = a391 } #{ a39 = a392 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a391 a392) in
+  let expected = { r with b40 = next_r.b40 } in
+  Idx_mut.set r ((.b40) : (t40, _) idx_mut) next_r.b40;
+  mark_test_run 139;
+  let test = eq r expected in
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
+  let test = sub_eq (Idx_mut.get r ((.b40) : (t40, _) idx_mut)) next_r.b40 in
+  if not test then failwithf "test 140 failed";
   (* Paths of depth 2 *)
   let next_r = { a40 = #200.; b40 = #{ a39 = #201. } } in
   (* .b40.#a39 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with b40 = #{ r.b40 with a39 = next_r.b40.#a39 } } in
+  Idx_mut.set r ((.b40.#a39) : (t40, _) idx_mut) next_r.b40.#a39;
+  mark_test_run 141;
+  let test = eq r expected in
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
+  let test = sub_eq (Idx_mut.get r ((.b40.#a39) : (t40, _) idx_mut)) next_r.b40.#a39 in
+  if not test then failwithf "test 142 failed";
   (*********************************************)
   (*   t41 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1240,12 +1260,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a41 = next_r.a41 } in
   Idx_mut.set r ((.a41) : (t41, _) idx_mut) next_r.a41;
-  mark_test_run 133;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.a41) : (t41, _) idx_mut)) next_r.a41 in
-  if not test then failwithf "test 134 failed";
+  if not test then failwithf "test 144 failed";
   let r = { a41 = #0.; b41 = #{ a34 = #1.; b34 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a41 = #100.; b41 = #{ a34 = #101.; b34 = #102. } } in
@@ -1253,34 +1273,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b341 b342) in
   let expected = { r with b41 = next_r.b41 } in
   Idx_mut.set r ((.b41) : (t41, _) idx_mut) next_r.b41;
-  mark_test_run 135;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.b41) : (t41, _) idx_mut)) next_r.b41 in
-  if not test then failwithf "test 136 failed";
+  if not test then failwithf "test 146 failed";
   (* Paths of depth 2 *)
   let next_r = { a41 = #200.; b41 = #{ a34 = #201.; b34 = #202. } } in
   (* .b41.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b41 = #{ r.b41 with a34 = next_r.b41.#a34 } } in
   Idx_mut.set r ((.b41.#a34) : (t41, _) idx_mut) next_r.b41.#a34;
-  mark_test_run 137;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.b41.#a34) : (t41, _) idx_mut)) next_r.b41.#a34 in
-  if not test then failwithf "test 138 failed";
+  if not test then failwithf "test 148 failed";
   (* .b41.#b34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b41 = #{ r.b41 with b34 = next_r.b41.#b34 } } in
   Idx_mut.set r ((.b41.#b34) : (t41, _) idx_mut) next_r.b41.#b34;
-  mark_test_run 139;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.b41.#b34) : (t41, _) idx_mut)) next_r.b41.#b34 in
-  if not test then failwithf "test 140 failed";
+  if not test then failwithf "test 150 failed";
   (************************)
   (*   t42 = { string }   *)
   (************************)
@@ -1292,12 +1312,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a42 = next_r.a42 } in
   Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 141;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 152 failed";
   (****************************)
   (*   t44 = { (| unit_u) }   *)
   (****************************)
@@ -1309,12 +1329,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C43_0(a0), C43_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a44 = next_r.a44 } in
   Idx_mut.set r ((.a44) : (t44, _) idx_mut) next_r.a44;
-  mark_test_run 143;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.a44) : (t44, _) idx_mut)) next_r.a44 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 154 failed";
   (***********************************)
   (*   t45 = { (| unit_u); int64 }   *)
   (***********************************)
@@ -1326,12 +1346,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C43_0(a0), C43_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 145;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 146 failed";
+  if not test then failwithf "test 156 failed";
   let r = { a45 = (C43_0 (unbox_unit ())); b45 = 0L } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (C43_0 (unbox_unit ())); b45 = 100L } in
@@ -1339,12 +1359,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64.equal (globalize a) (globalize b)) in
   let expected = { r with b45 = next_r.b45 } in
   Idx_mut.set r ((.b45) : (t45, _) idx_mut) next_r.b45;
-  mark_test_run 147;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.b45) : (t45, _) idx_mut)) next_r.b45 in
-  if not test then failwithf "test 148 failed";
+  if not test then failwithf "test 158 failed";
   (************************************)
   (*   t46 = { (| unit_u); int64# }   *)
   (************************************)
@@ -1356,12 +1376,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C43_0(a0), C43_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a46 = next_r.a46 } in
   Idx_mut.set r ((.a46) : (t46, _) idx_mut) next_r.a46;
-  mark_test_run 149;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.a46) : (t46, _) idx_mut)) next_r.a46 in
-  if not test then failwithf "test 150 failed";
+  if not test then failwithf "test 160 failed";
   let r = { a46 = (C43_0 (unbox_unit ())); b46 = #0L } in
   (* Paths of depth 1 *)
   let next_r = { a46 = (C43_0 (unbox_unit ())); b46 = #100L } in
@@ -1369,12 +1389,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b46 = next_r.b46 } in
   Idx_mut.set r ((.b46) : (t46, _) idx_mut) next_r.b46;
-  mark_test_run 151;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.b46) : (t46, _) idx_mut)) next_r.b46 in
-  if not test then failwithf "test 152 failed";
+  if not test then failwithf "test 162 failed";
   (**************************)
   (*   t47 = { #{ int } }   *)
   (**************************)
@@ -1386,24 +1406,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 153;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 154 failed";
+  if not test then failwithf "test 164 failed";
   (* Paths of depth 2 *)
   let next_r = { a47 = #{ a3 = 200 } } in
   (* .a47.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a47 = #{ r.a47 with a3 = next_r.a47.#a3 } } in
   Idx_mut.set r ((.a47.#a3) : (t47, _) idx_mut) next_r.a47.#a3;
-  mark_test_run 155;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.a47.#a3) : (t47, _) idx_mut)) next_r.a47.#a3 in
-  if not test then failwithf "test 156 failed";
+  if not test then failwithf "test 166 failed";
   (*******************************)
   (*   t48 = { #{ int }; int }   *)
   (*******************************)
@@ -1415,24 +1435,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a48 = next_r.a48 } in
   Idx_mut.set r ((.a48) : (t48, _) idx_mut) next_r.a48;
-  mark_test_run 157;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.a48) : (t48, _) idx_mut)) next_r.a48 in
-  if not test then failwithf "test 158 failed";
+  if not test then failwithf "test 168 failed";
   (* Paths of depth 2 *)
   let next_r = { a48 = #{ a3 = 200 }; b48 = 201 } in
   (* .a48.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a48 = #{ r.a48 with a3 = next_r.a48.#a3 } } in
   Idx_mut.set r ((.a48.#a3) : (t48, _) idx_mut) next_r.a48.#a3;
-  mark_test_run 159;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.a48.#a3) : (t48, _) idx_mut)) next_r.a48.#a3 in
-  if not test then failwithf "test 160 failed";
+  if not test then failwithf "test 170 failed";
   let r = { a48 = #{ a3 = 0 }; b48 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a48 = #{ a3 = 100 }; b48 = 101 } in
@@ -1440,12 +1460,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b48 = next_r.b48 } in
   Idx_mut.set r ((.b48) : (t48, _) idx_mut) next_r.b48;
-  mark_test_run 161;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.b48) : (t48, _) idx_mut)) next_r.b48 in
-  if not test then failwithf "test 162 failed";
+  if not test then failwithf "test 172 failed";
   (***************************************)
   (*   t49 = { #{ int; int }; int32# }   *)
   (***************************************)
@@ -1457,34 +1477,34 @@ let to_run () =
   let sub_eq = (fun #{ a5 = a51; b5 = b51 } #{ a5 = a52; b5 = b52 } -> (fun a b -> Int.equal a b) a51 a52 && (fun a b -> Int.equal a b) b51 b52) in
   let expected = { r with a49 = next_r.a49 } in
   Idx_mut.set r ((.a49) : (t49, _) idx_mut) next_r.a49;
-  mark_test_run 163;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.a49) : (t49, _) idx_mut)) next_r.a49 in
-  if not test then failwithf "test 164 failed";
+  if not test then failwithf "test 174 failed";
   (* Paths of depth 2 *)
   let next_r = { a49 = #{ a5 = 200; b5 = 201 }; b49 = #202l } in
   (* .a49.#a5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a49 = #{ r.a49 with a5 = next_r.a49.#a5 } } in
   Idx_mut.set r ((.a49.#a5) : (t49, _) idx_mut) next_r.a49.#a5;
-  mark_test_run 165;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.a49.#a5) : (t49, _) idx_mut)) next_r.a49.#a5 in
-  if not test then failwithf "test 166 failed";
+  if not test then failwithf "test 176 failed";
   (* .a49.#b5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a49 = #{ r.a49 with b5 = next_r.a49.#b5 } } in
   Idx_mut.set r ((.a49.#b5) : (t49, _) idx_mut) next_r.a49.#b5;
-  mark_test_run 167;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.a49.#b5) : (t49, _) idx_mut)) next_r.a49.#b5 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 178 failed";
   let r = { a49 = #{ a5 = 0; b5 = 1 }; b49 = #2l } in
   (* Paths of depth 1 *)
   let next_r = { a49 = #{ a5 = 100; b5 = 101 }; b49 = #102l } in
@@ -1492,12 +1512,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b49 = next_r.b49 } in
   Idx_mut.set r ((.b49) : (t49, _) idx_mut) next_r.b49;
-  mark_test_run 169;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.b49) : (t49, _) idx_mut)) next_r.b49 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 180 failed";
   (***************************************)
   (*   t51 = { #{ int; int32# }; int }   *)
   (***************************************)
@@ -1509,34 +1529,34 @@ let to_run () =
   let sub_eq = (fun #{ a50 = a501; b50 = b501 } #{ a50 = a502; b50 = b502 } -> (fun a b -> Int.equal a b) a501 a502 && (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) b501 b502) in
   let expected = { r with a51 = next_r.a51 } in
   Idx_mut.set r ((.a51) : (t51, _) idx_mut) next_r.a51;
-  mark_test_run 171;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.a51) : (t51, _) idx_mut)) next_r.a51 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 182 failed";
   (* Paths of depth 2 *)
   let next_r = { a51 = #{ a50 = 200; b50 = #201l }; b51 = 202 } in
   (* .a51.#a50 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a51 = #{ r.a51 with a50 = next_r.a51.#a50 } } in
   Idx_mut.set r ((.a51.#a50) : (t51, _) idx_mut) next_r.a51.#a50;
-  mark_test_run 173;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a51.#a50) : (t51, _) idx_mut)) next_r.a51.#a50 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 184 failed";
   (* .a51.#b50 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a51 = #{ r.a51 with b50 = next_r.a51.#b50 } } in
   Idx_mut.set r ((.a51.#b50) : (t51, _) idx_mut) next_r.a51.#b50;
-  mark_test_run 175;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.a51.#b50) : (t51, _) idx_mut)) next_r.a51.#b50 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 186 failed";
   let r = { a51 = #{ a50 = 0; b50 = #1l }; b51 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a51 = #{ a50 = 100; b50 = #101l }; b51 = 102 } in
@@ -1544,12 +1564,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b51 = next_r.b51 } in
   Idx_mut.set r ((.b51) : (t51, _) idx_mut) next_r.b51;
-  mark_test_run 177;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.b51) : (t51, _) idx_mut)) next_r.b51 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 188 failed";
   (**************************************)
   (*   t53 = { #{ int; float }; int }   *)
   (**************************************)
@@ -1561,34 +1581,34 @@ let to_run () =
   let sub_eq = (fun #{ a52 = a521; b52 = b521 } #{ a52 = a522; b52 = b522 } -> (fun a b -> Int.equal a b) a521 a522 && (fun a b -> Float.equal (globalize a) (globalize b)) b521 b522) in
   let expected = { r with a53 = next_r.a53 } in
   Idx_mut.set r ((.a53) : (t53, _) idx_mut) next_r.a53;
-  mark_test_run 179;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.a53) : (t53, _) idx_mut)) next_r.a53 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 190 failed";
   (* Paths of depth 2 *)
   let next_r = { a53 = #{ a52 = 200; b52 = 201. }; b53 = 202 } in
   (* .a53.#a52 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a53 = #{ r.a53 with a52 = next_r.a53.#a52 } } in
   Idx_mut.set r ((.a53.#a52) : (t53, _) idx_mut) next_r.a53.#a52;
-  mark_test_run 181;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.a53.#a52) : (t53, _) idx_mut)) next_r.a53.#a52 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 192 failed";
   (* .a53.#b52 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a53 = #{ r.a53 with b52 = next_r.a53.#b52 } } in
   Idx_mut.set r ((.a53.#b52) : (t53, _) idx_mut) next_r.a53.#b52;
-  mark_test_run 183;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a53.#b52) : (t53, _) idx_mut)) next_r.a53.#b52 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 194 failed";
   let r = { a53 = #{ a52 = 0; b52 = 1. }; b53 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a53 = #{ a52 = 100; b52 = 101. }; b53 = 102 } in
@@ -1596,12 +1616,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b53 = next_r.b53 } in
   Idx_mut.set r ((.b53) : (t53, _) idx_mut) next_r.b53;
-  mark_test_run 185;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.b53) : (t53, _) idx_mut)) next_r.b53 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 196 failed";
   (*************************************)
   (*   t55 = { #{ unit_u }; string }   *)
   (*************************************)
@@ -1613,24 +1633,24 @@ let to_run () =
   let sub_eq = (fun #{ a54 = a541 } #{ a54 = a542 } -> (fun _ _ -> true) a541 a542) in
   let expected = { r with a55 = next_r.a55 } in
   Idx_mut.set r ((.a55) : (t55, _) idx_mut) next_r.a55;
-  mark_test_run 187;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.a55) : (t55, _) idx_mut)) next_r.a55 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 198 failed";
   (* Paths of depth 2 *)
   let next_r = { a55 = #{ a54 = (unbox_unit ()) }; b55 = "200" } in
   (* .a55.#a54 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a55 = #{ r.a55 with a54 = next_r.a55.#a54 } } in
   Idx_mut.set r ((.a55.#a54) : (t55, _) idx_mut) next_r.a55.#a54;
-  mark_test_run 189;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a55.#a54) : (t55, _) idx_mut)) next_r.a55.#a54 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 200 failed";
   let r = { a55 = #{ a54 = (unbox_unit ()) }; b55 = "0" } in
   (* Paths of depth 1 *)
   let next_r = { a55 = #{ a54 = (unbox_unit ()) }; b55 = "100" } in
@@ -1638,12 +1658,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b55 = next_r.b55 } in
   Idx_mut.set r ((.b55) : (t55, _) idx_mut) next_r.b55;
-  mark_test_run 191;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.b55) : (t55, _) idx_mut)) next_r.b55 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 202 failed";
   (*************************************)
   (*   t57 = { #{ unit_u; string } }   *)
   (*************************************)
@@ -1655,34 +1675,34 @@ let to_run () =
   let sub_eq = (fun #{ a56 = a561; b56 = b561 } #{ a56 = a562; b56 = b562 } -> (fun _ _ -> true) a561 a562 && (fun a b -> String.equal (globalize a) (globalize b)) b561 b562) in
   let expected = { r with a57 = next_r.a57 } in
   Idx_mut.set r ((.a57) : (t57, _) idx_mut) next_r.a57;
-  mark_test_run 193;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a57) : (t57, _) idx_mut)) next_r.a57 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 204 failed";
   (* Paths of depth 2 *)
   let next_r = { a57 = #{ a56 = (unbox_unit ()); b56 = "200" } } in
   (* .a57.#a56 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a57 = #{ r.a57 with a56 = next_r.a57.#a56 } } in
   Idx_mut.set r ((.a57.#a56) : (t57, _) idx_mut) next_r.a57.#a56;
-  mark_test_run 195;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a57.#a56) : (t57, _) idx_mut)) next_r.a57.#a56 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 206 failed";
   (* .a57.#b56 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a57 = #{ r.a57 with b56 = next_r.a57.#b56 } } in
   Idx_mut.set r ((.a57.#b56) : (t57, _) idx_mut) next_r.a57.#b56;
-  mark_test_run 197;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.a57.#b56) : (t57, _) idx_mut)) next_r.a57.#b56 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 208 failed";
   (***********************************)
   (*   t59 = { #{ float; float } }   *)
   (***********************************)
@@ -1694,34 +1714,34 @@ let to_run () =
   let sub_eq = (fun #{ a58 = a581; b58 = b581 } #{ a58 = a582; b58 = b582 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a581 a582 && (fun a b -> Float.equal (globalize a) (globalize b)) b581 b582) in
   let expected = { r with a59 = next_r.a59 } in
   Idx_mut.set r ((.a59) : (t59, _) idx_mut) next_r.a59;
-  mark_test_run 199;
+  mark_test_run 209;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 209 failed";
+  mark_test_run 210;
   let test = sub_eq (Idx_mut.get r ((.a59) : (t59, _) idx_mut)) next_r.a59 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 210 failed";
   (* Paths of depth 2 *)
   let next_r = { a59 = #{ a58 = 200.; b58 = 201. } } in
   (* .a59.#a58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with a58 = next_r.a59.#a58 } } in
   Idx_mut.set r ((.a59.#a58) : (t59, _) idx_mut) next_r.a59.#a58;
-  mark_test_run 201;
+  mark_test_run 211;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 211 failed";
+  mark_test_run 212;
   let test = sub_eq (Idx_mut.get r ((.a59.#a58) : (t59, _) idx_mut)) next_r.a59.#a58 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 212 failed";
   (* .a59.#b58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with b58 = next_r.a59.#b58 } } in
   Idx_mut.set r ((.a59.#b58) : (t59, _) idx_mut) next_r.a59.#b58;
-  mark_test_run 203;
+  mark_test_run 213;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 213 failed";
+  mark_test_run 214;
   let test = sub_eq (Idx_mut.get r ((.a59.#b58) : (t59, _) idx_mut)) next_r.a59.#b58 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 214 failed";
   (****************************************)
   (*   t60 = { #{ float; float }; int }   *)
   (****************************************)
@@ -1733,34 +1753,34 @@ let to_run () =
   let sub_eq = (fun #{ a58 = a581; b58 = b581 } #{ a58 = a582; b58 = b582 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a581 a582 && (fun a b -> Float.equal (globalize a) (globalize b)) b581 b582) in
   let expected = { r with a60 = next_r.a60 } in
   Idx_mut.set r ((.a60) : (t60, _) idx_mut) next_r.a60;
-  mark_test_run 205;
+  mark_test_run 215;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 215 failed";
+  mark_test_run 216;
   let test = sub_eq (Idx_mut.get r ((.a60) : (t60, _) idx_mut)) next_r.a60 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 216 failed";
   (* Paths of depth 2 *)
   let next_r = { a60 = #{ a58 = 200.; b58 = 201. }; b60 = 202 } in
   (* .a60.#a58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with a58 = next_r.a60.#a58 } } in
   Idx_mut.set r ((.a60.#a58) : (t60, _) idx_mut) next_r.a60.#a58;
-  mark_test_run 207;
+  mark_test_run 217;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 217 failed";
+  mark_test_run 218;
   let test = sub_eq (Idx_mut.get r ((.a60.#a58) : (t60, _) idx_mut)) next_r.a60.#a58 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 218 failed";
   (* .a60.#b58 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with b58 = next_r.a60.#b58 } } in
   Idx_mut.set r ((.a60.#b58) : (t60, _) idx_mut) next_r.a60.#b58;
-  mark_test_run 209;
+  mark_test_run 219;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 219 failed";
+  mark_test_run 220;
   let test = sub_eq (Idx_mut.get r ((.a60.#b58) : (t60, _) idx_mut)) next_r.a60.#b58 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 220 failed";
   let r = { a60 = #{ a58 = 0.; b58 = 1. }; b60 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a60 = #{ a58 = 100.; b58 = 101. }; b60 = 102 } in
@@ -1768,12 +1788,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b60 = next_r.b60 } in
   Idx_mut.set r ((.b60) : (t60, _) idx_mut) next_r.b60;
-  mark_test_run 211;
+  mark_test_run 221;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 221 failed";
+  mark_test_run 222;
   let test = sub_eq (Idx_mut.get r ((.b60) : (t60, _) idx_mut)) next_r.b60 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 222 failed";
   (*************************************)
   (*   t62 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -1785,24 +1805,24 @@ let to_run () =
   let sub_eq = (fun #{ a61 = a611 } #{ a61 = a612 } -> (fun a b -> String.equal (globalize a) (globalize b)) a611 a612) in
   let expected = { r with a62 = next_r.a62 } in
   Idx_mut.set r ((.a62) : (t62, _) idx_mut) next_r.a62;
-  mark_test_run 213;
+  mark_test_run 223;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 223 failed";
+  mark_test_run 224;
   let test = sub_eq (Idx_mut.get r ((.a62) : (t62, _) idx_mut)) next_r.a62 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 224 failed";
   (* Paths of depth 2 *)
   let next_r = { a62 = #{ a61 = "200" }; b62 = (unbox_unit ()) } in
   (* .a62.#a61 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a62 = #{ r.a62 with a61 = next_r.a62.#a61 } } in
   Idx_mut.set r ((.a62.#a61) : (t62, _) idx_mut) next_r.a62.#a61;
-  mark_test_run 215;
+  mark_test_run 225;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 225 failed";
+  mark_test_run 226;
   let test = sub_eq (Idx_mut.get r ((.a62.#a61) : (t62, _) idx_mut)) next_r.a62.#a61 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 226 failed";
   let r = { a62 = #{ a61 = "0" }; b62 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a62 = #{ a61 = "100" }; b62 = (unbox_unit ()) } in
@@ -1810,12 +1830,12 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b62 = next_r.b62 } in
   Idx_mut.set r ((.b62) : (t62, _) idx_mut) next_r.b62;
-  mark_test_run 217;
+  mark_test_run 227;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 227 failed";
+  mark_test_run 228;
   let test = sub_eq (Idx_mut.get r ((.b62) : (t62, _) idx_mut)) next_r.b62 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 228 failed";
   (*************************************)
   (*   t63 = { #{ string }; string }   *)
   (*************************************)
@@ -1827,24 +1847,24 @@ let to_run () =
   let sub_eq = (fun #{ a61 = a611 } #{ a61 = a612 } -> (fun a b -> String.equal (globalize a) (globalize b)) a611 a612) in
   let expected = { r with a63 = next_r.a63 } in
   Idx_mut.set r ((.a63) : (t63, _) idx_mut) next_r.a63;
-  mark_test_run 219;
+  mark_test_run 229;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 229 failed";
+  mark_test_run 230;
   let test = sub_eq (Idx_mut.get r ((.a63) : (t63, _) idx_mut)) next_r.a63 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 230 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a61 = "200" }; b63 = "201" } in
   (* .a63.#a61 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a63 = #{ r.a63 with a61 = next_r.a63.#a61 } } in
   Idx_mut.set r ((.a63.#a61) : (t63, _) idx_mut) next_r.a63.#a61;
-  mark_test_run 221;
+  mark_test_run 231;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 231 failed";
+  mark_test_run 232;
   let test = sub_eq (Idx_mut.get r ((.a63.#a61) : (t63, _) idx_mut)) next_r.a63.#a61 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 232 failed";
   let r = { a63 = #{ a61 = "0" }; b63 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a63 = #{ a61 = "100" }; b63 = "101" } in
@@ -1852,12 +1872,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b63 = next_r.b63 } in
   Idx_mut.set r ((.b63) : (t63, _) idx_mut) next_r.b63;
-  mark_test_run 223;
+  mark_test_run 233;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 233 failed";
+  mark_test_run 234;
   let test = sub_eq (Idx_mut.get r ((.b63) : (t63, _) idx_mut)) next_r.b63 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 234 failed";
   (*********************************************)
   (*   t65 = { #{ string; unit_u }; string }   *)
   (*********************************************)
@@ -1869,34 +1889,34 @@ let to_run () =
   let sub_eq = (fun #{ a64 = a641; b64 = b641 } #{ a64 = a642; b64 = b642 } -> (fun a b -> String.equal (globalize a) (globalize b)) a641 a642 && (fun _ _ -> true) b641 b642) in
   let expected = { r with a65 = next_r.a65 } in
   Idx_mut.set r ((.a65) : (t65, _) idx_mut) next_r.a65;
-  mark_test_run 225;
+  mark_test_run 235;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 235 failed";
+  mark_test_run 236;
   let test = sub_eq (Idx_mut.get r ((.a65) : (t65, _) idx_mut)) next_r.a65 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 236 failed";
   (* Paths of depth 2 *)
   let next_r = { a65 = #{ a64 = "200"; b64 = (unbox_unit ()) }; b65 = "201" } in
   (* .a65.#a64 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a65 = #{ r.a65 with a64 = next_r.a65.#a64 } } in
   Idx_mut.set r ((.a65.#a64) : (t65, _) idx_mut) next_r.a65.#a64;
-  mark_test_run 227;
+  mark_test_run 237;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 237 failed";
+  mark_test_run 238;
   let test = sub_eq (Idx_mut.get r ((.a65.#a64) : (t65, _) idx_mut)) next_r.a65.#a64 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 238 failed";
   (* .a65.#b64 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a65 = #{ r.a65 with b64 = next_r.a65.#b64 } } in
   Idx_mut.set r ((.a65.#b64) : (t65, _) idx_mut) next_r.a65.#b64;
-  mark_test_run 229;
+  mark_test_run 239;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 239 failed";
+  mark_test_run 240;
   let test = sub_eq (Idx_mut.get r ((.a65.#b64) : (t65, _) idx_mut)) next_r.a65.#b64 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 240 failed";
   let r = { a65 = #{ a64 = "0"; b64 = (unbox_unit ()) }; b65 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a65 = #{ a64 = "100"; b64 = (unbox_unit ()) }; b65 = "101" } in
@@ -1904,17 +1924,17 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b65 = next_r.b65 } in
   Idx_mut.set r ((.b65) : (t65, _) idx_mut) next_r.b65;
-  mark_test_run 231;
+  mark_test_run 241;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 241 failed";
+  mark_test_run 242;
   let test = sub_eq (Idx_mut.get r ((.b65) : (t65, _) idx_mut)) next_r.b65 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 242 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 232 do
+for i = 1 to 242 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_bytecode_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_bytecode_test.ml
@@ -1053,20 +1053,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a34 = #100.; b34 = #101. } in
   (* .a34 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with a34 = next_r.a34 } in
+  Idx_mut.set r ((.a34) : (t34, _) idx_mut) next_r.a34;
+  mark_test_run 113;
+  let test = eq r expected in
+  if not test then failwithf "test 113 failed";
+  mark_test_run 114;
+  let test = sub_eq (Idx_mut.get r ((.a34) : (t34, _) idx_mut)) next_r.a34 in
+  if not test then failwithf "test 114 failed";
   let r = { a34 = #0.; b34 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a34 = #100.; b34 = #101. } in
   (* .b34 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with b34 = next_r.b34 } in
+  Idx_mut.set r ((.b34) : (t34, _) idx_mut) next_r.b34;
+  mark_test_run 115;
+  let test = eq r expected in
+  if not test then failwithf "test 115 failed";
+  mark_test_run 116;
+  let test = sub_eq (Idx_mut.get r ((.b34) : (t34, _) idx_mut)) next_r.b34 in
+  if not test then failwithf "test 116 failed";
   (*********************************************)
   (*   t35 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1078,12 +1086,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a35 = next_r.a35 } in
   Idx_mut.set r ((.a35) : (t35, _) idx_mut) next_r.a35;
-  mark_test_run 113;
+  mark_test_run 117;
   let test = eq r expected in
-  if not test then failwithf "test 113 failed";
-  mark_test_run 114;
+  if not test then failwithf "test 117 failed";
+  mark_test_run 118;
   let test = sub_eq (Idx_mut.get r ((.a35) : (t35, _) idx_mut)) next_r.a35 in
-  if not test then failwithf "test 114 failed";
+  if not test then failwithf "test 118 failed";
   let r = { a35 = #0.; b35 = #{ a30 = #1.; b30 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a35 = #100.; b35 = #{ a30 = #101.; b30 = #102. } } in
@@ -1091,34 +1099,34 @@ let to_run () =
   let sub_eq = (fun #{ a30 = a301; b30 = b301 } #{ a30 = a302; b30 = b302 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a301 a302 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b301 b302) in
   let expected = { r with b35 = next_r.b35 } in
   Idx_mut.set r ((.b35) : (t35, _) idx_mut) next_r.b35;
-  mark_test_run 115;
+  mark_test_run 119;
   let test = eq r expected in
-  if not test then failwithf "test 115 failed";
-  mark_test_run 116;
+  if not test then failwithf "test 119 failed";
+  mark_test_run 120;
   let test = sub_eq (Idx_mut.get r ((.b35) : (t35, _) idx_mut)) next_r.b35 in
-  if not test then failwithf "test 116 failed";
+  if not test then failwithf "test 120 failed";
   (* Paths of depth 2 *)
   let next_r = { a35 = #200.; b35 = #{ a30 = #201.; b30 = #202. } } in
   (* .b35.#a30 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with a30 = next_r.b35.#a30 } } in
   Idx_mut.set r ((.b35.#a30) : (t35, _) idx_mut) next_r.b35.#a30;
-  mark_test_run 117;
+  mark_test_run 121;
   let test = eq r expected in
-  if not test then failwithf "test 117 failed";
-  mark_test_run 118;
+  if not test then failwithf "test 121 failed";
+  mark_test_run 122;
   let test = sub_eq (Idx_mut.get r ((.b35.#a30) : (t35, _) idx_mut)) next_r.b35.#a30 in
-  if not test then failwithf "test 118 failed";
+  if not test then failwithf "test 122 failed";
   (* .b35.#b30 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with b30 = next_r.b35.#b30 } } in
   Idx_mut.set r ((.b35.#b30) : (t35, _) idx_mut) next_r.b35.#b30;
-  mark_test_run 119;
+  mark_test_run 123;
   let test = eq r expected in
-  if not test then failwithf "test 119 failed";
-  mark_test_run 120;
+  if not test then failwithf "test 123 failed";
+  mark_test_run 124;
   let test = sub_eq (Idx_mut.get r ((.b35.#b30) : (t35, _) idx_mut)) next_r.b35.#b30 in
-  if not test then failwithf "test 120 failed";
+  if not test then failwithf "test 124 failed";
   (*********************************************)
   (*   t37 = { string; #{ unit_u; unit_u } }   *)
   (*********************************************)
@@ -1130,12 +1138,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a37 = next_r.a37 } in
   Idx_mut.set r ((.a37) : (t37, _) idx_mut) next_r.a37;
-  mark_test_run 121;
+  mark_test_run 125;
   let test = eq r expected in
-  if not test then failwithf "test 121 failed";
-  mark_test_run 122;
+  if not test then failwithf "test 125 failed";
+  mark_test_run 126;
   let test = sub_eq (Idx_mut.get r ((.a37) : (t37, _) idx_mut)) next_r.a37 in
-  if not test then failwithf "test 122 failed";
+  if not test then failwithf "test 126 failed";
   let r = { a37 = "0"; b37 = #{ a36 = (unbox_unit ()); b36 = (unbox_unit ()) } } in
   (* Paths of depth 1 *)
   let next_r = { a37 = "100"; b37 = #{ a36 = (unbox_unit ()); b36 = (unbox_unit ()) } } in
@@ -1143,34 +1151,34 @@ let to_run () =
   let sub_eq = (fun #{ a36 = a361; b36 = b361 } #{ a36 = a362; b36 = b362 } -> (fun _ _ -> true) a361 a362 && (fun _ _ -> true) b361 b362) in
   let expected = { r with b37 = next_r.b37 } in
   Idx_mut.set r ((.b37) : (t37, _) idx_mut) next_r.b37;
-  mark_test_run 123;
+  mark_test_run 127;
   let test = eq r expected in
-  if not test then failwithf "test 123 failed";
-  mark_test_run 124;
+  if not test then failwithf "test 127 failed";
+  mark_test_run 128;
   let test = sub_eq (Idx_mut.get r ((.b37) : (t37, _) idx_mut)) next_r.b37 in
-  if not test then failwithf "test 124 failed";
+  if not test then failwithf "test 128 failed";
   (* Paths of depth 2 *)
   let next_r = { a37 = "200"; b37 = #{ a36 = (unbox_unit ()); b36 = (unbox_unit ()) } } in
   (* .b37.#a36 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b37 = #{ r.b37 with a36 = next_r.b37.#a36 } } in
   Idx_mut.set r ((.b37.#a36) : (t37, _) idx_mut) next_r.b37.#a36;
-  mark_test_run 125;
+  mark_test_run 129;
   let test = eq r expected in
-  if not test then failwithf "test 125 failed";
-  mark_test_run 126;
+  if not test then failwithf "test 129 failed";
+  mark_test_run 130;
   let test = sub_eq (Idx_mut.get r ((.b37.#a36) : (t37, _) idx_mut)) next_r.b37.#a36 in
-  if not test then failwithf "test 126 failed";
+  if not test then failwithf "test 130 failed";
   (* .b37.#b36 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b37 = #{ r.b37 with b36 = next_r.b37.#b36 } } in
   Idx_mut.set r ((.b37.#b36) : (t37, _) idx_mut) next_r.b37.#b36;
-  mark_test_run 127;
+  mark_test_run 131;
   let test = eq r expected in
-  if not test then failwithf "test 127 failed";
-  mark_test_run 128;
+  if not test then failwithf "test 131 failed";
+  mark_test_run 132;
   let test = sub_eq (Idx_mut.get r ((.b37.#b36) : (t37, _) idx_mut)) next_r.b37.#b36 in
-  if not test then failwithf "test 128 failed";
+  if not test then failwithf "test 132 failed";
   (***********************************)
   (*   t38 = { (| unit_u); float }   *)
   (***********************************)
@@ -1182,12 +1190,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C10_0(a0), C10_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a38 = next_r.a38 } in
   Idx_mut.set r ((.a38) : (t38, _) idx_mut) next_r.a38;
-  mark_test_run 129;
+  mark_test_run 133;
   let test = eq r expected in
-  if not test then failwithf "test 129 failed";
-  mark_test_run 130;
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
   let test = sub_eq (Idx_mut.get r ((.a38) : (t38, _) idx_mut)) next_r.a38 in
-  if not test then failwithf "test 130 failed";
+  if not test then failwithf "test 134 failed";
   let r = { a38 = (C10_0 (unbox_unit ())); b38 = 0. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = (C10_0 (unbox_unit ())); b38 = 100. } in
@@ -1195,12 +1203,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b38 = next_r.b38 } in
   Idx_mut.set r ((.b38) : (t38, _) idx_mut) next_r.b38;
-  mark_test_run 131;
+  mark_test_run 135;
   let test = eq r expected in
-  if not test then failwithf "test 131 failed";
-  mark_test_run 132;
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
   let test = sub_eq (Idx_mut.get r ((.b38) : (t38, _) idx_mut)) next_r.b38 in
-  if not test then failwithf "test 132 failed";
+  if not test then failwithf "test 136 failed";
   (**************************)
   (*   t39 = { #{ int } }   *)
   (**************************)
@@ -1212,24 +1220,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a39 = next_r.a39 } in
   Idx_mut.set r ((.a39) : (t39, _) idx_mut) next_r.a39;
-  mark_test_run 133;
+  mark_test_run 137;
   let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
   let test = sub_eq (Idx_mut.get r ((.a39) : (t39, _) idx_mut)) next_r.a39 in
-  if not test then failwithf "test 134 failed";
+  if not test then failwithf "test 138 failed";
   (* Paths of depth 2 *)
   let next_r = { a39 = #{ a2 = 200 } } in
   (* .a39.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a39 = #{ r.a39 with a2 = next_r.a39.#a2 } } in
   Idx_mut.set r ((.a39.#a2) : (t39, _) idx_mut) next_r.a39.#a2;
-  mark_test_run 135;
+  mark_test_run 139;
   let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
   let test = sub_eq (Idx_mut.get r ((.a39.#a2) : (t39, _) idx_mut)) next_r.a39.#a2 in
-  if not test then failwithf "test 136 failed";
+  if not test then failwithf "test 140 failed";
   (*******************************)
   (*   t40 = { #{ int }; int }   *)
   (*******************************)
@@ -1241,24 +1249,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a40 = next_r.a40 } in
   Idx_mut.set r ((.a40) : (t40, _) idx_mut) next_r.a40;
-  mark_test_run 137;
+  mark_test_run 141;
   let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
   let test = sub_eq (Idx_mut.get r ((.a40) : (t40, _) idx_mut)) next_r.a40 in
-  if not test then failwithf "test 138 failed";
+  if not test then failwithf "test 142 failed";
   (* Paths of depth 2 *)
   let next_r = { a40 = #{ a2 = 200 }; b40 = 201 } in
   (* .a40.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a40 = #{ r.a40 with a2 = next_r.a40.#a2 } } in
   Idx_mut.set r ((.a40.#a2) : (t40, _) idx_mut) next_r.a40.#a2;
-  mark_test_run 139;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.a40.#a2) : (t40, _) idx_mut)) next_r.a40.#a2 in
-  if not test then failwithf "test 140 failed";
+  if not test then failwithf "test 144 failed";
   let r = { a40 = #{ a2 = 0 }; b40 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a40 = #{ a2 = 100 }; b40 = 101 } in
@@ -1266,12 +1274,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b40 = next_r.b40 } in
   Idx_mut.set r ((.b40) : (t40, _) idx_mut) next_r.b40;
-  mark_test_run 141;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.b40) : (t40, _) idx_mut)) next_r.b40 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 146 failed";
   (**********************************)
   (*   t41 = { #{ int }; int32# }   *)
   (**********************************)
@@ -1283,24 +1291,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a41 = next_r.a41 } in
   Idx_mut.set r ((.a41) : (t41, _) idx_mut) next_r.a41;
-  mark_test_run 143;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.a41) : (t41, _) idx_mut)) next_r.a41 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 148 failed";
   (* Paths of depth 2 *)
   let next_r = { a41 = #{ a2 = 200 }; b41 = #201l } in
   (* .a41.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a41 = #{ r.a41 with a2 = next_r.a41.#a2 } } in
   Idx_mut.set r ((.a41.#a2) : (t41, _) idx_mut) next_r.a41.#a2;
-  mark_test_run 145;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.a41.#a2) : (t41, _) idx_mut)) next_r.a41.#a2 in
-  if not test then failwithf "test 146 failed";
+  if not test then failwithf "test 150 failed";
   let r = { a41 = #{ a2 = 0 }; b41 = #1l } in
   (* Paths of depth 1 *)
   let next_r = { a41 = #{ a2 = 100 }; b41 = #101l } in
@@ -1308,12 +1316,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b41 = next_r.b41 } in
   Idx_mut.set r ((.b41) : (t41, _) idx_mut) next_r.b41;
-  mark_test_run 147;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.b41) : (t41, _) idx_mut)) next_r.b41 in
-  if not test then failwithf "test 148 failed";
+  if not test then failwithf "test 152 failed";
   (*********************************)
   (*   t42 = { #{ int }; float }   *)
   (*********************************)
@@ -1325,24 +1333,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a42 = next_r.a42 } in
   Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 149;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 150 failed";
+  if not test then failwithf "test 154 failed";
   (* Paths of depth 2 *)
   let next_r = { a42 = #{ a2 = 200 }; b42 = 201. } in
   (* .a42.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a42 = #{ r.a42 with a2 = next_r.a42.#a2 } } in
   Idx_mut.set r ((.a42.#a2) : (t42, _) idx_mut) next_r.a42.#a2;
-  mark_test_run 151;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.a42.#a2) : (t42, _) idx_mut)) next_r.a42.#a2 in
-  if not test then failwithf "test 152 failed";
+  if not test then failwithf "test 156 failed";
   let r = { a42 = #{ a2 = 0 }; b42 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a42 = #{ a2 = 100 }; b42 = 101. } in
@@ -1350,12 +1358,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b42 = next_r.b42 } in
   Idx_mut.set r ((.b42) : (t42, _) idx_mut) next_r.b42;
-  mark_test_run 153;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.b42) : (t42, _) idx_mut)) next_r.b42 in
-  if not test then failwithf "test 154 failed";
+  if not test then failwithf "test 158 failed";
   (*******************************)
   (*   t43 = { #{ int; int } }   *)
   (*******************************)
@@ -1367,34 +1375,34 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41; b4 = b41 } #{ a4 = a42; b4 = b42 } -> (fun a b -> Int.equal a b) a41 a42 && (fun a b -> Int.equal a b) b41 b42) in
   let expected = { r with a43 = next_r.a43 } in
   Idx_mut.set r ((.a43) : (t43, _) idx_mut) next_r.a43;
-  mark_test_run 155;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.a43) : (t43, _) idx_mut)) next_r.a43 in
-  if not test then failwithf "test 156 failed";
+  if not test then failwithf "test 160 failed";
   (* Paths of depth 2 *)
   let next_r = { a43 = #{ a4 = 200; b4 = 201 } } in
   (* .a43.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a43 = #{ r.a43 with a4 = next_r.a43.#a4 } } in
   Idx_mut.set r ((.a43.#a4) : (t43, _) idx_mut) next_r.a43.#a4;
-  mark_test_run 157;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.a43.#a4) : (t43, _) idx_mut)) next_r.a43.#a4 in
-  if not test then failwithf "test 158 failed";
+  if not test then failwithf "test 162 failed";
   (* .a43.#b4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a43 = #{ r.a43 with b4 = next_r.a43.#b4 } } in
   Idx_mut.set r ((.a43.#b4) : (t43, _) idx_mut) next_r.a43.#b4;
-  mark_test_run 159;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.a43.#b4) : (t43, _) idx_mut)) next_r.a43.#b4 in
-  if not test then failwithf "test 160 failed";
+  if not test then failwithf "test 164 failed";
   (*****************************)
   (*   t45 = { #{ int32# } }   *)
   (*****************************)
@@ -1406,24 +1414,24 @@ let to_run () =
   let sub_eq = (fun #{ a44 = a441 } #{ a44 = a442 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a441 a442) in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 161;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 162 failed";
+  if not test then failwithf "test 166 failed";
   (* Paths of depth 2 *)
   let next_r = { a45 = #{ a44 = #200l } } in
   (* .a45.#a44 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a45 = #{ r.a45 with a44 = next_r.a45.#a44 } } in
   Idx_mut.set r ((.a45.#a44) : (t45, _) idx_mut) next_r.a45.#a44;
-  mark_test_run 163;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.a45.#a44) : (t45, _) idx_mut)) next_r.a45.#a44 in
-  if not test then failwithf "test 164 failed";
+  if not test then failwithf "test 168 failed";
   (**********************************)
   (*   t47 = { #{ int32#; int } }   *)
   (**********************************)
@@ -1435,34 +1443,34 @@ let to_run () =
   let sub_eq = (fun #{ a46 = a461; b46 = b461 } #{ a46 = a462; b46 = b462 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a461 a462 && (fun a b -> Int.equal a b) b461 b462) in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 165;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 166 failed";
+  if not test then failwithf "test 170 failed";
   (* Paths of depth 2 *)
   let next_r = { a47 = #{ a46 = #200l; b46 = 201 } } in
   (* .a47.#a46 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a47 = #{ r.a47 with a46 = next_r.a47.#a46 } } in
   Idx_mut.set r ((.a47.#a46) : (t47, _) idx_mut) next_r.a47.#a46;
-  mark_test_run 167;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.a47.#a46) : (t47, _) idx_mut)) next_r.a47.#a46 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 172 failed";
   (* .a47.#b46 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a47 = #{ r.a47 with b46 = next_r.a47.#b46 } } in
   Idx_mut.set r ((.a47.#b46) : (t47, _) idx_mut) next_r.a47.#b46;
-  mark_test_run 169;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.a47.#b46) : (t47, _) idx_mut)) next_r.a47.#b46 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 174 failed";
   (***********************************)
   (*   t49 = { #{ float }; float }   *)
   (***********************************)
@@ -1504,34 +1512,34 @@ let to_run () =
   let sub_eq = (fun #{ a28 = a281; b28 = b281 } #{ a28 = a282; b28 = b282 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a281 a282 && (fun a b -> Float.equal (globalize a) (globalize b)) b281 b282) in
   let expected = { r with a50 = next_r.a50 } in
   Idx_mut.set r ((.a50) : (t50, _) idx_mut) next_r.a50;
-  mark_test_run 171;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.a50) : (t50, _) idx_mut)) next_r.a50 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 176 failed";
   (* Paths of depth 2 *)
   let next_r = { a50 = #{ a28 = 200.; b28 = 201. }; b50 = 202 } in
   (* .a50.#a28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a50 = #{ r.a50 with a28 = next_r.a50.#a28 } } in
   Idx_mut.set r ((.a50.#a28) : (t50, _) idx_mut) next_r.a50.#a28;
-  mark_test_run 173;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.a50.#a28) : (t50, _) idx_mut)) next_r.a50.#a28 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 178 failed";
   (* .a50.#b28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a50 = #{ r.a50 with b28 = next_r.a50.#b28 } } in
   Idx_mut.set r ((.a50.#b28) : (t50, _) idx_mut) next_r.a50.#b28;
-  mark_test_run 175;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.a50.#b28) : (t50, _) idx_mut)) next_r.a50.#b28 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 180 failed";
   let r = { a50 = #{ a28 = 0.; b28 = 1. }; b50 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a50 = #{ a28 = 100.; b28 = 101. }; b50 = 102 } in
@@ -1539,12 +1547,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b50 = next_r.b50 } in
   Idx_mut.set r ((.b50) : (t50, _) idx_mut) next_r.b50;
-  mark_test_run 177;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.b50) : (t50, _) idx_mut)) next_r.b50 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 182 failed";
   (******************************************)
   (*   t51 = { #{ float; float }; float }   *)
   (******************************************)
@@ -1556,34 +1564,34 @@ let to_run () =
   let sub_eq = (fun #{ a28 = a281; b28 = b281 } #{ a28 = a282; b28 = b282 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a281 a282 && (fun a b -> Float.equal (globalize a) (globalize b)) b281 b282) in
   let expected = { r with a51 = next_r.a51 } in
   Idx_mut.set r ((.a51) : (t51, _) idx_mut) next_r.a51;
-  mark_test_run 179;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a51) : (t51, _) idx_mut)) next_r.a51 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 184 failed";
   (* Paths of depth 2 *)
   let next_r = { a51 = #{ a28 = 200.; b28 = 201. }; b51 = 202. } in
   (* .a51.#a28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a51 = #{ r.a51 with a28 = next_r.a51.#a28 } } in
   Idx_mut.set r ((.a51.#a28) : (t51, _) idx_mut) next_r.a51.#a28;
-  mark_test_run 181;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.a51.#a28) : (t51, _) idx_mut)) next_r.a51.#a28 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 186 failed";
   (* .a51.#b28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a51 = #{ r.a51 with b28 = next_r.a51.#b28 } } in
   Idx_mut.set r ((.a51.#b28) : (t51, _) idx_mut) next_r.a51.#b28;
-  mark_test_run 183;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.a51.#b28) : (t51, _) idx_mut)) next_r.a51.#b28 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 188 failed";
   let r = { a51 = #{ a28 = 0.; b28 = 1. }; b51 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a51 = #{ a28 = 100.; b28 = 101. }; b51 = 102. } in
@@ -1591,12 +1599,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b51 = next_r.b51 } in
   Idx_mut.set r ((.b51) : (t51, _) idx_mut) next_r.b51;
-  mark_test_run 185;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.b51) : (t51, _) idx_mut)) next_r.b51 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 190 failed";
   (************************************************************)
   (*   t54 = { #{ float32#; int64# }; #{ string; int64# } }   *)
   (************************************************************)
@@ -1608,34 +1616,34 @@ let to_run () =
   let sub_eq = (fun #{ a52 = a521; b52 = b521 } #{ a52 = a522; b52 = b522 } -> (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) a521 a522 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b521 b522) in
   let expected = { r with a54 = next_r.a54 } in
   Idx_mut.set r ((.a54) : (t54, _) idx_mut) next_r.a54;
-  mark_test_run 187;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.a54) : (t54, _) idx_mut)) next_r.a54 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 192 failed";
   (* Paths of depth 2 *)
   let next_r = { a54 = #{ a52 = #200.s; b52 = #201L }; b54 = #{ a53 = "202"; b53 = #203L } } in
   (* .a54.#a52 *)
   let sub_eq = (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) in
   let expected = { r with a54 = #{ r.a54 with a52 = next_r.a54.#a52 } } in
   Idx_mut.set r ((.a54.#a52) : (t54, _) idx_mut) next_r.a54.#a52;
-  mark_test_run 189;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a54.#a52) : (t54, _) idx_mut)) next_r.a54.#a52 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 194 failed";
   (* .a54.#b52 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with a54 = #{ r.a54 with b52 = next_r.a54.#b52 } } in
   Idx_mut.set r ((.a54.#b52) : (t54, _) idx_mut) next_r.a54.#b52;
-  mark_test_run 191;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.a54.#b52) : (t54, _) idx_mut)) next_r.a54.#b52 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 196 failed";
   let r = { a54 = #{ a52 = #0.s; b52 = #1L }; b54 = #{ a53 = "2"; b53 = #3L } } in
   (* Paths of depth 1 *)
   let next_r = { a54 = #{ a52 = #100.s; b52 = #101L }; b54 = #{ a53 = "102"; b53 = #103L } } in
@@ -1643,34 +1651,34 @@ let to_run () =
   let sub_eq = (fun #{ a53 = a531; b53 = b531 } #{ a53 = a532; b53 = b532 } -> (fun a b -> String.equal (globalize a) (globalize b)) a531 a532 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b531 b532) in
   let expected = { r with b54 = next_r.b54 } in
   Idx_mut.set r ((.b54) : (t54, _) idx_mut) next_r.b54;
-  mark_test_run 193;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.b54) : (t54, _) idx_mut)) next_r.b54 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 198 failed";
   (* Paths of depth 2 *)
   let next_r = { a54 = #{ a52 = #200.s; b52 = #201L }; b54 = #{ a53 = "202"; b53 = #203L } } in
   (* .b54.#a53 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b54 = #{ r.b54 with a53 = next_r.b54.#a53 } } in
   Idx_mut.set r ((.b54.#a53) : (t54, _) idx_mut) next_r.b54.#a53;
-  mark_test_run 195;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.b54.#a53) : (t54, _) idx_mut)) next_r.b54.#a53 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 200 failed";
   (* .b54.#b53 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b54 = #{ r.b54 with b53 = next_r.b54.#b53 } } in
   Idx_mut.set r ((.b54.#b53) : (t54, _) idx_mut) next_r.b54.#b53;
-  mark_test_run 197;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.b54.#b53) : (t54, _) idx_mut)) next_r.b54.#b53 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 202 failed";
   (*************************************)
   (*   t56 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -1682,24 +1690,24 @@ let to_run () =
   let sub_eq = (fun #{ a55 = a551 } #{ a55 = a552 } -> (fun a b -> String.equal (globalize a) (globalize b)) a551 a552) in
   let expected = { r with a56 = next_r.a56 } in
   Idx_mut.set r ((.a56) : (t56, _) idx_mut) next_r.a56;
-  mark_test_run 199;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a56) : (t56, _) idx_mut)) next_r.a56 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 204 failed";
   (* Paths of depth 2 *)
   let next_r = { a56 = #{ a55 = "200" }; b56 = (unbox_unit ()) } in
   (* .a56.#a55 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a56 = #{ r.a56 with a55 = next_r.a56.#a55 } } in
   Idx_mut.set r ((.a56.#a55) : (t56, _) idx_mut) next_r.a56.#a55;
-  mark_test_run 201;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a56.#a55) : (t56, _) idx_mut)) next_r.a56.#a55 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 206 failed";
   let r = { a56 = #{ a55 = "0" }; b56 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a56 = #{ a55 = "100" }; b56 = (unbox_unit ()) } in
@@ -1707,17 +1715,17 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b56 = next_r.b56 } in
   Idx_mut.set r ((.b56) : (t56, _) idx_mut) next_r.b56;
-  mark_test_run 203;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.b56) : (t56, _) idx_mut)) next_r.b56 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 208 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 204 do
+for i = 1 to 208 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_bytecode_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_bytecode_test.ml
@@ -812,30 +812,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a25 = 100.; b25 = 101. } in
   (* .a25 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a25 = next_r.a25 } in
-  Idx_mut.set r ((.a25) : (t25, _) idx_mut) (Float_u.of_float next_r.a25);
-  mark_test_run 97;
-  let test = eq r expected in
-  if not test then failwithf "test 97 failed";
-  mark_test_run 98;
-  let test = sub_eq (Idx_mut.get r ((.a25) : (t25, _) idx_mut)) (Float_u.of_float next_r.a25) in
-  if not test then failwithf "test 98 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a25 = 0.; b25 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a25 = 100.; b25 = 101. } in
   (* .b25 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b25 = next_r.b25 } in
-  Idx_mut.set r ((.b25) : (t25, _) idx_mut) (Float_u.of_float next_r.b25);
-  mark_test_run 99;
-  let test = eq r expected in
-  if not test then failwithf "test 99 failed";
-  mark_test_run 100;
-  let test = sub_eq (Idx_mut.get r ((.b25) : (t25, _) idx_mut)) (Float_u.of_float next_r.b25) in
-  if not test then failwithf "test 100 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*************************************)
   (*   t26 = { float; float; float }   *)
   (*************************************)
@@ -844,44 +834,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a26 = 100.; b26 = 101.; c26 = 102. } in
   (* .a26 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a26 = next_r.a26 } in
-  Idx_mut.set r ((.a26) : (t26, _) idx_mut) (Float_u.of_float next_r.a26);
-  mark_test_run 101;
-  let test = eq r expected in
-  if not test then failwithf "test 101 failed";
-  mark_test_run 102;
-  let test = sub_eq (Idx_mut.get r ((.a26) : (t26, _) idx_mut)) (Float_u.of_float next_r.a26) in
-  if not test then failwithf "test 102 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a26 = 0.; b26 = 1.; c26 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a26 = 100.; b26 = 101.; c26 = 102. } in
   (* .b26 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b26 = next_r.b26 } in
-  Idx_mut.set r ((.b26) : (t26, _) idx_mut) (Float_u.of_float next_r.b26);
-  mark_test_run 103;
-  let test = eq r expected in
-  if not test then failwithf "test 103 failed";
-  mark_test_run 104;
-  let test = sub_eq (Idx_mut.get r ((.b26) : (t26, _) idx_mut)) (Float_u.of_float next_r.b26) in
-  if not test then failwithf "test 104 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a26 = 0.; b26 = 1.; c26 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a26 = 100.; b26 = 101.; c26 = 102. } in
   (* .c26 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c26 = next_r.c26 } in
-  Idx_mut.set r ((.c26) : (t26, _) idx_mut) (Float_u.of_float next_r.c26);
-  mark_test_run 105;
-  let test = eq r expected in
-  if not test then failwithf "test 105 failed";
-  mark_test_run 106;
-  let test = sub_eq (Idx_mut.get r ((.c26) : (t26, _) idx_mut)) (Float_u.of_float next_r.c26) in
-  if not test then failwithf "test 106 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (**************************************)
   (*   t27 = { float; float; float# }   *)
   (**************************************)
@@ -890,43 +865,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101.; c27 = #102. } in
   (* .a27 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a27 = next_r.a27 } in
-  Idx_mut.set r ((.a27) : (t27, _) idx_mut) (Float_u.of_float next_r.a27);
-  mark_test_run 107;
-  let test = eq r expected in
-  if not test then failwithf "test 107 failed";
-  mark_test_run 108;
-  let test = sub_eq (Idx_mut.get r ((.a27) : (t27, _) idx_mut)) (Float_u.of_float next_r.a27) in
-  if not test then failwithf "test 108 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a27 = 0.; b27 = 1.; c27 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101.; c27 = #102. } in
   (* .b27 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b27 = next_r.b27 } in
-  Idx_mut.set r ((.b27) : (t27, _) idx_mut) (Float_u.of_float next_r.b27);
-  mark_test_run 109;
-  let test = eq r expected in
-  if not test then failwithf "test 109 failed";
-  mark_test_run 110;
-  let test = sub_eq (Idx_mut.get r ((.b27) : (t27, _) idx_mut)) (Float_u.of_float next_r.b27) in
-  if not test then failwithf "test 110 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a27 = 0.; b27 = 1.; c27 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101.; c27 = #102. } in
   (* .c27 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c27 = next_r.c27 } in
-  Idx_mut.set r ((.c27) : (t27, _) idx_mut) next_r.c27;
-  mark_test_run 111;
-  let test = eq r expected in
-  if not test then failwithf "test 111 failed";
-  mark_test_run 112;
-  let test = sub_eq (Idx_mut.get r ((.c27) : (t27, _) idx_mut)) next_r.c27 in
-  if not test then failwithf "test 112 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (******************************************)
   (*   t29 = { float; #{ float; float } }   *)
   (******************************************)
@@ -938,12 +899,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a29 = next_r.a29 } in
   Idx_mut.set r ((.a29) : (t29, _) idx_mut) next_r.a29;
-  mark_test_run 113;
+  mark_test_run 97;
   let test = eq r expected in
-  if not test then failwithf "test 113 failed";
-  mark_test_run 114;
+  if not test then failwithf "test 97 failed";
+  mark_test_run 98;
   let test = sub_eq (Idx_mut.get r ((.a29) : (t29, _) idx_mut)) next_r.a29 in
-  if not test then failwithf "test 114 failed";
+  if not test then failwithf "test 98 failed";
   let r = { a29 = 0.; b29 = #{ a28 = 1.; b28 = 2. } } in
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = #{ a28 = 101.; b28 = 102. } } in
@@ -951,34 +912,34 @@ let to_run () =
   let sub_eq = (fun #{ a28 = a281; b28 = b281 } #{ a28 = a282; b28 = b282 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a281 a282 && (fun a b -> Float.equal (globalize a) (globalize b)) b281 b282) in
   let expected = { r with b29 = next_r.b29 } in
   Idx_mut.set r ((.b29) : (t29, _) idx_mut) next_r.b29;
-  mark_test_run 115;
+  mark_test_run 99;
   let test = eq r expected in
-  if not test then failwithf "test 115 failed";
-  mark_test_run 116;
+  if not test then failwithf "test 99 failed";
+  mark_test_run 100;
   let test = sub_eq (Idx_mut.get r ((.b29) : (t29, _) idx_mut)) next_r.b29 in
-  if not test then failwithf "test 116 failed";
+  if not test then failwithf "test 100 failed";
   (* Paths of depth 2 *)
   let next_r = { a29 = 200.; b29 = #{ a28 = 201.; b28 = 202. } } in
   (* .b29.#a28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b29 = #{ r.b29 with a28 = next_r.b29.#a28 } } in
   Idx_mut.set r ((.b29.#a28) : (t29, _) idx_mut) next_r.b29.#a28;
-  mark_test_run 117;
+  mark_test_run 101;
   let test = eq r expected in
-  if not test then failwithf "test 117 failed";
-  mark_test_run 118;
+  if not test then failwithf "test 101 failed";
+  mark_test_run 102;
   let test = sub_eq (Idx_mut.get r ((.b29.#a28) : (t29, _) idx_mut)) next_r.b29.#a28 in
-  if not test then failwithf "test 118 failed";
+  if not test then failwithf "test 102 failed";
   (* .b29.#b28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b29 = #{ r.b29 with b28 = next_r.b29.#b28 } } in
   Idx_mut.set r ((.b29.#b28) : (t29, _) idx_mut) next_r.b29.#b28;
-  mark_test_run 119;
+  mark_test_run 103;
   let test = eq r expected in
-  if not test then failwithf "test 119 failed";
-  mark_test_run 120;
+  if not test then failwithf "test 103 failed";
+  mark_test_run 104;
   let test = sub_eq (Idx_mut.get r ((.b29.#b28) : (t29, _) idx_mut)) next_r.b29.#b28 in
-  if not test then failwithf "test 120 failed";
+  if not test then failwithf "test 104 failed";
   (********************************************)
   (*   t31 = { float; #{ float#; float# } }   *)
   (********************************************)
@@ -990,12 +951,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a31 = next_r.a31 } in
   Idx_mut.set r ((.a31) : (t31, _) idx_mut) next_r.a31;
-  mark_test_run 121;
+  mark_test_run 105;
   let test = eq r expected in
-  if not test then failwithf "test 121 failed";
-  mark_test_run 122;
+  if not test then failwithf "test 105 failed";
+  mark_test_run 106;
   let test = sub_eq (Idx_mut.get r ((.a31) : (t31, _) idx_mut)) next_r.a31 in
-  if not test then failwithf "test 122 failed";
+  if not test then failwithf "test 106 failed";
   let r = { a31 = 0.; b31 = #{ a30 = #1.; b30 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = #{ a30 = #101.; b30 = #102. } } in
@@ -1003,34 +964,34 @@ let to_run () =
   let sub_eq = (fun #{ a30 = a301; b30 = b301 } #{ a30 = a302; b30 = b302 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a301 a302 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b301 b302) in
   let expected = { r with b31 = next_r.b31 } in
   Idx_mut.set r ((.b31) : (t31, _) idx_mut) next_r.b31;
-  mark_test_run 123;
+  mark_test_run 107;
   let test = eq r expected in
-  if not test then failwithf "test 123 failed";
-  mark_test_run 124;
+  if not test then failwithf "test 107 failed";
+  mark_test_run 108;
   let test = sub_eq (Idx_mut.get r ((.b31) : (t31, _) idx_mut)) next_r.b31 in
-  if not test then failwithf "test 124 failed";
+  if not test then failwithf "test 108 failed";
   (* Paths of depth 2 *)
   let next_r = { a31 = 200.; b31 = #{ a30 = #201.; b30 = #202. } } in
   (* .b31.#a30 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b31 = #{ r.b31 with a30 = next_r.b31.#a30 } } in
   Idx_mut.set r ((.b31.#a30) : (t31, _) idx_mut) next_r.b31.#a30;
-  mark_test_run 125;
+  mark_test_run 109;
   let test = eq r expected in
-  if not test then failwithf "test 125 failed";
-  mark_test_run 126;
+  if not test then failwithf "test 109 failed";
+  mark_test_run 110;
   let test = sub_eq (Idx_mut.get r ((.b31.#a30) : (t31, _) idx_mut)) next_r.b31.#a30 in
-  if not test then failwithf "test 126 failed";
+  if not test then failwithf "test 110 failed";
   (* .b31.#b30 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b31 = #{ r.b31 with b30 = next_r.b31.#b30 } } in
   Idx_mut.set r ((.b31.#b30) : (t31, _) idx_mut) next_r.b31.#b30;
-  mark_test_run 127;
+  mark_test_run 111;
   let test = eq r expected in
-  if not test then failwithf "test 127 failed";
-  mark_test_run 128;
+  if not test then failwithf "test 111 failed";
+  mark_test_run 112;
   let test = sub_eq (Idx_mut.get r ((.b31.#b30) : (t31, _) idx_mut)) next_r.b31.#b30 in
-  if not test then failwithf "test 128 failed";
+  if not test then failwithf "test 112 failed";
   (*******************************)
   (*   t32 = { float#; float }   *)
   (*******************************)
@@ -1039,29 +1000,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a32 = #100.; b32 = 101. } in
   (* .a32 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a32 = next_r.a32 } in
-  Idx_mut.set r ((.a32) : (t32, _) idx_mut) next_r.a32;
-  mark_test_run 129;
-  let test = eq r expected in
-  if not test then failwithf "test 129 failed";
-  mark_test_run 130;
-  let test = sub_eq (Idx_mut.get r ((.a32) : (t32, _) idx_mut)) next_r.a32 in
-  if not test then failwithf "test 130 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a32 = #0.; b32 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a32 = #100.; b32 = 101. } in
   (* .b32 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b32 = next_r.b32 } in
-  Idx_mut.set r ((.b32) : (t32, _) idx_mut) (Float_u.of_float next_r.b32);
-  mark_test_run 131;
-  let test = eq r expected in
-  if not test then failwithf "test 131 failed";
-  mark_test_run 132;
-  let test = sub_eq (Idx_mut.get r ((.b32) : (t32, _) idx_mut)) (Float_u.of_float next_r.b32) in
-  if not test then failwithf "test 132 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (***************************************)
   (*   t33 = { float#; float; float# }   *)
   (***************************************)
@@ -1070,42 +1022,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a33 = #100.; b33 = 101.; c33 = #102. } in
   (* .a33 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a33 = next_r.a33 } in
-  Idx_mut.set r ((.a33) : (t33, _) idx_mut) next_r.a33;
-  mark_test_run 133;
-  let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
-  let test = sub_eq (Idx_mut.get r ((.a33) : (t33, _) idx_mut)) next_r.a33 in
-  if not test then failwithf "test 134 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a33 = #0.; b33 = 1.; c33 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a33 = #100.; b33 = 101.; c33 = #102. } in
   (* .b33 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b33 = next_r.b33 } in
-  Idx_mut.set r ((.b33) : (t33, _) idx_mut) (Float_u.of_float next_r.b33);
-  mark_test_run 135;
-  let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
-  let test = sub_eq (Idx_mut.get r ((.b33) : (t33, _) idx_mut)) (Float_u.of_float next_r.b33) in
-  if not test then failwithf "test 136 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a33 = #0.; b33 = 1.; c33 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a33 = #100.; b33 = 101.; c33 = #102. } in
   (* .c33 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c33 = next_r.c33 } in
-  Idx_mut.set r ((.c33) : (t33, _) idx_mut) next_r.c33;
-  mark_test_run 137;
-  let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
-  let test = sub_eq (Idx_mut.get r ((.c33) : (t33, _) idx_mut)) next_r.c33 in
-  if not test then failwithf "test 138 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (********************************)
   (*   t34 = { float#; float# }   *)
   (********************************)
@@ -1114,28 +1053,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a34 = #100.; b34 = #101. } in
   (* .a34 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a34 = next_r.a34 } in
-  Idx_mut.set r ((.a34) : (t34, _) idx_mut) next_r.a34;
-  mark_test_run 139;
-  let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
-  let test = sub_eq (Idx_mut.get r ((.a34) : (t34, _) idx_mut)) next_r.a34 in
-  if not test then failwithf "test 140 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a34 = #0.; b34 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a34 = #100.; b34 = #101. } in
   (* .b34 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b34 = next_r.b34 } in
-  Idx_mut.set r ((.b34) : (t34, _) idx_mut) next_r.b34;
-  mark_test_run 141;
-  let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
-  let test = sub_eq (Idx_mut.get r ((.b34) : (t34, _) idx_mut)) next_r.b34 in
-  if not test then failwithf "test 142 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*********************************************)
   (*   t35 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1147,12 +1078,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a35 = next_r.a35 } in
   Idx_mut.set r ((.a35) : (t35, _) idx_mut) next_r.a35;
-  mark_test_run 143;
+  mark_test_run 113;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 113 failed";
+  mark_test_run 114;
   let test = sub_eq (Idx_mut.get r ((.a35) : (t35, _) idx_mut)) next_r.a35 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 114 failed";
   let r = { a35 = #0.; b35 = #{ a30 = #1.; b30 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a35 = #100.; b35 = #{ a30 = #101.; b30 = #102. } } in
@@ -1160,34 +1091,34 @@ let to_run () =
   let sub_eq = (fun #{ a30 = a301; b30 = b301 } #{ a30 = a302; b30 = b302 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a301 a302 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b301 b302) in
   let expected = { r with b35 = next_r.b35 } in
   Idx_mut.set r ((.b35) : (t35, _) idx_mut) next_r.b35;
-  mark_test_run 145;
+  mark_test_run 115;
   let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
+  if not test then failwithf "test 115 failed";
+  mark_test_run 116;
   let test = sub_eq (Idx_mut.get r ((.b35) : (t35, _) idx_mut)) next_r.b35 in
-  if not test then failwithf "test 146 failed";
+  if not test then failwithf "test 116 failed";
   (* Paths of depth 2 *)
   let next_r = { a35 = #200.; b35 = #{ a30 = #201.; b30 = #202. } } in
   (* .b35.#a30 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with a30 = next_r.b35.#a30 } } in
   Idx_mut.set r ((.b35.#a30) : (t35, _) idx_mut) next_r.b35.#a30;
-  mark_test_run 147;
+  mark_test_run 117;
   let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
+  if not test then failwithf "test 117 failed";
+  mark_test_run 118;
   let test = sub_eq (Idx_mut.get r ((.b35.#a30) : (t35, _) idx_mut)) next_r.b35.#a30 in
-  if not test then failwithf "test 148 failed";
+  if not test then failwithf "test 118 failed";
   (* .b35.#b30 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with b30 = next_r.b35.#b30 } } in
   Idx_mut.set r ((.b35.#b30) : (t35, _) idx_mut) next_r.b35.#b30;
-  mark_test_run 149;
+  mark_test_run 119;
   let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
+  if not test then failwithf "test 119 failed";
+  mark_test_run 120;
   let test = sub_eq (Idx_mut.get r ((.b35.#b30) : (t35, _) idx_mut)) next_r.b35.#b30 in
-  if not test then failwithf "test 150 failed";
+  if not test then failwithf "test 120 failed";
   (*********************************************)
   (*   t37 = { string; #{ unit_u; unit_u } }   *)
   (*********************************************)
@@ -1199,12 +1130,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a37 = next_r.a37 } in
   Idx_mut.set r ((.a37) : (t37, _) idx_mut) next_r.a37;
-  mark_test_run 151;
+  mark_test_run 121;
   let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
+  if not test then failwithf "test 121 failed";
+  mark_test_run 122;
   let test = sub_eq (Idx_mut.get r ((.a37) : (t37, _) idx_mut)) next_r.a37 in
-  if not test then failwithf "test 152 failed";
+  if not test then failwithf "test 122 failed";
   let r = { a37 = "0"; b37 = #{ a36 = (unbox_unit ()); b36 = (unbox_unit ()) } } in
   (* Paths of depth 1 *)
   let next_r = { a37 = "100"; b37 = #{ a36 = (unbox_unit ()); b36 = (unbox_unit ()) } } in
@@ -1212,34 +1143,34 @@ let to_run () =
   let sub_eq = (fun #{ a36 = a361; b36 = b361 } #{ a36 = a362; b36 = b362 } -> (fun _ _ -> true) a361 a362 && (fun _ _ -> true) b361 b362) in
   let expected = { r with b37 = next_r.b37 } in
   Idx_mut.set r ((.b37) : (t37, _) idx_mut) next_r.b37;
-  mark_test_run 153;
+  mark_test_run 123;
   let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
+  if not test then failwithf "test 123 failed";
+  mark_test_run 124;
   let test = sub_eq (Idx_mut.get r ((.b37) : (t37, _) idx_mut)) next_r.b37 in
-  if not test then failwithf "test 154 failed";
+  if not test then failwithf "test 124 failed";
   (* Paths of depth 2 *)
   let next_r = { a37 = "200"; b37 = #{ a36 = (unbox_unit ()); b36 = (unbox_unit ()) } } in
   (* .b37.#a36 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b37 = #{ r.b37 with a36 = next_r.b37.#a36 } } in
   Idx_mut.set r ((.b37.#a36) : (t37, _) idx_mut) next_r.b37.#a36;
-  mark_test_run 155;
+  mark_test_run 125;
   let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
+  if not test then failwithf "test 125 failed";
+  mark_test_run 126;
   let test = sub_eq (Idx_mut.get r ((.b37.#a36) : (t37, _) idx_mut)) next_r.b37.#a36 in
-  if not test then failwithf "test 156 failed";
+  if not test then failwithf "test 126 failed";
   (* .b37.#b36 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b37 = #{ r.b37 with b36 = next_r.b37.#b36 } } in
   Idx_mut.set r ((.b37.#b36) : (t37, _) idx_mut) next_r.b37.#b36;
-  mark_test_run 157;
+  mark_test_run 127;
   let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
+  if not test then failwithf "test 127 failed";
+  mark_test_run 128;
   let test = sub_eq (Idx_mut.get r ((.b37.#b36) : (t37, _) idx_mut)) next_r.b37.#b36 in
-  if not test then failwithf "test 158 failed";
+  if not test then failwithf "test 128 failed";
   (***********************************)
   (*   t38 = { (| unit_u); float }   *)
   (***********************************)
@@ -1251,12 +1182,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C10_0(a0), C10_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a38 = next_r.a38 } in
   Idx_mut.set r ((.a38) : (t38, _) idx_mut) next_r.a38;
-  mark_test_run 159;
+  mark_test_run 129;
   let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
+  if not test then failwithf "test 129 failed";
+  mark_test_run 130;
   let test = sub_eq (Idx_mut.get r ((.a38) : (t38, _) idx_mut)) next_r.a38 in
-  if not test then failwithf "test 160 failed";
+  if not test then failwithf "test 130 failed";
   let r = { a38 = (C10_0 (unbox_unit ())); b38 = 0. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = (C10_0 (unbox_unit ())); b38 = 100. } in
@@ -1264,12 +1195,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b38 = next_r.b38 } in
   Idx_mut.set r ((.b38) : (t38, _) idx_mut) next_r.b38;
-  mark_test_run 161;
+  mark_test_run 131;
   let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
+  if not test then failwithf "test 131 failed";
+  mark_test_run 132;
   let test = sub_eq (Idx_mut.get r ((.b38) : (t38, _) idx_mut)) next_r.b38 in
-  if not test then failwithf "test 162 failed";
+  if not test then failwithf "test 132 failed";
   (**************************)
   (*   t39 = { #{ int } }   *)
   (**************************)
@@ -1281,24 +1212,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a39 = next_r.a39 } in
   Idx_mut.set r ((.a39) : (t39, _) idx_mut) next_r.a39;
-  mark_test_run 163;
+  mark_test_run 133;
   let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
   let test = sub_eq (Idx_mut.get r ((.a39) : (t39, _) idx_mut)) next_r.a39 in
-  if not test then failwithf "test 164 failed";
+  if not test then failwithf "test 134 failed";
   (* Paths of depth 2 *)
   let next_r = { a39 = #{ a2 = 200 } } in
   (* .a39.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a39 = #{ r.a39 with a2 = next_r.a39.#a2 } } in
   Idx_mut.set r ((.a39.#a2) : (t39, _) idx_mut) next_r.a39.#a2;
-  mark_test_run 165;
+  mark_test_run 135;
   let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
   let test = sub_eq (Idx_mut.get r ((.a39.#a2) : (t39, _) idx_mut)) next_r.a39.#a2 in
-  if not test then failwithf "test 166 failed";
+  if not test then failwithf "test 136 failed";
   (*******************************)
   (*   t40 = { #{ int }; int }   *)
   (*******************************)
@@ -1310,24 +1241,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a40 = next_r.a40 } in
   Idx_mut.set r ((.a40) : (t40, _) idx_mut) next_r.a40;
-  mark_test_run 167;
+  mark_test_run 137;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
   let test = sub_eq (Idx_mut.get r ((.a40) : (t40, _) idx_mut)) next_r.a40 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 138 failed";
   (* Paths of depth 2 *)
   let next_r = { a40 = #{ a2 = 200 }; b40 = 201 } in
   (* .a40.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a40 = #{ r.a40 with a2 = next_r.a40.#a2 } } in
   Idx_mut.set r ((.a40.#a2) : (t40, _) idx_mut) next_r.a40.#a2;
-  mark_test_run 169;
+  mark_test_run 139;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
   let test = sub_eq (Idx_mut.get r ((.a40.#a2) : (t40, _) idx_mut)) next_r.a40.#a2 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 140 failed";
   let r = { a40 = #{ a2 = 0 }; b40 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a40 = #{ a2 = 100 }; b40 = 101 } in
@@ -1335,12 +1266,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b40 = next_r.b40 } in
   Idx_mut.set r ((.b40) : (t40, _) idx_mut) next_r.b40;
-  mark_test_run 171;
+  mark_test_run 141;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
   let test = sub_eq (Idx_mut.get r ((.b40) : (t40, _) idx_mut)) next_r.b40 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 142 failed";
   (**********************************)
   (*   t41 = { #{ int }; int32# }   *)
   (**********************************)
@@ -1352,24 +1283,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a41 = next_r.a41 } in
   Idx_mut.set r ((.a41) : (t41, _) idx_mut) next_r.a41;
-  mark_test_run 173;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.a41) : (t41, _) idx_mut)) next_r.a41 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 144 failed";
   (* Paths of depth 2 *)
   let next_r = { a41 = #{ a2 = 200 }; b41 = #201l } in
   (* .a41.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a41 = #{ r.a41 with a2 = next_r.a41.#a2 } } in
   Idx_mut.set r ((.a41.#a2) : (t41, _) idx_mut) next_r.a41.#a2;
-  mark_test_run 175;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.a41.#a2) : (t41, _) idx_mut)) next_r.a41.#a2 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 146 failed";
   let r = { a41 = #{ a2 = 0 }; b41 = #1l } in
   (* Paths of depth 1 *)
   let next_r = { a41 = #{ a2 = 100 }; b41 = #101l } in
@@ -1377,12 +1308,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b41 = next_r.b41 } in
   Idx_mut.set r ((.b41) : (t41, _) idx_mut) next_r.b41;
-  mark_test_run 177;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.b41) : (t41, _) idx_mut)) next_r.b41 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 148 failed";
   (*********************************)
   (*   t42 = { #{ int }; float }   *)
   (*********************************)
@@ -1394,24 +1325,24 @@ let to_run () =
   let sub_eq = (fun #{ a2 = a21 } #{ a2 = a22 } -> (fun a b -> Int.equal a b) a21 a22) in
   let expected = { r with a42 = next_r.a42 } in
   Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 179;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 150 failed";
   (* Paths of depth 2 *)
   let next_r = { a42 = #{ a2 = 200 }; b42 = 201. } in
   (* .a42.#a2 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a42 = #{ r.a42 with a2 = next_r.a42.#a2 } } in
   Idx_mut.set r ((.a42.#a2) : (t42, _) idx_mut) next_r.a42.#a2;
-  mark_test_run 181;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.a42.#a2) : (t42, _) idx_mut)) next_r.a42.#a2 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 152 failed";
   let r = { a42 = #{ a2 = 0 }; b42 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a42 = #{ a2 = 100 }; b42 = 101. } in
@@ -1419,12 +1350,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b42 = next_r.b42 } in
   Idx_mut.set r ((.b42) : (t42, _) idx_mut) next_r.b42;
-  mark_test_run 183;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.b42) : (t42, _) idx_mut)) next_r.b42 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 154 failed";
   (*******************************)
   (*   t43 = { #{ int; int } }   *)
   (*******************************)
@@ -1436,34 +1367,34 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41; b4 = b41 } #{ a4 = a42; b4 = b42 } -> (fun a b -> Int.equal a b) a41 a42 && (fun a b -> Int.equal a b) b41 b42) in
   let expected = { r with a43 = next_r.a43 } in
   Idx_mut.set r ((.a43) : (t43, _) idx_mut) next_r.a43;
-  mark_test_run 185;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.a43) : (t43, _) idx_mut)) next_r.a43 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 156 failed";
   (* Paths of depth 2 *)
   let next_r = { a43 = #{ a4 = 200; b4 = 201 } } in
   (* .a43.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a43 = #{ r.a43 with a4 = next_r.a43.#a4 } } in
   Idx_mut.set r ((.a43.#a4) : (t43, _) idx_mut) next_r.a43.#a4;
-  mark_test_run 187;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.a43.#a4) : (t43, _) idx_mut)) next_r.a43.#a4 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 158 failed";
   (* .a43.#b4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a43 = #{ r.a43 with b4 = next_r.a43.#b4 } } in
   Idx_mut.set r ((.a43.#b4) : (t43, _) idx_mut) next_r.a43.#b4;
-  mark_test_run 189;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.a43.#b4) : (t43, _) idx_mut)) next_r.a43.#b4 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 160 failed";
   (*****************************)
   (*   t45 = { #{ int32# } }   *)
   (*****************************)
@@ -1475,24 +1406,24 @@ let to_run () =
   let sub_eq = (fun #{ a44 = a441 } #{ a44 = a442 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a441 a442) in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 191;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 162 failed";
   (* Paths of depth 2 *)
   let next_r = { a45 = #{ a44 = #200l } } in
   (* .a45.#a44 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a45 = #{ r.a45 with a44 = next_r.a45.#a44 } } in
   Idx_mut.set r ((.a45.#a44) : (t45, _) idx_mut) next_r.a45.#a44;
-  mark_test_run 193;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.a45.#a44) : (t45, _) idx_mut)) next_r.a45.#a44 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 164 failed";
   (**********************************)
   (*   t47 = { #{ int32#; int } }   *)
   (**********************************)
@@ -1504,34 +1435,34 @@ let to_run () =
   let sub_eq = (fun #{ a46 = a461; b46 = b461 } #{ a46 = a462; b46 = b462 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a461 a462 && (fun a b -> Int.equal a b) b461 b462) in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 195;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 166 failed";
   (* Paths of depth 2 *)
   let next_r = { a47 = #{ a46 = #200l; b46 = 201 } } in
   (* .a47.#a46 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a47 = #{ r.a47 with a46 = next_r.a47.#a46 } } in
   Idx_mut.set r ((.a47.#a46) : (t47, _) idx_mut) next_r.a47.#a46;
-  mark_test_run 197;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.a47.#a46) : (t47, _) idx_mut)) next_r.a47.#a46 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 168 failed";
   (* .a47.#b46 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a47 = #{ r.a47 with b46 = next_r.a47.#b46 } } in
   Idx_mut.set r ((.a47.#b46) : (t47, _) idx_mut) next_r.a47.#b46;
-  mark_test_run 199;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.a47.#b46) : (t47, _) idx_mut)) next_r.a47.#b46 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 170 failed";
   (***********************************)
   (*   t49 = { #{ float }; float }   *)
   (***********************************)
@@ -1542,34 +1473,26 @@ let to_run () =
   (* .a49 *)
   (* Note: skipping test as this is not a valid block index,
      due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
   let _ = next_r in
   (* Paths of depth 2 *)
   let next_r = { a49 = #{ a48 = 200. }; b49 = 201. } in
   (* .a49.#a48 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a49 = #{ r.a49 with a48 = next_r.a49.#a48 } } in
-  Idx_mut.set r ((.a49.#a48) : (t49, _) idx_mut) (Float_u.of_float next_r.a49.#a48);
-  mark_test_run 201;
-  let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
-  let test = sub_eq (Idx_mut.get r ((.a49.#a48) : (t49, _) idx_mut)) (Float_u.of_float next_r.a49.#a48) in
-  if not test then failwithf "test 202 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a49 = #{ a48 = 0. }; b49 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a49 = #{ a48 = 100. }; b49 = 101. } in
   (* .b49 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b49 = next_r.b49 } in
-  Idx_mut.set r ((.b49) : (t49, _) idx_mut) (Float_u.of_float next_r.b49);
-  mark_test_run 203;
-  let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
-  let test = sub_eq (Idx_mut.get r ((.b49) : (t49, _) idx_mut)) (Float_u.of_float next_r.b49) in
-  if not test then failwithf "test 204 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (****************************************)
   (*   t50 = { #{ float; float }; int }   *)
   (****************************************)
@@ -1581,34 +1504,34 @@ let to_run () =
   let sub_eq = (fun #{ a28 = a281; b28 = b281 } #{ a28 = a282; b28 = b282 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a281 a282 && (fun a b -> Float.equal (globalize a) (globalize b)) b281 b282) in
   let expected = { r with a50 = next_r.a50 } in
   Idx_mut.set r ((.a50) : (t50, _) idx_mut) next_r.a50;
-  mark_test_run 205;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.a50) : (t50, _) idx_mut)) next_r.a50 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 172 failed";
   (* Paths of depth 2 *)
   let next_r = { a50 = #{ a28 = 200.; b28 = 201. }; b50 = 202 } in
   (* .a50.#a28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a50 = #{ r.a50 with a28 = next_r.a50.#a28 } } in
   Idx_mut.set r ((.a50.#a28) : (t50, _) idx_mut) next_r.a50.#a28;
-  mark_test_run 207;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.a50.#a28) : (t50, _) idx_mut)) next_r.a50.#a28 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 174 failed";
   (* .a50.#b28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a50 = #{ r.a50 with b28 = next_r.a50.#b28 } } in
   Idx_mut.set r ((.a50.#b28) : (t50, _) idx_mut) next_r.a50.#b28;
-  mark_test_run 209;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.a50.#b28) : (t50, _) idx_mut)) next_r.a50.#b28 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 176 failed";
   let r = { a50 = #{ a28 = 0.; b28 = 1. }; b50 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a50 = #{ a28 = 100.; b28 = 101. }; b50 = 102 } in
@@ -1616,12 +1539,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b50 = next_r.b50 } in
   Idx_mut.set r ((.b50) : (t50, _) idx_mut) next_r.b50;
-  mark_test_run 211;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.b50) : (t50, _) idx_mut)) next_r.b50 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 178 failed";
   (******************************************)
   (*   t51 = { #{ float; float }; float }   *)
   (******************************************)
@@ -1633,34 +1556,34 @@ let to_run () =
   let sub_eq = (fun #{ a28 = a281; b28 = b281 } #{ a28 = a282; b28 = b282 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a281 a282 && (fun a b -> Float.equal (globalize a) (globalize b)) b281 b282) in
   let expected = { r with a51 = next_r.a51 } in
   Idx_mut.set r ((.a51) : (t51, _) idx_mut) next_r.a51;
-  mark_test_run 213;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.a51) : (t51, _) idx_mut)) next_r.a51 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 180 failed";
   (* Paths of depth 2 *)
   let next_r = { a51 = #{ a28 = 200.; b28 = 201. }; b51 = 202. } in
   (* .a51.#a28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a51 = #{ r.a51 with a28 = next_r.a51.#a28 } } in
   Idx_mut.set r ((.a51.#a28) : (t51, _) idx_mut) next_r.a51.#a28;
-  mark_test_run 215;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.a51.#a28) : (t51, _) idx_mut)) next_r.a51.#a28 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 182 failed";
   (* .a51.#b28 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a51 = #{ r.a51 with b28 = next_r.a51.#b28 } } in
   Idx_mut.set r ((.a51.#b28) : (t51, _) idx_mut) next_r.a51.#b28;
-  mark_test_run 217;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a51.#b28) : (t51, _) idx_mut)) next_r.a51.#b28 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 184 failed";
   let r = { a51 = #{ a28 = 0.; b28 = 1. }; b51 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a51 = #{ a28 = 100.; b28 = 101. }; b51 = 102. } in
@@ -1668,12 +1591,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b51 = next_r.b51 } in
   Idx_mut.set r ((.b51) : (t51, _) idx_mut) next_r.b51;
-  mark_test_run 219;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.b51) : (t51, _) idx_mut)) next_r.b51 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 186 failed";
   (************************************************************)
   (*   t54 = { #{ float32#; int64# }; #{ string; int64# } }   *)
   (************************************************************)
@@ -1685,34 +1608,34 @@ let to_run () =
   let sub_eq = (fun #{ a52 = a521; b52 = b521 } #{ a52 = a522; b52 = b522 } -> (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) a521 a522 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b521 b522) in
   let expected = { r with a54 = next_r.a54 } in
   Idx_mut.set r ((.a54) : (t54, _) idx_mut) next_r.a54;
-  mark_test_run 221;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.a54) : (t54, _) idx_mut)) next_r.a54 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 188 failed";
   (* Paths of depth 2 *)
   let next_r = { a54 = #{ a52 = #200.s; b52 = #201L }; b54 = #{ a53 = "202"; b53 = #203L } } in
   (* .a54.#a52 *)
   let sub_eq = (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) in
   let expected = { r with a54 = #{ r.a54 with a52 = next_r.a54.#a52 } } in
   Idx_mut.set r ((.a54.#a52) : (t54, _) idx_mut) next_r.a54.#a52;
-  mark_test_run 223;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.a54.#a52) : (t54, _) idx_mut)) next_r.a54.#a52 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 190 failed";
   (* .a54.#b52 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with a54 = #{ r.a54 with b52 = next_r.a54.#b52 } } in
   Idx_mut.set r ((.a54.#b52) : (t54, _) idx_mut) next_r.a54.#b52;
-  mark_test_run 225;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.a54.#b52) : (t54, _) idx_mut)) next_r.a54.#b52 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 192 failed";
   let r = { a54 = #{ a52 = #0.s; b52 = #1L }; b54 = #{ a53 = "2"; b53 = #3L } } in
   (* Paths of depth 1 *)
   let next_r = { a54 = #{ a52 = #100.s; b52 = #101L }; b54 = #{ a53 = "102"; b53 = #103L } } in
@@ -1720,34 +1643,34 @@ let to_run () =
   let sub_eq = (fun #{ a53 = a531; b53 = b531 } #{ a53 = a532; b53 = b532 } -> (fun a b -> String.equal (globalize a) (globalize b)) a531 a532 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b531 b532) in
   let expected = { r with b54 = next_r.b54 } in
   Idx_mut.set r ((.b54) : (t54, _) idx_mut) next_r.b54;
-  mark_test_run 227;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.b54) : (t54, _) idx_mut)) next_r.b54 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 194 failed";
   (* Paths of depth 2 *)
   let next_r = { a54 = #{ a52 = #200.s; b52 = #201L }; b54 = #{ a53 = "202"; b53 = #203L } } in
   (* .b54.#a53 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b54 = #{ r.b54 with a53 = next_r.b54.#a53 } } in
   Idx_mut.set r ((.b54.#a53) : (t54, _) idx_mut) next_r.b54.#a53;
-  mark_test_run 229;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.b54.#a53) : (t54, _) idx_mut)) next_r.b54.#a53 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 196 failed";
   (* .b54.#b53 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b54 = #{ r.b54 with b53 = next_r.b54.#b53 } } in
   Idx_mut.set r ((.b54.#b53) : (t54, _) idx_mut) next_r.b54.#b53;
-  mark_test_run 231;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.b54.#b53) : (t54, _) idx_mut)) next_r.b54.#b53 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 198 failed";
   (*************************************)
   (*   t56 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -1759,24 +1682,24 @@ let to_run () =
   let sub_eq = (fun #{ a55 = a551 } #{ a55 = a552 } -> (fun a b -> String.equal (globalize a) (globalize b)) a551 a552) in
   let expected = { r with a56 = next_r.a56 } in
   Idx_mut.set r ((.a56) : (t56, _) idx_mut) next_r.a56;
-  mark_test_run 233;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 233 failed";
-  mark_test_run 234;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a56) : (t56, _) idx_mut)) next_r.a56 in
-  if not test then failwithf "test 234 failed";
+  if not test then failwithf "test 200 failed";
   (* Paths of depth 2 *)
   let next_r = { a56 = #{ a55 = "200" }; b56 = (unbox_unit ()) } in
   (* .a56.#a55 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a56 = #{ r.a56 with a55 = next_r.a56.#a55 } } in
   Idx_mut.set r ((.a56.#a55) : (t56, _) idx_mut) next_r.a56.#a55;
-  mark_test_run 235;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 235 failed";
-  mark_test_run 236;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.a56.#a55) : (t56, _) idx_mut)) next_r.a56.#a55 in
-  if not test then failwithf "test 236 failed";
+  if not test then failwithf "test 202 failed";
   let r = { a56 = #{ a55 = "0" }; b56 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a56 = #{ a55 = "100" }; b56 = (unbox_unit ()) } in
@@ -1784,17 +1707,17 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b56 = next_r.b56 } in
   Idx_mut.set r ((.b56) : (t56, _) idx_mut) next_r.b56;
-  mark_test_run 237;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 237 failed";
-  mark_test_run 238;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.b56) : (t56, _) idx_mut)) next_r.b56 in
-  if not test then failwithf "test 238 failed";
+  if not test then failwithf "test 204 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 238 do
+for i = 1 to 204 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_native_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_native_test.ml
@@ -1192,20 +1192,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101. } in
   (* .a38 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with a38 = next_r.a38 } in
+  Idx_mut.set r ((.a38) : (t38, _) idx_mut) next_r.a38;
+  mark_test_run 129;
+  let test = eq r expected in
+  if not test then failwithf "test 129 failed";
+  mark_test_run 130;
+  let test = sub_eq (Idx_mut.get r ((.a38) : (t38, _) idx_mut)) next_r.a38 in
+  if not test then failwithf "test 130 failed";
   let r = { a38 = #0.; b38 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101. } in
   (* .b38 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with b38 = next_r.b38 } in
+  Idx_mut.set r ((.b38) : (t38, _) idx_mut) next_r.b38;
+  mark_test_run 131;
+  let test = eq r expected in
+  if not test then failwithf "test 131 failed";
+  mark_test_run 132;
+  let test = sub_eq (Idx_mut.get r ((.b38) : (t38, _) idx_mut)) next_r.b38 in
+  if not test then failwithf "test 132 failed";
   (*********************************************)
   (*   t39 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1217,12 +1225,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a39 = next_r.a39 } in
   Idx_mut.set r ((.a39) : (t39, _) idx_mut) next_r.a39;
-  mark_test_run 129;
+  mark_test_run 133;
   let test = eq r expected in
-  if not test then failwithf "test 129 failed";
-  mark_test_run 130;
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
   let test = sub_eq (Idx_mut.get r ((.a39) : (t39, _) idx_mut)) next_r.a39 in
-  if not test then failwithf "test 130 failed";
+  if not test then failwithf "test 134 failed";
   let r = { a39 = #0.; b39 = #{ a34 = #1.; b34 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a39 = #100.; b39 = #{ a34 = #101.; b34 = #102. } } in
@@ -1230,34 +1238,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b341 b342) in
   let expected = { r with b39 = next_r.b39 } in
   Idx_mut.set r ((.b39) : (t39, _) idx_mut) next_r.b39;
-  mark_test_run 131;
+  mark_test_run 135;
   let test = eq r expected in
-  if not test then failwithf "test 131 failed";
-  mark_test_run 132;
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
   let test = sub_eq (Idx_mut.get r ((.b39) : (t39, _) idx_mut)) next_r.b39 in
-  if not test then failwithf "test 132 failed";
+  if not test then failwithf "test 136 failed";
   (* Paths of depth 2 *)
   let next_r = { a39 = #200.; b39 = #{ a34 = #201.; b34 = #202. } } in
   (* .b39.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b39 = #{ r.b39 with a34 = next_r.b39.#a34 } } in
   Idx_mut.set r ((.b39.#a34) : (t39, _) idx_mut) next_r.b39.#a34;
-  mark_test_run 133;
+  mark_test_run 137;
   let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
   let test = sub_eq (Idx_mut.get r ((.b39.#a34) : (t39, _) idx_mut)) next_r.b39.#a34 in
-  if not test then failwithf "test 134 failed";
+  if not test then failwithf "test 138 failed";
   (* .b39.#b34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b39 = #{ r.b39 with b34 = next_r.b39.#b34 } } in
   Idx_mut.set r ((.b39.#b34) : (t39, _) idx_mut) next_r.b39.#b34;
-  mark_test_run 135;
+  mark_test_run 139;
   let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
   let test = sub_eq (Idx_mut.get r ((.b39.#b34) : (t39, _) idx_mut)) next_r.b39.#b34 in
-  if not test then failwithf "test 136 failed";
+  if not test then failwithf "test 140 failed";
   (*********************************************)
   (*   t41 = { string; #{ unit_u; unit_u } }   *)
   (*********************************************)
@@ -1269,12 +1277,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a41 = next_r.a41 } in
   Idx_mut.set r ((.a41) : (t41, _) idx_mut) next_r.a41;
-  mark_test_run 137;
+  mark_test_run 141;
   let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
   let test = sub_eq (Idx_mut.get r ((.a41) : (t41, _) idx_mut)) next_r.a41 in
-  if not test then failwithf "test 138 failed";
+  if not test then failwithf "test 142 failed";
   let r = { a41 = "0"; b41 = #{ a40 = (unbox_unit ()); b40 = (unbox_unit ()) } } in
   (* Paths of depth 1 *)
   let next_r = { a41 = "100"; b41 = #{ a40 = (unbox_unit ()); b40 = (unbox_unit ()) } } in
@@ -1282,34 +1290,34 @@ let to_run () =
   let sub_eq = (fun #{ a40 = a401; b40 = b401 } #{ a40 = a402; b40 = b402 } -> (fun _ _ -> true) a401 a402 && (fun _ _ -> true) b401 b402) in
   let expected = { r with b41 = next_r.b41 } in
   Idx_mut.set r ((.b41) : (t41, _) idx_mut) next_r.b41;
-  mark_test_run 139;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.b41) : (t41, _) idx_mut)) next_r.b41 in
-  if not test then failwithf "test 140 failed";
+  if not test then failwithf "test 144 failed";
   (* Paths of depth 2 *)
   let next_r = { a41 = "200"; b41 = #{ a40 = (unbox_unit ()); b40 = (unbox_unit ()) } } in
   (* .b41.#a40 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b41 = #{ r.b41 with a40 = next_r.b41.#a40 } } in
   Idx_mut.set r ((.b41.#a40) : (t41, _) idx_mut) next_r.b41.#a40;
-  mark_test_run 141;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.b41.#a40) : (t41, _) idx_mut)) next_r.b41.#a40 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 146 failed";
   (* .b41.#b40 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b41 = #{ r.b41 with b40 = next_r.b41.#b40 } } in
   Idx_mut.set r ((.b41.#b40) : (t41, _) idx_mut) next_r.b41.#b40;
-  mark_test_run 143;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.b41.#b40) : (t41, _) idx_mut)) next_r.b41.#b40 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 148 failed";
   (*******************************)
   (*   t42 = { int64x2#; int }   *)
   (*******************************)
@@ -1321,12 +1329,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a42 = next_r.a42 } in
   Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 145;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 146 failed";
+  if not test then failwithf "test 150 failed";
   let r = { a42 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b42 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a42 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b42 = 102 } in
@@ -1334,12 +1342,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b42 = next_r.b42 } in
   Idx_mut.set r ((.b42) : (t42, _) idx_mut) next_r.b42;
-  mark_test_run 147;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.b42) : (t42, _) idx_mut)) next_r.b42 in
-  if not test then failwithf "test 148 failed";
+  if not test then failwithf "test 152 failed";
   (************************************)
   (*   t43 = { int64x2#; int; int }   *)
   (************************************)
@@ -1351,12 +1359,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a43 = next_r.a43 } in
   Idx_mut.set r ((.a43) : (t43, _) idx_mut) next_r.a43;
-  mark_test_run 149;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.a43) : (t43, _) idx_mut)) next_r.a43 in
-  if not test then failwithf "test 150 failed";
+  if not test then failwithf "test 154 failed";
   let r = { a43 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b43 = 2; c43 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a43 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b43 = 102; c43 = 103 } in
@@ -1364,12 +1372,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b43 = next_r.b43 } in
   Idx_mut.set r ((.b43) : (t43, _) idx_mut) next_r.b43;
-  mark_test_run 151;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.b43) : (t43, _) idx_mut)) next_r.b43 in
-  if not test then failwithf "test 152 failed";
+  if not test then failwithf "test 156 failed";
   let r = { a43 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b43 = 2; c43 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a43 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b43 = 102; c43 = 103 } in
@@ -1377,12 +1385,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with c43 = next_r.c43 } in
   Idx_mut.set r ((.c43) : (t43, _) idx_mut) next_r.c43;
-  mark_test_run 153;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.c43) : (t43, _) idx_mut)) next_r.c43 in
-  if not test then failwithf "test 154 failed";
+  if not test then failwithf "test 158 failed";
   (*****************************************)
   (*   t44 = { int64x2#; int; int64x2# }   *)
   (*****************************************)
@@ -1394,12 +1402,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a44 = next_r.a44 } in
   Idx_mut.set r ((.a44) : (t44, _) idx_mut) next_r.a44;
-  mark_test_run 155;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.a44) : (t44, _) idx_mut)) next_r.a44 in
-  if not test then failwithf "test 156 failed";
+  if not test then failwithf "test 160 failed";
   let r = { a44 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b44 = 2; c44 = (interleave_low_64 (int64x2_of_int64 3L) (int64x2_of_int64 4L)) } in
   (* Paths of depth 1 *)
   let next_r = { a44 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b44 = 102; c44 = (interleave_low_64 (int64x2_of_int64 103L) (int64x2_of_int64 104L)) } in
@@ -1407,12 +1415,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b44 = next_r.b44 } in
   Idx_mut.set r ((.b44) : (t44, _) idx_mut) next_r.b44;
-  mark_test_run 157;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.b44) : (t44, _) idx_mut)) next_r.b44 in
-  if not test then failwithf "test 158 failed";
+  if not test then failwithf "test 162 failed";
   let r = { a44 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b44 = 2; c44 = (interleave_low_64 (int64x2_of_int64 3L) (int64x2_of_int64 4L)) } in
   (* Paths of depth 1 *)
   let next_r = { a44 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b44 = 102; c44 = (interleave_low_64 (int64x2_of_int64 103L) (int64x2_of_int64 104L)) } in
@@ -1420,12 +1428,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with c44 = next_r.c44 } in
   Idx_mut.set r ((.c44) : (t44, _) idx_mut) next_r.c44;
-  mark_test_run 159;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.c44) : (t44, _) idx_mut)) next_r.c44 in
-  if not test then failwithf "test 160 failed";
+  if not test then failwithf "test 164 failed";
   (************************************)
   (*   t45 = { int64x2#; int64x2# }   *)
   (************************************)
@@ -1437,12 +1445,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 161;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 162 failed";
+  if not test then failwithf "test 166 failed";
   let r = { a45 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b45 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b45 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -1450,12 +1458,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b45 = next_r.b45 } in
   Idx_mut.set r ((.b45) : (t45, _) idx_mut) next_r.b45;
-  mark_test_run 163;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.b45) : (t45, _) idx_mut)) next_r.b45 in
-  if not test then failwithf "test 164 failed";
+  if not test then failwithf "test 168 failed";
   (*****************************************)
   (*   t46 = { int64x2#; #{ int; int } }   *)
   (*****************************************)
@@ -1467,12 +1475,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a46 = next_r.a46 } in
   Idx_mut.set r ((.a46) : (t46, _) idx_mut) next_r.a46;
-  mark_test_run 165;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.a46) : (t46, _) idx_mut)) next_r.a46 in
-  if not test then failwithf "test 166 failed";
+  if not test then failwithf "test 170 failed";
   let r = { a46 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b46 = #{ a6 = 2; b6 = 3 } } in
   (* Paths of depth 1 *)
   let next_r = { a46 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b46 = #{ a6 = 102; b6 = 103 } } in
@@ -1480,34 +1488,34 @@ let to_run () =
   let sub_eq = (fun #{ a6 = a61; b6 = b61 } #{ a6 = a62; b6 = b62 } -> (fun a b -> Int.equal a b) a61 a62 && (fun a b -> Int.equal a b) b61 b62) in
   let expected = { r with b46 = next_r.b46 } in
   Idx_mut.set r ((.b46) : (t46, _) idx_mut) next_r.b46;
-  mark_test_run 167;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.b46) : (t46, _) idx_mut)) next_r.b46 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 172 failed";
   (* Paths of depth 2 *)
   let next_r = { a46 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)); b46 = #{ a6 = 202; b6 = 203 } } in
   (* .b46.#a6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b46 = #{ r.b46 with a6 = next_r.b46.#a6 } } in
   Idx_mut.set r ((.b46.#a6) : (t46, _) idx_mut) next_r.b46.#a6;
-  mark_test_run 169;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.b46.#a6) : (t46, _) idx_mut)) next_r.b46.#a6 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 174 failed";
   (* .b46.#b6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b46 = #{ r.b46 with b6 = next_r.b46.#b6 } } in
   Idx_mut.set r ((.b46.#b6) : (t46, _) idx_mut) next_r.b46.#b6;
-  mark_test_run 171;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.b46.#b6) : (t46, _) idx_mut)) next_r.b46.#b6 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 176 failed";
   (***********************************)
   (*   t47 = { (| unit_u); float }   *)
   (***********************************)
@@ -1519,12 +1527,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C14_0(a0), C14_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 173;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 178 failed";
   let r = { a47 = (C14_0 (unbox_unit ())); b47 = 0. } in
   (* Paths of depth 1 *)
   let next_r = { a47 = (C14_0 (unbox_unit ())); b47 = 100. } in
@@ -1532,12 +1540,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b47 = next_r.b47 } in
   Idx_mut.set r ((.b47) : (t47, _) idx_mut) next_r.b47;
-  mark_test_run 175;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.b47) : (t47, _) idx_mut)) next_r.b47 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 180 failed";
   (**************************)
   (*   t48 = { #{ int } }   *)
   (**************************)
@@ -1549,24 +1557,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a48 = next_r.a48 } in
   Idx_mut.set r ((.a48) : (t48, _) idx_mut) next_r.a48;
-  mark_test_run 177;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.a48) : (t48, _) idx_mut)) next_r.a48 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 182 failed";
   (* Paths of depth 2 *)
   let next_r = { a48 = #{ a4 = 200 } } in
   (* .a48.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a48 = #{ r.a48 with a4 = next_r.a48.#a4 } } in
   Idx_mut.set r ((.a48.#a4) : (t48, _) idx_mut) next_r.a48.#a4;
-  mark_test_run 179;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a48.#a4) : (t48, _) idx_mut)) next_r.a48.#a4 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 184 failed";
   (*******************************)
   (*   t49 = { #{ int }; int }   *)
   (*******************************)
@@ -1578,24 +1586,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a49 = next_r.a49 } in
   Idx_mut.set r ((.a49) : (t49, _) idx_mut) next_r.a49;
-  mark_test_run 181;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.a49) : (t49, _) idx_mut)) next_r.a49 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 186 failed";
   (* Paths of depth 2 *)
   let next_r = { a49 = #{ a4 = 200 }; b49 = 201 } in
   (* .a49.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a49 = #{ r.a49 with a4 = next_r.a49.#a4 } } in
   Idx_mut.set r ((.a49.#a4) : (t49, _) idx_mut) next_r.a49.#a4;
-  mark_test_run 183;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.a49.#a4) : (t49, _) idx_mut)) next_r.a49.#a4 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 188 failed";
   let r = { a49 = #{ a4 = 0 }; b49 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a49 = #{ a4 = 100 }; b49 = 101 } in
@@ -1603,12 +1611,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b49 = next_r.b49 } in
   Idx_mut.set r ((.b49) : (t49, _) idx_mut) next_r.b49;
-  mark_test_run 185;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.b49) : (t49, _) idx_mut)) next_r.b49 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 190 failed";
   (**********************************)
   (*   t50 = { #{ int }; int32# }   *)
   (**********************************)
@@ -1620,24 +1628,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a50 = next_r.a50 } in
   Idx_mut.set r ((.a50) : (t50, _) idx_mut) next_r.a50;
-  mark_test_run 187;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.a50) : (t50, _) idx_mut)) next_r.a50 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 192 failed";
   (* Paths of depth 2 *)
   let next_r = { a50 = #{ a4 = 200 }; b50 = #201l } in
   (* .a50.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a50 = #{ r.a50 with a4 = next_r.a50.#a4 } } in
   Idx_mut.set r ((.a50.#a4) : (t50, _) idx_mut) next_r.a50.#a4;
-  mark_test_run 189;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a50.#a4) : (t50, _) idx_mut)) next_r.a50.#a4 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 194 failed";
   let r = { a50 = #{ a4 = 0 }; b50 = #1l } in
   (* Paths of depth 1 *)
   let next_r = { a50 = #{ a4 = 100 }; b50 = #101l } in
@@ -1645,12 +1653,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b50 = next_r.b50 } in
   Idx_mut.set r ((.b50) : (t50, _) idx_mut) next_r.b50;
-  mark_test_run 191;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.b50) : (t50, _) idx_mut)) next_r.b50 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 196 failed";
   (*********************************)
   (*   t51 = { #{ int }; float }   *)
   (*********************************)
@@ -1662,24 +1670,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a51 = next_r.a51 } in
   Idx_mut.set r ((.a51) : (t51, _) idx_mut) next_r.a51;
-  mark_test_run 193;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.a51) : (t51, _) idx_mut)) next_r.a51 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 198 failed";
   (* Paths of depth 2 *)
   let next_r = { a51 = #{ a4 = 200 }; b51 = 201. } in
   (* .a51.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a51 = #{ r.a51 with a4 = next_r.a51.#a4 } } in
   Idx_mut.set r ((.a51.#a4) : (t51, _) idx_mut) next_r.a51.#a4;
-  mark_test_run 195;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a51.#a4) : (t51, _) idx_mut)) next_r.a51.#a4 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 200 failed";
   let r = { a51 = #{ a4 = 0 }; b51 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a51 = #{ a4 = 100 }; b51 = 101. } in
@@ -1687,12 +1695,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b51 = next_r.b51 } in
   Idx_mut.set r ((.b51) : (t51, _) idx_mut) next_r.b51;
-  mark_test_run 197;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.b51) : (t51, _) idx_mut)) next_r.b51 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 202 failed";
   (*******************************)
   (*   t52 = { #{ int; int } }   *)
   (*******************************)
@@ -1704,34 +1712,34 @@ let to_run () =
   let sub_eq = (fun #{ a6 = a61; b6 = b61 } #{ a6 = a62; b6 = b62 } -> (fun a b -> Int.equal a b) a61 a62 && (fun a b -> Int.equal a b) b61 b62) in
   let expected = { r with a52 = next_r.a52 } in
   Idx_mut.set r ((.a52) : (t52, _) idx_mut) next_r.a52;
-  mark_test_run 199;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a52) : (t52, _) idx_mut)) next_r.a52 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 204 failed";
   (* Paths of depth 2 *)
   let next_r = { a52 = #{ a6 = 200; b6 = 201 } } in
   (* .a52.#a6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a52 = #{ r.a52 with a6 = next_r.a52.#a6 } } in
   Idx_mut.set r ((.a52.#a6) : (t52, _) idx_mut) next_r.a52.#a6;
-  mark_test_run 201;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a52.#a6) : (t52, _) idx_mut)) next_r.a52.#a6 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 206 failed";
   (* .a52.#b6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a52 = #{ r.a52 with b6 = next_r.a52.#b6 } } in
   Idx_mut.set r ((.a52.#b6) : (t52, _) idx_mut) next_r.a52.#b6;
-  mark_test_run 203;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.a52.#b6) : (t52, _) idx_mut)) next_r.a52.#b6 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 208 failed";
   (*****************************)
   (*   t54 = { #{ int32# } }   *)
   (*****************************)
@@ -1743,24 +1751,24 @@ let to_run () =
   let sub_eq = (fun #{ a53 = a531 } #{ a53 = a532 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a531 a532) in
   let expected = { r with a54 = next_r.a54 } in
   Idx_mut.set r ((.a54) : (t54, _) idx_mut) next_r.a54;
-  mark_test_run 205;
+  mark_test_run 209;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 209 failed";
+  mark_test_run 210;
   let test = sub_eq (Idx_mut.get r ((.a54) : (t54, _) idx_mut)) next_r.a54 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 210 failed";
   (* Paths of depth 2 *)
   let next_r = { a54 = #{ a53 = #200l } } in
   (* .a54.#a53 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a54 = #{ r.a54 with a53 = next_r.a54.#a53 } } in
   Idx_mut.set r ((.a54.#a53) : (t54, _) idx_mut) next_r.a54.#a53;
-  mark_test_run 207;
+  mark_test_run 211;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 211 failed";
+  mark_test_run 212;
   let test = sub_eq (Idx_mut.get r ((.a54.#a53) : (t54, _) idx_mut)) next_r.a54.#a53 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 212 failed";
   (**********************************)
   (*   t56 = { #{ int32#; int } }   *)
   (**********************************)
@@ -1772,34 +1780,34 @@ let to_run () =
   let sub_eq = (fun #{ a55 = a551; b55 = b551 } #{ a55 = a552; b55 = b552 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a551 a552 && (fun a b -> Int.equal a b) b551 b552) in
   let expected = { r with a56 = next_r.a56 } in
   Idx_mut.set r ((.a56) : (t56, _) idx_mut) next_r.a56;
-  mark_test_run 209;
+  mark_test_run 213;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 213 failed";
+  mark_test_run 214;
   let test = sub_eq (Idx_mut.get r ((.a56) : (t56, _) idx_mut)) next_r.a56 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 214 failed";
   (* Paths of depth 2 *)
   let next_r = { a56 = #{ a55 = #200l; b55 = 201 } } in
   (* .a56.#a55 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a56 = #{ r.a56 with a55 = next_r.a56.#a55 } } in
   Idx_mut.set r ((.a56.#a55) : (t56, _) idx_mut) next_r.a56.#a55;
-  mark_test_run 211;
+  mark_test_run 215;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 215 failed";
+  mark_test_run 216;
   let test = sub_eq (Idx_mut.get r ((.a56.#a55) : (t56, _) idx_mut)) next_r.a56.#a55 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 216 failed";
   (* .a56.#b55 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a56 = #{ r.a56 with b55 = next_r.a56.#b55 } } in
   Idx_mut.set r ((.a56.#b55) : (t56, _) idx_mut) next_r.a56.#b55;
-  mark_test_run 213;
+  mark_test_run 217;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 217 failed";
+  mark_test_run 218;
   let test = sub_eq (Idx_mut.get r ((.a56.#b55) : (t56, _) idx_mut)) next_r.a56.#b55 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 218 failed";
   (***********************************)
   (*   t58 = { #{ float }; float }   *)
   (***********************************)
@@ -1841,34 +1849,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a321 a322 && (fun a b -> Float.equal (globalize a) (globalize b)) b321 b322) in
   let expected = { r with a59 = next_r.a59 } in
   Idx_mut.set r ((.a59) : (t59, _) idx_mut) next_r.a59;
-  mark_test_run 215;
+  mark_test_run 219;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 219 failed";
+  mark_test_run 220;
   let test = sub_eq (Idx_mut.get r ((.a59) : (t59, _) idx_mut)) next_r.a59 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 220 failed";
   (* Paths of depth 2 *)
   let next_r = { a59 = #{ a32 = 200.; b32 = 201. }; b59 = 202 } in
   (* .a59.#a32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with a32 = next_r.a59.#a32 } } in
   Idx_mut.set r ((.a59.#a32) : (t59, _) idx_mut) next_r.a59.#a32;
-  mark_test_run 217;
+  mark_test_run 221;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 221 failed";
+  mark_test_run 222;
   let test = sub_eq (Idx_mut.get r ((.a59.#a32) : (t59, _) idx_mut)) next_r.a59.#a32 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 222 failed";
   (* .a59.#b32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with b32 = next_r.a59.#b32 } } in
   Idx_mut.set r ((.a59.#b32) : (t59, _) idx_mut) next_r.a59.#b32;
-  mark_test_run 219;
+  mark_test_run 223;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 223 failed";
+  mark_test_run 224;
   let test = sub_eq (Idx_mut.get r ((.a59.#b32) : (t59, _) idx_mut)) next_r.a59.#b32 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 224 failed";
   let r = { a59 = #{ a32 = 0.; b32 = 1. }; b59 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a59 = #{ a32 = 100.; b32 = 101. }; b59 = 102 } in
@@ -1876,12 +1884,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b59 = next_r.b59 } in
   Idx_mut.set r ((.b59) : (t59, _) idx_mut) next_r.b59;
-  mark_test_run 221;
+  mark_test_run 225;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 225 failed";
+  mark_test_run 226;
   let test = sub_eq (Idx_mut.get r ((.b59) : (t59, _) idx_mut)) next_r.b59 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 226 failed";
   (******************************************)
   (*   t60 = { #{ float; float }; float }   *)
   (******************************************)
@@ -1893,34 +1901,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a321 a322 && (fun a b -> Float.equal (globalize a) (globalize b)) b321 b322) in
   let expected = { r with a60 = next_r.a60 } in
   Idx_mut.set r ((.a60) : (t60, _) idx_mut) next_r.a60;
-  mark_test_run 223;
+  mark_test_run 227;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 227 failed";
+  mark_test_run 228;
   let test = sub_eq (Idx_mut.get r ((.a60) : (t60, _) idx_mut)) next_r.a60 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 228 failed";
   (* Paths of depth 2 *)
   let next_r = { a60 = #{ a32 = 200.; b32 = 201. }; b60 = 202. } in
   (* .a60.#a32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with a32 = next_r.a60.#a32 } } in
   Idx_mut.set r ((.a60.#a32) : (t60, _) idx_mut) next_r.a60.#a32;
-  mark_test_run 225;
+  mark_test_run 229;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 229 failed";
+  mark_test_run 230;
   let test = sub_eq (Idx_mut.get r ((.a60.#a32) : (t60, _) idx_mut)) next_r.a60.#a32 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 230 failed";
   (* .a60.#b32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with b32 = next_r.a60.#b32 } } in
   Idx_mut.set r ((.a60.#b32) : (t60, _) idx_mut) next_r.a60.#b32;
-  mark_test_run 227;
+  mark_test_run 231;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 231 failed";
+  mark_test_run 232;
   let test = sub_eq (Idx_mut.get r ((.a60.#b32) : (t60, _) idx_mut)) next_r.a60.#b32 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 232 failed";
   let r = { a60 = #{ a32 = 0.; b32 = 1. }; b60 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a60 = #{ a32 = 100.; b32 = 101. }; b60 = 102. } in
@@ -1928,12 +1936,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b60 = next_r.b60 } in
   Idx_mut.set r ((.b60) : (t60, _) idx_mut) next_r.b60;
-  mark_test_run 229;
+  mark_test_run 233;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 233 failed";
+  mark_test_run 234;
   let test = sub_eq (Idx_mut.get r ((.b60) : (t60, _) idx_mut)) next_r.b60 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 234 failed";
   (************************************************************)
   (*   t63 = { #{ float32#; int64# }; #{ string; int64# } }   *)
   (************************************************************)
@@ -1945,34 +1953,34 @@ let to_run () =
   let sub_eq = (fun #{ a61 = a611; b61 = b611 } #{ a61 = a612; b61 = b612 } -> (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) a611 a612 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b611 b612) in
   let expected = { r with a63 = next_r.a63 } in
   Idx_mut.set r ((.a63) : (t63, _) idx_mut) next_r.a63;
-  mark_test_run 231;
+  mark_test_run 235;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 235 failed";
+  mark_test_run 236;
   let test = sub_eq (Idx_mut.get r ((.a63) : (t63, _) idx_mut)) next_r.a63 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 236 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a61 = #200.s; b61 = #201L }; b63 = #{ a62 = "202"; b62 = #203L } } in
   (* .a63.#a61 *)
   let sub_eq = (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) in
   let expected = { r with a63 = #{ r.a63 with a61 = next_r.a63.#a61 } } in
   Idx_mut.set r ((.a63.#a61) : (t63, _) idx_mut) next_r.a63.#a61;
-  mark_test_run 233;
+  mark_test_run 237;
   let test = eq r expected in
-  if not test then failwithf "test 233 failed";
-  mark_test_run 234;
+  if not test then failwithf "test 237 failed";
+  mark_test_run 238;
   let test = sub_eq (Idx_mut.get r ((.a63.#a61) : (t63, _) idx_mut)) next_r.a63.#a61 in
-  if not test then failwithf "test 234 failed";
+  if not test then failwithf "test 238 failed";
   (* .a63.#b61 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with a63 = #{ r.a63 with b61 = next_r.a63.#b61 } } in
   Idx_mut.set r ((.a63.#b61) : (t63, _) idx_mut) next_r.a63.#b61;
-  mark_test_run 235;
+  mark_test_run 239;
   let test = eq r expected in
-  if not test then failwithf "test 235 failed";
-  mark_test_run 236;
+  if not test then failwithf "test 239 failed";
+  mark_test_run 240;
   let test = sub_eq (Idx_mut.get r ((.a63.#b61) : (t63, _) idx_mut)) next_r.a63.#b61 in
-  if not test then failwithf "test 236 failed";
+  if not test then failwithf "test 240 failed";
   let r = { a63 = #{ a61 = #0.s; b61 = #1L }; b63 = #{ a62 = "2"; b62 = #3L } } in
   (* Paths of depth 1 *)
   let next_r = { a63 = #{ a61 = #100.s; b61 = #101L }; b63 = #{ a62 = "102"; b62 = #103L } } in
@@ -1980,34 +1988,34 @@ let to_run () =
   let sub_eq = (fun #{ a62 = a621; b62 = b621 } #{ a62 = a622; b62 = b622 } -> (fun a b -> String.equal (globalize a) (globalize b)) a621 a622 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b621 b622) in
   let expected = { r with b63 = next_r.b63 } in
   Idx_mut.set r ((.b63) : (t63, _) idx_mut) next_r.b63;
-  mark_test_run 237;
+  mark_test_run 241;
   let test = eq r expected in
-  if not test then failwithf "test 237 failed";
-  mark_test_run 238;
+  if not test then failwithf "test 241 failed";
+  mark_test_run 242;
   let test = sub_eq (Idx_mut.get r ((.b63) : (t63, _) idx_mut)) next_r.b63 in
-  if not test then failwithf "test 238 failed";
+  if not test then failwithf "test 242 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a61 = #200.s; b61 = #201L }; b63 = #{ a62 = "202"; b62 = #203L } } in
   (* .b63.#a62 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b63 = #{ r.b63 with a62 = next_r.b63.#a62 } } in
   Idx_mut.set r ((.b63.#a62) : (t63, _) idx_mut) next_r.b63.#a62;
-  mark_test_run 239;
+  mark_test_run 243;
   let test = eq r expected in
-  if not test then failwithf "test 239 failed";
-  mark_test_run 240;
+  if not test then failwithf "test 243 failed";
+  mark_test_run 244;
   let test = sub_eq (Idx_mut.get r ((.b63.#a62) : (t63, _) idx_mut)) next_r.b63.#a62 in
-  if not test then failwithf "test 240 failed";
+  if not test then failwithf "test 244 failed";
   (* .b63.#b62 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b63 = #{ r.b63 with b62 = next_r.b63.#b62 } } in
   Idx_mut.set r ((.b63.#b62) : (t63, _) idx_mut) next_r.b63.#b62;
-  mark_test_run 241;
+  mark_test_run 245;
   let test = eq r expected in
-  if not test then failwithf "test 241 failed";
-  mark_test_run 242;
+  if not test then failwithf "test 245 failed";
+  mark_test_run 246;
   let test = sub_eq (Idx_mut.get r ((.b63.#b62) : (t63, _) idx_mut)) next_r.b63.#b62 in
-  if not test then failwithf "test 242 failed";
+  if not test then failwithf "test 246 failed";
   (*************************************)
   (*   t65 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -2019,24 +2027,24 @@ let to_run () =
   let sub_eq = (fun #{ a64 = a641 } #{ a64 = a642 } -> (fun a b -> String.equal (globalize a) (globalize b)) a641 a642) in
   let expected = { r with a65 = next_r.a65 } in
   Idx_mut.set r ((.a65) : (t65, _) idx_mut) next_r.a65;
-  mark_test_run 243;
+  mark_test_run 247;
   let test = eq r expected in
-  if not test then failwithf "test 243 failed";
-  mark_test_run 244;
+  if not test then failwithf "test 247 failed";
+  mark_test_run 248;
   let test = sub_eq (Idx_mut.get r ((.a65) : (t65, _) idx_mut)) next_r.a65 in
-  if not test then failwithf "test 244 failed";
+  if not test then failwithf "test 248 failed";
   (* Paths of depth 2 *)
   let next_r = { a65 = #{ a64 = "200" }; b65 = (unbox_unit ()) } in
   (* .a65.#a64 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a65 = #{ r.a65 with a64 = next_r.a65.#a64 } } in
   Idx_mut.set r ((.a65.#a64) : (t65, _) idx_mut) next_r.a65.#a64;
-  mark_test_run 245;
+  mark_test_run 249;
   let test = eq r expected in
-  if not test then failwithf "test 245 failed";
-  mark_test_run 246;
+  if not test then failwithf "test 249 failed";
+  mark_test_run 250;
   let test = sub_eq (Idx_mut.get r ((.a65.#a64) : (t65, _) idx_mut)) next_r.a65.#a64 in
-  if not test then failwithf "test 246 failed";
+  if not test then failwithf "test 250 failed";
   let r = { a65 = #{ a64 = "0" }; b65 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a65 = #{ a64 = "100" }; b65 = (unbox_unit ()) } in
@@ -2044,12 +2052,12 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b65 = next_r.b65 } in
   Idx_mut.set r ((.b65) : (t65, _) idx_mut) next_r.b65;
-  mark_test_run 247;
+  mark_test_run 251;
   let test = eq r expected in
-  if not test then failwithf "test 247 failed";
-  mark_test_run 248;
+  if not test then failwithf "test 251 failed";
+  mark_test_run 252;
   let test = sub_eq (Idx_mut.get r ((.b65) : (t65, _) idx_mut)) next_r.b65 in
-  if not test then failwithf "test 248 failed";
+  if not test then failwithf "test 252 failed";
   (*****************************************)
   (*   t66 = { #{ int64x2# }; int64x2# }   *)
   (*****************************************)
@@ -2061,24 +2069,24 @@ let to_run () =
   let sub_eq = (fun #{ a10 = a101 } #{ a10 = a102 } -> int64x2_u_equal a101 a102) in
   let expected = { r with a66 = next_r.a66 } in
   Idx_mut.set r ((.a66) : (t66, _) idx_mut) next_r.a66;
-  mark_test_run 249;
+  mark_test_run 253;
   let test = eq r expected in
-  if not test then failwithf "test 249 failed";
-  mark_test_run 250;
+  if not test then failwithf "test 253 failed";
+  mark_test_run 254;
   let test = sub_eq (Idx_mut.get r ((.a66) : (t66, _) idx_mut)) next_r.a66 in
-  if not test then failwithf "test 250 failed";
+  if not test then failwithf "test 254 failed";
   (* Paths of depth 2 *)
   let next_r = { a66 = #{ a10 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)) }; b66 = (interleave_low_64 (int64x2_of_int64 202L) (int64x2_of_int64 203L)) } in
   (* .a66.#a10 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with a66 = #{ r.a66 with a10 = next_r.a66.#a10 } } in
   Idx_mut.set r ((.a66.#a10) : (t66, _) idx_mut) next_r.a66.#a10;
-  mark_test_run 251;
+  mark_test_run 255;
   let test = eq r expected in
-  if not test then failwithf "test 251 failed";
-  mark_test_run 252;
+  if not test then failwithf "test 255 failed";
+  mark_test_run 256;
   let test = sub_eq (Idx_mut.get r ((.a66.#a10) : (t66, _) idx_mut)) next_r.a66.#a10 in
-  if not test then failwithf "test 252 failed";
+  if not test then failwithf "test 256 failed";
   let r = { a66 = #{ a10 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)) }; b66 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a66 = #{ a10 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)) }; b66 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -2086,17 +2094,17 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b66 = next_r.b66 } in
   Idx_mut.set r ((.b66) : (t66, _) idx_mut) next_r.b66;
-  mark_test_run 253;
+  mark_test_run 257;
   let test = eq r expected in
-  if not test then failwithf "test 253 failed";
-  mark_test_run 254;
+  if not test then failwithf "test 257 failed";
+  mark_test_run 258;
   let test = sub_eq (Idx_mut.get r ((.b66) : (t66, _) idx_mut)) next_r.b66 in
-  if not test then failwithf "test 254 failed";
+  if not test then failwithf "test 258 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 254 do
+for i = 1 to 258 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_native_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_local_native_test.ml
@@ -951,30 +951,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = 101. } in
   (* .a29 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a29 = next_r.a29 } in
-  Idx_mut.set r ((.a29) : (t29, _) idx_mut) (Float_u.of_float next_r.a29);
-  mark_test_run 113;
-  let test = eq r expected in
-  if not test then failwithf "test 113 failed";
-  mark_test_run 114;
-  let test = sub_eq (Idx_mut.get r ((.a29) : (t29, _) idx_mut)) (Float_u.of_float next_r.a29) in
-  if not test then failwithf "test 114 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a29 = 0.; b29 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = 101. } in
   (* .b29 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b29 = next_r.b29 } in
-  Idx_mut.set r ((.b29) : (t29, _) idx_mut) (Float_u.of_float next_r.b29);
-  mark_test_run 115;
-  let test = eq r expected in
-  if not test then failwithf "test 115 failed";
-  mark_test_run 116;
-  let test = sub_eq (Idx_mut.get r ((.b29) : (t29, _) idx_mut)) (Float_u.of_float next_r.b29) in
-  if not test then failwithf "test 116 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*************************************)
   (*   t30 = { float; float; float }   *)
   (*************************************)
@@ -983,44 +973,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a30 = 100.; b30 = 101.; c30 = 102. } in
   (* .a30 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a30 = next_r.a30 } in
-  Idx_mut.set r ((.a30) : (t30, _) idx_mut) (Float_u.of_float next_r.a30);
-  mark_test_run 117;
-  let test = eq r expected in
-  if not test then failwithf "test 117 failed";
-  mark_test_run 118;
-  let test = sub_eq (Idx_mut.get r ((.a30) : (t30, _) idx_mut)) (Float_u.of_float next_r.a30) in
-  if not test then failwithf "test 118 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a30 = 0.; b30 = 1.; c30 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a30 = 100.; b30 = 101.; c30 = 102. } in
   (* .b30 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b30 = next_r.b30 } in
-  Idx_mut.set r ((.b30) : (t30, _) idx_mut) (Float_u.of_float next_r.b30);
-  mark_test_run 119;
-  let test = eq r expected in
-  if not test then failwithf "test 119 failed";
-  mark_test_run 120;
-  let test = sub_eq (Idx_mut.get r ((.b30) : (t30, _) idx_mut)) (Float_u.of_float next_r.b30) in
-  if not test then failwithf "test 120 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a30 = 0.; b30 = 1.; c30 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a30 = 100.; b30 = 101.; c30 = 102. } in
   (* .c30 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c30 = next_r.c30 } in
-  Idx_mut.set r ((.c30) : (t30, _) idx_mut) (Float_u.of_float next_r.c30);
-  mark_test_run 121;
-  let test = eq r expected in
-  if not test then failwithf "test 121 failed";
-  mark_test_run 122;
-  let test = sub_eq (Idx_mut.get r ((.c30) : (t30, _) idx_mut)) (Float_u.of_float next_r.c30) in
-  if not test then failwithf "test 122 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (**************************************)
   (*   t31 = { float; float; float# }   *)
   (**************************************)
@@ -1029,43 +1004,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = 101.; c31 = #102. } in
   (* .a31 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a31 = next_r.a31 } in
-  Idx_mut.set r ((.a31) : (t31, _) idx_mut) (Float_u.of_float next_r.a31);
-  mark_test_run 123;
-  let test = eq r expected in
-  if not test then failwithf "test 123 failed";
-  mark_test_run 124;
-  let test = sub_eq (Idx_mut.get r ((.a31) : (t31, _) idx_mut)) (Float_u.of_float next_r.a31) in
-  if not test then failwithf "test 124 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a31 = 0.; b31 = 1.; c31 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = 101.; c31 = #102. } in
   (* .b31 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b31 = next_r.b31 } in
-  Idx_mut.set r ((.b31) : (t31, _) idx_mut) (Float_u.of_float next_r.b31);
-  mark_test_run 125;
-  let test = eq r expected in
-  if not test then failwithf "test 125 failed";
-  mark_test_run 126;
-  let test = sub_eq (Idx_mut.get r ((.b31) : (t31, _) idx_mut)) (Float_u.of_float next_r.b31) in
-  if not test then failwithf "test 126 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a31 = 0.; b31 = 1.; c31 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = 101.; c31 = #102. } in
   (* .c31 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c31 = next_r.c31 } in
-  Idx_mut.set r ((.c31) : (t31, _) idx_mut) next_r.c31;
-  mark_test_run 127;
-  let test = eq r expected in
-  if not test then failwithf "test 127 failed";
-  mark_test_run 128;
-  let test = sub_eq (Idx_mut.get r ((.c31) : (t31, _) idx_mut)) next_r.c31 in
-  if not test then failwithf "test 128 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (******************************************)
   (*   t33 = { float; #{ float; float } }   *)
   (******************************************)
@@ -1077,12 +1038,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a33 = next_r.a33 } in
   Idx_mut.set r ((.a33) : (t33, _) idx_mut) next_r.a33;
-  mark_test_run 129;
+  mark_test_run 113;
   let test = eq r expected in
-  if not test then failwithf "test 129 failed";
-  mark_test_run 130;
+  if not test then failwithf "test 113 failed";
+  mark_test_run 114;
   let test = sub_eq (Idx_mut.get r ((.a33) : (t33, _) idx_mut)) next_r.a33 in
-  if not test then failwithf "test 130 failed";
+  if not test then failwithf "test 114 failed";
   let r = { a33 = 0.; b33 = #{ a32 = 1.; b32 = 2. } } in
   (* Paths of depth 1 *)
   let next_r = { a33 = 100.; b33 = #{ a32 = 101.; b32 = 102. } } in
@@ -1090,34 +1051,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a321 a322 && (fun a b -> Float.equal (globalize a) (globalize b)) b321 b322) in
   let expected = { r with b33 = next_r.b33 } in
   Idx_mut.set r ((.b33) : (t33, _) idx_mut) next_r.b33;
-  mark_test_run 131;
+  mark_test_run 115;
   let test = eq r expected in
-  if not test then failwithf "test 131 failed";
-  mark_test_run 132;
+  if not test then failwithf "test 115 failed";
+  mark_test_run 116;
   let test = sub_eq (Idx_mut.get r ((.b33) : (t33, _) idx_mut)) next_r.b33 in
-  if not test then failwithf "test 132 failed";
+  if not test then failwithf "test 116 failed";
   (* Paths of depth 2 *)
   let next_r = { a33 = 200.; b33 = #{ a32 = 201.; b32 = 202. } } in
   (* .b33.#a32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b33 = #{ r.b33 with a32 = next_r.b33.#a32 } } in
   Idx_mut.set r ((.b33.#a32) : (t33, _) idx_mut) next_r.b33.#a32;
-  mark_test_run 133;
+  mark_test_run 117;
   let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
+  if not test then failwithf "test 117 failed";
+  mark_test_run 118;
   let test = sub_eq (Idx_mut.get r ((.b33.#a32) : (t33, _) idx_mut)) next_r.b33.#a32 in
-  if not test then failwithf "test 134 failed";
+  if not test then failwithf "test 118 failed";
   (* .b33.#b32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b33 = #{ r.b33 with b32 = next_r.b33.#b32 } } in
   Idx_mut.set r ((.b33.#b32) : (t33, _) idx_mut) next_r.b33.#b32;
-  mark_test_run 135;
+  mark_test_run 119;
   let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
+  if not test then failwithf "test 119 failed";
+  mark_test_run 120;
   let test = sub_eq (Idx_mut.get r ((.b33.#b32) : (t33, _) idx_mut)) next_r.b33.#b32 in
-  if not test then failwithf "test 136 failed";
+  if not test then failwithf "test 120 failed";
   (********************************************)
   (*   t35 = { float; #{ float#; float# } }   *)
   (********************************************)
@@ -1129,12 +1090,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a35 = next_r.a35 } in
   Idx_mut.set r ((.a35) : (t35, _) idx_mut) next_r.a35;
-  mark_test_run 137;
+  mark_test_run 121;
   let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
+  if not test then failwithf "test 121 failed";
+  mark_test_run 122;
   let test = sub_eq (Idx_mut.get r ((.a35) : (t35, _) idx_mut)) next_r.a35 in
-  if not test then failwithf "test 138 failed";
+  if not test then failwithf "test 122 failed";
   let r = { a35 = 0.; b35 = #{ a34 = #1.; b34 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a35 = 100.; b35 = #{ a34 = #101.; b34 = #102. } } in
@@ -1142,34 +1103,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b341 b342) in
   let expected = { r with b35 = next_r.b35 } in
   Idx_mut.set r ((.b35) : (t35, _) idx_mut) next_r.b35;
-  mark_test_run 139;
+  mark_test_run 123;
   let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
+  if not test then failwithf "test 123 failed";
+  mark_test_run 124;
   let test = sub_eq (Idx_mut.get r ((.b35) : (t35, _) idx_mut)) next_r.b35 in
-  if not test then failwithf "test 140 failed";
+  if not test then failwithf "test 124 failed";
   (* Paths of depth 2 *)
   let next_r = { a35 = 200.; b35 = #{ a34 = #201.; b34 = #202. } } in
   (* .b35.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with a34 = next_r.b35.#a34 } } in
   Idx_mut.set r ((.b35.#a34) : (t35, _) idx_mut) next_r.b35.#a34;
-  mark_test_run 141;
+  mark_test_run 125;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 125 failed";
+  mark_test_run 126;
   let test = sub_eq (Idx_mut.get r ((.b35.#a34) : (t35, _) idx_mut)) next_r.b35.#a34 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 126 failed";
   (* .b35.#b34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with b34 = next_r.b35.#b34 } } in
   Idx_mut.set r ((.b35.#b34) : (t35, _) idx_mut) next_r.b35.#b34;
-  mark_test_run 143;
+  mark_test_run 127;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 127 failed";
+  mark_test_run 128;
   let test = sub_eq (Idx_mut.get r ((.b35.#b34) : (t35, _) idx_mut)) next_r.b35.#b34 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 128 failed";
   (*******************************)
   (*   t36 = { float#; float }   *)
   (*******************************)
@@ -1178,29 +1139,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a36 = #100.; b36 = 101. } in
   (* .a36 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a36 = next_r.a36 } in
-  Idx_mut.set r ((.a36) : (t36, _) idx_mut) next_r.a36;
-  mark_test_run 145;
-  let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
-  let test = sub_eq (Idx_mut.get r ((.a36) : (t36, _) idx_mut)) next_r.a36 in
-  if not test then failwithf "test 146 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a36 = #0.; b36 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a36 = #100.; b36 = 101. } in
   (* .b36 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b36 = next_r.b36 } in
-  Idx_mut.set r ((.b36) : (t36, _) idx_mut) (Float_u.of_float next_r.b36);
-  mark_test_run 147;
-  let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
-  let test = sub_eq (Idx_mut.get r ((.b36) : (t36, _) idx_mut)) (Float_u.of_float next_r.b36) in
-  if not test then failwithf "test 148 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (***************************************)
   (*   t37 = { float#; float; float# }   *)
   (***************************************)
@@ -1209,42 +1161,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = 101.; c37 = #102. } in
   (* .a37 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a37 = next_r.a37 } in
-  Idx_mut.set r ((.a37) : (t37, _) idx_mut) next_r.a37;
-  mark_test_run 149;
-  let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
-  let test = sub_eq (Idx_mut.get r ((.a37) : (t37, _) idx_mut)) next_r.a37 in
-  if not test then failwithf "test 150 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a37 = #0.; b37 = 1.; c37 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = 101.; c37 = #102. } in
   (* .b37 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b37 = next_r.b37 } in
-  Idx_mut.set r ((.b37) : (t37, _) idx_mut) (Float_u.of_float next_r.b37);
-  mark_test_run 151;
-  let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
-  let test = sub_eq (Idx_mut.get r ((.b37) : (t37, _) idx_mut)) (Float_u.of_float next_r.b37) in
-  if not test then failwithf "test 152 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a37 = #0.; b37 = 1.; c37 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a37 = #100.; b37 = 101.; c37 = #102. } in
   (* .c37 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c37 = next_r.c37 } in
-  Idx_mut.set r ((.c37) : (t37, _) idx_mut) next_r.c37;
-  mark_test_run 153;
-  let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
-  let test = sub_eq (Idx_mut.get r ((.c37) : (t37, _) idx_mut)) next_r.c37 in
-  if not test then failwithf "test 154 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (********************************)
   (*   t38 = { float#; float# }   *)
   (********************************)
@@ -1253,28 +1192,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101. } in
   (* .a38 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a38 = next_r.a38 } in
-  Idx_mut.set r ((.a38) : (t38, _) idx_mut) next_r.a38;
-  mark_test_run 155;
-  let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
-  let test = sub_eq (Idx_mut.get r ((.a38) : (t38, _) idx_mut)) next_r.a38 in
-  if not test then failwithf "test 156 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a38 = #0.; b38 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = #101. } in
   (* .b38 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b38 = next_r.b38 } in
-  Idx_mut.set r ((.b38) : (t38, _) idx_mut) next_r.b38;
-  mark_test_run 157;
-  let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
-  let test = sub_eq (Idx_mut.get r ((.b38) : (t38, _) idx_mut)) next_r.b38 in
-  if not test then failwithf "test 158 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*********************************************)
   (*   t39 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1286,12 +1217,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a39 = next_r.a39 } in
   Idx_mut.set r ((.a39) : (t39, _) idx_mut) next_r.a39;
-  mark_test_run 159;
+  mark_test_run 129;
   let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
+  if not test then failwithf "test 129 failed";
+  mark_test_run 130;
   let test = sub_eq (Idx_mut.get r ((.a39) : (t39, _) idx_mut)) next_r.a39 in
-  if not test then failwithf "test 160 failed";
+  if not test then failwithf "test 130 failed";
   let r = { a39 = #0.; b39 = #{ a34 = #1.; b34 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a39 = #100.; b39 = #{ a34 = #101.; b34 = #102. } } in
@@ -1299,34 +1230,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b341 b342) in
   let expected = { r with b39 = next_r.b39 } in
   Idx_mut.set r ((.b39) : (t39, _) idx_mut) next_r.b39;
-  mark_test_run 161;
+  mark_test_run 131;
   let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
+  if not test then failwithf "test 131 failed";
+  mark_test_run 132;
   let test = sub_eq (Idx_mut.get r ((.b39) : (t39, _) idx_mut)) next_r.b39 in
-  if not test then failwithf "test 162 failed";
+  if not test then failwithf "test 132 failed";
   (* Paths of depth 2 *)
   let next_r = { a39 = #200.; b39 = #{ a34 = #201.; b34 = #202. } } in
   (* .b39.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b39 = #{ r.b39 with a34 = next_r.b39.#a34 } } in
   Idx_mut.set r ((.b39.#a34) : (t39, _) idx_mut) next_r.b39.#a34;
-  mark_test_run 163;
+  mark_test_run 133;
   let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
   let test = sub_eq (Idx_mut.get r ((.b39.#a34) : (t39, _) idx_mut)) next_r.b39.#a34 in
-  if not test then failwithf "test 164 failed";
+  if not test then failwithf "test 134 failed";
   (* .b39.#b34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b39 = #{ r.b39 with b34 = next_r.b39.#b34 } } in
   Idx_mut.set r ((.b39.#b34) : (t39, _) idx_mut) next_r.b39.#b34;
-  mark_test_run 165;
+  mark_test_run 135;
   let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
   let test = sub_eq (Idx_mut.get r ((.b39.#b34) : (t39, _) idx_mut)) next_r.b39.#b34 in
-  if not test then failwithf "test 166 failed";
+  if not test then failwithf "test 136 failed";
   (*********************************************)
   (*   t41 = { string; #{ unit_u; unit_u } }   *)
   (*********************************************)
@@ -1338,12 +1269,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a41 = next_r.a41 } in
   Idx_mut.set r ((.a41) : (t41, _) idx_mut) next_r.a41;
-  mark_test_run 167;
+  mark_test_run 137;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
   let test = sub_eq (Idx_mut.get r ((.a41) : (t41, _) idx_mut)) next_r.a41 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 138 failed";
   let r = { a41 = "0"; b41 = #{ a40 = (unbox_unit ()); b40 = (unbox_unit ()) } } in
   (* Paths of depth 1 *)
   let next_r = { a41 = "100"; b41 = #{ a40 = (unbox_unit ()); b40 = (unbox_unit ()) } } in
@@ -1351,34 +1282,34 @@ let to_run () =
   let sub_eq = (fun #{ a40 = a401; b40 = b401 } #{ a40 = a402; b40 = b402 } -> (fun _ _ -> true) a401 a402 && (fun _ _ -> true) b401 b402) in
   let expected = { r with b41 = next_r.b41 } in
   Idx_mut.set r ((.b41) : (t41, _) idx_mut) next_r.b41;
-  mark_test_run 169;
+  mark_test_run 139;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
   let test = sub_eq (Idx_mut.get r ((.b41) : (t41, _) idx_mut)) next_r.b41 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 140 failed";
   (* Paths of depth 2 *)
   let next_r = { a41 = "200"; b41 = #{ a40 = (unbox_unit ()); b40 = (unbox_unit ()) } } in
   (* .b41.#a40 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b41 = #{ r.b41 with a40 = next_r.b41.#a40 } } in
   Idx_mut.set r ((.b41.#a40) : (t41, _) idx_mut) next_r.b41.#a40;
-  mark_test_run 171;
+  mark_test_run 141;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
   let test = sub_eq (Idx_mut.get r ((.b41.#a40) : (t41, _) idx_mut)) next_r.b41.#a40 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 142 failed";
   (* .b41.#b40 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b41 = #{ r.b41 with b40 = next_r.b41.#b40 } } in
   Idx_mut.set r ((.b41.#b40) : (t41, _) idx_mut) next_r.b41.#b40;
-  mark_test_run 173;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.b41.#b40) : (t41, _) idx_mut)) next_r.b41.#b40 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 144 failed";
   (*******************************)
   (*   t42 = { int64x2#; int }   *)
   (*******************************)
@@ -1390,12 +1321,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a42 = next_r.a42 } in
   Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 175;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 146 failed";
   let r = { a42 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b42 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a42 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b42 = 102 } in
@@ -1403,12 +1334,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b42 = next_r.b42 } in
   Idx_mut.set r ((.b42) : (t42, _) idx_mut) next_r.b42;
-  mark_test_run 177;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.b42) : (t42, _) idx_mut)) next_r.b42 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 148 failed";
   (************************************)
   (*   t43 = { int64x2#; int; int }   *)
   (************************************)
@@ -1420,12 +1351,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a43 = next_r.a43 } in
   Idx_mut.set r ((.a43) : (t43, _) idx_mut) next_r.a43;
-  mark_test_run 179;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.a43) : (t43, _) idx_mut)) next_r.a43 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 150 failed";
   let r = { a43 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b43 = 2; c43 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a43 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b43 = 102; c43 = 103 } in
@@ -1433,12 +1364,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b43 = next_r.b43 } in
   Idx_mut.set r ((.b43) : (t43, _) idx_mut) next_r.b43;
-  mark_test_run 181;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.b43) : (t43, _) idx_mut)) next_r.b43 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 152 failed";
   let r = { a43 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b43 = 2; c43 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a43 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b43 = 102; c43 = 103 } in
@@ -1446,12 +1377,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with c43 = next_r.c43 } in
   Idx_mut.set r ((.c43) : (t43, _) idx_mut) next_r.c43;
-  mark_test_run 183;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.c43) : (t43, _) idx_mut)) next_r.c43 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 154 failed";
   (*****************************************)
   (*   t44 = { int64x2#; int; int64x2# }   *)
   (*****************************************)
@@ -1463,12 +1394,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a44 = next_r.a44 } in
   Idx_mut.set r ((.a44) : (t44, _) idx_mut) next_r.a44;
-  mark_test_run 185;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.a44) : (t44, _) idx_mut)) next_r.a44 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 156 failed";
   let r = { a44 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b44 = 2; c44 = (interleave_low_64 (int64x2_of_int64 3L) (int64x2_of_int64 4L)) } in
   (* Paths of depth 1 *)
   let next_r = { a44 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b44 = 102; c44 = (interleave_low_64 (int64x2_of_int64 103L) (int64x2_of_int64 104L)) } in
@@ -1476,12 +1407,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b44 = next_r.b44 } in
   Idx_mut.set r ((.b44) : (t44, _) idx_mut) next_r.b44;
-  mark_test_run 187;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.b44) : (t44, _) idx_mut)) next_r.b44 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 158 failed";
   let r = { a44 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b44 = 2; c44 = (interleave_low_64 (int64x2_of_int64 3L) (int64x2_of_int64 4L)) } in
   (* Paths of depth 1 *)
   let next_r = { a44 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b44 = 102; c44 = (interleave_low_64 (int64x2_of_int64 103L) (int64x2_of_int64 104L)) } in
@@ -1489,12 +1420,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with c44 = next_r.c44 } in
   Idx_mut.set r ((.c44) : (t44, _) idx_mut) next_r.c44;
-  mark_test_run 189;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.c44) : (t44, _) idx_mut)) next_r.c44 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 160 failed";
   (************************************)
   (*   t45 = { int64x2#; int64x2# }   *)
   (************************************)
@@ -1506,12 +1437,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 191;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 162 failed";
   let r = { a45 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b45 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b45 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -1519,12 +1450,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b45 = next_r.b45 } in
   Idx_mut.set r ((.b45) : (t45, _) idx_mut) next_r.b45;
-  mark_test_run 193;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.b45) : (t45, _) idx_mut)) next_r.b45 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 164 failed";
   (*****************************************)
   (*   t46 = { int64x2#; #{ int; int } }   *)
   (*****************************************)
@@ -1536,12 +1467,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a46 = next_r.a46 } in
   Idx_mut.set r ((.a46) : (t46, _) idx_mut) next_r.a46;
-  mark_test_run 195;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.a46) : (t46, _) idx_mut)) next_r.a46 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 166 failed";
   let r = { a46 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b46 = #{ a6 = 2; b6 = 3 } } in
   (* Paths of depth 1 *)
   let next_r = { a46 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b46 = #{ a6 = 102; b6 = 103 } } in
@@ -1549,34 +1480,34 @@ let to_run () =
   let sub_eq = (fun #{ a6 = a61; b6 = b61 } #{ a6 = a62; b6 = b62 } -> (fun a b -> Int.equal a b) a61 a62 && (fun a b -> Int.equal a b) b61 b62) in
   let expected = { r with b46 = next_r.b46 } in
   Idx_mut.set r ((.b46) : (t46, _) idx_mut) next_r.b46;
-  mark_test_run 197;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.b46) : (t46, _) idx_mut)) next_r.b46 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 168 failed";
   (* Paths of depth 2 *)
   let next_r = { a46 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)); b46 = #{ a6 = 202; b6 = 203 } } in
   (* .b46.#a6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b46 = #{ r.b46 with a6 = next_r.b46.#a6 } } in
   Idx_mut.set r ((.b46.#a6) : (t46, _) idx_mut) next_r.b46.#a6;
-  mark_test_run 199;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.b46.#a6) : (t46, _) idx_mut)) next_r.b46.#a6 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 170 failed";
   (* .b46.#b6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b46 = #{ r.b46 with b6 = next_r.b46.#b6 } } in
   Idx_mut.set r ((.b46.#b6) : (t46, _) idx_mut) next_r.b46.#b6;
-  mark_test_run 201;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.b46.#b6) : (t46, _) idx_mut)) next_r.b46.#b6 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 172 failed";
   (***********************************)
   (*   t47 = { (| unit_u); float }   *)
   (***********************************)
@@ -1588,12 +1519,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C14_0(a0), C14_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 203;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 174 failed";
   let r = { a47 = (C14_0 (unbox_unit ())); b47 = 0. } in
   (* Paths of depth 1 *)
   let next_r = { a47 = (C14_0 (unbox_unit ())); b47 = 100. } in
@@ -1601,12 +1532,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b47 = next_r.b47 } in
   Idx_mut.set r ((.b47) : (t47, _) idx_mut) next_r.b47;
-  mark_test_run 205;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.b47) : (t47, _) idx_mut)) next_r.b47 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 176 failed";
   (**************************)
   (*   t48 = { #{ int } }   *)
   (**************************)
@@ -1618,24 +1549,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a48 = next_r.a48 } in
   Idx_mut.set r ((.a48) : (t48, _) idx_mut) next_r.a48;
-  mark_test_run 207;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.a48) : (t48, _) idx_mut)) next_r.a48 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 178 failed";
   (* Paths of depth 2 *)
   let next_r = { a48 = #{ a4 = 200 } } in
   (* .a48.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a48 = #{ r.a48 with a4 = next_r.a48.#a4 } } in
   Idx_mut.set r ((.a48.#a4) : (t48, _) idx_mut) next_r.a48.#a4;
-  mark_test_run 209;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.a48.#a4) : (t48, _) idx_mut)) next_r.a48.#a4 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 180 failed";
   (*******************************)
   (*   t49 = { #{ int }; int }   *)
   (*******************************)
@@ -1647,24 +1578,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a49 = next_r.a49 } in
   Idx_mut.set r ((.a49) : (t49, _) idx_mut) next_r.a49;
-  mark_test_run 211;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.a49) : (t49, _) idx_mut)) next_r.a49 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 182 failed";
   (* Paths of depth 2 *)
   let next_r = { a49 = #{ a4 = 200 }; b49 = 201 } in
   (* .a49.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a49 = #{ r.a49 with a4 = next_r.a49.#a4 } } in
   Idx_mut.set r ((.a49.#a4) : (t49, _) idx_mut) next_r.a49.#a4;
-  mark_test_run 213;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a49.#a4) : (t49, _) idx_mut)) next_r.a49.#a4 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 184 failed";
   let r = { a49 = #{ a4 = 0 }; b49 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a49 = #{ a4 = 100 }; b49 = 101 } in
@@ -1672,12 +1603,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b49 = next_r.b49 } in
   Idx_mut.set r ((.b49) : (t49, _) idx_mut) next_r.b49;
-  mark_test_run 215;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.b49) : (t49, _) idx_mut)) next_r.b49 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 186 failed";
   (**********************************)
   (*   t50 = { #{ int }; int32# }   *)
   (**********************************)
@@ -1689,24 +1620,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a50 = next_r.a50 } in
   Idx_mut.set r ((.a50) : (t50, _) idx_mut) next_r.a50;
-  mark_test_run 217;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.a50) : (t50, _) idx_mut)) next_r.a50 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 188 failed";
   (* Paths of depth 2 *)
   let next_r = { a50 = #{ a4 = 200 }; b50 = #201l } in
   (* .a50.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a50 = #{ r.a50 with a4 = next_r.a50.#a4 } } in
   Idx_mut.set r ((.a50.#a4) : (t50, _) idx_mut) next_r.a50.#a4;
-  mark_test_run 219;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.a50.#a4) : (t50, _) idx_mut)) next_r.a50.#a4 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 190 failed";
   let r = { a50 = #{ a4 = 0 }; b50 = #1l } in
   (* Paths of depth 1 *)
   let next_r = { a50 = #{ a4 = 100 }; b50 = #101l } in
@@ -1714,12 +1645,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b50 = next_r.b50 } in
   Idx_mut.set r ((.b50) : (t50, _) idx_mut) next_r.b50;
-  mark_test_run 221;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.b50) : (t50, _) idx_mut)) next_r.b50 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 192 failed";
   (*********************************)
   (*   t51 = { #{ int }; float }   *)
   (*********************************)
@@ -1731,24 +1662,24 @@ let to_run () =
   let sub_eq = (fun #{ a4 = a41 } #{ a4 = a42 } -> (fun a b -> Int.equal a b) a41 a42) in
   let expected = { r with a51 = next_r.a51 } in
   Idx_mut.set r ((.a51) : (t51, _) idx_mut) next_r.a51;
-  mark_test_run 223;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a51) : (t51, _) idx_mut)) next_r.a51 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 194 failed";
   (* Paths of depth 2 *)
   let next_r = { a51 = #{ a4 = 200 }; b51 = 201. } in
   (* .a51.#a4 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a51 = #{ r.a51 with a4 = next_r.a51.#a4 } } in
   Idx_mut.set r ((.a51.#a4) : (t51, _) idx_mut) next_r.a51.#a4;
-  mark_test_run 225;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.a51.#a4) : (t51, _) idx_mut)) next_r.a51.#a4 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 196 failed";
   let r = { a51 = #{ a4 = 0 }; b51 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a51 = #{ a4 = 100 }; b51 = 101. } in
@@ -1756,12 +1687,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b51 = next_r.b51 } in
   Idx_mut.set r ((.b51) : (t51, _) idx_mut) next_r.b51;
-  mark_test_run 227;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.b51) : (t51, _) idx_mut)) next_r.b51 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 198 failed";
   (*******************************)
   (*   t52 = { #{ int; int } }   *)
   (*******************************)
@@ -1773,34 +1704,34 @@ let to_run () =
   let sub_eq = (fun #{ a6 = a61; b6 = b61 } #{ a6 = a62; b6 = b62 } -> (fun a b -> Int.equal a b) a61 a62 && (fun a b -> Int.equal a b) b61 b62) in
   let expected = { r with a52 = next_r.a52 } in
   Idx_mut.set r ((.a52) : (t52, _) idx_mut) next_r.a52;
-  mark_test_run 229;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a52) : (t52, _) idx_mut)) next_r.a52 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 200 failed";
   (* Paths of depth 2 *)
   let next_r = { a52 = #{ a6 = 200; b6 = 201 } } in
   (* .a52.#a6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a52 = #{ r.a52 with a6 = next_r.a52.#a6 } } in
   Idx_mut.set r ((.a52.#a6) : (t52, _) idx_mut) next_r.a52.#a6;
-  mark_test_run 231;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.a52.#a6) : (t52, _) idx_mut)) next_r.a52.#a6 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 202 failed";
   (* .a52.#b6 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a52 = #{ r.a52 with b6 = next_r.a52.#b6 } } in
   Idx_mut.set r ((.a52.#b6) : (t52, _) idx_mut) next_r.a52.#b6;
-  mark_test_run 233;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 233 failed";
-  mark_test_run 234;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a52.#b6) : (t52, _) idx_mut)) next_r.a52.#b6 in
-  if not test then failwithf "test 234 failed";
+  if not test then failwithf "test 204 failed";
   (*****************************)
   (*   t54 = { #{ int32# } }   *)
   (*****************************)
@@ -1812,24 +1743,24 @@ let to_run () =
   let sub_eq = (fun #{ a53 = a531 } #{ a53 = a532 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a531 a532) in
   let expected = { r with a54 = next_r.a54 } in
   Idx_mut.set r ((.a54) : (t54, _) idx_mut) next_r.a54;
-  mark_test_run 235;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 235 failed";
-  mark_test_run 236;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a54) : (t54, _) idx_mut)) next_r.a54 in
-  if not test then failwithf "test 236 failed";
+  if not test then failwithf "test 206 failed";
   (* Paths of depth 2 *)
   let next_r = { a54 = #{ a53 = #200l } } in
   (* .a54.#a53 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a54 = #{ r.a54 with a53 = next_r.a54.#a53 } } in
   Idx_mut.set r ((.a54.#a53) : (t54, _) idx_mut) next_r.a54.#a53;
-  mark_test_run 237;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 237 failed";
-  mark_test_run 238;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.a54.#a53) : (t54, _) idx_mut)) next_r.a54.#a53 in
-  if not test then failwithf "test 238 failed";
+  if not test then failwithf "test 208 failed";
   (**********************************)
   (*   t56 = { #{ int32#; int } }   *)
   (**********************************)
@@ -1841,34 +1772,34 @@ let to_run () =
   let sub_eq = (fun #{ a55 = a551; b55 = b551 } #{ a55 = a552; b55 = b552 } -> (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) a551 a552 && (fun a b -> Int.equal a b) b551 b552) in
   let expected = { r with a56 = next_r.a56 } in
   Idx_mut.set r ((.a56) : (t56, _) idx_mut) next_r.a56;
-  mark_test_run 239;
+  mark_test_run 209;
   let test = eq r expected in
-  if not test then failwithf "test 239 failed";
-  mark_test_run 240;
+  if not test then failwithf "test 209 failed";
+  mark_test_run 210;
   let test = sub_eq (Idx_mut.get r ((.a56) : (t56, _) idx_mut)) next_r.a56 in
-  if not test then failwithf "test 240 failed";
+  if not test then failwithf "test 210 failed";
   (* Paths of depth 2 *)
   let next_r = { a56 = #{ a55 = #200l; b55 = 201 } } in
   (* .a56.#a55 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a56 = #{ r.a56 with a55 = next_r.a56.#a55 } } in
   Idx_mut.set r ((.a56.#a55) : (t56, _) idx_mut) next_r.a56.#a55;
-  mark_test_run 241;
+  mark_test_run 211;
   let test = eq r expected in
-  if not test then failwithf "test 241 failed";
-  mark_test_run 242;
+  if not test then failwithf "test 211 failed";
+  mark_test_run 212;
   let test = sub_eq (Idx_mut.get r ((.a56.#a55) : (t56, _) idx_mut)) next_r.a56.#a55 in
-  if not test then failwithf "test 242 failed";
+  if not test then failwithf "test 212 failed";
   (* .a56.#b55 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a56 = #{ r.a56 with b55 = next_r.a56.#b55 } } in
   Idx_mut.set r ((.a56.#b55) : (t56, _) idx_mut) next_r.a56.#b55;
-  mark_test_run 243;
+  mark_test_run 213;
   let test = eq r expected in
-  if not test then failwithf "test 243 failed";
-  mark_test_run 244;
+  if not test then failwithf "test 213 failed";
+  mark_test_run 214;
   let test = sub_eq (Idx_mut.get r ((.a56.#b55) : (t56, _) idx_mut)) next_r.a56.#b55 in
-  if not test then failwithf "test 244 failed";
+  if not test then failwithf "test 214 failed";
   (***********************************)
   (*   t58 = { #{ float }; float }   *)
   (***********************************)
@@ -1879,34 +1810,26 @@ let to_run () =
   (* .a58 *)
   (* Note: skipping test as this is not a valid block index,
      due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
   let _ = next_r in
   (* Paths of depth 2 *)
   let next_r = { a58 = #{ a57 = 200. }; b58 = 201. } in
   (* .a58.#a57 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a58 = #{ r.a58 with a57 = next_r.a58.#a57 } } in
-  Idx_mut.set r ((.a58.#a57) : (t58, _) idx_mut) (Float_u.of_float next_r.a58.#a57);
-  mark_test_run 245;
-  let test = eq r expected in
-  if not test then failwithf "test 245 failed";
-  mark_test_run 246;
-  let test = sub_eq (Idx_mut.get r ((.a58.#a57) : (t58, _) idx_mut)) (Float_u.of_float next_r.a58.#a57) in
-  if not test then failwithf "test 246 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a58 = #{ a57 = 0. }; b58 = 1. } in
   (* Paths of depth 1 *)
   let next_r = { a58 = #{ a57 = 100. }; b58 = 101. } in
   (* .b58 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b58 = next_r.b58 } in
-  Idx_mut.set r ((.b58) : (t58, _) idx_mut) (Float_u.of_float next_r.b58);
-  mark_test_run 247;
-  let test = eq r expected in
-  if not test then failwithf "test 247 failed";
-  mark_test_run 248;
-  let test = sub_eq (Idx_mut.get r ((.b58) : (t58, _) idx_mut)) (Float_u.of_float next_r.b58) in
-  if not test then failwithf "test 248 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (****************************************)
   (*   t59 = { #{ float; float }; int }   *)
   (****************************************)
@@ -1918,34 +1841,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a321 a322 && (fun a b -> Float.equal (globalize a) (globalize b)) b321 b322) in
   let expected = { r with a59 = next_r.a59 } in
   Idx_mut.set r ((.a59) : (t59, _) idx_mut) next_r.a59;
-  mark_test_run 249;
+  mark_test_run 215;
   let test = eq r expected in
-  if not test then failwithf "test 249 failed";
-  mark_test_run 250;
+  if not test then failwithf "test 215 failed";
+  mark_test_run 216;
   let test = sub_eq (Idx_mut.get r ((.a59) : (t59, _) idx_mut)) next_r.a59 in
-  if not test then failwithf "test 250 failed";
+  if not test then failwithf "test 216 failed";
   (* Paths of depth 2 *)
   let next_r = { a59 = #{ a32 = 200.; b32 = 201. }; b59 = 202 } in
   (* .a59.#a32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with a32 = next_r.a59.#a32 } } in
   Idx_mut.set r ((.a59.#a32) : (t59, _) idx_mut) next_r.a59.#a32;
-  mark_test_run 251;
+  mark_test_run 217;
   let test = eq r expected in
-  if not test then failwithf "test 251 failed";
-  mark_test_run 252;
+  if not test then failwithf "test 217 failed";
+  mark_test_run 218;
   let test = sub_eq (Idx_mut.get r ((.a59.#a32) : (t59, _) idx_mut)) next_r.a59.#a32 in
-  if not test then failwithf "test 252 failed";
+  if not test then failwithf "test 218 failed";
   (* .a59.#b32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a59 = #{ r.a59 with b32 = next_r.a59.#b32 } } in
   Idx_mut.set r ((.a59.#b32) : (t59, _) idx_mut) next_r.a59.#b32;
-  mark_test_run 253;
+  mark_test_run 219;
   let test = eq r expected in
-  if not test then failwithf "test 253 failed";
-  mark_test_run 254;
+  if not test then failwithf "test 219 failed";
+  mark_test_run 220;
   let test = sub_eq (Idx_mut.get r ((.a59.#b32) : (t59, _) idx_mut)) next_r.a59.#b32 in
-  if not test then failwithf "test 254 failed";
+  if not test then failwithf "test 220 failed";
   let r = { a59 = #{ a32 = 0.; b32 = 1. }; b59 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a59 = #{ a32 = 100.; b32 = 101. }; b59 = 102 } in
@@ -1953,12 +1876,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b59 = next_r.b59 } in
   Idx_mut.set r ((.b59) : (t59, _) idx_mut) next_r.b59;
-  mark_test_run 255;
+  mark_test_run 221;
   let test = eq r expected in
-  if not test then failwithf "test 255 failed";
-  mark_test_run 256;
+  if not test then failwithf "test 221 failed";
+  mark_test_run 222;
   let test = sub_eq (Idx_mut.get r ((.b59) : (t59, _) idx_mut)) next_r.b59 in
-  if not test then failwithf "test 256 failed";
+  if not test then failwithf "test 222 failed";
   (******************************************)
   (*   t60 = { #{ float; float }; float }   *)
   (******************************************)
@@ -1970,34 +1893,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a321 a322 && (fun a b -> Float.equal (globalize a) (globalize b)) b321 b322) in
   let expected = { r with a60 = next_r.a60 } in
   Idx_mut.set r ((.a60) : (t60, _) idx_mut) next_r.a60;
-  mark_test_run 257;
+  mark_test_run 223;
   let test = eq r expected in
-  if not test then failwithf "test 257 failed";
-  mark_test_run 258;
+  if not test then failwithf "test 223 failed";
+  mark_test_run 224;
   let test = sub_eq (Idx_mut.get r ((.a60) : (t60, _) idx_mut)) next_r.a60 in
-  if not test then failwithf "test 258 failed";
+  if not test then failwithf "test 224 failed";
   (* Paths of depth 2 *)
   let next_r = { a60 = #{ a32 = 200.; b32 = 201. }; b60 = 202. } in
   (* .a60.#a32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with a32 = next_r.a60.#a32 } } in
   Idx_mut.set r ((.a60.#a32) : (t60, _) idx_mut) next_r.a60.#a32;
-  mark_test_run 259;
+  mark_test_run 225;
   let test = eq r expected in
-  if not test then failwithf "test 259 failed";
-  mark_test_run 260;
+  if not test then failwithf "test 225 failed";
+  mark_test_run 226;
   let test = sub_eq (Idx_mut.get r ((.a60.#a32) : (t60, _) idx_mut)) next_r.a60.#a32 in
-  if not test then failwithf "test 260 failed";
+  if not test then failwithf "test 226 failed";
   (* .a60.#b32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a60 = #{ r.a60 with b32 = next_r.a60.#b32 } } in
   Idx_mut.set r ((.a60.#b32) : (t60, _) idx_mut) next_r.a60.#b32;
-  mark_test_run 261;
+  mark_test_run 227;
   let test = eq r expected in
-  if not test then failwithf "test 261 failed";
-  mark_test_run 262;
+  if not test then failwithf "test 227 failed";
+  mark_test_run 228;
   let test = sub_eq (Idx_mut.get r ((.a60.#b32) : (t60, _) idx_mut)) next_r.a60.#b32 in
-  if not test then failwithf "test 262 failed";
+  if not test then failwithf "test 228 failed";
   let r = { a60 = #{ a32 = 0.; b32 = 1. }; b60 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a60 = #{ a32 = 100.; b32 = 101. }; b60 = 102. } in
@@ -2005,12 +1928,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b60 = next_r.b60 } in
   Idx_mut.set r ((.b60) : (t60, _) idx_mut) next_r.b60;
-  mark_test_run 263;
+  mark_test_run 229;
   let test = eq r expected in
-  if not test then failwithf "test 263 failed";
-  mark_test_run 264;
+  if not test then failwithf "test 229 failed";
+  mark_test_run 230;
   let test = sub_eq (Idx_mut.get r ((.b60) : (t60, _) idx_mut)) next_r.b60 in
-  if not test then failwithf "test 264 failed";
+  if not test then failwithf "test 230 failed";
   (************************************************************)
   (*   t63 = { #{ float32#; int64# }; #{ string; int64# } }   *)
   (************************************************************)
@@ -2022,34 +1945,34 @@ let to_run () =
   let sub_eq = (fun #{ a61 = a611; b61 = b611 } #{ a61 = a612; b61 = b612 } -> (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) a611 a612 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b611 b612) in
   let expected = { r with a63 = next_r.a63 } in
   Idx_mut.set r ((.a63) : (t63, _) idx_mut) next_r.a63;
-  mark_test_run 265;
+  mark_test_run 231;
   let test = eq r expected in
-  if not test then failwithf "test 265 failed";
-  mark_test_run 266;
+  if not test then failwithf "test 231 failed";
+  mark_test_run 232;
   let test = sub_eq (Idx_mut.get r ((.a63) : (t63, _) idx_mut)) next_r.a63 in
-  if not test then failwithf "test 266 failed";
+  if not test then failwithf "test 232 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a61 = #200.s; b61 = #201L }; b63 = #{ a62 = "202"; b62 = #203L } } in
   (* .a63.#a61 *)
   let sub_eq = (fun a b -> Float32_u.(equal (add #0.s a) (add #0.s b))) in
   let expected = { r with a63 = #{ r.a63 with a61 = next_r.a63.#a61 } } in
   Idx_mut.set r ((.a63.#a61) : (t63, _) idx_mut) next_r.a63.#a61;
-  mark_test_run 267;
+  mark_test_run 233;
   let test = eq r expected in
-  if not test then failwithf "test 267 failed";
-  mark_test_run 268;
+  if not test then failwithf "test 233 failed";
+  mark_test_run 234;
   let test = sub_eq (Idx_mut.get r ((.a63.#a61) : (t63, _) idx_mut)) next_r.a63.#a61 in
-  if not test then failwithf "test 268 failed";
+  if not test then failwithf "test 234 failed";
   (* .a63.#b61 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with a63 = #{ r.a63 with b61 = next_r.a63.#b61 } } in
   Idx_mut.set r ((.a63.#b61) : (t63, _) idx_mut) next_r.a63.#b61;
-  mark_test_run 269;
+  mark_test_run 235;
   let test = eq r expected in
-  if not test then failwithf "test 269 failed";
-  mark_test_run 270;
+  if not test then failwithf "test 235 failed";
+  mark_test_run 236;
   let test = sub_eq (Idx_mut.get r ((.a63.#b61) : (t63, _) idx_mut)) next_r.a63.#b61 in
-  if not test then failwithf "test 270 failed";
+  if not test then failwithf "test 236 failed";
   let r = { a63 = #{ a61 = #0.s; b61 = #1L }; b63 = #{ a62 = "2"; b62 = #3L } } in
   (* Paths of depth 1 *)
   let next_r = { a63 = #{ a61 = #100.s; b61 = #101L }; b63 = #{ a62 = "102"; b62 = #103L } } in
@@ -2057,34 +1980,34 @@ let to_run () =
   let sub_eq = (fun #{ a62 = a621; b62 = b621 } #{ a62 = a622; b62 = b622 } -> (fun a b -> String.equal (globalize a) (globalize b)) a621 a622 && (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) b621 b622) in
   let expected = { r with b63 = next_r.b63 } in
   Idx_mut.set r ((.b63) : (t63, _) idx_mut) next_r.b63;
-  mark_test_run 271;
+  mark_test_run 237;
   let test = eq r expected in
-  if not test then failwithf "test 271 failed";
-  mark_test_run 272;
+  if not test then failwithf "test 237 failed";
+  mark_test_run 238;
   let test = sub_eq (Idx_mut.get r ((.b63) : (t63, _) idx_mut)) next_r.b63 in
-  if not test then failwithf "test 272 failed";
+  if not test then failwithf "test 238 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a61 = #200.s; b61 = #201L }; b63 = #{ a62 = "202"; b62 = #203L } } in
   (* .b63.#a62 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b63 = #{ r.b63 with a62 = next_r.b63.#a62 } } in
   Idx_mut.set r ((.b63.#a62) : (t63, _) idx_mut) next_r.b63.#a62;
-  mark_test_run 273;
+  mark_test_run 239;
   let test = eq r expected in
-  if not test then failwithf "test 273 failed";
-  mark_test_run 274;
+  if not test then failwithf "test 239 failed";
+  mark_test_run 240;
   let test = sub_eq (Idx_mut.get r ((.b63.#a62) : (t63, _) idx_mut)) next_r.b63.#a62 in
-  if not test then failwithf "test 274 failed";
+  if not test then failwithf "test 240 failed";
   (* .b63.#b62 *)
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b63 = #{ r.b63 with b62 = next_r.b63.#b62 } } in
   Idx_mut.set r ((.b63.#b62) : (t63, _) idx_mut) next_r.b63.#b62;
-  mark_test_run 275;
+  mark_test_run 241;
   let test = eq r expected in
-  if not test then failwithf "test 275 failed";
-  mark_test_run 276;
+  if not test then failwithf "test 241 failed";
+  mark_test_run 242;
   let test = sub_eq (Idx_mut.get r ((.b63.#b62) : (t63, _) idx_mut)) next_r.b63.#b62 in
-  if not test then failwithf "test 276 failed";
+  if not test then failwithf "test 242 failed";
   (*************************************)
   (*   t65 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -2096,24 +2019,24 @@ let to_run () =
   let sub_eq = (fun #{ a64 = a641 } #{ a64 = a642 } -> (fun a b -> String.equal (globalize a) (globalize b)) a641 a642) in
   let expected = { r with a65 = next_r.a65 } in
   Idx_mut.set r ((.a65) : (t65, _) idx_mut) next_r.a65;
-  mark_test_run 277;
+  mark_test_run 243;
   let test = eq r expected in
-  if not test then failwithf "test 277 failed";
-  mark_test_run 278;
+  if not test then failwithf "test 243 failed";
+  mark_test_run 244;
   let test = sub_eq (Idx_mut.get r ((.a65) : (t65, _) idx_mut)) next_r.a65 in
-  if not test then failwithf "test 278 failed";
+  if not test then failwithf "test 244 failed";
   (* Paths of depth 2 *)
   let next_r = { a65 = #{ a64 = "200" }; b65 = (unbox_unit ()) } in
   (* .a65.#a64 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a65 = #{ r.a65 with a64 = next_r.a65.#a64 } } in
   Idx_mut.set r ((.a65.#a64) : (t65, _) idx_mut) next_r.a65.#a64;
-  mark_test_run 279;
+  mark_test_run 245;
   let test = eq r expected in
-  if not test then failwithf "test 279 failed";
-  mark_test_run 280;
+  if not test then failwithf "test 245 failed";
+  mark_test_run 246;
   let test = sub_eq (Idx_mut.get r ((.a65.#a64) : (t65, _) idx_mut)) next_r.a65.#a64 in
-  if not test then failwithf "test 280 failed";
+  if not test then failwithf "test 246 failed";
   let r = { a65 = #{ a64 = "0" }; b65 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a65 = #{ a64 = "100" }; b65 = (unbox_unit ()) } in
@@ -2121,12 +2044,12 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b65 = next_r.b65 } in
   Idx_mut.set r ((.b65) : (t65, _) idx_mut) next_r.b65;
-  mark_test_run 281;
+  mark_test_run 247;
   let test = eq r expected in
-  if not test then failwithf "test 281 failed";
-  mark_test_run 282;
+  if not test then failwithf "test 247 failed";
+  mark_test_run 248;
   let test = sub_eq (Idx_mut.get r ((.b65) : (t65, _) idx_mut)) next_r.b65 in
-  if not test then failwithf "test 282 failed";
+  if not test then failwithf "test 248 failed";
   (*****************************************)
   (*   t66 = { #{ int64x2# }; int64x2# }   *)
   (*****************************************)
@@ -2138,24 +2061,24 @@ let to_run () =
   let sub_eq = (fun #{ a10 = a101 } #{ a10 = a102 } -> int64x2_u_equal a101 a102) in
   let expected = { r with a66 = next_r.a66 } in
   Idx_mut.set r ((.a66) : (t66, _) idx_mut) next_r.a66;
-  mark_test_run 283;
+  mark_test_run 249;
   let test = eq r expected in
-  if not test then failwithf "test 283 failed";
-  mark_test_run 284;
+  if not test then failwithf "test 249 failed";
+  mark_test_run 250;
   let test = sub_eq (Idx_mut.get r ((.a66) : (t66, _) idx_mut)) next_r.a66 in
-  if not test then failwithf "test 284 failed";
+  if not test then failwithf "test 250 failed";
   (* Paths of depth 2 *)
   let next_r = { a66 = #{ a10 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)) }; b66 = (interleave_low_64 (int64x2_of_int64 202L) (int64x2_of_int64 203L)) } in
   (* .a66.#a10 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with a66 = #{ r.a66 with a10 = next_r.a66.#a10 } } in
   Idx_mut.set r ((.a66.#a10) : (t66, _) idx_mut) next_r.a66.#a10;
-  mark_test_run 285;
+  mark_test_run 251;
   let test = eq r expected in
-  if not test then failwithf "test 285 failed";
-  mark_test_run 286;
+  if not test then failwithf "test 251 failed";
+  mark_test_run 252;
   let test = sub_eq (Idx_mut.get r ((.a66.#a10) : (t66, _) idx_mut)) next_r.a66.#a10 in
-  if not test then failwithf "test 286 failed";
+  if not test then failwithf "test 252 failed";
   let r = { a66 = #{ a10 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)) }; b66 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a66 = #{ a10 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)) }; b66 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -2163,17 +2086,17 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b66 = next_r.b66 } in
   Idx_mut.set r ((.b66) : (t66, _) idx_mut) next_r.b66;
-  mark_test_run 287;
+  mark_test_run 253;
   let test = eq r expected in
-  if not test then failwithf "test 287 failed";
-  mark_test_run 288;
+  if not test then failwithf "test 253 failed";
+  mark_test_run 254;
   let test = sub_eq (Idx_mut.get r ((.b66) : (t66, _) idx_mut)) next_r.b66 in
-  if not test then failwithf "test 288 failed";
+  if not test then failwithf "test 254 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 288 do
+for i = 1 to 254 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_native_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_native_test.ml
@@ -815,16 +815,11 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a25 = 100. } in
   (* .a25 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a25 = next_r.a25 } in
-  Idx_mut.set r ((.a25) : (t25, _) idx_mut) (Float_u.of_float next_r.a25);
-  mark_test_run 95;
-  let test = eq r expected in
-  if not test then failwithf "test 95 failed";
-  mark_test_run 96;
-  let test = sub_eq (Idx_mut.get r ((.a25) : (t25, _) idx_mut)) (Float_u.of_float next_r.a25) in
-  if not test then failwithf "test 96 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (****************************)
   (*   t26 = { float; int }   *)
   (****************************)
@@ -836,12 +831,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a26 = next_r.a26 } in
   Idx_mut.set r ((.a26) : (t26, _) idx_mut) next_r.a26;
-  mark_test_run 97;
+  mark_test_run 95;
   let test = eq r expected in
-  if not test then failwithf "test 97 failed";
-  mark_test_run 98;
+  if not test then failwithf "test 95 failed";
+  mark_test_run 96;
   let test = sub_eq (Idx_mut.get r ((.a26) : (t26, _) idx_mut)) next_r.a26 in
-  if not test then failwithf "test 98 failed";
+  if not test then failwithf "test 96 failed";
   let r = { a26 = 0.; b26 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a26 = 100.; b26 = 101 } in
@@ -849,12 +844,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b26 = next_r.b26 } in
   Idx_mut.set r ((.b26) : (t26, _) idx_mut) next_r.b26;
-  mark_test_run 99;
+  mark_test_run 97;
   let test = eq r expected in
-  if not test then failwithf "test 99 failed";
-  mark_test_run 100;
+  if not test then failwithf "test 97 failed";
+  mark_test_run 98;
   let test = sub_eq (Idx_mut.get r ((.b26) : (t26, _) idx_mut)) next_r.b26 in
-  if not test then failwithf "test 100 failed";
+  if not test then failwithf "test 98 failed";
   (*********************************)
   (*   t27 = { float; int; int }   *)
   (*********************************)
@@ -866,12 +861,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a27 = next_r.a27 } in
   Idx_mut.set r ((.a27) : (t27, _) idx_mut) next_r.a27;
-  mark_test_run 101;
+  mark_test_run 99;
   let test = eq r expected in
-  if not test then failwithf "test 101 failed";
-  mark_test_run 102;
+  if not test then failwithf "test 99 failed";
+  mark_test_run 100;
   let test = sub_eq (Idx_mut.get r ((.a27) : (t27, _) idx_mut)) next_r.a27 in
-  if not test then failwithf "test 102 failed";
+  if not test then failwithf "test 100 failed";
   let r = { a27 = 0.; b27 = 1; c27 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101; c27 = 102 } in
@@ -879,12 +874,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b27 = next_r.b27 } in
   Idx_mut.set r ((.b27) : (t27, _) idx_mut) next_r.b27;
-  mark_test_run 103;
+  mark_test_run 101;
   let test = eq r expected in
-  if not test then failwithf "test 103 failed";
-  mark_test_run 104;
+  if not test then failwithf "test 101 failed";
+  mark_test_run 102;
   let test = sub_eq (Idx_mut.get r ((.b27) : (t27, _) idx_mut)) next_r.b27 in
-  if not test then failwithf "test 104 failed";
+  if not test then failwithf "test 102 failed";
   let r = { a27 = 0.; b27 = 1; c27 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a27 = 100.; b27 = 101; c27 = 102 } in
@@ -892,12 +887,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with c27 = next_r.c27 } in
   Idx_mut.set r ((.c27) : (t27, _) idx_mut) next_r.c27;
-  mark_test_run 105;
+  mark_test_run 103;
   let test = eq r expected in
-  if not test then failwithf "test 105 failed";
-  mark_test_run 106;
+  if not test then failwithf "test 103 failed";
+  mark_test_run 104;
   let test = sub_eq (Idx_mut.get r ((.c27) : (t27, _) idx_mut)) next_r.c27 in
-  if not test then failwithf "test 106 failed";
+  if not test then failwithf "test 104 failed";
   (******************************)
   (*   t28 = { float; int64 }   *)
   (******************************)
@@ -909,12 +904,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a28 = next_r.a28 } in
   Idx_mut.set r ((.a28) : (t28, _) idx_mut) next_r.a28;
-  mark_test_run 107;
+  mark_test_run 105;
   let test = eq r expected in
-  if not test then failwithf "test 107 failed";
-  mark_test_run 108;
+  if not test then failwithf "test 105 failed";
+  mark_test_run 106;
   let test = sub_eq (Idx_mut.get r ((.a28) : (t28, _) idx_mut)) next_r.a28 in
-  if not test then failwithf "test 108 failed";
+  if not test then failwithf "test 106 failed";
   let r = { a28 = 0.; b28 = 1L } in
   (* Paths of depth 1 *)
   let next_r = { a28 = 100.; b28 = 101L } in
@@ -922,12 +917,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64.equal (globalize a) (globalize b)) in
   let expected = { r with b28 = next_r.b28 } in
   Idx_mut.set r ((.b28) : (t28, _) idx_mut) next_r.b28;
-  mark_test_run 109;
+  mark_test_run 107;
   let test = eq r expected in
-  if not test then failwithf "test 109 failed";
-  mark_test_run 110;
+  if not test then failwithf "test 107 failed";
+  mark_test_run 108;
   let test = sub_eq (Idx_mut.get r ((.b28) : (t28, _) idx_mut)) next_r.b28 in
-  if not test then failwithf "test 110 failed";
+  if not test then failwithf "test 108 failed";
   (**************************************)
   (*   t29 = { float; float; float# }   *)
   (**************************************)
@@ -936,43 +931,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = 101.; c29 = #102. } in
   (* .a29 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a29 = next_r.a29 } in
-  Idx_mut.set r ((.a29) : (t29, _) idx_mut) (Float_u.of_float next_r.a29);
-  mark_test_run 111;
-  let test = eq r expected in
-  if not test then failwithf "test 111 failed";
-  mark_test_run 112;
-  let test = sub_eq (Idx_mut.get r ((.a29) : (t29, _) idx_mut)) (Float_u.of_float next_r.a29) in
-  if not test then failwithf "test 112 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a29 = 0.; b29 = 1.; c29 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = 101.; c29 = #102. } in
   (* .b29 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b29 = next_r.b29 } in
-  Idx_mut.set r ((.b29) : (t29, _) idx_mut) (Float_u.of_float next_r.b29);
-  mark_test_run 113;
-  let test = eq r expected in
-  if not test then failwithf "test 113 failed";
-  mark_test_run 114;
-  let test = sub_eq (Idx_mut.get r ((.b29) : (t29, _) idx_mut)) (Float_u.of_float next_r.b29) in
-  if not test then failwithf "test 114 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a29 = 0.; b29 = 1.; c29 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a29 = 100.; b29 = 101.; c29 = #102. } in
   (* .c29 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c29 = next_r.c29 } in
-  Idx_mut.set r ((.c29) : (t29, _) idx_mut) next_r.c29;
-  mark_test_run 115;
-  let test = eq r expected in
-  if not test then failwithf "test 115 failed";
-  mark_test_run 116;
-  let test = sub_eq (Idx_mut.get r ((.c29) : (t29, _) idx_mut)) next_r.c29 in
-  if not test then failwithf "test 116 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (**************************************)
   (*   t30 = { float; #{ int; int } }   *)
   (**************************************)
@@ -984,12 +965,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a30 = next_r.a30 } in
   Idx_mut.set r ((.a30) : (t30, _) idx_mut) next_r.a30;
-  mark_test_run 117;
+  mark_test_run 109;
   let test = eq r expected in
-  if not test then failwithf "test 117 failed";
-  mark_test_run 118;
+  if not test then failwithf "test 109 failed";
+  mark_test_run 110;
   let test = sub_eq (Idx_mut.get r ((.a30) : (t30, _) idx_mut)) next_r.a30 in
-  if not test then failwithf "test 118 failed";
+  if not test then failwithf "test 110 failed";
   let r = { a30 = 0.; b30 = #{ a5 = 1; b5 = 2 } } in
   (* Paths of depth 1 *)
   let next_r = { a30 = 100.; b30 = #{ a5 = 101; b5 = 102 } } in
@@ -997,34 +978,34 @@ let to_run () =
   let sub_eq = (fun #{ a5 = a51; b5 = b51 } #{ a5 = a52; b5 = b52 } -> (fun a b -> Int.equal a b) a51 a52 && (fun a b -> Int.equal a b) b51 b52) in
   let expected = { r with b30 = next_r.b30 } in
   Idx_mut.set r ((.b30) : (t30, _) idx_mut) next_r.b30;
-  mark_test_run 119;
+  mark_test_run 111;
   let test = eq r expected in
-  if not test then failwithf "test 119 failed";
-  mark_test_run 120;
+  if not test then failwithf "test 111 failed";
+  mark_test_run 112;
   let test = sub_eq (Idx_mut.get r ((.b30) : (t30, _) idx_mut)) next_r.b30 in
-  if not test then failwithf "test 120 failed";
+  if not test then failwithf "test 112 failed";
   (* Paths of depth 2 *)
   let next_r = { a30 = 200.; b30 = #{ a5 = 201; b5 = 202 } } in
   (* .b30.#a5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b30 = #{ r.b30 with a5 = next_r.b30.#a5 } } in
   Idx_mut.set r ((.b30.#a5) : (t30, _) idx_mut) next_r.b30.#a5;
-  mark_test_run 121;
+  mark_test_run 113;
   let test = eq r expected in
-  if not test then failwithf "test 121 failed";
-  mark_test_run 122;
+  if not test then failwithf "test 113 failed";
+  mark_test_run 114;
   let test = sub_eq (Idx_mut.get r ((.b30.#a5) : (t30, _) idx_mut)) next_r.b30.#a5 in
-  if not test then failwithf "test 122 failed";
+  if not test then failwithf "test 114 failed";
   (* .b30.#b5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b30 = #{ r.b30 with b5 = next_r.b30.#b5 } } in
   Idx_mut.set r ((.b30.#b5) : (t30, _) idx_mut) next_r.b30.#b5;
-  mark_test_run 123;
+  mark_test_run 115;
   let test = eq r expected in
-  if not test then failwithf "test 123 failed";
-  mark_test_run 124;
+  if not test then failwithf "test 115 failed";
+  mark_test_run 116;
   let test = sub_eq (Idx_mut.get r ((.b30.#b5) : (t30, _) idx_mut)) next_r.b30.#b5 in
-  if not test then failwithf "test 124 failed";
+  if not test then failwithf "test 116 failed";
   (***********************************)
   (*   t31 = { float; #{ float } }   *)
   (***********************************)
@@ -1033,36 +1014,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = #{ a9 = 101. } } in
   (* .a31 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a31 = next_r.a31 } in
-  Idx_mut.set r ((.a31) : (t31, _) idx_mut) (Float_u.of_float next_r.a31);
-  mark_test_run 125;
-  let test = eq r expected in
-  if not test then failwithf "test 125 failed";
-  mark_test_run 126;
-  let test = sub_eq (Idx_mut.get r ((.a31) : (t31, _) idx_mut)) (Float_u.of_float next_r.a31) in
-  if not test then failwithf "test 126 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a31 = 0.; b31 = #{ a9 = 1. } } in
   (* Paths of depth 1 *)
   let next_r = { a31 = 100.; b31 = #{ a9 = 101. } } in
   (* .b31 *)
   (* Note: skipping test as this is not a valid block index,
      due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
   let _ = next_r in
   (* Paths of depth 2 *)
   let next_r = { a31 = 200.; b31 = #{ a9 = 201. } } in
   (* .b31.#a9 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b31 = #{ r.b31 with a9 = next_r.b31.#a9 } } in
-  Idx_mut.set r ((.b31.#a9) : (t31, _) idx_mut) (Float_u.of_float next_r.b31.#a9);
-  mark_test_run 127;
-  let test = eq r expected in
-  if not test then failwithf "test 127 failed";
-  mark_test_run 128;
-  let test = sub_eq (Idx_mut.get r ((.b31.#a9) : (t31, _) idx_mut)) (Float_u.of_float next_r.b31.#a9) in
-  if not test then failwithf "test 128 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (****************************************)
   (*   t33 = { float; #{ float; int } }   *)
   (****************************************)
@@ -1074,12 +1047,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a33 = next_r.a33 } in
   Idx_mut.set r ((.a33) : (t33, _) idx_mut) next_r.a33;
-  mark_test_run 129;
+  mark_test_run 117;
   let test = eq r expected in
-  if not test then failwithf "test 129 failed";
-  mark_test_run 130;
+  if not test then failwithf "test 117 failed";
+  mark_test_run 118;
   let test = sub_eq (Idx_mut.get r ((.a33) : (t33, _) idx_mut)) next_r.a33 in
-  if not test then failwithf "test 130 failed";
+  if not test then failwithf "test 118 failed";
   let r = { a33 = 0.; b33 = #{ a32 = 1.; b32 = 2 } } in
   (* Paths of depth 1 *)
   let next_r = { a33 = 100.; b33 = #{ a32 = 101.; b32 = 102 } } in
@@ -1087,34 +1060,34 @@ let to_run () =
   let sub_eq = (fun #{ a32 = a321; b32 = b321 } #{ a32 = a322; b32 = b322 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a321 a322 && (fun a b -> Int.equal a b) b321 b322) in
   let expected = { r with b33 = next_r.b33 } in
   Idx_mut.set r ((.b33) : (t33, _) idx_mut) next_r.b33;
-  mark_test_run 131;
+  mark_test_run 119;
   let test = eq r expected in
-  if not test then failwithf "test 131 failed";
-  mark_test_run 132;
+  if not test then failwithf "test 119 failed";
+  mark_test_run 120;
   let test = sub_eq (Idx_mut.get r ((.b33) : (t33, _) idx_mut)) next_r.b33 in
-  if not test then failwithf "test 132 failed";
+  if not test then failwithf "test 120 failed";
   (* Paths of depth 2 *)
   let next_r = { a33 = 200.; b33 = #{ a32 = 201.; b32 = 202 } } in
   (* .b33.#a32 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b33 = #{ r.b33 with a32 = next_r.b33.#a32 } } in
   Idx_mut.set r ((.b33.#a32) : (t33, _) idx_mut) next_r.b33.#a32;
-  mark_test_run 133;
+  mark_test_run 121;
   let test = eq r expected in
-  if not test then failwithf "test 133 failed";
-  mark_test_run 134;
+  if not test then failwithf "test 121 failed";
+  mark_test_run 122;
   let test = sub_eq (Idx_mut.get r ((.b33.#a32) : (t33, _) idx_mut)) next_r.b33.#a32 in
-  if not test then failwithf "test 134 failed";
+  if not test then failwithf "test 122 failed";
   (* .b33.#b32 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b33 = #{ r.b33 with b32 = next_r.b33.#b32 } } in
   Idx_mut.set r ((.b33.#b32) : (t33, _) idx_mut) next_r.b33.#b32;
-  mark_test_run 135;
+  mark_test_run 123;
   let test = eq r expected in
-  if not test then failwithf "test 135 failed";
-  mark_test_run 136;
+  if not test then failwithf "test 123 failed";
+  mark_test_run 124;
   let test = sub_eq (Idx_mut.get r ((.b33.#b32) : (t33, _) idx_mut)) next_r.b33.#b32 in
-  if not test then failwithf "test 136 failed";
+  if not test then failwithf "test 124 failed";
   (*******************************************)
   (*   t35 = { float; #{ float#; float } }   *)
   (*******************************************)
@@ -1126,12 +1099,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a35 = next_r.a35 } in
   Idx_mut.set r ((.a35) : (t35, _) idx_mut) next_r.a35;
-  mark_test_run 137;
+  mark_test_run 125;
   let test = eq r expected in
-  if not test then failwithf "test 137 failed";
-  mark_test_run 138;
+  if not test then failwithf "test 125 failed";
+  mark_test_run 126;
   let test = sub_eq (Idx_mut.get r ((.a35) : (t35, _) idx_mut)) next_r.a35 in
-  if not test then failwithf "test 138 failed";
+  if not test then failwithf "test 126 failed";
   let r = { a35 = 0.; b35 = #{ a34 = #1.; b34 = 2. } } in
   (* Paths of depth 1 *)
   let next_r = { a35 = 100.; b35 = #{ a34 = #101.; b34 = 102. } } in
@@ -1139,34 +1112,34 @@ let to_run () =
   let sub_eq = (fun #{ a34 = a341; b34 = b341 } #{ a34 = a342; b34 = b342 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a341 a342 && (fun a b -> Float.equal (globalize a) (globalize b)) b341 b342) in
   let expected = { r with b35 = next_r.b35 } in
   Idx_mut.set r ((.b35) : (t35, _) idx_mut) next_r.b35;
-  mark_test_run 139;
+  mark_test_run 127;
   let test = eq r expected in
-  if not test then failwithf "test 139 failed";
-  mark_test_run 140;
+  if not test then failwithf "test 127 failed";
+  mark_test_run 128;
   let test = sub_eq (Idx_mut.get r ((.b35) : (t35, _) idx_mut)) next_r.b35 in
-  if not test then failwithf "test 140 failed";
+  if not test then failwithf "test 128 failed";
   (* Paths of depth 2 *)
   let next_r = { a35 = 200.; b35 = #{ a34 = #201.; b34 = 202. } } in
   (* .b35.#a34 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b35 = #{ r.b35 with a34 = next_r.b35.#a34 } } in
   Idx_mut.set r ((.b35.#a34) : (t35, _) idx_mut) next_r.b35.#a34;
-  mark_test_run 141;
+  mark_test_run 129;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 129 failed";
+  mark_test_run 130;
   let test = sub_eq (Idx_mut.get r ((.b35.#a34) : (t35, _) idx_mut)) next_r.b35.#a34 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 130 failed";
   (* .b35.#b34 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with b35 = #{ r.b35 with b34 = next_r.b35.#b34 } } in
   Idx_mut.set r ((.b35.#b34) : (t35, _) idx_mut) next_r.b35.#b34;
-  mark_test_run 143;
+  mark_test_run 131;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 131 failed";
+  mark_test_run 132;
   let test = sub_eq (Idx_mut.get r ((.b35.#b34) : (t35, _) idx_mut)) next_r.b35.#b34 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 132 failed";
   (********************************************)
   (*   t37 = { float; #{ float#; float# } }   *)
   (********************************************)
@@ -1178,12 +1151,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a37 = next_r.a37 } in
   Idx_mut.set r ((.a37) : (t37, _) idx_mut) next_r.a37;
-  mark_test_run 145;
+  mark_test_run 133;
   let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
+  if not test then failwithf "test 133 failed";
+  mark_test_run 134;
   let test = sub_eq (Idx_mut.get r ((.a37) : (t37, _) idx_mut)) next_r.a37 in
-  if not test then failwithf "test 146 failed";
+  if not test then failwithf "test 134 failed";
   let r = { a37 = 0.; b37 = #{ a36 = #1.; b36 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a37 = 100.; b37 = #{ a36 = #101.; b36 = #102. } } in
@@ -1191,34 +1164,34 @@ let to_run () =
   let sub_eq = (fun #{ a36 = a361; b36 = b361 } #{ a36 = a362; b36 = b362 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a361 a362 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b361 b362) in
   let expected = { r with b37 = next_r.b37 } in
   Idx_mut.set r ((.b37) : (t37, _) idx_mut) next_r.b37;
-  mark_test_run 147;
+  mark_test_run 135;
   let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
+  if not test then failwithf "test 135 failed";
+  mark_test_run 136;
   let test = sub_eq (Idx_mut.get r ((.b37) : (t37, _) idx_mut)) next_r.b37 in
-  if not test then failwithf "test 148 failed";
+  if not test then failwithf "test 136 failed";
   (* Paths of depth 2 *)
   let next_r = { a37 = 200.; b37 = #{ a36 = #201.; b36 = #202. } } in
   (* .b37.#a36 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b37 = #{ r.b37 with a36 = next_r.b37.#a36 } } in
   Idx_mut.set r ((.b37.#a36) : (t37, _) idx_mut) next_r.b37.#a36;
-  mark_test_run 149;
+  mark_test_run 137;
   let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
+  if not test then failwithf "test 137 failed";
+  mark_test_run 138;
   let test = sub_eq (Idx_mut.get r ((.b37.#a36) : (t37, _) idx_mut)) next_r.b37.#a36 in
-  if not test then failwithf "test 150 failed";
+  if not test then failwithf "test 138 failed";
   (* .b37.#b36 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b37 = #{ r.b37 with b36 = next_r.b37.#b36 } } in
   Idx_mut.set r ((.b37.#b36) : (t37, _) idx_mut) next_r.b37.#b36;
-  mark_test_run 151;
+  mark_test_run 139;
   let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
+  if not test then failwithf "test 139 failed";
+  mark_test_run 140;
   let test = sub_eq (Idx_mut.get r ((.b37.#b36) : (t37, _) idx_mut)) next_r.b37.#b36 in
-  if not test then failwithf "test 152 failed";
+  if not test then failwithf "test 140 failed";
   (***************************************)
   (*   t38 = { float#; float; float# }   *)
   (***************************************)
@@ -1227,42 +1200,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = 101.; c38 = #102. } in
   (* .a38 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a38 = next_r.a38 } in
-  Idx_mut.set r ((.a38) : (t38, _) idx_mut) next_r.a38;
-  mark_test_run 153;
-  let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
-  let test = sub_eq (Idx_mut.get r ((.a38) : (t38, _) idx_mut)) next_r.a38 in
-  if not test then failwithf "test 154 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a38 = #0.; b38 = 1.; c38 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = 101.; c38 = #102. } in
   (* .b38 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b38 = next_r.b38 } in
-  Idx_mut.set r ((.b38) : (t38, _) idx_mut) (Float_u.of_float next_r.b38);
-  mark_test_run 155;
-  let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
-  let test = sub_eq (Idx_mut.get r ((.b38) : (t38, _) idx_mut)) (Float_u.of_float next_r.b38) in
-  if not test then failwithf "test 156 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a38 = #0.; b38 = 1.; c38 = #2. } in
   (* Paths of depth 1 *)
   let next_r = { a38 = #100.; b38 = 101.; c38 = #102. } in
   (* .c38 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c38 = next_r.c38 } in
-  Idx_mut.set r ((.c38) : (t38, _) idx_mut) next_r.c38;
-  mark_test_run 157;
-  let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
-  let test = sub_eq (Idx_mut.get r ((.c38) : (t38, _) idx_mut)) next_r.c38 in
-  if not test then failwithf "test 158 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (********************************)
   (*   t39 = { float#; float# }   *)
   (********************************)
@@ -1271,28 +1231,20 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a39 = #100.; b39 = #101. } in
   (* .a39 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a39 = next_r.a39 } in
-  Idx_mut.set r ((.a39) : (t39, _) idx_mut) next_r.a39;
-  mark_test_run 159;
-  let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
-  let test = sub_eq (Idx_mut.get r ((.a39) : (t39, _) idx_mut)) next_r.a39 in
-  if not test then failwithf "test 160 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a39 = #0.; b39 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a39 = #100.; b39 = #101. } in
   (* .b39 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b39 = next_r.b39 } in
-  Idx_mut.set r ((.b39) : (t39, _) idx_mut) next_r.b39;
-  mark_test_run 161;
-  let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
-  let test = sub_eq (Idx_mut.get r ((.b39) : (t39, _) idx_mut)) next_r.b39 in
-  if not test then failwithf "test 162 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (***************************************)
   (*   t40 = { float#; float#; float }   *)
   (***************************************)
@@ -1301,42 +1253,29 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #101.; c40 = 102. } in
   (* .a40 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a40 = next_r.a40 } in
-  Idx_mut.set r ((.a40) : (t40, _) idx_mut) next_r.a40;
-  mark_test_run 163;
-  let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
-  let test = sub_eq (Idx_mut.get r ((.a40) : (t40, _) idx_mut)) next_r.a40 in
-  if not test then failwithf "test 164 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a40 = #0.; b40 = #1.; c40 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #101.; c40 = 102. } in
   (* .b40 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b40 = next_r.b40 } in
-  Idx_mut.set r ((.b40) : (t40, _) idx_mut) next_r.b40;
-  mark_test_run 165;
-  let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
-  let test = sub_eq (Idx_mut.get r ((.b40) : (t40, _) idx_mut)) next_r.b40 in
-  if not test then failwithf "test 166 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a40 = #0.; b40 = #1.; c40 = 2. } in
   (* Paths of depth 1 *)
   let next_r = { a40 = #100.; b40 = #101.; c40 = 102. } in
   (* .c40 *)
-  (* ff *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with c40 = next_r.c40 } in
-  Idx_mut.set r ((.c40) : (t40, _) idx_mut) (Float_u.of_float next_r.c40);
-  mark_test_run 167;
-  let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
-  let test = sub_eq (Idx_mut.get r ((.c40) : (t40, _) idx_mut)) (Float_u.of_float next_r.c40) in
-  if not test then failwithf "test 168 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*************************************)
   (*   t42 = { float#; #{ float# } }   *)
   (*************************************)
@@ -1345,40 +1284,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a42 = #100.; b42 = #{ a41 = #101. } } in
   (* .a42 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with a42 = next_r.a42 } in
-  Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
-  mark_test_run 169;
-  let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
-  let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
-  if not test then failwithf "test 170 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   let r = { a42 = #0.; b42 = #{ a41 = #1. } } in
   (* Paths of depth 1 *)
   let next_r = { a42 = #100.; b42 = #{ a41 = #101. } } in
   (* .b42 *)
-  let sub_eq = (fun #{ a41 = a411 } #{ a41 = a412 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a411 a412) in
-  let expected = { r with b42 = next_r.b42 } in
-  Idx_mut.set r ((.b42) : (t42, _) idx_mut) next_r.b42;
-  mark_test_run 171;
-  let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
-  let test = sub_eq (Idx_mut.get r ((.b42) : (t42, _) idx_mut)) next_r.b42 in
-  if not test then failwithf "test 172 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (* Paths of depth 2 *)
   let next_r = { a42 = #200.; b42 = #{ a41 = #201. } } in
   (* .b42.#a41 *)
-  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
-  let expected = { r with b42 = #{ r.b42 with a41 = next_r.b42.#a41 } } in
-  Idx_mut.set r ((.b42.#a41) : (t42, _) idx_mut) next_r.b42.#a41;
-  mark_test_run 173;
-  let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
-  let test = sub_eq (Idx_mut.get r ((.b42.#a41) : (t42, _) idx_mut)) next_r.b42.#a41 in
-  if not test then failwithf "test 174 failed";
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  let _ = eq in
+  let _ = r in
+  let _ = next_r in
   (*********************************************)
   (*   t43 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1390,12 +1317,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a43 = next_r.a43 } in
   Idx_mut.set r ((.a43) : (t43, _) idx_mut) next_r.a43;
-  mark_test_run 175;
+  mark_test_run 141;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
   let test = sub_eq (Idx_mut.get r ((.a43) : (t43, _) idx_mut)) next_r.a43 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 142 failed";
   let r = { a43 = #0.; b43 = #{ a36 = #1.; b36 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a43 = #100.; b43 = #{ a36 = #101.; b36 = #102. } } in
@@ -1403,34 +1330,34 @@ let to_run () =
   let sub_eq = (fun #{ a36 = a361; b36 = b361 } #{ a36 = a362; b36 = b362 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a361 a362 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b361 b362) in
   let expected = { r with b43 = next_r.b43 } in
   Idx_mut.set r ((.b43) : (t43, _) idx_mut) next_r.b43;
-  mark_test_run 177;
+  mark_test_run 143;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
   let test = sub_eq (Idx_mut.get r ((.b43) : (t43, _) idx_mut)) next_r.b43 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 144 failed";
   (* Paths of depth 2 *)
   let next_r = { a43 = #200.; b43 = #{ a36 = #201.; b36 = #202. } } in
   (* .b43.#a36 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b43 = #{ r.b43 with a36 = next_r.b43.#a36 } } in
   Idx_mut.set r ((.b43.#a36) : (t43, _) idx_mut) next_r.b43.#a36;
-  mark_test_run 179;
+  mark_test_run 145;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
   let test = sub_eq (Idx_mut.get r ((.b43.#a36) : (t43, _) idx_mut)) next_r.b43.#a36 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 146 failed";
   (* .b43.#b36 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b43 = #{ r.b43 with b36 = next_r.b43.#b36 } } in
   Idx_mut.set r ((.b43.#b36) : (t43, _) idx_mut) next_r.b43.#b36;
-  mark_test_run 181;
+  mark_test_run 147;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
   let test = sub_eq (Idx_mut.get r ((.b43.#b36) : (t43, _) idx_mut)) next_r.b43.#b36 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 148 failed";
   (************************)
   (*   t44 = { string }   *)
   (************************)
@@ -1442,12 +1369,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a44 = next_r.a44 } in
   Idx_mut.set r ((.a44) : (t44, _) idx_mut) next_r.a44;
-  mark_test_run 183;
+  mark_test_run 149;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
   let test = sub_eq (Idx_mut.get r ((.a44) : (t44, _) idx_mut)) next_r.a44 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 150 failed";
   (************************************)
   (*   t45 = { int64x2#; int; int }   *)
   (************************************)
@@ -1459,12 +1386,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 185;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 152 failed";
   let r = { a45 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b45 = 2; c45 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b45 = 102; c45 = 103 } in
@@ -1472,12 +1399,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b45 = next_r.b45 } in
   Idx_mut.set r ((.b45) : (t45, _) idx_mut) next_r.b45;
-  mark_test_run 187;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.b45) : (t45, _) idx_mut)) next_r.b45 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 154 failed";
   let r = { a45 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b45 = 2; c45 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b45 = 102; c45 = 103 } in
@@ -1485,12 +1412,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with c45 = next_r.c45 } in
   Idx_mut.set r ((.c45) : (t45, _) idx_mut) next_r.c45;
-  mark_test_run 189;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.c45) : (t45, _) idx_mut)) next_r.c45 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 156 failed";
   (************************************)
   (*   t46 = { int64x2#; int64x2# }   *)
   (************************************)
@@ -1502,12 +1429,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a46 = next_r.a46 } in
   Idx_mut.set r ((.a46) : (t46, _) idx_mut) next_r.a46;
-  mark_test_run 191;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.a46) : (t46, _) idx_mut)) next_r.a46 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 158 failed";
   let r = { a46 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b46 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a46 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b46 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -1515,12 +1442,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b46 = next_r.b46 } in
   Idx_mut.set r ((.b46) : (t46, _) idx_mut) next_r.b46;
-  mark_test_run 193;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.b46) : (t46, _) idx_mut)) next_r.b46 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 160 failed";
   (**********************************************)
   (*   t47 = { int64x2#; int64x2#; int64x2# }   *)
   (**********************************************)
@@ -1532,12 +1459,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 195;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 162 failed";
   let r = { a47 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b47 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)); c47 = (interleave_low_64 (int64x2_of_int64 4L) (int64x2_of_int64 5L)) } in
   (* Paths of depth 1 *)
   let next_r = { a47 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b47 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)); c47 = (interleave_low_64 (int64x2_of_int64 104L) (int64x2_of_int64 105L)) } in
@@ -1545,12 +1472,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b47 = next_r.b47 } in
   Idx_mut.set r ((.b47) : (t47, _) idx_mut) next_r.b47;
-  mark_test_run 197;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.b47) : (t47, _) idx_mut)) next_r.b47 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 164 failed";
   let r = { a47 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b47 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)); c47 = (interleave_low_64 (int64x2_of_int64 4L) (int64x2_of_int64 5L)) } in
   (* Paths of depth 1 *)
   let next_r = { a47 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b47 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)); c47 = (interleave_low_64 (int64x2_of_int64 104L) (int64x2_of_int64 105L)) } in
@@ -1558,12 +1485,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with c47 = next_r.c47 } in
   Idx_mut.set r ((.c47) : (t47, _) idx_mut) next_r.c47;
-  mark_test_run 199;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.c47) : (t47, _) idx_mut)) next_r.c47 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 166 failed";
   (**********************************************)
   (*   t48 = { int64x2#; #{ int; int64x2# } }   *)
   (**********************************************)
@@ -1575,12 +1502,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a48 = next_r.a48 } in
   Idx_mut.set r ((.a48) : (t48, _) idx_mut) next_r.a48;
-  mark_test_run 201;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.a48) : (t48, _) idx_mut)) next_r.a48 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 168 failed";
   let r = { a48 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b48 = #{ a7 = 2; b7 = (interleave_low_64 (int64x2_of_int64 3L) (int64x2_of_int64 4L)) } } in
   (* Paths of depth 1 *)
   let next_r = { a48 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b48 = #{ a7 = 102; b7 = (interleave_low_64 (int64x2_of_int64 103L) (int64x2_of_int64 104L)) } } in
@@ -1588,34 +1515,34 @@ let to_run () =
   let sub_eq = (fun #{ a7 = a71; b7 = b71 } #{ a7 = a72; b7 = b72 } -> (fun a b -> Int.equal a b) a71 a72 && int64x2_u_equal b71 b72) in
   let expected = { r with b48 = next_r.b48 } in
   Idx_mut.set r ((.b48) : (t48, _) idx_mut) next_r.b48;
-  mark_test_run 203;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.b48) : (t48, _) idx_mut)) next_r.b48 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 170 failed";
   (* Paths of depth 2 *)
   let next_r = { a48 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)); b48 = #{ a7 = 202; b7 = (interleave_low_64 (int64x2_of_int64 203L) (int64x2_of_int64 204L)) } } in
   (* .b48.#a7 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b48 = #{ r.b48 with a7 = next_r.b48.#a7 } } in
   Idx_mut.set r ((.b48.#a7) : (t48, _) idx_mut) next_r.b48.#a7;
-  mark_test_run 205;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.b48.#a7) : (t48, _) idx_mut)) next_r.b48.#a7 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 172 failed";
   (* .b48.#b7 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with b48 = #{ r.b48 with b7 = next_r.b48.#b7 } } in
   Idx_mut.set r ((.b48.#b7) : (t48, _) idx_mut) next_r.b48.#b7;
-  mark_test_run 207;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.b48.#b7) : (t48, _) idx_mut)) next_r.b48.#b7 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 174 failed";
   (***************************************************)
   (*   t50 = { int64x2#; #{ int64x2#; int64x2# } }   *)
   (***************************************************)
@@ -1627,12 +1554,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a50 = next_r.a50 } in
   Idx_mut.set r ((.a50) : (t50, _) idx_mut) next_r.a50;
-  mark_test_run 209;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.a50) : (t50, _) idx_mut)) next_r.a50 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 176 failed";
   let r = { a50 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b50 = #{ a49 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)); b49 = (interleave_low_64 (int64x2_of_int64 4L) (int64x2_of_int64 5L)) } } in
   (* Paths of depth 1 *)
   let next_r = { a50 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b50 = #{ a49 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)); b49 = (interleave_low_64 (int64x2_of_int64 104L) (int64x2_of_int64 105L)) } } in
@@ -1640,34 +1567,34 @@ let to_run () =
   let sub_eq = (fun #{ a49 = a491; b49 = b491 } #{ a49 = a492; b49 = b492 } -> int64x2_u_equal a491 a492 && int64x2_u_equal b491 b492) in
   let expected = { r with b50 = next_r.b50 } in
   Idx_mut.set r ((.b50) : (t50, _) idx_mut) next_r.b50;
-  mark_test_run 211;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.b50) : (t50, _) idx_mut)) next_r.b50 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 178 failed";
   (* Paths of depth 2 *)
   let next_r = { a50 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)); b50 = #{ a49 = (interleave_low_64 (int64x2_of_int64 202L) (int64x2_of_int64 203L)); b49 = (interleave_low_64 (int64x2_of_int64 204L) (int64x2_of_int64 205L)) } } in
   (* .b50.#a49 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with b50 = #{ r.b50 with a49 = next_r.b50.#a49 } } in
   Idx_mut.set r ((.b50.#a49) : (t50, _) idx_mut) next_r.b50.#a49;
-  mark_test_run 213;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.b50.#a49) : (t50, _) idx_mut)) next_r.b50.#a49 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 180 failed";
   (* .b50.#b49 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with b50 = #{ r.b50 with b49 = next_r.b50.#b49 } } in
   Idx_mut.set r ((.b50.#b49) : (t50, _) idx_mut) next_r.b50.#b49;
-  mark_test_run 215;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.b50.#b49) : (t50, _) idx_mut)) next_r.b50.#b49 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 182 failed";
   (****************************)
   (*   t52 = { (| unit_u) }   *)
   (****************************)
@@ -1679,12 +1606,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C51_0(a0), C51_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a52 = next_r.a52 } in
   Idx_mut.set r ((.a52) : (t52, _) idx_mut) next_r.a52;
-  mark_test_run 217;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.a52) : (t52, _) idx_mut)) next_r.a52 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 184 failed";
   (***********************************)
   (*   t53 = { (| unit_u); int64 }   *)
   (***********************************)
@@ -1696,12 +1623,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C51_0(a0), C51_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a53 = next_r.a53 } in
   Idx_mut.set r ((.a53) : (t53, _) idx_mut) next_r.a53;
-  mark_test_run 219;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.a53) : (t53, _) idx_mut)) next_r.a53 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 186 failed";
   let r = { a53 = (C51_0 (unbox_unit ())); b53 = 0L } in
   (* Paths of depth 1 *)
   let next_r = { a53 = (C51_0 (unbox_unit ())); b53 = 100L } in
@@ -1709,12 +1636,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64.equal (globalize a) (globalize b)) in
   let expected = { r with b53 = next_r.b53 } in
   Idx_mut.set r ((.b53) : (t53, _) idx_mut) next_r.b53;
-  mark_test_run 221;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.b53) : (t53, _) idx_mut)) next_r.b53 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 188 failed";
   (************************************)
   (*   t54 = { (| unit_u); int64# }   *)
   (************************************)
@@ -1726,12 +1653,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C51_0(a0), C51_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a54 = next_r.a54 } in
   Idx_mut.set r ((.a54) : (t54, _) idx_mut) next_r.a54;
-  mark_test_run 223;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.a54) : (t54, _) idx_mut)) next_r.a54 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 190 failed";
   let r = { a54 = (C51_0 (unbox_unit ())); b54 = #0L } in
   (* Paths of depth 1 *)
   let next_r = { a54 = (C51_0 (unbox_unit ())); b54 = #100L } in
@@ -1739,12 +1666,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b54 = next_r.b54 } in
   Idx_mut.set r ((.b54) : (t54, _) idx_mut) next_r.b54;
-  mark_test_run 225;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.b54) : (t54, _) idx_mut)) next_r.b54 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 192 failed";
   (**************************)
   (*   t55 = { #{ int } }   *)
   (**************************)
@@ -1756,24 +1683,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a55 = next_r.a55 } in
   Idx_mut.set r ((.a55) : (t55, _) idx_mut) next_r.a55;
-  mark_test_run 227;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a55) : (t55, _) idx_mut)) next_r.a55 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 194 failed";
   (* Paths of depth 2 *)
   let next_r = { a55 = #{ a3 = 200 } } in
   (* .a55.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a55 = #{ r.a55 with a3 = next_r.a55.#a3 } } in
   Idx_mut.set r ((.a55.#a3) : (t55, _) idx_mut) next_r.a55.#a3;
-  mark_test_run 229;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.a55.#a3) : (t55, _) idx_mut)) next_r.a55.#a3 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 196 failed";
   (*******************************)
   (*   t56 = { #{ int }; int }   *)
   (*******************************)
@@ -1785,24 +1712,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a56 = next_r.a56 } in
   Idx_mut.set r ((.a56) : (t56, _) idx_mut) next_r.a56;
-  mark_test_run 231;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.a56) : (t56, _) idx_mut)) next_r.a56 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 198 failed";
   (* Paths of depth 2 *)
   let next_r = { a56 = #{ a3 = 200 }; b56 = 201 } in
   (* .a56.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a56 = #{ r.a56 with a3 = next_r.a56.#a3 } } in
   Idx_mut.set r ((.a56.#a3) : (t56, _) idx_mut) next_r.a56.#a3;
-  mark_test_run 233;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 233 failed";
-  mark_test_run 234;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a56.#a3) : (t56, _) idx_mut)) next_r.a56.#a3 in
-  if not test then failwithf "test 234 failed";
+  if not test then failwithf "test 200 failed";
   let r = { a56 = #{ a3 = 0 }; b56 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a56 = #{ a3 = 100 }; b56 = 101 } in
@@ -1810,12 +1737,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b56 = next_r.b56 } in
   Idx_mut.set r ((.b56) : (t56, _) idx_mut) next_r.b56;
-  mark_test_run 235;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 235 failed";
-  mark_test_run 236;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.b56) : (t56, _) idx_mut)) next_r.b56 in
-  if not test then failwithf "test 236 failed";
+  if not test then failwithf "test 202 failed";
   (***************************************)
   (*   t57 = { #{ int; int }; int32# }   *)
   (***************************************)
@@ -1827,34 +1754,34 @@ let to_run () =
   let sub_eq = (fun #{ a5 = a51; b5 = b51 } #{ a5 = a52; b5 = b52 } -> (fun a b -> Int.equal a b) a51 a52 && (fun a b -> Int.equal a b) b51 b52) in
   let expected = { r with a57 = next_r.a57 } in
   Idx_mut.set r ((.a57) : (t57, _) idx_mut) next_r.a57;
-  mark_test_run 237;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 237 failed";
-  mark_test_run 238;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a57) : (t57, _) idx_mut)) next_r.a57 in
-  if not test then failwithf "test 238 failed";
+  if not test then failwithf "test 204 failed";
   (* Paths of depth 2 *)
   let next_r = { a57 = #{ a5 = 200; b5 = 201 }; b57 = #202l } in
   (* .a57.#a5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a57 = #{ r.a57 with a5 = next_r.a57.#a5 } } in
   Idx_mut.set r ((.a57.#a5) : (t57, _) idx_mut) next_r.a57.#a5;
-  mark_test_run 239;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 239 failed";
-  mark_test_run 240;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a57.#a5) : (t57, _) idx_mut)) next_r.a57.#a5 in
-  if not test then failwithf "test 240 failed";
+  if not test then failwithf "test 206 failed";
   (* .a57.#b5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a57 = #{ r.a57 with b5 = next_r.a57.#b5 } } in
   Idx_mut.set r ((.a57.#b5) : (t57, _) idx_mut) next_r.a57.#b5;
-  mark_test_run 241;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 241 failed";
-  mark_test_run 242;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.a57.#b5) : (t57, _) idx_mut)) next_r.a57.#b5 in
-  if not test then failwithf "test 242 failed";
+  if not test then failwithf "test 208 failed";
   let r = { a57 = #{ a5 = 0; b5 = 1 }; b57 = #2l } in
   (* Paths of depth 1 *)
   let next_r = { a57 = #{ a5 = 100; b5 = 101 }; b57 = #102l } in
@@ -1862,12 +1789,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b57 = next_r.b57 } in
   Idx_mut.set r ((.b57) : (t57, _) idx_mut) next_r.b57;
-  mark_test_run 243;
+  mark_test_run 209;
   let test = eq r expected in
-  if not test then failwithf "test 243 failed";
-  mark_test_run 244;
+  if not test then failwithf "test 209 failed";
+  mark_test_run 210;
   let test = sub_eq (Idx_mut.get r ((.b57) : (t57, _) idx_mut)) next_r.b57 in
-  if not test then failwithf "test 244 failed";
+  if not test then failwithf "test 210 failed";
   (***************************************)
   (*   t59 = { #{ int; int32# }; int }   *)
   (***************************************)
@@ -1879,34 +1806,34 @@ let to_run () =
   let sub_eq = (fun #{ a58 = a581; b58 = b581 } #{ a58 = a582; b58 = b582 } -> (fun a b -> Int.equal a b) a581 a582 && (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) b581 b582) in
   let expected = { r with a59 = next_r.a59 } in
   Idx_mut.set r ((.a59) : (t59, _) idx_mut) next_r.a59;
-  mark_test_run 245;
+  mark_test_run 211;
   let test = eq r expected in
-  if not test then failwithf "test 245 failed";
-  mark_test_run 246;
+  if not test then failwithf "test 211 failed";
+  mark_test_run 212;
   let test = sub_eq (Idx_mut.get r ((.a59) : (t59, _) idx_mut)) next_r.a59 in
-  if not test then failwithf "test 246 failed";
+  if not test then failwithf "test 212 failed";
   (* Paths of depth 2 *)
   let next_r = { a59 = #{ a58 = 200; b58 = #201l }; b59 = 202 } in
   (* .a59.#a58 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a59 = #{ r.a59 with a58 = next_r.a59.#a58 } } in
   Idx_mut.set r ((.a59.#a58) : (t59, _) idx_mut) next_r.a59.#a58;
-  mark_test_run 247;
+  mark_test_run 213;
   let test = eq r expected in
-  if not test then failwithf "test 247 failed";
-  mark_test_run 248;
+  if not test then failwithf "test 213 failed";
+  mark_test_run 214;
   let test = sub_eq (Idx_mut.get r ((.a59.#a58) : (t59, _) idx_mut)) next_r.a59.#a58 in
-  if not test then failwithf "test 248 failed";
+  if not test then failwithf "test 214 failed";
   (* .a59.#b58 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a59 = #{ r.a59 with b58 = next_r.a59.#b58 } } in
   Idx_mut.set r ((.a59.#b58) : (t59, _) idx_mut) next_r.a59.#b58;
-  mark_test_run 249;
+  mark_test_run 215;
   let test = eq r expected in
-  if not test then failwithf "test 249 failed";
-  mark_test_run 250;
+  if not test then failwithf "test 215 failed";
+  mark_test_run 216;
   let test = sub_eq (Idx_mut.get r ((.a59.#b58) : (t59, _) idx_mut)) next_r.a59.#b58 in
-  if not test then failwithf "test 250 failed";
+  if not test then failwithf "test 216 failed";
   let r = { a59 = #{ a58 = 0; b58 = #1l }; b59 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a59 = #{ a58 = 100; b58 = #101l }; b59 = 102 } in
@@ -1914,12 +1841,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b59 = next_r.b59 } in
   Idx_mut.set r ((.b59) : (t59, _) idx_mut) next_r.b59;
-  mark_test_run 251;
+  mark_test_run 217;
   let test = eq r expected in
-  if not test then failwithf "test 251 failed";
-  mark_test_run 252;
+  if not test then failwithf "test 217 failed";
+  mark_test_run 218;
   let test = sub_eq (Idx_mut.get r ((.b59) : (t59, _) idx_mut)) next_r.b59 in
-  if not test then failwithf "test 252 failed";
+  if not test then failwithf "test 218 failed";
   (**************************************)
   (*   t61 = { #{ int; float }; int }   *)
   (**************************************)
@@ -1931,34 +1858,34 @@ let to_run () =
   let sub_eq = (fun #{ a60 = a601; b60 = b601 } #{ a60 = a602; b60 = b602 } -> (fun a b -> Int.equal a b) a601 a602 && (fun a b -> Float.equal (globalize a) (globalize b)) b601 b602) in
   let expected = { r with a61 = next_r.a61 } in
   Idx_mut.set r ((.a61) : (t61, _) idx_mut) next_r.a61;
-  mark_test_run 253;
+  mark_test_run 219;
   let test = eq r expected in
-  if not test then failwithf "test 253 failed";
-  mark_test_run 254;
+  if not test then failwithf "test 219 failed";
+  mark_test_run 220;
   let test = sub_eq (Idx_mut.get r ((.a61) : (t61, _) idx_mut)) next_r.a61 in
-  if not test then failwithf "test 254 failed";
+  if not test then failwithf "test 220 failed";
   (* Paths of depth 2 *)
   let next_r = { a61 = #{ a60 = 200; b60 = 201. }; b61 = 202 } in
   (* .a61.#a60 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a61 = #{ r.a61 with a60 = next_r.a61.#a60 } } in
   Idx_mut.set r ((.a61.#a60) : (t61, _) idx_mut) next_r.a61.#a60;
-  mark_test_run 255;
+  mark_test_run 221;
   let test = eq r expected in
-  if not test then failwithf "test 255 failed";
-  mark_test_run 256;
+  if not test then failwithf "test 221 failed";
+  mark_test_run 222;
   let test = sub_eq (Idx_mut.get r ((.a61.#a60) : (t61, _) idx_mut)) next_r.a61.#a60 in
-  if not test then failwithf "test 256 failed";
+  if not test then failwithf "test 222 failed";
   (* .a61.#b60 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a61 = #{ r.a61 with b60 = next_r.a61.#b60 } } in
   Idx_mut.set r ((.a61.#b60) : (t61, _) idx_mut) next_r.a61.#b60;
-  mark_test_run 257;
+  mark_test_run 223;
   let test = eq r expected in
-  if not test then failwithf "test 257 failed";
-  mark_test_run 258;
+  if not test then failwithf "test 223 failed";
+  mark_test_run 224;
   let test = sub_eq (Idx_mut.get r ((.a61.#b60) : (t61, _) idx_mut)) next_r.a61.#b60 in
-  if not test then failwithf "test 258 failed";
+  if not test then failwithf "test 224 failed";
   let r = { a61 = #{ a60 = 0; b60 = 1. }; b61 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a61 = #{ a60 = 100; b60 = 101. }; b61 = 102 } in
@@ -1966,12 +1893,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b61 = next_r.b61 } in
   Idx_mut.set r ((.b61) : (t61, _) idx_mut) next_r.b61;
-  mark_test_run 259;
+  mark_test_run 225;
   let test = eq r expected in
-  if not test then failwithf "test 259 failed";
-  mark_test_run 260;
+  if not test then failwithf "test 225 failed";
+  mark_test_run 226;
   let test = sub_eq (Idx_mut.get r ((.b61) : (t61, _) idx_mut)) next_r.b61 in
-  if not test then failwithf "test 260 failed";
+  if not test then failwithf "test 226 failed";
   (*************************************)
   (*   t63 = { #{ unit_u }; string }   *)
   (*************************************)
@@ -1983,24 +1910,24 @@ let to_run () =
   let sub_eq = (fun #{ a62 = a621 } #{ a62 = a622 } -> (fun _ _ -> true) a621 a622) in
   let expected = { r with a63 = next_r.a63 } in
   Idx_mut.set r ((.a63) : (t63, _) idx_mut) next_r.a63;
-  mark_test_run 261;
+  mark_test_run 227;
   let test = eq r expected in
-  if not test then failwithf "test 261 failed";
-  mark_test_run 262;
+  if not test then failwithf "test 227 failed";
+  mark_test_run 228;
   let test = sub_eq (Idx_mut.get r ((.a63) : (t63, _) idx_mut)) next_r.a63 in
-  if not test then failwithf "test 262 failed";
+  if not test then failwithf "test 228 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a62 = (unbox_unit ()) }; b63 = "200" } in
   (* .a63.#a62 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a63 = #{ r.a63 with a62 = next_r.a63.#a62 } } in
   Idx_mut.set r ((.a63.#a62) : (t63, _) idx_mut) next_r.a63.#a62;
-  mark_test_run 263;
+  mark_test_run 229;
   let test = eq r expected in
-  if not test then failwithf "test 263 failed";
-  mark_test_run 264;
+  if not test then failwithf "test 229 failed";
+  mark_test_run 230;
   let test = sub_eq (Idx_mut.get r ((.a63.#a62) : (t63, _) idx_mut)) next_r.a63.#a62 in
-  if not test then failwithf "test 264 failed";
+  if not test then failwithf "test 230 failed";
   let r = { a63 = #{ a62 = (unbox_unit ()) }; b63 = "0" } in
   (* Paths of depth 1 *)
   let next_r = { a63 = #{ a62 = (unbox_unit ()) }; b63 = "100" } in
@@ -2008,12 +1935,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b63 = next_r.b63 } in
   Idx_mut.set r ((.b63) : (t63, _) idx_mut) next_r.b63;
-  mark_test_run 265;
+  mark_test_run 231;
   let test = eq r expected in
-  if not test then failwithf "test 265 failed";
-  mark_test_run 266;
+  if not test then failwithf "test 231 failed";
+  mark_test_run 232;
   let test = sub_eq (Idx_mut.get r ((.b63) : (t63, _) idx_mut)) next_r.b63 in
-  if not test then failwithf "test 266 failed";
+  if not test then failwithf "test 232 failed";
   (*************************************)
   (*   t65 = { #{ unit_u; string } }   *)
   (*************************************)
@@ -2025,34 +1952,34 @@ let to_run () =
   let sub_eq = (fun #{ a64 = a641; b64 = b641 } #{ a64 = a642; b64 = b642 } -> (fun _ _ -> true) a641 a642 && (fun a b -> String.equal (globalize a) (globalize b)) b641 b642) in
   let expected = { r with a65 = next_r.a65 } in
   Idx_mut.set r ((.a65) : (t65, _) idx_mut) next_r.a65;
-  mark_test_run 267;
+  mark_test_run 233;
   let test = eq r expected in
-  if not test then failwithf "test 267 failed";
-  mark_test_run 268;
+  if not test then failwithf "test 233 failed";
+  mark_test_run 234;
   let test = sub_eq (Idx_mut.get r ((.a65) : (t65, _) idx_mut)) next_r.a65 in
-  if not test then failwithf "test 268 failed";
+  if not test then failwithf "test 234 failed";
   (* Paths of depth 2 *)
   let next_r = { a65 = #{ a64 = (unbox_unit ()); b64 = "200" } } in
   (* .a65.#a64 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a65 = #{ r.a65 with a64 = next_r.a65.#a64 } } in
   Idx_mut.set r ((.a65.#a64) : (t65, _) idx_mut) next_r.a65.#a64;
-  mark_test_run 269;
+  mark_test_run 235;
   let test = eq r expected in
-  if not test then failwithf "test 269 failed";
-  mark_test_run 270;
+  if not test then failwithf "test 235 failed";
+  mark_test_run 236;
   let test = sub_eq (Idx_mut.get r ((.a65.#a64) : (t65, _) idx_mut)) next_r.a65.#a64 in
-  if not test then failwithf "test 270 failed";
+  if not test then failwithf "test 236 failed";
   (* .a65.#b64 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a65 = #{ r.a65 with b64 = next_r.a65.#b64 } } in
   Idx_mut.set r ((.a65.#b64) : (t65, _) idx_mut) next_r.a65.#b64;
-  mark_test_run 271;
+  mark_test_run 237;
   let test = eq r expected in
-  if not test then failwithf "test 271 failed";
-  mark_test_run 272;
+  if not test then failwithf "test 237 failed";
+  mark_test_run 238;
   let test = sub_eq (Idx_mut.get r ((.a65.#b64) : (t65, _) idx_mut)) next_r.a65.#b64 in
-  if not test then failwithf "test 272 failed";
+  if not test then failwithf "test 238 failed";
   (***********************************)
   (*   t67 = { #{ float; float } }   *)
   (***********************************)
@@ -2064,34 +1991,34 @@ let to_run () =
   let sub_eq = (fun #{ a66 = a661; b66 = b661 } #{ a66 = a662; b66 = b662 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a661 a662 && (fun a b -> Float.equal (globalize a) (globalize b)) b661 b662) in
   let expected = { r with a67 = next_r.a67 } in
   Idx_mut.set r ((.a67) : (t67, _) idx_mut) next_r.a67;
-  mark_test_run 273;
+  mark_test_run 239;
   let test = eq r expected in
-  if not test then failwithf "test 273 failed";
-  mark_test_run 274;
+  if not test then failwithf "test 239 failed";
+  mark_test_run 240;
   let test = sub_eq (Idx_mut.get r ((.a67) : (t67, _) idx_mut)) next_r.a67 in
-  if not test then failwithf "test 274 failed";
+  if not test then failwithf "test 240 failed";
   (* Paths of depth 2 *)
   let next_r = { a67 = #{ a66 = 200.; b66 = 201. } } in
   (* .a67.#a66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a67 = #{ r.a67 with a66 = next_r.a67.#a66 } } in
   Idx_mut.set r ((.a67.#a66) : (t67, _) idx_mut) next_r.a67.#a66;
-  mark_test_run 275;
+  mark_test_run 241;
   let test = eq r expected in
-  if not test then failwithf "test 275 failed";
-  mark_test_run 276;
+  if not test then failwithf "test 241 failed";
+  mark_test_run 242;
   let test = sub_eq (Idx_mut.get r ((.a67.#a66) : (t67, _) idx_mut)) next_r.a67.#a66 in
-  if not test then failwithf "test 276 failed";
+  if not test then failwithf "test 242 failed";
   (* .a67.#b66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a67 = #{ r.a67 with b66 = next_r.a67.#b66 } } in
   Idx_mut.set r ((.a67.#b66) : (t67, _) idx_mut) next_r.a67.#b66;
-  mark_test_run 277;
+  mark_test_run 243;
   let test = eq r expected in
-  if not test then failwithf "test 277 failed";
-  mark_test_run 278;
+  if not test then failwithf "test 243 failed";
+  mark_test_run 244;
   let test = sub_eq (Idx_mut.get r ((.a67.#b66) : (t67, _) idx_mut)) next_r.a67.#b66 in
-  if not test then failwithf "test 278 failed";
+  if not test then failwithf "test 244 failed";
   (****************************************)
   (*   t68 = { #{ float; float }; int }   *)
   (****************************************)
@@ -2103,34 +2030,34 @@ let to_run () =
   let sub_eq = (fun #{ a66 = a661; b66 = b661 } #{ a66 = a662; b66 = b662 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a661 a662 && (fun a b -> Float.equal (globalize a) (globalize b)) b661 b662) in
   let expected = { r with a68 = next_r.a68 } in
   Idx_mut.set r ((.a68) : (t68, _) idx_mut) next_r.a68;
-  mark_test_run 279;
+  mark_test_run 245;
   let test = eq r expected in
-  if not test then failwithf "test 279 failed";
-  mark_test_run 280;
+  if not test then failwithf "test 245 failed";
+  mark_test_run 246;
   let test = sub_eq (Idx_mut.get r ((.a68) : (t68, _) idx_mut)) next_r.a68 in
-  if not test then failwithf "test 280 failed";
+  if not test then failwithf "test 246 failed";
   (* Paths of depth 2 *)
   let next_r = { a68 = #{ a66 = 200.; b66 = 201. }; b68 = 202 } in
   (* .a68.#a66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a68 = #{ r.a68 with a66 = next_r.a68.#a66 } } in
   Idx_mut.set r ((.a68.#a66) : (t68, _) idx_mut) next_r.a68.#a66;
-  mark_test_run 281;
+  mark_test_run 247;
   let test = eq r expected in
-  if not test then failwithf "test 281 failed";
-  mark_test_run 282;
+  if not test then failwithf "test 247 failed";
+  mark_test_run 248;
   let test = sub_eq (Idx_mut.get r ((.a68.#a66) : (t68, _) idx_mut)) next_r.a68.#a66 in
-  if not test then failwithf "test 282 failed";
+  if not test then failwithf "test 248 failed";
   (* .a68.#b66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a68 = #{ r.a68 with b66 = next_r.a68.#b66 } } in
   Idx_mut.set r ((.a68.#b66) : (t68, _) idx_mut) next_r.a68.#b66;
-  mark_test_run 283;
+  mark_test_run 249;
   let test = eq r expected in
-  if not test then failwithf "test 283 failed";
-  mark_test_run 284;
+  if not test then failwithf "test 249 failed";
+  mark_test_run 250;
   let test = sub_eq (Idx_mut.get r ((.a68.#b66) : (t68, _) idx_mut)) next_r.a68.#b66 in
-  if not test then failwithf "test 284 failed";
+  if not test then failwithf "test 250 failed";
   let r = { a68 = #{ a66 = 0.; b66 = 1. }; b68 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a68 = #{ a66 = 100.; b66 = 101. }; b68 = 102 } in
@@ -2138,12 +2065,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b68 = next_r.b68 } in
   Idx_mut.set r ((.b68) : (t68, _) idx_mut) next_r.b68;
-  mark_test_run 285;
+  mark_test_run 251;
   let test = eq r expected in
-  if not test then failwithf "test 285 failed";
-  mark_test_run 286;
+  if not test then failwithf "test 251 failed";
+  mark_test_run 252;
   let test = sub_eq (Idx_mut.get r ((.b68) : (t68, _) idx_mut)) next_r.b68 in
-  if not test then failwithf "test 286 failed";
+  if not test then failwithf "test 252 failed";
   (*************************************)
   (*   t70 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -2155,24 +2082,24 @@ let to_run () =
   let sub_eq = (fun #{ a69 = a691 } #{ a69 = a692 } -> (fun a b -> String.equal (globalize a) (globalize b)) a691 a692) in
   let expected = { r with a70 = next_r.a70 } in
   Idx_mut.set r ((.a70) : (t70, _) idx_mut) next_r.a70;
-  mark_test_run 287;
+  mark_test_run 253;
   let test = eq r expected in
-  if not test then failwithf "test 287 failed";
-  mark_test_run 288;
+  if not test then failwithf "test 253 failed";
+  mark_test_run 254;
   let test = sub_eq (Idx_mut.get r ((.a70) : (t70, _) idx_mut)) next_r.a70 in
-  if not test then failwithf "test 288 failed";
+  if not test then failwithf "test 254 failed";
   (* Paths of depth 2 *)
   let next_r = { a70 = #{ a69 = "200" }; b70 = (unbox_unit ()) } in
   (* .a70.#a69 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a70 = #{ r.a70 with a69 = next_r.a70.#a69 } } in
   Idx_mut.set r ((.a70.#a69) : (t70, _) idx_mut) next_r.a70.#a69;
-  mark_test_run 289;
+  mark_test_run 255;
   let test = eq r expected in
-  if not test then failwithf "test 289 failed";
-  mark_test_run 290;
+  if not test then failwithf "test 255 failed";
+  mark_test_run 256;
   let test = sub_eq (Idx_mut.get r ((.a70.#a69) : (t70, _) idx_mut)) next_r.a70.#a69 in
-  if not test then failwithf "test 290 failed";
+  if not test then failwithf "test 256 failed";
   let r = { a70 = #{ a69 = "0" }; b70 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a70 = #{ a69 = "100" }; b70 = (unbox_unit ()) } in
@@ -2180,12 +2107,12 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b70 = next_r.b70 } in
   Idx_mut.set r ((.b70) : (t70, _) idx_mut) next_r.b70;
-  mark_test_run 291;
+  mark_test_run 257;
   let test = eq r expected in
-  if not test then failwithf "test 291 failed";
-  mark_test_run 292;
+  if not test then failwithf "test 257 failed";
+  mark_test_run 258;
   let test = sub_eq (Idx_mut.get r ((.b70) : (t70, _) idx_mut)) next_r.b70 in
-  if not test then failwithf "test 292 failed";
+  if not test then failwithf "test 258 failed";
   (*************************************)
   (*   t71 = { #{ string }; string }   *)
   (*************************************)
@@ -2197,24 +2124,24 @@ let to_run () =
   let sub_eq = (fun #{ a69 = a691 } #{ a69 = a692 } -> (fun a b -> String.equal (globalize a) (globalize b)) a691 a692) in
   let expected = { r with a71 = next_r.a71 } in
   Idx_mut.set r ((.a71) : (t71, _) idx_mut) next_r.a71;
-  mark_test_run 293;
+  mark_test_run 259;
   let test = eq r expected in
-  if not test then failwithf "test 293 failed";
-  mark_test_run 294;
+  if not test then failwithf "test 259 failed";
+  mark_test_run 260;
   let test = sub_eq (Idx_mut.get r ((.a71) : (t71, _) idx_mut)) next_r.a71 in
-  if not test then failwithf "test 294 failed";
+  if not test then failwithf "test 260 failed";
   (* Paths of depth 2 *)
   let next_r = { a71 = #{ a69 = "200" }; b71 = "201" } in
   (* .a71.#a69 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a71 = #{ r.a71 with a69 = next_r.a71.#a69 } } in
   Idx_mut.set r ((.a71.#a69) : (t71, _) idx_mut) next_r.a71.#a69;
-  mark_test_run 295;
+  mark_test_run 261;
   let test = eq r expected in
-  if not test then failwithf "test 295 failed";
-  mark_test_run 296;
+  if not test then failwithf "test 261 failed";
+  mark_test_run 262;
   let test = sub_eq (Idx_mut.get r ((.a71.#a69) : (t71, _) idx_mut)) next_r.a71.#a69 in
-  if not test then failwithf "test 296 failed";
+  if not test then failwithf "test 262 failed";
   let r = { a71 = #{ a69 = "0" }; b71 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a71 = #{ a69 = "100" }; b71 = "101" } in
@@ -2222,12 +2149,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b71 = next_r.b71 } in
   Idx_mut.set r ((.b71) : (t71, _) idx_mut) next_r.b71;
-  mark_test_run 297;
+  mark_test_run 263;
   let test = eq r expected in
-  if not test then failwithf "test 297 failed";
-  mark_test_run 298;
+  if not test then failwithf "test 263 failed";
+  mark_test_run 264;
   let test = sub_eq (Idx_mut.get r ((.b71) : (t71, _) idx_mut)) next_r.b71 in
-  if not test then failwithf "test 298 failed";
+  if not test then failwithf "test 264 failed";
   (*********************************************)
   (*   t73 = { #{ string; unit_u }; string }   *)
   (*********************************************)
@@ -2239,34 +2166,34 @@ let to_run () =
   let sub_eq = (fun #{ a72 = a721; b72 = b721 } #{ a72 = a722; b72 = b722 } -> (fun a b -> String.equal (globalize a) (globalize b)) a721 a722 && (fun _ _ -> true) b721 b722) in
   let expected = { r with a73 = next_r.a73 } in
   Idx_mut.set r ((.a73) : (t73, _) idx_mut) next_r.a73;
-  mark_test_run 299;
+  mark_test_run 265;
   let test = eq r expected in
-  if not test then failwithf "test 299 failed";
-  mark_test_run 300;
+  if not test then failwithf "test 265 failed";
+  mark_test_run 266;
   let test = sub_eq (Idx_mut.get r ((.a73) : (t73, _) idx_mut)) next_r.a73 in
-  if not test then failwithf "test 300 failed";
+  if not test then failwithf "test 266 failed";
   (* Paths of depth 2 *)
   let next_r = { a73 = #{ a72 = "200"; b72 = (unbox_unit ()) }; b73 = "201" } in
   (* .a73.#a72 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a73 = #{ r.a73 with a72 = next_r.a73.#a72 } } in
   Idx_mut.set r ((.a73.#a72) : (t73, _) idx_mut) next_r.a73.#a72;
-  mark_test_run 301;
+  mark_test_run 267;
   let test = eq r expected in
-  if not test then failwithf "test 301 failed";
-  mark_test_run 302;
+  if not test then failwithf "test 267 failed";
+  mark_test_run 268;
   let test = sub_eq (Idx_mut.get r ((.a73.#a72) : (t73, _) idx_mut)) next_r.a73.#a72 in
-  if not test then failwithf "test 302 failed";
+  if not test then failwithf "test 268 failed";
   (* .a73.#b72 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a73 = #{ r.a73 with b72 = next_r.a73.#b72 } } in
   Idx_mut.set r ((.a73.#b72) : (t73, _) idx_mut) next_r.a73.#b72;
-  mark_test_run 303;
+  mark_test_run 269;
   let test = eq r expected in
-  if not test then failwithf "test 303 failed";
-  mark_test_run 304;
+  if not test then failwithf "test 269 failed";
+  mark_test_run 270;
   let test = sub_eq (Idx_mut.get r ((.a73.#b72) : (t73, _) idx_mut)) next_r.a73.#b72 in
-  if not test then failwithf "test 304 failed";
+  if not test then failwithf "test 270 failed";
   let r = { a73 = #{ a72 = "0"; b72 = (unbox_unit ()) }; b73 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a73 = #{ a72 = "100"; b72 = (unbox_unit ()) }; b73 = "101" } in
@@ -2274,12 +2201,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b73 = next_r.b73 } in
   Idx_mut.set r ((.b73) : (t73, _) idx_mut) next_r.b73;
-  mark_test_run 305;
+  mark_test_run 271;
   let test = eq r expected in
-  if not test then failwithf "test 305 failed";
-  mark_test_run 306;
+  if not test then failwithf "test 271 failed";
+  mark_test_run 272;
   let test = sub_eq (Idx_mut.get r ((.b73) : (t73, _) idx_mut)) next_r.b73 in
-  if not test then failwithf "test 306 failed";
+  if not test then failwithf "test 272 failed";
   (************************************)
   (*   t75 = { #{ int64x2# }; int }   *)
   (************************************)
@@ -2291,24 +2218,24 @@ let to_run () =
   let sub_eq = (fun #{ a74 = a741 } #{ a74 = a742 } -> int64x2_u_equal a741 a742) in
   let expected = { r with a75 = next_r.a75 } in
   Idx_mut.set r ((.a75) : (t75, _) idx_mut) next_r.a75;
-  mark_test_run 307;
+  mark_test_run 273;
   let test = eq r expected in
-  if not test then failwithf "test 307 failed";
-  mark_test_run 308;
+  if not test then failwithf "test 273 failed";
+  mark_test_run 274;
   let test = sub_eq (Idx_mut.get r ((.a75) : (t75, _) idx_mut)) next_r.a75 in
-  if not test then failwithf "test 308 failed";
+  if not test then failwithf "test 274 failed";
   (* Paths of depth 2 *)
   let next_r = { a75 = #{ a74 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)) }; b75 = 202 } in
   (* .a75.#a74 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with a75 = #{ r.a75 with a74 = next_r.a75.#a74 } } in
   Idx_mut.set r ((.a75.#a74) : (t75, _) idx_mut) next_r.a75.#a74;
-  mark_test_run 309;
+  mark_test_run 275;
   let test = eq r expected in
-  if not test then failwithf "test 309 failed";
-  mark_test_run 310;
+  if not test then failwithf "test 275 failed";
+  mark_test_run 276;
   let test = sub_eq (Idx_mut.get r ((.a75.#a74) : (t75, _) idx_mut)) next_r.a75.#a74 in
-  if not test then failwithf "test 310 failed";
+  if not test then failwithf "test 276 failed";
   let r = { a75 = #{ a74 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)) }; b75 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a75 = #{ a74 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)) }; b75 = 102 } in
@@ -2316,12 +2243,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b75 = next_r.b75 } in
   Idx_mut.set r ((.b75) : (t75, _) idx_mut) next_r.b75;
-  mark_test_run 311;
+  mark_test_run 277;
   let test = eq r expected in
-  if not test then failwithf "test 311 failed";
-  mark_test_run 312;
+  if not test then failwithf "test 277 failed";
+  mark_test_run 278;
   let test = sub_eq (Idx_mut.get r ((.b75) : (t75, _) idx_mut)) next_r.b75 in
-  if not test then failwithf "test 312 failed";
+  if not test then failwithf "test 278 failed";
   (*****************************************)
   (*   t76 = { #{ int64x2# }; int64x2# }   *)
   (*****************************************)
@@ -2333,24 +2260,24 @@ let to_run () =
   let sub_eq = (fun #{ a74 = a741 } #{ a74 = a742 } -> int64x2_u_equal a741 a742) in
   let expected = { r with a76 = next_r.a76 } in
   Idx_mut.set r ((.a76) : (t76, _) idx_mut) next_r.a76;
-  mark_test_run 313;
+  mark_test_run 279;
   let test = eq r expected in
-  if not test then failwithf "test 313 failed";
-  mark_test_run 314;
+  if not test then failwithf "test 279 failed";
+  mark_test_run 280;
   let test = sub_eq (Idx_mut.get r ((.a76) : (t76, _) idx_mut)) next_r.a76 in
-  if not test then failwithf "test 314 failed";
+  if not test then failwithf "test 280 failed";
   (* Paths of depth 2 *)
   let next_r = { a76 = #{ a74 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)) }; b76 = (interleave_low_64 (int64x2_of_int64 202L) (int64x2_of_int64 203L)) } in
   (* .a76.#a74 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with a76 = #{ r.a76 with a74 = next_r.a76.#a74 } } in
   Idx_mut.set r ((.a76.#a74) : (t76, _) idx_mut) next_r.a76.#a74;
-  mark_test_run 315;
+  mark_test_run 281;
   let test = eq r expected in
-  if not test then failwithf "test 315 failed";
-  mark_test_run 316;
+  if not test then failwithf "test 281 failed";
+  mark_test_run 282;
   let test = sub_eq (Idx_mut.get r ((.a76.#a74) : (t76, _) idx_mut)) next_r.a76.#a74 in
-  if not test then failwithf "test 316 failed";
+  if not test then failwithf "test 282 failed";
   let r = { a76 = #{ a74 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)) }; b76 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a76 = #{ a74 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)) }; b76 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -2358,17 +2285,17 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b76 = next_r.b76 } in
   Idx_mut.set r ((.b76) : (t76, _) idx_mut) next_r.b76;
-  mark_test_run 317;
+  mark_test_run 283;
   let test = eq r expected in
-  if not test then failwithf "test 317 failed";
-  mark_test_run 318;
+  if not test then failwithf "test 283 failed";
+  mark_test_run 284;
   let test = sub_eq (Idx_mut.get r ((.b76) : (t76, _) idx_mut)) next_r.b76 in
-  if not test then failwithf "test 318 failed";
+  if not test then failwithf "test 284 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 318 do
+for i = 1 to 284 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_access_native_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_access_native_test.ml
@@ -1231,20 +1231,28 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a39 = #100.; b39 = #101. } in
   (* .a39 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with a39 = next_r.a39 } in
+  Idx_mut.set r ((.a39) : (t39, _) idx_mut) next_r.a39;
+  mark_test_run 141;
+  let test = eq r expected in
+  if not test then failwithf "test 141 failed";
+  mark_test_run 142;
+  let test = sub_eq (Idx_mut.get r ((.a39) : (t39, _) idx_mut)) next_r.a39 in
+  if not test then failwithf "test 142 failed";
   let r = { a39 = #0.; b39 = #1. } in
   (* Paths of depth 1 *)
   let next_r = { a39 = #100.; b39 = #101. } in
   (* .b39 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with b39 = next_r.b39 } in
+  Idx_mut.set r ((.b39) : (t39, _) idx_mut) next_r.b39;
+  mark_test_run 143;
+  let test = eq r expected in
+  if not test then failwithf "test 143 failed";
+  mark_test_run 144;
+  let test = sub_eq (Idx_mut.get r ((.b39) : (t39, _) idx_mut)) next_r.b39 in
+  if not test then failwithf "test 144 failed";
   (***************************************)
   (*   t40 = { float#; float#; float }   *)
   (***************************************)
@@ -1284,28 +1292,40 @@ let to_run () =
   (* Paths of depth 1 *)
   let next_r = { a42 = #100.; b42 = #{ a41 = #101. } } in
   (* .a42 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with a42 = next_r.a42 } in
+  Idx_mut.set r ((.a42) : (t42, _) idx_mut) next_r.a42;
+  mark_test_run 145;
+  let test = eq r expected in
+  if not test then failwithf "test 145 failed";
+  mark_test_run 146;
+  let test = sub_eq (Idx_mut.get r ((.a42) : (t42, _) idx_mut)) next_r.a42 in
+  if not test then failwithf "test 146 failed";
   let r = { a42 = #0.; b42 = #{ a41 = #1. } } in
   (* Paths of depth 1 *)
   let next_r = { a42 = #100.; b42 = #{ a41 = #101. } } in
   (* .b42 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun #{ a41 = a411 } #{ a41 = a412 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a411 a412) in
+  let expected = { r with b42 = next_r.b42 } in
+  Idx_mut.set r ((.b42) : (t42, _) idx_mut) next_r.b42;
+  mark_test_run 147;
+  let test = eq r expected in
+  if not test then failwithf "test 147 failed";
+  mark_test_run 148;
+  let test = sub_eq (Idx_mut.get r ((.b42) : (t42, _) idx_mut)) next_r.b42 in
+  if not test then failwithf "test 148 failed";
   (* Paths of depth 2 *)
   let next_r = { a42 = #200.; b42 = #{ a41 = #201. } } in
   (* .b42.#a41 *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  let _ = eq in
-  let _ = r in
-  let _ = next_r in
+  let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
+  let expected = { r with b42 = #{ r.b42 with a41 = next_r.b42.#a41 } } in
+  Idx_mut.set r ((.b42.#a41) : (t42, _) idx_mut) next_r.b42.#a41;
+  mark_test_run 149;
+  let test = eq r expected in
+  if not test then failwithf "test 149 failed";
+  mark_test_run 150;
+  let test = sub_eq (Idx_mut.get r ((.b42.#a41) : (t42, _) idx_mut)) next_r.b42.#a41 in
+  if not test then failwithf "test 150 failed";
   (*********************************************)
   (*   t43 = { float#; #{ float#; float# } }   *)
   (*********************************************)
@@ -1317,12 +1337,12 @@ let to_run () =
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with a43 = next_r.a43 } in
   Idx_mut.set r ((.a43) : (t43, _) idx_mut) next_r.a43;
-  mark_test_run 141;
+  mark_test_run 151;
   let test = eq r expected in
-  if not test then failwithf "test 141 failed";
-  mark_test_run 142;
+  if not test then failwithf "test 151 failed";
+  mark_test_run 152;
   let test = sub_eq (Idx_mut.get r ((.a43) : (t43, _) idx_mut)) next_r.a43 in
-  if not test then failwithf "test 142 failed";
+  if not test then failwithf "test 152 failed";
   let r = { a43 = #0.; b43 = #{ a36 = #1.; b36 = #2. } } in
   (* Paths of depth 1 *)
   let next_r = { a43 = #100.; b43 = #{ a36 = #101.; b36 = #102. } } in
@@ -1330,34 +1350,34 @@ let to_run () =
   let sub_eq = (fun #{ a36 = a361; b36 = b361 } #{ a36 = a362; b36 = b362 } -> (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) a361 a362 && (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) b361 b362) in
   let expected = { r with b43 = next_r.b43 } in
   Idx_mut.set r ((.b43) : (t43, _) idx_mut) next_r.b43;
-  mark_test_run 143;
+  mark_test_run 153;
   let test = eq r expected in
-  if not test then failwithf "test 143 failed";
-  mark_test_run 144;
+  if not test then failwithf "test 153 failed";
+  mark_test_run 154;
   let test = sub_eq (Idx_mut.get r ((.b43) : (t43, _) idx_mut)) next_r.b43 in
-  if not test then failwithf "test 144 failed";
+  if not test then failwithf "test 154 failed";
   (* Paths of depth 2 *)
   let next_r = { a43 = #200.; b43 = #{ a36 = #201.; b36 = #202. } } in
   (* .b43.#a36 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b43 = #{ r.b43 with a36 = next_r.b43.#a36 } } in
   Idx_mut.set r ((.b43.#a36) : (t43, _) idx_mut) next_r.b43.#a36;
-  mark_test_run 145;
+  mark_test_run 155;
   let test = eq r expected in
-  if not test then failwithf "test 145 failed";
-  mark_test_run 146;
+  if not test then failwithf "test 155 failed";
+  mark_test_run 156;
   let test = sub_eq (Idx_mut.get r ((.b43.#a36) : (t43, _) idx_mut)) next_r.b43.#a36 in
-  if not test then failwithf "test 146 failed";
+  if not test then failwithf "test 156 failed";
   (* .b43.#b36 *)
   let sub_eq = (fun a b -> Float_u.(equal (add #0. a) (add #0. b))) in
   let expected = { r with b43 = #{ r.b43 with b36 = next_r.b43.#b36 } } in
   Idx_mut.set r ((.b43.#b36) : (t43, _) idx_mut) next_r.b43.#b36;
-  mark_test_run 147;
+  mark_test_run 157;
   let test = eq r expected in
-  if not test then failwithf "test 147 failed";
-  mark_test_run 148;
+  if not test then failwithf "test 157 failed";
+  mark_test_run 158;
   let test = sub_eq (Idx_mut.get r ((.b43.#b36) : (t43, _) idx_mut)) next_r.b43.#b36 in
-  if not test then failwithf "test 148 failed";
+  if not test then failwithf "test 158 failed";
   (************************)
   (*   t44 = { string }   *)
   (************************)
@@ -1369,12 +1389,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a44 = next_r.a44 } in
   Idx_mut.set r ((.a44) : (t44, _) idx_mut) next_r.a44;
-  mark_test_run 149;
+  mark_test_run 159;
   let test = eq r expected in
-  if not test then failwithf "test 149 failed";
-  mark_test_run 150;
+  if not test then failwithf "test 159 failed";
+  mark_test_run 160;
   let test = sub_eq (Idx_mut.get r ((.a44) : (t44, _) idx_mut)) next_r.a44 in
-  if not test then failwithf "test 150 failed";
+  if not test then failwithf "test 160 failed";
   (************************************)
   (*   t45 = { int64x2#; int; int }   *)
   (************************************)
@@ -1386,12 +1406,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a45 = next_r.a45 } in
   Idx_mut.set r ((.a45) : (t45, _) idx_mut) next_r.a45;
-  mark_test_run 151;
+  mark_test_run 161;
   let test = eq r expected in
-  if not test then failwithf "test 151 failed";
-  mark_test_run 152;
+  if not test then failwithf "test 161 failed";
+  mark_test_run 162;
   let test = sub_eq (Idx_mut.get r ((.a45) : (t45, _) idx_mut)) next_r.a45 in
-  if not test then failwithf "test 152 failed";
+  if not test then failwithf "test 162 failed";
   let r = { a45 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b45 = 2; c45 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b45 = 102; c45 = 103 } in
@@ -1399,12 +1419,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b45 = next_r.b45 } in
   Idx_mut.set r ((.b45) : (t45, _) idx_mut) next_r.b45;
-  mark_test_run 153;
+  mark_test_run 163;
   let test = eq r expected in
-  if not test then failwithf "test 153 failed";
-  mark_test_run 154;
+  if not test then failwithf "test 163 failed";
+  mark_test_run 164;
   let test = sub_eq (Idx_mut.get r ((.b45) : (t45, _) idx_mut)) next_r.b45 in
-  if not test then failwithf "test 154 failed";
+  if not test then failwithf "test 164 failed";
   let r = { a45 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b45 = 2; c45 = 3 } in
   (* Paths of depth 1 *)
   let next_r = { a45 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b45 = 102; c45 = 103 } in
@@ -1412,12 +1432,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with c45 = next_r.c45 } in
   Idx_mut.set r ((.c45) : (t45, _) idx_mut) next_r.c45;
-  mark_test_run 155;
+  mark_test_run 165;
   let test = eq r expected in
-  if not test then failwithf "test 155 failed";
-  mark_test_run 156;
+  if not test then failwithf "test 165 failed";
+  mark_test_run 166;
   let test = sub_eq (Idx_mut.get r ((.c45) : (t45, _) idx_mut)) next_r.c45 in
-  if not test then failwithf "test 156 failed";
+  if not test then failwithf "test 166 failed";
   (************************************)
   (*   t46 = { int64x2#; int64x2# }   *)
   (************************************)
@@ -1429,12 +1449,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a46 = next_r.a46 } in
   Idx_mut.set r ((.a46) : (t46, _) idx_mut) next_r.a46;
-  mark_test_run 157;
+  mark_test_run 167;
   let test = eq r expected in
-  if not test then failwithf "test 157 failed";
-  mark_test_run 158;
+  if not test then failwithf "test 167 failed";
+  mark_test_run 168;
   let test = sub_eq (Idx_mut.get r ((.a46) : (t46, _) idx_mut)) next_r.a46 in
-  if not test then failwithf "test 158 failed";
+  if not test then failwithf "test 168 failed";
   let r = { a46 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b46 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a46 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b46 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -1442,12 +1462,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b46 = next_r.b46 } in
   Idx_mut.set r ((.b46) : (t46, _) idx_mut) next_r.b46;
-  mark_test_run 159;
+  mark_test_run 169;
   let test = eq r expected in
-  if not test then failwithf "test 159 failed";
-  mark_test_run 160;
+  if not test then failwithf "test 169 failed";
+  mark_test_run 170;
   let test = sub_eq (Idx_mut.get r ((.b46) : (t46, _) idx_mut)) next_r.b46 in
-  if not test then failwithf "test 160 failed";
+  if not test then failwithf "test 170 failed";
   (**********************************************)
   (*   t47 = { int64x2#; int64x2#; int64x2# }   *)
   (**********************************************)
@@ -1459,12 +1479,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a47 = next_r.a47 } in
   Idx_mut.set r ((.a47) : (t47, _) idx_mut) next_r.a47;
-  mark_test_run 161;
+  mark_test_run 171;
   let test = eq r expected in
-  if not test then failwithf "test 161 failed";
-  mark_test_run 162;
+  if not test then failwithf "test 171 failed";
+  mark_test_run 172;
   let test = sub_eq (Idx_mut.get r ((.a47) : (t47, _) idx_mut)) next_r.a47 in
-  if not test then failwithf "test 162 failed";
+  if not test then failwithf "test 172 failed";
   let r = { a47 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b47 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)); c47 = (interleave_low_64 (int64x2_of_int64 4L) (int64x2_of_int64 5L)) } in
   (* Paths of depth 1 *)
   let next_r = { a47 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b47 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)); c47 = (interleave_low_64 (int64x2_of_int64 104L) (int64x2_of_int64 105L)) } in
@@ -1472,12 +1492,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b47 = next_r.b47 } in
   Idx_mut.set r ((.b47) : (t47, _) idx_mut) next_r.b47;
-  mark_test_run 163;
+  mark_test_run 173;
   let test = eq r expected in
-  if not test then failwithf "test 163 failed";
-  mark_test_run 164;
+  if not test then failwithf "test 173 failed";
+  mark_test_run 174;
   let test = sub_eq (Idx_mut.get r ((.b47) : (t47, _) idx_mut)) next_r.b47 in
-  if not test then failwithf "test 164 failed";
+  if not test then failwithf "test 174 failed";
   let r = { a47 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b47 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)); c47 = (interleave_low_64 (int64x2_of_int64 4L) (int64x2_of_int64 5L)) } in
   (* Paths of depth 1 *)
   let next_r = { a47 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b47 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)); c47 = (interleave_low_64 (int64x2_of_int64 104L) (int64x2_of_int64 105L)) } in
@@ -1485,12 +1505,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with c47 = next_r.c47 } in
   Idx_mut.set r ((.c47) : (t47, _) idx_mut) next_r.c47;
-  mark_test_run 165;
+  mark_test_run 175;
   let test = eq r expected in
-  if not test then failwithf "test 165 failed";
-  mark_test_run 166;
+  if not test then failwithf "test 175 failed";
+  mark_test_run 176;
   let test = sub_eq (Idx_mut.get r ((.c47) : (t47, _) idx_mut)) next_r.c47 in
-  if not test then failwithf "test 166 failed";
+  if not test then failwithf "test 176 failed";
   (**********************************************)
   (*   t48 = { int64x2#; #{ int; int64x2# } }   *)
   (**********************************************)
@@ -1502,12 +1522,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a48 = next_r.a48 } in
   Idx_mut.set r ((.a48) : (t48, _) idx_mut) next_r.a48;
-  mark_test_run 167;
+  mark_test_run 177;
   let test = eq r expected in
-  if not test then failwithf "test 167 failed";
-  mark_test_run 168;
+  if not test then failwithf "test 177 failed";
+  mark_test_run 178;
   let test = sub_eq (Idx_mut.get r ((.a48) : (t48, _) idx_mut)) next_r.a48 in
-  if not test then failwithf "test 168 failed";
+  if not test then failwithf "test 178 failed";
   let r = { a48 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b48 = #{ a7 = 2; b7 = (interleave_low_64 (int64x2_of_int64 3L) (int64x2_of_int64 4L)) } } in
   (* Paths of depth 1 *)
   let next_r = { a48 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b48 = #{ a7 = 102; b7 = (interleave_low_64 (int64x2_of_int64 103L) (int64x2_of_int64 104L)) } } in
@@ -1515,34 +1535,34 @@ let to_run () =
   let sub_eq = (fun #{ a7 = a71; b7 = b71 } #{ a7 = a72; b7 = b72 } -> (fun a b -> Int.equal a b) a71 a72 && int64x2_u_equal b71 b72) in
   let expected = { r with b48 = next_r.b48 } in
   Idx_mut.set r ((.b48) : (t48, _) idx_mut) next_r.b48;
-  mark_test_run 169;
+  mark_test_run 179;
   let test = eq r expected in
-  if not test then failwithf "test 169 failed";
-  mark_test_run 170;
+  if not test then failwithf "test 179 failed";
+  mark_test_run 180;
   let test = sub_eq (Idx_mut.get r ((.b48) : (t48, _) idx_mut)) next_r.b48 in
-  if not test then failwithf "test 170 failed";
+  if not test then failwithf "test 180 failed";
   (* Paths of depth 2 *)
   let next_r = { a48 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)); b48 = #{ a7 = 202; b7 = (interleave_low_64 (int64x2_of_int64 203L) (int64x2_of_int64 204L)) } } in
   (* .b48.#a7 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b48 = #{ r.b48 with a7 = next_r.b48.#a7 } } in
   Idx_mut.set r ((.b48.#a7) : (t48, _) idx_mut) next_r.b48.#a7;
-  mark_test_run 171;
+  mark_test_run 181;
   let test = eq r expected in
-  if not test then failwithf "test 171 failed";
-  mark_test_run 172;
+  if not test then failwithf "test 181 failed";
+  mark_test_run 182;
   let test = sub_eq (Idx_mut.get r ((.b48.#a7) : (t48, _) idx_mut)) next_r.b48.#a7 in
-  if not test then failwithf "test 172 failed";
+  if not test then failwithf "test 182 failed";
   (* .b48.#b7 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with b48 = #{ r.b48 with b7 = next_r.b48.#b7 } } in
   Idx_mut.set r ((.b48.#b7) : (t48, _) idx_mut) next_r.b48.#b7;
-  mark_test_run 173;
+  mark_test_run 183;
   let test = eq r expected in
-  if not test then failwithf "test 173 failed";
-  mark_test_run 174;
+  if not test then failwithf "test 183 failed";
+  mark_test_run 184;
   let test = sub_eq (Idx_mut.get r ((.b48.#b7) : (t48, _) idx_mut)) next_r.b48.#b7 in
-  if not test then failwithf "test 174 failed";
+  if not test then failwithf "test 184 failed";
   (***************************************************)
   (*   t50 = { int64x2#; #{ int64x2#; int64x2# } }   *)
   (***************************************************)
@@ -1554,12 +1574,12 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with a50 = next_r.a50 } in
   Idx_mut.set r ((.a50) : (t50, _) idx_mut) next_r.a50;
-  mark_test_run 175;
+  mark_test_run 185;
   let test = eq r expected in
-  if not test then failwithf "test 175 failed";
-  mark_test_run 176;
+  if not test then failwithf "test 185 failed";
+  mark_test_run 186;
   let test = sub_eq (Idx_mut.get r ((.a50) : (t50, _) idx_mut)) next_r.a50 in
-  if not test then failwithf "test 176 failed";
+  if not test then failwithf "test 186 failed";
   let r = { a50 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)); b50 = #{ a49 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)); b49 = (interleave_low_64 (int64x2_of_int64 4L) (int64x2_of_int64 5L)) } } in
   (* Paths of depth 1 *)
   let next_r = { a50 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)); b50 = #{ a49 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)); b49 = (interleave_low_64 (int64x2_of_int64 104L) (int64x2_of_int64 105L)) } } in
@@ -1567,34 +1587,34 @@ let to_run () =
   let sub_eq = (fun #{ a49 = a491; b49 = b491 } #{ a49 = a492; b49 = b492 } -> int64x2_u_equal a491 a492 && int64x2_u_equal b491 b492) in
   let expected = { r with b50 = next_r.b50 } in
   Idx_mut.set r ((.b50) : (t50, _) idx_mut) next_r.b50;
-  mark_test_run 177;
+  mark_test_run 187;
   let test = eq r expected in
-  if not test then failwithf "test 177 failed";
-  mark_test_run 178;
+  if not test then failwithf "test 187 failed";
+  mark_test_run 188;
   let test = sub_eq (Idx_mut.get r ((.b50) : (t50, _) idx_mut)) next_r.b50 in
-  if not test then failwithf "test 178 failed";
+  if not test then failwithf "test 188 failed";
   (* Paths of depth 2 *)
   let next_r = { a50 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)); b50 = #{ a49 = (interleave_low_64 (int64x2_of_int64 202L) (int64x2_of_int64 203L)); b49 = (interleave_low_64 (int64x2_of_int64 204L) (int64x2_of_int64 205L)) } } in
   (* .b50.#a49 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with b50 = #{ r.b50 with a49 = next_r.b50.#a49 } } in
   Idx_mut.set r ((.b50.#a49) : (t50, _) idx_mut) next_r.b50.#a49;
-  mark_test_run 179;
+  mark_test_run 189;
   let test = eq r expected in
-  if not test then failwithf "test 179 failed";
-  mark_test_run 180;
+  if not test then failwithf "test 189 failed";
+  mark_test_run 190;
   let test = sub_eq (Idx_mut.get r ((.b50.#a49) : (t50, _) idx_mut)) next_r.b50.#a49 in
-  if not test then failwithf "test 180 failed";
+  if not test then failwithf "test 190 failed";
   (* .b50.#b49 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with b50 = #{ r.b50 with b49 = next_r.b50.#b49 } } in
   Idx_mut.set r ((.b50.#b49) : (t50, _) idx_mut) next_r.b50.#b49;
-  mark_test_run 181;
+  mark_test_run 191;
   let test = eq r expected in
-  if not test then failwithf "test 181 failed";
-  mark_test_run 182;
+  if not test then failwithf "test 191 failed";
+  mark_test_run 192;
   let test = sub_eq (Idx_mut.get r ((.b50.#b49) : (t50, _) idx_mut)) next_r.b50.#b49 in
-  if not test then failwithf "test 182 failed";
+  if not test then failwithf "test 192 failed";
   (****************************)
   (*   t52 = { (| unit_u) }   *)
   (****************************)
@@ -1606,12 +1626,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C51_0(a0), C51_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a52 = next_r.a52 } in
   Idx_mut.set r ((.a52) : (t52, _) idx_mut) next_r.a52;
-  mark_test_run 183;
+  mark_test_run 193;
   let test = eq r expected in
-  if not test then failwithf "test 183 failed";
-  mark_test_run 184;
+  if not test then failwithf "test 193 failed";
+  mark_test_run 194;
   let test = sub_eq (Idx_mut.get r ((.a52) : (t52, _) idx_mut)) next_r.a52 in
-  if not test then failwithf "test 184 failed";
+  if not test then failwithf "test 194 failed";
   (***********************************)
   (*   t53 = { (| unit_u); int64 }   *)
   (***********************************)
@@ -1623,12 +1643,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C51_0(a0), C51_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a53 = next_r.a53 } in
   Idx_mut.set r ((.a53) : (t53, _) idx_mut) next_r.a53;
-  mark_test_run 185;
+  mark_test_run 195;
   let test = eq r expected in
-  if not test then failwithf "test 185 failed";
-  mark_test_run 186;
+  if not test then failwithf "test 195 failed";
+  mark_test_run 196;
   let test = sub_eq (Idx_mut.get r ((.a53) : (t53, _) idx_mut)) next_r.a53 in
-  if not test then failwithf "test 186 failed";
+  if not test then failwithf "test 196 failed";
   let r = { a53 = (C51_0 (unbox_unit ())); b53 = 0L } in
   (* Paths of depth 1 *)
   let next_r = { a53 = (C51_0 (unbox_unit ())); b53 = 100L } in
@@ -1636,12 +1656,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64.equal (globalize a) (globalize b)) in
   let expected = { r with b53 = next_r.b53 } in
   Idx_mut.set r ((.b53) : (t53, _) idx_mut) next_r.b53;
-  mark_test_run 187;
+  mark_test_run 197;
   let test = eq r expected in
-  if not test then failwithf "test 187 failed";
-  mark_test_run 188;
+  if not test then failwithf "test 197 failed";
+  mark_test_run 198;
   let test = sub_eq (Idx_mut.get r ((.b53) : (t53, _) idx_mut)) next_r.b53 in
-  if not test then failwithf "test 188 failed";
+  if not test then failwithf "test 198 failed";
   (************************************)
   (*   t54 = { (| unit_u); int64# }   *)
   (************************************)
@@ -1653,12 +1673,12 @@ let to_run () =
   let sub_eq = (fun a b -> match a, b with C51_0(a0), C51_0(b0) -> (fun _ _ -> true) a0 b0) in
   let expected = { r with a54 = next_r.a54 } in
   Idx_mut.set r ((.a54) : (t54, _) idx_mut) next_r.a54;
-  mark_test_run 189;
+  mark_test_run 199;
   let test = eq r expected in
-  if not test then failwithf "test 189 failed";
-  mark_test_run 190;
+  if not test then failwithf "test 199 failed";
+  mark_test_run 200;
   let test = sub_eq (Idx_mut.get r ((.a54) : (t54, _) idx_mut)) next_r.a54 in
-  if not test then failwithf "test 190 failed";
+  if not test then failwithf "test 200 failed";
   let r = { a54 = (C51_0 (unbox_unit ())); b54 = #0L } in
   (* Paths of depth 1 *)
   let next_r = { a54 = (C51_0 (unbox_unit ())); b54 = #100L } in
@@ -1666,12 +1686,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int64_u.(equal (add #0L a) (add #0L b))) in
   let expected = { r with b54 = next_r.b54 } in
   Idx_mut.set r ((.b54) : (t54, _) idx_mut) next_r.b54;
-  mark_test_run 191;
+  mark_test_run 201;
   let test = eq r expected in
-  if not test then failwithf "test 191 failed";
-  mark_test_run 192;
+  if not test then failwithf "test 201 failed";
+  mark_test_run 202;
   let test = sub_eq (Idx_mut.get r ((.b54) : (t54, _) idx_mut)) next_r.b54 in
-  if not test then failwithf "test 192 failed";
+  if not test then failwithf "test 202 failed";
   (**************************)
   (*   t55 = { #{ int } }   *)
   (**************************)
@@ -1683,24 +1703,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a55 = next_r.a55 } in
   Idx_mut.set r ((.a55) : (t55, _) idx_mut) next_r.a55;
-  mark_test_run 193;
+  mark_test_run 203;
   let test = eq r expected in
-  if not test then failwithf "test 193 failed";
-  mark_test_run 194;
+  if not test then failwithf "test 203 failed";
+  mark_test_run 204;
   let test = sub_eq (Idx_mut.get r ((.a55) : (t55, _) idx_mut)) next_r.a55 in
-  if not test then failwithf "test 194 failed";
+  if not test then failwithf "test 204 failed";
   (* Paths of depth 2 *)
   let next_r = { a55 = #{ a3 = 200 } } in
   (* .a55.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a55 = #{ r.a55 with a3 = next_r.a55.#a3 } } in
   Idx_mut.set r ((.a55.#a3) : (t55, _) idx_mut) next_r.a55.#a3;
-  mark_test_run 195;
+  mark_test_run 205;
   let test = eq r expected in
-  if not test then failwithf "test 195 failed";
-  mark_test_run 196;
+  if not test then failwithf "test 205 failed";
+  mark_test_run 206;
   let test = sub_eq (Idx_mut.get r ((.a55.#a3) : (t55, _) idx_mut)) next_r.a55.#a3 in
-  if not test then failwithf "test 196 failed";
+  if not test then failwithf "test 206 failed";
   (*******************************)
   (*   t56 = { #{ int }; int }   *)
   (*******************************)
@@ -1712,24 +1732,24 @@ let to_run () =
   let sub_eq = (fun #{ a3 = a31 } #{ a3 = a32 } -> (fun a b -> Int.equal a b) a31 a32) in
   let expected = { r with a56 = next_r.a56 } in
   Idx_mut.set r ((.a56) : (t56, _) idx_mut) next_r.a56;
-  mark_test_run 197;
+  mark_test_run 207;
   let test = eq r expected in
-  if not test then failwithf "test 197 failed";
-  mark_test_run 198;
+  if not test then failwithf "test 207 failed";
+  mark_test_run 208;
   let test = sub_eq (Idx_mut.get r ((.a56) : (t56, _) idx_mut)) next_r.a56 in
-  if not test then failwithf "test 198 failed";
+  if not test then failwithf "test 208 failed";
   (* Paths of depth 2 *)
   let next_r = { a56 = #{ a3 = 200 }; b56 = 201 } in
   (* .a56.#a3 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a56 = #{ r.a56 with a3 = next_r.a56.#a3 } } in
   Idx_mut.set r ((.a56.#a3) : (t56, _) idx_mut) next_r.a56.#a3;
-  mark_test_run 199;
+  mark_test_run 209;
   let test = eq r expected in
-  if not test then failwithf "test 199 failed";
-  mark_test_run 200;
+  if not test then failwithf "test 209 failed";
+  mark_test_run 210;
   let test = sub_eq (Idx_mut.get r ((.a56.#a3) : (t56, _) idx_mut)) next_r.a56.#a3 in
-  if not test then failwithf "test 200 failed";
+  if not test then failwithf "test 210 failed";
   let r = { a56 = #{ a3 = 0 }; b56 = 1 } in
   (* Paths of depth 1 *)
   let next_r = { a56 = #{ a3 = 100 }; b56 = 101 } in
@@ -1737,12 +1757,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b56 = next_r.b56 } in
   Idx_mut.set r ((.b56) : (t56, _) idx_mut) next_r.b56;
-  mark_test_run 201;
+  mark_test_run 211;
   let test = eq r expected in
-  if not test then failwithf "test 201 failed";
-  mark_test_run 202;
+  if not test then failwithf "test 211 failed";
+  mark_test_run 212;
   let test = sub_eq (Idx_mut.get r ((.b56) : (t56, _) idx_mut)) next_r.b56 in
-  if not test then failwithf "test 202 failed";
+  if not test then failwithf "test 212 failed";
   (***************************************)
   (*   t57 = { #{ int; int }; int32# }   *)
   (***************************************)
@@ -1754,34 +1774,34 @@ let to_run () =
   let sub_eq = (fun #{ a5 = a51; b5 = b51 } #{ a5 = a52; b5 = b52 } -> (fun a b -> Int.equal a b) a51 a52 && (fun a b -> Int.equal a b) b51 b52) in
   let expected = { r with a57 = next_r.a57 } in
   Idx_mut.set r ((.a57) : (t57, _) idx_mut) next_r.a57;
-  mark_test_run 203;
+  mark_test_run 213;
   let test = eq r expected in
-  if not test then failwithf "test 203 failed";
-  mark_test_run 204;
+  if not test then failwithf "test 213 failed";
+  mark_test_run 214;
   let test = sub_eq (Idx_mut.get r ((.a57) : (t57, _) idx_mut)) next_r.a57 in
-  if not test then failwithf "test 204 failed";
+  if not test then failwithf "test 214 failed";
   (* Paths of depth 2 *)
   let next_r = { a57 = #{ a5 = 200; b5 = 201 }; b57 = #202l } in
   (* .a57.#a5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a57 = #{ r.a57 with a5 = next_r.a57.#a5 } } in
   Idx_mut.set r ((.a57.#a5) : (t57, _) idx_mut) next_r.a57.#a5;
-  mark_test_run 205;
+  mark_test_run 215;
   let test = eq r expected in
-  if not test then failwithf "test 205 failed";
-  mark_test_run 206;
+  if not test then failwithf "test 215 failed";
+  mark_test_run 216;
   let test = sub_eq (Idx_mut.get r ((.a57.#a5) : (t57, _) idx_mut)) next_r.a57.#a5 in
-  if not test then failwithf "test 206 failed";
+  if not test then failwithf "test 216 failed";
   (* .a57.#b5 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a57 = #{ r.a57 with b5 = next_r.a57.#b5 } } in
   Idx_mut.set r ((.a57.#b5) : (t57, _) idx_mut) next_r.a57.#b5;
-  mark_test_run 207;
+  mark_test_run 217;
   let test = eq r expected in
-  if not test then failwithf "test 207 failed";
-  mark_test_run 208;
+  if not test then failwithf "test 217 failed";
+  mark_test_run 218;
   let test = sub_eq (Idx_mut.get r ((.a57.#b5) : (t57, _) idx_mut)) next_r.a57.#b5 in
-  if not test then failwithf "test 208 failed";
+  if not test then failwithf "test 218 failed";
   let r = { a57 = #{ a5 = 0; b5 = 1 }; b57 = #2l } in
   (* Paths of depth 1 *)
   let next_r = { a57 = #{ a5 = 100; b5 = 101 }; b57 = #102l } in
@@ -1789,12 +1809,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with b57 = next_r.b57 } in
   Idx_mut.set r ((.b57) : (t57, _) idx_mut) next_r.b57;
-  mark_test_run 209;
+  mark_test_run 219;
   let test = eq r expected in
-  if not test then failwithf "test 209 failed";
-  mark_test_run 210;
+  if not test then failwithf "test 219 failed";
+  mark_test_run 220;
   let test = sub_eq (Idx_mut.get r ((.b57) : (t57, _) idx_mut)) next_r.b57 in
-  if not test then failwithf "test 210 failed";
+  if not test then failwithf "test 220 failed";
   (***************************************)
   (*   t59 = { #{ int; int32# }; int }   *)
   (***************************************)
@@ -1806,34 +1826,34 @@ let to_run () =
   let sub_eq = (fun #{ a58 = a581; b58 = b581 } #{ a58 = a582; b58 = b582 } -> (fun a b -> Int.equal a b) a581 a582 && (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) b581 b582) in
   let expected = { r with a59 = next_r.a59 } in
   Idx_mut.set r ((.a59) : (t59, _) idx_mut) next_r.a59;
-  mark_test_run 211;
+  mark_test_run 221;
   let test = eq r expected in
-  if not test then failwithf "test 211 failed";
-  mark_test_run 212;
+  if not test then failwithf "test 221 failed";
+  mark_test_run 222;
   let test = sub_eq (Idx_mut.get r ((.a59) : (t59, _) idx_mut)) next_r.a59 in
-  if not test then failwithf "test 212 failed";
+  if not test then failwithf "test 222 failed";
   (* Paths of depth 2 *)
   let next_r = { a59 = #{ a58 = 200; b58 = #201l }; b59 = 202 } in
   (* .a59.#a58 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a59 = #{ r.a59 with a58 = next_r.a59.#a58 } } in
   Idx_mut.set r ((.a59.#a58) : (t59, _) idx_mut) next_r.a59.#a58;
-  mark_test_run 213;
+  mark_test_run 223;
   let test = eq r expected in
-  if not test then failwithf "test 213 failed";
-  mark_test_run 214;
+  if not test then failwithf "test 223 failed";
+  mark_test_run 224;
   let test = sub_eq (Idx_mut.get r ((.a59.#a58) : (t59, _) idx_mut)) next_r.a59.#a58 in
-  if not test then failwithf "test 214 failed";
+  if not test then failwithf "test 224 failed";
   (* .a59.#b58 *)
   let sub_eq = (fun a b -> Int32_u.(equal (add #0l a) (add #0l b))) in
   let expected = { r with a59 = #{ r.a59 with b58 = next_r.a59.#b58 } } in
   Idx_mut.set r ((.a59.#b58) : (t59, _) idx_mut) next_r.a59.#b58;
-  mark_test_run 215;
+  mark_test_run 225;
   let test = eq r expected in
-  if not test then failwithf "test 215 failed";
-  mark_test_run 216;
+  if not test then failwithf "test 225 failed";
+  mark_test_run 226;
   let test = sub_eq (Idx_mut.get r ((.a59.#b58) : (t59, _) idx_mut)) next_r.a59.#b58 in
-  if not test then failwithf "test 216 failed";
+  if not test then failwithf "test 226 failed";
   let r = { a59 = #{ a58 = 0; b58 = #1l }; b59 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a59 = #{ a58 = 100; b58 = #101l }; b59 = 102 } in
@@ -1841,12 +1861,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b59 = next_r.b59 } in
   Idx_mut.set r ((.b59) : (t59, _) idx_mut) next_r.b59;
-  mark_test_run 217;
+  mark_test_run 227;
   let test = eq r expected in
-  if not test then failwithf "test 217 failed";
-  mark_test_run 218;
+  if not test then failwithf "test 227 failed";
+  mark_test_run 228;
   let test = sub_eq (Idx_mut.get r ((.b59) : (t59, _) idx_mut)) next_r.b59 in
-  if not test then failwithf "test 218 failed";
+  if not test then failwithf "test 228 failed";
   (**************************************)
   (*   t61 = { #{ int; float }; int }   *)
   (**************************************)
@@ -1858,34 +1878,34 @@ let to_run () =
   let sub_eq = (fun #{ a60 = a601; b60 = b601 } #{ a60 = a602; b60 = b602 } -> (fun a b -> Int.equal a b) a601 a602 && (fun a b -> Float.equal (globalize a) (globalize b)) b601 b602) in
   let expected = { r with a61 = next_r.a61 } in
   Idx_mut.set r ((.a61) : (t61, _) idx_mut) next_r.a61;
-  mark_test_run 219;
+  mark_test_run 229;
   let test = eq r expected in
-  if not test then failwithf "test 219 failed";
-  mark_test_run 220;
+  if not test then failwithf "test 229 failed";
+  mark_test_run 230;
   let test = sub_eq (Idx_mut.get r ((.a61) : (t61, _) idx_mut)) next_r.a61 in
-  if not test then failwithf "test 220 failed";
+  if not test then failwithf "test 230 failed";
   (* Paths of depth 2 *)
   let next_r = { a61 = #{ a60 = 200; b60 = 201. }; b61 = 202 } in
   (* .a61.#a60 *)
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with a61 = #{ r.a61 with a60 = next_r.a61.#a60 } } in
   Idx_mut.set r ((.a61.#a60) : (t61, _) idx_mut) next_r.a61.#a60;
-  mark_test_run 221;
+  mark_test_run 231;
   let test = eq r expected in
-  if not test then failwithf "test 221 failed";
-  mark_test_run 222;
+  if not test then failwithf "test 231 failed";
+  mark_test_run 232;
   let test = sub_eq (Idx_mut.get r ((.a61.#a60) : (t61, _) idx_mut)) next_r.a61.#a60 in
-  if not test then failwithf "test 222 failed";
+  if not test then failwithf "test 232 failed";
   (* .a61.#b60 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a61 = #{ r.a61 with b60 = next_r.a61.#b60 } } in
   Idx_mut.set r ((.a61.#b60) : (t61, _) idx_mut) next_r.a61.#b60;
-  mark_test_run 223;
+  mark_test_run 233;
   let test = eq r expected in
-  if not test then failwithf "test 223 failed";
-  mark_test_run 224;
+  if not test then failwithf "test 233 failed";
+  mark_test_run 234;
   let test = sub_eq (Idx_mut.get r ((.a61.#b60) : (t61, _) idx_mut)) next_r.a61.#b60 in
-  if not test then failwithf "test 224 failed";
+  if not test then failwithf "test 234 failed";
   let r = { a61 = #{ a60 = 0; b60 = 1. }; b61 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a61 = #{ a60 = 100; b60 = 101. }; b61 = 102 } in
@@ -1893,12 +1913,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b61 = next_r.b61 } in
   Idx_mut.set r ((.b61) : (t61, _) idx_mut) next_r.b61;
-  mark_test_run 225;
+  mark_test_run 235;
   let test = eq r expected in
-  if not test then failwithf "test 225 failed";
-  mark_test_run 226;
+  if not test then failwithf "test 235 failed";
+  mark_test_run 236;
   let test = sub_eq (Idx_mut.get r ((.b61) : (t61, _) idx_mut)) next_r.b61 in
-  if not test then failwithf "test 226 failed";
+  if not test then failwithf "test 236 failed";
   (*************************************)
   (*   t63 = { #{ unit_u }; string }   *)
   (*************************************)
@@ -1910,24 +1930,24 @@ let to_run () =
   let sub_eq = (fun #{ a62 = a621 } #{ a62 = a622 } -> (fun _ _ -> true) a621 a622) in
   let expected = { r with a63 = next_r.a63 } in
   Idx_mut.set r ((.a63) : (t63, _) idx_mut) next_r.a63;
-  mark_test_run 227;
+  mark_test_run 237;
   let test = eq r expected in
-  if not test then failwithf "test 227 failed";
-  mark_test_run 228;
+  if not test then failwithf "test 237 failed";
+  mark_test_run 238;
   let test = sub_eq (Idx_mut.get r ((.a63) : (t63, _) idx_mut)) next_r.a63 in
-  if not test then failwithf "test 228 failed";
+  if not test then failwithf "test 238 failed";
   (* Paths of depth 2 *)
   let next_r = { a63 = #{ a62 = (unbox_unit ()) }; b63 = "200" } in
   (* .a63.#a62 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a63 = #{ r.a63 with a62 = next_r.a63.#a62 } } in
   Idx_mut.set r ((.a63.#a62) : (t63, _) idx_mut) next_r.a63.#a62;
-  mark_test_run 229;
+  mark_test_run 239;
   let test = eq r expected in
-  if not test then failwithf "test 229 failed";
-  mark_test_run 230;
+  if not test then failwithf "test 239 failed";
+  mark_test_run 240;
   let test = sub_eq (Idx_mut.get r ((.a63.#a62) : (t63, _) idx_mut)) next_r.a63.#a62 in
-  if not test then failwithf "test 230 failed";
+  if not test then failwithf "test 240 failed";
   let r = { a63 = #{ a62 = (unbox_unit ()) }; b63 = "0" } in
   (* Paths of depth 1 *)
   let next_r = { a63 = #{ a62 = (unbox_unit ()) }; b63 = "100" } in
@@ -1935,12 +1955,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b63 = next_r.b63 } in
   Idx_mut.set r ((.b63) : (t63, _) idx_mut) next_r.b63;
-  mark_test_run 231;
+  mark_test_run 241;
   let test = eq r expected in
-  if not test then failwithf "test 231 failed";
-  mark_test_run 232;
+  if not test then failwithf "test 241 failed";
+  mark_test_run 242;
   let test = sub_eq (Idx_mut.get r ((.b63) : (t63, _) idx_mut)) next_r.b63 in
-  if not test then failwithf "test 232 failed";
+  if not test then failwithf "test 242 failed";
   (*************************************)
   (*   t65 = { #{ unit_u; string } }   *)
   (*************************************)
@@ -1952,34 +1972,34 @@ let to_run () =
   let sub_eq = (fun #{ a64 = a641; b64 = b641 } #{ a64 = a642; b64 = b642 } -> (fun _ _ -> true) a641 a642 && (fun a b -> String.equal (globalize a) (globalize b)) b641 b642) in
   let expected = { r with a65 = next_r.a65 } in
   Idx_mut.set r ((.a65) : (t65, _) idx_mut) next_r.a65;
-  mark_test_run 233;
+  mark_test_run 243;
   let test = eq r expected in
-  if not test then failwithf "test 233 failed";
-  mark_test_run 234;
+  if not test then failwithf "test 243 failed";
+  mark_test_run 244;
   let test = sub_eq (Idx_mut.get r ((.a65) : (t65, _) idx_mut)) next_r.a65 in
-  if not test then failwithf "test 234 failed";
+  if not test then failwithf "test 244 failed";
   (* Paths of depth 2 *)
   let next_r = { a65 = #{ a64 = (unbox_unit ()); b64 = "200" } } in
   (* .a65.#a64 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a65 = #{ r.a65 with a64 = next_r.a65.#a64 } } in
   Idx_mut.set r ((.a65.#a64) : (t65, _) idx_mut) next_r.a65.#a64;
-  mark_test_run 235;
+  mark_test_run 245;
   let test = eq r expected in
-  if not test then failwithf "test 235 failed";
-  mark_test_run 236;
+  if not test then failwithf "test 245 failed";
+  mark_test_run 246;
   let test = sub_eq (Idx_mut.get r ((.a65.#a64) : (t65, _) idx_mut)) next_r.a65.#a64 in
-  if not test then failwithf "test 236 failed";
+  if not test then failwithf "test 246 failed";
   (* .a65.#b64 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a65 = #{ r.a65 with b64 = next_r.a65.#b64 } } in
   Idx_mut.set r ((.a65.#b64) : (t65, _) idx_mut) next_r.a65.#b64;
-  mark_test_run 237;
+  mark_test_run 247;
   let test = eq r expected in
-  if not test then failwithf "test 237 failed";
-  mark_test_run 238;
+  if not test then failwithf "test 247 failed";
+  mark_test_run 248;
   let test = sub_eq (Idx_mut.get r ((.a65.#b64) : (t65, _) idx_mut)) next_r.a65.#b64 in
-  if not test then failwithf "test 238 failed";
+  if not test then failwithf "test 248 failed";
   (***********************************)
   (*   t67 = { #{ float; float } }   *)
   (***********************************)
@@ -1991,34 +2011,34 @@ let to_run () =
   let sub_eq = (fun #{ a66 = a661; b66 = b661 } #{ a66 = a662; b66 = b662 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a661 a662 && (fun a b -> Float.equal (globalize a) (globalize b)) b661 b662) in
   let expected = { r with a67 = next_r.a67 } in
   Idx_mut.set r ((.a67) : (t67, _) idx_mut) next_r.a67;
-  mark_test_run 239;
+  mark_test_run 249;
   let test = eq r expected in
-  if not test then failwithf "test 239 failed";
-  mark_test_run 240;
+  if not test then failwithf "test 249 failed";
+  mark_test_run 250;
   let test = sub_eq (Idx_mut.get r ((.a67) : (t67, _) idx_mut)) next_r.a67 in
-  if not test then failwithf "test 240 failed";
+  if not test then failwithf "test 250 failed";
   (* Paths of depth 2 *)
   let next_r = { a67 = #{ a66 = 200.; b66 = 201. } } in
   (* .a67.#a66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a67 = #{ r.a67 with a66 = next_r.a67.#a66 } } in
   Idx_mut.set r ((.a67.#a66) : (t67, _) idx_mut) next_r.a67.#a66;
-  mark_test_run 241;
+  mark_test_run 251;
   let test = eq r expected in
-  if not test then failwithf "test 241 failed";
-  mark_test_run 242;
+  if not test then failwithf "test 251 failed";
+  mark_test_run 252;
   let test = sub_eq (Idx_mut.get r ((.a67.#a66) : (t67, _) idx_mut)) next_r.a67.#a66 in
-  if not test then failwithf "test 242 failed";
+  if not test then failwithf "test 252 failed";
   (* .a67.#b66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a67 = #{ r.a67 with b66 = next_r.a67.#b66 } } in
   Idx_mut.set r ((.a67.#b66) : (t67, _) idx_mut) next_r.a67.#b66;
-  mark_test_run 243;
+  mark_test_run 253;
   let test = eq r expected in
-  if not test then failwithf "test 243 failed";
-  mark_test_run 244;
+  if not test then failwithf "test 253 failed";
+  mark_test_run 254;
   let test = sub_eq (Idx_mut.get r ((.a67.#b66) : (t67, _) idx_mut)) next_r.a67.#b66 in
-  if not test then failwithf "test 244 failed";
+  if not test then failwithf "test 254 failed";
   (****************************************)
   (*   t68 = { #{ float; float }; int }   *)
   (****************************************)
@@ -2030,34 +2050,34 @@ let to_run () =
   let sub_eq = (fun #{ a66 = a661; b66 = b661 } #{ a66 = a662; b66 = b662 } -> (fun a b -> Float.equal (globalize a) (globalize b)) a661 a662 && (fun a b -> Float.equal (globalize a) (globalize b)) b661 b662) in
   let expected = { r with a68 = next_r.a68 } in
   Idx_mut.set r ((.a68) : (t68, _) idx_mut) next_r.a68;
-  mark_test_run 245;
+  mark_test_run 255;
   let test = eq r expected in
-  if not test then failwithf "test 245 failed";
-  mark_test_run 246;
+  if not test then failwithf "test 255 failed";
+  mark_test_run 256;
   let test = sub_eq (Idx_mut.get r ((.a68) : (t68, _) idx_mut)) next_r.a68 in
-  if not test then failwithf "test 246 failed";
+  if not test then failwithf "test 256 failed";
   (* Paths of depth 2 *)
   let next_r = { a68 = #{ a66 = 200.; b66 = 201. }; b68 = 202 } in
   (* .a68.#a66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a68 = #{ r.a68 with a66 = next_r.a68.#a66 } } in
   Idx_mut.set r ((.a68.#a66) : (t68, _) idx_mut) next_r.a68.#a66;
-  mark_test_run 247;
+  mark_test_run 257;
   let test = eq r expected in
-  if not test then failwithf "test 247 failed";
-  mark_test_run 248;
+  if not test then failwithf "test 257 failed";
+  mark_test_run 258;
   let test = sub_eq (Idx_mut.get r ((.a68.#a66) : (t68, _) idx_mut)) next_r.a68.#a66 in
-  if not test then failwithf "test 248 failed";
+  if not test then failwithf "test 258 failed";
   (* .a68.#b66 *)
   let sub_eq = (fun a b -> Float.equal (globalize a) (globalize b)) in
   let expected = { r with a68 = #{ r.a68 with b66 = next_r.a68.#b66 } } in
   Idx_mut.set r ((.a68.#b66) : (t68, _) idx_mut) next_r.a68.#b66;
-  mark_test_run 249;
+  mark_test_run 259;
   let test = eq r expected in
-  if not test then failwithf "test 249 failed";
-  mark_test_run 250;
+  if not test then failwithf "test 259 failed";
+  mark_test_run 260;
   let test = sub_eq (Idx_mut.get r ((.a68.#b66) : (t68, _) idx_mut)) next_r.a68.#b66 in
-  if not test then failwithf "test 250 failed";
+  if not test then failwithf "test 260 failed";
   let r = { a68 = #{ a66 = 0.; b66 = 1. }; b68 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a68 = #{ a66 = 100.; b66 = 101. }; b68 = 102 } in
@@ -2065,12 +2085,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b68 = next_r.b68 } in
   Idx_mut.set r ((.b68) : (t68, _) idx_mut) next_r.b68;
-  mark_test_run 251;
+  mark_test_run 261;
   let test = eq r expected in
-  if not test then failwithf "test 251 failed";
-  mark_test_run 252;
+  if not test then failwithf "test 261 failed";
+  mark_test_run 262;
   let test = sub_eq (Idx_mut.get r ((.b68) : (t68, _) idx_mut)) next_r.b68 in
-  if not test then failwithf "test 252 failed";
+  if not test then failwithf "test 262 failed";
   (*************************************)
   (*   t70 = { #{ string }; unit_u }   *)
   (*************************************)
@@ -2082,24 +2102,24 @@ let to_run () =
   let sub_eq = (fun #{ a69 = a691 } #{ a69 = a692 } -> (fun a b -> String.equal (globalize a) (globalize b)) a691 a692) in
   let expected = { r with a70 = next_r.a70 } in
   Idx_mut.set r ((.a70) : (t70, _) idx_mut) next_r.a70;
-  mark_test_run 253;
+  mark_test_run 263;
   let test = eq r expected in
-  if not test then failwithf "test 253 failed";
-  mark_test_run 254;
+  if not test then failwithf "test 263 failed";
+  mark_test_run 264;
   let test = sub_eq (Idx_mut.get r ((.a70) : (t70, _) idx_mut)) next_r.a70 in
-  if not test then failwithf "test 254 failed";
+  if not test then failwithf "test 264 failed";
   (* Paths of depth 2 *)
   let next_r = { a70 = #{ a69 = "200" }; b70 = (unbox_unit ()) } in
   (* .a70.#a69 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a70 = #{ r.a70 with a69 = next_r.a70.#a69 } } in
   Idx_mut.set r ((.a70.#a69) : (t70, _) idx_mut) next_r.a70.#a69;
-  mark_test_run 255;
+  mark_test_run 265;
   let test = eq r expected in
-  if not test then failwithf "test 255 failed";
-  mark_test_run 256;
+  if not test then failwithf "test 265 failed";
+  mark_test_run 266;
   let test = sub_eq (Idx_mut.get r ((.a70.#a69) : (t70, _) idx_mut)) next_r.a70.#a69 in
-  if not test then failwithf "test 256 failed";
+  if not test then failwithf "test 266 failed";
   let r = { a70 = #{ a69 = "0" }; b70 = (unbox_unit ()) } in
   (* Paths of depth 1 *)
   let next_r = { a70 = #{ a69 = "100" }; b70 = (unbox_unit ()) } in
@@ -2107,12 +2127,12 @@ let to_run () =
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with b70 = next_r.b70 } in
   Idx_mut.set r ((.b70) : (t70, _) idx_mut) next_r.b70;
-  mark_test_run 257;
+  mark_test_run 267;
   let test = eq r expected in
-  if not test then failwithf "test 257 failed";
-  mark_test_run 258;
+  if not test then failwithf "test 267 failed";
+  mark_test_run 268;
   let test = sub_eq (Idx_mut.get r ((.b70) : (t70, _) idx_mut)) next_r.b70 in
-  if not test then failwithf "test 258 failed";
+  if not test then failwithf "test 268 failed";
   (*************************************)
   (*   t71 = { #{ string }; string }   *)
   (*************************************)
@@ -2124,24 +2144,24 @@ let to_run () =
   let sub_eq = (fun #{ a69 = a691 } #{ a69 = a692 } -> (fun a b -> String.equal (globalize a) (globalize b)) a691 a692) in
   let expected = { r with a71 = next_r.a71 } in
   Idx_mut.set r ((.a71) : (t71, _) idx_mut) next_r.a71;
-  mark_test_run 259;
+  mark_test_run 269;
   let test = eq r expected in
-  if not test then failwithf "test 259 failed";
-  mark_test_run 260;
+  if not test then failwithf "test 269 failed";
+  mark_test_run 270;
   let test = sub_eq (Idx_mut.get r ((.a71) : (t71, _) idx_mut)) next_r.a71 in
-  if not test then failwithf "test 260 failed";
+  if not test then failwithf "test 270 failed";
   (* Paths of depth 2 *)
   let next_r = { a71 = #{ a69 = "200" }; b71 = "201" } in
   (* .a71.#a69 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a71 = #{ r.a71 with a69 = next_r.a71.#a69 } } in
   Idx_mut.set r ((.a71.#a69) : (t71, _) idx_mut) next_r.a71.#a69;
-  mark_test_run 261;
+  mark_test_run 271;
   let test = eq r expected in
-  if not test then failwithf "test 261 failed";
-  mark_test_run 262;
+  if not test then failwithf "test 271 failed";
+  mark_test_run 272;
   let test = sub_eq (Idx_mut.get r ((.a71.#a69) : (t71, _) idx_mut)) next_r.a71.#a69 in
-  if not test then failwithf "test 262 failed";
+  if not test then failwithf "test 272 failed";
   let r = { a71 = #{ a69 = "0" }; b71 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a71 = #{ a69 = "100" }; b71 = "101" } in
@@ -2149,12 +2169,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b71 = next_r.b71 } in
   Idx_mut.set r ((.b71) : (t71, _) idx_mut) next_r.b71;
-  mark_test_run 263;
+  mark_test_run 273;
   let test = eq r expected in
-  if not test then failwithf "test 263 failed";
-  mark_test_run 264;
+  if not test then failwithf "test 273 failed";
+  mark_test_run 274;
   let test = sub_eq (Idx_mut.get r ((.b71) : (t71, _) idx_mut)) next_r.b71 in
-  if not test then failwithf "test 264 failed";
+  if not test then failwithf "test 274 failed";
   (*********************************************)
   (*   t73 = { #{ string; unit_u }; string }   *)
   (*********************************************)
@@ -2166,34 +2186,34 @@ let to_run () =
   let sub_eq = (fun #{ a72 = a721; b72 = b721 } #{ a72 = a722; b72 = b722 } -> (fun a b -> String.equal (globalize a) (globalize b)) a721 a722 && (fun _ _ -> true) b721 b722) in
   let expected = { r with a73 = next_r.a73 } in
   Idx_mut.set r ((.a73) : (t73, _) idx_mut) next_r.a73;
-  mark_test_run 265;
+  mark_test_run 275;
   let test = eq r expected in
-  if not test then failwithf "test 265 failed";
-  mark_test_run 266;
+  if not test then failwithf "test 275 failed";
+  mark_test_run 276;
   let test = sub_eq (Idx_mut.get r ((.a73) : (t73, _) idx_mut)) next_r.a73 in
-  if not test then failwithf "test 266 failed";
+  if not test then failwithf "test 276 failed";
   (* Paths of depth 2 *)
   let next_r = { a73 = #{ a72 = "200"; b72 = (unbox_unit ()) }; b73 = "201" } in
   (* .a73.#a72 *)
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with a73 = #{ r.a73 with a72 = next_r.a73.#a72 } } in
   Idx_mut.set r ((.a73.#a72) : (t73, _) idx_mut) next_r.a73.#a72;
-  mark_test_run 267;
+  mark_test_run 277;
   let test = eq r expected in
-  if not test then failwithf "test 267 failed";
-  mark_test_run 268;
+  if not test then failwithf "test 277 failed";
+  mark_test_run 278;
   let test = sub_eq (Idx_mut.get r ((.a73.#a72) : (t73, _) idx_mut)) next_r.a73.#a72 in
-  if not test then failwithf "test 268 failed";
+  if not test then failwithf "test 278 failed";
   (* .a73.#b72 *)
   let sub_eq = (fun _ _ -> true) in
   let expected = { r with a73 = #{ r.a73 with b72 = next_r.a73.#b72 } } in
   Idx_mut.set r ((.a73.#b72) : (t73, _) idx_mut) next_r.a73.#b72;
-  mark_test_run 269;
+  mark_test_run 279;
   let test = eq r expected in
-  if not test then failwithf "test 269 failed";
-  mark_test_run 270;
+  if not test then failwithf "test 279 failed";
+  mark_test_run 280;
   let test = sub_eq (Idx_mut.get r ((.a73.#b72) : (t73, _) idx_mut)) next_r.a73.#b72 in
-  if not test then failwithf "test 270 failed";
+  if not test then failwithf "test 280 failed";
   let r = { a73 = #{ a72 = "0"; b72 = (unbox_unit ()) }; b73 = "1" } in
   (* Paths of depth 1 *)
   let next_r = { a73 = #{ a72 = "100"; b72 = (unbox_unit ()) }; b73 = "101" } in
@@ -2201,12 +2221,12 @@ let to_run () =
   let sub_eq = (fun a b -> String.equal (globalize a) (globalize b)) in
   let expected = { r with b73 = next_r.b73 } in
   Idx_mut.set r ((.b73) : (t73, _) idx_mut) next_r.b73;
-  mark_test_run 271;
+  mark_test_run 281;
   let test = eq r expected in
-  if not test then failwithf "test 271 failed";
-  mark_test_run 272;
+  if not test then failwithf "test 281 failed";
+  mark_test_run 282;
   let test = sub_eq (Idx_mut.get r ((.b73) : (t73, _) idx_mut)) next_r.b73 in
-  if not test then failwithf "test 272 failed";
+  if not test then failwithf "test 282 failed";
   (************************************)
   (*   t75 = { #{ int64x2# }; int }   *)
   (************************************)
@@ -2218,24 +2238,24 @@ let to_run () =
   let sub_eq = (fun #{ a74 = a741 } #{ a74 = a742 } -> int64x2_u_equal a741 a742) in
   let expected = { r with a75 = next_r.a75 } in
   Idx_mut.set r ((.a75) : (t75, _) idx_mut) next_r.a75;
-  mark_test_run 273;
+  mark_test_run 283;
   let test = eq r expected in
-  if not test then failwithf "test 273 failed";
-  mark_test_run 274;
+  if not test then failwithf "test 283 failed";
+  mark_test_run 284;
   let test = sub_eq (Idx_mut.get r ((.a75) : (t75, _) idx_mut)) next_r.a75 in
-  if not test then failwithf "test 274 failed";
+  if not test then failwithf "test 284 failed";
   (* Paths of depth 2 *)
   let next_r = { a75 = #{ a74 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)) }; b75 = 202 } in
   (* .a75.#a74 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with a75 = #{ r.a75 with a74 = next_r.a75.#a74 } } in
   Idx_mut.set r ((.a75.#a74) : (t75, _) idx_mut) next_r.a75.#a74;
-  mark_test_run 275;
+  mark_test_run 285;
   let test = eq r expected in
-  if not test then failwithf "test 275 failed";
-  mark_test_run 276;
+  if not test then failwithf "test 285 failed";
+  mark_test_run 286;
   let test = sub_eq (Idx_mut.get r ((.a75.#a74) : (t75, _) idx_mut)) next_r.a75.#a74 in
-  if not test then failwithf "test 276 failed";
+  if not test then failwithf "test 286 failed";
   let r = { a75 = #{ a74 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)) }; b75 = 2 } in
   (* Paths of depth 1 *)
   let next_r = { a75 = #{ a74 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)) }; b75 = 102 } in
@@ -2243,12 +2263,12 @@ let to_run () =
   let sub_eq = (fun a b -> Int.equal a b) in
   let expected = { r with b75 = next_r.b75 } in
   Idx_mut.set r ((.b75) : (t75, _) idx_mut) next_r.b75;
-  mark_test_run 277;
+  mark_test_run 287;
   let test = eq r expected in
-  if not test then failwithf "test 277 failed";
-  mark_test_run 278;
+  if not test then failwithf "test 287 failed";
+  mark_test_run 288;
   let test = sub_eq (Idx_mut.get r ((.b75) : (t75, _) idx_mut)) next_r.b75 in
-  if not test then failwithf "test 278 failed";
+  if not test then failwithf "test 288 failed";
   (*****************************************)
   (*   t76 = { #{ int64x2# }; int64x2# }   *)
   (*****************************************)
@@ -2260,24 +2280,24 @@ let to_run () =
   let sub_eq = (fun #{ a74 = a741 } #{ a74 = a742 } -> int64x2_u_equal a741 a742) in
   let expected = { r with a76 = next_r.a76 } in
   Idx_mut.set r ((.a76) : (t76, _) idx_mut) next_r.a76;
-  mark_test_run 279;
+  mark_test_run 289;
   let test = eq r expected in
-  if not test then failwithf "test 279 failed";
-  mark_test_run 280;
+  if not test then failwithf "test 289 failed";
+  mark_test_run 290;
   let test = sub_eq (Idx_mut.get r ((.a76) : (t76, _) idx_mut)) next_r.a76 in
-  if not test then failwithf "test 280 failed";
+  if not test then failwithf "test 290 failed";
   (* Paths of depth 2 *)
   let next_r = { a76 = #{ a74 = (interleave_low_64 (int64x2_of_int64 200L) (int64x2_of_int64 201L)) }; b76 = (interleave_low_64 (int64x2_of_int64 202L) (int64x2_of_int64 203L)) } in
   (* .a76.#a74 *)
   let sub_eq = int64x2_u_equal in
   let expected = { r with a76 = #{ r.a76 with a74 = next_r.a76.#a74 } } in
   Idx_mut.set r ((.a76.#a74) : (t76, _) idx_mut) next_r.a76.#a74;
-  mark_test_run 281;
+  mark_test_run 291;
   let test = eq r expected in
-  if not test then failwithf "test 281 failed";
-  mark_test_run 282;
+  if not test then failwithf "test 291 failed";
+  mark_test_run 292;
   let test = sub_eq (Idx_mut.get r ((.a76.#a74) : (t76, _) idx_mut)) next_r.a76.#a74 in
-  if not test then failwithf "test 282 failed";
+  if not test then failwithf "test 292 failed";
   let r = { a76 = #{ a74 = (interleave_low_64 (int64x2_of_int64 0L) (int64x2_of_int64 1L)) }; b76 = (interleave_low_64 (int64x2_of_int64 2L) (int64x2_of_int64 3L)) } in
   (* Paths of depth 1 *)
   let next_r = { a76 = #{ a74 = (interleave_low_64 (int64x2_of_int64 100L) (int64x2_of_int64 101L)) }; b76 = (interleave_low_64 (int64x2_of_int64 102L) (int64x2_of_int64 103L)) } in
@@ -2285,17 +2305,17 @@ let to_run () =
   let sub_eq = int64x2_u_equal in
   let expected = { r with b76 = next_r.b76 } in
   Idx_mut.set r ((.b76) : (t76, _) idx_mut) next_r.b76;
-  mark_test_run 283;
+  mark_test_run 293;
   let test = eq r expected in
-  if not test then failwithf "test 283 failed";
-  mark_test_run 284;
+  if not test then failwithf "test 293 failed";
+  mark_test_run 294;
   let test = sub_eq (Idx_mut.get r ((.b76) : (t76, _) idx_mut)) next_r.b76 in
-  if not test then failwithf "test 284 failed";
+  if not test then failwithf "test 294 failed";
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 284 do
+for i = 1 to 294 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_bytecode_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_bytecode_test.ml
@@ -777,9 +777,15 @@ let to_run () =
   (*   t30 = { float# }   *)
   (************************)
   (* Deepening to (.a30) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t30, _) idx_mut = (.a30) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a30) *)
+    let shallow : (t30, _) idx_mut = (.a30) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 51;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 51 failed %d" i;
+  );
 
   (*******************************)
   (*   t31 = { float#; float }   *)
@@ -797,13 +803,25 @@ let to_run () =
   (*   t32 = { float#; float# }   *)
   (********************************)
   (* Deepening to (.a32) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t32, _) idx_mut = (.a32) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a32) *)
+    let shallow : (t32, _) idx_mut = (.a32) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 52;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 52 failed %d" i;
+  );
   (* Deepening to (.b32) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t32, _) idx_mut = (.b32) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.b32) *)
+    let shallow : (t32, _) idx_mut = (.b32) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 53;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 53 failed %d" i;
+  );
 
   (*******************************************)
   (*   t33 = { float#; #{ float; float } }   *)
@@ -814,9 +832,9 @@ let to_run () =
     (* from (.a33) *)
     let shallow : (t33, _) idx_mut = (.a33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 51;
+    mark_test_run 54;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 51 failed %d" i;
+    if not test then failwithf "test 54 failed %d" i;
   );
   (* Deepening to (.b33) *)
   let idx : (t33, _) idx_mut = (.b33) in
@@ -824,9 +842,9 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 52;
+    mark_test_run 55;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 52 failed %d" i;
+    if not test then failwithf "test 55 failed %d" i;
   );
   (* Deepening to (.b33.#a28) *)
   let idx : (t33, _) idx_mut = (.b33.#a28) in
@@ -834,15 +852,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 53;
+    mark_test_run 56;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 53 failed %d" i;
+    if not test then failwithf "test 56 failed %d" i;
     (* from (.b33.#a28) *)
     let shallow : (t33, _) idx_mut = (.b33.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 54;
+    mark_test_run 57;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 54 failed %d" i;
+    if not test then failwithf "test 57 failed %d" i;
   );
   (* Deepening to (.b33.#b28) *)
   let idx : (t33, _) idx_mut = (.b33.#b28) in
@@ -850,15 +868,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 55;
+    mark_test_run 58;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 55 failed %d" i;
+    if not test then failwithf "test 58 failed %d" i;
     (* from (.b33.#b28) *)
     let shallow : (t33, _) idx_mut = (.b33.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 56;
+    mark_test_run 59;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 56 failed %d" i;
+    if not test then failwithf "test 59 failed %d" i;
   );
 
   (********************************************)
@@ -870,9 +888,9 @@ let to_run () =
     (* from (.a35) *)
     let shallow : (t35, _) idx_mut = (.a35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 57;
+    mark_test_run 60;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 57 failed %d" i;
+    if not test then failwithf "test 60 failed %d" i;
   );
   (* Deepening to (.b35) *)
   let idx : (t35, _) idx_mut = (.b35) in
@@ -880,9 +898,9 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 58;
+    mark_test_run 61;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 58 failed %d" i;
+    if not test then failwithf "test 61 failed %d" i;
   );
   (* Deepening to (.b35.#a34) *)
   let idx : (t35, _) idx_mut = (.b35.#a34) in
@@ -890,15 +908,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#a34) in
-    mark_test_run 59;
+    mark_test_run 62;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 59 failed %d" i;
+    if not test then failwithf "test 62 failed %d" i;
     (* from (.b35.#a34) *)
     let shallow : (t35, _) idx_mut = (.b35.#a34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 60;
+    mark_test_run 63;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 60 failed %d" i;
+    if not test then failwithf "test 63 failed %d" i;
   );
   (* Deepening to (.b35.#b34) *)
   let idx : (t35, _) idx_mut = (.b35.#b34) in
@@ -906,15 +924,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#b34) in
-    mark_test_run 61;
+    mark_test_run 64;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 61 failed %d" i;
+    if not test then failwithf "test 64 failed %d" i;
     (* from (.b35.#b34) *)
     let shallow : (t35, _) idx_mut = (.b35.#b34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 62;
+    mark_test_run 65;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 62 failed %d" i;
+    if not test then failwithf "test 65 failed %d" i;
   );
 
   (****************************************)
@@ -926,9 +944,9 @@ let to_run () =
     (* from (.a36) *)
     let shallow : (t36, _) idx_mut = (.a36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 63;
+    mark_test_run 66;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 63 failed %d" i;
+    if not test then failwithf "test 66 failed %d" i;
   );
   (* Deepening to (.b36) *)
   let idx : (t36, _) idx_mut = (.b36) in
@@ -936,9 +954,9 @@ let to_run () =
     (* from (.b36) *)
     let shallow : (t36, _) idx_mut = (.b36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 64;
+    mark_test_run 67;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 64 failed %d" i;
+    if not test then failwithf "test 67 failed %d" i;
   );
   (* Deepening to (.c36) *)
   let idx : (t36, _) idx_mut = (.c36) in
@@ -960,9 +978,9 @@ let to_run () =
     (* from (.a38) *)
     let shallow : (t38, _) idx_mut = (.a38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 65;
+    mark_test_run 68;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 65 failed %d" i;
+    if not test then failwithf "test 68 failed %d" i;
   );
   (* Deepening to (.b38) *)
   let idx : (t38, _) idx_mut = (.b38) in
@@ -970,9 +988,9 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 66;
+    mark_test_run 69;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 66 failed %d" i;
+    if not test then failwithf "test 69 failed %d" i;
   );
   (* Deepening to (.b38.#a37) *)
   let idx : (t38, _) idx_mut = (.b38.#a37) in
@@ -980,15 +998,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 67;
+    mark_test_run 70;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 67 failed %d" i;
+    if not test then failwithf "test 70 failed %d" i;
     (* from (.b38.#a37) *)
     let shallow : (t38, _) idx_mut = (.b38.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 68;
+    mark_test_run 71;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 68 failed %d" i;
+    if not test then failwithf "test 71 failed %d" i;
   );
   (* Deepening to (.b38.#b37) *)
   let idx : (t38, _) idx_mut = (.b38.#b37) in
@@ -996,15 +1014,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 69;
+    mark_test_run 72;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 69 failed %d" i;
+    if not test then failwithf "test 72 failed %d" i;
     (* from (.b38.#b37) *)
     let shallow : (t38, _) idx_mut = (.b38.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 70;
+    mark_test_run 73;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 70 failed %d" i;
+    if not test then failwithf "test 73 failed %d" i;
   );
 
   (****************************************)
@@ -1016,9 +1034,9 @@ let to_run () =
     (* from (.a39) *)
     let shallow : (t39, _) idx_mut = (.a39) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 71;
+    mark_test_run 74;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 71 failed %d" i;
+    if not test then failwithf "test 74 failed %d" i;
   );
   (* Deepening to (.b39) *)
   let idx : (t39, _) idx_mut = (.b39) in
@@ -1026,9 +1044,9 @@ let to_run () =
     (* from (.b39) *)
     let shallow : (t39, _) idx_mut = (.b39) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 72;
+    mark_test_run 75;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 72 failed %d" i;
+    if not test then failwithf "test 75 failed %d" i;
   );
 
   (************************************)
@@ -1040,9 +1058,9 @@ let to_run () =
     (* from (.a40) *)
     let shallow : (t40, _) idx_mut = (.a40) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 73;
+    mark_test_run 76;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 73 failed %d" i;
+    if not test then failwithf "test 76 failed %d" i;
   );
   (* Deepening to (.b40) *)
   let idx : (t40, _) idx_mut = (.b40) in
@@ -1064,9 +1082,9 @@ let to_run () =
     (* from (.a41) *)
     let shallow : (t41, _) idx_mut = (.a41) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 74;
+    mark_test_run 77;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 74 failed %d" i;
+    if not test then failwithf "test 77 failed %d" i;
   );
   (* Deepening to (.b41) *)
   let idx : (t41, _) idx_mut = (.b41) in
@@ -1074,9 +1092,9 @@ let to_run () =
     (* from (.b41) *)
     let shallow : (t41, _) idx_mut = (.b41) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 75;
+    mark_test_run 78;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 75 failed %d" i;
+    if not test then failwithf "test 78 failed %d" i;
   );
 
   (**************************)
@@ -1088,9 +1106,9 @@ let to_run () =
     (* from (.a43) *)
     let shallow : (t43, _) idx_mut = (.a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 76;
+    mark_test_run 79;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 76 failed %d" i;
+    if not test then failwithf "test 79 failed %d" i;
   );
   (* Deepening to (.a43.#a42) *)
   let idx : (t43, _) idx_mut = (.a43.#a42) in
@@ -1098,15 +1116,15 @@ let to_run () =
     (* from (.a43) *)
     let shallow : (t43, _) idx_mut = (.a43) in
     let deepened = (.idx_mut(shallow).#a42) in
-    mark_test_run 77;
+    mark_test_run 80;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 77 failed %d" i;
+    if not test then failwithf "test 80 failed %d" i;
     (* from (.a43.#a42) *)
     let shallow : (t43, _) idx_mut = (.a43.#a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 78;
+    mark_test_run 81;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 78 failed %d" i;
+    if not test then failwithf "test 81 failed %d" i;
   );
 
   (*******************************)
@@ -1118,9 +1136,9 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 79;
+    mark_test_run 82;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 79 failed %d" i;
+    if not test then failwithf "test 82 failed %d" i;
   );
   (* Deepening to (.a44.#a42) *)
   let idx : (t44, _) idx_mut = (.a44.#a42) in
@@ -1128,15 +1146,15 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow).#a42) in
-    mark_test_run 80;
+    mark_test_run 83;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 80 failed %d" i;
+    if not test then failwithf "test 83 failed %d" i;
     (* from (.a44.#a42) *)
     let shallow : (t44, _) idx_mut = (.a44.#a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 81;
+    mark_test_run 84;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 81 failed %d" i;
+    if not test then failwithf "test 84 failed %d" i;
   );
   (* Deepening to (.b44) *)
   let idx : (t44, _) idx_mut = (.b44) in
@@ -1144,9 +1162,9 @@ let to_run () =
     (* from (.b44) *)
     let shallow : (t44, _) idx_mut = (.b44) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 82;
+    mark_test_run 85;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 82 failed %d" i;
+    if not test then failwithf "test 85 failed %d" i;
   );
 
   (**********************************)
@@ -1158,9 +1176,9 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 83;
+    mark_test_run 86;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 83 failed %d" i;
+    if not test then failwithf "test 86 failed %d" i;
   );
   (* Deepening to (.a45.#a42) *)
   let idx : (t45, _) idx_mut = (.a45.#a42) in
@@ -1168,15 +1186,15 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow).#a42) in
-    mark_test_run 84;
+    mark_test_run 87;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 84 failed %d" i;
+    if not test then failwithf "test 87 failed %d" i;
     (* from (.a45.#a42) *)
     let shallow : (t45, _) idx_mut = (.a45.#a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 85;
+    mark_test_run 88;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 85 failed %d" i;
+    if not test then failwithf "test 88 failed %d" i;
   );
   (* Deepening to (.b45) *)
   let idx : (t45, _) idx_mut = (.b45) in
@@ -1184,9 +1202,9 @@ let to_run () =
     (* from (.b45) *)
     let shallow : (t45, _) idx_mut = (.b45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 86;
+    mark_test_run 89;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 86 failed %d" i;
+    if not test then failwithf "test 89 failed %d" i;
   );
 
   (*******************************)
@@ -1198,9 +1216,9 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 87;
+    mark_test_run 90;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 87 failed %d" i;
+    if not test then failwithf "test 90 failed %d" i;
   );
   (* Deepening to (.a46.#a13) *)
   let idx : (t46, _) idx_mut = (.a46.#a13) in
@@ -1208,15 +1226,15 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 88;
+    mark_test_run 91;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 88 failed %d" i;
+    if not test then failwithf "test 91 failed %d" i;
     (* from (.a46.#a13) *)
     let shallow : (t46, _) idx_mut = (.a46.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 89;
+    mark_test_run 92;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 89 failed %d" i;
+    if not test then failwithf "test 92 failed %d" i;
   );
   (* Deepening to (.a46.#b13) *)
   let idx : (t46, _) idx_mut = (.a46.#b13) in
@@ -1224,15 +1242,15 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 90;
+    mark_test_run 93;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 90 failed %d" i;
+    if not test then failwithf "test 93 failed %d" i;
     (* from (.a46.#b13) *)
     let shallow : (t46, _) idx_mut = (.a46.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 91;
+    mark_test_run 94;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 91 failed %d" i;
+    if not test then failwithf "test 94 failed %d" i;
   );
 
   (************************************)
@@ -1244,9 +1262,9 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 92;
+    mark_test_run 95;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 92 failed %d" i;
+    if not test then failwithf "test 95 failed %d" i;
   );
   (* Deepening to (.a47.#a13) *)
   let idx : (t47, _) idx_mut = (.a47.#a13) in
@@ -1254,15 +1272,15 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 93;
+    mark_test_run 96;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 93 failed %d" i;
+    if not test then failwithf "test 96 failed %d" i;
     (* from (.a47.#a13) *)
     let shallow : (t47, _) idx_mut = (.a47.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 94;
+    mark_test_run 97;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 94 failed %d" i;
+    if not test then failwithf "test 97 failed %d" i;
   );
   (* Deepening to (.a47.#b13) *)
   let idx : (t47, _) idx_mut = (.a47.#b13) in
@@ -1270,15 +1288,15 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 95;
+    mark_test_run 98;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 95 failed %d" i;
+    if not test then failwithf "test 98 failed %d" i;
     (* from (.a47.#b13) *)
     let shallow : (t47, _) idx_mut = (.a47.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 96;
+    mark_test_run 99;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 96 failed %d" i;
+    if not test then failwithf "test 99 failed %d" i;
   );
   (* Deepening to (.b47) *)
   let idx : (t47, _) idx_mut = (.b47) in
@@ -1286,9 +1304,9 @@ let to_run () =
     (* from (.b47) *)
     let shallow : (t47, _) idx_mut = (.b47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 97;
+    mark_test_run 100;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 97 failed %d" i;
+    if not test then failwithf "test 100 failed %d" i;
   );
 
   (***************************************)
@@ -1300,9 +1318,9 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 98;
+    mark_test_run 101;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 98 failed %d" i;
+    if not test then failwithf "test 101 failed %d" i;
   );
   (* Deepening to (.a48.#a13) *)
   let idx : (t48, _) idx_mut = (.a48.#a13) in
@@ -1310,15 +1328,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 99;
+    mark_test_run 102;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 99 failed %d" i;
+    if not test then failwithf "test 102 failed %d" i;
     (* from (.a48.#a13) *)
     let shallow : (t48, _) idx_mut = (.a48.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 100;
+    mark_test_run 103;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 100 failed %d" i;
+    if not test then failwithf "test 103 failed %d" i;
   );
   (* Deepening to (.a48.#b13) *)
   let idx : (t48, _) idx_mut = (.a48.#b13) in
@@ -1326,15 +1344,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 101;
+    mark_test_run 104;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 101 failed %d" i;
+    if not test then failwithf "test 104 failed %d" i;
     (* from (.a48.#b13) *)
     let shallow : (t48, _) idx_mut = (.a48.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 102;
+    mark_test_run 105;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 102 failed %d" i;
+    if not test then failwithf "test 105 failed %d" i;
   );
   (* Deepening to (.b48) *)
   let idx : (t48, _) idx_mut = (.b48) in
@@ -1342,9 +1360,9 @@ let to_run () =
     (* from (.b48) *)
     let shallow : (t48, _) idx_mut = (.b48) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 103;
+    mark_test_run 106;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 103 failed %d" i;
+    if not test then failwithf "test 106 failed %d" i;
   );
 
   (***************************************)
@@ -1356,9 +1374,9 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 104;
+    mark_test_run 107;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 104 failed %d" i;
+    if not test then failwithf "test 107 failed %d" i;
   );
   (* Deepening to (.a50.#a49) *)
   let idx : (t50, _) idx_mut = (.a50.#a49) in
@@ -1366,15 +1384,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#a49) in
-    mark_test_run 105;
+    mark_test_run 108;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 105 failed %d" i;
+    if not test then failwithf "test 108 failed %d" i;
     (* from (.a50.#a49) *)
     let shallow : (t50, _) idx_mut = (.a50.#a49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 106;
+    mark_test_run 109;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 106 failed %d" i;
+    if not test then failwithf "test 109 failed %d" i;
   );
   (* Deepening to (.a50.#b49) *)
   let idx : (t50, _) idx_mut = (.a50.#b49) in
@@ -1382,15 +1400,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#b49) in
-    mark_test_run 107;
+    mark_test_run 110;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 107 failed %d" i;
+    if not test then failwithf "test 110 failed %d" i;
     (* from (.a50.#b49) *)
     let shallow : (t50, _) idx_mut = (.a50.#b49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 108;
+    mark_test_run 111;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 108 failed %d" i;
+    if not test then failwithf "test 111 failed %d" i;
   );
   (* Deepening to (.b50) *)
   let idx : (t50, _) idx_mut = (.b50) in
@@ -1398,9 +1416,9 @@ let to_run () =
     (* from (.b50) *)
     let shallow : (t50, _) idx_mut = (.b50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 109;
+    mark_test_run 112;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 109 failed %d" i;
+    if not test then failwithf "test 112 failed %d" i;
   );
 
   (**************************************)
@@ -1412,9 +1430,9 @@ let to_run () =
     (* from (.a51) *)
     let shallow : (t51, _) idx_mut = (.a51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 110;
+    mark_test_run 113;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 110 failed %d" i;
+    if not test then failwithf "test 113 failed %d" i;
   );
   (* Deepening to (.a51.#a5) *)
   let idx : (t51, _) idx_mut = (.a51.#a5) in
@@ -1422,15 +1440,15 @@ let to_run () =
     (* from (.a51) *)
     let shallow : (t51, _) idx_mut = (.a51) in
     let deepened = (.idx_mut(shallow).#a5) in
-    mark_test_run 111;
+    mark_test_run 114;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 111 failed %d" i;
+    if not test then failwithf "test 114 failed %d" i;
     (* from (.a51.#a5) *)
     let shallow : (t51, _) idx_mut = (.a51.#a5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 112;
+    mark_test_run 115;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 112 failed %d" i;
+    if not test then failwithf "test 115 failed %d" i;
   );
   (* Deepening to (.a51.#b5) *)
   let idx : (t51, _) idx_mut = (.a51.#b5) in
@@ -1438,15 +1456,15 @@ let to_run () =
     (* from (.a51) *)
     let shallow : (t51, _) idx_mut = (.a51) in
     let deepened = (.idx_mut(shallow).#b5) in
-    mark_test_run 113;
+    mark_test_run 116;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 113 failed %d" i;
+    if not test then failwithf "test 116 failed %d" i;
     (* from (.a51.#b5) *)
     let shallow : (t51, _) idx_mut = (.a51.#b5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 114;
+    mark_test_run 117;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 114 failed %d" i;
+    if not test then failwithf "test 117 failed %d" i;
   );
   (* Deepening to (.b51) *)
   let idx : (t51, _) idx_mut = (.b51) in
@@ -1454,9 +1472,9 @@ let to_run () =
     (* from (.b51) *)
     let shallow : (t51, _) idx_mut = (.b51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 115;
+    mark_test_run 118;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 115 failed %d" i;
+    if not test then failwithf "test 118 failed %d" i;
   );
 
   (*********************************************************)
@@ -1468,9 +1486,9 @@ let to_run () =
     (* from (.a54) *)
     let shallow : (t54, _) idx_mut = (.a54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 116;
+    mark_test_run 119;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 116 failed %d" i;
+    if not test then failwithf "test 119 failed %d" i;
   );
   (* Deepening to (.a54.#a52) *)
   let idx : (t54, _) idx_mut = (.a54.#a52) in
@@ -1478,15 +1496,15 @@ let to_run () =
     (* from (.a54) *)
     let shallow : (t54, _) idx_mut = (.a54) in
     let deepened = (.idx_mut(shallow).#a52) in
-    mark_test_run 117;
+    mark_test_run 120;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 117 failed %d" i;
+    if not test then failwithf "test 120 failed %d" i;
     (* from (.a54.#a52) *)
     let shallow : (t54, _) idx_mut = (.a54.#a52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 118;
+    mark_test_run 121;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 118 failed %d" i;
+    if not test then failwithf "test 121 failed %d" i;
   );
   (* Deepening to (.a54.#b52) *)
   let idx : (t54, _) idx_mut = (.a54.#b52) in
@@ -1494,15 +1512,15 @@ let to_run () =
     (* from (.a54) *)
     let shallow : (t54, _) idx_mut = (.a54) in
     let deepened = (.idx_mut(shallow).#b52) in
-    mark_test_run 119;
+    mark_test_run 122;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 119 failed %d" i;
+    if not test then failwithf "test 122 failed %d" i;
     (* from (.a54.#b52) *)
     let shallow : (t54, _) idx_mut = (.a54.#b52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 120;
+    mark_test_run 123;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 120 failed %d" i;
+    if not test then failwithf "test 123 failed %d" i;
   );
   (* Deepening to (.b54) *)
   let idx : (t54, _) idx_mut = (.b54) in
@@ -1510,9 +1528,9 @@ let to_run () =
     (* from (.b54) *)
     let shallow : (t54, _) idx_mut = (.b54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 121;
+    mark_test_run 124;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 121 failed %d" i;
+    if not test then failwithf "test 124 failed %d" i;
   );
   (* Deepening to (.b54.#a53) *)
   let idx : (t54, _) idx_mut = (.b54.#a53) in
@@ -1520,15 +1538,15 @@ let to_run () =
     (* from (.b54) *)
     let shallow : (t54, _) idx_mut = (.b54) in
     let deepened = (.idx_mut(shallow).#a53) in
-    mark_test_run 122;
+    mark_test_run 125;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 122 failed %d" i;
+    if not test then failwithf "test 125 failed %d" i;
     (* from (.b54.#a53) *)
     let shallow : (t54, _) idx_mut = (.b54.#a53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 123;
+    mark_test_run 126;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 123 failed %d" i;
+    if not test then failwithf "test 126 failed %d" i;
   );
   (* Deepening to (.b54.#b53) *)
   let idx : (t54, _) idx_mut = (.b54.#b53) in
@@ -1536,15 +1554,15 @@ let to_run () =
     (* from (.b54) *)
     let shallow : (t54, _) idx_mut = (.b54) in
     let deepened = (.idx_mut(shallow).#b53) in
-    mark_test_run 124;
+    mark_test_run 127;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 124 failed %d" i;
+    if not test then failwithf "test 127 failed %d" i;
     (* from (.b54.#b53) *)
     let shallow : (t54, _) idx_mut = (.b54.#b53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 125;
+    mark_test_run 128;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 125 failed %d" i;
+    if not test then failwithf "test 128 failed %d" i;
   );
 
   (*****************************)
@@ -1556,9 +1574,9 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 126;
+    mark_test_run 129;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 126 failed %d" i;
+    if not test then failwithf "test 129 failed %d" i;
   );
   (* Deepening to (.a56.#a55) *)
   let idx : (t56, _) idx_mut = (.a56.#a55) in
@@ -1566,15 +1584,15 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow).#a55) in
-    mark_test_run 127;
+    mark_test_run 130;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 127 failed %d" i;
+    if not test then failwithf "test 130 failed %d" i;
     (* from (.a56.#a55) *)
     let shallow : (t56, _) idx_mut = (.a56.#a55) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 128;
+    mark_test_run 131;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 128 failed %d" i;
+    if not test then failwithf "test 131 failed %d" i;
   );
 
   (*************************************)
@@ -1586,9 +1604,9 @@ let to_run () =
     (* from (.a57) *)
     let shallow : (t57, _) idx_mut = (.a57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 129;
+    mark_test_run 132;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 129 failed %d" i;
+    if not test then failwithf "test 132 failed %d" i;
   );
   (* Deepening to (.a57.#a55) *)
   let idx : (t57, _) idx_mut = (.a57.#a55) in
@@ -1596,15 +1614,15 @@ let to_run () =
     (* from (.a57) *)
     let shallow : (t57, _) idx_mut = (.a57) in
     let deepened = (.idx_mut(shallow).#a55) in
-    mark_test_run 130;
+    mark_test_run 133;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 130 failed %d" i;
+    if not test then failwithf "test 133 failed %d" i;
     (* from (.a57.#a55) *)
     let shallow : (t57, _) idx_mut = (.a57.#a55) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 131;
+    mark_test_run 134;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 131 failed %d" i;
+    if not test then failwithf "test 134 failed %d" i;
   );
   (* Deepening to (.b57) *)
   let idx : (t57, _) idx_mut = (.b57) in
@@ -1612,9 +1630,9 @@ let to_run () =
     (* from (.b57) *)
     let shallow : (t57, _) idx_mut = (.b57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 132;
+    mark_test_run 135;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 132 failed %d" i;
+    if not test then failwithf "test 135 failed %d" i;
   );
 
   (****************************)
@@ -1638,9 +1656,9 @@ let to_run () =
     (* from (.a60) *)
     let shallow : (t60, _) idx_mut = (.a60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 133;
+    mark_test_run 136;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 133 failed %d" i;
+    if not test then failwithf "test 136 failed %d" i;
   );
   (* Deepening to (.a60.#a59) *)
   let idx : (t60, _) idx_mut = (.a60.#a59) in
@@ -1648,15 +1666,15 @@ let to_run () =
     (* from (.a60) *)
     let shallow : (t60, _) idx_mut = (.a60) in
     let deepened = (.idx_mut(shallow).#a59) in
-    mark_test_run 134;
+    mark_test_run 137;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 134 failed %d" i;
+    if not test then failwithf "test 137 failed %d" i;
     (* from (.a60.#a59) *)
     let shallow : (t60, _) idx_mut = (.a60.#a59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 135;
+    mark_test_run 138;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 135 failed %d" i;
+    if not test then failwithf "test 138 failed %d" i;
   );
   (* Deepening to (.a60.#b59) *)
   let idx : (t60, _) idx_mut = (.a60.#b59) in
@@ -1664,15 +1682,15 @@ let to_run () =
     (* from (.a60) *)
     let shallow : (t60, _) idx_mut = (.a60) in
     let deepened = (.idx_mut(shallow).#b59) in
-    mark_test_run 136;
+    mark_test_run 139;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 136 failed %d" i;
+    if not test then failwithf "test 139 failed %d" i;
     (* from (.a60.#b59) *)
     let shallow : (t60, _) idx_mut = (.a60.#b59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 137;
+    mark_test_run 140;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 137 failed %d" i;
+    if not test then failwithf "test 140 failed %d" i;
   );
   (* Deepening to (.b60) *)
   let idx : (t60, _) idx_mut = (.b60) in
@@ -1680,9 +1698,9 @@ let to_run () =
     (* from (.b60) *)
     let shallow : (t60, _) idx_mut = (.b60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 138;
+    mark_test_run 141;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 138 failed %d" i;
+    if not test then failwithf "test 141 failed %d" i;
   );
 
   (***********************************)
@@ -1694,9 +1712,9 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 139;
+    mark_test_run 142;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 139 failed %d" i;
+    if not test then failwithf "test 142 failed %d" i;
   );
   (* Deepening to (.a61.#a28) *)
   let idx : (t61, _) idx_mut = (.a61.#a28) in
@@ -1704,15 +1722,15 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 140;
+    mark_test_run 143;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 140 failed %d" i;
+    if not test then failwithf "test 143 failed %d" i;
     (* from (.a61.#a28) *)
     let shallow : (t61, _) idx_mut = (.a61.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 141;
+    mark_test_run 144;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 141 failed %d" i;
+    if not test then failwithf "test 144 failed %d" i;
   );
   (* Deepening to (.a61.#b28) *)
   let idx : (t61, _) idx_mut = (.a61.#b28) in
@@ -1720,15 +1738,15 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 142;
+    mark_test_run 145;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 142 failed %d" i;
+    if not test then failwithf "test 145 failed %d" i;
     (* from (.a61.#b28) *)
     let shallow : (t61, _) idx_mut = (.a61.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 143;
+    mark_test_run 146;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 143 failed %d" i;
+    if not test then failwithf "test 146 failed %d" i;
   );
 
   (********************************************)
@@ -1740,9 +1758,9 @@ let to_run () =
     (* from (.a63) *)
     let shallow : (t63, _) idx_mut = (.a63) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 144;
+    mark_test_run 147;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 144 failed %d" i;
+    if not test then failwithf "test 147 failed %d" i;
   );
   (* Deepening to (.a63.#a62) *)
   let idx : (t63, _) idx_mut = (.a63.#a62) in
@@ -1750,15 +1768,15 @@ let to_run () =
     (* from (.a63) *)
     let shallow : (t63, _) idx_mut = (.a63) in
     let deepened = (.idx_mut(shallow).#a62) in
-    mark_test_run 145;
+    mark_test_run 148;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 145 failed %d" i;
+    if not test then failwithf "test 148 failed %d" i;
     (* from (.a63.#a62) *)
     let shallow : (t63, _) idx_mut = (.a63.#a62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 146;
+    mark_test_run 149;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 146 failed %d" i;
+    if not test then failwithf "test 149 failed %d" i;
   );
   (* Deepening to (.a63.#b62) *)
   let idx : (t63, _) idx_mut = (.a63.#b62) in
@@ -1766,15 +1784,15 @@ let to_run () =
     (* from (.a63) *)
     let shallow : (t63, _) idx_mut = (.a63) in
     let deepened = (.idx_mut(shallow).#b62) in
-    mark_test_run 147;
+    mark_test_run 150;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 147 failed %d" i;
+    if not test then failwithf "test 150 failed %d" i;
     (* from (.a63.#b62) *)
     let shallow : (t63, _) idx_mut = (.a63.#b62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 148;
+    mark_test_run 151;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 148 failed %d" i;
+    if not test then failwithf "test 151 failed %d" i;
   );
   (* Deepening to (.b63) *)
   let idx : (t63, _) idx_mut = (.b63) in
@@ -1782,26 +1800,50 @@ let to_run () =
     (* from (.b63) *)
     let shallow : (t63, _) idx_mut = (.b63) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 149;
+    mark_test_run 152;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 149 failed %d" i;
+    if not test then failwithf "test 152 failed %d" i;
   );
 
   (*************************************)
   (*   t65 = { #{ float# }; float# }   *)
   (*************************************)
   (* Deepening to (.a65) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t65, _) idx_mut = (.a65) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a65) *)
+    let shallow : (t65, _) idx_mut = (.a65) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 153;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 153 failed %d" i;
+  );
   (* Deepening to (.a65.#a64) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t65, _) idx_mut = (.a65.#a64) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a65) *)
+    let shallow : (t65, _) idx_mut = (.a65) in
+    let deepened = (.idx_mut(shallow).#a64) in
+    mark_test_run 154;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 154 failed %d" i;
+    (* from (.a65.#a64) *)
+    let shallow : (t65, _) idx_mut = (.a65.#a64) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 155;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 155 failed %d" i;
+  );
   (* Deepening to (.b65) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t65, _) idx_mut = (.b65) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.b65) *)
+    let shallow : (t65, _) idx_mut = (.b65) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 156;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 156 failed %d" i;
+  );
 
   (*********************************************)
   (*   t66 = { #{ string; string }; unit_u }   *)
@@ -1812,9 +1854,9 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 150;
+    mark_test_run 157;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 150 failed %d" i;
+    if not test then failwithf "test 157 failed %d" i;
   );
   (* Deepening to (.a66.#a37) *)
   let idx : (t66, _) idx_mut = (.a66.#a37) in
@@ -1822,15 +1864,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 151;
+    mark_test_run 158;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 151 failed %d" i;
+    if not test then failwithf "test 158 failed %d" i;
     (* from (.a66.#a37) *)
     let shallow : (t66, _) idx_mut = (.a66.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 152;
+    mark_test_run 159;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 152 failed %d" i;
+    if not test then failwithf "test 159 failed %d" i;
   );
   (* Deepening to (.a66.#b37) *)
   let idx : (t66, _) idx_mut = (.a66.#b37) in
@@ -1838,15 +1880,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 153;
+    mark_test_run 160;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 153 failed %d" i;
+    if not test then failwithf "test 160 failed %d" i;
     (* from (.a66.#b37) *)
     let shallow : (t66, _) idx_mut = (.a66.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 154;
+    mark_test_run 161;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 154 failed %d" i;
+    if not test then failwithf "test 161 failed %d" i;
   );
   (* Deepening to (.b66) *)
   let idx : (t66, _) idx_mut = (.b66) in
@@ -1863,7 +1905,7 @@ let to_run () =
 ;;
 let () = to_run ();;
 
-for i = 1 to 154 do
+for i = 1 to 161 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_bytecode_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_bytecode_test.ml
@@ -633,181 +633,89 @@ let to_run () =
   (*   t21 = { float; float }   *)
   (******************************)
   (* Deepening to (.a21) *)
-  let idx : (t21, _) idx_mut = (.a21) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a21) *)
-    let shallow : (t21, _) idx_mut = (.a21) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 45;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 45 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b21) *)
-  let idx : (t21, _) idx_mut = (.b21) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b21) *)
-    let shallow : (t21, _) idx_mut = (.b21) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 46;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 46 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*************************************)
   (*   t22 = { float; float; float }   *)
   (*************************************)
   (* Deepening to (.a22) *)
-  let idx : (t22, _) idx_mut = (.a22) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a22) *)
-    let shallow : (t22, _) idx_mut = (.a22) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 47;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 47 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b22) *)
-  let idx : (t22, _) idx_mut = (.b22) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b22) *)
-    let shallow : (t22, _) idx_mut = (.b22) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 48;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 48 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.c22) *)
-  let idx : (t22, _) idx_mut = (.c22) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.c22) *)
-    let shallow : (t22, _) idx_mut = (.c22) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 49;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 49 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (**************************************)
   (*   t23 = { float; float; float# }   *)
   (**************************************)
   (* Deepening to (.a23) *)
-  let idx : (t23, _) idx_mut = (.a23) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a23) *)
-    let shallow : (t23, _) idx_mut = (.a23) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 50;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 50 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b23) *)
-  let idx : (t23, _) idx_mut = (.b23) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b23) *)
-    let shallow : (t23, _) idx_mut = (.b23) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 51;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 51 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.c23) *)
-  let idx : (t23, _) idx_mut = (.c23) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.c23) *)
-    let shallow : (t23, _) idx_mut = (.c23) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 52;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 52 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*******************************)
   (*   t24 = { float; float# }   *)
   (*******************************)
   (* Deepening to (.a24) *)
-  let idx : (t24, _) idx_mut = (.a24) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a24) *)
-    let shallow : (t24, _) idx_mut = (.a24) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 53;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 53 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b24) *)
-  let idx : (t24, _) idx_mut = (.b24) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b24) *)
-    let shallow : (t24, _) idx_mut = (.b24) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 54;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 54 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (***************************************)
   (*   t25 = { float; float#; float# }   *)
   (***************************************)
   (* Deepening to (.a25) *)
-  let idx : (t25, _) idx_mut = (.a25) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a25) *)
-    let shallow : (t25, _) idx_mut = (.a25) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 55;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 55 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b25) *)
-  let idx : (t25, _) idx_mut = (.b25) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b25) *)
-    let shallow : (t25, _) idx_mut = (.b25) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 56;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 56 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.c25) *)
-  let idx : (t25, _) idx_mut = (.c25) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.c25) *)
-    let shallow : (t25, _) idx_mut = (.c25) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 57;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 57 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (***********************************)
   (*   t27 = { float; #{ float } }   *)
   (***********************************)
   (* Deepening to (.a27) *)
-  let idx : (t27, _) idx_mut = (.a27) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a27) *)
-    let shallow : (t27, _) idx_mut = (.a27) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 58;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 58 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b27) *)
   (* Note: skipping test as this is not a valid block index,
      due to the float record optimization *)
   ();
   (* Deepening to (.b27.#a26) *)
-  let idx : (t27, _) idx_mut = (.b27.#a26) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* Note: can't deepen (.b27) because it's a path to a flattened
-       float, making its element type [float#] *)
-    (* from (.b27.#a26) *)
-    let shallow : (t27, _) idx_mut = (.b27.#a26) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 59;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 59 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (******************************************)
   (*   t29 = { float; #{ float; float } }   *)
@@ -818,9 +726,9 @@ let to_run () =
     (* from (.a29) *)
     let shallow : (t29, _) idx_mut = (.a29) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 60;
+    mark_test_run 45;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 60 failed %d" i;
+    if not test then failwithf "test 45 failed %d" i;
   );
   (* Deepening to (.b29) *)
   let idx : (t29, _) idx_mut = (.b29) in
@@ -828,9 +736,9 @@ let to_run () =
     (* from (.b29) *)
     let shallow : (t29, _) idx_mut = (.b29) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 61;
+    mark_test_run 46;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 61 failed %d" i;
+    if not test then failwithf "test 46 failed %d" i;
   );
   (* Deepening to (.b29.#a28) *)
   let idx : (t29, _) idx_mut = (.b29.#a28) in
@@ -838,15 +746,15 @@ let to_run () =
     (* from (.b29) *)
     let shallow : (t29, _) idx_mut = (.b29) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 62;
+    mark_test_run 47;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 62 failed %d" i;
+    if not test then failwithf "test 47 failed %d" i;
     (* from (.b29.#a28) *)
     let shallow : (t29, _) idx_mut = (.b29.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 63;
+    mark_test_run 48;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 63 failed %d" i;
+    if not test then failwithf "test 48 failed %d" i;
   );
   (* Deepening to (.b29.#b28) *)
   let idx : (t29, _) idx_mut = (.b29.#b28) in
@@ -854,78 +762,48 @@ let to_run () =
     (* from (.b29) *)
     let shallow : (t29, _) idx_mut = (.b29) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 64;
+    mark_test_run 49;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 64 failed %d" i;
+    if not test then failwithf "test 49 failed %d" i;
     (* from (.b29.#b28) *)
     let shallow : (t29, _) idx_mut = (.b29.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 65;
+    mark_test_run 50;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 65 failed %d" i;
+    if not test then failwithf "test 50 failed %d" i;
   );
 
   (************************)
   (*   t30 = { float# }   *)
   (************************)
   (* Deepening to (.a30) *)
-  let idx : (t30, _) idx_mut = (.a30) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a30) *)
-    let shallow : (t30, _) idx_mut = (.a30) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 66;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 66 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*******************************)
   (*   t31 = { float#; float }   *)
   (*******************************)
   (* Deepening to (.a31) *)
-  let idx : (t31, _) idx_mut = (.a31) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a31) *)
-    let shallow : (t31, _) idx_mut = (.a31) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 67;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 67 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b31) *)
-  let idx : (t31, _) idx_mut = (.b31) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b31) *)
-    let shallow : (t31, _) idx_mut = (.b31) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 68;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 68 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (********************************)
   (*   t32 = { float#; float# }   *)
   (********************************)
   (* Deepening to (.a32) *)
-  let idx : (t32, _) idx_mut = (.a32) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a32) *)
-    let shallow : (t32, _) idx_mut = (.a32) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 69;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 69 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b32) *)
-  let idx : (t32, _) idx_mut = (.b32) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b32) *)
-    let shallow : (t32, _) idx_mut = (.b32) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 70;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 70 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*******************************************)
   (*   t33 = { float#; #{ float; float } }   *)
@@ -936,9 +814,9 @@ let to_run () =
     (* from (.a33) *)
     let shallow : (t33, _) idx_mut = (.a33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 71;
+    mark_test_run 51;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 71 failed %d" i;
+    if not test then failwithf "test 51 failed %d" i;
   );
   (* Deepening to (.b33) *)
   let idx : (t33, _) idx_mut = (.b33) in
@@ -946,9 +824,9 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 72;
+    mark_test_run 52;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 72 failed %d" i;
+    if not test then failwithf "test 52 failed %d" i;
   );
   (* Deepening to (.b33.#a28) *)
   let idx : (t33, _) idx_mut = (.b33.#a28) in
@@ -956,15 +834,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 73;
+    mark_test_run 53;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 73 failed %d" i;
+    if not test then failwithf "test 53 failed %d" i;
     (* from (.b33.#a28) *)
     let shallow : (t33, _) idx_mut = (.b33.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 74;
+    mark_test_run 54;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 74 failed %d" i;
+    if not test then failwithf "test 54 failed %d" i;
   );
   (* Deepening to (.b33.#b28) *)
   let idx : (t33, _) idx_mut = (.b33.#b28) in
@@ -972,15 +850,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 75;
+    mark_test_run 55;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 75 failed %d" i;
+    if not test then failwithf "test 55 failed %d" i;
     (* from (.b33.#b28) *)
     let shallow : (t33, _) idx_mut = (.b33.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 76;
+    mark_test_run 56;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 76 failed %d" i;
+    if not test then failwithf "test 56 failed %d" i;
   );
 
   (********************************************)
@@ -992,9 +870,9 @@ let to_run () =
     (* from (.a35) *)
     let shallow : (t35, _) idx_mut = (.a35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 77;
+    mark_test_run 57;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 77 failed %d" i;
+    if not test then failwithf "test 57 failed %d" i;
   );
   (* Deepening to (.b35) *)
   let idx : (t35, _) idx_mut = (.b35) in
@@ -1002,9 +880,9 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 78;
+    mark_test_run 58;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 78 failed %d" i;
+    if not test then failwithf "test 58 failed %d" i;
   );
   (* Deepening to (.b35.#a34) *)
   let idx : (t35, _) idx_mut = (.b35.#a34) in
@@ -1012,15 +890,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#a34) in
-    mark_test_run 79;
+    mark_test_run 59;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 79 failed %d" i;
+    if not test then failwithf "test 59 failed %d" i;
     (* from (.b35.#a34) *)
     let shallow : (t35, _) idx_mut = (.b35.#a34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 80;
+    mark_test_run 60;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 80 failed %d" i;
+    if not test then failwithf "test 60 failed %d" i;
   );
   (* Deepening to (.b35.#b34) *)
   let idx : (t35, _) idx_mut = (.b35.#b34) in
@@ -1028,15 +906,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#b34) in
-    mark_test_run 81;
+    mark_test_run 61;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 81 failed %d" i;
+    if not test then failwithf "test 61 failed %d" i;
     (* from (.b35.#b34) *)
     let shallow : (t35, _) idx_mut = (.b35.#b34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 82;
+    mark_test_run 62;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 82 failed %d" i;
+    if not test then failwithf "test 62 failed %d" i;
   );
 
   (****************************************)
@@ -1048,9 +926,9 @@ let to_run () =
     (* from (.a36) *)
     let shallow : (t36, _) idx_mut = (.a36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 83;
+    mark_test_run 63;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 83 failed %d" i;
+    if not test then failwithf "test 63 failed %d" i;
   );
   (* Deepening to (.b36) *)
   let idx : (t36, _) idx_mut = (.b36) in
@@ -1058,9 +936,9 @@ let to_run () =
     (* from (.b36) *)
     let shallow : (t36, _) idx_mut = (.b36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 84;
+    mark_test_run 64;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 84 failed %d" i;
+    if not test then failwithf "test 64 failed %d" i;
   );
   (* Deepening to (.c36) *)
   let idx : (t36, _) idx_mut = (.c36) in
@@ -1082,9 +960,9 @@ let to_run () =
     (* from (.a38) *)
     let shallow : (t38, _) idx_mut = (.a38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 85;
+    mark_test_run 65;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 85 failed %d" i;
+    if not test then failwithf "test 65 failed %d" i;
   );
   (* Deepening to (.b38) *)
   let idx : (t38, _) idx_mut = (.b38) in
@@ -1092,9 +970,9 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 86;
+    mark_test_run 66;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 86 failed %d" i;
+    if not test then failwithf "test 66 failed %d" i;
   );
   (* Deepening to (.b38.#a37) *)
   let idx : (t38, _) idx_mut = (.b38.#a37) in
@@ -1102,15 +980,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 87;
+    mark_test_run 67;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 87 failed %d" i;
+    if not test then failwithf "test 67 failed %d" i;
     (* from (.b38.#a37) *)
     let shallow : (t38, _) idx_mut = (.b38.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 88;
+    mark_test_run 68;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 88 failed %d" i;
+    if not test then failwithf "test 68 failed %d" i;
   );
   (* Deepening to (.b38.#b37) *)
   let idx : (t38, _) idx_mut = (.b38.#b37) in
@@ -1118,15 +996,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 89;
+    mark_test_run 69;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 89 failed %d" i;
+    if not test then failwithf "test 69 failed %d" i;
     (* from (.b38.#b37) *)
     let shallow : (t38, _) idx_mut = (.b38.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 90;
+    mark_test_run 70;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 90 failed %d" i;
+    if not test then failwithf "test 70 failed %d" i;
   );
 
   (****************************************)
@@ -1138,9 +1016,9 @@ let to_run () =
     (* from (.a39) *)
     let shallow : (t39, _) idx_mut = (.a39) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 91;
+    mark_test_run 71;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 91 failed %d" i;
+    if not test then failwithf "test 71 failed %d" i;
   );
   (* Deepening to (.b39) *)
   let idx : (t39, _) idx_mut = (.b39) in
@@ -1148,9 +1026,9 @@ let to_run () =
     (* from (.b39) *)
     let shallow : (t39, _) idx_mut = (.b39) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 92;
+    mark_test_run 72;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 92 failed %d" i;
+    if not test then failwithf "test 72 failed %d" i;
   );
 
   (************************************)
@@ -1162,9 +1040,9 @@ let to_run () =
     (* from (.a40) *)
     let shallow : (t40, _) idx_mut = (.a40) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 93;
+    mark_test_run 73;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 93 failed %d" i;
+    if not test then failwithf "test 73 failed %d" i;
   );
   (* Deepening to (.b40) *)
   let idx : (t40, _) idx_mut = (.b40) in
@@ -1186,9 +1064,9 @@ let to_run () =
     (* from (.a41) *)
     let shallow : (t41, _) idx_mut = (.a41) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 94;
+    mark_test_run 74;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 94 failed %d" i;
+    if not test then failwithf "test 74 failed %d" i;
   );
   (* Deepening to (.b41) *)
   let idx : (t41, _) idx_mut = (.b41) in
@@ -1196,9 +1074,9 @@ let to_run () =
     (* from (.b41) *)
     let shallow : (t41, _) idx_mut = (.b41) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 95;
+    mark_test_run 75;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 95 failed %d" i;
+    if not test then failwithf "test 75 failed %d" i;
   );
 
   (**************************)
@@ -1210,9 +1088,9 @@ let to_run () =
     (* from (.a43) *)
     let shallow : (t43, _) idx_mut = (.a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 96;
+    mark_test_run 76;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 96 failed %d" i;
+    if not test then failwithf "test 76 failed %d" i;
   );
   (* Deepening to (.a43.#a42) *)
   let idx : (t43, _) idx_mut = (.a43.#a42) in
@@ -1220,15 +1098,15 @@ let to_run () =
     (* from (.a43) *)
     let shallow : (t43, _) idx_mut = (.a43) in
     let deepened = (.idx_mut(shallow).#a42) in
-    mark_test_run 97;
+    mark_test_run 77;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 97 failed %d" i;
+    if not test then failwithf "test 77 failed %d" i;
     (* from (.a43.#a42) *)
     let shallow : (t43, _) idx_mut = (.a43.#a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 98;
+    mark_test_run 78;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 98 failed %d" i;
+    if not test then failwithf "test 78 failed %d" i;
   );
 
   (*******************************)
@@ -1240,9 +1118,9 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 99;
+    mark_test_run 79;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 99 failed %d" i;
+    if not test then failwithf "test 79 failed %d" i;
   );
   (* Deepening to (.a44.#a42) *)
   let idx : (t44, _) idx_mut = (.a44.#a42) in
@@ -1250,15 +1128,15 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow).#a42) in
-    mark_test_run 100;
+    mark_test_run 80;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 100 failed %d" i;
+    if not test then failwithf "test 80 failed %d" i;
     (* from (.a44.#a42) *)
     let shallow : (t44, _) idx_mut = (.a44.#a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 101;
+    mark_test_run 81;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 101 failed %d" i;
+    if not test then failwithf "test 81 failed %d" i;
   );
   (* Deepening to (.b44) *)
   let idx : (t44, _) idx_mut = (.b44) in
@@ -1266,9 +1144,9 @@ let to_run () =
     (* from (.b44) *)
     let shallow : (t44, _) idx_mut = (.b44) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 102;
+    mark_test_run 82;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 102 failed %d" i;
+    if not test then failwithf "test 82 failed %d" i;
   );
 
   (**********************************)
@@ -1280,9 +1158,9 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 103;
+    mark_test_run 83;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 103 failed %d" i;
+    if not test then failwithf "test 83 failed %d" i;
   );
   (* Deepening to (.a45.#a42) *)
   let idx : (t45, _) idx_mut = (.a45.#a42) in
@@ -1290,15 +1168,15 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow).#a42) in
-    mark_test_run 104;
+    mark_test_run 84;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 104 failed %d" i;
+    if not test then failwithf "test 84 failed %d" i;
     (* from (.a45.#a42) *)
     let shallow : (t45, _) idx_mut = (.a45.#a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 105;
+    mark_test_run 85;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 105 failed %d" i;
+    if not test then failwithf "test 85 failed %d" i;
   );
   (* Deepening to (.b45) *)
   let idx : (t45, _) idx_mut = (.b45) in
@@ -1306,9 +1184,9 @@ let to_run () =
     (* from (.b45) *)
     let shallow : (t45, _) idx_mut = (.b45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 106;
+    mark_test_run 86;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 106 failed %d" i;
+    if not test then failwithf "test 86 failed %d" i;
   );
 
   (*******************************)
@@ -1320,9 +1198,9 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 107;
+    mark_test_run 87;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 107 failed %d" i;
+    if not test then failwithf "test 87 failed %d" i;
   );
   (* Deepening to (.a46.#a13) *)
   let idx : (t46, _) idx_mut = (.a46.#a13) in
@@ -1330,15 +1208,15 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 108;
+    mark_test_run 88;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 108 failed %d" i;
+    if not test then failwithf "test 88 failed %d" i;
     (* from (.a46.#a13) *)
     let shallow : (t46, _) idx_mut = (.a46.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 109;
+    mark_test_run 89;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 109 failed %d" i;
+    if not test then failwithf "test 89 failed %d" i;
   );
   (* Deepening to (.a46.#b13) *)
   let idx : (t46, _) idx_mut = (.a46.#b13) in
@@ -1346,15 +1224,15 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 110;
+    mark_test_run 90;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 110 failed %d" i;
+    if not test then failwithf "test 90 failed %d" i;
     (* from (.a46.#b13) *)
     let shallow : (t46, _) idx_mut = (.a46.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 111;
+    mark_test_run 91;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 111 failed %d" i;
+    if not test then failwithf "test 91 failed %d" i;
   );
 
   (************************************)
@@ -1366,9 +1244,9 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 112;
+    mark_test_run 92;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 112 failed %d" i;
+    if not test then failwithf "test 92 failed %d" i;
   );
   (* Deepening to (.a47.#a13) *)
   let idx : (t47, _) idx_mut = (.a47.#a13) in
@@ -1376,15 +1254,15 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 113;
+    mark_test_run 93;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 113 failed %d" i;
+    if not test then failwithf "test 93 failed %d" i;
     (* from (.a47.#a13) *)
     let shallow : (t47, _) idx_mut = (.a47.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 114;
+    mark_test_run 94;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 114 failed %d" i;
+    if not test then failwithf "test 94 failed %d" i;
   );
   (* Deepening to (.a47.#b13) *)
   let idx : (t47, _) idx_mut = (.a47.#b13) in
@@ -1392,15 +1270,15 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 115;
+    mark_test_run 95;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 115 failed %d" i;
+    if not test then failwithf "test 95 failed %d" i;
     (* from (.a47.#b13) *)
     let shallow : (t47, _) idx_mut = (.a47.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 116;
+    mark_test_run 96;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 116 failed %d" i;
+    if not test then failwithf "test 96 failed %d" i;
   );
   (* Deepening to (.b47) *)
   let idx : (t47, _) idx_mut = (.b47) in
@@ -1408,9 +1286,9 @@ let to_run () =
     (* from (.b47) *)
     let shallow : (t47, _) idx_mut = (.b47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 117;
+    mark_test_run 97;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 117 failed %d" i;
+    if not test then failwithf "test 97 failed %d" i;
   );
 
   (***************************************)
@@ -1422,9 +1300,9 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 118;
+    mark_test_run 98;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 118 failed %d" i;
+    if not test then failwithf "test 98 failed %d" i;
   );
   (* Deepening to (.a48.#a13) *)
   let idx : (t48, _) idx_mut = (.a48.#a13) in
@@ -1432,15 +1310,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 119;
+    mark_test_run 99;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 119 failed %d" i;
+    if not test then failwithf "test 99 failed %d" i;
     (* from (.a48.#a13) *)
     let shallow : (t48, _) idx_mut = (.a48.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 120;
+    mark_test_run 100;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 120 failed %d" i;
+    if not test then failwithf "test 100 failed %d" i;
   );
   (* Deepening to (.a48.#b13) *)
   let idx : (t48, _) idx_mut = (.a48.#b13) in
@@ -1448,15 +1326,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 121;
+    mark_test_run 101;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 121 failed %d" i;
+    if not test then failwithf "test 101 failed %d" i;
     (* from (.a48.#b13) *)
     let shallow : (t48, _) idx_mut = (.a48.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 122;
+    mark_test_run 102;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 122 failed %d" i;
+    if not test then failwithf "test 102 failed %d" i;
   );
   (* Deepening to (.b48) *)
   let idx : (t48, _) idx_mut = (.b48) in
@@ -1464,9 +1342,9 @@ let to_run () =
     (* from (.b48) *)
     let shallow : (t48, _) idx_mut = (.b48) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 123;
+    mark_test_run 103;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 123 failed %d" i;
+    if not test then failwithf "test 103 failed %d" i;
   );
 
   (***************************************)
@@ -1478,9 +1356,9 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 124;
+    mark_test_run 104;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 124 failed %d" i;
+    if not test then failwithf "test 104 failed %d" i;
   );
   (* Deepening to (.a50.#a49) *)
   let idx : (t50, _) idx_mut = (.a50.#a49) in
@@ -1488,15 +1366,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#a49) in
-    mark_test_run 125;
+    mark_test_run 105;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 125 failed %d" i;
+    if not test then failwithf "test 105 failed %d" i;
     (* from (.a50.#a49) *)
     let shallow : (t50, _) idx_mut = (.a50.#a49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 126;
+    mark_test_run 106;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 126 failed %d" i;
+    if not test then failwithf "test 106 failed %d" i;
   );
   (* Deepening to (.a50.#b49) *)
   let idx : (t50, _) idx_mut = (.a50.#b49) in
@@ -1504,15 +1382,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#b49) in
-    mark_test_run 127;
+    mark_test_run 107;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 127 failed %d" i;
+    if not test then failwithf "test 107 failed %d" i;
     (* from (.a50.#b49) *)
     let shallow : (t50, _) idx_mut = (.a50.#b49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 128;
+    mark_test_run 108;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 128 failed %d" i;
+    if not test then failwithf "test 108 failed %d" i;
   );
   (* Deepening to (.b50) *)
   let idx : (t50, _) idx_mut = (.b50) in
@@ -1520,9 +1398,9 @@ let to_run () =
     (* from (.b50) *)
     let shallow : (t50, _) idx_mut = (.b50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 129;
+    mark_test_run 109;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 129 failed %d" i;
+    if not test then failwithf "test 109 failed %d" i;
   );
 
   (**************************************)
@@ -1534,9 +1412,9 @@ let to_run () =
     (* from (.a51) *)
     let shallow : (t51, _) idx_mut = (.a51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 130;
+    mark_test_run 110;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 130 failed %d" i;
+    if not test then failwithf "test 110 failed %d" i;
   );
   (* Deepening to (.a51.#a5) *)
   let idx : (t51, _) idx_mut = (.a51.#a5) in
@@ -1544,15 +1422,15 @@ let to_run () =
     (* from (.a51) *)
     let shallow : (t51, _) idx_mut = (.a51) in
     let deepened = (.idx_mut(shallow).#a5) in
-    mark_test_run 131;
+    mark_test_run 111;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 131 failed %d" i;
+    if not test then failwithf "test 111 failed %d" i;
     (* from (.a51.#a5) *)
     let shallow : (t51, _) idx_mut = (.a51.#a5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 132;
+    mark_test_run 112;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 132 failed %d" i;
+    if not test then failwithf "test 112 failed %d" i;
   );
   (* Deepening to (.a51.#b5) *)
   let idx : (t51, _) idx_mut = (.a51.#b5) in
@@ -1560,15 +1438,15 @@ let to_run () =
     (* from (.a51) *)
     let shallow : (t51, _) idx_mut = (.a51) in
     let deepened = (.idx_mut(shallow).#b5) in
-    mark_test_run 133;
+    mark_test_run 113;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 133 failed %d" i;
+    if not test then failwithf "test 113 failed %d" i;
     (* from (.a51.#b5) *)
     let shallow : (t51, _) idx_mut = (.a51.#b5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 134;
+    mark_test_run 114;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 134 failed %d" i;
+    if not test then failwithf "test 114 failed %d" i;
   );
   (* Deepening to (.b51) *)
   let idx : (t51, _) idx_mut = (.b51) in
@@ -1576,9 +1454,9 @@ let to_run () =
     (* from (.b51) *)
     let shallow : (t51, _) idx_mut = (.b51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 135;
+    mark_test_run 115;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 135 failed %d" i;
+    if not test then failwithf "test 115 failed %d" i;
   );
 
   (*********************************************************)
@@ -1590,9 +1468,9 @@ let to_run () =
     (* from (.a54) *)
     let shallow : (t54, _) idx_mut = (.a54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 136;
+    mark_test_run 116;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 136 failed %d" i;
+    if not test then failwithf "test 116 failed %d" i;
   );
   (* Deepening to (.a54.#a52) *)
   let idx : (t54, _) idx_mut = (.a54.#a52) in
@@ -1600,15 +1478,15 @@ let to_run () =
     (* from (.a54) *)
     let shallow : (t54, _) idx_mut = (.a54) in
     let deepened = (.idx_mut(shallow).#a52) in
-    mark_test_run 137;
+    mark_test_run 117;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 137 failed %d" i;
+    if not test then failwithf "test 117 failed %d" i;
     (* from (.a54.#a52) *)
     let shallow : (t54, _) idx_mut = (.a54.#a52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 138;
+    mark_test_run 118;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 138 failed %d" i;
+    if not test then failwithf "test 118 failed %d" i;
   );
   (* Deepening to (.a54.#b52) *)
   let idx : (t54, _) idx_mut = (.a54.#b52) in
@@ -1616,15 +1494,15 @@ let to_run () =
     (* from (.a54) *)
     let shallow : (t54, _) idx_mut = (.a54) in
     let deepened = (.idx_mut(shallow).#b52) in
-    mark_test_run 139;
+    mark_test_run 119;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 139 failed %d" i;
+    if not test then failwithf "test 119 failed %d" i;
     (* from (.a54.#b52) *)
     let shallow : (t54, _) idx_mut = (.a54.#b52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 140;
+    mark_test_run 120;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 140 failed %d" i;
+    if not test then failwithf "test 120 failed %d" i;
   );
   (* Deepening to (.b54) *)
   let idx : (t54, _) idx_mut = (.b54) in
@@ -1632,9 +1510,9 @@ let to_run () =
     (* from (.b54) *)
     let shallow : (t54, _) idx_mut = (.b54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 141;
+    mark_test_run 121;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 141 failed %d" i;
+    if not test then failwithf "test 121 failed %d" i;
   );
   (* Deepening to (.b54.#a53) *)
   let idx : (t54, _) idx_mut = (.b54.#a53) in
@@ -1642,15 +1520,15 @@ let to_run () =
     (* from (.b54) *)
     let shallow : (t54, _) idx_mut = (.b54) in
     let deepened = (.idx_mut(shallow).#a53) in
-    mark_test_run 142;
+    mark_test_run 122;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 142 failed %d" i;
+    if not test then failwithf "test 122 failed %d" i;
     (* from (.b54.#a53) *)
     let shallow : (t54, _) idx_mut = (.b54.#a53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 143;
+    mark_test_run 123;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 143 failed %d" i;
+    if not test then failwithf "test 123 failed %d" i;
   );
   (* Deepening to (.b54.#b53) *)
   let idx : (t54, _) idx_mut = (.b54.#b53) in
@@ -1658,15 +1536,15 @@ let to_run () =
     (* from (.b54) *)
     let shallow : (t54, _) idx_mut = (.b54) in
     let deepened = (.idx_mut(shallow).#b53) in
-    mark_test_run 144;
+    mark_test_run 124;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 144 failed %d" i;
+    if not test then failwithf "test 124 failed %d" i;
     (* from (.b54.#b53) *)
     let shallow : (t54, _) idx_mut = (.b54.#b53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 145;
+    mark_test_run 125;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 145 failed %d" i;
+    if not test then failwithf "test 125 failed %d" i;
   );
 
   (*****************************)
@@ -1678,9 +1556,9 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 146;
+    mark_test_run 126;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 146 failed %d" i;
+    if not test then failwithf "test 126 failed %d" i;
   );
   (* Deepening to (.a56.#a55) *)
   let idx : (t56, _) idx_mut = (.a56.#a55) in
@@ -1688,15 +1566,15 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow).#a55) in
-    mark_test_run 147;
+    mark_test_run 127;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 147 failed %d" i;
+    if not test then failwithf "test 127 failed %d" i;
     (* from (.a56.#a55) *)
     let shallow : (t56, _) idx_mut = (.a56.#a55) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 148;
+    mark_test_run 128;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 148 failed %d" i;
+    if not test then failwithf "test 128 failed %d" i;
   );
 
   (*************************************)
@@ -1708,9 +1586,9 @@ let to_run () =
     (* from (.a57) *)
     let shallow : (t57, _) idx_mut = (.a57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 149;
+    mark_test_run 129;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 149 failed %d" i;
+    if not test then failwithf "test 129 failed %d" i;
   );
   (* Deepening to (.a57.#a55) *)
   let idx : (t57, _) idx_mut = (.a57.#a55) in
@@ -1718,15 +1596,15 @@ let to_run () =
     (* from (.a57) *)
     let shallow : (t57, _) idx_mut = (.a57) in
     let deepened = (.idx_mut(shallow).#a55) in
-    mark_test_run 150;
+    mark_test_run 130;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 150 failed %d" i;
+    if not test then failwithf "test 130 failed %d" i;
     (* from (.a57.#a55) *)
     let shallow : (t57, _) idx_mut = (.a57.#a55) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 151;
+    mark_test_run 131;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 151 failed %d" i;
+    if not test then failwithf "test 131 failed %d" i;
   );
   (* Deepening to (.b57) *)
   let idx : (t57, _) idx_mut = (.b57) in
@@ -1734,9 +1612,9 @@ let to_run () =
     (* from (.b57) *)
     let shallow : (t57, _) idx_mut = (.b57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 152;
+    mark_test_run 132;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 152 failed %d" i;
+    if not test then failwithf "test 132 failed %d" i;
   );
 
   (****************************)
@@ -1747,17 +1625,9 @@ let to_run () =
      due to the float record optimization *)
   ();
   (* Deepening to (.a58.#a26) *)
-  let idx : (t58, _) idx_mut = (.a58.#a26) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* Note: can't deepen (.a58) because it's a path to a flattened
-       float, making its element type [float#] *)
-    (* from (.a58.#a26) *)
-    let shallow : (t58, _) idx_mut = (.a58.#a26) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 153;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 153 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (**************************************)
   (*   t60 = { #{ float; int }; int }   *)
@@ -1768,9 +1638,9 @@ let to_run () =
     (* from (.a60) *)
     let shallow : (t60, _) idx_mut = (.a60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 154;
+    mark_test_run 133;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 154 failed %d" i;
+    if not test then failwithf "test 133 failed %d" i;
   );
   (* Deepening to (.a60.#a59) *)
   let idx : (t60, _) idx_mut = (.a60.#a59) in
@@ -1778,15 +1648,15 @@ let to_run () =
     (* from (.a60) *)
     let shallow : (t60, _) idx_mut = (.a60) in
     let deepened = (.idx_mut(shallow).#a59) in
-    mark_test_run 155;
+    mark_test_run 134;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 155 failed %d" i;
+    if not test then failwithf "test 134 failed %d" i;
     (* from (.a60.#a59) *)
     let shallow : (t60, _) idx_mut = (.a60.#a59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 156;
+    mark_test_run 135;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 156 failed %d" i;
+    if not test then failwithf "test 135 failed %d" i;
   );
   (* Deepening to (.a60.#b59) *)
   let idx : (t60, _) idx_mut = (.a60.#b59) in
@@ -1794,15 +1664,15 @@ let to_run () =
     (* from (.a60) *)
     let shallow : (t60, _) idx_mut = (.a60) in
     let deepened = (.idx_mut(shallow).#b59) in
-    mark_test_run 157;
+    mark_test_run 136;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 157 failed %d" i;
+    if not test then failwithf "test 136 failed %d" i;
     (* from (.a60.#b59) *)
     let shallow : (t60, _) idx_mut = (.a60.#b59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 158;
+    mark_test_run 137;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 158 failed %d" i;
+    if not test then failwithf "test 137 failed %d" i;
   );
   (* Deepening to (.b60) *)
   let idx : (t60, _) idx_mut = (.b60) in
@@ -1810,9 +1680,9 @@ let to_run () =
     (* from (.b60) *)
     let shallow : (t60, _) idx_mut = (.b60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 159;
+    mark_test_run 138;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 159 failed %d" i;
+    if not test then failwithf "test 138 failed %d" i;
   );
 
   (***********************************)
@@ -1824,9 +1694,9 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 160;
+    mark_test_run 139;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 160 failed %d" i;
+    if not test then failwithf "test 139 failed %d" i;
   );
   (* Deepening to (.a61.#a28) *)
   let idx : (t61, _) idx_mut = (.a61.#a28) in
@@ -1834,15 +1704,15 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 161;
+    mark_test_run 140;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 161 failed %d" i;
+    if not test then failwithf "test 140 failed %d" i;
     (* from (.a61.#a28) *)
     let shallow : (t61, _) idx_mut = (.a61.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 162;
+    mark_test_run 141;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 162 failed %d" i;
+    if not test then failwithf "test 141 failed %d" i;
   );
   (* Deepening to (.a61.#b28) *)
   let idx : (t61, _) idx_mut = (.a61.#b28) in
@@ -1850,15 +1720,15 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 163;
+    mark_test_run 142;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 163 failed %d" i;
+    if not test then failwithf "test 142 failed %d" i;
     (* from (.a61.#b28) *)
     let shallow : (t61, _) idx_mut = (.a61.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 164;
+    mark_test_run 143;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 164 failed %d" i;
+    if not test then failwithf "test 143 failed %d" i;
   );
 
   (********************************************)
@@ -1870,9 +1740,9 @@ let to_run () =
     (* from (.a63) *)
     let shallow : (t63, _) idx_mut = (.a63) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 165;
+    mark_test_run 144;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 165 failed %d" i;
+    if not test then failwithf "test 144 failed %d" i;
   );
   (* Deepening to (.a63.#a62) *)
   let idx : (t63, _) idx_mut = (.a63.#a62) in
@@ -1880,15 +1750,15 @@ let to_run () =
     (* from (.a63) *)
     let shallow : (t63, _) idx_mut = (.a63) in
     let deepened = (.idx_mut(shallow).#a62) in
-    mark_test_run 166;
+    mark_test_run 145;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 166 failed %d" i;
+    if not test then failwithf "test 145 failed %d" i;
     (* from (.a63.#a62) *)
     let shallow : (t63, _) idx_mut = (.a63.#a62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 167;
+    mark_test_run 146;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 167 failed %d" i;
+    if not test then failwithf "test 146 failed %d" i;
   );
   (* Deepening to (.a63.#b62) *)
   let idx : (t63, _) idx_mut = (.a63.#b62) in
@@ -1896,15 +1766,15 @@ let to_run () =
     (* from (.a63) *)
     let shallow : (t63, _) idx_mut = (.a63) in
     let deepened = (.idx_mut(shallow).#b62) in
-    mark_test_run 168;
+    mark_test_run 147;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 168 failed %d" i;
+    if not test then failwithf "test 147 failed %d" i;
     (* from (.a63.#b62) *)
     let shallow : (t63, _) idx_mut = (.a63.#b62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 169;
+    mark_test_run 148;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 169 failed %d" i;
+    if not test then failwithf "test 148 failed %d" i;
   );
   (* Deepening to (.b63) *)
   let idx : (t63, _) idx_mut = (.b63) in
@@ -1912,50 +1782,26 @@ let to_run () =
     (* from (.b63) *)
     let shallow : (t63, _) idx_mut = (.b63) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 170;
+    mark_test_run 149;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 170 failed %d" i;
+    if not test then failwithf "test 149 failed %d" i;
   );
 
   (*************************************)
   (*   t65 = { #{ float# }; float# }   *)
   (*************************************)
   (* Deepening to (.a65) *)
-  let idx : (t65, _) idx_mut = (.a65) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a65) *)
-    let shallow : (t65, _) idx_mut = (.a65) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 171;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 171 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.a65.#a64) *)
-  let idx : (t65, _) idx_mut = (.a65.#a64) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a65) *)
-    let shallow : (t65, _) idx_mut = (.a65) in
-    let deepened = (.idx_mut(shallow).#a64) in
-    mark_test_run 172;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 172 failed %d" i;
-    (* from (.a65.#a64) *)
-    let shallow : (t65, _) idx_mut = (.a65.#a64) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 173;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 173 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b65) *)
-  let idx : (t65, _) idx_mut = (.b65) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b65) *)
-    let shallow : (t65, _) idx_mut = (.b65) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 174;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 174 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*********************************************)
   (*   t66 = { #{ string; string }; unit_u }   *)
@@ -1966,9 +1812,9 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 175;
+    mark_test_run 150;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 175 failed %d" i;
+    if not test then failwithf "test 150 failed %d" i;
   );
   (* Deepening to (.a66.#a37) *)
   let idx : (t66, _) idx_mut = (.a66.#a37) in
@@ -1976,15 +1822,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 176;
+    mark_test_run 151;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 176 failed %d" i;
+    if not test then failwithf "test 151 failed %d" i;
     (* from (.a66.#a37) *)
     let shallow : (t66, _) idx_mut = (.a66.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 177;
+    mark_test_run 152;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 177 failed %d" i;
+    if not test then failwithf "test 152 failed %d" i;
   );
   (* Deepening to (.a66.#b37) *)
   let idx : (t66, _) idx_mut = (.a66.#b37) in
@@ -1992,15 +1838,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 178;
+    mark_test_run 153;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 178 failed %d" i;
+    if not test then failwithf "test 153 failed %d" i;
     (* from (.a66.#b37) *)
     let shallow : (t66, _) idx_mut = (.a66.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 179;
+    mark_test_run 154;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 179 failed %d" i;
+    if not test then failwithf "test 154 failed %d" i;
   );
   (* Deepening to (.b66) *)
   let idx : (t66, _) idx_mut = (.b66) in
@@ -2017,7 +1863,7 @@ let to_run () =
 ;;
 let () = to_run ();;
 
-for i = 1 to 179 do
+for i = 1 to 154 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_native_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_native_test.ml
@@ -801,9 +801,15 @@ let to_run () =
   (*   t30 = { float# }   *)
   (************************)
   (* Deepening to (.a30) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t30, _) idx_mut = (.a30) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a30) *)
+    let shallow : (t30, _) idx_mut = (.a30) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 51;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 51 failed %d" i;
+  );
 
   (*******************************)
   (*   t31 = { float#; float }   *)
@@ -821,13 +827,25 @@ let to_run () =
   (*   t32 = { float#; float# }   *)
   (********************************)
   (* Deepening to (.a32) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t32, _) idx_mut = (.a32) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a32) *)
+    let shallow : (t32, _) idx_mut = (.a32) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 52;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 52 failed %d" i;
+  );
   (* Deepening to (.b32) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t32, _) idx_mut = (.b32) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.b32) *)
+    let shallow : (t32, _) idx_mut = (.b32) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 53;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 53 failed %d" i;
+  );
 
   (*******************************************)
   (*   t33 = { float#; #{ float; float } }   *)
@@ -838,9 +856,9 @@ let to_run () =
     (* from (.a33) *)
     let shallow : (t33, _) idx_mut = (.a33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 51;
+    mark_test_run 54;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 51 failed %d" i;
+    if not test then failwithf "test 54 failed %d" i;
   );
   (* Deepening to (.b33) *)
   let idx : (t33, _) idx_mut = (.b33) in
@@ -848,9 +866,9 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 52;
+    mark_test_run 55;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 52 failed %d" i;
+    if not test then failwithf "test 55 failed %d" i;
   );
   (* Deepening to (.b33.#a28) *)
   let idx : (t33, _) idx_mut = (.b33.#a28) in
@@ -858,15 +876,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 53;
+    mark_test_run 56;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 53 failed %d" i;
+    if not test then failwithf "test 56 failed %d" i;
     (* from (.b33.#a28) *)
     let shallow : (t33, _) idx_mut = (.b33.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 54;
+    mark_test_run 57;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 54 failed %d" i;
+    if not test then failwithf "test 57 failed %d" i;
   );
   (* Deepening to (.b33.#b28) *)
   let idx : (t33, _) idx_mut = (.b33.#b28) in
@@ -874,15 +892,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 55;
+    mark_test_run 58;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 55 failed %d" i;
+    if not test then failwithf "test 58 failed %d" i;
     (* from (.b33.#b28) *)
     let shallow : (t33, _) idx_mut = (.b33.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 56;
+    mark_test_run 59;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 56 failed %d" i;
+    if not test then failwithf "test 59 failed %d" i;
   );
 
   (********************************************)
@@ -894,9 +912,9 @@ let to_run () =
     (* from (.a35) *)
     let shallow : (t35, _) idx_mut = (.a35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 57;
+    mark_test_run 60;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 57 failed %d" i;
+    if not test then failwithf "test 60 failed %d" i;
   );
   (* Deepening to (.b35) *)
   let idx : (t35, _) idx_mut = (.b35) in
@@ -904,9 +922,9 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 58;
+    mark_test_run 61;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 58 failed %d" i;
+    if not test then failwithf "test 61 failed %d" i;
   );
   (* Deepening to (.b35.#a34) *)
   let idx : (t35, _) idx_mut = (.b35.#a34) in
@@ -914,15 +932,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#a34) in
-    mark_test_run 59;
+    mark_test_run 62;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 59 failed %d" i;
+    if not test then failwithf "test 62 failed %d" i;
     (* from (.b35.#a34) *)
     let shallow : (t35, _) idx_mut = (.b35.#a34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 60;
+    mark_test_run 63;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 60 failed %d" i;
+    if not test then failwithf "test 63 failed %d" i;
   );
   (* Deepening to (.b35.#b34) *)
   let idx : (t35, _) idx_mut = (.b35.#b34) in
@@ -930,15 +948,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#b34) in
-    mark_test_run 61;
+    mark_test_run 64;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 61 failed %d" i;
+    if not test then failwithf "test 64 failed %d" i;
     (* from (.b35.#b34) *)
     let shallow : (t35, _) idx_mut = (.b35.#b34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 62;
+    mark_test_run 65;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 62 failed %d" i;
+    if not test then failwithf "test 65 failed %d" i;
   );
 
   (****************************************)
@@ -950,9 +968,9 @@ let to_run () =
     (* from (.a36) *)
     let shallow : (t36, _) idx_mut = (.a36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 63;
+    mark_test_run 66;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 63 failed %d" i;
+    if not test then failwithf "test 66 failed %d" i;
   );
   (* Deepening to (.b36) *)
   let idx : (t36, _) idx_mut = (.b36) in
@@ -960,9 +978,9 @@ let to_run () =
     (* from (.b36) *)
     let shallow : (t36, _) idx_mut = (.b36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 64;
+    mark_test_run 67;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 64 failed %d" i;
+    if not test then failwithf "test 67 failed %d" i;
   );
   (* Deepening to (.c36) *)
   let idx : (t36, _) idx_mut = (.c36) in
@@ -984,9 +1002,9 @@ let to_run () =
     (* from (.a38) *)
     let shallow : (t38, _) idx_mut = (.a38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 65;
+    mark_test_run 68;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 65 failed %d" i;
+    if not test then failwithf "test 68 failed %d" i;
   );
   (* Deepening to (.b38) *)
   let idx : (t38, _) idx_mut = (.b38) in
@@ -994,9 +1012,9 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 66;
+    mark_test_run 69;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 66 failed %d" i;
+    if not test then failwithf "test 69 failed %d" i;
   );
   (* Deepening to (.b38.#a37) *)
   let idx : (t38, _) idx_mut = (.b38.#a37) in
@@ -1004,15 +1022,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 67;
+    mark_test_run 70;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 67 failed %d" i;
+    if not test then failwithf "test 70 failed %d" i;
     (* from (.b38.#a37) *)
     let shallow : (t38, _) idx_mut = (.b38.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 68;
+    mark_test_run 71;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 68 failed %d" i;
+    if not test then failwithf "test 71 failed %d" i;
   );
   (* Deepening to (.b38.#b37) *)
   let idx : (t38, _) idx_mut = (.b38.#b37) in
@@ -1020,15 +1038,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 69;
+    mark_test_run 72;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 69 failed %d" i;
+    if not test then failwithf "test 72 failed %d" i;
     (* from (.b38.#b37) *)
     let shallow : (t38, _) idx_mut = (.b38.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 70;
+    mark_test_run 73;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 70 failed %d" i;
+    if not test then failwithf "test 73 failed %d" i;
   );
 
   (**************************)
@@ -1040,9 +1058,9 @@ let to_run () =
     (* from (.a39) *)
     let shallow : (t39, _) idx_mut = (.a39) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 71;
+    mark_test_run 74;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 71 failed %d" i;
+    if not test then failwithf "test 74 failed %d" i;
   );
 
   (****************************************)
@@ -1054,9 +1072,9 @@ let to_run () =
     (* from (.a40) *)
     let shallow : (t40, _) idx_mut = (.a40) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 72;
+    mark_test_run 75;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 72 failed %d" i;
+    if not test then failwithf "test 75 failed %d" i;
   );
   (* Deepening to (.b40) *)
   let idx : (t40, _) idx_mut = (.b40) in
@@ -1064,9 +1082,9 @@ let to_run () =
     (* from (.b40) *)
     let shallow : (t40, _) idx_mut = (.b40) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 73;
+    mark_test_run 76;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 73 failed %d" i;
+    if not test then failwithf "test 76 failed %d" i;
   );
 
   (************************************)
@@ -1078,9 +1096,9 @@ let to_run () =
     (* from (.a41) *)
     let shallow : (t41, _) idx_mut = (.a41) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 74;
+    mark_test_run 77;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 74 failed %d" i;
+    if not test then failwithf "test 77 failed %d" i;
   );
   (* Deepening to (.b41) *)
   let idx : (t41, _) idx_mut = (.b41) in
@@ -1102,9 +1120,9 @@ let to_run () =
     (* from (.a42) *)
     let shallow : (t42, _) idx_mut = (.a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 75;
+    mark_test_run 78;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 75 failed %d" i;
+    if not test then failwithf "test 78 failed %d" i;
   );
   (* Deepening to (.b42) *)
   let idx : (t42, _) idx_mut = (.b42) in
@@ -1112,9 +1130,9 @@ let to_run () =
     (* from (.b42) *)
     let shallow : (t42, _) idx_mut = (.b42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 76;
+    mark_test_run 79;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 76 failed %d" i;
+    if not test then failwithf "test 79 failed %d" i;
   );
 
   (**************************)
@@ -1126,9 +1144,9 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 77;
+    mark_test_run 80;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 77 failed %d" i;
+    if not test then failwithf "test 80 failed %d" i;
   );
   (* Deepening to (.a44.#a43) *)
   let idx : (t44, _) idx_mut = (.a44.#a43) in
@@ -1136,15 +1154,15 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 78;
+    mark_test_run 81;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 78 failed %d" i;
+    if not test then failwithf "test 81 failed %d" i;
     (* from (.a44.#a43) *)
     let shallow : (t44, _) idx_mut = (.a44.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 79;
+    mark_test_run 82;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 79 failed %d" i;
+    if not test then failwithf "test 82 failed %d" i;
   );
 
   (*******************************)
@@ -1156,9 +1174,9 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 80;
+    mark_test_run 83;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 80 failed %d" i;
+    if not test then failwithf "test 83 failed %d" i;
   );
   (* Deepening to (.a45.#a43) *)
   let idx : (t45, _) idx_mut = (.a45.#a43) in
@@ -1166,15 +1184,15 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 81;
+    mark_test_run 84;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 81 failed %d" i;
+    if not test then failwithf "test 84 failed %d" i;
     (* from (.a45.#a43) *)
     let shallow : (t45, _) idx_mut = (.a45.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 82;
+    mark_test_run 85;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 82 failed %d" i;
+    if not test then failwithf "test 85 failed %d" i;
   );
   (* Deepening to (.b45) *)
   let idx : (t45, _) idx_mut = (.b45) in
@@ -1182,9 +1200,9 @@ let to_run () =
     (* from (.b45) *)
     let shallow : (t45, _) idx_mut = (.b45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 83;
+    mark_test_run 86;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 83 failed %d" i;
+    if not test then failwithf "test 86 failed %d" i;
   );
 
   (**********************************)
@@ -1196,9 +1214,9 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 84;
+    mark_test_run 87;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 84 failed %d" i;
+    if not test then failwithf "test 87 failed %d" i;
   );
   (* Deepening to (.a46.#a43) *)
   let idx : (t46, _) idx_mut = (.a46.#a43) in
@@ -1206,15 +1224,15 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 85;
+    mark_test_run 88;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 85 failed %d" i;
+    if not test then failwithf "test 88 failed %d" i;
     (* from (.a46.#a43) *)
     let shallow : (t46, _) idx_mut = (.a46.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 86;
+    mark_test_run 89;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 86 failed %d" i;
+    if not test then failwithf "test 89 failed %d" i;
   );
   (* Deepening to (.b46) *)
   let idx : (t46, _) idx_mut = (.b46) in
@@ -1222,9 +1240,9 @@ let to_run () =
     (* from (.b46) *)
     let shallow : (t46, _) idx_mut = (.b46) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 87;
+    mark_test_run 90;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 87 failed %d" i;
+    if not test then failwithf "test 90 failed %d" i;
   );
 
   (************************************)
@@ -1236,9 +1254,9 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 88;
+    mark_test_run 91;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 88 failed %d" i;
+    if not test then failwithf "test 91 failed %d" i;
   );
   (* Deepening to (.a47.#a43) *)
   let idx : (t47, _) idx_mut = (.a47.#a43) in
@@ -1246,15 +1264,15 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 89;
+    mark_test_run 92;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 89 failed %d" i;
+    if not test then failwithf "test 92 failed %d" i;
     (* from (.a47.#a43) *)
     let shallow : (t47, _) idx_mut = (.a47.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 90;
+    mark_test_run 93;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 90 failed %d" i;
+    if not test then failwithf "test 93 failed %d" i;
   );
   (* Deepening to (.b47) *)
   let idx : (t47, _) idx_mut = (.b47) in
@@ -1262,9 +1280,9 @@ let to_run () =
     (* from (.b47) *)
     let shallow : (t47, _) idx_mut = (.b47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 91;
+    mark_test_run 94;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 91 failed %d" i;
+    if not test then failwithf "test 94 failed %d" i;
   );
 
   (*******************************)
@@ -1276,9 +1294,9 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 92;
+    mark_test_run 95;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 92 failed %d" i;
+    if not test then failwithf "test 95 failed %d" i;
   );
   (* Deepening to (.a48.#a13) *)
   let idx : (t48, _) idx_mut = (.a48.#a13) in
@@ -1286,15 +1304,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 93;
+    mark_test_run 96;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 93 failed %d" i;
+    if not test then failwithf "test 96 failed %d" i;
     (* from (.a48.#a13) *)
     let shallow : (t48, _) idx_mut = (.a48.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 94;
+    mark_test_run 97;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 94 failed %d" i;
+    if not test then failwithf "test 97 failed %d" i;
   );
   (* Deepening to (.a48.#b13) *)
   let idx : (t48, _) idx_mut = (.a48.#b13) in
@@ -1302,15 +1320,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 95;
+    mark_test_run 98;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 95 failed %d" i;
+    if not test then failwithf "test 98 failed %d" i;
     (* from (.a48.#b13) *)
     let shallow : (t48, _) idx_mut = (.a48.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 96;
+    mark_test_run 99;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 96 failed %d" i;
+    if not test then failwithf "test 99 failed %d" i;
   );
 
   (************************************)
@@ -1322,9 +1340,9 @@ let to_run () =
     (* from (.a49) *)
     let shallow : (t49, _) idx_mut = (.a49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 97;
+    mark_test_run 100;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 97 failed %d" i;
+    if not test then failwithf "test 100 failed %d" i;
   );
   (* Deepening to (.a49.#a13) *)
   let idx : (t49, _) idx_mut = (.a49.#a13) in
@@ -1332,15 +1350,15 @@ let to_run () =
     (* from (.a49) *)
     let shallow : (t49, _) idx_mut = (.a49) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 98;
+    mark_test_run 101;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 98 failed %d" i;
+    if not test then failwithf "test 101 failed %d" i;
     (* from (.a49.#a13) *)
     let shallow : (t49, _) idx_mut = (.a49.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 99;
+    mark_test_run 102;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 99 failed %d" i;
+    if not test then failwithf "test 102 failed %d" i;
   );
   (* Deepening to (.a49.#b13) *)
   let idx : (t49, _) idx_mut = (.a49.#b13) in
@@ -1348,15 +1366,15 @@ let to_run () =
     (* from (.a49) *)
     let shallow : (t49, _) idx_mut = (.a49) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 100;
+    mark_test_run 103;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 100 failed %d" i;
+    if not test then failwithf "test 103 failed %d" i;
     (* from (.a49.#b13) *)
     let shallow : (t49, _) idx_mut = (.a49.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 101;
+    mark_test_run 104;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 101 failed %d" i;
+    if not test then failwithf "test 104 failed %d" i;
   );
   (* Deepening to (.b49) *)
   let idx : (t49, _) idx_mut = (.b49) in
@@ -1364,9 +1382,9 @@ let to_run () =
     (* from (.b49) *)
     let shallow : (t49, _) idx_mut = (.b49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 102;
+    mark_test_run 105;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 102 failed %d" i;
+    if not test then failwithf "test 105 failed %d" i;
   );
 
   (***************************************)
@@ -1378,9 +1396,9 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 103;
+    mark_test_run 106;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 103 failed %d" i;
+    if not test then failwithf "test 106 failed %d" i;
   );
   (* Deepening to (.a50.#a13) *)
   let idx : (t50, _) idx_mut = (.a50.#a13) in
@@ -1388,15 +1406,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 104;
+    mark_test_run 107;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 104 failed %d" i;
+    if not test then failwithf "test 107 failed %d" i;
     (* from (.a50.#a13) *)
     let shallow : (t50, _) idx_mut = (.a50.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 105;
+    mark_test_run 108;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 105 failed %d" i;
+    if not test then failwithf "test 108 failed %d" i;
   );
   (* Deepening to (.a50.#b13) *)
   let idx : (t50, _) idx_mut = (.a50.#b13) in
@@ -1404,15 +1422,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 106;
+    mark_test_run 109;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 106 failed %d" i;
+    if not test then failwithf "test 109 failed %d" i;
     (* from (.a50.#b13) *)
     let shallow : (t50, _) idx_mut = (.a50.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 107;
+    mark_test_run 110;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 107 failed %d" i;
+    if not test then failwithf "test 110 failed %d" i;
   );
   (* Deepening to (.b50) *)
   let idx : (t50, _) idx_mut = (.b50) in
@@ -1420,9 +1438,9 @@ let to_run () =
     (* from (.b50) *)
     let shallow : (t50, _) idx_mut = (.b50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 108;
+    mark_test_run 111;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 108 failed %d" i;
+    if not test then failwithf "test 111 failed %d" i;
   );
 
   (***************************************)
@@ -1434,9 +1452,9 @@ let to_run () =
     (* from (.a52) *)
     let shallow : (t52, _) idx_mut = (.a52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 109;
+    mark_test_run 112;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 109 failed %d" i;
+    if not test then failwithf "test 112 failed %d" i;
   );
   (* Deepening to (.a52.#a51) *)
   let idx : (t52, _) idx_mut = (.a52.#a51) in
@@ -1444,15 +1462,15 @@ let to_run () =
     (* from (.a52) *)
     let shallow : (t52, _) idx_mut = (.a52) in
     let deepened = (.idx_mut(shallow).#a51) in
-    mark_test_run 110;
+    mark_test_run 113;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 110 failed %d" i;
+    if not test then failwithf "test 113 failed %d" i;
     (* from (.a52.#a51) *)
     let shallow : (t52, _) idx_mut = (.a52.#a51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 111;
+    mark_test_run 114;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 111 failed %d" i;
+    if not test then failwithf "test 114 failed %d" i;
   );
   (* Deepening to (.a52.#b51) *)
   let idx : (t52, _) idx_mut = (.a52.#b51) in
@@ -1460,15 +1478,15 @@ let to_run () =
     (* from (.a52) *)
     let shallow : (t52, _) idx_mut = (.a52) in
     let deepened = (.idx_mut(shallow).#b51) in
-    mark_test_run 112;
+    mark_test_run 115;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 112 failed %d" i;
+    if not test then failwithf "test 115 failed %d" i;
     (* from (.a52.#b51) *)
     let shallow : (t52, _) idx_mut = (.a52.#b51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 113;
+    mark_test_run 116;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 113 failed %d" i;
+    if not test then failwithf "test 116 failed %d" i;
   );
   (* Deepening to (.b52) *)
   let idx : (t52, _) idx_mut = (.b52) in
@@ -1476,9 +1494,9 @@ let to_run () =
     (* from (.b52) *)
     let shallow : (t52, _) idx_mut = (.b52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 114;
+    mark_test_run 117;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 114 failed %d" i;
+    if not test then failwithf "test 117 failed %d" i;
   );
 
   (**************************************)
@@ -1490,9 +1508,9 @@ let to_run () =
     (* from (.a53) *)
     let shallow : (t53, _) idx_mut = (.a53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 115;
+    mark_test_run 118;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 115 failed %d" i;
+    if not test then failwithf "test 118 failed %d" i;
   );
   (* Deepening to (.a53.#a5) *)
   let idx : (t53, _) idx_mut = (.a53.#a5) in
@@ -1500,15 +1518,15 @@ let to_run () =
     (* from (.a53) *)
     let shallow : (t53, _) idx_mut = (.a53) in
     let deepened = (.idx_mut(shallow).#a5) in
-    mark_test_run 116;
+    mark_test_run 119;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 116 failed %d" i;
+    if not test then failwithf "test 119 failed %d" i;
     (* from (.a53.#a5) *)
     let shallow : (t53, _) idx_mut = (.a53.#a5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 117;
+    mark_test_run 120;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 117 failed %d" i;
+    if not test then failwithf "test 120 failed %d" i;
   );
   (* Deepening to (.a53.#b5) *)
   let idx : (t53, _) idx_mut = (.a53.#b5) in
@@ -1516,15 +1534,15 @@ let to_run () =
     (* from (.a53) *)
     let shallow : (t53, _) idx_mut = (.a53) in
     let deepened = (.idx_mut(shallow).#b5) in
-    mark_test_run 118;
+    mark_test_run 121;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 118 failed %d" i;
+    if not test then failwithf "test 121 failed %d" i;
     (* from (.a53.#b5) *)
     let shallow : (t53, _) idx_mut = (.a53.#b5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 119;
+    mark_test_run 122;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 119 failed %d" i;
+    if not test then failwithf "test 122 failed %d" i;
   );
   (* Deepening to (.b53) *)
   let idx : (t53, _) idx_mut = (.b53) in
@@ -1532,9 +1550,9 @@ let to_run () =
     (* from (.b53) *)
     let shallow : (t53, _) idx_mut = (.b53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 120;
+    mark_test_run 123;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 120 failed %d" i;
+    if not test then failwithf "test 123 failed %d" i;
   );
 
   (************************************)
@@ -1546,9 +1564,9 @@ let to_run () =
     (* from (.a55) *)
     let shallow : (t55, _) idx_mut = (.a55) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 121;
+    mark_test_run 124;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 121 failed %d" i;
+    if not test then failwithf "test 124 failed %d" i;
   );
   (* Deepening to (.a55.#a54) *)
   let idx : (t55, _) idx_mut = (.a55.#a54) in
@@ -1556,15 +1574,15 @@ let to_run () =
     (* from (.a55) *)
     let shallow : (t55, _) idx_mut = (.a55) in
     let deepened = (.idx_mut(shallow).#a54) in
-    mark_test_run 122;
+    mark_test_run 125;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 122 failed %d" i;
+    if not test then failwithf "test 125 failed %d" i;
     (* from (.a55.#a54) *)
     let shallow : (t55, _) idx_mut = (.a55.#a54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 123;
+    mark_test_run 126;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 123 failed %d" i;
+    if not test then failwithf "test 126 failed %d" i;
   );
   (* Deepening to (.a55.#b54) *)
   let idx : (t55, _) idx_mut = (.a55.#b54) in
@@ -1572,15 +1590,15 @@ let to_run () =
     (* from (.a55) *)
     let shallow : (t55, _) idx_mut = (.a55) in
     let deepened = (.idx_mut(shallow).#b54) in
-    mark_test_run 124;
+    mark_test_run 127;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 124 failed %d" i;
+    if not test then failwithf "test 127 failed %d" i;
     (* from (.a55.#b54) *)
     let shallow : (t55, _) idx_mut = (.a55.#b54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 125;
+    mark_test_run 128;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 125 failed %d" i;
+    if not test then failwithf "test 128 failed %d" i;
   );
 
   (*****************************************)
@@ -1592,9 +1610,9 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 126;
+    mark_test_run 129;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 126 failed %d" i;
+    if not test then failwithf "test 129 failed %d" i;
   );
   (* Deepening to (.a56.#a54) *)
   let idx : (t56, _) idx_mut = (.a56.#a54) in
@@ -1602,15 +1620,15 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow).#a54) in
-    mark_test_run 127;
+    mark_test_run 130;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 127 failed %d" i;
+    if not test then failwithf "test 130 failed %d" i;
     (* from (.a56.#a54) *)
     let shallow : (t56, _) idx_mut = (.a56.#a54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 128;
+    mark_test_run 131;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 128 failed %d" i;
+    if not test then failwithf "test 131 failed %d" i;
   );
   (* Deepening to (.a56.#b54) *)
   let idx : (t56, _) idx_mut = (.a56.#b54) in
@@ -1618,15 +1636,15 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow).#b54) in
-    mark_test_run 129;
+    mark_test_run 132;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 129 failed %d" i;
+    if not test then failwithf "test 132 failed %d" i;
     (* from (.a56.#b54) *)
     let shallow : (t56, _) idx_mut = (.a56.#b54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 130;
+    mark_test_run 133;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 130 failed %d" i;
+    if not test then failwithf "test 133 failed %d" i;
   );
   (* Deepening to (.b56) *)
   let idx : (t56, _) idx_mut = (.b56) in
@@ -1634,9 +1652,9 @@ let to_run () =
     (* from (.b56) *)
     let shallow : (t56, _) idx_mut = (.b56) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 131;
+    mark_test_run 134;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 131 failed %d" i;
+    if not test then failwithf "test 134 failed %d" i;
   );
 
   (*********************************************************)
@@ -1648,9 +1666,9 @@ let to_run () =
     (* from (.a59) *)
     let shallow : (t59, _) idx_mut = (.a59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 132;
+    mark_test_run 135;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 132 failed %d" i;
+    if not test then failwithf "test 135 failed %d" i;
   );
   (* Deepening to (.a59.#a57) *)
   let idx : (t59, _) idx_mut = (.a59.#a57) in
@@ -1658,15 +1676,15 @@ let to_run () =
     (* from (.a59) *)
     let shallow : (t59, _) idx_mut = (.a59) in
     let deepened = (.idx_mut(shallow).#a57) in
-    mark_test_run 133;
+    mark_test_run 136;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 133 failed %d" i;
+    if not test then failwithf "test 136 failed %d" i;
     (* from (.a59.#a57) *)
     let shallow : (t59, _) idx_mut = (.a59.#a57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 134;
+    mark_test_run 137;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 134 failed %d" i;
+    if not test then failwithf "test 137 failed %d" i;
   );
   (* Deepening to (.a59.#b57) *)
   let idx : (t59, _) idx_mut = (.a59.#b57) in
@@ -1674,15 +1692,15 @@ let to_run () =
     (* from (.a59) *)
     let shallow : (t59, _) idx_mut = (.a59) in
     let deepened = (.idx_mut(shallow).#b57) in
-    mark_test_run 135;
+    mark_test_run 138;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 135 failed %d" i;
+    if not test then failwithf "test 138 failed %d" i;
     (* from (.a59.#b57) *)
     let shallow : (t59, _) idx_mut = (.a59.#b57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 136;
+    mark_test_run 139;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 136 failed %d" i;
+    if not test then failwithf "test 139 failed %d" i;
   );
   (* Deepening to (.b59) *)
   let idx : (t59, _) idx_mut = (.b59) in
@@ -1690,9 +1708,9 @@ let to_run () =
     (* from (.b59) *)
     let shallow : (t59, _) idx_mut = (.b59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 137;
+    mark_test_run 140;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 137 failed %d" i;
+    if not test then failwithf "test 140 failed %d" i;
   );
   (* Deepening to (.b59.#a58) *)
   let idx : (t59, _) idx_mut = (.b59.#a58) in
@@ -1700,15 +1718,15 @@ let to_run () =
     (* from (.b59) *)
     let shallow : (t59, _) idx_mut = (.b59) in
     let deepened = (.idx_mut(shallow).#a58) in
-    mark_test_run 138;
+    mark_test_run 141;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 138 failed %d" i;
+    if not test then failwithf "test 141 failed %d" i;
     (* from (.b59.#a58) *)
     let shallow : (t59, _) idx_mut = (.b59.#a58) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 139;
+    mark_test_run 142;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 139 failed %d" i;
+    if not test then failwithf "test 142 failed %d" i;
   );
   (* Deepening to (.b59.#b58) *)
   let idx : (t59, _) idx_mut = (.b59.#b58) in
@@ -1716,15 +1734,15 @@ let to_run () =
     (* from (.b59) *)
     let shallow : (t59, _) idx_mut = (.b59) in
     let deepened = (.idx_mut(shallow).#b58) in
-    mark_test_run 140;
+    mark_test_run 143;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 140 failed %d" i;
+    if not test then failwithf "test 143 failed %d" i;
     (* from (.b59.#b58) *)
     let shallow : (t59, _) idx_mut = (.b59.#b58) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 141;
+    mark_test_run 144;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 141 failed %d" i;
+    if not test then failwithf "test 144 failed %d" i;
   );
 
   (*****************************)
@@ -1736,9 +1754,9 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 142;
+    mark_test_run 145;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 142 failed %d" i;
+    if not test then failwithf "test 145 failed %d" i;
   );
   (* Deepening to (.a61.#a60) *)
   let idx : (t61, _) idx_mut = (.a61.#a60) in
@@ -1746,15 +1764,15 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow).#a60) in
-    mark_test_run 143;
+    mark_test_run 146;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 143 failed %d" i;
+    if not test then failwithf "test 146 failed %d" i;
     (* from (.a61.#a60) *)
     let shallow : (t61, _) idx_mut = (.a61.#a60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 144;
+    mark_test_run 147;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 144 failed %d" i;
+    if not test then failwithf "test 147 failed %d" i;
   );
 
   (*************************************)
@@ -1766,9 +1784,9 @@ let to_run () =
     (* from (.a62) *)
     let shallow : (t62, _) idx_mut = (.a62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 145;
+    mark_test_run 148;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 145 failed %d" i;
+    if not test then failwithf "test 148 failed %d" i;
   );
   (* Deepening to (.a62.#a60) *)
   let idx : (t62, _) idx_mut = (.a62.#a60) in
@@ -1776,15 +1794,15 @@ let to_run () =
     (* from (.a62) *)
     let shallow : (t62, _) idx_mut = (.a62) in
     let deepened = (.idx_mut(shallow).#a60) in
-    mark_test_run 146;
+    mark_test_run 149;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 146 failed %d" i;
+    if not test then failwithf "test 149 failed %d" i;
     (* from (.a62.#a60) *)
     let shallow : (t62, _) idx_mut = (.a62.#a60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 147;
+    mark_test_run 150;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 147 failed %d" i;
+    if not test then failwithf "test 150 failed %d" i;
   );
   (* Deepening to (.b62) *)
   let idx : (t62, _) idx_mut = (.b62) in
@@ -1792,9 +1810,9 @@ let to_run () =
     (* from (.b62) *)
     let shallow : (t62, _) idx_mut = (.b62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 148;
+    mark_test_run 151;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 148 failed %d" i;
+    if not test then failwithf "test 151 failed %d" i;
   );
 
   (****************************)
@@ -1818,9 +1836,9 @@ let to_run () =
     (* from (.a65) *)
     let shallow : (t65, _) idx_mut = (.a65) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 149;
+    mark_test_run 152;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 149 failed %d" i;
+    if not test then failwithf "test 152 failed %d" i;
   );
   (* Deepening to (.a65.#a64) *)
   let idx : (t65, _) idx_mut = (.a65.#a64) in
@@ -1828,15 +1846,15 @@ let to_run () =
     (* from (.a65) *)
     let shallow : (t65, _) idx_mut = (.a65) in
     let deepened = (.idx_mut(shallow).#a64) in
-    mark_test_run 150;
+    mark_test_run 153;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 150 failed %d" i;
+    if not test then failwithf "test 153 failed %d" i;
     (* from (.a65.#a64) *)
     let shallow : (t65, _) idx_mut = (.a65.#a64) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 151;
+    mark_test_run 154;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 151 failed %d" i;
+    if not test then failwithf "test 154 failed %d" i;
   );
   (* Deepening to (.a65.#b64) *)
   let idx : (t65, _) idx_mut = (.a65.#b64) in
@@ -1844,15 +1862,15 @@ let to_run () =
     (* from (.a65) *)
     let shallow : (t65, _) idx_mut = (.a65) in
     let deepened = (.idx_mut(shallow).#b64) in
-    mark_test_run 152;
+    mark_test_run 155;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 152 failed %d" i;
+    if not test then failwithf "test 155 failed %d" i;
     (* from (.a65.#b64) *)
     let shallow : (t65, _) idx_mut = (.a65.#b64) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 153;
+    mark_test_run 156;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 153 failed %d" i;
+    if not test then failwithf "test 156 failed %d" i;
   );
   (* Deepening to (.b65) *)
   let idx : (t65, _) idx_mut = (.b65) in
@@ -1860,9 +1878,9 @@ let to_run () =
     (* from (.b65) *)
     let shallow : (t65, _) idx_mut = (.b65) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 154;
+    mark_test_run 157;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 154 failed %d" i;
+    if not test then failwithf "test 157 failed %d" i;
   );
 
   (***********************************)
@@ -1874,9 +1892,9 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 155;
+    mark_test_run 158;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 155 failed %d" i;
+    if not test then failwithf "test 158 failed %d" i;
   );
   (* Deepening to (.a66.#a28) *)
   let idx : (t66, _) idx_mut = (.a66.#a28) in
@@ -1884,15 +1902,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 156;
+    mark_test_run 159;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 156 failed %d" i;
+    if not test then failwithf "test 159 failed %d" i;
     (* from (.a66.#a28) *)
     let shallow : (t66, _) idx_mut = (.a66.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 157;
+    mark_test_run 160;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 157 failed %d" i;
+    if not test then failwithf "test 160 failed %d" i;
   );
   (* Deepening to (.a66.#b28) *)
   let idx : (t66, _) idx_mut = (.a66.#b28) in
@@ -1900,15 +1918,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 158;
+    mark_test_run 161;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 158 failed %d" i;
+    if not test then failwithf "test 161 failed %d" i;
     (* from (.a66.#b28) *)
     let shallow : (t66, _) idx_mut = (.a66.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 159;
+    mark_test_run 162;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 159 failed %d" i;
+    if not test then failwithf "test 162 failed %d" i;
   );
 
   (********************************************)
@@ -1920,9 +1938,9 @@ let to_run () =
     (* from (.a68) *)
     let shallow : (t68, _) idx_mut = (.a68) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 160;
+    mark_test_run 163;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 160 failed %d" i;
+    if not test then failwithf "test 163 failed %d" i;
   );
   (* Deepening to (.a68.#a67) *)
   let idx : (t68, _) idx_mut = (.a68.#a67) in
@@ -1930,15 +1948,15 @@ let to_run () =
     (* from (.a68) *)
     let shallow : (t68, _) idx_mut = (.a68) in
     let deepened = (.idx_mut(shallow).#a67) in
-    mark_test_run 161;
+    mark_test_run 164;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 161 failed %d" i;
+    if not test then failwithf "test 164 failed %d" i;
     (* from (.a68.#a67) *)
     let shallow : (t68, _) idx_mut = (.a68.#a67) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 162;
+    mark_test_run 165;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 162 failed %d" i;
+    if not test then failwithf "test 165 failed %d" i;
   );
   (* Deepening to (.a68.#b67) *)
   let idx : (t68, _) idx_mut = (.a68.#b67) in
@@ -1946,15 +1964,15 @@ let to_run () =
     (* from (.a68) *)
     let shallow : (t68, _) idx_mut = (.a68) in
     let deepened = (.idx_mut(shallow).#b67) in
-    mark_test_run 163;
+    mark_test_run 166;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 163 failed %d" i;
+    if not test then failwithf "test 166 failed %d" i;
     (* from (.a68.#b67) *)
     let shallow : (t68, _) idx_mut = (.a68.#b67) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 164;
+    mark_test_run 167;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 164 failed %d" i;
+    if not test then failwithf "test 167 failed %d" i;
   );
   (* Deepening to (.b68) *)
   let idx : (t68, _) idx_mut = (.b68) in
@@ -1962,26 +1980,50 @@ let to_run () =
     (* from (.b68) *)
     let shallow : (t68, _) idx_mut = (.b68) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 165;
+    mark_test_run 168;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 165 failed %d" i;
+    if not test then failwithf "test 168 failed %d" i;
   );
 
   (*************************************)
   (*   t70 = { #{ float# }; float# }   *)
   (*************************************)
   (* Deepening to (.a70) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t70, _) idx_mut = (.a70) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a70) *)
+    let shallow : (t70, _) idx_mut = (.a70) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 169;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 169 failed %d" i;
+  );
   (* Deepening to (.a70.#a69) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t70, _) idx_mut = (.a70.#a69) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.a70) *)
+    let shallow : (t70, _) idx_mut = (.a70) in
+    let deepened = (.idx_mut(shallow).#a69) in
+    mark_test_run 170;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 170 failed %d" i;
+    (* from (.a70.#a69) *)
+    let shallow : (t70, _) idx_mut = (.a70.#a69) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 171;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 171 failed %d" i;
+  );
   (* Deepening to (.b70) *)
-  (* Note: skipping test as this is not a valid block index,
-     due to the float record optimization *)
-  ();
+  let idx : (t70, _) idx_mut = (.b70) in
+  iter indices_in_deepening_tests ~f:(fun i ->
+    (* from (.b70) *)
+    let shallow : (t70, _) idx_mut = (.b70) in
+    let deepened = (.idx_mut(shallow)) in
+    mark_test_run 172;
+    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
+    if not test then failwithf "test 172 failed %d" i;
+  );
 
   (*********************************************)
   (*   t71 = { #{ string; string }; unit_u }   *)
@@ -1992,9 +2034,9 @@ let to_run () =
     (* from (.a71) *)
     let shallow : (t71, _) idx_mut = (.a71) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 166;
+    mark_test_run 173;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 166 failed %d" i;
+    if not test then failwithf "test 173 failed %d" i;
   );
   (* Deepening to (.a71.#a37) *)
   let idx : (t71, _) idx_mut = (.a71.#a37) in
@@ -2002,15 +2044,15 @@ let to_run () =
     (* from (.a71) *)
     let shallow : (t71, _) idx_mut = (.a71) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 167;
+    mark_test_run 174;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 167 failed %d" i;
+    if not test then failwithf "test 174 failed %d" i;
     (* from (.a71.#a37) *)
     let shallow : (t71, _) idx_mut = (.a71.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 168;
+    mark_test_run 175;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 168 failed %d" i;
+    if not test then failwithf "test 175 failed %d" i;
   );
   (* Deepening to (.a71.#b37) *)
   let idx : (t71, _) idx_mut = (.a71.#b37) in
@@ -2018,15 +2060,15 @@ let to_run () =
     (* from (.a71) *)
     let shallow : (t71, _) idx_mut = (.a71) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 169;
+    mark_test_run 176;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 169 failed %d" i;
+    if not test then failwithf "test 176 failed %d" i;
     (* from (.a71.#b37) *)
     let shallow : (t71, _) idx_mut = (.a71.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 170;
+    mark_test_run 177;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 170 failed %d" i;
+    if not test then failwithf "test 177 failed %d" i;
   );
   (* Deepening to (.b71) *)
   let idx : (t71, _) idx_mut = (.b71) in
@@ -2048,9 +2090,9 @@ let to_run () =
     (* from (.a74) *)
     let shallow : (t74, _) idx_mut = (.a74) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 171;
+    mark_test_run 178;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 171 failed %d" i;
+    if not test then failwithf "test 178 failed %d" i;
   );
   (* Deepening to (.a74.#a72) *)
   let idx : (t74, _) idx_mut = (.a74.#a72) in
@@ -2058,15 +2100,15 @@ let to_run () =
     (* from (.a74) *)
     let shallow : (t74, _) idx_mut = (.a74) in
     let deepened = (.idx_mut(shallow).#a72) in
-    mark_test_run 172;
+    mark_test_run 179;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 172 failed %d" i;
+    if not test then failwithf "test 179 failed %d" i;
     (* from (.a74.#a72) *)
     let shallow : (t74, _) idx_mut = (.a74.#a72) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 173;
+    mark_test_run 180;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 173 failed %d" i;
+    if not test then failwithf "test 180 failed %d" i;
   );
   (* Deepening to (.a74.#b72) *)
   let idx : (t74, _) idx_mut = (.a74.#b72) in
@@ -2074,15 +2116,15 @@ let to_run () =
     (* from (.a74) *)
     let shallow : (t74, _) idx_mut = (.a74) in
     let deepened = (.idx_mut(shallow).#b72) in
-    mark_test_run 174;
+    mark_test_run 181;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 174 failed %d" i;
+    if not test then failwithf "test 181 failed %d" i;
     (* from (.a74.#b72) *)
     let shallow : (t74, _) idx_mut = (.a74.#b72) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 175;
+    mark_test_run 182;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 175 failed %d" i;
+    if not test then failwithf "test 182 failed %d" i;
   );
   (* Deepening to (.b74) *)
   let idx : (t74, _) idx_mut = (.b74) in
@@ -2090,9 +2132,9 @@ let to_run () =
     (* from (.b74) *)
     let shallow : (t74, _) idx_mut = (.b74) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 176;
+    mark_test_run 183;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 176 failed %d" i;
+    if not test then failwithf "test 183 failed %d" i;
   );
   (* Deepening to (.b74.#a73) *)
   let idx : (t74, _) idx_mut = (.b74.#a73) in
@@ -2100,15 +2142,15 @@ let to_run () =
     (* from (.b74) *)
     let shallow : (t74, _) idx_mut = (.b74) in
     let deepened = (.idx_mut(shallow).#a73) in
-    mark_test_run 177;
+    mark_test_run 184;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 177 failed %d" i;
+    if not test then failwithf "test 184 failed %d" i;
     (* from (.b74.#a73) *)
     let shallow : (t74, _) idx_mut = (.b74.#a73) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 178;
+    mark_test_run 185;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 178 failed %d" i;
+    if not test then failwithf "test 185 failed %d" i;
   );
   (* Deepening to (.b74.#b73) *)
   let idx : (t74, _) idx_mut = (.b74.#b73) in
@@ -2116,15 +2158,15 @@ let to_run () =
     (* from (.b74) *)
     let shallow : (t74, _) idx_mut = (.b74) in
     let deepened = (.idx_mut(shallow).#b73) in
-    mark_test_run 179;
+    mark_test_run 186;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 179 failed %d" i;
+    if not test then failwithf "test 186 failed %d" i;
     (* from (.b74.#b73) *)
     let shallow : (t74, _) idx_mut = (.b74.#b73) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 180;
+    mark_test_run 187;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 180 failed %d" i;
+    if not test then failwithf "test 187 failed %d" i;
   );
 
   (**********************************************)
@@ -2136,9 +2178,9 @@ let to_run () =
     (* from (.a76) *)
     let shallow : (t76, _) idx_mut = (.a76) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 181;
+    mark_test_run 188;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 181 failed %d" i;
+    if not test then failwithf "test 188 failed %d" i;
   );
   (* Deepening to (.a76.#a75) *)
   let idx : (t76, _) idx_mut = (.a76.#a75) in
@@ -2146,15 +2188,15 @@ let to_run () =
     (* from (.a76) *)
     let shallow : (t76, _) idx_mut = (.a76) in
     let deepened = (.idx_mut(shallow).#a75) in
-    mark_test_run 182;
+    mark_test_run 189;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 182 failed %d" i;
+    if not test then failwithf "test 189 failed %d" i;
     (* from (.a76.#a75) *)
     let shallow : (t76, _) idx_mut = (.a76.#a75) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 183;
+    mark_test_run 190;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 183 failed %d" i;
+    if not test then failwithf "test 190 failed %d" i;
   );
   (* Deepening to (.a76.#b75) *)
   let idx : (t76, _) idx_mut = (.a76.#b75) in
@@ -2162,15 +2204,15 @@ let to_run () =
     (* from (.a76) *)
     let shallow : (t76, _) idx_mut = (.a76) in
     let deepened = (.idx_mut(shallow).#b75) in
-    mark_test_run 184;
+    mark_test_run 191;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 184 failed %d" i;
+    if not test then failwithf "test 191 failed %d" i;
     (* from (.a76.#b75) *)
     let shallow : (t76, _) idx_mut = (.a76.#b75) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 185;
+    mark_test_run 192;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 185 failed %d" i;
+    if not test then failwithf "test 192 failed %d" i;
   );
   (* Deepening to (.b76) *)
   let idx : (t76, _) idx_mut = (.b76) in
@@ -2178,16 +2220,16 @@ let to_run () =
     (* from (.b76) *)
     let shallow : (t76, _) idx_mut = (.b76) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 186;
+    mark_test_run 193;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 186 failed %d" i;
+    if not test then failwithf "test 193 failed %d" i;
   );
 
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 186 do
+for i = 1 to 193 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_native_test.ml
+++ b/testsuite/tests/records-and-block-indices/generated_record_idx_deepening_native_test.ml
@@ -657,181 +657,89 @@ let to_run () =
   (*   t21 = { float; float }   *)
   (******************************)
   (* Deepening to (.a21) *)
-  let idx : (t21, _) idx_mut = (.a21) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a21) *)
-    let shallow : (t21, _) idx_mut = (.a21) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 45;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 45 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b21) *)
-  let idx : (t21, _) idx_mut = (.b21) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b21) *)
-    let shallow : (t21, _) idx_mut = (.b21) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 46;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 46 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*************************************)
   (*   t22 = { float; float; float }   *)
   (*************************************)
   (* Deepening to (.a22) *)
-  let idx : (t22, _) idx_mut = (.a22) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a22) *)
-    let shallow : (t22, _) idx_mut = (.a22) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 47;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 47 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b22) *)
-  let idx : (t22, _) idx_mut = (.b22) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b22) *)
-    let shallow : (t22, _) idx_mut = (.b22) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 48;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 48 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.c22) *)
-  let idx : (t22, _) idx_mut = (.c22) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.c22) *)
-    let shallow : (t22, _) idx_mut = (.c22) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 49;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 49 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (**************************************)
   (*   t23 = { float; float; float# }   *)
   (**************************************)
   (* Deepening to (.a23) *)
-  let idx : (t23, _) idx_mut = (.a23) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a23) *)
-    let shallow : (t23, _) idx_mut = (.a23) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 50;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 50 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b23) *)
-  let idx : (t23, _) idx_mut = (.b23) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b23) *)
-    let shallow : (t23, _) idx_mut = (.b23) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 51;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 51 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.c23) *)
-  let idx : (t23, _) idx_mut = (.c23) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.c23) *)
-    let shallow : (t23, _) idx_mut = (.c23) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 52;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 52 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*******************************)
   (*   t24 = { float; float# }   *)
   (*******************************)
   (* Deepening to (.a24) *)
-  let idx : (t24, _) idx_mut = (.a24) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a24) *)
-    let shallow : (t24, _) idx_mut = (.a24) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 53;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 53 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b24) *)
-  let idx : (t24, _) idx_mut = (.b24) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b24) *)
-    let shallow : (t24, _) idx_mut = (.b24) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 54;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 54 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (***************************************)
   (*   t25 = { float; float#; float# }   *)
   (***************************************)
   (* Deepening to (.a25) *)
-  let idx : (t25, _) idx_mut = (.a25) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a25) *)
-    let shallow : (t25, _) idx_mut = (.a25) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 55;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 55 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b25) *)
-  let idx : (t25, _) idx_mut = (.b25) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b25) *)
-    let shallow : (t25, _) idx_mut = (.b25) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 56;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 56 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.c25) *)
-  let idx : (t25, _) idx_mut = (.c25) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.c25) *)
-    let shallow : (t25, _) idx_mut = (.c25) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 57;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 57 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (***********************************)
   (*   t27 = { float; #{ float } }   *)
   (***********************************)
   (* Deepening to (.a27) *)
-  let idx : (t27, _) idx_mut = (.a27) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a27) *)
-    let shallow : (t27, _) idx_mut = (.a27) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 58;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 58 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b27) *)
   (* Note: skipping test as this is not a valid block index,
      due to the float record optimization *)
   ();
   (* Deepening to (.b27.#a26) *)
-  let idx : (t27, _) idx_mut = (.b27.#a26) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* Note: can't deepen (.b27) because it's a path to a flattened
-       float, making its element type [float#] *)
-    (* from (.b27.#a26) *)
-    let shallow : (t27, _) idx_mut = (.b27.#a26) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 59;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 59 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (******************************************)
   (*   t29 = { float; #{ float; float } }   *)
@@ -842,9 +750,9 @@ let to_run () =
     (* from (.a29) *)
     let shallow : (t29, _) idx_mut = (.a29) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 60;
+    mark_test_run 45;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 60 failed %d" i;
+    if not test then failwithf "test 45 failed %d" i;
   );
   (* Deepening to (.b29) *)
   let idx : (t29, _) idx_mut = (.b29) in
@@ -852,9 +760,9 @@ let to_run () =
     (* from (.b29) *)
     let shallow : (t29, _) idx_mut = (.b29) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 61;
+    mark_test_run 46;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 61 failed %d" i;
+    if not test then failwithf "test 46 failed %d" i;
   );
   (* Deepening to (.b29.#a28) *)
   let idx : (t29, _) idx_mut = (.b29.#a28) in
@@ -862,15 +770,15 @@ let to_run () =
     (* from (.b29) *)
     let shallow : (t29, _) idx_mut = (.b29) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 62;
+    mark_test_run 47;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 62 failed %d" i;
+    if not test then failwithf "test 47 failed %d" i;
     (* from (.b29.#a28) *)
     let shallow : (t29, _) idx_mut = (.b29.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 63;
+    mark_test_run 48;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 63 failed %d" i;
+    if not test then failwithf "test 48 failed %d" i;
   );
   (* Deepening to (.b29.#b28) *)
   let idx : (t29, _) idx_mut = (.b29.#b28) in
@@ -878,78 +786,48 @@ let to_run () =
     (* from (.b29) *)
     let shallow : (t29, _) idx_mut = (.b29) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 64;
+    mark_test_run 49;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 64 failed %d" i;
+    if not test then failwithf "test 49 failed %d" i;
     (* from (.b29.#b28) *)
     let shallow : (t29, _) idx_mut = (.b29.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 65;
+    mark_test_run 50;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 65 failed %d" i;
+    if not test then failwithf "test 50 failed %d" i;
   );
 
   (************************)
   (*   t30 = { float# }   *)
   (************************)
   (* Deepening to (.a30) *)
-  let idx : (t30, _) idx_mut = (.a30) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a30) *)
-    let shallow : (t30, _) idx_mut = (.a30) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 66;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 66 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*******************************)
   (*   t31 = { float#; float }   *)
   (*******************************)
   (* Deepening to (.a31) *)
-  let idx : (t31, _) idx_mut = (.a31) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a31) *)
-    let shallow : (t31, _) idx_mut = (.a31) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 67;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 67 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b31) *)
-  let idx : (t31, _) idx_mut = (.b31) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b31) *)
-    let shallow : (t31, _) idx_mut = (.b31) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 68;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 68 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (********************************)
   (*   t32 = { float#; float# }   *)
   (********************************)
   (* Deepening to (.a32) *)
-  let idx : (t32, _) idx_mut = (.a32) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a32) *)
-    let shallow : (t32, _) idx_mut = (.a32) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 69;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 69 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b32) *)
-  let idx : (t32, _) idx_mut = (.b32) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b32) *)
-    let shallow : (t32, _) idx_mut = (.b32) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 70;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 70 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*******************************************)
   (*   t33 = { float#; #{ float; float } }   *)
@@ -960,9 +838,9 @@ let to_run () =
     (* from (.a33) *)
     let shallow : (t33, _) idx_mut = (.a33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 71;
+    mark_test_run 51;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 71 failed %d" i;
+    if not test then failwithf "test 51 failed %d" i;
   );
   (* Deepening to (.b33) *)
   let idx : (t33, _) idx_mut = (.b33) in
@@ -970,9 +848,9 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 72;
+    mark_test_run 52;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 72 failed %d" i;
+    if not test then failwithf "test 52 failed %d" i;
   );
   (* Deepening to (.b33.#a28) *)
   let idx : (t33, _) idx_mut = (.b33.#a28) in
@@ -980,15 +858,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 73;
+    mark_test_run 53;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 73 failed %d" i;
+    if not test then failwithf "test 53 failed %d" i;
     (* from (.b33.#a28) *)
     let shallow : (t33, _) idx_mut = (.b33.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 74;
+    mark_test_run 54;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 74 failed %d" i;
+    if not test then failwithf "test 54 failed %d" i;
   );
   (* Deepening to (.b33.#b28) *)
   let idx : (t33, _) idx_mut = (.b33.#b28) in
@@ -996,15 +874,15 @@ let to_run () =
     (* from (.b33) *)
     let shallow : (t33, _) idx_mut = (.b33) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 75;
+    mark_test_run 55;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 75 failed %d" i;
+    if not test then failwithf "test 55 failed %d" i;
     (* from (.b33.#b28) *)
     let shallow : (t33, _) idx_mut = (.b33.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 76;
+    mark_test_run 56;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 76 failed %d" i;
+    if not test then failwithf "test 56 failed %d" i;
   );
 
   (********************************************)
@@ -1016,9 +894,9 @@ let to_run () =
     (* from (.a35) *)
     let shallow : (t35, _) idx_mut = (.a35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 77;
+    mark_test_run 57;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 77 failed %d" i;
+    if not test then failwithf "test 57 failed %d" i;
   );
   (* Deepening to (.b35) *)
   let idx : (t35, _) idx_mut = (.b35) in
@@ -1026,9 +904,9 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 78;
+    mark_test_run 58;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 78 failed %d" i;
+    if not test then failwithf "test 58 failed %d" i;
   );
   (* Deepening to (.b35.#a34) *)
   let idx : (t35, _) idx_mut = (.b35.#a34) in
@@ -1036,15 +914,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#a34) in
-    mark_test_run 79;
+    mark_test_run 59;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 79 failed %d" i;
+    if not test then failwithf "test 59 failed %d" i;
     (* from (.b35.#a34) *)
     let shallow : (t35, _) idx_mut = (.b35.#a34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 80;
+    mark_test_run 60;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 80 failed %d" i;
+    if not test then failwithf "test 60 failed %d" i;
   );
   (* Deepening to (.b35.#b34) *)
   let idx : (t35, _) idx_mut = (.b35.#b34) in
@@ -1052,15 +930,15 @@ let to_run () =
     (* from (.b35) *)
     let shallow : (t35, _) idx_mut = (.b35) in
     let deepened = (.idx_mut(shallow).#b34) in
-    mark_test_run 81;
+    mark_test_run 61;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 81 failed %d" i;
+    if not test then failwithf "test 61 failed %d" i;
     (* from (.b35.#b34) *)
     let shallow : (t35, _) idx_mut = (.b35.#b34) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 82;
+    mark_test_run 62;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 82 failed %d" i;
+    if not test then failwithf "test 62 failed %d" i;
   );
 
   (****************************************)
@@ -1072,9 +950,9 @@ let to_run () =
     (* from (.a36) *)
     let shallow : (t36, _) idx_mut = (.a36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 83;
+    mark_test_run 63;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 83 failed %d" i;
+    if not test then failwithf "test 63 failed %d" i;
   );
   (* Deepening to (.b36) *)
   let idx : (t36, _) idx_mut = (.b36) in
@@ -1082,9 +960,9 @@ let to_run () =
     (* from (.b36) *)
     let shallow : (t36, _) idx_mut = (.b36) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 84;
+    mark_test_run 64;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 84 failed %d" i;
+    if not test then failwithf "test 64 failed %d" i;
   );
   (* Deepening to (.c36) *)
   let idx : (t36, _) idx_mut = (.c36) in
@@ -1106,9 +984,9 @@ let to_run () =
     (* from (.a38) *)
     let shallow : (t38, _) idx_mut = (.a38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 85;
+    mark_test_run 65;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 85 failed %d" i;
+    if not test then failwithf "test 65 failed %d" i;
   );
   (* Deepening to (.b38) *)
   let idx : (t38, _) idx_mut = (.b38) in
@@ -1116,9 +994,9 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 86;
+    mark_test_run 66;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 86 failed %d" i;
+    if not test then failwithf "test 66 failed %d" i;
   );
   (* Deepening to (.b38.#a37) *)
   let idx : (t38, _) idx_mut = (.b38.#a37) in
@@ -1126,15 +1004,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 87;
+    mark_test_run 67;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 87 failed %d" i;
+    if not test then failwithf "test 67 failed %d" i;
     (* from (.b38.#a37) *)
     let shallow : (t38, _) idx_mut = (.b38.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 88;
+    mark_test_run 68;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 88 failed %d" i;
+    if not test then failwithf "test 68 failed %d" i;
   );
   (* Deepening to (.b38.#b37) *)
   let idx : (t38, _) idx_mut = (.b38.#b37) in
@@ -1142,15 +1020,15 @@ let to_run () =
     (* from (.b38) *)
     let shallow : (t38, _) idx_mut = (.b38) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 89;
+    mark_test_run 69;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 89 failed %d" i;
+    if not test then failwithf "test 69 failed %d" i;
     (* from (.b38.#b37) *)
     let shallow : (t38, _) idx_mut = (.b38.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 90;
+    mark_test_run 70;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 90 failed %d" i;
+    if not test then failwithf "test 70 failed %d" i;
   );
 
   (**************************)
@@ -1162,9 +1040,9 @@ let to_run () =
     (* from (.a39) *)
     let shallow : (t39, _) idx_mut = (.a39) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 91;
+    mark_test_run 71;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 91 failed %d" i;
+    if not test then failwithf "test 71 failed %d" i;
   );
 
   (****************************************)
@@ -1176,9 +1054,9 @@ let to_run () =
     (* from (.a40) *)
     let shallow : (t40, _) idx_mut = (.a40) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 92;
+    mark_test_run 72;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 92 failed %d" i;
+    if not test then failwithf "test 72 failed %d" i;
   );
   (* Deepening to (.b40) *)
   let idx : (t40, _) idx_mut = (.b40) in
@@ -1186,9 +1064,9 @@ let to_run () =
     (* from (.b40) *)
     let shallow : (t40, _) idx_mut = (.b40) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 93;
+    mark_test_run 73;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 93 failed %d" i;
+    if not test then failwithf "test 73 failed %d" i;
   );
 
   (************************************)
@@ -1200,9 +1078,9 @@ let to_run () =
     (* from (.a41) *)
     let shallow : (t41, _) idx_mut = (.a41) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 94;
+    mark_test_run 74;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 94 failed %d" i;
+    if not test then failwithf "test 74 failed %d" i;
   );
   (* Deepening to (.b41) *)
   let idx : (t41, _) idx_mut = (.b41) in
@@ -1224,9 +1102,9 @@ let to_run () =
     (* from (.a42) *)
     let shallow : (t42, _) idx_mut = (.a42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 95;
+    mark_test_run 75;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 95 failed %d" i;
+    if not test then failwithf "test 75 failed %d" i;
   );
   (* Deepening to (.b42) *)
   let idx : (t42, _) idx_mut = (.b42) in
@@ -1234,9 +1112,9 @@ let to_run () =
     (* from (.b42) *)
     let shallow : (t42, _) idx_mut = (.b42) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 96;
+    mark_test_run 76;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 96 failed %d" i;
+    if not test then failwithf "test 76 failed %d" i;
   );
 
   (**************************)
@@ -1248,9 +1126,9 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 97;
+    mark_test_run 77;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 97 failed %d" i;
+    if not test then failwithf "test 77 failed %d" i;
   );
   (* Deepening to (.a44.#a43) *)
   let idx : (t44, _) idx_mut = (.a44.#a43) in
@@ -1258,15 +1136,15 @@ let to_run () =
     (* from (.a44) *)
     let shallow : (t44, _) idx_mut = (.a44) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 98;
+    mark_test_run 78;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 98 failed %d" i;
+    if not test then failwithf "test 78 failed %d" i;
     (* from (.a44.#a43) *)
     let shallow : (t44, _) idx_mut = (.a44.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 99;
+    mark_test_run 79;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 99 failed %d" i;
+    if not test then failwithf "test 79 failed %d" i;
   );
 
   (*******************************)
@@ -1278,9 +1156,9 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 100;
+    mark_test_run 80;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 100 failed %d" i;
+    if not test then failwithf "test 80 failed %d" i;
   );
   (* Deepening to (.a45.#a43) *)
   let idx : (t45, _) idx_mut = (.a45.#a43) in
@@ -1288,15 +1166,15 @@ let to_run () =
     (* from (.a45) *)
     let shallow : (t45, _) idx_mut = (.a45) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 101;
+    mark_test_run 81;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 101 failed %d" i;
+    if not test then failwithf "test 81 failed %d" i;
     (* from (.a45.#a43) *)
     let shallow : (t45, _) idx_mut = (.a45.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 102;
+    mark_test_run 82;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 102 failed %d" i;
+    if not test then failwithf "test 82 failed %d" i;
   );
   (* Deepening to (.b45) *)
   let idx : (t45, _) idx_mut = (.b45) in
@@ -1304,9 +1182,9 @@ let to_run () =
     (* from (.b45) *)
     let shallow : (t45, _) idx_mut = (.b45) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 103;
+    mark_test_run 83;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 103 failed %d" i;
+    if not test then failwithf "test 83 failed %d" i;
   );
 
   (**********************************)
@@ -1318,9 +1196,9 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 104;
+    mark_test_run 84;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 104 failed %d" i;
+    if not test then failwithf "test 84 failed %d" i;
   );
   (* Deepening to (.a46.#a43) *)
   let idx : (t46, _) idx_mut = (.a46.#a43) in
@@ -1328,15 +1206,15 @@ let to_run () =
     (* from (.a46) *)
     let shallow : (t46, _) idx_mut = (.a46) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 105;
+    mark_test_run 85;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 105 failed %d" i;
+    if not test then failwithf "test 85 failed %d" i;
     (* from (.a46.#a43) *)
     let shallow : (t46, _) idx_mut = (.a46.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 106;
+    mark_test_run 86;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 106 failed %d" i;
+    if not test then failwithf "test 86 failed %d" i;
   );
   (* Deepening to (.b46) *)
   let idx : (t46, _) idx_mut = (.b46) in
@@ -1344,9 +1222,9 @@ let to_run () =
     (* from (.b46) *)
     let shallow : (t46, _) idx_mut = (.b46) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 107;
+    mark_test_run 87;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 107 failed %d" i;
+    if not test then failwithf "test 87 failed %d" i;
   );
 
   (************************************)
@@ -1358,9 +1236,9 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 108;
+    mark_test_run 88;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 108 failed %d" i;
+    if not test then failwithf "test 88 failed %d" i;
   );
   (* Deepening to (.a47.#a43) *)
   let idx : (t47, _) idx_mut = (.a47.#a43) in
@@ -1368,15 +1246,15 @@ let to_run () =
     (* from (.a47) *)
     let shallow : (t47, _) idx_mut = (.a47) in
     let deepened = (.idx_mut(shallow).#a43) in
-    mark_test_run 109;
+    mark_test_run 89;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 109 failed %d" i;
+    if not test then failwithf "test 89 failed %d" i;
     (* from (.a47.#a43) *)
     let shallow : (t47, _) idx_mut = (.a47.#a43) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 110;
+    mark_test_run 90;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 110 failed %d" i;
+    if not test then failwithf "test 90 failed %d" i;
   );
   (* Deepening to (.b47) *)
   let idx : (t47, _) idx_mut = (.b47) in
@@ -1384,9 +1262,9 @@ let to_run () =
     (* from (.b47) *)
     let shallow : (t47, _) idx_mut = (.b47) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 111;
+    mark_test_run 91;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 111 failed %d" i;
+    if not test then failwithf "test 91 failed %d" i;
   );
 
   (*******************************)
@@ -1398,9 +1276,9 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 112;
+    mark_test_run 92;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 112 failed %d" i;
+    if not test then failwithf "test 92 failed %d" i;
   );
   (* Deepening to (.a48.#a13) *)
   let idx : (t48, _) idx_mut = (.a48.#a13) in
@@ -1408,15 +1286,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 113;
+    mark_test_run 93;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 113 failed %d" i;
+    if not test then failwithf "test 93 failed %d" i;
     (* from (.a48.#a13) *)
     let shallow : (t48, _) idx_mut = (.a48.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 114;
+    mark_test_run 94;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 114 failed %d" i;
+    if not test then failwithf "test 94 failed %d" i;
   );
   (* Deepening to (.a48.#b13) *)
   let idx : (t48, _) idx_mut = (.a48.#b13) in
@@ -1424,15 +1302,15 @@ let to_run () =
     (* from (.a48) *)
     let shallow : (t48, _) idx_mut = (.a48) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 115;
+    mark_test_run 95;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 115 failed %d" i;
+    if not test then failwithf "test 95 failed %d" i;
     (* from (.a48.#b13) *)
     let shallow : (t48, _) idx_mut = (.a48.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 116;
+    mark_test_run 96;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 116 failed %d" i;
+    if not test then failwithf "test 96 failed %d" i;
   );
 
   (************************************)
@@ -1444,9 +1322,9 @@ let to_run () =
     (* from (.a49) *)
     let shallow : (t49, _) idx_mut = (.a49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 117;
+    mark_test_run 97;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 117 failed %d" i;
+    if not test then failwithf "test 97 failed %d" i;
   );
   (* Deepening to (.a49.#a13) *)
   let idx : (t49, _) idx_mut = (.a49.#a13) in
@@ -1454,15 +1332,15 @@ let to_run () =
     (* from (.a49) *)
     let shallow : (t49, _) idx_mut = (.a49) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 118;
+    mark_test_run 98;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 118 failed %d" i;
+    if not test then failwithf "test 98 failed %d" i;
     (* from (.a49.#a13) *)
     let shallow : (t49, _) idx_mut = (.a49.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 119;
+    mark_test_run 99;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 119 failed %d" i;
+    if not test then failwithf "test 99 failed %d" i;
   );
   (* Deepening to (.a49.#b13) *)
   let idx : (t49, _) idx_mut = (.a49.#b13) in
@@ -1470,15 +1348,15 @@ let to_run () =
     (* from (.a49) *)
     let shallow : (t49, _) idx_mut = (.a49) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 120;
+    mark_test_run 100;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 120 failed %d" i;
+    if not test then failwithf "test 100 failed %d" i;
     (* from (.a49.#b13) *)
     let shallow : (t49, _) idx_mut = (.a49.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 121;
+    mark_test_run 101;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 121 failed %d" i;
+    if not test then failwithf "test 101 failed %d" i;
   );
   (* Deepening to (.b49) *)
   let idx : (t49, _) idx_mut = (.b49) in
@@ -1486,9 +1364,9 @@ let to_run () =
     (* from (.b49) *)
     let shallow : (t49, _) idx_mut = (.b49) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 122;
+    mark_test_run 102;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 122 failed %d" i;
+    if not test then failwithf "test 102 failed %d" i;
   );
 
   (***************************************)
@@ -1500,9 +1378,9 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 123;
+    mark_test_run 103;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 123 failed %d" i;
+    if not test then failwithf "test 103 failed %d" i;
   );
   (* Deepening to (.a50.#a13) *)
   let idx : (t50, _) idx_mut = (.a50.#a13) in
@@ -1510,15 +1388,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#a13) in
-    mark_test_run 124;
+    mark_test_run 104;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 124 failed %d" i;
+    if not test then failwithf "test 104 failed %d" i;
     (* from (.a50.#a13) *)
     let shallow : (t50, _) idx_mut = (.a50.#a13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 125;
+    mark_test_run 105;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 125 failed %d" i;
+    if not test then failwithf "test 105 failed %d" i;
   );
   (* Deepening to (.a50.#b13) *)
   let idx : (t50, _) idx_mut = (.a50.#b13) in
@@ -1526,15 +1404,15 @@ let to_run () =
     (* from (.a50) *)
     let shallow : (t50, _) idx_mut = (.a50) in
     let deepened = (.idx_mut(shallow).#b13) in
-    mark_test_run 126;
+    mark_test_run 106;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 126 failed %d" i;
+    if not test then failwithf "test 106 failed %d" i;
     (* from (.a50.#b13) *)
     let shallow : (t50, _) idx_mut = (.a50.#b13) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 127;
+    mark_test_run 107;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 127 failed %d" i;
+    if not test then failwithf "test 107 failed %d" i;
   );
   (* Deepening to (.b50) *)
   let idx : (t50, _) idx_mut = (.b50) in
@@ -1542,9 +1420,9 @@ let to_run () =
     (* from (.b50) *)
     let shallow : (t50, _) idx_mut = (.b50) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 128;
+    mark_test_run 108;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 128 failed %d" i;
+    if not test then failwithf "test 108 failed %d" i;
   );
 
   (***************************************)
@@ -1556,9 +1434,9 @@ let to_run () =
     (* from (.a52) *)
     let shallow : (t52, _) idx_mut = (.a52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 129;
+    mark_test_run 109;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 129 failed %d" i;
+    if not test then failwithf "test 109 failed %d" i;
   );
   (* Deepening to (.a52.#a51) *)
   let idx : (t52, _) idx_mut = (.a52.#a51) in
@@ -1566,15 +1444,15 @@ let to_run () =
     (* from (.a52) *)
     let shallow : (t52, _) idx_mut = (.a52) in
     let deepened = (.idx_mut(shallow).#a51) in
-    mark_test_run 130;
+    mark_test_run 110;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 130 failed %d" i;
+    if not test then failwithf "test 110 failed %d" i;
     (* from (.a52.#a51) *)
     let shallow : (t52, _) idx_mut = (.a52.#a51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 131;
+    mark_test_run 111;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 131 failed %d" i;
+    if not test then failwithf "test 111 failed %d" i;
   );
   (* Deepening to (.a52.#b51) *)
   let idx : (t52, _) idx_mut = (.a52.#b51) in
@@ -1582,15 +1460,15 @@ let to_run () =
     (* from (.a52) *)
     let shallow : (t52, _) idx_mut = (.a52) in
     let deepened = (.idx_mut(shallow).#b51) in
-    mark_test_run 132;
+    mark_test_run 112;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 132 failed %d" i;
+    if not test then failwithf "test 112 failed %d" i;
     (* from (.a52.#b51) *)
     let shallow : (t52, _) idx_mut = (.a52.#b51) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 133;
+    mark_test_run 113;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 133 failed %d" i;
+    if not test then failwithf "test 113 failed %d" i;
   );
   (* Deepening to (.b52) *)
   let idx : (t52, _) idx_mut = (.b52) in
@@ -1598,9 +1476,9 @@ let to_run () =
     (* from (.b52) *)
     let shallow : (t52, _) idx_mut = (.b52) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 134;
+    mark_test_run 114;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 134 failed %d" i;
+    if not test then failwithf "test 114 failed %d" i;
   );
 
   (**************************************)
@@ -1612,9 +1490,9 @@ let to_run () =
     (* from (.a53) *)
     let shallow : (t53, _) idx_mut = (.a53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 135;
+    mark_test_run 115;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 135 failed %d" i;
+    if not test then failwithf "test 115 failed %d" i;
   );
   (* Deepening to (.a53.#a5) *)
   let idx : (t53, _) idx_mut = (.a53.#a5) in
@@ -1622,15 +1500,15 @@ let to_run () =
     (* from (.a53) *)
     let shallow : (t53, _) idx_mut = (.a53) in
     let deepened = (.idx_mut(shallow).#a5) in
-    mark_test_run 136;
+    mark_test_run 116;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 136 failed %d" i;
+    if not test then failwithf "test 116 failed %d" i;
     (* from (.a53.#a5) *)
     let shallow : (t53, _) idx_mut = (.a53.#a5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 137;
+    mark_test_run 117;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 137 failed %d" i;
+    if not test then failwithf "test 117 failed %d" i;
   );
   (* Deepening to (.a53.#b5) *)
   let idx : (t53, _) idx_mut = (.a53.#b5) in
@@ -1638,15 +1516,15 @@ let to_run () =
     (* from (.a53) *)
     let shallow : (t53, _) idx_mut = (.a53) in
     let deepened = (.idx_mut(shallow).#b5) in
-    mark_test_run 138;
+    mark_test_run 118;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 138 failed %d" i;
+    if not test then failwithf "test 118 failed %d" i;
     (* from (.a53.#b5) *)
     let shallow : (t53, _) idx_mut = (.a53.#b5) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 139;
+    mark_test_run 119;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 139 failed %d" i;
+    if not test then failwithf "test 119 failed %d" i;
   );
   (* Deepening to (.b53) *)
   let idx : (t53, _) idx_mut = (.b53) in
@@ -1654,9 +1532,9 @@ let to_run () =
     (* from (.b53) *)
     let shallow : (t53, _) idx_mut = (.b53) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 140;
+    mark_test_run 120;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 140 failed %d" i;
+    if not test then failwithf "test 120 failed %d" i;
   );
 
   (************************************)
@@ -1668,9 +1546,9 @@ let to_run () =
     (* from (.a55) *)
     let shallow : (t55, _) idx_mut = (.a55) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 141;
+    mark_test_run 121;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 141 failed %d" i;
+    if not test then failwithf "test 121 failed %d" i;
   );
   (* Deepening to (.a55.#a54) *)
   let idx : (t55, _) idx_mut = (.a55.#a54) in
@@ -1678,15 +1556,15 @@ let to_run () =
     (* from (.a55) *)
     let shallow : (t55, _) idx_mut = (.a55) in
     let deepened = (.idx_mut(shallow).#a54) in
-    mark_test_run 142;
+    mark_test_run 122;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 142 failed %d" i;
+    if not test then failwithf "test 122 failed %d" i;
     (* from (.a55.#a54) *)
     let shallow : (t55, _) idx_mut = (.a55.#a54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 143;
+    mark_test_run 123;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 143 failed %d" i;
+    if not test then failwithf "test 123 failed %d" i;
   );
   (* Deepening to (.a55.#b54) *)
   let idx : (t55, _) idx_mut = (.a55.#b54) in
@@ -1694,15 +1572,15 @@ let to_run () =
     (* from (.a55) *)
     let shallow : (t55, _) idx_mut = (.a55) in
     let deepened = (.idx_mut(shallow).#b54) in
-    mark_test_run 144;
+    mark_test_run 124;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 144 failed %d" i;
+    if not test then failwithf "test 124 failed %d" i;
     (* from (.a55.#b54) *)
     let shallow : (t55, _) idx_mut = (.a55.#b54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 145;
+    mark_test_run 125;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 145 failed %d" i;
+    if not test then failwithf "test 125 failed %d" i;
   );
 
   (*****************************************)
@@ -1714,9 +1592,9 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 146;
+    mark_test_run 126;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 146 failed %d" i;
+    if not test then failwithf "test 126 failed %d" i;
   );
   (* Deepening to (.a56.#a54) *)
   let idx : (t56, _) idx_mut = (.a56.#a54) in
@@ -1724,15 +1602,15 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow).#a54) in
-    mark_test_run 147;
+    mark_test_run 127;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 147 failed %d" i;
+    if not test then failwithf "test 127 failed %d" i;
     (* from (.a56.#a54) *)
     let shallow : (t56, _) idx_mut = (.a56.#a54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 148;
+    mark_test_run 128;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 148 failed %d" i;
+    if not test then failwithf "test 128 failed %d" i;
   );
   (* Deepening to (.a56.#b54) *)
   let idx : (t56, _) idx_mut = (.a56.#b54) in
@@ -1740,15 +1618,15 @@ let to_run () =
     (* from (.a56) *)
     let shallow : (t56, _) idx_mut = (.a56) in
     let deepened = (.idx_mut(shallow).#b54) in
-    mark_test_run 149;
+    mark_test_run 129;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 149 failed %d" i;
+    if not test then failwithf "test 129 failed %d" i;
     (* from (.a56.#b54) *)
     let shallow : (t56, _) idx_mut = (.a56.#b54) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 150;
+    mark_test_run 130;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 150 failed %d" i;
+    if not test then failwithf "test 130 failed %d" i;
   );
   (* Deepening to (.b56) *)
   let idx : (t56, _) idx_mut = (.b56) in
@@ -1756,9 +1634,9 @@ let to_run () =
     (* from (.b56) *)
     let shallow : (t56, _) idx_mut = (.b56) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 151;
+    mark_test_run 131;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 151 failed %d" i;
+    if not test then failwithf "test 131 failed %d" i;
   );
 
   (*********************************************************)
@@ -1770,9 +1648,9 @@ let to_run () =
     (* from (.a59) *)
     let shallow : (t59, _) idx_mut = (.a59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 152;
+    mark_test_run 132;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 152 failed %d" i;
+    if not test then failwithf "test 132 failed %d" i;
   );
   (* Deepening to (.a59.#a57) *)
   let idx : (t59, _) idx_mut = (.a59.#a57) in
@@ -1780,15 +1658,15 @@ let to_run () =
     (* from (.a59) *)
     let shallow : (t59, _) idx_mut = (.a59) in
     let deepened = (.idx_mut(shallow).#a57) in
-    mark_test_run 153;
+    mark_test_run 133;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 153 failed %d" i;
+    if not test then failwithf "test 133 failed %d" i;
     (* from (.a59.#a57) *)
     let shallow : (t59, _) idx_mut = (.a59.#a57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 154;
+    mark_test_run 134;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 154 failed %d" i;
+    if not test then failwithf "test 134 failed %d" i;
   );
   (* Deepening to (.a59.#b57) *)
   let idx : (t59, _) idx_mut = (.a59.#b57) in
@@ -1796,15 +1674,15 @@ let to_run () =
     (* from (.a59) *)
     let shallow : (t59, _) idx_mut = (.a59) in
     let deepened = (.idx_mut(shallow).#b57) in
-    mark_test_run 155;
+    mark_test_run 135;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 155 failed %d" i;
+    if not test then failwithf "test 135 failed %d" i;
     (* from (.a59.#b57) *)
     let shallow : (t59, _) idx_mut = (.a59.#b57) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 156;
+    mark_test_run 136;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 156 failed %d" i;
+    if not test then failwithf "test 136 failed %d" i;
   );
   (* Deepening to (.b59) *)
   let idx : (t59, _) idx_mut = (.b59) in
@@ -1812,9 +1690,9 @@ let to_run () =
     (* from (.b59) *)
     let shallow : (t59, _) idx_mut = (.b59) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 157;
+    mark_test_run 137;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 157 failed %d" i;
+    if not test then failwithf "test 137 failed %d" i;
   );
   (* Deepening to (.b59.#a58) *)
   let idx : (t59, _) idx_mut = (.b59.#a58) in
@@ -1822,15 +1700,15 @@ let to_run () =
     (* from (.b59) *)
     let shallow : (t59, _) idx_mut = (.b59) in
     let deepened = (.idx_mut(shallow).#a58) in
-    mark_test_run 158;
+    mark_test_run 138;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 158 failed %d" i;
+    if not test then failwithf "test 138 failed %d" i;
     (* from (.b59.#a58) *)
     let shallow : (t59, _) idx_mut = (.b59.#a58) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 159;
+    mark_test_run 139;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 159 failed %d" i;
+    if not test then failwithf "test 139 failed %d" i;
   );
   (* Deepening to (.b59.#b58) *)
   let idx : (t59, _) idx_mut = (.b59.#b58) in
@@ -1838,15 +1716,15 @@ let to_run () =
     (* from (.b59) *)
     let shallow : (t59, _) idx_mut = (.b59) in
     let deepened = (.idx_mut(shallow).#b58) in
-    mark_test_run 160;
+    mark_test_run 140;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 160 failed %d" i;
+    if not test then failwithf "test 140 failed %d" i;
     (* from (.b59.#b58) *)
     let shallow : (t59, _) idx_mut = (.b59.#b58) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 161;
+    mark_test_run 141;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 161 failed %d" i;
+    if not test then failwithf "test 141 failed %d" i;
   );
 
   (*****************************)
@@ -1858,9 +1736,9 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 162;
+    mark_test_run 142;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 162 failed %d" i;
+    if not test then failwithf "test 142 failed %d" i;
   );
   (* Deepening to (.a61.#a60) *)
   let idx : (t61, _) idx_mut = (.a61.#a60) in
@@ -1868,15 +1746,15 @@ let to_run () =
     (* from (.a61) *)
     let shallow : (t61, _) idx_mut = (.a61) in
     let deepened = (.idx_mut(shallow).#a60) in
-    mark_test_run 163;
+    mark_test_run 143;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 163 failed %d" i;
+    if not test then failwithf "test 143 failed %d" i;
     (* from (.a61.#a60) *)
     let shallow : (t61, _) idx_mut = (.a61.#a60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 164;
+    mark_test_run 144;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 164 failed %d" i;
+    if not test then failwithf "test 144 failed %d" i;
   );
 
   (*************************************)
@@ -1888,9 +1766,9 @@ let to_run () =
     (* from (.a62) *)
     let shallow : (t62, _) idx_mut = (.a62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 165;
+    mark_test_run 145;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 165 failed %d" i;
+    if not test then failwithf "test 145 failed %d" i;
   );
   (* Deepening to (.a62.#a60) *)
   let idx : (t62, _) idx_mut = (.a62.#a60) in
@@ -1898,15 +1776,15 @@ let to_run () =
     (* from (.a62) *)
     let shallow : (t62, _) idx_mut = (.a62) in
     let deepened = (.idx_mut(shallow).#a60) in
-    mark_test_run 166;
+    mark_test_run 146;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 166 failed %d" i;
+    if not test then failwithf "test 146 failed %d" i;
     (* from (.a62.#a60) *)
     let shallow : (t62, _) idx_mut = (.a62.#a60) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 167;
+    mark_test_run 147;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 167 failed %d" i;
+    if not test then failwithf "test 147 failed %d" i;
   );
   (* Deepening to (.b62) *)
   let idx : (t62, _) idx_mut = (.b62) in
@@ -1914,9 +1792,9 @@ let to_run () =
     (* from (.b62) *)
     let shallow : (t62, _) idx_mut = (.b62) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 168;
+    mark_test_run 148;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 168 failed %d" i;
+    if not test then failwithf "test 148 failed %d" i;
   );
 
   (****************************)
@@ -1927,17 +1805,9 @@ let to_run () =
      due to the float record optimization *)
   ();
   (* Deepening to (.a63.#a26) *)
-  let idx : (t63, _) idx_mut = (.a63.#a26) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* Note: can't deepen (.a63) because it's a path to a flattened
-       float, making its element type [float#] *)
-    (* from (.a63.#a26) *)
-    let shallow : (t63, _) idx_mut = (.a63.#a26) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 169;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 169 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (**************************************)
   (*   t65 = { #{ float; int }; int }   *)
@@ -1948,9 +1818,9 @@ let to_run () =
     (* from (.a65) *)
     let shallow : (t65, _) idx_mut = (.a65) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 170;
+    mark_test_run 149;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 170 failed %d" i;
+    if not test then failwithf "test 149 failed %d" i;
   );
   (* Deepening to (.a65.#a64) *)
   let idx : (t65, _) idx_mut = (.a65.#a64) in
@@ -1958,15 +1828,15 @@ let to_run () =
     (* from (.a65) *)
     let shallow : (t65, _) idx_mut = (.a65) in
     let deepened = (.idx_mut(shallow).#a64) in
-    mark_test_run 171;
+    mark_test_run 150;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 171 failed %d" i;
+    if not test then failwithf "test 150 failed %d" i;
     (* from (.a65.#a64) *)
     let shallow : (t65, _) idx_mut = (.a65.#a64) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 172;
+    mark_test_run 151;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 172 failed %d" i;
+    if not test then failwithf "test 151 failed %d" i;
   );
   (* Deepening to (.a65.#b64) *)
   let idx : (t65, _) idx_mut = (.a65.#b64) in
@@ -1974,15 +1844,15 @@ let to_run () =
     (* from (.a65) *)
     let shallow : (t65, _) idx_mut = (.a65) in
     let deepened = (.idx_mut(shallow).#b64) in
-    mark_test_run 173;
+    mark_test_run 152;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 173 failed %d" i;
+    if not test then failwithf "test 152 failed %d" i;
     (* from (.a65.#b64) *)
     let shallow : (t65, _) idx_mut = (.a65.#b64) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 174;
+    mark_test_run 153;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 174 failed %d" i;
+    if not test then failwithf "test 153 failed %d" i;
   );
   (* Deepening to (.b65) *)
   let idx : (t65, _) idx_mut = (.b65) in
@@ -1990,9 +1860,9 @@ let to_run () =
     (* from (.b65) *)
     let shallow : (t65, _) idx_mut = (.b65) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 175;
+    mark_test_run 154;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 175 failed %d" i;
+    if not test then failwithf "test 154 failed %d" i;
   );
 
   (***********************************)
@@ -2004,9 +1874,9 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 176;
+    mark_test_run 155;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 176 failed %d" i;
+    if not test then failwithf "test 155 failed %d" i;
   );
   (* Deepening to (.a66.#a28) *)
   let idx : (t66, _) idx_mut = (.a66.#a28) in
@@ -2014,15 +1884,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#a28) in
-    mark_test_run 177;
+    mark_test_run 156;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 177 failed %d" i;
+    if not test then failwithf "test 156 failed %d" i;
     (* from (.a66.#a28) *)
     let shallow : (t66, _) idx_mut = (.a66.#a28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 178;
+    mark_test_run 157;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 178 failed %d" i;
+    if not test then failwithf "test 157 failed %d" i;
   );
   (* Deepening to (.a66.#b28) *)
   let idx : (t66, _) idx_mut = (.a66.#b28) in
@@ -2030,15 +1900,15 @@ let to_run () =
     (* from (.a66) *)
     let shallow : (t66, _) idx_mut = (.a66) in
     let deepened = (.idx_mut(shallow).#b28) in
-    mark_test_run 179;
+    mark_test_run 158;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 179 failed %d" i;
+    if not test then failwithf "test 158 failed %d" i;
     (* from (.a66.#b28) *)
     let shallow : (t66, _) idx_mut = (.a66.#b28) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 180;
+    mark_test_run 159;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 180 failed %d" i;
+    if not test then failwithf "test 159 failed %d" i;
   );
 
   (********************************************)
@@ -2050,9 +1920,9 @@ let to_run () =
     (* from (.a68) *)
     let shallow : (t68, _) idx_mut = (.a68) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 181;
+    mark_test_run 160;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 181 failed %d" i;
+    if not test then failwithf "test 160 failed %d" i;
   );
   (* Deepening to (.a68.#a67) *)
   let idx : (t68, _) idx_mut = (.a68.#a67) in
@@ -2060,15 +1930,15 @@ let to_run () =
     (* from (.a68) *)
     let shallow : (t68, _) idx_mut = (.a68) in
     let deepened = (.idx_mut(shallow).#a67) in
-    mark_test_run 182;
+    mark_test_run 161;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 182 failed %d" i;
+    if not test then failwithf "test 161 failed %d" i;
     (* from (.a68.#a67) *)
     let shallow : (t68, _) idx_mut = (.a68.#a67) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 183;
+    mark_test_run 162;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 183 failed %d" i;
+    if not test then failwithf "test 162 failed %d" i;
   );
   (* Deepening to (.a68.#b67) *)
   let idx : (t68, _) idx_mut = (.a68.#b67) in
@@ -2076,15 +1946,15 @@ let to_run () =
     (* from (.a68) *)
     let shallow : (t68, _) idx_mut = (.a68) in
     let deepened = (.idx_mut(shallow).#b67) in
-    mark_test_run 184;
+    mark_test_run 163;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 184 failed %d" i;
+    if not test then failwithf "test 163 failed %d" i;
     (* from (.a68.#b67) *)
     let shallow : (t68, _) idx_mut = (.a68.#b67) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 185;
+    mark_test_run 164;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 185 failed %d" i;
+    if not test then failwithf "test 164 failed %d" i;
   );
   (* Deepening to (.b68) *)
   let idx : (t68, _) idx_mut = (.b68) in
@@ -2092,50 +1962,26 @@ let to_run () =
     (* from (.b68) *)
     let shallow : (t68, _) idx_mut = (.b68) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 186;
+    mark_test_run 165;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 186 failed %d" i;
+    if not test then failwithf "test 165 failed %d" i;
   );
 
   (*************************************)
   (*   t70 = { #{ float# }; float# }   *)
   (*************************************)
   (* Deepening to (.a70) *)
-  let idx : (t70, _) idx_mut = (.a70) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a70) *)
-    let shallow : (t70, _) idx_mut = (.a70) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 187;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 187 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.a70.#a69) *)
-  let idx : (t70, _) idx_mut = (.a70.#a69) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.a70) *)
-    let shallow : (t70, _) idx_mut = (.a70) in
-    let deepened = (.idx_mut(shallow).#a69) in
-    mark_test_run 188;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 188 failed %d" i;
-    (* from (.a70.#a69) *)
-    let shallow : (t70, _) idx_mut = (.a70.#a69) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 189;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 189 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
   (* Deepening to (.b70) *)
-  let idx : (t70, _) idx_mut = (.b70) in
-  iter indices_in_deepening_tests ~f:(fun i ->
-    (* from (.b70) *)
-    let shallow : (t70, _) idx_mut = (.b70) in
-    let deepened = (.idx_mut(shallow)) in
-    mark_test_run 190;
-    let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 190 failed %d" i;
-  );
+  (* Note: skipping test as this is not a valid block index,
+     due to the float record optimization *)
+  ();
 
   (*********************************************)
   (*   t71 = { #{ string; string }; unit_u }   *)
@@ -2146,9 +1992,9 @@ let to_run () =
     (* from (.a71) *)
     let shallow : (t71, _) idx_mut = (.a71) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 191;
+    mark_test_run 166;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 191 failed %d" i;
+    if not test then failwithf "test 166 failed %d" i;
   );
   (* Deepening to (.a71.#a37) *)
   let idx : (t71, _) idx_mut = (.a71.#a37) in
@@ -2156,15 +2002,15 @@ let to_run () =
     (* from (.a71) *)
     let shallow : (t71, _) idx_mut = (.a71) in
     let deepened = (.idx_mut(shallow).#a37) in
-    mark_test_run 192;
+    mark_test_run 167;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 192 failed %d" i;
+    if not test then failwithf "test 167 failed %d" i;
     (* from (.a71.#a37) *)
     let shallow : (t71, _) idx_mut = (.a71.#a37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 193;
+    mark_test_run 168;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 193 failed %d" i;
+    if not test then failwithf "test 168 failed %d" i;
   );
   (* Deepening to (.a71.#b37) *)
   let idx : (t71, _) idx_mut = (.a71.#b37) in
@@ -2172,15 +2018,15 @@ let to_run () =
     (* from (.a71) *)
     let shallow : (t71, _) idx_mut = (.a71) in
     let deepened = (.idx_mut(shallow).#b37) in
-    mark_test_run 194;
+    mark_test_run 169;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 194 failed %d" i;
+    if not test then failwithf "test 169 failed %d" i;
     (* from (.a71.#b37) *)
     let shallow : (t71, _) idx_mut = (.a71.#b37) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 195;
+    mark_test_run 170;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 195 failed %d" i;
+    if not test then failwithf "test 170 failed %d" i;
   );
   (* Deepening to (.b71) *)
   let idx : (t71, _) idx_mut = (.b71) in
@@ -2202,9 +2048,9 @@ let to_run () =
     (* from (.a74) *)
     let shallow : (t74, _) idx_mut = (.a74) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 196;
+    mark_test_run 171;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 196 failed %d" i;
+    if not test then failwithf "test 171 failed %d" i;
   );
   (* Deepening to (.a74.#a72) *)
   let idx : (t74, _) idx_mut = (.a74.#a72) in
@@ -2212,15 +2058,15 @@ let to_run () =
     (* from (.a74) *)
     let shallow : (t74, _) idx_mut = (.a74) in
     let deepened = (.idx_mut(shallow).#a72) in
-    mark_test_run 197;
+    mark_test_run 172;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 197 failed %d" i;
+    if not test then failwithf "test 172 failed %d" i;
     (* from (.a74.#a72) *)
     let shallow : (t74, _) idx_mut = (.a74.#a72) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 198;
+    mark_test_run 173;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 198 failed %d" i;
+    if not test then failwithf "test 173 failed %d" i;
   );
   (* Deepening to (.a74.#b72) *)
   let idx : (t74, _) idx_mut = (.a74.#b72) in
@@ -2228,15 +2074,15 @@ let to_run () =
     (* from (.a74) *)
     let shallow : (t74, _) idx_mut = (.a74) in
     let deepened = (.idx_mut(shallow).#b72) in
-    mark_test_run 199;
+    mark_test_run 174;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 199 failed %d" i;
+    if not test then failwithf "test 174 failed %d" i;
     (* from (.a74.#b72) *)
     let shallow : (t74, _) idx_mut = (.a74.#b72) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 200;
+    mark_test_run 175;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 200 failed %d" i;
+    if not test then failwithf "test 175 failed %d" i;
   );
   (* Deepening to (.b74) *)
   let idx : (t74, _) idx_mut = (.b74) in
@@ -2244,9 +2090,9 @@ let to_run () =
     (* from (.b74) *)
     let shallow : (t74, _) idx_mut = (.b74) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 201;
+    mark_test_run 176;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 201 failed %d" i;
+    if not test then failwithf "test 176 failed %d" i;
   );
   (* Deepening to (.b74.#a73) *)
   let idx : (t74, _) idx_mut = (.b74.#a73) in
@@ -2254,15 +2100,15 @@ let to_run () =
     (* from (.b74) *)
     let shallow : (t74, _) idx_mut = (.b74) in
     let deepened = (.idx_mut(shallow).#a73) in
-    mark_test_run 202;
+    mark_test_run 177;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 202 failed %d" i;
+    if not test then failwithf "test 177 failed %d" i;
     (* from (.b74.#a73) *)
     let shallow : (t74, _) idx_mut = (.b74.#a73) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 203;
+    mark_test_run 178;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 203 failed %d" i;
+    if not test then failwithf "test 178 failed %d" i;
   );
   (* Deepening to (.b74.#b73) *)
   let idx : (t74, _) idx_mut = (.b74.#b73) in
@@ -2270,15 +2116,15 @@ let to_run () =
     (* from (.b74) *)
     let shallow : (t74, _) idx_mut = (.b74) in
     let deepened = (.idx_mut(shallow).#b73) in
-    mark_test_run 204;
+    mark_test_run 179;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 204 failed %d" i;
+    if not test then failwithf "test 179 failed %d" i;
     (* from (.b74.#b73) *)
     let shallow : (t74, _) idx_mut = (.b74.#b73) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 205;
+    mark_test_run 180;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 205 failed %d" i;
+    if not test then failwithf "test 180 failed %d" i;
   );
 
   (**********************************************)
@@ -2290,9 +2136,9 @@ let to_run () =
     (* from (.a76) *)
     let shallow : (t76, _) idx_mut = (.a76) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 206;
+    mark_test_run 181;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 206 failed %d" i;
+    if not test then failwithf "test 181 failed %d" i;
   );
   (* Deepening to (.a76.#a75) *)
   let idx : (t76, _) idx_mut = (.a76.#a75) in
@@ -2300,15 +2146,15 @@ let to_run () =
     (* from (.a76) *)
     let shallow : (t76, _) idx_mut = (.a76) in
     let deepened = (.idx_mut(shallow).#a75) in
-    mark_test_run 207;
+    mark_test_run 182;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 207 failed %d" i;
+    if not test then failwithf "test 182 failed %d" i;
     (* from (.a76.#a75) *)
     let shallow : (t76, _) idx_mut = (.a76.#a75) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 208;
+    mark_test_run 183;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 208 failed %d" i;
+    if not test then failwithf "test 183 failed %d" i;
   );
   (* Deepening to (.a76.#b75) *)
   let idx : (t76, _) idx_mut = (.a76.#b75) in
@@ -2316,15 +2162,15 @@ let to_run () =
     (* from (.a76) *)
     let shallow : (t76, _) idx_mut = (.a76) in
     let deepened = (.idx_mut(shallow).#b75) in
-    mark_test_run 209;
+    mark_test_run 184;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 209 failed %d" i;
+    if not test then failwithf "test 184 failed %d" i;
     (* from (.a76.#b75) *)
     let shallow : (t76, _) idx_mut = (.a76.#b75) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 210;
+    mark_test_run 185;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 210 failed %d" i;
+    if not test then failwithf "test 185 failed %d" i;
   );
   (* Deepening to (.b76) *)
   let idx : (t76, _) idx_mut = (.b76) in
@@ -2332,16 +2178,16 @@ let to_run () =
     (* from (.b76) *)
     let shallow : (t76, _) idx_mut = (.b76) in
     let deepened = (.idx_mut(shallow)) in
-    mark_test_run 211;
+    mark_test_run 186;
     let test = Idx_repr.equal (Idx_repr.of_idx_mut idx) (Idx_repr.of_idx_mut deepened) in
-    if not test then failwithf "test 211 failed %d" i;
+    if not test then failwithf "test 186 failed %d" i;
   );
 
   ()
 ;;
 let () = to_run ();;
 
-for i = 1 to 211 do
+for i = 1 to 186 do
   if not (Int_set.mem i !tests_run) then failwithf "test %d not run" i
 done;;
 let () = Printf.printf "All tests passed.%!\n";;

--- a/testsuite/tests/records-and-block-indices/metaprogramming.ml
+++ b/testsuite/tests/records-and-block-indices/metaprogramming.ml
@@ -285,11 +285,30 @@ module Type_structure = struct
     | Unit_u -> Void
     | Int64x2_u -> Vec128
 
-  let is_flat_float_record t =
+  let record_float_flattening t =
     match t with
     | Record (ts, Boxed) ->
-      List.for_all ts ~f:(fun t -> layout t = Float64 || scrape t = Float)
-    | _ -> false
+      let has_float = List.exists ts ~f:(fun t -> scrape t = Float) in
+      let has_float_u = List.exists ts ~f:(fun t -> layout t = Float64) in
+      let flattens_floats =
+        has_float
+        && List.for_all ts ~f:(fun t -> layout t = Float64 || scrape t = Float)
+      in
+      let is_mixed_float_float64_record = has_float_u && flattens_floats in
+      Some (~flattens_floats, ~is_mixed_float_float64_record)
+    | _ -> None
+
+  let flattens_floats t =
+    match record_float_flattening t with
+    | Some (~flattens_floats, ~is_mixed_float_float64_record:_) ->
+      flattens_floats
+    | None -> false
+
+  let is_mixed_float_float64_record t =
+    match record_float_flattening t with
+    | Some (~flattens_floats:_, ~is_mixed_float_float64_record) ->
+      is_mixed_float_float64_record
+    | None -> false
 
   let rec contains_vec128 t =
     match t with
@@ -934,27 +953,10 @@ module Type_naming = struct
             | _ -> assert false
           in
           let type_name = Type.code ty in
-          let needs_flatten_floats =
-            match ty_structure with
-            | Record (ts, Boxed) ->
-              let has_float =
-                List.exists ts ~f:(fun t -> Type_structure.scrape t = Float)
-              in
-              let has_float_u =
-                List.exists ts ~f:(fun t ->
-                    Type_structure.layout t = Float64
-                    && Type_structure.scrape t <> Float
-                )
-              in
-              has_float && has_float_u
-              && List.for_all ts ~f:(fun t ->
-                  Type_structure.layout t = Float64
-                  || Type_structure.scrape t = Float
-              )
-            | _ -> false
-          in
           let attr =
-            if needs_flatten_floats then " [@@flatten_floats]" else ""
+            if Type_structure.is_mixed_float_float64_record (Type.structure ty)
+            then " [@@flatten_floats]"
+            else ""
           in
           ( id,
             sprintf "type %s = %s%s (* %s *)" type_name type_definition attr

--- a/testsuite/tests/records-and-block-indices/metaprogramming.mli
+++ b/testsuite/tests/records-and-block-indices/metaprogramming.mli
@@ -101,7 +101,9 @@ module Type_structure : sig
   (** [None] if the tree is a [Leaf] (thus will always produce a boxed record *)
   val boxed_record_containing_unboxed_records : t Tree.t -> t option
 
-  val is_flat_float_record : t -> bool
+  val flattens_floats : t -> bool
+
+  val is_mixed_float_float64_record : t -> bool
 
   (** [None] if block indices to arrays of [nested_unboxed_record t] are not
       supported *)

--- a/testsuite/tests/records-and-block-indices/test_generation.ml
+++ b/testsuite/tests/records-and-block-indices/test_generation.ml
@@ -381,7 +381,7 @@ let test_array_idx_deepening ty =
 
 (* Block indices are not supported on records that flatten floats. *)
 let path_is_valid_block_idx ty _path =
-  not (Type_structure.is_flat_float_record (Type.structure ty))
+  not (Type_structure.flattens_floats (Type.structure ty))
 
 let test_record_idx_access ty ~local =
   type_section ty;
@@ -402,20 +402,7 @@ let test_record_idx_access ty ~local =
               line "(* .%s%s *)" lbl (Path.to_string unboxed_path);
               let full_path = Path.Field lbl :: unboxed_path in
               let test_deepening () =
-                let flattened_float =
-                  Type_structure.is_flat_float_record (Type.structure ty)
-                  && Type_structure.layout
-                       (Type.structure (Type.follow_path ty full_path))
-                     = Value { ignorable = false; non_float = false }
-                in
-                let sub_ty =
-                  if flattened_float
-                  then (
-                    line "(* ff *)";
-                    Type.Float_u
-                  )
-                  else Type.follow_path ty full_path
-                in
+                let sub_ty = Type.follow_path ty full_path in
                 line "let sub_eq = %s in" (Type.eq_code sub_ty);
                 let reference_update =
                   (* To perform our reference update (without block indices) to
@@ -446,33 +433,7 @@ let test_record_idx_access ty ~local =
                     (Type.code ty)
                 in
                 let next_r_sub_element_flat =
-                  if flattened_float
-                  then
-                    (* next_r at some path must be a float(#) or nested
-                       singleton unboxed records to one *)
-                    let ty' = ty in
-                    let rec path_to_float (ty : Type.t) =
-                      match ty with
-                      | Float | Float_u -> []
-                      | Record
-                          { fields = [(lbl, ty)]; boxing = Unboxed; name = _ }
-                        ->
-                        Path.Unboxed_field lbl :: path_to_float ty
-                      | Tuple (_, Unboxed) -> failwith "unimplemented"
-                      | _ ->
-                        failwith
-                          (sprintf "ty %s; %s; subty %s; stuck at %s"
-                             (Type.code ty') (Path.to_string full_path)
-                             (Type.code (Type.follow_path ty' full_path))
-                             (Type.code ty)
-                          )
-                    in
-                    sprintf "(Float_u.of_float next_r%s%s)"
-                      (Path.to_string full_path)
-                      (Path.to_string
-                         (path_to_float (Type.follow_path ty full_path))
-                      )
-                  else sprintf "next_r%s" (Path.to_string full_path)
+                  sprintf "next_r%s" (Path.to_string full_path)
                 in
                 line "Idx_mut.set r %s %s;" idx next_r_sub_element_flat;
                 seq_assert ~debug_exprs "eq r expected";
@@ -518,7 +479,7 @@ let test_record_idx_deepening ty =
                       let prefix, suffix = take_n unboxed_path prefix_len in
                       let prefix = Path.Field lbl :: prefix in
                       let from_flattened_float =
-                        Type_structure.is_flat_float_record (Type.structure ty)
+                        Type_structure.flattens_floats (Type.structure ty)
                         && Type_structure.layout
                              (Type.structure (Type.follow_path ty prefix))
                            = Value { ignorable = false; non_float = false }

--- a/testsuite/tests/records-and-block-indices/test_generation.ml
+++ b/testsuite/tests/records-and-block-indices/test_generation.ml
@@ -478,44 +478,27 @@ let test_record_idx_deepening ty =
                     for prefix_len = 0 to depth do
                       let prefix, suffix = take_n unboxed_path prefix_len in
                       let prefix = Path.Field lbl :: prefix in
-                      let from_flattened_float =
-                        Type_structure.flattens_floats (Type.structure ty)
-                        && Type_structure.layout
-                             (Type.structure (Type.follow_path ty prefix))
-                           = Value { ignorable = false; non_float = false }
-                      in
                       let to_void =
                         Type_structure.layout
                           (Type.structure (Type.follow_path ty full_path))
                         = Void
                       in
-                      if (not from_flattened_float) || suffix = []
+                      line "(* from (%s) *)" (Path.to_string prefix);
+                      line "let shallow : (%s, _) idx_mut = (%s) in"
+                        (Type.code ty) (Path.to_string prefix);
+                      line "let deepened = (.idx_mut(shallow)%s) in"
+                        (Path.to_string suffix);
+                      if to_void
                       then (
-                        line "(* from (%s) *)" (Path.to_string prefix);
-                        line "let shallow : (%s, _) idx_mut = (%s) in"
-                          (Type.code ty) (Path.to_string prefix);
-                        line "let deepened = (.idx_mut(shallow)%s) in"
-                          (Path.to_string suffix);
-                        if to_void
-                        then (
-                          line
-                            "(* No guarantees on representation of idx to void \
-                             *)";
-                          line "let _ignore = #(idx, deepened) in";
-                          line "();"
-                        )
-                        else
-                          seq_assert ~debug_exprs
-                            "Idx_repr.equal (Idx_repr.of_idx_mut idx) \
-                             (Idx_repr.of_idx_mut deepened)"
-                      )
-                      else (
                         line
-                          "(* Note: can't deepen (%s) because it's a path to a \
-                           flattened"
-                          (Path.to_string prefix);
-                        line "   float, making its element type [float#] *)"
+                          "(* No guarantees on representation of idx to void *)";
+                        line "let _ignore = #(idx, deepened) in";
+                        line "();"
                       )
+                      else
+                        seq_assert ~debug_exprs
+                          "Idx_repr.equal (Idx_repr.of_idx_mut idx) \
+                           (Idx_repr.of_idx_mut deepened)"
                     done
                 );
                 line ");"

--- a/testsuite/tests/records-and-block-indices/test_generation.ml
+++ b/testsuite/tests/records-and-block-indices/test_generation.ml
@@ -379,16 +379,9 @@ let test_array_idx_deepening ty =
   );
   print_newline ()
 
-(* If it's represented as a flattened float, then we can only create an idx if
-   the type is [float] (rather than a singleton unboxed record containing a
-   float *)
-let path_is_valid_block_idx ty path =
-  let flattened_float =
-    Type_structure.is_flat_float_record (Type.structure ty)
-    && Type_structure.layout (Type.structure (Type.follow_path ty path))
-       = Value { ignorable = false; non_float = false }
-  in
-  (not flattened_float) || Type.follow_path ty path = Type.Float
+(* Block indices are not supported on records that flatten floats. *)
+let path_is_valid_block_idx ty _path =
+  not (Type_structure.is_flat_float_record (Type.structure ty))
 
 let test_record_idx_access ty ~local =
   type_section ty;
@@ -494,6 +487,8 @@ let test_record_idx_access ty ~local =
                 line
                   "(* Note: skipping test as this is not a valid block index,";
                 line "   due to the float record optimization *)";
+                line "let _ = eq in";
+                line "let _ = r in";
                 line "let _ = next_r in"
               )
           )

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -186,45 +186,72 @@ Error: Block indices do not support float records.
 type t_float64 : float64
 type t = { f : float; t_float64 : t_float64; fu : float#; fr : fr  }
 [@@flatten_floats]
-let f () = (.f)
-let fu () = (.fu)
-let t_float64 () = (.t_float64)
-let fr_f () = (.fr.#f)
+let bad_f () = (.f)
 [%%expect{|
 type t_float64 : float64
 type t = { f : float; t_float64 : t_float64; fu : float#; fr : fr; }
-Line 4, characters 13-14:
-4 | let f () = (.f)
-                 ^
+Line 4, characters 17-18:
+4 | let bad_f () = (.f)
+                     ^
 Error: Block indices do not support [@@flatten_floats] records.
 |}]
 
-let bad () = (.fr)
+let bad_fu () = (.fu)
 [%%expect{|
-Line 1, characters 15-17:
-1 | let bad () = (.fr)
-                   ^^
+Line 1, characters 18-20:
+1 | let bad_fu () = (.fu)
+                      ^^
+Error: Block indices do not support [@@flatten_floats] records.
+|}]
+
+let bad_t_float64 () = (.t_float64)
+[%%expect{|
+Line 1, characters 25-34:
+1 | let bad_t_float64 () = (.t_float64)
+                             ^^^^^^^^^
+Error: Block indices do not support [@@flatten_floats] records.
+|}]
+
+let bad_fr_f () = (.fr.#f)
+[%%expect{|
+Line 1, characters 20-22:
+1 | let bad_fr_f () = (.fr.#f)
+                        ^^
+Error: Block indices do not support [@@flatten_floats] records.
+|}]
+
+let bad_fr () = (.fr)
+[%%expect{|
+Line 1, characters 18-20:
+1 | let bad_fr () = (.fr)
+                      ^^
 Error: Block indices do not support [@@flatten_floats] records.
 |}]
 
 type t = { f : float# } [@@represent_as_float_array]
-let f () = (.f)
+let bad_f () = (.f)
 [%%expect{|
 type t = { f : float#; }
-Line 2, characters 13-14:
-2 | let f () = (.f)
-                 ^
+Line 2, characters 17-18:
+2 | let bad_f () = (.f)
+                     ^
 Error: Block indices do not support [@@represent_as_float_array] records.
 |}]
 
 type t = { f : float; f' : float# } [@@flatten_floats]
-let f () = (.f)
-let f' () = (.f')
+let bad_f () = (.f)
 [%%expect{|
 type t = { f : float; f' : float#; }
-Line 2, characters 13-14:
-2 | let f () = (.f)
-                 ^
+Line 2, characters 17-18:
+2 | let bad_f () = (.f)
+                     ^
+Error: Block indices do not support [@@flatten_floats] records.
+|}]
+let bad_f' () = (.f')
+[%%expect{|
+Line 1, characters 18-20:
+1 | let bad_f' () = (.f')
+                      ^^
 Error: Block indices do not support [@@flatten_floats] records.
 |}]
 

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -134,12 +134,14 @@ Error: This unboxed access is expected to have base type "y#"
 (*****************)
 (* Float records *)
 
-(* Indicies to flattened float always have element type [float#] *)
 type t = { f : float }
 let f () = (.f)
 [%%expect{|
 type t = { f : float; }
-val f : unit -> (t, float#) idx_imm = <fun>
+Line 2, characters 13-14:
+2 | let f () = (.f)
+                 ^
+Error: Block indices do not support float records.
 |}]
 
 (* Unboxed float record *)
@@ -159,75 +161,71 @@ type t = { t_float64 : t_float64; }
 val t_float64 : unit -> (t, t_float64) idx_imm = <fun>
 |}]
 
-(* Singleton unboxed records containing floats can appear in float records *)
+(* We can't create an index to float records *)
 type fr = #{ f : float }
 type t = { f : float; fr : fr  }
 let fr_f () = (.fr.#f)
 [%%expect{|
 type fr = #{ f : float; }
 type t = { f : float; fr : fr; }
-val fr_f : unit -> (t, float#) idx_imm = <fun>
+Line 3, characters 16-18:
+3 | let fr_f () = (.fr.#f)
+                    ^^
+Error: Block indices do not support float records.
 |}]
 
-(* But we can't create a pointer to a flattened [fr], because it has no unboxed
-   version *)
 let bad () = (.fr)
 [%%expect{|
-Line 1, characters 13-18:
+Line 1, characters 15-17:
 1 | let bad () = (.fr)
-                 ^^^^^
-Error: This block index points to an element stored as a flattened float.
-       Such block indices require the element type to have an unboxed
-       version, but "fr" does not.
+                   ^^
+Error: Block indices do not support float records.
 |}]
 
 (* Mixed float record *)
 type t_float64 : float64
 type t = { f : float; t_float64 : t_float64; fu : float#; fr : fr  }
+[@@flatten_floats]
 let f () = (.f)
 let fu () = (.fu)
 let t_float64 () = (.t_float64)
 let fr_f () = (.fr.#f)
 [%%expect{|
 type t_float64 : float64
-Line 2, characters 0-68:
-2 | type t = { f : float; t_float64 : t_float64; fu : float#; fr : fr  }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This record type mixes boxed and unboxed float fields,
-       which causes the flat float record optimization.
-       You must annotate it with "[@@flatten_floats]".
+type t = { f : float; t_float64 : t_float64; fu : float#; fr : fr; }
+Line 4, characters 13-14:
+4 | let f () = (.f)
+                 ^
+Error: Block indices do not support [@@flatten_floats] records.
 |}]
 
-(* Can't take a block index to a flattened [fr] because it doesn't have an
-   unboxed version *)
 let bad () = (.fr)
 [%%expect{|
-Line 1, characters 13-18:
+Line 1, characters 15-17:
 1 | let bad () = (.fr)
-                 ^^^^^
-Error: This block index points to an element stored as a flattened float.
-       Such block indices require the element type to have an unboxed
-       version, but "fr" does not.
+                   ^^
+Error: Block indices do not support [@@flatten_floats] records.
 |}]
 
-type pfa = private float
-type r = { mutable pfa : pfa }
-let f () : (r, pfa#) idx_mut = (.pfa)
+type t = { f : float# } [@@represent_as_float_array]
+let f () = (.f)
 [%%expect{|
-type pfa = private float
-type r = { mutable pfa : pfa; }
-val f : unit -> (r, pfa#) idx_mut = <fun>
+type t = { f : float#; }
+Line 2, characters 13-14:
+2 | let f () = (.f)
+                 ^
+Error: Block indices do not support [@@represent_as_float_array] records.
 |}]
 
-(* Cannot bypass private float aliases *)
-let bad () : (r, float#) idx_mut = (.pfa)
+type t = { f : float; f' : float# } [@@flatten_floats]
+let f () = (.f)
+let f' () = (.f')
 [%%expect{|
-Line 1, characters 35-41:
-1 | let bad () : (r, float#) idx_mut = (.pfa)
-                                       ^^^^^^
-Error: This expression has type "(r, pfa#) idx_mut"
-       but an expression was expected of type "(r, float#) idx_mut"
-       Type "pfa#" is not compatible with type "float#"
+type t = { f : float; f' : float#; }
+Line 2, characters 13-14:
+2 | let f () = (.f)
+                 ^
+Error: Block indices do not support [@@flatten_floats] records.
 |}]
 
 (***************)

--- a/testsuite/tests/typing-layouts-block-indices/block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices.ml
@@ -62,17 +62,6 @@ let () =
   Printf.printf "%f\n" r.f;
   print_newline ()
 
-type float_record = { f' : float; mutable f : float }
-
-let () =
-  print_endline "Float record";
-  let r = { f' = -100.0; f = 1.0 } in
-  let x = Idx_mut.get r (.f) in
-  Printf.printf "%f\n" (Float_u.to_float x);
-  Idx_mut.set r (.f) #2.0;
-  Printf.printf "%f\n" r.f;
-  print_newline ()
-
 type mixed_record = { i : int; mutable u : float#; s : string }
 
 let () =
@@ -104,26 +93,6 @@ let () =
   Printf.printf "%f\n" x;
   Idx_mut.set r (.r.#f) 2.0;
   Printf.printf "%f\n" r.r.#f;
-  print_newline ()
-
-type mixed_float_record = { mutable f : float; mutable u : float# } [@@flatten_floats]
-
-let () =
-  print_endline "Mixed float record (float field)";
-  let r = { f = 1.0; u = -#100.0 } in
-  let x = Idx_mut.get r (.f) in
-  Printf.printf "%f\n" (Float_u.to_float x);
-  Idx_mut.set r (.f) #2.0;
-  Printf.printf "%f\n" r.f;
-  print_newline ()
-
-let () =
-  print_endline "Mixed float record (float# field)";
-  let r = { f = -100.0; u = #1.0 } in
-  let x = Idx_mut.get r (.u) in
-  Printf.printf "%f\n" (Float_u.to_float x);
-  Idx_mut.set r (.u) #2.0;
-  Printf.printf "%f\n" (Float_u.to_float r.u);
   print_newline ()
 
 type floatu_floatu = #{ f1: float#; f2 : float# }

--- a/testsuite/tests/typing-layouts-block-indices/block_indices.reference
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices.reference
@@ -2,10 +2,6 @@ Boxed record
 1.000000
 2.000000
 
-Float record
-1.000000
-2.000000
-
 Mixed block record
 1.000000
 2.000000
@@ -15,14 +11,6 @@ Mixed block record (float32# field)
 2.000000
 
 Nested mixed block record
-1.000000
-2.000000
-
-Mixed float record (float field)
-1.000000
-2.000000
-
-Mixed float record (float# field)
 1.000000
 2.000000
 

--- a/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.ml
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.ml
@@ -67,17 +67,6 @@ let () =
   Printf.printf "%f\n" r.f;
   print_newline ()
 
-type float_record = { f' : float; mutable f : float }
-
-let () =
-  print_endline "Float record";
-  let r = { f' = -100.0; f = 1.0 } in
-  let x = unsafe_get_ptr #(r, (.f)) in
-  Printf.printf "%f\n" (Float_u.to_float x);
-  unsafe_set_ptr #(r, (.f)) #2.0;
-  Printf.printf "%f\n" r.f;
-  print_newline ()
-
 type mixed_record = { i : int; mutable u : float#; s : string }
 
 let () =
@@ -109,26 +98,6 @@ let () =
   Printf.printf "%f\n" x;
   unsafe_set_ptr #(r, (.r.#f)) 2.0;
   Printf.printf "%f\n" r.r.#f;
-  print_newline ()
-
-type mixed_float_record = { mutable f : float; mutable u : float# } [@@flatten_floats]
-
-let () =
-  print_endline "Mixed float record (float field)";
-  let r = { f = 1.0; u = -#100.0 } in
-  let x = unsafe_get_ptr #(r, (.f)) in
-  Printf.printf "%f\n" (Float_u.to_float x);
-  unsafe_set_ptr #(r, (.f)) #2.0;
-  Printf.printf "%f\n" r.f;
-  print_newline ()
-
-let () =
-  print_endline "Mixed float record (float# field)";
-  let r = { f = -100.0; u = #1.0 } in
-  let x = unsafe_get_ptr #(r, (.u)) in
-  Printf.printf "%f\n" (Float_u.to_float x);
-  unsafe_set_ptr #(r, (.u)) #2.0;
-  Printf.printf "%f\n" (Float_u.to_float r.u);
   print_newline ()
 
 type floatu_floatu = #{ f1: float#; f2 : float# }

--- a/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.reference
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.reference
@@ -2,10 +2,6 @@ Boxed record
 1.000000
 2.000000
 
-Float record
-1.000000
-2.000000
-
 Mixed block record
 1.000000
 2.000000
@@ -15,14 +11,6 @@ Mixed block record (float32# field)
 2.000000
 
 Nested mixed block record
-1.000000
-2.000000
-
-Mixed float record (float field)
-1.000000
-2.000000
-
-Mixed float record (float# field)
 1.000000
 2.000000
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -95,7 +95,7 @@ let record_form_to_wrong_kind_sort
   | Unboxed_product -> Record_unboxed_product
 
 type type_block_access_result =
-  { ba : block_access; base_ty: type_expr; el_ty: type_expr; flat_float : bool;
+  { ba : block_access; base_ty: type_expr; el_ty: type_expr;
     modality : Modality.Const.t }
 
 type contains_gadt =
@@ -272,9 +272,7 @@ type error =
   | Expr_record_type_has_wrong_boxing of record_form_packed * type_expr
   | Invalid_unboxed_access of
       { prev_el_type : type_expr; ua : Parsetree.unboxed_access }
-  | Block_access_record_unboxed
-  | Block_access_private_record
-  | Block_index_flattened_record of type_expr
+  | Block_access_bad_record of string
   | Block_index_modality_mismatch of
       { mut : bool; err : Modality.equate_error }
   | Block_index_atomic_unsupported
@@ -5897,7 +5895,7 @@ let may_lower_contravariant_then_generalize env exp =
   generalize exp.exp_type
 
 let generalize_structure_type_block_access_result
-      { ba; base_ty; el_ty; flat_float = _ } =
+      { ba; base_ty; el_ty; modality = _ } =
   generalize_structure base_ty;
   generalize_structure el_ty;
   match ba with
@@ -7082,7 +7080,7 @@ and type_expect_
     in
     let expected_base_ty = expected_base_ty ty_expected in
     let principal = is_principal ty_expected in
-    let { ba; base_ty; el_ty; flat_float; modality } =
+    let { ba; base_ty; el_ty; modality } =
       with_local_level_if_principal
         ~post:generalize_structure_type_block_access_result
         (fun () ->
@@ -7140,24 +7138,6 @@ and type_expect_
       | Error err ->
         raise (Error(loc, env, Block_index_modality_mismatch { mut; err }))
     end;
-    let el_ty =
-      if flat_float then
-        let has_unboxed_version p =
-          not (Path.is_unboxed_version p) &&
-          try
-            ignore (Env.find_type (Path.unboxed_version p) env);
-            true
-          with Not_found ->
-            false
-        in
-        match get_desc (expand_head env el_ty) with
-        | Tconstr(p, args, _) when has_unboxed_version p ->
-          newconstr (Path.unboxed_version p) args
-        | _ ->
-          raise (Error(loc, env, Block_index_flattened_record el_ty))
-      else
-        el_ty
-    in
     let ty =
       if mut then
         Predef.type_idx_mut base_ty el_ty
@@ -8113,35 +8093,26 @@ and type_block_access env expected_base_ty principal
     let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
     if mut then Env.mark_label_used Mutation label.lbl_uid;
     let ba = Baccess_field (lid, label) in
-    let flat_float  =
-      (* whether we change the final el ty to [float#]. we don't set [el_ty]
-          to [float#] here because it could be a singleton unboxed record
-          containing a float, and thus be followed by an unboxed access *)
-      match label.lbl_repres with
-      | Record_boxed -> false
-      | Record_mixed mixed ->
-        begin match mixed.(label.lbl_pos) with
-        | Float_boxed -> true
-        | Float64 | Float32 | Scannable _ | Bits8 | Bits16 | Bits32 | Bits64
-        | Vec128 | Vec256 | Vec512 | Word | Product _ | Void
-        | Untagged_immediate ->
-          false
-        end
-      | Record_float -> true
-      | Record_ufloat -> false
-      | Record_unboxed ->
-        raise (Error (lid.loc, env, Block_access_record_unboxed))
-      | Record_inlined _ ->
-        Misc.fatal_error "Typecore.type_block_access: inlined record"
+    let bad_record_error reason =
+      raise (Error (lid.loc, env, Block_access_bad_record reason))
     in
-    let () =
-      match label.lbl_private with
-      | Public -> ()
-      | Private ->
-        raise (Error (lid.loc, env, Block_access_private_record))
-    in
+    (match label.lbl_repres with
+     | Record_boxed -> ()
+     | Record_mixed shape ->
+       if Array.exists (function Float_boxed -> true | _ -> false) shape then
+         bad_record_error "[@@flatten_floats]"
+       else
+         ()
+     | Record_float -> bad_record_error "float"
+     | Record_ufloat -> bad_record_error "[@@represent_as_float_array]"
+     | Record_unboxed -> bad_record_error "[@@unboxed]"
+     | Record_inlined _ ->
+       Misc.fatal_error "Typecore.type_block_access: inlined record");
+    (match label.lbl_private with
+     | Public -> ()
+     | Private -> bad_record_error "private");
     let modality = label.lbl_modalities in
-    { ba; base_ty = ty_res; el_ty = ty_arg; flat_float; modality }
+    { ba; base_ty = ty_res; el_ty = ty_arg; modality }
   | Baccess_block (mut, idx) ->
     let base_ty = newvar (Jkind.Builtin.value_or_null ~why:Idx_base) in
     let el_ty =
@@ -8158,7 +8129,7 @@ and type_block_access env expected_base_ty principal
     let ba = Baccess_block (mut, idx) in
     let mut = match mut with Immutable -> false | Mutable -> true in
     let modality = Typemode.idx_expected_modalities ~mut in
-    { ba; base_ty; el_ty; flat_float = false; modality }
+    { ba; base_ty; el_ty; modality }
 
 and type_unboxed_access env loc el_ty ua =
   match ua with
@@ -12382,18 +12353,9 @@ let report_error ~loc env =
           (Style.as_inline_code Printtyp.type_expr) prev_el_type
           (Style.as_inline_code longident) lid
       end
-  | Block_access_record_unboxed ->
-    Location.error ~loc
-      "Block indices do not support [@@unboxed] records."
-  | Block_access_private_record ->
-    Location.error ~loc
-      "Block indices do not support private records."
-  | Block_index_flattened_record el_ty ->
+  | Block_access_bad_record kind ->
     Location.errorf ~loc
-      "This block index points to an element stored as a flattened float.@ \
-       Such block indices require the element type to have an unboxed@ \
-       version, but %a does not."
-      (Style.as_inline_code Printtyp.type_expr) el_ty
+      "Block indices do not support %s records." kind
   | Block_index_modality_mismatch { mut; err } ->
     let step, Modality.Error(ax, { left; right }) = err in
     let print_modality_doc id =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -320,9 +320,7 @@ type error =
   | Expr_record_type_has_wrong_boxing of record_form_packed * type_expr
   | Invalid_unboxed_access of
       { prev_el_type : type_expr; ua : Parsetree.unboxed_access }
-  | Block_access_record_unboxed
-  | Block_access_private_record
-  | Block_index_flattened_record of type_expr
+  | Block_access_bad_record of string
   | Block_index_modality_mismatch of
       { mut : bool; err : Mode.Modality.equate_error }
   | Block_index_atomic_unsupported

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1271,14 +1271,12 @@ let transl_declaration env sdecl (id, uid) =
    also have unboxed versions, but these aren't stored in
    [type_unboxed_version].
 *)
-let rec shape_has_float_boxed shape =
+let shape_has_float_boxed shape =
   Array.exists
     (fun (kind : mixed_block_element) ->
-      match kind with
-      | Scannable _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-      | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate | Void -> false
-      | Float_boxed -> true
-      | Product shape -> shape_has_float_boxed shape)
+       (* Note we don't have to recurse into products, as [Float_boxed] can only
+          occur at the top level of a shape *)
+       match kind with Float_boxed -> true | _ -> false)
     shape
 
 let record_has_float_boxed = function


### PR DESCRIPTION
Currently, we allow block indices to all of the following:

```ocaml
module Float_record = struct
  type t = { f : float }
  let i () = (.f)
end

module Float_array_record = struct
  type t = { f : float# }
  [@@represent_as_float_array]

  let i () = (.f)
end

module Mixed_float_record = struct
  type t = { f : float; f' : float# }
  [@@flatten_floats]

  let i () = (.f)
end
```

This PR disallows all, in preparation for `box`.