### PR TITLE
fix: Use correct kinds for results of unboxed c calls

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -55,7 +55,18 @@ include Container_types.Make (struct
       Flambda_kind.With_subkind.print kind
 end)
 
-let create param kind uid = { param; kind; uid }
+let create param kind uid =
+  if
+    not
+      (Flambda_kind.equal
+         (Flambda_kind.With_subkind.kind kind)
+         (Variable.kind param))
+  then
+    Misc.fatal_errorf
+      "Cannot create parameter %a with kind %a: it must have a subkind of %a"
+      Variable.print param Flambda_kind.With_subkind.print kind
+      Flambda_kind.print (Variable.kind param);
+  { param; kind; uid }
 
 let var t = t.param
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -931,10 +931,14 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
         let_bound_vars
     in
     let handler_params =
-      List.map
-        (fun (let_bound_var, let_bound_var_duid) ->
-          Variable.rename let_bound_var, let_bound_var_duid)
-        let_bound_vars
+      List.map2
+        (fun { kind; _ } (let_bound_var, let_bound_var_duid) ->
+          let user_visible =
+            if Variable.user_visible let_bound_var then Some () else None
+          in
+          let name = Variable.name let_bound_var in
+          Variable.create ?user_visible name kind, let_bound_var_duid)
+        unarized_results let_bound_vars
     in
     let body acc =
       let acc, body = keep_body acc in

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -709,6 +709,11 @@ let add_variable_definition t var kind name_mode =
   then
     Misc.fatal_errorf "Cannot rebind %a in environment:@ %a" Name.print name
       print t;
+  if not (K.equal kind (Variable.kind var))
+  then
+    Misc.fatal_errorf
+      "Cannot define variable %a (which has kind %a) with kind %a"
+      Variable.print var K.print (Variable.kind var) K.print kind;
   let level =
     TEL.add_definition
       (One_level.level t.current_level)


### PR DESCRIPTION
This was missed in #4243 and revealed as a latent bug by #5886, causing the issue described in #6083. Merging this should allow to safely re-introduce #5886.

This patch makes sure to explicitly create new variables with the right kind instead of calling `Variable.rename` to create the boxed version of the result from their unboxed version, which was a somewhat dubious use of `Variable.rename` in the first place.

Also, add assertions that the kinds are as expected in bound parameters and when defining variables in the typing env (without the fix in this PR, the assertions fail when compiling the standard library). There are currently very few uses of the kinds stored on variables, but as we start to use them more, it is critical that we can trust them or there will be miscompilations.