### PR TITLE
Instance type constructors in typeopt

### DIFF
--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -385,7 +385,8 @@ let _ =fun a b -> match a, b with
 (function {nlocal = 0} a/9[value<int>]
   b/9[value<
        (consts (0))
-        (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        (non_consts ([0:
+                      value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch
@@ -402,7 +403,8 @@ let _ =fun a b -> match a, b with
 (function {nlocal = 0} a/9[value<int>]
   b/9[value<
        (consts (0))
-        (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        (non_consts ([0:
+                      value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch (if a/9 (if b/9 (field_imm 0 b/9) (exit 42)) (exit 42)) with (42)
@@ -418,7 +420,8 @@ let _ = fun a b -> match a, b with
 (function {nlocal = 0} a/10[value<int>]
   b/10[value<
         (consts (0))
-         (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+         (non_consts ([0:
+                       value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch
@@ -443,7 +446,8 @@ let _ = fun a b -> match a, b with
 (function {nlocal = 0} a/10[value<int>]
   b/10[value<
         (consts (0))
-         (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+         (non_consts ([0:
+                       value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch

--- a/testsuite/tests/flambda/match_in_match_seq.raw.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.raw.reference
@@ -167,7 +167,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
        `fn[match_in_match_seq.ml:55,11--63]_9` (i : imm tagged)
          my_closure _region _ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * val ] =
+         : [ 0 | 0 of imm tagged * imm tagged ] =
    let next_depth = rec_info (succ my_depth) in
    let hi =
      %project_value_slot.[`fn[match_in_match_seq.ml:55,11--63]`].[hi]

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
@@ -11,7 +11,7 @@ let code loopify(never) size(22) newer_version_of(f_0)
       f_0_1 (arr : val array)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of imm tagged ] =
   (let prim = %array_length.generic (arr) in
    let prim_1 = %int_comp.unsigned.lt (0, prim) in
    switch prim_1
@@ -25,10 +25,10 @@ let code loopify(never) size(22) newer_version_of(f_0)
 in
 let $camlArray_specialisation_examples__f_4 = closure f_0_1 @f in
 let code loopify(never) size(8) newer_version_of(g_1)
-      g_1_1 (x : [ 0 | 0 of val ])
+      g_1_1 (x : [ 0 | 0 of imm tagged ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of imm tagged ] =
   let a = %array.mut (x) in
   let ifnot_result = %array_load.mut (a, 0) in
   cont k (ifnot_result)

--- a/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
@@ -37,7 +37,7 @@ let $camlFrom_odoc_texi__foo_3 = closure foo_1_1 @foo in
           in
           let Pmakeblock_1 = %block.[`0`] (Pmakeblock, 0) in
           cont k (Pmakeblock_1)))
-  where k (y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  where k (y : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
     let $camlFrom_odoc_texi =
       Block 0 ($`camlFrom_odoc_texi__!_2`,
                esc_8bits,

--- a/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
@@ -1,6 +1,8 @@
 let code foo_1 deleted in
 let code loopify(never) size(17) newer_version_of(foo_1)
-      foo_1_1 (x : imm tagged, y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      foo_1_1
+        (x : imm tagged,
+         y : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/examples/tests.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests.raw.reference
@@ -10,8 +10,8 @@ let $camlTests__first_const = Block 0 () in
  let code size(79)
        f_1
          (c : imm tagged,
-          m : [ 0 | 0 of val ],
-          n : [ 0 | 0 of val ],
+          m : [ 0 | 0 of imm tagged ],
+          n : [ 0 | 0 of imm tagged ],
           x' : imm tagged,
           y' : imm tagged)
          my_closure _region _ghost_region my_depth

--- a/testsuite/tests/flambda2/examples/tests.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests.simplify.reference
@@ -11,8 +11,8 @@ let $camlTests__to_inline_2 = closure to_inline_0_1 @to_inline in
 let code loopify(never) size(22) newer_version_of(f_1)
       f_1_1
         (c : imm tagged,
-         m : [ 0 | 0 of val ],
-         n : [ 0 | 0 of val ],
+         m : [ 0 | 0 of imm tagged ],
+         n : [ 0 | 0 of imm tagged ],
          x' : imm tagged,
          y' : imm tagged)
         my_closure _region _ghost_region my_depth

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -114,7 +114,7 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
       inv_3_1 (param : [ 0 | 0 of val * val ], param_1, param_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
+        : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ] =
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
@@ -154,10 +154,13 @@ let code loopify(never) size(11) newer_version_of(div_4)
    let tuple_field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (i2) in
    let tuple_field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (i2) in
    apply direct(inv_3_1)
-     ($camlAlt_ergo__inv_8 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+     ($camlAlt_ergo__inv_8
+      : _ -> [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ])
        (tuple_field, tuple_field_1, tuple_field_2)
        -> k3 * k1
-     where k3 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+     where k3
+             (param :
+                [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
        cont k2)
     where k2 =
       cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock106)

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -58,12 +58,20 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
 in
 let $camlEmitcode_repro__emit_instr_4 = closure emit_instr_1_1 @emit_instr in
 let code loopify(done) size(121) newer_version_of(emit_2)
-      emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      emit_2_1
+        (param :
+           [ 0
+           | 0 of [ 0 |1 | 0 of imm tagged |1 of imm tagged ] *
+               [ 0 | 0 of val * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
-    where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+    where rec `self`
+                (param_1 :
+                   [ 0
+                   | 0 of [ 0 |1 | 0 of imm tagged |1 of imm tagged ] *
+                       [ 0 | 0 of val * val ] ]) =
       let `region` = %begin_region () in
       let ghost_region = %begin_ghost_region () in
       ((let prim = %is_int (param_1) in

--- a/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
@@ -1,6 +1,6 @@
 let code f_0 deleted in
 let code loopify(never) size(48) newer_version_of(f_0)
-      f_0_1 (read : val, x : [ 0 | 0 of val ])
+      f_0_1 (read : val, x : [ 0 | 0 of imm tagged ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
@@ -40,7 +40,7 @@ let code loopify(never) size(44) newer_version_of(test_3)
       test_3_1 (x)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of [ 0 of val * val ] ] =
   apply direct(f_1_1)
     ($camlGadt_meet__f_6 : _ -> [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]
      )
@@ -68,7 +68,7 @@ let code loopify(never) size(44) newer_version_of(test_3)
                      cont k (Pmakeblock_1))))
 in
 let $camlGadt_meet__test_8 = closure test_3_1 @test in
-let $camlGadt_meet__Pmakeblock146 =
+let $camlGadt_meet__Pmakeblock149 =
   Block 0 ($`*predef*`.caml_exn_Failure, $camlGadt_meet__immstring59)
 in
 let code loopify(never) size(17) newer_version_of(foo_4)
@@ -77,12 +77,14 @@ let code loopify(never) size(17) newer_version_of(foo_4)
         -> k * k1
         : [ 0 of imm tagged * [ 0 of val |1 of imm tagged ] ] =
   apply direct(test_3_1)
-    ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of val ]) (0) -> k2 * k1
-    where k2 (`*match*` : [ 0 | 0 of val ]) =
+    ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of [ 0 of imm tagged * val ] ])
+      (0)
+      -> k2 * k1
+    where k2 (`*match*` : [ 0 | 0 of [ 0 of imm tagged * val ] ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock146)
+         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock149)
          where k2 =
            let Pfield = %block_load.[`0`] (`*match*`) in
            cont k (Pfield))

--- a/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
@@ -11,7 +11,7 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
            [ 0 of [ 0 |1 | 0 of imm tagged * imm tagged |1 of imm tagged ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ] =
   let `*match*` = %block_load.[`0`] (x) in
   let `*match*_1` = %block_load.[`0`] (y) in
   (let prim = %is_int (`*match*_1`) in
@@ -90,11 +90,12 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
 in
 let $camlIncludecore_repro__f_1 = closure f_0_1 @f in
 apply direct(f_0_1)
-  ($camlIncludecore_repro__f_1 : _ -> [ 0 | 0 of val ])
+  ($camlIncludecore_repro__f_1
+   : _ -> [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ])
     ($camlIncludecore_repro__const_block61,
      $camlIncludecore_repro__const_block61)
     -> k1 * error
-  where k1 (param : [ 0 | 0 of val ]) =
+  where k1 (param : [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ]) =
     cont k
   where k =
     let $camlIncludecore_repro = Block 0 ($camlIncludecore_repro__f_1) in

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -5,7 +5,7 @@
        return_local_0 (param : imm tagged)
          my_closure my_region my_ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+         : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
    cont k1 ($camlLocal__const_block15)
  in
@@ -154,7 +154,7 @@
          (break_here : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure my_region my_ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+         : [ 0 | 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
    let rev_app = %project_value_slot.[spans].[rev_app] (my_closure) in
    let find_span = %project_function_slot.[spans].[find_span] (my_closure) in
@@ -178,12 +178,17 @@
             ((let Pfield = %block_load.[`1`] (`*match*`) in
               apply direct(spans_5 &my_region &my_ghost_region)
                 (my_closure ~ depth my_depth -> next_depth
-                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                 : _ ->
+                   [ 0 | 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ]
+                   ]
+                 )
                   (break_here, Pfield)
                   -> k3 * k2)
                where k3
                        (apply_result :
-                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                          [ 0
+                          | 0 of [ 0 | 0 of val * val ] *
+                              [ 0 | 0 of val * val ] ]) =
                  ((let Pfield = %block_load.[`0`] (`*match*`) in
                    apply direct(rev_app_4 &my_region &my_ghost_region)
                      (rev_app
@@ -262,10 +267,13 @@
      ((let `region` = %begin_region () in
        let ghost_region = %begin_ghost_region () in
        apply direct(return_local_0 &`region` &ghost_region)
-         (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+         (return_local
+          : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
            (0)
            -> k5 * error
-         where k5 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+         where k5
+                 (apply_result :
+                    [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]) =
            apply direct(length_2) unroll(3)
              (length : _ -> imm tagged) (apply_result) -> k4 * error
          where k4 (apply_result : imm tagged) =
@@ -287,20 +295,32 @@
           ((let `region` = %begin_region () in
             let ghost_region = %begin_ghost_region () in
             apply direct(return_local_0 &`region` &ghost_region)
-              (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+              (return_local
+               : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]
+               )
                 (0)
                 -> k3 * error
-              where k3 (ns : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+              where k3
+                      (ns :
+                         [ 0
+                         | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]) =
                 ((let `fn[local.ml:32,27--43]` =
                     closure `fn[local.ml:32,27--43]_3`
                       @`fn[local.ml:32,27--43]`
                   in
                   apply direct(map_local_1 &`region` &ghost_region)
                     (map_local
-                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                     : _ ->
+                       [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ]
+                       ]
+                     )
                       (`fn[local.ml:32,27--43]`, ns)
                       -> k3 * error)
-                   where k3 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                   where k3
+                           (ms :
+                              [ 0
+                              | 0 of imm tagged *
+                                  [ 0 | 0 of imm tagged * val ] ]) =
                      (apply direct(length_2)
                         (length : _ -> imm tagged) (ms) -> k4 * error
                         where k4 (apply_result : imm tagged) =
@@ -330,12 +350,19 @@
                ((let `region` = %begin_region () in
                  let ghost_region = %begin_ghost_region () in
                  apply direct(spans_5 &`region` &ghost_region)
-                   (spans : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                   (spans
+                    : _ ->
+                      [ 0
+                      | 0 of [ 0 | 0 of imm tagged * val ] *
+                          [ 0 | 0 of val * val ] ]
+                    )
                      (is_even, $camlLocal__const_block176)
                      -> k3 * error
                    where k3
                            (even_spans :
-                              [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                              [ 0
+                              | 0 of [ 0 | 0 of imm tagged * val ] *
+                                  [ 0 | 0 of val * val ] ]) =
                      (apply direct(length_2)
                         (length : _ -> imm tagged) (even_spans) -> k4 * error
                         where k4 (apply_result : imm tagged) =

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -36,7 +36,7 @@ let code loopify(never) size(1) newer_version_of(return_local_0)
       return_local_0_1 (param : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+        : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ] local =
   cont k ($camlLocal__const_block15)
 in
 let $camlLocal__return_local_8 = closure return_local_0_1 @return_local in
@@ -129,11 +129,14 @@ apply direct(length_2_1)
            in
            apply direct(map_local_1_1 &`region` &ghost_region)
              ($camlLocal__map_local_9
-              : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+              : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
                ($`camlLocal__fn[local.ml:32,27--43]_11`,
                 $camlLocal__const_block15)
                -> k1 * error)
-            where k1 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+            where k1
+                    (ms :
+                       [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ]
+                       ]) =
               (apply direct(length_2_1)
                  ($camlLocal__length_10 : _ -> imm tagged) (ms) -> k1 * error
                  where k1 (apply_result : imm tagged) =
@@ -227,7 +230,9 @@ apply direct(length_2_1)
                        l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       my_closure my_region my_ghost_region my_depth
                       -> k * k1
-                      : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+                      : [ 0
+                        | 0 of [ 0 | 0 of val * val ] *
+                            [ 0 | 0 of val * val ] ] local =
                 let prim = %is_int (l) in
                 switch prim
                   | 0 -> k2
@@ -251,14 +256,17 @@ apply direct(length_2_1)
                                   &my_region &my_ghost_region)
                              ($camlLocal__spans_13 ~ depth my_depth -> succ my_depth
                               : _ ->
-                                [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
+                                [ 0
+                                | 0 of [ 0 | 0 of val * val ] *
+                                    [ 0 | 0 of val * val ] ]
                               )
                                (break_here, Pfield)
                                -> k2 * k1)
                             where k2
                                     (apply_result :
                                        [ 0
-                                       | 0 of val * [ 0 | 0 of val * val ] ]) =
+                                       | 0 of [ 0 | 0 of val * val ] *
+                                           [ 0 | 0 of val * val ] ]) =
                               ((let Pfield = %block_load.[`0`] (`*match*`) in
                                 apply
                                        direct(rev_app_4_1
@@ -296,12 +304,18 @@ apply direct(length_2_1)
               let ghost_region_1 = %begin_ghost_region () in
               (apply direct(spans_5_1 &region_1 &ghost_region_1)
                  ($camlLocal__spans_13
-                  : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                  : _ ->
+                    [ 0
+                    | 0 of [ 0 | 0 of imm tagged * val ] *
+                        [ 0 | 0 of val * val ] ]
+                  )
                    ($camlLocal__is_even_15, $camlLocal__const_block176)
                    -> k1 * error
                  where k1
                          (even_spans :
-                            [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                            [ 0
+                            | 0 of [ 0 | 0 of imm tagged * val ] *
+                                [ 0 | 0 of val * val ] ]) =
                    (apply direct(length_2_1)
                       ($camlLocal__length_10 : _ -> imm tagged)
                         (even_spans)

--- a/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
@@ -41,7 +41,8 @@ let $`camlProtect_refs__fn[protect_refs.ml:28,24--50]_8` =
 in
 let code loopify(never) size(11) newer_version_of(`fn[protect_refs.ml:29,2--43]_3`)
       `fn[protect_refs.ml:29,2--43]_3_1`
-        (refs : [ 0 | 0 of val * [ 0 | 0 of val * val ] ], f : val)
+        (refs : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ],
+         f : val)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply direct(iter_0_1) inlining_state(depth(10))

--- a/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
@@ -21,6 +21,6 @@ let $camlOpt_flags__immstring26 = "foo" in
       | 0 -> k (99)
       | 1 -> k (-1)
   where k (y : imm tagged) =
-    let $camlOpt_flags__Pmakeblock138 = Block 0 (42, y, 1701) in
-    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock138) in
+    let $camlOpt_flags__Pmakeblock139 = Block 0 (42, y, 1701) in
+    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock139) in
     cont done ($camlOpt_flags)

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -25,7 +25,9 @@ let code loopify(never) size(10) newer_version_of(h_2)
       cont k (int_add_1)
 in
 let code loopify(never) size(58) newer_version_of(f_0)
-      f_0_1 (x : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      f_0_1
+        (x : imm tagged,
+         l : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
+++ b/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
@@ -416,7 +416,8 @@ in
 let code loopify(never) size(2) newer_version_of(match_symbol_tagged_or_null_22)
       match_symbol_tagged_or_null_22_1 (t : imm tagged)
         my_closure _region _ghost_region my_depth
-        -> k * k1 =
+        -> k * k1
+        : [ 0 |1 | 0 of imm tagged |1 of val ] =
   let arg = %array_load ($camlTOP15__switch_block467, t) in
   cont k (arg)
 in

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -152,7 +152,7 @@ Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
      (function {nlocal = 0} r/0 : int
        (region
          (let
-           (*match*/5 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/5 =[value<(consts (0)) (non_consts ([0: *]))>]
               (makelocalblock 0 (*) r/0))
            (catch
              (if *match*/5
@@ -191,8 +191,13 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
   (test/0 =
      (function {nlocal = 0}
-       param/0[value<(consts (0)) (non_consts ([0: ?]))>] : int
-       (if param/0 (field_imm 0 (field_imm 0 param/0)) 0)))
+       param/0[value<
+                (consts (0))
+                 (non_consts ([0:
+                               value<
+                                (consts ()) (non_consts ([1: value<int>]
+                                 [0: value<int>]))>]))>]
+       : int (if param/0 (field_imm 0 (field_imm 0 param/0)) 0)))
   (apply (field_imm 1 (global Toploop!)) "test" test/0))
 val test : int t option -> int = <fun>
 |}]
@@ -240,7 +245,11 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
      (function {nlocal = 0} n/0? : int
        (region
          (let
-           (*match*/9 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/9 =[value<
+                         (consts (0))
+                          (non_consts ([0:
+                                        value<
+                                         (consts ()) (non_consts ([0: *, *]))>]))>]
               (makelocalblock 0 (value<
                                   (consts ())
                                    (non_consts ([0: *,
@@ -301,7 +310,7 @@ Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
      (function {nlocal = 0} r/1 : int
        (region
          (let
-           (*match*/12 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/12 =[value<(consts (0)) (non_consts ([0: *]))>]
               (makelocalblock 0 (*) r/1))
            (catch
              (if *match*/12
@@ -518,16 +527,18 @@ let check_results r1 r2 =
 (let
   (check_results/0 =
      (function {nlocal = 0} r1/0 r2/0?
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: *] [0: ?]))
        (let
          (*match*/16 =[value<
                         (consts ())
                          (non_consts ([0:
                                        value<
-                                        (consts ()) (non_consts ([1: ?]
+                                        (consts ())
+                                         (non_consts ([1: value<int>]
                                          [0: ?]))>,
                                        value<
-                                        (consts ()) (non_consts ([1: ?]
+                                        (consts ())
+                                         (non_consts ([1: value<int>]
                                          [0: ?]))>]))>]
             (apply r1/0 r2/0))
          (catch
@@ -555,7 +566,7 @@ let check_results r1 r2 =
                 with (52) (exit 50 (field_imm 1 *match*/16))))
             with (50 r/3[value<(consts ()) (non_consts ([1: ?] [0: ?]))>])
              r/3)
-          with (51 r/4[value<(consts ()) (non_consts ([1: ?] [0: ?]))>]) r/4))))
+          with (51 r/4[value<(consts ()) (non_consts ([1: *] [0: ?]))>]) r/4))))
   (apply (field_imm 1 (global Toploop!)) "check_results" check_results/0))
 val check_results :
   ('a -> ('b, [< `A | `B ]) result * ('b, [< `A | `B ]) result) ->

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -34,13 +34,14 @@ let example_1 () =
 (let
   (example_1/0 =
      (function {nlocal = 0} param/0[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/0 =
               (makelocalmutable 0 (value<int>,value<
                                                (consts ())
-                                                (non_consts ([1: ?] [0: ?]))>)
+                                                (non_consts ([1: value<int>]
+                                                [0: value<int>]))>)
                 1 [0: 1]))
            (if (field_int 0 input/0)
              (let (*match*/0 =o? (field_mut 1 input/0))
@@ -89,14 +90,15 @@ let example_2 () =
 (let
   (example_2/0 =
      (function {nlocal = 0} param/1[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/1 =[value<(consts ()) (non_consts ([0: value<int>, *]))>]
               (makelocalblock 0 (value<int>,*) 1
                 (makelocalmutable 0 (value<
-                                      (consts ()) (non_consts ([1: ?]
-                                       [0: ?]))>)
+                                      (consts ())
+                                       (non_consts ([1: value<int>]
+                                       [0: value<int>]))>)
                   [0: 1])))
            (if (field_int 0 input/1)
              (let (*match*/2 =o? (field_mut 0 (field_imm 1 input/1)))
@@ -147,15 +149,16 @@ let example_3 () =
 (let
   (example_3/0 =
      (function {nlocal = 0} param/2[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/2 =mut[value<
                           (consts ())
                            (non_consts ([0: value<int>,
                                          value<
-                                          (consts ()) (non_consts ([1: ?]
-                                           [0: ?]))>]))>]
+                                          (consts ())
+                                           (non_consts ([1: value<int>]
+                                           [0: value<int>]))>]))>]
               [0: 1 [0: 1]]
             *match*/4 =o? *input/2)
            (if (field_imm 0 *match*/4)

--- a/testsuite/tests/quotation/typing/eval/reductions.ml
+++ b/testsuite/tests/quotation/typing/eval/reductions.ml
@@ -120,8 +120,7 @@ val f :
 |}]
 let f (x : <[?l:$('a) -> $('b)]> expr) : ?l:('a eval) -> 'b eval = eval x
 [%%expect {|
-val f :
-  ('a : any) ('b : any). <[?l:$('a) -> $('b)]> expr -> ?l:'a eval -> 'b eval =
+val f : 'a ('b : any). <[?l:$('a) -> $('b)]> expr -> ?l:'a eval -> 'b eval =
   <fun>
 |}]
 let f (x : <[$('a) @ local -> $('b) @ local]> expr)

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -75,32 +75,50 @@ let[@tail_mod_cons] rec rec_map f = function
 (letrec
   (rec_map
      (function {nlocal = 0} f
-       param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
-       : (consts (0)) (non_consts ([0: ?]))
+       param[value<
+              (consts (0))
+               (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+       tail_mod_cons
+       : (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))
        (if param
          (let (*match* =a? (field_imm 0 param))
            (makeblock 0 (value<
                           (consts ())
                            (non_consts ([0: *,
                                          value<
-                                          (consts (0)) (non_consts ([0: ?]))>]))>)
+                                          (consts (0)) (non_consts ([0: *]))>]))>)
              (let
                (block =
-                  (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+                  (makemutable 0 (*,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts ())
+                                                      (non_consts ([0: *, *]))>]))>)
                     (apply f (field_imm 0 *match*)) 24029))
                (seq (apply rec_map_dps block 1 f (field_imm 1 *match*))
                  block))))
          0))
     rec_map_dps
       (function {nlocal = 0} dst offset[value<int>] f
-        param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
-        : (consts (0)) (non_consts ([0: ?]))
+        param[value<
+               (consts (0))
+                (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        tail_mod_cons
+        : (consts (0))
+           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))
         (if param
           (let
             (*match* =a? (field_imm 0 param)
              block1_arg0 =? (apply f (field_imm 0 *match*))
              block =
-               (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+               (makemutable 0 (*,value<
+                                  (consts (0))
+                                   (non_consts ([0:
+                                                 value<
+                                                  (consts ())
+                                                   (non_consts ([0: *, *]))>]))>)
                  block1_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
@@ -109,7 +127,7 @@ let[@tail_mod_cons] rec rec_map f = function
                                 (non_consts ([0: *,
                                               value<
                                                (consts (0))
-                                                (non_consts ([0: ?]))>]))>)
+                                                (non_consts ([0: *]))>]))>)
                   block))
               (apply rec_map_dps block 1 f (field_imm 1 *match*) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -134,21 +152,27 @@ let[@tail_mod_cons] rec trip = function
                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
        : (consts (0))
-          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+                        value<(consts (0)) (non_consts ([0: *, *]))>]))
        (if param
          (let (x =a? (field_imm 0 param))
            (makeblock 0 (value<(consts ()) (non_consts ([0: ?, value<int>]))>,
              value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (non_consts ([0:
+                             value<
+                              (consts ()) (non_consts ([0: ?, value<int>]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>)
              (makeblock 0 (?,value<int>) x 0)
              (makeblock 0 (value<
                             (consts ()) (non_consts ([0: ?, value<int>]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<
+                                (consts ()) (non_consts ([0: ?, value<int>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (?,value<int>) x 1)
                (let
                  (block =
@@ -157,9 +181,12 @@ let[@tail_mod_cons] rec trip = function
                                       (non_consts ([0: ?, value<int>]))>,
                       value<
                        (consts (0))
-                        (non_consts ([0: ?,
+                        (non_consts ([0:
                                       value<
-                                       (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                       (consts ())
+                                        (non_consts ([0: ?, value<int>]))>,
+                                      value<
+                                       (consts (0)) (non_consts ([0: *, *]))>]))>)
                       (makeblock 0 (?,value<int>) x 2) 24029))
                  (seq (apply trip_dps block 1 (field_imm 1 param)) block)))))
          0))
@@ -171,7 +198,9 @@ let[@tail_mod_cons] rec trip = function
                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
         : (consts (0))
-           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+           (non_consts ([0:
+                         value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+                         value<(consts (0)) (non_consts ([0: *, *]))>]))
         (if param
           (let
             (x =a? (field_imm 0 param)
@@ -183,8 +212,11 @@ let[@tail_mod_cons] rec trip = function
                                 (consts ()) (non_consts ([0: ?, value<int>]))>,
                  value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (non_consts ([0:
+                                 value<
+                                  (consts ())
+                                   (non_consts ([0: ?, value<int>]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                  block2_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
@@ -192,18 +224,24 @@ let[@tail_mod_cons] rec trip = function
                                (consts ()) (non_consts ([0: ?, value<int>]))>,
                   value<
                    (consts (0))
-                    (non_consts ([0: ?,
+                    (non_consts ([0:
                                   value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                   (consts ())
+                                    (non_consts ([0: ?, value<int>]))>,
+                                  value<
+                                   (consts (0)) (non_consts ([0: *, *]))>]))>)
                   block0_arg0
                   (makeblock 0 (value<
                                  (consts ())
                                   (non_consts ([0: ?, value<int>]))>,
                     value<
                      (consts (0))
-                      (non_consts ([0: ?,
+                      (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                     (consts ())
+                                      (non_consts ([0: ?, value<int>]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: *, *]))>]))>)
                     block1_arg0 block)))
               (apply trip_dps block 1 (field_imm 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -224,8 +262,8 @@ let[@tail_mod_cons] rec effects f = function
      (function {nlocal = 0} f
        param[value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+               (non_consts ([0: value<(consts ()) (non_consts ([0: ?, ?]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>]
        tail_mod_cons
        : (consts (0))
           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
@@ -253,8 +291,8 @@ let[@tail_mod_cons] rec effects f = function
       (function {nlocal = 0} dst offset[value<int>] f
         param[value<
                (consts (0))
-                (non_consts ([0: ?,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                (non_consts ([0: value<(consts ()) (non_consts ([0: ?, ?]))>,
+                              value<(consts (0)) (non_consts ([0: *, *]))>]))>]
         tail_mod_cons
         : (consts (0))
            (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))

--- a/testsuite/tests/translprim/comparison_table.stack.reference
+++ b/testsuite/tests/translprim/comparison_table.stack.reference
@@ -342,54 +342,77 @@
        stub : int (%nativeint_greaterequal prim prim))
    int_vec =[value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+               (non_consts ([0:
+                             value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
    bool_vec =[value<
                (consts (0))
-                (non_consts ([0: ?,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                (non_consts ([0:
+                              value<
+                               (consts ())
+                                (non_consts ([0: value<int>, value<int>]))>,
+                              value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
    intlike_vec =[value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                   (non_consts ([0:
+                                 value<
+                                  (consts ())
+                                   (non_consts ([0: value<int>, value<int>]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
    float_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<float>, value<float>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
    string_vec =[value<
                  (consts (0))
-                  (non_consts ([0: ?,
-                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  (non_consts ([0:
+                                value<(consts ()) (non_consts ([0: *, *]))>,
+                                value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
    int32_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<int32>, value<int32>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
    int64_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<int64>, value<int64>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
    nativeint_vec =[value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                                    (consts ())
+                                     (non_consts ([0: value<nativeint>,
+                                                   value<nativeint>]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
    test_vec =
      (function {nlocal = 0} cmp eq ne lt gt le ge
        vec[value<
             (consts (0))
-             (non_consts ([0: ?,
-                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+             (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                           value<(consts (0)) (non_consts ([0: *, *]))>]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                        value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                        value<(consts (0)) (non_consts ([0: *, *]))>]))
        (let
          (uncurry =
             (function {nlocal = 0} f
@@ -399,8 +422,9 @@
             (function {nlocal = 2} f
               l[value<
                  (consts (0))
-                  (non_consts ([0: ?,
-                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  (non_consts ([0:
+                                value<(consts ()) (non_consts ([0: ?, ?]))>,
+                                value<(consts (0)) (non_consts ([0: *, *]))>]))>]
               : (consts (0))
                  (non_consts ([0: ?,
                                value<(consts (0)) (non_consts ([0: ?, *]))>]))
@@ -410,19 +434,20 @@
                         (consts ())
                          (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>,
+                                        (consts (0))
+                                         (non_consts ([0: value<int>, *]))>,
                                        value<
                                         (consts (0)) (non_consts ([0: ?, *]))>]))>,
            value<
             (consts (0))
-             (non_consts ([0: ?,
-                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+             (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                           value<(consts (0)) (non_consts ([0: *, *]))>]))>)
            (makeblock 0 (value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0: value<int>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>,
+                                           (non_consts ([0: value<int>, *]))>]))>,
              value<
               (consts (0))
                (non_consts ([0: ?,
@@ -432,14 +457,17 @@
              (function {nlocal = 2} gen spec
                : (consts ())
                   (non_consts ([0:
-                                value<(consts (0)) (non_consts ([0: ?, *]))>,
+                                value<
+                                 (consts (0))
+                                  (non_consts ([0: value<int>, *]))>,
                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))
                (makeblock 0 (value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0: value<int>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>,
+                                               (non_consts ([0: value<int>,
+                                                             *]))>]))>,
                  value<
                   (consts (0))
                    (non_consts ([0: ?,
@@ -448,45 +476,56 @@
              (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (*,*) gen_eq eq)
                (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                  value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (non_consts ([0:
+                                 value<(consts ()) (non_consts ([0: *, *]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                  (makeblock 0 (*,*) gen_ne ne)
                  (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>)
                    (makeblock 0 (*,*) gen_lt lt)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
-                       (non_consts ([0: ?,
+                       (non_consts ([0:
                                      value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                                     value<
+                                      (consts (0)) (non_consts ([0: *, *]))>]))>)
                      (makeblock 0 (*,*) gen_gt gt)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
                         (consts (0))
-                         (non_consts ([0: ?,
+                         (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: *, *]))>]))>)
                        (makeblock 0 (*,*) gen_le le)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0:
+                                         value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
+                                           (non_consts ([0: *, *]))>]))>)
                          (makeblock 0 (*,*) gen_ge ge) 0)))))))))))
   (seq
     (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
@@ -510,11 +549,12 @@
          (function {nlocal = 0} cmp eq ne lt gt le ge
            vec[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
            : (consts ())
               (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                            value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                            value<(consts (0)) (non_consts ([0: *, *]))>]))
            (let
              (uncurry =
                 (function {nlocal = 0} f
@@ -524,9 +564,11 @@
                 (function {nlocal = 2} f
                   l[value<
                      (consts (0))
-                      (non_consts ([0: ?,
+                      (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                                     (consts ()) (non_consts ([0: ?, ?]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: *, *]))>]))>]
                   : (consts (0))
                      (non_consts ([0: ?,
                                    value<
@@ -538,20 +580,22 @@
                              (non_consts ([0:
                                            value<
                                             (consts (0))
-                                             (non_consts ([0: ?, *]))>,
+                                             (non_consts ([0: value<int>, *]))>,
                                            value<
                                             (consts (0))
                                              (non_consts ([0: ?, *]))>]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0: value<int>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>,
+                                               (non_consts ([0: value<int>,
+                                                             *]))>]))>,
                  value<
                   (consts (0))
                    (non_consts ([0: ?,
@@ -562,15 +606,18 @@
                    : (consts ())
                       (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>,
+                                     (consts (0))
+                                      (non_consts ([0: value<int>, *]))>,
                                     value<
                                      (consts (0)) (non_consts ([0: ?, *]))>]))
                    (makeblock 0 (value<
                                   (consts (0))
-                                   (non_consts ([0: ?,
+                                   (non_consts ([0: value<int>,
                                                  value<
                                                   (consts (0))
-                                                   (non_consts ([0: ?, *]))>]))>,
+                                                   (non_consts ([0:
+                                                                 value<int>,
+                                                                 *]))>]))>,
                      value<
                       (consts (0))
                        (non_consts ([0: ?,
@@ -580,52 +627,67 @@
                  (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>)
                    (makeblock 0 (*,*) eta_gen_eq eq)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
-                       (non_consts ([0: ?,
+                       (non_consts ([0:
                                      value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                                     value<
+                                      (consts (0)) (non_consts ([0: *, *]))>]))>)
                      (makeblock 0 (*,*) eta_gen_ne ne)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
                         (consts (0))
-                         (non_consts ([0: ?,
+                         (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: *, *]))>]))>)
                        (makeblock 0 (*,*) eta_gen_lt lt)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0:
+                                         value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
+                                           (non_consts ([0: *, *]))>]))>)
                          (makeblock 0 (*,*) eta_gen_gt gt)
                          (makeblock 0 (value<
                                         (consts ()) (non_consts ([0: *, *]))>,
                            value<
                             (consts (0))
-                             (non_consts ([0: ?,
+                             (non_consts ([0:
+                                           value<
+                                            (consts ())
+                                             (non_consts ([0: *, *]))>,
                                            value<
                                             (consts (0))
-                                             (non_consts ([0: ?, *]))>]))>)
+                                             (non_consts ([0: *, *]))>]))>)
                            (makeblock 0 (*,*) eta_gen_le le)
                            (makeblock 0 (value<
                                           (consts ())
                                            (non_consts ([0: *, *]))>,
                              value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0:
+                                             value<
+                                              (consts ())
+                                               (non_consts ([0: *, *]))>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>)
+                                               (non_consts ([0: *, *]))>]))>)
                              (makeblock 0 (*,*) eta_gen_ge ge) 0)))))))))))
       (seq
         (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt

--- a/testsuite/tests/typing-layouts-caml-modify/immediate_or_null_record.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/immediate_or_null_record.ml
@@ -1,0 +1,40 @@
+(* TEST
+ modules = "replace_caml_modify.c";
+ {
+   not-macos;
+   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
+            -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
+   native;
+ }
+*)
+
+(* This test verifies that setting an immediate_or_null field in a mixed record
+   doesn't call [caml_modify]. See [typing-layouts-caml-modify/basics.ml]
+   for an explanation how stubbing [caml_modify] works. *)
+
+external called_caml_modify : unit -> int
+  = "replace_caml_modify_called_modify" [@@noalloc]
+external reset : unit -> unit = "replace_caml_modify_reset" [@@noalloc]
+
+let test ~(call_pos : [%call_pos]) ~expect_caml_modifies f =
+  reset ();
+  f ();
+  let actual_modifies = called_caml_modify () in
+  if not (expect_caml_modifies = actual_modifies) then
+    failwith @@
+      Format.sprintf
+        "On line %d, expected %d calls to caml_modify, but saw %d"
+        call_pos.pos_lnum expect_caml_modifies actual_modifies
+
+type t =
+  { mutable a : int or_null
+  ; mutable b : int64#
+  }
+
+let set t ~a =
+  t.a <- a
+
+let () =
+  let t = { a = Null; b = #0L } in
+  test ~expect_caml_modifies:0
+    (fun () -> set t ~a:(This 5))

--- a/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
+++ b/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
@@ -34,3 +34,31 @@ external product_edge_case : ('a : any separable). #('a * 'a) array -> int
 val product_edge_case : ('a : value_maybe_null). #('a * 'a) array -> int =
   <fun>
 |}]
+
+type ('a : any mod separable) unboxed_record : any mod separable =
+  { field : 'a array } [@@unboxed]
+external unboxed_record_edge_case
+  : ('a : any mod separable). 'a unboxed_record array -> int
+  = "%identity"
+let unboxed_record_edge_case x = unboxed_record_edge_case x
+[%%expect{|
+type ('a : any separable) unboxed_record = { field : 'a array; } [@@unboxed]
+external unboxed_record_edge_case :
+  ('a : any separable). 'a unboxed_record array -> int = "%identity"
+val unboxed_record_edge_case :
+  ('a : any separable). 'a unboxed_record array -> int = <fun>
+|}]
+
+type ('a : any mod separable) unboxed_variant : any mod separable =
+  | Unboxed_variant of 'a array [@@unboxed]
+external unboxed_variant_edge_case
+  : ('a : any mod separable). 'a unboxed_variant array -> int
+  = "%identity"
+let unboxed_variant_edge_case x = unboxed_variant_edge_case x
+[%%expect{|
+type ('a : any separable) unboxed_variant = Unboxed_variant of 'a array [@@unboxed]
+external unboxed_variant_edge_case :
+  ('a : any separable). 'a unboxed_variant array -> int = "%identity"
+val unboxed_variant_edge_case :
+  ('a : any separable). 'a unboxed_variant array -> int = <fun>
+|}]

--- a/testsuite/tests/typing-layouts/any_gadt_value_kind.ml
+++ b/testsuite/tests/typing-layouts/any_gadt_value_kind.ml
@@ -1,0 +1,28 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* Regression test: a locally abstract type with layout [any] that is refined
+   to [value] by a GADT match may legitimately be used where a [value] is
+   required (here as the argument of a [value]-kinded type constructor). *)
+
+type ('a : value) t = A of 'a | B
+
+type (_ : any) w = W : ('a : value). 'a w
+
+let f : type (a : any). a w -> unit = function
+  | W -> (fun _ -> ()) (B : a t)
+[%%expect{|
+type 'a t = A of 'a | B
+type (_ : any) w = W : 'a w
+Line 6, characters 14-15:
+6 |   | W -> (fun _ -> ()) (B : a t)
+                  ^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be a value layout
+         because it has to be value for the V1 safety check.
+|}]

--- a/testsuite/tests/typing-layouts/any_gadt_value_kind.ml
+++ b/testsuite/tests/typing-layouts/any_gadt_value_kind.ml
@@ -16,13 +16,5 @@ let f : type (a : any). a w -> unit = function
 [%%expect{|
 type 'a t = A of 'a | B
 type (_ : any) w = W : 'a w
-Line 6, characters 14-15:
-6 |   | W -> (fun _ -> ()) (B : a t)
-                  ^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of a is any
-         because of the annotation on the abstract type declaration for a.
-       But the layout of a must be a value layout
-         because it has to be value for the V1 safety check.
+val f : ('a : any). 'a w -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-layouts/optional_arg_value_kind.ml
+++ b/testsuite/tests/typing-layouts/optional_arg_value_kind.ml
@@ -4,20 +4,15 @@
 *)
 
 (* Regression test: the content type of an optional argument must be
-   constrained to a value (or null) layout. When the content type is left
-   unconstrained (here written as [_]), its layout must default to [value]
+   constrained to [value_or_null]. When the content type is left
+   unconstrained (here written as [_]), its layout must default
    rather than leaking [any] into [value_kind]. *)
 
 let f (g : ?opt:_ -> _ -> _) x = g x
 let _ = f
 [%%expect{|
-File "_none_", line 1:
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of 'a is any
-         because of the definition of f at line 1, characters 6-36.
-       But the layout of 'a must be a value layout
-         because it has to be value for the V1 safety check.
+val f : (?opt:'a -> 'b -> 'c) -> 'b -> 'c = <fun>
+- : (?opt:'a -> 'b -> 'c) -> 'b -> 'c = <fun>
 |}]
 
 (* An explicitly non-value optional content type is rejected with a layout
@@ -25,11 +20,12 @@ Error: Non-value detected in [value_kind].
 
 let g (h : ?opt:(_ : float64) -> _ -> _) x = h x
 [%%expect{|
-File "_none_", line 1:
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of 'a is float64
-         because of the definition of g at line 1, characters 6-48.
-       But the layout of 'a must be a value layout
-         because it has to be value for the V1 safety check.
+Line 1, characters 16-29:
+1 | let g (h : ?opt:(_ : float64) -> _ -> _) x = h x
+                    ^^^^^^^^^^^^^
+Error: Optional argument types must have layout value.
+       The layout of "'a" is float64
+         because of the annotation on the wildcard _ at line 1, characters 16-29.
+       But the layout of "'a" must be a value layout
+         because the type argument of option has layout value_or_null.
 |}]

--- a/testsuite/tests/typing-layouts/optional_arg_value_kind.ml
+++ b/testsuite/tests/typing-layouts/optional_arg_value_kind.ml
@@ -1,0 +1,35 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* Regression test: the content type of an optional argument must be
+   constrained to a value (or null) layout. When the content type is left
+   unconstrained (here written as [_]), its layout must default to [value]
+   rather than leaking [any] into [value_kind]. *)
+
+let f (g : ?opt:_ -> _ -> _) x = g x
+let _ = f
+[%%expect{|
+File "_none_", line 1:
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of 'a is any
+         because of the definition of f at line 1, characters 6-36.
+       But the layout of 'a must be a value layout
+         because it has to be value for the V1 safety check.
+|}]
+
+(* An explicitly non-value optional content type is rejected with a layout
+   error, rather than panicking in [value_kind]. *)
+
+let g (h : ?opt:(_ : float64) -> _ -> _) x = h x
+[%%expect{|
+File "_none_", line 1:
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of 'a is float64
+         because of the definition of g at line 1, characters 6-48.
+       But the layout of 'a must be a value layout
+         because it has to be value for the V1 safety check.
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2237,6 +2237,14 @@ let apply ?(use_current_level = false) env params body args =
   with
     Cannot_subst -> raise Cannot_apply
 
+let instance_declaration_components_for_application env args decl =
+  let args = instance_list args in
+  let decl = instance_declaration decl in
+  let apply ty = apply env decl.type_params ty args in
+  ( ~kind:(map_kind apply decl.type_kind),
+    ~jkind:(Jkind.map_type_expr apply decl.type_jkind),
+    ~manifest:(Option.map apply decl.type_manifest) )
+
                               (****************************)
                               (*  Abbreviation expansion  *)
                               (****************************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2238,8 +2238,12 @@ let apply ?(use_current_level = false) env params body args =
     Cannot_subst -> raise Cannot_apply
 
 let instance_declaration_components_for_application env args decl =
+  (* [apply] already copies each component it substitutes, so there is no need
+     to first [instance_declaration decl]. Doing so deep-copies the whole
+     declaration graph (including the recursive unboxed-version chain) on every
+     type constructor, which is the dominant time and memory cost of
+     [Typeopt.value_kind] on declaration-heavy modules. *)
   let args = instance_list args in
-  let decl = instance_declaration decl in
   let apply ty = apply env decl.type_params ty args in
   ( ~kind:(map_kind apply decl.type_kind),
     ~jkind:(Jkind.map_type_expr apply decl.type_jkind),

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4648,9 +4648,9 @@ let add_jkind_equation ~reason uenv destination jkind1 =
     intersect_type_jkind ~reason env destination jkind1
   with
   | Jkind.No_intersection err -> raise_for Unify (Bad_jkind (destination,err))
-  | Jkind.Unknown -> ()
+  | Jkind.Unknown -> None
   | Jkind.Intersection jkind -> begin
-      match get_desc destination with
+      (match get_desc destination with
       | Tconstr (p, _, _)
         when is_instantiable ~for_jkind_eqn:true env p ->
         begin
@@ -4671,7 +4671,9 @@ let add_jkind_equation ~reason uenv destination jkind1 =
           with
             Not_found -> ()
         end
-      | _ -> ()
+      | _ -> ());
+      (* Return the refined jkind so the equation's [source] can record it. *)
+      Some jkind
     end
 
 (* This function can be called only in [Pattern] mode. *)
@@ -4701,8 +4703,14 @@ let add_gadt_equation uenv source destination =
                   jkind
       | Some jkind -> jkind
     in
-    add_jkind_equation ~reason:(Gadt_equation source)
-      uenv destination jkind;
+    let jkind =
+      match
+        add_jkind_equation ~reason:(Gadt_equation source)
+          uenv destination jkind
+      with
+      | Some refined_jkind -> refined_jkind
+      | None -> jkind
+    in
     (* Adding a jkind equation may change the uenv. *)
     let env = get_env uenv in
     let decl =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -288,6 +288,13 @@ val apply:
            set to true.
            Exception [Cannot_apply] is raised in case of failure. *)
 
+val instance_declaration_components_for_application:
+        Env.t -> type_expr list -> type_declaration ->
+        kind:type_decl_kind * jkind:jkind_l * manifest:type_expr option
+        (* Freshens the relevant components of a type declaration and applies
+           them to actual type-constructor arguments.
+           Exception [Cannot_apply] is raised in case of failure. *)
+
 val reduce_head:
   expand_reducible_abbrevs:bool -> Env.t -> type_expr -> type_expr
 (** Exhaustively beta-reduce head-position quotes, splices, quote-evals, and

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -488,32 +488,6 @@ let bigarray_specialize_kind_and_layout env ~kind ~layout typ =
   | _ ->
       (kind, layout)
 
-let value_kind_of_scannable_jkind env jkind =
-  let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
-  (* In other places, we use [Ctype.type_jkind_purely_if_principal]. Here, we omit
-     the principality check, as we're just trying to compute optimizations. *)
-  let context = Ctype.mk_jkind_context_always_principal env in
-  let externality_upper_bound =
-    Jkind.get_externality_upper_bound ~context env jkind
-  in
-  match layout with
-  | Some (Base (Scannable, { separability; _ })) -> (
-    (* use the better of the two [immediate_or_pointer]s *)
-    match pointerness_of_separability separability,
-          pointerness_of_scannable_with_externality externality_upper_bound with
-    | Immediate, Immediate | Immediate, Pointer | Pointer, Immediate -> Pintval
-    | Pointer, Pointer -> Pgenval)
-  | None
-  | Some ( Any _
-         | Product _
-         | Univar _
-         | Genvar _
-         | Base ( ( Void | Untagged_immediate | Float64 | Float32 | Word
-                  | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256
-                  | Vec512 ),
-                  _ )) ->
-    Misc.fatal_error "expected a layout of scannable"
-
 (* [value_kind] has a pre-condition that it is only called on values.  With the
    current set of sort restrictions, there are two reasons this invariant may
    be violated:
@@ -579,11 +553,12 @@ let non_nullable raw_kind = { raw_kind; nullable = Non_nullable }
 
 let nullable raw_kind = { raw_kind; nullable = Nullable }
 
-let add_nullability_from_ty env ty raw_kind =
-  let nullable =
-    match Ctype.check_type_nullability env ty Non_null with
-    | true -> Non_nullable
-    | false -> Nullable
+let estimate_value_kind_from_jkind env ty =
+  let immediate_or_pointer, nullable = maybe_pointer_type env ty in
+  let raw_kind =
+    match immediate_or_pointer with
+    | Immediate -> Pintval
+    | Pointer -> Pgenval
   in
   { raw_kind; nullable }
 
@@ -628,7 +603,8 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
 
        This should be understood, but for now the simple fall back thing is
        sufficient.  *)
-    match Ctype.check_type_jkind env scty (Jkind.Builtin.value_or_null ~why:V1_safety_check)
+    match Ctype.check_type_jkind env scty
+      (Jkind.Builtin.value_or_null ~why:V1_safety_check)
     with
     | Ok _ -> ()
     | Error _ ->
@@ -710,20 +686,18 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           || Path.same p Predef.path_iarray) ->
     let ak = array_type_kind ~elt_ty:(Some arg) env loc ty in
     num_nodes_visited, non_nullable (Parrayval ak)
-  | Tconstr(p, _, _) -> begin
-      (* CR layouts v2.8: The uses of [decl.type_jkind] here are suspect:
-         with with-kinds, [decl.type_jkind] will mention variables bound
-         by the parameters of the declaration. The code below loses this
-         connection and will continue processing with e.g. ['a : value]
-         instead of [string] when looking at a [string list]. This should
-         probably just call a [type_jkind] function. Internal ticket 5101. *)
-      let decl =
-        try Env.find_type p env with Not_found -> raise Missing_cmi_fallback
+  | Tconstr(p, params, _) -> begin
+      let ~kind:type_kind, .. =
+        try
+          Env.find_type p env
+          |> Ctype.instance_declaration_components_for_application env params
+        with Ctype.Cannot_apply ->
+          Misc.fatal_error "Typeopt.value_kind: invalid type application"
+        | Not_found -> raise Missing_cmi_fallback
       in
       if cannot_proceed () then
         num_nodes_visited,
-        add_nullability_from_ty env scty
-          (value_kind_of_scannable_jkind env decl.type_jkind)
+        estimate_value_kind_from_jkind env ty
       else
         let visited = Numbers.Int.Set.add (get_id ty) visited in
         (* Default of [Pgenval] is currently safe for the missing cmi fallback
@@ -731,7 +705,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
            of [value_kind]. Conservatively saying that types from missing
            cmis might be nullable, which is possible in the case of @@unboxed
            types. *)
-        match decl.type_kind with
+        match type_kind with
         | Type_variant (cstrs, rep, _) ->
           fallback_if_missing_cmi
             ~default:(num_nodes_visited, nullable Pgenval)
@@ -761,8 +735,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
             "Typeopt.value_kind: non-unary unboxed record can't have kind value"
         | Type_abstract _ ->
           num_nodes_visited,
-          add_nullability_from_ty env scty
-            (value_kind_of_scannable_jkind env decl.type_jkind)
+          estimate_value_kind_from_jkind env ty
         | Type_open -> num_nodes_visited, non_nullable Pgenval
     end
   | Ttuple labeled_fields ->
@@ -794,7 +767,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
     else non_nullable Pintval
   | _ ->
     num_nodes_visited,
-    add_nullability_from_ty env scty Pgenval
+    estimate_value_kind_from_jkind env ty
 
 and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
       (field : Types.mixed_block_element) ty

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -45,7 +45,7 @@ type unbound_variable_reason = | Upstream_compatibility
 type jkind_initialization_choice = Sort | Any
 
 type value_loc =
-    Tuple | Poly_variant | Object_field
+    Tuple | Poly_variant | Object_field | Optional_arg
 
 type sort_loc =
     Fun_arg | Fun_ret
@@ -917,8 +917,17 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             else begin
               if not (Btype.tpoly_is_mono arg_ty) then
                 raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
-              newmono
-                (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
+              let arg_content_ty = Btype.tpoly_get_mono arg_ty in
+              (match
+                 constrain_type_jkind env arg_content_ty
+                   Predef.option_argument_jkind
+               with
+               | Ok _ -> ()
+               | Error err ->
+                 raise (Error (arg.ptyp_loc, env,
+                               Non_value {vloc = Optional_arg;
+                                          typ = arg_content_ty; err})));
+              newmono (newconstr Predef.path_option [arg_content_ty])
             end
           in
           let arg_mode_desc = Alloc.of_const arg_mode.mode_modes in
@@ -1924,6 +1933,7 @@ let report_error_doc loc env = function
       | Tuple -> "Tuple element"
       | Poly_variant -> "Polymorphic variant constructor argument"
       | Object_field -> "Object field"
+      | Optional_arg -> "Optional argument"
     in
     Location.errorf ~loc "%s types must have layout value.@ %a"
       s (Jkind.Violation.report_with_offender

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -148,7 +148,7 @@ val get_type_param_name: Parsetree.core_type -> string option
 exception Already_bound
 
 type value_loc =
-    Tuple | Poly_variant | Object_field
+    Tuple | Poly_variant | Object_field | Optional_arg
 
 type sort_loc =
     Fun_arg | Fun_ret


### PR DESCRIPTION
Instance type constructors in `Typeopt` to improve optimizations. Originally done by https://github.com/oxcaml/oxcaml/pull/5108, but I later found that that approach led to a slowdown in benchmarks due to extra compiler state snapshotting, and didn't merge the final PR. This is an improved version. This avoids making the instance unnecessarily general as well.