### PR TITLE
Remove alloc_mode from Set_of_closures.t

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -278,8 +278,7 @@ let subst_set_of_closures env set =
         subst_value_slot env var, subst_simple env simple)
     |> Value_slot.Map.of_list
   in
-  let alloc = Set_of_closures.alloc_mode set in
-  Set_of_closures.create alloc ~value_slots decls
+  Set_of_closures.create ~value_slots decls
 
 let subst_rec_info_expr _env ri =
   (* Only depth variables can occur in [Rec_info_expr], and we only mess with
@@ -320,8 +319,8 @@ and subst_named env (n : Named.t) =
   match n with
   | Simple s -> Named.create_simple (subst_simple env s)
   | Prim (p, dbg) -> Named.create_prim (subst_primitive env p) dbg
-  | Set_of_closures set ->
-    Named.create_set_of_closures (subst_set_of_closures env set)
+  | Set_of_closures (set, alloc_mode) ->
+    Named.create_set_of_closures ~alloc_mode (subst_set_of_closures env set)
   | Static_consts sc -> Named.create_static_consts (subst_static_consts env sc)
   | Rec_info ri -> Named.create_rec_info (subst_rec_info_expr env ri)
 
@@ -887,9 +886,13 @@ let named_exprs env named1 named2 : Named.t Comparison.t =
   | Prim (prim1, dbg1), Prim (prim2, _) ->
     primitives env prim1 prim2
     |> Comparison.map ~f:(fun prim -> Named.create_prim prim dbg1)
-  | Set_of_closures set1, Set_of_closures set2 ->
-    sets_of_closures env set1 set2
-    |> Comparison.map ~f:Named.create_set_of_closures
+  | Set_of_closures (set1, alloc_mode1), Set_of_closures (set2, alloc_mode2) ->
+    if Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2 = 0
+    then
+      sets_of_closures env set1 set2
+      |> Comparison.map
+           ~f:(Named.create_set_of_closures ~alloc_mode:alloc_mode1)
+    else Different { approximant = named1 }
   | Rec_info rec_info_expr1, Rec_info rec_info_expr2 ->
     rec_info_exprs env rec_info_expr1 rec_info_expr2
     |> Comparison.map ~f:Named.create_rec_info

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -48,7 +48,10 @@ type 'a close_program_result =
 
 type close_functions_result =
   | Lifted of (Symbol.t * Env.value_approximation) Function_slot.Lmap.t
-  | Dynamic of Set_of_closures.t * Env.value_approximation Function_slot.Map.t
+  | Dynamic of
+      Set_of_closures.t
+      * Alloc_mode.For_allocations.t
+      * Env.value_approximation Function_slot.Map.t
 
 let manufacture_symbol acc proposed_name =
   let acc, linkage_name =
@@ -3151,13 +3154,12 @@ let close_functions acc external_env ~current_region function_declarations =
           { code_id; function_slot; code; symbol = None })
       approximations
   in
-  let set_of_closures =
-    Set_of_closures.create ~value_slots
-      (Alloc_mode.For_allocations.from_lambda
-         (Function_decls.alloc_mode function_declarations)
-         ~current_region)
-      function_decls
+  let alloc_mode =
+    Alloc_mode.For_allocations.from_lambda
+      (Function_decls.alloc_mode function_declarations)
+      ~current_region
   in
+  let set_of_closures = Set_of_closures.create ~value_slots function_decls in
   let acc =
     Acc.add_set_of_closures_offsets ~is_phantom:false acc set_of_closures
   in
@@ -3182,7 +3184,7 @@ let close_functions acc external_env ~current_region function_declarations =
     let symbols = Function_slot.Lmap.map fst symbols_with_approx in
     let acc = Acc.add_lifted_set_of_closures ~symbols ~set_of_closures acc in
     acc, Lifted symbols_with_approx
-  else acc, Dynamic (set_of_closures, approximations)
+  else acc, Dynamic (set_of_closures, alloc_mode, approximations)
 
 let close_let_rec acc env ~function_declarations
     ~(body : Acc.t -> Env.t -> Expr_with_acc.t) ~current_region =
@@ -3256,7 +3258,7 @@ let close_let_rec acc env ~function_declarations
         symbols (acc, env)
     in
     body acc env
-  | Dynamic (set_of_closures, approximations) ->
+  | Dynamic (set_of_closures, alloc_mode, approximations) ->
     let generated_closures =
       Function_slot.Set.diff
         (Function_slot.Map.keys
@@ -3291,7 +3293,7 @@ let close_let_rec acc env ~function_declarations
         fun_vars_map env
     in
     let acc, body = body acc env in
-    let named = Named.create_set_of_closures set_of_closures in
+    let named = Named.create_set_of_closures ~alloc_mode set_of_closures in
     Let_with_acc.create acc
       (Bound_pattern.set_of_closures bound_vars)
       named ~body

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -1100,7 +1100,7 @@ module Let_with_acc = struct
           |> Cost_metrics.from_size
         | Simple simple -> Code_size.simple simple |> Cost_metrics.from_size
         | Static_consts _consts -> Cost_metrics.zero
-        | Set_of_closures set_of_closures ->
+        | Set_of_closures (set_of_closures, _alloc_mode) ->
           let code_mapping = Acc.code_map acc in
           Cost_metrics.set_of_closures
             ~find_code_characteristics:(fun code_id ->

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -239,7 +239,7 @@ module Acc = struct
       } )
 end
 
-let set_of_closures env fun_decls value_slots alloc =
+let set_of_closures env fun_decls value_slots =
   let fun_decls : Function_declarations.t =
     let translate_fun_decl (fun_decl : Fexpr.fun_decl) :
         Function_slot.t * Code_id.t =
@@ -266,8 +266,7 @@ let set_of_closures env fun_decls value_slots alloc =
     in
     List.map convert value_slots |> Value_slot.Map.of_list
   in
-  let alloc = alloc_mode_for_allocations env alloc in
-  Set_of_closures.create ~value_slots alloc fun_decls
+  Set_of_closures.create ~value_slots fun_decls
 
 let apply_cont env acc ({ cont; args; trap_action } : Fexpr.apply_cont) =
   let trap_action : Trap_action.t option =
@@ -330,11 +329,12 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
     in
     let bound = Bound_pattern.set_of_closures bound_vars in
     let closure_bindings = List.map snd vars_and_closure_bindings in
-    let soc = set_of_closures env closure_bindings value_slots alloc in
+    let soc = set_of_closures env closure_bindings value_slots in
     let name_mode = Bound_pattern.name_mode bound in
     let is_phantom = Name_mode.is_phantom name_mode in
     let acc = Acc.add_set_of_closures_offsets ~is_phantom acc soc in
-    let named = Flambda.Named.create_set_of_closures soc in
+    let alloc_mode = alloc_mode_for_allocations env alloc in
+    let named = Flambda.Named.create_set_of_closures ~alloc_mode soc in
     let acc, body = expr env acc body in
     let let_expr =
       Flambda.Let.create bound named ~body ~free_names_of_body:Unknown
@@ -581,7 +581,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             (fun (b : Fexpr.static_closure_binding) -> b.fun_decl)
             bindings
         in
-        let set = set_of_closures env fun_decls elements Heap in
+        let set = set_of_closures env fun_decls elements in
         static_const (SC.set_of_closures set)
       | Closure _ -> assert false (* should have been filtered out above *)
       | Deleted_code _ -> acc, Flambda.Static_const_or_code.deleted_code

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -212,11 +212,9 @@ let function_declaration env code_id function_slot alloc : Fexpr.fun_decl =
     then None
     else Some function_slot
   in
-  let alloc = alloc |> alloc_mode_for_allocations env in
   { code_id; function_slot; alloc }
 
-let set_of_closures env sc =
-  let alloc = Set_of_closures.alloc_mode sc in
+let set_of_closures env sc alloc =
   let fun_decls =
     List.map
       (fun (function_slot, fun_decl) ->
@@ -324,8 +322,9 @@ and dynamic_let_expr env vars (defining_expr : Flambda.Named.t) body :
     match defining_expr with
     | Simple s -> ([Simple (simple env s)] : Fexpr.named list), None
     | Prim (p, _dbg) -> ([Prim (prim env p)] : Fexpr.named list), None
-    | Set_of_closures sc ->
-      let fun_decls, value_slots = set_of_closures env sc in
+    | Set_of_closures (sc, alloc_mode) ->
+      let alloc_mode = alloc_mode_for_allocations env alloc_mode in
+      let fun_decls, value_slots = set_of_closures env sc alloc_mode in
       let defining_exprs =
         List.map (fun decl : Fexpr.named -> Fexpr.Closure decl) fun_decls
       in
@@ -376,7 +375,7 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
       Data { symbol; defining_expr }
     | Set_of_closures closure_symbols, Static_const const ->
       let set = Static_const.must_be_set_of_closures const in
-      let fun_decls, elements = set_of_closures env set in
+      let fun_decls, elements = set_of_closures env set Heap in
       let symbols_by_function_slot =
         closure_symbols |> Function_slot.Lmap.bindings
         |> Function_slot.Map.of_list
@@ -723,7 +722,7 @@ module Iter = struct
   and named let_expr (bound_pattern : Bound_pattern.t) f_c f_s n =
     match (n : Named.t) with
     | Simple _ | Prim _ | Rec_info _ -> ()
-    | Set_of_closures s ->
+    | Set_of_closures (s, _alloc_mode) ->
       let is_phantom =
         Name_mode.is_phantom (Bound_pattern.name_mode bound_pattern)
       in

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -398,8 +398,7 @@ let rewrite_simples_with_debuginfo env simples =
   List.map (rewrite_simple_with_debuginfo env) simples
 
 let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
-    ({ Rev_expr.function_decls; value_slots; alloc_mode } :
-      Rev_expr.rev_set_of_closures) =
+    ({ Rev_expr.function_decls; value_slots } : Rev_expr.rev_set_of_closures) =
   let slot_is_used slot =
     List.exists
       (fun bound_name ->
@@ -565,9 +564,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
   let function_decls =
     Function_declarations.create (Function_slot.Lmap.of_list function_decls)
   in
-  let set_of_closures =
-    Set_of_closures.create ~value_slots alloc_mode function_decls
-  in
+  let set_of_closures = Set_of_closures.create ~value_slots function_decls in
   let res =
     { res with
       all_slot_offsets =
@@ -764,7 +761,7 @@ let rebuild_named_default_case env (named : Named.t) =
     let prim = P.map_args (rewrite_simple env) prim in
     ( Named.create_prim prim dbg,
       Code_size.prim ~machine_width:env.machine_width prim )
-  | Set_of_closures s ->
+  | Set_of_closures (s, _alloc_mode) ->
     Misc.fatal_errorf
       "[rebuild_named_default_case] called on set of closures:@ %a@."
       Set_of_closures.print s
@@ -1784,7 +1781,8 @@ let rebuild_make_block_default_case env (bp : Bound_pattern.t)
       (Code_size.prim ~machine_width:env.machine_width prim)
     ~body:hole
 
-let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures ~hole =
+let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
+    ~alloc_mode ~hole =
   if bound_vars_will_be_unboxed env bvs
   then
     ( rebuild_set_of_closures_binding_which_is_being_unboxed env bvs
@@ -1830,7 +1828,7 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures ~hole =
     in
     let expr =
       RE.create_let bound_pattern
-        (Named.create_set_of_closures set_of_closures)
+        (Named.create_set_of_closures ~alloc_mode set_of_closures)
         ~size_of_defining_expr ~body:hole
     in
     expr, res
@@ -1968,9 +1966,10 @@ and rebuild_let_expr_holed (env : env) res ~(bound_pattern : Bound_pattern.t)
         rebuild_let_expr_singleton env res bv ~defining_expr ~hole
       | Static bound_static, Static_consts group ->
         rebuild_let_expr_static_consts env res bound_static group ~hole
-      | Set_of_closures bound_vars, Set_of_closures set_of_closures ->
+      | Set_of_closures bound_vars, Set_of_closures (set_of_closures, alloc_mode)
+        ->
         rebuild_let_expr_holed_set_of_closures env res bound_vars
-          ~set_of_closures ~hole
+          ~set_of_closures ~alloc_mode ~hole
       | ( (Singleton _ | Static _ | Set_of_closures _),
           (Named _ | Static_consts _ | Set_of_closures _) ) ->
         Misc.fatal_errorf "Bound pattern %a does not match defining expr"

--- a/middle_end/flambda2/reaper/rev_expr.ml
+++ b/middle_end/flambda2/reaper/rev_expr.ml
@@ -39,7 +39,7 @@ type rev_expr_holed =
 
 and rev_named =
   | Named of Flambda.named
-  | Set_of_closures of rev_set_of_closures
+  | Set_of_closures of rev_set_of_closures * Alloc_mode.For_allocations.t
   | Static_consts of rev_static_const_or_code list
 
 and rev_static_const_or_code =
@@ -69,8 +69,7 @@ and rev_params_and_body =
 
 and rev_set_of_closures =
   { value_slots : Simple.t Value_slot.Map.t;
-    function_decls : Function_declarations.t;
-    alloc_mode : Alloc_mode.For_allocations.t
+    function_decls : Function_declarations.t
   }
 
 and cont_handler =

--- a/middle_end/flambda2/reaper/rev_expr.mli
+++ b/middle_end/flambda2/reaper/rev_expr.mli
@@ -39,7 +39,7 @@ type rev_expr_holed =
 
 and rev_named =
   | Named of Flambda.named
-  | Set_of_closures of rev_set_of_closures
+  | Set_of_closures of rev_set_of_closures * Alloc_mode.For_allocations.t
   | Static_consts of rev_static_const_or_code list
 
 and rev_static_const_or_code =
@@ -71,8 +71,7 @@ and rev_params_and_body =
 
 and rev_set_of_closures =
   { value_slots : Simple.t Value_slot.Map.t;
-    function_decls : Function_declarations.t;
-    alloc_mode : Alloc_mode.For_allocations.t
+    function_decls : Function_declarations.t
   }
 
 and cont_handler =

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -525,7 +525,7 @@ let rec traverse_let denv acc let_expr : rev_expr =
       (Named.free_names defining_expr)
   in
   (match defining_expr with
-  | Set_of_closures set_of_closures ->
+  | Set_of_closures (set_of_closures, _alloc_mode) ->
     traverse_set_of_closures denv acc ~bound_pattern set_of_closures
   | Static_consts group -> traverse_static_consts denv acc ~bound_pattern group
   | Prim (prim, _dbg) ->
@@ -540,13 +540,12 @@ let rec traverse_let denv acc let_expr : rev_expr =
   let make_set_of_closures set_of_closures =
     let function_decls = Set_of_closures.function_decls set_of_closures in
     let value_slots = Set_of_closures.value_slots set_of_closures in
-    let alloc_mode = Set_of_closures.alloc_mode set_of_closures in
-    { function_decls; value_slots; alloc_mode }
+    { function_decls; value_slots }
   in
   let named : rev_named =
     match defining_expr with
-    | Set_of_closures set_of_closures ->
-      Set_of_closures (make_set_of_closures set_of_closures)
+    | Set_of_closures (set_of_closures, alloc_mode) ->
+      Set_of_closures (make_set_of_closures set_of_closures, alloc_mode)
     | Static_consts group ->
       let bound_static =
         match bound_pattern with

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -307,7 +307,6 @@ let remove_unused_value_slots uacc static_const =
           (Set_of_closures.value_slots set_of_closures)
       in
       Set_of_closures.create ~value_slots
-        (Set_of_closures.alloc_mode set_of_closures)
         (Set_of_closures.function_decls set_of_closures))
 
 let create_let_symbols uacc lifted_constant ~body =

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -104,13 +104,9 @@ let create_code' code =
     }
 
 let create_set_of_closures are_rebuilding ~find_code_metadata set =
-  (* Even if the set of closures was locally allocated, this allocation is
-     global. This will not cause leaks, as lifted constants are static and
-     therefore only allocated once. *)
   let set =
     Set_of_closures.create
       ~value_slots:(Set_of_closures.value_slots set)
-      Alloc_mode.For_allocations.heap
       (Set_of_closures.function_decls set)
   in
   let free_names = Set_of_closures.free_names set in

--- a/middle_end/flambda2/simplify/simplified_named.ml
+++ b/middle_end/flambda2/simplify/simplified_named.ml
@@ -19,13 +19,14 @@ open! Flambda.Import
 type simplified_named =
   | Simple of Simple.t
   | Prim of Flambda_primitive.t * Debuginfo.t
-  | Set_of_closures of Set_of_closures.t
+  | Set_of_closures of Set_of_closures.t * Alloc_mode.For_allocations.t
   | Rec_info of Rec_info_expr.t
 
 let to_named = function
   | Simple simple -> Named.create_simple simple
   | Prim (prim, dbg) -> Named.create_prim prim dbg
-  | Set_of_closures set -> Named.create_set_of_closures set
+  | Set_of_closures (set, alloc_mode) ->
+    Named.create_set_of_closures ~alloc_mode set
   | Rec_info rec_info_expr -> Named.create_rec_info rec_info_expr
 
 type t =
@@ -68,8 +69,8 @@ let create_with_known_free_names ~machine_width ~find_code_characteristics
     | Prim (prim, dbg) ->
       ( Prim (prim, dbg),
         Cost_metrics.from_size (Code_size.prim ~machine_width prim) )
-    | Set_of_closures set ->
-      ( Set_of_closures set,
+    | Set_of_closures (set, alloc_mode) ->
+      ( Set_of_closures (set, alloc_mode),
         Cost_metrics.set_of_closures ~find_code_characteristics set )
     | Static_consts _ ->
       Misc.fatal_errorf

--- a/middle_end/flambda2/simplify/simplified_named.mli
+++ b/middle_end/flambda2/simplify/simplified_named.mli
@@ -21,7 +21,7 @@ open! Flambda.Import
 type simplified_named = private
   | Simple of Simple.t
   | Prim of Flambda_primitive.t * Debuginfo.t
-  | Set_of_closures of Set_of_closures.t
+  | Set_of_closures of Set_of_closures.t * Alloc_mode.For_allocations.t
   | Rec_info of Rec_info_expr.t
 
 val to_named : simplified_named -> Named.t

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -492,7 +492,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
              alloc mode is [Local]: direct partial application:@ %a"
             Apply.print apply));
       let result_mode = Code_metadata.result_mode callee's_code_metadata in
-      let wrapper_taking_remaining_args, dacc, code_id, code =
+      let wrapper_taking_remaining_args, wrapper_alloc_mode, dacc, code_id, code
+          =
         let return_continuation = Continuation.create () in
         let remaining_params =
           List.map
@@ -724,8 +725,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           | Local { region; ghost_region = _ } ->
             Alloc_mode.For_allocations.local ~region
         in
-        ( Set_of_closures.create ~value_slots new_closure_alloc_mode
-            function_decls,
+        ( Set_of_closures.create ~value_slots function_decls,
+          new_closure_alloc_mode,
           dacc,
           code_id,
           code )
@@ -741,7 +742,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         let bound = Bound_pattern.set_of_closures bound_vars in
         let body =
           Let.create bound
-            (Named.create_set_of_closures wrapper_taking_remaining_args)
+            (Named.create_set_of_closures ~alloc_mode:wrapper_alloc_mode
+               wrapper_taking_remaining_args)
             ~body:(Expr.create_apply_cont apply_cont)
             ~free_names_of_body:Unknown
           |> Expr.create_let

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -177,10 +177,10 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
                        }))
             in
             Simplified_named.Simplified result))
-  | Set_of_closures set_of_closures ->
+  | Set_of_closures (set_of_closures, alloc_mode) ->
     ok
       (Simplify_set_of_closures.simplify_non_lifted_set_of_closures dacc
-         bound_pattern set_of_closures ~simplify_function_body)
+         bound_pattern set_of_closures alloc_mode ~simplify_function_body)
   | Static_consts static_consts ->
     let bound_static = Bound_pattern.must_be_static bound_pattern in
     let binds_symbols = Bound_static.binds_symbols bound_static in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -861,8 +861,8 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
       in
       { set_of_closures; dacc }
   in
-  let named = Named.create_set_of_closures ~alloc_mode set_of_closures in
   let defining_expr =
+    let named = Named.create_set_of_closures ~alloc_mode set_of_closures in
     let find_code_characteristics code_id =
       let env = Downwards_acc.denv dacc in
       let code_metadata =
@@ -891,7 +891,10 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     (Expr_builder.Keep_binding
        { let_bound = bound_vars;
          simplified_defining_expr = defining_expr;
-         original_defining_expr = Some named (* CR ncourant: this is strange *)
+         original_defining_expr =
+           Some (Named.create_set_of_closures ~alloc_mode set_of_closures)
+           (* CR ncourant: this is surprising; I suspect accidental shadowing
+              took place here. *)
        })
 
 type lifting_decision_result =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -569,7 +569,7 @@ type simplify_set_of_closures0_result =
     dacc : Downwards_acc.t
   }
 
-let simplify_set_of_closures0 outer_dacc context set_of_closures
+let simplify_set_of_closures0 outer_dacc context set_of_closures alloc_mode
     ~closure_bound_names ~closure_bound_names_inside ~value_slots
     ~value_slot_types =
   let dacc = C.dacc_prior_to_sets context in
@@ -654,9 +654,7 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
             T.exactly_this_closure function_slot
               ~all_function_slots_in_set:fun_types
               ~all_closure_types_in_set:closure_types_via_aliases
-              ~all_value_slots_in_set:value_slot_types
-              (Alloc_mode.For_allocations.as_type
-                 (Set_of_closures.alloc_mode set_of_closures))
+              ~all_value_slots_in_set:value_slot_types alloc_mode
           in
           (bound_name, closure_type) :: closure_types)
       fun_types []
@@ -675,13 +673,12 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
   let set_of_closures =
     Function_declarations.create all_function_decls_in_set
     |> Set_of_closures.create ~value_slots
-         (Set_of_closures.alloc_mode set_of_closures)
   in
   { set_of_closures; dacc }
 
 let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
-    ~closure_bound_vars set_of_closures ~value_slots ~symbol_projections
-    ~simplify_function_body =
+    ~closure_bound_vars set_of_closures alloc_mode ~value_slots
+    ~symbol_projections ~simplify_function_body =
   let function_decls = Set_of_closures.function_decls set_of_closures in
   let closure_symbols =
     Function_slot.Lmap.mapi
@@ -725,7 +722,8 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
   in
   let context =
     C.create ~dacc_prior_to_sets:dacc ~simplify_function_body
-      ~all_sets_of_closures:[set_of_closures]
+      ~all_sets_of_closures:
+        [set_of_closures, Alloc_mode.For_allocations.as_type alloc_mode]
       ~closure_bound_names_all_sets:[closure_bound_names]
       ~value_slot_types_all_sets:[value_slot_types]
   in
@@ -733,8 +731,10 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
     C.closure_bound_names_inside_functions_exactly_one_set context
   in
   let { set_of_closures; dacc } =
-    simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
-      ~closure_bound_names_inside ~value_slots ~value_slot_types
+    simplify_set_of_closures0 dacc context set_of_closures
+      (Alloc_mode.For_allocations.as_type alloc_mode)
+      ~closure_bound_names ~closure_bound_names_inside ~value_slots
+      ~value_slot_types
   in
   let closure_symbols_set =
     Symbol.Set.of_list (Function_slot.Lmap.data closure_symbols)
@@ -792,16 +792,19 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
   in
   Simplify_named_result.create_have_lifted_set_of_closures
     (DA.with_denv dacc denv) bindings
-    ~original_defining_expr:(Named.create_set_of_closures set_of_closures)
+    ~original_defining_expr:
+      (Named.create_set_of_closures ~alloc_mode set_of_closures)
 
 let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
-    set_of_closures ~value_slots ~value_slot_types ~simplify_function_body =
+    set_of_closures alloc_mode ~value_slots ~value_slot_types
+    ~simplify_function_body =
   let closure_bound_names =
     Function_slot.Map.map Bound_name.create_var closure_bound_vars
   in
   let context =
     C.create ~dacc_prior_to_sets:dacc ~simplify_function_body
-      ~all_sets_of_closures:[set_of_closures]
+      ~all_sets_of_closures:
+        [set_of_closures, Alloc_mode.For_allocations.as_type alloc_mode]
       ~closure_bound_names_all_sets:[closure_bound_names]
       ~value_slot_types_all_sets:[value_slot_types]
   in
@@ -812,6 +815,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     if Name_mode.is_normal (Bound_pattern.name_mode bound_vars)
     then
       simplify_set_of_closures0 dacc context set_of_closures
+        (Alloc_mode.For_allocations.as_type alloc_mode)
         ~closure_bound_names ~closure_bound_names_inside ~value_slots
         ~value_slot_types
     else
@@ -853,13 +857,12 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
                (Set_of_closures.function_decls set_of_closures))
         in
         Set_of_closures.create ~value_slots
-          (Set_of_closures.alloc_mode set_of_closures)
           (Function_declarations.create function_decls)
       in
       { set_of_closures; dacc }
   in
+  let named = Named.create_set_of_closures ~alloc_mode set_of_closures in
   let defining_expr =
-    let named = Named.create_set_of_closures set_of_closures in
     let find_code_characteristics code_id =
       let env = Downwards_acc.denv dacc in
       let code_metadata =
@@ -876,9 +879,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     in
     let machine_width = DE.machine_width (DA.denv dacc) in
     Simplified_named.create_with_known_free_names ~machine_width
-      ~find_code_characteristics
-      (Named.create_set_of_closures set_of_closures)
-      ~free_names:(Named.free_names named)
+      ~find_code_characteristics named ~free_names:(Named.free_names named)
   in
   let dacc =
     DA.map_denv dacc
@@ -890,8 +891,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     (Expr_builder.Keep_binding
        { let_bound = bound_vars;
          simplified_defining_expr = defining_expr;
-         original_defining_expr =
-           Some (Named.create_set_of_closures set_of_closures)
+         original_defining_expr = Some named (* CR ncourant: this is strange *)
        })
 
 type lifting_decision_result =
@@ -902,7 +902,8 @@ type lifting_decision_result =
   }
 
 let type_value_slots_and_make_lifting_decision_for_one_set dacc
-    ~name_mode_of_bound_vars set_of_closures =
+    ~name_mode_of_bound_vars set_of_closures
+    (alloc_mode : Alloc_mode.For_types.t) =
   (* By computing the types of the closure elements, attempt to show that the
      set of closures can be lifted, and hence statically allocated. Note that
      simplifying the bodies of the functions won't change the set-of-closures'
@@ -971,8 +972,8 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
     Variable.Map.mem var symbol_projections
     || DE.is_defined_at_toplevel (DA.denv dacc) var
        &&
-       match Set_of_closures.alloc_mode set_of_closures with
-       | Local _ -> (
+       match alloc_mode with
+       | Local | Heap_or_local -> (
          match
            T.never_holds_locally_allocated_values (DA.typing_env dacc) var
          with
@@ -994,7 +995,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
   { can_lift; value_slots; value_slot_types; symbol_projections }
 
 let simplify_non_lifted_set_of_closures dacc (bound_vars : Bound_pattern.t)
-    set_of_closures =
+    set_of_closures alloc_mode =
   let closure_bound_vars = Bound_pattern.must_be_set_of_closures bound_vars in
   (* CR-someday mshinwell: This should probably be handled differently, but will
      require some threading through *)
@@ -1013,14 +1014,16 @@ let simplify_non_lifted_set_of_closures dacc (bound_vars : Bound_pattern.t)
   let { can_lift; value_slots; value_slot_types; symbol_projections } =
     type_value_slots_and_make_lifting_decision_for_one_set dacc
       ~name_mode_of_bound_vars set_of_closures
+      (Alloc_mode.For_allocations.as_type alloc_mode)
   in
   if can_lift
   then
     simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
-      ~closure_bound_vars set_of_closures ~value_slots ~symbol_projections
+      ~closure_bound_vars set_of_closures alloc_mode ~value_slots
+      ~symbol_projections
   else
     simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
-      set_of_closures ~value_slots ~value_slot_types
+      set_of_closures alloc_mode ~value_slots ~value_slot_types
 
 let simplify_lifted_set_of_closures0 dacc context ~closure_symbols
     ~closure_bound_names_inside ~value_slots ~value_slot_types set_of_closures =
@@ -1029,8 +1032,9 @@ let simplify_lifted_set_of_closures0 dacc context ~closure_symbols
     |> Function_slot.Lmap.bindings |> Function_slot.Map.of_list
   in
   let { set_of_closures; dacc } =
-    simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
-      ~closure_bound_names_inside ~value_slots ~value_slot_types
+    simplify_set_of_closures0 dacc context set_of_closures
+      Alloc_mode.For_types.heap ~closure_bound_names ~closure_bound_names_inside
+      ~value_slots ~value_slot_types
   in
   let find_code_metadata code_id =
     let env = DA.denv dacc in
@@ -1067,17 +1071,22 @@ end
 
 let simplify_lifted_sets_of_closures dacc ~all_sets_of_closures_and_symbols
     ~closure_bound_names_all_sets ~simplify_function_body =
-  let all_sets_of_closures = List.map snd all_sets_of_closures_and_symbols in
+  let all_sets_of_closures =
+    List.map
+      (fun (_symbols, set_of_closures) ->
+        set_of_closures, Alloc_mode.For_types.heap)
+      all_sets_of_closures_and_symbols
+  in
   let value_slots_and_types_all_sets =
     List.map
-      (fun set_of_closures ->
+      (fun (set_of_closures, alloc_mode) ->
         let { can_lift = _;
               value_slots;
               value_slot_types;
               symbol_projections = _
             } =
           type_value_slots_and_make_lifting_decision_for_one_set dacc
-            ~name_mode_of_bound_vars:Name_mode.normal set_of_closures
+            ~name_mode_of_bound_vars:Name_mode.normal set_of_closures alloc_mode
         in
         value_slots, value_slot_types)
       all_sets_of_closures

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.mli
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.mli
@@ -31,6 +31,7 @@ val simplify_non_lifted_set_of_closures :
   Downwards_acc.t ->
   Bound_pattern.t ->
   Set_of_closures.t ->
+  Alloc_mode.For_allocations.t ->
   simplify_function_body:Simplify_common.simplify_function_body ->
   Simplify_named_result.t
 

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -91,7 +91,7 @@ let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
   in
   let closure_types_inside_functions =
     List.map2
-      (fun set_of_closures
+      (fun (set_of_closures, alloc_mode)
            (closure_types_via_aliases, value_slot_types_inside_function) ->
         let function_decls = Set_of_closures.function_decls set_of_closures in
         let all_function_slots_in_set =
@@ -148,8 +148,7 @@ let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
             T.exactly_this_closure function_slot ~all_function_slots_in_set
               ~all_closure_types_in_set:closure_types_via_aliases
               ~all_value_slots_in_set:value_slot_types_inside_function
-              (Alloc_mode.For_allocations.as_type
-                 (Set_of_closures.alloc_mode set_of_closures)))
+              alloc_mode)
           all_function_slots_in_set)
       all_sets_of_closures
       (List.combine closure_types_via_aliases_all_sets
@@ -201,7 +200,7 @@ let bind_closure_types_inside_functions denv_inside_functions
 
 let compute_old_to_new_code_ids_all_sets denv ~all_sets_of_closures =
   List.fold_left
-    (fun old_to_new_code_ids_all_sets set_of_closures ->
+    (fun old_to_new_code_ids_all_sets (set_of_closures, _alloc_mode) ->
       let function_decls = Set_of_closures.function_decls set_of_closures in
       Function_slot.Map.fold
         (fun _

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.mli
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.mli
@@ -26,7 +26,7 @@ type t
 val create :
   dacc_prior_to_sets:DA.t ->
   simplify_function_body:Simplify_common.simplify_function_body ->
-  all_sets_of_closures:Set_of_closures.t list ->
+  all_sets_of_closures:(Set_of_closures.t * Alloc_mode.For_types.t) list ->
   closure_bound_names_all_sets:Bound_name.t Function_slot.Map.t list ->
   value_slot_types_all_sets:T.t Value_slot.Map.t list ->
   t

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -81,7 +81,7 @@ and let_expr =
 and named =
   | Simple of Simple.t
   | Prim of Flambda_primitive.t * Debuginfo.t
-  | Set_of_closures of Set_of_closures.t
+  | Set_of_closures of Set_of_closures.t * Alloc_mode.For_allocations.t
   | Static_consts of static_const_group
   | Rec_info of Rec_info_expr.t
 
@@ -175,9 +175,14 @@ and apply_renaming_named (named : named) renaming : named =
   | Prim (prim, dbg) ->
     let prim' = Flambda_primitive.apply_renaming prim renaming in
     if prim == prim' then named else Prim (prim', dbg)
-  | Set_of_closures set ->
+  | Set_of_closures (set, alloc_mode) ->
     let set' = Set_of_closures.apply_renaming set renaming in
-    if set == set' then named else Set_of_closures set'
+    let alloc_mode' =
+      Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
+    in
+    if set == set' && alloc_mode == alloc_mode'
+    then named
+    else Set_of_closures (set', alloc_mode')
   | Static_consts consts ->
     let consts' = apply_renaming_static_const_group consts renaming in
     if consts == consts' then named else Static_consts consts'
@@ -391,7 +396,10 @@ and ids_for_export_named t =
   match t with
   | Simple simple -> Ids_for_export.from_simple simple
   | Prim (prim, _dbg) -> Flambda_primitive.ids_for_export prim
-  | Set_of_closures set -> Set_of_closures.ids_for_export set
+  | Set_of_closures (set, alloc_mode) ->
+    Ids_for_export.union
+      (Set_of_closures.ids_for_export set)
+      (Alloc_mode.For_allocations.ids_for_export alloc_mode)
   | Static_consts consts -> ids_for_export_static_const_group consts
   | Rec_info rec_info_expr -> Rec_info_expr.ids_for_export rec_info_expr
 
@@ -887,7 +895,9 @@ and print_named ppf (t : named) =
   | Prim (prim, dbg) ->
     fprintf ppf "@[<hov 1>(%a%t%a%t)@]" Flambda_primitive.print prim
       Flambda_colours.debuginfo print_or_elide_debuginfo dbg Flambda_colours.pop
-  | Set_of_closures set_of_closures -> Set_of_closures.print ppf set_of_closures
+  | Set_of_closures (set_of_closures, alloc_mode) ->
+    fprintf ppf "%a@ (alloc_mode@ %a)" Set_of_closures.print set_of_closures
+      Alloc_mode.For_allocations.print alloc_mode
   | Static_consts consts -> print_static_const_group ppf consts
   | Rec_info rec_info_expr -> Rec_info_expr.print ppf rec_info_expr
 
@@ -1378,7 +1388,8 @@ module Named = struct
 
   let create_prim prim dbg = Prim (prim, dbg)
 
-  let create_set_of_closures set_of_closures = Set_of_closures set_of_closures
+  let create_set_of_closures ~alloc_mode set_of_closures =
+    Set_of_closures (set_of_closures, alloc_mode)
 
   let create_static_consts consts = Static_consts consts
 
@@ -1388,7 +1399,10 @@ module Named = struct
     match t with
     | Simple simple -> Simple.free_names simple
     | Prim (prim, _dbg) -> Flambda_primitive.free_names prim
-    | Set_of_closures set -> Set_of_closures.free_names set
+    | Set_of_closures (set, alloc_mode) ->
+      Name_occurrences.union
+        (Set_of_closures.free_names set)
+        (Alloc_mode.For_allocations.free_names alloc_mode)
     | Static_consts consts -> Static_const_group.free_names consts
     | Rec_info rec_info_expr -> Rec_info_expr.free_names rec_info_expr
 
@@ -1466,7 +1480,7 @@ module Named = struct
 
   let fold_code_and_sets_of_closures t ~init ~f_code ~f_set =
     match t with
-    | Set_of_closures s -> f_set init s
+    | Set_of_closures (s, _alloc_mode) -> f_set init s
     | Rec_info _ | Simple _ | Prim _ -> init
     | Static_consts group ->
       Static_const_group.to_list group

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -896,8 +896,11 @@ and print_named ppf (t : named) =
     fprintf ppf "@[<hov 1>(%a%t%a%t)@]" Flambda_primitive.print prim
       Flambda_colours.debuginfo print_or_elide_debuginfo dbg Flambda_colours.pop
   | Set_of_closures (set_of_closures, alloc_mode) ->
-    fprintf ppf "%a@ (alloc_mode@ %a)" Set_of_closures.print set_of_closures
-      Alloc_mode.For_allocations.print alloc_mode
+    Set_of_closures.print_with_extra_fields
+      (fun ppf ->
+        Format.fprintf ppf "@[<hov 1>(alloc_mode@ %a)@]@ "
+          Alloc_mode.For_allocations.print alloc_mode)
+      ppf set_of_closures
   | Static_consts consts -> print_static_const_group ppf consts
   | Rec_info rec_info_expr -> Rec_info_expr.print ppf rec_info_expr
 

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -73,7 +73,7 @@ and named = private
           do not have to be [Let]-bound but are allowed here for convenience. *)
   | Prim of Flambda_primitive.t * Debuginfo.t
       (** Primitive operations (arithmetic, memory access, allocation, etc). *)
-  | Set_of_closures of Set_of_closures.t
+  | Set_of_closures of Set_of_closures.t * Alloc_mode.For_allocations.t
       (** Definition of a set of (dynamically allocated) possibly
           mutually-recursive closures. *)
   | Static_consts of static_const_group
@@ -176,7 +176,8 @@ module Named : sig
   val create_prim : Flambda_primitive.t -> Debuginfo.t -> t
 
   (** Convert a set of closures into the defining expression of a [Let]. *)
-  val create_set_of_closures : Set_of_closures.t -> t
+  val create_set_of_closures :
+    alloc_mode:Alloc_mode.For_allocations.t -> Set_of_closures.t -> t
 
   (** Convert one or more statically-allocated constants into the defining
       expression of a [Let]. *)

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -19,18 +19,22 @@ type t =
     value_slots : Simple.t Value_slot.Map.t
   }
 
-let [@ocamlformat "disable"] print ppf
+let [@ocamlformat "disable"] print_with_extra_fields extra_fields ppf
       { function_decls;
         value_slots
       } =
   Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ \
+      %t\
       @[<hov 1>(function_decls@ %a)@]@ \
       @[<hov 1>(value_slots@ %a)@]\
       )@]"
     Flambda_colours.prim_constructive
     Flambda_colours.pop
+    extra_fields
     (Function_declarations.print) function_decls
     (Value_slot.Map.print Simple.print) value_slots
+
+let print ppf t = print_with_extra_fields (fun _ppf -> ()) ppf t
 
 include Container_types.Make (struct
   type nonrec t = t

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -16,25 +16,21 @@
 
 type t =
   { function_decls : Function_declarations.t;
-    value_slots : Simple.t Value_slot.Map.t;
-    alloc_mode : Alloc_mode.For_allocations.t
+    value_slots : Simple.t Value_slot.Map.t
   }
 
 let [@ocamlformat "disable"] print ppf
       { function_decls;
-        value_slots;
-        alloc_mode;
+        value_slots
       } =
   Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ \
       @[<hov 1>(function_decls@ %a)@]@ \
-      @[<hov 1>(value_slots@ %a)@]@ \
-      @[<hov 1>(alloc_mode@ %a)@]\
+      @[<hov 1>(value_slots@ %a)@]\
       )@]"
     Flambda_colours.prim_constructive
     Flambda_colours.pop
     (Function_declarations.print) function_decls
     (Value_slot.Map.print Simple.print) value_slots
-    Alloc_mode.For_allocations.print alloc_mode
 
 include Container_types.Make (struct
   type nonrec t = t
@@ -43,67 +39,50 @@ include Container_types.Make (struct
 
   let hash _ = Misc.fatal_error "Not yet implemented"
 
-  let compare
-      { function_decls = function_decls1;
-        value_slots = value_slots1;
-        alloc_mode = alloc_mode1
-      }
-      { function_decls = function_decls2;
-        value_slots = value_slots2;
-        alloc_mode = alloc_mode2
-      } =
+  let compare { function_decls = function_decls1; value_slots = value_slots1 }
+      { function_decls = function_decls2; value_slots = value_slots2 } =
     let c = Function_declarations.compare function_decls1 function_decls2 in
     if c <> 0
     then c
-    else
-      let c = Value_slot.Map.compare Simple.compare value_slots1 value_slots2 in
-      if c <> 0
-      then c
-      else Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2
+    else Value_slot.Map.compare Simple.compare value_slots1 value_slots2
 
   let equal t1 t2 = compare t1 t2 = 0
 end)
 
-let is_empty { function_decls; value_slots; alloc_mode = _ } =
+let is_empty { function_decls; value_slots } =
   Function_declarations.is_empty function_decls
   && Value_slot.Map.is_empty value_slots
 
-let create ~value_slots alloc_mode function_decls =
-  { function_decls; value_slots; alloc_mode }
+let create ~value_slots function_decls = { function_decls; value_slots }
 
 let function_decls t = t.function_decls
 
 let value_slots t = t.value_slots
-
-let alloc_mode t = t.alloc_mode
 
 let is_closed t = Value_slot.Map.is_empty t.value_slots
 
 let [@ocamlformat "disable"] print ppf
       { function_decls;
         value_slots;
-        alloc_mode;
       } =
   if Value_slot.Map.is_empty value_slots then
-    Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ %a@ \
+    Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ \
         @[<hov 1>%a@]\
         )@]"
       Flambda_colours.prim_constructive
       Flambda_colours.pop
-      Alloc_mode.For_allocations.print alloc_mode
       (Function_declarations.print) function_decls
   else
-    Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ %a@ \
+    Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ \
         @[<hov 1>%a@]@ \
         @[<hov 1>(env@ %a)@]\
         )@]"
       Flambda_colours.prim_constructive
       Flambda_colours.pop
-      Alloc_mode.For_allocations.print alloc_mode
       Function_declarations.print function_decls
       (Value_slot.Map.print Simple.print) value_slots
 
-let free_names { function_decls; value_slots; alloc_mode } =
+let free_names { function_decls; value_slots } =
   let free_names_of_value_slots =
     Value_slot.Map.fold
       (fun value_slot simple free_names ->
@@ -112,15 +91,11 @@ let free_names { function_decls; value_slots; alloc_mode } =
              (Simple.free_names simple) value_slot Name_mode.normal))
       value_slots Name_occurrences.empty
   in
-  Name_occurrences.union_list
-    [ Function_declarations.free_names function_decls;
-      free_names_of_value_slots;
-      Alloc_mode.For_allocations.free_names alloc_mode ]
+  Name_occurrences.union
+    (Function_declarations.free_names function_decls)
+    free_names_of_value_slots
 
-let apply_renaming ({ function_decls; value_slots; alloc_mode } as t) renaming =
-  let alloc_mode' =
-    Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
-  in
+let apply_renaming ({ function_decls; value_slots } as t) renaming =
   let function_decls' =
     Function_declarations.apply_renaming function_decls renaming
   in
@@ -138,26 +113,17 @@ let apply_renaming ({ function_decls; value_slots; alloc_mode } as t) renaming =
           None))
       value_slots
   in
-  if
-    alloc_mode == alloc_mode'
-    && function_decls == function_decls'
-    && not !changed
+  if function_decls == function_decls' && not !changed
   then t
-  else
-    { function_decls = function_decls';
-      value_slots = value_slots';
-      alloc_mode = alloc_mode'
-    }
+  else { function_decls = function_decls'; value_slots = value_slots' }
 
-let ids_for_export { function_decls; value_slots; alloc_mode } =
+let ids_for_export { function_decls; value_slots } =
   let function_decls_ids =
     Function_declarations.ids_for_export function_decls
   in
-  Ids_for_export.union
-    (Value_slot.Map.fold
-       (fun _value_slot simple ids -> Ids_for_export.add_simple ids simple)
-       value_slots function_decls_ids)
-    (Alloc_mode.For_allocations.ids_for_export alloc_mode)
+  Value_slot.Map.fold
+    (fun _value_slot simple ids -> Ids_for_export.add_simple ids simple)
+    value_slots function_decls_ids
 
 let filter_function_declarations t ~f =
   let function_decls = Function_declarations.filter t.function_decls ~f in

--- a/middle_end/flambda2/terms/set_of_closures.mli
+++ b/middle_end/flambda2/terms/set_of_closures.mli
@@ -25,10 +25,7 @@ val is_empty : t -> bool
 (** Create a set of closures given the code for its functions and the closure
     variables. *)
 val create :
-  value_slots:Simple.t Value_slot.Map.t ->
-  Alloc_mode.For_allocations.t ->
-  Function_declarations.t ->
-  t
+  value_slots:Simple.t Value_slot.Map.t -> Function_declarations.t -> t
 
 (** The function declarations associated with the set of closures. *)
 val function_decls : t -> Function_declarations.t
@@ -38,8 +35,6 @@ val value_slots : t -> Simple.t Value_slot.Map.t
 
 (** Returns true iff the given set of closures has no value slots. *)
 val is_closed : t -> bool
-
-val alloc_mode : t -> Alloc_mode.For_allocations.t
 
 val filter_function_declarations :
   t ->

--- a/middle_end/flambda2/terms/set_of_closures.mli
+++ b/middle_end/flambda2/terms/set_of_closures.mli
@@ -20,6 +20,9 @@ include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
 
+val print_with_extra_fields :
+  (Format.formatter -> unit) -> Format.formatter -> t -> unit
+
 val is_empty : t -> bool
 
 (** Create a set of closures given the code for its functions and the closure

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -781,9 +781,9 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     cmm, free_vars, symbol_inits, res
   | Singleton v, Prim (p, dbg) ->
     let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
-  | Set_of_closures bound_vars, Set_of_closures soc ->
+  | Set_of_closures bound_vars, Set_of_closures (soc, alloc_mode) ->
     To_cmm_set_of_closures.let_dynamic_set_of_closures env res ~body ~bound_vars
-      ~num_normal_occurrences_of_bound_vars soc ~translate_expr:expr
+      ~num_normal_occurrences_of_bound_vars soc alloc_mode ~translate_expr:expr
   | Static bound_static, Static_consts consts -> (
     let env, res, update_opt =
       To_cmm_static.static_consts env res

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -827,8 +827,8 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   translate_expr env res body
 
 let let_dynamic_set_of_closures env res ~body ~bound_vars
-    ~num_normal_occurrences_of_bound_vars set ~(translate_expr : translate_expr)
-    =
+    ~num_normal_occurrences_of_bound_vars set closure_alloc_mode
+    ~(translate_expr : translate_expr) =
   let layout = layout_for_set_of_closures env set in
   if layout.empty_env
   then
@@ -836,6 +836,5 @@ let let_dynamic_set_of_closures env res ~body ~bound_vars
       ~num_normal_occurrences_of_bound_vars
   else
     let_dynamic_set_of_closures0 env res ~body ~bound_vars
-      ~num_normal_occurrences_of_bound_vars set layout
-      ~closure_alloc_mode:(Set_of_closures.alloc_mode set)
+      ~num_normal_occurrences_of_bound_vars set layout ~closure_alloc_mode
       ~translate_expr

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -43,6 +43,7 @@ val let_dynamic_set_of_closures :
   bound_vars:Bound_var.t list ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   Set_of_closures.t ->
+  Alloc_mode.For_allocations.t ->
   translate_expr:translate_expr ->
   Cmm.expression
   * To_cmm_env.free_vars

--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -125,7 +125,7 @@ and let_expr_normal ~env ~res e ~(bound_pattern : Bound_pattern.t)
       let fvar = Bound_var.var v in
       To_jsir_result.with_debuginfo_exn res dbg ~f:(fun res ->
           create_let_prim ~env ~res fvar p)
-    | Set_of_closures bound_vars, Set_of_closures soc ->
+    | Set_of_closures bound_vars, Set_of_closures (soc, _alloc_mode) ->
       To_jsir_set_of_closures.dynamic_set_of_closures ~env ~res ~bound_vars soc
     | Static bound_static, Static_consts consts ->
       (* Definitions within this group can reference each others' symbols


### PR DESCRIPTION
Set of closures which are lifted at toplevel must still carry an alloc mode, for which we put `Heap`. However, this will no longer work well with zero_alloc regions, for which `Heap` must still take a current alloc region, causing a whole lot of problems. This PR cleans up the code by removing alloc_mode from `Set_of_closures.t`, leaving an alloc_mode only for set of closures which are not at toplevel.