### PR TITLE
flambda2: Erase all in-types depth variables

### DIFF
--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
@@ -59,19 +59,52 @@ type on_unknown =
 let rec simplify_rec_info_expr0 denv orig ~on_unknown : Rec_info_expr.t =
   match (orig : Rec_info_expr.t) with
   | Const _ -> orig
-  | Var dv -> (
-    let ty = TE.find (DE.typing_env denv) (Name.var dv) (Some K.rec_info) in
-    match T.meet_rec_info (DE.typing_env denv) ty with
-    | Known_result rec_info_expr ->
-      (* All bound names are fresh, so fine to use the same environment *)
-      simplify_rec_info_expr0 denv rec_info_expr ~on_unknown
-    | Need_meet -> (
-      match on_unknown with
-      | Leave_unevaluated -> orig
-      | Assume_value value -> value)
-    | Invalid ->
-      (* Shouldn't currently be possible *)
-      Misc.fatal_errorf "Invalid result from [check_rec_info] of %a" T.print ty)
+  | Var dv ->
+    let[@local] normal_case () =
+      let ty = TE.find (DE.typing_env denv) (Name.var dv) (Some K.rec_info) in
+      match T.meet_rec_info (DE.typing_env denv) ty with
+      | Known_result rec_info_expr ->
+        (* All bound names are fresh, so fine to use the same environment *)
+        simplify_rec_info_expr0 denv rec_info_expr ~on_unknown
+      | Need_meet -> (
+        match on_unknown with
+        | Leave_unevaluated -> orig
+        | Assume_value value -> value)
+      | Invalid ->
+        (* Shouldn't currently be possible *)
+        Misc.fatal_errorf "Invalid result from [check_rec_info] of %a" T.print
+          ty
+    in
+    (* Normally, we would expect that all variables appearing in a
+       [Rec_info_expr] are available in the current context.
+
+       However, when the "erase in-types depth variables" flag is set, we might
+       see depth variables appearing inside coercions that only exist at the
+       [In_types] name mode: these come from the value slots of the current
+       closure. Without that flag, we would have explicitly set those variables
+       to have type [Rec_info_expr.do_not_inline]; but with the flag, we have
+       left them as is when entering the set of closures and need to replace
+       them with [Rec_info_expr.do_not_inline] explicitly here.
+
+       mshinwell: Leo and I have discussed allowing In_types variables in
+       closures, which should cover this case, if we allowed such variables to
+       be of kinds other than [Value]. *)
+    if Flambda_features.erase_in_types_depth_variables ()
+    then
+      (* Note that we use [get_canonical_simple_exn] to check if the variable
+         has an alias at [Normal] name mode, rather than simply checking (with
+         [TE.mem ~min_name_mode]) that the variable itself has [Normal] name
+         mode.
+
+         While it is unlikely to matter, checking the canonical is more robust
+         and avoids accidentally preventing more inlining than necessary. *)
+      match
+        TE.get_canonical_simple_exn (DE.typing_env denv)
+          ~min_name_mode:Name_mode.normal (Simple.var dv)
+      with
+      | exception Not_found -> Rec_info_expr.do_not_inline
+      | _canonical -> normal_case ()
+    else normal_case ()
   | Succ ri -> (
     match simplify_rec_info_expr0 denv ri ~on_unknown with
     | Const { depth; unrolling } -> compute_succ ~depth ~unrolling

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -247,41 +247,24 @@ let bind_existing_code_to_new_code_ids denv ~old_to_new_code_ids_all_sets =
         else denv)
     old_to_new_code_ids_all_sets denv
 
-let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
-    ~closure_bound_names_all_sets ~value_slot_types_all_sets =
-  let denv = DA.denv dacc_prior_to_sets in
-  let denv_inside_functions =
-    DE.enter_set_of_closures denv ~in_stub:false
-    (* Even if we are not rebuilding terms we should always rebuild them for
-       local functions. The type of a function is dependent on its term and not
-       knowing it prohibits us from inlining it. *)
-    |> DE.set_rebuild_terms
-  in
-  let free_depth_variables =
-    List.concat_map
-      (fun value_slot_types ->
-        Value_slot.Map.mapi
-          (fun _value_slot ty ->
-            let vars = TE.free_names_transitive (DE.typing_env denv) ty in
-            NO.fold_variables vars ~init:Variable.Set.empty
-              ~f:(fun free_depth_variables var ->
-                let ty =
-                  TE.find
-                    (DE.typing_env denv_inside_functions)
-                    (Name.var var) None
-                in
-                match T.kind ty with
-                | Rec_info -> Variable.Set.add var free_depth_variables
-                | Value | Naked_number _ | Region -> free_depth_variables))
-          value_slot_types
-        |> Value_slot.Map.data)
-      value_slot_types_all_sets
-    |> Variable.Set.union_list
-  in
-  (* Pretend that any depth variables appearing free in the closure elements are
-     bound to "never inline anything" in the function. This ensures that
-     in-types depth variables do not end up in terms. *)
-  (* CR-someday lmaurer: It would be better to propagate depth variables into
+let compute_and_erase_depth_variables ~typing_env ~denv_inside_functions
+    ~value_slot_types_all_sets =
+  (* The purpose of the code below is to compute the set of depth variables that
+     appear in value slots and might end up free in the body of the function
+     through simplification of the [Project_value_slot] primitive. This would be
+     wrong, because these depth variables are not accessible from the closure
+     (they are now bound with [In_types] name mode, and cannot appear in terms).
+     See discussion below for details.
+
+     If the "erase in-types depth variables" option is set, we don't have to do
+     anything here: instead, any depth variable with [In_types] that is actually
+     accessed during the simplification of the function's body will be replaced
+     with [Rec_info_expr.do_not_inline] in by [simplify_rec_info_expr]. This is
+     important for performance, as the computation of the transitive free names
+     below can be extremely expensive (upwards of 5% of the total compilation
+     time in pathological cases).
+
+     CR-someday lmaurer: It would be better to propagate depth variables into
      closures properly, as this would allow things like unrolling [Seq.map]
      where the recursive call goes through a closure. For the moment, we often
      just stop unrolling cold in that situation. (It's important that we use
@@ -292,22 +275,65 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
      mshinwell: Leo and I have discussed allowing In_types variables in
      closures, which should cover this case, if we allowed such variables to be
      of kinds other than [Value]. *)
+  if Flambda_features.erase_in_types_depth_variables ()
+  then denv_inside_functions, Variable.Set.empty
+  else
+    let free_depth_variables =
+      List.concat_map
+        (fun value_slot_types ->
+          Value_slot.Map.mapi
+            (fun _value_slot ty ->
+              let vars = TE.free_names_transitive typing_env ty in
+              NO.fold_variables vars ~init:Variable.Set.empty
+                ~f:(fun free_depth_variables var ->
+                  let ty =
+                    TE.find
+                      (DE.typing_env denv_inside_functions)
+                      (Name.var var) None
+                  in
+                  match T.kind ty with
+                  | Rec_info -> Variable.Set.add var free_depth_variables
+                  | Value | Naked_number _ | Region -> free_depth_variables))
+            value_slot_types
+          |> Value_slot.Map.data)
+        value_slot_types_all_sets
+      |> Variable.Set.union_list
+    in
+    (* Pretend that any depth variables appearing free in the closure elements
+       are bound to "never inline anything" in the function. This ensures that
+       in-types depth variables do not end up in terms. *)
+    let denv_inside_functions =
+      Variable.Set.fold
+        (fun dv env_inside_functions ->
+          let name = Name.var dv in
+          DE.add_equation_on_name env_inside_functions name
+            (T.this_rec_info Rec_info_expr.do_not_inline))
+        free_depth_variables denv_inside_functions
+    in
+    denv_inside_functions, free_depth_variables
+
+let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
+    ~closure_bound_names_all_sets ~value_slot_types_all_sets =
+  let denv = DA.denv dacc_prior_to_sets in
   let denv_inside_functions =
-    Variable.Set.fold
-      (fun dv env_inside_functions ->
-        let name = Name.var dv in
-        DE.add_equation_on_name env_inside_functions name
-          (T.this_rec_info Rec_info_expr.do_not_inline))
-      free_depth_variables denv_inside_functions
+    DE.enter_set_of_closures denv ~in_stub:false
+    (* Even if we are not rebuilding terms we should always rebuild them for
+       local functions. The type of a function is dependent on its term and not
+       knowing it prohibits us from inlining it. *)
+    |> DE.set_rebuild_terms
   in
-  let value_slot_types_inside_functions_all_sets = value_slot_types_all_sets in
+  let denv_inside_functions, previously_free_depth_variables =
+    compute_and_erase_depth_variables ~typing_env:(DE.typing_env denv)
+      ~denv_inside_functions ~value_slot_types_all_sets
+  in
   let old_to_new_code_ids_all_sets =
     compute_old_to_new_code_ids_all_sets denv ~all_sets_of_closures
   in
   let ( closure_bound_names_inside_functions_all_sets,
         closure_types_inside_functions_all_sets ) =
     compute_closure_types_inside_functions ~denv ~all_sets_of_closures
-      ~closure_bound_names_all_sets ~value_slot_types_inside_functions_all_sets
+      ~closure_bound_names_all_sets
+      ~value_slot_types_inside_functions_all_sets:value_slot_types_all_sets
       ~old_to_new_code_ids_all_sets
   in
   let dacc_inside_functions =
@@ -323,5 +349,5 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
     closure_bound_names_inside_functions_all_sets;
     old_to_new_code_ids_all_sets;
     simplify_function_body;
-    previously_free_depth_variables = free_depth_variables
+    previously_free_depth_variables
   }

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -178,6 +178,10 @@ let dump_reaper () = !Oxcaml_flags.Flambda2.Dump.reaper
 
 let freshen_when_printing () = !Oxcaml_flags.Flambda2.Dump.freshen
 
+let erase_in_types_depth_variables =
+  Oxcaml_args.Extra_options.bool __LOC__
+    "flambda2-erase-in-types-depth-variables"
+
 module Inlining = struct
   module I = Oxcaml_flags.Flambda2.Inlining
   module IH = Clflags.Int_arg_helper

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -123,6 +123,8 @@ val dump_reaper : unit -> bool
 
 val freshen_when_printing : unit -> bool
 
+val erase_in_types_depth_variables : unit -> bool
+
 module Inlining : sig
   type round_or_default =
     | Round of int


### PR DESCRIPTION
This patch removes the transitive computation of the free names of value
slots when simplifying a set of closures, which is only used to capture
the depth variables occuring in the value slots of the closure and could
thus appear at the "in types" name mode inside the closure, replacing
them with `Rec_info_expr.do_not_inline`.

Instead, we simply replace *all* the depth variables occuring at the "in
types" name mode with `Rec_info_expr.do_not_inline` when we simplify a
`Rec_info_expr` (and in particular, within coercions, where those
variables would occur).

This PR gates the implementation behind a flag (`-X
flambda2-erase-in-types-depth-variables=1`), but the intent is to make
that the default very quickly, the only risk being a compiler failure if
there are some places where we don't simplify the `Rec_info_expr`s.

This computation of the transitive free names can be very expensive: on
the compiler's `typing/mode.ml` file this reduces the total compilation
time by more than 10% on my laptop:

> Benchmark 1: new
>   Time (mean ± σ):      4.067 s ±  0.023 s    [User: 3.833 s, System: 0.211 s]
>   Range (min … max):    4.032 s …  4.107 s    10 runs
>  
> Benchmark 2: old
>   Time (mean ± σ):      4.619 s ±  0.026 s    [User: 4.377 s, System: 0.216 s]
>   Range (min … max):    4.584 s …  4.660 s    10 runs
>  
> Summary
>   new ran
>     1.14 ± 0.01 times faster than old

Note: this is rebased on top of #6100 