### PR TITLE
to_cmm: optimise a few patterns related to low bits

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -683,17 +683,21 @@ let max_signed_bit_length =
   check_equal_int_1 "max_signed_bit_length" max_signed_bit_length
     max_signed_bit_length'
 
-let ignore_low_bit_int = function
+let rec ignore_low_bit_int = function
   | Cop
       ( Caddi,
         [(Cop (Clsl, [_; Cconst_int (n, _)], _) as c); Cconst_int (1, _)],
         _ )
     when n > 0 && is_defined_shift n ->
-    c
-  | Cop (Cor, [c; Cconst_int (1, _)], _) -> c
+    ignore_low_bit_int c
+  | Cop (Cor, [c; Cconst_int (1, _)], _) -> ignore_low_bit_int c
+  | Cop (Clsl, [Cop (Clsr, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
+    ignore_low_bit_int c
+  | Cop (Clsl, [Cop (Casr, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
+    ignore_low_bit_int c
   | c -> c
 
-let ignore_low_bit_int' arg =
+let rec ignore_low_bit_int' arg =
   let open P.Default_variables in
   P.run arg
     [ ( Guarded
@@ -704,8 +708,13 @@ let ignore_low_bit_int' arg =
                   Const_int_fixed 1 );
             guard = (fun env -> env#.n > 0 && is_defined_shift env#.n)
           }
-      => fun env -> env#.c );
-      (Binop (Or, Any c, Const_int_fixed 1) => fun env -> env#.c) ]
+      => fun env -> ignore_low_bit_int' env#.c );
+      ( Binop (Or, Any c, Const_int_fixed 1) => fun env ->
+        ignore_low_bit_int' env#.c );
+      ( Binop (Lsl, Binop (Lsr, Any c, Const_int_fixed 1), Const_int_fixed 1)
+      => fun env -> ignore_low_bit_int' env#.c );
+      ( Binop (Lsl, Binop (Asr, Any c, Const_int_fixed 1), Const_int_fixed 1)
+      => fun env -> ignore_low_bit_int' env#.c ) ]
 
 let ignore_low_bit_int =
   check_equal_1 "ignore_low_bit_int" ignore_low_bit_int ignore_low_bit_int'
@@ -752,6 +761,9 @@ let rec or_const e n dbg =
   | n ->
     map_tail1 e ~f:(fun e ->
         let[@local] default () =
+          let e =
+            if Nativeint.logand n 1n = 1n then ignore_low_bit_int e else e
+          in
           (* prefer putting constants on the right *)
           Cop (Cor, [e; natint_const_untagged dbg n], dbg)
         in
@@ -775,6 +787,9 @@ let rec and_const e n dbg =
         | Some e -> natint_const_untagged dbg (Nativeint.logand e n)
         | None -> (
           let[@local] default () =
+            let e =
+              if Nativeint.logand n 1n = 0n then ignore_low_bit_int e else e
+            in
             (* prefer putting constants on the right *)
             Cop (Cand, [e; natint_const_untagged dbg n], dbg)
           in
@@ -4723,11 +4738,9 @@ let float_of_float32 = unary (Cstatic_cast Float_of_float32)
 let lsl_int_caml_raw ~dbg arg1 arg2 =
   incr_int (lsl_int (decr_int arg1 dbg) arg2 dbg) dbg
 
-let lsr_int_caml_raw ~dbg arg1 arg2 =
-  Cop (Cor, [lsr_int arg1 arg2 dbg; Cconst_int (1, dbg)], dbg)
+let lsr_int_caml_raw ~dbg arg1 arg2 = or_const (lsr_int arg1 arg2 dbg) 1n dbg
 
-let asr_int_caml_raw ~dbg arg1 arg2 =
-  Cop (Cor, [asr_int arg1 arg2 dbg; Cconst_int (1, dbg)], dbg)
+let asr_int_caml_raw ~dbg arg1 arg2 = or_const (asr_int arg1 arg2 dbg) 1n dbg
 
 let eq ~dbg x y =
   match x, y with


### PR DESCRIPTION
This allows to optimize `let f x = Nativeint.(logor (shift_left (of_int x) 1) 1n)` to a single `or` operation instead of two shifts and an `or`. Sadly, it is a bit more complex to optimize it completely to the identity function, as this would require to_cmm to know the input must have its low bit set.