### PR TITLE
Add -dloading, for use instead of strace etc

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -393,6 +393,12 @@ let mk_davail f =
 
 let mk_dranges f = ("-dranges", Arg.Unit f, " Dump results of Compute_ranges")
 
+let mk_dloading f =
+  ( "-dloading",
+    Arg.Unit f,
+    " Trace lookup, open, read and close of build artifacts (e.g. .cmi, .cmx) \
+     and Flambda 2 cross-unit loads" )
+
 let mk_ddebug_invariants f =
   ( "-ddebug-invariants",
     Arg.Unit f,
@@ -1239,6 +1245,7 @@ module type Oxcaml_options = sig
   val dump_inlining_paths : unit -> unit
   val davail : unit -> unit
   val dranges : unit -> unit
+  val dloading : unit -> unit
   val ddebug_invariants : unit -> unit
   val ddebug_available_regs : unit -> unit
   val ddwarf_types : unit -> unit
@@ -1416,6 +1423,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_dump_inlining_paths F.dump_inlining_paths;
       mk_davail F.davail;
       mk_dranges F.dranges;
+      mk_dloading F.dloading;
       mk_ddebug_invariants F.ddebug_invariants;
       mk_ddebug_available_regs F.ddebug_available_regs;
       mk_ddwarf_types F.ddwarf_types;
@@ -1810,6 +1818,7 @@ module Oxcaml_options_impl = struct
   let dump_inlining_paths = set' Oxcaml_flags.dump_inlining_paths
   let davail = set' Oxcaml_flags.davail
   let dranges = set' Oxcaml_flags.dranges
+  let dloading = set' Oxcaml_flags.dloading
   let ddebug_invariants = set' Dwarf_flags.ddebug_invariants
   let ddebug_available_regs = set' Dwarf_flags.ddebug_available_regs
   let ddwarf_types = set' Dwarf_flags.ddwarf_types
@@ -2352,6 +2361,7 @@ module Extra_params = struct
     | "dump-inlining-paths" -> set' Oxcaml_flags.dump_inlining_paths
     | "davail" -> set' Oxcaml_flags.davail
     | "dranges" -> set' Oxcaml_flags.dranges
+    | "dloading" -> set' Oxcaml_flags.dloading
     | "ddebug-invariants" -> set' Dwarf_flags.ddebug_invariants
     | "ddebug-available-regs" -> set' Dwarf_flags.ddebug_available_regs
     | "ddwarf-types" -> set' Dwarf_flags.ddwarf_types

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -25,6 +25,7 @@ module type Oxcaml_options = sig
   val dump_inlining_paths : unit -> unit
   val davail : unit -> unit
   val dranges : unit -> unit
+  val dloading : unit -> unit
   val ddebug_invariants : unit -> unit
   val ddebug_available_regs : unit -> unit
   val ddwarf_types : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -128,6 +128,7 @@ type 'a or_default = Set of 'a | Default
 let dump_inlining_paths = ref false
 let davail = ref false
 let dranges = ref false
+let dloading = Misc.dloading
 
 let opt_level = ref Default
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -64,6 +64,11 @@ val disable_zero_alloc_checker : bool ref
 val disable_precise_zero_alloc_checker : bool ref
 val davail : bool ref
 val dranges : bool ref
+val dloading : bool ref
+  (** [-dloading]: emit strace-like output showing attempts to stat,
+      open, read and close build artifacts (e.g. [.cmi] and [.cmx] files),
+      together with informational messages from Flambda 2 (such as
+      "opening to find code ID ..."). *)
 
 type zero_alloc_checker_details_cutoff =
   | Keep_all

--- a/file_formats/cfg_format.ml
+++ b/file_formats/cfg_format.ml
@@ -57,13 +57,16 @@ let save filename cfg_unit_info =
     ~exceptionally:(fun () -> raise (Error (Marshal_failed filename)))
 
 let restore filename =
+  Misc.dloading_log "open %s (cfg)" filename;
   let ic = open_in_bin filename in
   Misc.try_finally
     (fun () ->
+       Misc.dloading_log "read magic number from %s (cfg)" filename;
        let magic = Config.cfg_magic_number in
        let buffer = really_input_string ic (String.length magic) in
        if String.equal buffer magic then begin
          try
+           Misc.dloading_log "read contents of %s (cfg)" filename;
            let cfg_unit_info = (input_value ic : cfg_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();
@@ -78,7 +81,9 @@ let restore filename =
        else
          raise (Error (Wrong_format filename))
     )
-    ~always:(fun () -> close_in ic)
+    ~always:(fun () ->
+      Misc.dloading_log "close %s (cfg)" filename;
+      close_in ic)
 
 (* Error report *)
 

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -186,13 +186,19 @@ let input_cmi_lazy ic =
     }
 
 let read_cmi_lazy filename =
+  Misc.dloading_log "open %s (cmi)" filename;
   let ic = open_in_bin filename in
+  let close_in_log ic =
+    Misc.dloading_log "close %s (cmi)" filename;
+    close_in ic
+  in
   try
+    Misc.dloading_log "read magic number from %s (cmi)" filename;
     let buffer =
       really_input_string ic (String.length Config.cmi_magic_number)
     in
     if buffer <> Config.cmi_magic_number then begin
-      close_in ic;
+      close_in_log ic;
       let pre_len = String.length Config.cmi_magic_number - 3 in
       if String.sub buffer 0 pre_len
           = String.sub Config.cmi_magic_number 0 pre_len then
@@ -204,14 +210,15 @@ let read_cmi_lazy filename =
         raise(Error(Not_an_interface filename))
       end
     end;
+    Misc.dloading_log "read contents of %s (cmi)" filename;
     let cmi = input_cmi_lazy ic in
-    close_in ic;
+    close_in_log ic;
     cmi
   with End_of_file | Failure _ ->
-      close_in ic;
+      close_in_log ic;
       raise(Error(Corrupted_interface(filename)))
     | Error e ->
-      close_in ic;
+      close_in_log ic;
       raise (Error e)
 
 let output_cmi filename oc cmi =

--- a/file_formats/cms_format.ml
+++ b/file_formats/cms_format.ml
@@ -53,14 +53,19 @@ let output_cms oc cms =
   output_value oc (cms : cms_infos)
 
 let read filename =
+  Misc.dloading_log "open %s (cms)" filename;
   let ic = open_in_bin filename in
   Misc.try_finally
-    ~always:(fun () -> close_in ic)
+    ~always:(fun () ->
+      Misc.dloading_log "close %s (cms)" filename;
+      close_in ic)
     (fun () ->
+       Misc.dloading_log "read magic number from %s (cms)" filename;
        let magic_number = read_magic_number ic in
-        if magic_number = Config.cms_magic_number then
+        if magic_number = Config.cms_magic_number then begin
+          Misc.dloading_log "read contents of %s (cms)" filename;
           input_cms ic
-        else
+        end else
           raise (Error (Not_a_shape filename))
     )
 

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -437,26 +437,33 @@ let output_cmt oc cmt =
 
 let read filename =
 (*  Printf.fprintf stderr "Cmt_format.read %s\n%!" filename; *)
+  Misc.dloading_log "open %s (cmt/cmi)" filename;
   let ic = open_in_bin filename in
   Misc.try_finally
-    ~always:(fun () -> close_in ic)
+    ~always:(fun () ->
+      Misc.dloading_log "close %s (cmt/cmi)" filename;
+      close_in ic)
     (fun () ->
+       Misc.dloading_log "read magic number from %s (cmt/cmi)" filename;
        let magic_number = read_magic_number ic in
        let cmi, cmt =
-         if magic_number = Config.cmt_magic_number then
+         if magic_number = Config.cmt_magic_number then begin
+           Misc.dloading_log "read cmt body from %s" filename;
            None, Some (input_cmt ic)
-         else if magic_number = Config.cmi_magic_number then
+         end else if magic_number = Config.cmi_magic_number then begin
+           Misc.dloading_log "read cmi body from %s" filename;
            let cmi = Cmi_format.input_cmi_lazy ic in
            let cmt = try
                let magic_number = read_magic_number ic in
-               if magic_number = Config.cmt_magic_number then
+               if magic_number = Config.cmt_magic_number then begin
+                 Misc.dloading_log "read trailing cmt body from %s" filename;
                  let cmt = input_cmt ic in
                  Some cmt
-               else None
+               end else None
              with _ -> None
            in
            Some cmi, cmt
-         else
+         end else
            raise(Cmi_format.Error(Cmi_format.Not_an_interface filename))
        in
        cmi, cmt

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -50,13 +50,16 @@ let save filename linear_unit_info =
     ~exceptionally:(fun () -> raise (Error (Marshal_failed filename)))
 
 let restore filename =
+  Misc.dloading_log "open %s (linear)" filename;
   let ic = open_in_bin filename in
   Misc.try_finally
     (fun () ->
+       Misc.dloading_log "read magic number from %s (linear)" filename;
        let magic = Config.linear_magic_number in
        let buffer = really_input_string ic (String.length magic) in
        if String.equal buffer magic then begin
          try
+           Misc.dloading_log "read contents of %s (linear)" filename;
            let linear_unit_info = (input_value ic : linear_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();
@@ -71,7 +74,9 @@ let restore filename =
        else
          raise (Error (Wrong_format filename))
     )
-    ~always:(fun () -> close_in ic)
+    ~always:(fun () ->
+      Misc.dloading_log "close %s (linear)" filename;
+      close_in ic)
 
 (* Error report *)
 

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -101,18 +101,26 @@ let current_unit_infos () =
   current_unit
 
 let read_unit_info filename =
+  Misc.dloading_log "open %s (cmx)" filename;
   let ic = open_in_bin filename in
   try
+    Misc.dloading_log "read magic number from %s (cmx)" filename;
     let buffer = really_input_string ic (String.length cmx_magic_number) in
     if buffer <> cmx_magic_number then begin
+      Misc.dloading_log "close %s (cmx, bad magic)" filename;
       close_in ic;
       raise(Error(Not_a_unit_info filename))
     end;
+    Misc.dloading_log "read unit_infos header from %s (cmx)" filename;
     let uir = (input_value ic : unit_infos_raw) in
     let first_section_offset = pos_in ic in
     seek_in ic (first_section_offset + uir.uir_sections_length);
+    Misc.dloading_log "read crc from %s (cmx)" filename;
     let crc = Digest.input ic in
     (* This consumes the channel *)
+    Misc.dloading_log
+      "hand %s (cmx) to File_sections (channel will be closed lazily)"
+      filename;
     let sections = File_sections.create uir.uir_section_toc filename ic ~first_section_offset in
     let export_info =
       Option.map (Flambda2_cmx.Flambda_cmx_format.from_raw ~sections)
@@ -137,15 +145,22 @@ let read_unit_info filename =
     in
     (ui, crc)
   with End_of_file | Failure _ ->
+    Misc.dloading_log "close %s (cmx, corrupted)" filename;
     close_in ic;
     raise(Error(Corrupted_unit_info(filename)))
 
 let read_library_info filename =
+  Misc.dloading_log "open %s (cmxa)" filename;
   let ic = open_in_bin filename in
+  Misc.dloading_log "read magic number from %s (cmxa)" filename;
   let buffer = really_input_string ic (String.length cmxa_magic_number) in
-  if buffer <> cmxa_magic_number then
-    raise(Error(Not_a_unit_info filename));
+  if buffer <> cmxa_magic_number then begin
+    Misc.dloading_log "close %s (cmxa, bad magic)" filename;
+    raise(Error(Not_a_unit_info filename))
+  end;
+  Misc.dloading_log "read library_infos from %s (cmxa)" filename;
   let infos = (input_value ic : library_infos) in
+  Misc.dloading_log "close %s (cmxa)" filename;
   close_in ic;
   infos
 
@@ -186,15 +201,27 @@ let get_unit_export_info comp_unit =
             | true -> "cmjx"
           in
           try
+            Misc.dloading_log
+              "compilenv: looking up .%s for compilation unit %a"
+              missing_extension
+              (Format_doc.compat CU.print) comp_unit;
             let filename =
               Load_path.find_normalized
                 (CU.base_filename comp_unit ^ "." ^ missing_extension) in
+            Misc.dloading_log
+              "compilenv: found .%s for compilation unit %a at %s"
+              missing_extension
+              (Format_doc.compat CU.print) comp_unit filename;
             let (ui, crc) = read_unit_info filename in
             if not (CU.equal ui.ui_unit comp_unit) then
               raise(Error(Illegal_renaming(comp_unit, ui.ui_unit, filename)));
             cache_zero_alloc_info ui.ui_zero_alloc_info;
             (Some ui, Some crc)
           with Not_found ->
+            Misc.dloading_log
+              "compilenv: no .%s found for compilation unit %a"
+              missing_extension
+              (Format_doc.compat CU.print) comp_unit;
             let warn =
               Warnings.No_cmx_file
                 { missing_extension

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -37,14 +37,25 @@ let load_cmx_file_contents loader comp_unit =
   match Imported_unit_map.find cmx_file loader.imported_units with
   | typing_env_or_none -> typing_env_or_none
   | exception Not_found -> (
+    Misc.dloading_log
+      "Flambda 2: requesting .cmx contents for compilation unit %a"
+      (Format_doc.compat Compilation_unit.print)
+      accessible_comp_unit;
     match loader.get_module_info accessible_comp_unit with
     | None ->
+      Misc.dloading_log "Flambda 2: .cmx for compilation unit %a is unavailable"
+        (Format_doc.compat Compilation_unit.print)
+        accessible_comp_unit;
       (* To make things easier to think about, we never retry after a .cmx load
          fails. *)
       loader.imported_units
         <- Imported_unit_map.add cmx_file None loader.imported_units;
       None
     | Some cmx ->
+      Misc.dloading_log
+        "Flambda 2: importing typing env and code from .cmx for %a"
+        (Format_doc.compat Compilation_unit.print)
+        accessible_comp_unit;
       Profile.record_call ~accumulate:true "load_cmx" (fun () ->
           let typing_env, all_code =
             Flambda_cmx_format.import_typing_env_and_code cmx

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -532,6 +532,11 @@ let find_code_exn t id =
        references it. However we force loading of the corresponding .cmx to make
        sure that we will have access to the actual code (assuming the .cmx isn't
        missing). *)
+    Misc.dloading_log
+      "Flambda 2: opening compilation unit %a to find code ID %a"
+      (Format_doc.compat Compilation_unit.print)
+      (Code_id.get_compilation_unit id)
+      Code_id.print id;
     let (_ : TE.Serializable.t option) =
       TE.resolver t.typing_env (Code_id.get_compilation_unit id)
     in

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -73,13 +73,25 @@ module Persistent_signature = struct
 
   let load = ref (fun ~allow_hidden ~unit_name ->
     let unit_name = CU.Name.to_string unit_name in
+    Misc.dloading_log
+      "type checker: looking up .cmi for module %s" unit_name;
     match Load_path.find_normalized_with_visibility (unit_name ^ ".cmi") with
     | filename, visibility when allow_hidden ->
+      Misc.dloading_log
+        "type checker: found .cmi for module %s at %s" unit_name filename;
       Some { filename; cmi = read_cmi_lazy filename; visibility}
     | filename, (Visible _ as visibility) ->
+      Misc.dloading_log
+        "type checker: found .cmi for module %s at %s" unit_name filename;
       Some { filename; cmi = read_cmi_lazy filename; visibility}
-    | _, Hidden
-    | exception Not_found -> None)
+    | _, Hidden ->
+      Misc.dloading_log
+        "type checker: .cmi for module %s is hidden" unit_name;
+      None
+    | exception Not_found ->
+      Misc.dloading_log
+        "type checker: no .cmi found for module %s" unit_name;
+      None)
 end
 
 type can_load_cmis =
@@ -402,6 +414,9 @@ let acknowledge_import penv ~check modname pers_sig =
 
 let read_import penv ~check modname cmi =
   let filename = Unit_info.Artifact.filename cmi in
+  Misc.dloading_log
+    "type checker: reading .cmi for module %a from %s"
+    (Format_doc.compat CU.Name.print) modname filename;
   add_import penv modname;
   let cmi = read_cmi_lazy filename in
   let pers_sig =

--- a/utils/file_sections.ml
+++ b/utils/file_sections.ml
@@ -23,9 +23,13 @@ module File_lru_cache = Lru.Make (struct
 
   type uncached = string
 
-  let load = open_in_bin
+  let load file =
+    Misc.dloading_log "reopen %s (cmx, section access)" file;
+    open_in_bin file
 
-  let unload _ ic = close_in ic
+  let unload file ic =
+    Misc.dloading_log "close %s (cmx, evicted from cache)" file;
+    close_in ic
 end)
 
 let file_lru = File_lru_cache.create ~capacity:128
@@ -34,7 +38,8 @@ let () = at_exit (fun () -> File_lru_cache.unload_all file_lru)
 
 type t =
   | From_file of
-      { channel : File_lru_cache.slot;
+      { filename : string;
+        channel : File_lru_cache.slot;
         sections : section array
       }
   | In_memory of Obj.t array
@@ -44,6 +49,7 @@ type t =
 let create section_toc file channel ~first_section_offset =
   if Array.length section_toc = 0
   then (
+    Misc.dloading_log "close %s (cmx, no sections)" file;
     close_in channel;
     In_memory [||])
   else
@@ -54,7 +60,7 @@ let create section_toc file channel ~first_section_offset =
           Pending { byte_offset_in_file = offset + first_section_offset })
         section_toc
     in
-    From_file { channel; sections }
+    From_file { filename = file; channel; sections }
 
 let empty = In_memory [||]
 
@@ -63,10 +69,12 @@ let length = function
   | In_memory sections -> Array.length sections
   | Cat (length, _, _) -> length
 
-let read_section sections channel index =
+let read_section ~filename sections channel index =
   match sections.(index) with
   | Loaded section_contents -> section_contents
   | Pending { byte_offset_in_file } ->
+    Misc.dloading_log "read section %d of %s (cmx) at offset %d" index filename
+      byte_offset_in_file;
     let channel = File_lru_cache.load_slot channel file_lru in
     seek_in channel byte_offset_in_file;
     let section_contents : Obj.t = input_value channel in
@@ -75,7 +83,8 @@ let read_section sections channel index =
 
 let rec unsafe_get t index =
   match t with
-  | From_file { sections; channel } -> read_section sections channel index
+  | From_file { filename; sections; channel } ->
+    read_section ~filename sections channel index
   | In_memory sections -> sections.(index)
   | Cat (_, t1, t2) ->
     let n = length t1 in
@@ -92,9 +101,9 @@ let get t index =
 
 let rec unsafe_blit_to_array t dest start_index =
   match t with
-  | From_file { sections; channel } ->
+  | From_file { filename; sections; channel } ->
     for i = 0 to Array.length sections - 1 do
-      dest.(start_index + i) <- read_section sections channel i
+      dest.(start_index + i) <- read_section ~filename sections channel i
     done
   | In_memory sections ->
     Array.blit sections 0 dest start_index (Array.length sections)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -669,17 +669,36 @@ let repeated_label l =
   in
   go Set.empty l
 
+(* Tracing of artifact loading (-dloading). *)
+
+let dloading = ref false
+
+let dloading_log fmt =
+  if !dloading
+  then
+    Format.kfprintf
+      (fun ppf -> Format.pp_print_newline ppf ())
+      Format.err_formatter
+      ("[dloading] " ^^ fmt)
+  else Format.ifprintf Format.err_formatter fmt
+
+let dloading_stat path =
+  let exists = Sys.file_exists path in
+  if !dloading
+  then dloading_log "stat %s -> %s" path (if exists then "yes" else "no");
+  exists
+
 (* File functions *)
 
 let find_in_path path name =
   if not (Filename.is_implicit name) then
-    if Sys.file_exists name then name else raise Not_found
+    if dloading_stat name then name else raise Not_found
   else begin
     let rec try_dir = function
       [] -> raise Not_found
     | dir::rem ->
         let fullname = Filename.concat dir name in
-        if Sys.file_exists fullname then fullname else try_dir rem
+        if dloading_stat fullname then fullname else try_dir rem
     in try_dir path
   end
 
@@ -696,7 +715,7 @@ let find_in_path_rel path name =
     [] -> raise Not_found
   | dir::rem ->
       let fullname = simplify (Filename.concat dir name) in
-      if Sys.file_exists fullname then fullname else try_dir rem
+      if dloading_stat fullname then fullname else try_dir rem
   in try_dir path
 
 let normalized_unit_filename = String.uncapitalize_ascii
@@ -708,8 +727,8 @@ let find_in_path_normalized path name =
   | dir::rem ->
       let fullname = Filename.concat dir name
       and ufullname = Filename.concat dir uname in
-      if Sys.file_exists ufullname then ufullname
-      else if Sys.file_exists fullname then fullname
+      if dloading_stat ufullname then ufullname
+      else if dloading_stat fullname then fullname
       else try_dir rem
   in try_dir path
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -424,6 +424,18 @@ end
 
 (** {1 Operations on files and file paths} *)
 
+val dloading: bool ref
+       (** When set, the compiler emits strace-like trace messages on
+           [stderr] showing each attempt to look up, open, read or close a
+           build artifact (e.g. [.cmi], [.cmx], [.cms] files), together with
+           higher-level informational messages such as "opening to find code
+           ID ..." emitted by Flambda 2. Controlled by [-dloading]. *)
+
+val dloading_log: ('a, Format.formatter, unit) format -> 'a
+       (** [dloading_log fmt ...] prints a [dloading] trace line to
+           [stderr] (prefixed with ["[dloading] "]) when {!dloading} is
+           set, otherwise does nothing. *)
+
 val find_in_path: string list -> string -> string
        (** Search a file in a list of directories. *)
 


### PR DESCRIPTION
Traditionally it has been possible to use `strace` to see what the compiler is doing in terms of loading build artifacts etc, but in more complicated build systems, this may be problematic.  This PR adds a new flag `-dloading` which is intended to give a full trace of the I/O during compilation for the various artifacts such as `.cmi` and `.cmx` files, together with additional information (such as the compilation unit being looked for) which is very useful when manifest files are being used and the actual on-disk names of the artifacts may not contain the unit name.