### PR TITLE
Reduce subtlety of major GC fix

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -996,24 +996,26 @@ static void shrink_mark_stack (void)
 void caml_darken_cont(value cont);
 
 /* Mark a single block's header. Lifted from the various marking
- * functions to ensure the lazy logic is consistently correct. */
+ * functions to ensure the lazy logic is consistently correct.
+ * Return the final header value (whose colour and tag may have
+ * changed). */
 
-Caml_inline void mark_header(value block, header_t hd,
-                             struct global_heap_state state)
+Caml_inline header_t mark_header(value block, header_t hd, status marked)
 {
+  header_t marked_hd;
 again:
+  marked_hd = With_status_hd(hd, marked);
   if (Tag_hd(hd) == Lazy_tag && Tag_hd(hd) == Forcing_tag) {
     /* To detect and mitigate a race against some other domain
      * short-circuiting alazy block, we compare-and-swap */
-    if (!atomic_compare_exchange_strong(Hp_atomic_val(block), &hd,
-                                        With_status_hd(hd, state.MARKED))) {
+    if (!atomic_compare_exchange_strong(Hp_atomic_val(block), &hd, marked_hd)) {
       hd = Hd_val(block);
       goto again;
     }
   } else {
-    atomic_store_relaxed(Hp_atomic_val(block),
-                         With_status_hd(hd, state.MARKED));
+    atomic_store_relaxed(Hp_atomic_val(block), marked_hd);
   }
+  return marked_hd;
 }
 
 static void mark_slice_darken(struct mark_stack* stk, value child,
@@ -1042,7 +1044,7 @@ static void mark_slice_darken(struct mark_stack* stk, value child,
         caml_darken_cont(child);
         *work -= Wosize_hd(chd);
       } else {
-        mark_header(child, chd, caml_global_heap_state);
+        chd = mark_header(child, chd, caml_global_heap_state.MARKED);
         if(Scannable_hd(chd)) {
           *work -= mark_stack_push_block(stk, child);
         } else {
@@ -1107,8 +1109,7 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
         budget -= Whsize_hd(hd);
         continue;
       }
-
-      mark_header(block, hd, heap_state);
+      hd = mark_header(block, hd, heap_state.MARKED);
       budget--; /* header word */
       if (!Scannable_hd(hd)) {
         /* Nothing to scan here */
@@ -1301,7 +1302,7 @@ void caml_darken(void* state, value v, volatile value* ignored) {
     if (Tag_hd(hd) == Cont_tag) {
       caml_darken_cont(v);
     } else {
-      mark_header(v, hd, caml_global_heap_state);
+      hd = mark_header(v, hd, caml_global_heap_state.MARKED);
       if (Scannable_hd(hd)) {
         mark_stack_push_block(domain_state->mark_stack, v);
         Caml_state->mark_work_done_between_slices += 1; /* just the header */


### PR DESCRIPTION
#6109 had a subtlety pointed out by @gasche during review of the same change (ocaml/ocaml#14816): the header value changes during `mark_header` which in the previous (inlined) versions of the code was reflected in the value of the corresponding local variable at each site. In fact this had no semantic effect because of the particular operations subsequently done to that variable, but it makes the code a little fragile. This PR modifies the #6109 code such that `mark_header` now always returns the value that the header word is set to; then at the various call-sites we assign that into the relevant local variable.