### PR TITLE
Add a Punspecializedarray array kind

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -444,7 +444,9 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
           | [] -> block
           | _ :: _ ->
             (* for the floatarray hack *)
-            Prim (Ccall "caml_array_of_uniform_array", [block])))
+            Prim (Ccall "caml_array_of_uniform_array", [block]))
+        | Punspecializedarray ->
+          Misc.fatal_error "Blambda_of_lambda: Pmakearray Punspecializedarray")
     | Presume -> context_switch Resume ~arity:3
     | Pwith_stack -> context_switch With_stack ~arity:5
     | Pwith_stack_bind -> context_switch With_stack_bind ~arity:7
@@ -463,6 +465,9 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
               "Array kind %s should have been ruled out by the frontend for \
                %%makearray_dynamic_uninit"
               (Printlambda.array_kind kind)
+          | Punspecializedarray ->
+            Misc.fatal_error
+              "Blambda_of_lambda: Pmakearray_dynamic Punspecializedarray"
           | Punboxedfloatarray Unboxed_float32 ->
             Lconst (Const_base (Const_float32 "0.0"))
           | Punboxedfloatarray Unboxed_float64 ->
@@ -777,6 +782,12 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Parrayrefu (Punboxedvectorarray_ref _, _, _)
     | Parraysetu (Punboxedvectorarray_set _, _) ->
       simd_is_not_supported ()
+    | Parrayrefs (Punspecializedarray_ref _, _, _)
+    | Parraysets (Punspecializedarray_set _, _)
+    | Parrayrefu (Punspecializedarray_ref _, _, _)
+    | Parraysetu (Punspecializedarray_set _, _) ->
+      Misc.fatal_error
+        "Blambda_of_lambda: array primitive on Punspecializedarray"
     | Pctconst c -> unary (caml_sys_const c)
     | Pisint _ -> unary Isint
     | Pisout -> binary (Intcomp Ultint)
@@ -883,7 +894,10 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | Pgcscannableproductarray _ | Pgcignorableproductarray _ -> (
         match locality with
         | Alloc_heap -> binary (Ccall "caml_array_make")
-        | Alloc_local -> binary (Ccall "caml_array_make_local")))
+        | Alloc_local -> binary (Ccall "caml_array_make_local"))
+      | Punspecializedarray ->
+        Misc.fatal_error
+          "Blambda_of_lambda: Pmakearray_dynamic Punspecializedarray")
     | Parrayblit { src_mutability = _; dst_array_set_kind } -> (
       match dst_array_set_kind with
       | Punboxedvectorarray_set _ -> simd_is_not_supported ()
@@ -891,7 +905,10 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | Pgcignorableaddrarray_set | Punboxedoruntaggedintarray_set _
       | Pfloatarray_set | Punboxedfloatarray_set _
       | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ->
-        n_ary (Ccall "caml_array_blit") ~arity:5)
+        n_ary (Ccall "caml_array_blit") ~arity:5
+      | Punspecializedarray_set _ ->
+        Misc.fatal_error "Blambda_of_lambda: Parrayblit Punspecializedarray_set"
+      )
     | Pprobe_is_enabled _ | Ppeek _ | Ppoke _ | Pget_ptr _ | Pset_ptr _ ->
       Misc.fatal_errorf "Blambda_of_lambda: %a is not supported in bytecode"
         Printlambda.primitive primitive

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -498,6 +498,7 @@ and array_kind =
   | Punboxedvectorarray of unboxed_vector
   | Pgcscannableproductarray of scannable_product_element_kind list
   | Pgcignorableproductarray of ignorable_product_element_kind list
+  | Punspecializedarray
 
 and array_ref_kind =
   | Pgenarray_ref of locality_mode
@@ -510,6 +511,7 @@ and array_ref_kind =
   | Punboxedvectorarray_ref of unboxed_vector
   | Pgcscannableproductarray_ref of scannable_product_element_kind list
   | Pgcignorableproductarray_ref of ignorable_product_element_kind list
+  | Punspecializedarray_ref of locality_mode
 
 and array_set_kind =
   | Pgenarray_set of modify_mode
@@ -523,6 +525,7 @@ and array_set_kind =
   | Pgcscannableproductarray_set of
       modify_mode * scannable_product_element_kind list
   | Pgcignorableproductarray_set of ignorable_product_element_kind list
+  | Punspecializedarray_set of modify_mode
 
 and ignorable_product_element_kind =
   | Pint_ignorable
@@ -2486,6 +2489,9 @@ let primitive_may_allocate : primitive -> locality_mode option = function
       | Pgcignorableproductarray_ref _), _, _) -> None
   | Parrayrefu ((Pgenarray_ref m | Pfloatarray_ref m), _, _)
   | Parrayrefs ((Pgenarray_ref m | Pfloatarray_ref m), _, _) -> Some m
+  | Parrayrefu (Punspecializedarray_ref _, _, _)
+  | Parrayrefs (Punspecializedarray_ref _, _, _) ->
+    Misc.fatal_error "Lambda.primitive_may_allocate: Punspecializedarray_ref"
   | Pisint _ | Pisnull | Pisout -> None
   | Pbigarrayset _ | Pbigarraydim _ -> None
   | Pbigarrayref (_, _, _, _) ->
@@ -2883,6 +2889,9 @@ let array_ref_kind_result_layout = function
   | Punboxedvectorarray_ref bv -> layout_unboxed_vector bv
   | Pgcscannableproductarray_ref kinds -> layout_of_scannable_kinds kinds
   | Pgcignorableproductarray_ref kinds -> layout_of_ignorable_kinds kinds
+  | Punspecializedarray_ref _ ->
+    Misc.fatal_error
+      "Lambda.array_ref_kind_result_layout: Punspecializedarray_ref"
 
 let rec layout_of_mixed_block_element element =
   match element with
@@ -3238,6 +3247,7 @@ let array_ref_kind mode = function
   | Punboxedvectorarray vec_kind -> Punboxedvectorarray_ref vec_kind
   | Pgcscannableproductarray kinds -> Pgcscannableproductarray_ref kinds
   | Pgcignorableproductarray kinds -> Pgcignorableproductarray_ref kinds
+  | Punspecializedarray -> Punspecializedarray_ref mode
 
 let array_set_kind mode = function
   | Pgenarray -> Pgenarray_set mode
@@ -3251,6 +3261,7 @@ let array_set_kind mode = function
   | Punboxedvectorarray vec_kind -> Punboxedvectorarray_set vec_kind
   | Pgcscannableproductarray kinds -> Pgcscannableproductarray_set (mode, kinds)
   | Pgcignorableproductarray kinds -> Pgcignorableproductarray_set kinds
+  | Punspecializedarray -> Punspecializedarray_set mode
 
 let array_ref_kind_of_array_set_kind (kind : array_set_kind) mode
       : array_ref_kind =
@@ -3267,6 +3278,7 @@ let array_ref_kind_of_array_set_kind (kind : array_set_kind) mode
   | Paddrarray_set _ -> Paddrarray_ref
   | Pgcignorableaddrarray_set -> Pgcignorableaddrarray_ref
   | Pfloatarray_set -> Pfloatarray_ref mode
+  | Punspecializedarray_set _ -> Punspecializedarray_ref mode
 
 let may_allocate_in_region lam =
   (* loop_region raises, if the lambda might allocate in parent region *)
@@ -3373,6 +3385,9 @@ let count_initializers_array_kind (lambda_array_kind : array_kind) =
     List.fold_left
       (fun acc ignorable -> acc + count_initializers_ignorable ignorable)
       0 ignorables
+  | Punspecializedarray ->
+    Misc.fatal_error
+      "Lambda.count_initializers_array_kind: Punspecializedarray"
 
 (* CR mshinwell: This function might need revisiting for JSIR and any
    Flambda 2 -> WASM backend *)
@@ -3402,6 +3417,9 @@ let array_element_size_in_bytes (array_kind : array_kind) =
   | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
     (* All elements of unboxed product arrays are currently 8 bytes wide. *)
     count_initializers_array_kind array_kind * 8
+  | Punspecializedarray ->
+    Misc.fatal_error
+      "Lambda.array_element_size_in_bytes: Punspecializedarray"
 
 let element_layout_of_array_kind ak =
   (* [alloc_heap] is ignored by [array_ref_kind_result_layout]. *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -451,6 +451,19 @@ and array_kind =
   | Pgcscannableproductarray of scannable_product_element_kind list
   | Pgcignorableproductarray of ignorable_product_element_kind list
   (* Invariant: the product element kind lists have length >= 2 *)
+  | Punspecializedarray
+  (* Used only in the definition of primitives, to represent primitives that
+     have not yet been specialized. Note that [Punspecializedarray] and
+     [Pgenarray] are not the same thing:
+
+     - [Pgenarray] represent arrays that can be either [Paddrarray] or
+       [Pfloatarray]
+     - [Punspecializedarray] is for arrays that can be of any kind, including
+       [Pgenarray].
+
+     When [Config.flat_float_array] is [false], then [Pgenarray] must not be
+     used, but [Punspecializedarray] always is. After specialization, no value
+     of this kind should remain. *)
 
 (** When accessing a flat float array, we need to know the mode which we should
     box the resulting float at. *)
@@ -466,6 +479,8 @@ and array_ref_kind =
   | Pgcscannableproductarray_ref of scannable_product_element_kind list
   | Pgcignorableproductarray_ref of ignorable_product_element_kind list
   (* Invariant: the product element kind lists have length >= 2 *)
+  | Punspecializedarray_ref of locality_mode
+    (* See [Punspecializedarray]. *)
 
 (** When updating an array that might contain pointers, we need to know what
     mode they're at; otherwise, access is uniform. *)
@@ -482,6 +497,8 @@ and array_set_kind =
       modify_mode * scannable_product_element_kind list
   | Pgcignorableproductarray_set of ignorable_product_element_kind list
   (* Invariant: the product element kind lists have length >= 2 *)
+  | Punspecializedarray_set of modify_mode
+    (* See [Punspecializedarray]. *)
 
 and ignorable_product_element_kind =
   | Pint_ignorable

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -96,6 +96,7 @@ let array_kind = function
     "scannableproduct " ^ scannable_product_element_kinds kinds
   | Pgcignorableproductarray kinds ->
     "ignorableproduct " ^ ignorable_product_element_kinds kinds
+  | Punspecializedarray -> "unspecialized"
 
 let array_mut = function
   | Mutable -> "array"
@@ -122,6 +123,7 @@ let array_ref_kind ppf k =
     fprintf ppf "scannableproduct %s" (scannable_product_element_kinds kinds)
   | Pgcignorableproductarray_ref kinds ->
     fprintf ppf "ignorableproduct %s" (ignorable_product_element_kinds kinds)
+  | Punspecializedarray_ref mode -> fprintf ppf "unspecialized%a" pp_mode mode
 
 let array_index_kind ppf k =
   match k with
@@ -151,6 +153,7 @@ let array_set_kind ppf k =
       (scannable_product_element_kinds kinds)
   | Pgcignorableproductarray_set kinds ->
     fprintf ppf "ignorableproduct %s" (ignorable_product_element_kinds kinds)
+  | Punspecializedarray_set mode -> fprintf ppf "unspecialized%a" pp_mode mode
 
 let locality_mode_if_local = function
   | Alloc_heap -> ""

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -777,6 +777,9 @@ let initial_array ~loc ~array_kind ~array_size ~array_sizing =
     | _, (Pgcscannableproductarray _ | Pgcignorableproductarray _) ->
       Misc.fatal_error
         "Transl_array_comprehension.initial_array: unboxed product array"
+    | _, Punspecializedarray ->
+      Misc.fatal_error
+        "Transl_array_comprehension.initial_array: Punspecializedarray"
   in
   Let_binding.make array_let_kind layout_any_value "array" Lambda.debug_uid_none
     array_value
@@ -869,6 +872,8 @@ let body ~loc ~array_kind ~array_size ~array_sizing ~array ~index ~body =
       set_element_in_bounds body
     | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
       Misc.fatal_error "Transl_array_comprehension.body: unboxed product array"
+    | Punspecializedarray ->
+      Misc.fatal_error "Transl_array_comprehension.body: Punspecializedarray"
   in
   Lsequence
     (set_element_known_kind_in_bounds, Lassign (index.id, index.var + l1))
@@ -893,7 +898,10 @@ let comprehension ~transl_exp ~scopes ~loc ~(array_kind : Lambda.array_kind)
         (Printlambda.array_kind array_kind)
   | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
     Misc.fatal_error
-      "Transl_array_comprehension.comprehension: unboxed product array");
+      "Transl_array_comprehension.comprehension: unboxed product array"
+  | Punspecializedarray ->
+    Misc.fatal_error
+      "Transl_array_comprehension.comprehension: Punspecializedarray");
   let { array_sizing_info; array_size; make_comprehension } =
     clauses ~transl_exp ~scopes ~loc comp_clauses
   in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -980,6 +980,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                 | Punboxedvectorarray _
                 | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
                   Misc.fatal_error "Use flambda2 for unboxed arrays"
+                | Punspecializedarray ->
+                  Misc.fatal_error "Translcore: Punspecializedarray"
             in
             if Types.is_mutable amut then duparray_to_mutable const else const
         end
@@ -1005,6 +1007,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         raise (Error(e.exp_loc, Unboxed_vector_in_array_comprehension))
       | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
         raise (Error(e.exp_loc, Unboxed_product_in_array_comprehension))
+      | Punspecializedarray ->
+        Misc.fatal_error
+          "Translcore: array comprehension with Punspecializedarray"
       end;
       Transl_array_comprehension.comprehension
         ~transl_exp ~scopes ~loc ~array_kind comp

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -54,6 +54,10 @@ let unboxed_product_uninitialized_array_check loc array_kind =
   | Pgenarray | Paddrarray | Pgcignorableaddrarray | Pintarray | Pfloatarray
   | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
     raise (Error (loc, Invalid_array_kind_for_uninitialized_makearray_dynamic))
+  | Punspecializedarray ->
+    Misc.fatal_error
+      "Translprim.unboxed_product_uninitialized_array_check: \
+       Punspecializedarray"
 
 (* Insertion of debugging events *)
 
@@ -162,6 +166,8 @@ let clear_used_primitives () = Hashtbl.clear units_with_used_primitives
 let get_units_with_used_primitives () =
   Hashtbl.fold (fun path _ acc -> path :: acc) units_with_used_primitives []
 
+(* For the [%obj_*] primitives, which re-use the array primitives but should
+   not be specialized, we resolve the array kind right away. *)
 let gen_array_kind =
   if Config.flat_float_array then Pgenarray else Paddrarray
 
@@ -753,148 +759,154 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%bytes_safe_set" -> Primitive (Pbytessets, 3)
     | "%bytes_unsafe_get" -> Primitive (Pbytesrefu, 2)
     | "%bytes_unsafe_set" -> Primitive (Pbytessetu, 3)
-    | "%array_length" -> Primitive ((Parraylength gen_array_kind), 1)
+    | "%array_length" -> Primitive ((Parraylength Punspecializedarray), 1)
     | "%array_safe_get" ->
       Primitive
-        ((Parrayrefs (gen_array_ref_kind mode, Ptagged_int_index, Mutable)), 2)
+        ((Parrayrefs (Punspecializedarray_ref mode,
+                      Ptagged_int_index, Mutable)), 2)
     | "%array_safe_set" ->
       Primitive
-        (Parraysets (gen_array_set_kind (get_first_arg_mode ()), Ptagged_int_index),
+        (Parraysets (Punspecializedarray_set (get_first_arg_mode ()),
+                     Ptagged_int_index),
          3)
     | "%array_unsafe_get" ->
       Primitive
-        (Parrayrefu (gen_array_ref_kind mode, Ptagged_int_index, Mutable), 2)
+        (Parrayrefu (Punspecializedarray_ref mode,
+                     Ptagged_int_index, Mutable), 2)
     | "%array_unsafe_set" ->
       Primitive
-        ((Parraysetu (gen_array_set_kind (get_first_arg_mode ()), Ptagged_int_index)),
+        ((Parraysetu (Punspecializedarray_set (get_first_arg_mode ()),
+                      Ptagged_int_index)),
         3)
     | "%array_safe_get_indexed_by_int64#" ->
       Primitive
-        ((Parrayrefs (gen_array_ref_kind mode,
+        ((Parrayrefs (Punspecializedarray_ref mode,
                       Punboxed_or_untagged_integer_index Unboxed_int64,
                       Mutable)), 2)
     | "%array_safe_set_indexed_by_int64#" ->
       Primitive
         (Parraysets
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Unboxed_int64),
          3)
     | "%array_unsafe_get_indexed_by_int64#" ->
       Primitive
-        (Parrayrefu (gen_array_ref_kind mode,
+        (Parrayrefu (Punspecializedarray_ref mode,
                      Punboxed_or_untagged_integer_index Unboxed_int64,
                      Mutable), 2)
     | "%array_unsafe_set_indexed_by_int64#" ->
       Primitive
         ((Parraysetu
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Unboxed_int64)),
         3)
     | "%array_safe_get_indexed_by_int32#" ->
       Primitive
-        ((Parrayrefs (gen_array_ref_kind mode,
+        ((Parrayrefs (Punspecializedarray_ref mode,
                       Punboxed_or_untagged_integer_index Unboxed_int32,
                       Mutable)), 2)
     | "%array_safe_set_indexed_by_int32#" ->
       Primitive
         (Parraysets
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Unboxed_int32),
          3)
     | "%array_unsafe_get_indexed_by_int32#" ->
       Primitive
-        (Parrayrefu (gen_array_ref_kind mode,
+        (Parrayrefu (Punspecializedarray_ref mode,
                      Punboxed_or_untagged_integer_index Unboxed_int32,
                      Mutable), 2)
     | "%array_unsafe_set_indexed_by_int32#" ->
       Primitive
         ((Parraysetu
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Unboxed_int32)),
         3)
     | "%array_safe_get_indexed_by_int16#" ->
       Primitive
-        ((Parrayrefs (gen_array_ref_kind mode,
+        ((Parrayrefs (Punspecializedarray_ref mode,
                       Punboxed_or_untagged_integer_index Untagged_int16,
                       Mutable)), 2)
     | "%array_safe_set_indexed_by_int16#" ->
       Primitive
         (Parraysets
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Untagged_int16),
          3)
     | "%array_unsafe_get_indexed_by_int16#" ->
       Primitive
-        (Parrayrefu (gen_array_ref_kind mode,
+        (Parrayrefu (Punspecializedarray_ref mode,
                      Punboxed_or_untagged_integer_index Untagged_int16,
                      Mutable), 2)
     | "%array_unsafe_set_indexed_by_int16#" ->
       Primitive
         ((Parraysetu
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Untagged_int16)),
         3)
     | "%array_safe_get_indexed_by_int8#" ->
       Primitive
-        ((Parrayrefs (gen_array_ref_kind mode,
+        ((Parrayrefs (Punspecializedarray_ref mode,
                       Punboxed_or_untagged_integer_index Untagged_int8,
                       Mutable)), 2)
     | "%array_safe_set_indexed_by_int8#" ->
       Primitive
         (Parraysets
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Untagged_int8),
          3)
     | "%array_unsafe_get_indexed_by_int8#" ->
       Primitive
-        (Parrayrefu (gen_array_ref_kind mode,
+        (Parrayrefu (Punspecializedarray_ref mode,
                      Punboxed_or_untagged_integer_index Untagged_int8,
                      Mutable), 2)
     | "%array_unsafe_set_indexed_by_int8#" ->
       Primitive
         ((Parraysetu
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Untagged_int8)),
         3)
     | "%array_safe_get_indexed_by_nativeint#" ->
       Primitive
-        ((Parrayrefs (gen_array_ref_kind mode,
+        ((Parrayrefs (Punspecializedarray_ref mode,
                       Punboxed_or_untagged_integer_index Unboxed_nativeint,
                       Mutable)), 2)
     | "%array_safe_set_indexed_by_nativeint#" ->
       Primitive
         (Parraysets
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Unboxed_nativeint),
          3)
     | "%array_unsafe_get_indexed_by_nativeint#" ->
       Primitive
-        (Parrayrefu (gen_array_ref_kind mode,
+        (Parrayrefu (Punspecializedarray_ref mode,
                      Punboxed_or_untagged_integer_index Unboxed_nativeint,
                      Mutable), 2)
     | "%array_unsafe_set_indexed_by_nativeint#" ->
       Primitive
         ((Parraysetu
-          (gen_array_set_kind (get_first_arg_mode ()),
+          (Punspecializedarray_set (get_first_arg_mode ()),
            Punboxed_or_untagged_integer_index Unboxed_nativeint)),
         3)
     | "%makearray_dynamic" ->
-      Primitive (Pmakearray_dynamic (gen_array_kind, mode, With_initializer), 2)
+      Primitive
+        (Pmakearray_dynamic (Punspecializedarray, mode, With_initializer), 2)
     | "%makearray_dynamic_uninit" ->
-      Primitive (Pmakearray_dynamic (gen_array_kind, mode, Uninitialized), 1)
+      Primitive
+        (Pmakearray_dynamic (Punspecializedarray, mode, Uninitialized), 1)
     | "%arrayblit" ->
       Primitive (Parrayblit {
         src_mutability = Mutable;
-        dst_array_set_kind = gen_array_set_kind (get_third_arg_mode ())
+        dst_array_set_kind = Punspecializedarray_set (get_third_arg_mode ())
       }, 5);
     | "%arrayblit_src_immut" ->
       Primitive (Parrayblit {
         src_mutability = Immutable;
-        dst_array_set_kind = gen_array_set_kind (get_third_arg_mode ())
+        dst_array_set_kind = Punspecializedarray_set (get_third_arg_mode ())
       }, 5);
     | "%array_element_size_in_bytes" ->
       (* The array kind will be filled in later *)
-      Primitive (Parray_element_size_in_bytes Pgenarray, 1)
+      Primitive (Parray_element_size_in_bytes Punspecializedarray, 1)
     | "%obj_size" -> Primitive ((Parraylength gen_array_kind), 1)
     | "%obj_field" ->
       Primitive
@@ -1185,31 +1197,31 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
       Primitive(Pset_idx (layout, get_first_arg_mode ()), 3)
     | "%unsafe_array_idx" ->
       Primitive(Pmake_idx_array
-        (gen_array_kind, Ptagged_int_index,
+        (Punspecializedarray, Ptagged_int_index,
          Value generic_value, []), 1)
     | "%unsafe_array_idx_indexed_by_int8#" ->
       Primitive(Pmake_idx_array
-        (gen_array_kind,
+        (Punspecializedarray,
          Punboxed_or_untagged_integer_index Untagged_int8,
          Value generic_value, []), 1)
     | "%unsafe_array_idx_indexed_by_int16#" ->
       Primitive(Pmake_idx_array
-        (gen_array_kind,
+        (Punspecializedarray,
          Punboxed_or_untagged_integer_index Untagged_int16,
          Value generic_value, []), 1)
     | "%unsafe_array_idx_indexed_by_int32#" ->
       Primitive(Pmake_idx_array
-        (gen_array_kind,
+        (Punspecializedarray,
          Punboxed_or_untagged_integer_index Unboxed_int32,
          Value generic_value, []), 1)
     | "%unsafe_array_idx_indexed_by_int64#" ->
       Primitive(Pmake_idx_array
-        (gen_array_kind,
+        (Punspecializedarray,
          Punboxed_or_untagged_integer_index Unboxed_int64,
          Value generic_value, []), 1)
     | "%unsafe_array_idx_indexed_by_nativeint#" ->
       Primitive(Pmake_idx_array
-        (gen_array_kind,
+        (Punspecializedarray,
          Punboxed_or_untagged_integer_index Unboxed_nativeint,
          Value generic_value, []), 1)
     | "%unsafe_get_ptr_imm" ->
@@ -1280,7 +1292,9 @@ and glb_scannable_kind kind1 kind2 =
 
 (* The following function computes the greatest lower bound of array kinds:
 
-        gen      unboxed-{float,int,int8,int16,int32,int64,nativeint}
+          unspecialized
+          /           \
+        gen      unboxed-{float,int,int8,int16,int32,int64,nativeint,vec*}
          |
       /------\
       |      |
@@ -1290,7 +1304,9 @@ and glb_scannable_kind kind1 kind2 =
       |
     int
 
-   For product kinds, we take the product of this lattice.
+   [unspecialized] sits above every other kind and is the placeholder used
+   for primitives that have not been specialized yet. For product kinds, we
+   take the product of this lattice.
 
    Note that the GLB is not guaranteed to exist.
    In case of array kinds working with layout value, we return
@@ -1306,58 +1322,51 @@ let glb_array_type loc t1 t2 =
       (Printlambda.array_kind t1) (Printlambda.array_kind t2)
   in
   match t1, t2 with
-  (* Handle unboxed array kinds which should only match with themselves.
-
-     However, a cheat is added just for [Pgenarray] to allow the [%array_*]
-     primitives to work with unboxed types.
-
-     WARNING: This trick will stop working when [Config.flat_float_array]
-     becomes [false].*)
+  (* [Punspecializedarray] is the top of the lattice: it is the marker placed
+     on primitives before specialization, and so the GLB with any other
+     array kind is that other kind. *)
+  | Punspecializedarray, x | x, Punspecializedarray -> x
+  (* Handle unboxed array kinds which can only match with themselves. *)
   | Pfloatarray, (Punboxedfloatarray _ | Punboxedoruntaggedintarray _
                  | Punboxedvectorarray _) ->
     (* Have a nice error message for a case reachable. *)
     raise(Error(loc, Invalid_floatarray_glb))
-  | (Pgenarray | Punboxedfloatarray Unboxed_float64), Punboxedfloatarray Unboxed_float64 ->
+  | Punboxedfloatarray Unboxed_float64, Punboxedfloatarray Unboxed_float64 ->
     Punboxedfloatarray Unboxed_float64
-  | (Pgenarray | Punboxedfloatarray Unboxed_float32), Punboxedfloatarray Unboxed_float32 ->
+  | Punboxedfloatarray Unboxed_float32, Punboxedfloatarray Unboxed_float32 ->
     Punboxedfloatarray Unboxed_float32
   | Punboxedfloatarray _, _ | _, Punboxedfloatarray _ ->
     unexpected ()
-  | (Pgenarray | Punboxedoruntaggedintarray Untagged_int),
+  | Punboxedoruntaggedintarray Untagged_int,
     Punboxedoruntaggedintarray Untagged_int ->
     Punboxedoruntaggedintarray Untagged_int
-  | (Pgenarray | Punboxedoruntaggedintarray Untagged_int8),
+  | Punboxedoruntaggedintarray Untagged_int8,
     Punboxedoruntaggedintarray Untagged_int8 ->
     Punboxedoruntaggedintarray Untagged_int8
-  | (Pgenarray | Punboxedoruntaggedintarray Untagged_int16),
+  | Punboxedoruntaggedintarray Untagged_int16,
     Punboxedoruntaggedintarray Untagged_int16 ->
     Punboxedoruntaggedintarray Untagged_int16
-  | (Pgenarray | Punboxedoruntaggedintarray Unboxed_int32),
+  | Punboxedoruntaggedintarray Unboxed_int32,
     Punboxedoruntaggedintarray Unboxed_int32 ->
     Punboxedoruntaggedintarray Unboxed_int32
-  | (Pgenarray | Punboxedoruntaggedintarray Unboxed_int64),
+  | Punboxedoruntaggedintarray Unboxed_int64,
     Punboxedoruntaggedintarray Unboxed_int64 ->
     Punboxedoruntaggedintarray Unboxed_int64
-  | (Pgenarray | Punboxedoruntaggedintarray Unboxed_nativeint),
+  | Punboxedoruntaggedintarray Unboxed_nativeint,
     Punboxedoruntaggedintarray Unboxed_nativeint ->
     Punboxedoruntaggedintarray Unboxed_nativeint
   | Punboxedoruntaggedintarray _, _ | _, Punboxedoruntaggedintarray _ ->
     unexpected ()
-  | (Pgenarray | Punboxedvectorarray Unboxed_vec128),
-    Punboxedvectorarray Unboxed_vec128 ->
+  | Punboxedvectorarray Unboxed_vec128, Punboxedvectorarray Unboxed_vec128 ->
     Punboxedvectorarray Unboxed_vec128
-  | (Pgenarray | Punboxedvectorarray Unboxed_vec256),
-    Punboxedvectorarray Unboxed_vec256 ->
+  | Punboxedvectorarray Unboxed_vec256, Punboxedvectorarray Unboxed_vec256 ->
     Punboxedvectorarray Unboxed_vec256
-  | (Pgenarray | Punboxedvectorarray Unboxed_vec512),
-    Punboxedvectorarray Unboxed_vec512 ->
+  | Punboxedvectorarray Unboxed_vec512, Punboxedvectorarray Unboxed_vec512 ->
     Punboxedvectorarray Unboxed_vec512
   | Punboxedvectorarray _, _ | _, Punboxedvectorarray _ ->
     unexpected ()
 
-  (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
-  | Pgenarray,
-    ((Pgcignorableproductarray _ | Pgcscannableproductarray _) as k) -> k
+  (* Unboxed product arrays. *)
   | (Pgcignorableproductarray kinds1) as k, Pgcignorableproductarray kinds2 ->
     if List.equal equal_ignorable_product_element_kind kinds1 kinds2
     then k
@@ -1400,61 +1409,58 @@ let glb_array_ref_type loc t1 t2 =
       Printlambda.array_ref_kind t1 (Printlambda.array_kind t2)
   in
   match t1, t2 with
-  (* Handle unboxed array kinds which should only match with themselves.
-
-     However, a cheat is added just for [Pgenarray_ref] to allow the [%array_*]
-     primitives to work with unboxed types.
-
-     WARNING: This trick will stop working when [Config.flat_float_array]
-     becomes [false].*)
+  (* [Punspecializedarray] / [Punspecializedarray_ref] sit above every other
+     kind in the lattice (see [glb_array_type]); the GLB with any other kind
+     is therefore that other kind. *)
+  | Punspecializedarray_ref m, t2 -> Lambda.array_ref_kind m t2
+  | t1, Punspecializedarray -> t1
+  (* Handle unboxed array kinds which can only match with themselves. *)
   | Pfloatarray_ref _, (Punboxedfloatarray _ | Punboxedoruntaggedintarray _
                        | Punboxedvectorarray _) ->
     (* Have a nice error message for a case reachable. *)
     raise(Error(loc, Invalid_floatarray_glb))
-  | (Pgenarray_ref _ | Punboxedfloatarray_ref Unboxed_float64), Punboxedfloatarray Unboxed_float64 ->
+  | Punboxedfloatarray_ref Unboxed_float64,
+    Punboxedfloatarray Unboxed_float64 ->
     Punboxedfloatarray_ref Unboxed_float64
-  | (Pgenarray_ref _ | Punboxedfloatarray_ref Unboxed_float32), Punboxedfloatarray Unboxed_float32 ->
+  | Punboxedfloatarray_ref Unboxed_float32,
+    Punboxedfloatarray Unboxed_float32 ->
     Punboxedfloatarray_ref Unboxed_float32
   | Punboxedfloatarray_ref _, _
   | _, Punboxedfloatarray _ ->
     unexpected ()
-  | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Untagged_int),
+  | Punboxedoruntaggedintarray_ref Untagged_int,
     Punboxedoruntaggedintarray Untagged_int ->
     Punboxedoruntaggedintarray_ref Untagged_int
-  | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Untagged_int8),
+  | Punboxedoruntaggedintarray_ref Untagged_int8,
     Punboxedoruntaggedintarray Untagged_int8 ->
     Punboxedoruntaggedintarray_ref Untagged_int8
-  | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Untagged_int16),
+  | Punboxedoruntaggedintarray_ref Untagged_int16,
     Punboxedoruntaggedintarray Untagged_int16 ->
     Punboxedoruntaggedintarray_ref Untagged_int16
-  | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Unboxed_int32),
+  | Punboxedoruntaggedintarray_ref Unboxed_int32,
     Punboxedoruntaggedintarray Unboxed_int32 ->
     Punboxedoruntaggedintarray_ref Unboxed_int32
-  | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Unboxed_int64),
+  | Punboxedoruntaggedintarray_ref Unboxed_int64,
     Punboxedoruntaggedintarray Unboxed_int64 ->
     Punboxedoruntaggedintarray_ref Unboxed_int64
-  | (Pgenarray_ref _ | Punboxedoruntaggedintarray_ref Unboxed_nativeint),
+  | Punboxedoruntaggedintarray_ref Unboxed_nativeint,
     Punboxedoruntaggedintarray Unboxed_nativeint ->
     Punboxedoruntaggedintarray_ref Unboxed_nativeint
   | Punboxedoruntaggedintarray_ref _, _ | _, Punboxedoruntaggedintarray _ ->
     unexpected ()
-  | (Pgenarray_ref _ | Punboxedvectorarray_ref Unboxed_vec128),
+  | Punboxedvectorarray_ref Unboxed_vec128,
     Punboxedvectorarray Unboxed_vec128 ->
     Punboxedvectorarray_ref Unboxed_vec128
-  | (Pgenarray_ref _ | Punboxedvectorarray_ref Unboxed_vec256),
+  | Punboxedvectorarray_ref Unboxed_vec256,
     Punboxedvectorarray Unboxed_vec256 ->
     Punboxedvectorarray_ref Unboxed_vec256
-  | (Pgenarray_ref _ | Punboxedvectorarray_ref Unboxed_vec512),
+  | Punboxedvectorarray_ref Unboxed_vec512,
     Punboxedvectorarray Unboxed_vec512 ->
     Punboxedvectorarray_ref Unboxed_vec512
   | Punboxedvectorarray_ref _, _ | _, Punboxedvectorarray _ ->
     unexpected ()
 
-  (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
-  | Pgenarray_ref _, Pgcignorableproductarray kinds ->
-    Pgcignorableproductarray_ref kinds
-  | Pgenarray_ref _, Pgcscannableproductarray kinds ->
-    Pgcscannableproductarray_ref kinds
+  (* Unboxed product arrays. *)
   | (Pgcignorableproductarray_ref kinds1) as k,
     Pgcignorableproductarray kinds2 ->
     if kinds1 = kinds2 then k
@@ -1510,61 +1516,58 @@ let glb_array_set_type loc t1 t2 =
       Printlambda.array_set_kind t1 (Printlambda.array_kind t2)
   in
   match t1, t2 with
-  (* Handle unboxed array kinds which can only match with themselves.
-
-     However, a cheat is added just for [Pgenarray_set] to allow the [%array_*]
-     primitives to work with unboxed types.
-
-     WARNING: This trick will stop working when [Config.flat_float_array]
-     becomes [false].*)
+  (* [Punspecializedarray] / [Punspecializedarray_set] sit above every other
+     kind in the lattice (see [glb_array_type]); the GLB with any other kind
+     is therefore that other kind. *)
+  | Punspecializedarray_set m, t2 -> Lambda.array_set_kind m t2
+  | t1, Punspecializedarray -> t1
+  (* Handle unboxed array kinds which can only match with themselves. *)
   | Pfloatarray_set, (Punboxedfloatarray _ | Punboxedoruntaggedintarray _
                      | Punboxedvectorarray _) ->
     (* Have a nice error message for a case reachable. *)
     raise(Error(loc, Invalid_floatarray_glb))
-  | (Pgenarray_set _ | Punboxedfloatarray_set Unboxed_float64), Punboxedfloatarray Unboxed_float64 ->
+  | Punboxedfloatarray_set Unboxed_float64,
+    Punboxedfloatarray Unboxed_float64 ->
     Punboxedfloatarray_set Unboxed_float64
-  | (Pgenarray_set _ | Punboxedfloatarray_set Unboxed_float32), Punboxedfloatarray Unboxed_float32 ->
+  | Punboxedfloatarray_set Unboxed_float32,
+    Punboxedfloatarray Unboxed_float32 ->
     Punboxedfloatarray_set Unboxed_float32
   | Punboxedfloatarray_set _, _
   | _, Punboxedfloatarray _ ->
     unexpected ()
-  | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Untagged_int),
+  | Punboxedoruntaggedintarray_set Untagged_int,
     Punboxedoruntaggedintarray Untagged_int ->
     Punboxedoruntaggedintarray_set Untagged_int
-  | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Untagged_int8),
+  | Punboxedoruntaggedintarray_set Untagged_int8,
     Punboxedoruntaggedintarray Untagged_int8 ->
     Punboxedoruntaggedintarray_set Untagged_int8
-  | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Untagged_int16),
+  | Punboxedoruntaggedintarray_set Untagged_int16,
     Punboxedoruntaggedintarray Untagged_int16 ->
     Punboxedoruntaggedintarray_set Untagged_int16
-  | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Unboxed_int32),
+  | Punboxedoruntaggedintarray_set Unboxed_int32,
     Punboxedoruntaggedintarray Unboxed_int32 ->
     Punboxedoruntaggedintarray_set Unboxed_int32
-  | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Unboxed_int64),
+  | Punboxedoruntaggedintarray_set Unboxed_int64,
     Punboxedoruntaggedintarray Unboxed_int64 ->
     Punboxedoruntaggedintarray_set Unboxed_int64
-  | (Pgenarray_set _ | Punboxedoruntaggedintarray_set Unboxed_nativeint),
+  | Punboxedoruntaggedintarray_set Unboxed_nativeint,
     Punboxedoruntaggedintarray Unboxed_nativeint ->
     Punboxedoruntaggedintarray_set Unboxed_nativeint
   | Punboxedoruntaggedintarray_set _, _ | _, Punboxedoruntaggedintarray _ ->
     unexpected ()
-  | (Pgenarray_set _ | Punboxedvectorarray_set Unboxed_vec128),
+  | Punboxedvectorarray_set Unboxed_vec128,
     Punboxedvectorarray Unboxed_vec128 ->
     Punboxedvectorarray_set Unboxed_vec128
-  | (Pgenarray_set _ | Punboxedvectorarray_set Unboxed_vec256),
+  | Punboxedvectorarray_set Unboxed_vec256,
     Punboxedvectorarray Unboxed_vec256 ->
-  Punboxedvectorarray_set Unboxed_vec256
-  | (Pgenarray_set _ | Punboxedvectorarray_set Unboxed_vec512),
+    Punboxedvectorarray_set Unboxed_vec256
+  | Punboxedvectorarray_set Unboxed_vec512,
     Punboxedvectorarray Unboxed_vec512 ->
     Punboxedvectorarray_set Unboxed_vec512
   | Punboxedvectorarray_set _, _ | _, Punboxedvectorarray _ ->
     unexpected ()
 
-  (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
-  | Pgenarray_set _, Pgcignorableproductarray kinds ->
-    Pgcignorableproductarray_set kinds
-  | Pgenarray_set m, Pgcscannableproductarray kinds ->
-    Pgcscannableproductarray_set (m, kinds)
+  (* Unboxed product arrays. *)
   | (Pgcignorableproductarray_set kinds1) as k,
     Pgcignorableproductarray kinds2 ->
     if kinds1 = kinds2 then k
@@ -2576,6 +2579,10 @@ let lambda_primitive_needs_event_after = function
   | Pbox_vector (_, _)
   | Punbox_unit
     -> false
+  | Pmakearray (Punspecializedarray, _, _)
+  | Pmakearray_dynamic (Punspecializedarray, _, _) ->
+    Misc.fatal_error
+      "Translprim.lambda_primitive_needs_event_after: Punspecializedarray"
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2601,6 +2601,23 @@ let transl_primitive_application loc p env ty ~poly_mode ~stack ~poly_sort
     lookup_primitive_and_mark_used
       (to_location loc) ~poly_mode ~poly_sort pos p env (Some path)
   in
+  let has_constant_constructor =
+    match arg_exps with
+    | [_; {exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}]
+    | [{exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}; _] ->
+        cstr_constant
+    | [_; {exp_desc = Texp_variant(_, None)}]
+    | [{exp_desc = Texp_variant(_, None)}; _] -> true
+    | _ -> false
+  in
+  let prim =
+    if should_specialize_primitive p then
+      match specialize_primitive env loc ty ~has_constant_constructor prim with
+      | None -> prim
+      | Some prim -> prim
+    else
+      prim
+  in
   if stack then begin
     match prim with
     | Primitive (prim, _) ->
@@ -2624,23 +2641,6 @@ let transl_primitive_application loc p env ty ~poly_mode ~stack ~poly_sort
         end
     | _ -> raise (Error (to_location loc, Invalid_stack_primitive Not_primitive))
   end;
-  let has_constant_constructor =
-    match arg_exps with
-    | [_; {exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}]
-    | [{exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}; _] ->
-        cstr_constant
-    | [_; {exp_desc = Texp_variant(_, None)}]
-    | [{exp_desc = Texp_variant(_, None)}; _] -> true
-    | _ -> false
-  in
-  let prim =
-    if should_specialize_primitive p then
-      match specialize_primitive env loc ty ~has_constant_constructor prim with
-      | None -> prim
-      | Some prim -> prim
-    else
-      prim
-  in
   let lam = lambda_of_prim p.prim_name prim loc args (Some arg_exps) in
   let lam =
     if primitive_needs_event_after prim then begin

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -590,7 +590,12 @@ let array_vec_primitives =
   |> List.to_seq
   |> String.Map.of_seq
 
-let lookup_primitive loc ~poly_mode ~poly_sort pos p =
+(* Resolve a primitive according to its name. The return value is unspecialized
+   in the sense that the array kind in the various primitives that deal with
+   arrays is set to [Punspecializedarray{,_ref,set}]. The caller is meant to
+   then specialize the array kind based on the context.
+*)
+let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
   let runtime5 = Config.runtime5 in
   let mode = to_locality ~poly:poly_mode p.prim_native_repr_res in
   let arg_modes =
@@ -1259,11 +1264,6 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
   in
   prim
 
-let lookup_primitive_and_mark_used loc ~poly_mode ~poly_sort pos p env path =
-  match lookup_primitive loc ~poly_mode ~poly_sort pos p with
-  | External _ as e -> add_used_primitive loc env path; e
-  | x -> x
-
 let simplify_constant_constructor = function
   | Equal -> true
   | Not_equal -> true
@@ -1645,8 +1645,9 @@ let peek_or_poke_layout_from_type ~prim_name error_loc env ty
 let should_specialize_primitive p =
   match p.prim_name with
   | "%obj_size" | "%obj_field" | "%obj_set_field" ->
-    (* The obj primitives re-use the array primitives (see [lookup_primitive]),
-       but we shouldn't specialize their array kinds.
+    (* The obj primitives re-use the array primitives (see
+       [lookup_primitive_unspecialized]), but we shouldn't specialize
+       their array kinds.
        CR layouts v4: we should just make separate object primitives. *)
     false
   | _ ->
@@ -2339,7 +2340,8 @@ let check_primitive_arity loc p =
      to lie here. *)
   let sort = Some (Jkind.Sort.of_base Scannable) in
   let prim =
-    lookup_primitive loc ~poly_mode:mode ~poly_sort:sort Rc_normal p
+    lookup_primitive_unspecialized loc
+      ~poly_mode:mode ~poly_sort:sort Rc_normal p
   in
   let ok =
     match prim with
@@ -2363,19 +2365,34 @@ let check_primitive_arity loc p =
 
 (* Eta-expand a primitive *)
 
+let transl_primitive_common loc ~poly_mode ~poly_sort
+      pos p env ty path arg_exps =
+  let prim =
+    let loc = to_location loc in
+    match lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p with
+    | External _ as e -> add_used_primitive loc env path; e
+    | x -> x
+  in
+  let has_constant_constructor =
+    match arg_exps with
+    | [_; {exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}]
+    | [{exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}; _] ->
+        cstr_constant
+    | [_; {exp_desc = Texp_variant(_, None)}]
+    | [{exp_desc = Texp_variant(_, None)}; _] -> true
+    | _ -> false
+  in
+  if should_specialize_primitive p then
+    match specialize_primitive env loc ty ~has_constant_constructor prim with
+    | None -> prim
+    | Some prim -> prim
+  else
+    prim
+
 let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
   let prim =
-    lookup_primitive_and_mark_used
-      (to_location loc) ~poly_mode ~poly_sort Rc_normal p env path
-  in
-  let has_constant_constructor = false in
-  let prim =
-    if should_specialize_primitive p then
-      match specialize_primitive env loc ty ~has_constant_constructor prim with
-      | None -> prim
-      | Some prim -> prim
-    else
-      prim
+    transl_primitive_common loc
+      ~poly_mode ~poly_sort Rc_normal p env ty path []
   in
   let to_locality = to_locality ~poly:poly_mode in
   let error_loc = to_location loc in
@@ -2598,25 +2615,8 @@ let primitive_needs_event_after = function
 let transl_primitive_application loc p env ty ~poly_mode ~stack ~poly_sort
     path exp args arg_exps pos =
   let prim =
-    lookup_primitive_and_mark_used
-      (to_location loc) ~poly_mode ~poly_sort pos p env (Some path)
-  in
-  let has_constant_constructor =
-    match arg_exps with
-    | [_; {exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}]
-    | [{exp_desc = Texp_construct(_, {cstr_constant}, _, _, _)}; _] ->
-        cstr_constant
-    | [_; {exp_desc = Texp_variant(_, None)}]
-    | [{exp_desc = Texp_variant(_, None)}; _] -> true
-    | _ -> false
-  in
-  let prim =
-    if should_specialize_primitive p then
-      match specialize_primitive env loc ty ~has_constant_constructor prim with
-      | None -> prim
-      | Some prim -> prim
-    else
-      prim
+    transl_primitive_common
+      loc ~poly_mode ~poly_sort pos p env ty (Some path) arg_exps
   in
   if stack then begin
     match prim with

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -359,6 +359,8 @@ let compute_static_size lam =
         | Punboxedvectorarray _ | Pgcscannableproductarray _
         | Pgcignorableproductarray _ ->
             Misc.fatal_error "size_of_primitive"
+        | Punspecializedarray ->
+            Misc.fatal_error "size_of_primitive: Punspecializedarray"
         end
     | Pmakearray_dynamic _ -> Misc.fatal_error "size_of_primitive"
     | Parrayblit _ -> Constant

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -204,6 +204,9 @@ let convert_array_kind dbg (kind : L.array_kind) : converted_array_kind =
         Unboxed_product (List.map convert_kind kinds)
     in
     Array_kind (Unboxed_product (List.map convert_kind kinds))
+  | Punspecializedarray ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_kind: Punspecializedarray"
 
 let convert_array_kind_for_length dbg kind : P.Array_kind_for_length.t =
   match convert_array_kind dbg kind with
@@ -304,6 +307,10 @@ let convert_array_ref_kind dbg (kind : L.array_ref_kind) :
     in
     Array_ref_kind
       (No_float_array_opt (Unboxed_product (List.map convert_kind kinds)))
+  | Punspecializedarray_ref _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_ref_kind: \
+       Punspecializedarray_ref"
 
 let rec convert_unboxed_product_array_ref_kind
     (kind : Array_ref_kind.no_float_array_opt) : P.Array_kind.t =
@@ -472,6 +479,10 @@ let convert_array_set_kind dbg (kind : L.array_set_kind) :
     in
     Array_set_kind
       (No_float_array_opt (Unboxed_product (List.map convert_kind kinds)))
+  | Punspecializedarray_set _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_set_kind: \
+       Punspecializedarray_set"
 
 let rec convert_unboxed_product_array_set_kind
     (kind : Array_set_kind.no_float_array_opt) : P.Array_kind.t =
@@ -581,6 +592,10 @@ let convert_array_kind_to_duplicate_array_kind dbg (kind : L.array_kind) :
     Misc.fatal_error
       "Lambda_to_flambda_primitives.convert_array_kind_to_duplicate_array_kind: \
        unimplemented"
+  | Punspecializedarray ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_kind_to_duplicate_array_kind: \
+       Punspecializedarray"
 
 let convert_field_read_semantics (sem : L.field_read_semantics) : Mutability.t =
   match sem with Reads_agree -> Immutable | Reads_vary -> Mutable
@@ -2049,6 +2064,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
           args
         | Pfloatarray -> List.map unbox_float args
+        | Punspecializedarray ->
+          Misc.fatal_error
+            "Lambda_to_flambda_primitives: Pmakearray Punspecializedarray"
       in
       [Variadic (Make_array (array_kind, mutability, mode), args)]
     | Float_array_opt_dynamic -> (
@@ -3258,14 +3276,16 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pgcignorableaddrarray_ref
             | Pintarray_ref | Pfloatarray_ref _ | Punboxedfloatarray_ref _
             | Punboxedoruntaggedintarray_ref _ | Punboxedvectorarray_ref _
-            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
+            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _
+            | Punspecializedarray_ref _ ),
             _,
             _ )
       | Parrayrefs
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pgcignorableaddrarray_ref
             | Pintarray_ref | Pfloatarray_ref _ | Punboxedfloatarray_ref _
             | Punboxedoruntaggedintarray_ref _ | Punboxedvectorarray_ref _
-            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
+            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _
+            | Punspecializedarray_ref _ ),
             _,
             _ )
       | Patomic_load_field _ | Ppoke _ | Pphys_equal _
@@ -3285,13 +3305,15 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           ( ( Pgenarray_set _ | Paddrarray_set _ | Pgcignorableaddrarray_set
             | Pintarray_set | Pfloatarray_set | Punboxedfloatarray_set _
             | Punboxedoruntaggedintarray_set _ | Punboxedvectorarray_set _
-            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
+            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _
+            | Punspecializedarray_set _ ),
             _ )
       | Parraysets
           ( ( Pgenarray_set _ | Paddrarray_set _ | Pgcignorableaddrarray_set
             | Pintarray_set | Pfloatarray_set | Punboxedfloatarray_set _
             | Punboxedoruntaggedintarray_set _ | Punboxedvectorarray_set _
-            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
+            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _
+            | Punspecializedarray_set _ ),
             _ )
       | Pbytes_set_8 _ | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_f32 _
       | Pbytes_set_64 _ | Pbytes_set_vec _ | Pbigstring_set_8 _

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -500,6 +500,9 @@ let makearray_dynamic_scannable_unboxed_product env
       Misc.fatal_errorf
         "%s: should have been sent to [makearray_dynamic_singleton]"
         (Printlambda.array_kind lambda_array_kind)
+    | Punspecializedarray ->
+      Misc.fatal_error
+        "makearray_dynamic_scannable_unboxed_product: Punspecializedarray"
   in
   if must_be_scanned
   then
@@ -536,7 +539,10 @@ let makearray_dynamic0 env (lambda_array_kind : L.array_kind)
           "Cannot compile Pmakearray_dynamic at layout %s without an \
            initializer:@ %a"
           (Printlambda.array_kind lambda_array_kind)
-          Debuginfo.print_compact dbg)
+          Debuginfo.print_compact dbg
+      | Punspecializedarray ->
+        Misc.fatal_error
+          "makearray_dynamic0: Pmakearray_dynamic on Punspecializedarray")
   in
   match lambda_array_kind with
   | Pgenarray | Paddrarray | Pgcignorableaddrarray | Pintarray | Pfloatarray ->
@@ -628,6 +634,8 @@ let makearray_dynamic0 env (lambda_array_kind : L.array_kind)
     in
     makearray_dynamic_non_scannable_unboxed_product env lambda_array_kind mode
       ~length ~init loc
+  | Punspecializedarray ->
+    Misc.fatal_error "makearray_dynamic0: Punspecializedarray"
 
 let makearray_dynamic env (lambda_array_kind : L.array_kind)
     (mode : L.locality_mode) (has_init : L.has_initializer) args loc :
@@ -818,6 +826,8 @@ let arrayblit env ~src_mutability ~(dst_array_set_kind : L.array_set_kind) args
   | Punboxedoruntaggedintarray_set _ | Punboxedvectorarray_set _
   | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ->
     arrayblit_expanded env ~src_mutability ~dst_array_set_kind args loc
+  | Punspecializedarray_set _ ->
+    Misc.fatal_error "arrayblit: Punspecializedarray_set"
 
 (* Only used on amd64. *)
 let cast_vec128_to_vec256 =

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -1102,6 +1102,9 @@ module With_subkind = struct
       | Parrayval (Punboxedvectorarray Unboxed_vec512) -> Unboxed_vec512_array
       | Parrayval (Pgcscannableproductarray _ | Pgcignorableproductarray _) ->
         Unboxed_product_array
+      | Parrayval Punspecializedarray ->
+        Misc.fatal_error
+          "Flambda_kind.from_lambda_value_kind: Punspecializedarray"
     in
     let nullable : Nullable.t =
       match vk.nullable with

--- a/middle_end/flambda2/term_basics/empty_array_kind.ml
+++ b/middle_end/flambda2/term_basics/empty_array_kind.ml
@@ -79,3 +79,5 @@ let of_lambda array_kind =
   | Punboxedvectorarray Unboxed_vec256 -> Naked_vec256s
   | Punboxedvectorarray Unboxed_vec512 -> Naked_vec512s
   | Pgcscannableproductarray _ | Pgcignorableproductarray _ -> Unboxed_products
+  | Punspecializedarray ->
+    Misc.fatal_error "Empty_array_kind.of_lambda: Punspecializedarray"

--- a/testsuite/tests/translprim/array_spec.compilers.no-flat.reference
+++ b/testsuite/tests/translprim/array_spec.compilers.no-flat.reference
@@ -1,68 +1,99 @@
-(setglobal Array_spec!
-  (let
-    (int_a =[intarray] (makearray[int] 1 2 3)
-     float_a =[addrarray] (makearray[addr] 1. 2. 3.)
-     addr_a =[addrarray] (makearray[addr] "a" "b" "c"))
-    (seq (array.length[int] int_a) (array.length[addr] float_a)
-      (array.length[addr] addr_a)
-      (function a[addrarray] : int (array.length[addr] a))
-      (array.get[int] int_a 0) (array.get[addr] float_a 0)
-      (array.get[addr] addr_a 0)
-      (function a[addrarray] (array.get[addr] a 0))
-      (array.unsafe_get[int] int_a 0) (array.unsafe_get[addr] float_a 0)
-      (array.unsafe_get[addr] addr_a 0)
-      (function a[addrarray] (array.unsafe_get[addr] a 0))
-      (array.set[int] int_a 0 1) (array.set[addr] float_a 0 1.)
-      (array.set[addr] addr_a 0 "a")
-      (function a[addrarray] x : int (array.set[addr] a 0 x))
-      (array.unsafe_set[int] int_a 0 1) (array.unsafe_set[addr] float_a 0 1.)
-      (array.unsafe_set[addr] addr_a 0 "a")
-      (function a[addrarray] x : int (array.unsafe_set[addr] a 0 x))
-      (let
-        (eta_gen_len = (function prim stub (array.length[addr] prim))
-         eta_gen_safe_get =
-           (function prim prim stub (array.get[addr] prim prim))
-         eta_gen_unsafe_get =
-           (function prim prim stub (array.unsafe_get[addr] prim prim))
-         eta_gen_safe_set =
-           (function prim prim prim stub (array.set[addr] prim prim prim))
-         eta_gen_unsafe_set =
-           (function prim prim prim stub
-             (array.unsafe_set[addr] prim prim prim))
-         eta_int_len = (function prim stub (array.length[int] prim))
-         eta_int_safe_get =
-           (function prim prim stub (array.get[int] prim prim))
-         eta_int_unsafe_get =
-           (function prim prim stub (array.unsafe_get[int] prim prim))
-         eta_int_safe_set =
-           (function prim prim prim stub (array.set[int] prim prim prim))
-         eta_int_unsafe_set =
-           (function prim prim prim stub
-             (array.unsafe_set[int] prim prim prim))
-         eta_float_len = (function prim stub (array.length[addr] prim))
-         eta_float_safe_get =
-           (function prim prim stub (array.get[addr] prim prim))
-         eta_float_unsafe_get =
-           (function prim prim stub (array.unsafe_get[addr] prim prim))
-         eta_float_safe_set =
-           (function prim prim prim stub (array.set[addr] prim prim prim))
-         eta_float_unsafe_set =
-           (function prim prim prim stub
-             (array.unsafe_set[addr] prim prim prim))
-         eta_addr_len = (function prim stub (array.length[addr] prim))
-         eta_addr_safe_get =
-           (function prim prim stub (array.get[addr] prim prim))
-         eta_addr_unsafe_get =
-           (function prim prim stub (array.unsafe_get[addr] prim prim))
-         eta_addr_safe_set =
-           (function prim prim prim stub (array.set[addr] prim prim prim))
-         eta_addr_unsafe_set =
-           (function prim prim prim stub
-             (array.unsafe_set[addr] prim prim prim)))
-        (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
-          eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len
-          eta_int_safe_get eta_int_unsafe_get eta_int_safe_set
-          eta_int_unsafe_set eta_float_len eta_float_safe_get
-          eta_float_unsafe_get eta_float_safe_set eta_float_unsafe_set
-          eta_addr_len eta_addr_safe_get eta_addr_unsafe_get
-          eta_addr_safe_set eta_addr_unsafe_set)))))
+(let
+  (int_a =[value<intarray>] (makearray[int] 1 2 3)
+   float_a =[value<addrarray>] (makearray[addr] 1. 2. 3.)
+   addr_a =[value<addrarray>] (makearray[addr] "a" "b" "c"))
+  (seq (array.length[int] int_a) (array.length[addr] float_a)
+    (array.length[addr] addr_a)
+    (function {nlocal = 0} a[value<addrarray>] : int (array.length[addr] a))
+    (array.get[int indexed by int] int_a 0)
+    (array.get[addr indexed by int] float_a 0)
+    (array.get[addr indexed by int] addr_a 0)
+    (function {nlocal = 0} a[value<addrarray>]
+      (array.get[addr indexed by int] a 0))
+    (array.unsafe_get[int indexed by int] int_a 0)
+    (array.unsafe_get[addr indexed by int] float_a 0)
+    (array.unsafe_get[addr indexed by int] addr_a 0)
+    (function {nlocal = 0} a[value<addrarray>]
+      (array.unsafe_get[addr indexed by int] a 0))
+    (array.set[int indexed by int] int_a 0 1)
+    (array.set[addr indexed by int] float_a 0 1.)
+    (array.set[addr indexed by int] addr_a 0 "a")
+    (function {nlocal = 2} a[value<addrarray>] x : int
+      (array.set[addr indexed by int] a 0 x))
+    (array.unsafe_set[int indexed by int] int_a 0 1)
+    (array.unsafe_set[addr indexed by int] float_a 0 1.)
+    (array.unsafe_set[addr indexed by int] addr_a 0 "a")
+    (function {nlocal = 2} a[value<addrarray>] x : int
+      (array.unsafe_set[addr indexed by int] a 0 x))
+    (let
+      (eta_gen_len =
+         (function {nlocal = 0} prim[value<addrarray>] stub : int
+           (array.length[addr] prim))
+       eta_gen_safe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           (array.get[addr indexed by int] prim prim))
+       eta_gen_unsafe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           (array.unsafe_get[addr indexed by int] prim prim))
+       eta_gen_safe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+           stub : int (array.set[addr indexed by int] prim prim prim))
+       eta_gen_unsafe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+           stub : int (array.unsafe_set[addr indexed by int] prim prim prim))
+       eta_int_len =
+         (function {nlocal = 0} prim[value<intarray>] stub : int
+           (array.length[int] prim))
+       eta_int_safe_get =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+           : int (array.get[int indexed by int] prim prim))
+       eta_int_unsafe_get =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+           : int (array.unsafe_get[int indexed by int] prim prim))
+       eta_int_safe_set =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+           prim[value<int>] stub : int
+           (array.set[int indexed by int] prim prim prim))
+       eta_int_unsafe_set =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+           prim[value<int>] stub : int
+           (array.unsafe_set[int indexed by int] prim prim prim))
+       eta_float_len =
+         (function {nlocal = 0} prim[value<addrarray>] stub : int
+           (array.length[addr] prim))
+       eta_float_safe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           : float (array.get[addr indexed by int] prim prim))
+       eta_float_unsafe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           : float (array.unsafe_get[addr indexed by int] prim prim))
+       eta_float_safe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+           prim[value<float>] stub : int
+           (array.set[addr indexed by int] prim prim prim))
+       eta_float_unsafe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+           prim[value<float>] stub : int
+           (array.unsafe_set[addr indexed by int] prim prim prim))
+       eta_addr_len =
+         (function {nlocal = 0} prim[value<addrarray>] stub : int
+           (array.length[addr] prim))
+       eta_addr_safe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           (array.get[addr indexed by int] prim prim))
+       eta_addr_unsafe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           (array.unsafe_get[addr indexed by int] prim prim))
+       eta_addr_safe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+           stub : int (array.set[addr indexed by int] prim prim prim))
+       eta_addr_unsafe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+           stub : int (array.unsafe_set[addr indexed by int] prim prim prim)))
+      (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
+        eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len
+        eta_int_safe_get eta_int_unsafe_get eta_int_safe_set
+        eta_int_unsafe_set eta_float_len eta_float_safe_get
+        eta_float_unsafe_get eta_float_safe_set eta_float_unsafe_set
+        eta_addr_len eta_addr_safe_get eta_addr_unsafe_get eta_addr_safe_set
+        eta_addr_unsafe_set))))

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -402,7 +402,7 @@ let array_type_kind ~elt_ty env loc ty =
     | Some elt_ty ->
       let rhs = Jkind.Builtin.value ~why:Array_type_kind in
       begin match Ctype.constrain_type_jkind env elt_ty rhs with
-      | Ok _ -> Pgenarray
+      | Ok _ -> if Config.flat_float_array then Pgenarray else Paddrarray
       | Error e ->
         (* CR layouts v4: rather than constraining [elt_ty]'s jkind to be value,
            we could instead use its jkind to determine a non-value array kind.

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -640,6 +640,8 @@ let array_mode exp =
   | Lambda.Punboxedvectorarray _
   | Lambda.Pgcscannableproductarray _ | Lambda.Pgcignorableproductarray _ ->
     Dereference
+  | Lambda.Punspecializedarray ->
+    Misc.fatal_error "Value_rec_check.array_mode: Punspecializedarray"
 
 (* Expression judgment:
      G |- e : m


### PR DESCRIPTION
In `Lambda.array_kind`, `Pgenarray` means: either a `Paddrarray` or a `Pfloatarray`. However, in OxCaml this constructor is also used to mean an array kind that has not yet been specialized. This is to support array primitives for unboxed/untagged arrays.

This is fine except that when the flat float array optimization is disabled, we avoid generating `Pgenarray` and instead define primitives with `Paddrarray`. As a result, primitives are not specialized when the flat float array optimization is disabled.

To remedy this, this PR proposes to introduce an explicit `Punspecializedarray` array kind. This constuctor is used in the definition of primitives in all places where the kind should be specialized later. This constructor should never appear after specialization and is rejected with a fatal error wherever it does.

As a bonus, this PR makes the `glb_array*` functions slightly clearer.

It doesn't yet completely fix the build with `--disable-flat-float-array`, but it goes a bit further.

## Summary of changes (as reported by claude):

Introduced `Punspecializedarray`, `Punspecializedarray_ref`, and `Punspecializedarray_set` constructors to represent primitives that have not yet been specialized.

**`lambda/lambda.mli` and `lambda/lambda.ml`:**
- Added new constructors with documentation explaining they should never reach later phases
- Added `Misc.fatal_error` handling in `array_ref_kind_result_layout`, `count_initializers_array_kind`, `array_element_size_in_bytes`, and `primitive_may_allocate`
- `array_ref_kind`/`array_set_kind` map `Punspecializedarray` to the corresponding `_ref`/`_set` variant

**`lambda/translprim.ml`:**
- Use `Punspecializedarray*` constructors directly in `lookup_primitive` for all `%array_*` primitives, `%makearray_dynamic*`,`%arrayblit*`, `%array_element_size_in_bytes`, and `%unsafe_array_idx*` (kept `gen_array_kind` for `%obj_size`, `%obj_field`,`%obj_set_field` which aren't specialized)
- Updated `glb_array_type`/`glb_array_ref_type`/`glb_array_set_type` to treat `Punspecializedarray*` as the top of the lattice (returns the other operand)
- Removed the old `Pgenarray`-as-unspecialized hack from the GLB functions
- Updated the lattice diagram comment to show `unspecialized` above both `gen` and the unboxed kinds

**`lambda/printlambda.ml`:** Added printing cases (`unspecialized`).

**Other files** (bytecomp, middle_end, typing, etc.): Added `Punspecializedarray*` pattern-match cases that raise `Misc.fatal_error` since the constructor should never reach those phases.

`testsuite/tests/translprim/array_spec.compilers.no-flat.reference` was promoted — with `--disable-flat-float-array`, primitives now specialize correctly (e.g. `array.length[addr]` instead of `array.length[gen]`).
