### PR TITLE
Implicit kinds in structures

### DIFF
--- a/jane/doc/extensions/_06-kinds/05-implicit.md
+++ b/jane/doc/extensions/_06-kinds/05-implicit.md
@@ -6,7 +6,7 @@ title: Implicit Kind Declarations
 
 # Implicit Kind Declarations
 
-In signatures, type variable names can be declared to have *implicit kinds*.
+Type variable names can be declared to have *implicit kinds*.
 A type variable with a name that has an implicit kind will be instantiated
 with that kind. Here's an example:
 
@@ -87,10 +87,19 @@ module type Outer = sig
 end
 ```
 
-Implicit kinds can't be declared in structures, though we plan to support that.
+Implicit kind declarations can be made in structures (or at the module toplevel):
 
-Implicit kinds are syntactically limited to the signature
-they are declared in and won't be `include`d:
+```ocaml
+module M = struct
+  [@@@implicit_kind: ('elt : bits64)]
+
+  let f : 'elt -> 'elt array = fun x -> [| x |]
+end
+```
+
+Implicit kinds are lexical defaults, not a part of the module interface. They
+are syntactically limited to the signature or structure they are declared in and
+won't be `include`d:
 
 ```ocaml
 module type S = sig

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -14,7 +14,7 @@ end
 module type S0 = sig val f : ('elt : bits64). 'elt -> 'elt array end
 |}]
 
-(* CR implicit-variables: implicit kinds don't work in structures. *)
+(* Implicit kinds in structures. *)
 
 (* This doesn't raise an unused attribute warning because expect tests
    are run at toplevel.
@@ -28,6 +28,151 @@ end
 
 [%%expect{|
 module M : sig val f : ('elt : value_maybe_null). 'elt -> 'elt array end
+|}]
+
+(* File-level structure attributes affect later declarations only. *)
+
+let file_before (x : 'file_before) = x
+
+[@@@implicit_kind: ('file_after : bits64) * ('file_ext : word)]
+
+let file_after (x : 'file_after) = [| x |]
+external file_ignore : 'file_ext -> unit = "%ignore"
+
+[%%expect{|
+val file_before : 'file_before -> 'file_before = <fun>
+val file_after :
+  ('file_after : value_maybe_null). 'file_after -> 'file_after array = <fun>
+external file_ignore : 'file_ext -> unit = "%ignore"
+|}]
+
+(* Module structure attributes affect later declarations only. *)
+
+module Structure_order = struct
+  let before (x : 'before) = x
+  type 'box before_box
+  external before_ignore : 'ext -> unit = "%ignore"
+
+  [@@@implicit_kind: ('after : bits64) * ('box : word) * ('ext : word)]
+
+  let after (x : 'after) = [| x |]
+  type 'box after_box
+  external after_ignore : 'ext -> unit = "%ignore"
+end
+
+[%%expect{|
+module Structure_order :
+  sig
+    val before : 'before -> 'before
+    type 'box before_box
+    external before_ignore : 'ext -> unit = "%ignore"
+    val after : ('after : value_maybe_null). 'after -> 'after array
+    type 'box after_box
+    external after_ignore : 'ext -> unit = "%ignore"
+  end
+|}]
+
+(* Layout-polymorphic external declarations use structure implicit kinds. *)
+
+module Structure_external = struct
+  [@@@implicit_kind: ('ext_any : any)]
+
+  external[@layout_poly] ignore_any : 'ext_any -> unit = "%ignore"
+end
+
+[%%expect{|
+Line 4, characters 38-54:
+4 |   external[@layout_poly] ignore_any : 'ext_any -> unit = "%ignore"
+                                          ^^^^^^^^^^^^^^^^
+Error: "[@layout_poly]" on this external declaration has no
+       effect. Consider removing it or adding a type
+       variable for it to operate on.
+|}]
+
+(* Nested structures inherit and can shadow implicit kinds. *)
+
+module Nested_structures = struct
+  [@@@implicit_kind: ('nested : bits64)]
+
+  module Inherits = struct
+    let inherited (x : 'nested) = [| x |]
+  end
+
+  module Shadows = struct
+    [@@@implicit_kind: ('nested : immediate)]
+
+    let shadowed (x : 'nested) = x
+  end
+
+  let outer_after (x : 'nested) = [| x |]
+end
+
+[%%expect{|
+module Nested_structures :
+  sig
+    module Inherits :
+      sig
+        val inherited :
+          ('nested : value_maybe_null). 'nested -> 'nested array
+      end
+    module Shadows : sig val shadowed : 'nested -> 'nested end
+    val outer_after : ('nested : value_maybe_null). 'nested -> 'nested array
+  end
+|}]
+
+(* [module type of struct] inherits the incoming implicit-kind environment. *)
+
+module Mto_struct = struct
+  [@@@implicit_kind: ('mto : word)]
+
+  module type T = module type of struct
+    let id (x : 'mto) = x
+  end
+end
+
+[%%expect{|
+module Mto_struct :
+  sig module type T = sig val id : 'mto -> 'mto @@ stateless end end
+|}]
+
+(* Conflicting explicit annotations in structures fail like signatures. *)
+
+module Structure_conflict = struct
+  [@@@implicit_kind: ('conflict : word)]
+
+  let bad (x : ('conflict : value_or_null)) = x
+end
+
+[%%expect{|
+module Structure_conflict : sig val bad : 'conflict -> 'conflict end
+|}]
+
+(* Lexical defaults do not cross module boundaries as ambient defaults. *)
+
+module Boundary = struct
+  module Source = struct
+    [@@@implicit_kind: ('boundary : word)]
+
+    let baked (x : 'boundary) = x
+  end
+
+  module Consumer = struct
+    include Source
+
+    let fresh (x : 'boundary) = x
+  end
+end
+
+[%%expect{|
+module Boundary :
+  sig
+    module Source : sig val baked : 'boundary -> 'boundary end
+    module Consumer :
+      sig
+        val baked : 'boundary -> 'boundary
+        val fresh : 'boundary -> 'boundary
+      end
+  end
 |}]
 
 (* Implicit kind without jkind annotation fails. *)
@@ -515,7 +660,6 @@ end
 module type S27 = sig val f : (('w : word). 'w -> 'w) -> unit end
 |}]
 
-(* CR implicit-variables: inherit the annotation here? *)
 (* [module type of struct]. *)
 
 module type S28 = sig
@@ -721,7 +865,7 @@ Error: The type variable 'a has conflicting kind annotations.
        but was already implicitly annotated with any
 |}]
 
-(* Clearing the env inside of a struct. *)
+(* Keeping the env inside of a struct. *)
 
 module type S37 = sig
   [@@@implicit_kind: ('t : word)]

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -16,10 +16,6 @@ module type S0 = sig val f : ('elt : bits64). 'elt -> 'elt array end
 
 (* Implicit kinds in structures. *)
 
-(* This doesn't raise an unused attribute warning because expect tests
-   are run at toplevel.
-
-   See [implicit_kinds_unused.ml] for the unused attribute test. *)
 module M = struct
   [@@@implicit_kind: ('elt : bits64)]
 
@@ -33,6 +29,8 @@ module M : sig val f : ('elt : bits64). 'elt -> 'elt array end
 (* File-level structure attributes affect later declarations only. *)
 
 let file_before (x : 'file_before) = x
+let file_before_after_name (x : 'file_after) = x
+external file_before_ext : 'file_ext -> unit = "%ignore"
 
 [@@@implicit_kind: ('file_after : bits64) * ('file_ext : word)]
 
@@ -41,6 +39,8 @@ external file_ignore : 'file_ext -> unit = "%ignore"
 
 [%%expect{|
 val file_before : 'file_before -> 'file_before = <fun>
+val file_before_after_name : 'file_after -> 'file_after = <fun>
+external file_before_ext : 'file_ext -> unit = "%ignore"
 val file_after : ('file_after : bits64). 'file_after -> 'file_after array =
   <fun>
 external file_ignore : ('file_ext : word). 'file_ext -> unit = "%ignore"
@@ -50,8 +50,11 @@ external file_ignore : ('file_ext : word). 'file_ext -> unit = "%ignore"
 
 module Structure_order = struct
   let before (x : 'before) = x
+  let before_after_name (x : 'after) = x
   type 'box before_box
+  type 'box before_later_box
   external before_ignore : 'ext -> unit = "%ignore"
+  external before_later_ignore : 'ext -> unit = "%ignore"
 
   [@@@implicit_kind: ('after : bits64) * ('box : word) * ('ext : word)]
 
@@ -64,8 +67,11 @@ end
 module Structure_order :
   sig
     val before : 'before -> 'before
+    val before_after_name : 'after -> 'after
     type 'box before_box
+    type 'box before_later_box
     external before_ignore : 'ext -> unit = "%ignore"
+    external before_later_ignore : 'ext -> unit = "%ignore"
     val after : ('after : bits64). 'after -> 'after array
     type ('box : word) after_box
     external after_ignore : ('ext : word). 'ext -> unit = "%ignore"
@@ -131,6 +137,150 @@ end
 module Mto_struct :
   sig
     module type T = sig val id : ('mto : word). 'mto -> 'mto @@ stateless end
+  end
+|}]
+
+(* Signature implicit kinds do not affect an ascribed structure's environment. *)
+
+module Sig_default_used_by_struct : sig
+  [@@@implicit_kind: ('from_sig : bits64)]
+
+  module type T = sig
+    val pack : 'from_sig -> 'from_sig array
+  end
+end = struct
+  module type T = module type of struct
+    let pack (x : 'from_sig) = [| x |]
+  end
+end
+
+[%%expect{|
+Lines 7-11, characters 6-3:
+ 7 | ......struct
+ 8 |   module type T = module type of struct
+ 9 |     let pack (x : 'from_sig) = [| x |]
+10 |   end
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module type T =
+             sig
+               val pack :
+                 ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array
+                 @@ stateless
+             end
+         end
+       is not included in
+         sig
+           module type T =
+             sig
+               val pack : ('from_sig : bits64). 'from_sig -> 'from_sig array
+             end
+         end
+       Module type declarations do not match:
+         module type T =
+           sig
+             val pack :
+               ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array
+               @@ stateless
+           end
+       does not match
+         module type T =
+           sig
+             val pack : ('from_sig : bits64). 'from_sig -> 'from_sig array
+           end
+       At position "module type T = <here>"
+       Module types do not match:
+         sig
+           val pack :
+             ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array @@
+             stateless
+         end
+       is not equal to
+         sig
+           val pack : ('from_sig : bits64). 'from_sig -> 'from_sig array
+         end
+       At position "module type T = <here>"
+       Values do not match:
+         val pack :
+           ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array @@
+           stateless
+       is not included in
+         val pack : ('from_sig : bits64). 'from_sig -> 'from_sig array
+       The type "'a -> 'a array" is not compatible with the type "'b -> 'b array"
+       The layout of 'a is bits64
+         because of the definition of pack at line 5, characters 4-43.
+       But the layout of 'a must be a value layout
+         because of the definition of pack at line 9, characters 13-38.
+|}]
+
+(* Signature implicit kinds affect structures defined in that signature. *)
+
+module type Sig_default_defines_struct = sig
+  [@@@implicit_kind: ('from_defined_sig : bits64)]
+
+  module type T = module type of struct
+    let pack (x : 'from_defined_sig) = [| x |]
+  end
+end
+
+[%%expect{|
+module type Sig_default_defines_struct =
+  sig
+    module type T =
+      sig
+        val pack :
+          ('from_defined_sig : bits64).
+            'from_defined_sig -> 'from_defined_sig array
+          @@ stateless
+      end
+  end
+|}]
+
+(* Structure implicit kinds can be used by a signature. *)
+
+module Struct_default_used_by_sig = struct
+  [@@@implicit_kind: ('from_struct : bits64)]
+
+  module type S = sig
+    val pack : 'from_struct -> 'from_struct array
+  end
+end
+
+[%%expect{|
+module Struct_default_used_by_sig :
+  sig
+    module type S =
+      sig
+        val pack :
+          ('from_struct : bits64). 'from_struct -> 'from_struct array
+      end
+  end
+|}]
+
+(* Local modules inherit the surrounding implicit-kind environment. *)
+
+module Local_module = struct
+  [@@@implicit_kind: ('local : word)]
+
+  module type S = sig
+    val id : 'local -> 'local
+  end
+
+  let f () =
+    let module M = struct
+      let id (x : 'local) = x
+    end
+    in
+    (module M : S)
+end
+
+[%%expect{|
+module Local_module :
+  sig
+    module type S = sig val id : ('local : word). 'local -> 'local end
+    val f : unit -> (module S)
   end
 |}]
 

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -27,7 +27,7 @@ module M = struct
 end
 
 [%%expect{|
-module M : sig val f : ('elt : value_maybe_null). 'elt -> 'elt array end
+module M : sig val f : ('elt : bits64). 'elt -> 'elt array end
 |}]
 
 (* File-level structure attributes affect later declarations only. *)
@@ -41,9 +41,9 @@ external file_ignore : 'file_ext -> unit = "%ignore"
 
 [%%expect{|
 val file_before : 'file_before -> 'file_before = <fun>
-val file_after :
-  ('file_after : value_maybe_null). 'file_after -> 'file_after array = <fun>
-external file_ignore : 'file_ext -> unit = "%ignore"
+val file_after : ('file_after : bits64). 'file_after -> 'file_after array =
+  <fun>
+external file_ignore : ('file_ext : word). 'file_ext -> unit = "%ignore"
 |}]
 
 (* Module structure attributes affect later declarations only. *)
@@ -66,9 +66,9 @@ module Structure_order :
     val before : 'before -> 'before
     type 'box before_box
     external before_ignore : 'ext -> unit = "%ignore"
-    val after : ('after : value_maybe_null). 'after -> 'after array
-    type 'box after_box
-    external after_ignore : 'ext -> unit = "%ignore"
+    val after : ('after : bits64). 'after -> 'after array
+    type ('box : word) after_box
+    external after_ignore : ('ext : word). 'ext -> unit = "%ignore"
   end
 |}]
 
@@ -81,12 +81,11 @@ module Structure_external = struct
 end
 
 [%%expect{|
-Line 4, characters 38-54:
-4 |   external[@layout_poly] ignore_any : 'ext_any -> unit = "%ignore"
-                                          ^^^^^^^^^^^^^^^^
-Error: "[@layout_poly]" on this external declaration has no
-       effect. Consider removing it or adding a type
-       variable for it to operate on.
+module Structure_external :
+  sig
+    external ignore_any : ('ext_any : any). 'ext_any -> unit = "%ignore"
+      [@@layout_poly]
+  end
 |}]
 
 (* Nested structures inherit and can shadow implicit kinds. *)
@@ -111,12 +110,10 @@ end
 module Nested_structures :
   sig
     module Inherits :
-      sig
-        val inherited :
-          ('nested : value_maybe_null). 'nested -> 'nested array
-      end
-    module Shadows : sig val shadowed : 'nested -> 'nested end
-    val outer_after : ('nested : value_maybe_null). 'nested -> 'nested array
+      sig val inherited : ('nested : bits64). 'nested -> 'nested array end
+    module Shadows :
+      sig val shadowed : ('nested : immediate). 'nested -> 'nested end
+    val outer_after : ('nested : bits64). 'nested -> 'nested array
   end
 |}]
 
@@ -132,7 +129,9 @@ end
 
 [%%expect{|
 module Mto_struct :
-  sig module type T = sig val id : 'mto -> 'mto @@ stateless end end
+  sig
+    module type T = sig val id : ('mto : word). 'mto -> 'mto @@ stateless end
+  end
 |}]
 
 (* Conflicting explicit annotations in structures fail like signatures. *)
@@ -144,7 +143,14 @@ module Structure_conflict = struct
 end
 
 [%%expect{|
-module Structure_conflict : sig val bad : 'conflict -> 'conflict end
+Line 4, characters 28-41:
+4 |   let bad (x : ('conflict : value_or_null)) = x
+                                ^^^^^^^^^^^^^
+Error: Bad layout annotation:
+         The layout of "'conflict" is word
+           because of the annotation on the implicit kind of type variables named conflict.
+         But the layout of "'conflict" must be a value layout
+           because of the annotation on the type variable 'conflict.
 |}]
 
 (* Lexical defaults do not cross module boundaries as ambient defaults. *)
@@ -166,10 +172,11 @@ end
 [%%expect{|
 module Boundary :
   sig
-    module Source : sig val baked : 'boundary -> 'boundary end
+    module Source :
+      sig val baked : ('boundary : word). 'boundary -> 'boundary end
     module Consumer :
       sig
-        val baked : 'boundary -> 'boundary
+        val baked : ('boundary : word). 'boundary -> 'boundary
         val fresh : 'boundary -> 'boundary
       end
   end
@@ -672,7 +679,9 @@ end
 
 [%%expect{|
 module type S28 =
-  sig module type Evil = sig val x : 'w -> 'w @@ stateless end end
+  sig
+    module type Evil = sig val x : ('w : word). 'w -> 'w @@ stateless end
+  end
 |}]
 
 (* [module type of struct] and unification. *)
@@ -878,7 +887,7 @@ end
 [%%expect{|
 module type S37 =
   sig
-    module type Inner = sig val id : 't -> unit @@ stateless end
+    module type Inner = sig val id : ('t : word). 't -> unit @@ stateless end
     val f : ('t : word). 't -> 't
   end
 |}]

--- a/testsuite/tests/implicit-types/implicit_kinds_unused.compilers.reference
+++ b/testsuite/tests/implicit-types/implicit_kinds_unused.compilers.reference
@@ -1,13 +1,3 @@
-File "implicit_kinds_unused.ml", line 8, characters 4-17:
-8 | [@@@implicit_kind: ('a : bits64)]
-        ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the implicit_kind attribute cannot appear in this context
-
-File "implicit_kinds_unused.ml", line 11, characters 6-19:
-11 |   [@@@implicit_kind: ('b : bits32)]
-           ^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the implicit_kind attribute cannot appear in this context
-
 File "implicit_kinds_unused.ml", line 16, characters 5-18:
 16 | let[@implicit_kind: ('c : immediate)] f x = x
           ^^^^^^^^^^^^^

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2173,6 +2173,15 @@ and transl_with ~loc env remove_aliases (rev_tcstrs, sg) constr =
   in
   ((path, lid, constr) :: rev_tcstrs, sg)
 
+and add_implicit_jkinds env attrs =
+  let register_default env (var_name, jkind_annot) =
+    let context = Jkind.History.Implicit_jkind var_name in
+    Env.add_implicit_jkind
+      ~loc:jkind_annot.pjka_loc var_name
+      (Jkind.of_annotation ~context env jkind_annot) env
+  in
+  List.fold_left register_default env attrs
+
 and transl_signature env {psg_items; psg_modalities; psg_loc} =
   let names = Signature_names.create () in
 
@@ -2525,15 +2534,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
     | Psig_attribute attr ->
         Builtin_attributes.parse_standard_interface_attributes attr;
         let newenv =
-          let register_default env (var_name, jkind_annot) =
-            let context =
-              Jkind.History.Implicit_jkind var_name
-            in
-            Env.add_implicit_jkind
-              ~loc:jkind_annot.pjka_loc var_name
-              (Jkind.of_annotation ~context env jkind_annot) env
-          in
-          List.fold_left register_default env
+          add_implicit_jkinds env
             (Builtin_attributes.get_implicit_jkind_attr attr)
         in
         mksig (Tsig_attribute attr) env loc, [], newenv
@@ -3631,8 +3632,6 @@ and type_open_decl_aux ?used_slot ?toplevel ~funct_body names env od =
     open_descr, mode, sg, newenv
 
 and type_structure ?(toplevel = None) ~funct_body anchor env sstr =
-  (* CR implicit-types: implement implicit variable jkinds in structures. *)
-  let env = Env.clear_implicit_jkinds env in
   let names = Signature_names.create () in
   let _, md_mode = register_allocation () in
   let loc_md = location_of_structure sstr in
@@ -4068,7 +4067,11 @@ and type_structure ?(toplevel = None) ~funct_body anchor env sstr =
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute x ->
         Builtin_attributes.parse_standard_implementation_attributes x;
-        Tstr_attribute x, [], shape_map, env
+        let new_env =
+          add_implicit_jkinds env
+            (Builtin_attributes.get_implicit_jkind_attr x)
+        in
+        Tstr_attribute x, [], shape_map, new_env
     | Pstr_jkind x ->
         let id, env, decl = Typedecl.transl_jkind_decl env x in
         Signature_names.check_jkind names decl.jkind_loc decl.jkind_id;


### PR DESCRIPTION
Enable implicit kinds in structures. 

There wass no theoretical justification to disable implicit kinds in structures in the first place. We only added the restriction in the initial version to be conservative.