### PR TITLE
  Add alloc_regions to alloc_modes, and all primitives that allocate 

### DIFF
--- a/middle_end/flambda2/bound_identifiers/alloc_mode.ml
+++ b/middle_end/flambda2/bound_identifiers/alloc_mode.ml
@@ -62,168 +62,254 @@ end
 
 module For_applications = struct
   type t =
-    | Heap
+    | Heap of { alloc_region : Variable.t }
     | Local of
-        { region : Variable.t;
+        { alloc_region : Variable.t;
+          region : Variable.t;
           ghost_region : Variable.t
         }
 
   let print ppf t =
     match t with
-    | Heap -> Format.pp_print_string ppf "Heap"
-    | Local { region; ghost_region } ->
-      Format.fprintf ppf "@[<hov 1>(Local (region@ %a)@ (ghost_region@ %a))@]"
-        Variable.print region Variable.print ghost_region
+    | Heap { alloc_region } ->
+      Format.fprintf ppf "@[<hov 1>(Heap (alloc@ %a))@]" Variable.print
+        alloc_region
+    | Local { region; ghost_region; alloc_region } ->
+      Format.fprintf ppf
+        "@[<hov 1>(Local (region@ %a)@ (ghost_region@ %a)@ (alloc@ %a))@]"
+        Variable.print region Variable.print ghost_region Variable.print
+        alloc_region
 
   let compare t1 t2 =
     match t1, t2 with
-    | Heap, Heap -> 0
-    | ( Local { region = region1; ghost_region = ghost_region1 },
-        Local { region = region2; ghost_region = ghost_region2 } ) ->
+    | ( Heap { alloc_region = alloc_region1 },
+        Heap { alloc_region = alloc_region2 } ) ->
+      Variable.compare alloc_region1 alloc_region2
+    | ( Local
+          { region = region1;
+            ghost_region = ghost_region1;
+            alloc_region = alloc_region1
+          },
+        Local
+          { region = region2;
+            ghost_region = ghost_region2;
+            alloc_region = alloc_region2
+          } ) ->
       let c = Variable.compare region1 region2 in
-      if c <> 0 then c else Variable.compare ghost_region1 ghost_region2
-    | Heap, Local _ -> -1
-    | Local _, Heap -> 1
+      if c <> 0
+      then c
+      else
+        let c = Variable.compare ghost_region1 ghost_region2 in
+        if c <> 0 then c else Variable.compare alloc_region1 alloc_region2
+    | Heap _, Local _ -> -1
+    | Local _, Heap _ -> 1
 
-  let heap = Heap
+  let heap ~alloc_region = Heap { alloc_region }
 
-  let local ~region ~ghost_region =
+  let local ~alloc_region ~region ~ghost_region =
     if Flambda_features.stack_allocation_enabled ()
-    then Local { region; ghost_region }
-    else Heap
+    then Local { alloc_region; region; ghost_region }
+    else Heap { alloc_region }
 
   let as_type t : For_types.t =
-    match t with Heap -> Heap | Local _ -> Heap_or_local
+    match t with Heap _ -> Heap | Local _ -> Heap_or_local
 
-  let from_lambda (mode : Lambda.locality_mode) ~current_region
-      ~current_ghost_region =
+  let from_lambda (mode : Lambda.locality_mode) ~current_alloc_region
+      ~current_region ~current_ghost_region =
     if not (Flambda_features.stack_allocation_enabled ())
-    then Heap
+    then Heap { alloc_region = current_alloc_region }
     else
       match mode with
-      | Alloc_heap -> Heap
+      | Alloc_heap -> Heap { alloc_region = current_alloc_region }
       | Alloc_local -> (
         match current_region, current_ghost_region with
         | Some current_region, Some current_ghost_region ->
-          Local { region = current_region; ghost_region = current_ghost_region }
+          Local
+            { alloc_region = current_alloc_region;
+              region = current_region;
+              ghost_region = current_ghost_region
+            }
         | None, _ | _, None ->
           Misc.fatal_error "Local application without a region")
 
   let free_names t =
     match t with
-    | Heap -> Name_occurrences.empty
-    | Local { region; ghost_region } ->
+    | Heap { alloc_region } ->
+      Name_occurrences.singleton_variable alloc_region Name_mode.normal
+    | Local { alloc_region; region; ghost_region } ->
       Name_occurrences.add_variable
-        (Name_occurrences.singleton_variable region Name_mode.normal)
-        ghost_region Name_mode.normal
+        (Name_occurrences.add_variable
+           (Name_occurrences.singleton_variable region Name_mode.normal)
+           ghost_region Name_mode.normal)
+        alloc_region Name_mode.normal
 
   let rename = function
-    | Heap -> Heap
-    | Local { region; ghost_region } ->
+    | Heap { alloc_region } ->
+      Heap { alloc_region = Variable.rename alloc_region }
+    | Local { alloc_region; region; ghost_region } ->
       Local
-        { region = Variable.rename region;
+        { alloc_region = Variable.rename alloc_region;
+          region = Variable.rename region;
           ghost_region = Variable.rename ghost_region
         }
 
   let is_renamed_version_of t t' =
     match t, t' with
-    | Heap, Heap -> true
-    | Heap, Local _ | Local _, Heap -> false
-    | ( Local { region; ghost_region },
-        Local { region = region'; ghost_region = ghost_region' } ) ->
-      Variable.is_renamed_version_of region region'
+    | Heap { alloc_region }, Heap { alloc_region = alloc_region' } ->
+      Variable.is_renamed_version_of alloc_region alloc_region'
+    | Heap _, Local _ | Local _, Heap _ -> false
+    | ( Local { alloc_region; region; ghost_region },
+        Local
+          { alloc_region = alloc_region';
+            region = region';
+            ghost_region = ghost_region'
+          } ) ->
+      Variable.is_renamed_version_of alloc_region alloc_region'
+      && Variable.is_renamed_version_of region region'
       && Variable.is_renamed_version_of ghost_region ghost_region'
 
   let renaming t ~guaranteed_fresh =
     match t, guaranteed_fresh with
-    | Heap, Heap -> Renaming.empty
-    | ( Local { region; ghost_region },
-        Local { region = region'; ghost_region = ghost_region' } ) ->
+    | Heap { alloc_region }, Heap { alloc_region = alloc_region' } ->
+      Renaming.add_fresh_variable Renaming.empty alloc_region
+        ~guaranteed_fresh:alloc_region'
+    | ( Local { alloc_region; region; ghost_region },
+        Local
+          { alloc_region = alloc_region';
+            region = region';
+            ghost_region = ghost_region'
+          } ) ->
       let renaming =
-        Renaming.add_fresh_variable Renaming.empty region
-          ~guaranteed_fresh:region'
+        Renaming.add_fresh_variable Renaming.empty alloc_region
+          ~guaranteed_fresh:alloc_region'
+      in
+      let renaming =
+        Renaming.add_fresh_variable renaming region ~guaranteed_fresh:region'
       in
       Renaming.add_fresh_variable renaming ghost_region
         ~guaranteed_fresh:ghost_region'
-    | Heap, Local _ | Local _, Heap ->
+    | Heap _, Local _ | Local _, Heap _ ->
       Misc.fatal_error "Mismatched alloc_mode in renaming"
 
   let apply_renaming t renaming =
     match t with
-    | Heap -> Heap
-    | Local { region; ghost_region } ->
+    | Heap { alloc_region } ->
+      let alloc_region' = Renaming.apply_variable renaming alloc_region in
+      if alloc_region == alloc_region'
+      then t
+      else Heap { alloc_region = alloc_region' }
+    | Local { alloc_region; region; ghost_region } ->
+      let alloc_region' = Renaming.apply_variable renaming alloc_region in
       let region' = Renaming.apply_variable renaming region in
       let ghost_region' = Renaming.apply_variable renaming ghost_region in
-      if region == region' && ghost_region == ghost_region'
+      if
+        alloc_region == alloc_region'
+        && region == region'
+        && ghost_region == ghost_region'
       then t
-      else Local { region = region'; ghost_region = ghost_region' }
+      else
+        Local
+          { alloc_region = alloc_region';
+            region = region';
+            ghost_region = ghost_region'
+          }
 
   let ids_for_export t =
     match t with
-    | Heap -> Ids_for_export.empty
-    | Local { region; ghost_region } ->
+    | Heap { alloc_region } -> Ids_for_export.singleton_variable alloc_region
+    | Local { alloc_region; region; ghost_region } ->
       Ids_for_export.add_variable
-        (Ids_for_export.singleton_variable region)
-        ghost_region
+        (Ids_for_export.add_variable
+           (Ids_for_export.singleton_variable region)
+           ghost_region)
+        alloc_region
+
+  let alloc_region t =
+    match t with
+    | Heap { alloc_region } | Local { alloc_region; _ } -> alloc_region
 end
 
 module For_allocations = struct
   type t =
-    | Heap
-    | Local of { region : Variable.t }
+    | Heap of { alloc_region : Variable.t }
+    | Local of
+        { alloc_region : Variable.t;
+          region : Variable.t
+        }
 
   let print ppf t =
     match t with
-    | Heap -> Format.pp_print_string ppf "Heap"
-    | Local { region } ->
-      Format.fprintf ppf "@[<hov 1>(Local (region@ %a))@]" Variable.print region
+    | Heap { alloc_region } ->
+      Format.fprintf ppf "@[<hov 1>(Heap (alloc_region@ %a))@]" Variable.print
+        alloc_region
+    | Local { alloc_region; region } ->
+      Format.fprintf ppf "@[<hov 1>(Local (alloc_region@ %a) (region@ %a))@]"
+        Variable.print alloc_region Variable.print region
 
   let compare t1 t2 =
     match t1, t2 with
-    | Heap, Heap -> 0
-    | Local { region = region1 }, Local { region = region2 } ->
-      Variable.compare region1 region2
-    | Heap, Local _ -> -1
-    | Local _, Heap -> 1
+    | ( Heap { alloc_region = alloc_region1 },
+        Heap { alloc_region = alloc_region2 } ) ->
+      Variable.compare alloc_region1 alloc_region2
+    | ( Local { alloc_region = alloc_region1; region = region1 },
+        Local { alloc_region = alloc_region2; region = region2 } ) ->
+      let c = Variable.compare region1 region2 in
+      if c <> 0 then c else Variable.compare alloc_region1 alloc_region2
+    | Heap _, Local _ -> -1
+    | Local _, Heap _ -> 1
 
-  let heap = Heap
+  let heap ~alloc_region = Heap { alloc_region }
 
-  let local ~region =
+  let local ~alloc_region ~region =
     if Flambda_features.stack_allocation_enabled ()
-    then Local { region }
-    else Heap
+    then Local { alloc_region; region }
+    else Heap { alloc_region }
 
   let as_type t : For_types.t =
-    match t with Heap -> Heap | Local _ -> Heap_or_local
+    match t with Heap _ -> Heap | Local _ -> Heap_or_local
 
-  let from_lambda (mode : Lambda.locality_mode) ~current_region =
+  let from_lambda (mode : Lambda.locality_mode) ~current_alloc_region
+      ~current_region =
     if not (Flambda_features.stack_allocation_enabled ())
-    then Heap
+    then Heap { alloc_region = current_alloc_region }
     else
       match mode with
-      | Alloc_heap -> Heap
+      | Alloc_heap -> Heap { alloc_region = current_alloc_region }
       | Alloc_local -> (
         match current_region with
-        | Some region -> Local { region }
+        | Some region -> Local { alloc_region = current_alloc_region; region }
         | None -> Misc.fatal_error "Local allocation without a region")
 
   let free_names t =
     match t with
-    | Heap -> Name_occurrences.empty
-    | Local { region } ->
-      Name_occurrences.singleton_variable region Name_mode.normal
+    | Heap { alloc_region } ->
+      Name_occurrences.singleton_variable alloc_region Name_mode.normal
+    | Local { alloc_region; region } ->
+      Name_occurrences.add_variable
+        (Name_occurrences.singleton_variable region Name_mode.normal)
+        alloc_region Name_mode.normal
 
   let apply_renaming t renaming =
     match t with
-    | Heap -> Heap
-    | Local { region } ->
+    | Heap { alloc_region } ->
+      let alloc_region' = Renaming.apply_variable renaming alloc_region in
+      if alloc_region == alloc_region'
+      then t
+      else Heap { alloc_region = alloc_region' }
+    | Local { alloc_region; region } ->
+      let alloc_region' = Renaming.apply_variable renaming alloc_region in
       let region' = Renaming.apply_variable renaming region in
-      if region == region' then t else Local { region = region' }
+      if alloc_region == alloc_region' && region == region'
+      then t
+      else Local { alloc_region = alloc_region'; region = region' }
 
   let ids_for_export t =
     match t with
-    | Heap -> Ids_for_export.empty
-    | Local { region } -> Ids_for_export.singleton_variable region
+    | Heap { alloc_region } -> Ids_for_export.singleton_variable alloc_region
+    | Local { alloc_region; region } ->
+      Ids_for_export.add_variable
+        (Ids_for_export.singleton_variable region)
+        alloc_region
 end
 
 module For_assignments = struct

--- a/middle_end/flambda2/bound_identifiers/alloc_mode.mli
+++ b/middle_end/flambda2/bound_identifiers/alloc_mode.mli
@@ -45,26 +45,32 @@ end
 module For_applications : sig
   (** Decisions on allocation locations for application expressions. *)
   type t = private
-    | Heap  (** Normal allocation on the OCaml heap. *)
+    | Heap of { alloc_region : Variable.t }
+        (** Normal allocation on the OCaml heap. *)
     | Local of
-        { region : Variable.t;
+        { alloc_region : Variable.t;
+          region : Variable.t;
           ghost_region : Variable.t
         }  (** Allocation on the local allocation stack in the given region. *)
 
   val compare : t -> t -> int
 
-  val heap : t
+  val heap : alloc_region:Variable.t -> t
 
   (** Returns [Heap] if stack allocation is disabled! *)
-  val local : region:Variable.t -> ghost_region:Variable.t -> t
+  val local :
+    alloc_region:Variable.t -> region:Variable.t -> ghost_region:Variable.t -> t
 
   val as_type : t -> For_types.t
 
   val from_lambda :
     Lambda.locality_mode ->
+    current_alloc_region:Variable.t ->
     current_region:Variable.t option ->
     current_ghost_region:Variable.t option ->
     t
+
+  val alloc_region : t -> Variable.t
 
   include Contains_names.S with type t := t
 
@@ -76,23 +82,29 @@ end
 module For_allocations : sig
   (** Decisions on allocation locations *)
   type t = private
-    | Heap  (** Normal allocation on the OCaml heap. *)
-    | Local of { region : Variable.t }
-        (** Allocation on the local allocation stack in the given region. *)
+    | Heap of { alloc_region : Variable.t }
+        (** Normal allocation on the OCaml heap. *)
+    | Local of
+        { alloc_region : Variable.t;
+          region : Variable.t
+        }  (** Allocation on the local allocation stack in the given region. *)
 
   val print : Format.formatter -> t -> unit
 
   val compare : t -> t -> int
 
-  val heap : t
+  val heap : alloc_region:Variable.t -> t
 
   (** Returns [Heap] if stack allocation is disabled! *)
-  val local : region:Variable.t -> t
+  val local : alloc_region:Variable.t -> region:Variable.t -> t
 
   val as_type : t -> For_types.t
 
   val from_lambda :
-    Lambda.locality_mode -> current_region:Variable.t option -> t
+    Lambda.locality_mode ->
+    current_alloc_region:Variable.t ->
+    current_region:Variable.t option ->
+    t
 
   include Contains_names.S with type t := t
 

--- a/middle_end/flambda2/bound_identifiers/bound_for_function.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_for_function.ml
@@ -49,8 +49,9 @@ let create ~return_continuation ~exn_continuation ~params ~my_closure
      let my_set, expected_size =
        let regions, num_regions =
          match (my_alloc_mode : Alloc_mode.For_applications.t) with
-         | Heap -> [], 0
-         | Local { region; ghost_region } -> [region; ghost_region], 2
+         | Heap { alloc_region } -> [alloc_region], 1
+         | Local { alloc_region; region; ghost_region } ->
+           [alloc_region; region; ghost_region], 3
        in
        Variable.Set.of_list (my_closure :: my_depth :: regions), 2 + num_regions
      in
@@ -78,12 +79,18 @@ let params t = t.params
 let my_closure t = t.my_closure
 
 let my_region t =
-  match t.my_alloc_mode with Heap -> None | Local { region; _ } -> Some region
+  match t.my_alloc_mode with
+  | Heap _ -> None
+  | Local { region; _ } -> Some region
 
 let my_ghost_region t =
   match t.my_alloc_mode with
-  | Heap -> None
+  | Heap _ -> None
   | Local { ghost_region; _ } -> Some ghost_region
+
+let my_alloc_region t =
+  match t.my_alloc_mode with
+  | Heap { alloc_region } | Local { alloc_region; _ } -> alloc_region
 
 let my_alloc_mode t = t.my_alloc_mode
 

--- a/middle_end/flambda2/bound_identifiers/bound_for_function.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_for_function.mli
@@ -41,6 +41,8 @@ val my_region : t -> Variable.t option
 
 val my_ghost_region : t -> Variable.t option
 
+val my_alloc_region : t -> Variable.t
+
 val my_alloc_mode : t -> Alloc_mode.For_applications.t
 
 val my_depth : t -> Variable.t

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1363,6 +1363,9 @@ and cont_handlers env handler1 handler2 =
 let flambda_units u1 u2 =
   let ret_cont = Continuation.create ~sort:Toplevel_return () in
   let exn_cont = Continuation.create () in
+  let toplevel_my_alloc_region =
+    Variable.create "toplevel_my_alloc_region" Flambda_kind.region
+  in
   let toplevel_my_region =
     Variable.create "toplevel_my_region" Flambda_kind.region
   in
@@ -1380,6 +1383,11 @@ let flambda_units u1 u2 =
       Renaming.add_fresh_continuation renaming
         (Flambda_unit.exn_continuation u)
         ~guaranteed_fresh:exn_cont
+    in
+    let renaming =
+      Renaming.add_fresh_variable renaming
+        (Flambda_unit.toplevel_my_alloc_region u)
+        ~guaranteed_fresh:toplevel_my_alloc_region
     in
     let renaming =
       Renaming.add_fresh_variable renaming
@@ -1401,4 +1409,5 @@ let flambda_units u1 u2 =
       let module_symbol = Flambda_unit.module_symbol u1 in
       Flambda_unit.create ~return_continuation:ret_cont
         ~exn_continuation:exn_cont ~body ~module_symbol
-        ~used_value_slots:Unknown ~toplevel_my_region ~toplevel_my_ghost_region)
+        ~used_value_slots:Unknown ~toplevel_my_alloc_region ~toplevel_my_region
+        ~toplevel_my_ghost_region)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -732,7 +732,8 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
        Lambda.external_call_description) as prim_desc)
     ~(args : Simple.t list list) exn_continuation dbg
     ~(current_region : Variable.t option) ~current_ghost_region
-    (k : Acc.t -> Named.t list -> Expr_with_acc.t) : Expr_with_acc.t =
+    ~current_alloc_region (k : Acc.t -> Named.t list -> Expr_with_acc.t) :
+    Expr_with_acc.t =
   if prim_is_layout_poly
   then
     Misc.fatal_errorf
@@ -754,18 +755,19 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
     match Lambda.locality_mode_of_primitive_description prim_desc with
     | None ->
       (* This happens when stack allocation is disabled. *)
-      Alloc_mode.For_applications.heap
+      Alloc_mode.For_applications.heap ~alloc_region:current_alloc_region
     | Some alloc_mode ->
-      Alloc_mode.For_applications.from_lambda alloc_mode ~current_region
-        ~current_ghost_region
+      Alloc_mode.For_applications.from_lambda alloc_mode ~current_alloc_region
+        ~current_region ~current_ghost_region
   in
   let alloc_mode =
     match Lambda.locality_mode_of_primitive_description prim_desc with
     | None ->
       (* This happens when stack allocation is disabled. *)
-      Alloc_mode.For_allocations.heap
+      Alloc_mode.For_allocations.heap ~alloc_region:current_alloc_region
     | Some alloc_mode ->
-      Alloc_mode.For_allocations.from_lambda alloc_mode ~current_region
+      Alloc_mode.For_allocations.from_lambda alloc_mode ~current_alloc_region
+        ~current_region
   in
   let machine_width = Acc.machine_width acc in
   let unarized_params =
@@ -1082,7 +1084,8 @@ let close_raise acc env ~raise_kind ~arg ~dbg exn_continuation =
 
 let close_effect_primitive acc env ~dbg exn_continuation
     (prim : Lambda.primitive) ~args ~let_bound_ids_with_kinds
-    (k : Acc.t -> Named.t list -> Expr_with_acc.t) : Expr_with_acc.t =
+    ~current_alloc_region (k : Acc.t -> Named.t list -> Expr_with_acc.t) :
+    Expr_with_acc.t =
   (* CR mshinwell: share with close_c_call, above *)
   let _env, let_bound_vars =
     List.fold_left_map
@@ -1119,8 +1122,10 @@ let close_effect_primitive acc env ~dbg exn_continuation
         ~return_arity:
           (Flambda_arity.create_singletons
              [Flambda_kind.With_subkind.any_value])
-        ~call_kind ~alloc_mode:Alloc_mode.For_applications.heap dbg
-        ~inlined:Never_inlined
+        ~call_kind
+        ~alloc_mode:
+          (Alloc_mode.For_applications.heap ~alloc_region:current_alloc_region)
+        dbg ~inlined:Never_inlined
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe:None ~position:Normal
         ~relative_history:Inlining_history.Relative.empty
@@ -1171,9 +1176,9 @@ let close_effect_primitive acc env ~dbg exn_continuation
 
 let close_primitive acc env ~let_bound_ids_with_kinds named
     (prim : Lambda.primitive) ~args loc
-    (exn_continuation : IR.exn_continuation option) ~current_region
-    ~current_ghost_region (k : Acc.t -> Named.t list -> Expr_with_acc.t) :
-    Expr_with_acc.t =
+    (exn_continuation : IR.exn_continuation option) ~current_alloc_region
+    ~current_region ~current_ghost_region
+    (k : Acc.t -> Named.t list -> Expr_with_acc.t) : Expr_with_acc.t =
   let orig_exn_continuation = exn_continuation in
   let acc, exn_continuation =
     match exn_continuation with
@@ -1196,7 +1201,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_c_call acc env ~loc ~let_bound_ids_with_kinds prim ~args
-      exn_continuation dbg ~current_region ~current_ghost_region k
+      exn_continuation dbg ~current_region ~current_ghost_region
+      ~current_alloc_region k
   | Pgetglobal (cu, _), [] ->
     if Compilation_unit.equal cu (Env.current_unit env)
     then
@@ -1314,11 +1320,11 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_effect_primitive acc env ~dbg exn_continuation prim ~args
-      ~let_bound_ids_with_kinds k
+      ~let_bound_ids_with_kinds ~current_alloc_region k
   | prim, args ->
     Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
       ~big_endian:(Env.big_endian env) ~register_const0 prim ~args dbg
-      ~current_region ~current_ghost_region k
+      ~current_alloc_region ~current_region ~current_ghost_region k
 
 let close_trap_action_opt trap_action =
   Option.map
@@ -1372,13 +1378,16 @@ let close_named acc env ~let_bound_ids_with_kinds (named : IR.named)
     in
     Lambda_to_flambda_primitives_helpers.bind_recs acc None ~register_const0
       prim Debuginfo.none k
-  | Prim { prim; args; loc; exn_continuation; region; ghost_region } ->
+  | Prim
+      { prim; args; loc; exn_continuation; region; ghost_region; alloc_region }
+    ->
     let get_region_ident region =
       Option.map (fun region -> fst (Env.find_var env region)) region
     in
     close_primitive acc env ~let_bound_ids_with_kinds named prim ~args loc
       exn_continuation ~current_region:(get_region_ident region)
       ~current_ghost_region:(get_region_ident ghost_region)
+      ~current_alloc_region:(fst (Env.find_var env alloc_region))
       k
 
 type simplified_block_load =
@@ -1411,7 +1420,7 @@ let classify_fields_of_block env fields alloc_mode =
   let is_local =
     match (alloc_mode : Alloc_mode.For_allocations.t) with
     | Local _ -> true
-    | Heap -> false
+    | Heap _ -> false
   in
   let static_fields =
     List.fold_left
@@ -1776,6 +1785,7 @@ let close_exact_or_unknown_apply acc env
        region_close;
        region;
        ghost_region;
+       alloc_region;
        args_arity;
        return_arity
      } :
@@ -1791,8 +1801,9 @@ let close_exact_or_unknown_apply acc env
         convert_region region, convert_region ghost_region
       | Some (region, ghost_region) -> Some region, Some ghost_region
     in
-    Alloc_mode.For_applications.from_lambda mode ~current_region
-      ~current_ghost_region
+    Alloc_mode.For_applications.from_lambda mode
+      ~current_alloc_region:(fst (Env.find_var env alloc_region))
+      ~current_region ~current_ghost_region
   in
   let dbg = Debuginfo.from_location loc in
   let acc, call_kind, can_erase_callee =
@@ -2102,7 +2113,7 @@ let boxing_primitive (k : Function_decl.unboxing_kind) alloc_mode
       ( Make_block (Naked_floats, Immutable, alloc_mode),
         Simple.vars unboxed_variables )
 
-let compute_body_of_unboxed_function acc my_region my_closure
+let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
     ~unarized_params:params params_arity ~unarized_param_modes:param_modes
     function_slot compute_body return return_continuation unboxed_params
     unboxed_return unboxed_function_slot =
@@ -2130,7 +2141,8 @@ let compute_body_of_unboxed_function acc my_region my_closure
         let body acc =
           let acc, body = body acc in
           let alloc_mode =
-            Alloc_mode.For_allocations.from_lambda ~current_region:my_region
+            Alloc_mode.For_allocations.from_lambda
+              ~current_alloc_region:my_alloc_region ~current_region:my_region
               (Alloc_mode.For_types.to_lambda param_mode)
           in
           let param_duid = Flambda_debug_uid.none in
@@ -2280,6 +2292,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
   let return_continuation = Continuation.create () in
   let exn_continuation = Continuation.create () in
   let my_closure = Variable.create "my_closure" K.value in
+  let my_alloc_region = Variable.create "my_alloc_region" K.region in
   let my_region =
     if contains_no_escaping_local_allocs
     then None
@@ -2363,7 +2376,8 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
         ~alloc_mode:
           (Alloc_mode.For_applications.from_lambda
              (Function_decl.result_mode decl)
-             ~current_region:my_region ~current_ghost_region:my_ghost_region)
+             ~current_alloc_region:my_alloc_region ~current_region:my_region
+             ~current_ghost_region:my_ghost_region)
         Debuginfo.none ~inlined:Inlined_attribute.Default_inlined
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe:None ~position:Normal
@@ -2458,7 +2472,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
   let alloc_mode =
     Alloc_mode.For_allocations.from_lambda
       (Function_decl.result_mode decl)
-      ~current_region:my_region
+      ~current_alloc_region:my_alloc_region ~current_region:my_region
   in
   let body, free_names_of_body =
     match unboxed_return with
@@ -2468,7 +2482,8 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
   let my_alloc_mode =
     Alloc_mode.For_applications.from_lambda
       (Function_decl.result_mode decl)
-      ~current_region:my_region ~current_ghost_region:my_ghost_region
+      ~current_alloc_region:my_alloc_region ~current_region:my_region
+      ~current_ghost_region:my_ghost_region
   in
   let wrapper_params_and_body =
     Function_params_and_body.create ~return_continuation ~exn_continuation
@@ -2481,13 +2496,14 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
          (Name_occurrences.remove_var ~var:my_closure
             (Name_occurrences.remove_var_opt ~var:my_region
                (Name_occurrences.remove_var_opt ~var:my_ghost_region
-                  (Name_occurrences.remove_var ~var:my_depth
-                     (List.fold_left
-                        (fun free_names param ->
-                          Name_occurrences.remove_var free_names
-                            ~var:(Bound_parameter.var param))
-                        free_names_of_body
-                        (Bound_parameters.to_list params)))))))
+                  (Name_occurrences.remove_var ~var:my_alloc_region
+                     (Name_occurrences.remove_var ~var:my_depth
+                        (List.fold_left
+                           (fun free_names param ->
+                             Name_occurrences.remove_var free_names
+                               ~var:(Bound_parameter.var param))
+                           free_names_of_body
+                           (Bound_parameters.to_list params))))))))
   in
   let wrapper_code =
     Code.create code_id ~params_and_body:wrapper_params_and_body
@@ -2574,6 +2590,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
     Acc.push_closure_info acc ~return_continuation ~exn_continuation ~my_closure
       ~is_purely_tailrec:is_single_recursive_function ~code_id
   in
+  let my_alloc_region = Function_decl.my_alloc_region decl in
   let my_region = Function_decl.my_region decl in
   let my_ghost_region = Function_decl.my_ghost_region decl in
   let function_slot = Function_decl.function_slot decl in
@@ -2677,9 +2694,14 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
         env)
       unarized_params closure_env
   in
+  let closure_env, alloc_region =
+    Env.add_var_like closure_env my_alloc_region Not_user_visible
+      K.With_subkind.region
+  in
   let closure_env, my_region, my_ghost_region, my_alloc_mode =
     match my_region, my_ghost_region with
-    | None, None -> closure_env, None, None, Alloc_mode.For_applications.heap
+    | None, None ->
+      closure_env, None, None, Alloc_mode.For_applications.heap ~alloc_region
     | Some _, None | None, Some _ ->
       Misc.fatal_errorf
         "In [close_one_function], only one of [my_region] and \
@@ -2696,7 +2718,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
       ( env,
         Some region,
         Some ghost_region,
-        Alloc_mode.For_applications.local ~region ~ghost_region )
+        Alloc_mode.For_applications.local ~alloc_region ~region ~ghost_region )
   in
   let closure_env = Env.with_depth closure_env my_depth in
   let closure_env, absolute_history, relative_history =
@@ -2813,9 +2835,10 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
         my_closure )
     | Unboxed_calling_convention
         (unboxed_params, unboxed_return, unboxed_function_slot) ->
-      compute_body_of_unboxed_function acc my_region my_closure ~unarized_params
-        params_arity ~unarized_param_modes function_slot compute_body return
-        return_continuation unboxed_params unboxed_return unboxed_function_slot
+      compute_body_of_unboxed_function acc my_region alloc_region my_closure
+        ~unarized_params params_arity ~unarized_param_modes function_slot
+        compute_body return return_continuation unboxed_params unboxed_return
+        unboxed_function_slot
   in
   let contains_subfunctions = Acc.seen_a_function acc in
   let cost_metrics = Acc.cost_metrics acc in
@@ -2857,6 +2880,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
     |> Acc.remove_var_from_free_names my_closure
     |> Acc.remove_var_opt_from_free_names my_region
     |> Acc.remove_var_opt_from_free_names my_ghost_region
+    |> Acc.remove_var_from_free_names alloc_region
     |> Acc.remove_var_from_free_names my_depth
     |> Acc.remove_continuation_from_free_names return_continuation
     |> Acc.remove_continuation_from_free_names
@@ -2956,7 +2980,8 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
     ( Function_slot.Map.add function_slot approx by_function_slot,
       function_code_ids ) )
 
-let close_functions acc external_env ~current_region function_declarations =
+let close_functions acc external_env ~current_alloc_region ~current_region
+    function_declarations =
   let compilation_unit = Compilation_unit.get_current_exn () in
   let value_slots_from_idents =
     Ident.Set.fold
@@ -3177,7 +3202,7 @@ let close_functions acc external_env ~current_region function_declarations =
   let alloc_mode =
     Alloc_mode.For_allocations.from_lambda
       (Function_decls.alloc_mode function_declarations)
-      ~current_region
+      ~current_alloc_region ~current_region
   in
   let set_of_closures = Set_of_closures.create ~value_slots function_decls in
   let acc =
@@ -3207,7 +3232,9 @@ let close_functions acc external_env ~current_region function_declarations =
   else acc, Dynamic (set_of_closures, alloc_mode, approximations)
 
 let close_let_rec acc env ~function_declarations
-    ~(body : Acc.t -> Env.t -> Expr_with_acc.t) ~current_region =
+    ~(body : Acc.t -> Env.t -> Expr_with_acc.t) ~current_alloc_region
+    ~current_region =
+  let current_alloc_region = fst (Env.find_var env current_alloc_region) in
   let current_region =
     Option.map (fun region -> fst (Env.find_var env region)) current_region
   in
@@ -3262,7 +3289,7 @@ let close_let_rec acc env ~function_declarations
   let acc, closed_functions =
     close_functions acc env
       (Function_decls.create function_declarations alloc_mode)
-      ~current_region
+      ~current_alloc_region ~current_region
   in
   match closed_functions with
   | Lifted symbols ->
@@ -3377,6 +3404,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     | Alloc_heap -> true
     | Alloc_local -> false
   in
+  let my_alloc_region = Ident.create_local "my_alloc_region" in
   let my_region =
     if contains_no_escaping_local_allocs
     then None
@@ -3399,7 +3427,8 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
         mode = result_mode;
         return_arity = result_arity;
         region = my_region;
-        ghost_region = my_ghost_region
+        ghost_region = my_ghost_region;
+        alloc_region = my_alloc_region
       }
       (Some approx) ~replace_region:None
   in
@@ -3453,8 +3482,8 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
                })
           ~params ~params_arity ~removed_params:Ident.Set.empty
           ~return:result_arity ~calling_convention:Normal_calling_convention
-          ~return_continuation ~exn_continuation ~my_region ~my_ghost_region
-          ~body:fbody ~attr ~loc:apply.loc ~free_idents_of_body
+          ~return_continuation ~exn_continuation ~my_alloc_region ~my_region
+          ~my_ghost_region ~body:fbody ~attr ~loc:apply.loc ~free_idents_of_body
           ~closure_alloc_mode ~first_complex_local_param ~result_mode
           Recursive.Non_recursive ]
     in
@@ -3468,7 +3497,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
       Expr_with_acc.create_apply_cont acc apply_cont
     in
     close_let_rec acc env ~function_declarations ~body
-      ~current_region:apply.region
+      ~current_alloc_region:apply.alloc_region ~current_region:apply.region
 
 let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
     ~remaining_arity ~result_mode =
@@ -3492,6 +3521,7 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
       Some (over_app_region, over_app_ghost_region, Continuation.create ())
     | Alloc_heap, Alloc_heap | Alloc_local, _ -> None
   in
+  let apply_alloc_region = fst (Env.find_var env apply.alloc_region) in
   let apply_region, apply_ghost_region =
     match needs_region with
     | None ->
@@ -3515,7 +3545,8 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
     in
     let alloc_mode =
       Alloc_mode.For_applications.from_lambda apply.mode
-        ~current_region:apply_region ~current_ghost_region:apply_ghost_region
+        ~current_alloc_region:apply_alloc_region ~current_region:apply_region
+        ~current_ghost_region:apply_ghost_region
     in
     let continuation =
       match needs_region with
@@ -4036,7 +4067,8 @@ let wrap_final_module_block acc env ~program ~prog_return_cont
 let close_program (type mode) ~(mode : mode Flambda_features.mode)
     ~machine_width ~big_endian ~cmx_loader ~compilation_unit ~module_repr
     ~program ~prog_return_cont ~exn_continuation ~toplevel_my_region
-    ~toplevel_my_ghost_region ~sections : mode close_program_result =
+    ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~sections :
+    mode close_program_result =
   let env = Env.create ~big_endian in
   let module_symbol =
     Symbol.create_wrapped
@@ -4049,6 +4081,10 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
   in
   let env, toplevel_my_ghost_region =
     Env.add_var_like env toplevel_my_ghost_region Not_user_visible
+      Flambda_kind.With_subkind.region
+  in
+  let env, toplevel_my_alloc_region =
+    Env.add_var_like env toplevel_my_alloc_region Not_user_visible
       Flambda_kind.With_subkind.region
   in
   let acc = Acc.create ~cmx_loader ~machine_width in
@@ -4113,8 +4149,8 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
        offsets constraints accumulation is not needed in "normal" mode. *)
     let unit =
       Flambda_unit.create ~return_continuation:return_cont ~exn_continuation
-        ~toplevel_my_region ~toplevel_my_ghost_region ~body ~module_symbol
-        ~used_value_slots:Unknown
+        ~toplevel_my_region ~toplevel_my_ghost_region ~toplevel_my_alloc_region
+        ~body ~module_symbol ~used_value_slots:Unknown
     in
     { unit; code_slot_offsets; metadata = Normal }
   | Classic ->
@@ -4148,8 +4184,8 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
     in
     let unit =
       Flambda_unit.create ~return_continuation:return_cont ~exn_continuation
-        ~toplevel_my_region ~toplevel_my_ghost_region ~body ~module_symbol
-        ~used_value_slots:(Known used_value_slots)
+        ~toplevel_my_region ~toplevel_my_ghost_region ~toplevel_my_alloc_region
+        ~body ~module_symbol ~used_value_slots:(Known used_value_slots)
     in
     { unit;
       code_slot_offsets;

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -36,6 +36,7 @@ val close_let_rec :
   Env.t ->
   function_declarations:Function_decl.t list ->
   body:(Acc.t -> Env.t -> Expr_with_acc.t) ->
+  current_alloc_region:Ident.t ->
   current_region:Ident.t option ->
   Expr_with_acc.t
 
@@ -110,5 +111,6 @@ val close_program :
   exn_continuation:Continuation.t ->
   toplevel_my_region:Ident.t ->
   toplevel_my_ghost_region:Ident.t ->
+  toplevel_my_alloc_region:Ident.t ->
   sections:File_sections.Builder.t ->
   'mode close_program_result

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -52,7 +52,8 @@ module IR = struct
           loc : Lambda.scoped_location;
           exn_continuation : exn_continuation option;
           region : Ident.t option;
-          ghost_region : Ident.t option
+          ghost_region : Ident.t option;
+          alloc_region : Ident.t
         }
 
   type apply_kind =
@@ -75,6 +76,7 @@ module IR = struct
       mode : Lambda.locality_mode;
       region : Ident.t option;
       ghost_region : Ident.t option;
+      alloc_region : Ident.t;
       args_arity : [`Complex] Flambda_arity.t;
       return_arity : [`Unarized] Flambda_arity.t
     }
@@ -797,6 +799,7 @@ module Function_decls = struct
         exn_continuation : IR.exn_continuation;
         my_region : Ident.t option;
         my_ghost_region : Ident.t option;
+        my_alloc_region : Ident.t;
         body : Acc.t -> Env.t -> Acc.t * Flambda.Import.Expr.t;
         free_idents_of_body : Ident.Set.t;
         attr : Lambda.function_attribute;
@@ -809,9 +812,10 @@ module Function_decls = struct
 
     let create ~let_rec_ident ~let_rec_uid ~function_slot ~kind ~params
         ~params_arity ~removed_params ~return ~calling_convention
-        ~return_continuation ~exn_continuation ~my_region ~my_ghost_region ~body
-        ~(attr : Lambda.function_attribute) ~loc ~free_idents_of_body recursive
-        ~closure_alloc_mode ~first_complex_local_param ~result_mode =
+        ~return_continuation ~exn_continuation ~my_alloc_region ~my_region
+        ~my_ghost_region ~body ~(attr : Lambda.function_attribute) ~loc
+        ~free_idents_of_body recursive ~closure_alloc_mode
+        ~first_complex_local_param ~result_mode =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -842,6 +846,7 @@ module Function_decls = struct
         exn_continuation;
         my_region;
         my_ghost_region;
+        my_alloc_region;
         body;
         free_idents_of_body;
         attr;
@@ -875,6 +880,8 @@ module Function_decls = struct
     let my_region t = t.my_region
 
     let my_ghost_region t = t.my_ghost_region
+
+    let my_alloc_region t = t.my_alloc_region
 
     let body t = t.body
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -56,7 +56,8 @@ module IR : sig
           loc : Lambda.scoped_location;
           exn_continuation : exn_continuation option;
           region : Ident.t option;
-          ghost_region : Ident.t option
+          ghost_region : Ident.t option;
+          alloc_region : Ident.t
         }
 
   type apply_kind =
@@ -79,6 +80,7 @@ module IR : sig
       mode : Lambda.locality_mode;
       region : Ident.t option;
       ghost_region : Ident.t option;
+      alloc_region : Ident.t;
       args_arity : [`Complex] Flambda_arity.t;
       return_arity : [`Unarized] Flambda_arity.t
     }
@@ -368,6 +370,7 @@ module Function_decls : sig
       calling_convention:calling_convention ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
+      my_alloc_region:Ident.t ->
       my_region:Ident.t option ->
       my_ghost_region:Ident.t option ->
       body:(Acc.t -> Env.t -> Acc.t * Flambda.Import.Expr.t) ->
@@ -403,6 +406,8 @@ module Function_decls : sig
     val my_region : t -> Ident.t option
 
     val my_ghost_region : t -> Ident.t option
+
+    val my_alloc_region : t -> Ident.t
 
     val body : t -> Acc.t -> Env.t -> Acc.t * Flambda.Import.Expr.t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -533,6 +533,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         (Singleton Flambda_kind.With_subkind.any_value)
     in
     CC.close_let_rec acc ccenv ~function_declarations:[func] ~body
+      ~current_alloc_region:(Env.current_alloc_region env)
       ~current_region:
         (Env.current_region env |> Option.map Env.Region_stack_element.region)
   | Lmutlet (layout, id, _duid, defining_expr, body) ->
@@ -577,6 +578,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
       List.fold_left
         (fun body func acc ccenv ->
           CC.close_let_rec acc ccenv ~function_declarations:[func] ~body
+            ~current_alloc_region:(Env.current_alloc_region env)
             ~current_region:
               (Env.current_region env
               |> Option.map Env.Region_stack_element.region))
@@ -658,8 +660,17 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           let ghost_region =
             Option.map Env.Region_stack_element.ghost_region current_region
           in
+          let alloc_region = Env.current_alloc_region env in
           CC.close_let acc ccenv ids_with_kinds (is_user_visible env id)
-            (Prim { prim; args; loc; exn_continuation; region; ghost_region })
+            (Prim
+               { prim;
+                 args;
+                 loc;
+                 exn_continuation;
+                 region;
+                 ghost_region;
+                 alloc_region
+               })
             ~body)
         k_exn
     | Transformed lam ->
@@ -726,6 +737,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     let function_declarations = cps_function_bindings env bindings in
     let body acc ccenv = cps acc env ccenv body k k_exn in
     CC.close_let_rec acc ccenv ~function_declarations ~body
+      ~current_alloc_region:(Env.current_alloc_region env)
       ~current_region:
         (Env.current_region env |> Option.map Env.Region_stack_element.region)
   | Lprim (prim, args, loc) -> (
@@ -882,6 +894,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                       }
                     in
                     let current_region = Env.current_region env in
+                    let current_alloc_region = Env.current_alloc_region env in
                     let apply : IR.apply =
                       { kind = Method { kind = meth_kind; obj };
                         func = meth;
@@ -899,6 +912,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         ghost_region =
                           Option.map Env.Region_stack_element.ghost_region
                             current_region;
+                        alloc_region = current_alloc_region;
                         args_arity = Flambda_arity.create args_arity;
                         return_arity =
                           Flambda_arity.unarize_t
@@ -1258,6 +1272,7 @@ and cps_tail_apply acc env ccenv ap_func ap_args ap_region_close ap_mode ap_loc
               region = Option.map Env.Region_stack_element.region current_region;
               ghost_region =
                 Option.map Env.Region_stack_element.ghost_region current_region;
+              alloc_region = Env.current_alloc_region env;
               args_arity = Flambda_arity.create args_arity;
               return_arity =
                 Flambda_arity.unarize_t
@@ -1529,10 +1544,12 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
         Some my_region,
         Some my_ghost_region )
   in
+  let my_alloc_region = Ident.create_local "my_alloc_region" in
   let new_env =
     Env.create ~current_unit:(Env.current_unit env)
       ~machine_width:(Env.machine_width env) ~return_continuation:body_cont
       ~exn_continuation:body_exn_cont ~my_region:my_region_stack_elt
+      ~my_alloc_region
   in
   let exn_continuation : IR.exn_continuation =
     { exn_handler = body_exn_cont; extra_args = [] }
@@ -1616,8 +1633,9 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
   Function_decl.create ~let_rec_ident:(Some fid) ~let_rec_uid:fuid
     ~function_slot ~kind ~params ~params_arity ~removed_params ~return
     ~calling_convention ~return_continuation:body_cont ~exn_continuation
-    ~my_region ~my_ghost_region ~body ~attr ~loc ~free_idents_of_body recursive
-    ~closure_alloc_mode:mode ~first_complex_local_param ~result_mode:ret_mode
+    ~my_region ~my_ghost_region ~my_alloc_region ~body ~attr ~loc
+    ~free_idents_of_body recursive ~closure_alloc_mode:mode
+    ~first_complex_local_param ~result_mode:ret_mode
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
     ~scrutinee (k : Continuation.t) (k_exn : Continuation.t) : Expr_with_acc.t =
@@ -1791,6 +1809,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
             let ghost_region =
               Option.map Env.Region_stack_element.ghost_region current_region
             in
+            let alloc_region = Env.current_alloc_region env in
             CC.close_let acc ccenv
               [ ( is_scrutinee_int,
                   is_scrutinee_int_duid,
@@ -1802,7 +1821,8 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
                    loc = Loc_unknown;
                    exn_continuation = None;
                    region;
-                   ghost_region
+                   ghost_region;
+                   alloc_region
                  })
               ~body
           in
@@ -1831,9 +1851,13 @@ let lambda_to_flambda ~mode ~machine_width ~big_endian ~cmx_loader
   let toplevel_my_ghost_region =
     Ident.create_local "toplevel_my_ghost_region"
   in
+  let toplevel_my_alloc_region =
+    Ident.create_local "toplevel_my_alloc_region"
+  in
   let env =
     Env.create ~current_unit:compilation_unit ~machine_width
       ~return_continuation ~exn_continuation ~my_region:None
+      ~my_alloc_region:toplevel_my_alloc_region
   in
   let program acc ccenv =
     cps_tail acc env ccenv lam return_continuation exn_continuation
@@ -1841,4 +1865,4 @@ let lambda_to_flambda ~mode ~machine_width ~big_endian ~cmx_loader
   CC.close_program ~mode ~machine_width ~big_endian ~cmx_loader
     ~compilation_unit ~module_repr ~program
     ~prog_return_cont:return_continuation ~exn_continuation ~toplevel_my_region
-    ~toplevel_my_ghost_region ~sections
+    ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~sections

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
@@ -90,11 +90,12 @@ type t =
     region_stack_in_cont_scope : Region_stack_element.t list Continuation.Map.t;
     region_closure_continuations :
       region_closure_continuation Region_stack_element.Map.t;
+    my_alloc_region : Ident.t;
     ident_stamp_upon_starting : int
   }
 
 let create ~current_unit ~machine_width ~return_continuation ~exn_continuation
-    ~my_region =
+    ~my_region ~my_alloc_region =
   let mutables_needed_by_continuations =
     Continuation.Map.of_list
       [return_continuation, Ident.Set.empty; exn_continuation, Ident.Set.empty]
@@ -115,6 +116,7 @@ let create ~current_unit ~machine_width ~return_continuation ~exn_continuation
     region_stack_in_cont_scope =
       Continuation.Map.singleton return_continuation [];
     region_closure_continuations = Region_stack_element.Map.empty;
+    my_alloc_region;
     ident_stamp_upon_starting
   }
 
@@ -350,6 +352,11 @@ let current_region t =
     match t.region_stack with
     | [] -> t.my_region
     | region_stack_elt :: _ -> Some region_stack_elt
+
+(* CR alloc_regions: in the future, there will be a region stack for
+   alloc_regions. It will be used here, but this is not required for now, as we
+   have a single alloc_region for a function. *)
+let current_alloc_region t = t.my_alloc_region
 
 let parent_region t =
   if not (Flambda_features.stack_allocation_enabled ())

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -34,6 +34,7 @@ val create :
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
   my_region:Region_stack_element.t option ->
+  my_alloc_region:Ident.t ->
   t
 
 val current_unit : t -> Compilation_unit.t
@@ -213,3 +214,5 @@ type region_closure_continuation = private
 
 val region_closure_continuation :
   t -> Region_stack_element.t -> region_closure_continuation
+
+val current_alloc_region : t -> Ident.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -621,63 +621,69 @@ let unbox_float32 (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number K.Boxable_number.Naked_float32, arg))
 
 let box_float32 (mode : L.locality_mode) (arg : H.expr_primitive)
-    ~current_region : H.expr_primitive =
+    ~current_alloc_region ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( K.Boxable_number.Naked_float32,
-          Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+            ~current_region ),
       Prim arg )
 
-let box_float (mode : L.locality_mode) (arg : H.expr_primitive) ~current_region
-    : H.expr_primitive =
+let box_float (mode : L.locality_mode) (arg : H.expr_primitive)
+    ~current_alloc_region ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( K.Boxable_number.Naked_float,
-          Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+            ~current_region ),
       Prim arg )
 
 let unbox_float (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number K.Boxable_number.Naked_float, arg))
 
-let box_bint bi mode (arg : H.expr_primitive) ~current_region : H.expr_primitive
-    =
+let box_bint bi mode (arg : H.expr_primitive) ~current_alloc_region
+    ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( boxable_number_of_boxed_integer bi,
-          Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+            ~current_region ),
       Prim arg )
 
 let unbox_bint bi (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number (boxable_number_of_boxed_integer bi), arg))
 
-let box_vec128 mode (arg : H.expr_primitive) ~current_region : H.expr_primitive
-    =
+let box_vec128 mode (arg : H.expr_primitive) ~current_alloc_region
+    ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( Naked_vec128,
-          Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+            ~current_region ),
       Prim arg )
 
 let unbox_vec128 (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number Naked_vec128, arg))
 
-let box_vec256 mode (arg : H.expr_primitive) ~current_region : H.expr_primitive
-    =
+let box_vec256 mode (arg : H.expr_primitive) ~current_alloc_region
+    ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( Naked_vec256,
-          Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+            ~current_region ),
       Prim arg )
 
 let unbox_vec256 (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number Naked_vec256, arg))
 
-let box_vec512 mode (arg : H.expr_primitive) ~current_region : H.expr_primitive
-    =
+let box_vec512 mode (arg : H.expr_primitive) ~current_alloc_region
+    ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( Naked_vec512,
-          Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+            ~current_region ),
       Prim arg )
 
 let unbox_vec512 (arg : H.simple_or_prim) : H.simple_or_prim =
@@ -881,7 +887,7 @@ let checked_bigstring_access ~dbg ~machine_width ~access_len ~align ~primitive
 let string_like_load ~dbg ~checks
     ~(access_size : Flambda_primitive.string_accessor_width) ~machine_width
     (kind : P.string_like_value) mode ~boxed_or_tagged string ~index_kind index
-    ~current_region =
+    ~current_alloc_region ~current_region =
   let unsafe_load =
     let index = convert_index_to_naked_nativeint ~index ~index_kind in
     let wrap =
@@ -893,20 +899,28 @@ let string_like_load ~dbg ~checks
       | Sixteen_signed, None -> if boxed_or_tagged then tag_int16 else Fun.id
       | Thirty_two, Some mode ->
         if boxed_or_tagged
-        then box_bint Boxed_int32 mode ~current_region
+        then box_bint Boxed_int32 mode ~current_alloc_region ~current_region
         else Fun.id
       | Single, Some mode ->
-        if boxed_or_tagged then box_float32 mode ~current_region else Fun.id
+        if boxed_or_tagged
+        then box_float32 mode ~current_alloc_region ~current_region
+        else Fun.id
       | Sixty_four, Some mode ->
         if boxed_or_tagged
-        then box_bint Boxed_int64 mode ~current_region
+        then box_bint Boxed_int64 mode ~current_alloc_region ~current_region
         else Fun.id
       | One_twenty_eight _, Some mode ->
-        if boxed_or_tagged then box_vec128 mode ~current_region else Fun.id
+        if boxed_or_tagged
+        then box_vec128 mode ~current_alloc_region ~current_region
+        else Fun.id
       | Two_fifty_six _, Some mode ->
-        if boxed_or_tagged then box_vec256 mode ~current_region else Fun.id
+        if boxed_or_tagged
+        then box_vec256 mode ~current_alloc_region ~current_region
+        else Fun.id
       | Five_twelve _, Some mode ->
-        if boxed_or_tagged then box_vec512 mode ~current_region else Fun.id
+        if boxed_or_tagged
+        then box_vec512 mode ~current_alloc_region ~current_region
+        else Fun.id
       | (Eight | Eight_signed | Sixteen | Sixteen_signed), Some _
       | ( ( Thirty_two | Single | Sixty_four | One_twenty_eight _
           | Two_fifty_six _ | Five_twelve _ ),
@@ -927,8 +941,10 @@ let string_like_load ~dbg ~checks
     check_access ~dbg ~machine_width ~access_len:len ~align
       ~primitive:unsafe_load string ~index_kind index
 
-let get_header obj mode ~current_region =
-  let wrap hd = box_bint Boxed_nativeint mode hd ~current_region in
+let get_header obj mode ~current_alloc_region ~current_region =
+  let wrap hd =
+    box_bint Boxed_nativeint mode hd ~current_alloc_region ~current_region
+  in
   wrap (Unary (Get_header, obj))
 
 (* Bytes-like set *)
@@ -1108,8 +1124,9 @@ let check_array_vector_access ~dbg ~machine_width ~array array_kind ~index
           array_kind index ]
     ~dbg
 
-let array_like_load_vec ~dbg ~machine_width ~unsafe ~mode ~boxed ~current_region
-    ~(vec_kind : Vector_types.Kind.t) array_kind array ~index_kind index =
+let array_like_load_vec ~dbg ~machine_width ~unsafe ~mode ~boxed
+    ~current_alloc_region ~current_region ~(vec_kind : Vector_types.Kind.t)
+    array_kind array ~index_kind index =
   let index = convert_index_to_tagged_int ~index ~index_kind in
   let load_kind, box =
     match vec_kind with
@@ -1121,7 +1138,9 @@ let array_like_load_vec ~dbg ~machine_width ~unsafe ~mode ~boxed ~current_region
     H.Binary (Array_load (array_kind, load_kind, Mutable), array, index)
   in
   let primitive =
-    if boxed then box mode ~current_region primitive else primitive
+    if boxed
+    then box mode ~current_alloc_region ~current_region primitive
+    else primitive
   in
   if unsafe
   then primitive
@@ -1320,7 +1339,7 @@ let compute_array_indexes ~machine_width ~index ~num_elts =
 
 let rec array_load_unsafe ~machine_width ~array ~index
     ~(mut : Lambda.mutable_flag) array_kind (array_ref_kind : Array_ref_kind.t)
-    ~current_region : H.expr_primitive list =
+    ~current_alloc_region ~current_region : H.expr_primitive list =
   (* CR mshinwell/ncourant: can we avoid taking [array_kind] here? *)
   let mut' : Mutability.t =
     match mut with
@@ -1331,7 +1350,7 @@ let rec array_load_unsafe ~machine_width ~array ~index
   | Naked_floats_to_be_boxed mode ->
     [ box_float mode
         (Binary (Array_load (array_kind, Naked_floats, mut'), array, index))
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | No_float_array_opt (Unboxed_product array_ref_kinds) ->
     let rec unarize_kind (array_ref_kind : Array_ref_kind.no_float_array_opt) :
         Array_ref_kind.t list =
@@ -1370,7 +1389,7 @@ let rec array_load_unsafe ~machine_width ~array ~index
     List.concat_map
       (fun (index, array_ref_kind) ->
         array_load_unsafe ~machine_width ~array ~index ~mut array_kind
-          array_ref_kind ~current_region)
+          array_ref_kind ~current_alloc_region ~current_region)
       (List.combine indexes unarized)
   | No_float_array_opt
       (( Immediates | Gc_ignorable_values | Values | Naked_floats
@@ -1398,9 +1417,9 @@ let rec array_load_unsafe ~machine_width ~array ~index
     [Binary (Array_load (array_kind, array_load_kind, mut'), array, index)]
 
 let array_load_unsafe ~machine_width ~array ~index ~mut array_kind
-    array_load_kind ~current_region =
+    array_load_kind ~current_alloc_region ~current_region =
   array_load_unsafe ~machine_width ~array ~index ~mut array_kind array_load_kind
-    ~current_region
+    ~current_alloc_region ~current_region
   |> H.maybe_create_unboxed_product
 
 let rec array_set_unsafe ~machine_width dbg ~array ~index array_kind
@@ -1565,8 +1584,8 @@ let opaque ~machine_width layout arg ~middle_end_only : H.expr_primitive list =
     arg kinds
 
 let rec static_cast0 ~(src : L.any_locality_mode Scalar.t)
-    ~(dst : L.locality_mode Scalar.t) (arg : H.simple_or_prim) ~current_region :
-    H.simple_or_prim =
+    ~(dst : L.locality_mode Scalar.t) (arg : H.simple_or_prim)
+    ~current_alloc_region ~current_region : H.simple_or_prim =
   match src, dst with
   | Value src, dst ->
     (* First, untag/unbox the value if necessary, then do the conversion. *)
@@ -1593,16 +1612,20 @@ let rec static_cast0 ~(src : L.any_locality_mode Scalar.t)
       | Floating (Float64 Any_locality_mode) ->
         Unary (Unbox_number Naked_float, arg)
     in
-    static_cast (H.Prim arg) ~src:(Scalar.naked src) ~dst ~current_region
+    static_cast (H.Prim arg) ~src:(Scalar.naked src) ~dst ~current_alloc_region
+      ~current_region
   | src, Value dst -> (
     (* The inverse of the previous case: first do the conversion, then tag/box
        the result. *)
     let arg =
       let dst = Scalar.naked (Scalar.Width.ignore_locality dst) in
-      static_cast arg ~src ~dst ~current_region
+      static_cast arg ~src ~dst ~current_alloc_region ~current_region
     in
     let box_number width mode : H.simple_or_prim =
-      let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+      let mode =
+        Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+          ~current_region
+      in
       Prim (Unary (Box_number (width, mode), arg))
     in
     match dst with
@@ -1637,10 +1660,11 @@ let rec static_cast0 ~(src : L.any_locality_mode Scalar.t)
     Prim (Unary (Num_conv { src; dst }, arg))
 
 and static_cast ~(src : L.any_locality_mode Scalar.t)
-    ~(dst : L.locality_mode Scalar.t) (arg : H.simple_or_prim) ~current_region =
+    ~(dst : L.locality_mode Scalar.t) (arg : H.simple_or_prim)
+    ~current_alloc_region ~current_region =
   if Scalar.equal (fun _ _ -> true) src dst
   then arg
-  else static_cast0 ~src ~dst arg ~current_region
+  else static_cast0 ~src ~dst arg ~current_alloc_region ~current_region
 
 let to_expr : H.simple_or_prim -> H.expr_primitive = function
   | Prim prim -> prim
@@ -1785,7 +1809,8 @@ let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
 (* Primitive conversion *)
 let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     (prim : L.primitive) (args : Simple.t list list) (dbg : Debuginfo.t)
-    ~current_region ~current_ghost_region : H.expr_primitive list =
+    ~current_alloc_region ~current_region ~current_ghost_region :
+    H.expr_primitive list =
   let orig_args = args in
   let args =
     List.map (List.map (fun arg : H.simple_or_prim -> Simple arg)) args
@@ -1797,7 +1822,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [tag_int (Binary (Phys_equal eq, arg1, arg2))]
   | Pmakeblock (tag, mutability, shape, mode), _ -> (
     let args = List.flatten args in
-    let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+    let mode =
+      Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+        ~current_region
+    in
     let tag = Tag.Scannable.create_exn tag in
     let mutability = Mutability.from_lambda mutability in
     match L.mixed_block_of_block_shape shape with
@@ -1851,7 +1879,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
              from_mixed_block_shape returned Value_only"
       in
       [Variadic (Make_block (Mixed (tag, kind_shape), mutability, mode), args)])
-  | Pmakelazyblock lazy_tag, [[arg]] -> [Unary (Make_lazy lazy_tag, arg)]
+  | Pmakelazyblock lazy_tag, [[arg]] ->
+    [Unary (Make_lazy { lazy_tag; alloc_region = current_alloc_region }, arg)]
   | Pmake_unboxed_product layouts, _ ->
     (* CR mshinwell: this should check the unarized lengths of [layouts] and
        [args] (like [Parray_element_size_in_bytes] below) *)
@@ -2030,19 +2059,28 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [H.simple_i64_expr 0L])
   | Pmakefloatblock (mutability, mode), _ ->
     let args = List.flatten args in
-    let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+    let mode =
+      Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+        ~current_region
+    in
     let mutability = Mutability.from_lambda mutability in
     [ Variadic
         (Make_block (Naked_floats, mutability, mode), List.map unbox_float args)
     ]
   | Pmakeufloatblock (mutability, mode), _ ->
     let args = List.flatten args in
-    let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+    let mode =
+      Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+        ~current_region
+    in
     let mutability = Mutability.from_lambda mutability in
     [Variadic (Make_block (Naked_floats, mutability, mode), args)]
   | Pmakearray (lambda_array_kind, mutability, mode), _ -> (
     let args = List.flatten args in
-    let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+    let mode =
+      Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+        ~current_region
+    in
     let array_kind = convert_array_kind dbg lambda_array_kind in
     let mutability = Mutability.from_lambda mutability in
     match array_kind with
@@ -2069,8 +2107,12 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       match args with
       | [] ->
         [ Variadic
-            (Make_array (Values, Immutable, Alloc_mode.For_allocations.heap), [])
-        ]
+            ( Make_array
+                ( Values,
+                  Immutable,
+                  Alloc_mode.For_allocations.heap
+                    ~alloc_region:current_alloc_region ),
+              [] ) ]
       | elt :: _ ->
         (* Test the first element to see if it's a boxed float: if it is, this
            array must be created as a flat float array. *)
@@ -2154,22 +2196,23 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Record_variable | Record_inlined (_, Constructor_variable, _) ->
         Misc.fatal_error "convert_lprim: Pduprecord: variable representation"
     in
-    [Unary (Duplicate_block { kind }, arg)]
+    [Unary (Duplicate_block { kind; alloc_region = current_alloc_region }, arg)]
   | Pnot, [[arg]] -> [Unary (Boolean_not, arg)]
   | Pscalar (Unary unary), [[arg]] -> (
     match unary with
     | Static_cast { src; dst } ->
-      [to_expr (static_cast arg ~src ~dst ~current_region)]
+      [to_expr (static_cast arg ~src ~dst ~current_alloc_region ~current_region)]
     | Integral (outer, op) ->
       let width = integral_width (Scalar.Integral.ignore_locality outer) in
       let outer = Scalar.integral outer in
       let arg =
-        static_cast arg ~current_region
+        static_cast arg ~current_alloc_region ~current_region
           ~src:(Scalar.ignore_locality outer)
           ~dst:(integral_scalar width)
       in
       let maybe_wrap =
-        static_cast ~src:(integral_scalar width) ~dst:outer ~current_region
+        static_cast ~src:(integral_scalar width) ~dst:outer
+          ~current_alloc_region ~current_region
       in
       let result : H.expr_primitive =
         match op with
@@ -2191,10 +2234,11 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       let arg =
         static_cast arg
           ~src:(Scalar.ignore_locality outer)
-          ~dst:(floating_scalar width) ~current_region
+          ~dst:(floating_scalar width) ~current_alloc_region ~current_region
       in
       let maybe_wrap =
-        static_cast ~src:(floating_scalar width) ~dst:outer ~current_region
+        static_cast ~src:(floating_scalar width) ~dst:outer
+          ~current_alloc_region ~current_region
       in
       let result : H.expr_primitive =
         match op with
@@ -2208,14 +2252,15 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       let width = integral_width (Scalar.Integral.ignore_locality outer) in
       let outer = Scalar.integral outer in
       let maybe_unwrap arg =
-        static_cast arg ~current_region
+        static_cast arg ~current_alloc_region ~current_region
           ~src:(Scalar.ignore_locality outer)
           ~dst:(integral_scalar width)
       in
       let arg1 = maybe_unwrap arg1 in
       let arg2 = maybe_unwrap arg2 in
       let maybe_wrap =
-        static_cast ~src:(integral_scalar width) ~dst:outer ~current_region
+        static_cast ~src:(integral_scalar width) ~dst:outer
+          ~current_alloc_region ~current_region
       in
       let result : H.expr_primitive =
         match op with
@@ -2237,7 +2282,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       let arg1 =
         static_cast arg1
           ~src:(Scalar.ignore_locality outer)
-          ~dst:(integral_scalar width) ~current_region
+          ~dst:(integral_scalar width) ~current_alloc_region ~current_region
       in
       let arg2 =
         let int_scalar : _ Scalar.Integral.t = Value (Taggable Int) in
@@ -2245,10 +2290,11 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         let src = match rhs with Int -> Scalar.integral int_scalar in
         static_cast arg2 ~src
           ~dst:(Scalar.integral naked_int_scalar)
-          ~current_region
+          ~current_alloc_region ~current_region
       in
       let maybe_wrap =
-        static_cast ~src:(integral_scalar width) ~dst:outer ~current_region
+        static_cast ~src:(integral_scalar width) ~dst:outer
+          ~current_alloc_region ~current_region
       in
       let result : H.expr_primitive =
         match op with
@@ -2261,12 +2307,13 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       let width = floating_width outer in
       let outer = Scalar.floating outer in
       let maybe_unwrap =
-        static_cast ~current_region
+        static_cast ~current_alloc_region ~current_region
           ~src:(Scalar.ignore_locality outer)
           ~dst:(floating_scalar width)
       in
       let maybe_wrap =
-        static_cast ~src:(floating_scalar width) ~dst:outer ~current_region
+        static_cast ~src:(floating_scalar width) ~dst:outer
+          ~current_alloc_region ~current_region
       in
       let arg1 = maybe_unwrap arg1 in
       let arg2 = maybe_unwrap arg2 in
@@ -2281,8 +2328,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     | Icmp (size, cmp) ->
       let width = integral_width size in
       let maybe_unwrap arg =
-        static_cast arg ~current_region ~src:(Scalar.integral size)
-          ~dst:(integral_scalar width)
+        static_cast arg ~current_alloc_region ~current_region
+          ~src:(Scalar.integral size) ~dst:(integral_scalar width)
       in
       let arg1 = maybe_unwrap arg1 in
       let arg2 = maybe_unwrap arg2 in
@@ -2293,8 +2340,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     | Fcmp (size, cmp) ->
       let width = floating_width size in
       let maybe_unwrap arg =
-        static_cast arg ~current_region ~src:(Scalar.floating size)
-          ~dst:(floating_scalar width)
+        static_cast arg ~current_alloc_region ~current_region
+          ~src:(Scalar.floating size) ~dst:(floating_scalar width)
       in
       let arg1 = maybe_unwrap arg1 in
       let arg2 = maybe_unwrap arg2 in
@@ -2308,8 +2355,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       in
       let width = integral_width size in
       let maybe_unwrap arg =
-        static_cast arg ~current_region ~src:(Scalar.integral size)
-          ~dst:(integral_scalar width)
+        static_cast arg ~current_alloc_region ~current_region
+          ~src:(Scalar.integral size) ~dst:(integral_scalar width)
       in
       let arg1 = maybe_unwrap arg1 in
       let arg2 = maybe_unwrap arg2 in
@@ -2321,8 +2368,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     | Three_way_compare_float size ->
       let width = floating_width size in
       let maybe_unwrap arg =
-        static_cast arg ~current_region ~src:(Scalar.floating size)
-          ~dst:(floating_scalar width)
+        static_cast arg ~current_alloc_region ~current_region
+          ~src:(Scalar.floating size) ~dst:(floating_scalar width)
       in
       let arg1 = maybe_unwrap arg1 in
       let arg2 = maybe_unwrap arg2 in
@@ -2341,19 +2388,22 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [ Unary
         ( Box_number
             ( Naked_vec128,
-              Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+              Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+                ~current_region ),
           arg ) ]
   | Pbox_vector (Boxed_vec256, mode), [[arg]] ->
     [ Unary
         ( Box_number
             ( Naked_vec256,
-              Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+              Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+                ~current_region ),
           arg ) ]
   | Pbox_vector (Boxed_vec512, mode), [[arg]] ->
     [ Unary
         ( Box_number
             ( Naked_vec512,
-              Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+              Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
+                ~current_region ),
           arg ) ]
   | Punbox_unit, [[_]] -> [Unboxed_product []]
   | Pfield_computed sem, [[obj]; [field]] ->
@@ -2414,7 +2464,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
           ( Duplicate_array
               { kind = duplicate_array_kind;
                 source_mutability;
-                destination_mutability
+                destination_mutability;
+                alloc_region = current_alloc_region
               },
             arg ) ]
     | Float_array_opt_dynamic ->
@@ -2424,12 +2475,17 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
               ( Duplicate_array
                   { kind = Naked_floats { length = None };
                     source_mutability;
-                    destination_mutability
+                    destination_mutability;
+                    alloc_region = current_alloc_region
                   },
                 arg ),
             Unary
               ( Duplicate_array
-                  { kind = Values; source_mutability; destination_mutability },
+                  { kind = Values;
+                    source_mutability;
+                    destination_mutability;
+                    alloc_region = current_alloc_region
+                  },
                 arg ),
             [K.With_subkind.any_value] ) ])
   | Pstringlength, [[arg]] -> [tag_int (Unary (String_length String, arg))]
@@ -2438,94 +2494,96 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let checks = string_or_bytes_checks Eight true in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight String
         None ~boxed_or_tagged:true str ~index_kind:Ptagged_int_index index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbytesrefu, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Eight true in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight Bytes None
         ~boxed_or_tagged:true bytes ~index_kind:Ptagged_int_index index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstringrefs, [[str]; [index]] ->
     let checks = string_or_bytes_checks Eight false in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight String
         ~boxed_or_tagged:true None str ~index_kind:Ptagged_int_index index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbytesrefs, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Eight false in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight Bytes
         ~boxed_or_tagged:true None bytes ~index_kind:Ptagged_int_index index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstring_load_i8 { unsafe; index_kind; tagged }, [[str]; [index]] ->
     let checks = string_or_bytes_checks Eight_signed unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight_signed
         String ~boxed_or_tagged:tagged None str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbytes_load_i8 { unsafe; index_kind; tagged }, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Eight_signed unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight_signed
         Bytes ~boxed_or_tagged:tagged None bytes ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstring_load_i16 { unsafe; index_kind; tagged }, [[str]; [index]] ->
     let checks = string_or_bytes_checks Sixteen_signed unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixteen_signed
         String ~boxed_or_tagged:tagged None str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbytes_load_i16 { unsafe; index_kind; tagged }, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Sixteen_signed unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixteen_signed
         Bytes ~boxed_or_tagged:tagged None bytes ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstring_load_16 { unsafe; index_kind }, [[str]; [index]] ->
     let checks = string_or_bytes_checks Sixteen unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixteen String
-        ~boxed_or_tagged:true None str ~index_kind index ~current_region ]
+        ~boxed_or_tagged:true None str ~index_kind index ~current_alloc_region
+        ~current_region ]
   | Pbytes_load_16 { unsafe; index_kind }, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Sixteen unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixteen Bytes
-        ~boxed_or_tagged:true None bytes ~index_kind index ~current_region ]
+        ~boxed_or_tagged:true None bytes ~index_kind index ~current_alloc_region
+        ~current_region ]
   | Pstring_load_32 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
     let checks = string_or_bytes_checks Thirty_two unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Thirty_two
         String ~boxed_or_tagged:boxed (Some mode) str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstring_load_f32 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
     let checks = string_or_bytes_checks Single unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Single String
-        ~boxed_or_tagged:boxed (Some mode) str ~index_kind index ~current_region
-    ]
+        ~boxed_or_tagged:boxed (Some mode) str ~index_kind index
+        ~current_alloc_region ~current_region ]
   | Pbytes_load_32 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Thirty_two unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Thirty_two Bytes
         ~boxed_or_tagged:boxed (Some mode) bytes ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbytes_load_f32 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Single unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Single Bytes
         ~boxed_or_tagged:boxed (Some mode) bytes ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstring_load_64 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
     let checks = string_or_bytes_checks Sixty_four unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixty_four
         String ~boxed_or_tagged:boxed (Some mode) str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbytes_load_64 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
     let checks = string_or_bytes_checks Sixty_four unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixty_four Bytes
         ~boxed_or_tagged:boxed (Some mode) bytes ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pstring_load_vec { size; unsafe; index_kind; mode; boxed }, [[str]; [index]]
     ->
     let access_size = vec_accessor_width ~aligned:false size in
     let checks = string_or_bytes_checks access_size unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size String
-        ~boxed_or_tagged:boxed (Some mode) str ~index_kind index ~current_region
-    ]
+        ~boxed_or_tagged:boxed (Some mode) str ~index_kind index
+        ~current_alloc_region ~current_region ]
   | Pbytes_load_vec { size; unsafe; index_kind; mode; boxed }, [[str]; [index]]
     ->
     let access_size = vec_accessor_width ~aligned:false size in
     let checks = string_or_bytes_checks access_size unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size Bytes
-        ~boxed_or_tagged:boxed (Some mode) str ~index_kind index ~current_region
-    ]
+        ~boxed_or_tagged:boxed (Some mode) str ~index_kind index
+        ~current_alloc_region ~current_region ]
   | Pbytes_set_8 { unsafe; index_kind; tagged }, [[bytes]; [index]; [new_value]]
     ->
     let checks = string_or_bytes_checks Eight unsafe in
@@ -2588,7 +2646,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         (Unary
            ( Block_load { kind = block_access; mut = mutability; field = imm },
              arg ))
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pufloatfield (field, sem), [[arg]] ->
     let imm = Target_ocaml_int.of_int machine_width field in
     check_non_negative_imm imm "Pufloatfield";
@@ -2630,7 +2688,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         in
         match field_elt with
         | Float_boxed (mode : Lambda.locality_mode) ->
-          box_float mode prim ~current_region
+          box_float mode prim ~current_alloc_region ~current_region
         | Value _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
         | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
           prim)
@@ -2728,7 +2786,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [ match_on_array_ref_kind dbg ~array array_ref_kind
         (array_load_unsafe ~machine_width ~array ~mut
            ~index:(convert_index_to_tagged_int ~index ~index_kind)
-           ~current_region) ]
+           ~current_alloc_region ~current_region) ]
   | Parrayrefs (array_ref_kind, index_kind, mut), [[array]; [index]] ->
     let array_length_kind =
       convert_array_ref_kind_for_length dbg array_ref_kind
@@ -2738,7 +2796,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         (match_on_array_ref_kind dbg ~array array_ref_kind
            (array_load_unsafe ~machine_width ~array ~mut
               ~index:(convert_index_to_tagged_int ~index ~index_kind)
-              ~current_region)) ]
+              ~current_alloc_region ~current_region)) ]
   | Parraysetu (array_set_kind, index_kind), [[array]; [index]; new_values] ->
     [ match_on_array_set_kind dbg ~array array_set_kind
         (array_set_unsafe ~machine_width dbg ~array
@@ -2850,8 +2908,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Pint_as_pointer mode, [[arg]] ->
     (* This is not a stack allocation, but nonetheless has a region
        constraint. *)
+    (* CR ncourant: it should maybe not have an [alloc_region] in case it is
+       [Heap]? *)
     let mode =
-      Alloc_mode.For_allocations.from_lambda mode
+      Alloc_mode.For_allocations.from_lambda mode ~current_alloc_region
         ~current_region:current_ghost_region
     in
     [Unary (Int_as_pointer mode, arg)]
@@ -2880,7 +2940,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       in
       let box =
         bigarray_box_or_tag_raw_value_to_read kind
-          Alloc_mode.For_allocations.heap
+          (Alloc_mode.For_allocations.heap ~alloc_region:current_alloc_region)
       in
       [box (bigarray_load ~machine_width ~dbg ~unsafe kind layout b indexes)]
     | None, _ ->
@@ -2932,41 +2992,41 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let checks = string_or_bytes_checks Eight_signed unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Eight_signed
         Bigstring ~boxed_or_tagged:tagged None big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbigstring_load_i16 { unsafe; index_kind; tagged }, [[big_str]; [index]] ->
     let checks = string_or_bytes_checks Sixteen_signed unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixteen_signed
         Bigstring ~boxed_or_tagged:tagged None big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbigstring_load_16 { unsafe; index_kind }, [[big_str]; [index]] ->
     let checks = string_or_bytes_checks Sixteen unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixteen
         Bigstring ~boxed_or_tagged:true None big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbigstring_load_32 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
     let checks = string_or_bytes_checks Thirty_two unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Thirty_two
         Bigstring (Some mode) ~boxed_or_tagged:boxed big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbigstring_load_f32 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
     let checks = string_or_bytes_checks Single unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Single Bigstring
         (Some mode) ~boxed_or_tagged:boxed big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | Pbigstring_load_64 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
     let checks = string_or_bytes_checks Sixty_four unsafe in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size:Sixty_four
         Bigstring (Some mode) ~boxed_or_tagged:boxed big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | ( Pbigstring_load_vec { size; checks; aligned; index_kind; mode; boxed },
       [[big_str]; [index]] ) ->
     let access_size = vec_accessor_width ~aligned size in
     [ string_like_load ~checks ~dbg ~machine_width ~access_size Bigstring
         (Some mode) ~boxed_or_tagged:boxed big_str ~index_kind index
-        ~current_region ]
+        ~current_alloc_region ~current_region ]
   | ( Pbigstring_set_8 { unsafe; index_kind; tagged },
       [[bigstring]; [index]; [new_value]] ) ->
     let checks = string_or_bytes_checks Eight unsafe in
@@ -3003,25 +3063,28 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [[array]; [index]] )
   | ( Punboxed_float_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_floats array ~index_kind index ]
   | ( Punboxed_float32_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_float32s array ~index_kind index
-    ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_float32s array ~index_kind index ]
   | ( Pint_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
     (match machine_width with
     | Sixty_four -> ()
     | Thirty_two | Thirty_two_no_gc_tag_bit ->
       Misc.fatal_error "[Pint_array_load_vec]: immediates must be 64 bits.");
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Immediates array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Immediates array ~index_kind index ]
   | ( Punboxed_int64_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_int64s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_int64s array ~index_kind index ]
   | ( Punboxed_nativeint_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
     (match machine_width with
@@ -3029,21 +3092,24 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     | Thirty_two | Thirty_two_no_gc_tag_bit ->
       Misc.fatal_error
         "[Punboxed_nativeint_array_load_vec]: nativeint must be 64 bits.");
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_nativeints array ~index_kind
-        index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_nativeints array ~index_kind index ]
   | ( Punboxed_int32_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_int32s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_int32s array ~index_kind index ]
   | ( Puntagged_int8_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_int8s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_int8s array ~index_kind index ]
   | ( Puntagged_int16_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_int16s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_alloc_region
+        ~current_region ~unsafe ~mode ~boxed ~vec_kind:(vec_kind size)
+        Naked_int16s array ~index_kind index ]
   | ( Pfloatarray_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] )
   | ( Punboxed_float_array_set_vec { size; unsafe; index_kind; boxed },
@@ -3097,8 +3163,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     ]
   | Pprobe_is_enabled { name; enabled_at_init }, [] ->
     [tag_int (Nullary (Probe_is_enabled { name; enabled_at_init }))]
-  | Pobj_dup, [[v]] -> [Unary (Obj_dup, v)]
-  | Pget_header m, [[obj]] -> [get_header obj m ~current_region]
+  | Pobj_dup, [[v]] ->
+    [Unary (Obj_dup { alloc_region = current_alloc_region }, v)]
+  | Pget_header m, [[obj]] ->
+    [get_header obj m ~current_alloc_region ~current_region]
   | Patomic_load_field { immediate_or_pointer }, [[atomic]; [field]] ->
     [ Binary
         ( Atomic_load_field
@@ -3373,13 +3441,13 @@ module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
 let convert_and_bind acc ~big_endian exn_cont ~register_const0
     (prim : L.primitive) ~(args : Simple.t list list) (dbg : Debuginfo.t)
-    ~current_region ~current_ghost_region
+    ~current_alloc_region ~current_region ~current_ghost_region
     (cont : Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) : Expr_with_acc.t
     =
   let machine_width = Acc.machine_width acc in
   let exprs =
-    convert_lprim ~machine_width ~big_endian prim args dbg ~current_region
-      ~current_ghost_region
+    convert_lprim ~machine_width ~big_endian prim args dbg ~current_alloc_region
+      ~current_region ~current_ghost_region
   in
   H.bind_recs acc exn_cont ~register_const0
     (H.maybe_create_unboxed_product exprs)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -27,6 +27,7 @@ val convert_and_bind :
   Lambda.primitive ->
   args:Simple.t list list ->
   Debuginfo.t ->
+  current_alloc_region:Variable.t ->
   current_region:Variable.t option ->
   current_ghost_region:Variable.t option ->
   (Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) ->

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -49,7 +49,9 @@ type continuation_sort =
 
 type region =
   | Named of variable
-  | Toplevel
+  | Toplevel_alloc_region
+  | Toplevel_region
+  | Toplevel_ghost_region
 
 type tag_scannable = int
 
@@ -212,14 +214,18 @@ type simple =
 type cont_extra_arg = simple * kind_with_subkind
 
 type alloc_mode_for_allocations =
-  | Heap
-  | Local of { region : region }
-
-type alloc_mode_for_applications =
-  | Heap
+  | Heap of { alloc_region : region }
   | Local of
-      { region : region;
-        ghost_region : region
+      { alloc_region : region;
+        region : region
+      }
+
+type 'a alloc_mode_for_applications =
+  | Heap of { alloc_region : 'a }
+  | Local of
+      { alloc_region : 'a;
+        region : 'a;
+        ghost_region : 'a
       }
 
 type alloc_mode_for_assignments =
@@ -290,7 +296,7 @@ type apply =
     exn_continuation : continuation * cont_extra_arg list;
     args : simple list;
     call_kind : call_kind;
-    alloc_mode : alloc_mode_for_applications;
+    alloc_mode : region alloc_mode_for_applications;
     arities : function_arities option;
     inlined : inlined_attribute option;
     inlining_state : inlining_state option
@@ -409,8 +415,7 @@ and code_size = int
 and params_and_body =
   { params : kinded_parameter list;
     closure_var : variable;
-    region_var : variable;
-    ghost_region_var : variable;
+    region_vars : variable alloc_mode_for_applications;
     depth_var : variable;
     ret_cont : continuation_id;
     exn_cont : continuation_id;

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -262,26 +262,76 @@ let alloc_mode_for_allocation =
   patterns
   @@
   let| local =
-    ( labeled "local" string,
-      fun env r ->
-        let region =
-          if String.equal (unwrap_loc r) "toplevel"
-          then env.toplevel_region
-          else Fexpr_to_flambda_commons.find_var env r
+    ( param2 string (labeled "local" string),
+      fun env (alloc_region, region) ->
+        let alloc_region =
+          if String.equal (unwrap_loc alloc_region) "toplevel"
+          then env.toplevel_alloc_region
+          else Fexpr_to_flambda_commons.find_var env alloc_region
         in
-        Alloc_mode.For_allocations.local ~region )
+        (* CR-someday ncourant: right now this is unable to produce ghost
+           regions at toplevel, which is a bit unfortunate *)
+        let region =
+          if String.equal (unwrap_loc region) "toplevel"
+          then env.toplevel_region
+          else Fexpr_to_flambda_commons.find_var env region
+        in
+        Alloc_mode.For_allocations.local ~alloc_region ~region )
   in
-  let| heap = param0, fun _ () -> Alloc_mode.For_allocations.heap in
+  let| heap =
+    ( string,
+      fun env alloc_region ->
+        let alloc_region =
+          if String.equal (unwrap_loc alloc_region) "toplevel"
+          then env.toplevel_alloc_region
+          else Fexpr_to_flambda_commons.find_var env alloc_region
+        in
+        Alloc_mode.For_allocations.heap ~alloc_region )
+  in
   return_either (fun alloc env ->
       match alloc with
-      | Alloc_mode.For_allocations.Local { region } ->
-        let r =
-          match Flambda_to_fexpr_commons.Env.find_region_exn env region with
-          | Fexpr.Toplevel -> wrap_loc "toplevel"
+      | Alloc_mode.For_allocations.Local { alloc_region; region } ->
+        let alloc_region =
+          match
+            Flambda_to_fexpr_commons.Env.find_region_exn env alloc_region
+          with
+          | Fexpr.Toplevel_alloc_region | Toplevel_region
+          | Toplevel_ghost_region ->
+            wrap_loc "toplevel"
           | Named s -> s
         in
-        local r env
-      | Alloc_mode.For_allocations.Heap -> heap () env)
+        let region =
+          match Flambda_to_fexpr_commons.Env.find_region_exn env region with
+          | Fexpr.Toplevel_alloc_region | Toplevel_region
+          | Toplevel_ghost_region ->
+            wrap_loc "toplevel"
+          | Named s -> s
+        in
+        local (alloc_region, region) env
+      | Alloc_mode.For_allocations.Heap { alloc_region } ->
+        let alloc_region =
+          match
+            Flambda_to_fexpr_commons.Env.find_region_exn env alloc_region
+          with
+          | Fexpr.Toplevel_alloc_region | Toplevel_region
+          | Toplevel_ghost_region ->
+            wrap_loc "toplevel"
+          | Named s -> s
+        in
+        heap alloc_region env)
+
+let alloc_region =
+  D.maps
+    ~to_:(fun env alloc_region ->
+      match Flambda_to_fexpr_commons.Env.find_region_exn env alloc_region with
+      | Fexpr.Toplevel_alloc_region | Toplevel_region | Toplevel_ghost_region ->
+        wrap_loc "toplevel"
+      | Named s -> s)
+    ~from:(fun env alloc_region ->
+      if String.equal (unwrap_loc alloc_region) "toplevel"
+      then env.toplevel_alloc_region
+      else Fexpr_to_flambda_commons.find_var env alloc_region)
+    D.string
 
 let alloc_mode_for_assignments =
   let open D in
@@ -699,7 +749,10 @@ let box_num =
 let tag_immediate =
   D.(unary "%tag_imm" ~params:param0 (fun _ () -> P.Tag_immediate))
 
-let obj_dup = D.(unary "%obj_dup" ~params:param0 (fun _ () -> P.Obj_dup))
+let obj_dup =
+  D.(
+    unary "%obj_dup" ~params:alloc_region (fun _ alloc_region ->
+        P.Obj_dup { alloc_region }))
 
 let get_header =
   D.(unary "%get_header" ~params:param0 (fun _ () -> P.Get_header))
@@ -740,10 +793,11 @@ let duplicate_array =
   D.(
     unary "%duplicate_array"
       ~params:
-        (param3 duplicate_array_kind (positional mutability)
-           (positional mutability))
-      (fun _ (kind, source_mutability, destination_mutability) ->
-        P.Duplicate_array { kind; source_mutability; destination_mutability }))
+        (param4 duplicate_array_kind (positional mutability)
+           (positional mutability) alloc_region)
+      (fun _ (kind, source_mutability, destination_mutability, alloc_region) ->
+        P.Duplicate_array
+          { kind; source_mutability; destination_mutability; alloc_region }))
 
 let int_as_pointer =
   D.(
@@ -779,7 +833,10 @@ let num_conv =
            (positional standard_int_or_float))
       (fun _ (src, dst) -> P.Num_conv { src; dst }))
 
-let make_lazy = D.(unary "%lazy" ~params:lazy_tag (fun _ lt -> P.Make_lazy lt))
+let make_lazy =
+  D.(
+    unary "%lazy" ~params:(param2 lazy_tag alloc_region)
+      (fun _ (lazy_tag, alloc_region) -> P.Make_lazy { lazy_tag; alloc_region }))
 
 let opaque_identity =
   D.(
@@ -870,8 +927,8 @@ let duplicate_block =
       | Naked_floats { length } -> floats length
       | Mixed -> mixed ())
   in
-  unary "%duplicate_block" ~params:kind (fun _ kind ->
-      P.Duplicate_block { kind })
+  unary "%duplicate_block" ~params:(param2 kind alloc_region)
+    (fun _ (kind, alloc_region) -> P.Duplicate_block { kind; alloc_region })
 
 (* Binaries *)
 let atomic_load_field =
@@ -1259,8 +1316,10 @@ module OfFlambda = struct
     | End_try_region { ghost = false } -> end_try_region env ()
     | End_region { ghost = true } -> end_ghost_region env ()
     | End_try_region { ghost = true } -> end_try_ghost_region env ()
-    | Duplicate_array { kind; source_mutability; destination_mutability } ->
-      duplicate_array env (kind, source_mutability, destination_mutability)
+    | Duplicate_array
+        { kind; source_mutability; destination_mutability; alloc_region } ->
+      duplicate_array env
+        (kind, source_mutability, destination_mutability, alloc_region)
     | Float_arith (w, o) -> ufloat_arith env (w, o)
     | Get_tag -> get_tag env ()
     | Is_boxed_float -> is_boxed_float env ()
@@ -1269,7 +1328,8 @@ module OfFlambda = struct
     | Is_flat_float_array -> is_flat_float_array env ()
     | Is_int _ -> is_int env () (* CR vlaviron: discuss *)
     | Is_null -> is_null env ()
-    | Make_lazy lt -> make_lazy env lt
+    | Make_lazy { lazy_tag; alloc_region } ->
+      make_lazy env (lazy_tag, alloc_region)
     | Num_conv { src; dst } -> num_conv env (src, dst)
     | Opaque_identity _ -> opaque_identity env ()
     | Unbox_number bk -> unbox_num env bk
@@ -1282,11 +1342,12 @@ module OfFlambda = struct
     | String_length String -> string_length env ()
     | String_length Bytes -> bytes_length env ()
     | Tag_immediate -> tag_immediate env ()
-    | Obj_dup -> obj_dup env ()
+    | Obj_dup { alloc_region } -> obj_dup env alloc_region
     | Get_header -> get_header env ()
     | Reinterpret_boxed_vector -> reinterpret_boxed_vector env ()
     | Peek standard_int_or_float -> peek env standard_int_or_float
-    | Duplicate_block { kind } -> duplicate_block env kind
+    | Duplicate_block { kind; alloc_region } ->
+      duplicate_block env (kind, alloc_region)
 
   let binop env (op : P.binary_primitive) =
     match op with

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -164,19 +164,25 @@ let or_variable f env (ov : _ Fexpr.or_variable) : _ Or_variable.t =
 
 let alloc_mode_for_allocations env (alloc : Fexpr.alloc_mode_for_allocations) =
   match alloc with
-  | Heap -> Alloc_mode.For_allocations.heap
-  | Local { region = r } ->
-    let r = find_region env r in
-    Alloc_mode.For_allocations.local ~region:r
+  | Heap { alloc_region } ->
+    let alloc_region = find_region env alloc_region in
+    Alloc_mode.For_allocations.heap ~alloc_region
+  | Local { alloc_region; region } ->
+    let alloc_region = find_region env alloc_region in
+    let region = find_region env region in
+    Alloc_mode.For_allocations.local ~alloc_region ~region
 
-let alloc_mode_for_applications env (alloc : Fexpr.alloc_mode_for_applications)
-    =
+let alloc_mode_for_applications env
+    (alloc : Fexpr.region Fexpr.alloc_mode_for_applications) =
   match alloc with
-  | Heap -> Alloc_mode.For_applications.heap
-  | Local { region = r; ghost_region = r' } ->
-    let r = find_region env r in
-    let r' = find_region env r' in
-    Alloc_mode.For_applications.local ~region:r ~ghost_region:r'
+  | Heap { alloc_region } ->
+    let alloc_region = find_region env alloc_region in
+    Alloc_mode.For_applications.heap ~alloc_region
+  | Local { alloc_region; region; ghost_region } ->
+    let alloc_region = find_region env alloc_region in
+    let region = find_region env region in
+    let ghost_region = find_region env ghost_region in
+    Alloc_mode.For_applications.local ~alloc_region ~region ~ghost_region
 
 let prim env ((p, args) : Fexpr.prim) : Flambda_primitive.t =
   let args = List.map (simple env) args in
@@ -690,8 +696,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
               acc ) =
           let { Fexpr.params;
                 closure_var;
-                region_var;
-                ghost_region_var;
+                region_vars;
                 depth_var;
                 ret_cont;
                 exn_cont;
@@ -713,11 +718,26 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
           let my_closure, _my_closure_duid, env =
             fresh_var env closure_var Flambda_kind.value
           in
-          let my_region, _my_region_duid, env =
-            fresh_var env region_var Flambda_kind.region
-          in
-          let my_ghost_region, _my_ghost_region, env =
-            fresh_var env ghost_region_var Flambda_kind.region
+          let my_alloc_mode, env =
+            match region_vars with
+            | Heap { alloc_region } ->
+              let alloc_region, _duid, env =
+                fresh_var env alloc_region Flambda_kind.region
+              in
+              Alloc_mode.For_applications.heap ~alloc_region, env
+            | Local { alloc_region; region; ghost_region } ->
+              let alloc_region, _duid, env =
+                fresh_var env alloc_region Flambda_kind.region
+              in
+              let region, _duid, env =
+                fresh_var env region Flambda_kind.region
+              in
+              let ghost_region, _duid, env =
+                fresh_var env ghost_region Flambda_kind.region
+              in
+              ( Alloc_mode.For_applications.local ~alloc_region ~region
+                  ~ghost_region,
+                env )
           in
           let my_depth, _my_depth, env =
             fresh_var env depth_var Flambda_kind.rec_info
@@ -735,11 +755,8 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             Flambda.Function_params_and_body.create ~return_continuation
               ~exn_continuation
               (Bound_parameters.create params)
-              ~body ~my_closure
-              ~my_alloc_mode:
-                (Alloc_mode.For_applications.local ~region:my_region
-                   ~ghost_region:my_ghost_region)
-              ~my_depth ~free_names_of_body:Unknown
+              ~body ~my_closure ~my_alloc_mode ~my_depth
+              ~free_names_of_body:Unknown
           in
           let free_names =
             (* CR mshinwell: This needs fixing XXX *)
@@ -750,6 +767,11 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             free_names,
             Flambda.Function_params_and_body.is_my_closure_used params_and_body,
             acc )
+        in
+        let result_mode =
+          match result_mode with
+          | Heap -> Lambda.alloc_heap
+          | Local -> Lambda.alloc_local
         in
         let recursive = convert_recursive_flag recursive in
         let inline =
@@ -768,11 +790,6 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
           List.map
             (fun _ -> Alloc_mode.For_types.heap)
             (Flambda_arity.unarize params_arity)
-        in
-        let result_mode =
-          match result_mode with
-          | Heap -> Lambda.alloc_heap
-          | Local -> Lambda.alloc_local
         in
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
@@ -983,7 +1000,9 @@ let conv comp_unit (fexpr : Fexpr.flambda_unit) : conv_result =
   let env = init_env () in
   let { done_continuation = return_continuation;
         error_continuation;
+        toplevel_alloc_region;
         toplevel_region;
+        toplevel_ghost_region;
         _
       } =
     env
@@ -994,9 +1013,9 @@ let conv comp_unit (fexpr : Fexpr.flambda_unit) : conv_result =
   let code_slot_offsets = acc.Acc.code_slot_offsets in
   let unit =
     Flambda_unit.create ~return_continuation ~exn_continuation
+      ~toplevel_my_alloc_region:toplevel_alloc_region
       ~toplevel_my_region:toplevel_region
-      ~toplevel_my_ghost_region:
-        (Variable.create "my_ghost_region" Flambda_kind.region)
-      ~body ~module_symbol ~used_value_slots:Unknown
+      ~toplevel_my_ghost_region:toplevel_ghost_region ~body ~module_symbol
+      ~used_value_slots:Unknown
   in
   { unit; code_slot_offsets }

--- a/middle_end/flambda2/parser/fexpr_to_flambda_commons.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda_commons.ml
@@ -73,7 +73,9 @@ type env =
     error_continuation : Exn_continuation.t;
     continuations : (Continuation.t * int) CM.t;
     exn_continuations : Continuation.t CM.t;
+    toplevel_alloc_region : Variable.t;
     toplevel_region : Variable.t;
+    toplevel_ghost_region : Variable.t;
     variables : Variable.t VM.t;
     symbols : Symbol.t SM.t;
     code_ids : Code_id.t DM.t;
@@ -89,12 +91,20 @@ let init_env () =
   let error_continuation =
     Exn_continuation.create ~exn_handler ~extra_args:[]
   in
-  let toplevel_region = Variable.create "toplevel" Flambda_kind.region in
+  let toplevel_alloc_region =
+    Variable.create "toplevel_alloc_region" Flambda_kind.region
+  in
+  let toplevel_region = Variable.create "toplevel_region" Flambda_kind.region in
+  let toplevel_ghost_region =
+    Variable.create "toplevel_ghost_region" Flambda_kind.region
+  in
   { done_continuation;
     error_continuation;
     continuations = CM.empty;
     exn_continuations = CM.empty;
     toplevel_region;
+    toplevel_alloc_region;
+    toplevel_ghost_region;
     variables = VM.empty;
     symbols = SM.create 10;
     code_ids = DM.create 10;
@@ -105,7 +115,9 @@ let init_env () =
 let enter_code env =
   { continuations = CM.empty;
     exn_continuations = CM.empty;
+    toplevel_alloc_region = env.toplevel_alloc_region;
     toplevel_region = env.toplevel_region;
+    toplevel_ghost_region = env.toplevel_ghost_region;
     variables = env.variables;
     done_continuation = env.done_continuation;
     error_continuation = env.error_continuation;
@@ -251,6 +263,10 @@ let find_var env v =
   find_with ~descr:"variable" ~find:VM.find_opt env.variables v
 
 let find_region env (r : Fexpr.region) =
-  match r with Toplevel -> env.toplevel_region | Named v -> find_var env v
+  match r with
+  | Toplevel_alloc_region -> env.toplevel_alloc_region
+  | Toplevel_region -> env.toplevel_region
+  | Toplevel_ghost_region -> env.toplevel_ghost_region
+  | Named v -> find_var env v
 
 let find_code_id env code_id = fresh_or_existing_code_id env code_id

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -2,68 +2,13 @@
 # burden of a messages file for a large grammar is ... substantial. As of this
 # writing, there should be 175 messages in this file.
 
-flambda_unit: KWD_APPLY SYMBOL LPAREN RPAREN KWD_WITH
-##
-## Ends in an error in state: 584.
-##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple simple_args
-##
 
-Expected -> followed by a continuation.
-Example of an application:
-  apply f (arg1 arg2) -> cont * exn_cont
 
-flambda_unit: KWD_APPLY SYMBOL MINUSGREATER IDENT KWD_WITH
-##
-## Ends in an error in state: 586.
-##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation
-##
 
-Expected * followed by an exception continuation.
-Example of an application:
-  apply f (arg1 arg2) -> cont * exn_cont
-
-flambda_unit: KWD_APPLY SYMBOL MINUSGREATER KWD_WITH
-##
-## Ends in an error in state: 585.
-##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER
-##
-
-Expected a continuation.
-Example of an application:
-  apply f (arg1 arg2) -> cont * exn_cont
-
-flambda_unit: KWD_APPLY SYMBOL KWD_WITH
-##
-## Ends in an error in state: 583.
-##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
-##
-## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple
-##
-
-Expected an argument list in parentheses, or -> followed by a continuation.
-Examples of applications:
-  apply f -> cont * exn_cont
-  apply f () -> cont * exn_cont
-  apply f (arg1 arg2) -> cont * exn_cont
 
 flambda_unit: KWD_APPLY KWD_WITH
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 514.
 ##
 ## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -78,7 +23,7 @@ Example of an application:
 
 flambda_unit: KWD_CONT IDENT LPAREN SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 217.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
@@ -92,7 +37,7 @@ Expected a simple value (a symbol, variable, or literal).
 
 flambda_unit: KWD_CONT IDENT LPAREN KWD_WITH
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 216.
 ##
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ RPAREN PIPE MINUSGREATER KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -109,7 +54,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT IDENT KWD_VAL
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 496.
 ##
 ## apply_cont_expr -> continuation . option(trap_action) simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -125,7 +70,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT KWD_WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 491.
 ##
 ## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -151,7 +96,7 @@ Example of a continuation call:
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_WITH
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 191.
 ##
 ## deleted_code -> KWD_CODE code_id . KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -171,7 +116,7 @@ Examples of argument lists:
 
 flambda_unit: KWD_LET KWD_CODE KWD_REC KWD_HCF
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 148.
 ##
 ## code_header -> KWD_CODE recursive . option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -183,7 +128,7 @@ Expected a code id.
 
 flambda_unit: KWD_LET KWD_CODE KWD_WITH
 ##
-## Ends in an error in state: 142.
+## Ends in an error in state: 146.
 ##
 ## code_header -> KWD_CODE . recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ## deleted_code -> KWD_CODE . code_id KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
@@ -201,58 +146,13 @@ Examples of code definitions:
 
 
 
-flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND KWD_WITH
-##
-## Ends in an error in state: 223.
-##
-## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
-##
-## The known suffix of the stack is as follows:
-## symbol_binding KWD_AND
-##
 
-Expected "code" or "symbol".
-
-flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
-##
-## Ends in an error in state: 222.
-##
-## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
-## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
-##
-## The known suffix of the stack is as follows:
-## symbol_binding
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 112, spurious reduction of production function_slot_opt ->
-## In state 116, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 121, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 122, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
-## In state 442, spurious reduction of production symbol_binding -> static_closure_binding
-##
-
-Expected "and", "with", or "in".
-
-flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN KWD_WITH
-##
-## Ends in an error in state: 478.
-##
-## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN
-##
-
-Expected an expression.
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_VAL
 ##
 ## Ends in an error in state: 112.
 ##
-## fun_decl -> KWD_CLOSURE code_id . function_slot_opt alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+## fun_decl -> KWD_CLOSURE code_id . function_slot_opt alloc_mode_for_allocations [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CLOSURE code_id
@@ -262,7 +162,7 @@ Expected "with", "in", "end", or "and".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_WITH
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 229.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol EQUAL . static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -279,7 +179,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 228.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol . EQUAL static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -296,7 +196,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET KWD_WITH
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 484.
 ##
 ## let_expr(expr) -> KWD_LET . let_(expr) [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## let_symbol(expr) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
@@ -313,7 +213,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 674.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -326,11 +226,11 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 80, spurious reduction of production option(PIPE) ->
 ## In state 103, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
-## In state 656, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
+## In state 671, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
 ## In state 102, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
-## In state 630, spurious reduction of production inner_expr -> inlined_expr
-## In state 595, spurious reduction of production expr -> inner_expr
-## In state 662, spurious reduction of production module_ -> expr
+## In state 645, spurious reduction of production inner_expr -> inlined_expr
+## In state 610, spurious reduction of production expr -> inner_expr
+## In state 677, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -348,6 +248,58 @@ flambda_unit: KWD_WITH
 ##
 
 Expected an expression.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -879,7 +831,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_ANY TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT DOT
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT DOT
 ##
 ## Ends in an error in state: 58.
 ##
@@ -899,7 +851,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT DOT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT STAR TILDE
 ##
 ## Ends in an error in state: 59.
 ##
@@ -1189,7 +1141,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 ##
 ## Ends in an error in state: 110.
 ##
-## fun_decl -> KWD_CLOSURE . code_id function_slot_opt alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+## fun_decl -> KWD_CLOSURE . code_id function_slot_opt alloc_mode_for_allocations [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CLOSURE
@@ -1201,7 +1153,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 ##
 ## Ends in an error in state: 113.
 ##
-## function_slot_opt -> AT . function_slot [ RPAREN KWD_WITH KWD_IN KWD_END KWD_AND AMP ]
+## function_slot_opt -> AT . function_slot [ AMP ]
 ##
 ## The known suffix of the stack is as follows:
 ## AT
@@ -1213,7 +1165,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 ##
 ## Ends in an error in state: 116.
 ##
-## fun_decl -> KWD_CLOSURE code_id function_slot_opt . alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+## fun_decl -> KWD_CLOSURE code_id function_slot_opt . alloc_mode_for_allocations [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CLOSURE code_id function_slot_opt
@@ -1225,7 +1177,8 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 ##
 ## Ends in an error in state: 117.
 ##
-## alloc_mode_for_allocations_opt -> AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+## alloc_mode_for_allocations -> AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+## alloc_mode_for_allocations -> AMP . region AMP region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP
@@ -1233,9 +1186,58 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN
+flambda_unit: KWD_APPLY AMP KWD_TOPLEVEL TILDE
+##
+## Ends in an error in state: 118.
+##
+## region -> KWD_TOPLEVEL . DOT IDENT [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_WITH KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED KWD_IN KWD_END KWD_AND INT IDENT FLOAT AMP ]
+##
+## The known suffix of the stack is as follows:
+## KWD_TOPLEVEL
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP KWD_TOPLEVEL DOT TILDE
+##
+## Ends in an error in state: 119.
+##
+## region -> KWD_TOPLEVEL DOT . IDENT [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_WITH KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED KWD_IN KWD_END KWD_AND INT IDENT FLOAT AMP ]
+##
+## The known suffix of the stack is as follows:
+## KWD_TOPLEVEL DOT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT TILDE
+##
+## Ends in an error in state: 122.
+##
+## alloc_mode_for_allocations -> AMP region . [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+## alloc_mode_for_allocations -> AMP region . AMP region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## AMP region
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT AMP TILDE
 ##
 ## Ends in an error in state: 123.
+##
+## alloc_mode_for_allocations -> AMP region AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## AMP region AMP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT KWD_IN
+##
+## Ends in an error in state: 127.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . [ KWD_WITH KWD_END ]
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . KWD_AND separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
@@ -1247,17 +1249,16 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 112, spurious reduction of production function_slot_opt ->
-## In state 116, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 121, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 122, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
+## In state 122, spurious reduction of production alloc_mode_for_allocations -> AMP region
+## In state 125, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations
+## In state 126, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND TILDE
+flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT KWD_AND TILDE
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 128.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding KWD_AND . separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
 ##
@@ -1269,7 +1270,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 131.
 ##
 ## with_value_slots_opt -> KWD_WITH . LBRACE loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -1281,7 +1282,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 132.
 ##
 ## with_value_slots_opt -> KWD_WITH LBRACE . loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -1293,7 +1294,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 ##
-## Ends in an error in state: 130.
+## Ends in an error in state: 134.
 ##
 ## value_slot -> value_slot_for_projection . EQUAL simple [ SEMICOLON RBRACE ]
 ##
@@ -1305,7 +1306,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 131.
+## Ends in an error in state: 135.
 ##
 ## value_slot -> value_slot_for_projection EQUAL . simple [ SEMICOLON RBRACE ]
 ##
@@ -1317,7 +1318,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 136.
 ##
 ## simple -> simple . TILDE coercion [ TILDE SEMICOLON RBRACE ]
 ## value_slot -> value_slot_for_projection EQUAL simple . [ SEMICOLON RBRACE ]
@@ -1330,7 +1331,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 139.
 ##
 ## separated_nonempty_list(SEMICOLON,value_slot) -> value_slot SEMICOLON . separated_nonempty_list(SEMICOLON,value_slot) [ RBRACE ]
 ##
@@ -1340,9 +1341,9 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_WITH LBRACE RBRACE TILDE
+flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 144.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt . KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1354,7 +1355,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_WIT
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 149.
 ##
 ## inline -> KWD_UNROLL . LPAREN plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1366,7 +1367,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 150.
 ##
 ## inline -> KWD_UNROLL LPAREN . plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1378,7 +1379,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 151.
 ##
 ## inline -> KWD_UNROLL LPAREN plain_int . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1390,7 +1391,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 153.
 ##
 ## inline -> KWD_INLINE . LPAREN KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE . LPAREN KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1405,7 +1406,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 154.
 ##
 ## inline -> KWD_INLINE LPAREN . KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE LPAREN . KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1420,7 +1421,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 155.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_NEVER . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1432,7 +1433,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 157.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_DEFAULT . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1444,7 +1445,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 159.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_AVAILABLE . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1456,7 +1457,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 161.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_ALWAYS . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1468,7 +1469,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 159.
+## Ends in an error in state: 163.
 ##
 ## code_header -> KWD_CODE recursive option(inline) . loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1480,7 +1481,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 164.
 ##
 ## loopify_opt -> KWD_LOOPIFY . LPAREN loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1492,7 +1493,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 165.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN . loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1504,7 +1505,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 168.
 ##
 ## loopify -> KWD_DEFAULT . KWD_TAILREC [ RPAREN ]
 ## loopify -> KWD_DEFAULT . [ RPAREN ]
@@ -1517,7 +1518,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 171.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN loopify . RPAREN [ KWD_SIZE ]
 ##
@@ -1529,7 +1530,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 173.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt . KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1541,7 +1542,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 174.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE . LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1553,7 +1554,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 175.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN . code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1565,7 +1566,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 177.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size . RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1577,7 +1578,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 178.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN . option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1589,7 +1590,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF TILDE
 ##
-## Ends in an error in state: 175.
+## Ends in an error in state: 179.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF . LPAREN code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1601,7 +1602,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF T
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN TILDE
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 180.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN . code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1613,7 +1614,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 181.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN code_id . RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1625,7 +1626,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 183.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) . boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1637,7 +1638,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 185.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) . boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1649,7 +1650,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 187.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) . code_id [ LPAREN IDENT ]
 ##
@@ -1661,7 +1662,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
 
 flambda_unit: KWD_LET IDENT TILDE
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 193.
 ##
 ## let_binding -> variable . EQUAL named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1673,7 +1674,7 @@ flambda_unit: KWD_LET IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 194.
 ##
 ## let_binding -> variable EQUAL . named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1685,7 +1686,7 @@ flambda_unit: KWD_LET IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 195.
 ##
 ## prim_op -> PRIM . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1697,7 +1698,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 196.
 ##
 ## list(pair(DOT,prim_param)) -> DOT . prim_param list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1709,7 +1710,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 197.
 ##
 ## prim_param -> LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
@@ -1721,7 +1722,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 202.
 ##
 ## prim_param -> prim_param_val . [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ## prim_param -> prim_param_val . LBRACK separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
@@ -1734,7 +1735,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 203.
 ##
 ## prim_param -> prim_param_val LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
@@ -1746,7 +1747,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 206.
 ##
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param . [ RBRACK ]
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param . COMMA separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
@@ -1758,14 +1759,14 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 198, spurious reduction of production prim_param -> prim_param_val
+## In state 202, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 207.
 ##
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param COMMA . separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
 ##
@@ -1777,7 +1778,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 209.
 ##
 ## list(pair(DOT,prim_param)) -> DOT prim_param . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1788,14 +1789,14 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 198, spurious reduction of production prim_param -> prim_param_val
+## In state 202, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 212.
 ##
 ## named -> KWD_REC_INFO . rec_info_atom [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1807,7 +1808,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 214.
 ##
 ## named -> simple . [ KWD_WITH KWD_IN KWD_AND ]
 ## simple -> simple . TILDE coercion [ TILDE KWD_WITH KWD_IN KWD_AND ]
@@ -1818,9 +1819,9 @@ flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
+flambda_unit: KWD_CONT IDENT LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 218.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple COMMA . separated_nonempty_list(COMMA,simple) [ RPAREN ]
 ##
@@ -1830,9 +1831,34 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY TILDE
+flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED RPAREN
+##
+## Ends in an error in state: 226.
+##
+## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
+## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
+##
+## The known suffix of the stack is as follows:
+## symbol_binding
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_AND TILDE
 ##
 ## Ends in an error in state: 227.
+##
+## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
+##
+## The known suffix of the stack is as follows:
+## symbol_binding KWD_AND
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY TILDE
+##
+## Ends in an error in state: 231.
 ##
 ## static_data -> STATIC_CONST_VEC512_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(vec512))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1844,7 +1870,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 232.
 ##
 ## static_data -> STATIC_CONST_VEC512_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(vec512))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1856,7 +1882,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 TILDE
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 233.
 ##
 ## vec512 -> KWD_VEC512 . LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1868,7 +1894,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK TILDE
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 234.
 ##
 ## vec512 -> KWD_VEC512 LBRACK . INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1880,7 +1906,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT TILDE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 235.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT . COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1892,7 +1918,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON TILDE
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 236.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON . INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1904,7 +1930,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT TILDE
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 237.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT . COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1916,7 +1942,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 238.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON . INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1928,7 +1954,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 239.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT . COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1940,7 +1966,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 240.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON . INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1952,7 +1978,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 241.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT . COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1964,7 +1990,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 242.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON . INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1976,7 +2002,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 243.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT . COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1988,7 +2014,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 244.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON . INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2000,7 +2026,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 245.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT . COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2012,7 +2038,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 246.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON . INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2024,7 +2050,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 247.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT . COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2036,7 +2062,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 248.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON . INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2048,7 +2074,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 249.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT . RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2060,7 +2086,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 254.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec512)) -> or_variable(vec512) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(vec512)) -> or_variable(vec512) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(vec512)) [ RBRACKPIPE ]
@@ -2073,7 +2099,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 255.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec512)) -> or_variable(vec512) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(vec512)) [ RBRACKPIPE ]
 ##
@@ -2085,7 +2111,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY TILDE
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 259.
 ##
 ## static_data -> STATIC_CONST_VEC256_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(vec256))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2097,7 +2123,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 260.
 ##
 ## static_data -> STATIC_CONST_VEC256_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(vec256))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2109,7 +2135,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 TILDE
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 261.
 ##
 ## vec256 -> KWD_VEC256 . LBRACK INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2121,7 +2147,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK TILDE
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 262.
 ##
 ## vec256 -> KWD_VEC256 LBRACK . INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2133,7 +2159,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT TILDE
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 263.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT . COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2145,7 +2171,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON TILDE
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 264.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON . INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2157,7 +2183,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT TILDE
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 265.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT . COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2169,7 +2195,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 266.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON . INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2181,7 +2207,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 267.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON INT . COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2193,7 +2219,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 268.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON INT COLON . INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2205,7 +2231,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 269.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON INT COLON INT . RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2217,7 +2243,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 274.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec256)) -> or_variable(vec256) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(vec256)) -> or_variable(vec256) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(vec256)) [ RBRACKPIPE ]
@@ -2230,7 +2256,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 275.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec256)) -> or_variable(vec256) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(vec256)) [ RBRACKPIPE ]
 ##
@@ -2242,7 +2268,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY TILDE
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 279.
 ##
 ## static_data -> STATIC_CONST_VEC128_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(vec128))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2254,7 +2280,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 280.
 ##
 ## static_data -> STATIC_CONST_VEC128_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(vec128))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2266,7 +2292,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 TILDE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 281.
 ##
 ## vec128 -> KWD_VEC128 . LBRACK INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2278,7 +2304,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK TILDE
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 282.
 ##
 ## vec128 -> KWD_VEC128 LBRACK . INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2290,7 +2316,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK INT TILDE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 283.
 ##
 ## vec128 -> KWD_VEC128 LBRACK INT . COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2302,7 +2328,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK INT COLON TILDE
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 284.
 ##
 ## vec128 -> KWD_VEC128 LBRACK INT COLON . INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2314,7 +2340,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK INT COLON INT TILDE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 285.
 ##
 ## vec128 -> KWD_VEC128 LBRACK INT COLON INT . RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2326,7 +2352,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 290.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec128)) -> or_variable(vec128) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(vec128)) -> or_variable(vec128) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(vec128)) [ RBRACKPIPE ]
@@ -2339,7 +2365,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 291.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec128)) -> or_variable(vec128) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(vec128)) [ RBRACKPIPE ]
 ##
@@ -2351,7 +2377,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 295.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2363,7 +2389,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 296.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2375,7 +2401,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT TILDE
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 302.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . SEMICOLON separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
@@ -2388,7 +2414,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 303.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block SEMICOLON . separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
 ##
@@ -2400,7 +2426,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT SEM
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY TILDE
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 306.
 ##
 ## static_data -> STATIC_CONST_NATIVEINT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(nativeint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2412,7 +2438,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 307.
 ##
 ## static_data -> STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(nativeint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2424,7 +2450,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 311.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(nativeint)) [ RBRACKPIPE ]
@@ -2437,7 +2463,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 312.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(nativeint)) [ RBRACKPIPE ]
 ##
@@ -2449,7 +2475,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT S
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY TILDE
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 317.
 ##
 ## static_data -> STATIC_CONST_INT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(targetint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2461,7 +2487,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 318.
 ##
 ## static_data -> STATIC_CONST_INT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(targetint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2473,7 +2499,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 323.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(targetint)) [ RBRACKPIPE ]
@@ -2486,7 +2512,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 324.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(targetint)) [ RBRACKPIPE ]
 ##
@@ -2498,7 +2524,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT SEMICOL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY TILDE
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 328.
 ##
 ## static_data -> STATIC_CONST_INT8_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int8))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2510,7 +2536,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 329.
 ##
 ## static_data -> STATIC_CONST_INT8_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int8))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2522,7 +2548,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 333.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int8)) [ RBRACKPIPE ]
@@ -2535,7 +2561,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 334.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int8)) [ RBRACKPIPE ]
 ##
@@ -2547,7 +2573,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT SEMICO
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY TILDE
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 339.
 ##
 ## static_data -> STATIC_CONST_INT64_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int64))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2559,7 +2585,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 340.
 ##
 ## static_data -> STATIC_CONST_INT64_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int64))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2571,7 +2597,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 344.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int64)) [ RBRACKPIPE ]
@@ -2584,7 +2610,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 345.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int64)) [ RBRACKPIPE ]
 ##
@@ -2596,7 +2622,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY TILDE
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 350.
 ##
 ## static_data -> STATIC_CONST_INT32_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int32))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2608,7 +2634,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 351.
 ##
 ## static_data -> STATIC_CONST_INT32_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int32))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2620,7 +2646,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 355.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int32)) [ RBRACKPIPE ]
@@ -2633,7 +2659,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 356.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int32)) [ RBRACKPIPE ]
 ##
@@ -2645,7 +2671,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY TILDE
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 361.
 ##
 ## static_data -> STATIC_CONST_INT16_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int16))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2657,7 +2683,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 362.
 ##
 ## static_data -> STATIC_CONST_INT16_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int16))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2669,7 +2695,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 366.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int16)) [ RBRACKPIPE ]
@@ -2682,7 +2708,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 367.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int16)) [ RBRACKPIPE ]
 ##
@@ -2694,7 +2720,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 372.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK . LPAREN loption(separated_nonempty_list(COMMA,or_variable(float))) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2706,7 +2732,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 373.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK LPAREN . loption(separated_nonempty_list(COMMA,or_variable(float))) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2718,7 +2744,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT TILDE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 377.
 ##
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) . [ RPAREN ]
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) . COMMA separated_nonempty_list(COMMA,or_variable(float)) [ RPAREN ]
@@ -2731,7 +2757,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 378.
 ##
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) COMMA . separated_nonempty_list(COMMA,or_variable(float)) [ RPAREN ]
 ##
@@ -2743,7 +2769,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT COMMA T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 383.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2755,7 +2781,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 384.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2767,7 +2793,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT TILDE
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 386.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(float)) [ RBRACKPIPE ]
@@ -2780,7 +2806,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 387.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(float)) [ RBRACKPIPE ]
 ##
@@ -2792,7 +2818,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT S
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY TILDE
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 391.
 ##
 ## static_data -> STATIC_CONST_FLOAT32_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2804,7 +2830,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 392.
 ##
 ## static_data -> STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2816,7 +2842,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_EMPTY_ARRAY TILDE
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 395.
 ##
 ## static_data -> STATIC_CONST_EMPTY_ARRAY . empty_array_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2828,7 +2854,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_EMPTY_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 ##
-## Ends in an error in state: 404.
+## Ends in an error in state: 408.
 ##
 ## static_data -> STATIC_CONST_BLOCK . mutability tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2840,7 +2866,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 411.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability . tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2852,7 +2878,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 412.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag . LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2864,7 +2890,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 413.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag LPAREN . loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2876,7 +2902,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT TILDE
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 417.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . [ RPAREN ]
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . COMMA separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
@@ -2889,7 +2915,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 418.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block COMMA . separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
 ##
@@ -2901,7 +2927,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 420.
 ##
 ## static_data -> KWD_MUTABLE . STRING [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2913,7 +2939,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 424.
 ##
 ## static_data -> variable . COLON static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2925,7 +2951,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 425.
 ##
 ## static_data -> variable COLON . static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2937,7 +2963,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC512 TILDE
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 426.
 ##
 ## static_data_kind -> KWD_VEC512 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2949,7 +2975,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC512 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC256 TILDE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 428.
 ##
 ## static_data_kind -> KWD_VEC256 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2961,7 +2987,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC256 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC128 TILDE
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 430.
 ##
 ## static_data_kind -> KWD_VEC128 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2973,7 +2999,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC128 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 428.
+## Ends in an error in state: 432.
 ##
 ## static_data_kind -> KWD_NATIVEINT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2985,7 +3011,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 434.
 ##
 ## static_data_kind -> KWD_INT64 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2997,7 +3023,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 436.
 ##
 ## static_data_kind -> KWD_INT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3009,7 +3035,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 438.
 ##
 ## static_data_kind -> KWD_FLOAT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3021,7 +3047,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 440.
 ##
 ## static_data_kind -> KWD_FLOAT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3033,9 +3059,9 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 449.
 ##
-## code -> code_header . kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header . kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## code_header
@@ -3045,7 +3071,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 450.
 ##
 ## kinded_args -> LPAREN . separated_nonempty_list(COMMA,kinded_variable) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EQUAL EOF ]
 ##
@@ -3057,7 +3083,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 451.
 ##
 ## kinded_variable -> variable . kind_with_subkind_opt [ RPAREN COMMA ]
 ##
@@ -3069,7 +3095,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 452.
 ##
 ## kind_with_subkind_opt -> COLON . kind_with_subkind [ RPAREN COMMA ]
 ##
@@ -3081,7 +3107,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_FLOAT STAR
 ##
-## Ends in an error in state: 453.
+## Ends in an error in state: 457.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . COMMA separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
@@ -3095,15 +3121,15 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_FLOAT STAR
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
 ## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 449, spurious reduction of production kind_with_subkind_opt -> COLON kind_with_subkind
-## In state 450, spurious reduction of production kinded_variable -> variable kind_with_subkind_opt
+## In state 453, spurious reduction of production kind_with_subkind_opt -> COLON kind_with_subkind
+## In state 454, spurious reduction of production kinded_variable -> variable kind_with_subkind_opt
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 458.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable COMMA . separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
 ##
@@ -3115,9 +3141,9 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 460.
 ##
-## code -> code_header kinded_args . variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header kinded_args . variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## code_header kinded_args
@@ -3127,9 +3153,9 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPA
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 461.
 ##
-## code -> code_header kinded_args variable . variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header kinded_args variable . alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## code_header kinded_args variable
@@ -3137,69 +3163,119 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP TILDE
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 462.
 ##
-## code -> code_header kinded_args variable variable . variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## alloc_mode_for_function_params -> AMP . variable [ IDENT ]
+## alloc_mode_for_function_params -> AMP . variable AMP variable AMP variable [ IDENT ]
 ##
 ## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable
+## AMP
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT TILDE
-##
-## Ends in an error in state: 459.
-##
-## code -> code_header kinded_args variable variable variable . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
-##
-## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT TILDE
-##
-## Ends in an error in state: 460.
-##
-## code -> code_header kinded_args variable variable variable variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
-##
-## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER TILDE
-##
-## Ends in an error in state: 461.
-##
-## code -> code_header kinded_args variable variable variable variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
-##
-## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable MINUSGREATER
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT TILDE
 ##
 ## Ends in an error in state: 463.
 ##
-## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## alloc_mode_for_function_params -> AMP variable . [ IDENT ]
+## alloc_mode_for_function_params -> AMP variable . AMP variable AMP variable [ IDENT ]
 ##
 ## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable MINUSGREATER continuation_id
+## AMP variable
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP TILDE
 ##
 ## Ends in an error in state: 464.
+##
+## alloc_mode_for_function_params -> AMP variable AMP . variable AMP variable [ IDENT ]
+##
+## The known suffix of the stack is as follows:
+## AMP variable AMP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP IDENT TILDE
+##
+## Ends in an error in state: 465.
+##
+## alloc_mode_for_function_params -> AMP variable AMP variable . AMP variable [ IDENT ]
+##
+## The known suffix of the stack is as follows:
+## AMP variable AMP variable
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP IDENT AMP TILDE
+##
+## Ends in an error in state: 466.
+##
+## alloc_mode_for_function_params -> AMP variable AMP variable AMP . variable [ IDENT ]
+##
+## The known suffix of the stack is as follows:
+## AMP variable AMP variable AMP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP IDENT AMP IDENT TILDE
+##
+## Ends in an error in state: 468.
+##
+## code -> code_header kinded_args variable alloc_mode_for_function_params . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## code_header kinded_args variable alloc_mode_for_function_params
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT TILDE
+##
+## Ends in an error in state: 469.
+##
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## code_header kinded_args variable alloc_mode_for_function_params variable
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER TILDE
+##
+## Ends in an error in state: 470.
+##
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT TILDE
+##
+## Ends in an error in state: 472.
+##
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+##
+## The known suffix of the stack is as follows:
+## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR TILDE
+##
+## Ends in an error in state: 473.
 ##
 ## exn_continuation_id -> STAR . continuation_id [ KWD_LOCAL EQUAL COLON ]
 ##
@@ -3209,21 +3285,21 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 466.
+## Ends in an error in state: 475.
 ##
-## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id
+## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
 ##
-## Ends in an error in state: 467.
+## Ends in an error in state: 476.
 ##
 ## return_arity -> COLON . kinds_with_subkinds [ KWD_LOCAL EQUAL ]
 ##
@@ -3233,14 +3309,14 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_FLOAT RPAREN
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_FLOAT RPAREN
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 480.
 ##
-## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity
+## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -3249,39 +3325,39 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 ## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
 ## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
 ## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 469, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 470, spurious reduction of production return_arity -> COLON kinds_with_subkinds
+## In state 478, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 479, spurious reduction of production return_arity -> COLON kinds_with_subkinds
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_LOCAL TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_LOCAL TILDE
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 482.
 ##
-## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL)
+## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 474.
+## Ends in an error in state: 483.
 ##
-## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
+## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
-## code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL
+## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 486.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3291,9 +3367,21 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
+##
+## Ends in an error in state: 487.
+##
+## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_INVALID TILDE
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 488.
 ##
 ## atomic_expr -> KWD_INVALID . STRING [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3305,7 +3393,7 @@ flambda_unit: KWD_INVALID TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 497.
 ##
 ## trap_action -> KWD_PUSH . LPAREN continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3317,7 +3405,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 498.
 ##
 ## trap_action -> KWD_PUSH LPAREN . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3329,7 +3417,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 499.
 ##
 ## trap_action -> KWD_PUSH LPAREN continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3341,7 +3429,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 501.
 ##
 ## trap_action -> KWD_POP . LPAREN option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3353,7 +3441,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 502.
 ##
 ## trap_action -> KWD_POP LPAREN . option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3365,7 +3453,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 507.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3377,7 +3465,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 508.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3389,7 +3477,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 511.
 ##
 ## apply_cont_expr -> continuation option(trap_action) . simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3401,9 +3489,9 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL TILDE
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 515.
 ##
-## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL
@@ -3413,9 +3501,9 @@ flambda_unit: KWD_APPLY KWD_MCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
 ##
-## Ends in an error in state: 507.
+## Ends in an error in state: 516.
 ##
-## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN
@@ -3425,9 +3513,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 520.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN method_kind
@@ -3437,9 +3525,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 521.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -3448,11 +3536,35 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT RPAREN TILDE
+##
+## Ends in an error in state: 522.
+##
+## call_kind -> KWD_MCALL LPAREN method_kind simple RPAREN . AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MCALL LPAREN method_kind simple RPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT RPAREN AMP TILDE
+##
+## Ends in an error in state: 523.
+##
+## call_kind -> KWD_MCALL LPAREN method_kind simple RPAREN AMP . region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MCALL LPAREN method_kind simple RPAREN AMP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 525.
 ##
-## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT
@@ -3462,9 +3574,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 526.
 ##
-## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN
@@ -3474,9 +3586,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 527.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id
@@ -3486,9 +3598,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 528.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id function_slot_opt
@@ -3498,9 +3610,10 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 529.
 ##
-## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP . region AMP region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP
@@ -3510,9 +3623,10 @@ flambda_unit: KWD_APPLY AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 519.
+## Ends in an error in state: 530.
 ##
-## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region . [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region . AMP region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region
@@ -3522,9 +3636,9 @@ flambda_unit: KWD_APPLY AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 531.
 ##
-## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region AMP
@@ -3532,23 +3646,53 @@ flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
+flambda_unit: KWD_APPLY AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 532.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
-## KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt
+## AMP region AMP region
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT AMP IDENT AMP TILDE
+##
+## Ends in an error in state: 533.
+##
+## alloc_mode_for_applications -> AMP region AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## AMP region AMP region AMP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT SYMBOL
+##
+## Ends in an error in state: 535.
+##
+## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 530, spurious reduction of production alloc_mode_for_applications -> AMP region
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 537.
 ##
-## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CCALL
@@ -3558,7 +3702,31 @@ flambda_unit: KWD_APPLY KWD_CCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 539.
+##
+## call_kind -> KWD_CCALL boption(KWD_NOALLOC) . AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_CCALL boption(KWD_NOALLOC)
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_CCALL AMP TILDE
+##
+## Ends in an error in state: 540.
+##
+## call_kind -> KWD_CCALL boption(KWD_NOALLOC) AMP . region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_CCALL boption(KWD_NOALLOC) AMP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT RPAREN
+##
+## Ends in an error in state: 542.
 ##
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3567,12 +3735,19 @@ flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ## The known suffix of the stack is as follows:
 ## call_kind
 ##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 530, spurious reduction of production alloc_mode_for_applications -> AMP region
+## In state 606, spurious reduction of production call_kind -> alloc_mode_for_applications
+##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_UNROLL TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 543.
 ##
 ## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3582,9 +3757,9 @@ flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 544.
 ##
 ## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3594,9 +3769,9 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 545.
 ##
 ## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3606,9 +3781,9 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED TILDE
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 547.
 ##
 ## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -3621,9 +3796,9 @@ flambda_unit: KWD_APPLY KWD_INLINED TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 533.
+## Ends in an error in state: 548.
 ##
 ## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -3636,9 +3811,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 549.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3648,9 +3823,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 551.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3660,9 +3835,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 538.
+## Ends in an error in state: 553.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3672,9 +3847,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 555.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -3684,9 +3859,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 557.
 ##
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3698,9 +3873,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 558.
 ##
 ## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
@@ -3710,9 +3885,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 559.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
@@ -3722,9 +3897,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 560.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -3734,9 +3909,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 561.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -3746,9 +3921,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 547.
+## Ends in an error in state: 562.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -3758,9 +3933,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 564.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
@@ -3770,9 +3945,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TI
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 551.
+## Ends in an error in state: 566.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3784,9 +3959,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RP
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 567.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
@@ -3797,9 +3972,9 @@ flambda_unit: KWD_APPLY LPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 568.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
@@ -3812,9 +3987,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 554.
+## Ends in an error in state: 569.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3824,9 +3999,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT RPAREN
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT RPAREN
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 572.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3840,15 +4015,15 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT RPAREN
 ## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
 ## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
 ## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 469, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 556, spurious reduction of production blank_or(kinds_with_subkinds) -> kinds_with_subkinds
+## In state 478, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 571, spurious reduction of production blank_or(kinds_with_subkinds) -> kinds_with_subkinds
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 573.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3858,9 +4033,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RBRACK
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RBRACK
 ##
-## Ends in an error in state: 559.
+## Ends in an error in state: 574.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3874,14 +4049,14 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RBRA
 ## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
 ## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
 ## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 469, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 478, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 575.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3891,9 +4066,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 561.
+## Ends in an error in state: 576.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3903,9 +4078,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 577.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3915,9 +4090,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 564.
+## Ends in an error in state: 579.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3927,9 +4102,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 565.
+## Ends in an error in state: 580.
 ##
 ## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3939,9 +4114,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 566.
+## Ends in an error in state: 581.
 ##
 ## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3951,9 +4126,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 567.
+## Ends in an error in state: 582.
 ##
 ## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3963,9 +4138,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 583.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
 ## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
@@ -3976,9 +4151,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT STAR
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT STAR
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 587.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -3992,14 +4167,14 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT STA
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
 ## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 569, spurious reduction of production exn_extra_arg -> simple kind_with_subkind
+## In state 584, spurious reduction of production exn_extra_arg -> simple kind_with_subkind
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 573.
+## Ends in an error in state: 588.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -4009,9 +4184,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COM
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
+flambda_unit: KWD_APPLY AMP IDENT LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 594.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4021,9 +4196,9 @@ flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER TILDE
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 580.
+## Ends in an error in state: 595.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4033,9 +4208,9 @@ flambda_unit: KWD_APPLY MINUSGREATER TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 581.
+## Ends in an error in state: 596.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4045,9 +4220,58 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_APPLY AMP IDENT FLOAT SYMBOL
+##
+## Ends in an error in state: 598.
+##
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
+##
+## The known suffix of the stack is as follows:
+## call_kind option(inlined) option(inlining_state) simple
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT FLOAT LPAREN RPAREN TILDE
+##
+## Ends in an error in state: 599.
+##
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## call_kind option(inlined) option(inlining_state) simple simple_args
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT FLOAT MINUSGREATER TILDE
+##
+## Ends in an error in state: 600.
+##
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT FLOAT MINUSGREATER IDENT TILDE
+##
+## Ends in an error in state: 601.
+##
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_HCF KWD_ANDWHERE
 ##
-## Ends in an error in state: 595.
+## Ends in an error in state: 610.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -4060,7 +4284,7 @@ flambda_unit: KWD_HCF KWD_ANDWHERE
 
 flambda_unit: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 596.
+## Ends in an error in state: 611.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -4072,7 +4296,7 @@ flambda_unit: KWD_HCF KWD_WHERE TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 612.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF ]
 ##
@@ -4084,7 +4308,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 614.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -4096,7 +4320,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 602.
+## Ends in an error in state: 617.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4108,7 +4332,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 605.
+## Ends in an error in state: 620.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4120,7 +4344,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 621.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4132,7 +4356,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 607.
+## Ends in an error in state: 622.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4144,7 +4368,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 608.
+## Ends in an error in state: 623.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -4157,7 +4381,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 625.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4169,7 +4393,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 626.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4181,7 +4405,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 618.
+## Ends in an error in state: 633.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4193,7 +4417,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LB
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 634.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4203,9 +4427,9 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILD
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET IDENT EQUAL KWD_CLOSURE IDENT KWD_END
+flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT KWD_END
 ##
-## Ends in an error in state: 621.
+## Ends in an error in state: 636.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -4213,22 +4437,12 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_CLOSURE IDENT KWD_END
 ## The known suffix of the stack is as follows:
 ## let_binding
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 112, spurious reduction of production function_slot_opt ->
-## In state 116, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 121, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 221, spurious reduction of production named -> fun_decl
-## In state 220, spurious reduction of production let_binding -> variable EQUAL named
-##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 637.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -4240,7 +4454,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF PIPE
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 642.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -4253,7 +4467,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF PIPE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 628.
+## Ends in an error in state: 643.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -4265,7 +4479,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 633.
+## Ends in an error in state: 648.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -4277,7 +4491,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 634.
+## Ends in an error in state: 649.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -4289,7 +4503,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 639.
+## Ends in an error in state: 654.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4301,7 +4515,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 655.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4313,7 +4527,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 646.
+## Ends in an error in state: 661.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4325,7 +4539,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WIT
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 662.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4337,7 +4551,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN 
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 ##
-## Ends in an error in state: 652.
+## Ends in an error in state: 667.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -4350,7 +4564,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 668.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4362,7 +4576,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 
 flambda_unit: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 657.
+## Ends in an error in state: 672.
 ##
 ## atomic_expr -> LPAREN expr . RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4373,7 +4587,7 @@ flambda_unit: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 595, spurious reduction of production expr -> inner_expr
+## In state 610, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -213,8 +213,11 @@ let make_boxed_const_int (i, m) : static_data =
 %token STATIC_CONST_EMPTY_ARRAY [@symbol "Empty_array"]
 
 %start flambda_unit
-%type <Fexpr.alloc_mode_for_allocations> alloc_mode_for_allocations_opt
-%type <Fexpr.alloc_mode_for_applications> alloc_mode_for_applications_opt
+%type <Fexpr.alloc_mode_for_allocations> alloc_mode_for_allocations
+%type <Fexpr.region Fexpr.alloc_mode_for_applications>
+  alloc_mode_for_applications
+%type <Fexpr.variable Fexpr.alloc_mode_for_applications>
+  alloc_mode_for_function_params
 %type <Fexpr.empty_array_kind> empty_array_kind
 %type <Fexpr.const> const
 %type <Fexpr.continuation> continuation
@@ -295,8 +298,7 @@ code:
   | header = code_header;
     params = kinded_args;
     closure_var = variable;
-    region_var = variable;
-    ghost_region_var = variable;
+    region_vars = alloc_mode_for_function_params;
     depth_var = variable;
     MINUSGREATER; ret_cont = continuation_id;
     exn_cont = exn_continuation_id;
@@ -311,7 +313,7 @@ code:
       in
       let result_mode : alloc_mode_for_assignments = if result_mode then Local else Heap in
       { id; newer_version_of; param_arity = None; ret_arity; recursive; inline;
-        params_and_body = { params; closure_var; region_var; ghost_region_var; depth_var;
+        params_and_body = { params; closure_var; region_vars; depth_var;
                             ret_cont; exn_cont; body };
         code_size; is_tupled; stub; loopify; result_mode; } }
 ;
@@ -369,13 +371,24 @@ empty_array_kind:
   | KWD_VEC512 { Naked_vec512s }
   | KWD_PRODUCT { Unboxed_products }
 
-alloc_mode_for_allocations_opt:
-  | { Heap }
-  | AMP; region = region { Local { region } }
+alloc_mode_for_allocations:
+  | AMP; alloc_region = region { Heap { alloc_region } }
+  | AMP; alloc_region = region; AMP; region = region
+    { Local { alloc_region; region } }
 
-alloc_mode_for_applications_opt:
-  | { Heap }
-  | AMP; region = region; AMP; ghost_region = region { Local { region; ghost_region } }
+alloc_mode_for_applications:
+  | AMP; alloc_region = region { Heap { alloc_region } }
+  | AMP; alloc_region = region;
+    AMP; region = region;
+    AMP; ghost_region = region
+    { Local { alloc_region; region; ghost_region } }
+
+alloc_mode_for_function_params:
+  | AMP; alloc_region = variable { Heap { alloc_region } }
+  | AMP; alloc_region = variable;
+    AMP; region = variable;
+    AMP; ghost_region = variable
+    { Local { alloc_region; region; ghost_region } }
 
 prim_param_val:
   | i = IDENT { make_located i ($startpos, $endpos) }
@@ -603,7 +616,7 @@ value_slot:
 fun_decl:
   | KWD_CLOSURE; code_id = code_id;
     function_slot = function_slot_opt;
-    alloc = alloc_mode_for_allocations_opt;
+    alloc = alloc_mode_for_allocations;
     { { code_id; function_slot; alloc; } }
 ;
 
@@ -635,17 +648,20 @@ method_kind:
   | KWD_CACHED { Call_kind.Method_kind.Cached }
 
 call_kind:
-  | alloc = alloc_mode_for_applications_opt; { (Function Indirect, alloc) }
+  | alloc = alloc_mode_for_applications; { (Function Indirect, alloc) }
   | KWD_DIRECT; LPAREN;
       code_id = code_id;
       function_slot = function_slot_opt;
-      alloc = alloc_mode_for_applications_opt;
+      alloc = alloc_mode_for_applications;
     RPAREN
     { (Function (Direct { code_id; function_slot; }), alloc) }
-  | KWD_CCALL; noalloc = boption(KWD_NOALLOC)
-    { (C_call { alloc = not noalloc }, (Heap : alloc_mode_for_applications)) }
-  | KWD_MCALL LPAREN; kind = method_kind; obj = simple; RPAREN
-    { (Method { kind; obj }, (Heap : alloc_mode_for_applications)) }
+  | KWD_CCALL; noalloc = boption(KWD_NOALLOC); AMP; alloc_region = region
+    { (C_call { alloc = not noalloc },
+      (Heap { alloc_region } : region alloc_mode_for_applications)) }
+  | KWD_MCALL LPAREN; kind = method_kind; obj = simple; RPAREN;
+      AMP; alloc_region = region
+    { (Method { kind; obj },
+        (Heap { alloc_region } : region alloc_mode_for_applications)) }
 ;
 
 inline:
@@ -688,7 +704,13 @@ loopify:
 
 region:
   | v = variable { Named v }
-  | KWD_TOPLEVEL { Toplevel }
+  | KWD_TOPLEVEL; DOT; i = IDENT {
+    match i with
+    | "alloc_region" -> Toplevel_alloc_region
+    | "region" -> Toplevel_region
+    | "ghost_region" -> Toplevel_ghost_region
+    | _ -> Misc.fatal_errorf "toplevel. must be followed \
+      by alloc_region, region or ghost_region" }
 ;
 
 result_continuation:

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -183,19 +183,25 @@ let recursive_flag (r : Recursive.t) : Fexpr.is_recursive =
 let alloc_mode_for_allocations env (alloc : Alloc_mode.For_allocations.t) :
     Fexpr.alloc_mode_for_allocations =
   match alloc with
-  | Heap -> Heap
-  | Local { region = r } ->
-    let r = Env.find_region_exn env r in
-    Local { region = r }
+  | Heap { alloc_region } ->
+    let alloc_region = Env.find_region_exn env alloc_region in
+    Heap { alloc_region }
+  | Local { alloc_region; region } ->
+    let alloc_region = Env.find_region_exn env alloc_region in
+    let region = Env.find_region_exn env region in
+    Local { alloc_region; region }
 
 let alloc_mode_for_applications env (alloc : Alloc_mode.For_applications.t) :
-    Fexpr.alloc_mode_for_applications =
+    Fexpr.region Fexpr.alloc_mode_for_applications =
   match alloc with
-  | Heap -> Heap
-  | Local { region = r; ghost_region = r' } ->
-    let r = Env.find_region_exn env r in
-    let r' = Env.find_region_exn env r' in
-    Local { region = r; ghost_region = r' }
+  | Heap { alloc_region } ->
+    let alloc_region = Env.find_region_exn env alloc_region in
+    Heap { alloc_region }
+  | Local { alloc_region; region; ghost_region } ->
+    let alloc_region = Env.find_region_exn env alloc_region in
+    let region = Env.find_region_exn env region in
+    let ghost_region = Env.find_region_exn env ghost_region in
+    Local { alloc_region; region; ghost_region }
 
 let prim env (p : Flambda_primitive.t) : Fexpr.prim =
   let p, args = Fexpr_prim.OfFlambda.prim env p in
@@ -393,7 +399,9 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
       Data { symbol; defining_expr }
     | Set_of_closures closure_symbols, Static_const const ->
       let set = Static_const.must_be_set_of_closures const in
-      let fun_decls, elements = set_of_closures env set Heap in
+      let fun_decls, elements =
+        set_of_closures env set (Heap { alloc_region = Toplevel_alloc_region })
+      in
       let symbols_by_function_slot =
         closure_symbols |> Function_slot.Lmap.bindings
         |> Function_slot.Map.of_list
@@ -462,13 +470,20 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
                 (Bound_parameters.to_list params)
             in
             let closure_var, env = Env.bind_var env my_closure in
-            let region_var, ghost_region_var, env =
+            let (region_vars : _ Fexpr.alloc_mode_for_applications), env =
               match my_alloc_mode with
-              | Heap -> nowhere "_region", nowhere "_ghost_region", env
-              | Local { region = my_region; ghost_region = my_ghost_region } ->
-                let region_var, env = Env.bind_var env my_region in
-                let ghost_region_var, env = Env.bind_var env my_ghost_region in
-                region_var, ghost_region_var, env
+              | Heap { alloc_region } ->
+                let alloc_region, env = Env.bind_var env alloc_region in
+                Heap { alloc_region }, env
+              | Local
+                  { alloc_region = my_alloc_region;
+                    region = my_region;
+                    ghost_region = my_ghost_region
+                  } ->
+                let alloc_region, env = Env.bind_var env my_alloc_region in
+                let region, env = Env.bind_var env my_region in
+                let ghost_region, env = Env.bind_var env my_ghost_region in
+                Local { alloc_region; region; ghost_region }, env
             in
             let depth_var, env = Env.bind_var env my_depth in
             let body = expr env body in
@@ -477,8 +492,7 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
               ret_cont;
               exn_cont;
               closure_var;
-              region_var;
-              ghost_region_var;
+              region_vars;
               depth_var;
               body
             })
@@ -839,11 +853,20 @@ let bind_all_code_ids env unit =
 let conv flambda_unit =
   let done_ = Flambda_unit.return_continuation flambda_unit in
   let error = Flambda_unit.exn_continuation flambda_unit in
-  let toplevel = Flambda_unit.toplevel_my_region flambda_unit in
   let env = Env.create () in
   let env = Env.bind_special_continuation env done_ ~to_:Done in
   let env = Env.bind_special_continuation env error ~to_:Error in
-  let env = Env.bind_toplevel_region env toplevel in
+  let env =
+    Env.bind_toplevel_alloc_region env
+      (Flambda_unit.toplevel_my_alloc_region flambda_unit)
+  in
+  let env =
+    Env.bind_toplevel_region env (Flambda_unit.toplevel_my_region flambda_unit)
+  in
+  let env =
+    Env.bind_toplevel_ghost_region env
+      (Flambda_unit.toplevel_my_ghost_region flambda_unit)
+  in
   (* Bind all code ids in toplevel let bindings at the start, since they don't
      necessarily occur in dependency order *)
   let env = bind_all_code_ids env flambda_unit in

--- a/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
@@ -156,7 +156,11 @@ module Env : sig
   val bind_special_continuation :
     t -> Continuation.t -> to_:Fexpr.special_continuation -> t
 
+  val bind_toplevel_alloc_region : t -> Variable.t -> t
+
   val bind_toplevel_region : t -> Variable.t -> t
+
+  val bind_toplevel_ghost_region : t -> Variable.t -> t
 
   val find_var_exn : t -> Variable.t -> Fexpr.variable
 
@@ -280,7 +284,9 @@ end = struct
       function_slots : Function_slot_name_map.t;
       vars_within_closures : Value_slot_name_map.t;
       continuations : Continuation_name_map.t;
-      toplevel_region : Variable.t option
+      toplevel_alloc_region : Variable.t option;
+      toplevel_region : Variable.t option;
+      toplevel_ghost_region : Variable.t option
     }
 
   let create () =
@@ -290,7 +296,9 @@ end = struct
       function_slots = Function_slot_name_map.create ();
       vars_within_closures = Value_slot_name_map.create ();
       continuations = Continuation_name_map.empty;
-      toplevel_region = None
+      toplevel_alloc_region = None;
+      toplevel_region = None;
+      toplevel_ghost_region = None
     }
 
   let bind_var t v =
@@ -329,7 +337,11 @@ end = struct
     in
     { t with continuations }
 
+  let bind_toplevel_alloc_region t v = { t with toplevel_alloc_region = Some v }
+
   let bind_toplevel_region t v = { t with toplevel_region = Some v }
+
+  let bind_toplevel_ghost_region t v = { t with toplevel_ghost_region = Some v }
 
   let find_var_exn t v = Variable_name_map.find_exn t.variables v
 
@@ -360,9 +372,18 @@ end = struct
     Continuation_name_map.find_exn t.continuations c
 
   let find_region_exn t r : Fexpr.region =
-    match t.toplevel_region with
-    | Some toplevel_region when Variable.equal toplevel_region r -> Toplevel
-    | _ -> Named (find_var_exn t r)
+    match
+      List.find_map
+        (function
+          | Some region, result ->
+            if Variable.equal region r then Some result else None
+          | None, _ -> None)
+        [ t.toplevel_alloc_region, Fexpr.Toplevel_alloc_region;
+          t.toplevel_region, Fexpr.Toplevel_region;
+          t.toplevel_ghost_region, Fexpr.Toplevel_ghost_region ]
+    with
+    | Some result -> result
+    | None -> Named (find_var_exn t r)
 
   let translate_function_slot t c =
     Function_slot_name_map.translate t.function_slots c

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -139,7 +139,9 @@ let result_continuation ppf rcont =
 let region ppf (r : region) =
   match r with
   | Named v -> variable ppf v
-  | Toplevel -> Format.pp_print_string ppf "toplevel"
+  | Toplevel_alloc_region -> Format.pp_print_string ppf "toplevel.alloc_region"
+  | Toplevel_region -> Format.pp_print_string ppf "toplevel.region"
+  | Toplevel_ghost_region -> Format.pp_print_string ppf "toplevel.ghost_region"
 
 let cfprintf directive ppf fmt =
   directive ppf;
@@ -378,12 +380,12 @@ let empty_array_kind ~space ppf (ak : empty_array_kind) =
   in
   pp_option ~space Format.pp_print_string ppf str
 
-let alloc_mode_for_applications_opt ppf (alloc : alloc_mode_for_applications)
+let alloc_mode_for_applications pp ppf (alloc : _ alloc_mode_for_applications)
     ~space =
   match alloc with
-  | Heap -> ()
-  | Local { region = r; ghost_region = r' } ->
-    pp_spaced ~space ppf "&%a &%a" region r region r'
+  | Heap { alloc_region } -> pp_spaced ~space ppf "&%a" pp alloc_region
+  | Local { alloc_region; region; ghost_region } ->
+    pp_spaced ~space ppf "&%a &%a &%a" pp alloc_region pp region pp ghost_region
 
 let boxed_variable ppf var ~kind =
   Format.fprintf ppf "%a : %s boxed" variable var kind
@@ -548,13 +550,19 @@ let value_slots expr_or_static ppf = function
       ppf ces;
     Format.fprintf ppf "@;<1 -2>}@]"
 
+let alloc_mode_for_allocations ppf (alloc_mode : alloc_mode_for_allocations) =
+  match alloc_mode with
+  | Heap { alloc_region } -> Format.fprintf ppf "@ &%a" region alloc_region
+  | Local { alloc_region; region = r } ->
+    Format.fprintf ppf "@ &%a@ &%a" region alloc_region region r
+
 let fun_decl expr_or_static ppf (decl : fun_decl) =
   let pp_at_function_slot ppf cid =
     pp_option ~space:Before (pp_like "@@%a" function_slot) ppf cid
   in
-  Format.fprintf ppf "@[<2>%tclosure%t@ %a%a@]" expr_or_static
+  Format.fprintf ppf "@[<2>%tclosure%t@ %a%a%a@]" expr_or_static
     Flambda_colours.pop code_id decl.code_id pp_at_function_slot
-    decl.function_slot
+    decl.function_slot alloc_mode_for_allocations decl.alloc
 
 let named ppf = function
   | (Simple s : named) -> simple ppf s
@@ -576,12 +584,13 @@ let method_kind ppf mk =
 
 let call_kind_and_alloc_mode ~space ppf (ck, alloc_mode) =
   match ck with
-  | Function Indirect -> alloc_mode_for_applications_opt ppf alloc_mode ~space
+  | Function Indirect ->
+    (alloc_mode_for_applications region) ppf alloc_mode ~space
   | Function (Direct { code_id = c; function_slot = cl }) ->
     pp_spaced ~space ppf "@[direct(%a%a%a)@]" code_id c
       (pp_option ~space:Before (pp_like "@@%a" function_slot))
       cl
-      (alloc_mode_for_applications_opt ~space:Before)
+      (alloc_mode_for_applications region ~space:Before)
       alloc_mode
   | C_call { alloc } ->
     let noalloc_kwd = if alloc then None else Some "noalloc" in
@@ -845,22 +854,17 @@ and code_binding ppf
     is_tupled
     (fun ppf stub -> if stub then Format.fprintf ppf "@ stub")
     stub Flambda_colours.pop code_id id;
-  let { params;
-        closure_var;
-        region_var;
-        ghost_region_var;
-        depth_var;
-        ret_cont;
-        exn_cont;
-        body
-      } =
+  let { params; closure_var; region_vars; depth_var; ret_cont; exn_cont; body }
+      =
     params_and_body
   in
   Format.fprintf ppf
-    "%a@]@ @[<hov 2>%a@ %a@ %a %a@]@ @[<hv 2>-> %a@ * %a@]%a%s@]@] =@ %a"
+    "%a@]@ @[<hov 2>%a%a@ %a@]@ @[<hv 2>-> %a@ * %a@]%a%s@]@] =@ %a"
     (kinded_parameters ~space:Before)
-    params variable closure_var variable region_var variable ghost_region_var
-    variable depth_var continuation_id ret_cont continuation_id exn_cont
+    params variable closure_var
+    (alloc_mode_for_applications variable ~space:Before)
+    region_vars variable depth_var continuation_id ret_cont continuation_id
+    exn_cont
     (pp_option ~space:Before (pp_like ": %a" arity))
     ret_arity
     (match result_mode with Heap -> "" | Local -> " local")

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -316,8 +316,9 @@ let function_params_and_body_free_names fpb =
       in
       let regions =
         match (my_alloc_mode : Alloc_mode.For_applications.t) with
-        | Heap -> []
-        | Local { region; ghost_region } -> [region; ghost_region]
+        | Heap { alloc_region } -> [alloc_region]
+        | Local { alloc_region; region; ghost_region } ->
+          [alloc_region; region; ghost_region]
       in
       List.fold_left
         (fun f var -> Name_occurrences.remove_var f ~var)
@@ -2186,8 +2187,9 @@ and rebuild_function_params_and_body (env : env) res code_metadata
   let rebuild_body () =
     let region_vars =
       match (my_alloc_mode : Alloc_mode.For_applications.t) with
-      | Heap -> []
-      | Local { region; ghost_region } -> [region; ghost_region]
+      | Heap { alloc_region } -> [alloc_region]
+      | Local { alloc_region; region; ghost_region } ->
+        [alloc_region; region; ghost_region]
     in
     let all_vars = region_vars @ (my_closure :: Bound_parameters.vars params) in
     match List.filter (is_dead_var env) all_vars with

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -221,7 +221,7 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
         | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
         | Reinterpret_boxed_vector | Untag_immediate | Tag_immediate
         | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
-        | Obj_dup | Get_header | Peek _ | Make_lazy _ ),
+        | Obj_dup _ | Get_header | Peek _ | Make_lazy _ ),
         _ )
   | Binary
       ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
@@ -783,8 +783,10 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
   Bound_parameters.iter (fun bp -> Acc.bound_parameter_kind acc bp) params;
   Acc.kind acc (Name.var my_closure) K.value;
   (match (my_alloc_mode : Alloc_mode.For_applications.t) with
-  | Heap -> ()
-  | Local { region; ghost_region } ->
+  | Heap { alloc_region } ->
+    Acc.kind acc (Name.var alloc_region) Flambda_kind.region
+  | Local { alloc_region; region; ghost_region } ->
+    Acc.kind acc (Name.var alloc_region) Flambda_kind.region;
     Acc.kind acc (Name.var region) Flambda_kind.region;
     Acc.kind acc (Name.var ghost_region) Flambda_kind.region);
   Acc.kind acc (Name.var my_depth) K.rec_info;
@@ -812,8 +814,9 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
     any_source my_closure;
     any_source my_depth;
     (match (my_alloc_mode : Alloc_mode.For_applications.t) with
-    | Heap -> ()
-    | Local { region; ghost_region } ->
+    | Heap { alloc_region } -> any_source alloc_region
+    | Local { alloc_region; region; ghost_region } ->
+      any_source alloc_region;
       any_source region;
       any_source ghost_region);
     List.iter any_source (code_dep.exn :: code_dep.return);

--- a/middle_end/flambda2/simplify/env/closure_info.ml
+++ b/middle_end/flambda2/simplify/env/closure_info.ml
@@ -20,7 +20,8 @@ type t =
       { code_id : Code_id.t;
         return_continuation : Continuation.t;
         exn_continuation : Continuation.t;
-        my_closure : Variable.t
+        my_closure : Variable.t;
+        my_alloc_region : Variable.t
       }
 
 let [@ocamlformat "disable"] print ppf = function
@@ -28,25 +29,38 @@ let [@ocamlformat "disable"] print ppf = function
     Format.fprintf ppf "not_in_a_closure"
   | In_a_set_of_closures_but_not_yet_in_a_specific_closure ->
     Format.fprintf ppf "in_a_set_of_closures"
-  | Closure { code_id; return_continuation; exn_continuation; my_closure } ->
+  | Closure {
+      code_id; return_continuation;
+      exn_continuation; my_closure;
+      my_alloc_region
+    } ->
     Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(code_id@ %a)@]@ \
       @[<hov 1>(return_continuation@ %a)@]@ \
       @[<hov 1>(exn_continuation@ %a)@]@ \
-      @[<hov 1>(my_closure@ %a)@]\
+      @[<hov 1>(my_closure@ %a)@]@ \
+      @[<hov 1>(my_alloc_region@ %a)@]\
       )@]"
       Code_id.print code_id
       Continuation.print return_continuation
       Continuation.print exn_continuation
       Variable.print my_closure
+      Variable.print my_alloc_region
 
 let not_in_a_closure = Not_in_a_closure
 
 let in_a_set_of_closures =
   In_a_set_of_closures_but_not_yet_in_a_specific_closure
 
-let in_a_closure code_id ~return_continuation ~exn_continuation ~my_closure =
-  Closure { code_id; return_continuation; exn_continuation; my_closure }
+let in_a_closure code_id ~return_continuation ~exn_continuation ~my_closure
+    ~my_alloc_region =
+  Closure
+    { code_id;
+      return_continuation;
+      exn_continuation;
+      my_closure;
+      my_alloc_region
+    }
 
 type in_or_out_of_closure =
   | In_a_closure

--- a/middle_end/flambda2/simplify/env/closure_info.mli
+++ b/middle_end/flambda2/simplify/env/closure_info.mli
@@ -20,7 +20,8 @@ type t = private
       { code_id : Code_id.t;
         return_continuation : Continuation.t;
         exn_continuation : Continuation.t;
-        my_closure : Variable.t
+        my_closure : Variable.t;
+        my_alloc_region : Variable.t
       }
 
 val print : Format.formatter -> t -> unit
@@ -34,6 +35,7 @@ val in_a_closure :
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
   my_closure:Variable.t ->
+  my_alloc_region:Variable.t ->
   t
 
 type in_or_out_of_closure =

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -59,6 +59,7 @@ type t =
     at_unit_toplevel : bool;
     unit_toplevel_return_continuation : Continuation.t;
     unit_toplevel_exn_continuation : Continuation.t;
+    unit_toplevel_alloc_region : Variable.t;
     variables_defined_at_toplevel : Variable.Set.t;
     cse : CSE.t;
     comparison_results : Comparison_result.t Variable.Map.t;
@@ -108,7 +109,7 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
                 at_unit_toplevel; unit_toplevel_exn_continuation;
                 variables_defined_at_toplevel; cse; comparison_results;
                 are_rebuilding_terms; closure_info;
-                unit_toplevel_return_continuation; all_code;
+                unit_toplevel_return_continuation; unit_toplevel_alloc_region; all_code;
                 get_imported_code = _; inlining_history_tracker = _;
                 loopify_state; replay_history; specialization_cost; defined_variables_by_scope;
                 lifted = _; cost_of_lifting_continuations_out_of_current_one;
@@ -125,6 +126,7 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
       @[<hov 1>(at_unit_toplevel@ %b)@]@ \
       @[<hov 1>(unit_toplevel_return_continuation@ %a)@]@ \
       @[<hov 1>(unit_toplevel_exn_continuation@ %a)@]@ \
+      @[<hov 1>(unit_toplevel_alloc_region@ %a)@]@ \
       @[<hov 1>(variables_defined_at_toplevel@ %a)@]@ \
       @[<hov 1>(cse@ @[<hov 1>%a@])@]@ \
       @[<hov 1>(comparison_results@ @[<hov 1>%a@])@]@ \
@@ -149,6 +151,7 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
     at_unit_toplevel
     Continuation.print unit_toplevel_return_continuation
     Continuation.print unit_toplevel_exn_continuation
+    Variable.print unit_toplevel_alloc_region
     Variable.Set.print variables_defined_at_toplevel
     CSE.print cse
     (Variable.Map.print Comparison_result.print) comparison_results
@@ -217,7 +220,7 @@ let define_extra_variable t var kind =
 let create ~round ~machine_width ~(resolver : resolver)
     ~(get_imported_code : get_imported_code) ~propagating_float_consts
     ~unit_toplevel_exn_continuation ~unit_toplevel_return_continuation
-    ~toplevel_my_region ~toplevel_my_ghost_region =
+    ~toplevel_my_region ~toplevel_my_ghost_region ~toplevel_my_alloc_region =
   let typing_env = TE.create ~machine_width ~resolver in
   let t =
     { round;
@@ -230,6 +233,7 @@ let create ~round ~machine_width ~(resolver : resolver)
       at_unit_toplevel = true;
       unit_toplevel_return_continuation;
       unit_toplevel_exn_continuation;
+      unit_toplevel_alloc_region = toplevel_my_alloc_region;
       variables_defined_at_toplevel = Variable.Set.empty;
       cse = CSE.empty;
       comparison_results = Variable.Map.empty;
@@ -279,6 +283,8 @@ let unit_toplevel_exn_continuation t = t.unit_toplevel_exn_continuation
 
 let unit_toplevel_return_continuation t = t.unit_toplevel_return_continuation
 
+let unit_toplevel_alloc_region t = t.unit_toplevel_alloc_region
+
 let at_unit_toplevel t = t.at_unit_toplevel
 
 let set_at_unit_toplevel_state t at_unit_toplevel = { t with at_unit_toplevel }
@@ -317,6 +323,7 @@ let enter_set_of_closures
       at_unit_toplevel = _;
       unit_toplevel_return_continuation;
       unit_toplevel_exn_continuation;
+      unit_toplevel_alloc_region;
       variables_defined_at_toplevel;
       cse = _;
       comparison_results = _;
@@ -347,6 +354,7 @@ let enter_set_of_closures
     at_unit_toplevel = false;
     unit_toplevel_return_continuation;
     unit_toplevel_exn_continuation;
+    unit_toplevel_alloc_region;
     variables_defined_at_toplevel;
     cse = CSE.empty;
     comparison_results = Variable.Map.empty;
@@ -596,11 +604,12 @@ let set_rebuild_terms t =
 
 let are_rebuilding_terms t = t.are_rebuilding_terms
 
-let enter_closure code_id ~return_continuation ~exn_continuation ~my_closure t =
+let enter_closure code_id ~return_continuation ~exn_continuation ~my_closure
+    ~my_alloc_region t =
   { t with
     closure_info =
       Closure_info.in_a_closure code_id ~return_continuation ~exn_continuation
-        ~my_closure
+        ~my_closure ~my_alloc_region
   }
 
 let closure_info t = t.closure_info
@@ -796,6 +805,7 @@ let denv_for_lifted_continuation ~denv_for_join ~denv =
     propagating_float_consts = denv.propagating_float_consts;
     unit_toplevel_return_continuation = denv.unit_toplevel_return_continuation;
     unit_toplevel_exn_continuation = denv.unit_toplevel_exn_continuation;
+    unit_toplevel_alloc_region = denv.unit_toplevel_alloc_region;
     are_rebuilding_terms = denv.are_rebuilding_terms;
     closure_info = denv.closure_info;
     get_imported_code = denv.get_imported_code;

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -38,6 +38,7 @@ val create :
   unit_toplevel_return_continuation:Continuation.t ->
   toplevel_my_region:Variable.t ->
   toplevel_my_ghost_region:Variable.t ->
+  toplevel_my_alloc_region:Variable.t ->
   t
 
 val all_code : t -> Code.t Code_id.Map.t
@@ -62,6 +63,8 @@ val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
 val unit_toplevel_return_continuation : t -> Continuation.t
 
 val unit_toplevel_exn_continuation : t -> Continuation.t
+
+val unit_toplevel_alloc_region : t -> Variable.t
 
 val increment_continuation_scope : t -> t
 
@@ -197,6 +200,7 @@ val enter_closure :
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
   my_closure:Variable.t ->
+  my_alloc_region:Variable.t ->
   t ->
   t
 

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -132,7 +132,7 @@ let inline dacc ~apply ~unroll_to ~was_inline_always function_decl =
     | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
   in
   match region_inlined_into, Code.result_mode code with
-  | Heap, Alloc_local ->
+  | Heap _, Alloc_local ->
     (* The alloc_mode of the application and of the code are incompatible. This
        should have been prevented by the typer; therefore we are in GADT-caused
        unreachable code; we replace the inlined body by [Invalid]. *)
@@ -142,7 +142,7 @@ let inline dacc ~apply ~unroll_to ~was_inline_always function_decl =
     )
   | Local _, Alloc_heap (* This is allowed by subtyping *)
   | Local _, Alloc_local
-  | Heap, Alloc_heap ->
+  | Heap _, Alloc_heap ->
     let denv =
       DE.enter_inlined_apply ~called_code:code ~apply ~was_inline_always denv
     in

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -472,7 +472,10 @@ module Group = struct
          ~body:(Expr.create_invalid Code_not_rebuilt)
          ~free_names_of_body:Unknown
          ~my_closure:(Variable.create "my_closure" Flambda_kind.value)
-         ~my_alloc_mode:Alloc_mode.For_applications.heap
+         ~my_alloc_mode:
+           (Alloc_mode.For_applications.heap
+              ~alloc_region:
+                (Variable.create "my_alloc_region" Flambda_kind.region))
          ~my_depth:(Variable.create "my_depth" Flambda_kind.rec_info))
 
   let pieces_of_code_including_those_not_rebuilt t =

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -29,6 +29,7 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   let exn_continuation = FU.exn_continuation unit in
   let toplevel_my_region = FU.toplevel_my_region unit in
   let toplevel_my_ghost_region = FU.toplevel_my_ghost_region unit in
+  let toplevel_my_alloc_region = FU.toplevel_my_alloc_region unit in
   let module_symbol = FU.module_symbol unit in
   let resolver = Flambda_cmx.load_cmx_file_contents cmx_loader in
   let get_imported_code = Flambda_cmx.get_imported_code cmx_loader in
@@ -37,7 +38,7 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
       ~propagating_float_consts:(Flambda_features.float_const_prop ())
       ~unit_toplevel_return_continuation:return_continuation
       ~unit_toplevel_exn_continuation:exn_continuation ~toplevel_my_region
-      ~toplevel_my_ghost_region
+      ~toplevel_my_ghost_region ~toplevel_my_alloc_region
   in
   (* CR gbury: only compute closure offsets if this is the last round. (same
      remark for the cmx contents) *)
@@ -52,7 +53,11 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   NO.fold_names name_occurrences ~init:() ~f:(fun () name ->
       Name.pattern_match name
         ~var:(fun var ->
-          if not (Variable.equal var toplevel_my_region)
+          if
+            not
+              (Variable.equal var toplevel_my_region
+              || Variable.equal var toplevel_my_ghost_region
+              || Variable.equal var toplevel_my_alloc_region)
           then
             Misc.fatal_errorf
               "Variable %a not expected to be free in whole-compilation-unit \
@@ -81,7 +86,8 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   in
   let unit =
     FU.create ~return_continuation ~exn_continuation ~toplevel_my_region
-      ~toplevel_my_ghost_region ~module_symbol ~body ~used_value_slots:Unknown
+      ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~module_symbol ~body
+      ~used_value_slots:Unknown
   in
   { unit;
     free_names = name_occurrences;

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -486,12 +486,16 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
          partial closure made by the first application. Due to this, the first
          application must have a closure allocated on the heap as well, even
          though it was with a local alloc_mode. *)
+      let alloc_region =
+        match Apply_expr.alloc_mode apply with
+        | Heap { alloc_region } | Local { alloc_region; _ } -> alloc_region
+      in
       Ok
-        ( Alloc_mode.For_applications.heap,
+        ( Alloc_mode.For_applications.heap ~alloc_region,
           first_complex_local_param - num_non_unarized_args )
     else
       match Apply_expr.alloc_mode apply with
-      | Heap -> (* This can happen in dead GADT match cases. *) Bottom
+      | Heap _ -> (* This can happen in dead GADT match cases. *) Bottom
       | Local _ as apply_alloc_mode -> Ok (apply_alloc_mode, 0)
   in
   let expr, dacc =
@@ -507,7 +511,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       | Local -> (
         match (new_closure_alloc_mode : Alloc_mode.For_applications.t) with
         | Local _ -> ()
-        | Heap ->
+        | Heap _ ->
           Misc.fatal_errorf
             "New closure alloc mode cannot be [Heap] when existing closure \
              alloc mode is [Local]: direct partial application:@ %a"
@@ -599,9 +603,12 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         let my_closure = Variable.create "my_closure" K.value in
         let my_alloc_mode =
           if contains_no_escaping_local_allocs
-          then Alloc_mode.For_applications.heap
+          then
+            Alloc_mode.For_applications.heap
+              ~alloc_region:(Variable.create "my_alloc_region" K.region)
           else
             Alloc_mode.For_applications.local
+              ~alloc_region:(Variable.create "my_alloc_region" K.region)
               ~region:(Variable.create "my_region" K.region)
               ~ghost_region:(Variable.create "my_ghost_region" K.region)
         in
@@ -742,9 +749,10 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         in
         let new_closure_alloc_mode =
           match (new_closure_alloc_mode : Alloc_mode.For_applications.t) with
-          | Heap -> Alloc_mode.For_allocations.heap
-          | Local { region; ghost_region = _ } ->
-            Alloc_mode.For_allocations.local ~region
+          | Heap { alloc_region } ->
+            Alloc_mode.For_allocations.heap ~alloc_region
+          | Local { alloc_region; region; ghost_region = _ } ->
+            Alloc_mode.For_allocations.local ~alloc_region ~region
         in
         ( Set_of_closures.create ~value_slots function_decls,
           new_closure_alloc_mode,

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -67,8 +67,22 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_alloc_mode
   in
   let denv =
     match (my_alloc_mode : Alloc_mode.For_applications.t) with
-    | Heap -> denv
-    | Local { region = my_region; ghost_region = my_ghost_region } ->
+    | Heap { alloc_region = my_alloc_region } ->
+      let my_alloc_region_duid = Flambda_debug_uid.none in
+      let my_alloc_region =
+        Bound_var.create my_alloc_region my_alloc_region_duid Name_mode.normal
+      in
+      DE.add_variable denv my_alloc_region (T.unknown K.region)
+    | Local
+        { alloc_region = my_alloc_region;
+          region = my_region;
+          ghost_region = my_ghost_region
+        } ->
+      let my_alloc_region_duid = Flambda_debug_uid.none in
+      let my_alloc_region =
+        Bound_var.create my_alloc_region my_alloc_region_duid Name_mode.normal
+      in
+      let denv = DE.add_variable denv my_alloc_region (T.unknown K.region) in
       let my_region_duid = Flambda_debug_uid.none in
       let my_region =
         Bound_var.create my_region my_region_duid Name_mode.normal
@@ -90,6 +104,8 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_alloc_mode
       (DA.get_lifted_constants outer_dacc)
     |> DE.enter_closure code_id ~return_continuation ~exn_continuation
          ~my_closure
+         ~my_alloc_region:
+           (Alloc_mode.For_applications.alloc_region my_alloc_mode)
     |> DE.set_loopify_state loopify_state
     |> DE.increment_continuation_scope
   in
@@ -184,13 +200,18 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     Misc.fatal_errorf "Did not expect lifted constants in [dacc]:@ %a" DA.print
       dacc;
   assert (not (DE.at_unit_toplevel (DA.denv dacc)));
+  let my_alloc_region_duid = Flambda_debug_uid.none in
   let my_region_duid = Flambda_debug_uid.none in
   let my_ghost_region_duid = Flambda_debug_uid.none in
   let region_params =
     match (my_alloc_mode : Alloc_mode.For_applications.t) with
-    | Heap -> []
-    | Local { region; ghost_region } ->
-      [ Bound_parameter.create region Flambda_kind.With_subkind.region
+    | Heap { alloc_region } ->
+      [ Bound_parameter.create alloc_region Flambda_kind.With_subkind.region
+          my_alloc_region_duid ]
+    | Local { alloc_region; region; ghost_region } ->
+      [ Bound_parameter.create alloc_region Flambda_kind.With_subkind.region
+          my_alloc_region_duid;
+        Bound_parameter.create region Flambda_kind.With_subkind.region
           my_region_duid;
         Bound_parameter.create ghost_region Flambda_kind.With_subkind.region
           my_ghost_region_duid ]

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -21,6 +21,14 @@ module Float = Numeric_types.Float_by_bit_pattern
 module Int32 = Numeric_types.Int32
 module Int64 = Numeric_types.Int64
 
+let get_my_alloc_region dacc =
+  match DE.closure_info (DA.denv dacc) with
+  | Closure { my_alloc_region; _ } -> my_alloc_region
+  | In_a_set_of_closures_but_not_yet_in_a_specific_closure ->
+    Misc.fatal_error
+      "Inconsistent closure_info in [simplify_immutable_block_load0]"
+  | Not_in_a_closure -> DE.unit_toplevel_alloc_region (DA.denv dacc)
+
 let simplify_project_function_slot ~move_from ~move_to ~min_name_mode dacc
     ~original_term ~arg:closure ~arg_ty:closure_ty ~result_var =
   match
@@ -143,12 +151,14 @@ let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t) dacc
       match alloc_mode with
       | Unknown | Proved (Local | Heap_or_local) -> dacc
       | Proved Heap ->
+        let alloc_region = get_my_alloc_region dacc in
         DA.map_denv dacc ~f:(fun denv ->
             DE.add_cse denv
               (P.Eligible_for_cse.create_exn
                  (Unary
                     ( Box_number
-                        (boxable_number_kind, Alloc_mode.For_allocations.heap),
+                        ( boxable_number_kind,
+                          Alloc_mode.For_allocations.heap ~alloc_region ),
                       Simple.var result_var' )))
               ~bound_to:arg
               ~name_mode:(Bound_var.name_mode result_var)))
@@ -709,8 +719,8 @@ let simplify_bigarray_length ~dimension:_ dacc ~original_term ~arg:_ ~arg_ty:_
   SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
 
 let simplify_duplicate_array ~kind:_ ~(source_mutability : Mutability.t)
-    ~(destination_mutability : Mutability.t) dacc ~original_term ~arg:_ ~arg_ty
-    ~result_var =
+    ~(destination_mutability : Mutability.t) ~alloc_region:_ dacc ~original_term
+    ~arg:_ ~arg_ty ~result_var =
   (* This simplification should eliminate bounds checks on array literals. *)
   let denv = DA.denv dacc in
   let machine_width = DE.machine_width denv in
@@ -735,15 +745,16 @@ let simplify_duplicate_array ~kind:_ ~(source_mutability : Mutability.t)
       "Combination of mutabilities not supported for [Duplicate_array]:@ %a"
       Named.print original_term
 
-let simplify_duplicate_block ~kind:_ dacc ~original_term ~arg:_ ~arg_ty
-    ~result_var =
+let simplify_duplicate_block ~kind:_ ~alloc_region:_ dacc ~original_term ~arg:_
+    ~arg_ty ~result_var =
   (* Any alias in the type to the whole block will be dropped, but aliases
      inside the type (e.g. in fields) can remain. *)
   let ty = T.remove_outermost_alias (DA.typing_env dacc) arg_ty in
   let dacc = DA.add_variable dacc result_var ty in
   SPR.create original_term ~try_reify:false dacc
 
-let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
+let simplify_obj_dup ~alloc_region dbg dacc ~original_term ~arg ~arg_ty
+    ~result_var =
   (* This must respect the semantics of physical equality. *)
   let typing_env = DA.typing_env dacc in
   let[@inline] elide_primitive () =
@@ -781,7 +792,8 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
       let box_expr =
         Named.create_prim
           (Unary
-             ( Box_number (boxable_number, Alloc_mode.For_allocations.heap),
+             ( Box_number
+                 (boxable_number, Alloc_mode.For_allocations.heap ~alloc_region),
                contents_simple ))
           dbg
       in
@@ -812,7 +824,8 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
       SPR.create
         (Named.create_prim
            (Unary
-              ( Box_number (boxable_number, Alloc_mode.For_allocations.heap),
+              ( Box_number
+                  (boxable_number, Alloc_mode.For_allocations.heap ~alloc_region),
                 contents ))
            dbg)
         ~try_reify:true dacc)
@@ -916,11 +929,17 @@ let[@inline always] simplify_immutable_block_load0
                       "Block access kind disagrees with block shape from type");
                   Mixed (tag, shape)
               in
+              (* CR alloc_regions: this uses the function's [my_alloc_region] to
+                 put in the CSE. This deserves testing with zero_alloc functions
+                 to figure out whether this is what we really want. *)
+              let alloc_region = get_my_alloc_region dacc in
               let prim =
                 P.Eligible_for_cse.create
                   (Variadic
                      ( Make_block
-                         (block_kind, Immutable, Alloc_mode.For_allocations.heap),
+                         ( block_kind,
+                           Immutable,
+                           Alloc_mode.For_allocations.heap ~alloc_region ),
                        field_simples ))
               in
               match prim with
@@ -1030,14 +1049,17 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Is_flat_float_array -> simplify_is_flat_float_array
     | Int_as_pointer mode -> simplify_int_as_pointer ~mode
     | Bigarray_length { dimension } -> simplify_bigarray_length ~dimension
-    | Duplicate_array { kind; source_mutability; destination_mutability } ->
+    | Duplicate_array
+        { kind; source_mutability; destination_mutability; alloc_region } ->
       simplify_duplicate_array ~kind ~source_mutability ~destination_mutability
-    | Duplicate_block { kind } -> simplify_duplicate_block ~kind
+        ~alloc_region
+    | Duplicate_block { kind; alloc_region } ->
+      simplify_duplicate_block ~kind ~alloc_region
     | Opaque_identity { middle_end_only = _; kind } ->
       simplify_opaque_identity ~kind
     | End_region { ghost = _ } -> simplify_end_region
     | End_try_region { ghost = _ } -> simplify_end_try_region
-    | Obj_dup -> simplify_obj_dup dbg
+    | Obj_dup { alloc_region } -> simplify_obj_dup dbg ~alloc_region
     | Get_header -> simplify_get_header ~original_prim
     | Peek _ -> simplify_peek ~original_prim
     | Make_lazy _ -> simplify_lazy ~original_prim

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -35,18 +35,33 @@ let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
        value, and as such, never allocate in the caller's region. As such,
        [my_region] should be unused in the body. *)
     match (region_inlined_into : Alloc_mode.For_applications.t) with
-    | Heap -> renaming
-    | Local { region; ghost_region } -> (
+    | Heap { alloc_region } -> (
+      match (my_alloc_mode : Alloc_mode.For_applications.t) with
+      | Heap { alloc_region = my_alloc_region } ->
+        Renaming.add_variable renaming my_alloc_region alloc_region
+      | Local _ ->
+        Misc.fatal_error
+          "Cannot inline a local returning function into a global function; \
+           this application should have been replaced by [Invalid] before \
+           reaching make_inlined_body.")
+    | Local { alloc_region; region; ghost_region } -> (
       (* Unlike for parameters, we know that the argument for the [my_region]
          parameter is fresh for [body], so we can use a permutation without fear
          of swapping out existing occurrences of such argument within [body].
          Similarly for [ghost_region]. *)
       match (my_alloc_mode : Alloc_mode.For_applications.t) with
-      | Local { region = my_region; ghost_region = my_ghost_region } ->
+      | Local
+          { alloc_region = my_alloc_region;
+            region = my_region;
+            ghost_region = my_ghost_region
+          } ->
         Renaming.add_variable
-          (Renaming.add_variable renaming my_region region)
-          my_ghost_region ghost_region
-      | Heap -> renaming)
+          (Renaming.add_variable
+             (Renaming.add_variable renaming my_region region)
+             my_ghost_region ghost_region)
+          my_alloc_region alloc_region
+      | Heap { alloc_region = my_alloc_region } ->
+        Renaming.add_variable renaming my_alloc_region alloc_region)
   in
   let body =
     match callee with

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -446,7 +446,7 @@ let unary_prim_size ~machine_width prim =
   | Is_boxed_float -> 4 (* tag load + comparison *)
   | Is_flat_float_array -> 4 (* tag load + comparison *)
   | End_region { ghost } | End_try_region { ghost } -> if ghost then 0 else 1
-  | Obj_dup -> needs_caml_c_call_extcall_size + 1
+  | Obj_dup _ -> needs_caml_c_call_extcall_size + 1
   | Get_header -> 2
   | Peek _ -> 1
   | Make_lazy _ -> alloc_size + 1

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -597,8 +597,8 @@ and print_continuation_handler (recursive : Recursive.t) invariant_params ppf k
 
 and print_function_params_and_body ppf t =
   let print ~return_continuation ~exn_continuation params ~body ~my_closure
-      ~is_my_closure_used:_ ~my_region ~my_ghost_region ~my_depth
-      ~free_names_of_body:_ =
+      ~is_my_closure_used:_ ~my_alloc_region ~my_region ~my_ghost_region
+      ~my_depth ~free_names_of_body:_ =
     let my_closure =
       Bound_parameter.create my_closure
         (K.With_subkind.create K.value Anything Non_nullable)
@@ -607,10 +607,12 @@ and print_function_params_and_body ppf t =
     fprintf ppf
       "@[<hov 1>(%t@<1>\u{03bb}%t@[<hov \
        1>@<1>\u{3008}%a@<1>\u{3009}@<1>\u{300a}%a@<1>\u{300b}\u{27c5}%t%a%t\u{27c6}@ \
-       \u{27c5}%t%a%t\u{27c6}@ %a %a %t%a%t %t.%t@]@ %a))@]"
+       \u{27c5}%t%a%t\u{27c6}@ \u{27c5}%t%a%t\u{27c6}@ %a %a %t%a%t %t.%t@]@ \
+       %a))@]"
       Flambda_colours.lambda Flambda_colours.pop Continuation.print
       return_continuation Continuation.print exn_continuation
-      Flambda_colours.parameter
+      Flambda_colours.parameter Variable.print my_alloc_region
+      Flambda_colours.pop Flambda_colours.parameter
       (Format.pp_print_option Variable.print)
       my_region Flambda_colours.pop Flambda_colours.parameter
       (Format.pp_print_option Variable.print)
@@ -628,7 +630,9 @@ and print_function_params_and_body ppf t =
         ~return_continuation:(BFF.return_continuation bff)
         ~exn_continuation:(BFF.exn_continuation bff) (BFF.params bff) ~body:expr
         ~my_closure:(BFF.my_closure bff)
-        ~is_my_closure_used:t.is_my_closure_used ~my_region:(BFF.my_region bff)
+        ~is_my_closure_used:t.is_my_closure_used
+        ~my_alloc_region:(BFF.my_alloc_region bff)
+        ~my_region:(BFF.my_region bff)
         ~my_ghost_region:(BFF.my_ghost_region bff) ~my_depth:(BFF.my_depth bff)
         ~free_names_of_body:free_names)
 

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1146,7 +1146,7 @@ let result_kind_of_nullary_primitive p : result_kind =
 
 let coeffects_of_mode : Alloc_mode.For_allocations.t -> Coeffects.t = function
   | Local _ -> Coeffects.Has_coeffects
-  | Heap -> Coeffects.No_coeffects
+  | Heap _ -> Coeffects.No_coeffects
 
 let effects_and_coeffects_of_nullary_primitive p : Effects_and_coeffects.t =
   match p with
@@ -1200,11 +1200,15 @@ type unary_primitive =
         mut : Mutability.t;
         field : Target_ocaml_int.t
       }
-  | Duplicate_block of { kind : Duplicate_block_kind.t }
+  | Duplicate_block of
+      { kind : Duplicate_block_kind.t;
+        alloc_region : Variable.t
+      }
   | Duplicate_array of
       { kind : Duplicate_array_kind.t;
         source_mutability : Mutability.t;
-        destination_mutability : Mutability.t
+        destination_mutability : Mutability.t;
+        alloc_region : Variable.t
       }
   | Is_int of { variant_only : bool }
   | Is_null
@@ -1242,10 +1246,13 @@ type unary_primitive =
   | Is_flat_float_array
   | End_region of { ghost : bool }
   | End_try_region of { ghost : bool }
-  | Obj_dup
+  | Obj_dup of { alloc_region : Variable.t }
   | Get_header
   | Peek of Flambda_kind.Standard_int_or_float.t
-  | Make_lazy of Lazy_block_tag.t
+  | Make_lazy of
+      { lazy_tag : Lazy_block_tag.t;
+        alloc_region : Variable.t
+      }
 
 (* Here and below, operations that are genuine projections shouldn't be eligible
    for CSE, since we deal with projections through types. *)
@@ -1253,12 +1260,12 @@ let unary_primitive_eligible_for_cse p ~arg =
   match p with
   | Block_load _ -> false
   | Duplicate_array _ -> false
-  | Duplicate_block { kind = _ } -> false
+  | Duplicate_block { kind = _; alloc_region = _ } -> false
   | Is_int _ | Is_null | Get_tag | Get_header -> true
   | Array_length _ -> true
   | Bigarray_length _ -> false
   | String_length _ -> true
-  | Int_as_pointer m -> ( match m with Heap -> true | Local _ -> false)
+  | Int_as_pointer m -> ( match m with Heap _ -> true | Local _ -> false)
   | Opaque_identity _ -> false
   | Int_arith _ -> true
   | Float_arith _ ->
@@ -1272,14 +1279,14 @@ let unary_primitive_eligible_for_cse p ~arg =
     (* For the moment we don't CSE any local allocations. *)
     (* CR mshinwell: relax this in the future? *)
     false
-  | Box_number (_, Heap) | Tag_immediate ->
+  | Box_number (_, Heap _) | Tag_immediate ->
     (* Boxing or tagging of constants will yield values that can be lifted and
        if needs be deduplicated -- so there's no point in adding CSE variables
        to hold them. *)
     Simple.is_var arg
   | Project_function_slot _ | Project_value_slot _ -> false
   | Is_boxed_float | Is_flat_float_array -> true
-  | End_region _ | End_try_region _ | Obj_dup | Peek _ | Make_lazy _ -> false
+  | End_region _ | End_try_region _ | Obj_dup _ | Peek _ | Make_lazy _ -> false
 
 let compare_unary_primitive p1 p2 =
   let unary_primitive_numbering p =
@@ -1309,7 +1316,7 @@ let compare_unary_primitive p1 p2 =
     | Is_flat_float_array -> 22
     | End_region _ -> 23
     | End_try_region _ -> 24
-    | Obj_dup -> 25
+    | Obj_dup _ -> 25
     | Get_header -> 26
     | Is_null -> 27
     | Peek _ -> 28
@@ -1328,12 +1335,14 @@ let compare_unary_primitive p1 p2 =
   | ( Duplicate_array
         { kind = kind1;
           source_mutability = source_mutability1;
-          destination_mutability = destination_mutability1
+          destination_mutability = destination_mutability1;
+          alloc_region = alloc_region1
         },
       Duplicate_array
         { kind = kind2;
           source_mutability = source_mutability2;
-          destination_mutability = destination_mutability2
+          destination_mutability = destination_mutability2;
+          alloc_region = alloc_region2
         } ) ->
     let c = Duplicate_array_kind.compare kind1 kind2 in
     if c <> 0
@@ -1342,9 +1351,15 @@ let compare_unary_primitive p1 p2 =
       let c = Stdlib.compare source_mutability1 source_mutability2 in
       if c <> 0
       then c
-      else Stdlib.compare destination_mutability1 destination_mutability2
-  | Duplicate_block { kind = kind1 }, Duplicate_block { kind = kind2 } ->
-    Duplicate_block_kind.compare kind1 kind2
+      else
+        let c =
+          Stdlib.compare destination_mutability1 destination_mutability2
+        in
+        if c <> 0 then c else Variable.compare alloc_region1 alloc_region2
+  | ( Duplicate_block { kind = kind1; alloc_region = alloc_region1 },
+      Duplicate_block { kind = kind2; alloc_region = alloc_region2 } ) ->
+    let c = Duplicate_block_kind.compare kind1 kind2 in
+    if c <> 0 then c else Variable.compare alloc_region1 alloc_region2
   | ( Is_int { variant_only = variant_only1 },
       Is_int { variant_only = variant_only2 } ) ->
     Bool.compare variant_only1 variant_only2
@@ -1396,10 +1411,15 @@ let compare_unary_primitive p1 p2 =
     Bool.compare ghost1 ghost2
   | End_try_region { ghost = ghost1 }, End_try_region { ghost = ghost2 } ->
     Bool.compare ghost1 ghost2
+  | ( Obj_dup { alloc_region = alloc_region1 },
+      Obj_dup { alloc_region = alloc_region2 } ) ->
+    Variable.compare alloc_region1 alloc_region2
   | Peek kind1, Peek kind2 ->
     Flambda_kind.Standard_int_or_float.compare kind1 kind2
-  | Make_lazy lazy_tag1, Make_lazy lazy_tag2 ->
-    Lazy_block_tag.compare lazy_tag1 lazy_tag2
+  | ( Make_lazy { lazy_tag = lazy_tag1; alloc_region = alloc_region1 },
+      Make_lazy { lazy_tag = lazy_tag2; alloc_region = alloc_region2 } ) ->
+    let c = Lazy_block_tag.compare lazy_tag1 lazy_tag2 in
+    if c <> 0 then c else Variable.compare alloc_region1 alloc_region2
   | ( ( Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _
       | Is_null | Get_tag | String_length _ | Int_as_pointer _
       | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
@@ -1407,7 +1427,7 @@ let compare_unary_primitive p1 p2 =
       | Array_length _ | Bigarray_length _ | Unbox_number _ | Box_number _
       | Untag_immediate | Tag_immediate | Project_function_slot _
       | Project_value_slot _ | Is_boxed_float | Is_flat_float_array
-      | End_region _ | End_try_region _ | Obj_dup | Get_header | Peek _
+      | End_region _ | End_try_region _ | Obj_dup _ | Get_header | Peek _
       | Make_lazy _ ),
       _ ) ->
     Stdlib.compare (unary_primitive_numbering p1) (unary_primitive_numbering p2)
@@ -1420,13 +1440,15 @@ let print_unary_primitive ppf p =
   | Block_load { kind; mut; field } ->
     fprintf ppf "@[(Block_load@ %a@ %a@ %a)@]" Block_access_kind.print kind
       Mutability.print mut Target_ocaml_int.print field
-  | Duplicate_block { kind } ->
-    fprintf ppf "@[<hov 1>(Duplicate_block %a)@]" Duplicate_block_kind.print
-      kind
-  | Duplicate_array { kind; source_mutability; destination_mutability } ->
-    fprintf ppf "@[<hov 1>(Duplicate_array %a (source %a) (dest %a))@]"
+  | Duplicate_block { kind; alloc_region } ->
+    fprintf ppf "@[<hov 1>(Duplicate_block (kind %a) (alloc_region %a))@]"
+      Duplicate_block_kind.print kind Variable.print alloc_region
+  | Duplicate_array
+      { kind; source_mutability; destination_mutability; alloc_region } ->
+    fprintf ppf
+      "@[<hov 1>(Duplicate_array %a (source %a) (dest %a) (alloc_region %a))@]"
       Duplicate_array_kind.print kind Mutability.print source_mutability
-      Mutability.print destination_mutability
+      Mutability.print destination_mutability Variable.print alloc_region
   | Is_int { variant_only } ->
     if variant_only then fprintf ppf "Is_int" else fprintf ppf "Is_int_generic"
   | Is_null -> fprintf ppf "Is_null"
@@ -1471,13 +1493,15 @@ let print_unary_primitive ppf p =
     Format.fprintf ppf "End_region%s" (if ghost then "_ghost" else "")
   | End_try_region { ghost } ->
     Format.fprintf ppf "End_try_region%s" (if ghost then "_ghost" else "")
-  | Obj_dup -> Format.pp_print_string ppf "Obj_dup"
+  | Obj_dup { alloc_region } ->
+    Format.fprintf ppf "(Obj_dup (alloc_region %a))" Variable.print alloc_region
   | Get_header -> Format.pp_print_string ppf "Get_header"
   | Peek kind ->
     fprintf ppf "@[(Peek@ %a)@]"
       Flambda_kind.Standard_int_or_float.print_lowercase kind
-  | Make_lazy lazy_tag ->
-    fprintf ppf "@[<hov 1>(Make_lazy@ %a)@]" Lazy_block_tag.print lazy_tag
+  | Make_lazy { lazy_tag; alloc_region } ->
+    fprintf ppf "@[<hov 1>(Make_lazy@ (lazy_tag %a)@ (alloc_region %a))@]"
+      Lazy_block_tag.print lazy_tag Variable.print alloc_region
 
 let arg_kind_of_unary_primitive p =
   match p with
@@ -1510,7 +1534,7 @@ let arg_kind_of_unary_primitive p =
     K.value
   | End_region _ -> K.region
   | End_try_region _ -> K.region
-  | Obj_dup -> K.value
+  | Obj_dup _ -> K.value
   | Get_header -> K.value
   | Peek _ -> K.naked_nativeint
   | Make_lazy _ -> K.value
@@ -1549,7 +1573,7 @@ let result_kind_of_unary_primitive p : result_kind =
   | Is_boxed_float | Is_flat_float_array -> Singleton K.naked_immediate
   | End_region _ -> Singleton K.value
   | End_try_region _ -> Singleton K.value
-  | Obj_dup -> Singleton K.value
+  | Obj_dup _ -> Singleton K.value
   | Get_header -> Singleton K.naked_nativeint
   | Peek kind -> Singleton (K.Standard_int_or_float.to_kind kind)
   | Make_lazy _ -> Singleton K.value
@@ -1582,7 +1606,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
         Has_coeffects,
         Strict,
         Can't_move_before_any_branch ))
-  | Duplicate_block { kind = _ } ->
+  | Duplicate_block { kind = _; alloc_region = _ } ->
     (* We have to assume that the fields might be mutable. (This information
        isn't currently propagated from [Lambda].) *)
     ( Only_generative_effects Mutable,
@@ -1644,7 +1668,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
            begin/end region. Hence, it is not safe to force the allocation to be
            moved, so we cannot use the `Delay` mode for those. *)
         match alloc_mode with
-        | Heap -> Delay
+        | Heap _ -> Delay
         | Local _ -> Strict
       else Strict
     in
@@ -1663,7 +1687,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
        special cases in [Simplify_let_expr] and [Expr_builder] for this
        primitive. *)
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
-  | Obj_dup ->
+  | Obj_dup _ ->
     ( Only_generative_effects Mutable (* Mutable is conservative *),
       Has_coeffects,
       Strict,
@@ -1680,7 +1704,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
 
 let unary_classify_for_printing p =
   match p with
-  | Duplicate_array _ | Duplicate_block _ | Obj_dup -> Constructive
+  | Duplicate_array _ | Duplicate_block _ | Obj_dup _ -> Constructive
   | String_length _ | Get_tag -> Destructive
   | Is_int _ | Is_null | Opaque_identity _ | Int_arith _ | Num_conv _
   | Boolean_not | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector
@@ -1710,14 +1734,18 @@ let free_names_unary_primitive p =
       (Name_occurrences.add_value_slot_in_projection Name_occurrences.empty
          value_slot Name_mode.normal)
       project_from Name_mode.normal
-  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Is_null
-  | Get_tag | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _
-  | Boolean_not | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector
-  | Float_arith _ | Array_length _ | Bigarray_length _ | Unbox_number _
-  | Untag_immediate | Tag_immediate | Is_boxed_float | Is_flat_float_array
-  | End_region _ | End_try_region _ | Obj_dup | Get_header
-  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
-  | Make_lazy _ ->
+  | Duplicate_array { alloc_region; _ }
+  | Duplicate_block { alloc_region; _ }
+  | Obj_dup { alloc_region }
+  | Make_lazy { alloc_region; _ } ->
+    Name_occurrences.singleton_variable alloc_region Name_mode.normal
+  | Block_load _ | Is_int _ | Is_null | Get_tag | String_length _
+  | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector | Float_arith _
+  | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
+  | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
+  | End_try_region _ | Get_header
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
     Name_occurrences.empty
 
 let apply_renaming_unary_primitive p renaming =
@@ -1732,30 +1760,60 @@ let apply_renaming_unary_primitive p renaming =
       Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
     in
     if alloc_mode == alloc_mode' then p else Int_as_pointer alloc_mode'
-  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Is_null
-  | Get_tag | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _
-  | Boolean_not | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector
-  | Float_arith _ | Array_length _ | Bigarray_length _ | Unbox_number _
-  | Untag_immediate | Tag_immediate | Is_boxed_float | Is_flat_float_array
-  | End_region _ | End_try_region _ | Project_function_slot _
-  | Project_value_slot _ | Obj_dup | Get_header
-  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
-  | Make_lazy _ ->
+  | Duplicate_array
+      { alloc_region; kind; source_mutability; destination_mutability } ->
+    let alloc_region' = Renaming.apply_variable renaming alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else
+      Duplicate_array
+        { alloc_region = alloc_region';
+          kind;
+          source_mutability;
+          destination_mutability
+        }
+  | Duplicate_block { alloc_region; kind } ->
+    let alloc_region' = Renaming.apply_variable renaming alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else Duplicate_block { alloc_region = alloc_region'; kind }
+  | Obj_dup { alloc_region } ->
+    let alloc_region' = Renaming.apply_variable renaming alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else Obj_dup { alloc_region = alloc_region' }
+  | Make_lazy { alloc_region; lazy_tag } ->
+    let alloc_region' = Renaming.apply_variable renaming alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else Make_lazy { alloc_region = alloc_region'; lazy_tag }
+  | Block_load _ | Is_int _ | Is_null | Get_tag | String_length _
+  | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector | Float_arith _
+  | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
+  | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
+  | End_try_region _ | Project_function_slot _ | Project_value_slot _
+  | Get_header
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
     p
 
 let ids_for_export_unary_primitive p =
   match p with
   | Box_number (_, alloc_mode) | Int_as_pointer alloc_mode ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
-  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Is_null
-  | Get_tag | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _
-  | Boolean_not | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector
-  | Float_arith _ | Array_length _ | Bigarray_length _ | Unbox_number _
-  | Untag_immediate | Tag_immediate | Is_boxed_float | Is_flat_float_array
-  | End_region _ | End_try_region _ | Project_function_slot _
-  | Project_value_slot _ | Obj_dup | Get_header
-  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
-  | Make_lazy _ ->
+  | Duplicate_array { alloc_region; _ }
+  | Duplicate_block { alloc_region; _ }
+  | Obj_dup { alloc_region }
+  | Make_lazy { alloc_region; _ } ->
+    Ids_for_export.singleton_variable alloc_region
+  | Block_load _ | Is_int _ | Is_null | Get_tag | String_length _
+  | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector | Float_arith _
+  | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
+  | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
+  | End_try_region _ | Project_function_slot _ | Project_value_slot _
+  | Get_header
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
     Ids_for_export.empty
 
 type binary_int_arith_op =
@@ -2434,7 +2492,7 @@ let variadic_primitive_eligible_for_cse p ~args =
   | Make_block (_, Mutable, _) | Make_array (_, Mutable, _) -> false
   | Make_block (_, Immutable_unique, _) | Make_array (_, Immutable_unique, _) ->
     false
-  | Make_block (_, Immutable, Heap) | Make_array (_, Immutable, Heap) ->
+  | Make_block (_, Immutable, Heap _) | Make_array (_, Immutable, Heap _) ->
     (* See comment in [unary_primitive_eligible_for_cse], above, on [Box_number]
        case. *)
     List.exists (fun arg -> Simple.is_var arg) args
@@ -2515,7 +2573,7 @@ let effects_and_coeffects_of_variadic_primitive p : Effects_and_coeffects.t =
   | Make_block (_, mut, alloc_mode) | Make_array (_, mut, alloc_mode) ->
     let coeffects : Coeffects.t =
       match alloc_mode with
-      | Heap -> Coeffects.No_coeffects
+      | Heap _ -> Coeffects.No_coeffects
       | Local _ -> Coeffects.Has_coeffects
     in
     Only_generative_effects mut, coeffects, Strict, Can't_move_before_any_branch

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -413,13 +413,17 @@ type unary_primitive =
         mut : Mutability.t;
         field : Target_ocaml_int.t
       }
-  | Duplicate_block of { kind : Duplicate_block_kind.t }
+  | Duplicate_block of
+      { kind : Duplicate_block_kind.t;
+        alloc_region : Variable.t
+      }
       (** [Duplicate_block] may not be used to change the tag or the mutability
           of a block. *)
   | Duplicate_array of
       { kind : Duplicate_array_kind.t;
         source_mutability : Mutability.t;
-        destination_mutability : Mutability.t
+        destination_mutability : Mutability.t;
+        alloc_region : Variable.t
       }
   | Is_int of { variant_only : bool }
   | Is_null
@@ -487,7 +491,8 @@ type unary_primitive =
       *)
   | End_try_region of { ghost : bool }
       (** Corresponding delimiter for [Begin_try_region]. *)
-  | Obj_dup  (** Corresponds to [Obj.dup]; see the documentation in obj.mli. *)
+  | Obj_dup of { alloc_region : Variable.t }
+      (** Corresponds to [Obj.dup]; see the documentation in obj.mli. *)
   | Get_header
       (** Get the header of a block. This primitive is invalid if provided with
           an immediate value. It should also not be used to read tags above
@@ -497,7 +502,10 @@ type unary_primitive =
           Tag reads that are allowed to be lazy tags (by the type system) should
           always go through caml_obj_tag, which is opaque to the compiler. *)
   | Peek of Flambda_kind.Standard_int_or_float.t
-  | Make_lazy of Lazy_block_tag.t
+  | Make_lazy of
+      { lazy_tag : Lazy_block_tag.t;
+        alloc_region : Variable.t
+      }
 
 (** Whether a comparison is to yield a boolean result, as given by a particular
     comparison operator, or whether it is to behave in the manner of "compare"

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -19,17 +19,20 @@ type t =
     exn_continuation : Continuation.t;
     toplevel_my_region : Variable.t;
     toplevel_my_ghost_region : Variable.t;
+    toplevel_my_alloc_region : Variable.t;
     body : Flambda.Expr.t;
     module_symbol : Symbol.t;
     used_value_slots : Value_slot.Set.t Or_unknown.t
   }
 
 let create ~return_continuation ~exn_continuation ~toplevel_my_region
-    ~toplevel_my_ghost_region ~body ~module_symbol ~used_value_slots =
+    ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~body ~module_symbol
+    ~used_value_slots =
   { return_continuation;
     exn_continuation;
     toplevel_my_region;
     toplevel_my_ghost_region;
+    toplevel_my_alloc_region;
     body;
     module_symbol;
     used_value_slots
@@ -42,6 +45,8 @@ let exn_continuation t = t.exn_continuation
 let toplevel_my_region t = t.toplevel_my_region
 
 let toplevel_my_ghost_region t = t.toplevel_my_ghost_region
+
+let toplevel_my_alloc_region t = t.toplevel_my_alloc_region
 
 let body t = t.body
 
@@ -56,7 +61,8 @@ let with_body t body = { t with body }
 
 let [@ocamlformat "disable"] print ppf
       { return_continuation; exn_continuation; toplevel_my_region;
-        toplevel_my_ghost_region; body; module_symbol; used_value_slots;
+        toplevel_my_ghost_region; toplevel_my_alloc_region; body;
+        module_symbol; used_value_slots;
       } =
   Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(module_symbol@ %a)@]@ \
@@ -64,6 +70,7 @@ let [@ocamlformat "disable"] print ppf
         @[<hov 1>(exn_continuation@ %a)@]@ \
         @[<hov 1>(toplevel_my_region@ %a)@]@ \
         @[<hov 1>(toplevel_my_ghost_region@ %a)@]@ \
+        @[<hov 1>(toplevel_my_alloc_region@ %a)@]@ \
         @[<hov 1>(used_value_slots@ %a)@]@ \
         @[<hov 1>%a@]\
       )@]"
@@ -72,5 +79,6 @@ let [@ocamlformat "disable"] print ppf
     Continuation.print exn_continuation
     Variable.print toplevel_my_region
     Variable.print toplevel_my_ghost_region
+    Variable.print toplevel_my_alloc_region
     (Or_unknown.print Value_slot.Set.print) used_value_slots
     Flambda.Expr.print body

--- a/middle_end/flambda2/terms/flambda_unit.mli
+++ b/middle_end/flambda2/terms/flambda_unit.mli
@@ -25,6 +25,7 @@ val create :
   exn_continuation:Continuation.t ->
   toplevel_my_region:Variable.t ->
   toplevel_my_ghost_region:Variable.t ->
+  toplevel_my_alloc_region:Variable.t ->
   body:Flambda.Expr.t ->
   module_symbol:Symbol.t ->
   used_value_slots:Value_slot.Set.t Or_unknown.t ->
@@ -37,6 +38,8 @@ val exn_continuation : t -> Continuation.t
 val toplevel_my_region : t -> Variable.t
 
 val toplevel_my_ghost_region : t -> Variable.t
+
+val toplevel_my_alloc_region : t -> Variable.t
 
 val module_symbol : t -> Symbol.t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1125,7 +1125,11 @@ let unary_primitive env res dbg f (_arg_simple : Simple.t option)
   match (f : P.unary_primitive) with
   | Block_load { kind; mut; field } ->
     None, res, block_load ~dbg kind mut ~field ~block:arg
-  | Duplicate_array _ | Duplicate_block _ | Obj_dup ->
+  | Duplicate_array { alloc_region; _ }
+  | Duplicate_block { alloc_region; _ }
+  | Obj_dup { alloc_region } ->
+    (* CR alloc_regions: propagate alloc_regions to CMM. *)
+    let () = ignore alloc_region in
     ( None,
       res,
       (C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false
@@ -1171,6 +1175,7 @@ let unary_primitive env res dbg f (_arg_simple : Simple.t option)
   | Unbox_number kind -> None, res, unbox_number ~dbg kind arg
   | Untag_immediate -> Some (Env.Untag arg), res, C.untag_int arg dbg
   | Box_number (kind, alloc_mode) ->
+    (* CR alloc_regions: propagate alloc_regions to CMM. *)
     None, res, box_number ~dbg kind alloc_mode arg
   | Tag_immediate ->
     (* We could return [Env.Tag] here, but probably unnecessary at the
@@ -1251,7 +1256,8 @@ let unary_primitive env res dbg f (_arg_simple : Simple.t option)
       |> C.memory_chunk_of_kind
     in
     None, res, C.load ~dbg memory_chunk Mutable ~addr:arg
-  | Make_lazy lazy_tag ->
+  | Make_lazy { lazy_tag; alloc_region = _ } ->
+    (* CR alloc_regions: propagate alloc_regions to CMM. *)
     let tag = Tag.to_int (P.Lazy_block_tag.to_tag lazy_tag) in
     None, res, C.make_alloc ~mode:Heap dbg ~tag [arg]
 
@@ -1372,8 +1378,12 @@ let variadic_primitive _env dbg f args =
     C.beginregion ~dbg
   | Begin_region { ghost = true } | Begin_try_region { ghost = true } ->
     C.int ~dbg 0
-  | Make_block (kind, _mut, alloc_mode) -> make_block ~dbg kind alloc_mode args
-  | Make_array (kind, _mut, alloc_mode) -> make_array ~dbg kind alloc_mode args
+  | Make_block (kind, _mut, alloc_mode) ->
+    (* CR alloc_regions: propagate alloc_regions to CMM. *)
+    make_block ~dbg kind alloc_mode args
+  | Make_array (kind, _mut, alloc_mode) ->
+    (* CR alloc_regions: propagate alloc_regions to CMM. *)
+    make_array ~dbg kind alloc_mode args
 
 let arg ?consider_inlining_effectful_expressions ~dbg env res simple =
   C.simple ?consider_inlining_effectful_expressions ~dbg env res simple

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -493,9 +493,12 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
      [_bound_var]). If it does end up in generated code, Selection will complain
      and refuse to compile the code. *)
   let env, my_region_var, my_ghost_region_var =
+    (* CR alloc_regions: my_alloc_region should be propagated as well. *)
     match (my_alloc_mode : Alloc_mode.For_applications.t) with
-    | Heap -> env, None, None
-    | Local { region = my_region; ghost_region = my_ghost_region } ->
+    | Heap { alloc_region = _ } -> env, None, None
+    | Local
+        { alloc_region = _; region = my_region; ghost_region = my_ghost_region }
+      ->
       let my_region_duid = Flambda_debug_uid.none in
       let env, region =
         Env.create_bound_parameter env (my_region, my_region_duid)
@@ -754,7 +757,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   let effs : Ece.t =
     ( Only_generative_effects Immutable,
       (match closure_alloc_mode with
-      | Heap -> No_coeffects
+      | Heap _ -> No_coeffects
       | Local _ -> Has_coeffects),
       Strict,
       Can_move_anywhere )
@@ -767,6 +770,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
       env res effs ~prev_updates:None layout.slots
   in
   assert (Option.is_none updates);
+  (* CR alloc_regions: propagate alloc_regions to CMM. *)
   let csoc =
     assert (List.compare_length_with l 0 > 0);
     let tag = Tag.(to_int closure_tag) in

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -548,11 +548,13 @@ let extended_machtype_of_return_arity arity =
 let alloc_mode_for_applications_to_cmx t =
   match t with
   | Alloc_mode.For_applications.Local _ -> Cmx_format.Alloc_local
-  | Alloc_mode.For_applications.Heap -> Cmx_format.Alloc_heap
+  | Alloc_mode.For_applications.Heap _ -> Cmx_format.Alloc_heap
 
 let alloc_mode_for_allocations_to_cmm t =
   match t with
-  | Alloc_mode.For_allocations.Heap -> Cmm.Alloc_mode.Heap
+  | Alloc_mode.For_allocations.Heap _ ->
+    (* XXX todo propagate alloc_modes in cmm *)
+    Cmm.Alloc_mode.Heap
   | Alloc_mode.For_allocations.Local _ ->
     assert (Flambda_features.stack_allocation_enabled ());
     Cmm.Alloc_mode.Local

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -186,7 +186,7 @@ let unary_exn ~env ~res (f : Flambda_primitive.unary_primitive) x =
       | Pc _, _res -> Misc.fatal_error "Block_load on constant"
     in
     Some var, env, To_jsir_result.add_instr_exn res (Let (var, expr))
-  | Duplicate_block _ | Duplicate_array _ | Obj_dup ->
+  | Duplicate_block _ | Duplicate_array _ | Obj_dup _ ->
     use_prim' (Extern "caml_obj_dup")
   | Is_int _ -> use_prim' IsInt
   | Is_null ->
@@ -314,8 +314,8 @@ let unary_exn ~env ~res (f : Flambda_primitive.unary_primitive) x =
   | Peek _ ->
     (* Unsupported in bytecode *)
     raise Primitive_not_supported
-  | Make_lazy tag ->
-    let tag = Flambda_primitive.Lazy_block_tag.to_tag tag in
+  | Make_lazy { lazy_tag; alloc_region = _ } ->
+    let tag = Flambda_primitive.Lazy_block_tag.to_tag lazy_tag in
     let expr, env, res =
       To_jsir_shared.block ~env ~res ~tag ~mut:Mutable ~fields:[x]
     in

--- a/oxcaml/tests/backend/llvmize/alloc_ir.output
+++ b/oxcaml/tests/backend/llvmize/alloc_ir.output
@@ -864,7 +864,7 @@ L201:
   store i64 %67, ptr %10
   %68 = load i64, ptr %10
   store i64 %68, ptr %11
-  %69 = ptrtoint ptr @camlAlloc__const_block115 to i64
+  %69 = ptrtoint ptr @camlAlloc__const_block125 to i64
   store i64 %69, ptr %12
   store i64 1, ptr %13
   %70 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -937,7 +937,7 @@ L205:
   store i64 %108, ptr %21
   %109 = load i64, ptr %21
   store i64 %109, ptr %22
-  %110 = ptrtoint ptr @camlAlloc__const_block127 to i64
+  %110 = ptrtoint ptr @camlAlloc__const_block137 to i64
   store i64 %110, ptr %23
   store i64 1, ptr %24
   %111 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1051,7 +1051,7 @@ L209:
   store ptr addrspace(1) %173, ptr %46
   %174 = load ptr addrspace(1), ptr %46
   store ptr addrspace(1) %174, ptr %47
-  %175 = ptrtoint ptr @camlAlloc__const_block138 to i64
+  %175 = ptrtoint ptr @camlAlloc__const_block148 to i64
   store i64 %175, ptr %48
   store i64 1, ptr %49
   %176 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1150,22 +1150,22 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlAlloc__local_iota_10 = global { ptr, i64, ptr } { ptr @caml_curry2L1, i64 180143985094819847, ptr @camlAlloc__local_iota_HIDE_STAMP }, section ".data", align 8
 @header.camlAlloc__my_fold_9 = global i64 4087, section ".data", align 8
 @camlAlloc__my_fold_9 = global { ptr, i64, ptr } { ptr @caml_curry3L1, i64 252201579132747783, ptr @camlAlloc__my_fold_HIDE_STAMP }, section ".data", align 8
-@header.camlAlloc__const_block115 = global i64 2827, section ".data", align 8
-@camlAlloc__const_block115 = global { ptr, ptr } { ptr @camlAlloc__immstring109, ptr @camlAlloc__const_block113 }, section ".data", align 8
-@header.camlAlloc__immstring109 = global i64 4092, section ".data", align 8
-@camlAlloc__immstring109 = global { [ 17 x i8 ], [ 6 x i8 ], i8 } { [ 17 x i8 ] c"\62\69\67\5f\6c\6f\63\61\6c\5f\61\6c\6c\6f\63\3a\20", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
-@header.camlAlloc__const_block127 = global i64 2827, section ".data", align 8
-@camlAlloc__const_block127 = global { ptr, ptr } { ptr @camlAlloc__immstring125, ptr @camlAlloc__const_block113 }, section ".data", align 8
-@header.camlAlloc__immstring125 = global i64 4092, section ".data", align 8
-@camlAlloc__immstring125 = global { [ 16 x i8 ], [ 7 x i8 ], i8 } { [ 16 x i8 ] c"\62\69\67\5f\68\65\61\70\5f\61\6c\6c\6f\63\3a\20", [ 7 x i8 ] zeroinitializer, i8 7 }, section ".data", align 8
-@header.camlAlloc__const_block138 = global i64 2827, section ".data", align 8
-@camlAlloc__const_block138 = global { ptr, ptr } { ptr @camlAlloc__immstring136, ptr @camlAlloc__const_block113 }, section ".data", align 8
-@header.camlAlloc__immstring136 = global i64 3068, section ".data", align 8
-@camlAlloc__immstring136 = global { [ 15 x i8 ], [ 0 x i8 ], i8 } { [ 15 x i8 ] c"\68\65\61\70\5f\72\65\66\5f\69\6e\63\72\3a\20", [ 0 x i8 ] zeroinitializer, i8 0 }, section ".data", align 8
-@header.camlAlloc__const_block113 = global i64 4868, section ".data", align 8
-@camlAlloc__const_block113 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlAlloc__const_block111 }, section ".data", align 8
-@header.camlAlloc__const_block111 = global i64 2828, section ".data", align 8
-@camlAlloc__const_block111 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
+@header.camlAlloc__const_block125 = global i64 2827, section ".data", align 8
+@camlAlloc__const_block125 = global { ptr, ptr } { ptr @camlAlloc__immstring119, ptr @camlAlloc__const_block123 }, section ".data", align 8
+@header.camlAlloc__immstring119 = global i64 4092, section ".data", align 8
+@camlAlloc__immstring119 = global { [ 17 x i8 ], [ 6 x i8 ], i8 } { [ 17 x i8 ] c"\62\69\67\5f\6c\6f\63\61\6c\5f\61\6c\6c\6f\63\3a\20", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
+@header.camlAlloc__const_block137 = global i64 2827, section ".data", align 8
+@camlAlloc__const_block137 = global { ptr, ptr } { ptr @camlAlloc__immstring135, ptr @camlAlloc__const_block123 }, section ".data", align 8
+@header.camlAlloc__immstring135 = global i64 4092, section ".data", align 8
+@camlAlloc__immstring135 = global { [ 16 x i8 ], [ 7 x i8 ], i8 } { [ 16 x i8 ] c"\62\69\67\5f\68\65\61\70\5f\61\6c\6c\6f\63\3a\20", [ 7 x i8 ] zeroinitializer, i8 7 }, section ".data", align 8
+@header.camlAlloc__const_block148 = global i64 2827, section ".data", align 8
+@camlAlloc__const_block148 = global { ptr, ptr } { ptr @camlAlloc__immstring146, ptr @camlAlloc__const_block123 }, section ".data", align 8
+@header.camlAlloc__immstring146 = global i64 3068, section ".data", align 8
+@camlAlloc__immstring146 = global { [ 15 x i8 ], [ 0 x i8 ], i8 } { [ 15 x i8 ] c"\68\65\61\70\5f\72\65\66\5f\69\6e\63\72\3a\20", [ 0 x i8 ] zeroinitializer, i8 0 }, section ".data", align 8
+@header.camlAlloc__const_block123 = global i64 4868, section ".data", align 8
+@camlAlloc__const_block123 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlAlloc__const_block121 }, section ".data", align 8
+@header.camlAlloc__const_block121 = global i64 2828, section ".data", align 8
+@camlAlloc__const_block121 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 = external global ptr
 @caml_apply2 = external global ptr

--- a/oxcaml/tests/backend/llvmize/csel_ir.output
+++ b/oxcaml/tests/backend/llvmize/csel_ir.output
@@ -189,7 +189,7 @@ L114:
   store i64 %86, ptr %12
   %87 = load i64, ptr %12
   store i64 %87, ptr %13
-  %88 = ptrtoint ptr @camlCsel__const_block34 to i64
+  %88 = ptrtoint ptr @camlCsel__const_block37 to i64
   store i64 %88, ptr %14
   store i64 1, ptr %15
   %89 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -270,7 +270,7 @@ L118:
   store i64 %131, ptr %25
   %132 = load i64, ptr %25
   store i64 %132, ptr %26
-  %133 = ptrtoint ptr @camlCsel__const_block46 to i64
+  %133 = ptrtoint ptr @camlCsel__const_block49 to i64
   store i64 %133, ptr %27
   store i64 1, ptr %28
   %134 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -347,7 +347,7 @@ L122:
   store i64 %174, ptr %37
   %175 = load i64, ptr %37
   store i64 %175, ptr %38
-  %176 = ptrtoint ptr @camlCsel__const_block58 to i64
+  %176 = ptrtoint ptr @camlCsel__const_block61 to i64
   store i64 %176, ptr %39
   store i64 1, ptr %40
   %177 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -424,7 +424,7 @@ L126:
   store i64 %217, ptr %49
   %218 = load i64, ptr %49
   store i64 %218, ptr %50
-  %219 = ptrtoint ptr @camlCsel__const_block70 to i64
+  %219 = ptrtoint ptr @camlCsel__const_block73 to i64
   store i64 %219, ptr %51
   store i64 1, ptr %52
   %220 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -501,7 +501,7 @@ L130:
   store i64 %260, ptr %61
   %261 = load i64, ptr %61
   store i64 %261, ptr %62
-  %262 = ptrtoint ptr @camlCsel__const_block81 to i64
+  %262 = ptrtoint ptr @camlCsel__const_block84 to i64
   store i64 %262, ptr %63
   store i64 1, ptr %64
   %263 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -588,30 +588,30 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlCsel__min_3 = global { ptr, i64, ptr } { ptr @caml_curry2, i64 180143985094819847, ptr @camlCsel__min_HIDE_STAMP }, section ".data", align 8
 @header.camlCsel__csel_2 = global i64 4087, section ".data", align 8
 @camlCsel__csel_2 = global { ptr, i64, ptr } { ptr @caml_curry3, i64 252201579132747783, ptr @camlCsel__csel_HIDE_STAMP }, section ".data", align 8
-@header.camlCsel__const_block34 = global i64 2827, section ".data", align 8
-@camlCsel__const_block34 = global { ptr, ptr } { ptr @camlCsel__immstring28, ptr @camlCsel__const_block32 }, section ".data", align 8
-@header.camlCsel__immstring28 = global i64 4092, section ".data", align 8
-@camlCsel__immstring28 = global { [ 17 x i8 ], [ 6 x i8 ], i8 } { [ 17 x i8 ] c"\63\73\65\6c\20\66\61\6c\73\65\20\31\20\32\20\3d\20", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
-@header.camlCsel__const_block46 = global i64 2827, section ".data", align 8
-@camlCsel__const_block46 = global { ptr, ptr } { ptr @camlCsel__immstring44, ptr @camlCsel__const_block32 }, section ".data", align 8
-@header.camlCsel__immstring44 = global i64 4092, section ".data", align 8
-@camlCsel__immstring44 = global { [ 16 x i8 ], [ 7 x i8 ], i8 } { [ 16 x i8 ] c"\63\73\65\6c\20\74\72\75\65\20\33\20\34\20\3d\20", [ 7 x i8 ] zeroinitializer, i8 7 }, section ".data", align 8
-@header.camlCsel__const_block58 = global i64 2827, section ".data", align 8
-@camlCsel__const_block58 = global { ptr, ptr } { ptr @camlCsel__immstring56, ptr @camlCsel__const_block32 }, section ".data", align 8
-@header.camlCsel__immstring56 = global i64 3068, section ".data", align 8
-@camlCsel__immstring56 = global { [ 10 x i8 ], [ 5 x i8 ], i8 } { [ 10 x i8 ] c"\6d\69\6e\20\32\20\33\20\3d\20", [ 5 x i8 ] zeroinitializer, i8 5 }, section ".data", align 8
-@header.camlCsel__const_block70 = global i64 2827, section ".data", align 8
-@camlCsel__const_block70 = global { ptr, ptr } { ptr @camlCsel__immstring68, ptr @camlCsel__const_block32 }, section ".data", align 8
-@header.camlCsel__immstring68 = global i64 3068, section ".data", align 8
-@camlCsel__immstring68 = global { [ 10 x i8 ], [ 5 x i8 ], i8 } { [ 10 x i8 ] c"\6d\69\6e\20\33\20\32\20\3d\20", [ 5 x i8 ] zeroinitializer, i8 5 }, section ".data", align 8
-@header.camlCsel__const_block81 = global i64 2827, section ".data", align 8
-@camlCsel__const_block81 = global { ptr, ptr } { ptr @camlCsel__immstring79, ptr @camlCsel__const_block32 }, section ".data", align 8
-@header.camlCsel__immstring79 = global i64 3068, section ".data", align 8
-@camlCsel__immstring79 = global { [ 10 x i8 ], [ 5 x i8 ], i8 } { [ 10 x i8 ] c"\6d\69\6e\20\31\20\31\20\3d\20", [ 5 x i8 ] zeroinitializer, i8 5 }, section ".data", align 8
-@header.camlCsel__const_block32 = global i64 4868, section ".data", align 8
-@camlCsel__const_block32 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlCsel__const_block30 }, section ".data", align 8
-@header.camlCsel__const_block30 = global i64 2828, section ".data", align 8
-@camlCsel__const_block30 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
+@header.camlCsel__const_block37 = global i64 2827, section ".data", align 8
+@camlCsel__const_block37 = global { ptr, ptr } { ptr @camlCsel__immstring31, ptr @camlCsel__const_block35 }, section ".data", align 8
+@header.camlCsel__immstring31 = global i64 4092, section ".data", align 8
+@camlCsel__immstring31 = global { [ 17 x i8 ], [ 6 x i8 ], i8 } { [ 17 x i8 ] c"\63\73\65\6c\20\66\61\6c\73\65\20\31\20\32\20\3d\20", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
+@header.camlCsel__const_block49 = global i64 2827, section ".data", align 8
+@camlCsel__const_block49 = global { ptr, ptr } { ptr @camlCsel__immstring47, ptr @camlCsel__const_block35 }, section ".data", align 8
+@header.camlCsel__immstring47 = global i64 4092, section ".data", align 8
+@camlCsel__immstring47 = global { [ 16 x i8 ], [ 7 x i8 ], i8 } { [ 16 x i8 ] c"\63\73\65\6c\20\74\72\75\65\20\33\20\34\20\3d\20", [ 7 x i8 ] zeroinitializer, i8 7 }, section ".data", align 8
+@header.camlCsel__const_block61 = global i64 2827, section ".data", align 8
+@camlCsel__const_block61 = global { ptr, ptr } { ptr @camlCsel__immstring59, ptr @camlCsel__const_block35 }, section ".data", align 8
+@header.camlCsel__immstring59 = global i64 3068, section ".data", align 8
+@camlCsel__immstring59 = global { [ 10 x i8 ], [ 5 x i8 ], i8 } { [ 10 x i8 ] c"\6d\69\6e\20\32\20\33\20\3d\20", [ 5 x i8 ] zeroinitializer, i8 5 }, section ".data", align 8
+@header.camlCsel__const_block73 = global i64 2827, section ".data", align 8
+@camlCsel__const_block73 = global { ptr, ptr } { ptr @camlCsel__immstring71, ptr @camlCsel__const_block35 }, section ".data", align 8
+@header.camlCsel__immstring71 = global i64 3068, section ".data", align 8
+@camlCsel__immstring71 = global { [ 10 x i8 ], [ 5 x i8 ], i8 } { [ 10 x i8 ] c"\6d\69\6e\20\33\20\32\20\3d\20", [ 5 x i8 ] zeroinitializer, i8 5 }, section ".data", align 8
+@header.camlCsel__const_block84 = global i64 2827, section ".data", align 8
+@camlCsel__const_block84 = global { ptr, ptr } { ptr @camlCsel__immstring82, ptr @camlCsel__const_block35 }, section ".data", align 8
+@header.camlCsel__immstring82 = global i64 3068, section ".data", align 8
+@camlCsel__immstring82 = global { [ 10 x i8 ], [ 5 x i8 ], i8 } { [ 10 x i8 ] c"\6d\69\6e\20\31\20\31\20\3d\20", [ 5 x i8 ] zeroinitializer, i8 5 }, section ".data", align 8
+@header.camlCsel__const_block35 = global i64 4868, section ".data", align 8
+@camlCsel__const_block35 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlCsel__const_block33 }, section ".data", align 8
+@header.camlCsel__const_block33 = global i64 2828, section ".data", align 8
+@camlCsel__const_block33 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
 @temp.Csel.0 = global { ptr } { ptr @caml_csel_value }, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 = external global ptr

--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -219,7 +219,7 @@ L1:
 L123:
   store i64 61, ptr %13
   store i64 1, ptr %14
-  %58 = ptrtoint ptr @camlData_decl__immstring35 to i64
+  %58 = ptrtoint ptr @camlData_decl__immstring38 to i64
   store i64 %58, ptr %15
   %59 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
   store i64 %59, ptr %16
@@ -316,9 +316,9 @@ L131:
   store ptr addrspace(1) %114, ptr %30
   %115 = load ptr addrspace(1), ptr %30
   store ptr addrspace(1) %115, ptr %31
-  %116 = ptrtoint ptr @camlData_decl__float327 to i64
+  %116 = ptrtoint ptr @camlData_decl__float328 to i64
   store i64 %116, ptr %32
-  %117 = ptrtoint ptr @camlData_decl__immstring38 to i64
+  %117 = ptrtoint ptr @camlData_decl__immstring41 to i64
   store i64 %117, ptr %33
   %118 = load i64, ptr %33
   %119 = inttoptr i64 %118 to ptr addrspace(1)
@@ -343,7 +343,7 @@ L134:
   store ptr addrspace(1) %130, ptr %34
   %131 = load ptr addrspace(1), ptr %34
   store ptr addrspace(1) %131, ptr %35
-  %132 = ptrtoint ptr @camlData_decl__const_block54 to i64
+  %132 = ptrtoint ptr @camlData_decl__const_block57 to i64
   store i64 %132, ptr %36
   store i64 1, ptr %37
   %133 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -372,7 +372,7 @@ L135:
   store ptr addrspace(1) %146, ptr %39
   %147 = load ptr addrspace(1), ptr %39
   store ptr addrspace(1) %147, ptr %40
-  %148 = ptrtoint ptr @camlData_decl__float4 to i64
+  %148 = ptrtoint ptr @camlData_decl__float5 to i64
   store i64 %148, ptr %41
   %149 = load i64, ptr %41
   store i64 %149, ptr %4
@@ -417,7 +417,7 @@ L137:
   store i64 %171, ptr %45
   %172 = load i64, ptr %45
   store i64 %172, ptr %46
-  %173 = ptrtoint ptr @camlData_decl__const_block67 to i64
+  %173 = ptrtoint ptr @camlData_decl__const_block70 to i64
   store i64 %173, ptr %47
   store i64 1, ptr %48
   %174 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -499,37 +499,37 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 @camlData_decl__gc_roots = global { i64 } { i64 0 }, section ".data", align 8
 @header.camlData_decl = global i64 4864, section ".data", align 8
-@camlData_decl = global { ptr, ptr, ptr, ptr } { ptr @camlData_decl__float4, ptr @camlData_decl__float327, ptr @camlData_decl__f_2, ptr @camlData_decl__g_3 }, section ".data", align 8
+@camlData_decl = global { ptr, ptr, ptr, ptr } { ptr @camlData_decl__float5, ptr @camlData_decl__float328, ptr @camlData_decl__f_2, ptr @camlData_decl__g_3 }, section ".data", align 8
 @header.camlData_decl__g_3 = global i64 7159, section ".data", align 8
 @camlData_decl__g_3 = global { ptr, i64, ptr } { ptr @caml_curry2, i64 144115188075855885, ptr @camlData_decl__g_HIDE_STAMP }, section ".data", align 8
 @header.camlData_decl__f_2 = global i64 4345, section ".data", align 8
 @camlData_decl__f_2 = global { ptr, i64 } { ptr @camlData_decl__f_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
-@header.camlData_decl__float4 = global i64 2045, section ".data", align 8
-@camlData_decl__float4 = global { double } { double 0x400921fb54442d18 }, section ".data", align 8
-@header.camlData_decl__float327 = global i64 3071, section ".data", align 8
-@camlData_decl__float327 = global { ptr, float } { ptr @caml_float32_ops, float 0x4005bf0a80000000 }, section ".data", align 8
-@header.camlData_decl__immstring35 = global i64 5116, section ".data", align 8
-@camlData_decl__immstring35 = global { [ 30 x i8 ], [ 1 x i8 ], i8 } { [ 30 x i8 ] c"\6f\6e\65\20\6f\66\20\74\68\65\20\73\74\72\69\6e\67\73\0a\6f\66\20\61\6c\6c\20\74\69\6d\65", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
-@header.camlData_decl__immstring38 = global i64 2044, section ".data", align 8
-@camlData_decl__immstring38 = global { [ 5 x i8 ], [ 2 x i8 ], i8 } { [ 5 x i8 ] c"\25\2e\31\30\67", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
-@header.camlData_decl__const_block54 = global i64 4872, section ".data", align 8
-@camlData_decl__const_block54 = global { ptr, i64, ptr, ptr } { ptr @camlData_decl__const_block44, i64 1, ptr @camlData_decl__const_block46, ptr @camlData_decl__const_block52 }, section ".data", align 8
-@header.camlData_decl__const_block52 = global i64 2828, section ".data", align 8
-@camlData_decl__const_block52 = global { i64, ptr } { i64 65, ptr @camlData_decl__const_block50 }, section ".data", align 8
-@header.camlData_decl__const_block50 = global i64 2818, section ".data", align 8
-@camlData_decl__const_block50 = global { i64, ptr } { i64 1, ptr @camlData_decl__const_block48 }, section ".data", align 8
-@header.camlData_decl__const_block46 = global i64 1792, section ".data", align 8
-@camlData_decl__const_block46 = global { i64 } { i64 41 }, section ".data", align 8
-@header.camlData_decl__const_block44 = global i64 2816, section ".data", align 8
-@camlData_decl__const_block44 = global { i64, i64 } { i64 1, i64 1 }, section ".data", align 8
-@header.camlData_decl__const_block67 = global i64 2827, section ".data", align 8
-@camlData_decl__const_block67 = global { ptr, ptr } { ptr @camlData_decl__immstring63, ptr @camlData_decl__const_block65 }, section ".data", align 8
-@header.camlData_decl__const_block65 = global i64 4868, section ".data", align 8
-@camlData_decl__const_block65 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlData_decl__const_block48 }, section ".data", align 8
-@header.camlData_decl__const_block48 = global i64 2828, section ".data", align 8
-@camlData_decl__const_block48 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
-@header.camlData_decl__immstring63 = global i64 4092, section ".data", align 8
-@camlData_decl__immstring63 = global { [ 20 x i8 ], [ 3 x i8 ], i8 } { [ 20 x i8 ] c"\6d\75\74\75\61\6c\6c\79\5f\72\65\63\75\72\73\69\76\65\3a\20", [ 3 x i8 ] zeroinitializer, i8 3 }, section ".data", align 8
+@header.camlData_decl__float5 = global i64 2045, section ".data", align 8
+@camlData_decl__float5 = global { double } { double 0x400921fb54442d18 }, section ".data", align 8
+@header.camlData_decl__float328 = global i64 3071, section ".data", align 8
+@camlData_decl__float328 = global { ptr, float } { ptr @caml_float32_ops, float 0x4005bf0a80000000 }, section ".data", align 8
+@header.camlData_decl__immstring38 = global i64 5116, section ".data", align 8
+@camlData_decl__immstring38 = global { [ 30 x i8 ], [ 1 x i8 ], i8 } { [ 30 x i8 ] c"\6f\6e\65\20\6f\66\20\74\68\65\20\73\74\72\69\6e\67\73\0a\6f\66\20\61\6c\6c\20\74\69\6d\65", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
+@header.camlData_decl__immstring41 = global i64 2044, section ".data", align 8
+@camlData_decl__immstring41 = global { [ 5 x i8 ], [ 2 x i8 ], i8 } { [ 5 x i8 ] c"\25\2e\31\30\67", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
+@header.camlData_decl__const_block57 = global i64 4872, section ".data", align 8
+@camlData_decl__const_block57 = global { ptr, i64, ptr, ptr } { ptr @camlData_decl__const_block47, i64 1, ptr @camlData_decl__const_block49, ptr @camlData_decl__const_block55 }, section ".data", align 8
+@header.camlData_decl__const_block55 = global i64 2828, section ".data", align 8
+@camlData_decl__const_block55 = global { i64, ptr } { i64 65, ptr @camlData_decl__const_block53 }, section ".data", align 8
+@header.camlData_decl__const_block53 = global i64 2818, section ".data", align 8
+@camlData_decl__const_block53 = global { i64, ptr } { i64 1, ptr @camlData_decl__const_block51 }, section ".data", align 8
+@header.camlData_decl__const_block49 = global i64 1792, section ".data", align 8
+@camlData_decl__const_block49 = global { i64 } { i64 41 }, section ".data", align 8
+@header.camlData_decl__const_block47 = global i64 2816, section ".data", align 8
+@camlData_decl__const_block47 = global { i64, i64 } { i64 1, i64 1 }, section ".data", align 8
+@header.camlData_decl__const_block70 = global i64 2827, section ".data", align 8
+@camlData_decl__const_block70 = global { ptr, ptr } { ptr @camlData_decl__immstring66, ptr @camlData_decl__const_block68 }, section ".data", align 8
+@header.camlData_decl__const_block68 = global i64 4868, section ".data", align 8
+@camlData_decl__const_block68 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlData_decl__const_block51 }, section ".data", align 8
+@header.camlData_decl__const_block51 = global i64 2828, section ".data", align 8
+@camlData_decl__const_block51 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
+@header.camlData_decl__immstring66 = global i64 4092, section ".data", align 8
+@camlData_decl__immstring66 = global { [ 20 x i8 ], [ 3 x i8 ], i8 } { [ 20 x i8 ] c"\6d\75\74\75\61\6c\6c\79\5f\72\65\63\75\72\73\69\76\65\3a\20", [ 3 x i8 ] zeroinitializer, i8 3 }, section ".data", align 8
 @temp.Data_decl.0 = global { ptr } { ptr @caml_format_float32 }, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 = external global ptr

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -897,7 +897,7 @@ L1:
 L234:
   %7 = load i64, ptr %4
   store i64 %7, ptr %5
-  %8 = ptrtoint ptr @camlExn_part2__Exn3235 to i64
+  %8 = ptrtoint ptr @camlExn_part2__Exn3245 to i64
   store i64 %8, ptr %6
   %9 = load i64, ptr %6
   store i64 %9, ptr %4
@@ -1420,7 +1420,7 @@ L244:
   store i64 1, ptr %68
   %328 = load i64, ptr %68
   store i64 %328, ptr %69
-  %329 = ptrtoint ptr @camlExn_part2__Exn3235 to i64
+  %329 = ptrtoint ptr @camlExn_part2__Exn3245 to i64
   store i64 %329, ptr %70
   %330 = load i64, ptr %18
   %331 = load i64, ptr %70
@@ -1645,7 +1645,7 @@ L399:
   %122 = icmp sgt i64 %120, %121
   br i1 %122, label %L379, label %L386
 L379:
-  %123 = ptrtoint ptr @camlExn_part2__Pmakeblock201 to i64
+  %123 = ptrtoint ptr @camlExn_part2__Pmakeblock210 to i64
   store i64 %123, ptr %30
   %124 = load i64, ptr %30
   store i64 %124, ptr %4
@@ -1839,7 +1839,7 @@ L405:
   store i64 %89, ptr %17
   store i64 13, ptr %18
   store i64 1, ptr %19
-  %90 = ptrtoint ptr @camlExn_part2__immstring221 to i64
+  %90 = ptrtoint ptr @camlExn_part2__immstring231 to i64
   store i64 %90, ptr %20
   %91 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
   store i64 %91, ptr %21
@@ -1988,7 +1988,7 @@ L436:
   store ptr addrspace(1) %26, ptr %9
   %27 = load ptr addrspace(1), ptr %9
   store ptr addrspace(1) %27, ptr %10
-  %28 = ptrtoint ptr @camlExn_part2__Exn3235 to i64
+  %28 = ptrtoint ptr @camlExn_part2__Exn3245 to i64
   store i64 %28, ptr %11
   %29 = load ptr addrspace(1), ptr %11
   %30 = getelementptr i8, ptr addrspace(1) %29, i64 8
@@ -2063,9 +2063,9 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
   ret { { i64, i64 }, { i64 } } %5
 }
 
-@camlExn_part2__gc_roots = global { ptr, i64 } { ptr @camlExn_part2__Exn3235, i64 0 }, section ".data", align 8
+@camlExn_part2__gc_roots = global { ptr, i64 } { ptr @camlExn_part2__Exn3245, i64 0 }, section ".data", align 8
 @header.camlExn_part2 = global i64 11008, section ".data", align 8
-@camlExn_part2 = global { ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { ptr @camlExn_part2__Exn3235, ptr @camlExn_part2__catch_exn1_from_llvm_9, ptr @camlExn_part2__raise_exn1_catch_exn2_from_llvm_10, ptr @camlExn_part2__catch_exn1_nested_from_llvm_11, ptr @camlExn_part2__raise_1_12, ptr @camlExn_part2__raise_2_13, ptr @camlExn_part2__raise_HIDE_STAMP, ptr @camlExn_part2__complicated_15, ptr @camlExn_part2__raise_in_loop_16, ptr @camlExn_part2__catch_wildcard_17 }, section ".data", align 8
+@camlExn_part2 = global { ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { ptr @camlExn_part2__Exn3245, ptr @camlExn_part2__catch_exn1_from_llvm_9, ptr @camlExn_part2__raise_exn1_catch_exn2_from_llvm_10, ptr @camlExn_part2__catch_exn1_nested_from_llvm_11, ptr @camlExn_part2__raise_1_12, ptr @camlExn_part2__raise_2_13, ptr @camlExn_part2__raise_HIDE_STAMP, ptr @camlExn_part2__complicated_15, ptr @camlExn_part2__raise_in_loop_16, ptr @camlExn_part2__catch_wildcard_17 }, section ".data", align 8
 @header.camlExn_part2__catch_wildcard_17 = global i64 3063, section ".data", align 8
 @camlExn_part2__catch_wildcard_17 = global { ptr, i64 } { ptr @camlExn_part2__catch_wildcard_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 @header.camlExn_part2__raise_in_loop_16 = global i64 3063, section ".data", align 8
@@ -2084,18 +2084,18 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlExn_part2__raise_exn1_catch_exn2_from_llvm_10 = global { ptr, i64 } { ptr @camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 @header.camlExn_part2__catch_exn1_from_llvm_9 = global i64 3063, section ".data", align 8
 @camlExn_part2__catch_exn1_from_llvm_9 = global { ptr, i64 } { ptr @camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
-@header.camlExn_part2__Exn3235 = global i64 3064, section ".data", align 8
-@camlExn_part2__Exn3235 = global { ptr, i64 } { ptr @camlExn_part2__immstring6, i64 1 }, section ".data", align 8
-@header.camlExn_part2__immstring6 = global i64 3068, section ".data", align 8
-@camlExn_part2__immstring6 = global { [ 14 x i8 ], [ 1 x i8 ], i8 } { [ 14 x i8 ] c"\45\78\6e\5f\70\61\72\74\32\2e\45\78\6e\33", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
-@header.camlExn_part2__immstring221 = global i64 2044, section ".data", align 8
-@camlExn_part2__immstring221 = global { [ 6 x i8 ], [ 1 x i8 ], i8 } { [ 6 x i8 ] c"\63\61\75\67\68\74", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
-@header.camlExn_part2__Pmakeblock201 = global i64 2816, section ".data", align 8
-@camlExn_part2__Pmakeblock201 = global { ptr, ptr } { ptr @caml_exn_Assert_failure, ptr @camlExn_part2__const_block198 }, section ".data", align 8
-@header.camlExn_part2__const_block198 = global i64 3840, section ".data", align 8
-@camlExn_part2__const_block198 = global { ptr, i64, i64 } { ptr @camlExn_part2__immstring196, i64 101, i64 95 }, section ".data", align 8
-@header.camlExn_part2__immstring196 = global i64 3068, section ".data", align 8
-@camlExn_part2__immstring196 = global { [ 12 x i8 ], [ 3 x i8 ], i8 } { [ 12 x i8 ] c"\65\78\6e\5f\70\61\72\74\32\2e\6d\6c", [ 3 x i8 ] zeroinitializer, i8 3 }, section ".data", align 8
+@header.camlExn_part2__Exn3245 = global i64 3064, section ".data", align 8
+@camlExn_part2__Exn3245 = global { ptr, i64 } { ptr @camlExn_part2__immstring7, i64 1 }, section ".data", align 8
+@header.camlExn_part2__immstring7 = global i64 3068, section ".data", align 8
+@camlExn_part2__immstring7 = global { [ 14 x i8 ], [ 1 x i8 ], i8 } { [ 14 x i8 ] c"\45\78\6e\5f\70\61\72\74\32\2e\45\78\6e\33", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
+@header.camlExn_part2__immstring231 = global i64 2044, section ".data", align 8
+@camlExn_part2__immstring231 = global { [ 6 x i8 ], [ 1 x i8 ], i8 } { [ 6 x i8 ] c"\63\61\75\67\68\74", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
+@header.camlExn_part2__Pmakeblock210 = global i64 2816, section ".data", align 8
+@camlExn_part2__Pmakeblock210 = global { ptr, ptr } { ptr @caml_exn_Assert_failure, ptr @camlExn_part2__const_block207 }, section ".data", align 8
+@header.camlExn_part2__const_block207 = global i64 3840, section ".data", align 8
+@camlExn_part2__const_block207 = global { ptr, i64, i64 } { ptr @camlExn_part2__immstring205, i64 101, i64 95 }, section ".data", align 8
+@header.camlExn_part2__immstring205 = global i64 3068, section ".data", align 8
+@camlExn_part2__immstring205 = global { [ 12 x i8 ], [ 3 x i8 ], i8 } { [ 12 x i8 ] c"\65\78\6e\5f\70\61\72\74\32\2e\6d\6c", [ 3 x i8 ] zeroinitializer, i8 3 }, section ".data", align 8
 @camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_asm.L428 = external global ptr
 @camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_var.L428 = global ptr zeroinitializer, section ".data", align 8
 @camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_asm.L396 = external global ptr

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -441,10 +441,10 @@ L1:
 L129:
   %16 = load i64, ptr %4
   store i64 %16, ptr %10
-  %17 = ptrtoint ptr @camlExtcalls__float38 to i64
+  %17 = ptrtoint ptr @camlExtcalls__float43 to i64
   store i64 %17, ptr %11
   store i64 7, ptr %12
-  %18 = ptrtoint ptr @camlExtcalls__float36 to i64
+  %18 = ptrtoint ptr @camlExtcalls__float41 to i64
   store i64 %18, ptr %13
   store i64 3, ptr %14
   %19 = load i64, ptr %14
@@ -538,10 +538,10 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlExtcalls__call_too_many_with_try_5 = global { ptr, i64 } { ptr @camlExtcalls__call_too_many_with_try_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 @header.camlExtcalls__call_too_many_4 = global i64 3063, section ".data", align 8
 @camlExtcalls__call_too_many_4 = global { ptr, i64 } { ptr @camlExtcalls__call_too_many_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
-@header.camlExtcalls__float38 = global i64 2045, section ".data", align 8
-@camlExtcalls__float38 = global { double } { double 0x4010000000000000 }, section ".data", align 8
-@header.camlExtcalls__float36 = global i64 2045, section ".data", align 8
-@camlExtcalls__float36 = global { double } { double 0x4000000000000000 }, section ".data", align 8
+@header.camlExtcalls__float43 = global i64 2045, section ".data", align 8
+@camlExtcalls__float43 = global { double } { double 0x4010000000000000 }, section ".data", align 8
+@header.camlExtcalls__float41 = global i64 2045, section ".data", align 8
+@camlExtcalls__float41 = global { double } { double 0x4000000000000000 }, section ".data", align 8
 @temp.Extcalls.0 = global { ptr, ptr, ptr } { ptr @int_and_float, ptr @too_many, ptr @print_and_add }, section ".data", align 8
 @camlExtcalls__call_too_many_with_try_HIDE_STAMP.recover_rbp_asm.L122 = external global ptr
 @camlExtcalls__call_too_many_with_try_HIDE_STAMP.recover_rbp_var.L122 = global ptr zeroinitializer, section ".data", align 8

--- a/oxcaml/tests/backend/llvmize/float_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/float_ops_ir.output
@@ -318,9 +318,9 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 @camlFloat_ops__gc_roots = global { i64 } { i64 0 }, section ".data", align 8
 @header.camlFloat_ops = global i64 1792, section ".data", align 8
-@camlFloat_ops = global { ptr } { ptr @camlFloat_ops__Pmakeblock251 }, section ".data", align 8
-@header.camlFloat_ops__Pmakeblock251 = global i64 7936, section ".data", align 8
-@camlFloat_ops__Pmakeblock251 = global { ptr, ptr, ptr, ptr, ptr, ptr, ptr } { ptr @camlFloat_ops__add_7, ptr @camlFloat_ops__sub_8, ptr @camlFloat_ops__mul_9, ptr @camlFloat_ops__div_10, ptr @camlFloat_ops__neg_11, ptr @camlFloat_ops__abs_12, ptr @camlFloat_ops__compare_13 }, section ".data", align 8
+@camlFloat_ops = global { ptr } { ptr @camlFloat_ops__Pmakeblock267 }, section ".data", align 8
+@header.camlFloat_ops__Pmakeblock267 = global i64 7936, section ".data", align 8
+@camlFloat_ops__Pmakeblock267 = global { ptr, ptr, ptr, ptr, ptr, ptr, ptr } { ptr @camlFloat_ops__add_7, ptr @camlFloat_ops__sub_8, ptr @camlFloat_ops__mul_9, ptr @camlFloat_ops__div_10, ptr @camlFloat_ops__neg_11, ptr @camlFloat_ops__abs_12, ptr @camlFloat_ops__compare_13 }, section ".data", align 8
 @header.camlFloat_ops__compare_13 = global i64 4087, section ".data", align 8
 @camlFloat_ops__compare_13 = global { ptr, i64, ptr } { ptr @caml_curryF_F, i64 180143985094819847, ptr @camlFloat_ops__compare_HIDE_STAMP }, section ".data", align 8
 @header.camlFloat_ops__abs_12 = global i64 3063, section ".data", align 8

--- a/oxcaml/tests/backend/llvmize/multi_ret_ir.output
+++ b/oxcaml/tests/backend/llvmize/multi_ret_ir.output
@@ -94,11 +94,11 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 @camlMulti_ret__gc_roots = global { i64 } { i64 0 }, section ".data", align 8
 @header.camlMulti_ret = global i64 2816, section ".data", align 8
-@camlMulti_ret = global { ptr, ptr } { ptr @camlMulti_ret__empty_block4, ptr @camlMulti_ret__permute_1 }, section ".data", align 8
+@camlMulti_ret = global { ptr, ptr } { ptr @camlMulti_ret__empty_block5, ptr @camlMulti_ret__permute_1 }, section ".data", align 8
 @header.camlMulti_ret__permute_1 = global i64 4087, section ".data", align 8
 @camlMulti_ret__permute_1 = global { ptr, i64, ptr } { ptr @caml_curryF_F_F_F_RFFFF, i64 324259173170675719, ptr @camlMulti_ret__permute_HIDE_STAMP }, section ".data", align 8
-@header.camlMulti_ret__empty_block4 = global i64 768, section ".data", align 8
-@camlMulti_ret__empty_block4 = global {  } {  }, section ".data", align 8
+@header.camlMulti_ret__empty_block5 = global i64 768, section ".data", align 8
+@camlMulti_ret__empty_block5 = global {  } {  }, section ".data", align 8
 @caml_curryF_F_F_F_RFFFF = external global ptr
 
 

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -41,7 +41,7 @@ L129:
   %27 = icmp ugt i64 %26, 17
   br i1 %27, label %L104, label %L106
 L104:
-  %28 = ptrtoint ptr @camlSwitch__Pmakeblock20 to i64
+  %28 = ptrtoint ptr @camlSwitch__Pmakeblock22 to i64
   store i64 %28, ptr %8
   %29 = load i64, ptr %8
   store i64 %29, ptr %4
@@ -94,7 +94,7 @@ L109:
   %49 = insertvalue { { i64, i64 }, { i64 } } %48, i64 %44, 1, 0
   ret { { i64, i64 }, { i64 } } %49
 L111:
-  %50 = ptrtoint ptr @camlSwitch__Pmakeblock20 to i64
+  %50 = ptrtoint ptr @camlSwitch__Pmakeblock22 to i64
   store i64 %50, ptr %12
   %51 = load i64, ptr %12
   store i64 %51, ptr %4
@@ -123,7 +123,7 @@ L113:
   %67 = insertvalue { { i64, i64 }, { i64 } } %66, i64 %62, 1, 0
   ret { { i64, i64 }, { i64 } } %67
 L115:
-  %68 = ptrtoint ptr @camlSwitch__Pmakeblock20 to i64
+  %68 = ptrtoint ptr @camlSwitch__Pmakeblock22 to i64
   store i64 %68, ptr %14
   %69 = load i64, ptr %14
   store i64 %69, ptr %4
@@ -152,7 +152,7 @@ L117:
   %85 = insertvalue { { i64, i64 }, { i64 } } %84, i64 %80, 1, 0
   ret { { i64, i64 }, { i64 } } %85
 L119:
-  %86 = ptrtoint ptr @camlSwitch__Pmakeblock20 to i64
+  %86 = ptrtoint ptr @camlSwitch__Pmakeblock22 to i64
   store i64 %86, ptr %16
   %87 = load i64, ptr %16
   store i64 %87, ptr %4
@@ -181,7 +181,7 @@ L121:
   %103 = insertvalue { { i64, i64 }, { i64 } } %102, i64 %98, 1, 0
   ret { { i64, i64 }, { i64 } } %103
 L123:
-  %104 = ptrtoint ptr @camlSwitch__Pmakeblock20 to i64
+  %104 = ptrtoint ptr @camlSwitch__Pmakeblock22 to i64
   store i64 %104, ptr %18
   %105 = load i64, ptr %18
   store i64 %105, ptr %4
@@ -307,7 +307,7 @@ L146:
   store i64 %65, ptr %16
   %66 = load i64, ptr %16
   store i64 %66, ptr %17
-  %67 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %67 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %67, ptr %18
   %68 = load i64, ptr %18
   %69 = inttoptr i64 %68 to ptr addrspace(1)
@@ -358,7 +358,7 @@ L138:
   store i64 1, ptr %22
   %95 = load i64, ptr %22
   store i64 %95, ptr %23
-  %96 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %96 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %96, ptr %24
   %97 = load i64, ptr %24
   store i64 %97, ptr %25
@@ -367,7 +367,7 @@ L138:
   store ptr addrspace(1) %99, ptr %12
   br label %L153
 L153:
-  %100 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %100 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %100, ptr %26
   store i64 1, ptr %27
   %101 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -673,7 +673,7 @@ L178:
   store i64 %231, ptr %16
   %232 = load i64, ptr %16
   store i64 %232, ptr %17
-  %233 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %233 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %233, ptr %18
   %234 = load i64, ptr %18
   %235 = inttoptr i64 %234 to ptr addrspace(1)
@@ -724,7 +724,7 @@ L170:
   store i64 1, ptr %22
   %261 = load i64, ptr %22
   store i64 %261, ptr %23
-  %262 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %262 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %262, ptr %24
   %263 = load i64, ptr %24
   store i64 %263, ptr %25
@@ -733,7 +733,7 @@ L170:
   store ptr addrspace(1) %265, ptr %11
   br label %L185
 L185:
-  %266 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %266 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %266, ptr %26
   store i64 1, ptr %27
   %267 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -845,7 +845,7 @@ L201:
   store i64 %329, ptr %39
   %330 = load i64, ptr %39
   store i64 %330, ptr %40
-  %331 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %331 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %331, ptr %41
   %332 = load i64, ptr %41
   %333 = inttoptr i64 %332 to ptr addrspace(1)
@@ -896,7 +896,7 @@ L193:
   store i64 1, ptr %45
   %359 = load i64, ptr %45
   store i64 %359, ptr %46
-  %360 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %360 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %360, ptr %47
   %361 = load i64, ptr %47
   store i64 %361, ptr %48
@@ -905,7 +905,7 @@ L193:
   store ptr addrspace(1) %363, ptr %34
   br label %L208
 L208:
-  %364 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %364 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %364, ptr %49
   store i64 1, ptr %50
   %365 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1017,7 +1017,7 @@ L224:
   store i64 %427, ptr %62
   %428 = load i64, ptr %62
   store i64 %428, ptr %63
-  %429 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %429 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %429, ptr %64
   %430 = load i64, ptr %64
   %431 = inttoptr i64 %430 to ptr addrspace(1)
@@ -1068,7 +1068,7 @@ L216:
   store i64 1, ptr %68
   %457 = load i64, ptr %68
   store i64 %457, ptr %69
-  %458 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %458 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %458, ptr %70
   %459 = load i64, ptr %70
   store i64 %459, ptr %71
@@ -1077,7 +1077,7 @@ L216:
   store ptr addrspace(1) %461, ptr %57
   br label %L231
 L231:
-  %462 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %462 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %462, ptr %72
   store i64 1, ptr %73
   %463 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1189,7 +1189,7 @@ L247:
   store i64 %525, ptr %85
   %526 = load i64, ptr %85
   store i64 %526, ptr %86
-  %527 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %527 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %527, ptr %87
   %528 = load i64, ptr %87
   %529 = inttoptr i64 %528 to ptr addrspace(1)
@@ -1240,7 +1240,7 @@ L239:
   store i64 1, ptr %91
   %555 = load i64, ptr %91
   store i64 %555, ptr %92
-  %556 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %556 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %556, ptr %93
   %557 = load i64, ptr %93
   store i64 %557, ptr %94
@@ -1249,7 +1249,7 @@ L239:
   store ptr addrspace(1) %559, ptr %80
   br label %L254
 L254:
-  %560 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %560 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %560, ptr %95
   store i64 1, ptr %96
   %561 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1361,7 +1361,7 @@ L270:
   store i64 %623, ptr %108
   %624 = load i64, ptr %108
   store i64 %624, ptr %109
-  %625 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %625 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %625, ptr %110
   %626 = load i64, ptr %110
   %627 = inttoptr i64 %626 to ptr addrspace(1)
@@ -1412,7 +1412,7 @@ L262:
   store i64 1, ptr %114
   %653 = load i64, ptr %114
   store i64 %653, ptr %115
-  %654 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %654 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %654, ptr %116
   %655 = load i64, ptr %116
   store i64 %655, ptr %117
@@ -1421,7 +1421,7 @@ L262:
   store ptr addrspace(1) %657, ptr %103
   br label %L277
 L277:
-  %658 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %658 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %658, ptr %118
   store i64 1, ptr %119
   %659 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1533,7 +1533,7 @@ L293:
   store i64 %721, ptr %131
   %722 = load i64, ptr %131
   store i64 %722, ptr %132
-  %723 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %723 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %723, ptr %133
   %724 = load i64, ptr %133
   %725 = inttoptr i64 %724 to ptr addrspace(1)
@@ -1584,7 +1584,7 @@ L285:
   store i64 1, ptr %137
   %751 = load i64, ptr %137
   store i64 %751, ptr %138
-  %752 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %752 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %752, ptr %139
   %753 = load i64, ptr %139
   store i64 %753, ptr %140
@@ -1593,7 +1593,7 @@ L285:
   store ptr addrspace(1) %755, ptr %126
   br label %L300
 L300:
-  %756 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %756 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %756, ptr %141
   store i64 1, ptr %142
   %757 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1705,7 +1705,7 @@ L316:
   store i64 %819, ptr %154
   %820 = load i64, ptr %154
   store i64 %820, ptr %155
-  %821 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %821 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %821, ptr %156
   %822 = load i64, ptr %156
   %823 = inttoptr i64 %822 to ptr addrspace(1)
@@ -1756,7 +1756,7 @@ L308:
   store i64 1, ptr %160
   %849 = load i64, ptr %160
   store i64 %849, ptr %161
-  %850 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %850 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %850, ptr %162
   %851 = load i64, ptr %162
   store i64 %851, ptr %163
@@ -1765,7 +1765,7 @@ L308:
   store ptr addrspace(1) %853, ptr %149
   br label %L323
 L323:
-  %854 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %854 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %854, ptr %164
   store i64 1, ptr %165
   %855 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -1877,7 +1877,7 @@ L339:
   store i64 %917, ptr %177
   %918 = load i64, ptr %177
   store i64 %918, ptr %178
-  %919 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  %919 = ptrtoint ptr @camlStdlib__Int__immstring72 to i64
   store i64 %919, ptr %179
   %920 = load i64, ptr %179
   %921 = inttoptr i64 %920 to ptr addrspace(1)
@@ -1928,7 +1928,7 @@ L331:
   store i64 1, ptr %183
   %947 = load i64, ptr %183
   store i64 %947, ptr %184
-  %948 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  %948 = ptrtoint ptr @camlSwitch__immstring41 to i64
   store i64 %948, ptr %185
   %949 = load i64, ptr %185
   store i64 %949, ptr %186
@@ -1937,7 +1937,7 @@ L331:
   store ptr addrspace(1) %951, ptr %172
   br label %L346
 L346:
-  %952 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  %952 = ptrtoint ptr @camlSwitch__const_block57 to i64
   store i64 %952, ptr %187
   store i64 1, ptr %188
   %953 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -2024,28 +2024,28 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlSwitch__test_next_3 = global { ptr, i64 } { ptr @camlSwitch__test_next_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 @header.camlSwitch__next_2 = global i64 3063, section ".data", align 8
 @camlSwitch__next_2 = global { ptr, i64 } { ptr @camlSwitch__next_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
-@header.camlSwitch__const_block54 = global i64 2827, section ".data", align 8
-@camlSwitch__const_block54 = global { ptr, ptr } { ptr @camlSwitch__immstring42, ptr @camlSwitch__const_block52 }, section ".data", align 8
-@header.camlSwitch__const_block52 = global i64 4868, section ".data", align 8
-@camlSwitch__const_block52 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlSwitch__const_block50 }, section ".data", align 8
-@header.camlSwitch__const_block50 = global i64 2827, section ".data", align 8
-@camlSwitch__const_block50 = global { ptr, ptr } { ptr @camlSwitch__immstring44, ptr @camlSwitch__const_block48 }, section ".data", align 8
-@header.camlSwitch__const_block48 = global i64 2818, section ".data", align 8
-@camlSwitch__const_block48 = global { i64, ptr } { i64 1, ptr @camlSwitch__const_block46 }, section ".data", align 8
-@header.camlSwitch__const_block46 = global i64 2828, section ".data", align 8
-@camlSwitch__const_block46 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
-@header.camlSwitch__immstring44 = global i64 2044, section ".data", align 8
-@camlSwitch__immstring44 = global { [ 3 x i8 ], [ 4 x i8 ], i8 } { [ 3 x i8 ] c"\20\3d\20", [ 4 x i8 ] zeroinitializer, i8 4 }, section ".data", align 8
-@header.camlSwitch__immstring42 = global i64 2044, section ".data", align 8
-@camlSwitch__immstring42 = global { [ 5 x i8 ], [ 2 x i8 ], i8 } { [ 5 x i8 ] c"\6e\65\78\74\20", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
-@header.camlSwitch__immstring38 = global i64 3068, section ".data", align 8
-@camlSwitch__immstring38 = global { [ 9 x i8 ], [ 6 x i8 ], i8 } { [ 9 x i8 ] c"\6e\6f\74\20\66\6f\75\6e\64", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
-@header.camlSwitch__Pmakeblock20 = global i64 2816, section ".data", align 8
-@camlSwitch__Pmakeblock20 = global { ptr, ptr } { ptr @caml_exn_Match_failure, ptr @camlSwitch__const_block17 }, section ".data", align 8
-@header.camlSwitch__const_block17 = global i64 3840, section ".data", align 8
-@camlSwitch__const_block17 = global { ptr, i64, i64 } { ptr @camlSwitch__immstring15, i64 5, i64 5 }, section ".data", align 8
-@header.camlSwitch__immstring15 = global i64 3068, section ".data", align 8
-@camlSwitch__immstring15 = global { [ 9 x i8 ], [ 6 x i8 ], i8 } { [ 9 x i8 ] c"\73\77\69\74\63\68\2e\6d\6c", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
+@header.camlSwitch__const_block57 = global i64 2827, section ".data", align 8
+@camlSwitch__const_block57 = global { ptr, ptr } { ptr @camlSwitch__immstring45, ptr @camlSwitch__const_block55 }, section ".data", align 8
+@header.camlSwitch__const_block55 = global i64 4868, section ".data", align 8
+@camlSwitch__const_block55 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlSwitch__const_block53 }, section ".data", align 8
+@header.camlSwitch__const_block53 = global i64 2827, section ".data", align 8
+@camlSwitch__const_block53 = global { ptr, ptr } { ptr @camlSwitch__immstring47, ptr @camlSwitch__const_block51 }, section ".data", align 8
+@header.camlSwitch__const_block51 = global i64 2818, section ".data", align 8
+@camlSwitch__const_block51 = global { i64, ptr } { i64 1, ptr @camlSwitch__const_block49 }, section ".data", align 8
+@header.camlSwitch__const_block49 = global i64 2828, section ".data", align 8
+@camlSwitch__const_block49 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
+@header.camlSwitch__immstring47 = global i64 2044, section ".data", align 8
+@camlSwitch__immstring47 = global { [ 3 x i8 ], [ 4 x i8 ], i8 } { [ 3 x i8 ] c"\20\3d\20", [ 4 x i8 ] zeroinitializer, i8 4 }, section ".data", align 8
+@header.camlSwitch__immstring45 = global i64 2044, section ".data", align 8
+@camlSwitch__immstring45 = global { [ 5 x i8 ], [ 2 x i8 ], i8 } { [ 5 x i8 ] c"\6e\65\78\74\20", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
+@header.camlSwitch__immstring41 = global i64 3068, section ".data", align 8
+@camlSwitch__immstring41 = global { [ 9 x i8 ], [ 6 x i8 ], i8 } { [ 9 x i8 ] c"\6e\6f\74\20\66\6f\75\6e\64", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
+@header.camlSwitch__Pmakeblock22 = global i64 2816, section ".data", align 8
+@camlSwitch__Pmakeblock22 = global { ptr, ptr } { ptr @caml_exn_Match_failure, ptr @camlSwitch__const_block19 }, section ".data", align 8
+@header.camlSwitch__const_block19 = global i64 3840, section ".data", align 8
+@camlSwitch__const_block19 = global { ptr, i64, i64 } { ptr @camlSwitch__immstring17, i64 5, i64 5 }, section ".data", align 8
+@header.camlSwitch__immstring17 = global i64 3068, section ".data", align 8
+@camlSwitch__immstring17 = global { [ 9 x i8 ], [ 6 x i8 ], i8 } { [ 9 x i8 ] c"\73\77\69\74\63\68\2e\6d\6c", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
 @camlSwitch__entry.recover_rbp_asm.L367 = external global ptr
 @camlSwitch__entry.recover_rbp_var.L367 = global ptr zeroinitializer, section ".data", align 8
 @camlSwitch__entry.recover_rbp_asm.L371 = external global ptr
@@ -2066,7 +2066,7 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlSwitch__test_next_HIDE_STAMP.recover_rbp_var.L158 = global ptr zeroinitializer, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 = external global ptr
-@camlStdlib__Int__immstring64 = external global ptr
+@camlStdlib__Int__immstring72 = external global ptr
 @caml_apply2 = external global ptr
 @caml_c_call = external global ptr
 @caml_exn_Match_failure = external global ptr

--- a/oxcaml/tests/backend/llvmize/tailcall_ir.output
+++ b/oxcaml/tests/backend/llvmize/tailcall_ir.output
@@ -661,7 +661,7 @@ L225:
   store i64 %103, ptr %10
   br label %L229
 L229:
-  %104 = ptrtoint ptr @camlTailcall__const_block89 to i64
+  %104 = ptrtoint ptr @camlTailcall__const_block95 to i64
   store i64 %104, ptr %28
   store i64 1, ptr %29
   %105 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -738,7 +738,7 @@ L234:
   store i64 %145, ptr %38
   %146 = load i64, ptr %38
   store i64 %146, ptr %39
-  %147 = ptrtoint ptr @camlTailcall__const_block101 to i64
+  %147 = ptrtoint ptr @camlTailcall__const_block107 to i64
   store i64 %147, ptr %40
   store i64 1, ptr %41
   %148 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 to i64
@@ -798,7 +798,7 @@ L236:
   %180 = inttoptr i64 %179 to ptr
   %181 = load ptr addrspace(1), ptr %180
   store ptr addrspace(1) %181, ptr %49
-  %182 = ptrtoint ptr @camlTailcall__float108 to i64
+  %182 = ptrtoint ptr @camlTailcall__float114 to i64
   store i64 %182, ptr %50
   store i64 149, ptr %51
   store i64 77, ptr %52
@@ -871,7 +871,7 @@ L242:
   %222 = inttoptr i64 %221 to ptr
   %223 = load ptr addrspace(1), ptr %222
   store ptr addrspace(1) %223, ptr %64
-  %224 = ptrtoint ptr @camlTailcall__float108 to i64
+  %224 = ptrtoint ptr @camlTailcall__float114 to i64
   store i64 %224, ptr %65
   store i64 149, ptr %66
   store i64 77, ptr %67
@@ -941,20 +941,20 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlTailcall__collatz_odd_6 = global { ptr, i64, ptr } { ptr @caml_curry2, i64 180143985094819847, ptr @camlTailcall__collatz_odd_HIDE_STAMP }, section ".data", align 8
 @header.camlTailcall__fib_general_5 = global i64 4087, section ".data", align 8
 @camlTailcall__fib_general_5 = global { ptr, i64, ptr } { ptr @caml_curry3, i64 252201579132747783, ptr @camlTailcall__fib_general_HIDE_STAMP }, section ".data", align 8
-@header.camlTailcall__const_block89 = global i64 2827, section ".data", align 8
-@camlTailcall__const_block89 = global { ptr, ptr } { ptr @camlTailcall__immstring83, ptr @camlTailcall__const_block87 }, section ".data", align 8
-@header.camlTailcall__immstring83 = global i64 3068, section ".data", align 8
-@camlTailcall__immstring83 = global { [ 13 x i8 ], [ 2 x i8 ], i8 } { [ 13 x i8 ] c"\66\69\62\5f\67\65\6e\65\72\61\6c\3a\20", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
-@header.camlTailcall__const_block101 = global i64 2827, section ".data", align 8
-@camlTailcall__const_block101 = global { ptr, ptr } { ptr @camlTailcall__immstring99, ptr @camlTailcall__const_block87 }, section ".data", align 8
-@header.camlTailcall__immstring99 = global i64 3068, section ".data", align 8
-@camlTailcall__immstring99 = global { [ 13 x i8 ], [ 2 x i8 ], i8 } { [ 13 x i8 ] c"\63\6f\6c\6c\61\74\7a\5f\6f\64\64\3a\20", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
-@header.camlTailcall__const_block87 = global i64 4868, section ".data", align 8
-@camlTailcall__const_block87 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlTailcall__const_block85 }, section ".data", align 8
-@header.camlTailcall__const_block85 = global i64 2828, section ".data", align 8
-@camlTailcall__const_block85 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
-@header.camlTailcall__float108 = global i64 2045, section ".data", align 8
-@camlTailcall__float108 = global { double } { double 0x4044a66666666666 }, section ".data", align 8
+@header.camlTailcall__const_block95 = global i64 2827, section ".data", align 8
+@camlTailcall__const_block95 = global { ptr, ptr } { ptr @camlTailcall__immstring89, ptr @camlTailcall__const_block93 }, section ".data", align 8
+@header.camlTailcall__immstring89 = global i64 3068, section ".data", align 8
+@camlTailcall__immstring89 = global { [ 13 x i8 ], [ 2 x i8 ], i8 } { [ 13 x i8 ] c"\66\69\62\5f\67\65\6e\65\72\61\6c\3a\20", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
+@header.camlTailcall__const_block107 = global i64 2827, section ".data", align 8
+@camlTailcall__const_block107 = global { ptr, ptr } { ptr @camlTailcall__immstring105, ptr @camlTailcall__const_block93 }, section ".data", align 8
+@header.camlTailcall__immstring105 = global i64 3068, section ".data", align 8
+@camlTailcall__immstring105 = global { [ 13 x i8 ], [ 2 x i8 ], i8 } { [ 13 x i8 ] c"\63\6f\6c\6c\61\74\7a\5f\6f\64\64\3a\20", [ 2 x i8 ] zeroinitializer, i8 2 }, section ".data", align 8
+@header.camlTailcall__const_block93 = global i64 4868, section ".data", align 8
+@camlTailcall__const_block93 = global { i64, i64, i64, ptr } { i64 1, i64 1, i64 1, ptr @camlTailcall__const_block91 }, section ".data", align 8
+@header.camlTailcall__const_block91 = global i64 2828, section ".data", align 8
+@camlTailcall__const_block91 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
+@header.camlTailcall__float114 = global i64 2045, section ".data", align 8
+@camlTailcall__float114 = global { double } { double 0x4044a66666666666 }, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1550$2c4$2d$2d59$5d_545 = external global ptr
 @camlTailcall2 = external global ptr

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -10,7 +10,7 @@ let immutable_load l = (List.hd l) + (List.hd l)
 immutable_load:
   testb $1, %al
   je    .L0
-  movq  camlStdlib__List__Pmakeblock2453@GOTPCREL(%rip), %rax
+  movq  camlStdlib__List__Pmakeblock2573@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -96,7 +96,7 @@ loop_with_non_dominating_load:
 .L0:
   testb $1, %bl
   je    .L1
-  movq  camlStdlib__List__Pmakeblock2453@GOTPCREL(%rip), %rax
+  movq  camlStdlib__List__Pmakeblock2573@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/flambda/match_in_match_seq.raw.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.raw.reference
@@ -1,12 +1,10 @@
 let $camlMatch_in_match_seq__first_const = Block 0 () in
 (let code rec inline(always) loopify(always) size(35)
-       aux_1 (acc, s : val)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2 =
+       aux_1 (acc, s : val) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[aux].[f] (my_closure) in
    let next = %project_value_slot.[aux].[next] (my_closure) in
-   apply inlined(hint) next (s) -> k3 * k2
+   apply &my_alloc_region inlined(hint) next (s) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -19,27 +17,29 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
           where k3 =
             let Pfield = %block_load.[`1`] (`*match*`) in
             ((let Pfield_1 = %block_load.[`0`] (`*match*`) in
-              apply f (acc, Pfield_1) -> k3 * k2)
+              apply &my_alloc_region f (acc, Pfield_1) -> k3 * k2)
                where k3 (apply_result) =
-                 apply direct(aux_1)
+                 apply direct(aux_1 &my_alloc_region)
                    my_closure ~ depth my_depth -> next_depth
                      (apply_result, Pfield)
                      -> k1 * k2))
  in
  let code inline(always) size(52)
        fold_left_0 (f : val, acc, param : [ 0 of [ 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let `*match*` = %block_load.[`0`] (param) in
    let next = %block_load.[`1`] (`*match*`) in
-   let aux = closure aux_1 @aux with { f = f; next = next } in
+   let aux = closure aux_1 @aux &my_alloc_region
+   with { f = f; next = next }
+   in
    let Pfield = %block_load.[`0`] (`*match*`) in
-   apply direct(aux_1) aux (acc, Pfield) -> k1 * k2
+   apply direct(aux_1 &my_alloc_region) aux (acc, Pfield) -> k1 * k2
  in
  let code size(39)
        `fn[match_in_match_seq.ml:35,14--125]_3` (s : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -51,7 +51,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
      %project_value_slot.[`fn[match_in_match_seq.ml:35,14--125]`].[next_1]
        (my_closure)
    in
-   apply inlined(hint) next (s) -> k3 * k2
+   apply &my_alloc_region inlined(hint) next (s) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -64,14 +64,16 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
           where k3 =
             let Pfield = %block_load.[`1`] (`*match*`) in
             ((let Pfield_1 = %block_load.[`0`] (`*match*`) in
-              apply f (Pfield_1) -> k3 * k2)
+              apply &my_alloc_region f (Pfield_1) -> k3 * k2)
                where k3 (apply_result : val) =
-                 let Pmakeblock = %block.[`0`] (apply_result, Pfield) in
+                 let Pmakeblock =
+                   %block.[`0`].my_alloc_region (apply_result, Pfield)
+                 in
                  cont k1 (Pmakeblock)))
  in
  let code inline(always) size(65)
        map_2 (f : val, param : [ 0 of [ 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of [ 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -79,25 +81,26 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
    let next = %block_load.[`1`] (`*match*`) in
    let `fn[match_in_match_seq.ml:35,14--125]` =
      closure `fn[match_in_match_seq.ml:35,14--125]_3`
-       @`fn[match_in_match_seq.ml:35,14--125]`
+       @`fn[match_in_match_seq.ml:35,14--125]` &my_alloc_region
    with { f_1 = f; next_1 = next }
    in
    let Pfield = %block_load.[`0`] (`*match*`) in
    let Pmakeblock =
-     %block.[`0`] (Pfield, `fn[match_in_match_seq.ml:35,14--125]`)
+     %block.[`0`].my_alloc_region
+       (Pfield, `fn[match_in_match_seq.ml:35,14--125]`)
    in
-   let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+   let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
    cont k1 (Pmakeblock_1)
  in
  let code rec inline(always) loopify(always) size(56)
        aux_5 (s : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[aux_1].[f_2] (my_closure) in
    let next = %project_value_slot.[aux_1].[next_2] (my_closure) in
-   apply inlined(hint) next (s) -> k3 * k2
+   apply &my_alloc_region inlined(hint) next (s) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -110,7 +113,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
           where k3 =
             let s' = %block_load.[`1`] (`*match*`) in
             let x = %block_load.[`0`] (`*match*`) in
-            (apply f (x) -> k5 * k2
+            (apply &my_alloc_region f (x) -> k5 * k2
                where k5 (apply_result : [ 0 |1 ]) =
                  ((let untagged = %untag_imm (apply_result) in
                    switch untagged
@@ -121,42 +124,44 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
                     where k5 =
                       cont k4)
                where k4 =
-                 apply direct(aux_5)
+                 apply direct(aux_5 &my_alloc_region)
                    (my_closure ~ depth my_depth -> next_depth
                     : _ -> [ 0 | 0 of val * val ])
                      (s')
                      -> k1 * k2
                where k3 =
-                 let Pmakeblock = %block.[`0`] (x, s') in
+                 let Pmakeblock = %block.[`0`].my_alloc_region (x, s') in
                  cont k1 (Pmakeblock)))
  in
  let code inline(always) size(82)
        filter_4 (f : val, param : [ 0 of [ 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of [ 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
    let `*match*` = %block_load.[`0`] (param) in
    let next = %block_load.[`1`] (`*match*`) in
-   let aux = closure aux_5 @aux_1 with { f_2 = f; next_2 = next } in
+   let aux = closure aux_5 @aux_1 &my_alloc_region
+   with { f_2 = f; next_2 = next }
+   in
    let Pfield = %block_load.[`0`] (`*match*`) in
-   let Pmakeblock = %block.[`0`] (Pfield, aux) in
-   let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+   let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, aux) in
+   let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
    cont k1 (Pmakeblock_1)
  in
  let code inline(always) size(14)
        unfold_6 (f : val, acc : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of [ 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let Pmakeblock = %block.[`0`] (acc, f) in
-   let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+   let Pmakeblock = %block.[`0`].my_alloc_region (acc, f) in
+   let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
    cont k1 (Pmakeblock_1)
  in
  let code inline(always) size(5)
        square_7 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -165,7 +170,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
  in
  let code size(27)
        `fn[match_in_match_seq.ml:55,11--63]_9` (i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -183,22 +188,22 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
         cont k3)
      where k3 =
        let int_add = %int_barith.add (i, 1) in
-       let Pmakeblock = %block.[`0`] (i, int_add) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (i, int_add) in
        cont k1 (Pmakeblock)
  in
  let code inline(always) size(40)
        ints_8 (lo : imm tagged, hi : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of [ 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
    let unfold = %project_value_slot.[ints].[unfold] (my_closure) in
    let `fn[match_in_match_seq.ml:55,11--63]` =
      closure `fn[match_in_match_seq.ml:55,11--63]_9`
-       @`fn[match_in_match_seq.ml:55,11--63]`
+       @`fn[match_in_match_seq.ml:55,11--63]` &my_alloc_region
    with { hi = hi }
    in
-   apply direct(unfold_6)
+   apply direct(unfold_6 &my_alloc_region)
      (unfold : _ -> [ 0 of [ 0 of val * val ] ])
        (`fn[match_in_match_seq.ml:55,11--63]`, lo)
        -> k1 * k2
@@ -206,7 +211,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
  let code size(3) stub
        `fn[match_in_match_seq.ml:57,33--36]_11`
          (prim : imm tagged, prim_1 : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -215,23 +220,23 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
  in
  let code inline(always) size(16)
        sum_10 (s : [ 0 of [ 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let fold_left = %project_value_slot.[sum].[fold_left] (my_closure) in
    let `fn[match_in_match_seq.ml:57,33--36]` =
      closure `fn[match_in_match_seq.ml:57,33--36]_11`
-       @`fn[match_in_match_seq.ml:57,33--36]`
+       @`fn[match_in_match_seq.ml:57,33--36]` &my_alloc_region
    in
-   apply direct(fold_left_0)
+   apply direct(fold_left_0 &my_alloc_region)
      (fold_left : _ -> imm tagged)
        (`fn[match_in_match_seq.ml:57,33--36]`, 0, s)
        -> k1 * k2
  in
  let code size(5)
        `fn[match_in_match_seq.ml:60,28--44]_13` (i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -241,7 +246,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
  in
  let code size(33)
        foo_12 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -250,33 +255,38 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
    let square = %project_value_slot.[foo].[square] (my_closure) in
    let ints = %project_value_slot.[foo].[ints] (my_closure) in
    let sum = %project_value_slot.[foo].[sum] (my_closure) in
-   apply direct(ints_8)
+   apply direct(ints_8 &my_alloc_region)
      (ints : _ -> [ 0 of [ 0 of val * val ] ]) (0, 11) -> k5 * k2
      where k5 (apply_result : [ 0 of [ 0 of val * val ] ]) =
        let `fn[match_in_match_seq.ml:60,28--44]` =
          closure `fn[match_in_match_seq.ml:60,28--44]_13`
-           @`fn[match_in_match_seq.ml:60,28--44]`
+           @`fn[match_in_match_seq.ml:60,28--44]` &my_alloc_region
        in
-       apply direct(filter_4)
+       apply direct(filter_4 &my_alloc_region)
          (filter : _ -> [ 0 of [ 0 of val * val ] ])
            (`fn[match_in_match_seq.ml:60,28--44]`, apply_result)
            -> k4 * k2
      where k4 (apply_result : [ 0 of [ 0 of val * val ] ]) =
-       apply direct(map_2)
+       apply direct(map_2 &my_alloc_region)
          (map : _ -> [ 0 of [ 0 of val * val ] ])
            (square, apply_result)
            -> k3 * k2
      where k3 (apply_result : [ 0 of [ 0 of val * val ] ]) =
-       apply direct(sum_10) (sum : _ -> imm tagged) (apply_result) -> k1 * k2
+       apply direct(sum_10 &my_alloc_region)
+         (sum : _ -> imm tagged) (apply_result) -> k1 * k2
  in
- (let fold_left = closure fold_left_0 @fold_left in
-  let map = closure map_2 @map in
-  let filter = closure filter_4 @filter in
-  let unfold = closure unfold_6 @unfold in
-  let square = closure square_7 @square in
-  let ints = closure ints_8 @ints with { unfold = unfold } in
-  let sum = closure sum_10 @sum with { fold_left = fold_left } in
-  let foo = closure foo_12 @foo
+ (let fold_left = closure fold_left_0 @fold_left &toplevel.alloc_region in
+  let map = closure map_2 @map &toplevel.alloc_region in
+  let filter = closure filter_4 @filter &toplevel.alloc_region in
+  let unfold = closure unfold_6 @unfold &toplevel.alloc_region in
+  let square = closure square_7 @square &toplevel.alloc_region in
+  let ints = closure ints_8 @ints &toplevel.alloc_region
+  with { unfold = unfold }
+  in
+  let sum = closure sum_10 @sum &toplevel.alloc_region
+  with { fold_left = fold_left }
+  in
+  let foo = closure foo_12 @foo &toplevel.alloc_region
   with {
     map = map;
     filter = filter;
@@ -285,10 +295,10 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
     sum = sum
   }
   in
-  let Pmakeblock = %block.[`0`] (foo) in
+  let Pmakeblock = %block.[`0`].`toplevel` (foo) in
   cont k1 (Pmakeblock))
    where k1 (Seq : val) =
-     let Pmakeblock = %block.[`0`] (Seq) in
+     let Pmakeblock = %block.[`0`].`toplevel` (Seq) in
      cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda/match_in_match_seq.simplify.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.simplify.reference
@@ -1,7 +1,7 @@
 let code foo_12 deleted in
 let code loopify(never) size(35) newer_version_of(foo_12)
       foo_12_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (0, 0)
@@ -17,19 +17,21 @@ let code loopify(never) size(35) newer_version_of(foo_12)
                 let prim_1 = %int_comp.gt (s_1, 5) in
                 switch prim_1
                   | 0 -> self_1 (int_add)
-                  | 1 -> k2 (s_1, int_add))
-         where k2 (s_1, int_add) =
+                  | 1 -> k2 (int_add, s_1))
+         where k2 (int_add, s_1) =
            let int_add_1 = int_add in
            let s_2 = s_1 in
            let int_mul = %int_barith.mul (s_2, s_2) in
            let int_add_2 = %int_barith.add (acc, int_mul) in
            cont `self` (int_add_2, int_add_1))
 in
-let $camlMatch_in_match_seq__foo_22 = closure foo_12_1 @foo in
-let $camlMatch_in_match_seq__Pmakeblock898 =
+let $camlMatch_in_match_seq__foo_22 =
+  closure foo_12_1 @foo &toplevel.alloc_region
+in
+let $camlMatch_in_match_seq__Pmakeblock971 =
   Block 0 ($camlMatch_in_match_seq__foo_22)
 in
 let $camlMatch_in_match_seq =
-  Block 0 ($camlMatch_in_match_seq__Pmakeblock898)
+  Block 0 ($camlMatch_in_match_seq__Pmakeblock971)
 in
 cont done ($camlMatch_in_match_seq)

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
@@ -1,7 +1,7 @@
 let code sum_0 deleted in
 let code loopify(never) size(49) newer_version_of(sum_0)
       sum_0_1 (t : [ 0 of imm tagged * imm tagged * val array ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`2`] (t) in
@@ -37,7 +37,9 @@ let code loopify(never) size(49) newer_version_of(sum_0)
                   | 0 -> k (return_val0)
                   | 1 -> k2 (for_next_naked, return_val0)))
 in
-let $camlArray_element_kind_meet__sum_2 = closure sum_0_1 @sum in
+let $camlArray_element_kind_meet__sum_2 =
+  closure sum_0_1 @sum &toplevel.alloc_region
+in
 let $camlArray_element_kind_meet =
   Block 0 ($camlArray_element_kind_meet__sum_2)
 in

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -1,7 +1,7 @@
 let code sum_0 deleted in
 let code loopify(never) size(52) newer_version_of(sum_0)
       sum_0_1 (t : [ 0 of imm tagged * imm tagged * val array ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`2`] (t) in
@@ -37,7 +37,9 @@ let code loopify(never) size(52) newer_version_of(sum_0)
                   | 0 -> k (return_val0)
                   | 1 -> k2 (for_next_naked, return_val0)))
 in
-let $camlArray_element_kind_meet__sum_2 = closure sum_0_1 @sum in
+let $camlArray_element_kind_meet__sum_2 =
+  closure sum_0_1 @sum &toplevel.alloc_region
+in
 let $camlArray_element_kind_meet =
   Block 0 ($camlArray_element_kind_meet__sum_2)
 in

--- a/testsuite/tests/flambda2/code_size_of_boolean_not_switch.simplify.reference
+++ b/testsuite/tests/flambda2/code_size_of_boolean_not_switch.simplify.reference
@@ -2,24 +2,28 @@ let code f_0 deleted in
 let code g_1 deleted in
 let code loopify(never) size(2) newer_version_of(f_0)
       f_0_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let not_scrutinee = %boolean_not (b) in
   cont k (not_scrutinee)
 in
-let $camlCode_size_of_boolean_not_switch__f_2 = closure f_0_1 @f in
+let $camlCode_size_of_boolean_not_switch__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(g_1)
       g_1_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1)
+  apply direct(f_0_1 &my_alloc_region)
     ($camlCode_size_of_boolean_not_switch__f_2 : _ -> imm tagged)
       (b)
       -> k * k1
 in
-let $camlCode_size_of_boolean_not_switch__g_3 = closure g_1_1 @g in
+let $camlCode_size_of_boolean_not_switch__g_3 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let $camlCode_size_of_boolean_not_switch =
   Block 0 ($camlCode_size_of_boolean_not_switch__f_2,
            $camlCode_size_of_boolean_not_switch__g_3)

--- a/testsuite/tests/flambda2/code_size_of_single_arg_switch.simplify.reference
+++ b/testsuite/tests/flambda2/code_size_of_single_arg_switch.simplify.reference
@@ -2,31 +2,31 @@ let code switch_converted_to_lookup_table_0 deleted in
 let code switch_converted_to_lookup_table'_1 deleted in
 let code switch_converted_to_affine_2 deleted in
 let code switch_converted_to_affine'_3 deleted in
-let $camlCode_size_of_single_arg_switch__switch_block40 =
+let $camlCode_size_of_single_arg_switch__switch_block46 =
   Value_array [|1;
   2;
   4|]
 in
 let code loopify(never) size(2) newer_version_of(switch_converted_to_lookup_table_0)
       switch_converted_to_lookup_table_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let arg =
-    %array_load ($camlCode_size_of_single_arg_switch__switch_block40, x)
+    %array_load ($camlCode_size_of_single_arg_switch__switch_block46, x)
   in
   cont k (arg)
 in
 let $camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table_4 =
   closure switch_converted_to_lookup_table_0_1
-    @switch_converted_to_lookup_table
+    @switch_converted_to_lookup_table &toplevel.alloc_region
 in
 let code loopify(never) size(4) newer_version_of(switch_converted_to_lookup_table'_1)
       switch_converted_to_lookup_table'_1_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(switch_converted_to_lookup_table_0_1)
+  apply direct(switch_converted_to_lookup_table_0_1 &my_alloc_region)
     ($camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table_4
      : _ -> imm tagged)
       (x)
@@ -34,11 +34,11 @@ let code loopify(never) size(4) newer_version_of(switch_converted_to_lookup_tabl
 in
 let $camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table'_5 =
   closure switch_converted_to_lookup_table'_1_1
-    @switch_converted_to_lookup_table'
+    @switch_converted_to_lookup_table' &toplevel.alloc_region
 in
 let code loopify(never) size(7) newer_version_of(switch_converted_to_affine_2)
       switch_converted_to_affine_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let scaled_arg = %int_barith.mul (x, 1) in
@@ -47,13 +47,14 @@ let code loopify(never) size(7) newer_version_of(switch_converted_to_affine_2)
 in
 let $camlCode_size_of_single_arg_switch__switch_converted_to_affine_6 =
   closure switch_converted_to_affine_2_1 @switch_converted_to_affine
+    &toplevel.alloc_region
 in
 let code loopify(never) size(4) newer_version_of(switch_converted_to_affine'_3)
       switch_converted_to_affine'_3_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(switch_converted_to_affine_2_1)
+  apply direct(switch_converted_to_affine_2_1 &my_alloc_region)
     ($camlCode_size_of_single_arg_switch__switch_converted_to_affine_6
      : _ -> imm tagged)
       (x)
@@ -61,6 +62,7 @@ let code loopify(never) size(4) newer_version_of(switch_converted_to_affine'_3)
 in
 let $camlCode_size_of_single_arg_switch__switch_converted_to_affine'_7 =
   closure switch_converted_to_affine'_3_1 @switch_converted_to_affine'
+    &toplevel.alloc_region
 in
 let $camlCode_size_of_single_arg_switch =
   Block 0 ($camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table_4,

--- a/testsuite/tests/flambda2/cse_immutable_array_load.simplify.reference
+++ b/testsuite/tests/flambda2/cse_immutable_array_load.simplify.reference
@@ -1,12 +1,14 @@
 let code f_0 deleted in
 let code loopify(never) size(1) newer_version_of(f_0)
       f_0_1 (arr : imm array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (1)
 in
-let $camlCse_immutable_array_load__f_1 = closure f_0_1 @f in
+let $camlCse_immutable_array_load__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlCse_immutable_array_load =
   Block 0 ($camlCse_immutable_array_load__f_1)
 in

--- a/testsuite/tests/flambda2/cse_immutable_array_load_var_index.simplify.reference
+++ b/testsuite/tests/flambda2/cse_immutable_array_load_var_index.simplify.reference
@@ -1,12 +1,14 @@
 let code f_0 deleted in
 let code loopify(never) size(1) newer_version_of(f_0)
       f_0_1 (arr : imm array, i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (1)
 in
-let $camlCse_immutable_array_load_var_index__f_1 = closure f_0_1 @f in
+let $camlCse_immutable_array_load_var_index__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlCse_immutable_array_load_var_index =
   Block 0 ($camlCse_immutable_array_load_var_index__f_1)
 in

--- a/testsuite/tests/flambda2/examples/andor.simplify.reference
+++ b/testsuite/tests/flambda2/examples/andor.simplify.reference
@@ -1,7 +1,7 @@
 let code is_valid_0 deleted in
 let code loopify(never) size(41) newer_version_of(is_valid_0)
       is_valid_0_1 (i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %int_comp.le (0, i) in
@@ -23,6 +23,8 @@ let code loopify(never) size(41) newer_version_of(is_valid_0)
            let int_lessequal = %tag_imm (prim_1) in
            cont k (int_lessequal))
 in
-let $camlAndor__is_valid_1 = closure is_valid_0_1 @is_valid in
+let $camlAndor__is_valid_1 =
+  closure is_valid_0_1 @is_valid &toplevel.alloc_region
+in
 let $camlAndor = Block 0 ($camlAndor__is_valid_1) in
 cont done ($camlAndor)

--- a/testsuite/tests/flambda2/examples/array_kind.compilers.reference
+++ b/testsuite/tests/flambda2/examples/array_kind.compilers.reference
@@ -13,12 +13,12 @@
  int 108086391056891909)
 (data
  int 2816
- "camlArray_kind__block13":
+ "camlArray_kind__block15":
  addr G:"caml_exn_Invalid_argument"
- addr L:"camlArray_kind__string11")
+ addr L:"camlArray_kind__string13")
 (data
  int 4092
- "camlArray_kind__string11":
+ "camlArray_kind__string13":
  string "index out of bounds"
  skip 4
  byte 4)
@@ -27,7 +27,7 @@
    (if (<u 1 (>>u (<< (load_mut int (+a a/1 -8)) 8) 17)) (load_mut val a/1)
      (exit 5))
  with(5)(cold)
-   (raise_notrace{array_kind.ml:35,14-19} L:"camlArray_kind__block13")) )
+   (raise_notrace{array_kind.ml:35,14-19} L:"camlArray_kind__block15")) )
 
 (function no_cse reduce_code_size linscan camlArray_kind__entry () : val
  (catch (exit 4 G:"camlArray_kind") with(4 *ret*/0: val) 1) )

--- a/testsuite/tests/flambda2/examples/array_kind.no-flat-float-array.compilers.reference
+++ b/testsuite/tests/flambda2/examples/array_kind.no-flat-float-array.compilers.reference
@@ -13,12 +13,12 @@
  int 108086391056891909)
 (data
  int 2816
- "camlArray_kind__block13":
+ "camlArray_kind__block15":
  addr G:"caml_exn_Invalid_argument"
- addr L:"camlArray_kind__string11")
+ addr L:"camlArray_kind__string13")
 (data
  int 4092
- "camlArray_kind__string11":
+ "camlArray_kind__string13":
  string "index out of bounds"
  skip 4
  byte 4)
@@ -27,7 +27,7 @@
    (if (<u 1 (>>u (<< (load_mut int (+a a/1 -8)) 8) 17)) (load_mut val a/1)
      (exit 5))
  with(5)(cold)
-   (raise_notrace{array_kind.ml:35,14-19} L:"camlArray_kind__block13")) )
+   (raise_notrace{array_kind.ml:35,14-19} L:"camlArray_kind__block15")) )
 
 (function no_cse reduce_code_size linscan camlArray_kind__entry () : val
  (catch (exit 4 G:"camlArray_kind") with(4 *ret*/0: val) 1) )

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.no-flat-float-array.reference
@@ -1,7 +1,7 @@
-let $camlArray_specialisation_examples__string11 = "index out of bounds" in
-let $camlArray_specialisation_examples__block13 =
+let $camlArray_specialisation_examples__string13 = "index out of bounds" in
+let $camlArray_specialisation_examples__block15 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument,
-           $camlArray_specialisation_examples__string11)
+           $camlArray_specialisation_examples__string13)
 in
 let code f_0 deleted in
 let code g_1 deleted in
@@ -9,7 +9,7 @@ let code h_2 deleted in
 let code i_3 deleted in
 let code loopify(never) size(19) newer_version_of(f_0)
       f_0_1 (arr : val array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
   (let prim = %array_length (arr) in
@@ -21,36 +21,42 @@ let code loopify(never) size(19) newer_version_of(f_0)
       let Parrayrefs = %array_load.mut (arr, 0) in
       cont k (Parrayrefs)
     where k2 =
-      cont k1 pop(regular k1) ($camlArray_specialisation_examples__block13)
+      cont k1 pop(regular k1) ($camlArray_specialisation_examples__block15)
 in
-let $camlArray_specialisation_examples__f_4 = closure f_0_1 @f in
+let $camlArray_specialisation_examples__f_4 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(8) newer_version_of(g_1)
       g_1_1 (x : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
-  let a = %array.mut (x) in
+  let a = %array.mut.my_alloc_region (x) in
   let Parrayrefs = %array_load.mut (a, 0) in
   cont k (Parrayrefs)
 in
-let $camlArray_specialisation_examples__g_5 = closure g_1_1 @g in
+let $camlArray_specialisation_examples__g_5 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let code loopify(never) size(8) newer_version_of(h_2)
       h_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let a = %array.mut (x) in
+  let a = %array.mut.my_alloc_region (x) in
   let Parrayrefs = %array_load.`imm`.mut (a, 0) in
   cont k (Parrayrefs)
 in
-let $camlArray_specialisation_examples__h_6 = closure h_2_1 @h in
+let $camlArray_specialisation_examples__h_6 =
+  closure h_2_1 @h &toplevel.alloc_region
+in
 let code loopify(never) size(22) newer_version_of(i_3)
       i_3_1 (w : imm tagged, x : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
-  (let a = %array.mut.`local`[`region`] (x) in
+  (let a = %array.mut.my_alloc_region.`local`[`region`] (x) in
    (let untagged = %untag_imm (w) in
     switch untagged
       | 0 -> k3
@@ -62,7 +68,9 @@ let code loopify(never) size(22) newer_version_of(i_3)
       let `unit` = %end_region (`region`) in
       cont k (region_return)
 in
-let $camlArray_specialisation_examples__i_7 = closure i_3_1 @i in
+let $camlArray_specialisation_examples__i_7 =
+  closure i_3_1 @i &toplevel.alloc_region
+in
 let $camlArray_specialisation_examples =
   Block 0 ($camlArray_specialisation_examples__f_4,
            $camlArray_specialisation_examples__g_5,

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
@@ -1,7 +1,7 @@
-let $camlArray_specialisation_examples__string11 = "index out of bounds" in
-let $camlArray_specialisation_examples__block13 =
+let $camlArray_specialisation_examples__string13 = "index out of bounds" in
+let $camlArray_specialisation_examples__block15 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument,
-           $camlArray_specialisation_examples__string11)
+           $camlArray_specialisation_examples__string13)
 in
 let code f_0 deleted in
 let code g_1 deleted in
@@ -9,7 +9,7 @@ let code h_2 deleted in
 let code i_3 deleted in
 let code loopify(never) size(22) newer_version_of(f_0)
       f_0_1 (arr : val array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
   (let prim = %array_length.generic (arr) in
@@ -21,32 +21,38 @@ let code loopify(never) size(22) newer_version_of(f_0)
       let ifnot_result = %array_load.mut (arr, 0) in
       cont k (ifnot_result)
     where k2 =
-      cont k1 pop(regular k1) ($camlArray_specialisation_examples__block13)
+      cont k1 pop(regular k1) ($camlArray_specialisation_examples__block15)
 in
-let $camlArray_specialisation_examples__f_4 = closure f_0_1 @f in
+let $camlArray_specialisation_examples__f_4 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(8) newer_version_of(g_1)
       g_1_1 (x : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
-  let a = %array.mut (x) in
+  let a = %array.mut.my_alloc_region (x) in
   let ifnot_result = %array_load.mut (a, 0) in
   cont k (ifnot_result)
 in
-let $camlArray_specialisation_examples__g_5 = closure g_1_1 @g in
+let $camlArray_specialisation_examples__g_5 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let code loopify(never) size(8) newer_version_of(h_2)
       h_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let ifnot_result = %array.mut (x) in
+  let ifnot_result = %array.mut.my_alloc_region (x) in
   let Parrayrefs = %array_load.`imm`.mut (ifnot_result, 0) in
   cont k (Parrayrefs)
 in
-let $camlArray_specialisation_examples__h_6 = closure h_2_1 @h in
+let $camlArray_specialisation_examples__h_6 =
+  closure h_2_1 @h &toplevel.alloc_region
+in
 let code loopify(never) size(62) newer_version_of(i_3)
       i_3_1 (w : imm tagged, x : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -55,11 +61,13 @@ let code loopify(never) size(62) newer_version_of(i_3)
      | 0 -> k5
      | 1 -> k4)
     where k5 =
-      let ifnot_result = %array.mut.`local`[`region`] (x) in
+      let ifnot_result = %array.mut.my_alloc_region.`local`[`region`] (x) in
       cont k3 (ifnot_result)
     where k4 =
       let prim = %unbox_num.`float` (x) in
-      let ifso_result = %array.`float`.mut.`local`[`region`] (prim) in
+      let ifso_result =
+        %array.`float`.mut.my_alloc_region.`local`[`region`] (prim)
+      in
       cont k3 (ifso_result)
     where k3 (if_then_else_result) =
       ((let untagged = %untag_imm (w) in
@@ -80,12 +88,14 @@ let code loopify(never) size(62) newer_version_of(i_3)
               where k3 =
                 cont k1
                        pop(regular k1)
-                       ($camlArray_specialisation_examples__block13)))
+                       ($camlArray_specialisation_examples__block15)))
     where k2 (region_return : imm tagged) =
       let `unit` = %end_region (`region`) in
       cont k (region_return)
 in
-let $camlArray_specialisation_examples__i_7 = closure i_3_1 @i in
+let $camlArray_specialisation_examples__i_7 =
+  closure i_3_1 @i &toplevel.alloc_region
+in
 let $camlArray_specialisation_examples =
   Block 0 ($camlArray_specialisation_examples__f_4,
            $camlArray_specialisation_examples__g_5,

--- a/testsuite/tests/flambda2/examples/arrays_compatibility.simplify.reference
+++ b/testsuite/tests/flambda2/examples/arrays_compatibility.simplify.reference
@@ -1,25 +1,27 @@
 let code index_0 deleted in
-let $camlArrays_compatibility__string32 = "index out of bounds" in
-let $camlArrays_compatibility__block34 =
+let $camlArrays_compatibility__string35 = "index out of bounds" in
+let $camlArrays_compatibility__block37 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument,
-           $camlArrays_compatibility__string32)
+           $camlArrays_compatibility__string35)
 in
 let code convert_fast_1 deleted in
-let $camlArrays_compatibility__empty_array5 = Empty_array in
+let $camlArrays_compatibility__empty_array6 = Empty_array in
 let code f_2 deleted in
 let code inline(never) loopify(never) size(8) newer_version_of(index_0)
       index_0_1 (source)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm array =
-  let Pmakearray = %array.`imm`.mut (0, 0) in
+  let Pmakearray = %array.`imm`.mut.my_alloc_region (0, 0) in
   let Popaque = %opaque (Pmakearray) in
   cont k (Popaque)
 in
-let $camlArrays_compatibility__index_3 = closure index_0_1 @index in
+let $camlArrays_compatibility__index_3 =
+  closure index_0_1 @index &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(60) newer_version_of(convert_fast_1)
       convert_fast_1_1 (offset : imm tagged, index : imm array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let line = %opaque (0) in
@@ -45,33 +47,33 @@ let code inline(always) loopify(never) size(60) newer_version_of(convert_fast_1)
                  let int_add = %int_barith.add (int_sub_1, 1) in
                  cont k2 (int_add)
                where k4 =
-                 cont k1 pop(regular k1) ($camlArrays_compatibility__block34))))
+                 cont k1 pop(regular k1) ($camlArrays_compatibility__block37))))
     where k3 =
       let int_add = %int_barith.add (offset, 1) in
       cont k2 (int_add)
     where k2 (col : imm tagged) =
-      let Pmakeblock = %block.[`0`] (line, col) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (line, col) in
       cont k (Pmakeblock)
 in
 let $camlArrays_compatibility__convert_fast_4 =
-  closure convert_fast_1_1 @convert_fast
+  closure convert_fast_1_1 @convert_fast &toplevel.alloc_region
 in
-let $camlArrays_compatibility__Pmakeblock95 =
-  Block 0 ($camlArrays_compatibility__empty_array5,
+let $camlArrays_compatibility__Pmakeblock101 =
+  Block 0 ($camlArrays_compatibility__empty_array6,
            $camlArrays_compatibility__index_3,
            $camlArrays_compatibility__convert_fast_4)
 in
 let code loopify(never) size(75) newer_version_of(f_2)
       f_2_1 (fast : imm tagged, source : val, offset : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   (let untagged = %untag_imm (fast) in
    switch untagged
-     | 0 -> k2 ($camlArrays_compatibility__empty_array5)
+     | 0 -> k2 ($camlArrays_compatibility__empty_array6)
      | 1 -> k3)
     where k3 =
-      apply direct(index_0_1)
+      apply direct(index_0_1 &my_alloc_region)
         ($camlArrays_compatibility__index_3 : _ -> val) (source) -> k2 * k1
     where k2 (index : val) =
       let line = %opaque (0) in
@@ -100,17 +102,18 @@ let code loopify(never) size(75) newer_version_of(f_2)
                     where k4 =
                       cont k1
                              pop(regular k1)
-                             ($camlArrays_compatibility__block34))))
+                             ($camlArrays_compatibility__block37))))
          where k3 =
            let int_add = %int_barith.add (offset, 1) in
            cont k2 (int_add)
          where k2 (col : imm tagged) =
-           let Pmakeblock = %block.[`0`] (line, col) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (line, col) in
            cont k (Pmakeblock))
 in
-let $camlArrays_compatibility__f_5 = closure f_2_1 @f in
+let $camlArrays_compatibility__f_5 = closure f_2_1 @f &toplevel.alloc_region
+in
 let $camlArrays_compatibility =
-  Block 0 ($camlArrays_compatibility__Pmakeblock95,
+  Block 0 ($camlArrays_compatibility__Pmakeblock101,
            $camlArrays_compatibility__f_5)
 in
 cont done ($camlArrays_compatibility)

--- a/testsuite/tests/flambda2/examples/block_closure_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/block_closure_rec.simplify.reference
@@ -1,10 +1,10 @@
 let code foo_0 deleted in
 let $camlBlock_closure_rec__foo_1 =
-  closure foo_0_1 @foo
+  closure foo_0_1 @foo &toplevel.alloc_region
 and code rec loopify(never) size(8) newer_version_of(foo_0)
-      foo_0_1 (x) my_closure _region _ghost_region my_depth -> k * k1 : val =
+      foo_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : val =
   let Pmakeblock =
-    %block.[`0`]
+    %block.[`0`].my_alloc_region
       (3505894,
        $camlBlock_closure_rec__foo_1 ~ depth my_depth -> succ my_depth)
   in

--- a/testsuite/tests/flambda2/examples/block_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/block_unboxed.simplify.reference
@@ -1,7 +1,7 @@
 let code foo_0 deleted in
 let code loopify(never) size(25) newer_version_of(foo_0)
       foo_0_1 (b : imm tagged, x : imm tagged, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (b) in
@@ -23,6 +23,7 @@ let code loopify(never) size(25) newer_version_of(foo_0)
       let int_add = %int_barith.add (unboxed_field_0, int_of_float) in
       cont k (int_add)
 in
-let $camlBlock_unboxed__foo_1 = closure foo_0_1 @foo in
+let $camlBlock_unboxed__foo_1 = closure foo_0_1 @foo &toplevel.alloc_region
+in
 let $camlBlock_unboxed = Block 0 ($camlBlock_unboxed__foo_1) in
 cont done ($camlBlock_unboxed)

--- a/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
@@ -1,11 +1,11 @@
-let $camlCode_id_join_b__const_block334 = Block 0 (2, 0) in
-let $camlCode_id_join_b__const_block336 =
-  Block 0 (1, $camlCode_id_join_b__const_block334)
+let $camlCode_id_join_b__const_block388 = Block 0 (2, 0) in
+let $camlCode_id_join_b__const_block390 =
+  Block 0 (1, $camlCode_id_join_b__const_block388)
 in
-let $camlCode_id_join_b__const_block338 =
-  Block 0 (0, $camlCode_id_join_b__const_block336)
+let $camlCode_id_join_b__const_block392 =
+  Block 0 (0, $camlCode_id_join_b__const_block390)
 in
-cont `self` ($camlCode_id_join_b__const_block338)
+cont `self` ($camlCode_id_join_b__const_block392)
   where rec `self` (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
     let prim = %is_int (param) in
     (switch prim
@@ -29,7 +29,8 @@ cont `self` ($camlCode_id_join_b__const_block338)
                    k1
                      ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_13`))
             where k1 (full_apply) =
-              (apply inlining_state(depth(20)) full_apply (42) -> k2 * error
+              (apply &toplevel.alloc_region inlining_state(depth(20))
+                 full_apply (42) -> k2 * error
                  where k2 (param_1 : imm tagged) =
                    cont k1
                  where k1 =

--- a/testsuite/tests/flambda2/examples/cross_function_cse_a.ml
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_a.ml
@@ -1,0 +1,27 @@
+(* TEST
+ compile_only = "true";
+ setup-ocamlopt.byte-build-env;
+ flags = "-Oclassic";
+ ocamlopt.byte with dump-raw;
+ check-fexpr-dump;
+*)
+
+(* Comes with cross_function_cse_b.ml.
+
+  We test that two allocations in different functions which are inlined are correctly CSE'd
+  together. Cross_function_cse_a is compiled in classic mode to test if resimplifying
+  after the inlining has been done in classic mode works for CSE as well. 
+*)
+
+let some x = Some x
+[@@inline]
+
+let f x =
+  let a = Some x in
+  let b = some x in
+  a, b
+
+let g x =
+  let a = some x in
+  let b = Some x in
+  a, b

--- a/testsuite/tests/flambda2/examples/cross_function_cse_a.raw.reference
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_a.raw.reference
@@ -1,0 +1,53 @@
+(let code inline(always) size(7)
+       some_0 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 | 0 of val ] =
+   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+   cont k1 (Pmakeblock)
+ in
+ let code size(21)
+       f_1 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+   let a = %block.[`0`].my_alloc_region (x) in
+   (let inlined_dbg = %inlined_apply () in
+    let x_1 = x in
+    let Pmakeblock = %block.[`0`].my_alloc_region (x_1) in
+    cont k3 (Pmakeblock))
+     where k3 (b : [ 0 | 0 of val ]) =
+       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
+       cont k1 (Pmakeblock)
+ in
+ let code size(21)
+       g_2 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+   (let inlined_dbg = %inlined_apply () in
+    let x_1 = x in
+    let Pmakeblock = %block.[`0`].my_alloc_region (x_1) in
+    cont k3 (Pmakeblock))
+     where k3 (a : [ 0 | 0 of val ]) =
+       let b = %block.[`0`].my_alloc_region (x) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
+       cont k1 (Pmakeblock)
+ in
+ let $camlCross_function_cse_a__s0 =
+   closure some_0 @some &toplevel.alloc_region
+ in
+ let $camlCross_function_cse_a__s1 = closure f_1 @f &toplevel.alloc_region in
+ let $camlCross_function_cse_a__s2 = closure g_2 @g &toplevel.alloc_region in
+ let $camlCross_function_cse_a__s3 =
+   Block 0 ($camlCross_function_cse_a__s0,
+            $camlCross_function_cse_a__s1,
+            $camlCross_function_cse_a__s2)
+ in
+ cont k ($camlCross_function_cse_a__s3))
+  where k define_root_symbol (module_block) =
+    let field_0 = $camlCross_function_cse_a__s0 in
+    let field_1 = $camlCross_function_cse_a__s1 in
+    let field_2 = $camlCross_function_cse_a__s2 in
+    let $camlCross_function_cse_a = Block 0 (field_0, field_1, field_2) in
+    cont done ($camlCross_function_cse_a)

--- a/testsuite/tests/flambda2/examples/cross_function_cse_b.ml
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_b.ml
@@ -1,0 +1,50 @@
+(* TEST
+ compile_only = "true";
+ readonly_files = "cross_function_cse_a.ml";
+ setup-ocamlopt.byte-build-env;
+ {
+   module = "cross_function_cse_a.ml";
+   flags = "-Oclassic";
+   ocamlopt.byte with dump-raw;
+ }{
+   module = "cross_function_cse_b.ml";
+   flags = "-O3";
+   ocamlopt.byte with dump-raw, dump-simplify;
+   check-fexpr-dump;
+ }
+*)
+(* CR ncourant: check fexpr dump for cross_function_cse_a.ml *)
+
+(* Comes with cross_function_cse_a.ml.
+
+  We test that two allocations in different functions which are inlined are correctly CSE'd
+  together. Cross_function_cse_a is compiled in classic mode to test if resimplifying
+  after the inlining has been done in classic mode works for CSE as well. 
+*)
+
+let some x = Some x
+[@@inline]
+
+let f x =
+  let a = Some x in
+  let b = some x in
+  a, b
+
+let g x =
+  let a = some x in
+  let b = Some x in
+  a, b
+
+let f_classic x = (Cross_function_cse_a.f [@inlined]) x
+let g_classic x = (Cross_function_cse_a.g [@inlined]) x
+
+(* TEST
+   module = "cross_function_cse_a.ml";
+   flags = "-Oclassic";
+   ocamlopt.opt with dump-raw;
+   check-fexpr-dump;
+   module = "cross_function_cse_b.ml";
+   flags = "-O3";
+   ocamlopt.opt with dump-raw, dump-simplify;
+   check-fexpr-dump;
+*)

--- a/testsuite/tests/flambda2/examples/cross_function_cse_b.raw.reference
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_b.raw.reference
@@ -1,0 +1,78 @@
+let $camlCross_function_cse_b__first_const = Block 0 () in
+(let code inline(always) size(7)
+       some_0 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 | 0 of val ] =
+   let next_depth = rec_info (succ my_depth) in
+   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+   cont k1 (Pmakeblock)
+ in
+ let code size(19)
+       f_1 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+   let next_depth = rec_info (succ my_depth) in
+   let some = %project_value_slot.[f].[some] (my_closure) in
+   let a = %block.[`0`].my_alloc_region (x) in
+   apply direct(some_0 &my_alloc_region)
+     (some : _ -> [ 0 | 0 of val ]) (x) -> k3 * k2
+     where k3 (b : [ 0 | 0 of val ]) =
+       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
+       cont k1 (Pmakeblock)
+ in
+ let code size(19)
+       g_2 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+   let next_depth = rec_info (succ my_depth) in
+   let some = %project_value_slot.[g].[some_1] (my_closure) in
+   apply direct(some_0 &my_alloc_region)
+     (some : _ -> [ 0 | 0 of val ]) (x) -> k3 * k2
+     where k3 (a : [ 0 | 0 of val ]) =
+       let b = %block.[`0`].my_alloc_region (x) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
+       cont k1 (Pmakeblock)
+ in
+ let code size(7)
+       f_classic_3 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+   let next_depth = rec_info (succ my_depth) in
+   let Pfield =
+     %block_load.[`1`] ($Cross_function_cse_a.camlCross_function_cse_a)
+   in
+   apply &my_alloc_region inlined(always) Pfield (x) -> k1 * k2
+ in
+ let code size(7)
+       g_classic_4 (x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+   let next_depth = rec_info (succ my_depth) in
+   let Pfield =
+     %block_load.[`2`] ($Cross_function_cse_a.camlCross_function_cse_a)
+   in
+   apply &my_alloc_region inlined(always) Pfield (x) -> k1 * k2
+ in
+ let some = closure some_0 @some &toplevel.alloc_region in
+ let f = closure f_1 @f &toplevel.alloc_region with { some = some } in
+ let g = closure g_2 @g &toplevel.alloc_region with { some_1 = some } in
+ let f_classic = closure f_classic_3 @f_classic &toplevel.alloc_region in
+ let g_classic = closure g_classic_4 @g_classic &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (some, f, g, f_classic, g_classic)
+ in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`5`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`5`].[`2`] (module_block) in
+    let field_3 = %block_load.tag[`0`].`size`[`5`].[`3`] (module_block) in
+    let field_4 = %block_load.tag[`0`].`size`[`5`].[`4`] (module_block) in
+    let $camlCross_function_cse_b =
+      Block 0 (field_0, field_1, field_2, field_3, field_4)
+    in
+    cont done ($camlCross_function_cse_b)

--- a/testsuite/tests/flambda2/examples/cross_function_cse_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_b.simplify.reference
@@ -1,0 +1,70 @@
+let code some_0 deleted in
+let code f_1 deleted in
+let code g_2 deleted in
+let code f_classic_3 deleted in
+let code g_classic_4 deleted in
+let code inline(always) loopify(never) size(7) newer_version_of(some_0)
+      some_0_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 | 0 of val ] =
+  let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+  cont k (Pmakeblock)
+in
+let $camlCross_function_cse_b__some_5 =
+  closure some_0_1 @some &toplevel.alloc_region
+in
+let code loopify(never) size(14) newer_version_of(f_1)
+      f_1_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+  let a = %block.[`0`].my_alloc_region (x) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (a, a) in
+  cont k (Pmakeblock)
+in
+let $camlCross_function_cse_b__f_6 = closure f_1_1 @f &toplevel.alloc_region
+in
+let code loopify(never) size(14) newer_version_of(g_2)
+      g_2_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+  let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+  let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, Pmakeblock) in
+  cont k (Pmakeblock_1)
+in
+let $camlCross_function_cse_b__g_7 = closure g_2_1 @g &toplevel.alloc_region
+in
+let code loopify(never) size(14) newer_version_of(f_classic_3)
+      f_classic_3_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+  let a = %block.[`0`].my_alloc_region (x) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (a, a) in
+  cont k (Pmakeblock)
+in
+let $camlCross_function_cse_b__f_classic_8 =
+  closure f_classic_3_1 @f_classic &toplevel.alloc_region
+in
+let code loopify(never) size(14) newer_version_of(g_classic_4)
+      g_classic_4_1 (x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
+  let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+  let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, Pmakeblock) in
+  cont k (Pmakeblock_1)
+in
+let $camlCross_function_cse_b__g_classic_9 =
+  closure g_classic_4_1 @g_classic &toplevel.alloc_region
+in
+let $camlCross_function_cse_b =
+  Block 0 ($camlCross_function_cse_b__some_5,
+           $camlCross_function_cse_b__f_6,
+           $camlCross_function_cse_b__g_7,
+           $camlCross_function_cse_b__f_classic_8,
+           $camlCross_function_cse_b__g_classic_9)
+in
+cont done ($camlCross_function_cse_b)

--- a/testsuite/tests/flambda2/examples/cse_minus.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cse_minus.simplify.reference
@@ -1,18 +1,18 @@
-let $camlCse_minus__string17 = "index out of bounds" in
-let $camlCse_minus__block19 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlCse_minus__string17)
+let $camlCse_minus__string19 = "index out of bounds" in
+let $camlCse_minus__block21 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlCse_minus__string19)
 in
-let $camlCse_minus__immstring26 = "cse_minus.ml" in
-let $camlCse_minus__const_block28 =
-  Block 0 ($camlCse_minus__immstring26, 24, 2)
+let $camlCse_minus__immstring28 = "cse_minus.ml" in
+let $camlCse_minus__const_block30 =
+  Block 0 ($camlCse_minus__immstring28, 24, 2)
 in
-let $camlCse_minus__Pmakeblock31 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlCse_minus__const_block28)
+let $camlCse_minus__Pmakeblock33 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlCse_minus__const_block30)
 in
 let code f_0 deleted in
 let code loopify(never) size(43) newer_version_of(f_0)
       f_0_1 (table, table_1 : val array, c : imm tagged, min : imm tagged, t)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let int_sub = %int_barith.sub (c, min) in
@@ -26,16 +26,16 @@ let code loopify(never) size(43) newer_version_of(f_0)
        let Parrayrefs = %array_load.mut (table_1, int_sub_2) in
        let prim = %phys_eq (Parrayrefs, 0) in
        switch prim
-         | 0 -> k1 pop(regular k1) ($camlCse_minus__Pmakeblock31)
+         | 0 -> k1 pop(regular k1) ($camlCse_minus__Pmakeblock33)
          | 1 -> k2 (int_sub_2)
      where k3 =
-       cont k1 pop(regular k1) ($camlCse_minus__block19))
+       cont k1 pop(regular k1) ($camlCse_minus__block21))
     where k2 (int_sub) =
       let cse_param = int_sub in
-      let Pmakeblock = %block.[`0`] (t) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (t) in
       let Parraysets = %array_set (table_1, cse_param, Pmakeblock) in
       cont k (0)
 in
-let $camlCse_minus__f_1 = closure f_0_1 @f in
+let $camlCse_minus__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlCse_minus = Block 0 ($camlCse_minus__f_1) in
 cont done ($camlCse_minus)

--- a/testsuite/tests/flambda2/examples/cse_needing_canonicalisation.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cse_needing_canonicalisation.simplify.reference
@@ -1,14 +1,16 @@
 let code f_0 deleted in
 let code loopify(never) size(10) newer_version_of(f_0)
       f_0_1 (x : imm tagged, y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let a = %int_barith.add (x, y) in
-  let Pmakeblock = %block.[`0`] (a, a) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (a, a) in
   cont k (Pmakeblock)
 in
-let $camlCse_needing_canonicalisation__f_1 = closure f_0_1 @f in
+let $camlCse_needing_canonicalisation__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlCse_needing_canonicalisation =
   Block 0 ($camlCse_needing_canonicalisation__f_1)
 in

--- a/testsuite/tests/flambda2/examples/data_flow_rec_exn.simplify.reference
+++ b/testsuite/tests/flambda2/examples/data_flow_rec_exn.simplify.reference
@@ -1,22 +1,24 @@
-let $camlData_flow_rec_exn__immstring10 = "data_flow_rec_exn.ml" in
-let $camlData_flow_rec_exn__const_block12 =
-  Block 0 ($camlData_flow_rec_exn__immstring10, 9, 19)
+let $camlData_flow_rec_exn__immstring12 = "data_flow_rec_exn.ml" in
+let $camlData_flow_rec_exn__const_block14 =
+  Block 0 ($camlData_flow_rec_exn__immstring12, 9, 19)
 in
-let $camlData_flow_rec_exn__Pmakeblock15 =
+let $camlData_flow_rec_exn__Pmakeblock17 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlData_flow_rec_exn__const_block12)
+           $camlData_flow_rec_exn__const_block14)
 in
 let code do_stuff_0 deleted in
-let $camlData_flow_rec_exn__const_block55 = Block 0 (12) in
+let $camlData_flow_rec_exn__const_block58 = Block 0 (12) in
 let code stuff_1 deleted in
 let code loopify(never) size(3) newer_version_of(do_stuff_0)
-      do_stuff_0_1 (env) my_closure _region _ghost_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlData_flow_rec_exn__Pmakeblock15)
+      do_stuff_0_1 (env) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k1 pop(regular k1) ($camlData_flow_rec_exn__Pmakeblock17)
 in
-let $camlData_flow_rec_exn__do_stuff_2 = closure do_stuff_0_1 @do_stuff in
+let $camlData_flow_rec_exn__do_stuff_2 =
+  closure do_stuff_0_1 @do_stuff &toplevel.alloc_region
+in
 let code loopify(never) size(35) newer_version_of(stuff_1)
       stuff_1_1 (env)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -28,12 +30,12 @@ let code loopify(never) size(35) newer_version_of(stuff_1)
       (cont k6 push(k5)
          where k6 =
            let Popaque = %opaque ($camlData_flow_rec_exn__do_stuff_2) in
-           (apply Popaque (env) -> k7 * k5
+           (apply &my_alloc_region Popaque (env) -> k7 * k5
               where k7 (param) =
                 cont k6
               where k6 =
                 let Popaque_1 =
-                  %opaque ($camlData_flow_rec_exn__const_block55)
+                  %opaque ($camlData_flow_rec_exn__const_block58)
                 in
                 cont k4 pop(k5))
          where k5 exn (`exn` : val) =
@@ -54,7 +56,9 @@ let code loopify(never) size(35) newer_version_of(stuff_1)
       let unit_1 = %end_ghost_region (ghost_region) in
       cont k (0)
 in
-let $camlData_flow_rec_exn__stuff_3 = closure stuff_1_1 @stuff in
+let $camlData_flow_rec_exn__stuff_3 =
+  closure stuff_1_1 @stuff &toplevel.alloc_region
+in
 let $camlData_flow_rec_exn =
   Block 0 ($camlData_flow_rec_exn__do_stuff_2,
            $camlData_flow_rec_exn__stuff_3)

--- a/testsuite/tests/flambda2/examples/deep_try_with.simplify.reference
+++ b/testsuite/tests/flambda2/examples/deep_try_with.simplify.reference
@@ -1,18 +1,18 @@
-let $camlDeep_try_with__immstring11 = "Deep_try_with.E2" in
-let $camlDeep_try_with__immstring6 = "Deep_try_with.E1" in
+let $camlDeep_try_with__immstring12 = "Deep_try_with.E2" in
+let $camlDeep_try_with__immstring7 = "Deep_try_with.E1" in
 apply ccall noalloc
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
-    let $camlDeep_try_with__E153 =
+    let $camlDeep_try_with__E154 =
       Block immutable_unique
-      248 ($camlDeep_try_with__immstring6, Pccall)
+      248 ($camlDeep_try_with__immstring7, Pccall)
     in
     (apply ccall noalloc
        ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
        where k (Pccall_1) =
-         let $camlDeep_try_with__E255 =
+         let $camlDeep_try_with__E256 =
            Block immutable_unique
-           248 ($camlDeep_try_with__immstring11, Pccall_1)
+           248 ($camlDeep_try_with__immstring12, Pccall_1)
          in
          ((let try_region = %begin_try_region () in
            let try_ghost_region = %begin_try_ghost_region () in
@@ -24,13 +24,13 @@ apply ccall noalloc
                 | 0 -> k (0, 1)
                 | 1 -> k3)
                where k3 =
-                 let Popaque_1 = %opaque ($camlDeep_try_with__E153) in
+                 let Popaque_1 = %opaque ($camlDeep_try_with__E154) in
                  cont k2 (Popaque_1))
               where k2 (Popaque) =
                 let `exn` = Popaque in
                 let `unit` = %end_try_region (try_region_1) in
                 let unit_1 = %end_try_ghost_region (try_ghost_region_1) in
-                let prim = %phys_eq (`exn`, $camlDeep_try_with__E153) in
+                let prim = %phys_eq (`exn`, $camlDeep_try_with__E154) in
                 (switch prim
                    | 0 -> k1 (`exn`)
                    | 1 -> k2
@@ -41,13 +41,13 @@ apply ccall noalloc
                          | 0 -> k (2, 3)
                          | 1 -> k2)
                         where k2 =
-                          let Popaque_2 = %opaque ($camlDeep_try_with__E255)
+                          let Popaque_2 = %opaque ($camlDeep_try_with__E256)
                           in
                           cont k1 (Popaque_2))))
              where k1 (`exn` : val) =
                let `unit` = %end_try_region (try_region) in
                let unit_1 = %end_try_ghost_region (try_ghost_region) in
-               let prim = %phys_eq (`exn`, $camlDeep_try_with__E255) in
+               let prim = %phys_eq (`exn`, $camlDeep_try_with__E256) in
                switch prim
                  | 0 -> error pop(reraise error) (`exn`)
                  | 1 -> k (4, 5))
@@ -55,6 +55,6 @@ apply ccall noalloc
               let int_add = %int_barith.add (x, y) in
               let Popaque = %opaque (int_add) in
               let $camlDeep_try_with =
-                Block 0 ($camlDeep_try_with__E153, $camlDeep_try_with__E255)
+                Block 0 ($camlDeep_try_with__E154, $camlDeep_try_with__E256)
               in
               cont done ($camlDeep_try_with)))

--- a/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
@@ -1,27 +1,27 @@
 let code aux_1 deleted in
 let code foobar_0 deleted in
-let env = %block.mut.[`0`] (42) in
+let env = %block.mut.[`0`].`toplevel` (42) in
 let env_1 = env in
 let set_of_closures
       $camlDeleted_code_printing__foobar_2 =
-      closure foobar_0_1 @foobar
+      closure foobar_0_1 @foobar &toplevel.alloc_region
       with { env = env }
     end
 and code loopify(never) size(4) newer_version_of(foobar_0)
       foobar_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(aux_1_1)
+  apply direct(aux_1_1 &my_alloc_region)
     ($camlDeleted_code_printing__aux_3 : _ -> imm tagged) (0) -> k * k1
 and set_of_closures
       $camlDeleted_code_printing__aux_3 =
-      closure aux_1_1 @aux
+      closure aux_1_1 @aux &toplevel.alloc_region
       with { env_1 = env_1 }
     end
 and code loopify(done) size(15) newer_version_of(aux_1)
       aux_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self`

--- a/testsuite/tests/flambda2/examples/direct_app_parameter_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/direct_app_parameter_kind_check_simplify.simplify.reference
@@ -2,7 +2,7 @@ let code send_0 deleted in
 let code create_1 deleted in
 let code loopify(never) size(21) newer_version_of(send_0)
       send_0_1 (t : val, c : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `*match*` = %block_load.mut.[`0`] (t) in
@@ -14,21 +14,21 @@ let code loopify(never) size(21) newer_version_of(send_0)
       let `*match*_1` = %block_load.[`0`] (`*match*`) in
       let Pfield = %block_load.[`1`] (`*match*_1`) in
       let Pfield_1 = %block_load.[`0`] (`*match*_1`) in
-      apply c (Pfield_1, Pfield) -> k * k1
+      apply &my_alloc_region c (Pfield_1, Pfield) -> k * k1
 in
 let $camlDirect_app_parameter_kind_check_simplify__send_3 =
-  closure send_0_1 @send
+  closure send_0_1 @send &toplevel.alloc_region
 in
 let code loopify(never) size(7) newer_version_of(create_1)
       create_1_1 (_arity : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  let Pmakeblock = %block.mut.[`0`] (0) in
+  let Pmakeblock = %block.mut.[`0`].my_alloc_region (0) in
   cont k (Pmakeblock)
 in
 let $camlDirect_app_parameter_kind_check_simplify__create_4 =
-  closure create_1_1 @create
+  closure create_1_1 @create &toplevel.alloc_region
 in
 (let Pmakeblock_0 = 0 in
  let `*match*` = Pmakeblock_0 in
@@ -37,7 +37,7 @@ in
    | 0 -> k1
    | 1 -> k
    where k1 =
-     invalid "(Direct_application_parameter_kind_mismatch\n (params_arity #(\240\157\149\141? \226\168\175 \240\157\149\141?)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (apply_expr\n  (((Some\n    Direct_app_parameter_kind_check_simplify.camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_5)\227\128\136k28\227\128\137\227\128\138k2\227\128\139(Pfield/85N\n    Pfield/84N)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call\n      (Direct camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_2_5_code))))\n   (alloc_mode Heap)\n   (dbg\n    direct_app_parameter_kind_check_simplify.ml:26,9--38;direct_app_parameter_kind_check_simplify.ml:21,32--43)\n   (inline Default_inlined) (inlining_state (depth 10, arguments O3))\n   (probe ()) (position Normal))))")
+     invalid "(Direct_application_parameter_kind_mismatch\n (params_arity #(\240\157\149\141? \226\168\175 \240\157\149\141?)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (apply_expr\n  (((Some\n    Direct_app_parameter_kind_check_simplify.camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_5)\227\128\136k28\227\128\137\227\128\138k2\227\128\139(Pfield/94N\n    Pfield/93N)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call\n      (Direct camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_2_5_code))))\n   (alloc_mode (Heap (alloc toplevel_my_alloc_region/2N)))\n   (dbg\n    direct_app_parameter_kind_check_simplify.ml:26,9--38;direct_app_parameter_kind_check_simplify.ml:21,32--43)\n   (inline Default_inlined) (inlining_state (depth 10, arguments O3))\n   (probe ()) (position Normal))))")
   where k =
     let $camlDirect_app_parameter_kind_check_simplify =
       Block 0 (0,

--- a/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
+++ b/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
@@ -1,17 +1,19 @@
-let $camlExn_extra_args__immstring9 = "bar" in
+let $camlExn_extra_args__immstring11 = "bar" in
 let code input_line_0 deleted in
 let code ld_conf_contents_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(input_line_0)
       input_line_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  cont k ($camlExn_extra_args__immstring9)
+  cont k ($camlExn_extra_args__immstring11)
 in
-let $camlExn_extra_args__input_line_2 = closure input_line_0_1 @input_line in
+let $camlExn_extra_args__input_line_2 =
+  closure input_line_0_1 @input_line &toplevel.alloc_region
+in
 let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
       ld_conf_contents_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let try_region = %begin_try_region () in
@@ -25,12 +27,13 @@ let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
                       (path_unboxed0 :
                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
             let path_unboxed0_1 = path_unboxed0 in
-            (apply direct(input_line_0_1)
+            (apply direct(input_line_0_1 &my_alloc_region)
                ($camlExn_extra_args__input_line_2 : _ -> val)
                  (0)
                  -> k7 * k5 (path_unboxed0 val)
                where k7 (return_val0 : val) =
-                 let Pmakeblock = %block.[`0`] (return_val0, path_unboxed0)
+                 let Pmakeblock =
+                   %block.[`0`].my_alloc_region (return_val0, path_unboxed0)
                  in
                  cont k6 (Pmakeblock)))
      where k5 exn (`exn` : val, path_unboxed0) =
@@ -39,12 +42,12 @@ let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
        let unit_1 = %end_try_ghost_region (try_ghost_region_1) in
        let prim = %phys_eq (`exn`, $`*predef*`.caml_exn_End_of_file) in
        switch prim
-         | 0 -> k3 (path_unboxed0, `exn`)
+         | 0 -> k3 (`exn`, path_unboxed0)
          | 1 -> k4 (path_unboxed0))
     where k4 (path_unboxed0) =
       let path_unboxed0_1 = path_unboxed0 in
       cont k2 (path_unboxed0)
-    where k3 (path_unboxed0, `exn`) =
+    where k3 (`exn`, path_unboxed0) =
       let exn_1 = `exn` in
       let path_unboxed0_1 = path_unboxed0 in
       let `unit` = %end_try_region (try_region) in
@@ -59,7 +62,7 @@ let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
       cont k (path_unboxed0_1)
 in
 let $camlExn_extra_args__ld_conf_contents_3 =
-  closure ld_conf_contents_1_1 @ld_conf_contents
+  closure ld_conf_contents_1_1 @ld_conf_contents &toplevel.alloc_region
 in
 let $camlExn_extra_args =
   Block 0 ($camlExn_extra_args__input_line_2,

--- a/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
+++ b/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(31) newer_version_of(f_0)
       f_0_1 (x : imm tagged, init : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.le (0, x) in
@@ -25,7 +25,9 @@ let code loopify(never) size(31) newer_version_of(f_0)
              | 0 -> k (int_add)
              | 1 -> k2 (for_next_naked, int_add))
 in
-let $camlExtra_args_and_staticraise__f_1 = closure f_0_1 @f in
+let $camlExtra_args_and_staticraise__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlExtra_args_and_staticraise =
   Block 0 ($camlExtra_args_and_staticraise__f_1)
 in

--- a/testsuite/tests/flambda2/examples/float_and_int_mix.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_and_int_mix.simplify.reference
@@ -1,30 +1,32 @@
 let code read_int_0 deleted in
-let $camlFloat_and_int_mix__float16 = 0x0p+0 in
+let $camlFloat_and_int_mix__float19 = 0x0p+0 in
 let code gasp_in_horror_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(read_int_0)
       read_int_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (42)
 in
-let $camlFloat_and_int_mix__read_int_2 = closure read_int_0_1 @read_int in
+let $camlFloat_and_int_mix__read_int_2 =
+  closure read_int_0_1 @read_int &toplevel.alloc_region
+in
 let code loopify(never) size(15) newer_version_of(gasp_in_horror_1)
       gasp_in_horror_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Popaque = %opaque (1) in
   (let untagged = %untag_imm (Popaque) in
    switch untagged
-     | 0 -> k ($camlFloat_and_int_mix__float16)
+     | 0 -> k ($camlFloat_and_int_mix__float19)
      | 1 -> k2)
     where k2 =
-      apply direct(read_int_0_1)
+      apply direct(read_int_0_1 &my_alloc_region)
         ($camlFloat_and_int_mix__read_int_2 : _ -> imm tagged) (0) -> k * k1
 in
 let $camlFloat_and_int_mix__gasp_in_horror_3 =
-  closure gasp_in_horror_1_1 @gasp_in_horror
+  closure gasp_in_horror_1_1 @gasp_in_horror &toplevel.alloc_region
 in
 let $camlFloat_and_int_mix =
   Block 0 ($camlFloat_and_int_mix__read_int_2,

--- a/testsuite/tests/flambda2/examples/float_fn.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_fn.simplify.reference
@@ -2,27 +2,28 @@ let code g_0 deleted in
 let code f_1 deleted in
 let code inline(never) loopify(never) size(9) newer_version_of(g_0)
       g_0_1 (x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let prim = %unbox_num.`float` (x) in
   let prim_1 = %bfloat_arith.add (prim, 0x1.5p+5) in
-  let float_add = %box_num.`float` (prim_1) in
+  let float_add = %box_num.`float`.my_alloc_region (prim_1) in
   cont k (float_add)
 in
-let $camlFloat_fn__g_2 = closure g_0_1 @g in
+let $camlFloat_fn__g_2 = closure g_0_1 @g &toplevel.alloc_region in
 let code loopify(never) size(13) newer_version_of(f_1)
       f_1_1 (b, x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  apply direct(g_0_1) ($camlFloat_fn__g_2 : _ -> float boxed) (x) -> k2 * k1
+  apply direct(g_0_1 &my_alloc_region)
+    ($camlFloat_fn__g_2 : _ -> float boxed) (x) -> k2 * k1
     where k2 (y : float boxed) =
       let prim = %unbox_num.`float` (y) in
       let prim_1 = %bfloat_arith.add (prim, 0x0p+0) in
-      let float_add = %box_num.`float` (prim_1) in
+      let float_add = %box_num.`float`.my_alloc_region (prim_1) in
       cont k (float_add)
 in
-let $camlFloat_fn__f_3 = closure f_1_1 @f in
+let $camlFloat_fn__f_3 = closure f_1_1 @f &toplevel.alloc_region in
 let $camlFloat_fn = Block 0 ($camlFloat_fn__g_2, $camlFloat_fn__f_3) in
 cont done ($camlFloat_fn)

--- a/testsuite/tests/flambda2/examples/float_fn_tuple.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_fn_tuple.simplify.reference
@@ -2,24 +2,24 @@ let code g_0 deleted in
 let code f_1 deleted in
 let code inline(never) loopify(never) size(23) newer_version_of(g_0)
       g_0_1 (x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of float boxed * float boxed ] =
   let prim = %unbox_num.`float` (x) in
   let prim_1 = %bfloat_arith.add (prim, 0x1p+0) in
-  let float_add = %box_num.`float` (prim_1) in
+  let float_add = %box_num.`float`.my_alloc_region (prim_1) in
   let prim_2 = %bfloat_arith.add (prim, 0x1.5p+5) in
-  let float_add_1 = %box_num.`float` (prim_2) in
-  let Pmakeblock = %block.[`0`] (float_add_1, float_add) in
+  let float_add_1 = %box_num.`float`.my_alloc_region (prim_2) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (float_add_1, float_add) in
   cont k (Pmakeblock)
 in
-let $camlFloat_fn_tuple__g_2 = closure g_0_1 @g in
+let $camlFloat_fn_tuple__g_2 = closure g_0_1 @g &toplevel.alloc_region in
 let code loopify(never) size(16) newer_version_of(f_1)
       f_1_1 (b, x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  apply direct(g_0_1)
+  apply direct(g_0_1 &my_alloc_region)
     ($camlFloat_fn_tuple__g_2 : _ -> [ 0 of float boxed * float boxed ])
       (x)
       -> k2 * k1
@@ -29,10 +29,10 @@ let code loopify(never) size(16) newer_version_of(f_1)
       let prim = %unbox_num.`float` (Pfield) in
       let prim_1 = %unbox_num.`float` (Pfield_1) in
       let prim_2 = %bfloat_arith.add (prim_1, prim) in
-      let float_add = %box_num.`float` (prim_2) in
+      let float_add = %box_num.`float`.my_alloc_region (prim_2) in
       cont k (float_add)
 in
-let $camlFloat_fn_tuple__f_3 = closure f_1_1 @f in
+let $camlFloat_fn_tuple__f_3 = closure f_1_1 @f &toplevel.alloc_region in
 let $camlFloat_fn_tuple =
   Block 0 ($camlFloat_fn_tuple__g_2, $camlFloat_fn_tuple__f_3)
 in

--- a/testsuite/tests/flambda2/examples/float_tuple.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_tuple.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(29) newer_version_of(f_0)
       f_0_1 (b : imm tagged, x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let untagged = %untag_imm (b) in
@@ -19,9 +19,9 @@ let code loopify(never) size(29) newer_version_of(f_0)
       cont k2 (prim_1, prim_2)
     where k2 (unboxed_float : float, unboxed_float_1 : float) =
       let prim = %bfloat_arith.add (unboxed_float_1, unboxed_float) in
-      let float_add = %box_num.`float` (prim) in
+      let float_add = %box_num.`float`.my_alloc_region (prim) in
       cont k (float_add)
 in
-let $camlFloat_tuple__f_1 = closure f_0_1 @f in
+let $camlFloat_tuple__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlFloat_tuple = Block 0 ($camlFloat_tuple__f_1) in
 cont done ($camlFloat_tuple)

--- a/testsuite/tests/flambda2/examples/float_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxed.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(27) newer_version_of(f_0)
       f_0_1 (b : imm tagged, x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let untagged = %untag_imm (b) in
@@ -18,9 +18,9 @@ let code loopify(never) size(27) newer_version_of(f_0)
       cont k2 (prim_1)
     where k2 (unboxed_float : float) =
       let prim = %bfloat_arith.add (unboxed_float, 0x0p+0) in
-      let float_add = %box_num.`float` (prim) in
+      let float_add = %box_num.`float`.my_alloc_region (prim) in
       cont k (float_add)
 in
-let $camlFloat_unboxed__f_1 = closure f_0_1 @f in
+let $camlFloat_unboxed__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlFloat_unboxed = Block 0 ($camlFloat_unboxed__f_1) in
 cont done ($camlFloat_unboxed)

--- a/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(44) newer_version_of(f_0)
       f_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   cont k3 (1L, 0x0p+0)
@@ -21,7 +21,7 @@ let code loopify(never) size(44) newer_version_of(f_0)
            let unboxed_float_2 = unboxed_float in
            let prim_2 = %bfloat_arith.add (unboxed_float_2, unboxed_float_1)
            in
-           let float_add = %box_num.`float` (prim_2) in
+           let float_add = %box_num.`float`.my_alloc_region (prim_2) in
            let for_next_naked =
              %int_barith.`int64`.add (for_counter_naked, 1L)
            in
@@ -33,8 +33,8 @@ let code loopify(never) size(44) newer_version_of(f_0)
       let r_unboxed0 = float_add in
       cont k (r_unboxed0)
 in
-let $camlFloat_unboxing__f_1 = closure f_0_1 @f in
-let $camlFloat_unboxing__Pmakeblock120 = Block 0 ($camlFloat_unboxing__f_1)
+let $camlFloat_unboxing__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let $camlFloat_unboxing__Pmakeblock123 = Block 0 ($camlFloat_unboxing__f_1)
 in
-let $camlFloat_unboxing = Block 0 ($camlFloat_unboxing__Pmakeblock120) in
+let $camlFloat_unboxing = Block 0 ($camlFloat_unboxing__Pmakeblock123) in
 cont done ($camlFloat_unboxing)

--- a/testsuite/tests/flambda2/examples/float_unboxing_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxing_rec.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(41) newer_version_of(f_0)
       f_0_1 (n : imm tagged, x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let prim = %int_comp.le (0, n) in
@@ -30,9 +30,9 @@ let code loopify(never) size(41) newer_version_of(f_0)
               | 1 -> k3 (for_next_naked, prim_3)))
     where k2 (unboxed_float : float) =
       let prim = %bfloat_arith.add (unboxed_float, 0x0p+0) in
-      let float_add = %box_num.`float` (prim) in
+      let float_add = %box_num.`float`.my_alloc_region (prim) in
       cont k (float_add)
 in
-let $camlFloat_unboxing_rec__f_1 = closure f_0_1 @f in
+let $camlFloat_unboxing_rec__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlFloat_unboxing_rec = Block 0 ($camlFloat_unboxing_rec__f_1) in
 cont done ($camlFloat_unboxing_rec)

--- a/testsuite/tests/flambda2/examples/from_core_char_test.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_core_char_test.simplify.reference
@@ -1,32 +1,32 @@
-let $camlFrom_core_char_test__string18 = "index out of bounds" in
-let $camlFrom_core_char_test__block20 =
+let $camlFrom_core_char_test__string20 = "index out of bounds" in
+let $camlFrom_core_char_test__block22 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument,
-           $camlFrom_core_char_test__string18)
+           $camlFrom_core_char_test__string20)
 in
-let $camlFrom_core_char_test__immstring26 = "from_core_char_test.ml" in
-let $camlFrom_core_char_test__const_block28 =
-  Block 0 ($camlFrom_core_char_test__immstring26, 24, 56)
+let $camlFrom_core_char_test__immstring28 = "from_core_char_test.ml" in
+let $camlFrom_core_char_test__const_block30 =
+  Block 0 ($camlFrom_core_char_test__immstring28, 24, 56)
 in
-let $camlFrom_core_char_test__Pmakeblock31 =
+let $camlFrom_core_char_test__Pmakeblock33 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlFrom_core_char_test__const_block28)
+           $camlFrom_core_char_test__const_block30)
 in
 let code char_of_string_0 deleted in
 let code result_is_error_1 deleted in
 let code result_try_with_2 deleted in
-let $camlFrom_core_char_test__immstring64 = "c" in
+let $camlFrom_core_char_test__immstring69 = "c" in
 let code test_3 deleted in
-let $camlFrom_core_char_test__const_block87 =
-  Block 0 ($camlFrom_core_char_test__immstring26, 35, 35)
+let $camlFrom_core_char_test__const_block94 =
+  Block 0 ($camlFrom_core_char_test__immstring28, 35, 35)
 in
-let $camlFrom_core_char_test__Pmakeblock90 =
+let $camlFrom_core_char_test__Pmakeblock97 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlFrom_core_char_test__const_block87)
+           $camlFrom_core_char_test__const_block94)
 in
 let code top_5 deleted in
 let code inline(always) loopify(never) size(40) newer_version_of(char_of_string_0)
       char_of_string_0_1 (s : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %string_length (s) in
@@ -34,7 +34,7 @@ let code inline(always) loopify(never) size(40) newer_version_of(char_of_string_
   let prim_1 = %int_comp.ne (`*match*`, 1) in
   switch prim_1
     | 0 -> k2
-    | 1 -> k1 pop(regular k1) ($camlFrom_core_char_test__Pmakeblock31)
+    | 1 -> k1 pop(regular k1) ($camlFrom_core_char_test__Pmakeblock33)
     where k2 =
       ((let prim_2 = %num_conv.[`imm`].[`nativeint`] (prim) in
         let prim_3 = %int_comp.`nativeint`.unsigned.lt (0n, prim_2) in
@@ -46,14 +46,14 @@ let code inline(always) loopify(never) size(40) newer_version_of(char_of_string_
            let Pstringrefs = %tag_imm (prim_2) in
            cont k (Pstringrefs)
          where k2 =
-           cont k1 pop(regular k1) ($camlFrom_core_char_test__block20))
+           cont k1 pop(regular k1) ($camlFrom_core_char_test__block22))
 in
 let $camlFrom_core_char_test__char_of_string_6 =
-  closure char_of_string_0_1 @char_of_string
+  closure char_of_string_0_1 @char_of_string &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(5) newer_version_of(result_is_error_1)
       result_is_error_1_1 (r : [ 0 of val |1 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %get_tag (r) in
@@ -61,36 +61,36 @@ let code inline(always) loopify(never) size(5) newer_version_of(result_is_error_
   cont k (tagged_scrutinee)
 in
 let $camlFrom_core_char_test__result_is_error_7 =
-  closure result_is_error_1_1 @result_is_error
+  closure result_is_error_1_1 @result_is_error &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(29) newer_version_of(result_try_with_2)
       result_try_with_2_1 (f : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val |1 of val ] =
   let try_region = %begin_try_region () in
   let try_ghost_region = %begin_try_ghost_region () in
   cont k3 push(k2)
     where k3 =
-      (apply f (0) -> k3 * k2
+      (apply &my_alloc_region f (0) -> k3 * k2
          where k3 (apply_result : val) =
-           let Pmakeblock = %block.[`0`] (apply_result) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (apply_result) in
            cont k pop(k2) (Pmakeblock))
     where k2 exn (`exn` : val) =
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
-      let Pmakeblock = %block.[`1`] (`exn`) in
+      let Pmakeblock = %block.[`1`].my_alloc_region (`exn`) in
       cont k (Pmakeblock)
 in
 let $camlFrom_core_char_test__result_try_with_8 =
-  closure result_try_with_2_1 @result_try_with
+  closure result_try_with_2_1 @result_try_with &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(20) newer_version_of(test_3)
       test_3_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let prim = %string_load.[`8`] ($camlFrom_core_char_test__immstring64, 0n)
+  let prim = %string_load.[`8`] ($camlFrom_core_char_test__immstring69, 0n)
   in
   let Pstringrefs = %tag_imm (prim) in
   let prim_1 = %phys_eq (Pstringrefs, 99) in
@@ -104,13 +104,15 @@ let code inline(always) loopify(never) size(20) newer_version_of(test_3)
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       cont k (1)
 in
-let $camlFrom_core_char_test__test_9 = closure test_3_1 @test in
+let $camlFrom_core_char_test__test_9 =
+  closure test_3_1 @test &toplevel.alloc_region
+in
 let code loopify(never) size(30) newer_version_of(top_5)
       top_5_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  (let prim = %string_load.[`8`] ($camlFrom_core_char_test__immstring64, 0n)
+  (let prim = %string_load.[`8`] ($camlFrom_core_char_test__immstring69, 0n)
    in
    let Pstringrefs = %tag_imm (prim) in
    let prim_1 = %phys_eq (Pstringrefs, 99) in
@@ -125,10 +127,12 @@ let code loopify(never) size(30) newer_version_of(top_5)
        cont k2 (1i))
     where k2 (naked_immediate : imm) =
       switch naked_immediate
-        | 0 -> k1 pop(regular k1) ($camlFrom_core_char_test__Pmakeblock90)
+        | 0 -> k1 pop(regular k1) ($camlFrom_core_char_test__Pmakeblock97)
         | 1 -> k (0)
 in
-let $camlFrom_core_char_test__top_11 = closure top_5_1 @top in
+let $camlFrom_core_char_test__top_11 =
+  closure top_5_1 @top &toplevel.alloc_region
+in
 let $camlFrom_core_char_test =
   Block 0 ($camlFrom_core_char_test__char_of_string_6,
            $camlFrom_core_char_test__result_is_error_7,

--- a/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
@@ -1,41 +1,41 @@
 let code `!_0` deleted in
 let code foo_1 deleted in
-let $camlFrom_odoc_texi__immstring23 = "b" in
-let $camlFrom_odoc_texi__immstring21 = "a" in
+let $camlFrom_odoc_texi__immstring26 = "b" in
+let $camlFrom_odoc_texi__immstring24 = "a" in
 let code loopify(never) size(2) newer_version_of(`!_0`)
       `!_0_1` (param : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   let Pfield = %block_load.mut.[`0`] (param) in
   cont k (Pfield)
 in
-let $`camlFrom_odoc_texi__!_2` = closure `!_0_1` @`!` in
-let esc_8bits = %block.mut.[`0`] (0) in
+let $`camlFrom_odoc_texi__!_2` = closure `!_0_1` @`!` &toplevel.alloc_region
+in
+let esc_8bits = %block.mut.[`0`].`toplevel` (0) in
 let code inline(never) loopify(never) size(1) newer_version_of(foo_1)
-      foo_1_1 (x : val)
-        my_closure _region _ghost_region my_depth
-        -> k * k1
-        : val =
+      foo_1_1 (x : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
   let Popaque = %opaque (x) in
   cont k (Popaque)
 in
-let $camlFrom_odoc_texi__foo_3 = closure foo_1_1 @foo in
+let $camlFrom_odoc_texi__foo_3 = closure foo_1_1 @foo &toplevel.alloc_region
+in
 (let Pfield = %block_load.mut.[`0`] (esc_8bits) in
  (let untagged = %untag_imm (Pfield) in
   switch untagged
     | 0 -> k (0)
     | 1 -> k1)
    where k1 =
-     (apply direct(foo_1_1)
+     (apply direct(foo_1_1 &toplevel.alloc_region)
         ($camlFrom_odoc_texi__foo_3 : _ -> val)
-          ($camlFrom_odoc_texi__immstring21)
+          ($camlFrom_odoc_texi__immstring24)
           -> k1 * error
         where k1 (apply_result : val) =
           let Pmakeblock =
-            %block.[`0`] (apply_result, $camlFrom_odoc_texi__immstring23)
+            %block.[`0`].`toplevel`
+              (apply_result, $camlFrom_odoc_texi__immstring26)
           in
-          let Pmakeblock_1 = %block.[`0`] (Pmakeblock, 0) in
+          let Pmakeblock_1 = %block.[`0`].`toplevel` (Pmakeblock, 0) in
           cont k (Pmakeblock_1)))
   where k (y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
     let $camlFrom_odoc_texi =

--- a/testsuite/tests/flambda2/examples/function_never_returns.simplify.reference
+++ b/testsuite/tests/flambda2/examples/function_never_returns.simplify.reference
@@ -3,30 +3,36 @@ let code foo_1 deleted in
 let code bar_2 deleted in
 let code inline(never) loopify(never) size(3) newer_version_of(f_0)
       f_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1434)
+  cont k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1554)
 in
-let $camlFunction_never_returns__f_3 = closure f_0_1 @f in
+let $camlFunction_never_returns__f_3 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(foo_1)
       foo_1_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1)
+  apply direct(f_0_1 &my_alloc_region)
     ($camlFunction_never_returns__f_3 : _ -> imm tagged) (0) -> never * k1
 in
-let $camlFunction_never_returns__foo_4 = closure foo_1_1 @foo in
+let $camlFunction_never_returns__foo_4 =
+  closure foo_1_1 @foo &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(bar_2)
       bar_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1) inlining_state(depth(1))
+  apply direct(f_0_1 &my_alloc_region) inlining_state(depth(1))
     ($camlFunction_never_returns__f_3 : _ -> imm tagged) (0) -> never * k1
 in
-let $camlFunction_never_returns__bar_5 = closure bar_2_1 @bar in
+let $camlFunction_never_returns__bar_5 =
+  closure bar_2_1 @bar &toplevel.alloc_region
+in
 let $camlFunction_never_returns =
   Block 0 ($camlFunction_never_returns__f_3,
            $camlFunction_never_returns__foo_4,

--- a/testsuite/tests/flambda2/examples/functor_call.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functor_call.simplify.reference
@@ -1,18 +1,19 @@
 let code test_3 deleted in
 let code inline(always) loopify(never) size(5) newer_version_of(test_3)
       test_3_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.gt (x, 0) in
   let int_greaterthan = %tag_imm (prim) in
   cont k (int_greaterthan)
 in
-let $camlFunctor_call__test_4 = closure test_3_1 @test in
-let $camlFunctor_call__Pmakeblock133 = Block 0 ($camlFunctor_call__test_4) in
+let $camlFunctor_call__test_4 = closure test_3_1 @test &toplevel.alloc_region
+in
+let $camlFunctor_call__Pmakeblock147 = Block 0 ($camlFunctor_call__test_4) in
 let code loopify(done) size(16) newer_version_of(foo_1_1)
       foo_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (x)
@@ -26,10 +27,10 @@ let code loopify(done) size(16) newer_version_of(foo_1_1)
            cont `self` (int_add))
 in
 let $camlFunctor_call__foo_5 =
-  closure foo_1 @foo
-  with { X = $camlFunctor_call__Pmakeblock133 }
+  closure foo_1 @foo &toplevel.alloc_region
+  with { X = $camlFunctor_call__Pmakeblock147 }
 in
 let $camlFunctor_call =
-  Block 0 ($camlFunctor_call__Pmakeblock133, $camlFunctor_call__foo_5)
+  Block 0 ($camlFunctor_call__Pmakeblock147, $camlFunctor_call__foo_5)
 in
 cont done ($camlFunctor_call)

--- a/testsuite/tests/flambda2/examples/functors.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functors.simplify.reference
@@ -2,26 +2,26 @@ let code na_1 deleted in
 let code foo_2 deleted in
 let code Make_0 deleted in
 let code foo_3 deleted in
-let $camlFunctors__immstring7 = "functors.ml" in
-let $camlFunctors__const_block18 = Block 0 ($camlFunctors__immstring7, 23, 6)
+let $camlFunctors__immstring8 = "functors.ml" in
+let $camlFunctors__const_block19 = Block 0 ($camlFunctors__immstring8, 23, 6)
 in
-let $camlFunctors__const_block11 = Block 0 (0) in
-let $camlFunctors__const_block13 = Block 0 ($camlFunctors__const_block11) in
-let $camlFunctors__const_block9 = Block 0 ($camlFunctors__immstring7, 13, 6)
+let $camlFunctors__const_block12 = Block 0 (0) in
+let $camlFunctors__const_block14 = Block 0 ($camlFunctors__const_block12) in
+let $camlFunctors__const_block10 = Block 0 ($camlFunctors__immstring8, 13, 6)
 in
-apply direct(init_mod_4)
+apply direct(init_mod_4 &toplevel.alloc_region)
   ($CamlinternalMod.camlCamlinternalMod__init_mod_10 : _ -> val)
-    ($camlFunctors__const_block9, $camlFunctors__const_block13)
+    ($camlFunctors__const_block10, $camlFunctors__const_block14)
     -> k * error
   where k (M0 : val) =
-    (apply direct(init_mod_4)
+    (apply direct(init_mod_4 &toplevel.alloc_region)
        ($CamlinternalMod.camlCamlinternalMod__init_mod_10 : _ -> val)
-         ($camlFunctors__const_block18, $camlFunctors__const_block13)
+         ($camlFunctors__const_block19, $camlFunctors__const_block14)
          -> k * error
        where k (M : val) =
          let code loopify(never) size(27) newer_version_of(foo_2)
                foo_2_1 (_i, t : [ 0 | 0 of val ])
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : [ 0 | 0 of val ] =
            let X = %project_value_slot.[foo].[X] (my_closure) in
@@ -32,73 +32,80 @@ apply direct(init_mod_4)
              where k2 =
                ((let Pfield = %block_load.[`0`] (t) in
                  let Pfield_1 = %block_load.[`0`] (X) in
-                 apply Pfield_1 (Pfield) -> k2 * k1)
+                 apply &my_alloc_region Pfield_1 (Pfield) -> k2 * k1)
                   where k2 (apply_result : val) =
-                    let Pmakeblock = %block.[`0`] (apply_result) in
+                    let Pmakeblock =
+                      %block.[`0`].my_alloc_region (apply_result)
+                    in
                     cont k (Pmakeblock))
          in
          let code loopify(never) size(7) newer_version_of(na_1)
                na_1_1 (x : val)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : [ 0 | 0 of val ] =
-           let Pmakeblock = %block.[`0`] (x) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (x) in
            cont k (Pmakeblock)
          in
-         let $camlFunctors__na_5 = closure na_1_1 @na in
+         let $camlFunctors__na_5 = closure na_1_1 @na &toplevel.alloc_region
+         in
          let code loopify(never) size(45) newer_version_of(Make_0)
                Make_0_1 (X : val)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : val =
-           let foo = closure foo_2_1 @foo with { X = X } in
-           let Pmakeblock = %block.[`0`] (0, $camlFunctors__na_5, foo) in
+           let foo = closure foo_2_1 @foo &my_alloc_region with { X = X } in
+           let Pmakeblock =
+             %block.[`0`].my_alloc_region (0, $camlFunctors__na_5, foo)
+           in
            cont k (Pmakeblock)
          in
-         let $camlFunctors__Make_4 = closure Make_0_1 @Make in
-         let $camlFunctors__Pmakeblock105 = Block 0 ($camlFunctors__Make_4)
+         let $camlFunctors__Make_4 =
+           closure Make_0_1 @Make &toplevel.alloc_region
+         in
+         let $camlFunctors__Pmakeblock113 = Block 0 ($camlFunctors__Make_4)
          in
          ((let $camlFunctors__foo_6 =
-             closure foo_3_1 @foo_1
+             closure foo_3_1 @foo_1 &toplevel.alloc_region
            and code loopify(never) size(8) newer_version_of(foo_3)
                  foo_3_1 (t : val)
-                   my_closure _region _ghost_region my_depth
+                   my_closure &my_alloc_region my_depth
                    -> k1 * k2
                    : val =
              let M_1 = %project_value_slot.[foo_1].[M] ($camlFunctors__foo_6)
              in
              let Pfield = %block_load.[`0`] (M_1) in
-             apply Pfield (42, t) -> k1 * k2
+             apply &my_alloc_region Pfield (42, t) -> k1 * k2
              with { M = M }
            in
-           let $camlFunctors__Pmakeblock115 = Block 0 ($camlFunctors__foo_6)
+           let $camlFunctors__Pmakeblock124 = Block 0 ($camlFunctors__foo_6)
            in
-           apply direct(update_mod_7)
+           apply direct(update_mod_7 &toplevel.alloc_region)
              ($CamlinternalMod.camlCamlinternalMod__update_mod_13
               : _ -> imm tagged)
-               ($camlFunctors__const_block13,
+               ($camlFunctors__const_block14,
                 M0,
-                $camlFunctors__Pmakeblock115)
+                $camlFunctors__Pmakeblock124)
                -> k1 * error
              where k1 (param : imm tagged) =
                cont k)
             where k =
-              (apply direct(Make_0_1)
+              (apply direct(Make_0_1 &toplevel.alloc_region)
                  ($camlFunctors__Make_4 : _ -> val) (M0) -> k1 * error
                  where k1 (include : val) =
                    let Pfield = %block_load.[`2`] (include) in
-                   let $camlFunctors__Pmakeblock123 = Block 0 (Pfield) in
-                   (apply direct(update_mod_7)
+                   let $camlFunctors__Pmakeblock132 = Block 0 (Pfield) in
+                   (apply direct(update_mod_7 &toplevel.alloc_region)
                       ($CamlinternalMod.camlCamlinternalMod__update_mod_13
                        : _ -> imm tagged)
-                        ($camlFunctors__const_block13,
+                        ($camlFunctors__const_block14,
                          M,
-                         $camlFunctors__Pmakeblock123)
+                         $camlFunctors__Pmakeblock132)
                         -> k1 * error
                       where k1 (param : imm tagged) =
                         cont k)
                  where k =
                    let $camlFunctors =
-                     Block 0 (M0, M, $camlFunctors__Pmakeblock105)
+                     Block 0 (M0, M, $camlFunctors__Pmakeblock113)
                    in
                    cont done ($camlFunctors))))

--- a/testsuite/tests/flambda2/examples/functors2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functors2.simplify.reference
@@ -2,41 +2,39 @@ let code F1_0 deleted in
 let code F2_1 deleted in
 let code F3_2 deleted in
 let code loopify(never) size(14) newer_version_of(F1_0)
-      F1_0_1 (M : val)
-        my_closure _region _ghost_region my_depth
-        -> k * k1
-        : val =
+      F1_0_1 (M : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
   let Pfield = %block_load.[`0`] (M) in
-  let x = %block.[`0`] (Pfield) in
-  let Pmakeblock = %block.[`0`] (x) in
+  let x = %block.[`0`].my_alloc_region (Pfield) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (x) in
   cont k (Pmakeblock)
 in
-let $camlFunctors2__F1_4 = closure F1_0_1 @F1 in
+let $camlFunctors2__F1_4 = closure F1_0_1 @F1 &toplevel.alloc_region in
 let code loopify(never) size(22) newer_version_of(F2_1)
       F2_1_1 (M1 : val, M2 : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   let Pfield = %block_load.[`0`] (M2) in
   let Pfield_1 = %block_load.[`0`] (M1) in
-  let x = %block.[`0`] (Pfield_1, Pfield) in
-  let Pmakeblock = %block.[`0`] (x) in
-  let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+  let x = %block.[`0`].my_alloc_region (Pfield_1, Pfield) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (x) in
+  let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
   cont k (Pmakeblock_1)
 in
-let $camlFunctors2__F2_5 = closure F2_1_1 @F2 in
+let $camlFunctors2__F2_5 = closure F2_1_1 @F2 &toplevel.alloc_region in
 let code loopify(never) size(13) newer_version_of(F3_2)
       F3_2_1 (M1 : val, M2 : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  apply direct(F2_1_1) ($camlFunctors2__F2_5 : _ -> val) (M1, M2) -> k2 * k1
+  apply direct(F2_1_1 &my_alloc_region)
+    ($camlFunctors2__F2_5 : _ -> val) (M1, M2) -> k2 * k1
     where k2 (include : val) =
       let Pfield = %block_load.[`0`] (include) in
-      let Pmakeblock = %block.[`0`] (Pfield, 0) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, 0) in
       cont k (Pmakeblock)
 in
-let $camlFunctors2__F3_6 = closure F3_2_1 @F3 in
+let $camlFunctors2__F3_6 = closure F3_2_1 @F3 &toplevel.alloc_region in
 let $camlFunctors2 =
   Block 0 ($camlFunctors2__F1_4, $camlFunctors2__F2_5, $camlFunctors2__F3_6)
 in

--- a/testsuite/tests/flambda2/examples/id_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/id_switch.simplify.reference
@@ -3,31 +3,35 @@ let code id_switch_1 deleted in
 let code not_switch_2 deleted in
 let code inline(always) loopify(never) size(5) newer_version_of(x_0)
       x_0_1 (xt0 : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.ne (xt0, 0) in
   let int_notequal = %tag_imm (prim) in
   cont k (int_notequal)
 in
-let $camlId_switch__x_3 = closure x_0_1 @x in
+let $camlId_switch__x_3 = closure x_0_1 @x &toplevel.alloc_region in
 let code loopify(never) size(1) newer_version_of(id_switch_1)
       id_switch_1_1 (t0 : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (t0)
 in
-let $camlId_switch__id_switch_4 = closure id_switch_1_1 @id_switch in
+let $camlId_switch__id_switch_4 =
+  closure id_switch_1_1 @id_switch &toplevel.alloc_region
+in
 let code loopify(never) size(2) newer_version_of(not_switch_2)
       not_switch_2_1 (t2 : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pnot = %boolean_not (t2) in
   cont k (Pnot)
 in
-let $camlId_switch__not_switch_5 = closure not_switch_2_1 @not_switch in
+let $camlId_switch__not_switch_5 =
+  closure not_switch_2_1 @not_switch &toplevel.alloc_region
+in
 let $camlId_switch =
   Block 0 ($camlId_switch__x_3,
            $camlId_switch__id_switch_4,

--- a/testsuite/tests/flambda2/examples/ifs_and_records.simplify.reference
+++ b/testsuite/tests/flambda2/examples/ifs_and_records.simplify.reference
@@ -16,11 +16,11 @@ let code main_no_if_14 deleted in
 let code main_no_if_tuple_15 deleted in
 let code main_hand_inline_16 deleted in
 let code main_hand_inline_tuple_17 deleted in
-let $camlIfs_and_records__empty_block4 = Block 0 () in
+let $camlIfs_and_records__empty_block5 = Block 0 () in
 let code inline(always) loopify(never) size(27) newer_version_of(help_desired_0)
       help_desired_0_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   (let untagged = %untag_imm (should_swap) in
@@ -28,19 +28,19 @@ let code inline(always) loopify(never) size(27) newer_version_of(help_desired_0)
      | 0 -> k2
      | 1 -> k3)
     where k3 =
-      let Pmakeblock = %block.[`0`] (b, a) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (b, a) in
       cont k (Pmakeblock)
     where k2 =
-      let Pmakeblock = %block.[`0`] (a, b) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
       cont k (Pmakeblock)
 in
 let $camlIfs_and_records__help_desired_18 =
-  closure help_desired_0_1 @help_desired
+  closure help_desired_0_1 @help_desired &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(19) newer_version_of(help_wrap_1)
       help_wrap_1_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   (let untagged = %untag_imm (should_swap) in
@@ -48,14 +48,16 @@ let code inline(always) loopify(never) size(19) newer_version_of(help_wrap_1)
      | 0 -> k2 (a, b)
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
-      let Pmakeblock = %block.[`0`] (a_1, b_1) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (a_1, b_1) in
       cont k (Pmakeblock)
 in
-let $camlIfs_and_records__help_wrap_19 = closure help_wrap_1_1 @help_wrap in
+let $camlIfs_and_records__help_wrap_19 =
+  closure help_wrap_1_1 @help_wrap &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(27) newer_version_of(help_variant_2)
       help_variant_2_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   (let untagged = %untag_imm (should_swap) in
@@ -63,19 +65,19 @@ let code inline(always) loopify(never) size(27) newer_version_of(help_variant_2)
      | 0 -> k2
      | 1 -> k3)
     where k3 =
-      let Pmakeblock = %block.[`0`] (b, a) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (b, a) in
       cont k (Pmakeblock)
     where k2 =
-      let Pmakeblock = %block.[`0`] (a, b) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
       cont k (Pmakeblock)
 in
 let $camlIfs_and_records__help_variant_20 =
-  closure help_variant_2_1 @help_variant
+  closure help_variant_2_1 @help_variant &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(19) newer_version_of(help_wrap_variant_3)
       help_wrap_variant_3_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   (let untagged = %untag_imm (should_swap) in
@@ -83,15 +85,15 @@ let code inline(always) loopify(never) size(19) newer_version_of(help_wrap_varia
      | 0 -> k2 (a, b)
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
-      let Pmakeblock = %block.[`0`] (a_1, b_1) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (a_1, b_1) in
       cont k (Pmakeblock)
 in
 let $camlIfs_and_records__help_wrap_variant_21 =
-  closure help_wrap_variant_3_1 @help_wrap_variant
+  closure help_wrap_variant_3_1 @help_wrap_variant &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(27) newer_version_of(help_tuple_4)
       help_tuple_4_1 (should_swap : imm tagged, a, b)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
   (let untagged = %untag_imm (should_swap) in
@@ -99,18 +101,19 @@ let code inline(always) loopify(never) size(27) newer_version_of(help_tuple_4)
      | 0 -> k2
      | 1 -> k3)
     where k3 =
-      let Pmakeblock = %block.[`0`] (b, a) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (b, a) in
       cont k (Pmakeblock)
     where k2 =
-      let Pmakeblock = %block.[`0`] (a, b) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
       cont k (Pmakeblock)
 in
-let $camlIfs_and_records__help_tuple_22 = closure help_tuple_4_1 @help_tuple
+let $camlIfs_and_records__help_tuple_22 =
+  closure help_tuple_4_1 @help_tuple &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(30) newer_version_of(help_interior_if_5)
       help_interior_if_5_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   (let untagged = %untag_imm (should_swap) in
@@ -123,37 +126,40 @@ let code inline(always) loopify(never) size(30) newer_version_of(help_interior_i
           | 0 -> k2 (a)
           | 1 -> k2 (b))
          where k2 (switch_result_1 : imm tagged) =
-           let Pmakeblock = %block.[`0`] (switch_result_1, switch_result) in
+           let Pmakeblock =
+             %block.[`0`].my_alloc_region (switch_result_1, switch_result)
+           in
            cont k (Pmakeblock))
 in
 let $camlIfs_and_records__help_interior_if_23 =
-  closure help_interior_if_5_1 @help_interior_if
+  closure help_interior_if_5_1 @help_interior_if &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(8) newer_version_of(help_no_if_6)
       help_no_if_6_1 (param, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
-  let Pmakeblock = %block.[`0`] (a, b) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
   cont k (Pmakeblock)
 in
-let $camlIfs_and_records__help_no_if_24 = closure help_no_if_6_1 @help_no_if
+let $camlIfs_and_records__help_no_if_24 =
+  closure help_no_if_6_1 @help_no_if &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(8) newer_version_of(help_no_if_tuple_7)
       help_no_if_tuple_7_1 (param, a, b)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
-  let Pmakeblock = %block.[`0`] (a, b) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
   cont k (Pmakeblock)
 in
 let $camlIfs_and_records__help_no_if_tuple_25 =
-  closure help_no_if_tuple_7_1 @help_no_if_tuple
+  closure help_no_if_tuple_7_1 @help_no_if_tuple &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(main_desired_8)
       main_desired_8_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -165,12 +171,12 @@ let code loopify(never) size(14) newer_version_of(main_desired_8)
       cont k (int_sub)
 in
 let $camlIfs_and_records__main_desired_26 =
-  closure main_desired_8_1 @main_desired
+  closure main_desired_8_1 @main_desired &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(main_wrap_9)
       main_wrap_9_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -181,11 +187,13 @@ let code loopify(never) size(14) newer_version_of(main_wrap_9)
       let int_sub = %int_barith.sub (a_1, b_1) in
       cont k (int_sub)
 in
-let $camlIfs_and_records__main_wrap_27 = closure main_wrap_9_1 @main_wrap in
+let $camlIfs_and_records__main_wrap_27 =
+  closure main_wrap_9_1 @main_wrap &toplevel.alloc_region
+in
 let code loopify(never) size(14) newer_version_of(main_variant_10)
       main_variant_10_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -197,12 +205,12 @@ let code loopify(never) size(14) newer_version_of(main_variant_10)
       cont k (int_sub)
 in
 let $camlIfs_and_records__main_variant_28 =
-  closure main_variant_10_1 @main_variant
+  closure main_variant_10_1 @main_variant &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(main_wrap_variant_11)
       main_wrap_variant_11_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -214,12 +222,12 @@ let code loopify(never) size(14) newer_version_of(main_wrap_variant_11)
       cont k (int_sub)
 in
 let $camlIfs_and_records__main_wrap_variant_29 =
-  closure main_wrap_variant_11_1 @main_wrap_variant
+  closure main_wrap_variant_11_1 @main_wrap_variant &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(main_tuple_12)
       main_tuple_12_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -230,12 +238,13 @@ let code loopify(never) size(14) newer_version_of(main_tuple_12)
       let int_sub = %int_barith.sub (unboxed_field_0, unboxed_field_1) in
       cont k (int_sub)
 in
-let $camlIfs_and_records__main_tuple_30 = closure main_tuple_12_1 @main_tuple
+let $camlIfs_and_records__main_tuple_30 =
+  closure main_tuple_12_1 @main_tuple &toplevel.alloc_region
 in
 let code loopify(never) size(25) newer_version_of(main_interior_if_13)
       main_interior_if_13_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -252,33 +261,34 @@ let code loopify(never) size(25) newer_version_of(main_interior_if_13)
            cont k (int_sub))
 in
 let $camlIfs_and_records__main_interior_if_31 =
-  closure main_interior_if_13_1 @main_interior_if
+  closure main_interior_if_13_1 @main_interior_if &toplevel.alloc_region
 in
 let code loopify(never) size(3) newer_version_of(main_no_if_14)
       main_no_if_14_1 (should_swap, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_sub = %int_barith.sub (a, b) in
   cont k (int_sub)
 in
-let $camlIfs_and_records__main_no_if_32 = closure main_no_if_14_1 @main_no_if
+let $camlIfs_and_records__main_no_if_32 =
+  closure main_no_if_14_1 @main_no_if &toplevel.alloc_region
 in
 let code loopify(never) size(3) newer_version_of(main_no_if_tuple_15)
       main_no_if_tuple_15_1 (should_swap, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_sub = %int_barith.sub (a, b) in
   cont k (int_sub)
 in
 let $camlIfs_and_records__main_no_if_tuple_33 =
-  closure main_no_if_tuple_15_1 @main_no_if_tuple
+  closure main_no_if_tuple_15_1 @main_no_if_tuple &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(main_hand_inline_16)
       main_hand_inline_16_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -290,12 +300,12 @@ let code loopify(never) size(14) newer_version_of(main_hand_inline_16)
       cont k (int_sub)
 in
 let $camlIfs_and_records__main_hand_inline_34 =
-  closure main_hand_inline_16_1 @main_hand_inline
+  closure main_hand_inline_16_1 @main_hand_inline &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(main_hand_inline_tuple_17)
       main_hand_inline_tuple_17_1
         (should_swap : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (should_swap) in
@@ -308,10 +318,11 @@ let code loopify(never) size(14) newer_version_of(main_hand_inline_tuple_17)
 in
 let $camlIfs_and_records__main_hand_inline_tuple_35 =
   closure main_hand_inline_tuple_17_1 @main_hand_inline_tuple
+    &toplevel.alloc_region
 in
 let $camlIfs_and_records =
-  Block 0 ($camlIfs_and_records__empty_block4,
-           $camlIfs_and_records__empty_block4,
+  Block 0 ($camlIfs_and_records__empty_block5,
+           $camlIfs_and_records__empty_block5,
            $camlIfs_and_records__help_desired_18,
            $camlIfs_and_records__help_wrap_19,
            $camlIfs_and_records__help_variant_20,

--- a/testsuite/tests/flambda2/examples/inlined_rec.raw.reference
+++ b/testsuite/tests/flambda2/examples/inlined_rec.raw.reference
@@ -1,14 +1,12 @@
 let $camlInlined_rec__first_const = Block 0 () in
 (let code inline(always) size(6)
-       apply_0 (f : val, i)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2 =
+       apply_0 (f : val, i) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   apply inlined(hint) f (i) -> k1 * k2
+   apply &my_alloc_region inlined(hint) f (i) -> k1 * k2
  in
  let code rec size(28)
        fact_1 (n : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -23,7 +21,7 @@ let $camlInlined_rec__first_const = Block 0 () in
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (n, 1) in
-         apply direct(apply_0)
+         apply direct(apply_0 &my_alloc_region)
            (`apply` : _ -> imm tagged)
              (my_closure ~ depth my_depth -> next_depth, int_sub)
              -> k3 * k2)
@@ -31,11 +29,14 @@ let $camlInlined_rec__first_const = Block 0 () in
             let int_mul = %int_barith.mul (n, apply_result) in
             cont k1 (int_mul))
  in
- let `apply` = closure apply_0 @`apply` in
- let fact = closure fact_1 @fact with { `apply` = `apply` } in
- apply direct(fact_1) (fact : _ -> imm tagged) (1000000) -> k1 * error
+ let `apply` = closure apply_0 @`apply` &toplevel.alloc_region in
+ let fact = closure fact_1 @fact &toplevel.alloc_region
+ with { `apply` = `apply` }
+ in
+ apply direct(fact_1 &toplevel.alloc_region)
+   (fact : _ -> imm tagged) (1000000) -> k1 * error
    where k1 (i : imm tagged) =
-     let Pmakeblock = %block.[`0`] (`apply`, fact, i) in
+     let Pmakeblock = %block.[`0`].`toplevel` (`apply`, fact, i) in
      cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/inlined_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/inlined_rec.simplify.reference
@@ -1,17 +1,17 @@
 let code apply_0 deleted in
 let code fact_1 deleted in
 let code inline(always) loopify(never) size(6) newer_version_of(apply_0)
-      apply_0_1 (f : val, i)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
-  apply inlined(hint) f (i) -> k * k1
+      apply_0_1 (f : val, i) my_closure &my_alloc_region my_depth -> k * k1 =
+  apply &my_alloc_region inlined(hint) f (i) -> k * k1
 in
-let $camlInlined_rec__apply_2 = closure apply_0_1 @`apply` in
+let $camlInlined_rec__apply_2 =
+  closure apply_0_1 @`apply` &toplevel.alloc_region
+in
 let $camlInlined_rec__fact_3 =
-  closure fact_1_1 @fact
+  closure fact_1_1 @fact &toplevel.alloc_region
 and code rec loopify(never) size(42) newer_version_of(fact_1)
       fact_1_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.ne (n, 0) in
@@ -26,7 +26,8 @@ and code rec loopify(never) size(42) newer_version_of(fact_1)
           | 1 -> k3
           where k3 =
             ((let int_sub_1 = %int_barith.sub (int_sub, 1) in
-              apply direct(fact_1_1) inlining_state(depth(12))
+              apply direct(fact_1_1 &my_alloc_region)
+                     inlining_state(depth(12))
                 $camlInlined_rec__fact_3 ~ depth my_depth -> succ (unroll 1 (succ my_depth))
                   (int_sub_1)
                   -> k3 * k1)
@@ -37,7 +38,7 @@ and code rec loopify(never) size(42) newer_version_of(fact_1)
            let int_mul = %int_barith.mul (n, apply_result) in
            cont k (int_mul))
 in
-apply direct(fact_1_1)
+apply direct(fact_1_1 &toplevel.alloc_region)
   ($camlInlined_rec__fact_3 : _ -> imm tagged) (1000000) -> k * error
   where k (i : imm tagged) =
     let $camlInlined_rec =

--- a/testsuite/tests/flambda2/examples/int_array_modify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/int_array_modify.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(12) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm array =
   apply ccall
@@ -10,6 +10,6 @@ let code loopify(never) size(12) newer_version_of(f_0)
       let Parraysetu = %array_set.gc_ign (a, 0, x) in
       cont k (a)
 in
-let $camlInt_array_modify__f_1 = closure f_0_1 @f in
+let $camlInt_array_modify__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlInt_array_modify = Block 0 ($camlInt_array_modify__f_1) in
 cont done ($camlInt_array_modify)

--- a/testsuite/tests/flambda2/examples/invalid.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.compilers.reference
@@ -12,10 +12,10 @@
  int 108086391056891909)
 (data
  int 21500
- "camlInvalid__invalid177":
- string "(Defining_expr_of_let (bound_pattern prim/110N)
+ "camlInvalid__invalid195":
+ string "(Defining_expr_of_let (bound_pattern prim/119N)
  (defining_expr
-  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)
+  (((Array_load Naked_floats Naked_floats Mutable) t2/115UV 0)
    invalid.ml:29,2--23)))"
  skip 7
  byte 7)
@@ -33,18 +33,18 @@
  addr G:"camlInvalid__check_0_3_code")
 (data
  int 2816
- "camlInvalid__Pmakeblock71":
+ "camlInvalid__Pmakeblock77":
  addr G:"caml_exn_Failure"
- addr L:"camlInvalid__immstring17")
-(data int 768 "camlInvalid__empty_array41":)
-(data int 2044 "camlInvalid__immstring17": string "lengths" skip 0 byte 0)
+ addr L:"camlInvalid__immstring19")
+(data int 768 "camlInvalid__empty_array45":)
+(data int 2044 "camlInvalid__immstring19": string "lengths" skip 0 byte 0)
 (function{invalid.ml:24,25-96} camlInvalid__check_0_3_code
      (t1/0: val t2/0: val) : int
  (if
    (!= (or (>>u (<< (load_mut int (+a t1/0 -8)) 8) 17) 1)
      (or (>>u (<< (load_mut int (+a t2/0 -8)) 8) 17) 1))
    (raise_notrace{invalid.ml:25,45-63;stdlib.ml:39,17-33}
-     L:"camlInvalid__Pmakeblock71")
+     L:"camlInvalid__Pmakeblock77")
    1) )
 
 (function{invalid.ml:27,17-68} camlInvalid__bar_1_4_code
@@ -60,10 +60,10 @@
     param/2
       (app{invalid.ml:31,13-30;invalid.ml:28,2-13}
         G:"camlInvalid__check_0_3_code" Pmakearray/0
-        L:"camlInvalid__empty_array41" int))
+        L:"camlInvalid__empty_array45" int))
    (invalid
-     "(Defining_expr_of_let (bound_pattern prim/110N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)\n   invalid.ml:29,2--23)))"
-     L:"camlInvalid__invalid177")) )
+     "(Defining_expr_of_let (bound_pattern prim/119N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/115UV 0)\n   invalid.ml:29,2--23)))"
+     L:"camlInvalid__invalid195")) )
 
 (function no_cse reduce_code_size linscan camlInvalid__entry () : val
  (catch (exit 7 G:"camlInvalid") with(7 *ret*/0: val) 1) )

--- a/testsuite/tests/flambda2/examples/invalid.no-flat-float-array.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.no-flat-float-array.compilers.reference
@@ -24,19 +24,19 @@
  addr G:"camlInvalid__check_0_3_code")
 (data
  int 2816
- "camlInvalid__Pmakeblock69":
+ "camlInvalid__Pmakeblock75":
  addr G:"caml_exn_Failure"
- addr L:"camlInvalid__immstring17")
-(data int 2045 "camlInvalid__float43": double 1.)
-(data int 768 "camlInvalid__empty_array40":)
-(data int 2044 "camlInvalid__immstring17": string "lengths" skip 0 byte 0)
+ addr L:"camlInvalid__immstring19")
+(data int 2045 "camlInvalid__float47": double 1.)
+(data int 768 "camlInvalid__empty_array44":)
+(data int 2044 "camlInvalid__immstring19": string "lengths" skip 0 byte 0)
 (function{invalid.ml:24,25-96} camlInvalid__check_0_3_code
      (t1/0: val t2/0: val) : int
  (if
    (!= (or (>>u (<< (load_mut int (+a t1/0 -8)) 8) 17) 1)
      (or (>>u (<< (load_mut int (+a t2/0 -8)) 8) 17) 1))
    (raise_notrace{invalid.ml:25,45-63;stdlib.ml:39,17-33}
-     L:"camlInvalid__Pmakeblock69")
+     L:"camlInvalid__Pmakeblock75")
    1) )
 
 (function{invalid.ml:27,17-68} camlInvalid__bar_1_4_code
@@ -48,14 +48,14 @@
 
 (function{invalid.ml:31,8-30} camlInvalid__foo_2_5_code (param/1: int) : int
  (let
-   (Pmakearray/0 (alloc{invalid.ml:31,17-25} 1024 L:"camlInvalid__float43")
+   (Pmakearray/0 (alloc{invalid.ml:31,17-25} 1024 L:"camlInvalid__float47")
     param/2
       (app{invalid.ml:31,13-30;invalid.ml:28,2-13}
         G:"camlInvalid__check_0_3_code" Pmakearray/0
-        L:"camlInvalid__empty_array40" int))
+        L:"camlInvalid__empty_array44" int))
    (+
      (<<
-       (==f (load float64 (load_mut val L:"camlInvalid__empty_array40")) 0.)
+       (==f (load float64 (load_mut val L:"camlInvalid__empty_array44")) 0.)
        1)
      1)) )
 

--- a/testsuite/tests/flambda2/examples/invalid.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/invalid.simplify.no-flat-float-array.reference
@@ -1,15 +1,15 @@
-let $camlInvalid__immstring17 = "lengths" in
+let $camlInvalid__immstring19 = "lengths" in
 let code check_0 deleted in
 let code bar_1 deleted in
-let $camlInvalid__empty_array40 = Empty_array in
-let $camlInvalid__float43 = 0x1p+0 in
+let $camlInvalid__empty_array44 = Empty_array in
+let $camlInvalid__float47 = 0x1p+0 in
 let code foo_2 deleted in
-let $camlInvalid__Pmakeblock69 =
-  Block 0 ($`*predef*`.caml_exn_Failure, $camlInvalid__immstring17)
+let $camlInvalid__Pmakeblock75 =
+  Block 0 ($`*predef*`.caml_exn_Failure, $camlInvalid__immstring19)
 in
 let code inline(never) loopify(never) size(16) newer_version_of(check_0)
       check_0_1 (t1 : val array, t2 : val array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Parraylength = %array_length (t2) in
@@ -17,15 +17,16 @@ let code inline(never) loopify(never) size(16) newer_version_of(check_0)
   let prim = %phys_ne (Parraylength_1, Parraylength) in
   switch prim
     | 0 -> k (0)
-    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock69)
+    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock75)
 in
-let $camlInvalid__check_3 = closure check_0_1 @check in
+let $camlInvalid__check_3 = closure check_0_1 @check &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(12) newer_version_of(bar_1)
       bar_1_1 (t1 : val array, t2 : val array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(check_0_1)
+  apply direct(check_0_1 &my_alloc_region)
     ($camlInvalid__check_3 : _ -> imm tagged) (t1, t2) -> k3 * k1
     where k3 (param : imm tagged) =
       cont k2
@@ -36,28 +37,28 @@ let code inline(always) loopify(never) size(12) newer_version_of(bar_1)
       let float_ordered_and_equal = %tag_imm (prim_1) in
       cont k (float_ordered_and_equal)
 in
-let $camlInvalid__bar_4 = closure bar_1_1 @bar in
+let $camlInvalid__bar_4 = closure bar_1_1 @bar &toplevel.alloc_region in
 let code loopify(never) size(18) newer_version_of(foo_2)
       foo_2_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let Pmakearray = %array.mut ($camlInvalid__float43) in
-  apply direct(check_0_1) inlining_state(depth(1))
+  let Pmakearray = %array.mut.my_alloc_region ($camlInvalid__float47) in
+  apply direct(check_0_1 &my_alloc_region) inlining_state(depth(1))
     ($camlInvalid__check_3 : _ -> imm tagged)
-      (Pmakearray, $camlInvalid__empty_array40)
+      (Pmakearray, $camlInvalid__empty_array44)
       -> k3 * k1
     where k3 (param_1 : imm tagged) =
       cont k2
     where k2 =
-      let Parrayrefu = %array_load.`imm`.mut ($camlInvalid__empty_array40, 0)
+      let Parrayrefu = %array_load.`imm`.mut ($camlInvalid__empty_array44, 0)
       in
       let prim = %unbox_num.`float` (Parrayrefu) in
       let prim_1 = %float_comp.eq (prim, 0x0p+0) in
       let float_ordered_and_equal = %tag_imm (prim_1) in
       cont k (float_ordered_and_equal)
 in
-let $camlInvalid__foo_5 = closure foo_2_1 @foo in
+let $camlInvalid__foo_5 = closure foo_2_1 @foo &toplevel.alloc_region in
 let $camlInvalid =
   Block 0 ($camlInvalid__check_3, $camlInvalid__bar_4, $camlInvalid__foo_5)
 in

--- a/testsuite/tests/flambda2/examples/invalid.simplify.reference
+++ b/testsuite/tests/flambda2/examples/invalid.simplify.reference
@@ -1,14 +1,14 @@
-let $camlInvalid__immstring17 = "lengths" in
+let $camlInvalid__immstring19 = "lengths" in
 let code check_0 deleted in
 let code bar_1 deleted in
-let $camlInvalid__empty_array41 = Empty_array in
+let $camlInvalid__empty_array45 = Empty_array in
 let code foo_2 deleted in
-let $camlInvalid__Pmakeblock71 =
-  Block 0 ($`*predef*`.caml_exn_Failure, $camlInvalid__immstring17)
+let $camlInvalid__Pmakeblock77 =
+  Block 0 ($`*predef*`.caml_exn_Failure, $camlInvalid__immstring19)
 in
 let code inline(never) loopify(never) size(22) newer_version_of(check_0)
       check_0_1 (t1 : any array, t2 : any array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Parraylength = %array_length.generic (t2) in
@@ -16,15 +16,16 @@ let code inline(never) loopify(never) size(22) newer_version_of(check_0)
   let prim = %phys_ne (Parraylength_1, Parraylength) in
   switch prim
     | 0 -> k (0)
-    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock71)
+    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock77)
 in
-let $camlInvalid__check_3 = closure check_0_1 @check in
+let $camlInvalid__check_3 = closure check_0_1 @check &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(11) newer_version_of(bar_1)
       bar_1_1 (t1 : any array, t2 : float array)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(check_0_1)
+  apply direct(check_0_1 &my_alloc_region)
     ($camlInvalid__check_3 : _ -> imm tagged) (t1, t2) -> k3 * k1
     where k3 (param : imm tagged) =
       cont k2
@@ -34,23 +35,23 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar_1)
       let float_ordered_and_equal = %tag_imm (prim_1) in
       cont k (float_ordered_and_equal)
 in
-let $camlInvalid__bar_4 = closure bar_1_1 @bar in
+let $camlInvalid__bar_4 = closure bar_1_1 @bar &toplevel.alloc_region in
 let code loopify(never) size(11) newer_version_of(foo_2)
       foo_2_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let Pmakearray = %array.`float`.mut (0x1p+0) in
-  apply direct(check_0_1) inlining_state(depth(1))
+  let Pmakearray = %array.`float`.mut.my_alloc_region (0x1p+0) in
+  apply direct(check_0_1 &my_alloc_region) inlining_state(depth(1))
     ($camlInvalid__check_3 : _ -> imm tagged)
-      (Pmakearray, $camlInvalid__empty_array41)
+      (Pmakearray, $camlInvalid__empty_array45)
       -> k3 * k1
     where k3 (param_1 : imm tagged) =
       cont k2
     where k2 =
-      invalid "(Defining_expr_of_let (bound_pattern prim/110N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)\n   invalid.ml:29,2--23)))"
+      invalid "(Defining_expr_of_let (bound_pattern prim/119N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/115UV 0)\n   invalid.ml:29,2--23)))"
 in
-let $camlInvalid__foo_5 = closure foo_2_1 @foo in
+let $camlInvalid__foo_5 = closure foo_2_1 @foo &toplevel.alloc_region in
 let $camlInvalid =
   Block 0 ($camlInvalid__check_3, $camlInvalid__bar_4, $camlInvalid__foo_5)
 in

--- a/testsuite/tests/flambda2/examples/is_int_2020_07_21.simplify.reference
+++ b/testsuite/tests/flambda2/examples/is_int_2020_07_21.simplify.reference
@@ -2,19 +2,21 @@ let code of_src_0 deleted in
 let code test_1 deleted in
 let code inline(always) loopify(never) size(4) newer_version_of(of_src_0)
       of_src_0_1 (param : [ 0 | 0 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %is_int (param) in
   let Pisint = %tag_imm (prim) in
   cont k (Pisint)
 in
-let $camlIs_int_2020_07_21__of_src_2 = closure of_src_0_1 @of_src in
+let $camlIs_int_2020_07_21__of_src_2 =
+  closure of_src_0_1 @of_src &toplevel.alloc_region
+in
 let code loopify(never) size(28) newer_version_of(test_1)
       test_1_1 (src : [ 0 | 0 of imm tagged ], f : val, g : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply f (0) -> k4 * k1
+  apply &my_alloc_region f (0) -> k4 * k1
     where k4 (param : [ 0 |1 ]) =
       let unboxed_field = %untag_imm (param) in
       cont k3 (unboxed_field)
@@ -28,9 +30,11 @@ let code loopify(never) size(28) newer_version_of(test_1)
            let Pisint = %tag_imm (prim) in
            cont k2 (Pisint))
     where k2 (dst : imm tagged) =
-      apply g (dst) -> k * k1
+      apply &my_alloc_region g (dst) -> k * k1
 in
-let $camlIs_int_2020_07_21__test_3 = closure test_1_1 @test in
+let $camlIs_int_2020_07_21__test_3 =
+  closure test_1_1 @test &toplevel.alloc_region
+in
 let $camlIs_int_2020_07_21 =
   Block 0 ($camlIs_int_2020_07_21__of_src_2, $camlIs_int_2020_07_21__test_3)
 in

--- a/testsuite/tests/flambda2/examples/let_symbol_order_atexit.simplify.reference
+++ b/testsuite/tests/flambda2/examples/let_symbol_order_atexit.simplify.reference
@@ -3,18 +3,22 @@ let code do_at_exit_1 deleted in
 let code exit_3 deleted in
 let code loopify(never) size(1) newer_version_of(id_0)
       id_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlLet_symbol_order_atexit__id_4 = closure id_0_1 @`id` in
-let exit_function = %block.mut.[`0`] ($camlLet_symbol_order_atexit__id_4) in
+let $camlLet_symbol_order_atexit__id_4 =
+  closure id_0_1 @`id` &toplevel.alloc_region
+in
+let exit_function =
+  %block.mut.[`0`].`toplevel` ($camlLet_symbol_order_atexit__id_4)
+in
 let $camlLet_symbol_order_atexit__do_at_exit_5 =
-  closure do_at_exit_1_1 @do_at_exit
+  closure do_at_exit_1_1 @do_at_exit &toplevel.alloc_region
 and code loopify(never) size(8) newer_version_of(do_at_exit_1)
       do_at_exit_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let exit_function_1 =
@@ -22,12 +26,12 @@ and code loopify(never) size(8) newer_version_of(do_at_exit_1)
       ($camlLet_symbol_order_atexit__do_at_exit_5)
   in
   let Pfield = %block_load.mut.[`0`] (exit_function_1) in
-  apply Pfield (0) -> k * k1
+  apply &my_alloc_region Pfield (0) -> k * k1
   with { exit_function = exit_function }
 in
 let code loopify(never) size(19) newer_version_of(exit_3)
       exit_3_1 (retcode : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   (let exit_function_1 =
@@ -35,14 +39,16 @@ let code loopify(never) size(19) newer_version_of(exit_3)
        ($camlLet_symbol_order_atexit__do_at_exit_5)
    in
    let Pfield = %block_load.mut.[`0`] (exit_function_1) in
-   apply inlining_state(depth(10)) Pfield (0) -> k3 * k1
+   apply &my_alloc_region inlining_state(depth(10)) Pfield (0) -> k3 * k1
      where k3 (param : imm tagged) =
        cont k2)
     where k2 =
       apply ccall
         ($`*extern*`.caml_sys_exit : val -> val) (retcode) -> k * k1
 in
-let $camlLet_symbol_order_atexit__exit_7 = closure exit_3_1 @exit in
+let $camlLet_symbol_order_atexit__exit_7 =
+  closure exit_3_1 @exit &toplevel.alloc_region
+in
 let $camlLet_symbol_order_atexit =
   Block 0 ($camlLet_symbol_order_atexit__exit_7,
            $camlLet_symbol_order_atexit__do_at_exit_5)

--- a/testsuite/tests/flambda2/examples/lift_rec_cont.fl
+++ b/testsuite/tests/flambda2/examples/lift_rec_cont.fl
@@ -8,7 +8,7 @@
 let code f_0 deleted in
 let code loopify(never) size(50) newer_version_of(f_0)
       f_0_1 (g : val, x : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %is_int (x) in
@@ -25,7 +25,7 @@ let code loopify(never) size(50) newer_version_of(f_0)
          | 0 -> k5 (0)
          | 1 -> k5 (1)
          where rec k5 (i : imm tagged) =
-           (apply g (i) -> k4 * k1
+           (apply &my_alloc_region g (i) -> k4 * k1
               where k4 (param) =
                 cont k3
               where k3 =
@@ -37,6 +37,6 @@ let code loopify(never) size(50) newer_version_of(f_0)
                      let Paddint = %int_barith.`add` (i, 1) in
                      cont k5 (Paddint))))
 in
-let $camlFoo__f_1 = closure f_0_1 @f in
+let $camlFoo__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlLift_rec_cont = Block 0 ($camlFoo__f_1) in
 cont done ($camlLift_rec_cont)

--- a/testsuite/tests/flambda2/examples/lift_rec_cont.raw.reference
+++ b/testsuite/tests/flambda2/examples/lift_rec_cont.raw.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(50) newer_version_of(f_0)
       f_0_1 (g : val, x : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %is_int (x) in
@@ -18,7 +18,7 @@ let code loopify(never) size(50) newer_version_of(f_0)
          | 0 -> k5 (0)
          | 1 -> k5 (1)
          where rec k5 (i : imm tagged) =
-           (apply g (i) -> k4 * k1
+           (apply &my_alloc_region g (i) -> k4 * k1
               where k4 (param) =
                 cont k3
               where k3 =
@@ -30,6 +30,6 @@ let code loopify(never) size(50) newer_version_of(f_0)
                      let Paddint = %int_barith.add (i, 1) in
                      cont k5 (Paddint))))
 in
-let $camlFoo__f_1 = closure f_0_1 @f in
+let $camlFoo__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlLift_rec_cont = Block 0 ($camlFoo__f_1) in
 cont done ($camlLift_rec_cont)

--- a/testsuite/tests/flambda2/examples/lift_rec_cont.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lift_rec_cont.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0_1 deleted in
 let code loopify(never) size(42) newer_version_of(f_0_1)
       f_0_1_1 (g : val, x : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %is_int (x) in
@@ -17,7 +17,7 @@ let code loopify(never) size(42) newer_version_of(f_0_1)
       ((let tagged_scrutinee = %tag_imm (prim) in
         cont k5 (tagged_scrutinee))
          where rec k5 (i : imm tagged) =
-           (apply g (i) -> k1_1 * k1
+           (apply &my_alloc_region g (i) -> k1_1 * k1
               where k1_1 (param) =
                 cont k4
               where k4 =
@@ -29,6 +29,6 @@ let code loopify(never) size(42) newer_version_of(f_0_1)
                      let Paddint = %int_barith.add (i, 1) in
                      cont k5 (Paddint))))
 in
-let $camlFoo__f_1 = closure f_0_1_1 @f in
+let $camlFoo__f_1 = closure f_0_1_1 @f &toplevel.alloc_region in
 let $camlLift_rec_cont = Block 0 ($camlFoo__f_1) in
 cont done ($camlLift_rec_cont)

--- a/testsuite/tests/flambda2/examples/lifting.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lifting.simplify.reference
@@ -6,10 +6,10 @@ apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
          (apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
             where k (r2) =
               let $camlLifting__f_1 =
-                closure f_0_1 @f
+                closure f_0_1 @f &toplevel.alloc_region
               and code inline(always) loopify(never) size(10) newer_version_of(f_0)
                     f_0_1 (x : imm tagged)
-                      my_closure _region _ghost_region my_depth
+                      my_closure &my_alloc_region my_depth
                       -> k * k1
                       : imm tagged =
                 let r0_1 = %project_value_slot.[f].[r0] ($camlLifting__f_1)

--- a/testsuite/tests/flambda2/examples/lifting2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lifting2.simplify.reference
@@ -4,6 +4,6 @@ apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
        where k (r1) =
          (apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
             where k (r2) =
-              let $camlLifting2__t17 = Block 0 (r0, r1, r2) in
-              let $camlLifting2 = Block 0 (r2, $camlLifting2__t17) in
+              let $camlLifting2__t18 = Block 0 (r0, r1, r2) in
+              let $camlLifting2 = Block 0 (r2, $camlLifting2__t18) in
               cont done ($camlLifting2)))

--- a/testsuite/tests/flambda2/examples/meet_with_incompatible_kinds.simplify.reference
+++ b/testsuite/tests/flambda2/examples/meet_with_incompatible_kinds.simplify.reference
@@ -1,35 +1,40 @@
-let $camlMeet_with_incompatible_kinds__float12 = 0x1.8p+1 in
+let $camlMeet_with_incompatible_kinds__float14 = 0x1.8p+1 in
 let code aux_0 deleted in
 let code f_1 deleted in
 let code inline(always) loopify(never) size(20) newer_version_of(aux_0)
       aux_0_1 (x : [ 0 of [ 0 of imm tagged * val ] |1 of float ^ 1 ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let prim = %get_tag (x) in
    switch prim
-     | 0 -> k ($camlMeet_with_incompatible_kinds__float12)
+     | 0 -> k ($camlMeet_with_incompatible_kinds__float14)
      | 1 -> k2)
     where k2 =
       let Pfield = %block_load.[`0`] (x) in
       let prim = %block_load.`float`.[`0`] (Pfield) in
-      let Pfloatfield = %box_num.`float` (prim) in
+      let Pfloatfield = %box_num.`float`.my_alloc_region (prim) in
       cont k (Pfloatfield)
 in
-let $camlMeet_with_incompatible_kinds__aux_2 = closure aux_0_1 @aux in
+let $camlMeet_with_incompatible_kinds__aux_2 =
+  closure aux_0_1 @aux &toplevel.alloc_region
+in
 let code loopify(never) size(10) newer_version_of(f_1)
       f_1_1 (x : [ 0 of [ 0 of imm tagged * val ] |1 of float ^ 1 ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of float boxed * imm tagged ] =
   let Pfield = %block_load.[`0`] (x) in
   let n = %block_load.[`0`] (Pfield) in
   let Pmakeblock =
-    %block.[`0`] ($camlMeet_with_incompatible_kinds__float12, n)
+    %block.[`0`].my_alloc_region
+      ($camlMeet_with_incompatible_kinds__float14, n)
   in
   cont k (Pmakeblock)
 in
-let $camlMeet_with_incompatible_kinds__f_3 = closure f_1_1 @f in
+let $camlMeet_with_incompatible_kinds__f_3 =
+  closure f_1_1 @f &toplevel.alloc_region
+in
 let $camlMeet_with_incompatible_kinds =
   Block 0 ($camlMeet_with_incompatible_kinds__aux_2,
            $camlMeet_with_incompatible_kinds__f_3)

--- a/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
+++ b/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
@@ -1,7 +1,7 @@
 let code escape_string_0 deleted in
 let code loopify(never) size(64) newer_version_of(escape_string_0)
       escape_string_0_1 (s : val, s' : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %string_length (s) in
@@ -48,7 +48,7 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
                   | 1 -> k2 (for_next_naked, int_add)))
 in
 let $camlMutable_vars1__escape_string_1 =
-  closure escape_string_0_1 @escape_string
+  closure escape_string_0_1 @escape_string &toplevel.alloc_region
 in
 let $camlMutable_vars1 = Block 0 ($camlMutable_vars1__escape_string_1) in
 cont done ($camlMutable_vars1)

--- a/testsuite/tests/flambda2/examples/nan.simplify.reference
+++ b/testsuite/tests/flambda2/examples/nan.simplify.reference
@@ -1,3 +1,3 @@
-let $camlNan__nan16 = nan in
-let $camlNan = Block 0 ($camlNan__nan16) in
+let $camlNan__nan17 = nan in
+let $camlNan = Block 0 ($camlNan__nan17) in
 cont done ($camlNan)

--- a/testsuite/tests/flambda2/examples/neg_float.simplify.reference
+++ b/testsuite/tests/flambda2/examples/neg_float.simplify.reference
@@ -1,30 +1,30 @@
 let code make_pos_float_0 deleted in
 let code make_neg_float_1 deleted in
-let $camlNeg_float__float4 = -0x1.5p+5 in
-let $camlNeg_float__float_sub44 = 0x1p+1 in
+let $camlNeg_float__float5 = -0x1.5p+5 in
+let $camlNeg_float__float_sub48 = 0x1p+1 in
 let code loopify(never) size(1) newer_version_of(make_pos_float_0)
       make_pos_float_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  cont k ($camlNeg_float__float_sub44)
+  cont k ($camlNeg_float__float_sub48)
 in
 let $camlNeg_float__make_pos_float_2 =
-  closure make_pos_float_0_1 @make_pos_float
+  closure make_pos_float_0_1 @make_pos_float &toplevel.alloc_region
 in
-let $camlNeg_float__float_sub54 = -0x1p+1 in
+let $camlNeg_float__float_sub59 = -0x1p+1 in
 let code loopify(never) size(1) newer_version_of(make_neg_float_1)
       make_neg_float_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  cont k ($camlNeg_float__float_sub54)
+  cont k ($camlNeg_float__float_sub59)
 in
 let $camlNeg_float__make_neg_float_3 =
-  closure make_neg_float_1_1 @make_neg_float
+  closure make_neg_float_1_1 @make_neg_float &toplevel.alloc_region
 in
 let $camlNeg_float =
-  Block 0 ($camlNeg_float__float4,
+  Block 0 ($camlNeg_float__float5,
            $camlNeg_float__make_pos_float_2,
            $camlNeg_float__make_neg_float_3)
 in

--- a/testsuite/tests/flambda2/examples/nested_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/nested_switch.simplify.reference
@@ -2,7 +2,7 @@ let code test_0 deleted in
 let code f_1 deleted in
 let code inline(always) loopify(never) size(31) newer_version_of(test_0)
       test_0_1 (foo : imm tagged, x, y)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (foo) in
@@ -16,10 +16,12 @@ let code inline(always) loopify(never) size(31) newer_version_of(test_0)
       apply ccall
         ($`*extern*`.caml_greaterthan : val * val -> val) (x, y) -> k * k1
 in
-let $camlNested_switch__test_2 = closure test_0_1 @test in
+let $camlNested_switch__test_2 =
+  closure test_0_1 @test &toplevel.alloc_region
+in
 let code loopify(never) size(21) newer_version_of(f_1)
       f_1_1 (foo : imm tagged, x, y)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (foo) in
@@ -30,7 +32,7 @@ let code loopify(never) size(21) newer_version_of(f_1)
       apply ccall inlining_state(depth(1))
         ($`*extern*`.caml_greaterthan : val * val -> val) (x, y) -> k * k1
 in
-let $camlNested_switch__f_3 = closure f_1_1 @f in
+let $camlNested_switch__f_3 = closure f_1_1 @f &toplevel.alloc_region in
 let $camlNested_switch =
   Block 0 ($camlNested_switch__test_2, $camlNested_switch__f_3)
 in

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_classic.raw.reference
@@ -1,24 +1,25 @@
 (let code inline(never) size(1)
-       f_1 (param)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2
-         : int64 =
+       f_1 (param) my_closure &my_alloc_region my_depth -> k1 * k2 : int64 =
    cont k1 (0L)
  in
  let code inline(never) size(10)
        test_0 (u : imm tagged, a, b)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
-   apply direct(f_1)  (0) -> k3 * k2
+   apply direct(f_1 &my_alloc_region)  (0) -> k3 * k2
      where k3 (func) =
-       apply func (0) -> k1 * k2
+       apply &my_alloc_region func (0) -> k1 * k2
  in
- let $camlOver_app_kind_check_classic__s0 = closure test_0 @test in
+ let $camlOver_app_kind_check_classic__s0 =
+   closure test_0 @test &toplevel.alloc_region
+ in
  let $camlOver_app_kind_check_classic__s2 =
    Block 0 ($camlOver_app_kind_check_classic__s0)
  in
- let $camlOver_app_kind_check_classic__s1 = closure f_1 @f in
+ let $camlOver_app_kind_check_classic__s1 =
+   closure f_1 @f &toplevel.alloc_region
+ in
  cont k ($camlOver_app_kind_check_classic__s2))
   where k define_root_symbol (module_block) =
     let field_0 = $camlOver_app_kind_check_classic__s0 in

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.simplify.reference
@@ -1,12 +1,14 @@
 let code test_0 deleted in
 let code loopify(never) size(0) newer_version_of(test_0)
       test_0_1 (u : imm tagged, a, b)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  invalid "(Application_result_kind_mismatch\n (result_arity \226\132\149\240\157\159\158\240\157\159\156) (apply_expr\n  (((Some Over_app_kind_check_simplify.camlOver_app_kind_check_simplify__f_3)\227\128\136k21\227\128\137\227\128\138k13\227\128\139(0))\n   (args_arity \240\157\149\141?) (return_arity \240\157\149\141?)\n   (call_kind\n    (Function\n     (function_call (Direct camlOver_app_kind_check_simplify__f_1_3_code))))\n   (alloc_mode Heap) (dbg over_app_kind_check_simplify.ml:16,2--16)\n   (inline Default_inlined) (inlining_state (depth 0, arguments O3))\n   (probe ()) (position Normal))))"
+  invalid "(Application_result_kind_mismatch\n (result_arity \226\132\149\240\157\159\158\240\157\159\156) (apply_expr\n  (((Some Over_app_kind_check_simplify.camlOver_app_kind_check_simplify__f_3)\227\128\136k21\227\128\137\227\128\138k13\227\128\139(0))\n   (args_arity \240\157\149\141?) (return_arity \240\157\149\141?)\n   (call_kind\n    (Function\n     (function_call (Direct camlOver_app_kind_check_simplify__f_1_3_code))))\n   (alloc_mode (Heap (alloc my_alloc_region/25N)))\n   (dbg over_app_kind_check_simplify.ml:16,2--16) (inline Default_inlined)\n   (inlining_state (depth 0, arguments O3)) (probe ()) (position Normal))))"
 in
-let $camlOver_app_kind_check_simplify__test_2 = closure test_0_1 @test in
+let $camlOver_app_kind_check_simplify__test_2 =
+  closure test_0_1 @test &toplevel.alloc_region
+in
 let $camlOver_app_kind_check_simplify =
   Block 0 ($camlOver_app_kind_check_simplify__test_2)
 in

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_classic.raw.reference
@@ -1,31 +1,36 @@
 (let code inline(never) size(1)
        f_1 (param, param_1)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    cont k1 (0)
  in
  let code size(4) stub
        partial_f_2 (param1)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
-   apply direct(f_1)  (0, param1) -> k1 * k2
+   apply direct(f_1 &my_alloc_region)  (0, param1) -> k1 * k2
  in
- let $camlPartial_app_kind_check_classic__s2 = closure partial_f_2 @partial_f
+ let $camlPartial_app_kind_check_classic__s2 =
+   closure partial_f_2 @partial_f &toplevel.alloc_region
  in
  let code inline(never) size(1)
        test_0 (u : imm tagged, a, b)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : int64 =
    cont k1 ($camlPartial_app_kind_check_classic__s2)
  in
- let $camlPartial_app_kind_check_classic__s0 = closure test_0 @test in
+ let $camlPartial_app_kind_check_classic__s0 =
+   closure test_0 @test &toplevel.alloc_region
+ in
  let $camlPartial_app_kind_check_classic__s3 =
    Block 0 ($camlPartial_app_kind_check_classic__s0)
  in
- let $camlPartial_app_kind_check_classic__s1 = closure f_1 @f in
+ let $camlPartial_app_kind_check_classic__s1 =
+   closure f_1 @f &toplevel.alloc_region
+ in
  cont k ($camlPartial_app_kind_check_classic__s3))
   where k define_root_symbol (module_block) =
     let field_0 = $camlPartial_app_kind_check_classic__s0 in

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
@@ -1,33 +1,37 @@
 let code f_1 deleted in
 let code loopify(never) size(7) stub
       partial_f_2 (param1)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let f = %project_value_slot.[partial_f].[f] (my_closure) in
-  apply (f : val * val -> imm tagged) (0, param1) -> k * k1
+  apply &my_alloc_region (f : val * val -> imm tagged) (0, param1) -> k * k1
 in
 let code test_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(f_1)
       f_1_1 (param, param_1)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlPartial_app_kind_check_simplify__f_4 = closure f_1_1 @f in
+let $camlPartial_app_kind_check_simplify__f_4 =
+  closure f_1_1 @f &toplevel.alloc_region
+in
 let $camlPartial_app_kind_check_simplify__partial_f_5 =
-  closure partial_f_2 @partial_f
+  closure partial_f_2 @partial_f &toplevel.alloc_region
   with { f = $camlPartial_app_kind_check_simplify__f_4 }
 in
 let code loopify(never) size(1) newer_version_of(test_0)
       test_0_1 (u : imm tagged, a, b)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 =
   cont k ($camlPartial_app_kind_check_simplify__partial_f_5)
 in
-let $camlPartial_app_kind_check_simplify__test_3 = closure test_0_1 @test in
+let $camlPartial_app_kind_check_simplify__test_3 =
+  closure test_0_1 @test &toplevel.alloc_region
+in
 let $camlPartial_app_kind_check_simplify =
   Block 0 ($camlPartial_app_kind_check_simplify__test_3)
 in

--- a/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
@@ -1,7 +1,7 @@
 let code foo_1 deleted in
 let code loopify(never) size(17) newer_version_of(foo_1)
       foo_1_1 (x : imm tagged, y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (x, y)
@@ -16,6 +16,7 @@ let code loopify(never) size(17) newer_version_of(foo_1)
            let int_add = %int_barith.add (accu, Pfield_1) in
            cont `self` (int_add, Pfield))
 in
-let $camlPartial_closure__foo_5 = closure foo_1_1 @foo in
+let $camlPartial_closure__foo_5 = closure foo_1_1 @foo &toplevel.alloc_region
+in
 let $camlPartial_closure = Block 0 ($camlPartial_closure__foo_5) in
 cont done ($camlPartial_closure)

--- a/testsuite/tests/flambda2/examples/phantom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/phantom.simplify.reference
@@ -1,19 +1,19 @@
 let code is_true_1 deleted in
 let code is_false_2 deleted in
-let $camlPhantom__immstring48 = "phantom.ml" in
-let $camlPhantom__const_block50 = Block 0 ($camlPhantom__immstring48, 42, 6)
+let $camlPhantom__immstring53 = "phantom.ml" in
+let $camlPhantom__const_block55 = Block 0 ($camlPhantom__immstring53, 42, 6)
 in
-let $camlPhantom__Pmakeblock53 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlPhantom__const_block50)
+let $camlPhantom__Pmakeblock58 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlPhantom__const_block55)
 in
 let code eval_level_3 deleted in
 let code true_at_level0_4 deleted in
-let $camlPhantom__immstring11 = "Phantom.Make(F).UndecidedLit" in
+let $camlPhantom__immstring13 = "Phantom.Make(F).UndecidedLit" in
 let code Make_0 deleted in
 let code Make2_5 deleted in
 let code loopify(never) size(77) newer_version_of(true_at_level0_4)
       true_at_level0_4_1 (st, a : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let UndecidedLit =
@@ -33,7 +33,7 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4)
           where k6 (lvl_1) =
             let prim = %int_comp.ge (lvl_1, 0) in
             switch prim
-              | 0 -> k2 pop(regular k2) ($camlPhantom__Pmakeblock53)
+              | 0 -> k2 pop(regular k2) ($camlPhantom__Pmakeblock58)
               | 1 -> k4 (lvl_1, 1i)
           where k5 (lvl_1) =
             let Pfield_2 = %block_load.[`2`] (a) in
@@ -63,7 +63,7 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4)
 in
 let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3)
       eval_level_3_1 (_st, a : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let UndecidedLit =
@@ -79,10 +79,10 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3)
     where k3 =
       ((let prim = %int_comp.ge (lvl, 0) in
         switch prim
-          | 0 -> k1 pop(regular k1) ($camlPhantom__Pmakeblock53)
+          | 0 -> k1 pop(regular k1) ($camlPhantom__Pmakeblock58)
           | 1 -> k3)
          where k3 =
-           let Pmakeblock = %block.[`0`] (1, lvl) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (1, lvl) in
            cont k (Pmakeblock))
     where k2 =
       let Pfield_2 = %block_load.[`2`] (a) in
@@ -92,51 +92,54 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3)
           | 0 -> k1 pop(reraise k1) (UndecidedLit)
           | 1 -> k2)
          where k2 =
-           let Pmakeblock = %block.[`0`] (0, lvl) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (0, lvl) in
            cont k (Pmakeblock))
 in
 let code inline(always) loopify(never) size(3) newer_version_of(is_false_2)
       is_false_2_1 (a : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`2`] (a) in
   let Pfield_1 = %block_load.mut.[`3`] (Pfield) in
   cont k (Pfield_1)
 in
-let $camlPhantom__is_false_8 = closure is_false_2_1 @is_false in
+let $camlPhantom__is_false_8 =
+  closure is_false_2_1 @is_false &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(2) newer_version_of(is_true_1)
       is_true_1_1 (a : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.mut.[`3`] (a) in
   cont k (Pfield)
 in
-let $camlPhantom__is_true_7 = closure is_true_1_1 @is_true in
+let $camlPhantom__is_true_7 =
+  closure is_true_1_1 @is_true &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(176) newer_version_of(Make_0)
-      Make_0_1 (F : val)
-        my_closure _region _ghost_region my_depth
-        -> k * k1
-        : val =
+      Make_0_1 (F : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
   apply ccall noalloc
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
     where k2 (Pccall) =
       let UndecidedLit =
-        %block.immut_uniq.[`248`] ($camlPhantom__immstring11, Pccall)
+        %block.immut_uniq.[`248`].my_alloc_region
+          ($camlPhantom__immstring13, Pccall)
       in
-      let eval_level = closure eval_level_3_1 @eval_level
+      let eval_level = closure eval_level_3_1 @eval_level &my_alloc_region
       with {
         UndecidedLit_1 = UndecidedLit;
         is_true = $camlPhantom__is_true_7;
         is_false = $camlPhantom__is_false_8
       }
       in
-      let true_at_level0 = closure true_at_level0_4_1 @true_at_level0
+      let true_at_level0 =
+        closure true_at_level0_4_1 @true_at_level0 &my_alloc_region
       with { UndecidedLit = UndecidedLit; eval_level = eval_level }
       in
       let Pmakeblock =
-        %block.[`0`]
+        %block.[`0`].my_alloc_region
           (UndecidedLit,
            $camlPhantom__is_true_7,
            $camlPhantom__is_false_8,
@@ -145,10 +148,10 @@ let code inline(always) loopify(never) size(176) newer_version_of(Make_0)
       in
       cont k (Pmakeblock)
 in
-let $camlPhantom__Make_6 = closure Make_0_1 @Make in
+let $camlPhantom__Make_6 = closure Make_0_1 @Make &toplevel.alloc_region in
 let code loopify(never) size(77) newer_version_of(true_at_level0_4_1)
       true_at_level0_4_2 (st, a : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let UndecidedLit =
@@ -168,7 +171,7 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4_1)
           where k6 (lvl_1) =
             let prim = %int_comp.ge (lvl_1, 0) in
             switch prim
-              | 0 -> k2 pop(regular k2) ($camlPhantom__Pmakeblock53)
+              | 0 -> k2 pop(regular k2) ($camlPhantom__Pmakeblock58)
               | 1 -> k4 (1i, lvl_1)
           where k5 (lvl_1) =
             let Pfield_2 = %block_load.[`2`] (a) in
@@ -198,7 +201,7 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4_1)
 in
 let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
       eval_level_3_2 (_st, a : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let UndecidedLit =
@@ -214,10 +217,10 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
     where k3 =
       ((let prim = %int_comp.ge (lvl, 0) in
         switch prim
-          | 0 -> k1 pop(regular k1) ($camlPhantom__Pmakeblock53)
+          | 0 -> k1 pop(regular k1) ($camlPhantom__Pmakeblock58)
           | 1 -> k3)
          where k3 =
-           let Pmakeblock = %block.[`0`] (1, lvl) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (1, lvl) in
            cont k (Pmakeblock))
     where k2 =
       let Pfield_2 = %block_load.[`2`] (a) in
@@ -227,32 +230,34 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
           | 0 -> k1 pop(reraise k1) (UndecidedLit)
           | 1 -> k2)
          where k2 =
-           let Pmakeblock = %block.[`0`] (0, lvl) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (0, lvl) in
            cont k (Pmakeblock))
 in
 let code inline(always) loopify(never) size(176) newer_version_of(Make2_5)
       Make2_5_1 (F : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   apply ccall noalloc inlining_state(depth(1))
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
     where k2 (Pccall) =
       let UndecidedLit =
-        %block.immut_uniq.[`248`] ($camlPhantom__immstring11, Pccall)
+        %block.immut_uniq.[`248`].my_alloc_region
+          ($camlPhantom__immstring13, Pccall)
       in
-      let eval_level = closure eval_level_3_2 @eval_level
+      let eval_level = closure eval_level_3_2 @eval_level &my_alloc_region
       with {
         UndecidedLit_1 = UndecidedLit;
         is_true = $camlPhantom__is_true_7;
         is_false = $camlPhantom__is_false_8
       }
       in
-      let true_at_level0 = closure true_at_level0_4_2 @true_at_level0
+      let true_at_level0 =
+        closure true_at_level0_4_2 @true_at_level0 &my_alloc_region
       with { UndecidedLit = UndecidedLit; eval_level = eval_level }
       in
       let Pmakeblock =
-        %block.[`0`]
+        %block.[`0`].my_alloc_region
           (UndecidedLit,
            $camlPhantom__is_true_7,
            $camlPhantom__is_false_8,
@@ -261,6 +266,7 @@ let code inline(always) loopify(never) size(176) newer_version_of(Make2_5)
       in
       cont k (Pmakeblock)
 in
-let $camlPhantom__Make2_9 = closure Make2_5_1 @Make2 in
+let $camlPhantom__Make2_9 = closure Make2_5_1 @Make2 &toplevel.alloc_region
+in
 let $camlPhantom = Block 0 ($camlPhantom__Make_6, $camlPhantom__Make2_9) in
 cont done ($camlPhantom)

--- a/testsuite/tests/flambda2/examples/product_join_with_mixed_kinds.simplify.reference
+++ b/testsuite/tests/flambda2/examples/product_join_with_mixed_kinds.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(34) newer_version_of(f_0)
       f_0_1 (b : imm tagged, w : float boxed, x : float boxed, y : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * imm tagged ] =
   (let untagged = %untag_imm (b) in
@@ -17,13 +17,15 @@ let code loopify(never) size(34) newer_version_of(f_0)
     where k3 =
       let prim = %unbox_num.`float` (x) in
       let prim_1 = %unbox_num.`float` (w) in
-      let Pmakefloatblock = %block.floats (prim_1, prim) in
+      let Pmakefloatblock = %block.floats.my_alloc_region (prim_1, prim) in
       cont k2 (Pmakefloatblock)
     where k2 (x_1 : val) =
-      let Pmakeblock = %block.[`0`] (x_1, 0) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (x_1, 0) in
       cont k (Pmakeblock)
 in
-let $camlProduct_join_with_mixed_kinds__f_1 = closure f_0_1 @f in
+let $camlProduct_join_with_mixed_kinds__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlProduct_join_with_mixed_kinds =
   Block 0 ($camlProduct_join_with_mixed_kinds__f_1)
 in

--- a/testsuite/tests/flambda2/examples/string_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/string_switch.simplify.reference
@@ -1,24 +1,24 @@
-let $camlString_switch__immstring9 = "Cow" in
-let $camlString_switch__immstring14 = "Goat" in
-let $camlString_switch__immstring19 = "Horse" in
-let $camlString_switch__immstring24 = "Sheep" in
-let $camlString_switch__immstring30 = "string_switch.ml" in
-let $camlString_switch__const_block32 =
-  Block 0 ($camlString_switch__immstring30, 21, 9)
+let $camlString_switch__immstring11 = "Cow" in
+let $camlString_switch__immstring16 = "Goat" in
+let $camlString_switch__immstring21 = "Horse" in
+let $camlString_switch__immstring26 = "Sheep" in
+let $camlString_switch__immstring32 = "string_switch.ml" in
+let $camlString_switch__const_block34 =
+  Block 0 ($camlString_switch__immstring32, 21, 9)
 in
-let $camlString_switch__Pmakeblock35 =
+let $camlString_switch__Pmakeblock37 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlString_switch__const_block32)
+           $camlString_switch__const_block34)
 in
 let code of_string_0 deleted in
 let code loopify(never) size(60) newer_version_of(of_string_0)
       of_string_0_1 (str : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   apply ccall noalloc
     ($`*extern*`.caml_string_notequal : val * val -> val)
-      (str, $camlString_switch__immstring9)
+      (str, $camlString_switch__immstring11)
       -> k2 * k1
     where k2 (Pccall) =
       ((let untagged = %untag_imm (Pccall) in
@@ -28,7 +28,7 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
          where k2 =
            (apply ccall noalloc
               ($`*extern*`.caml_string_notequal : val * val -> val)
-                (str, $camlString_switch__immstring14)
+                (str, $camlString_switch__immstring16)
                 -> k2 * k1
               where k2 (Pccall_1) =
                 ((let untagged = %untag_imm (Pccall_1) in
@@ -38,7 +38,7 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
                    where k2 =
                      (apply ccall noalloc
                         ($`*extern*`.caml_string_notequal : val * val -> val)
-                          (str, $camlString_switch__immstring19)
+                          (str, $camlString_switch__immstring21)
                           -> k2 * k1
                         where k2 (Pccall_2) =
                           ((let untagged = %untag_imm (Pccall_2) in
@@ -49,7 +49,7 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
                                (apply ccall noalloc
                                   ($`*extern*`.caml_string_notequal
                                    : val * val -> val)
-                                    (str, $camlString_switch__immstring24)
+                                    (str, $camlString_switch__immstring26)
                                     -> k2 * k1
                                   where k2 (Pccall_3) =
                                     let untagged = %untag_imm (Pccall_3) in
@@ -58,8 +58,10 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
                                       | 1 ->
                                         k1
                                           pop(regular k1)
-                                          ($camlString_switch__Pmakeblock35)))))))
+                                          ($camlString_switch__Pmakeblock37)))))))
 in
-let $camlString_switch__of_string_1 = closure of_string_0_1 @of_string in
+let $camlString_switch__of_string_1 =
+  closure of_string_0_1 @of_string &toplevel.alloc_region
+in
 let $camlString_switch = Block 0 ($camlString_switch__of_string_1) in
 cont done ($camlString_switch)

--- a/testsuite/tests/flambda2/examples/symbol_projections.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections.simplify.reference
@@ -1,13 +1,13 @@
 let code g_1 deleted in
 let code f_0 deleted in
-let $camlSymbol_projections__immstring10 = "FOO" in
+let $camlSymbol_projections__immstring11 = "FOO" in
 (let try_region = %begin_try_region () in
  let try_ghost_region = %begin_try_ghost_region () in
  cont k2 push(k1)
    where k2 =
      (apply ccall
         ($`*extern*`.caml_sys_getenv : val -> val)
-          ($camlSymbol_projections__immstring10)
+          ($camlSymbol_projections__immstring11)
           -> k3 * k1
         where k3 (param) =
           cont k2
@@ -21,24 +21,26 @@ let $camlSymbol_projections__immstring10 = "FOO" in
     let foo_1 = foo in
     let set_of_closures
           $camlSymbol_projections__f_2 =
-          closure f_0_1 @f
+          closure f_0_1 @f &toplevel.alloc_region
           with { foo = foo }
         end
     and code loopify(never) size(8) newer_version_of(f_0)
           f_0_1 (x)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of val * val ] =
-      let Pmakeblock = %block.[`0`] (x, $camlSymbol_projections__g_3) in
+      let Pmakeblock =
+        %block.[`0`].my_alloc_region (x, $camlSymbol_projections__g_3)
+      in
       cont k (Pmakeblock)
     and set_of_closures
           $camlSymbol_projections__g_3 =
-          closure g_1_1 @g
+          closure g_1_1 @g &toplevel.alloc_region
           with { foo_1 = foo_1 }
         end
     and code loopify(never) size(15) newer_version_of(g_1)
           g_1_1 (y : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let foo_2 =

--- a/testsuite/tests/flambda2/examples/symbol_projections2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections2.simplify.reference
@@ -3,25 +3,27 @@ let code `fn[symbol_projections2.ml:21,8--17]_2` deleted in
 let code g_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(ignore_0)
       ignore_0_1 (param)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlSymbol_projections2__ignore_3 = closure ignore_0_1 @ignore in
+let $camlSymbol_projections2__ignore_3 =
+  closure ignore_0_1 @ignore &toplevel.alloc_region
+in
 let v = %opaque (33) in
 let v_1 = v in
 let set_of_closures
       $camlSymbol_projections2__g_4 =
-      closure g_1_1 @g
+      closure g_1_1 @g &toplevel.alloc_region
       with { v = v }
     end
 and code loopify(never) size(5) newer_version_of(g_1)
       g_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  apply direct(ignore_0_1)
+  apply direct(ignore_0_1 &my_alloc_region)
     ($camlSymbol_projections2__ignore_3 : _ -> imm tagged) (0) -> k2 * k1
     where k2 (param_1 : imm tagged) =
       cont k
@@ -29,12 +31,12 @@ and code loopify(never) size(5) newer_version_of(g_1)
 and set_of_closures
       $`camlSymbol_projections2__fn[symbol_projections2.ml:21,8--17]_5` =
       closure `fn[symbol_projections2.ml:21,8--17]_2_1`
-        @`fn[symbol_projections2.ml:21,8--17]`
+        @`fn[symbol_projections2.ml:21,8--17]` &toplevel.alloc_region
       with { v_1 = v_1 }
     end
 and code loopify(never) size(4) newer_version_of(`fn[symbol_projections2.ml:21,8--17]_2`)
       `fn[symbol_projections2.ml:21,8--17]_2_1` (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let v_2 =

--- a/testsuite/tests/flambda2/examples/symbol_projections3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections3.simplify.reference
@@ -1,13 +1,13 @@
 let code g_1 deleted in
 let code f_0 deleted in
-let $camlSymbol_projections3__immstring10 = "FOO" in
+let $camlSymbol_projections3__immstring11 = "FOO" in
 (let try_region = %begin_try_region () in
  let try_ghost_region = %begin_try_ghost_region () in
  cont k2 push(k1)
    where k2 =
      (apply ccall
         ($`*extern*`.caml_sys_getenv : val -> val)
-          ($camlSymbol_projections3__immstring10)
+          ($camlSymbol_projections3__immstring11)
           -> k3 * k1
         where k3 (param) =
           cont k2
@@ -21,29 +21,29 @@ let $camlSymbol_projections3__immstring10 = "FOO" in
     let foo_1 = foo in
     let set_of_closures
           $camlSymbol_projections3__f_2 =
-          closure f_0_1 @f
+          closure f_0_1 @f &toplevel.alloc_region
           with { foo = foo }
         end
     and code loopify(never) size(9) newer_version_of(f_0)
           f_0_1 (x)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of val * val * [ 0 of imm tagged * imm tagged ] ] =
       let Pmakeblock =
-        %block.[`0`]
+        %block.[`0`].my_alloc_region
           (x,
            $camlSymbol_projections3__g_3,
-           $camlSymbol_projections3__block_to_lift60)
+           $camlSymbol_projections3__block_to_lift65)
       in
       cont k (Pmakeblock)
     and set_of_closures
           $camlSymbol_projections3__g_3 =
-          closure g_1_1 @g
+          closure g_1_1 @g &toplevel.alloc_region
           with { foo_1 = foo_1 }
         end
     and code loopify(never) size(15) newer_version_of(g_1)
           g_1_1 (y : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let foo_2 =
@@ -56,7 +56,7 @@ let $camlSymbol_projections3__immstring10 = "FOO" in
         where k2 =
           let int_add = %int_barith.add (y, y) in
           cont k (int_add)
-    and $camlSymbol_projections3__block_to_lift60 =
+    and $camlSymbol_projections3__block_to_lift65 =
       Block 0 (foo_1, foo_1)
     in
     let $camlSymbol_projections3 =

--- a/testsuite/tests/flambda2/examples/symbol_projections4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections4.simplify.reference
@@ -1,14 +1,14 @@
 let code h_1 deleted in
 let code g_2 deleted in
 let code f_0 deleted in
-let $camlSymbol_projections4__immstring10 = "FOO" in
+let $camlSymbol_projections4__immstring11 = "FOO" in
 (let try_region = %begin_try_region () in
  let try_ghost_region = %begin_try_ghost_region () in
  cont k2 push(k1)
    where k2 =
      (apply ccall
         ($`*extern*`.caml_sys_getenv : val -> val)
-          ($camlSymbol_projections4__immstring10)
+          ($camlSymbol_projections4__immstring11)
           -> k3 * k1
         where k3 (param) =
           cont k2
@@ -22,12 +22,12 @@ let $camlSymbol_projections4__immstring10 = "FOO" in
     let foo_1 = foo in
     let set_of_closures
           $camlSymbol_projections4__f_3 =
-          closure f_0_1 @f
+          closure f_0_1 @f &toplevel.alloc_region
           with { foo = foo }
         end
     and code loopify(never) size(27) newer_version_of(f_0)
           f_0_1 (x, b : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of val * val ] =
       (let untagged = %untag_imm (b) in
@@ -35,19 +35,23 @@ let $camlSymbol_projections4__immstring10 = "FOO" in
          | 0 -> k2
          | 1 -> k3)
         where k3 =
-          let Pmakeblock = %block.[`0`] (x, $camlSymbol_projections4__g_5) in
+          let Pmakeblock =
+            %block.[`0`].my_alloc_region (x, $camlSymbol_projections4__g_5)
+          in
           cont k (Pmakeblock)
         where k2 =
-          let Pmakeblock = %block.[`0`] (x, $camlSymbol_projections4__h_4) in
+          let Pmakeblock =
+            %block.[`0`].my_alloc_region (x, $camlSymbol_projections4__h_4)
+          in
           cont k (Pmakeblock)
     and set_of_closures
           $camlSymbol_projections4__h_4 =
-          closure h_1_1 @h
+          closure h_1_1 @h &toplevel.alloc_region
           with { foo_1 = foo_1 }
         end
     and code loopify(never) size(17) newer_version_of(h_1)
           h_1_1 (y : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let foo_2 =
@@ -63,12 +67,12 @@ let $camlSymbol_projections4__immstring10 = "FOO" in
           cont k (int_add_1)
     and set_of_closures
           $camlSymbol_projections4__g_5 =
-          closure g_2_1 @g
+          closure g_2_1 @g &toplevel.alloc_region
           with { foo_2 = foo_1 }
         end
     and code loopify(never) size(15) newer_version_of(g_2)
           g_2_1 (y : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let foo_2 =

--- a/testsuite/tests/flambda2/examples/symbol_projections5.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections5.simplify.reference
@@ -1,14 +1,14 @@
 let code h_1 deleted in
 let code g_2 deleted in
 let code f_0 deleted in
-let $camlSymbol_projections5__immstring10 = "FOO" in
+let $camlSymbol_projections5__immstring11 = "FOO" in
 (let try_region = %begin_try_region () in
  let try_ghost_region = %begin_try_ghost_region () in
  cont k2 push(k1)
    where k2 =
      (apply ccall
         ($`*extern*`.caml_sys_getenv : val -> val)
-          ($camlSymbol_projections5__immstring10)
+          ($camlSymbol_projections5__immstring11)
           -> k3 * k1
         where k3 (param) =
           cont k2
@@ -20,10 +20,10 @@ let $camlSymbol_projections5__immstring10 = "FOO" in
      cont k (0))
   where k (foo : imm tagged) =
     let $camlSymbol_projections5__g_5 =
-      closure g_2_1 @g
+      closure g_2_1 @g &toplevel.alloc_region
     and code rec loopify(never) size(26) newer_version_of(g_2)
           g_2_1 (y : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of val |1 of val ] =
       let prim = %int_comp.lt (y, 0) in
@@ -32,22 +32,22 @@ let $camlSymbol_projections5__immstring10 = "FOO" in
         | 1 -> k3
         where k3 =
           let Pmakeblock =
-            %block.[`0`]
+            %block.[`0`].my_alloc_region
               ($camlSymbol_projections5__g_5 ~ depth my_depth -> succ my_depth)
           in
           cont k (Pmakeblock)
         where k2 =
           let Pmakeblock =
-            %block.[`1`]
+            %block.[`1`].my_alloc_region
               ($camlSymbol_projections5__g_5 ~ depth my_depth -> succ my_depth)
           in
           cont k (Pmakeblock)
     in
     let $camlSymbol_projections5__h_4 =
-      closure h_1_1 @h
+      closure h_1_1 @h &toplevel.alloc_region
     and code rec loopify(never) size(26) newer_version_of(h_1)
           h_1_1 (z : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of val |1 of val ] =
       let prim = %int_comp.lt (z, 0) in
@@ -56,20 +56,20 @@ let $camlSymbol_projections5__immstring10 = "FOO" in
         | 1 -> k3
         where k3 =
           let Pmakeblock =
-            %block.[`0`]
+            %block.[`0`].my_alloc_region
               ($camlSymbol_projections5__h_4 ~ depth my_depth -> succ my_depth)
           in
           cont k (Pmakeblock)
         where k2 =
           let Pmakeblock =
-            %block.[`1`]
+            %block.[`1`].my_alloc_region
               ($camlSymbol_projections5__h_4 ~ depth my_depth -> succ my_depth)
           in
           cont k (Pmakeblock)
     in
     let code loopify(never) size(11) newer_version_of(f_0)
           f_0_1 (b : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : val =
       let untagged = %untag_imm (b) in
@@ -77,7 +77,9 @@ let $camlSymbol_projections5__immstring10 = "FOO" in
         | 0 -> k ($camlSymbol_projections5__h_4)
         | 1 -> k ($camlSymbol_projections5__g_5)
     in
-    let $camlSymbol_projections5__f_3 = closure f_0_1 @f in
+    let $camlSymbol_projections5__f_3 =
+      closure f_0_1 @f &toplevel.alloc_region
+    in
     let $camlSymbol_projections5 =
       Block 0 (foo, $camlSymbol_projections5__f_3)
     in

--- a/testsuite/tests/flambda2/examples/symbol_projections6.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections6.simplify.reference
@@ -1,14 +1,14 @@
 let code h_1 deleted in
 let code g_2 deleted in
 let code f_0 deleted in
-let $camlSymbol_projections6__immstring10 = "FOO" in
+let $camlSymbol_projections6__immstring11 = "FOO" in
 (let try_region = %begin_try_region () in
  let try_ghost_region = %begin_try_ghost_region () in
  cont k2 push(k1)
    where k2 =
      (apply ccall
         ($`*extern*`.caml_sys_getenv : val -> val)
-          ($camlSymbol_projections6__immstring10)
+          ($camlSymbol_projections6__immstring11)
           -> k3 * k1
         where k3 (param) =
           cont k2
@@ -22,12 +22,12 @@ let $camlSymbol_projections6__immstring10 = "FOO" in
     let foo_1 = foo in
     let set_of_closures
           $camlSymbol_projections6__f_3 =
-          closure f_0_1 @f
+          closure f_0_1 @f &toplevel.alloc_region
           with { foo = foo }
         end
     and code loopify(never) size(11) newer_version_of(f_0)
           f_0_1 (b : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : val =
       let untagged = %untag_imm (b) in
@@ -36,12 +36,12 @@ let $camlSymbol_projections6__immstring10 = "FOO" in
         | 1 -> k ($camlSymbol_projections6__g_5)
     and set_of_closures
           $camlSymbol_projections6__h_4 =
-          closure h_1_1 @h
+          closure h_1_1 @h &toplevel.alloc_region
           with { foo_1 = foo_1 }
         end
     and code rec loopify(never) size(52) newer_version_of(h_1)
           h_1_1 (z : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of [ 0 of val |1 of val ] * imm tagged ] =
       let foo_2 =
@@ -58,26 +58,29 @@ let $camlSymbol_projections6__immstring10 = "FOO" in
                | 1 -> k3)
               where k3 =
                 let Pmakeblock =
-                  %block.[`0`]
+                  %block.[`0`].my_alloc_region
                     ($camlSymbol_projections6__h_4 ~ depth my_depth -> succ my_depth)
                 in
-                let Pmakeblock_1 = %block.[`0`] (Pmakeblock, foo_2) in
+                let Pmakeblock_1 =
+                  %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
+                in
                 cont k (Pmakeblock_1)))
         where k2 =
           let Pmakeblock =
-            %block.[`1`]
+            %block.[`1`].my_alloc_region
               ($camlSymbol_projections6__h_4 ~ depth my_depth -> succ my_depth)
           in
-          let Pmakeblock_1 = %block.[`0`] (Pmakeblock, foo_2) in
+          let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
+          in
           cont k (Pmakeblock_1)
     and set_of_closures
           $camlSymbol_projections6__g_5 =
-          closure g_2_1 @g
+          closure g_2_1 @g &toplevel.alloc_region
           with { foo_2 = foo_1 }
         end
     and code rec loopify(never) size(52) newer_version_of(g_2)
           g_2_1 (y : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of [ 0 of val |1 of val ] * imm tagged ] =
       let foo_2 =
@@ -94,17 +97,20 @@ let $camlSymbol_projections6__immstring10 = "FOO" in
                | 1 -> k3)
               where k3 =
                 let Pmakeblock =
-                  %block.[`0`]
+                  %block.[`0`].my_alloc_region
                     ($camlSymbol_projections6__g_5 ~ depth my_depth -> succ my_depth)
                 in
-                let Pmakeblock_1 = %block.[`0`] (Pmakeblock, foo_2) in
+                let Pmakeblock_1 =
+                  %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
+                in
                 cont k (Pmakeblock_1)))
         where k2 =
           let Pmakeblock =
-            %block.[`1`]
+            %block.[`1`].my_alloc_region
               ($camlSymbol_projections6__g_5 ~ depth my_depth -> succ my_depth)
           in
-          let Pmakeblock_1 = %block.[`0`] (Pmakeblock, foo_2) in
+          let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
+          in
           cont k (Pmakeblock_1)
     in
     let $camlSymbol_projections6 =

--- a/testsuite/tests/flambda2/examples/symbol_projections7.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections7.simplify.reference
@@ -2,10 +2,10 @@ let code `fn[symbol_projections7.ml:20,4--18]_1` deleted in
 let y = %opaque (2) in
 let $`camlSymbol_projections7__fn[symbol_projections7.ml:20,4--18]_2` =
   closure `fn[symbol_projections7.ml:20,4--18]_1_1`
-    @`fn[symbol_projections7.ml:20,4--18]`
+    @`fn[symbol_projections7.ml:20,4--18]` &toplevel.alloc_region
 and code loopify(never) size(4) newer_version_of(`fn[symbol_projections7.ml:20,4--18]_1`)
       `fn[symbol_projections7.ml:20,4--18]_1_1` (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let y_1 =

--- a/testsuite/tests/flambda2/examples/tests.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests__first_const = Block 0 () in
 (let code inline(always) size(1)
        to_inline_0 (_x, _y)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -14,7 +14,7 @@ let $camlTests__first_const = Block 0 () in
           n : [ 0 | 0 of val ],
           x' : imm tagged,
           y' : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -65,14 +65,16 @@ let $camlTests__first_const = Block 0 () in
                       let Pfield_1 = %block_load.[`0`] (m) in
                       let int_add = %int_barith.add (Pfield_1, Pfield) in
                       let int_add_1 = %int_barith.add (x, y) in
-                      apply direct(to_inline_0)
+                      apply direct(to_inline_0 &my_alloc_region)
                         (to_inline : _ -> imm tagged)
                           (int_add_1, int_add)
                           -> k1 * k2)))
  in
- let to_inline = closure to_inline_0 @to_inline in
- let f = closure f_1 @f with { to_inline = to_inline } in
- let Pmakeblock = %block.[`0`] (to_inline, f) in
+ let to_inline = closure to_inline_0 @to_inline &toplevel.alloc_region in
+ let f = closure f_1 @f &toplevel.alloc_region
+ with { to_inline = to_inline }
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (to_inline, f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests.simplify.reference
@@ -2,12 +2,14 @@ let code to_inline_0 deleted in
 let code f_1 deleted in
 let code inline(always) loopify(never) size(1) newer_version_of(to_inline_0)
       to_inline_0_1 (_x, _y)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (42)
 in
-let $camlTests__to_inline_2 = closure to_inline_0_1 @to_inline in
+let $camlTests__to_inline_2 =
+  closure to_inline_0_1 @to_inline &toplevel.alloc_region
+in
 let code loopify(never) size(22) newer_version_of(f_1)
       f_1_1
         (c : imm tagged,
@@ -15,7 +17,7 @@ let code loopify(never) size(22) newer_version_of(f_1)
          n : [ 0 | 0 of val ],
          x' : imm tagged,
          y' : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %is_int (m) in
@@ -28,6 +30,6 @@ let code loopify(never) size(22) newer_version_of(f_1)
         | 0 -> k (42)
         | 1 -> k (1)
 in
-let $camlTests__f_3 = closure f_1_1 @f in
+let $camlTests__f_3 = closure f_1_1 @f &toplevel.alloc_region in
 let $camlTests = Block 0 ($camlTests__to_inline_2, $camlTests__f_3) in
 cont done ($camlTests)

--- a/testsuite/tests/flambda2/examples/tests0.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests0.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests0__first_const = Block 0 () in
 (let code size(31)
        f_0 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -22,8 +22,8 @@ let $camlTests0__first_const = Block 0 () in
          | 0 -> k1 (1)
          | 1 -> k1 (2)
  in
- let f = closure f_0 @f in
- let Pmakeblock = %block.[`0`] (f) in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests0.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests0.simplify.reference
@@ -1,11 +1,11 @@
 let code f_0 deleted in
 let code loopify(never) size(0) newer_version_of(f_0)
       f_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlTests0__f_1 = closure f_0_1 @f in
+let $camlTests0__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlTests0 = Block 0 ($camlTests0__f_1) in
 cont done ($camlTests0)

--- a/testsuite/tests/flambda2/examples/tests10.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests10.raw.reference
@@ -1,19 +1,19 @@
 let $camlTests10__first_const = Block 0 () in
 (let code rec size(8)
        f_0 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let Pmakeblock =
-     %block.[`0`]
+     %block.[`0`].my_alloc_region
        (my_closure ~ depth my_depth -> next_depth,
         my_closure ~ depth my_depth -> next_depth)
    in
    cont k1 (Pmakeblock)
  in
- let f = closure f_0 @f in
- let Pmakeblock = %block.[`0`] (f) in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests10.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests10.simplify.reference
@@ -1,13 +1,13 @@
 let code f_0 deleted in
 let $camlTests10__f_1 =
-  closure f_0_1 @f
+  closure f_0_1 @f &toplevel.alloc_region
 and code rec loopify(never) size(8) newer_version_of(f_0)
       f_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
   let Pmakeblock =
-    %block.[`0`]
+    %block.[`0`].my_alloc_region
       ($camlTests10__f_1 ~ depth my_depth -> succ my_depth,
        $camlTests10__f_1 ~ depth my_depth -> succ my_depth)
   in

--- a/testsuite/tests/flambda2/examples/tests11.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests11.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests11__first_const = Block 0 () in
 (let code size(1)
        `fn[tests11.ml:23,52--67]_2` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -9,14 +9,14 @@ let $camlTests11__first_const = Block 0 () in
  in
  let code size(1)
        `fn[tests11.ml:23,39--51]_3` (x)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
  let code size(23)
        `fn[tests11.ml:23,2--70]_1` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let map_foo =
@@ -24,35 +24,38 @@ let $camlTests11__first_const = Block 0 () in
    in
    let `fn[tests11.ml:23,52--67]` =
      closure `fn[tests11.ml:23,52--67]_2` @`fn[tests11.ml:23,52--67]`
+       &my_alloc_region
    in
    let `fn[tests11.ml:23,39--51]` =
      closure `fn[tests11.ml:23,39--51]_3` @`fn[tests11.ml:23,39--51]`
+       &my_alloc_region
    in
-   apply inlined(never)
+   apply &my_alloc_region inlined(never)
      map_foo
        (`fn[tests11.ml:23,39--51]`, `fn[tests11.ml:23,52--67]`, 0)
        -> k1 * k2
  in
  let code inline(always) size(32)
        bar_0 (map_foo : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
    let `fn[tests11.ml:23,2--70]` =
      closure `fn[tests11.ml:23,2--70]_1` @`fn[tests11.ml:23,2--70]`
+       &my_alloc_region
    with { map_foo = map_foo }
    in
    cont k1 (`fn[tests11.ml:23,2--70]`)
  in
  let code rec size(58)
        map_foo_4 (f : val, seq : val, param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
-   apply seq (0) -> k3 * k2
+   apply &my_alloc_region seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -73,27 +76,30 @@ let $camlTests11__first_const = Block 0 () in
                 where k6 =
                   cont k5)
                where k5 =
-                 apply direct(bar_0)
+                 apply direct(bar_0 &my_alloc_region)
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k4 =
-                 apply direct(bar_0)
+                 apply direct(bar_0 &my_alloc_region)
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k3 (staticcatch_result : val) =
                  ((let Pfield = %block_load.[`0`] (`*match*`) in
-                   apply f (Pfield) -> k3 * k2)
+                   apply &my_alloc_region f (Pfield) -> k3 * k2)
                     where k3 (apply_result : val) =
                       let Pmakeblock =
-                        %block.[`0`] (apply_result, staticcatch_result)
+                        %block.[`0`].my_alloc_region
+                          (apply_result, staticcatch_result)
                       in
                       cont k1 (Pmakeblock))))
  in
- let bar = closure bar_0 @bar in
- let map_foo = closure map_foo_4 @map_foo with { bar = bar } in
- let Pmakeblock = %block.[`0`] (map_foo) in
+ let bar = closure bar_0 @bar &toplevel.alloc_region in
+ let map_foo = closure map_foo_4 @map_foo &toplevel.alloc_region
+ with { bar = bar }
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (map_foo) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests11.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests11.simplify.reference
@@ -4,31 +4,33 @@ let code `fn[tests11.ml:23,2--70]_1` deleted in
 let code map_foo_4 deleted in
 let code loopify(never) size(1) newer_version_of(`fn[tests11.ml:23,39--51]_3`)
       `fn[tests11.ml:23,39--51]_3_1` (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   cont k (x)
 in
 let $`camlTests11__fn[tests11.ml:23,39--51]_7` =
   closure `fn[tests11.ml:23,39--51]_3_1` @`fn[tests11.ml:23,39--51]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(1) newer_version_of(`fn[tests11.ml:23,52--67]_2`)
       `fn[tests11.ml:23,52--67]_2_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
   cont k (0)
 in
 let $`camlTests11__fn[tests11.ml:23,52--67]_6` =
   closure `fn[tests11.ml:23,52--67]_2_1` @`fn[tests11.ml:23,52--67]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(7) newer_version_of(`fn[tests11.ml:23,2--70]_1`)
       `fn[tests11.ml:23,2--70]_1_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let map_foo =
     %project_value_slot.[`fn[tests11.ml:23,2--70]`].[map_foo] (my_closure)
   in
-  apply inlined(never)
+  apply &my_alloc_region inlined(never)
     map_foo
       ($`camlTests11__fn[tests11.ml:23,39--51]_7`,
        $`camlTests11__fn[tests11.ml:23,52--67]_6`,
@@ -36,13 +38,13 @@ let code loopify(never) size(7) newer_version_of(`fn[tests11.ml:23,2--70]_1`)
       -> k * k1
 in
 let $camlTests11__map_foo_8 =
-  closure map_foo_4_1 @map_foo
+  closure map_foo_4_1 @map_foo &toplevel.alloc_region
 and code rec loopify(never) size(69) newer_version_of(map_foo_4)
       map_foo_4_1 (f : val, seq : val, param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply seq (0) -> k2 * k1
+  apply &my_alloc_region seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
@@ -57,7 +59,7 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                where k4 =
                  let `fn[tests11.ml:23,2--70]` =
                    closure `fn[tests11.ml:23,2--70]_1_3`
-                     @`fn[tests11.ml:23,2--70]`
+                     @`fn[tests11.ml:23,2--70]` &my_alloc_region
                  with {
                    map_foo =
                      $camlTests11__map_foo_8 ~ depth my_depth -> succ my_depth
@@ -67,7 +69,7 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                where k3 =
                  let `fn[tests11.ml:23,2--70]` =
                    closure `fn[tests11.ml:23,2--70]_1_2`
-                     @`fn[tests11.ml:23,2--70]`
+                     @`fn[tests11.ml:23,2--70]` &my_alloc_region
                  with {
                    map_foo =
                      $camlTests11__map_foo_8 ~ depth my_depth -> succ my_depth
@@ -76,17 +78,19 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                  cont k2 (`fn[tests11.ml:23,2--70]`))
               where k2 (staticcatch_result : val) =
                 ((let Pfield = %block_load.[`0`] (`*match*`) in
-                  apply f (Pfield) -> k2 * k1)
+                  apply &my_alloc_region f (Pfield) -> k2 * k1)
                    where k2 (apply_result : val) =
                      let Pmakeblock =
-                       %block.[`0`] (apply_result, staticcatch_result)
+                       %block.[`0`].my_alloc_region
+                         (apply_result, staticcatch_result)
                      in
                      cont k (Pmakeblock))))
 and code loopify(never) size(4) newer_version_of(`fn[tests11.ml:23,2--70]_1_1`)
       `fn[tests11.ml:23,2--70]_1_2` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(map_foo_4_1) inlined(never) inlining_state(depth(1))
+  apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
+         inlining_state(depth(1))
     $camlTests11__map_foo_8 ~ depth do_not_inline -> do_not_inline
       ($`camlTests11__fn[tests11.ml:23,39--51]_7`,
        $`camlTests11__fn[tests11.ml:23,52--67]_6`,
@@ -94,9 +98,10 @@ and code loopify(never) size(4) newer_version_of(`fn[tests11.ml:23,2--70]_1_1`)
       -> k * k1
 and code loopify(never) size(4) newer_version_of(`fn[tests11.ml:23,2--70]_1_1`)
       `fn[tests11.ml:23,2--70]_1_3` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(map_foo_4_1) inlined(never) inlining_state(depth(1))
+  apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
+         inlining_state(depth(1))
     $camlTests11__map_foo_8 ~ depth do_not_inline -> do_not_inline
       ($`camlTests11__fn[tests11.ml:23,39--51]_7`,
        $`camlTests11__fn[tests11.ml:23,52--67]_6`,

--- a/testsuite/tests/flambda2/examples/tests12.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests12.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests12__first_const = Block 0 () in
 (let code size(1)
        `fn[tests12.ml:25,52--67]_2` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -9,14 +9,14 @@ let $camlTests12__first_const = Block 0 () in
  in
  let code size(1)
        `fn[tests12.ml:25,39--51]_3` (x)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
  let code size(23)
        `fn[tests12.ml:25,2--70]_1` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let map_foo =
@@ -24,35 +24,38 @@ let $camlTests12__first_const = Block 0 () in
    in
    let `fn[tests12.ml:25,52--67]` =
      closure `fn[tests12.ml:25,52--67]_2` @`fn[tests12.ml:25,52--67]`
+       &my_alloc_region
    in
    let `fn[tests12.ml:25,39--51]` =
      closure `fn[tests12.ml:25,39--51]_3` @`fn[tests12.ml:25,39--51]`
+       &my_alloc_region
    in
-   apply inlined(never)
+   apply &my_alloc_region inlined(never)
      map_foo
        (`fn[tests12.ml:25,39--51]`, `fn[tests12.ml:25,52--67]`, 0)
        -> k1 * k2
  in
  let code inline(always) size(32)
        bar_0 (map_foo : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
    let `fn[tests12.ml:25,2--70]` =
      closure `fn[tests12.ml:25,2--70]_1` @`fn[tests12.ml:25,2--70]`
+       &my_alloc_region
    with { map_foo = map_foo }
    in
    cont k1 (`fn[tests12.ml:25,2--70]`)
  in
  let code rec size(64)
        map_foo_4 (f : val, seq : val, param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
-   apply seq (0) -> k3 * k2
+   apply &my_alloc_region seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -73,28 +76,32 @@ let $camlTests12__first_const = Block 0 () in
                 where k6 =
                   cont k5)
                where k5 =
-                 apply direct(bar_0)
+                 apply direct(bar_0 &my_alloc_region)
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k4 =
-                 apply direct(bar_0)
+                 apply direct(bar_0 &my_alloc_region)
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k3 (g : val) =
-                 (apply inlined(always) g (0) -> k3 * k2
+                 (apply &my_alloc_region inlined(always) g (0) -> k3 * k2
                     where k3 (g_result : [ 0 | 0 of val * val ]) =
                       let Popaque = %opaque (g_result) in
                       ((let Pfield = %block_load.[`0`] (`*match*`) in
-                        apply f (Pfield) -> k3 * k2)
+                        apply &my_alloc_region f (Pfield) -> k3 * k2)
                          where k3 (apply_result : val) =
-                           let Pmakeblock = %block.[`0`] (apply_result, g) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (apply_result, g)
+                           in
                            cont k1 (Pmakeblock)))))
  in
- let bar = closure bar_0 @bar in
- let map_foo = closure map_foo_4 @map_foo with { bar = bar } in
- let Pmakeblock = %block.[`0`] (bar, map_foo) in
+ let bar = closure bar_0 @bar &toplevel.alloc_region in
+ let map_foo = closure map_foo_4 @map_foo &toplevel.alloc_region
+ with { bar = bar }
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (bar, map_foo) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests12.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests12.simplify.reference
@@ -5,31 +5,33 @@ let code bar_0 deleted in
 let code map_foo_4 deleted in
 let code loopify(never) size(1) newer_version_of(`fn[tests12.ml:25,39--51]_3`)
       `fn[tests12.ml:25,39--51]_3_1` (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   cont k (x)
 in
 let $`camlTests12__fn[tests12.ml:25,39--51]_7` =
   closure `fn[tests12.ml:25,39--51]_3_1` @`fn[tests12.ml:25,39--51]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(1) newer_version_of(`fn[tests12.ml:25,52--67]_2`)
       `fn[tests12.ml:25,52--67]_2_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
   cont k (0)
 in
 let $`camlTests12__fn[tests12.ml:25,52--67]_6` =
   closure `fn[tests12.ml:25,52--67]_2_1` @`fn[tests12.ml:25,52--67]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(7) newer_version_of(`fn[tests12.ml:25,2--70]_1`)
       `fn[tests12.ml:25,2--70]_1_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let map_foo =
     %project_value_slot.[`fn[tests12.ml:25,2--70]`].[map_foo] (my_closure)
   in
-  apply inlined(never)
+  apply &my_alloc_region inlined(never)
     map_foo
       ($`camlTests12__fn[tests12.ml:25,39--51]_7`,
        $`camlTests12__fn[tests12.ml:25,52--67]_6`,
@@ -38,24 +40,25 @@ let code loopify(never) size(7) newer_version_of(`fn[tests12.ml:25,2--70]_1`)
 in
 let code inline(always) loopify(never) size(16) newer_version_of(bar_0)
       bar_0_1 (map_foo : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   let `fn[tests12.ml:25,2--70]` =
     closure `fn[tests12.ml:25,2--70]_1_1` @`fn[tests12.ml:25,2--70]`
+      &my_alloc_region
   with { map_foo = map_foo }
   in
   cont k (`fn[tests12.ml:25,2--70]`)
 in
-let $camlTests12__bar_5 = closure bar_0_1 @bar in
+let $camlTests12__bar_5 = closure bar_0_1 @bar &toplevel.alloc_region in
 let $camlTests12__map_foo_8 =
-  closure map_foo_4_1 @map_foo
+  closure map_foo_4_1 @map_foo &toplevel.alloc_region
 and code rec loopify(never) size(75) newer_version_of(map_foo_4)
       map_foo_4_1 (f : val, seq : val, param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply seq (0) -> k2 * k1
+  apply &my_alloc_region seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
@@ -70,7 +73,7 @@ and code rec loopify(never) size(75) newer_version_of(map_foo_4)
                where k4 =
                  let `fn[tests12.ml:25,2--70]` =
                    closure `fn[tests12.ml:25,2--70]_1_3`
-                     @`fn[tests12.ml:25,2--70]`
+                     @`fn[tests12.ml:25,2--70]` &my_alloc_region
                  with {
                    map_foo =
                      $camlTests12__map_foo_8 ~ depth my_depth -> succ my_depth
@@ -80,7 +83,7 @@ and code rec loopify(never) size(75) newer_version_of(map_foo_4)
                where k3 =
                  let `fn[tests12.ml:25,2--70]` =
                    closure `fn[tests12.ml:25,2--70]_1_2`
-                     @`fn[tests12.ml:25,2--70]`
+                     @`fn[tests12.ml:25,2--70]` &my_alloc_region
                  with {
                    map_foo =
                      $camlTests12__map_foo_8 ~ depth my_depth -> succ my_depth
@@ -88,19 +91,22 @@ and code rec loopify(never) size(75) newer_version_of(map_foo_4)
                  in
                  cont k2 (`fn[tests12.ml:25,2--70]`))
               where k2 (g : val) =
-                (apply inlined(always) g (0) -> k2 * k1
+                (apply &my_alloc_region inlined(always) g (0) -> k2 * k1
                    where k2 (g_result : [ 0 | 0 of val * val ]) =
                      let Popaque = %opaque (g_result) in
                      ((let Pfield = %block_load.[`0`] (`*match*`) in
-                       apply f (Pfield) -> k2 * k1)
+                       apply &my_alloc_region f (Pfield) -> k2 * k1)
                         where k2 (apply_result : val) =
-                          let Pmakeblock = %block.[`0`] (apply_result, g) in
+                          let Pmakeblock =
+                            %block.[`0`].my_alloc_region (apply_result, g)
+                          in
                           cont k (Pmakeblock)))))
 and code loopify(never) size(4) newer_version_of(`fn[tests12.ml:25,2--70]_1_1`)
       `fn[tests12.ml:25,2--70]_1_2` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(map_foo_4_1) inlined(never) inlining_state(depth(1))
+  apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
+         inlining_state(depth(1))
     $camlTests12__map_foo_8 ~ depth do_not_inline -> do_not_inline
       ($`camlTests12__fn[tests12.ml:25,39--51]_7`,
        $`camlTests12__fn[tests12.ml:25,52--67]_6`,
@@ -108,9 +114,10 @@ and code loopify(never) size(4) newer_version_of(`fn[tests12.ml:25,2--70]_1_1`)
       -> k * k1
 and code loopify(never) size(4) newer_version_of(`fn[tests12.ml:25,2--70]_1_1`)
       `fn[tests12.ml:25,2--70]_1_3` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(map_foo_4_1) inlined(never) inlining_state(depth(1))
+  apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
+         inlining_state(depth(1))
     $camlTests12__map_foo_8 ~ depth do_not_inline -> do_not_inline
       ($`camlTests12__fn[tests12.ml:25,39--51]_7`,
        $`camlTests12__fn[tests12.ml:25,52--67]_6`,

--- a/testsuite/tests/flambda2/examples/tests13.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests13.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests13__first_const = Block 0 () in
 (let code size(1)
        `fn[tests13.ml:30,44--59]_2` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -9,14 +9,14 @@ let $camlTests13__first_const = Block 0 () in
  in
  let code size(1)
        `fn[tests13.ml:30,31--43]_3` (x)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
  let code size(26)
        `fn[tests13.ml:27,2--118]_1` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
@@ -28,30 +28,33 @@ let $camlTests13__first_const = Block 0 () in
    let Popaque = %opaque (j) in
    let `fn[tests13.ml:30,44--59]` =
      closure `fn[tests13.ml:30,44--59]_2` @`fn[tests13.ml:30,44--59]`
+       &my_alloc_region
    in
    let `fn[tests13.ml:30,31--43]` =
      closure `fn[tests13.ml:30,31--43]_3` @`fn[tests13.ml:30,31--43]`
+       &my_alloc_region
    in
-   apply inlined(never)
+   apply &my_alloc_region inlined(never)
      map_foo
        (`fn[tests13.ml:30,31--43]`, `fn[tests13.ml:30,44--59]`, 0)
        -> k1 * k2
  in
  let code inline(always) size(36)
        bar_0 (i : imm tagged, map_foo : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
    let `fn[tests13.ml:27,2--118]` =
      closure `fn[tests13.ml:27,2--118]_1` @`fn[tests13.ml:27,2--118]`
+       &my_alloc_region
    with { i = i; map_foo = map_foo }
    in
    cont k1 (`fn[tests13.ml:27,2--118]`)
  in
  let code size(1)
        `fn[tests13.ml:41,15--28]_5` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -59,12 +62,12 @@ let $camlTests13__first_const = Block 0 () in
  in
  let code rec size(72)
        map_foo_4 (f : val, seq : val, param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
-   apply seq (0) -> k3 * k2
+   apply &my_alloc_region seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -85,35 +88,37 @@ let $camlTests13__first_const = Block 0 () in
                 where k6 =
                   cont k5)
                where k5 =
-                 apply direct(bar_0)
+                 apply direct(bar_0 &my_alloc_region)
                    (bar : _ -> val)
                      (20, my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k4 =
-                 apply direct(bar_0)
+                 apply direct(bar_0 &my_alloc_region)
                    (bar : _ -> val)
                      (10, my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k3 (g : val) =
-                 (apply inlined(always) g (0) -> k3 * k2
+                 (apply &my_alloc_region inlined(always) g (0) -> k3 * k2
                     where k3 (g_result : [ 0 | 0 of val * val ]) =
                       let Popaque = %opaque (g_result) in
                       let `fn[tests13.ml:41,15--28]` =
                         closure `fn[tests13.ml:41,15--28]_5`
-                          @`fn[tests13.ml:41,15--28]`
+                          @`fn[tests13.ml:41,15--28]` &my_alloc_region
                       in
                       ((let Pfield = %block_load.[`0`] (`*match*`) in
-                        apply f (Pfield) -> k3 * k2)
+                        apply &my_alloc_region f (Pfield) -> k3 * k2)
                          where k3 (apply_result : val) =
                            let Pmakeblock =
-                             %block.[`0`]
+                             %block.[`0`].my_alloc_region
                                (apply_result, `fn[tests13.ml:41,15--28]`)
                            in
                            cont k1 (Pmakeblock)))))
  in
- let bar = closure bar_0 @bar in
- let map_foo = closure map_foo_4 @map_foo with { bar = bar } in
- let Pmakeblock = %block.[`0`] (map_foo) in
+ let bar = closure bar_0 @bar &toplevel.alloc_region in
+ let map_foo = closure map_foo_4 @map_foo &toplevel.alloc_region
+ with { bar = bar }
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (map_foo) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests13.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests13.simplify.reference
@@ -5,26 +5,28 @@ let code `fn[tests13.ml:41,15--28]_5` deleted in
 let code map_foo_4 deleted in
 let code loopify(never) size(1) newer_version_of(`fn[tests13.ml:30,31--43]_3`)
       `fn[tests13.ml:30,31--43]_3_1` (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   cont k (x)
 in
 let $`camlTests13__fn[tests13.ml:30,31--43]_8` =
   closure `fn[tests13.ml:30,31--43]_3_1` @`fn[tests13.ml:30,31--43]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(1) newer_version_of(`fn[tests13.ml:30,44--59]_2`)
       `fn[tests13.ml:30,44--59]_2_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
   cont k (0)
 in
 let $`camlTests13__fn[tests13.ml:30,44--59]_7` =
   closure `fn[tests13.ml:30,44--59]_2_1` @`fn[tests13.ml:30,44--59]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(10) newer_version_of(`fn[tests13.ml:27,2--118]_1`)
       `fn[tests13.ml:27,2--118]_1_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
   in
@@ -33,7 +35,7 @@ let code loopify(never) size(10) newer_version_of(`fn[tests13.ml:27,2--118]_1`)
   in
   let j = %int_barith.add (i, 3) in
   let Popaque = %opaque (j) in
-  apply inlined(never)
+  apply &my_alloc_region inlined(never)
     map_foo
       ($`camlTests13__fn[tests13.ml:30,31--43]_8`,
        $`camlTests13__fn[tests13.ml:30,44--59]_7`,
@@ -42,22 +44,23 @@ let code loopify(never) size(10) newer_version_of(`fn[tests13.ml:27,2--118]_1`)
 in
 let code loopify(never) size(1) newer_version_of(`fn[tests13.ml:41,15--28]_5`)
       `fn[tests13.ml:41,15--28]_5_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
   cont k (0)
 in
 let $`camlTests13__fn[tests13.ml:41,15--28]_10` =
   closure `fn[tests13.ml:41,15--28]_5_1` @`fn[tests13.ml:41,15--28]`
+    &toplevel.alloc_region
 in
 let $camlTests13__map_foo_9 =
-  closure map_foo_4_1 @map_foo
+  closure map_foo_4_1 @map_foo &toplevel.alloc_region
 and code rec loopify(never) size(77) newer_version_of(map_foo_4)
       map_foo_4_1 (f : val, seq : val, param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply seq (0) -> k2 * k1
+  apply &my_alloc_region seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
@@ -72,7 +75,7 @@ and code rec loopify(never) size(77) newer_version_of(map_foo_4)
                where k4 =
                  let `fn[tests13.ml:27,2--118]` =
                    closure `fn[tests13.ml:27,2--118]_1_3`
-                     @`fn[tests13.ml:27,2--118]`
+                     @`fn[tests13.ml:27,2--118]` &my_alloc_region
                  with {
                    i = 10;
                    map_foo =
@@ -83,7 +86,7 @@ and code rec loopify(never) size(77) newer_version_of(map_foo_4)
                where k3 =
                  let `fn[tests13.ml:27,2--118]` =
                    closure `fn[tests13.ml:27,2--118]_1_2`
-                     @`fn[tests13.ml:27,2--118]`
+                     @`fn[tests13.ml:27,2--118]` &my_alloc_region
                  with {
                    i = 20;
                    map_foo =
@@ -92,24 +95,25 @@ and code rec loopify(never) size(77) newer_version_of(map_foo_4)
                  in
                  cont k2 (`fn[tests13.ml:27,2--118]`))
               where k2 (g : val) =
-                (apply inlined(always) g (0) -> k2 * k1
+                (apply &my_alloc_region inlined(always) g (0) -> k2 * k1
                    where k2 (g_result : [ 0 | 0 of val * val ]) =
                      let Popaque = %opaque (g_result) in
                      ((let Pfield = %block_load.[`0`] (`*match*`) in
-                       apply f (Pfield) -> k2 * k1)
+                       apply &my_alloc_region f (Pfield) -> k2 * k1)
                         where k2 (apply_result : val) =
                           let Pmakeblock =
-                            %block.[`0`]
+                            %block.[`0`].my_alloc_region
                               (apply_result,
                                $`camlTests13__fn[tests13.ml:41,15--28]_10`)
                           in
                           cont k (Pmakeblock)))))
 and code loopify(never) size(4) newer_version_of(`fn[tests13.ml:27,2--118]_1_1`)
       `fn[tests13.ml:27,2--118]_1_2` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let Popaque = %opaque (23) in
-  apply direct(map_foo_4_1) inlined(never) inlining_state(depth(1))
+  apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
+         inlining_state(depth(1))
     $camlTests13__map_foo_9 ~ depth do_not_inline -> do_not_inline
       ($`camlTests13__fn[tests13.ml:30,31--43]_8`,
        $`camlTests13__fn[tests13.ml:30,44--59]_7`,
@@ -117,10 +121,11 @@ and code loopify(never) size(4) newer_version_of(`fn[tests13.ml:27,2--118]_1_1`)
       -> k * k1
 and code loopify(never) size(4) newer_version_of(`fn[tests13.ml:27,2--118]_1_1`)
       `fn[tests13.ml:27,2--118]_1_3` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let Popaque = %opaque (13) in
-  apply direct(map_foo_4_1) inlined(never) inlining_state(depth(1))
+  apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
+         inlining_state(depth(1))
     $camlTests13__map_foo_9 ~ depth do_not_inline -> do_not_inline
       ($`camlTests13__fn[tests13.ml:30,31--43]_8`,
        $`camlTests13__fn[tests13.ml:30,44--59]_7`,

--- a/testsuite/tests/flambda2/examples/tests14.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests14.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests14__first_const = Block 0 () in
 (let code size(5)
        set_0 (t : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -10,7 +10,7 @@ let $camlTests14__first_const = Block 0 () in
  in
  let code size(7)
        nth_char_1 (s : val, n : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -21,7 +21,7 @@ let $camlTests14__first_const = Block 0 () in
  in
  let code size(32)
        needs_try_region_2 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -52,7 +52,7 @@ let $camlTests14__first_const = Block 0 () in
  in
  let code size(12)
        gadt_match_3 (x : [ 0 |1 | 0 of imm tagged ], n : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
@@ -64,11 +64,14 @@ let $camlTests14__first_const = Block 0 () in
        let Popaque = %opaque (n) in
        cont k1 (Popaque)
  in
- let set = closure set_0 @set in
- let nth_char = closure nth_char_1 @nth_char in
- let needs_try_region = closure needs_try_region_2 @needs_try_region in
- let gadt_match = closure gadt_match_3 @gadt_match in
- let Pmakeblock = %block.[`0`] (set, nth_char, needs_try_region, gadt_match)
+ let set = closure set_0 @set &toplevel.alloc_region in
+ let nth_char = closure nth_char_1 @nth_char &toplevel.alloc_region in
+ let needs_try_region =
+   closure needs_try_region_2 @needs_try_region &toplevel.alloc_region
+ in
+ let gadt_match = closure gadt_match_3 @gadt_match &toplevel.alloc_region in
+ let Pmakeblock =
+   %block.[`0`].`toplevel` (set, nth_char, needs_try_region, gadt_match)
  in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =

--- a/testsuite/tests/flambda2/examples/tests14.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests14.simplify.reference
@@ -4,16 +4,16 @@ let code needs_try_region_2 deleted in
 let code gadt_match_3 deleted in
 let code loopify(never) size(5) newer_version_of(set_0)
       set_0_1 (t : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Psetfield = %block_set.`imm`.[`0`] (t, 42) in
   cont k (0)
 in
-let $camlTests14__set_4 = closure set_0_1 @set in
+let $camlTests14__set_4 = closure set_0_1 @set &toplevel.alloc_region in
 let code loopify(never) size(7) newer_version_of(nth_char_1)
       nth_char_1_1 (s : val, n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %num_conv.[tagged_imm].[`nativeint`] (n) in
@@ -21,21 +21,23 @@ let code loopify(never) size(7) newer_version_of(nth_char_1)
   let Pstringrefu = %tag_imm (prim_1) in
   cont k (Pstringrefu)
 in
-let $camlTests14__nth_char_5 = closure nth_char_1_1 @nth_char in
+let $camlTests14__nth_char_5 =
+  closure nth_char_1_1 @nth_char &toplevel.alloc_region
+in
 let code loopify(never) size(1) newer_version_of(needs_try_region_2)
       needs_try_region_2_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Popaque = %opaque (42) in
   cont k (1)
 in
 let $camlTests14__needs_try_region_6 =
-  closure needs_try_region_2_1 @needs_try_region
+  closure needs_try_region_2_1 @needs_try_region &toplevel.alloc_region
 in
 let code loopify(never) size(12) newer_version_of(gadt_match_3)
       gadt_match_3_1 (x : [ 0 |1 | 0 of imm tagged ], n : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   (let untagged = %untag_imm (x) in
@@ -46,7 +48,9 @@ let code loopify(never) size(12) newer_version_of(gadt_match_3)
       let Popaque = %opaque (n) in
       cont k (Popaque)
 in
-let $camlTests14__gadt_match_7 = closure gadt_match_3_1 @gadt_match in
+let $camlTests14__gadt_match_7 =
+  closure gadt_match_3_1 @gadt_match &toplevel.alloc_region
+in
 let $camlTests14 =
   Block 0 ($camlTests14__set_4,
            $camlTests14__nth_char_5,

--- a/testsuite/tests/flambda2/examples/tests15.raw.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests15.raw.no-flat-float-array.reference
@@ -1,14 +1,14 @@
-(let $camlTests15__immstring13 = "tests15.ml" in
- let $camlTests15__const_block15 =
-   Block 0 ($camlTests15__immstring13, 18, 52)
+(let $camlTests15__immstring15 = "tests15.ml" in
+ let $camlTests15__const_block17 =
+   Block 0 ($camlTests15__immstring15, 18, 52)
  in
- let $camlTests15__Pmakeblock18 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block15)
+ let $camlTests15__Pmakeblock20 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block17)
  in
- let $camlTests15__empty_array20 = Empty_array in
+ let $camlTests15__empty_array22 = Empty_array in
  let code size(20)
        list_to_array_0 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val array =
    let next_depth = rec_info (succ my_depth) in
@@ -23,9 +23,9 @@
       where k5 =
         cont k4)
      where k4 =
-       cont k2 pop(regular k2) ($camlTests15__Pmakeblock18)
+       cont k2 pop(regular k2) ($camlTests15__Pmakeblock20)
      where k3 =
-       cont k1 ($camlTests15__empty_array20)
+       cont k1 ($camlTests15__empty_array22)
  in
  let code size(18)
        is_c_1
@@ -33,7 +33,7 @@
           param :
             [ 0 of imm tagged |1 of imm tagged |2 of imm tagged
             |3 of imm tagged ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -49,7 +49,7 @@
  in
  let code size(6)
        set_to_x_2 (b : val, i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -60,7 +60,7 @@
  in
  let code size(3)
        classical_id_3 (b : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -70,7 +70,7 @@
  in
  let code size(8)
        swapped_4 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -79,7 +79,7 @@
  in
  let code size(3)
        negate_5 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -88,30 +88,34 @@
  in
  let code size(2)
        foo_6 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_or = %int_barith.or (x, 42) in
    cont k1 (int_or)
  in
- let $camlTests15__immstring61 = " \\ \n " in
- let list_to_array = closure list_to_array_0 @list_to_array in
- let is_c = closure is_c_1 @is_c in
- let set_to_x = closure set_to_x_2 @set_to_x in
- let classical_id = closure classical_id_3 @classical_id in
- let swapped = closure swapped_4 @swapped in
- let negate = closure negate_5 @negate in
- let foo = closure foo_6 @foo in
+ let $camlTests15__immstring68 = " \\ \n " in
+ let list_to_array =
+   closure list_to_array_0 @list_to_array &toplevel.alloc_region
+ in
+ let is_c = closure is_c_1 @is_c &toplevel.alloc_region in
+ let set_to_x = closure set_to_x_2 @set_to_x &toplevel.alloc_region in
+ let classical_id =
+   closure classical_id_3 @classical_id &toplevel.alloc_region
+ in
+ let swapped = closure swapped_4 @swapped &toplevel.alloc_region in
+ let negate = closure negate_5 @negate &toplevel.alloc_region in
+ let foo = closure foo_6 @foo &toplevel.alloc_region in
  let Pmakeblock =
-   %block.[`0`]
+   %block.[`0`].`toplevel`
      (list_to_array,
       is_c,
       set_to_x,
       classical_id,
       swapped,
       negate,
-      $camlTests15__immstring61,
+      $camlTests15__immstring68,
       foo)
  in
  cont k (Pmakeblock))
@@ -122,7 +126,7 @@
     let field_3 = %block_load.tag[`0`].`size`[`8`].[`3`] (module_block) in
     let field_4 = %block_load.tag[`0`].`size`[`8`].[`4`] (module_block) in
     let field_5 = %block_load.tag[`0`].`size`[`8`].[`5`] (module_block) in
-    let field_6 = $camlTests15__immstring61 in
+    let field_6 = $camlTests15__immstring68 in
     let field_7 = %block_load.tag[`0`].`size`[`8`].[`7`] (module_block) in
     let $camlTests15 =
       Block 0 (field_0,

--- a/testsuite/tests/flambda2/examples/tests15.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests15.raw.reference
@@ -1,14 +1,14 @@
-(let $camlTests15__immstring13 = "tests15.ml" in
- let $camlTests15__const_block15 =
-   Block 0 ($camlTests15__immstring13, 18, 52)
+(let $camlTests15__immstring15 = "tests15.ml" in
+ let $camlTests15__const_block17 =
+   Block 0 ($camlTests15__immstring15, 18, 52)
  in
- let $camlTests15__Pmakeblock18 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block15)
+ let $camlTests15__Pmakeblock20 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block17)
  in
- let $camlTests15__empty_array20 = Empty_array in
+ let $camlTests15__empty_array22 = Empty_array in
  let code size(20)
        list_to_array_0 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : any array =
    let next_depth = rec_info (succ my_depth) in
@@ -23,9 +23,9 @@
       where k5 =
         cont k4)
      where k4 =
-       cont k2 pop(regular k2) ($camlTests15__Pmakeblock18)
+       cont k2 pop(regular k2) ($camlTests15__Pmakeblock20)
      where k3 =
-       cont k1 ($camlTests15__empty_array20)
+       cont k1 ($camlTests15__empty_array22)
  in
  let code size(18)
        is_c_1
@@ -33,7 +33,7 @@
           param :
             [ 0 of imm tagged |1 of imm tagged |2 of imm tagged
             |3 of imm tagged ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -49,7 +49,7 @@
  in
  let code size(6)
        set_to_x_2 (b : val, i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -60,7 +60,7 @@
  in
  let code size(3)
        classical_id_3 (b : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -70,7 +70,7 @@
  in
  let code size(8)
        swapped_4 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -79,7 +79,7 @@
  in
  let code size(3)
        negate_5 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -88,30 +88,34 @@
  in
  let code size(2)
        foo_6 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_or = %int_barith.or (x, 42) in
    cont k1 (int_or)
  in
- let $camlTests15__immstring61 = " \\ \n " in
- let list_to_array = closure list_to_array_0 @list_to_array in
- let is_c = closure is_c_1 @is_c in
- let set_to_x = closure set_to_x_2 @set_to_x in
- let classical_id = closure classical_id_3 @classical_id in
- let swapped = closure swapped_4 @swapped in
- let negate = closure negate_5 @negate in
- let foo = closure foo_6 @foo in
+ let $camlTests15__immstring68 = " \\ \n " in
+ let list_to_array =
+   closure list_to_array_0 @list_to_array &toplevel.alloc_region
+ in
+ let is_c = closure is_c_1 @is_c &toplevel.alloc_region in
+ let set_to_x = closure set_to_x_2 @set_to_x &toplevel.alloc_region in
+ let classical_id =
+   closure classical_id_3 @classical_id &toplevel.alloc_region
+ in
+ let swapped = closure swapped_4 @swapped &toplevel.alloc_region in
+ let negate = closure negate_5 @negate &toplevel.alloc_region in
+ let foo = closure foo_6 @foo &toplevel.alloc_region in
  let Pmakeblock =
-   %block.[`0`]
+   %block.[`0`].`toplevel`
      (list_to_array,
       is_c,
       set_to_x,
       classical_id,
       swapped,
       negate,
-      $camlTests15__immstring61,
+      $camlTests15__immstring68,
       foo)
  in
  cont k (Pmakeblock))
@@ -122,7 +126,7 @@
     let field_3 = %block_load.tag[`0`].`size`[`8`].[`3`] (module_block) in
     let field_4 = %block_load.tag[`0`].`size`[`8`].[`4`] (module_block) in
     let field_5 = %block_load.tag[`0`].`size`[`8`].[`5`] (module_block) in
-    let field_6 = $camlTests15__immstring61 in
+    let field_6 = $camlTests15__immstring68 in
     let field_7 = %block_load.tag[`0`].`size`[`8`].[`7`] (module_block) in
     let $camlTests15 =
       Block 0 (field_0,

--- a/testsuite/tests/flambda2/examples/tests15.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests15.simplify.no-flat-float-array.reference
@@ -1,10 +1,10 @@
-let $camlTests15__immstring13 = "tests15.ml" in
-let $camlTests15__const_block15 = Block 0 ($camlTests15__immstring13, 18, 52)
+let $camlTests15__immstring15 = "tests15.ml" in
+let $camlTests15__const_block17 = Block 0 ($camlTests15__immstring15, 18, 52)
 in
-let $camlTests15__Pmakeblock18 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block15)
+let $camlTests15__Pmakeblock20 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block17)
 in
-let $camlTests15__empty_array20 = Empty_array in
+let $camlTests15__empty_array22 = Empty_array in
 let code list_to_array_0 deleted in
 let code is_c_1 deleted in
 let code set_to_x_2 deleted in
@@ -12,18 +12,19 @@ let code classical_id_3 deleted in
 let code swapped_4 deleted in
 let code negate_5 deleted in
 let code foo_6 deleted in
-let $camlTests15__immstring61 = " \\ \n " in
+let $camlTests15__immstring68 = " \\ \n " in
 let code loopify(never) size(11) newer_version_of(list_to_array_0)
       list_to_array_0_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val array =
   let prim = %is_int (param) in
   switch prim
-    | 0 -> k1 pop(regular k1) ($camlTests15__Pmakeblock18)
-    | 1 -> k ($camlTests15__empty_array20)
+    | 0 -> k1 pop(regular k1) ($camlTests15__Pmakeblock20)
+    | 1 -> k ($camlTests15__empty_array22)
 in
-let $camlTests15__list_to_array_7 = closure list_to_array_0_1 @list_to_array
+let $camlTests15__list_to_array_7 =
+  closure list_to_array_0_1 @list_to_array &toplevel.alloc_region
 in
 let code loopify(never) size(7) newer_version_of(is_c_1)
       is_c_1_1
@@ -31,7 +32,7 @@ let code loopify(never) size(7) newer_version_of(is_c_1)
          param :
            [ 0 of imm tagged |1 of imm tagged |2 of imm tagged
            |3 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %get_tag (param) in
@@ -39,53 +40,61 @@ let code loopify(never) size(7) newer_version_of(is_c_1)
   let tagged_scrutinee = %tag_imm (eq) in
   cont k (tagged_scrutinee)
 in
-let $camlTests15__is_c_8 = closure is_c_1_1 @is_c in
+let $camlTests15__is_c_8 = closure is_c_1_1 @is_c &toplevel.alloc_region in
 let code loopify(never) size(5) newer_version_of(set_to_x_2)
       set_to_x_2_1 (b : val, i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %num_conv.[tagged_imm].[`nativeint`] (i) in
   let Pbytessetu = %bytes_or_bigstring_set.bytes.[`8`] (b, prim, 120s) in
   cont k (0)
 in
-let $camlTests15__set_to_x_9 = closure set_to_x_2_1 @set_to_x in
+let $camlTests15__set_to_x_9 =
+  closure set_to_x_2_1 @set_to_x &toplevel.alloc_region
+in
 let code loopify(never) size(3) newer_version_of(classical_id_3)
       classical_id_3_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pnot = %boolean_not (b) in
   let Pnot_1 = %boolean_not (Pnot) in
   cont k (Pnot_1)
 in
-let $camlTests15__classical_id_10 = closure classical_id_3_1 @classical_id in
+let $camlTests15__classical_id_10 =
+  closure classical_id_3_1 @classical_id &toplevel.alloc_region
+in
 let code loopify(never) size(1) newer_version_of(swapped_4)
       swapped_4_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (17459)
 in
-let $camlTests15__swapped_11 = closure swapped_4_1 @swapped in
+let $camlTests15__swapped_11 =
+  closure swapped_4_1 @swapped &toplevel.alloc_region
+in
 let code loopify(never) size(3) newer_version_of(negate_5)
       negate_5_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_neg = %int_barith.sub (0, x) in
   cont k (int_neg)
 in
-let $camlTests15__negate_12 = closure negate_5_1 @negate in
+let $camlTests15__negate_12 =
+  closure negate_5_1 @negate &toplevel.alloc_region
+in
 let code loopify(never) size(2) newer_version_of(foo_6)
       foo_6_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_or = %int_barith.or (x, 42) in
   cont k (int_or)
 in
-let $camlTests15__foo_13 = closure foo_6_1 @foo in
+let $camlTests15__foo_13 = closure foo_6_1 @foo &toplevel.alloc_region in
 let $camlTests15 =
   Block 0 ($camlTests15__list_to_array_7,
            $camlTests15__is_c_8,
@@ -93,7 +102,7 @@ let $camlTests15 =
            $camlTests15__classical_id_10,
            $camlTests15__swapped_11,
            $camlTests15__negate_12,
-           $camlTests15__immstring61,
+           $camlTests15__immstring68,
            $camlTests15__foo_13)
 in
 cont done ($camlTests15)

--- a/testsuite/tests/flambda2/examples/tests15.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests15.simplify.reference
@@ -1,10 +1,10 @@
-let $camlTests15__immstring13 = "tests15.ml" in
-let $camlTests15__const_block15 = Block 0 ($camlTests15__immstring13, 18, 52)
+let $camlTests15__immstring15 = "tests15.ml" in
+let $camlTests15__const_block17 = Block 0 ($camlTests15__immstring15, 18, 52)
 in
-let $camlTests15__Pmakeblock18 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block15)
+let $camlTests15__Pmakeblock20 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests15__const_block17)
 in
-let $camlTests15__empty_array20 = Empty_array in
+let $camlTests15__empty_array22 = Empty_array in
 let code list_to_array_0 deleted in
 let code is_c_1 deleted in
 let code set_to_x_2 deleted in
@@ -12,18 +12,19 @@ let code classical_id_3 deleted in
 let code swapped_4 deleted in
 let code negate_5 deleted in
 let code foo_6 deleted in
-let $camlTests15__immstring61 = " \\ \n " in
+let $camlTests15__immstring68 = " \\ \n " in
 let code loopify(never) size(11) newer_version_of(list_to_array_0)
       list_to_array_0_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : any array =
   let prim = %is_int (param) in
   switch prim
-    | 0 -> k1 pop(regular k1) ($camlTests15__Pmakeblock18)
-    | 1 -> k ($camlTests15__empty_array20)
+    | 0 -> k1 pop(regular k1) ($camlTests15__Pmakeblock20)
+    | 1 -> k ($camlTests15__empty_array22)
 in
-let $camlTests15__list_to_array_7 = closure list_to_array_0_1 @list_to_array
+let $camlTests15__list_to_array_7 =
+  closure list_to_array_0_1 @list_to_array &toplevel.alloc_region
 in
 let code loopify(never) size(7) newer_version_of(is_c_1)
       is_c_1_1
@@ -31,7 +32,7 @@ let code loopify(never) size(7) newer_version_of(is_c_1)
          param :
            [ 0 of imm tagged |1 of imm tagged |2 of imm tagged
            |3 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %get_tag (param) in
@@ -39,53 +40,61 @@ let code loopify(never) size(7) newer_version_of(is_c_1)
   let tagged_scrutinee = %tag_imm (eq) in
   cont k (tagged_scrutinee)
 in
-let $camlTests15__is_c_8 = closure is_c_1_1 @is_c in
+let $camlTests15__is_c_8 = closure is_c_1_1 @is_c &toplevel.alloc_region in
 let code loopify(never) size(5) newer_version_of(set_to_x_2)
       set_to_x_2_1 (b : val, i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %num_conv.[tagged_imm].[`nativeint`] (i) in
   let Pbytessetu = %bytes_or_bigstring_set.bytes.[`8`] (b, prim, 120s) in
   cont k (0)
 in
-let $camlTests15__set_to_x_9 = closure set_to_x_2_1 @set_to_x in
+let $camlTests15__set_to_x_9 =
+  closure set_to_x_2_1 @set_to_x &toplevel.alloc_region
+in
 let code loopify(never) size(3) newer_version_of(classical_id_3)
       classical_id_3_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pnot = %boolean_not (b) in
   let Pnot_1 = %boolean_not (Pnot) in
   cont k (Pnot_1)
 in
-let $camlTests15__classical_id_10 = closure classical_id_3_1 @classical_id in
+let $camlTests15__classical_id_10 =
+  closure classical_id_3_1 @classical_id &toplevel.alloc_region
+in
 let code loopify(never) size(1) newer_version_of(swapped_4)
       swapped_4_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (17459)
 in
-let $camlTests15__swapped_11 = closure swapped_4_1 @swapped in
+let $camlTests15__swapped_11 =
+  closure swapped_4_1 @swapped &toplevel.alloc_region
+in
 let code loopify(never) size(3) newer_version_of(negate_5)
       negate_5_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_neg = %int_barith.sub (0, x) in
   cont k (int_neg)
 in
-let $camlTests15__negate_12 = closure negate_5_1 @negate in
+let $camlTests15__negate_12 =
+  closure negate_5_1 @negate &toplevel.alloc_region
+in
 let code loopify(never) size(2) newer_version_of(foo_6)
       foo_6_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_or = %int_barith.or (x, 42) in
   cont k (int_or)
 in
-let $camlTests15__foo_13 = closure foo_6_1 @foo in
+let $camlTests15__foo_13 = closure foo_6_1 @foo &toplevel.alloc_region in
 let $camlTests15 =
   Block 0 ($camlTests15__list_to_array_7,
            $camlTests15__is_c_8,
@@ -93,7 +102,7 @@ let $camlTests15 =
            $camlTests15__classical_id_10,
            $camlTests15__swapped_11,
            $camlTests15__negate_12,
-           $camlTests15__immstring61,
+           $camlTests15__immstring68,
            $camlTests15__foo_13)
 in
 cont done ($camlTests15)

--- a/testsuite/tests/flambda2/examples/tests2.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests2.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests2__first_const = Block 0 () in
 (let code rec size(25)
        f_0 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -15,7 +15,7 @@ let $camlTests2__first_const = Block 0 () in
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (x, 1) in
-         apply direct(f_0)
+         apply direct(f_0 &my_alloc_region)
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (int_sub)
              -> k3 * k2)
@@ -23,10 +23,11 @@ let $camlTests2__first_const = Block 0 () in
             let int_add = %int_barith.add (1, apply_result) in
             cont k1 (int_add))
  in
- let f = closure f_0 @f in
- apply direct(f_0) unroll(10) (f : _ -> imm tagged) (5) -> k1 * error
+ let f = closure f_0 @f &toplevel.alloc_region in
+ apply direct(f_0 &toplevel.alloc_region) unroll(10)
+   (f : _ -> imm tagged) (5) -> k1 * error
    where k1 (n : imm tagged) =
-     let Pmakeblock = %block.[`0`] (f, n) in
+     let Pmakeblock = %block.[`0`].`toplevel` (f, n) in
      cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests2.simplify.reference
@@ -1,9 +1,9 @@
 let code f_0 deleted in
 let $camlTests2__f_1 =
-  closure f_0_1 @f
+  closure f_0_1 @f &toplevel.alloc_region
 and code rec loopify(never) size(21) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.gt (x, 0) in
@@ -12,7 +12,7 @@ and code rec loopify(never) size(21) newer_version_of(f_0)
     | 1 -> k2
     where k2 =
       ((let int_sub = %int_barith.sub (x, 1) in
-        apply direct(f_0_1)
+        apply direct(f_0_1 &my_alloc_region)
           ($camlTests2__f_1 ~ depth my_depth -> succ my_depth
            : _ -> imm tagged)
             (int_sub)

--- a/testsuite/tests/flambda2/examples/tests3.raw.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests3.raw.no-flat-float-array.reference
@@ -1,10 +1,10 @@
-(let $camlTests3__string14 = "index out of bounds" in
- let $camlTests3__block16 =
-   Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string14)
+(let $camlTests3__string16 = "index out of bounds" in
+ let $camlTests3__block18 =
+   Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string16)
  in
  let code size(48)
        foo_0 (arr : val array, f : val, i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -16,10 +16,10 @@
      where k6 =
        cont k4
      where k5 =
-       cont k2 pop(regular k2) ($camlTests3__block16)
+       cont k2 pop(regular k2) ($camlTests3__block18)
      where k4 =
        let Parrayrefs = %array_load.mut (arr, i) in
-       apply f (Parrayrefs) -> k3 * k2
+       apply &my_alloc_region f (Parrayrefs) -> k3 * k2
      where k3 (apply_result : val) =
        ((let prim = %array_length (arr) in
          let prim_1 = %int_comp.unsigned.lt (i, prim) in
@@ -29,14 +29,14 @@
           where k5 =
             cont k3
           where k4 =
-            cont k2 pop(regular k2) ($camlTests3__block16)
+            cont k2 pop(regular k2) ($camlTests3__block18)
           where k3 =
             let Parraysets = %array_set (arr, i, apply_result) in
             cont k1 (Parraysets))
  in
  let code size(41)
        f_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -67,9 +67,9 @@
             let int_add = %int_barith.add (x, y) in
             cont k1 (int_add))
  in
- let foo = closure foo_0 @foo in
- let f = closure f_1 @f in
- let Pmakeblock = %block.[`0`] (foo, f) in
+ let foo = closure foo_0 @foo &toplevel.alloc_region in
+ let f = closure f_1 @f &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (foo, f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests3.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests3.raw.reference
@@ -1,10 +1,10 @@
-(let $camlTests3__string14 = "index out of bounds" in
- let $camlTests3__block16 =
-   Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string14)
+(let $camlTests3__string16 = "index out of bounds" in
+ let $camlTests3__block18 =
+   Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string16)
  in
  let code size(94)
        foo_0 (arr : any array, f : val, i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -16,7 +16,7 @@
      where k6 =
        cont k4
      where k5 =
-       cont k2 pop(regular k2) ($camlTests3__block16)
+       cont k2 pop(regular k2) ($camlTests3__block18)
      where k4 =
        ((let cond_result = %is_flat_float_array (arr) in
          switch cond_result
@@ -27,10 +27,10 @@
             cont k4 (ifnot_result)
           where k5 =
             let prim = %array_load.`float`.mut (arr, i) in
-            let ifso_result = %box_num.`float` (prim) in
+            let ifso_result = %box_num.`float`.my_alloc_region (prim) in
             cont k4 (ifso_result)
           where k4 (if_then_else_result) =
-            apply f (if_then_else_result) -> k3 * k2)
+            apply &my_alloc_region f (if_then_else_result) -> k3 * k2)
      where k3 (apply_result : val) =
        ((let prim = %array_length.generic (arr) in
          let prim_1 = %int_comp.unsigned.lt (i, prim) in
@@ -40,7 +40,7 @@
           where k5 =
             cont k3
           where k4 =
-            cont k2 pop(regular k2) ($camlTests3__block16)
+            cont k2 pop(regular k2) ($camlTests3__block18)
           where k3 =
             ((let cond_result = %is_flat_float_array (arr) in
               switch cond_result
@@ -58,7 +58,7 @@
  in
  let code size(41)
        f_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -89,9 +89,9 @@
             let int_add = %int_barith.add (x, y) in
             cont k1 (int_add))
  in
- let foo = closure foo_0 @foo in
- let f = closure f_1 @f in
- let Pmakeblock = %block.[`0`] (foo, f) in
+ let foo = closure foo_0 @foo &toplevel.alloc_region in
+ let f = closure f_1 @f &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (foo, f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests3.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests3.simplify.no-flat-float-array.reference
@@ -1,12 +1,12 @@
-let $camlTests3__string14 = "index out of bounds" in
-let $camlTests3__block16 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string14)
+let $camlTests3__string16 = "index out of bounds" in
+let $camlTests3__block18 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string16)
 in
 let code foo_0 deleted in
 let code f_1 deleted in
 let code loopify(never) size(29) newer_version_of(foo_0)
       foo_0_1 (arr : val array, f : val, i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %array_length (arr) in
@@ -16,17 +16,17 @@ let code loopify(never) size(29) newer_version_of(foo_0)
      | 1 -> k4)
     where k4 =
       let Parrayrefs = %array_load.mut (arr, i) in
-      apply f (Parrayrefs) -> k2 * k1
+      apply &my_alloc_region f (Parrayrefs) -> k2 * k1
     where k3 =
-      cont k1 pop(regular k1) ($camlTests3__block16)
+      cont k1 pop(regular k1) ($camlTests3__block18)
     where k2 (apply_result : val) =
       let Parraysets = %array_set (arr, i, apply_result) in
       cont k (0)
 in
-let $camlTests3__foo_2 = closure foo_0_1 @foo in
+let $camlTests3__foo_2 = closure foo_0_1 @foo &toplevel.alloc_region in
 let code loopify(never) size(33) newer_version_of(f_1)
       f_1_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %int_comp.lt (c, 0) in
@@ -48,6 +48,6 @@ let code loopify(never) size(33) newer_version_of(f_1)
            let int_add = %int_barith.add (x, y) in
            cont k (int_add))
 in
-let $camlTests3__f_3 = closure f_1_1 @f in
+let $camlTests3__f_3 = closure f_1_1 @f &toplevel.alloc_region in
 let $camlTests3 = Block 0 ($camlTests3__foo_2, $camlTests3__f_3) in
 cont done ($camlTests3)

--- a/testsuite/tests/flambda2/examples/tests3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests3.simplify.reference
@@ -1,12 +1,12 @@
-let $camlTests3__string14 = "index out of bounds" in
-let $camlTests3__block16 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string14)
+let $camlTests3__string16 = "index out of bounds" in
+let $camlTests3__block18 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string16)
 in
 let code foo_0 deleted in
 let code f_1 deleted in
 let code loopify(never) size(72) newer_version_of(foo_0)
       foo_0_1 (arr : any array, f : val, i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %array_length.generic (arr) in
@@ -24,12 +24,12 @@ let code loopify(never) size(72) newer_version_of(foo_0)
            cont k4 (ifnot_result)
          where k5 =
            let prim = %array_load.`float`.mut (arr, i) in
-           let ifso_result = %box_num.`float` (prim) in
+           let ifso_result = %box_num.`float`.my_alloc_region (prim) in
            cont k4 (ifso_result)
          where k4 (if_then_else_result) =
-           apply f (if_then_else_result) -> k2 * k1)
+           apply &my_alloc_region f (if_then_else_result) -> k2 * k1)
     where k3 =
-      cont k1 pop(regular k1) ($camlTests3__block16)
+      cont k1 pop(regular k1) ($camlTests3__block18)
     where k2 (apply_result : val) =
       ((let cond_result = %is_flat_float_array (arr) in
         switch cond_result
@@ -46,10 +46,10 @@ let code loopify(never) size(72) newer_version_of(foo_0)
            let if_then_else_result = 0 in
            cont k (if_then_else_result))
 in
-let $camlTests3__foo_2 = closure foo_0_1 @foo in
+let $camlTests3__foo_2 = closure foo_0_1 @foo &toplevel.alloc_region in
 let code loopify(never) size(33) newer_version_of(f_1)
       f_1_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %int_comp.lt (c, 0) in
@@ -71,6 +71,6 @@ let code loopify(never) size(33) newer_version_of(f_1)
            let int_add = %int_barith.add (x, y) in
            cont k (int_add))
 in
-let $camlTests3__f_3 = closure f_1_1 @f in
+let $camlTests3__f_3 = closure f_1_1 @f &toplevel.alloc_region in
 let $camlTests3 = Block 0 ($camlTests3__foo_2, $camlTests3__f_3) in
 cont done ($camlTests3)

--- a/testsuite/tests/flambda2/examples/tests4.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests4.raw.reference
@@ -1,8 +1,8 @@
-(let $camlTests4__float14 = 0x0p+0 in
- let $camlTests4__float20 = 0x1.8p+1 in
+(let $camlTests4__float16 = 0x0p+0 in
+ let $camlTests4__float22 = 0x1.8p+1 in
  let code size(54)
        pr2162_2_first_0 (z : imm tagged, x : imm tagged, y : float boxed)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : float boxed =
    let next_depth = rec_info (succ my_depth) in
@@ -15,31 +15,31 @@
      where k6 =
        cont k5
      where k5 =
-       let prim = %unbox_num.`float` ($camlTests4__float14) in
+       let prim = %unbox_num.`float` ($camlTests4__float16) in
        let prim_1 = %unbox_num.`float` (y) in
        let prim_2 = %bfloat_arith.add (prim_1, prim) in
-       let b = %box_num.`float` (prim_2) in
+       let b = %box_num.`float`.my_alloc_region (prim_2) in
        cont k3 (x, b)
      where k4 =
-       let prim = %unbox_num.`float` ($camlTests4__float20) in
+       let prim = %unbox_num.`float` ($camlTests4__float22) in
        let prim_1 = %unbox_num.`float` (y) in
        let prim_2 = %bfloat_arith.mul (prim_1, prim) in
-       let b = %box_num.`float` (prim_2) in
+       let b = %box_num.`float`.my_alloc_region (prim_2) in
        let a = %int_barith.mul (x, 2) in
        cont k3 (a, b)
      where k3 (a : imm tagged, b : float boxed) =
        let prim = %untag_imm (a) in
        let prim_1 = %num_conv.[`imm`].[`float`] (prim) in
-       let float_of_int = %box_num.`float` (prim_1) in
+       let float_of_int = %box_num.`float`.my_alloc_region (prim_1) in
        let prim_2 = %unbox_num.`float` (b) in
        let prim_3 = %unbox_num.`float` (float_of_int) in
        let prim_4 = %bfloat_arith.sub (prim_3, prim_2) in
-       let float_sub = %box_num.`float` (prim_4) in
+       let float_sub = %box_num.`float`.my_alloc_region (prim_4) in
        cont k1 (float_sub)
  in
  let code size(54)
        pr2162_2_1 (z : imm tagged, x : imm tagged, y : float boxed)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : float boxed =
    let next_depth = rec_info (succ my_depth) in
@@ -52,31 +52,31 @@
      where k6 =
        cont k5
      where k5 =
-       let prim = %unbox_num.`float` ($camlTests4__float14) in
+       let prim = %unbox_num.`float` ($camlTests4__float16) in
        let prim_1 = %unbox_num.`float` (y) in
        let prim_2 = %bfloat_arith.add (prim_1, prim) in
-       let b = %box_num.`float` (prim_2) in
+       let b = %box_num.`float`.my_alloc_region (prim_2) in
        cont k3 (x, b)
      where k4 =
-       let prim = %unbox_num.`float` ($camlTests4__float20) in
+       let prim = %unbox_num.`float` ($camlTests4__float22) in
        let prim_1 = %unbox_num.`float` (y) in
        let prim_2 = %bfloat_arith.mul (prim_1, prim) in
-       let b = %box_num.`float` (prim_2) in
+       let b = %box_num.`float`.my_alloc_region (prim_2) in
        let a = %int_barith.mul (x, 2) in
        cont k3 (a, b)
      where k3 (a : imm tagged, b : float boxed) =
        let prim = %untag_imm (a) in
        let prim_1 = %num_conv.[`imm`].[`float`] (prim) in
-       let float_of_int = %box_num.`float` (prim_1) in
+       let float_of_int = %box_num.`float`.my_alloc_region (prim_1) in
        let prim_2 = %unbox_num.`float` (b) in
        let prim_3 = %unbox_num.`float` (float_of_int) in
        let prim_4 = %bfloat_arith.sub (prim_3, prim_2) in
-       let float_sub = %box_num.`float` (prim_4) in
+       let float_sub = %box_num.`float`.my_alloc_region (prim_4) in
        cont k1 (float_sub)
  in
  let code size(70)
        pr2162_3_2 (z : imm tagged, x : imm tagged, y : float boxed)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : float boxed =
    let next_depth = rec_info (succ my_depth) in
@@ -89,40 +89,40 @@
      where k6 =
        cont k5
      where k5 =
-       let prim = %unbox_num.`float` ($camlTests4__float14) in
+       let prim = %unbox_num.`float` ($camlTests4__float16) in
        let prim_1 = %unbox_num.`float` (y) in
        let prim_2 = %bfloat_arith.add (prim_1, prim) in
-       let float_add = %box_num.`float` (prim_2) in
-       let Pmakeblock = %block.[`0`] (x, float_add) in
+       let float_add = %box_num.`float`.my_alloc_region (prim_2) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (x, float_add) in
        cont k3 (Pmakeblock)
      where k4 =
-       let prim = %unbox_num.`float` ($camlTests4__float20) in
+       let prim = %unbox_num.`float` ($camlTests4__float22) in
        let prim_1 = %unbox_num.`float` (y) in
        let prim_2 = %bfloat_arith.mul (prim_1, prim) in
-       let float_mul = %box_num.`float` (prim_2) in
+       let float_mul = %box_num.`float`.my_alloc_region (prim_2) in
        let int_mul = %int_barith.mul (x, 2) in
-       let Pmakeblock = %block.[`0`] (int_mul, float_mul) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (int_mul, float_mul) in
        cont k3 (Pmakeblock)
      where k3 (pair : [ 0 of imm tagged * float boxed ]) =
        let Pfield = %block_load.[`1`] (pair) in
        let Pfield_1 = %block_load.[`0`] (pair) in
        let prim = %untag_imm (Pfield_1) in
        let prim_1 = %num_conv.[`imm`].[`float`] (prim) in
-       let float_of_int = %box_num.`float` (prim_1) in
+       let float_of_int = %box_num.`float`.my_alloc_region (prim_1) in
        let prim_2 = %unbox_num.`float` (Pfield) in
        let prim_3 = %unbox_num.`float` (float_of_int) in
        let prim_4 = %bfloat_arith.sub (prim_3, prim_2) in
-       let float_sub = %box_num.`float` (prim_4) in
+       let float_sub = %box_num.`float`.my_alloc_region (prim_4) in
        cont k1 (float_sub)
  in
- let $camlTests4__int6499 = 0L in
- let $camlTests4__int32105 = 2l in
- let $camlTests4__int64109 = 3L in
- let $camlTests4__int32115 = 4l in
+ let $camlTests4__int64104 = 0L in
+ let $camlTests4__int32110 = 2l in
+ let $camlTests4__int64114 = 3L in
+ let $camlTests4__int32120 = 4l in
  let code size(125)
        pr2162_3_as_int64_3
          (z : imm tagged, x : imm tagged, y : int64 boxed, y' : int32 boxed)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of int64 boxed * int32 boxed ] =
    let next_depth = rec_info (succ my_depth) in
@@ -135,25 +135,29 @@
      where k6 =
        cont k5
      where k5 =
-       let prim = %unbox_num.`int64` ($camlTests4__int6499) in
+       let prim = %unbox_num.`int64` ($camlTests4__int64104) in
        let prim_1 = %unbox_num.`int64` (y) in
        let prim_2 = %int_barith.`int64`.add (prim_1, prim) in
-       let int64_add = %box_num.`int64` (prim_2) in
-       let Pmakeblock = %block.[`0`] ($camlTests4__int32105, int64_add) in
-       let Pmakeblock_1 = %block.[`0`] (x, Pmakeblock) in
+       let int64_add = %box_num.`int64`.my_alloc_region (prim_2) in
+       let Pmakeblock =
+         %block.[`0`].my_alloc_region ($camlTests4__int32110, int64_add)
+       in
+       let Pmakeblock_1 = %block.[`0`].my_alloc_region (x, Pmakeblock) in
        cont k3 (Pmakeblock_1)
      where k4 =
-       let prim = %unbox_num.`int64` ($camlTests4__int64109) in
+       let prim = %unbox_num.`int64` ($camlTests4__int64114) in
        let prim_1 = %unbox_num.`int64` (y) in
        let prim_2 = %int_barith.`int64`.mul (prim_1, prim) in
-       let int64_mul = %box_num.`int64` (prim_2) in
-       let prim_3 = %unbox_num.`int32` ($camlTests4__int32115) in
+       let int64_mul = %box_num.`int64`.my_alloc_region (prim_2) in
+       let prim_3 = %unbox_num.`int32` ($camlTests4__int32120) in
        let prim_4 = %unbox_num.`int32` (y') in
        let prim_5 = %int_barith.`int32`.mul (prim_4, prim_3) in
-       let int32_mul = %box_num.`int32` (prim_5) in
-       let Pmakeblock = %block.[`0`] (int32_mul, int64_mul) in
+       let int32_mul = %box_num.`int32`.my_alloc_region (prim_5) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (int32_mul, int64_mul)
+       in
        let int_mul = %int_barith.mul (x, 2) in
-       let Pmakeblock_1 = %block.[`0`] (int_mul, Pmakeblock) in
+       let Pmakeblock_1 = %block.[`0`].my_alloc_region (int_mul, Pmakeblock)
+       in
        cont k3 (Pmakeblock_1)
      where k3
              (pair : [ 0 of imm tagged * [ 0 of int32 boxed * int64 boxed ] ]) =
@@ -162,28 +166,34 @@
        let Pfield = %block_load.[`0`] (b) in
        let prim = %untag_imm (a) in
        let prim_1 = %num_conv.[`imm`].[`int32`] (prim) in
-       let int32_of_int = %box_num.`int32` (prim_1) in
+       let int32_of_int = %box_num.`int32`.my_alloc_region (prim_1) in
        let prim_2 = %unbox_num.`int32` (Pfield) in
        let prim_3 = %unbox_num.`int32` (int32_of_int) in
        let prim_4 = %int_barith.`int32`.sub (prim_3, prim_2) in
-       let int32_sub = %box_num.`int32` (prim_4) in
+       let int32_sub = %box_num.`int32`.my_alloc_region (prim_4) in
        let Pfield_1 = %block_load.[`1`] (b) in
        let prim_5 = %untag_imm (a) in
        let prim_6 = %num_conv.[`imm`].[`int64`] (prim_5) in
-       let int64_of_int = %box_num.`int64` (prim_6) in
+       let int64_of_int = %box_num.`int64`.my_alloc_region (prim_6) in
        let prim_7 = %unbox_num.`int64` (Pfield_1) in
        let prim_8 = %unbox_num.`int64` (int64_of_int) in
        let prim_9 = %int_barith.`int64`.sub (prim_8, prim_7) in
-       let int64_sub = %box_num.`int64` (prim_9) in
-       let Pmakeblock = %block.[`0`] (int64_sub, int32_sub) in
+       let int64_sub = %box_num.`int64`.my_alloc_region (prim_9) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (int64_sub, int32_sub)
+       in
        cont k1 (Pmakeblock)
  in
- let pr2162_2_first = closure pr2162_2_first_0 @pr2162_2_first in
- let pr2162_2 = closure pr2162_2_1 @pr2162_2 in
- let pr2162_3 = closure pr2162_3_2 @pr2162_3 in
- let pr2162_3_as_int64 = closure pr2162_3_as_int64_3 @pr2162_3_as_int64 in
+ let pr2162_2_first =
+   closure pr2162_2_first_0 @pr2162_2_first &toplevel.alloc_region
+ in
+ let pr2162_2 = closure pr2162_2_1 @pr2162_2 &toplevel.alloc_region in
+ let pr2162_3 = closure pr2162_3_2 @pr2162_3 &toplevel.alloc_region in
+ let pr2162_3_as_int64 =
+   closure pr2162_3_as_int64_3 @pr2162_3_as_int64 &toplevel.alloc_region
+ in
  let Pmakeblock =
-   %block.[`0`] (pr2162_2_first, pr2162_2, pr2162_3, pr2162_3_as_int64)
+   %block.[`0`].`toplevel`
+     (pr2162_2_first, pr2162_2, pr2162_3, pr2162_3_as_int64)
  in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =

--- a/testsuite/tests/flambda2/examples/tests4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests4.simplify.reference
@@ -4,7 +4,7 @@ let code pr2162_3_2 deleted in
 let code pr2162_3_as_int64_3 deleted in
 let code loopify(never) size(34) newer_version_of(pr2162_2_first_0)
       pr2162_2_first_0_1 (z : imm tagged, x : imm tagged, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let untagged = %untag_imm (z) in
@@ -25,15 +25,15 @@ let code loopify(never) size(34) newer_version_of(pr2162_2_first_0)
     where k2 (unboxed_float : float, naked_immediate : imm) =
       let prim = %num_conv.[`imm`].[`float`] (naked_immediate) in
       let prim_1 = %bfloat_arith.sub (prim, unboxed_float) in
-      let float_sub = %box_num.`float` (prim_1) in
+      let float_sub = %box_num.`float`.my_alloc_region (prim_1) in
       cont k (float_sub)
 in
 let $camlTests4__pr2162_2_first_4 =
-  closure pr2162_2_first_0_1 @pr2162_2_first
+  closure pr2162_2_first_0_1 @pr2162_2_first &toplevel.alloc_region
 in
 let code loopify(never) size(34) newer_version_of(pr2162_2_1)
       pr2162_2_1_1 (z : imm tagged, x : imm tagged, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let untagged = %untag_imm (z) in
@@ -54,13 +54,15 @@ let code loopify(never) size(34) newer_version_of(pr2162_2_1)
     where k2 (unboxed_float : float, naked_immediate : imm) =
       let prim = %num_conv.[`imm`].[`float`] (naked_immediate) in
       let prim_1 = %bfloat_arith.sub (prim, unboxed_float) in
-      let float_sub = %box_num.`float` (prim_1) in
+      let float_sub = %box_num.`float`.my_alloc_region (prim_1) in
       cont k (float_sub)
 in
-let $camlTests4__pr2162_2_5 = closure pr2162_2_1_1 @pr2162_2 in
+let $camlTests4__pr2162_2_5 =
+  closure pr2162_2_1_1 @pr2162_2 &toplevel.alloc_region
+in
 let code loopify(never) size(34) newer_version_of(pr2162_3_2)
       pr2162_3_2_1 (z : imm tagged, x : imm tagged, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   (let untagged = %untag_imm (z) in
@@ -81,14 +83,16 @@ let code loopify(never) size(34) newer_version_of(pr2162_3_2)
     where k2 (unboxed_float : float, naked_immediate : imm) =
       let prim = %num_conv.[`imm`].[`float`] (naked_immediate) in
       let prim_1 = %bfloat_arith.sub (prim, unboxed_float) in
-      let float_sub = %box_num.`float` (prim_1) in
+      let float_sub = %box_num.`float`.my_alloc_region (prim_1) in
       cont k (float_sub)
 in
-let $camlTests4__pr2162_3_6 = closure pr2162_3_2_1 @pr2162_3 in
+let $camlTests4__pr2162_3_6 =
+  closure pr2162_3_2_1 @pr2162_3 &toplevel.alloc_region
+in
 let code loopify(never) size(49) newer_version_of(pr2162_3_as_int64_3)
       pr2162_3_as_int64_3_1
         (z : imm tagged, x : imm tagged, y : int64 boxed, y' : int32 boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of int64 boxed * int32 boxed ] =
   (let untagged = %untag_imm (z) in
@@ -113,15 +117,15 @@ let code loopify(never) size(49) newer_version_of(pr2162_3_as_int64_3)
              naked_immediate : imm) =
       let prim = %num_conv.[`imm`].[`int32`] (naked_immediate) in
       let prim_1 = %int_barith.`int32`.sub (prim, unboxed_int32) in
-      let int32_sub = %box_num.`int32` (prim_1) in
+      let int32_sub = %box_num.`int32`.my_alloc_region (prim_1) in
       let prim_2 = %num_conv.[`imm`].[`int64`] (naked_immediate) in
       let prim_3 = %int_barith.`int64`.sub (prim_2, unboxed_int64) in
-      let int64_sub = %box_num.`int64` (prim_3) in
-      let Pmakeblock = %block.[`0`] (int64_sub, int32_sub) in
+      let int64_sub = %box_num.`int64`.my_alloc_region (prim_3) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (int64_sub, int32_sub) in
       cont k (Pmakeblock)
 in
 let $camlTests4__pr2162_3_as_int64_7 =
-  closure pr2162_3_as_int64_3_1 @pr2162_3_as_int64
+  closure pr2162_3_as_int64_3_1 @pr2162_3_as_int64 &toplevel.alloc_region
 in
 let $camlTests4 =
   Block 0 ($camlTests4__pr2162_2_first_4,

--- a/testsuite/tests/flambda2/examples/tests4a.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests4a.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests4a__first_const = Block 0 () in
 (let code size(22)
        pr2162_3_as_int64_0 (z : imm tagged, x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -19,8 +19,10 @@ let $camlTests4a__first_const = Block 0 () in
        let eq = %tag_imm (prim) in
        cont k1 (eq)
  in
- let pr2162_3_as_int64 = closure pr2162_3_as_int64_0 @pr2162_3_as_int64 in
- let Pmakeblock = %block.[`0`] (pr2162_3_as_int64) in
+ let pr2162_3_as_int64 =
+   closure pr2162_3_as_int64_0 @pr2162_3_as_int64 &toplevel.alloc_region
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (pr2162_3_as_int64) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests4a.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests4a.simplify.reference
@@ -1,7 +1,7 @@
 let code pr2162_3_as_int64_0 deleted in
 let code loopify(never) size(21) newer_version_of(pr2162_3_as_int64_0)
       pr2162_3_as_int64_0_1 (z : imm tagged, x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (z) in
@@ -17,7 +17,7 @@ let code loopify(never) size(21) newer_version_of(pr2162_3_as_int64_0)
       cont k (eq)
 in
 let $camlTests4a__pr2162_3_as_int64_1 =
-  closure pr2162_3_as_int64_0_1 @pr2162_3_as_int64
+  closure pr2162_3_as_int64_0_1 @pr2162_3_as_int64 &toplevel.alloc_region
 in
 let $camlTests4a = Block 0 ($camlTests4a__pr2162_3_as_int64_1) in
 cont done ($camlTests4a)

--- a/testsuite/tests/flambda2/examples/tests5.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests5.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests5__first_const = Block 0 () in
 (let code rec size(23)
        f_0 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -16,13 +16,13 @@ let $camlTests5__first_const = Block 0 () in
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (x, 1) in
-       apply direct(g_1)
+       apply direct(g_1 &my_alloc_region)
          (g ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
  and code rec size(23)
        g_1 (y : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -37,13 +37,15 @@ let $camlTests5__first_const = Block 0 () in
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (y, 1) in
-       apply direct(f_0)
+       apply direct(f_0 &my_alloc_region)
          (f ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
  in
- let f = closure f_0 @f and g = closure g_1 @g in
- let Pmakeblock = %block.[`0`] (f, g) in
+ let f = closure f_0 @f &toplevel.alloc_region
+ and g = closure g_1 @g &toplevel.alloc_region
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (f, g) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests5.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests5.simplify.reference
@@ -1,11 +1,11 @@
 let code g_1 deleted and code f_0 deleted in
 let $camlTests5__f_2 =
-  closure f_0_1 @f
+  closure f_0_1 @f &toplevel.alloc_region
 and $camlTests5__g_3 =
-  closure g_1_1 @g
+  closure g_1_1 @g &toplevel.alloc_region
 and code rec loopify(never) size(18) newer_version_of(g_1)
       g_1_1 (y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.gt (y, 3) in
@@ -14,14 +14,14 @@ and code rec loopify(never) size(18) newer_version_of(g_1)
     | 1 -> k2
     where k2 =
       let int_sub = %int_barith.sub (y, 1) in
-      apply direct(f_0_1)
+      apply direct(f_0_1 &my_alloc_region)
         ($camlTests5__f_2 ~ depth my_depth -> succ my_depth : _ -> imm tagged
          )
           (int_sub)
           -> k * k1
 and code rec loopify(never) size(18) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %int_comp.lt (x, 4) in
@@ -30,7 +30,7 @@ and code rec loopify(never) size(18) newer_version_of(f_0)
     | 1 -> k2
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(g_1_1)
+      apply direct(g_1_1 &my_alloc_region)
         ($camlTests5__g_3 ~ depth my_depth -> succ my_depth : _ -> imm tagged
          )
           (int_sub)

--- a/testsuite/tests/flambda2/examples/tests6.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests6.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests6__first_const = Block 0 () in
 (let code rec size(25)
        f_0 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -15,7 +15,7 @@ let $camlTests6__first_const = Block 0 () in
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (x, 1) in
-         apply direct(f_0)
+         apply direct(f_0 &my_alloc_region)
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (int_sub)
              -> k3 * k2)
@@ -25,14 +25,15 @@ let $camlTests6__first_const = Block 0 () in
  in
  (let `region` = %begin_region () in
   let ghost_region = %begin_ghost_region () in
-  (let f = closure f_0 @f in
-   apply direct(f_0) unroll(10) (f : _ -> imm tagged) (3) -> k2 * error)
+  (let f = closure f_0 @f &toplevel.alloc_region &`region` in
+   apply direct(f_0 &toplevel.alloc_region) unroll(10)
+     (f : _ -> imm tagged) (3) -> k2 * error)
     where k2 (region_return : imm tagged) =
       let `unit` = %end_region (`region`) in
       let unit_1 = %end_ghost_region (ghost_region) in
       cont k1 (region_return))
    where k1 (n : imm tagged) =
-     let Pmakeblock = %block.[`0`] (n) in
+     let Pmakeblock = %block.[`0`].`toplevel` (n) in
      cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests7.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests7.raw.reference
@@ -1,8 +1,8 @@
-(let $camlTests7__immstring7 = "Cow" in
- let $camlTests7__immstring10 = "Sheep" in
+(let $camlTests7__immstring8 = "Cow" in
+ let $camlTests7__immstring11 = "Sheep" in
  let code size(37)
        f_0 (x : imm tagged, str : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -10,9 +10,9 @@
    let Pstringlength = %tag_imm (prim) in
    let prim_1 = %string_length (str) in
    let Pstringlength_1 = %tag_imm (prim_1) in
-   let prim_2 = %string_length ($camlTests7__immstring10) in
+   let prim_2 = %string_length ($camlTests7__immstring11) in
    let Pstringlength_2 = %tag_imm (prim_2) in
-   let prim_3 = %string_length ($camlTests7__immstring7) in
+   let prim_3 = %string_length ($camlTests7__immstring8) in
    let Pstringlength_3 = %tag_imm (prim_3) in
    let int_add = %int_barith.add (x, Pstringlength_3) in
    let int_add_1 = %int_barith.add (int_add, Pstringlength_2) in
@@ -22,40 +22,40 @@
  in
  let code size(31)
        foo_1 (af : float ^ 2, y : float boxed)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : float boxed =
    let next_depth = rec_info (succ my_depth) in
    let prim = %block_load.`float`.[`1`] (af) in
-   let Pfloatfield = %box_num.`float` (prim) in
+   let Pfloatfield = %box_num.`float`.my_alloc_region (prim) in
    let prim_1 = %block_load.`float`.[`0`] (af) in
-   let Pfloatfield_1 = %box_num.`float` (prim_1) in
+   let Pfloatfield_1 = %box_num.`float`.my_alloc_region (prim_1) in
    let prim_2 = %unbox_num.`float` (Pfloatfield) in
    let prim_3 = %unbox_num.`float` (Pfloatfield_1) in
    let prim_4 = %bfloat_arith.mul (prim_3, prim_2) in
-   let x = %box_num.`float` (prim_4) in
+   let x = %box_num.`float`.my_alloc_region (prim_4) in
    let prim_5 = %unbox_num.`float` (y) in
    let prim_6 = %unbox_num.`float` (x) in
    let prim_7 = %bfloat_arith.add (prim_6, prim_5) in
-   let float_add = %box_num.`float` (prim_7) in
+   let float_add = %box_num.`float`.my_alloc_region (prim_7) in
    cont k1 (float_add)
  in
- let $camlTests7__empty_block4 = Block 0 () in
- let f = closure f_0 @f in
- let foo = closure foo_1 @foo in
+ let $camlTests7__empty_block5 = Block 0 () in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let foo = closure foo_1 @foo &toplevel.alloc_region in
  let Pmakeblock =
-   %block.[`0`]
-     ($camlTests7__empty_block4,
-      $camlTests7__immstring7,
-      $camlTests7__immstring10,
+   %block.[`0`].`toplevel`
+     ($camlTests7__empty_block5,
+      $camlTests7__immstring8,
+      $camlTests7__immstring11,
       f,
       foo)
  in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
-    let field_0 = $camlTests7__empty_block4 in
-    let field_1 = $camlTests7__immstring7 in
-    let field_2 = $camlTests7__immstring10 in
+    let field_0 = $camlTests7__empty_block5 in
+    let field_1 = $camlTests7__immstring8 in
+    let field_2 = $camlTests7__immstring11 in
     let field_3 = %block_load.tag[`0`].`size`[`5`].[`3`] (module_block) in
     let field_4 = %block_load.tag[`0`].`size`[`5`].[`4`] (module_block) in
     let $camlTests7 = Block 0 (field_0, field_1, field_2, field_3, field_4)

--- a/testsuite/tests/flambda2/examples/tests7.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests7.simplify.reference
@@ -1,11 +1,11 @@
-let $camlTests7__immstring7 = "Cow" in
-let $camlTests7__immstring10 = "Sheep" in
+let $camlTests7__immstring8 = "Cow" in
+let $camlTests7__immstring11 = "Sheep" in
 let code f_0 deleted in
 let code foo_1 deleted in
-let $camlTests7__empty_block4 = Block 0 () in
+let $camlTests7__empty_block5 = Block 0 () in
 let code loopify(never) size(16) newer_version_of(f_0)
       f_0_1 (x : imm tagged, str : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %string_length (str) in
@@ -16,10 +16,10 @@ let code loopify(never) size(16) newer_version_of(f_0)
   let int_add_3 = %int_barith.add (int_add_2, Pstringlength) in
   cont k (int_add_3)
 in
-let $camlTests7__f_2 = closure f_0_1 @f in
+let $camlTests7__f_2 = closure f_0_1 @f &toplevel.alloc_region in
 let code loopify(never) size(13) newer_version_of(foo_1)
       foo_1_1 (af : float ^ 2, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let prim = %block_load.`float`.[`1`] (af) in
@@ -27,14 +27,14 @@ let code loopify(never) size(13) newer_version_of(foo_1)
   let prim_2 = %bfloat_arith.mul (prim_1, prim) in
   let prim_3 = %unbox_num.`float` (y) in
   let prim_4 = %bfloat_arith.add (prim_2, prim_3) in
-  let float_add = %box_num.`float` (prim_4) in
+  let float_add = %box_num.`float`.my_alloc_region (prim_4) in
   cont k (float_add)
 in
-let $camlTests7__foo_3 = closure foo_1_1 @foo in
+let $camlTests7__foo_3 = closure foo_1_1 @foo &toplevel.alloc_region in
 let $camlTests7 =
-  Block 0 ($camlTests7__empty_block4,
-           $camlTests7__immstring7,
-           $camlTests7__immstring10,
+  Block 0 ($camlTests7__empty_block5,
+           $camlTests7__immstring8,
+           $camlTests7__immstring11,
            $camlTests7__f_2,
            $camlTests7__foo_3)
 in

--- a/testsuite/tests/flambda2/examples/tests8.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests8.raw.reference
@@ -1,7 +1,7 @@
 let $camlTests8__first_const = Block 0 () in
 (let code size(1)
        `fn[tests8.ml:20,62--77]_2` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -9,7 +9,7 @@ let $camlTests8__first_const = Block 0 () in
  in
  let code size(1)
        `fn[tests8.ml:20,49--61]_3` (x : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
@@ -17,7 +17,7 @@ let $camlTests8__first_const = Block 0 () in
  in
  let code size(21)
        `fn[tests8.ml:20,12--80]_1` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
@@ -27,21 +27,23 @@ let $camlTests8__first_const = Block 0 () in
    in
    let `fn[tests8.ml:20,62--77]` =
      closure `fn[tests8.ml:20,62--77]_2` @`fn[tests8.ml:20,62--77]`
+       &my_alloc_region
    in
    let `fn[tests8.ml:20,49--61]` =
      closure `fn[tests8.ml:20,49--61]_3` @`fn[tests8.ml:20,49--61]`
+       &my_alloc_region
    in
-   apply direct(map_foo_0) inlined(never)
+   apply direct(map_foo_0 &my_alloc_region) inlined(never)
      (map_foo : _ -> [ 0 | 0 of val * val ])
        (`fn[tests8.ml:20,49--61]`, `fn[tests8.ml:20,62--77]`, 0)
        -> k1 * k2
  and code rec size(65)
        map_foo_0 (f : val, seq : val, param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   apply seq (0) -> k3 * k2
+   apply &my_alloc_region seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
@@ -54,18 +56,20 @@ let $camlTests8__first_const = Block 0 () in
           where k3 =
             let `fn[tests8.ml:20,12--80]` =
               closure `fn[tests8.ml:20,12--80]_1` @`fn[tests8.ml:20,12--80]`
+                &my_alloc_region
             with { my_closure = my_closure ~ depth my_depth -> next_depth }
             in
             ((let Pfield = %block_load.[`0`] (`*match*`) in
-              apply f (Pfield) -> k3 * k2)
+              apply &my_alloc_region f (Pfield) -> k3 * k2)
                where k3 (apply_result : val) =
                  let Pmakeblock =
-                   %block.[`0`] (apply_result, `fn[tests8.ml:20,12--80]`)
+                   %block.[`0`].my_alloc_region
+                     (apply_result, `fn[tests8.ml:20,12--80]`)
                  in
                  cont k1 (Pmakeblock)))
  in
- let map_foo = closure map_foo_0 @map_foo in
- let Pmakeblock = %block.[`0`] (map_foo) in
+ let map_foo = closure map_foo_0 @map_foo &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (map_foo) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests8.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests8.simplify.reference
@@ -3,32 +3,34 @@ let code `fn[tests8.ml:20,49--61]_3` deleted in
 let code map_foo_0 deleted and code `fn[tests8.ml:20,12--80]_1` deleted in
 let code loopify(never) size(1) newer_version_of(`fn[tests8.ml:20,49--61]_3`)
       `fn[tests8.ml:20,49--61]_3_1` (x : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   cont k (x)
 in
 let $`camlTests8__fn[tests8.ml:20,49--61]_6` =
   closure `fn[tests8.ml:20,49--61]_3_1` @`fn[tests8.ml:20,49--61]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(1) newer_version_of(`fn[tests8.ml:20,62--77]_2`)
       `fn[tests8.ml:20,62--77]_2_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
   cont k (0)
 in
 let $`camlTests8__fn[tests8.ml:20,62--77]_5` =
   closure `fn[tests8.ml:20,62--77]_2_1` @`fn[tests8.ml:20,62--77]`
+    &toplevel.alloc_region
 in
 let $camlTests8__map_foo_4 =
-  closure map_foo_0_1 @map_foo
+  closure map_foo_0_1 @map_foo &toplevel.alloc_region
 and code rec loopify(never) size(44) newer_version_of(map_foo_0)
       map_foo_0_1 (f : val, seq : val, param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply seq (0) -> k2 * k1
+  apply &my_alloc_region seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
@@ -37,24 +39,26 @@ and code rec loopify(never) size(44) newer_version_of(map_foo_0)
          where k2 =
            let `fn[tests8.ml:20,12--80]` =
              closure `fn[tests8.ml:20,12--80]_1_1` @`fn[tests8.ml:20,12--80]`
+               &my_alloc_region
            with {
              my_closure =
                $camlTests8__map_foo_4 ~ depth my_depth -> succ my_depth
            }
            in
            ((let Pfield = %block_load.[`0`] (`*match*`) in
-             apply f (Pfield) -> k2 * k1)
+             apply &my_alloc_region f (Pfield) -> k2 * k1)
               where k2 (apply_result : val) =
                 let Pmakeblock =
-                  %block.[`0`] (apply_result, `fn[tests8.ml:20,12--80]`)
+                  %block.[`0`].my_alloc_region
+                    (apply_result, `fn[tests8.ml:20,12--80]`)
                 in
                 cont k (Pmakeblock)))
 and code loopify(never) size(4) newer_version_of(`fn[tests8.ml:20,12--80]_1`)
       `fn[tests8.ml:20,12--80]_1_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply direct(map_foo_0_1) inlined(never)
+  apply direct(map_foo_0_1 &my_alloc_region) inlined(never)
     ($camlTests8__map_foo_4 ~ depth do_not_inline -> do_not_inline
      : _ -> [ 0 | 0 of val * val ])
       ($`camlTests8__fn[tests8.ml:20,49--61]_6`,

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -1,7 +1,7 @@
 (let code rec loopify(default tailrec) size(22)
        length_aux_0
          (len : imm tagged, param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -16,26 +16,26 @@
      where k3 =
        let Pfield = %block_load.[`1`] (param) in
        let int_add = %int_barith.add (len, 1) in
-       apply direct(length_aux_0)
+       apply direct(length_aux_0 &my_alloc_region)
          (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_add, Pfield)
            -> k1 * k2
  in
  let code size(5)
        length_1 (l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let length_aux = %project_value_slot.[length].[length_aux] (my_closure) in
-   apply direct(length_aux_0)
+   apply direct(length_aux_0 &my_alloc_region)
      (length_aux : _ -> imm tagged) (0, l) -> k1 * k2
  in
  let code rec loopify(default tailrec) size(28)
        rev_append_2
          (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -49,23 +49,23 @@
         cont k3)
      where k3 =
        let Pfield = %block_load.[`0`] (l1) in
-       let Pmakeblock = %block.[`0`] (Pfield, l2) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, l2) in
        let Pfield_1 = %block_load.[`1`] (l1) in
-       apply direct(rev_append_2)
+       apply direct(rev_append_2 &my_alloc_region)
          (my_closure ~ depth my_depth -> next_depth
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (Pfield_1, Pmakeblock)
            -> k1 * k2
  in
- let $camlTests9__immstring48 = "tests9.ml" in
- let $camlTests9__const_block50 = Block 0 ($camlTests9__immstring48, 39, 52)
+ let $camlTests9__immstring53 = "tests9.ml" in
+ let $camlTests9__const_block55 = Block 0 ($camlTests9__immstring53, 39, 52)
  in
- let $camlTests9__Pmakeblock53 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests9__const_block50)
+ let $camlTests9__Pmakeblock58 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests9__const_block55)
  in
  let code rec loopify(default tailrec) size(42)
        chop_3 (k : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -91,20 +91,20 @@
           where k4 =
             let Pfield = %block_load.[`1`] (l) in
             let int_sub = %int_barith.sub (k, 1) in
-            apply direct(chop_3)
+            apply direct(chop_3 &my_alloc_region)
               (my_closure ~ depth my_depth -> next_depth
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (int_sub, Pfield)
                 -> k1 * k2
           where k3 =
-            cont k2 pop(regular k2) ($camlTests9__Pmakeblock53))
+            cont k2 pop(regular k2) ($camlTests9__Pmakeblock58))
  in
  let code rec loopify(default tailrec) size(119)
        rev_merge_5
          (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           accu : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -137,7 +137,7 @@
             let h2 = %block_load.[`0`] (l2) in
             let t1 = %block_load.[`1`] (l1) in
             let h1 = %block_load.[`0`] (l1) in
-            (apply cmp (h1, h2) -> k5 * k2
+            (apply &my_alloc_region cmp (h1, h2) -> k5 * k2
                where k5 (c : imm tagged) =
                  ((let prim = %phys_eq (c, 0) in
                    let eq = %tag_imm (prim) in
@@ -161,8 +161,10 @@
                           where k8 =
                             cont k7)
                          where k7 =
-                           let Pmakeblock = %block.[`0`] (h2, accu) in
-                           apply direct(rev_merge_5)
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (h2, accu)
+                           in
+                           apply direct(rev_merge_5 &my_alloc_region)
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -170,8 +172,10 @@
                                (l1, t2, Pmakeblock)
                                -> k1 * k2
                          where k6 =
-                           let Pmakeblock = %block.[`0`] (h1, accu) in
-                           apply direct(rev_merge_5)
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (h1, accu)
+                           in
+                           apply direct(rev_merge_5 &my_alloc_region)
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -179,19 +183,21 @@
                                (t1, l2, Pmakeblock)
                                -> k1 * k2)
                     where k5 =
-                      let Pmakeblock = %block.[`0`] (h1, accu) in
-                      apply direct(rev_merge_5)
+                      let Pmakeblock =
+                        %block.[`0`].my_alloc_region (h1, accu)
+                      in
+                      apply direct(rev_merge_5 &my_alloc_region)
                         (my_closure ~ depth my_depth -> next_depth
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (t1, t2, Pmakeblock)
                           -> k1 * k2))
           where k4 =
-            apply direct(rev_append_2)
+            apply direct(rev_append_2 &my_alloc_region)
               (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (l1, accu)
                 -> k1 * k2)
      where k3 =
-       apply direct(rev_append_2)
+       apply direct(rev_append_2 &my_alloc_region)
          (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (l2, accu)
            -> k1 * k2
@@ -201,7 +207,7 @@
          (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           accu : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -235,7 +241,7 @@
             let h2 = %block_load.[`0`] (l2) in
             let t1 = %block_load.[`1`] (l1) in
             let h1 = %block_load.[`0`] (l1) in
-            (apply cmp (h1, h2) -> k5 * k2
+            (apply &my_alloc_region cmp (h1, h2) -> k5 * k2
                where k5 (c : imm tagged) =
                  ((let prim = %phys_eq (c, 0) in
                    let eq = %tag_imm (prim) in
@@ -259,8 +265,10 @@
                           where k8 =
                             cont k7)
                          where k7 =
-                           let Pmakeblock = %block.[`0`] (h2, accu) in
-                           apply direct(rev_merge_rev_6)
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (h2, accu)
+                           in
+                           apply direct(rev_merge_rev_6 &my_alloc_region)
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -268,8 +276,10 @@
                                (l1, t2, Pmakeblock)
                                -> k1 * k2
                          where k6 =
-                           let Pmakeblock = %block.[`0`] (h1, accu) in
-                           apply direct(rev_merge_rev_6)
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (h1, accu)
+                           in
+                           apply direct(rev_merge_rev_6 &my_alloc_region)
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -277,26 +287,28 @@
                                (t1, l2, Pmakeblock)
                                -> k1 * k2)
                     where k5 =
-                      let Pmakeblock = %block.[`0`] (h1, accu) in
-                      apply direct(rev_merge_rev_6)
+                      let Pmakeblock =
+                        %block.[`0`].my_alloc_region (h1, accu)
+                      in
+                      apply direct(rev_merge_rev_6 &my_alloc_region)
                         (my_closure ~ depth my_depth -> next_depth
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (t1, t2, Pmakeblock)
                           -> k1 * k2))
           where k4 =
-            apply direct(rev_append_2)
+            apply direct(rev_append_2 &my_alloc_region)
               (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (l1, accu)
                 -> k1 * k2)
      where k3 =
-       apply direct(rev_append_2)
+       apply direct(rev_append_2 &my_alloc_region)
          (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (l2, accu)
            -> k1 * k2
  in
  let code rec size(696)
        sort_7 (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -343,7 +355,7 @@
                where k5 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply cmp (x1, x2) -> k5 * k2
+                 (apply &my_alloc_region cmp (x1, x2) -> k5 * k2
                     where k5 (c : imm tagged) =
                       ((let prim = %phys_eq (c, 0) in
                         let eq = %tag_imm (prim) in
@@ -367,19 +379,27 @@
                                where k8 =
                                  cont k7)
                               where k7 =
-                                let Pmakeblock = %block.[`0`] (x1, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x1, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x2, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x2, Pmakeblock)
                                 in
                                 cont k1 (Pmakeblock_1)
                               where k6 =
-                                let Pmakeblock = %block.[`0`] (x2, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x2, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x1, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x1, Pmakeblock)
                                 in
                                 cont k1 (Pmakeblock_1))
                          where k5 =
-                           let Pmakeblock = %block.[`0`] (x1, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x1, 0)
+                           in
                            cont k1 (Pmakeblock)))))
      where k4 =
        ((let prim = %int_comp.ne (n, 3) in
@@ -431,7 +451,7 @@
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply cmp (x1, x2) -> k4 * k2
+                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k2
                               where k4 (c : imm tagged) =
                                 ((let prim = %phys_eq (c, 0) in
                                   let eq = %tag_imm (prim) in
@@ -457,7 +477,8 @@
                                          where k7 =
                                            cont k6)
                                         where k6 =
-                                          (apply cmp (x1, x3) -> k6 * k2
+                                          (apply &my_alloc_region
+                                             cmp (x1, x3) -> k6 * k2
                                              where k6 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
                                                  in
@@ -492,6 +513,7 @@
                                                           cont k8)
                                                        where k8 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x2, x3)
                                                               -> k8 * k2
@@ -550,16 +572,16 @@
                                                                     where 
                                                                     k10 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -569,16 +591,16 @@
                                                                     where 
                                                                     k9 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock_1)
                                                                     in
@@ -588,11 +610,11 @@
                                                                  where 
                                                                    k8 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                    in
@@ -601,15 +623,15 @@
                                                                     (Pmakeblock_1)))
                                                        where k7 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2,
                                                               Pmakeblock_1)
                                                          in
@@ -617,15 +639,17 @@
                                                                 (Pmakeblock_2))
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x1, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x1, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1)))
                                         where k5 =
-                                          (apply cmp (x2, x3) -> k5 * k2
+                                          (apply &my_alloc_region
+                                             cmp (x2, x3) -> k5 * k2
                                              where k5 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
                                                  in
@@ -660,6 +684,7 @@
                                                           cont k7)
                                                        where k7 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x1, x3)
                                                               -> k7 * k2
@@ -718,16 +743,16 @@
                                                                     where 
                                                                     k9 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -737,16 +762,16 @@
                                                                     where 
                                                                     k8 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock_1)
                                                                     in
@@ -756,11 +781,11 @@
                                                                  where 
                                                                    k7 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                    in
@@ -769,15 +794,15 @@
                                                                     (Pmakeblock_1)))
                                                        where k6 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1,
                                                               Pmakeblock_1)
                                                          in
@@ -785,15 +810,17 @@
                                                                 (Pmakeblock_2))
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1))))
                                    where k4 =
-                                     (apply cmp (x2, x3) -> k4 * k2
+                                     (apply &my_alloc_region
+                                        cmp (x2, x3) -> k4 * k2
                                         where k4 (c_1 : imm tagged) =
                                           ((let prim = %phys_eq (c_1, 0) in
                                             let eq = %tag_imm (prim) in
@@ -825,49 +852,52 @@
                                                      cont k6)
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x3, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x3, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1))
                                              where k4 =
                                                let Pmakeblock =
-                                                 %block.[`0`] (x2, 0)
+                                                 %block.[`0`].my_alloc_region
+                                                   (x2, 0)
                                                in
                                                cont k1 (Pmakeblock)))))))))
      where k3 =
        let prim = %untag_imm (1) in
        let n1 = %int_shift.asr (n, prim) in
        let n2 = %int_barith.sub (n, n1) in
-       (apply direct(chop_3)
+       (apply direct(chop_3 &my_alloc_region)
           (chop : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
             (n1, l)
             -> k3 * k2
           where k3 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-            (apply direct(rev_sort_8)
+            (apply direct(rev_sort_8 &my_alloc_region)
                (rev_sort ~ depth my_depth -> next_depth
                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                  (n1, l)
                  -> k3 * k2
                where k3 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                 (apply direct(rev_sort_8)
+                 (apply direct(rev_sort_8 &my_alloc_region)
                     (rev_sort ~ depth my_depth -> next_depth
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (n2, l2)
                       -> k3 * k2
                     where k3 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                      apply direct(rev_merge_rev_6)
+                      apply direct(rev_merge_rev_6 &my_alloc_region)
                         (rev_merge_rev
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (s1, s2, 0)
@@ -875,7 +905,7 @@
  and code rec size(696)
        rev_sort_8
          (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -922,7 +952,7 @@
                where k5 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply cmp (x1, x2) -> k5 * k2
+                 (apply &my_alloc_region cmp (x1, x2) -> k5 * k2
                     where k5 (c : imm tagged) =
                       ((let prim = %phys_eq (c, 0) in
                         let eq = %tag_imm (prim) in
@@ -946,19 +976,27 @@
                                where k8 =
                                  cont k7)
                               where k7 =
-                                let Pmakeblock = %block.[`0`] (x1, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x1, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x2, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x2, Pmakeblock)
                                 in
                                 cont k1 (Pmakeblock_1)
                               where k6 =
-                                let Pmakeblock = %block.[`0`] (x2, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x2, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x1, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x1, Pmakeblock)
                                 in
                                 cont k1 (Pmakeblock_1))
                          where k5 =
-                           let Pmakeblock = %block.[`0`] (x1, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x1, 0)
+                           in
                            cont k1 (Pmakeblock)))))
      where k4 =
        ((let prim = %int_comp.ne (n, 3) in
@@ -1010,7 +1048,7 @@
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply cmp (x1, x2) -> k4 * k2
+                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k2
                               where k4 (c : imm tagged) =
                                 ((let prim = %phys_eq (c, 0) in
                                   let eq = %tag_imm (prim) in
@@ -1037,7 +1075,8 @@
                                          where k7 =
                                            cont k6)
                                         where k6 =
-                                          (apply cmp (x1, x3) -> k6 * k2
+                                          (apply &my_alloc_region
+                                             cmp (x1, x3) -> k6 * k2
                                              where k6 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
                                                  in
@@ -1072,6 +1111,7 @@
                                                           cont k8)
                                                        where k8 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x2, x3)
                                                               -> k8 * k2
@@ -1130,16 +1170,16 @@
                                                                     where 
                                                                     k10 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -1149,16 +1189,16 @@
                                                                     where 
                                                                     k9 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock_1)
                                                                     in
@@ -1168,11 +1208,11 @@
                                                                  where 
                                                                    k8 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                    in
@@ -1181,15 +1221,15 @@
                                                                     (Pmakeblock_1)))
                                                        where k7 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2,
                                                               Pmakeblock_1)
                                                          in
@@ -1197,15 +1237,17 @@
                                                                 (Pmakeblock_2))
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x1, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x1, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1)))
                                         where k5 =
-                                          (apply cmp (x2, x3) -> k5 * k2
+                                          (apply &my_alloc_region
+                                             cmp (x2, x3) -> k5 * k2
                                              where k5 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
                                                  in
@@ -1240,6 +1282,7 @@
                                                           cont k7)
                                                        where k7 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x1, x3)
                                                               -> k7 * k2
@@ -1298,16 +1341,16 @@
                                                                     where 
                                                                     k9 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -1317,16 +1360,16 @@
                                                                     where 
                                                                     k8 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock_1)
                                                                     in
@@ -1336,11 +1379,11 @@
                                                                  where 
                                                                    k7 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                    in
@@ -1349,15 +1392,15 @@
                                                                     (Pmakeblock_1)))
                                                        where k6 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1,
                                                               Pmakeblock_1)
                                                          in
@@ -1365,15 +1408,17 @@
                                                                 (Pmakeblock_2))
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1))))
                                    where k4 =
-                                     (apply cmp (x2, x3) -> k4 * k2
+                                     (apply &my_alloc_region
+                                        cmp (x2, x3) -> k4 * k2
                                         where k4 (c_1 : imm tagged) =
                                           ((let prim = %phys_eq (c_1, 0) in
                                             let eq = %tag_imm (prim) in
@@ -1406,49 +1451,52 @@
                                                      cont k6)
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x3, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x3, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k1 (Pmakeblock_1))
                                              where k4 =
                                                let Pmakeblock =
-                                                 %block.[`0`] (x2, 0)
+                                                 %block.[`0`].my_alloc_region
+                                                   (x2, 0)
                                                in
                                                cont k1 (Pmakeblock)))))))))
      where k3 =
        let prim = %untag_imm (1) in
        let n1 = %int_shift.asr (n, prim) in
        let n2 = %int_barith.sub (n, n1) in
-       (apply direct(chop_3)
+       (apply direct(chop_3 &my_alloc_region)
           (chop : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
             (n1, l)
             -> k3 * k2
           where k3 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-            (apply direct(sort_7)
+            (apply direct(sort_7 &my_alloc_region)
                (sort ~ depth my_depth -> next_depth
                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                  (n1, l)
                  -> k3 * k2
                where k3 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                 (apply direct(sort_7)
+                 (apply direct(sort_7 &my_alloc_region)
                     (sort ~ depth my_depth -> next_depth
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (n2, l2)
                       -> k3 * k2
                     where k3 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                      apply direct(rev_merge_5)
+                      apply direct(rev_merge_5 &my_alloc_region)
                         (rev_merge
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (s1, s2, 0)
@@ -1456,7 +1504,7 @@
  in
  let code size(1692)
        sort_uniq_4 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -1465,14 +1513,15 @@
      %project_value_slot.[sort_uniq].[rev_append_2] (my_closure)
    in
    let chop = %project_value_slot.[sort_uniq].[chop_1] (my_closure) in
-   let rev_merge = closure rev_merge_5 @rev_merge
+   let rev_merge = closure rev_merge_5 @rev_merge &my_alloc_region
    with { rev_append = rev_append; cmp = cmp }
    in
-   let rev_merge_rev = closure rev_merge_rev_6 @rev_merge_rev
+   let rev_merge_rev =
+     closure rev_merge_rev_6 @rev_merge_rev &my_alloc_region
    with { rev_append_1 = rev_append; cmp_1 = cmp }
    in
-   let sort = closure sort_7 @sort
-   and rev_sort = closure rev_sort_8 @rev_sort
+   let sort = closure sort_7 @sort &my_alloc_region
+   and rev_sort = closure rev_sort_8 @rev_sort &my_alloc_region
    with {
      chop = chop;
      cmp_2 = cmp;
@@ -1480,7 +1529,8 @@
      rev_merge_rev = rev_merge_rev
    }
    in
-   apply direct(length_1) (length : _ -> imm tagged) (l) -> k3 * k2
+   apply direct(length_1 &my_alloc_region)
+     (length : _ -> imm tagged) (l) -> k3 * k2
      where k3 (len : imm tagged) =
        ((let prim = %int_comp.lt (len, 2) in
          let int_lessthan = %tag_imm (prim) in
@@ -1491,7 +1541,7 @@
            where k4 =
              cont k3)
           where k3 =
-            apply direct(sort_7)
+            apply direct(sort_7 &my_alloc_region)
               (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (len, l)
                 -> k1 * k2)
@@ -1499,14 +1549,14 @@
  let code rec size(6)
        sort_10
          (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
    let cmp = %project_value_slot.[sort_1].[cmp_3] (my_closure) in
    let rev_sort = %project_function_slot.[sort_1].[rev_sort_1] (my_closure)
    in
-   apply direct(rev_sort_11)
+   apply direct(rev_sort_11 &my_alloc_region)
      (rev_sort ~ depth my_depth -> next_depth
       : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
        (n, l)
@@ -1514,7 +1564,7 @@
  and code rec size(97)
        rev_sort_11
          (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
@@ -1556,7 +1606,7 @@
                where k4 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply cmp (x1, x2) -> k4 * k2
+                 (apply &my_alloc_region cmp (x1, x2) -> k4 * k2
                     where k4 (c : imm tagged) =
                       ((let prim = %int_comp.lt (c, 0) in
                         let int_lessthan = %tag_imm (prim) in
@@ -1569,13 +1619,17 @@
                           where k6 =
                             cont k5)
                          where k5 =
-                           let Pmakeblock = %block.[`0`] (x2, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x2, 0)
+                           in
                            cont k1 (Pmakeblock)
                          where k4 =
-                           let Pmakeblock = %block.[`0`] (x1, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x1, 0)
+                           in
                            cont k1 (Pmakeblock)))))
      where k3 =
-       apply direct(sort_10)
+       apply direct(sort_10 &my_alloc_region)
          (sort ~ depth my_depth -> next_depth
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (n, l)
@@ -1583,29 +1637,32 @@
  in
  let code size(119)
        foo_9 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let sort = closure sort_10 @sort_1
-   and rev_sort = closure rev_sort_11 @rev_sort_1
+   let sort = closure sort_10 @sort_1 &my_alloc_region
+   and rev_sort = closure rev_sort_11 @rev_sort_1 &my_alloc_region
    with { cmp_3 = cmp }
    in
-   apply direct(sort_10)
+   apply direct(sort_10 &my_alloc_region)
      (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
        (42, l)
        -> k1 * k2
  in
- let length_aux = closure length_aux_0 @length_aux in
- let length = closure length_1 @length with { length_aux = length_aux } in
- let rev_append = closure rev_append_2 @rev_append in
- let chop = closure chop_3 @chop in
- let sort_uniq = closure sort_uniq_4 @sort_uniq
+ let length_aux = closure length_aux_0 @length_aux &toplevel.alloc_region in
+ let length = closure length_1 @length &toplevel.alloc_region
+ with { length_aux = length_aux }
+ in
+ let rev_append = closure rev_append_2 @rev_append &toplevel.alloc_region in
+ let chop = closure chop_3 @chop &toplevel.alloc_region in
+ let sort_uniq = closure sort_uniq_4 @sort_uniq &toplevel.alloc_region
  with { length = length; rev_append_2 = rev_append; chop_1 = chop }
  in
- let foo = closure foo_9 @foo in
+ let foo = closure foo_9 @foo &toplevel.alloc_region in
  let Pmakeblock =
-   %block.[`0`] (length_aux, length, rev_append, chop, sort_uniq, foo)
+   %block.[`0`].`toplevel`
+     (length_aux, length, rev_append, chop, sort_uniq, foo)
  in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -1,11 +1,11 @@
 let code length_aux_0 deleted in
 let code length_1 deleted in
 let code rev_append_2 deleted in
-let $camlTests9__immstring48 = "tests9.ml" in
-let $camlTests9__const_block50 = Block 0 ($camlTests9__immstring48, 39, 52)
+let $camlTests9__immstring53 = "tests9.ml" in
+let $camlTests9__const_block55 = Block 0 ($camlTests9__immstring53, 39, 52)
 in
-let $camlTests9__Pmakeblock53 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests9__const_block50)
+let $camlTests9__Pmakeblock58 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTests9__const_block55)
 in
 let code chop_3 deleted in
 let code rev_merge_5 deleted in
@@ -17,7 +17,7 @@ let code foo_9 deleted in
 let code loopify(done) size(16) newer_version_of(length_aux_0)
       length_aux_0_1
         (len : imm tagged, param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (len, param)
@@ -33,21 +33,25 @@ let code loopify(done) size(16) newer_version_of(length_aux_0)
            let int_add = %int_barith.add (len_1, 1) in
            cont `self` (int_add, Pfield))
 in
-let $camlTests9__length_aux_12 = closure length_aux_0_1 @length_aux in
+let $camlTests9__length_aux_12 =
+  closure length_aux_0_1 @length_aux &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(length_1)
       length_1_1 (l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(length_aux_0_1)
+  apply direct(length_aux_0_1 &my_alloc_region)
     ($camlTests9__length_aux_12 : _ -> imm tagged) (0, l) -> k * k1
 in
-let $camlTests9__length_13 = closure length_1_1 @length in
+let $camlTests9__length_13 =
+  closure length_1_1 @length &toplevel.alloc_region
+in
 let code loopify(done) size(22) newer_version_of(rev_append_2)
       rev_append_2_1
         (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
          l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   cont `self` (l1, l2)
@@ -60,15 +64,17 @@ let code loopify(done) size(22) newer_version_of(rev_append_2)
          | 1 -> k (l2_1)
          where k2 =
            let Pfield = %block_load.[`0`] (l1_1) in
-           let Pmakeblock = %block.[`0`] (Pfield, l2_1) in
+           let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, l2_1) in
            let Pfield_1 = %block_load.[`1`] (l1_1) in
            cont `self` (Pfield_1, Pmakeblock))
 in
-let $camlTests9__rev_append_14 = closure rev_append_2_1 @rev_append in
+let $camlTests9__rev_append_14 =
+  closure rev_append_2_1 @rev_append &toplevel.alloc_region
+in
 let code loopify(done) size(28) newer_version_of(chop_3)
       chop_3_1
         (k : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   cont `self` (k, l)
@@ -83,19 +89,19 @@ let code loopify(done) size(28) newer_version_of(chop_3)
            let prim_1 = %is_int (l_1) in
            (switch prim_1
               | 0 -> k2
-              | 1 -> k1 pop(regular k1) ($camlTests9__Pmakeblock53)
+              | 1 -> k1 pop(regular k1) ($camlTests9__Pmakeblock58)
               where k2 =
                 let Pfield = %block_load.[`1`] (l_1) in
                 let int_sub = %int_barith.sub (k_1, 1) in
                 cont `self` (int_sub, Pfield)))
 in
-let $camlTests9__chop_15 = closure chop_3_1 @chop in
+let $camlTests9__chop_15 = closure chop_3_1 @chop &toplevel.alloc_region in
 let code loopify(done) size(90) newer_version_of(rev_merge_5)
       rev_merge_5_1
         (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
          l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
          accu : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   cont `self` (l1, l2, accu)
@@ -109,7 +115,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
          | 0 -> k2
          | 1 -> k3
          where k3 =
-           apply direct(rev_append_2_1)
+           apply direct(rev_append_2_1 &my_alloc_region)
              ($camlTests9__rev_append_14
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                (l2_1, accu_1)
@@ -120,7 +126,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
               | 0 -> k2
               | 1 -> k3
               where k3 =
-                apply direct(rev_append_2_1)
+                apply direct(rev_append_2_1 &my_alloc_region)
                   ($camlTests9__rev_append_14
                    : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                     (l1_1, accu_1)
@@ -130,14 +136,16 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
                 let h2 = %block_load.[`0`] (l2_1) in
                 let t1 = %block_load.[`1`] (l1_1) in
                 let h1 = %block_load.[`0`] (l1_1) in
-                (apply cmp (h1, h2) -> k2 * k1
+                (apply &my_alloc_region cmp (h1, h2) -> k2 * k1
                    where k2 (c : imm tagged) =
                      let prim_2 = %phys_eq (c, 0) in
                      (switch prim_2
                         | 0 -> k2
                         | 1 -> k3
                         where k3 =
-                          let Pmakeblock = %block.[`0`] (h1, accu_1) in
+                          let Pmakeblock =
+                            %block.[`0`].my_alloc_region (h1, accu_1)
+                          in
                           cont `self` (t1, t2, Pmakeblock)
                         where k2 =
                           let prim_3 = %int_comp.lt (c, 0) in
@@ -145,10 +153,14 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
                              | 0 -> k2
                              | 1 -> k3
                              where k3 =
-                               let Pmakeblock = %block.[`0`] (h1, accu_1) in
+                               let Pmakeblock =
+                                 %block.[`0`].my_alloc_region (h1, accu_1)
+                               in
                                cont `self` (t1, l2_1, Pmakeblock)
                              where k2 =
-                               let Pmakeblock = %block.[`0`] (h2, accu_1) in
+                               let Pmakeblock =
+                                 %block.[`0`].my_alloc_region (h2, accu_1)
+                               in
                                cont `self` (l1_1, t2, Pmakeblock))))))
 in
 let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
@@ -156,7 +168,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
         (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
          l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
          accu : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   cont `self` (l1, l2, accu)
@@ -170,7 +182,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
          | 0 -> k2
          | 1 -> k3
          where k3 =
-           apply direct(rev_append_2_1)
+           apply direct(rev_append_2_1 &my_alloc_region)
              ($camlTests9__rev_append_14
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                (l2_1, accu_1)
@@ -181,7 +193,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
               | 0 -> k2
               | 1 -> k3
               where k3 =
-                apply direct(rev_append_2_1)
+                apply direct(rev_append_2_1 &my_alloc_region)
                   ($camlTests9__rev_append_14
                    : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                     (l1_1, accu_1)
@@ -191,14 +203,16 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
                 let h2 = %block_load.[`0`] (l2_1) in
                 let t1 = %block_load.[`1`] (l1_1) in
                 let h1 = %block_load.[`0`] (l1_1) in
-                (apply cmp (h1, h2) -> k2 * k1
+                (apply &my_alloc_region cmp (h1, h2) -> k2 * k1
                    where k2 (c : imm tagged) =
                      let prim_2 = %phys_eq (c, 0) in
                      (switch prim_2
                         | 0 -> k2
                         | 1 -> k3
                         where k3 =
-                          let Pmakeblock = %block.[`0`] (h1, accu_1) in
+                          let Pmakeblock =
+                            %block.[`0`].my_alloc_region (h1, accu_1)
+                          in
                           cont `self` (t1, t2, Pmakeblock)
                         where k2 =
                           let prim_3 = %int_comp.gt (c, 0) in
@@ -206,16 +220,20 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
                              | 0 -> k2
                              | 1 -> k3
                              where k3 =
-                               let Pmakeblock = %block.[`0`] (h1, accu_1) in
+                               let Pmakeblock =
+                                 %block.[`0`].my_alloc_region (h1, accu_1)
+                               in
                                cont `self` (t1, l2_1, Pmakeblock)
                              where k2 =
-                               let Pmakeblock = %block.[`0`] (h2, accu_1) in
+                               let Pmakeblock =
+                                 %block.[`0`].my_alloc_region (h2, accu_1)
+                               in
                                cont `self` (l1_1, t2, Pmakeblock))))))
 in
 let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
       rev_sort_8_1
         (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let cmp = %project_value_slot.[rev_sort].[cmp_2] (my_closure) in
@@ -251,14 +269,15 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply cmp (x1, x2) -> k4 * k1
+                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k1
                               where k4 (c : imm tagged) =
                                 let prim_5 = %phys_eq (c, 0) in
                                 (switch prim_5
                                    | 0 -> k4
                                    | 1 -> k5
                                    where k5 =
-                                     (apply cmp (x2, x3) -> k5 * k1
+                                     (apply &my_alloc_region
+                                        cmp (x2, x3) -> k5 * k1
                                         where k5 (c_1 : imm tagged) =
                                           let prim_6 = %phys_eq (c_1, 0) in
                                           (switch prim_6
@@ -266,7 +285,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                              | 1 -> k6
                                              where k6 =
                                                let Pmakeblock =
-                                                 %block.[`0`] (x2, 0)
+                                                 %block.[`0`].my_alloc_region
+                                                   (x2, 0)
                                                in
                                                cont k (Pmakeblock)
                                              where k5 =
@@ -278,19 +298,21 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                   | 1 -> k6
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x3, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x3, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1))))
@@ -300,7 +322,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                         | 0 -> k4
                                         | 1 -> k5
                                         where k5 =
-                                          (apply cmp (x2, x3) -> k5 * k1
+                                          (apply &my_alloc_region
+                                             cmp (x2, x3) -> k5 * k1
                                              where k5 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
                                                in
@@ -309,10 +332,11 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                   | 1 -> k6
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1)
@@ -325,15 +349,15 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                        | 1 -> k6
                                                        where k6 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1,
                                                               Pmakeblock_1)
                                                          in
@@ -341,6 +365,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                 (Pmakeblock_2)
                                                        where k5 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x1, x3)
                                                               -> k5 * k1
@@ -358,11 +383,11 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                  where 
                                                                    k6 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                    in
@@ -381,16 +406,16 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     where 
                                                                     k6 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock_1)
                                                                     in
@@ -400,16 +425,16 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     where 
                                                                     k5 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -417,7 +442,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     k
                                                                     (Pmakeblock_2)))))))
                                         where k4 =
-                                          (apply cmp (x1, x3) -> k4 * k1
+                                          (apply &my_alloc_region
+                                             cmp (x1, x3) -> k4 * k1
                                              where k4 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
                                                in
@@ -426,10 +452,11 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                   | 1 -> k5
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x1, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x1, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1)
@@ -442,15 +469,15 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                        | 1 -> k5
                                                        where k5 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2,
                                                               Pmakeblock_1)
                                                          in
@@ -458,6 +485,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                 (Pmakeblock_2)
                                                        where k4 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x2, x3)
                                                               -> k4 * k1
@@ -475,11 +503,11 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                  where 
                                                                    k5 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                    in
@@ -498,16 +526,16 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     where 
                                                                     k5 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock_1)
                                                                     in
@@ -517,16 +545,16 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     where 
                                                                     k4 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -547,14 +575,16 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                where k3 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply cmp (x1, x2) -> k3 * k1
+                 (apply &my_alloc_region cmp (x1, x2) -> k3 * k1
                     where k3 (c : imm tagged) =
                       let prim_3 = %phys_eq (c, 0) in
                       (switch prim_3
                          | 0 -> k3
                          | 1 -> k4
                          where k4 =
-                           let Pmakeblock = %block.[`0`] (x1, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x1, 0)
+                           in
                            cont k (Pmakeblock)
                          where k3 =
                            let prim_4 = %int_comp.gt (c, 0) in
@@ -562,39 +592,45 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                               | 0 -> k3
                               | 1 -> k4
                               where k4 =
-                                let Pmakeblock = %block.[`0`] (x2, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x2, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x1, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x1, Pmakeblock)
                                 in
                                 cont k (Pmakeblock_1)
                               where k3 =
-                                let Pmakeblock = %block.[`0`] (x1, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x1, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x2, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x2, Pmakeblock)
                                 in
                                 cont k (Pmakeblock_1)))))))
     where k2 =
       let n1 = %int_shift.asr (n, 1i) in
       let n2 = %int_barith.sub (n, n1) in
-      (apply direct(chop_3_1)
+      (apply direct(chop_3_1 &my_alloc_region)
          ($camlTests9__chop_15
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (n1, l)
            -> k2 * k1
          where k2 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-           (apply direct(sort_7_1)
+           (apply direct(sort_7_1 &my_alloc_region)
               (sort ~ depth my_depth -> succ my_depth
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (n1, l)
                 -> k2 * k1
               where k2 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                (apply direct(sort_7_1)
+                (apply direct(sort_7_1 &my_alloc_region)
                    (sort ~ depth my_depth -> succ my_depth
                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                      (n2, l2)
                      -> k2 * k1
                    where k2 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                     apply direct(rev_merge_5_1)
+                     apply direct(rev_merge_5_1 &my_alloc_region)
                        (rev_merge
                         : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                          (s1, s2, 0)
@@ -602,7 +638,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
 and code rec loopify(never) size(588) newer_version_of(sort_7)
       sort_7_1
         (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let cmp = %project_value_slot.[sort].[cmp_2] (my_closure) in
@@ -639,14 +675,15 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply cmp (x1, x2) -> k4 * k1
+                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k1
                               where k4 (c : imm tagged) =
                                 let prim_5 = %phys_eq (c, 0) in
                                 (switch prim_5
                                    | 0 -> k4
                                    | 1 -> k5
                                    where k5 =
-                                     (apply cmp (x2, x3) -> k5 * k1
+                                     (apply &my_alloc_region
+                                        cmp (x2, x3) -> k5 * k1
                                         where k5 (c_1 : imm tagged) =
                                           let prim_6 = %phys_eq (c_1, 0) in
                                           (switch prim_6
@@ -654,7 +691,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                              | 1 -> k6
                                              where k6 =
                                                let Pmakeblock =
-                                                 %block.[`0`] (x2, 0)
+                                                 %block.[`0`].my_alloc_region
+                                                   (x2, 0)
                                                in
                                                cont k (Pmakeblock)
                                              where k5 =
@@ -666,19 +704,21 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                   | 1 -> k6
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x3, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x3, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1))))
@@ -688,7 +728,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                         | 0 -> k4
                                         | 1 -> k5
                                         where k5 =
-                                          (apply cmp (x2, x3) -> k5 * k1
+                                          (apply &my_alloc_region
+                                             cmp (x2, x3) -> k5 * k1
                                              where k5 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
                                                in
@@ -697,10 +738,11 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                   | 1 -> k6
                                                   where k6 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x2, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x2, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1)
@@ -713,15 +755,15 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                        | 1 -> k6
                                                        where k6 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1,
                                                               Pmakeblock_1)
                                                          in
@@ -729,6 +771,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                 (Pmakeblock_2)
                                                        where k5 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x1, x3)
                                                               -> k5 * k1
@@ -746,11 +789,11 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                  where 
                                                                    k6 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                    in
@@ -769,16 +812,16 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     where 
                                                                     k6 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock_1)
                                                                     in
@@ -788,16 +831,16 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     where 
                                                                     k5 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -805,7 +848,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     k
                                                                     (Pmakeblock_2)))))))
                                         where k4 =
-                                          (apply cmp (x1, x3) -> k4 * k1
+                                          (apply &my_alloc_region
+                                             cmp (x1, x3) -> k4 * k1
                                              where k4 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
                                                in
@@ -814,10 +858,11 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                   | 1 -> k5
                                                   where k5 =
                                                     let Pmakeblock =
-                                                      %block.[`0`] (x1, 0)
+                                                      %block.[`0`].my_alloc_region
+                                                        (x1, 0)
                                                     in
                                                     let Pmakeblock_1 =
-                                                      %block.[`0`]
+                                                      %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
                                                     cont k (Pmakeblock_1)
@@ -830,15 +875,15 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                        | 1 -> k5
                                                        where k5 =
                                                          let Pmakeblock =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x3, 0)
                                                          in
                                                          let Pmakeblock_1 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x1, Pmakeblock)
                                                          in
                                                          let Pmakeblock_2 =
-                                                           %block.[`0`]
+                                                           %block.[`0`].my_alloc_region
                                                              (x2,
                                                               Pmakeblock_1)
                                                          in
@@ -846,6 +891,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                 (Pmakeblock_2)
                                                        where k4 =
                                                          (apply
+                                                                 &my_alloc_region
                                                             cmp
                                                               (x2, x3)
                                                               -> k4 * k1
@@ -863,11 +909,11 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                  where 
                                                                    k5 =
                                                                    let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                    in
                                                                    let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                    in
@@ -886,16 +932,16 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     where 
                                                                     k5 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock_1)
                                                                     in
@@ -905,16 +951,16 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     where 
                                                                     k4 =
                                                                     let Pmakeblock =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x1, 0)
                                                                     in
                                                                     let Pmakeblock_1 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x2,
                                                                     Pmakeblock)
                                                                     in
                                                                     let Pmakeblock_2 =
-                                                                    %block.[`0`]
+                                                                    %block.[`0`].my_alloc_region
                                                                     (x3,
                                                                     Pmakeblock_1)
                                                                     in
@@ -935,14 +981,16 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                where k3 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply cmp (x1, x2) -> k3 * k1
+                 (apply &my_alloc_region cmp (x1, x2) -> k3 * k1
                     where k3 (c : imm tagged) =
                       let prim_3 = %phys_eq (c, 0) in
                       (switch prim_3
                          | 0 -> k3
                          | 1 -> k4
                          where k4 =
-                           let Pmakeblock = %block.[`0`] (x1, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x1, 0)
+                           in
                            cont k (Pmakeblock)
                          where k3 =
                            let prim_4 = %int_comp.lt (c, 0) in
@@ -950,39 +998,45 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                               | 0 -> k3
                               | 1 -> k4
                               where k4 =
-                                let Pmakeblock = %block.[`0`] (x2, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x2, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x1, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x1, Pmakeblock)
                                 in
                                 cont k (Pmakeblock_1)
                               where k3 =
-                                let Pmakeblock = %block.[`0`] (x1, 0) in
+                                let Pmakeblock =
+                                  %block.[`0`].my_alloc_region (x1, 0)
+                                in
                                 let Pmakeblock_1 =
-                                  %block.[`0`] (x2, Pmakeblock)
+                                  %block.[`0`].my_alloc_region
+                                    (x2, Pmakeblock)
                                 in
                                 cont k (Pmakeblock_1)))))))
     where k2 =
       let n1 = %int_shift.asr (n, 1i) in
       let n2 = %int_barith.sub (n, n1) in
-      (apply direct(chop_3_1)
+      (apply direct(chop_3_1 &my_alloc_region)
          ($camlTests9__chop_15
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (n1, l)
            -> k2 * k1
          where k2 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-           (apply direct(rev_sort_8_1)
+           (apply direct(rev_sort_8_1 &my_alloc_region)
               (rev_sort ~ depth my_depth -> succ my_depth
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (n1, l)
                 -> k2 * k1
               where k2 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                (apply direct(rev_sort_8_1)
+                (apply direct(rev_sort_8_1 &my_alloc_region)
                    (rev_sort ~ depth my_depth -> succ my_depth
                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                      (n2, l2)
                      -> k2 * k1
                    where k2 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                     apply direct(rev_merge_rev_6_1)
+                     apply direct(rev_merge_rev_6_1 &my_alloc_region)
                        (rev_merge_rev
                         : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                          (s1, s2, 0)
@@ -991,17 +1045,18 @@ in
 let code loopify(never) size(1411) newer_version_of(sort_uniq_4)
       sort_uniq_4_1
         (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let rev_merge = closure rev_merge_5_1 @rev_merge
+  let rev_merge = closure rev_merge_5_1 @rev_merge &my_alloc_region
   with { rev_append_1 = $camlTests9__rev_append_14; cmp = cmp }
   in
-  let rev_merge_rev = closure rev_merge_rev_6_1 @rev_merge_rev
+  let rev_merge_rev =
+    closure rev_merge_rev_6_1 @rev_merge_rev &my_alloc_region
   with { rev_append = $camlTests9__rev_append_14; cmp_1 = cmp }
   in
-  let sort = closure sort_7_1 @sort
-  and rev_sort = closure rev_sort_8_1 @rev_sort
+  let sort = closure sort_7_1 @sort &my_alloc_region
+  and rev_sort = closure rev_sort_8_1 @rev_sort &my_alloc_region
   with {
     chop = $camlTests9__chop_15;
     cmp_2 = cmp;
@@ -1009,7 +1064,7 @@ let code loopify(never) size(1411) newer_version_of(sort_uniq_4)
     rev_merge_rev = rev_merge_rev
   }
   in
-  apply direct(length_aux_0_1) inlining_state(depth(10))
+  apply direct(length_aux_0_1 &my_alloc_region) inlining_state(depth(10))
     ($camlTests9__length_aux_12 : _ -> imm tagged) (0, l) -> k2 * k1
     where k2 (len : imm tagged) =
       let prim = %int_comp.lt (len, 2) in
@@ -1017,16 +1072,18 @@ let code loopify(never) size(1411) newer_version_of(sort_uniq_4)
          | 0 -> k2
          | 1 -> k (l)
          where k2 =
-           apply direct(sort_7_1)
+           apply direct(sort_7_1 &my_alloc_region)
              (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                (len, l)
                -> k * k1)
 in
-let $camlTests9__sort_uniq_16 = closure sort_uniq_4_1 @sort_uniq in
+let $camlTests9__sort_uniq_16 =
+  closure sort_uniq_4_1 @sort_uniq &toplevel.alloc_region
+in
 let code rec loopify(never) size(77) newer_version_of(rev_sort_11)
       rev_sort_11_1
         (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let cmp = %project_value_slot.[rev_sort_1].[cmp_3] (my_closure) in
@@ -1049,20 +1106,24 @@ let code rec loopify(never) size(77) newer_version_of(rev_sort_11)
                where k3 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply cmp (x1, x2) -> k3 * k1
+                 (apply &my_alloc_region cmp (x1, x2) -> k3 * k1
                     where k3 (c : imm tagged) =
                       let prim_3 = %int_comp.lt (c, 0) in
                       (switch prim_3
                          | 0 -> k3
                          | 1 -> k4
                          where k4 =
-                           let Pmakeblock = %block.[`0`] (x1, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x1, 0)
+                           in
                            cont k (Pmakeblock)
                          where k3 =
-                           let Pmakeblock = %block.[`0`] (x2, 0) in
+                           let Pmakeblock =
+                             %block.[`0`].my_alloc_region (x2, 0)
+                           in
                            cont k (Pmakeblock))))))
     where k2 =
-      apply direct(sort_10_1)
+      apply direct(sort_10_1 &my_alloc_region)
         (sort ~ depth my_depth -> succ my_depth
          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
           (n, l)
@@ -1070,11 +1131,11 @@ let code rec loopify(never) size(77) newer_version_of(rev_sort_11)
 and code rec loopify(never) size(5) newer_version_of(sort_10)
       sort_10_1
         (n : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let rev_sort = %project_function_slot.[sort_1].[rev_sort_1] (my_closure) in
-  apply direct(rev_sort_11_1)
+  apply direct(rev_sort_11_1 &my_alloc_region)
     (rev_sort ~ depth my_depth -> succ my_depth
      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
       (n, l)
@@ -1082,17 +1143,17 @@ and code rec loopify(never) size(5) newer_version_of(sort_10)
 in
 let code loopify(never) size(98) newer_version_of(foo_9)
       foo_9_1 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let sort = closure sort_10_1 @sort_1
-  and rev_sort = closure rev_sort_11_1 @rev_sort_1
+  let sort = closure sort_10_1 @sort_1 &my_alloc_region
+  and rev_sort = closure rev_sort_11_1 @rev_sort_1 &my_alloc_region
   with { cmp_3 = cmp }
   in
-  apply direct(sort_10_1)
+  apply direct(sort_10_1 &my_alloc_region)
     (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) (42, l) -> k * k1
 in
-let $camlTests9__foo_17 = closure foo_9_1 @foo in
+let $camlTests9__foo_17 = closure foo_9_1 @foo &toplevel.alloc_region in
 let $camlTests9 =
   Block 0 ($camlTests9__length_aux_12,
            $camlTests9__length_13,

--- a/testsuite/tests/flambda2/examples/toplevel_closures.simplify.reference
+++ b/testsuite/tests/flambda2/examples/toplevel_closures.simplify.reference
@@ -1,11 +1,11 @@
 let code f_0 deleted in
 let code g_1 deleted in
-let r = %block.mut.[`0`] (42) in
+let r = %block.mut.[`0`].`toplevel` (42) in
 let $camlToplevel_closures__f_2 =
-  closure f_0_1 @f
+  closure f_0_1 @f &toplevel.alloc_region
 and code loopify(never) size(5) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let r_1 = %project_value_slot.[f].[r] ($camlToplevel_closures__f_2) in
@@ -15,10 +15,10 @@ and code loopify(never) size(5) newer_version_of(f_0)
   with { r = r }
 in
 let $camlToplevel_closures__g_3 =
-  closure g_1_1 @g
+  closure g_1_1 @g &toplevel.alloc_region
 and code loopify(never) size(8) newer_version_of(g_1)
       g_1_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let r_1 = %project_value_slot.[g].[r_1] ($camlToplevel_closures__g_3) in

--- a/testsuite/tests/flambda2/examples/toplevel_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/toplevel_rec.simplify.reference
@@ -1,17 +1,17 @@
 let code g_1 deleted and code f_0 deleted in
 let z = %opaque (42) in
 let $camlToplevel_rec__f_2 =
-  closure f_0_1 @f
+  closure f_0_1 @f &toplevel.alloc_region
 and $camlToplevel_rec__g_3 =
-  closure g_1_1 @g
+  closure g_1_1 @g &toplevel.alloc_region
 and code rec loopify(never) size(10) newer_version_of(g_1)
       g_1_1 (y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let z_1 = %project_value_slot.[g].[z] ($camlToplevel_rec__g_3) in
   (let int_sub = %int_barith.sub (y, 1) in
-   apply direct(f_0_1)
+   apply direct(f_0_1 &my_alloc_region)
      ($camlToplevel_rec__f_2 ~ depth my_depth -> succ my_depth
       : _ -> imm tagged)
        (int_sub)
@@ -21,12 +21,12 @@ and code rec loopify(never) size(10) newer_version_of(g_1)
       cont k (int_add)
 and code rec loopify(never) size(10) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let z_1 = %project_value_slot.[f].[z] ($camlToplevel_rec__f_2) in
   (let int_add = %int_barith.add (x, 1) in
-   apply direct(g_1_1)
+   apply direct(g_1_1 &my_alloc_region)
      ($camlToplevel_rec__g_3 ~ depth my_depth -> succ my_depth
       : _ -> imm tagged)
        (int_add)

--- a/testsuite/tests/flambda2/examples/tuple_stub.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tuple_stub.simplify.reference
@@ -1,10 +1,11 @@
 let code thd3_0 deleted in
 let code loopify(never) size(1) newer_version_of(thd3_0) tupled 
       thd3_0_1 (param, param_1, param_2)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   cont k (param_2)
 in
-let $camlTuple_stub__thd3_1 = closure thd3_0_1 @thd3 in
+let $camlTuple_stub__thd3_1 = closure thd3_0_1 @thd3 &toplevel.alloc_region
+in
 let $camlTuple_stub = Block 0 ($camlTuple_stub__thd3_1) in
 cont done ($camlTuple_stub)

--- a/testsuite/tests/flambda2/examples/unboxing_gadt.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unboxing_gadt.simplify.reference
@@ -2,7 +2,7 @@ let code f_0 deleted in
 let code baz_1 deleted in
 let code loopify(never) size(13) newer_version_of(f_0)
       f_0_1 (param : [ 0 | 0 of [ 0 of float boxed |1 of imm tagged ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   let prim = %is_int (param) in
@@ -13,13 +13,13 @@ let code loopify(never) size(13) newer_version_of(f_0)
       let Pfield = %block_load.[`0`] (param) in
       cont k (Pfield)
 in
-let $camlUnboxing_gadt__f_2 = closure f_0_1 @f in
+let $camlUnboxing_gadt__f_2 = closure f_0_1 @f &toplevel.alloc_region in
 let code loopify(never) size(23) newer_version_of(baz_1)
       baz_1_1
         (p : imm tagged,
          x : [ 0 | 0 of [ 0 of float boxed |1 of imm tagged ] ],
          z : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of float boxed |1 of imm tagged ] =
   (let untagged = %untag_imm (p) in
@@ -27,19 +27,20 @@ let code loopify(never) size(23) newer_version_of(baz_1)
      | 0 -> k3
      | 1 -> k4)
     where k4 =
-      apply direct(f_0_1)
+      apply direct(f_0_1 &my_alloc_region)
         ($camlUnboxing_gadt__f_2 : _ -> [ 0 of float boxed |1 of imm tagged ]
          )
           (x)
           -> k2 * k1
     where k3 =
-      let Pmakeblock = %block.[`1`] (z) in
+      let Pmakeblock = %block.[`1`].my_alloc_region (z) in
       cont k2 (Pmakeblock)
     where k2 (a : [ 0 of float boxed |1 of imm tagged ]) =
       let Popaque = %opaque (a) in
       cont k (Popaque)
 in
-let $camlUnboxing_gadt__baz_3 = closure baz_1_1 @baz in
+let $camlUnboxing_gadt__baz_3 = closure baz_1_1 @baz &toplevel.alloc_region
+in
 let $camlUnboxing_gadt =
   Block 0 ($camlUnboxing_gadt__f_2, $camlUnboxing_gadt__baz_3)
 in

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -1,30 +1,30 @@
-let $camlAlt_ergo__immstring42 = "alt_ergo.ml" in
-let $camlAlt_ergo__const_block44 =
-  Block 0 ($camlAlt_ergo__immstring42, 23, 4)
+let $camlAlt_ergo__immstring45 = "alt_ergo.ml" in
+let $camlAlt_ergo__const_block47 =
+  Block 0 ($camlAlt_ergo__immstring45, 23, 4)
 in
-let $camlAlt_ergo__Pmakeblock47 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block44)
+let $camlAlt_ergo__Pmakeblock50 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block47)
 in
-let $camlAlt_ergo__const_block50 =
-  Block 0 ($camlAlt_ergo__immstring42, 21, 14)
+let $camlAlt_ergo__const_block53 =
+  Block 0 ($camlAlt_ergo__immstring45, 21, 14)
 in
-let $camlAlt_ergo__Pmakeblock53 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block50)
+let $camlAlt_ergo__Pmakeblock56 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block53)
 in
 let code inv_borne_sup_1 deleted in
 let code inv_bornes_2 deleted in
-let $camlAlt_ergo__const_block89 =
-  Block 0 ($camlAlt_ergo__immstring42, 35, 24)
+let $camlAlt_ergo__const_block94 =
+  Block 0 ($camlAlt_ergo__immstring45, 35, 24)
 in
-let $camlAlt_ergo__Pmakeblock92 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block89)
+let $camlAlt_ergo__Pmakeblock97 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block94)
 in
 let code inv_3 deleted in
-let $camlAlt_ergo__const_block103 =
-  Block 0 ($camlAlt_ergo__immstring42, 40, 2)
+let $camlAlt_ergo__const_block109 =
+  Block 0 ($camlAlt_ergo__immstring45, 40, 2)
 in
-let $camlAlt_ergo__Pmakeblock106 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block103)
+let $camlAlt_ergo__Pmakeblock112 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlAlt_ergo__const_block109)
 in
 let code div_4 deleted in
 let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
@@ -34,7 +34,7 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
            |1 of [ 0 of imm tagged * imm tagged ] ],
          is_int,
          other)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 |1 | 0 of [ 0 of imm tagged * imm tagged ]
           |1 of [ 0 of imm tagged * imm tagged ] ] =
@@ -45,14 +45,14 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
     where k3 =
       let untagged = %untag_imm (b) in
       switch untagged
-        | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock47)
-        | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock53)
+        | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock50)
+        | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock56)
     where k2 =
       ((let Pfield = %block_load.[`0`] (b) in
         let Pfield_1 = %block_load.[`0`] (Pfield) in
         let Popaque = %opaque (0) in
         let Pobj_magic = %opaque (Popaque) in
-        apply Pobj_magic (Pfield_1) -> k3 * k1
+        apply &my_alloc_region Pobj_magic (Pfield_1) -> k3 * k1
           where k3 (param : [ 0 |1 ]) =
             let unboxed_field = %untag_imm (param) in
             cont k2 (unboxed_field))
@@ -71,30 +71,39 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
                      let Pfield_1 = %block_load.[`1`] (Pfield) in
                      let Popaque = %opaque (0) in
                      let Pobj_magic = %opaque (Popaque) in
-                     let Pmakeblock = %block.[`0`] (Pobj_magic, Pfield_1) in
-                     let Pmakeblock_1 = %block.[`1`] (Pmakeblock) in
+                     let Pmakeblock =
+                       %block.[`0`].my_alloc_region (Pobj_magic, Pfield_1)
+                     in
+                     let Pmakeblock_1 =
+                       %block.[`1`].my_alloc_region (Pmakeblock)
+                     in
                      cont k (Pmakeblock_1)
                    where k2 =
                      let Pfield = %block_load.[`0`] (b) in
                      let Pfield_1 = %block_load.[`1`] (Pfield) in
                      let Popaque = %opaque (0) in
                      let Pobj_magic = %opaque (Popaque) in
-                     let Pmakeblock = %block.[`0`] (Pobj_magic, Pfield_1) in
-                     let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+                     let Pmakeblock =
+                       %block.[`0`].my_alloc_region (Pobj_magic, Pfield_1)
+                     in
+                     let Pmakeblock_1 =
+                       %block.[`0`].my_alloc_region (Pmakeblock)
+                     in
                      cont k (Pmakeblock_1))))
 in
-let $camlAlt_ergo__inv_borne_sup_6 = closure inv_borne_sup_1_1 @inv_borne_sup
+let $camlAlt_ergo__inv_borne_sup_6 =
+  closure inv_borne_sup_1_1 @inv_borne_sup &toplevel.alloc_region
 in
 let code loopify(never) size(14) newer_version_of(inv_bornes_2)
       inv_bornes_2_1
         (param : [ 0 of val * [ 0 |1 | 0 of val |1 of val ] ], is_int)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of [ 0 |1 | 0 of val |1 of val ] *
               [ 0 |1 | 0 of val |1 of val ] ] =
   let u = %block_load.[`1`] (param) in
   (let Pfield = %block_load.[`0`] (param) in
-   apply direct(inv_borne_sup_1_1)
+   apply direct(inv_borne_sup_1_1 &my_alloc_region)
      ($camlAlt_ergo__inv_borne_sup_6
       : _ ->
         [ 0 |1 | 0 of [ 0 of imm tagged * imm tagged ]
@@ -106,31 +115,35 @@ let code loopify(never) size(14) newer_version_of(inv_bornes_2)
             (apply_result :
                [ 0 |1 | 0 of [ 0 of imm tagged * imm tagged ]
                |1 of [ 0 of imm tagged * imm tagged ] ]) =
-      let Pmakeblock = %block.[`0`] (apply_result, u) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (apply_result, u) in
       cont k (Pmakeblock)
 in
-let $camlAlt_ergo__inv_bornes_7 = closure inv_bornes_2_1 @inv_bornes in
+let $camlAlt_ergo__inv_bornes_7 =
+  closure inv_bornes_2_1 @inv_bornes &toplevel.alloc_region
+in
 let code loopify(never) size(45) newer_version_of(inv_3) tupled 
       inv_3_1 (param : [ 0 | 0 of val * val ], param_1, param_2)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock92)
+    | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock97)
     where k2 =
       let Pfield = %block_load.[`1`] (param) in
       let prim_1 = %is_int (Pfield) in
       (switch prim_1
-         | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock92)
+         | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock97)
          | 1 -> k2
          where k2 =
            let `*match*` = %block_load.[`0`] (param) in
            ((let Pfield_1 = %block_load.[`1`] (`*match*`) in
              let Pfield_2 = %block_load.[`0`] (`*match*`) in
-             let Pmakeblock = %block.[`0`] (Pfield_2, Pfield_1) in
-             apply direct(inv_bornes_2_1)
+             let Pmakeblock =
+               %block.[`0`].my_alloc_region (Pfield_2, Pfield_1)
+             in
+             apply direct(inv_bornes_2_1 &my_alloc_region)
                ($camlAlt_ergo__inv_bornes_7
                 : _ ->
                   [ 0 of [ 0 |1 | 0 of val |1 of val ] *
@@ -142,26 +155,28 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
                       (apply_result :
                          [ 0 of [ 0 |1 | 0 of val |1 of val ] *
                              [ 0 |1 | 0 of val |1 of val ] ]) =
-                let Pmakeblock = %block.[`0`] (apply_result, 0) in
+                let Pmakeblock =
+                  %block.[`0`].my_alloc_region (apply_result, 0)
+                in
                 cont k (Pmakeblock)))
 in
-let $camlAlt_ergo__inv_8 = closure inv_3_1 @inv in
+let $camlAlt_ergo__inv_8 = closure inv_3_1 @inv &toplevel.alloc_region in
 let code loopify(never) size(11) newer_version_of(div_4)
       div_4_1 (i1, i2 : [ 0 of [ 0 | 0 of val * val ] * val * val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   (let tuple_field = %block_load.tag[`0`].`size`[`3`].[`0`] (i2) in
    let tuple_field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (i2) in
    let tuple_field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (i2) in
-   apply direct(inv_3_1)
+   apply direct(inv_3_1 &my_alloc_region)
      ($camlAlt_ergo__inv_8 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
        (tuple_field, tuple_field_1, tuple_field_2)
        -> k3 * k1
      where k3 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
        cont k2)
     where k2 =
-      cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock106)
+      cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock112)
 in
-let $camlAlt_ergo__div_9 = closure div_4_1 @div in
+let $camlAlt_ergo__div_9 = closure div_4_1 @div &toplevel.alloc_region in
 let $camlAlt_ergo = Block 0 ($camlAlt_ergo__div_9) in
 cont done ($camlAlt_ergo)

--- a/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.no-flat-float-array.reference
@@ -1,13 +1,13 @@
 let code f_0 deleted in
 let code loopify(never) size(5) newer_version_of(f_0)
       f_0_1 (a : imm tagged, v : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pobj_magic = %opaque (a) in
   let Parraysetu = %array_set (Pobj_magic, 0, v) in
   cont k (0)
 in
-let $camlArray_set_bottom__f_1 = closure f_0_1 @f in
+let $camlArray_set_bottom__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlArray_set_bottom = Block 0 ($camlArray_set_bottom__f_1) in
 cont done ($camlArray_set_bottom)

--- a/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(3) newer_version_of(f_0)
       f_0_1 (a : imm tagged, v : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pobj_magic = %opaque (a) in
@@ -9,6 +9,6 @@ let code loopify(never) size(3) newer_version_of(f_0)
   let Parraysetu = %array_set.`float` (Pobj_magic, 0, prim) in
   cont k (0)
 in
-let $camlArray_set_bottom__f_1 = closure f_0_1 @f in
+let $camlArray_set_bottom__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlArray_set_bottom = Block 0 ($camlArray_set_bottom__f_1) in
 cont done ($camlArray_set_bottom)

--- a/testsuite/tests/flambda2/examples/unknown/bigarrays.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/bigarrays.simplify.reference
@@ -1,9 +1,9 @@
-let $camlBigarrays__string21 = "index out of bounds" in
-let $camlBigarrays__block23 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlBigarrays__string21)
+let $camlBigarrays__string22 = "index out of bounds" in
+let $camlBigarrays__block24 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlBigarrays__string22)
 in
 (let `region` = %begin_region () in
- (let Pmakearray = %array.`imm`.mut.`local`[`region`] (3, 3) in
+ (let Pmakearray = %array.`imm`.mut.`toplevel`.`local`[`region`] (3, 3) in
   apply ccall inlining_state(depth(10))
     ($`*extern*`.caml_ba_create : val * val * val -> val)
       (8, 0, Pmakearray)
@@ -37,7 +37,7 @@ in
                in
                (apply ccall inlining_state(depth(20))
                   ($`*extern*`.caml_format_int : val * val -> val)
-                    ($Stdlib.camlStdlib__immstring191, i)
+                    ($Stdlib.camlStdlib__immstring204, i)
                     -> k2 * error
                   where k2 (apply_result : val) =
                     let prim_4 = %string_length (apply_result) in
@@ -50,7 +50,7 @@ in
                        where k2 (param) =
                          cont k)))
         where k1 =
-          cont error pop(regular error) ($camlBigarrays__block23)))
+          cont error pop(regular error) ($camlBigarrays__block24)))
   where k =
     let $camlBigarrays = Block 0 () in
     cont done ($camlBigarrays)

--- a/testsuite/tests/flambda2/examples/unknown/c.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/c.simplify.reference
@@ -1,14 +1,14 @@
 let code neg_0 deleted in
 let code loopify(never) size(9) newer_version_of(neg_0)
       neg_0_1 (x : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let prim = %unbox_num.`float` (x) in
   let prim_1 = %ufloat_arith.neg (prim) in
-  let float_neg = %box_num.`float` (prim_1) in
+  let float_neg = %box_num.`float`.my_alloc_region (prim_1) in
   cont k (float_neg)
 in
-let $camlC__neg_1 = closure neg_0_1 @neg in
+let $camlC__neg_1 = closure neg_0_1 @neg &toplevel.alloc_region in
 let $camlC = Block 0 ($camlC__neg_1) in
 cont done ($camlC)

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
@@ -1,23 +1,23 @@
-let $camlData_flow_bug__string63 = "index out of bounds" in
-let $camlData_flow_bug__block65 =
+let $camlData_flow_bug__string65 = "index out of bounds" in
+let $camlData_flow_bug__block67 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument,
-           $camlData_flow_bug__string63)
+           $camlData_flow_bug__string65)
 in
-let $camlData_flow_bug__immstring19 = "" in
-let $camlData_flow_bug__const_block10 = Block 0 (126, 0) in
-let $camlData_flow_bug__const_block12 =
-  Block 0 (63, $camlData_flow_bug__const_block10)
-in
+let $camlData_flow_bug__immstring21 = "" in
+let $camlData_flow_bug__const_block12 = Block 0 (126, 0) in
 let $camlData_flow_bug__const_block14 =
-  Block 0 (33, $camlData_flow_bug__const_block12)
+  Block 0 (63, $camlData_flow_bug__const_block12)
 in
-let Popaque = %opaque ($camlData_flow_bug__immstring19) in
+let $camlData_flow_bug__const_block16 =
+  Block 0 (33, $camlData_flow_bug__const_block14)
+in
+let Popaque = %opaque ($camlData_flow_bug__immstring21) in
 (let Popaque_1 = %opaque (1) in
  let untagged = %untag_imm (Popaque_1) in
- let $camlData_flow_bug__Pmakeblock101 = Block 0 (906850200, Popaque) in
+ let $camlData_flow_bug__Pmakeblock106 = Block 0 (906850200, Popaque) in
  switch untagged
    | 0 -> k (-453122489)
-   | 1 -> k ($camlData_flow_bug__Pmakeblock101))
+   | 1 -> k ($camlData_flow_bug__Pmakeblock106))
   where k (fix : val) =
     ((let prim = %is_int (fix) in
       switch prim
@@ -76,7 +76,7 @@ let Popaque = %opaque ($camlData_flow_bug__immstring19) in
                                      ($`*extern*`.caml_string_notequal
                                       : val * val -> val)
                                        (Popaque,
-                                        $camlData_flow_bug__immstring19)
+                                        $camlData_flow_bug__immstring21)
                                        -> k1 * error
                                      where k1 (Pccall) =
                                        ((let untagged = %untag_imm (Pccall)
@@ -108,7 +108,7 @@ let Popaque = %opaque ($camlData_flow_bug__immstring19) in
                                                    %tag_imm (prim)
                                                  in
                                                  (cont `self`
-                                                         ($camlData_flow_bug__const_block14)
+                                                         ($camlData_flow_bug__const_block16)
                                                     where rec `self`
                                                                 (param :
                                                                    [ 0
@@ -161,7 +161,7 @@ let Popaque = %opaque ($camlData_flow_bug__immstring19) in
                                                where k1 =
                                                  cont error
                                                         pop(regular error)
-                                                        ($camlData_flow_bug__block65)))))))))
+                                                        ($camlData_flow_bug__block67)))))))))
        where k =
          let $camlData_flow_bug = Block 0 () in
          cont done ($camlData_flow_bug))

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
@@ -1,23 +1,24 @@
-let $camlData_flow_exception_bug__immstring10 = "data_flow_exception_bug.ml"
+let $camlData_flow_exception_bug__immstring12 = "data_flow_exception_bug.ml"
 in
-let $camlData_flow_exception_bug__const_block12 =
-  Block 0 ($camlData_flow_exception_bug__immstring10, 9, 19)
+let $camlData_flow_exception_bug__const_block14 =
+  Block 0 ($camlData_flow_exception_bug__immstring12, 9, 19)
 in
-let $camlData_flow_exception_bug__Pmakeblock15 =
+let $camlData_flow_exception_bug__Pmakeblock17 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlData_flow_exception_bug__const_block12)
+           $camlData_flow_exception_bug__const_block14)
 in
 let code do_stuff_0 deleted in
 let code stuff_1 deleted in
 let code loopify(never) size(3) newer_version_of(do_stuff_0)
-      do_stuff_0_1 (env) my_closure _region _ghost_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlData_flow_exception_bug__Pmakeblock15)
+      do_stuff_0_1 (env) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k1 pop(regular k1) ($camlData_flow_exception_bug__Pmakeblock17)
 in
-let $camlData_flow_exception_bug__do_stuff_2 = closure do_stuff_0_1 @do_stuff
+let $camlData_flow_exception_bug__do_stuff_2 =
+  closure do_stuff_0_1 @do_stuff &toplevel.alloc_region
 in
 let code loopify(never) size(20) newer_version_of(stuff_1)
       stuff_1_1 (env)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
   let `region` = %begin_region () in
@@ -28,7 +29,7 @@ let code loopify(never) size(20) newer_version_of(stuff_1)
      where k4 =
        let r_unboxed0 = 0 in
        let Popaque = %opaque ($camlData_flow_exception_bug__do_stuff_2) in
-       (apply Popaque (env) -> k4 * k3
+       (apply &my_alloc_region Popaque (env) -> k4 * k3
           where k4 (return_val0 : [ 0 | 0 of val ]) =
             cont k2 pop(k3) (return_val0))
      where k3 exn (`exn` : val) =
@@ -42,7 +43,9 @@ let code loopify(never) size(20) newer_version_of(stuff_1)
       let unit_1 = %end_ghost_region (ghost_region) in
       cont k (region_return)
 in
-let $camlData_flow_exception_bug__stuff_3 = closure stuff_1_1 @stuff in
+let $camlData_flow_exception_bug__stuff_3 =
+  closure stuff_1_1 @stuff &toplevel.alloc_region
+in
 let $camlData_flow_exception_bug =
   Block 0 ($camlData_flow_exception_bug__do_stuff_2,
            $camlData_flow_exception_bug__stuff_3)

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_opam_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_opam_bug.simplify.reference
@@ -1,20 +1,21 @@
-let $camlData_flow_opam_bug__immstring18 = "plop" in
-let $camlData_flow_opam_bug__immstring20 = "plip" in
+let $camlData_flow_opam_bug__immstring20 = "plop" in
+let $camlData_flow_opam_bug__immstring22 = "plip" in
 let code to_string_0 deleted in
 let code loopify(never) size(11) newer_version_of(to_string_0)
       to_string_0_1 (context : val, t : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   (let prim = %is_int (t) in
    switch prim
-     | 0 -> k2 ($camlData_flow_opam_bug__immstring20)
-     | 1 -> k2 ($camlData_flow_opam_bug__immstring18))
+     | 0 -> k2 ($camlData_flow_opam_bug__immstring22)
+     | 1 -> k2 ($camlData_flow_opam_bug__immstring20))
     where k2 (f) =
       let is_int = 0i in
       cont k (f)
 in
-let $camlData_flow_opam_bug__to_string_1 = closure to_string_0_1 @to_string
+let $camlData_flow_opam_bug__to_string_1 =
+  closure to_string_0_1 @to_string &toplevel.alloc_region
 in
 let $camlData_flow_opam_bug = Block 0 ($camlData_flow_opam_bug__to_string_1)
 in

--- a/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
@@ -1,6 +1,6 @@
 (let code size(25)
        send_0 (t : val, c : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let `*match*` = %block_load.mut.[`0`] (t) in
@@ -16,36 +16,39 @@
        let `*match*_1` = %block_load.[`0`] (`*match*`) in
        let Pfield = %block_load.[`1`] (`*match*_1`) in
        let Pfield_1 = %block_load.[`0`] (`*match*_1`) in
-       apply c (Pfield_1, Pfield) -> k1 * k2
+       apply &my_alloc_region c (Pfield_1, Pfield) -> k1 * k2
  in
  let code size(7)
        create_1 (_arity : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
-   let Pmakeblock = %block.mut.[`0`] (0) in
+   let Pmakeblock = %block.mut.[`0`].my_alloc_region (0) in
    cont k1 (Pmakeblock)
  in
  let code size(1)
        fn_2 (param_unboxed0, param_unboxed1)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    cont k1 (0)
  in
- let $camlDirect_app_parameter_kind_check_classic__s0 = closure send_0 @send
+ let $camlDirect_app_parameter_kind_check_classic__s0 =
+   closure send_0 @send &toplevel.alloc_region
  in
  let $camlDirect_app_parameter_kind_check_classic__s1 =
-   closure create_1 @create
+   closure create_1 @create &toplevel.alloc_region
  in
  let $camlDirect_app_parameter_kind_check_classic__s3 =
    Block 0 (0,
             $camlDirect_app_parameter_kind_check_classic__s0,
             $camlDirect_app_parameter_kind_check_classic__s1)
  in
- let $camlDirect_app_parameter_kind_check_classic__s2 = closure fn_2 @fn in
+ let $camlDirect_app_parameter_kind_check_classic__s2 =
+   closure fn_2 @fn &toplevel.alloc_region
+ in
  (let inlined_dbg = %inlined_apply () in
-  let Pmakeblock = %block.mut.[`0`] (0) in
+  let Pmakeblock = %block.mut.[`0`].`toplevel` (0) in
   cont k2 (Pmakeblock))
    where k2 (apply_result : val) =
      let inlined_dbg = %inlined_apply () in
@@ -64,7 +67,7 @@
           let `*match*_1` = %block_load.[`0`] (`*match*`) in
           let Pfield = %block_load.[`1`] (`*match*_1`) in
           let Pfield_1 = %block_load.[`0`] (`*match*_1`) in
-          apply c (Pfield_1, Pfield) -> k1 * error)
+          apply &toplevel.alloc_region c (Pfield_1, Pfield) -> k1 * error)
    where k1 (`*match*` : imm tagged) =
      cont k ($camlDirect_app_parameter_kind_check_classic__s3))
   where k define_root_symbol (module_block) =

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -1,24 +1,25 @@
 let code out_0 deleted in
-let $camlEmitcode_repro__const_block32 = Block 0 (1, 1) in
-let $camlEmitcode_repro__const_block36 = Block 0 (1, 0) in
-let $camlEmitcode_repro__const_block40 = Block 0 (0, 1) in
-let $camlEmitcode_repro__const_block44 = Block 0 (0, 0) in
+let $camlEmitcode_repro__const_block35 = Block 0 (1, 1) in
+let $camlEmitcode_repro__const_block39 = Block 0 (1, 0) in
+let $camlEmitcode_repro__const_block43 = Block 0 (0, 1) in
+let $camlEmitcode_repro__const_block47 = Block 0 (0, 0) in
 let code emit_instr_1 deleted in
-let $camlEmitcode_repro__const_block70 = Block 0 (2, 2) in
-let $camlEmitcode_repro__const_block90 = Block 0 (2, 1) in
+let $camlEmitcode_repro__const_block74 = Block 0 (2, 2) in
+let $camlEmitcode_repro__const_block94 = Block 0 (2, 1) in
 let code emit_2 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(out_0)
       out_0_1 (_x)
-        my_closure my_region my_ghost_region my_depth
+        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
         -> k * k1
         : imm tagged local =
   let Popaque = %opaque (0) in
   cont k (Popaque)
 in
-let $camlEmitcode_repro__out_3 = closure out_0_1 @out in
+let $camlEmitcode_repro__out_3 = closure out_0_1 @out &toplevel.alloc_region
+in
 let code loopify(never) size(50) newer_version_of(emit_instr_1)
       emit_instr_1_1 (param : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
-        my_closure my_region my_ghost_region my_depth
+        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
         -> k * k1
         : imm tagged local =
   (let prim = %is_int (param) in
@@ -36,30 +37,32 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
         | 0 -> k4
         | 1 -> k5
     where k5 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block32)
+          ($camlEmitcode_repro__const_block35)
           -> k * k1
     where k4 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block36)
+          ($camlEmitcode_repro__const_block39)
           -> k * k1
     where k3 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block40)
+          ($camlEmitcode_repro__const_block43)
           -> k * k1
     where k2 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block44)
+          ($camlEmitcode_repro__const_block47)
           -> k * k1
 in
-let $camlEmitcode_repro__emit_instr_4 = closure emit_instr_1_1 @emit_instr in
+let $camlEmitcode_repro__emit_instr_4 =
+  closure emit_instr_1_1 @emit_instr &toplevel.alloc_region
+in
 let code loopify(done) size(121) newer_version_of(emit_2)
       emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
@@ -87,9 +90,11 @@ let code loopify(done) size(121) newer_version_of(emit_2)
                    | 0 -> k3
                    | 1 -> k5
                where k5 =
-                 (apply direct(out_0_1 &`region` &ghost_region)
+                 (apply
+                         direct(out_0_1
+                         &my_alloc_region &`region` &ghost_region)
                     ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-                      ($camlEmitcode_repro__const_block70)
+                      ($camlEmitcode_repro__const_block74)
                       -> k6 * k1
                     where k6 (param_2 : imm tagged) =
                       cont k5
@@ -124,10 +129,10 @@ let code loopify(done) size(121) newer_version_of(emit_2)
                               where k4 =
                                 (apply
                                         direct(out_0_1
-                                        &`region` &ghost_region)
+                                        &my_alloc_region &`region` &ghost_region)
                                    ($camlEmitcode_repro__out_3
                                     : _ -> imm tagged)
-                                     ($camlEmitcode_repro__const_block90)
+                                     ($camlEmitcode_repro__const_block94)
                                      -> k5 * k1
                                    where k5 (param_2 : imm tagged) =
                                      cont k4
@@ -141,7 +146,9 @@ let code loopify(done) size(121) newer_version_of(emit_2)
                                      in
                                      cont `self` (Pfield_1)))))
                where k3 =
-                 (apply direct(emit_instr_1_1 &`region` &ghost_region)
+                 (apply
+                         direct(emit_instr_1_1
+                         &my_alloc_region &`region` &ghost_region)
                     ($camlEmitcode_repro__emit_instr_4 : _ -> imm tagged)
                       (instr)
                       -> k4 * k1
@@ -157,6 +164,8 @@ let code loopify(done) size(121) newer_version_of(emit_2)
            let unit_1 = %end_ghost_region (ghost_region) in
            cont k (0))
 in
-let $camlEmitcode_repro__emit_5 = closure emit_2_1 @emit in
+let $camlEmitcode_repro__emit_5 =
+  closure emit_2_1 @emit &toplevel.alloc_region
+in
 let $camlEmitcode_repro = Block 0 ($camlEmitcode_repro__emit_5) in
 cont done ($camlEmitcode_repro)

--- a/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(48) newer_version_of(f_0)
       f_0_1 (read : val, x : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let try_region = %begin_try_region () in
@@ -10,7 +10,7 @@ let code loopify(never) size(48) newer_version_of(f_0)
     where k4 =
       (cont k5
          where rec k5 =
-           (apply read (0) -> k6 * k2
+           (apply &my_alloc_region read (0) -> k6 * k2
               where k6 (return_val0 : imm tagged) =
                 let prim = %phys_ne (return_val0, 10) in
                 switch prim
@@ -34,6 +34,6 @@ let code loopify(never) size(48) newer_version_of(f_0)
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       cont k (0)
 in
-let $camlEol_detect__f_1 = closure f_0_1 @f in
+let $camlEol_detect__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlEol_detect = Block 0 ($camlEol_detect__f_1) in
 cont done ($camlEol_detect)

--- a/testsuite/tests/flambda2/examples/unknown/f.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/f.simplify.reference
@@ -1,11 +1,11 @@
-let $camlF__string28 = "index out of bounds" in
-let $camlF__block30 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlF__string28)
+let $camlF__string30 = "index out of bounds" in
+let $camlF__block32 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlF__string30)
 in
 let code maxson_0 deleted in
 let code loopify(never) size(82) newer_version_of(maxson_0)
       maxson_0_1 (cmp : val, a : float array, l : imm tagged, i : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_add = %int_barith.add (i, i) in
@@ -25,25 +25,27 @@ let code loopify(never) size(82) newer_version_of(maxson_0)
          where k3 (prim_1) =
            let cse_param = prim_1 in
            let prim_2 = %array_load.`float`.mut (a, int_add_2) in
-           let Parrayrefs = %box_num.`float` (prim_2) in
+           let Parrayrefs = %box_num.`float`.my_alloc_region (prim_2) in
            ((let prim_3 = %int_comp.unsigned.lt (i31, cse_param) in
              switch prim_3
                | 0 -> k3
                | 1 -> k4)
               where k4 =
                 let prim_3 = %array_load.`float`.mut (a, i31) in
-                let Parrayrefs_1 = %box_num.`float` (prim_3) in
-                (apply cmp (Parrayrefs_1, Parrayrefs) -> k4 * k1
+                let Parrayrefs_1 = %box_num.`float`.my_alloc_region (prim_3)
+                in
+                (apply &my_alloc_region
+                   cmp (Parrayrefs_1, Parrayrefs) -> k4 * k1
                    where k4 (return_val0 : imm tagged) =
                      let prim_4 = %int_comp.lt (return_val0, 0) in
                      switch prim_4
                        | 0 -> k (0)
                        | 1 -> k (int_add_2))
               where k3 =
-                cont k1 pop(regular k1) ($camlF__block30))
+                cont k1 pop(regular k1) ($camlF__block32))
          where k2 =
-           cont k1 pop(regular k1) ($camlF__block30))
+           cont k1 pop(regular k1) ($camlF__block32))
 in
-let $camlF__maxson_1 = closure maxson_0_1 @maxson in
+let $camlF__maxson_1 = closure maxson_0_1 @maxson &toplevel.alloc_region in
 let $camlF = Block 0 ($camlF__maxson_1) in
 cont done ($camlF)

--- a/testsuite/tests/flambda2/examples/unknown/fob.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/fob.simplify.reference
@@ -1,3 +1,3 @@
-let $camlFob__infinity16 = infinity in
-let $camlFob = Block 0 ($camlFob__infinity16) in
+let $camlFob__infinity17 = infinity in
+let $camlFob = Block 0 ($camlFob__infinity17) in
 cont done ($camlFob)

--- a/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
@@ -1,61 +1,63 @@
 let code with_y_0 deleted in
-let $camlGadt_meet__const_block18 = Block 0 (0) in
-let $camlGadt_meet__const_block20 = Block 0 ($camlGadt_meet__const_block18)
+let $camlGadt_meet__const_block21 = Block 0 (0) in
+let $camlGadt_meet__const_block23 = Block 0 ($camlGadt_meet__const_block21)
 in
 let code f_1 deleted in
 let code get_2 deleted in
-let $camlGadt_meet__const_block39 = Block 0 (1) in
+let $camlGadt_meet__const_block44 = Block 0 (1) in
 let code test_3 deleted in
-let $camlGadt_meet__immstring59 = "Error" in
+let $camlGadt_meet__immstring65 = "Error" in
 let code foo_4 deleted in
 let code loopify(never) size(10) newer_version_of(with_y_0)
       with_y_0_1 (b : [ 0 of imm tagged ], y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged ] =
   let Pfield = %block_load.[`0`] (b) in
   let int_add = %int_barith.add (Pfield, y) in
-  let Pmakeblock = %block.[`0`] (int_add) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (int_add) in
   cont k (Pmakeblock)
 in
-let $camlGadt_meet__with_y_5 = closure with_y_0_1 @with_y in
+let $camlGadt_meet__with_y_5 =
+  closure with_y_0_1 @with_y &toplevel.alloc_region
+in
 let code inline(never) loopify(never) size(1) newer_version_of(f_1)
       f_1_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of [ 0 of imm tagged ] |1 of imm tagged ] =
-  cont k ($camlGadt_meet__const_block20)
+  cont k ($camlGadt_meet__const_block23)
 in
-let $camlGadt_meet__f_6 = closure f_1_1 @f in
+let $camlGadt_meet__f_6 = closure f_1_1 @f &toplevel.alloc_region in
 let code loopify(never) size(2) newer_version_of(get_2)
       get_2_1 (t : [ 0 of [ 0 of imm tagged ] |1 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged ] =
   let Pfield = %block_load.[`0`] (t) in
   cont k (Pfield)
 in
-let $camlGadt_meet__get_7 = closure get_2_1 @get in
+let $camlGadt_meet__get_7 = closure get_2_1 @get &toplevel.alloc_region in
 let code loopify(never) size(44) newer_version_of(test_3)
       test_3_1 (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
-  apply direct(f_1_1)
+  apply direct(f_1_1 &my_alloc_region)
     ($camlGadt_meet__f_6 : _ -> [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]
      )
       (0)
       -> k2 * k1
     where k2 (op : [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]) =
       let Pfield = %block_load.[`0`] (op) in
-      (apply direct(with_y_0_1)
+      (apply direct(with_y_0_1 &my_alloc_region)
          ($camlGadt_meet__with_y_5 : _ -> [ 0 of imm tagged ])
            (Pfield, 1)
            -> k2 * k1
          where k2 (apply_result : [ 0 of imm tagged ]) =
            (apply ccall
               ($`*extern*`.caml_equal : val * val -> val)
-                (apply_result, $camlGadt_meet__const_block39)
+                (apply_result, $camlGadt_meet__const_block44)
                 -> k2 * k1
               where k2 (Pccall) =
                 ((let untagged = %untag_imm (Pccall) in
@@ -63,31 +65,33 @@ let code loopify(never) size(44) newer_version_of(test_3)
                     | 0 -> k2
                     | 1 -> k (0))
                    where k2 =
-                     let Pmakeblock = %block.[`0`] (x, op) in
-                     let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+                     let Pmakeblock = %block.[`0`].my_alloc_region (x, op) in
+                     let Pmakeblock_1 =
+                       %block.[`0`].my_alloc_region (Pmakeblock)
+                     in
                      cont k (Pmakeblock_1))))
 in
-let $camlGadt_meet__test_8 = closure test_3_1 @test in
-let $camlGadt_meet__Pmakeblock146 =
-  Block 0 ($`*predef*`.caml_exn_Failure, $camlGadt_meet__immstring59)
+let $camlGadt_meet__test_8 = closure test_3_1 @test &toplevel.alloc_region in
+let $camlGadt_meet__Pmakeblock159 =
+  Block 0 ($`*predef*`.caml_exn_Failure, $camlGadt_meet__immstring65)
 in
 let code loopify(never) size(17) newer_version_of(foo_4)
       foo_4_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * [ 0 of val |1 of imm tagged ] ] =
-  apply direct(test_3_1)
+  apply direct(test_3_1 &my_alloc_region)
     ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of val ]) (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock146)
+         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock159)
          where k2 =
            let Pfield = %block_load.[`0`] (`*match*`) in
            cont k (Pfield))
 in
-let $camlGadt_meet__foo_9 = closure foo_4_1 @foo in
+let $camlGadt_meet__foo_9 = closure foo_4_1 @foo &toplevel.alloc_region in
 let $camlGadt_meet =
   Block 0 ($camlGadt_meet__with_y_5,
            $camlGadt_meet__f_6,

--- a/testsuite/tests/flambda2/examples/unknown/genlex2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/genlex2.simplify.reference
@@ -1,22 +1,22 @@
-let $camlGenlex2__immstring32 = "" in
+let $camlGenlex2__immstring34 = "" in
 let code foo_0 deleted in
-let $camlGenlex2__immstring6 = "Genlex2.Error" in
+let $camlGenlex2__immstring7 = "Genlex2.Error" in
 apply ccall noalloc
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
-    let $camlGenlex2__Error40 =
+    let $camlGenlex2__Error42 =
       Block immutable_unique
-      248 ($camlGenlex2__immstring6, Pccall)
+      248 ($camlGenlex2__immstring7, Pccall)
     in
-    let $camlGenlex2__Pmakeblock65 =
-      Block 0 ($camlGenlex2__Error40, $camlGenlex2__immstring32)
+    let $camlGenlex2__Pmakeblock68 =
+      Block 0 ($camlGenlex2__Error42, $camlGenlex2__immstring34)
     in
-    let $camlGenlex2__Pmakeblock64 =
-      Block 0 ($camlGenlex2__Error40, $camlGenlex2__immstring32)
+    let $camlGenlex2__Pmakeblock67 =
+      Block 0 ($camlGenlex2__Error42, $camlGenlex2__immstring34)
     in
     let code loopify(never) size(45) newer_version_of(foo_0)
           foo_0_1 (f : imm tagged, g : val)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 | 0 of val ] =
       let prim = %int_comp.ne (f, 97) in
@@ -28,7 +28,7 @@ apply ccall noalloc
           let try_ghost_region = %begin_try_ghost_region () in
           (cont k5 push(k3)
              where k5 =
-               (apply g (0) -> k5 * k3
+               (apply &my_alloc_region g (0) -> k5 * k3
                   where k5 (param : val) =
                     cont k4)
              where k4 =
@@ -41,11 +41,11 @@ apply ccall noalloc
                in
                switch prim_1
                  | 0 -> k1 pop(reraise k1) (`exn`)
-                 | 1 -> k1 pop(regular k1) ($camlGenlex2__Pmakeblock64)
+                 | 1 -> k1 pop(regular k1) ($camlGenlex2__Pmakeblock67)
              where k2 =
-               cont k1 pop(regular k1) ($camlGenlex2__Pmakeblock65))
+               cont k1 pop(regular k1) ($camlGenlex2__Pmakeblock68))
     in
-    let $camlGenlex2__foo_1 = closure foo_0_1 @foo in
-    let $camlGenlex2 = Block 0 ($camlGenlex2__Error40, $camlGenlex2__foo_1)
+    let $camlGenlex2__foo_1 = closure foo_0_1 @foo &toplevel.alloc_region in
+    let $camlGenlex2 = Block 0 ($camlGenlex2__Error42, $camlGenlex2__foo_1)
     in
     cont done ($camlGenlex2)

--- a/testsuite/tests/flambda2/examples/unknown/get_tag_2020_07_21.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/get_tag_2020_07_21.simplify.reference
@@ -2,19 +2,21 @@ let code of_src_0 deleted in
 let code test_1 deleted in
 let code inline(always) loopify(never) size(5) newer_version_of(of_src_0)
       of_src_0_1 (param : [ 0 of imm tagged |1 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %get_tag (param) in
   let tagged_scrutinee = %tag_imm (prim) in
   cont k (tagged_scrutinee)
 in
-let $camlGet_tag_2020_07_21__of_src_2 = closure of_src_0_1 @of_src in
+let $camlGet_tag_2020_07_21__of_src_2 =
+  closure of_src_0_1 @of_src &toplevel.alloc_region
+in
 let code loopify(never) size(29) newer_version_of(test_1)
       test_1_1 (src : [ 0 of imm tagged |1 of imm tagged ], f : val, g : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply f (0) -> k4 * k1
+  apply &my_alloc_region f (0) -> k4 * k1
     where k4 (param : [ 0 |1 ]) =
       let unboxed_field = %untag_imm (param) in
       cont k3 (unboxed_field)
@@ -28,9 +30,11 @@ let code loopify(never) size(29) newer_version_of(test_1)
            let tagged_scrutinee = %tag_imm (prim) in
            cont k2 (tagged_scrutinee))
     where k2 (dst : imm tagged) =
-      apply g (dst) -> k * k1
+      apply &my_alloc_region g (dst) -> k * k1
 in
-let $camlGet_tag_2020_07_21__test_3 = closure test_1_1 @test in
+let $camlGet_tag_2020_07_21__test_3 =
+  closure test_1_1 @test &toplevel.alloc_region
+in
 let $camlGet_tag_2020_07_21 =
   Block 0 ($camlGet_tag_2020_07_21__of_src_2, $camlGet_tag_2020_07_21__test_3)
 in

--- a/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
@@ -1,7 +1,7 @@
-let $camlIncludecore_repro__const_block56 = Block 0 (0, 0) in
+let $camlIncludecore_repro__const_block58 = Block 0 (0, 0) in
 let code f_0 deleted in
-let $camlIncludecore_repro__const_block61 =
-  Block 0 ($camlIncludecore_repro__const_block56)
+let $camlIncludecore_repro__const_block63 =
+  Block 0 ($camlIncludecore_repro__const_block58)
 in
 let code inline(never) loopify(never) size(160) newer_version_of(f_0)
       f_0_1
@@ -9,7 +9,7 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
            [ 0 of [ 0 |1 | 0 of imm tagged * imm tagged |1 of imm tagged ] ],
          y :
            [ 0 of [ 0 |1 | 0 of imm tagged * imm tagged |1 of imm tagged ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
   let `*match*` = %block_load.[`0`] (x) in
@@ -53,8 +53,11 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
                 let Popaque = %opaque (Pfield) in
                 let Pfield_1 = %block_load.[`0`] (`*match*`) in
                 let Popaque_1 = %opaque (Pfield_1) in
-                let Pmakeblock = %block.[`0`] (Popaque_1, Popaque) in
-                let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+                let Pmakeblock =
+                  %block.[`0`].my_alloc_region (Popaque_1, Popaque)
+                in
+                let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock)
+                in
                 cont k (Pmakeblock_1))
          where k4 =
            ((let prim = %is_int (`*match*_1`) in
@@ -75,8 +78,11 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
                 let Pfield_3 = %block_load.[`0`] (`*match*`) in
                 let int_add_1 = %int_barith.add (Pfield_3, Pfield_2) in
                 let Popaque_1 = %opaque (int_add_1) in
-                let Pmakeblock = %block.[`0`] (Popaque_1, Popaque) in
-                let Pmakeblock_1 = %block.[`0`] (Pmakeblock) in
+                let Pmakeblock =
+                  %block.[`0`].my_alloc_region (Popaque_1, Popaque)
+                in
+                let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock)
+                in
                 cont k (Pmakeblock_1))
          where k3 =
            let prim = %is_int (`*match*_1`) in
@@ -84,15 +90,15 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
              | 0 -> k2
              | 1 -> k (0))
     where k2 =
-      let Popaque = %opaque ($camlIncludecore_repro__const_block56) in
-      let Pmakeblock = %block.[`0`] (Popaque) in
+      let Popaque = %opaque ($camlIncludecore_repro__const_block58) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (Popaque) in
       cont k (Pmakeblock)
 in
-let $camlIncludecore_repro__f_1 = closure f_0_1 @f in
-apply direct(f_0_1)
+let $camlIncludecore_repro__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+apply direct(f_0_1 &toplevel.alloc_region)
   ($camlIncludecore_repro__f_1 : _ -> [ 0 | 0 of val ])
-    ($camlIncludecore_repro__const_block61,
-     $camlIncludecore_repro__const_block61)
+    ($camlIncludecore_repro__const_block63,
+     $camlIncludecore_repro__const_block63)
     -> k1 * error
   where k1 (param : [ 0 | 0 of val ]) =
     cont k

--- a/testsuite/tests/flambda2/examples/unknown/js.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/js.simplify.reference
@@ -1,39 +1,43 @@
-let $camlJs__immstring13 = "js.ml" in
-let $camlJs__const_block15 = Block 0 ($camlJs__immstring13, 14, 17) in
-let $camlJs__Pmakeblock18 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlJs__const_block15)
+let $camlJs__immstring15 = "js.ml" in
+let $camlJs__const_block17 = Block 0 ($camlJs__immstring15, 14, 17) in
+let $camlJs__Pmakeblock20 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlJs__const_block17)
 in
 let code init_0 deleted in
-let $camlJs__const_block26 = Block 0 ($camlJs__immstring13, 16, 21) in
-let $camlJs__Pmakeblock29 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlJs__const_block26)
+let $camlJs__const_block29 = Block 0 ($camlJs__immstring15, 16, 21) in
+let $camlJs__Pmakeblock32 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlJs__const_block29)
 in
 let code of__unsafe_1 deleted in
-let $camlJs__const_block37 = Block 0 ($camlJs__immstring13, 18, 20) in
-let $camlJs__Pmakeblock40 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlJs__const_block37)
+let $camlJs__const_block41 = Block 0 ($camlJs__immstring15, 18, 20) in
+let $camlJs__Pmakeblock44 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlJs__const_block41)
 in
 let code of__debug_2 deleted in
 let code loopify(never) size(3) newer_version_of(init_0)
-      init_0_1 (x, y) my_closure _region _ghost_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlJs__Pmakeblock18)
+      init_0_1 (x, y) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k1 pop(regular k1) ($camlJs__Pmakeblock20)
 in
-let $camlJs__init_3 = closure init_0_1 @init in
+let $camlJs__init_3 = closure init_0_1 @init &toplevel.alloc_region in
 let code loopify(never) size(3) newer_version_of(of__unsafe_1)
-      of__unsafe_1_1 (a) my_closure _region _ghost_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlJs__Pmakeblock29)
+      of__unsafe_1_1 (a) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k1 pop(regular k1) ($camlJs__Pmakeblock32)
 in
-let $camlJs__of__unsafe_4 = closure of__unsafe_1_1 @of__unsafe in
+let $camlJs__of__unsafe_4 =
+  closure of__unsafe_1_1 @of__unsafe &toplevel.alloc_region
+in
 let code loopify(never) size(3) newer_version_of(of__debug_2)
-      of__debug_2_1 (a) my_closure _region _ghost_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlJs__Pmakeblock40)
+      of__debug_2_1 (a) my_closure &my_alloc_region my_depth -> k * k1 =
+  cont k1 pop(regular k1) ($camlJs__Pmakeblock44)
 in
-let $camlJs__of__debug_5 = closure of__debug_2_1 @of__debug in
-let $camlJs__Pmakeblock70 =
+let $camlJs__of__debug_5 =
+  closure of__debug_2_1 @of__debug &toplevel.alloc_region
+in
+let $camlJs__Pmakeblock77 =
   Block 0 ($camlJs__init_3,
            $camlJs__of__unsafe_4,
            $camlJs__of__debug_5,
            $camlJs__of__unsafe_4)
 in
-let $camlJs = Block 0 (0, $camlJs__Pmakeblock70) in
+let $camlJs = Block 0 (0, $camlJs__Pmakeblock77) in
 cont done ($camlJs)

--- a/testsuite/tests/flambda2/examples/unknown/lazy_invalid.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/lazy_invalid.simplify.reference
@@ -1,9 +1,9 @@
 let code foo_0 deleted in
 let code `fn[lazy_invalid.ml:13,13--29]_1` deleted in
-let $camlLazy_invalid__immstring10 = "" in
+let $camlLazy_invalid__immstring11 = "" in
 apply ccall noalloc
   ($`*extern*`.caml_obj_tag : val -> val)
-    ($camlLazy_invalid__immstring10)
+    ($camlLazy_invalid__immstring11)
     -> k1 * error
   where k1 (tag) =
     let prim = %int_comp.eq (tag, 250) in
@@ -11,7 +11,7 @@ apply ccall noalloc
        | 0 -> k1
        | 1 -> k2
        where k2 =
-         let Pfield = %block_load.mut.[`0`] ($camlLazy_invalid__immstring10)
+         let Pfield = %block_load.mut.[`0`] ($camlLazy_invalid__immstring11)
          in
          cont k (Pfield)
        where k1 =
@@ -22,11 +22,12 @@ apply ccall noalloc
              where k2 =
                let prim_2 = %int_comp.eq (tag, 244) in
                switch prim_2
-                 | 0 -> k ($camlLazy_invalid__immstring10)
+                 | 0 -> k ($camlLazy_invalid__immstring11)
                  | 1 -> k1)
             where k1 =
-              let Popaque = %opaque ($camlLazy_invalid__immstring10) in
-              apply direct(force_lazy_block_4) inlined(never)
+              let Popaque = %opaque ($camlLazy_invalid__immstring11) in
+              apply direct(force_lazy_block_4 &toplevel.alloc_region)
+                     inlined(never)
                 $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_11
                   (Popaque)
                   -> k * error))
@@ -36,15 +37,17 @@ apply ccall noalloc
        where k (t) =
          let code loopify(never) size(1) newer_version_of(foo_0)
                foo_0_1 (x : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            cont k (x)
          in
-         let $camlLazy_invalid__foo_2 = closure foo_0_1 @foo in
+         let $camlLazy_invalid__foo_2 =
+           closure foo_0_1 @foo &toplevel.alloc_region
+         in
          let code loopify(never) size(44) newer_version_of(`fn[lazy_invalid.ml:13,13--29]_1`)
                `fn[lazy_invalid.ml:13,13--29]_1_1` (param : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1 =
            apply ccall noalloc
              ($`*extern*`.caml_obj_tag : val -> val)
@@ -56,7 +59,7 @@ apply ccall noalloc
                   | 0 -> k2
                   | 1 -> k3
                   where k3 =
-                    invalid "(Defining_expr_of_let (bound_pattern Pfield/56N)\n (defining_expr\n  (((Block_load (Values (tag \226\138\164) (size \226\138\164) (field_kind Any_value)) Mutable 0)\n    foo/40N) lazy_invalid.ml:13,13--29)))"
+                    invalid "(Defining_expr_of_let (bound_pattern Pfield/59N)\n (defining_expr\n  (((Block_load (Values (tag \226\138\164) (size \226\138\164) (field_kind Any_value)) Mutable 0)\n    foo/42N) lazy_invalid.ml:13,13--29)))"
                   where k2 =
                     ((let prim_1 = %int_comp.eq (tag, 246) in
                       switch prim_1
@@ -69,17 +72,19 @@ apply ccall noalloc
                             | 1 -> k2)
                        where k2 =
                          let Popaque = %opaque ($camlLazy_invalid__foo_2) in
-                         apply direct(force_lazy_block_4) inlined(never)
+                         apply direct(force_lazy_block_4 &my_alloc_region)
+                                inlined(never)
                            $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_11
                              (Popaque)
                              -> k * k1))
          in
          let $`camlLazy_invalid__fn[lazy_invalid.ml:13,13--29]_3` =
            closure `fn[lazy_invalid.ml:13,13--29]_1_1`
-             @`fn[lazy_invalid.ml:13,13--29]`
+             @`fn[lazy_invalid.ml:13,13--29]` &toplevel.alloc_region
          in
          let Pmakelazyblock =
-           %lazy ($`camlLazy_invalid__fn[lazy_invalid.ml:13,13--29]_3`)
+           %lazy.`toplevel`
+             ($`camlLazy_invalid__fn[lazy_invalid.ml:13,13--29]_3`)
          in
          (apply ccall
             ($`*extern*`.caml_update_dummy_lazy : val * val -> val)

--- a/testsuite/tests/flambda2/examples/unknown/let_symbol_var_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/let_symbol_var_inlining.simplify.reference
@@ -3,22 +3,26 @@ let code g_1 deleted in
 let b = %block_load.[`4`] ($Stdlib__Sys.camlStdlib__Sys) in
 let code loopify(never) size(3) newer_version_of(f_0)
       f_0_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_add = %int_barith.add (n, 42) in
   cont k (int_add)
 in
-let $camlLet_symbol_var_inlining__f_2 = closure f_0_1 @f in
+let $camlLet_symbol_var_inlining__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(5) newer_version_of(g_1)
       g_1_1 (m : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int_mul = %int_barith.mul (m, 42) in
   cont k (int_mul)
 in
-let $camlLet_symbol_var_inlining__g_3 = closure g_1_1 @g in
+let $camlLet_symbol_var_inlining__g_3 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let $camlLet_symbol_var_inlining =
   Block 0 ($Stdlib__List.camlStdlib__List__length_109,
            b,

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -1,17 +1,17 @@
-(let $camlLocal__const_block11 = Block 0 (3, 0) in
- let $camlLocal__const_block13 = Block 0 (2, $camlLocal__const_block11) in
- let $camlLocal__const_block15 = Block 0 (1, $camlLocal__const_block13) in
+(let $camlLocal__const_block13 = Block 0 (3, 0) in
+ let $camlLocal__const_block15 = Block 0 (2, $camlLocal__const_block13) in
+ let $camlLocal__const_block17 = Block 0 (1, $camlLocal__const_block15) in
  let code size(1)
        return_local_0 (param : imm tagged)
-         my_closure my_region my_ghost_region my_depth
+         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 ($camlLocal__const_block15)
+   cont k1 ($camlLocal__const_block17)
  in
  let code rec size(35)
        map_local_1 (f : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure my_region my_ghost_region my_depth
+         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
@@ -25,24 +25,26 @@
         cont k3)
      where k3 =
        ((let Pfield = %block_load.[`1`] (l) in
-         apply direct(map_local_1 &my_region &my_ghost_region)
+         apply
+                direct(map_local_1
+                &my_alloc_region &my_region &my_ghost_region)
            (my_closure ~ depth my_depth -> next_depth
             : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
              (f, Pfield)
              -> k3 * k2)
           where k3 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
             ((let Pfield = %block_load.[`0`] (l) in
-              apply f (Pfield) -> k3 * k2)
+              apply &my_alloc_region f (Pfield) -> k3 * k2)
                where k3 (apply_result_1 : val) =
                  let Pmakeblock =
-                   %block.[`0`].`local`[my_region]
+                   %block.[`0`].my_alloc_region.`local`[my_region]
                      (apply_result_1, apply_result)
                  in
                  cont k1 (Pmakeblock)))
  in
  let code rec size(23)
        length_2 (l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -56,7 +58,7 @@
         cont k3)
      where k3 =
        ((let Pfield = %block_load.[`1`] (l) in
-         apply direct(length_2)
+         apply direct(length_2 &my_alloc_region)
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (Pfield)
              -> k3 * k2)
@@ -66,7 +68,7 @@
  in
  let code size(3)
        `fn[local.ml:32,27--43]_3` (i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -77,7 +79,7 @@
        rev_app_4
          (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure my_region my_ghost_region my_depth
+         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
@@ -91,9 +93,11 @@
         cont k3)
      where k3 =
        let Pfield = %block_load.[`0`] (l1) in
-       let Pmakeblock = %block.[`0`].`local`[my_region] (Pfield, l2) in
+       let Pmakeblock =
+         %block.[`0`].my_alloc_region.`local`[my_region] (Pfield, l2)
+       in
        let Pfield_1 = %block_load.[`1`] (l1) in
-       apply direct(rev_app_4 &my_region &my_ghost_region)
+       apply direct(rev_app_4 &my_alloc_region &my_region &my_ghost_region)
          (my_closure ~ depth my_depth -> next_depth
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (Pfield_1, Pmakeblock)
@@ -104,7 +108,7 @@
          (break_here : val,
           l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
           acc : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure my_region my_ghost_region my_depth
+         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
          -> k1 * k2
          : [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
@@ -123,8 +127,9 @@
      where k4 =
        let l_1 = %block_load.[`1`] (l) in
        let a = %block_load.[`0`] (l) in
-       let acc_1 = %block.[`0`].`local`[my_region] (a, acc) in
-       (apply break_here (a) -> k6 * k2
+       let acc_1 = %block.[`0`].my_alloc_region.`local`[my_region] (a, acc)
+       in
+       (apply &my_alloc_region break_here (a) -> k6 * k2
           where k6 (apply_result : [ 0 |1 ]) =
             ((let untagged = %untag_imm (apply_result) in
               switch untagged
@@ -135,7 +140,9 @@
                where k6 =
                  cont k5)
           where k5 =
-            apply direct(find_span_6 &my_region &my_ghost_region)
+            apply
+                   direct(find_span_6
+                   &my_alloc_region &my_region &my_ghost_region)
               (my_closure ~ depth my_depth -> next_depth
                : _ ->
                  [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ]
@@ -143,16 +150,20 @@
                 (break_here, l_1, acc_1)
                 -> k1 * k2
           where k4 =
-            let Pmakeblock = %block.[`0`].`local`[my_region] (acc_1, l_1) in
+            let Pmakeblock =
+              %block.[`0`].my_alloc_region.`local`[my_region] (acc_1, l_1)
+            in
             cont k1 (Pmakeblock))
      where k3 =
-       let Pmakeblock = %block.[`0`].`local`[my_region] (acc, 0) in
+       let Pmakeblock =
+         %block.[`0`].my_alloc_region.`local`[my_region] (acc, 0)
+       in
        cont k1 (Pmakeblock)
  in
  let code rec size(39)
        spans_5
          (break_here : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-         my_closure my_region my_ghost_region my_depth
+         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
@@ -167,7 +178,9 @@
       where k4 =
         cont k3)
      where k3 =
-       (apply direct(find_span_6 &my_region &my_ghost_region)
+       (apply
+               direct(find_span_6
+               &my_alloc_region &my_region &my_ghost_region)
           (find_span ~ depth my_depth -> next_depth
            : _ -> [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ])
             (break_here, l, 0)
@@ -176,7 +189,9 @@
                   (`*match*` :
                      [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
             ((let Pfield = %block_load.[`1`] (`*match*`) in
-              apply direct(spans_5 &my_region &my_ghost_region)
+              apply
+                     direct(spans_5
+                     &my_alloc_region &my_region &my_ghost_region)
                 (my_closure ~ depth my_depth -> next_depth
                  : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                   (break_here, Pfield)
@@ -185,7 +200,9 @@
                        (apply_result :
                           [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                  ((let Pfield = %block_load.[`0`] (`*match*`) in
-                   apply direct(rev_app_4 &my_region &my_ghost_region)
+                   apply
+                          direct(rev_app_4
+                          &my_alloc_region &my_region &my_ghost_region)
                      (rev_app
                       : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                        (Pfield, 0)
@@ -194,14 +211,14 @@
                             (apply_result_1 :
                                [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                       let Pmakeblock =
-                        %block.[`0`].`local`[my_region]
+                        %block.[`0`].my_alloc_region.`local`[my_region]
                           (apply_result_1, apply_result)
                       in
                       cont k1 (Pmakeblock))))
  in
  let code size(25)
        is_even_7 (i : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -219,34 +236,36 @@
        let eq = %tag_imm (prim) in
        cont k1 (eq)
  in
- let $camlLocal__immstring52 = "local.ml" in
- let $camlLocal__const_block183 = Block 0 ($camlLocal__immstring52, 58, 2) in
- let $camlLocal__Pmakeblock186 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block183)
+ let $camlLocal__immstring56 = "local.ml" in
+ let $camlLocal__const_block192 = Block 0 ($camlLocal__immstring56, 58, 2) in
+ let $camlLocal__Pmakeblock195 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block192)
  in
- let $camlLocal__const_block168 = Block 0 (4, 0) in
- let $camlLocal__const_block170 = Block 0 (3, $camlLocal__const_block168) in
- let $camlLocal__const_block172 = Block 0 (2, $camlLocal__const_block170) in
- let $camlLocal__const_block174 = Block 0 (1, $camlLocal__const_block172) in
- let $camlLocal__const_block176 = Block 0 (0, $camlLocal__const_block174) in
- let $camlLocal__const_block93 = Block 0 ($camlLocal__immstring52, 33, 2) in
- let $camlLocal__Pmakeblock96 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block93)
+ let $camlLocal__const_block177 = Block 0 (4, 0) in
+ let $camlLocal__const_block179 = Block 0 (3, $camlLocal__const_block177) in
+ let $camlLocal__const_block181 = Block 0 (2, $camlLocal__const_block179) in
+ let $camlLocal__const_block183 = Block 0 (1, $camlLocal__const_block181) in
+ let $camlLocal__const_block185 = Block 0 (0, $camlLocal__const_block183) in
+ let $camlLocal__const_block98 = Block 0 ($camlLocal__immstring56, 33, 2) in
+ let $camlLocal__Pmakeblock101 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block98)
  in
- let $camlLocal__const_block69 = Block 0 ($camlLocal__immstring52, 28, 9) in
- let $camlLocal__Pmakeblock72 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block69)
+ let $camlLocal__const_block73 = Block 0 ($camlLocal__immstring56, 28, 9) in
+ let $camlLocal__Pmakeblock76 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block73)
  in
- let $camlLocal__const_block54 = Block 0 ($camlLocal__immstring52, 26, 9) in
- let $camlLocal__Pmakeblock57 =
-   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block54)
+ let $camlLocal__const_block58 = Block 0 ($camlLocal__immstring56, 26, 9) in
+ let $camlLocal__Pmakeblock61 =
+   Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block58)
  in
- let $camlLocal__const_block46 = Block 0 (1, 0) in
- let return_local = closure return_local_0 @return_local in
- let map_local = closure map_local_1 @map_local in
- let length = closure length_2 @length in
- apply direct(length_2)
-   (length : _ -> imm tagged) ($camlLocal__const_block46) -> k3 * error
+ let $camlLocal__const_block50 = Block 0 (1, 0) in
+ let return_local =
+   closure return_local_0 @return_local &toplevel.alloc_region
+ in
+ let map_local = closure map_local_1 @map_local &toplevel.alloc_region in
+ let length = closure length_2 @length &toplevel.alloc_region in
+ apply direct(length_2 &toplevel.alloc_region)
+   (length : _ -> imm tagged) ($camlLocal__const_block50) -> k3 * error
    where k3 (apply_result : imm tagged) =
      let prim = %phys_eq (apply_result, 1) in
      let eq = %tag_imm (prim) in
@@ -257,16 +276,18 @@
         where k3 =
           cont k2)
    where k2 =
-     cont error pop(regular error) ($camlLocal__Pmakeblock57)
+     cont error pop(regular error) ($camlLocal__Pmakeblock61)
    where k1 (`*match*` : imm tagged) =
      ((let `region` = %begin_region () in
        let ghost_region = %begin_ghost_region () in
-       apply direct(return_local_0 &`region` &ghost_region)
+       apply
+              direct(return_local_0
+              &toplevel.alloc_region &`region` &ghost_region)
          (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (0)
            -> k5 * error
          where k5 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-           apply direct(length_2) unroll(3)
+           apply direct(length_2 &toplevel.alloc_region) unroll(3)
              (length : _ -> imm tagged) (apply_result) -> k4 * error
          where k4 (apply_result : imm tagged) =
            let prim = %phys_eq (apply_result, 3) in
@@ -278,7 +299,7 @@
               where k4 =
                 cont k3)
          where k3 =
-           cont error pop(regular error) ($camlLocal__Pmakeblock72)
+           cont error pop(regular error) ($camlLocal__Pmakeblock76)
          where k2 (region_return : imm tagged) =
            let `unit` = %end_region (`region`) in
            let unit_1 = %end_ghost_region (ghost_region) in
@@ -286,22 +307,27 @@
         where k1 (`*match*_1` : imm tagged) =
           ((let `region` = %begin_region () in
             let ghost_region = %begin_ghost_region () in
-            apply direct(return_local_0 &`region` &ghost_region)
+            apply
+                   direct(return_local_0
+                   &toplevel.alloc_region &`region` &ghost_region)
               (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (0)
                 -> k3 * error
               where k3 (ns : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                 ((let `fn[local.ml:32,27--43]` =
                     closure `fn[local.ml:32,27--43]_3`
-                      @`fn[local.ml:32,27--43]`
+                      @`fn[local.ml:32,27--43]` &toplevel.alloc_region
+                      &`region`
                   in
-                  apply direct(map_local_1 &`region` &ghost_region)
+                  apply
+                         direct(map_local_1
+                         &toplevel.alloc_region &`region` &ghost_region)
                     (map_local
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (`fn[local.ml:32,27--43]`, ns)
                       -> k3 * error)
                    where k3 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                     (apply direct(length_2)
+                     (apply direct(length_2 &toplevel.alloc_region)
                         (length : _ -> imm tagged) (ms) -> k4 * error
                         where k4 (apply_result : imm tagged) =
                           let prim = %phys_eq (apply_result, 3) in
@@ -315,28 +341,35 @@
                         where k3 =
                           cont error
                                  pop(regular error)
-                                 ($camlLocal__Pmakeblock96)))
+                                 ($camlLocal__Pmakeblock101)))
               where k2 (region_return : imm tagged) =
                 let `unit` = %end_region (`region`) in
                 let unit_1 = %end_ghost_region (ghost_region) in
                 cont k1 (region_return))
              where k1 (`*match*_2` : imm tagged) =
-               let rev_app = closure rev_app_4 @rev_app in
-               let spans = closure spans_5 @spans
-               and find_span = closure find_span_6 @find_span
+               let rev_app =
+                 closure rev_app_4 @rev_app &toplevel.alloc_region
+               in
+               let spans = closure spans_5 @spans &toplevel.alloc_region
+               and find_span =
+                 closure find_span_6 @find_span &toplevel.alloc_region
                with { rev_app = rev_app }
                in
-               let is_even = closure is_even_7 @is_even in
+               let is_even =
+                 closure is_even_7 @is_even &toplevel.alloc_region
+               in
                ((let `region` = %begin_region () in
                  let ghost_region = %begin_ghost_region () in
-                 apply direct(spans_5 &`region` &ghost_region)
+                 apply
+                        direct(spans_5
+                        &toplevel.alloc_region &`region` &ghost_region)
                    (spans : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                     (is_even, $camlLocal__const_block176)
+                     (is_even, $camlLocal__const_block185)
                      -> k3 * error
                    where k3
                            (even_spans :
                               [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                     (apply direct(length_2)
+                     (apply direct(length_2 &toplevel.alloc_region)
                         (length : _ -> imm tagged) (even_spans) -> k4 * error
                         where k4 (apply_result : imm tagged) =
                           let prim = %phys_eq (apply_result, 3) in
@@ -350,14 +383,14 @@
                         where k3 =
                           cont error
                                  pop(regular error)
-                                 ($camlLocal__Pmakeblock186))
+                                 ($camlLocal__Pmakeblock195))
                    where k2 (region_return : imm tagged) =
                      let `unit` = %end_region (`region`) in
                      let unit_1 = %end_ghost_region (ghost_region) in
                      cont k1 (region_return))
                   where k1 (`*match*_3` : imm tagged) =
                     let Pmakeblock =
-                      %block.[`0`]
+                      %block.[`0`].`toplevel`
                         (return_local,
                          map_local,
                          length,

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -1,6 +1,6 @@
-let $camlLocal__const_block11 = Block 0 (3, 0) in
-let $camlLocal__const_block13 = Block 0 (2, $camlLocal__const_block11) in
-let $camlLocal__const_block15 = Block 0 (1, $camlLocal__const_block13) in
+let $camlLocal__const_block13 = Block 0 (3, 0) in
+let $camlLocal__const_block15 = Block 0 (2, $camlLocal__const_block13) in
+let $camlLocal__const_block17 = Block 0 (1, $camlLocal__const_block15) in
 let code return_local_0 deleted in
 let code map_local_1 deleted in
 let code length_2 deleted in
@@ -9,42 +9,44 @@ let code rev_app_4 deleted in
 let code find_span_6 deleted in
 let code spans_5 deleted in
 let code is_even_7 deleted in
-let $camlLocal__immstring52 = "local.ml" in
-let $camlLocal__const_block183 = Block 0 ($camlLocal__immstring52, 58, 2) in
-let $camlLocal__Pmakeblock186 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block183)
+let $camlLocal__immstring56 = "local.ml" in
+let $camlLocal__const_block192 = Block 0 ($camlLocal__immstring56, 58, 2) in
+let $camlLocal__Pmakeblock195 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block192)
 in
-let $camlLocal__const_block168 = Block 0 (4, 0) in
-let $camlLocal__const_block170 = Block 0 (3, $camlLocal__const_block168) in
-let $camlLocal__const_block172 = Block 0 (2, $camlLocal__const_block170) in
-let $camlLocal__const_block174 = Block 0 (1, $camlLocal__const_block172) in
-let $camlLocal__const_block176 = Block 0 (0, $camlLocal__const_block174) in
-let $camlLocal__const_block93 = Block 0 ($camlLocal__immstring52, 33, 2) in
-let $camlLocal__Pmakeblock96 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block93)
+let $camlLocal__const_block177 = Block 0 (4, 0) in
+let $camlLocal__const_block179 = Block 0 (3, $camlLocal__const_block177) in
+let $camlLocal__const_block181 = Block 0 (2, $camlLocal__const_block179) in
+let $camlLocal__const_block183 = Block 0 (1, $camlLocal__const_block181) in
+let $camlLocal__const_block185 = Block 0 (0, $camlLocal__const_block183) in
+let $camlLocal__const_block98 = Block 0 ($camlLocal__immstring56, 33, 2) in
+let $camlLocal__Pmakeblock101 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block98)
 in
-let $camlLocal__const_block69 = Block 0 ($camlLocal__immstring52, 28, 9) in
-let $camlLocal__Pmakeblock72 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block69)
+let $camlLocal__const_block73 = Block 0 ($camlLocal__immstring56, 28, 9) in
+let $camlLocal__Pmakeblock76 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block73)
 in
-let $camlLocal__const_block54 = Block 0 ($camlLocal__immstring52, 26, 9) in
-let $camlLocal__Pmakeblock57 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block54)
+let $camlLocal__const_block58 = Block 0 ($camlLocal__immstring56, 26, 9) in
+let $camlLocal__Pmakeblock61 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlLocal__const_block58)
 in
-let $camlLocal__const_block46 = Block 0 (1, 0) in
+let $camlLocal__const_block50 = Block 0 (1, 0) in
 let code loopify(never) size(1) newer_version_of(return_local_0)
       return_local_0_1 (param : imm tagged)
-        my_closure my_region my_ghost_region my_depth
+        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
-  cont k ($camlLocal__const_block15)
+  cont k ($camlLocal__const_block17)
 in
-let $camlLocal__return_local_8 = closure return_local_0_1 @return_local in
+let $camlLocal__return_local_8 =
+  closure return_local_0_1 @return_local &toplevel.alloc_region
+in
 let $camlLocal__map_local_9 =
-  closure map_local_1_1 @map_local
+  closure map_local_1_1 @map_local &toplevel.alloc_region
 and code rec loopify(never) size(31) newer_version_of(map_local_1)
       map_local_1_1 (f : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure my_region my_ghost_region my_depth
+        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
   let prim = %is_int (l) in
@@ -53,26 +55,28 @@ and code rec loopify(never) size(31) newer_version_of(map_local_1)
     | 1 -> k (0)
     where k2 =
       ((let Pfield = %block_load.[`1`] (l) in
-        apply direct(map_local_1_1 &my_region &my_ghost_region)
+        apply
+               direct(map_local_1_1
+               &my_alloc_region &my_region &my_ghost_region)
           ($camlLocal__map_local_9 ~ depth my_depth -> succ my_depth
            : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
             (f, Pfield)
             -> k2 * k1)
          where k2 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
            ((let Pfield = %block_load.[`0`] (l) in
-             apply f (Pfield) -> k2 * k1)
+             apply &my_alloc_region f (Pfield) -> k2 * k1)
               where k2 (apply_result_1 : val) =
                 let Pmakeblock =
-                  %block.[`0`].`local`[my_region]
+                  %block.[`0`].my_alloc_region.`local`[my_region]
                     (apply_result_1, apply_result)
                 in
                 cont k (Pmakeblock)))
 in
 let $camlLocal__length_10 =
-  closure length_2_1 @length
+  closure length_2_1 @length &toplevel.alloc_region
 and code rec loopify(never) size(19) newer_version_of(length_2)
       length_2_1 (l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %is_int (l) in
@@ -81,7 +85,7 @@ and code rec loopify(never) size(19) newer_version_of(length_2)
     | 1 -> k (0)
     where k2 =
       ((let Pfield = %block_load.[`1`] (l) in
-        apply direct(length_2_1)
+        apply direct(length_2_1 &my_alloc_region)
           ($camlLocal__length_10 ~ depth my_depth -> succ my_depth
            : _ -> imm tagged)
             (Pfield)
@@ -90,17 +94,18 @@ and code rec loopify(never) size(19) newer_version_of(length_2)
            let int_add = %int_barith.add (1, apply_result) in
            cont k (int_add))
 in
-apply direct(length_2_1)
+apply direct(length_2_1 &toplevel.alloc_region)
   ($camlLocal__length_10 : _ -> imm tagged)
-    ($camlLocal__const_block46)
+    ($camlLocal__const_block50)
     -> k1 * error
   where k1 (apply_result : imm tagged) =
     let prim = %phys_eq (apply_result, 1) in
     switch prim
-      | 0 -> error pop(regular error) ($camlLocal__Pmakeblock57)
+      | 0 -> error pop(regular error) ($camlLocal__Pmakeblock61)
       | 1 -> k
   where k =
-    (apply direct(length_2_1) inlining_state(depth(30))
+    (apply direct(length_2_1 &toplevel.alloc_region)
+            inlining_state(depth(30))
        ($camlLocal__length_10 ~ depth unroll 1 2 -> unroll 0 3
         : _ -> imm tagged)
          (0)
@@ -111,14 +116,14 @@ apply direct(length_2_1)
          let int_add_2 = %int_barith.add (1, int_add_1) in
          let prim = %phys_eq (int_add_2, 3) in
          switch prim
-           | 0 -> error pop(regular error) ($camlLocal__Pmakeblock72)
+           | 0 -> error pop(regular error) ($camlLocal__Pmakeblock76)
            | 1 -> k
        where k =
          let `region` = %begin_region () in
          let ghost_region = %begin_ghost_region () in
          ((let code loopify(never) size(3) newer_version_of(`fn[local.ml:32,27--43]_3`)
                  `fn[local.ml:32,27--43]_3_1` (i : imm tagged)
-                   my_closure _region _ghost_region my_depth
+                   my_closure &my_alloc_region my_depth
                    -> k2 * k3
                    : imm tagged =
              let int_add = %int_barith.add (i, 1) in
@@ -126,21 +131,24 @@ apply direct(length_2_1)
            in
            let $`camlLocal__fn[local.ml:32,27--43]_11` =
              closure `fn[local.ml:32,27--43]_3_1` @`fn[local.ml:32,27--43]`
+               &toplevel.alloc_region
            in
-           apply direct(map_local_1_1 &`region` &ghost_region)
+           apply
+                  direct(map_local_1_1
+                  &toplevel.alloc_region &`region` &ghost_region)
              ($camlLocal__map_local_9
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                ($`camlLocal__fn[local.ml:32,27--43]_11`,
-                $camlLocal__const_block15)
+                $camlLocal__const_block17)
                -> k1 * error)
             where k1 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-              (apply direct(length_2_1)
+              (apply direct(length_2_1 &toplevel.alloc_region)
                  ($camlLocal__length_10 : _ -> imm tagged) (ms) -> k1 * error
                  where k1 (apply_result : imm tagged) =
                    let prim = %phys_eq (apply_result, 3) in
                    switch prim
                      | 0 ->
-                       error pop(regular error) ($camlLocal__Pmakeblock96)
+                       error pop(regular error) ($camlLocal__Pmakeblock101)
                      | 1 -> k)
             where k =
               let `unit` = %end_region (`region`) in
@@ -149,7 +157,8 @@ apply direct(length_2_1)
                     rev_app_4_1
                       (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                        l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                      my_closure my_region my_ghost_region my_depth
+                      my_closure &my_alloc_region &my_region &my_ghost_region
+                        my_depth
                       -> k * k1
                       : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
                 cont `self` (l1, l2)
@@ -165,22 +174,26 @@ apply direct(length_2_1)
                        where k2 =
                          let Pfield = %block_load.[`0`] (l1_1) in
                          let Pmakeblock =
-                           %block.[`0`].`local`[my_region] (Pfield, l2_1)
+                           %block.[`0`].my_alloc_region.`local`[my_region]
+                             (Pfield, l2_1)
                          in
                          let Pfield_1 = %block_load.[`1`] (l1_1) in
                          cont `self` (Pfield_1, Pmakeblock))
               in
-              let $camlLocal__rev_app_12 = closure rev_app_4_1 @rev_app in
+              let $camlLocal__rev_app_12 =
+                closure rev_app_4_1 @rev_app &toplevel.alloc_region
+              in
               let $camlLocal__spans_13 =
-                closure spans_5_1 @spans
+                closure spans_5_1 @spans &toplevel.alloc_region
               and $camlLocal__find_span_14 =
-                closure find_span_6_1 @find_span
+                closure find_span_6_1 @find_span &toplevel.alloc_region
               and code rec loopify(never) size(58) newer_version_of(find_span_6)
                     find_span_6_1
                       (break_here : val,
                        l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                        acc : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                      my_closure my_region my_ghost_region my_depth
+                      my_closure &my_alloc_region &my_region &my_ghost_region
+                        my_depth
                       -> k * k1
                       : [ 0 of [ 0 | 0 of val * val ] *
                             [ 0 | 0 of val * val ] ] local =
@@ -189,14 +202,19 @@ apply direct(length_2_1)
                   | 0 -> k2
                   | 1 -> k3
                   where k3 =
-                    let Pmakeblock = %block.[`0`].`local`[my_region] (acc, 0)
+                    let Pmakeblock =
+                      %block.[`0`].my_alloc_region.`local`[my_region]
+                        (acc, 0)
                     in
                     cont k (Pmakeblock)
                   where k2 =
                     let l_1 = %block_load.[`1`] (l) in
                     let a = %block_load.[`0`] (l) in
-                    let acc_1 = %block.[`0`].`local`[my_region] (a, acc) in
-                    (apply break_here (a) -> k3 * k1
+                    let acc_1 =
+                      %block.[`0`].my_alloc_region.`local`[my_region]
+                        (a, acc)
+                    in
+                    (apply &my_alloc_region break_here (a) -> k3 * k1
                        where k3 (param : [ 0 |1 ]) =
                          let unboxed_field = %untag_imm (param) in
                          cont k2 (unboxed_field)
@@ -207,13 +225,14 @@ apply direct(length_2_1)
                             | 1 -> k3
                             where k3 =
                               let Pmakeblock =
-                                %block.[`0`].`local`[my_region] (acc_1, l_1)
+                                %block.[`0`].my_alloc_region.`local`[my_region]
+                                  (acc_1, l_1)
                               in
                               cont k (Pmakeblock)
                             where k2 =
                               apply
                                      direct(find_span_6_1
-                                     &my_region &my_ghost_region)
+                                     &my_alloc_region &my_region &my_ghost_region)
                                 ($camlLocal__find_span_14 ~ depth my_depth -> succ my_depth
                                  : _ ->
                                    [ 0 of [ 0 | 0 of val * val ] *
@@ -225,7 +244,8 @@ apply direct(length_2_1)
                     spans_5_1
                       (break_here : val,
                        l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                      my_closure my_region my_ghost_region my_depth
+                      my_closure &my_alloc_region &my_region &my_ghost_region
+                        my_depth
                       -> k * k1
                       : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
                 let prim = %is_int (l) in
@@ -233,7 +253,9 @@ apply direct(length_2_1)
                   | 0 -> k2
                   | 1 -> k (0)
                   where k2 =
-                    (apply direct(find_span_6_1 &my_region &my_ghost_region)
+                    (apply
+                            direct(find_span_6_1
+                            &my_alloc_region &my_region &my_ghost_region)
                        ($camlLocal__find_span_14 ~ depth my_depth -> succ my_depth
                         : _ ->
                           [ 0 of [ 0 | 0 of val * val ] *
@@ -248,7 +270,7 @@ apply direct(length_2_1)
                          ((let Pfield = %block_load.[`1`] (`*match*`) in
                            apply
                                   direct(spans_5_1
-                                  &my_region &my_ghost_region)
+                                  &my_alloc_region &my_region &my_ghost_region)
                              ($camlLocal__spans_13 ~ depth my_depth -> succ my_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -262,7 +284,7 @@ apply direct(length_2_1)
                               ((let Pfield = %block_load.[`0`] (`*match*`) in
                                 apply
                                        direct(rev_app_4_1
-                                       &my_region &my_ghost_region)
+                                       &my_alloc_region &my_region &my_ghost_region)
                                   ($camlLocal__rev_app_12
                                    : _ ->
                                      [ 0 | 0 of val * [ 0 | 0 of val * val ]
@@ -276,14 +298,14 @@ apply direct(length_2_1)
                                             | 0 of val *
                                                 [ 0 | 0 of val * val ] ]) =
                                    let Pmakeblock =
-                                     %block.[`0`].`local`[my_region]
+                                     %block.[`0`].my_alloc_region.`local`[my_region]
                                        (apply_result_1, apply_result)
                                    in
                                    cont k (Pmakeblock))))
               in
               let code loopify(never) size(9) newer_version_of(is_even_7)
                     is_even_7_1 (i : imm tagged)
-                      my_closure _region _ghost_region my_depth
+                      my_closure &my_alloc_region my_depth
                       -> k * k1
                       : imm tagged =
                 let int_mod = %int_barith.mod (i, 2) in
@@ -291,18 +313,22 @@ apply direct(length_2_1)
                 let eq = %tag_imm (prim) in
                 cont k (eq)
               in
-              let $camlLocal__is_even_15 = closure is_even_7_1 @is_even in
+              let $camlLocal__is_even_15 =
+                closure is_even_7_1 @is_even &toplevel.alloc_region
+              in
               let region_1 = %begin_region () in
               let ghost_region_1 = %begin_ghost_region () in
-              (apply direct(spans_5_1 &region_1 &ghost_region_1)
+              (apply
+                      direct(spans_5_1
+                      &toplevel.alloc_region &region_1 &ghost_region_1)
                  ($camlLocal__spans_13
                   : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                   ($camlLocal__is_even_15, $camlLocal__const_block176)
+                   ($camlLocal__is_even_15, $camlLocal__const_block185)
                    -> k1 * error
                  where k1
                          (even_spans :
                             [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                   (apply direct(length_2_1)
+                   (apply direct(length_2_1 &toplevel.alloc_region)
                       ($camlLocal__length_10 : _ -> imm tagged)
                         (even_spans)
                         -> k1 * error
@@ -312,7 +338,7 @@ apply direct(length_2_1)
                           | 0 ->
                             error
                               pop(regular error)
-                              ($camlLocal__Pmakeblock186)
+                              ($camlLocal__Pmakeblock195)
                           | 1 -> k)
                  where k =
                    let unit_2 = %end_region (region_1) in

--- a/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
@@ -1,6 +1,6 @@
 let code bal_0 deleted in
 let code min_binding_1 deleted in
-let $camlMap_remove__immstring46 = "Map.remove_min_elt" in
+let $camlMap_remove__immstring50 = "Map.remove_min_elt" in
 let code remove_min_binding_2 deleted in
 let code merge_3 deleted in
 let code remove_4 deleted in
@@ -15,22 +15,22 @@ let code inline(never) loopify(never) size(9) newer_version_of(bal_0)
            [ 0
            | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
                [ 0 | 0 of val * imm tagged * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0
           | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
               [ 0 | 0 of val * imm tagged * val ] ] =
-  let Pmakeblock = %block.[`0`] (l, v, r) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (l, v, r) in
   cont k (Pmakeblock)
 in
-let $camlMap_remove__bal_5 = closure bal_0_1 @bal in
+let $camlMap_remove__bal_5 = closure bal_0_1 @bal &toplevel.alloc_region in
 let code loopify(done) size(26) newer_version_of(min_binding_1)
       min_binding_1_1
         (param :
            [ 0
            | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
                [ 0 | 0 of val * imm tagged * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
@@ -53,20 +53,22 @@ let code loopify(done) size(26) newer_version_of(min_binding_1)
                 let Pfield = %block_load.[`1`] (param_1) in
                 cont k (Pfield)))
 in
-let $camlMap_remove__min_binding_6 = closure min_binding_1_1 @min_binding in
-let $camlMap_remove__Pmakeblock161 =
+let $camlMap_remove__min_binding_6 =
+  closure min_binding_1_1 @min_binding &toplevel.alloc_region
+in
+let $camlMap_remove__Pmakeblock171 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument,
-           $camlMap_remove__immstring46)
+           $camlMap_remove__immstring50)
 in
 let $camlMap_remove__remove_min_binding_7 =
-  closure remove_min_binding_2_1 @remove_min_binding
+  closure remove_min_binding_2_1 @remove_min_binding &toplevel.alloc_region
 and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
       remove_min_binding_2_1
         (param :
            [ 0
            | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
                [ 0 | 0 of val * imm tagged * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0
           | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
@@ -74,7 +76,7 @@ and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k1 pop(reraise k1) ($camlMap_remove__Pmakeblock161)
+    | 1 -> k1 pop(reraise k1) ($camlMap_remove__Pmakeblock171)
     where k2 =
       let l = %block_load.[`0`] (param) in
       let prim_1 = %is_int (l) in
@@ -87,7 +89,7 @@ and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
          where k2 =
            let Pfield = %block_load.[`2`] (param) in
            let Pfield_1 = %block_load.[`1`] (param) in
-           (apply direct(remove_min_binding_2_1)
+           (apply direct(remove_min_binding_2_1 &my_alloc_region)
               ($camlMap_remove__remove_min_binding_7 ~ depth my_depth -> succ my_depth
                : _ ->
                  [ 0
@@ -102,7 +104,7 @@ and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
                          | 0 of [ 0 | 0 of val * imm tagged * val ] *
                              imm tagged * [ 0 | 0 of val * imm tagged * val ]
                          ]) =
-                apply direct(bal_0_1)
+                apply direct(bal_0_1 &my_alloc_region)
                   ($camlMap_remove__bal_5
                    : _ ->
                      [ 0
@@ -122,7 +124,7 @@ let code loopify(never) size(34) newer_version_of(merge_3)
            [ 0
            | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
                [ 0 | 0 of val * imm tagged * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0
           | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
@@ -137,12 +139,12 @@ let code loopify(never) size(34) newer_version_of(merge_3)
          | 0 -> k2
          | 1 -> k (t1)
          where k2 =
-           (apply direct(min_binding_1_1)
+           (apply direct(min_binding_1_1 &my_alloc_region)
               ($camlMap_remove__min_binding_6 : _ -> imm tagged)
                 (t2)
                 -> k2 * k1
               where k2 (x : imm tagged) =
-                (apply direct(remove_min_binding_2_1)
+                (apply direct(remove_min_binding_2_1 &my_alloc_region)
                    ($camlMap_remove__remove_min_binding_7
                     : _ ->
                       [ 0
@@ -157,7 +159,7 @@ let code loopify(never) size(34) newer_version_of(merge_3)
                               | 0 of [ 0 | 0 of val * imm tagged * val ] *
                                   imm tagged *
                                   [ 0 | 0 of val * imm tagged * val ] ]) =
-                     apply direct(bal_0_1)
+                     apply direct(bal_0_1 &my_alloc_region)
                        ($camlMap_remove__bal_5
                         : _ ->
                           [ 0
@@ -168,7 +170,9 @@ let code loopify(never) size(34) newer_version_of(merge_3)
                          (t1, x, apply_result)
                          -> k * k1)))
 in
-let $camlMap_remove__merge_8 = closure merge_3_1 @merge in
+let $camlMap_remove__merge_8 =
+  closure merge_3_1 @merge &toplevel.alloc_region
+in
 let code loopify(never) size(36) newer_version_of(remove_4)
       remove_4_1
         (x : imm tagged,
@@ -176,7 +180,7 @@ let code loopify(never) size(36) newer_version_of(remove_4)
            [ 0
            | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
                [ 0 | 0 of val * imm tagged * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0
           | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
@@ -196,7 +200,7 @@ let code loopify(never) size(36) newer_version_of(remove_4)
          | 1 -> k2
          where k2 =
            let Pfield_1 = %block_load.[`2`] (param) in
-           apply direct(merge_3_1)
+           apply direct(merge_3_1 &my_alloc_region)
              ($camlMap_remove__merge_8
               : _ ->
                 [ 0
@@ -206,7 +210,9 @@ let code loopify(never) size(36) newer_version_of(remove_4)
                (l, Pfield_1)
                -> k * k1)
 in
-let $camlMap_remove__remove_9 = closure remove_4_1 @remove in
+let $camlMap_remove__remove_9 =
+  closure remove_4_1 @remove &toplevel.alloc_region
+in
 let $camlMap_remove =
   Block 0 ($camlMap_remove__bal_5,
            $camlMap_remove__min_binding_6,

--- a/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
@@ -4,7 +4,7 @@ let code h_4 deleted in
 let code inline_0 deleted in
 let code loopify(never) size(16) newer_version_of(f_2)
       f_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let a = %project_value_slot.[f].[a] (my_closure) in
@@ -19,7 +19,7 @@ let code loopify(never) size(16) newer_version_of(f_2)
 in
 let code loopify(never) size(20) newer_version_of(g_3)
       g_3_1 (x : imm tagged, y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let b = %project_value_slot.[g].[b] (my_closure) in
@@ -35,7 +35,7 @@ let code loopify(never) size(20) newer_version_of(g_3)
 in
 let code rec loopify(never) size(39) newer_version_of(h_4)
       h_4_1 (x : imm tagged, y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let a = %project_value_slot.[h].[a] (my_closure) in
@@ -47,7 +47,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
      | 0 -> k2 (0)
      | 1 -> k3)
     where k3 =
-      apply direct(g_3_1)
+      apply direct(g_3_1 &my_alloc_region)
         (g ~ depth my_depth -> succ my_depth : _ -> imm tagged)
           (x, y)
           -> k2 * k1
@@ -58,7 +58,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
           | 1 -> k3)
          where k3 =
            let int_add = %int_barith.add (x, y) in
-           apply direct(f_2_1)
+           apply direct(f_2_1 &my_alloc_region)
              (f ~ depth my_depth -> succ my_depth : _ -> imm tagged)
                (int_add)
                -> k2 * k1
@@ -70,36 +70,41 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
 in
 let code inline(always) loopify(never) size(101) newer_version_of(inline_0)
       inline_0_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  apply direct(partial_apply1_44) inlined(never) inlining_state(depth(10))
+  apply direct(partial_apply1_44 &my_alloc_region) inlined(never)
+         inlining_state(depth(10))
     ($Stdlib__Random.camlStdlib__Random__partial_apply1_104 : _ -> imm tagged
      )
       (10)
       -> k2 * k1
     where k2 (r : imm tagged) =
-      (apply direct(partial_apply1_44) inlined(never)
+      (apply direct(partial_apply1_44 &my_alloc_region) inlined(never)
               inlining_state(depth(10))
          ($Stdlib__Random.camlStdlib__Random__partial_apply1_104
           : _ -> imm tagged)
            (10)
            -> k2 * k1
          where k2 (s : imm tagged) =
-           let f = closure f_2_1 @f
-           and g = closure g_3_1 @g
-           and h = closure h_4_1 @h
+           let f = closure f_2_1 @f &my_alloc_region
+           and g = closure g_3_1 @g &my_alloc_region
+           and h = closure h_4_1 @h &my_alloc_region
            with { a = a; b = b; r = r; s = s }
            in
            cont k (h))
 in
-let $camlOffset__inline_5 = closure inline_0_1 @`inline` in
-apply direct(partial_apply1_44) inlined(never) inlining_state(depth(11))
+let $camlOffset__inline_5 =
+  closure inline_0_1 @`inline` &toplevel.alloc_region
+in
+apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
+       inlining_state(depth(11))
   ($Stdlib__Random.camlStdlib__Random__partial_apply1_104 : _ -> imm tagged)
     (10)
     -> k * error
   where k (r : imm tagged) =
-    (apply direct(partial_apply1_44) inlined(never) inlining_state(depth(11))
+    (apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
+            inlining_state(depth(11))
        ($Stdlib__Random.camlStdlib__Random__partial_apply1_104
         : _ -> imm tagged)
          (10)
@@ -107,31 +112,31 @@ apply direct(partial_apply1_44) inlined(never) inlining_state(depth(11))
        where k (s : imm tagged) =
          let code loopify(never) size(0) newer_version_of(g_3_1)
                g_3_2 (x : imm tagged, y : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            cont k (0)
          in
          let $camlOffset__f_7 =
-           closure f_2_2 @f
+           closure f_2_2 @f &toplevel.alloc_region
          and $camlOffset__g_8 =
-           closure g_3_2 @g
+           closure g_3_2 @g &toplevel.alloc_region
          and $camlOffset__h_9 =
-           closure h_4_2 @h
+           closure h_4_2 @h &toplevel.alloc_region
          and code rec loopify(never) size(6) newer_version_of(h_4_1)
                h_4_2 (x : imm tagged, y : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            let int_add = %int_barith.add (x, y) in
-           apply direct(f_2_2) inlining_state(depth(1))
+           apply direct(f_2_2 &my_alloc_region) inlining_state(depth(1))
              ($camlOffset__f_7 ~ depth my_depth -> succ my_depth
               : _ -> imm tagged)
                (int_add)
                -> k * k1
          and code loopify(never) size(4) newer_version_of(f_2_1)
                f_2_2 (x : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            let r_1 = %project_value_slot.[f].[r] ($camlOffset__f_7) in
@@ -139,15 +144,15 @@ apply direct(partial_apply1_44) inlined(never) inlining_state(depth(11))
            cont k (int_add)
            with { a = 1; b = 0; r = r; s = s }
          in
-         (apply direct(partial_apply1_44) inlined(never)
-                 inlining_state(depth(11))
+         (apply direct(partial_apply1_44 &toplevel.alloc_region)
+                 inlined(never) inlining_state(depth(11))
             ($Stdlib__Random.camlStdlib__Random__partial_apply1_104
              : _ -> imm tagged)
               (10)
               -> k * error
             where k (r_1 : imm tagged) =
-              (apply direct(partial_apply1_44) inlined(never)
-                      inlining_state(depth(11))
+              (apply direct(partial_apply1_44 &toplevel.alloc_region)
+                      inlined(never) inlining_state(depth(11))
                  ($Stdlib__Random.camlStdlib__Random__partial_apply1_104
                   : _ -> imm tagged)
                    (10)
@@ -155,31 +160,31 @@ apply direct(partial_apply1_44) inlined(never) inlining_state(depth(11))
                  where k (s_1 : imm tagged) =
                    let code loopify(never) size(0) newer_version_of(f_2_1)
                          f_2_3 (x : imm tagged)
-                           my_closure _region _ghost_region my_depth
+                           my_closure &my_alloc_region my_depth
                            -> k * k1
                            : imm tagged =
                      cont k (0)
                    in
                    let code loopify(never) size(0) newer_version_of(g_3_1)
                          g_3_3 (x : imm tagged, y : imm tagged)
-                           my_closure _region _ghost_region my_depth
+                           my_closure &my_alloc_region my_depth
                            -> k * k1
                            : imm tagged =
                      cont k (0)
                    in
                    let code loopify(never) size(0) newer_version_of(h_4_1)
                          h_4_3 (x : imm tagged, y : imm tagged)
-                           my_closure _region _ghost_region my_depth
+                           my_closure &my_alloc_region my_depth
                            -> k * k1
                            : imm tagged =
                      cont k (0)
                    in
                    let $camlOffset__f_10 =
-                     closure f_2_3 @f
+                     closure f_2_3 @f &toplevel.alloc_region
                    and $camlOffset__g_11 =
-                     closure g_3_3 @g
+                     closure g_3_3 @g &toplevel.alloc_region
                    and $camlOffset__h_12 =
-                     closure h_4_3 @h
+                     closure h_4_3 @h &toplevel.alloc_region
                      with { a = 0; b = 0; r = r_1; s = s_1 }
                    in
                    let $camlOffset =

--- a/testsuite/tests/flambda2/examples/unknown/p.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/p.simplify.reference
@@ -4,42 +4,40 @@ let code bar_1 deleted in
 let code f_3 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(foo_0)
       foo_0_1 (k, o, param)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlP__foo_4 = closure foo_0_1 @foo in
+let $camlP__foo_4 = closure foo_0_1 @foo &toplevel.alloc_region in
 let code loopify(never) size(1) newer_version_of(`fn[p.ml:11,19--31]_2`)
       `fn[p.ml:11,19--31]_2_1` (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   cont k (x)
 in
 let $`camlP__fn[p.ml:11,19--31]_6` =
   closure `fn[p.ml:11,19--31]_2_1` @`fn[p.ml:11,19--31]`
+    &toplevel.alloc_region
 in
 let code loopify(never) size(4) newer_version_of(bar_1)
       bar_1_1 (oc, z)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(foo_0_1)
+  apply direct(foo_0_1 &my_alloc_region)
     ($camlP__foo_4 : _ -> imm tagged)
       ($`camlP__fn[p.ml:11,19--31]_6`, oc, z)
       -> k * k1
 in
-let $camlP__bar_5 = closure bar_1_1 @bar in
+let $camlP__bar_5 = closure bar_1_1 @bar &toplevel.alloc_region in
 let code loopify(never) size(4) newer_version_of(f_3)
-      f_3_1 (z)
-        my_closure _region _ghost_region my_depth
-        -> k * k1
-        : imm tagged =
-  apply direct(foo_0_1) inlining_state(depth(10))
+      f_3_1 (z) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
+  apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(10))
     ($camlP__foo_4 : _ -> imm tagged)
       ($`camlP__fn[p.ml:11,19--31]_6`, 0, z)
       -> k * k1
 in
-let $camlP__f_7 = closure f_3_1 @f in
+let $camlP__f_7 = closure f_3_1 @f &toplevel.alloc_region in
 let $camlP = Block 0 ($camlP__foo_4, $camlP__bar_5, $camlP__f_7) in
 cont done ($camlP)

--- a/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
@@ -5,7 +5,7 @@ let code set_mode_pattern_4 deleted in
 let code `fn[protect_refs.ml:41,26--40]_5` deleted in
 let code loopify(done) size(22) newer_version_of(iter_0)
       iter_0_1 (f : val, param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
@@ -17,17 +17,18 @@ let code loopify(done) size(22) newer_version_of(iter_0)
          | 1 -> k (0)
          where k2 =
            ((let Pfield = %block_load.[`0`] (param_1) in
-             apply f_1 (Pfield) -> k3 * k1
+             apply &my_alloc_region f_1 (Pfield) -> k3 * k1
                where k3 (param_2) =
                  cont k2)
               where k2 =
                 let Pfield = %block_load.[`1`] (param_1) in
                 cont `self` (Pfield)))
 in
-let $camlProtect_refs__iter_6 = closure iter_0_1 @iter in
+let $camlProtect_refs__iter_6 = closure iter_0_1 @iter &toplevel.alloc_region
+in
 let code loopify(never) size(7) newer_version_of(`fn[protect_refs.ml:28,24--50]_2`)
       `fn[protect_refs.ml:28,24--50]_2_1` (param : [ 0 of val * val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`1`] (param) in
@@ -37,55 +38,56 @@ let code loopify(never) size(7) newer_version_of(`fn[protect_refs.ml:28,24--50]_
 in
 let $`camlProtect_refs__fn[protect_refs.ml:28,24--50]_8` =
   closure `fn[protect_refs.ml:28,24--50]_2_1`
-    @`fn[protect_refs.ml:28,24--50]`
+    @`fn[protect_refs.ml:28,24--50]` &toplevel.alloc_region
 in
 let code loopify(never) size(11) newer_version_of(`fn[protect_refs.ml:29,2--43]_3`)
       `fn[protect_refs.ml:29,2--43]_3_1`
         (refs : [ 0 | 0 of val * [ 0 | 0 of val * val ] ], f : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(iter_0_1) inlining_state(depth(10))
+  apply direct(iter_0_1 &my_alloc_region) inlining_state(depth(10))
     ($camlProtect_refs__iter_6 : _ -> imm tagged)
       ($`camlProtect_refs__fn[protect_refs.ml:28,24--50]_8`, refs)
       -> k3 * k1
     where k3 (param : imm tagged) =
       cont k2
     where k2 =
-      apply f (0) -> k * k1
+      apply &my_alloc_region f (0) -> k * k1
 in
 let $`camlProtect_refs__fn[protect_refs.ml:29,2--43]_9` =
   closure `fn[protect_refs.ml:29,2--43]_3_1` @`fn[protect_refs.ml:29,2--43]`
+    &toplevel.alloc_region
 in
-let umode = %block.mut.[`0`] (0) in
+let umode = %block.mut.[`0`].`toplevel` (0) in
 let umode_1 = umode in
 let $camlProtect_refs__set_mode_pattern_10 =
-  closure set_mode_pattern_4_1 @set_mode_pattern
+  closure set_mode_pattern_4_1 @set_mode_pattern &toplevel.alloc_region
 and code inline(never) loopify(never) size(4) newer_version_of(set_mode_pattern_4)
       set_mode_pattern_4_1 (f : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(`fn[protect_refs.ml:29,2--43]_3_1`)
+  apply direct(`fn[protect_refs.ml:29,2--43]_3_1` &my_alloc_region)
     $`camlProtect_refs__fn[protect_refs.ml:29,2--43]_9`
-      ($camlProtect_refs__Pmakeblock121, f)
+      ($camlProtect_refs__Pmakeblock134, f)
       -> k * k1
-and $camlProtect_refs__Pmakeblock120 =
+and $camlProtect_refs__Pmakeblock133 =
   Block 0 (umode_1, 1)
-and $camlProtect_refs__Pmakeblock121 =
-  Block 0 ($camlProtect_refs__Pmakeblock120, 0)
+and $camlProtect_refs__Pmakeblock134 =
+  Block 0 ($camlProtect_refs__Pmakeblock133, 0)
   with { umode = umode }
 in
 (let code loopify(never) size(1) newer_version_of(`fn[protect_refs.ml:41,26--40]_5`)
        `fn[protect_refs.ml:41,26--40]_5_1` (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    cont k1 (0)
  in
  let $`camlProtect_refs__fn[protect_refs.ml:41,26--40]_11` =
    closure `fn[protect_refs.ml:41,26--40]_5_1`
-     @`fn[protect_refs.ml:41,26--40]`
+     @`fn[protect_refs.ml:41,26--40]` &toplevel.alloc_region
  in
- apply direct(set_mode_pattern_4_1)
+ apply direct(set_mode_pattern_4_1 &toplevel.alloc_region)
    ($camlProtect_refs__set_mode_pattern_10 : _ -> imm tagged)
      ($`camlProtect_refs__fn[protect_refs.ml:41,26--40]_11`)
      -> k1 * error

--- a/testsuite/tests/flambda2/examples/unknown/ray.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/ray.simplify.reference
@@ -3,7 +3,7 @@ let code max_1 deleted in
 let code aabb_hit_2 deleted in
 let code inline(always) loopify(never) size(14) newer_version_of(min_0)
       min_0_1 (x : float boxed, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let prim = %unbox_num.`float` (y) in
@@ -13,10 +13,10 @@ let code inline(always) loopify(never) size(14) newer_version_of(min_0)
     | 0 -> k (y)
     | 1 -> k (x)
 in
-let $camlRay__min_4 = closure min_0_1 @min in
+let $camlRay__min_4 = closure min_0_1 @min &toplevel.alloc_region in
 let code inline(always) loopify(never) size(14) newer_version_of(max_1)
       max_1_1 (x : float boxed, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let prim = %unbox_num.`float` (y) in
@@ -26,14 +26,14 @@ let code inline(always) loopify(never) size(14) newer_version_of(max_1)
     | 0 -> k (y)
     | 1 -> k (x)
 in
-let $camlRay__max_5 = closure max_1_1 @max in
+let $camlRay__max_5 = closure max_1_1 @max &toplevel.alloc_region in
 let code loopify(never) size(222) newer_version_of(aabb_hit_2)
       aabb_hit_2_1
         (aabb : [ 0 of float ^ 3 * float ^ 3 ],
          r : [ 0 of float ^ 3 * float ^ 3 ],
          tmin0 : float boxed,
          tmax0 : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`1`] (r) in
@@ -195,7 +195,9 @@ let code loopify(never) size(222) newer_version_of(aabb_hit_2)
                                          in
                                          cont k (Pnot))))))))
 in
-let $camlRay__aabb_hit_6 = closure aabb_hit_2_1 @aabb_hit in
+let $camlRay__aabb_hit_6 =
+  closure aabb_hit_2_1 @aabb_hit &toplevel.alloc_region
+in
 let $camlRay =
   Block 0 ($camlRay__min_4, $camlRay__max_5, $camlRay__aabb_hit_6)
 in

--- a/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
@@ -3,13 +3,15 @@ let code p_2 deleted in
 let code g_1 deleted in
 let code f_3 deleted in
 let code loopify(never) size(1) newer_version_of(id_0)
-      id_0_1 (x) my_closure _region _ghost_region my_depth -> k * k1 =
+      id_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (x)
 in
-let $camlTest_exn_handler_inlining__id_4 = closure id_0_1 @`id` in
+let $camlTest_exn_handler_inlining__id_4 =
+  closure id_0_1 @`id` &toplevel.alloc_region
+in
 let code loopify(never) size(19) newer_version_of(p_2)
       p_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let prim = %is_int (param) in
@@ -22,24 +24,28 @@ let code loopify(never) size(19) newer_version_of(p_2)
     where k2 =
       let Pfield = %block_load.[`1`] (param) in
       let Popaque = %opaque ($camlTest_exn_handler_inlining__id_4) in
-      apply Popaque (Pfield) -> k * k1
+      apply &my_alloc_region Popaque (Pfield) -> k * k1
 in
-let $camlTest_exn_handler_inlining__p_6 = closure p_2_1 @p in
+let $camlTest_exn_handler_inlining__p_6 =
+  closure p_2_1 @p &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(g_1)
       g_1_1 (y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  apply direct(p_2_1)
+  apply direct(p_2_1 &my_alloc_region)
     ($camlTest_exn_handler_inlining__p_6
      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
       (y)
       -> k * k1
 in
-let $camlTest_exn_handler_inlining__g_5 = closure g_1_1 @g in
+let $camlTest_exn_handler_inlining__g_5 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let code loopify(never) size(18) newer_version_of(f_3)
       f_3_1 (x : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let try_region = %begin_try_region () in
@@ -48,7 +54,7 @@ let code loopify(never) size(18) newer_version_of(f_3)
     where rec k3 (c_unboxed0 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       (cont k6 push(k5)
          where k6 =
-           (apply direct(p_2_1) inlining_state(depth(10))
+           (apply direct(p_2_1 &my_alloc_region) inlining_state(depth(10))
               ($camlTest_exn_handler_inlining__p_6
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (c_unboxed0)
@@ -68,7 +74,9 @@ let code loopify(never) size(18) newer_version_of(f_3)
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       cont k (c_unboxed0_1)
 in
-let $camlTest_exn_handler_inlining__f_7 = closure f_3_1 @f in
+let $camlTest_exn_handler_inlining__f_7 =
+  closure f_3_1 @f &toplevel.alloc_region
+in
 let $camlTest_exn_handler_inlining =
   Block 0 ($camlTest_exn_handler_inlining__id_4,
            $camlTest_exn_handler_inlining__g_5,

--- a/testsuite/tests/flambda2/examples/unknown/to_hex.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/to_hex.simplify.reference
@@ -5,54 +5,61 @@ let code max_3 deleted in
 let code abs_4 deleted in
 let code lnot_5 deleted in
 let code char_hex_6 deleted in
-let $camlTo_hex__immstring121 = "Digest.to_hex" in
-let $camlTo_hex__immstring7 = "index out of bounds" in
-let $camlTo_hex__block142 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTo_hex__immstring7)
+let $camlTo_hex__immstring130 = "Digest.to_hex" in
+let $camlTo_hex__immstring8 = "index out of bounds" in
+let $camlTo_hex__block151 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTo_hex__immstring8)
 in
 let code to_hex_7 deleted in
-let $camlTo_hex__immstring32 = "To_hex.Stdlib.Exit" in
-let $camlTo_hex__immstring10 = "Pervasives.array_bound_error" in
-let $camlTo_hex__Pmakeblock171 =
-  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTo_hex__immstring7)
+let $camlTo_hex__immstring35 = "To_hex.Stdlib.Exit" in
+let $camlTo_hex__immstring11 = "Pervasives.array_bound_error" in
+let $camlTo_hex__Pmakeblock180 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTo_hex__immstring8)
 in
 apply ccall
   ($`*extern*`.caml_register_named_value : val * val -> val)
-    ($camlTo_hex__immstring10, $camlTo_hex__Pmakeblock171)
+    ($camlTo_hex__immstring11, $camlTo_hex__Pmakeblock180)
     -> k1 * error
   where k1 (param) =
     cont k
   where k =
     let code loopify(never) size(10) newer_version_of(failwith_0)
           failwith_0_1 (s : val)
-            my_closure _region _ghost_region my_depth
-            -> k * k1
-            : val =
-      let Pmakeblock = %block.[`0`] ($`*predef*`.caml_exn_Failure, s) in
-      cont k1 pop(regular k1) (Pmakeblock)
-    in
-    let $camlTo_hex__failwith_8 = closure failwith_0_1 @failwith in
-    let code loopify(never) size(10) newer_version_of(invalid_arg_1)
-          invalid_arg_1_1 (s : val)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : val =
       let Pmakeblock =
-        %block.[`0`] ($`*predef*`.caml_exn_Invalid_argument, s)
+        %block.[`0`].my_alloc_region ($`*predef*`.caml_exn_Failure, s)
       in
       cont k1 pop(regular k1) (Pmakeblock)
     in
-    let $camlTo_hex__invalid_arg_9 = closure invalid_arg_1_1 @invalid_arg in
+    let $camlTo_hex__failwith_8 =
+      closure failwith_0_1 @failwith &toplevel.alloc_region
+    in
+    let code loopify(never) size(10) newer_version_of(invalid_arg_1)
+          invalid_arg_1_1 (s : val)
+            my_closure &my_alloc_region my_depth
+            -> k * k1
+            : val =
+      let Pmakeblock =
+        %block.[`0`].my_alloc_region
+          ($`*predef*`.caml_exn_Invalid_argument, s)
+      in
+      cont k1 pop(regular k1) (Pmakeblock)
+    in
+    let $camlTo_hex__invalid_arg_9 =
+      closure invalid_arg_1_1 @invalid_arg &toplevel.alloc_region
+    in
     (apply ccall noalloc
        ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
        where k (Pccall) =
-         let $camlTo_hex__Exit190 =
+         let $camlTo_hex__Exit201 =
            Block immutable_unique
-           248 ($camlTo_hex__immstring32, Pccall)
+           248 ($camlTo_hex__immstring35, Pccall)
          in
          let code loopify(never) size(21) newer_version_of(min_2)
                min_2_1 (x : val, y : val)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : val =
            apply ccall
@@ -65,10 +72,12 @@ apply ccall
                  | 0 -> k (y)
                  | 1 -> k (x)
          in
-         let $camlTo_hex__min_10 = closure min_2_1 @min in
+         let $camlTo_hex__min_10 =
+           closure min_2_1 @min &toplevel.alloc_region
+         in
          let code loopify(never) size(21) newer_version_of(max_3)
                max_3_1 (x : val, y : val)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : val =
            apply ccall
@@ -81,10 +90,12 @@ apply ccall
                  | 0 -> k (y)
                  | 1 -> k (x)
          in
-         let $camlTo_hex__max_11 = closure max_3_1 @max in
+         let $camlTo_hex__max_11 =
+           closure max_3_1 @max &toplevel.alloc_region
+         in
          let code loopify(never) size(15) newer_version_of(abs_4)
                abs_4_1 (x : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            let prim = %int_comp.ge (x, 0) in
@@ -95,20 +106,24 @@ apply ccall
                let int_neg = %int_barith.sub (0, x) in
                cont k (int_neg)
          in
-         let $camlTo_hex__abs_12 = closure abs_4_1 @abs in
+         let $camlTo_hex__abs_12 =
+           closure abs_4_1 @abs &toplevel.alloc_region
+         in
          let code loopify(never) size(3) newer_version_of(lnot_5)
                lnot_5_1 (x : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            let int_xor = %int_barith.xor (x, -1) in
            cont k (int_xor)
          in
-         let $camlTo_hex__lnot_13 = closure lnot_5_1 @lnot in
-         let $camlTo_hex__Pmakeblock241 =
+         let $camlTo_hex__lnot_13 =
+           closure lnot_5_1 @lnot &toplevel.alloc_region
+         in
+         let $camlTo_hex__Pmakeblock256 =
            Block 0 ($camlTo_hex__failwith_8,
                     $camlTo_hex__invalid_arg_9,
-                    $camlTo_hex__Exit190,
+                    $camlTo_hex__Exit201,
                     $`*predef*`.caml_exn_Match_failure,
                     $`*predef*`.caml_exn_Assert_failure,
                     $`*predef*`.caml_exn_Invalid_argument,
@@ -130,7 +145,7 @@ apply ccall
          in
          let code loopify(never) size(15) newer_version_of(char_hex_6)
                char_hex_6_1 (n : imm tagged)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            (let prim = %int_comp.lt (n, 10) in
@@ -141,10 +156,12 @@ apply ccall
                let int_add = %int_barith.add (n, staticcatch_result) in
                cont k (int_add)
          in
-         let $camlTo_hex__char_hex_14 = closure char_hex_6_1 @char_hex in
+         let $camlTo_hex__char_hex_14 =
+           closure char_hex_6_1 @char_hex &toplevel.alloc_region
+         in
          let code loopify(never) size(97) newer_version_of(to_hex_7)
                to_hex_7_1 (d : val)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : val =
            (let prim = %string_length (d) in
@@ -154,9 +171,9 @@ apply ccall
               | 0 -> k2 (prim)
               | 1 -> k3
               where k3 =
-                apply direct(invalid_arg_1_1)
+                apply direct(invalid_arg_1_1 &my_alloc_region)
                   ($camlTo_hex__invalid_arg_9 : _ -> imm tagged)
-                    ($camlTo_hex__immstring121)
+                    ($camlTo_hex__immstring130)
                     -> never * k1)
              where k2 (prim : imm) =
                let cse_param = prim in
@@ -191,7 +208,7 @@ apply ccall
                               in
                               let x = %tag_imm (prim_3) in
                               ((let int_lsr = %int_shift.lsr (x, 4i) in
-                                apply direct(char_hex_6_1)
+                                apply direct(char_hex_6_1 &my_alloc_region)
                                   ($camlTo_hex__char_hex_14 : _ -> imm tagged
                                    )
                                     (int_lsr)
@@ -212,7 +229,9 @@ apply ccall
                                    in
                                    ((let int_and = %int_barith.`and` (x, 15)
                                      in
-                                     apply direct(char_hex_6_1)
+                                     apply
+                                            direct(char_hex_6_1
+                                            &my_alloc_region)
                                        ($camlTo_hex__char_hex_14
                                         : _ -> imm tagged)
                                          (int_and)
@@ -245,11 +264,13 @@ apply ccall
                                           | 0 -> k (result)
                                           | 1 -> k2 (for_next_naked)))
                             where k3 =
-                              cont k1 pop(regular k1) ($camlTo_hex__block142))))
+                              cont k1 pop(regular k1) ($camlTo_hex__block151))))
          in
-         let $camlTo_hex__to_hex_15 = closure to_hex_7_1 @to_hex in
+         let $camlTo_hex__to_hex_15 =
+           closure to_hex_7_1 @to_hex &toplevel.alloc_region
+         in
          let $camlTo_hex =
-           Block 0 ($camlTo_hex__Pmakeblock241,
+           Block 0 ($camlTo_hex__Pmakeblock256,
                     $camlTo_hex__char_hex_14,
                     $camlTo_hex__to_hex_15)
          in

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
@@ -3,7 +3,7 @@ let code bar_1 deleted in
 let code foobar_0 deleted in
 let code loopify(never) size(7) newer_version_of(`fn[unbox_closure.ml:12,12--25]_2`)
       `fn[unbox_closure.ml:12,12--25]_2_1` (z : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let x =
@@ -18,37 +18,41 @@ let code loopify(never) size(7) newer_version_of(`fn[unbox_closure.ml:12,12--25]
 in
 let code loopify(never) size(18) newer_version_of(bar_1)
       bar_1_1 (y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
   let x = %project_value_slot.[bar].[x_1] (my_closure) in
   let Popaque = %opaque (0) in
   let `fn[unbox_closure.ml:12,12--25]` =
     closure `fn[unbox_closure.ml:12,12--25]_2_1`
-      @`fn[unbox_closure.ml:12,12--25]`
+      @`fn[unbox_closure.ml:12,12--25]` &my_alloc_region
   with { x = x; y = y }
   in
   cont k (`fn[unbox_closure.ml:12,12--25]`)
 in
 let code loopify(never) size(53) newer_version_of(foobar_0)
       foobar_0_1 (b : imm tagged, x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
-  let bar = closure bar_1_1 @bar with { x_1 = x } in
+  let bar = closure bar_1_1 @bar &my_alloc_region &`region`
+  with { x_1 = x }
+  in
   (let untagged = %untag_imm (b) in
    switch untagged
      | 0 -> k3
      | 1 -> k4)
     where k4 =
-      apply direct(bar_1_1) (bar : _ -> val) (3) -> k2 * k1
+      apply direct(bar_1_1 &my_alloc_region) (bar : _ -> val) (3) -> k2 * k1
     where k3 =
-      apply direct(bar_1_1) (bar : _ -> val) (42) -> k2 * k1
+      apply direct(bar_1_1 &my_alloc_region) (bar : _ -> val) (42) -> k2 * k1
     where k2 (f : val) =
       let `unit` = %end_region (`region`) in
-      apply f (x) -> k * k1
+      apply &my_alloc_region f (x) -> k * k1
 in
-let $camlUnbox_closure__foobar_3 = closure foobar_0_1 @foobar in
+let $camlUnbox_closure__foobar_3 =
+  closure foobar_0_1 @foobar &toplevel.alloc_region
+in
 let $camlUnbox_closure = Block 0 ($camlUnbox_closure__foobar_3) in
 cont done ($camlUnbox_closure)

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
@@ -3,7 +3,7 @@ let code bar1_2 deleted in
 let code foobar_0 deleted in
 let code inline(always) loopify(never) size(4) newer_version_of(bar1_2)
       bar1_2_1 (y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let x = %project_value_slot.[bar1].[x] (my_closure) in
@@ -12,7 +12,7 @@ let code inline(always) loopify(never) size(4) newer_version_of(bar1_2)
 in
 let code inline(always) loopify(never) size(11) newer_version_of(bar2_1)
       bar2_1_1 (y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let x = %project_value_slot.[bar2].[x_1] (my_closure) in
@@ -23,7 +23,7 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar2_1)
 in
 let code loopify(never) size(64) newer_version_of(foobar_0)
       foobar_0_1 (b : imm tagged, x : imm tagged, z : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (b) in
@@ -31,17 +31,21 @@ let code loopify(never) size(64) newer_version_of(foobar_0)
      | 0 -> k3
      | 1 -> k4)
     where k4 =
-      let bar1 = closure bar1_2_1 @bar1 with { x = x } in
-      let Pmakeblock = %block.[`0`] (bar1) in
+      let bar1 = closure bar1_2_1 @bar1 &my_alloc_region with { x = x } in
+      let Pmakeblock = %block.[`0`].my_alloc_region (bar1) in
       cont k2 (Pmakeblock)
     where k3 =
-      let bar2 = closure bar2_1_1 @bar2 with { x_1 = x; z = z } in
-      let Pmakeblock = %block.[`1`] (bar2) in
+      let bar2 = closure bar2_1_1 @bar2 &my_alloc_region
+      with { x_1 = x; z = z }
+      in
+      let Pmakeblock = %block.[`1`].my_alloc_region (bar2) in
       cont k2 (Pmakeblock)
     where k2 (f : [ 0 of val |1 of val ]) =
       let Pfield = %block_load.[`0`] (f) in
-      apply Pfield (x) -> k * k1
+      apply &my_alloc_region Pfield (x) -> k * k1
 in
-let $camlUnbox_closure2__foobar_3 = closure foobar_0_1 @foobar in
+let $camlUnbox_closure2__foobar_3 =
+  closure foobar_0_1 @foobar &toplevel.alloc_region
+in
 let $camlUnbox_closure2 = Block 0 ($camlUnbox_closure2__foobar_3) in
 cont done ($camlUnbox_closure2)

--- a/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
@@ -2,7 +2,7 @@ let code `fn[wrong_allocation_moving.ml:21,15--28]_1` deleted in
 let code f_0 deleted in
 let code loopify(never) size(2) newer_version_of(`fn[wrong_allocation_moving.ml:21,15--28]_1`)
       `fn[wrong_allocation_moving.ml:21,15--28]_1_1` (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let y =
@@ -13,33 +13,35 @@ let code loopify(never) size(2) newer_version_of(`fn[wrong_allocation_moving.ml:
 in
 let code loopify(never) size(57) newer_version_of(f_0)
       f_0_1 (x : float boxed, foo : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply ccall
     ($`*extern*`.caml_gc_minor_words_unboxed : val -> float) (0) -> k2 * k1
     where k2 (before : float) =
       let prim = %unbox_num.`float` (x) in
       let prim_1 = %bfloat_arith.mul (prim, 0x1p+1) in
-      let y = %box_num.`float` (prim_1) in
+      let y = %box_num.`float`.my_alloc_region (prim_1) in
       (apply ccall
          ($`*extern*`.caml_gc_minor_words_unboxed : val -> float)
            (0)
            -> k2 * k1
          where k2 (after : float) =
            let prim_2 = %bfloat_arith.sub (after, before) in
-           let diff = %box_num.`float` (prim_2) in
+           let diff = %box_num.`float`.my_alloc_region (prim_2) in
            let `fn[wrong_allocation_moving.ml:21,15--28]` =
              closure `fn[wrong_allocation_moving.ml:21,15--28]_1_1`
-               @`fn[wrong_allocation_moving.ml:21,15--28]`
+               @`fn[wrong_allocation_moving.ml:21,15--28]` &my_alloc_region
            with { y = y }
            in
-           let Pmakeblock = %block.[`0`] (y) in
-           apply
+           let Pmakeblock = %block.[`0`].my_alloc_region (y) in
+           apply &my_alloc_region
              foo
                (Pmakeblock, `fn[wrong_allocation_moving.ml:21,15--28]`, diff)
                -> k * k1)
 in
-let $camlWrong_allocation_moving__f_2 = closure f_0_1 @f in
+let $camlWrong_allocation_moving__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlWrong_allocation_moving =
   Block 0 ($camlWrong_allocation_moving__f_2)
 in

--- a/testsuite/tests/flambda2/examples/unroll.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll.raw.reference
@@ -1,7 +1,7 @@
 let $camlUnroll__first_const = Block 0 () in
 (let code rec size(27)
        fact_0 (n : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -15,7 +15,7 @@ let $camlUnroll__first_const = Block 0 () in
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (n, 1) in
-         apply direct(fact_0)
+         apply direct(fact_0 &my_alloc_region)
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (int_sub)
              -> k3 * k2)
@@ -23,13 +23,14 @@ let $camlUnroll__first_const = Block 0 () in
             let int_mul = %int_barith.mul (n, apply_result) in
             cont k1 (int_mul))
  in
- let fact = closure fact_0 @fact in
- apply direct(fact_0) unroll(4) (fact : _ -> imm tagged) (6) -> k1 * error
+ let fact = closure fact_0 @fact &toplevel.alloc_region in
+ apply direct(fact_0 &toplevel.alloc_region) unroll(4)
+   (fact : _ -> imm tagged) (6) -> k1 * error
    where k1 (i : imm tagged) =
-     (apply direct(fact_0) unroll(7)
+     (apply direct(fact_0 &toplevel.alloc_region) unroll(7)
         (fact : _ -> imm tagged) (6) -> k1 * error
         where k1 (j : imm tagged) =
-          let Pmakeblock = %block.[`0`] (fact, i, j) in
+          let Pmakeblock = %block.[`0`].`toplevel` (fact, i, j) in
           cont k (Pmakeblock)))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll.simplify.reference
@@ -1,9 +1,9 @@
 let code fact_0 deleted in
 let $camlUnroll__fact_1 =
-  closure fact_0_1 @fact
+  closure fact_0_1 @fact &toplevel.alloc_region
 and code rec loopify(never) size(23) newer_version_of(fact_0)
       fact_0_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %phys_eq (n, 0) in
@@ -12,7 +12,7 @@ and code rec loopify(never) size(23) newer_version_of(fact_0)
     | 1 -> k (1)
     where k2 =
       ((let int_sub = %int_barith.sub (n, 1) in
-        apply direct(fact_0_1)
+        apply direct(fact_0_1 &my_alloc_region)
           ($camlUnroll__fact_1 ~ depth my_depth -> succ my_depth
            : _ -> imm tagged)
             (int_sub)
@@ -21,7 +21,7 @@ and code rec loopify(never) size(23) newer_version_of(fact_0)
            let int_mul = %int_barith.mul (n, apply_result) in
            cont k (int_mul))
 in
-apply direct(fact_0_1) inlining_state(depth(40))
+apply direct(fact_0_1 &toplevel.alloc_region) inlining_state(depth(40))
   ($camlUnroll__fact_1 ~ depth unroll 1 3 -> unroll 0 4 : _ -> imm tagged)
     (2)
     -> k * error

--- a/testsuite/tests/flambda2/examples/unroll2.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll2.raw.reference
@@ -1,8 +1,6 @@
 let $camlUnroll2__first_const = Block 0 () in
 (let code rec loopify(never) size(25)
-       foo_0 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2 =
+       foo_0 (x : imm tagged) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    (let Popaque = %opaque (1) in
     (let untagged = %untag_imm (Popaque) in
@@ -15,24 +13,22 @@ let $camlUnroll2__first_const = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (x, 1) in
-       apply direct(foo_0)
+       apply direct(foo_0 &my_alloc_region)
          my_closure ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
        let int_add = %int_barith.add (x, 1) in
-       apply direct(foo_0)
+       apply direct(foo_0 &my_alloc_region)
          my_closure ~ depth my_depth -> next_depth (int_add) -> k1 * k2
  in
  let code size(5)
-       bar_1 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2 =
+       bar_1 (x : imm tagged) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[bar].[foo] (my_closure) in
-   apply direct(foo_0) unroll(2) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) unroll(2) foo (x) -> k1 * k2
  in
- let foo = closure foo_0 @foo in
- let bar = closure bar_1 @bar with { foo = foo } in
- let Pmakeblock = %block.[`0`] (foo, bar) in
+ let foo = closure foo_0 @foo &toplevel.alloc_region in
+ let bar = closure bar_1 @bar &toplevel.alloc_region with { foo = foo } in
+ let Pmakeblock = %block.[`0`].`toplevel` (foo, bar) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll2.simplify.reference
@@ -1,11 +1,9 @@
 let code foo_0 deleted in
 let code bar_1 deleted in
 let $camlUnroll2__foo_2 =
-  closure foo_0_1 @foo
+  closure foo_0_1 @foo &toplevel.alloc_region
 and code rec loopify(never) size(23) newer_version_of(foo_0)
-      foo_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
+      foo_0_1 (x : imm tagged) my_closure &my_alloc_region my_depth -> k * k1 =
   let Popaque = %opaque (1) in
   (let untagged = %untag_imm (Popaque) in
    switch untagged
@@ -13,21 +11,19 @@ and code rec loopify(never) size(23) newer_version_of(foo_0)
      | 1 -> k3)
     where k3 =
       let int_add = %int_barith.add (x, 1) in
-      apply direct(foo_0_1)
+      apply direct(foo_0_1 &my_alloc_region)
         $camlUnroll2__foo_2 ~ depth my_depth -> succ my_depth
           (int_add)
           -> k * k1
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(foo_0_1)
+      apply direct(foo_0_1 &my_alloc_region)
         $camlUnroll2__foo_2 ~ depth my_depth -> succ my_depth
           (int_sub)
           -> k * k1
 in
 let code loopify(never) size(61) newer_version_of(bar_1)
-      bar_1_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
+      bar_1_1 (x : imm tagged) my_closure &my_alloc_region my_depth -> k * k1 =
   let Popaque = %opaque (1) in
   (let untagged = %untag_imm (Popaque) in
    switch untagged
@@ -42,13 +38,13 @@ let code loopify(never) size(61) newer_version_of(bar_1)
           | 1 -> k4)
          where k4 =
            let int_add_1 = %int_barith.add (int_add, 1) in
-           apply direct(foo_0_1) inlining_state(depth(20))
+           apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
              $camlUnroll2__foo_2 ~ depth unroll 1 1 -> unroll 0 2
                (int_add_1)
                -> k * k1
          where k3 =
            let int_sub = %int_barith.sub (int_add, 1) in
-           apply direct(foo_0_1) inlining_state(depth(20))
+           apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
              $camlUnroll2__foo_2 ~ depth unroll 1 1 -> unroll 0 2
                (int_sub)
                -> k * k1)
@@ -61,17 +57,17 @@ let code loopify(never) size(61) newer_version_of(bar_1)
           | 1 -> k3)
          where k3 =
            let int_add = %int_barith.add (int_sub, 1) in
-           apply direct(foo_0_1) inlining_state(depth(20))
+           apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
              $camlUnroll2__foo_2 ~ depth unroll 1 1 -> unroll 0 2
                (int_add)
                -> k * k1
          where k2 =
            let int_sub_1 = %int_barith.sub (int_sub, 1) in
-           apply direct(foo_0_1) inlining_state(depth(20))
+           apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
              $camlUnroll2__foo_2 ~ depth unroll 1 1 -> unroll 0 2
                (int_sub_1)
                -> k * k1)
 in
-let $camlUnroll2__bar_3 = closure bar_1_1 @bar in
+let $camlUnroll2__bar_3 = closure bar_1_1 @bar &toplevel.alloc_region in
 let $camlUnroll2 = Block 0 ($camlUnroll2__foo_2, $camlUnroll2__bar_3) in
 cont done ($camlUnroll2)

--- a/testsuite/tests/flambda2/examples/unroll3.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll3.raw.reference
@@ -1,7 +1,7 @@
 let $camlUnroll3__first_const = Block 0 () in
 (let code rec size(23)
        even_0 (n : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -16,13 +16,13 @@ let $camlUnroll3__first_const = Block 0 () in
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(odd_1)
+       apply direct(odd_1 &my_alloc_region)
          (odd ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
  and code rec size(23)
        odd_1 (n : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -37,18 +37,22 @@ let $camlUnroll3__first_const = Block 0 () in
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(even_0)
+       apply direct(even_0 &my_alloc_region)
          (even ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
  in
- let even = closure even_0 @even and odd = closure odd_1 @odd in
- apply direct(even_0) unroll(4) (even : _ -> imm tagged) (3) -> k1 * error
+ let even = closure even_0 @even &toplevel.alloc_region
+ and odd = closure odd_1 @odd &toplevel.alloc_region
+ in
+ apply direct(even_0 &toplevel.alloc_region) unroll(4)
+   (even : _ -> imm tagged) (3) -> k1 * error
    where k1 (three_is_even : imm tagged) =
-     (apply direct(odd_1) unroll(2) (odd : _ -> imm tagged) (4) -> k1 * error
+     (apply direct(odd_1 &toplevel.alloc_region) unroll(2)
+        (odd : _ -> imm tagged) (4) -> k1 * error
         where k1 (four_is_odd : imm tagged) =
           let Pmakeblock =
-            %block.[`0`] (even, odd, three_is_even, four_is_odd)
+            %block.[`0`].`toplevel` (even, odd, three_is_even, four_is_odd)
           in
           cont k (Pmakeblock)))
   where k define_root_symbol (module_block) =

--- a/testsuite/tests/flambda2/examples/unroll3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll3.simplify.reference
@@ -1,11 +1,11 @@
 let code odd_1 deleted and code even_0 deleted in
 let $camlUnroll3__even_2 =
-  closure even_0_1 @even
+  closure even_0_1 @even &toplevel.alloc_region
 and $camlUnroll3__odd_3 =
-  closure odd_1_1 @odd
+  closure odd_1_1 @odd &toplevel.alloc_region
 and code rec loopify(never) size(18) newer_version_of(odd_1)
       odd_1_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %phys_eq (n, 0) in
@@ -14,14 +14,14 @@ and code rec loopify(never) size(18) newer_version_of(odd_1)
     | 1 -> k (0)
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(even_0_1)
+      apply direct(even_0_1 &my_alloc_region)
         ($camlUnroll3__even_2 ~ depth my_depth -> succ my_depth
          : _ -> imm tagged)
           (int_sub)
           -> k * k1
 and code rec loopify(never) size(18) newer_version_of(even_0)
       even_0_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %phys_eq (n, 0) in
@@ -30,13 +30,13 @@ and code rec loopify(never) size(18) newer_version_of(even_0)
     | 1 -> k (1)
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(odd_1_1)
+      apply direct(odd_1_1 &my_alloc_region)
         ($camlUnroll3__odd_3 ~ depth my_depth -> succ my_depth
          : _ -> imm tagged)
           (int_sub)
           -> k * k1
 in
-apply direct(odd_1_1) inlining_state(depth(20))
+apply direct(odd_1_1 &toplevel.alloc_region) inlining_state(depth(20))
   ($camlUnroll3__odd_3 ~ depth unroll 1 1 -> unroll 0 2 : _ -> imm tagged)
     (2)
     -> k * error

--- a/testsuite/tests/flambda2/examples/unroll4.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.raw.reference
@@ -1,7 +1,7 @@
 let $camlUnroll4__first_const = Block 0 () in
 (let code rec size(31)
        even_1 (n : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let k = %project_value_slot.[even].[k] (my_closure) in
@@ -18,14 +18,12 @@ let $camlUnroll4__first_const = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(odd_2)
+       apply direct(odd_2 &my_alloc_region)
          odd ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
-       apply inlined(hint) k (1) -> k1 * k2
+       apply &my_alloc_region inlined(hint) k (1) -> k1 * k2
  and code rec size(31)
-       odd_2 (n : imm tagged)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2 =
+       odd_2 (n : imm tagged) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let k = %project_value_slot.[odd].[k] (my_closure) in
    let even = %project_function_slot.[odd].[even] (my_closure) in
@@ -41,18 +39,18 @@ let $camlUnroll4__first_const = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(even_1)
+       apply direct(even_1 &my_alloc_region)
          even ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
-       apply inlined(hint) k (0) -> k1 * k2
+       apply &my_alloc_region inlined(hint) k (0) -> k1 * k2
  in
  let code inline(always) size(93)
        parity_is_0 (p : imm tagged, n : imm tagged, k : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   let even = closure even_1 @even
-   and odd = closure odd_2 @odd
+   let even = closure even_1 @even &my_alloc_region
+   and odd = closure odd_2 @odd &my_alloc_region
    with { k = k }
    in
    (let untagged = %untag_imm (p) in
@@ -64,25 +62,25 @@ let $camlUnroll4__first_const = Block 0 () in
      where k5 =
        cont k4
      where k4 =
-       apply direct(even_1) unroll(3) even (n) -> k1 * k2
+       apply direct(even_1 &my_alloc_region) unroll(3) even (n) -> k1 * k2
      where k3 =
-       apply direct(odd_2) unroll(4) odd (n) -> k1 * k2
+       apply direct(odd_2 &my_alloc_region) unroll(4) odd (n) -> k1 * k2
  in
  let code inline(always) size(1)
-       k_3 (b) my_closure _region _ghost_region my_depth -> k1 * k2 =
+       k_3 (b) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    cont k1 (b)
  in
- let parity_is = closure parity_is_0 @parity_is in
- let k = closure k_3 @k in
- apply direct(parity_is_0)
+ let parity_is = closure parity_is_0 @parity_is &toplevel.alloc_region in
+ let k = closure k_3 @k &toplevel.alloc_region in
+ apply direct(parity_is_0 &toplevel.alloc_region)
    (parity_is : _ -> imm tagged) (0, 1, k) -> k1 * error
    where k1 (one_is_even : imm tagged) =
-     (apply direct(parity_is_0)
+     (apply direct(parity_is_0 &toplevel.alloc_region)
         (parity_is : _ -> imm tagged) (1, 4, k) -> k1 * error
         where k1 (four_is_odd : imm tagged) =
           let Pmakeblock =
-            %block.[`0`] (parity_is, k, one_is_even, four_is_odd)
+            %block.[`0`].`toplevel` (parity_is, k, one_is_even, four_is_odd)
           in
           cont k (Pmakeblock)))
   where k define_root_symbol (module_block) =

--- a/testsuite/tests/flambda2/examples/unroll4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.simplify.reference
@@ -2,9 +2,7 @@ let code odd_2 deleted and code even_1 deleted in
 let code parity_is_0 deleted in
 let code k_3 deleted in
 let code rec loopify(never) size(26) newer_version_of(odd_2)
-      odd_2_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
+      odd_2_1 (n : imm tagged) my_closure &my_alloc_region my_depth -> k * k1 =
   let k = %project_value_slot.[odd].[k] (my_closure) in
   let even = %project_function_slot.[odd].[even] (my_closure) in
   let prim = %phys_eq (n, 0) in
@@ -12,14 +10,14 @@ let code rec loopify(never) size(26) newer_version_of(odd_2)
     | 0 -> k2
     | 1 -> k3
     where k3 =
-      apply inlined(hint) k (0) -> k * k1
+      apply &my_alloc_region inlined(hint) k (0) -> k * k1
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(even_1_1)
+      apply direct(even_1_1 &my_alloc_region)
         even ~ depth my_depth -> succ my_depth (int_sub) -> k * k1
 and code rec loopify(never) size(26) newer_version_of(even_1)
       even_1_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let k = %project_value_slot.[even].[k] (my_closure) in
   let odd = %project_function_slot.[even].[odd] (my_closure) in
@@ -28,18 +26,18 @@ and code rec loopify(never) size(26) newer_version_of(even_1)
     | 0 -> k2
     | 1 -> k3
     where k3 =
-      apply inlined(hint) k (1) -> k * k1
+      apply &my_alloc_region inlined(hint) k (1) -> k * k1
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(odd_2_1)
+      apply direct(odd_2_1 &my_alloc_region)
         odd ~ depth my_depth -> succ my_depth (int_sub) -> k * k1
 in
 let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
       parity_is_0_1 (p : imm tagged, n : imm tagged, k : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  let even = closure even_1_1 @even
-  and odd = closure odd_2_1 @odd
+  let even = closure even_1_1 @even &my_alloc_region
+  and odd = closure odd_2_1 @odd &my_alloc_region
   with { k = k }
   in
   (let untagged = %untag_imm (p) in
@@ -52,7 +50,8 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
          | 0 -> k3
          | 1 -> k4
          where k4 =
-           apply inlined(hint) inlining_state(depth(10)) k (0) -> k * k1
+           apply &my_alloc_region inlined(hint) inlining_state(depth(10))
+             k (0) -> k * k1
          where k3 =
            let int_sub = %int_barith.sub (n, 1) in
            let prim_1 = %phys_eq (int_sub, 0) in
@@ -60,7 +59,9 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
               | 0 -> k3
               | 1 -> k4
               where k4 =
-                apply inlined(hint) inlining_state(depth(20)) k (1) -> k * k1
+                apply &my_alloc_region inlined(hint)
+                       inlining_state(depth(20))
+                  k (1) -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
                 let prim_2 = %phys_eq (int_sub_1, 0) in
@@ -68,7 +69,8 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                    | 0 -> k3
                    | 1 -> k4
                    where k4 =
-                     apply inlined(hint) inlining_state(depth(30))
+                     apply &my_alloc_region inlined(hint)
+                            inlining_state(depth(30))
                        k (0) -> k * k1
                    where k3 =
                      let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
@@ -77,11 +79,13 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                         | 0 -> k3
                         | 1 -> k4
                         where k4 =
-                          apply inlined(hint) inlining_state(depth(40))
+                          apply &my_alloc_region inlined(hint)
+                                 inlining_state(depth(40))
                             k (1) -> k * k1
                         where k3 =
                           let int_sub_3 = %int_barith.sub (int_sub_2, 1) in
-                          apply direct(odd_2_1) inlining_state(depth(40))
+                          apply direct(odd_2_1 &my_alloc_region)
+                                 inlining_state(depth(40))
                             odd ~ depth 0 -> unroll 0 4 (int_sub_3) -> k * k1))))
     where k2 =
       let prim = %phys_eq (n, 0) in
@@ -89,7 +93,8 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
          | 0 -> k2
          | 1 -> k3
          where k3 =
-           apply inlined(hint) inlining_state(depth(10)) k (1) -> k * k1
+           apply &my_alloc_region inlined(hint) inlining_state(depth(10))
+             k (1) -> k * k1
          where k2 =
            let int_sub = %int_barith.sub (n, 1) in
            let prim_1 = %phys_eq (int_sub, 0) in
@@ -97,7 +102,9 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
               | 0 -> k2
               | 1 -> k3
               where k3 =
-                apply inlined(hint) inlining_state(depth(20)) k (0) -> k * k1
+                apply &my_alloc_region inlined(hint)
+                       inlining_state(depth(20))
+                  k (0) -> k * k1
               where k2 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
                 let prim_2 = %phys_eq (int_sub_1, 0) in
@@ -105,29 +112,34 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                    | 0 -> k2
                    | 1 -> k3
                    where k3 =
-                     apply inlined(hint) inlining_state(depth(30))
+                     apply &my_alloc_region inlined(hint)
+                            inlining_state(depth(30))
                        k (1) -> k * k1
                    where k2 =
                      let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
-                     apply direct(odd_2_1) inlining_state(depth(30))
+                     apply direct(odd_2_1 &my_alloc_region)
+                            inlining_state(depth(30))
                        odd ~ depth 0 -> unroll 0 3 (int_sub_2) -> k * k1)))
 in
-let $camlUnroll4__parity_is_4 = closure parity_is_0_1 @parity_is in
+let $camlUnroll4__parity_is_4 =
+  closure parity_is_0_1 @parity_is &toplevel.alloc_region
+in
 let code inline(always) loopify(never) size(1) newer_version_of(k_3)
-      k_3_1 (b) my_closure _region _ghost_region my_depth -> k * k1 =
+      k_3_1 (b) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (b)
 in
-let $camlUnroll4__k_5 = closure k_3_1 @k in
-apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
+let $camlUnroll4__k_5 = closure k_3_1 @k &toplevel.alloc_region in
+apply direct(k_3_1 &toplevel.alloc_region) inlined(hint)
+       inlining_state(depth(21))
   $camlUnroll4__k_5 (0) -> k * error
   where k (one_is_even : imm tagged) =
     ((let $camlUnroll4__even_8 =
-        closure even_1_2 @even
+        closure even_1_2 @even &toplevel.alloc_region
       and $camlUnroll4__odd_9 =
-        closure odd_2_2 @odd
+        closure odd_2_2 @odd &toplevel.alloc_region
       and code rec loopify(never) size(18) newer_version_of(odd_2_1)
             odd_2_2 (n : imm tagged)
-              my_closure _region _ghost_region my_depth
+              my_closure &my_alloc_region my_depth
               -> k1 * k2 =
         let prim = %phys_eq (n, 0) in
         switch prim
@@ -135,13 +147,13 @@ apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
           | 1 -> k1 (0)
           where k3 =
             let int_sub = %int_barith.sub (n, 1) in
-            apply direct(even_1_2) inlining_state(depth(1))
+            apply direct(even_1_2 &my_alloc_region) inlining_state(depth(1))
               $camlUnroll4__even_8 ~ depth my_depth -> succ my_depth
                 (int_sub)
                 -> k1 * k2
       and code rec loopify(never) size(18) newer_version_of(even_1_1)
             even_1_2 (n : imm tagged)
-              my_closure _region _ghost_region my_depth
+              my_closure &my_alloc_region my_depth
               -> k1 * k2 =
         let prim = %phys_eq (n, 0) in
         switch prim
@@ -149,13 +161,13 @@ apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
           | 1 -> k1 (1)
           where k3 =
             let int_sub = %int_barith.sub (n, 1) in
-            apply direct(odd_2_2) inlining_state(depth(1))
+            apply direct(odd_2_2 &my_alloc_region) inlining_state(depth(1))
               $camlUnroll4__odd_9 ~ depth my_depth -> succ my_depth
                 (int_sub)
                 -> k1 * k2
         with { k = $camlUnroll4__k_5 }
       in
-      apply direct(odd_2_2) inlining_state(depth(41))
+      apply direct(odd_2_2 &toplevel.alloc_region) inlining_state(depth(41))
         $camlUnroll4__odd_9 ~ depth 0 -> unroll 0 4 (0) -> k * error)
        where k (four_is_odd : imm tagged) =
          let $camlUnroll4 =

--- a/testsuite/tests/flambda2/examples/unroll5.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll5.raw.reference
@@ -1,8 +1,6 @@
 let $camlUnroll5__first_const = Block 0 () in
 (let code rec loopify(never) size(25)
-       foo_0 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
-         -> k1 * k2 =
+       foo_0 (x : imm tagged) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    (let Popaque = %opaque (1) in
     (let untagged = %untag_imm (Popaque) in
@@ -15,42 +13,48 @@ let $camlUnroll5__first_const = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (x, 1) in
-       apply direct(foo_0)
+       apply direct(foo_0 &my_alloc_region)
          my_closure ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
        let int_add = %int_barith.add (x, 1) in
-       apply direct(foo_0) unroll(2)
+       apply direct(foo_0 &my_alloc_region) unroll(2)
          my_closure ~ depth my_depth -> next_depth (int_add) -> k1 * k2
  in
  let code size(5)
        test1_1 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[test1].[foo] (my_closure) in
-   apply direct(foo_0) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) foo (x) -> k1 * k2
  in
  let code size(5)
        test2_2 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[test2].[foo_1] (my_closure) in
-   apply direct(foo_0) unroll(1) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) unroll(1) foo (x) -> k1 * k2
  in
  let code size(5)
        test3_3 (x : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[test3].[foo_2] (my_closure) in
-   apply direct(foo_0) unroll(3) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) unroll(3) foo (x) -> k1 * k2
  in
- let foo = closure foo_0 @foo in
- let test1 = closure test1_1 @test1 with { foo = foo } in
- let test2 = closure test2_2 @test2 with { foo_1 = foo } in
- let test3 = closure test3_3 @test3 with { foo_2 = foo } in
- let Pmakeblock = %block.[`0`] (foo, test1, test2, test3) in
+ let foo = closure foo_0 @foo &toplevel.alloc_region in
+ let test1 = closure test1_1 @test1 &toplevel.alloc_region
+ with { foo = foo }
+ in
+ let test2 = closure test2_2 @test2 &toplevel.alloc_region
+ with { foo_1 = foo }
+ in
+ let test3 = closure test3_3 @test3 &toplevel.alloc_region
+ with { foo_2 = foo }
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (foo, test1, test2, test3) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`4`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll5.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll5.simplify.reference
@@ -3,11 +3,9 @@ let code test1_1 deleted in
 let code test2_2 deleted in
 let code test3_3 deleted in
 let $camlUnroll5__foo_4 =
-  closure foo_0_1 @foo
+  closure foo_0_1 @foo &toplevel.alloc_region
 and code rec loopify(never) size(80) newer_version_of(foo_0)
-      foo_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
+      foo_0_1 (x : imm tagged) my_closure &my_alloc_region my_depth -> k * k1 =
   let Popaque = %opaque (1) in
   (let untagged = %untag_imm (Popaque) in
    switch untagged
@@ -29,13 +27,15 @@ and code rec loopify(never) size(80) newer_version_of(foo_0)
                | 1 -> k5)
               where k5 =
                 let int_add_2 = %int_barith.add (int_add_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(20))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_add_2)
                     -> k * k1
               where k4 =
                 let int_sub = %int_barith.sub (int_add_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(20))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_sub)
                     -> k * k1)
@@ -48,33 +48,36 @@ and code rec loopify(never) size(80) newer_version_of(foo_0)
                | 1 -> k4)
               where k4 =
                 let int_add_1 = %int_barith.add (int_sub, 1) in
-                apply direct(foo_0_1) inlining_state(depth(20))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_add_1)
                     -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
-                apply direct(foo_0_1) inlining_state(depth(20))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_sub_1)
                     -> k * k1))
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(foo_0_1)
+      apply direct(foo_0_1 &my_alloc_region)
         $camlUnroll5__foo_4 ~ depth my_depth -> succ my_depth
           (int_sub)
           -> k * k1
 in
 let code loopify(never) size(4) newer_version_of(test1_1)
       test1_1_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(foo_0_1) $camlUnroll5__foo_4 (x) -> k * k1
+  apply direct(foo_0_1 &my_alloc_region) $camlUnroll5__foo_4 (x) -> k * k1
 in
-let $camlUnroll5__test1_5 = closure test1_1_1 @test1 in
+let $camlUnroll5__test1_5 = closure test1_1_1 @test1 &toplevel.alloc_region
+in
 let code loopify(never) size(80) newer_version_of(test2_2)
       test2_2_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let Popaque = %opaque (1) in
   (let untagged = %untag_imm (Popaque) in
@@ -97,13 +100,15 @@ let code loopify(never) size(80) newer_version_of(test2_2)
                | 1 -> k5)
               where k5 =
                 let int_add_2 = %int_barith.add (int_add_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (int_add_2)
                     -> k * k1
               where k4 =
                 let int_sub = %int_barith.sub (int_add_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (int_sub)
                     -> k * k1)
@@ -116,27 +121,30 @@ let code loopify(never) size(80) newer_version_of(test2_2)
                | 1 -> k4)
               where k4 =
                 let int_add_1 = %int_barith.add (int_sub, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (int_add_1)
                     -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (int_sub_1)
                     -> k * k1))
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(foo_0_1) inlining_state(depth(10))
+      apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(10))
         $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 1
           (int_sub)
           -> k * k1
 in
-let $camlUnroll5__test2_6 = closure test2_2_1 @test2 in
+let $camlUnroll5__test2_6 = closure test2_2_1 @test2 &toplevel.alloc_region
+in
 let code loopify(never) size(232) newer_version_of(test3_3)
       test3_3_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   let Popaque = %opaque (1) in
   (let untagged = %untag_imm (Popaque) in
@@ -159,13 +167,15 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                | 1 -> k5)
               where k5 =
                 let int_add_2 = %int_barith.add (int_add_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (int_add_2)
                     -> k * k1
               where k4 =
                 let int_sub = %int_barith.sub (int_add_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (int_sub)
                     -> k * k1)
@@ -178,13 +188,15 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                | 1 -> k4)
               where k4 =
                 let int_add_1 = %int_barith.add (int_sub, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (int_add_1)
                     -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (int_sub_1)
                     -> k * k1))
@@ -211,13 +223,15 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                     | 1 -> k5)
                    where k5 =
                      let int_add_2 = %int_barith.add (int_add_1, 1) in
-                     apply direct(foo_0_1) inlining_state(depth(40))
+                     apply direct(foo_0_1 &my_alloc_region)
+                            inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (int_add_2)
                          -> k * k1
                    where k4 =
                      let int_sub_1 = %int_barith.sub (int_add_1, 1) in
-                     apply direct(foo_0_1) inlining_state(depth(40))
+                     apply direct(foo_0_1 &my_alloc_region)
+                            inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (int_sub_1)
                          -> k * k1)
@@ -230,13 +244,15 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                     | 1 -> k4)
                    where k4 =
                      let int_add_1 = %int_barith.add (int_sub_1, 1) in
-                     apply direct(foo_0_1) inlining_state(depth(40))
+                     apply direct(foo_0_1 &my_alloc_region)
+                            inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (int_add_1)
                          -> k * k1
                    where k3 =
                      let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
-                     apply direct(foo_0_1) inlining_state(depth(40))
+                     apply direct(foo_0_1 &my_alloc_region)
+                            inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (int_sub_2)
                          -> k * k1))
@@ -263,13 +279,15 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                          | 1 -> k5)
                         where k5 =
                           let int_add_2 = %int_barith.add (int_add_1, 1) in
-                          apply direct(foo_0_1) inlining_state(depth(50))
+                          apply direct(foo_0_1 &my_alloc_region)
+                                 inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (int_add_2)
                               -> k * k1
                         where k4 =
                           let int_sub_2 = %int_barith.sub (int_add_1, 1) in
-                          apply direct(foo_0_1) inlining_state(depth(50))
+                          apply direct(foo_0_1 &my_alloc_region)
+                                 inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (int_sub_2)
                               -> k * k1)
@@ -282,24 +300,28 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                          | 1 -> k4)
                         where k4 =
                           let int_add_1 = %int_barith.add (int_sub_2, 1) in
-                          apply direct(foo_0_1) inlining_state(depth(50))
+                          apply direct(foo_0_1 &my_alloc_region)
+                                 inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (int_add_1)
                               -> k * k1
                         where k3 =
                           let int_sub_3 = %int_barith.sub (int_sub_2, 1) in
-                          apply direct(foo_0_1) inlining_state(depth(50))
+                          apply direct(foo_0_1 &my_alloc_region)
+                                 inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (int_sub_3)
                               -> k * k1))
               where k2 =
                 let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
-                apply direct(foo_0_1) inlining_state(depth(30))
+                apply direct(foo_0_1 &my_alloc_region)
+                       inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 3
                     (int_sub_2)
                     -> k * k1))
 in
-let $camlUnroll5__test3_7 = closure test3_3_1 @test3 in
+let $camlUnroll5__test3_7 = closure test3_3_1 @test3 &toplevel.alloc_region
+in
 let $camlUnroll5 =
   Block 0 ($camlUnroll5__foo_4,
            $camlUnroll5__test1_5,

--- a/testsuite/tests/flambda2/examples/value_slot_c.simplify.reference
+++ b/testsuite/tests/flambda2/examples/value_slot_c.simplify.reference
@@ -1,22 +1,22 @@
-let $camlValue_slot_c__immstring116 = "value_slot_c.ml" in
-let $camlValue_slot_c__const_block118 =
-  Block 0 ($camlValue_slot_c__immstring116, 24, 2)
+let $camlValue_slot_c__immstring130 = "value_slot_c.ml" in
+let $camlValue_slot_c__const_block132 =
+  Block 0 ($camlValue_slot_c__immstring130, 24, 2)
 in
-let $camlValue_slot_c__Pmakeblock121 =
+let $camlValue_slot_c__Pmakeblock135 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlValue_slot_c__const_block118)
+           $camlValue_slot_c__const_block132)
 in
-let $camlValue_slot_c__const_block129 =
-  Block 0 ($camlValue_slot_c__immstring116, 25, 2)
+let $camlValue_slot_c__const_block143 =
+  Block 0 ($camlValue_slot_c__immstring130, 25, 2)
 in
-let $camlValue_slot_c__Pmakeblock132 =
+let $camlValue_slot_c__Pmakeblock146 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlValue_slot_c__const_block129)
+           $camlValue_slot_c__const_block143)
 in
 let code f_3 deleted in
 let code loopify(never) size(59) newer_version_of(f_3)
       f_3_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (b) in
@@ -30,7 +30,7 @@ let code loopify(never) size(59) newer_version_of(f_3)
       let Pfield = %block_load.[`1`] ($Value_slot_b.camlValue_slot_b) in
       cont k2 (Pfield)
     where k2 (g : val) =
-      (apply inlined(always) g (3) -> k2 * k1
+      (apply &my_alloc_region inlined(always) g (3) -> k2 * k1
          where k2 (`*match*` : [ 0 of imm tagged * imm tagged ]) =
            let x = %block_load.[`0`] (`*match*`) in
            ((let prim = %phys_eq (x, 0) in
@@ -41,16 +41,16 @@ let code loopify(never) size(59) newer_version_of(f_3)
                  let prim_1 = %phys_eq (x, 1) in
                  switch prim_1
                    | 0 ->
-                     k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock121)
+                     k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock135)
                    | 1 -> k2)
               where k2 =
                 let Pfield = %block_load.[`1`] (`*match*`) in
                 let prim = %phys_eq (Pfield, 3) in
                 switch prim
                   | 0 ->
-                    k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock132)
+                    k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock146)
                   | 1 -> k (0)))
 in
-let $camlValue_slot_c__f_4 = closure f_3_1 @f in
+let $camlValue_slot_c__f_4 = closure f_3_1 @f &toplevel.alloc_region in
 let $camlValue_slot_c = Block 0 ($camlValue_slot_c__f_4) in
 cont done ($camlValue_slot_c)

--- a/testsuite/tests/flambda2/examples/value_slot_use_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/value_slot_use_b.simplify.reference
@@ -4,17 +4,17 @@
     | 0 -> k1
     | 1 -> k2)
    where k2 =
-     apply direct(f_0) inlined(always)
+     apply direct(f_0 &toplevel.alloc_region) inlined(always)
        ($Value_slot_use_a.camlValue_slot_use_a__f_2 : _ -> val)
          (0)
          -> k * error
    where k1 =
-     apply direct(f_0) inlined(always)
+     apply direct(f_0 &toplevel.alloc_region) inlined(always)
        ($Value_slot_use_a.camlValue_slot_use_a__f_2 : _ -> val)
          (1)
          -> k * error)
   where k (g : val) =
-    (apply inlined(never) g (2) -> k1 * error
+    (apply &toplevel.alloc_region inlined(never) g (2) -> k1 * error
        where k1 (param : [ 0 of imm tagged * imm tagged ]) =
          cont k
        where k =

--- a/testsuite/tests/flambda2/examples/variant_ah.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_ah.simplify.reference
@@ -2,7 +2,7 @@ let code maybe_0 deleted in
 let code shouldn't_alloc_1 deleted in
 let code inline(always) loopify(never) size(18) newer_version_of(maybe_0)
       maybe_0_1 (b : imm tagged, x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
   (let untagged = %untag_imm (b) in
@@ -10,13 +10,15 @@ let code inline(always) loopify(never) size(18) newer_version_of(maybe_0)
      | 0 -> k (0)
      | 1 -> k2)
     where k2 =
-      let Pmakeblock = %block.[`0`] (x) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (x) in
       cont k (Pmakeblock)
 in
-let $camlVariant_ah__maybe_2 = closure maybe_0_1 @maybe in
+let $camlVariant_ah__maybe_2 =
+  closure maybe_0_1 @maybe &toplevel.alloc_region
+in
 let code loopify(never) size(33) newer_version_of(shouldn't_alloc_1)
       shouldn't_alloc_1_1 (f : val, g : val, b : imm tagged, x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   (let untagged = %untag_imm (b) in
    switch untagged
@@ -27,12 +29,12 @@ let code loopify(never) size(33) newer_version_of(shouldn't_alloc_1)
          | 0 -> k2
          | 1 -> k3
          where k3 =
-           apply g (0) -> k * k1
+           apply &my_alloc_region g (0) -> k * k1
          where k2 =
-           apply f (unboxed_field_0_0) -> k * k1)
+           apply &my_alloc_region f (unboxed_field_0_0) -> k * k1)
 in
 let $camlVariant_ah__shouldn't_alloc_3 =
-  closure shouldn't_alloc_1_1 @shouldn't_alloc
+  closure shouldn't_alloc_1_1 @shouldn't_alloc &toplevel.alloc_region
 in
 let $camlVariant_ah =
   Block 0 ($camlVariant_ah__maybe_2, $camlVariant_ah__shouldn't_alloc_3)

--- a/testsuite/tests/flambda2/examples/variant_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_unboxed.simplify.reference
@@ -1,10 +1,10 @@
-let $camlVariant_unboxed__immstring26 = "variant_unboxed.ml" in
-let $camlVariant_unboxed__const_block28 =
-  Block 0 ($camlVariant_unboxed__immstring26, 32, 14)
+let $camlVariant_unboxed__immstring28 = "variant_unboxed.ml" in
+let $camlVariant_unboxed__const_block30 =
+  Block 0 ($camlVariant_unboxed__immstring28, 32, 14)
 in
-let $camlVariant_unboxed__Pmakeblock31 =
+let $camlVariant_unboxed__Pmakeblock33 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlVariant_unboxed__const_block28)
+           $camlVariant_unboxed__const_block30)
 in
 let code foo_0 deleted in
 let code loopify(never) size(47) newer_version_of(foo_0)
@@ -14,7 +14,7 @@ let code loopify(never) size(47) newer_version_of(foo_0)
          x1 : imm tagged,
          x2 : imm tagged,
          y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (b) in
@@ -53,7 +53,7 @@ let code loopify(never) size(47) newer_version_of(foo_0)
       (switch tag
          | 0 -> k2
          | 1 -> k3
-         | 2 -> k1 pop(regular k1) ($camlVariant_unboxed__Pmakeblock31)
+         | 2 -> k1 pop(regular k1) ($camlVariant_unboxed__Pmakeblock33)
          where k3 =
            let prim = %unbox_num.`float` (unboxed_field_1_1) in
            let prim_1 = %num_conv.[`float`].[`imm`] (prim) in
@@ -66,6 +66,7 @@ let code loopify(never) size(47) newer_version_of(foo_0)
            in
            cont k (int_add))
 in
-let $camlVariant_unboxed__foo_1 = closure foo_0_1 @foo in
+let $camlVariant_unboxed__foo_1 = closure foo_0_1 @foo &toplevel.alloc_region
+in
 let $camlVariant_unboxed = Block 0 ($camlVariant_unboxed__foo_1) in
 cont done ($camlVariant_unboxed)

--- a/testsuite/tests/flambda2/examples/variant_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_unboxing.simplify.reference
@@ -3,7 +3,7 @@ let code f2_1 deleted in
 let code f3_returning_a_2 deleted in
 let code loopify(never) size(11) newer_version_of(f1_0)
       f1_0_1 (b : imm tagged, x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (b) in
@@ -13,10 +13,11 @@ let code loopify(never) size(11) newer_version_of(f1_0)
         | 0 -> k (unboxed_field_0_0)
         | 1 -> k (1)
 in
-let $camlVariant_unboxing__f1_3 = closure f1_0_1 @f1 in
+let $camlVariant_unboxing__f1_3 = closure f1_0_1 @f1 &toplevel.alloc_region
+in
 let code loopify(never) size(94) newer_version_of(f2_1)
       f2_1_1 (x : imm tagged, y : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -39,7 +40,9 @@ let code loopify(never) size(94) newer_version_of(f2_1)
           | 0 -> k4
           | 1 -> k5)
          where k5 =
-           let Pmakeblock = %block.[`0`].`local`[`region`] (a) in
+           let Pmakeblock =
+             %block.[`0`].my_alloc_region.`local`[`region`] (a)
+           in
            cont k3
                   (Pmakeblock,
                    0i,
@@ -54,7 +57,9 @@ let code loopify(never) size(94) newer_version_of(f2_1)
                | 0 -> k4
                | 1 -> k5)
               where k5 =
-                let Pmakeblock = %block.[`0`].`local`[`region`] (b) in
+                let Pmakeblock =
+                  %block.[`0`].my_alloc_region.`local`[`region`] (b)
+                in
                 cont k3
                        (Pmakeblock,
                         0i,
@@ -63,7 +68,9 @@ let code loopify(never) size(94) newer_version_of(f2_1)
                         poison.val.variant_unboxing_field,
                         b)
               where k4 =
-                let Pmakeblock = %block.[`1`].`local`[`region`] (a, b) in
+                let Pmakeblock =
+                  %block.[`1`].my_alloc_region.`local`[`region`] (a, b)
+                in
                 cont k3
                        (Pmakeblock,
                         1i,
@@ -99,11 +106,12 @@ let code loopify(never) size(94) newer_version_of(f2_1)
       let `unit` = %end_region (`region`) in
       cont k (region_return)
 in
-let $camlVariant_unboxing__f2_4 = closure f2_1_1 @f2 in
+let $camlVariant_unboxing__f2_4 = closure f2_1_1 @f2 &toplevel.alloc_region
+in
 let code loopify(never) size(45) newer_version_of(f3_returning_a_2)
       f3_returning_a_2_1
         (x : imm tagged, y : imm tagged, a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -134,7 +142,7 @@ let code loopify(never) size(45) newer_version_of(f3_returning_a_2)
       cont k (region_return)
 in
 let $camlVariant_unboxing__f3_returning_a_5 =
-  closure f3_returning_a_2_1 @f3_returning_a
+  closure f3_returning_a_2_1 @f3_returning_a &toplevel.alloc_region
 in
 let $camlVariant_unboxing =
   Block 0 ($camlVariant_unboxing__f1_3,

--- a/testsuite/tests/flambda2/examples/variants.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variants.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(41) newer_version_of(f_0)
       f_0_1 (t : [ 0 |1 | 0 of imm tagged |1 of imm tagged * imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %is_int (t) in
@@ -27,6 +27,6 @@ let code loopify(never) size(41) newer_version_of(f_0)
       let Pfield = %block_load.[`0`] (t) in
       cont k (Pfield)
 in
-let $camlVariants__f_1 = closure f_0_1 @f in
+let $camlVariants__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlVariants = Block 0 ($camlVariants__f_1) in
 cont done ($camlVariants)

--- a/testsuite/tests/flambda2/examples/variants_and_if.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variants_and_if.simplify.reference
@@ -1,15 +1,15 @@
 let code f_0 deleted in
-let $camlVariants_and_if__immstring6 = "Variants_and_if.Foo" in
+let $camlVariants_and_if__immstring7 = "Variants_and_if.Foo" in
 apply ccall noalloc
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
-    let $camlVariants_and_if__Foo28 =
+    let $camlVariants_and_if__Foo30 =
       Block immutable_unique
-      248 ($camlVariants_and_if__immstring6, Pccall)
+      248 ($camlVariants_and_if__immstring7, Pccall)
     in
     let code loopify(never) size(33) newer_version_of(f_0)
           f_0_1 (x : imm tagged, t : [ 0 | 0 of imm tagged ])
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       (let untagged = %untag_imm (x) in
@@ -20,15 +20,16 @@ apply ccall noalloc
           let prim = %is_int (t) in
           switch prim
             | 0 -> k2
-            | 1 -> k1 pop(regular k1) ($camlVariants_and_if__Foo28)
+            | 1 -> k1 pop(regular k1) ($camlVariants_and_if__Foo30)
         where k2 =
           let prim = %is_int (t) in
           switch prim
             | 0 -> k (2)
             | 1 -> k (1)
     in
-    let $camlVariants_and_if__f_1 = closure f_0_1 @f in
+    let $camlVariants_and_if__f_1 = closure f_0_1 @f &toplevel.alloc_region
+    in
     let $camlVariants_and_if =
-      Block 0 ($camlVariants_and_if__Foo28, $camlVariants_and_if__f_1)
+      Block 0 ($camlVariants_and_if__Foo30, $camlVariants_and_if__f_1)
     in
     cont done ($camlVariants_and_if)

--- a/testsuite/tests/flambda2/examples/weird.simplify.reference
+++ b/testsuite/tests/flambda2/examples/weird.simplify.reference
@@ -1,18 +1,18 @@
-let $camlWeird__immstring24 = "weird.ml" in
-let $camlWeird__const_block26 = Block 0 ($camlWeird__immstring24, 16, 38) in
-let $camlWeird__Pmakeblock29 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlWeird__const_block26)
+let $camlWeird__immstring26 = "weird.ml" in
+let $camlWeird__const_block28 = Block 0 ($camlWeird__immstring26, 16, 38) in
+let $camlWeird__Pmakeblock31 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlWeird__const_block28)
 in
 let code f_0 deleted in
 let code loopify(never) size(35) newer_version_of(f_0)
       f_0_1 (r : [ 0 of imm tagged |1 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %get_tag (r) in
    switch prim
      | 0 -> k2
-     | 1 -> k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1434))
+     | 1 -> k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1554))
     where k2 =
       ((let Popaque = %opaque (0) in
         let untagged = %untag_imm (Popaque) in
@@ -26,8 +26,8 @@ let code loopify(never) size(35) newer_version_of(f_0)
            let tag = 0i in
            switch tag
              | 0 -> k (unboxed_field_0_0)
-             | 1 -> k1 pop(regular k1) ($camlWeird__Pmakeblock29))
+             | 1 -> k1 pop(regular k1) ($camlWeird__Pmakeblock31))
 in
-let $camlWeird__f_1 = closure f_0_1 @f in
+let $camlWeird__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlWeird = Block 0 ($camlWeird__f_1) in
 cont done ($camlWeird)

--- a/testsuite/tests/flambda2/examples/wrong/cse_with_alias_to_param.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/cse_with_alias_to_param.simplify.reference
@@ -1,13 +1,15 @@
 let code id_0 deleted in
 let code foo_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(id_0)
-      id_0_1 (lam) my_closure _region _ghost_region my_depth -> k * k1 =
+      id_0_1 (lam) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (lam)
 in
-let $camlCse_with_alias_to_param__id_2 = closure id_0_1 @`id` in
+let $camlCse_with_alias_to_param__id_2 =
+  closure id_0_1 @`id` &toplevel.alloc_region
+in
 let code loopify(never) size(42) newer_version_of(foo_1)
       foo_1_1 (v : val, opt : [ 0 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of [ 0 of val ] * [ 0 of val ] ] =
   (let prim = %is_int (opt) in
@@ -15,20 +17,22 @@ let code loopify(never) size(42) newer_version_of(foo_1)
      | 0 -> k3
      | 1 -> k4
      where k4 =
-       let Pmakeblock = %block.[`0`] (v) in
+       let Pmakeblock = %block.[`0`].my_alloc_region (v) in
        cont k2 (Pmakeblock)
      where k3 =
-       let Pmakeblock = %block.[`0`] (v) in
-       apply direct(id_0_1)
+       let Pmakeblock = %block.[`0`].my_alloc_region (v) in
+       apply direct(id_0_1 &my_alloc_region)
          ($camlCse_with_alias_to_param__id_2 : _ -> [ 0 of val ])
            (Pmakeblock)
            -> k2 * k1)
     where k2 (x : [ 0 of val ]) =
-      let Pmakeblock = %block.[`0`] (v) in
-      let Pmakeblock_1 = %block.[`0`] (Pmakeblock, x) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (v) in
+      let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, x) in
       cont k (Pmakeblock_1)
 in
-let $camlCse_with_alias_to_param__foo_3 = closure foo_1_1 @foo in
+let $camlCse_with_alias_to_param__foo_3 =
+  closure foo_1_1 @foo &toplevel.alloc_region
+in
 let $camlCse_with_alias_to_param =
   Block 0 ($camlCse_with_alias_to_param__id_2,
            $camlCse_with_alias_to_param__foo_3)

--- a/testsuite/tests/flambda2/examples/wrong/join_and_aliases.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/join_and_aliases.simplify.reference
@@ -1,21 +1,21 @@
-let $camlJoin_and_aliases__immstring24 = "join_and_aliases.ml" in
-let $camlJoin_and_aliases__const_block26 =
-  Block 0 ($camlJoin_and_aliases__immstring24, 35, 38)
+let $camlJoin_and_aliases__immstring26 = "join_and_aliases.ml" in
+let $camlJoin_and_aliases__const_block28 =
+  Block 0 ($camlJoin_and_aliases__immstring26, 35, 38)
 in
-let $camlJoin_and_aliases__Pmakeblock29 =
+let $camlJoin_and_aliases__Pmakeblock31 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlJoin_and_aliases__const_block26)
+           $camlJoin_and_aliases__const_block28)
 in
 let code f_0 deleted in
 let code loopify(never) size(35) newer_version_of(f_0)
       f_0_1 (r : [ 0 of imm tagged |1 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %get_tag (r) in
    switch prim
      | 0 -> k2
-     | 1 -> k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1434))
+     | 1 -> k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1554))
     where k2 =
       ((let Popaque = %opaque (0) in
         let untagged = %untag_imm (Popaque) in
@@ -29,8 +29,8 @@ let code loopify(never) size(35) newer_version_of(f_0)
            let tag = 0i in
            switch tag
              | 0 -> k (unboxed_field_0_0)
-             | 1 -> k1 pop(regular k1) ($camlJoin_and_aliases__Pmakeblock29))
+             | 1 -> k1 pop(regular k1) ($camlJoin_and_aliases__Pmakeblock31))
 in
-let $camlJoin_and_aliases__f_1 = closure f_0_1 @f in
+let $camlJoin_and_aliases__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlJoin_and_aliases = Block 0 ($camlJoin_and_aliases__f_1) in
 cont done ($camlJoin_and_aliases)

--- a/testsuite/tests/flambda2/examples/wrong/join_match.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/join_match.simplify.reference
@@ -2,7 +2,7 @@ let code g_0 deleted in
 let code bar_1 deleted in
 let code inline(always) loopify(never) size(33) newer_version_of(g_0)
       g_0_1 (t : [ 0 of imm tagged |1 of imm tagged |2 of imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %get_tag (t) in
@@ -23,10 +23,10 @@ let code inline(always) loopify(never) size(33) newer_version_of(g_0)
       let int_add = %int_barith.add (Pfield, 1) in
       cont k (int_add)
 in
-let $camlJoin_match__g_2 = closure g_0_1 @g in
+let $camlJoin_match__g_2 = closure g_0_1 @g &toplevel.alloc_region in
 let code loopify(never) size(40) newer_version_of(bar_1)
       bar_1_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %int_comp.lt (x, 0) in
@@ -49,7 +49,7 @@ let code loopify(never) size(40) newer_version_of(bar_1)
            let int_add = %int_barith.add (unboxed_field_0_0, 1) in
            cont k (int_add))
 in
-let $camlJoin_match__bar_3 = closure bar_1_1 @bar in
+let $camlJoin_match__bar_3 = closure bar_1_1 @bar &toplevel.alloc_region in
 let $camlJoin_match = Block 0 ($camlJoin_match__g_2, $camlJoin_match__bar_3)
 in
 cont done ($camlJoin_match)

--- a/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
@@ -2,18 +2,18 @@ let code f1_0 deleted in
 let code f2_1 deleted in
 let code f3_2 deleted in
 let code f4_3 deleted in
-let $camlLocal_exns_to_jumps__immstring143 = "Local_exns_to_jumps.Exit2" in
-let $camlLocal_exns_to_jumps__immstring6 = "Local_exns_to_jumps.Exit" in
+let $camlLocal_exns_to_jumps__immstring147 = "Local_exns_to_jumps.Exit2" in
+let $camlLocal_exns_to_jumps__immstring7 = "Local_exns_to_jumps.Exit" in
 apply ccall noalloc
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
-    let $camlLocal_exns_to_jumps__Exit209 =
+    let $camlLocal_exns_to_jumps__Exit214 =
       Block immutable_unique
-      248 ($camlLocal_exns_to_jumps__immstring6, Pccall)
+      248 ($camlLocal_exns_to_jumps__immstring7, Pccall)
     in
     let code loopify(never) size(53) newer_version_of(f1_0)
           f1_0_1 (x : imm tagged, g : val)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let try_region = %begin_try_region () in
@@ -27,7 +27,7 @@ apply ccall noalloc
                   | 0 -> k pop(k2) (0)
                   | 1 -> k4
                   where k4 =
-                    (apply g (r_unboxed0) -> k6 * k2
+                    (apply &my_alloc_region g (r_unboxed0) -> k6 * k2
                        where k6 (param : [ 0 |1 ]) =
                          let unboxed_field = %untag_imm (param) in
                          cont k5 (unboxed_field)
@@ -38,22 +38,24 @@ apply ccall noalloc
                            | 1 ->
                              k2
                                pop(regular k2)
-                               ($camlLocal_exns_to_jumps__Exit209)
+                               ($camlLocal_exns_to_jumps__Exit214)
                        where k4 =
                          let int_add = %int_barith.add (r_unboxed0, 1) in
                          cont k3 (int_add))))
         where k2 exn (`exn` : val) =
           let `unit` = %end_try_region (try_region) in
           let unit_1 = %end_try_ghost_region (try_ghost_region) in
-          let prim = %phys_eq (`exn`, $camlLocal_exns_to_jumps__Exit209) in
+          let prim = %phys_eq (`exn`, $camlLocal_exns_to_jumps__Exit214) in
           switch prim
             | 0 -> k1 pop(reraise k1) (`exn`)
             | 1 -> k (42)
     in
-    let $camlLocal_exns_to_jumps__f1_4 = closure f1_0_1 @f1 in
+    let $camlLocal_exns_to_jumps__f1_4 =
+      closure f1_0_1 @f1 &toplevel.alloc_region
+    in
     let code loopify(never) size(47) newer_version_of(f2_1)
           f2_1_1 (x : imm tagged, g : val)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let try_region = %begin_try_region () in
@@ -70,7 +72,7 @@ apply ccall noalloc
                  cont k7 push(k6)
                    where k7 =
                      let r_unboxed0_1 = r_unboxed0 in
-                     (apply g (r_unboxed0) -> k8 * k6
+                     (apply &my_alloc_region g (r_unboxed0) -> k8 * k6
                         where k8 (param : [ 0 |1 ]) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
@@ -97,10 +99,12 @@ apply ccall noalloc
           let unit_1 = %end_try_ghost_region (try_ghost_region) in
           cont k (42)
     in
-    let $camlLocal_exns_to_jumps__f2_5 = closure f2_1_1 @f2 in
+    let $camlLocal_exns_to_jumps__f2_5 =
+      closure f2_1_1 @f2 &toplevel.alloc_region
+    in
     let code loopify(never) size(47) newer_version_of(f3_2)
           f3_2_1 (x : imm tagged, g : val)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : imm tagged =
       let try_region = %begin_try_region () in
@@ -117,7 +121,7 @@ apply ccall noalloc
                  cont k7 push(k6)
                    where k7 =
                      let r_unboxed0_1 = r_unboxed0 in
-                     (apply g (r_unboxed0) -> k8 * k6
+                     (apply &my_alloc_region g (r_unboxed0) -> k8 * k6
                         where k8 (param : [ 0 |1 ]) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
@@ -144,17 +148,19 @@ apply ccall noalloc
           let unit_1 = %end_try_ghost_region (try_ghost_region) in
           cont k (42)
     in
-    let $camlLocal_exns_to_jumps__f3_6 = closure f3_2_1 @f3 in
+    let $camlLocal_exns_to_jumps__f3_6 =
+      closure f3_2_1 @f3 &toplevel.alloc_region
+    in
     (apply ccall noalloc
        ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
        where k (Pccall_1) =
-         let $camlLocal_exns_to_jumps__Exit2391 =
+         let $camlLocal_exns_to_jumps__Exit2399 =
            Block immutable_unique
-           248 ($camlLocal_exns_to_jumps__immstring143, Pccall_1)
+           248 ($camlLocal_exns_to_jumps__immstring147, Pccall_1)
          in
          let code loopify(never) size(55) newer_version_of(f4_3)
                f4_3_1 (x : imm tagged, g : val)
-                 my_closure _region _ghost_region my_depth
+                 my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
            let try_region = %begin_try_region () in
@@ -171,7 +177,7 @@ apply ccall noalloc
                       cont k7 push(k6)
                         where k7 =
                           let r_unboxed0_1 = r_unboxed0 in
-                          (apply g (r_unboxed0) -> k8 * k6
+                          (apply &my_alloc_region g (r_unboxed0) -> k8 * k6
                              where k8 (param : [ 0 |1 ]) =
                                let unboxed_field = %untag_imm (param) in
                                cont k7 (unboxed_field)
@@ -197,26 +203,28 @@ apply ccall noalloc
                                let int_add_1 =
                                  %int_barith.add (r_unboxed0_1, 2)
                                in
-                               cont k2 (int_add_1, int_add)))
+                               cont k2 (int_add, int_add_1)))
                        where k4 =
                          let r_unboxed0_1 = r_unboxed0 in
                          let int_add = %int_barith.add (r_unboxed0_1, 1) in
                          cont k3 (int_add)))
              where k2 (int_add, int_add_1) =
-               let cse_param = int_add_1 in
-               let cse_param_1 = int_add in
+               let cse_param = int_add in
+               let cse_param_1 = int_add_1 in
                let `unit` = %end_try_region (try_region) in
                let unit_1 = %end_try_ghost_region (try_ghost_region) in
                let int_add_2 = %int_barith.add (cse_param_1, cse_param) in
                cont k (int_add_2)
          in
-         let $camlLocal_exns_to_jumps__f4_7 = closure f4_3_1 @f4 in
+         let $camlLocal_exns_to_jumps__f4_7 =
+           closure f4_3_1 @f4 &toplevel.alloc_region
+         in
          let $camlLocal_exns_to_jumps =
-           Block 0 ($camlLocal_exns_to_jumps__Exit209,
+           Block 0 ($camlLocal_exns_to_jumps__Exit214,
                     $camlLocal_exns_to_jumps__f1_4,
                     $camlLocal_exns_to_jumps__f2_5,
                     $camlLocal_exns_to_jumps__f3_6,
-                    $camlLocal_exns_to_jumps__Exit2391,
+                    $camlLocal_exns_to_jumps__Exit2399,
                     $camlLocal_exns_to_jumps__f4_7)
          in
          cont done ($camlLocal_exns_to_jumps))

--- a/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
@@ -1,11 +1,11 @@
-let $camlOpt_flags__immstring26 = "foo" in
+let $camlOpt_flags__immstring29 = "foo" in
 (let try_region = %begin_try_region () in
  let try_ghost_region = %begin_try_ghost_region () in
  cont k3 push(k2)
    where k3 =
      (apply ccall
         ($`*extern*`.caml_sys_getenv : val -> val)
-          ($camlOpt_flags__immstring26)
+          ($camlOpt_flags__immstring29)
           -> k4 * k2
         where k4 (param) =
           cont k3
@@ -21,6 +21,6 @@ let $camlOpt_flags__immstring26 = "foo" in
       | 0 -> k (99)
       | 1 -> k (-1)
   where k (y : imm tagged) =
-    let $camlOpt_flags__Pmakeblock138 = Block 0 (42, y, 1701) in
-    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock138) in
+    let $camlOpt_flags__Pmakeblock151 = Block 0 (42, y, 1701) in
+    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock151) in
     cont done ($camlOpt_flags)

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -3,7 +3,7 @@ let code h_2 deleted in
 let code f_0 deleted in
 let code loopify(never) size(12) newer_version_of(g_1)
       g_1_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let x = %project_value_slot.[g].[x] (my_closure) in
@@ -14,11 +14,11 @@ let code loopify(never) size(12) newer_version_of(g_1)
 in
 let code loopify(never) size(10) newer_version_of(h_2)
       h_2_1 (acc : imm tagged, x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let g = %project_value_slot.[h].[g] (my_closure) in
-  apply direct(g_1_1) (g : _ -> imm tagged) (0) -> k2 * k1
+  apply direct(g_1_1 &my_alloc_region) (g : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (acc, x) in
       let int_add_1 = %int_barith.add (int_add, apply_result) in
@@ -26,11 +26,11 @@ let code loopify(never) size(10) newer_version_of(h_2)
 in
 let code loopify(never) size(58) newer_version_of(f_0)
       f_0_1 (x : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let g = closure g_1_1 @g with { x = x } in
-  let h = closure h_2_1 @h with { g = g } in
+  let g = closure g_1_1 @g &my_alloc_region with { x = x } in
+  let h = closure h_2_1 @h &my_alloc_region with { g = g } in
   cont `self` (0, l)
     where rec `self` (accu, l_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let prim = %is_int (l_1) in
@@ -40,11 +40,11 @@ let code loopify(never) size(58) newer_version_of(f_0)
          where k2 =
            let Pfield = %block_load.[`1`] (l_1) in
            ((let Pfield_1 = %block_load.[`0`] (l_1) in
-             apply direct(h_2_1) inlining_state(depth(10))
+             apply direct(h_2_1 &my_alloc_region) inlining_state(depth(10))
                h (accu, Pfield_1) -> k2 * k1)
               where k2 (apply_result) =
                 cont `self` (apply_result, Pfield)))
 in
-let $camlStatic__f_3 = closure f_0_1 @f in
+let $camlStatic__f_3 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlStatic = Block 0 ($camlStatic__f_3) in
 cont done ($camlStatic)

--- a/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
@@ -1,27 +1,29 @@
 let code opaque_0 deleted in
-let $camlUnused_bucket_switch__immstring27 = "urk" in
+let $camlUnused_bucket_switch__immstring30 = "urk" in
 let code f_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(opaque_0)
-      opaque_0_1 (x) my_closure _region _ghost_region my_depth -> k * k1 =
+      opaque_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (x)
 in
-let $camlUnused_bucket_switch__opaque_2 = closure opaque_0_1 @opaque in
+let $camlUnused_bucket_switch__opaque_2 =
+  closure opaque_0_1 @opaque &toplevel.alloc_region
+in
 let `region` = %begin_region () in
 let ghost_region = %begin_ghost_region () in
 (let try_region = %begin_try_region (`region`) in
  let try_ghost_region = %begin_try_ghost_region (ghost_region) in
  cont k3 push(k1)
    where k3 =
-     let $camlUnused_bucket_switch__Pmakeblock68 =
+     let $camlUnused_bucket_switch__Pmakeblock74 =
        Block 0 ($`*predef*`.caml_exn_Failure,
-                $camlUnused_bucket_switch__immstring27)
+                $camlUnused_bucket_switch__immstring30)
      in
      let code loopify(never) size(16) newer_version_of(f_1)
            f_1_1 (param : imm tagged)
-             my_closure _region _ghost_region my_depth
+             my_closure &my_alloc_region my_depth
              -> k3 * k4
              : imm tagged =
-       apply direct(opaque_0_1)
+       apply direct(opaque_0_1 &my_alloc_region)
          ($camlUnused_bucket_switch__opaque_2 : _ -> [ 0 |1 ]) (1) -> k6 * k4
          where k6 (param_1) =
            let unboxed_field = %untag_imm (param_1) in
@@ -30,11 +32,13 @@ let ghost_region = %begin_ghost_region () in
            let naked_immediate = unboxed_field in
            switch naked_immediate
              | 0 ->
-               k4 pop(reraise k4) ($camlUnused_bucket_switch__Pmakeblock68)
+               k4 pop(reraise k4) ($camlUnused_bucket_switch__Pmakeblock74)
              | 1 -> k3 (42)
      in
-     let $camlUnused_bucket_switch__f_3 = closure f_1_1 @f in
-     apply direct(f_1_1)
+     let $camlUnused_bucket_switch__f_3 =
+       closure f_1_1 @f &toplevel.alloc_region
+     in
+     apply direct(f_1_1 &toplevel.alloc_region)
        ($camlUnused_bucket_switch__f_3 : _ -> imm tagged) (0) -> k2 * k1
    where k2 (body_result : imm tagged) =
      cont k pop(k1) (body_result)

--- a/testsuite/tests/flambda2/gadt_simplified_switch.raw.reference
+++ b/testsuite/tests/flambda2/gadt_simplified_switch.raw.reference
@@ -1,6 +1,6 @@
 (let code size(21)
        extract_int_0 (x : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -18,22 +18,25 @@
        let Pfield = %block_load.[`0`] (x) in
        cont k1 (Pfield)
  in
- let $camlGadt_simplified_switch__immstring21 = "A" in
- let $camlGadt_simplified_switch__immstring23 = "B" in
+ let $camlGadt_simplified_switch__immstring24 = "A" in
+ let $camlGadt_simplified_switch__immstring26 = "B" in
  let code size(11)
        extract_string_1 (x : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
    let untagged = %untag_imm (x) in
    switch untagged
-     | 0 -> k1 ($camlGadt_simplified_switch__immstring21)
-     | 1 -> k1 ($camlGadt_simplified_switch__immstring23)
+     | 0 -> k1 ($camlGadt_simplified_switch__immstring24)
+     | 1 -> k1 ($camlGadt_simplified_switch__immstring26)
  in
- let extract_int = closure extract_int_0 @extract_int in
- let extract_string = closure extract_string_1 @extract_string in
- let Pmakeblock = %block.[`0`] (extract_int, extract_string) in
+ let extract_int = closure extract_int_0 @extract_int &toplevel.alloc_region
+ in
+ let extract_string =
+   closure extract_string_1 @extract_string &toplevel.alloc_region
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (extract_int, extract_string) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.simplify.reference
+++ b/testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.simplify.reference
@@ -2,25 +2,29 @@ let code f_0 deleted in
 let code g_1 deleted in
 let code loopify(never) size(8) newer_version_of(f_0)
       f_0_1 (x : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %string_length (x) in
   let Pstringlength = %tag_imm (prim) in
   cont k (Pstringlength)
 in
-let $camlInlining_cost_of_primitive_on_parameters__f_2 = closure f_0_1 @f in
+let $camlInlining_cost_of_primitive_on_parameters__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(g_1)
       g_1_1 (x : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1)
+  apply direct(f_0_1 &my_alloc_region)
     ($camlInlining_cost_of_primitive_on_parameters__f_2 : _ -> imm tagged)
       (x)
       -> k * k1
 in
-let $camlInlining_cost_of_primitive_on_parameters__g_3 = closure g_1_1 @g in
+let $camlInlining_cost_of_primitive_on_parameters__g_3 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let $camlInlining_cost_of_primitive_on_parameters =
   Block 0 ($camlInlining_cost_of_primitive_on_parameters__f_2,
            $camlInlining_cost_of_primitive_on_parameters__g_3)

--- a/testsuite/tests/flambda2/issue5721.simplify.reference
+++ b/testsuite/tests/flambda2/issue5721.simplify.reference
@@ -1,7 +1,7 @@
 let code main_0 deleted in
 let code loopify(never) size(33) newer_version_of(main_0)
       main_0_1 (f : val, x : [ 0 |1 | 0 of val ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %is_int (x) in
@@ -14,7 +14,7 @@ let code loopify(never) size(33) newer_version_of(main_0)
            | 0 -> k2 (1i)
            | 1 -> k3)
           where k3 =
-            (apply f (0) -> k3 * k1
+            (apply &my_alloc_region f (0) -> k3 * k1
                where k3 (param : imm tagged) =
                  cont k2 (1i))))
     where k2 (join_param : imm) =
@@ -22,6 +22,6 @@ let code loopify(never) size(33) newer_version_of(main_0)
       let Pnot = %boolean_not (Pisint) in
       cont k (Pnot)
 in
-let $camlIssue5721__main_1 = closure main_0_1 @main in
+let $camlIssue5721__main_1 = closure main_0_1 @main &toplevel.alloc_region in
 let $camlIssue5721 = Block 0 ($camlIssue5721__main_1) in
 cont done ($camlIssue5721)

--- a/testsuite/tests/flambda2/n_way_join_null.raw.reference
+++ b/testsuite/tests/flambda2/n_way_join_null.raw.reference
@@ -1,7 +1,7 @@
 let $camlN_way_join_null__first_const = Block 0 () in
 (let code size(17)
        main_0 (x)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -18,8 +18,8 @@ let $camlN_way_join_null__first_const = Block 0 () in
      where k3 (y) =
        cont k1 (y)
  in
- let main = closure main_0 @main in
- let Pmakeblock = %block.[`0`] (main) in
+ let main = closure main_0 @main &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (main) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/n_way_join_null.simplify.reference
+++ b/testsuite/tests/flambda2/n_way_join_null.simplify.reference
@@ -1,13 +1,15 @@
 let code main_0 deleted in
 let code loopify(never) size(4) newer_version_of(main_0)
       main_0_1 (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %is_null (x) in
   let tagged_scrutinee = %tag_imm (prim) in
   cont k (tagged_scrutinee)
 in
-let $camlN_way_join_null__main_1 = closure main_0_1 @main in
+let $camlN_way_join_null__main_1 =
+  closure main_0_1 @main &toplevel.alloc_region
+in
 let $camlN_way_join_null = Block 0 ($camlN_way_join_null__main_1) in
 cont done ($camlN_way_join_null)

--- a/testsuite/tests/flambda2/n_way_join_preserves_null.raw.reference
+++ b/testsuite/tests/flambda2/n_way_join_preserves_null.raw.reference
@@ -1,7 +1,7 @@
 let $camlN_way_join_preserves_null__first_const = Block 0 () in
 (let code size(38)
        f_0 (bit : imm tagged, bit' : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -29,8 +29,8 @@ let $camlN_way_join_preserves_null__first_const = Block 0 () in
             let noteq = %tag_imm (prim) in
             cont k1 (noteq))
  in
- let f = closure f_0 @f in
- let Pmakeblock = %block.[`0`] (f) in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/n_way_join_preserves_null.simplify.reference
+++ b/testsuite/tests/flambda2/n_way_join_preserves_null.simplify.reference
@@ -1,7 +1,7 @@
 let code f_0 deleted in
 let code loopify(never) size(30) newer_version_of(f_0)
       f_0_1 (bit : imm tagged, bit' : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %int_comp.lt (bit', 0) in
@@ -20,7 +20,9 @@ let code loopify(never) size(30) newer_version_of(f_0)
            let noteq = %tag_imm (prim) in
            cont k (noteq))
 in
-let $camlN_way_join_preserves_null__f_1 = closure f_0_1 @f in
+let $camlN_way_join_preserves_null__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlN_way_join_preserves_null =
   Block 0 ($camlN_way_join_preserves_null__f_1)
 in

--- a/testsuite/tests/flambda2/removed_operations_of_switch.simplify.reference
+++ b/testsuite/tests/flambda2/removed_operations_of_switch.simplify.reference
@@ -2,7 +2,7 @@ let code f_0 deleted in
 let code g_1 deleted in
 let code loopify(never) size(27) newer_version_of(f_0)
       f_0_1 (b : imm tagged, x, y)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
   (let untagged = %untag_imm (b) in
@@ -10,24 +10,28 @@ let code loopify(never) size(27) newer_version_of(f_0)
      | 0 -> k2
      | 1 -> k3)
     where k3 =
-      let Pmakeblock = %block.[`0`] (x, y) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (x, y) in
       cont k (Pmakeblock)
     where k2 =
-      let Pmakeblock = %block.[`0`] (y, x) in
+      let Pmakeblock = %block.[`0`].my_alloc_region (y, x) in
       cont k (Pmakeblock)
 in
-let $camlRemoved_operations_of_switch__f_2 = closure f_0_1 @f in
+let $camlRemoved_operations_of_switch__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let code loopify(never) size(4) newer_version_of(g_1)
       g_1_1 (b : imm tagged, x, y)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
-  apply direct(f_0_1)
+  apply direct(f_0_1 &my_alloc_region)
     ($camlRemoved_operations_of_switch__f_2 : _ -> [ 0 of val * val ])
       (b, x, y)
       -> k * k1
 in
-let $camlRemoved_operations_of_switch__g_3 = closure g_1_1 @g in
+let $camlRemoved_operations_of_switch__g_3 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
 let $camlRemoved_operations_of_switch =
   Block 0 ($camlRemoved_operations_of_switch__f_2,
            $camlRemoved_operations_of_switch__g_3)

--- a/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
+++ b/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
@@ -36,10 +36,10 @@ let r =
   let y = if Sys.opaque_identity true then A g else B f in
   (k[@inlined]) x y
 [%%expect_fexpr Simplify{|
-let $camlTOP3__immstring54 = "" in
-let $camlTOP3__const_block56 = Block 0 ($camlTOP3__immstring54, 27, 11) in
-let $camlTOP3__Pmakeblock59 =
-  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTOP3__const_block56)
+let $camlTOP3__immstring59 = "" in
+let $camlTOP3__const_block61 = Block 0 ($camlTOP3__immstring59, 27, 11) in
+let $camlTOP3__Pmakeblock64 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTOP3__const_block61)
 in
 (let Popaque = %opaque (1) in
  let untagged = %untag_imm (Popaque) in
@@ -58,12 +58,12 @@ in
             | 1 -> k2
             where k2 =
               switch tag_1
-                | 0 -> error pop(regular error) ($camlTOP3__Pmakeblock59)
+                | 0 -> error pop(regular error) ($camlTOP3__Pmakeblock64)
                 | 1 -> k
             where k1 =
               switch tag_1
                 | 0 -> k
-                | 1 -> error pop(regular error) ($camlTOP3__Pmakeblock59)))
+                | 1 -> error pop(regular error) ($camlTOP3__Pmakeblock64)))
   where k =
     let $camlTOP3 = Block 0 (0) in
     cont done ($camlTOP3)

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
@@ -1,32 +1,34 @@
 let $camlSpeculative_inlining_lifted_constants__first_const = Block 0 () in
 (let code size(8)
        f_0 (x)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   let Pmakeblock = %block.[`0`] (x, x) in
+   let Pmakeblock = %block.[`0`].my_alloc_region (x, x) in
    cont k1 (Pmakeblock)
  in
  let code size(6)
        v1_1 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : [ 0 of imm tagged * imm tagged ] =
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[v1].[f] (my_closure) in
    let one = %project_value_slot.[v1].[one] (my_closure) in
-   apply direct(f_0)
+   apply direct(f_0 &my_alloc_region)
      (f : _ -> [ 0 of imm tagged * imm tagged ]) (one) -> k1 * k2
  in
- let f = closure f_0 @f in
+ let f = closure f_0 @f &toplevel.alloc_region in
  let zero = %opaque (0) in
- apply direct(f_0)
+ apply direct(f_0 &toplevel.alloc_region)
    (f : _ -> [ 0 of imm tagged * imm tagged ]) (zero) -> k1 * error
    where k1 (v0 : [ 0 of imm tagged * imm tagged ]) =
      let one = %opaque (1) in
-     let v1 = closure v1_1 @v1 with { f = f; one = one } in
-     let Pmakeblock = %block.[`0`] (f, zero, v0, one, v1) in
+     let v1 = closure v1_1 @v1 &toplevel.alloc_region
+     with { f = f; one = one }
+     in
+     let Pmakeblock = %block.[`0`].`toplevel` (f, zero, v0, one, v1) in
      cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
@@ -2,15 +2,17 @@ let code f_0 deleted in
 let code v1_1 deleted in
 let code loopify(never) size(8) newer_version_of(f_0)
       f_0_1 (x)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
-  let Pmakeblock = %block.[`0`] (x, x) in
+  let Pmakeblock = %block.[`0`].my_alloc_region (x, x) in
   cont k (Pmakeblock)
 in
-let $camlSpeculative_inlining_lifted_constants__f_2 = closure f_0_1 @f in
+let $camlSpeculative_inlining_lifted_constants__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let zero = %opaque (0) in
-apply direct(f_0_1)
+apply direct(f_0_1 &toplevel.alloc_region)
   ($camlSpeculative_inlining_lifted_constants__f_2
    : _ -> [ 0 of imm tagged * imm tagged ])
     (zero)
@@ -18,17 +20,17 @@ apply direct(f_0_1)
   where k (v0 : [ 0 of imm tagged * imm tagged ]) =
     let one = %opaque (1) in
     let $camlSpeculative_inlining_lifted_constants__v1_3 =
-      closure v1_1_1 @v1
+      closure v1_1_1 @v1 &toplevel.alloc_region
     and code loopify(never) size(5) newer_version_of(v1_1)
           v1_1_1 (param : imm tagged)
-            my_closure _region _ghost_region my_depth
+            my_closure &my_alloc_region my_depth
             -> k * k1
             : [ 0 of imm tagged * imm tagged ] =
       let one_1 =
         %project_value_slot.[v1].[one]
           ($camlSpeculative_inlining_lifted_constants__v1_3)
       in
-      apply direct(f_0_1)
+      apply direct(f_0_1 &my_alloc_region)
         ($camlSpeculative_inlining_lifted_constants__f_2
          : _ -> [ 0 of imm tagged * imm tagged ])
           (one_1)

--- a/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
+++ b/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
@@ -35,17 +35,18 @@ match_tagged_immediate:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_tagged_immediate_0 deleted in
-let $camlTOP2__switch_block27 = Value_array [|5; 10; 2; 7|] in
+let $camlTOP2__switch_block31 = Value_array [|5; 10; 2; 7|] in
 let code loopify(never) size(2) newer_version_of(match_tagged_immediate_0)
       match_tagged_immediate_0_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  let arg = %array_load ($camlTOP2__switch_block27, t) in
+  let arg = %array_load ($camlTOP2__switch_block31, t) in
   cont k (arg)
 in
 let $camlTOP2__match_tagged_immediate_1 =
   closure match_tagged_immediate_0_1 @match_tagged_immediate
+    &toplevel.alloc_region
 in
 let $camlTOP2 = Block 0 ($camlTOP2__match_tagged_immediate_1) in
 cont done ($camlTOP2)
@@ -67,17 +68,18 @@ match_naked_immediate:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_immediate_2 deleted in
-let $camlTOP4__switch_block79 = Int_array [|5; 10; 2; 7|] in
+let $camlTOP4__switch_block90 = Int_array [|5; 10; 2; 7|] in
 let code loopify(never) size(2) newer_version_of(match_naked_immediate_2)
       match_naked_immediate_2_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm =
-  let arg = %array_load.`int` ($camlTOP4__switch_block79, t) in
+  let arg = %array_load.`int` ($camlTOP4__switch_block90, t) in
   cont k (arg)
 in
 let $camlTOP4__match_naked_immediate_3 =
   closure match_naked_immediate_2_1 @match_naked_immediate
+    &toplevel.alloc_region
 in
 let $camlTOP4 = Block 0 ($camlTOP4__match_naked_immediate_3) in
 cont done ($camlTOP4)
@@ -97,7 +99,7 @@ match_naked_float:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_float_4 deleted in
-let $camlTOP5__switch_block115 =
+let $camlTOP5__switch_block132 =
   Float_array [|0x1.4p+2;
   0x1.4p+3;
   0x1p+1;
@@ -105,14 +107,14 @@ let $camlTOP5__switch_block115 =
 in
 let code loopify(never) size(2) newer_version_of(match_naked_float_4)
       match_naked_float_4_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float =
-  let arg = %array_load.`float` ($camlTOP5__switch_block115, t) in
+  let arg = %array_load.`float` ($camlTOP5__switch_block132, t) in
   cont k (arg)
 in
 let $camlTOP5__match_naked_float_5 =
-  closure match_naked_float_4_1 @match_naked_float
+  closure match_naked_float_4_1 @match_naked_float &toplevel.alloc_region
 in
 let $camlTOP5 = Block 0 ($camlTOP5__match_naked_float_5) in
 cont done ($camlTOP5)
@@ -132,7 +134,7 @@ match_naked_float32:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_float32_6 deleted in
-let $camlTOP6__switch_block151 =
+let $camlTOP6__switch_block174 =
   Float32_array [|0x1.4p+2s;
   0x1.4p+3s;
   0x1p+1s;
@@ -140,14 +142,14 @@ let $camlTOP6__switch_block151 =
 in
 let code loopify(never) size(3) newer_version_of(match_naked_float32_6)
       match_naked_float32_6_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 =
-  let arg = %array_load.`float32` ($camlTOP6__switch_block151, t) in
+  let arg = %array_load.`float32` ($camlTOP6__switch_block174, t) in
   cont k (arg)
 in
 let $camlTOP6__match_naked_float32_7 =
-  closure match_naked_float32_6_1 @match_naked_float32
+  closure match_naked_float32_6_1 @match_naked_float32 &toplevel.alloc_region
 in
 let $camlTOP6 = Block 0 ($camlTOP6__match_naked_float32_7) in
 cont done ($camlTOP6)
@@ -167,17 +169,17 @@ match_naked_int32:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_int32_8 deleted in
-let $camlTOP7__switch_block187 = Int32_array [|5l; 10l; 2l; 7l|] in
+let $camlTOP7__switch_block216 = Int32_array [|5l; 10l; 2l; 7l|] in
 let code loopify(never) size(3) newer_version_of(match_naked_int32_8)
       match_naked_int32_8_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int32 =
-  let arg = %array_load.`int32` ($camlTOP7__switch_block187, t) in
+  let arg = %array_load.`int32` ($camlTOP7__switch_block216, t) in
   cont k (arg)
 in
 let $camlTOP7__match_naked_int32_9 =
-  closure match_naked_int32_8_1 @match_naked_int32
+  closure match_naked_int32_8_1 @match_naked_int32 &toplevel.alloc_region
 in
 let $camlTOP7 = Block 0 ($camlTOP7__match_naked_int32_9) in
 cont done ($camlTOP7)
@@ -197,17 +199,17 @@ match_naked_int64:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_int64_10 deleted in
-let $camlTOP8__switch_block223 = Int64_array [|5L; 10L; 2L; 7L|] in
+let $camlTOP8__switch_block258 = Int64_array [|5L; 10L; 2L; 7L|] in
 let code loopify(never) size(2) newer_version_of(match_naked_int64_10)
       match_naked_int64_10_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 =
-  let arg = %array_load.`int64` ($camlTOP8__switch_block223, t) in
+  let arg = %array_load.`int64` ($camlTOP8__switch_block258, t) in
   cont k (arg)
 in
 let $camlTOP8__match_naked_int64_11 =
-  closure match_naked_int64_10_1 @match_naked_int64
+  closure match_naked_int64_10_1 @match_naked_int64 &toplevel.alloc_region
 in
 let $camlTOP8 = Block 0 ($camlTOP8__match_naked_int64_11) in
 cont done ($camlTOP8)
@@ -227,17 +229,18 @@ match_naked_nativeint:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_nativeint_12 deleted in
-let $camlTOP9__switch_block259 = Nativeint_array [|5n; 10n; 2n; 7n|] in
+let $camlTOP9__switch_block300 = Nativeint_array [|5n; 10n; 2n; 7n|] in
 let code loopify(never) size(2) newer_version_of(match_naked_nativeint_12)
       match_naked_nativeint_12_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : nativeint =
-  let arg = %array_load.`nativeint` ($camlTOP9__switch_block259, t) in
+  let arg = %array_load.`nativeint` ($camlTOP9__switch_block300, t) in
   cont k (arg)
 in
 let $camlTOP9__match_naked_nativeint_13 =
   closure match_naked_nativeint_12_1 @match_naked_nativeint
+    &toplevel.alloc_region
 in
 let $camlTOP9 = Block 0 ($camlTOP9__match_naked_nativeint_13) in
 cont done ($camlTOP9)
@@ -258,17 +261,17 @@ match_naked_int8:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_int8_14 deleted in
-let $camlTOP10__switch_block295 = Int8_array [|5s; 10s; 2s; 7s|] in
+let $camlTOP10__switch_block342 = Int8_array [|5s; 10s; 2s; 7s|] in
 let code loopify(never) size(3) newer_version_of(match_naked_int8_14)
       match_naked_int8_14_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int8 =
-  let arg = %array_load.`int8` ($camlTOP10__switch_block295, t) in
+  let arg = %array_load.`int8` ($camlTOP10__switch_block342, t) in
   cont k (arg)
 in
 let $camlTOP10__match_naked_int8_15 =
-  closure match_naked_int8_14_1 @match_naked_int8
+  closure match_naked_int8_14_1 @match_naked_int8 &toplevel.alloc_region
 in
 let $camlTOP10 = Block 0 ($camlTOP10__match_naked_int8_15) in
 cont done ($camlTOP10)
@@ -288,17 +291,17 @@ match_naked_int16:
 |}]
 [%%expect_fexpr Simplify{|
 let code match_naked_int16_16 deleted in
-let $camlTOP11__switch_block331 = Int16_array [|5S; 10S; 2S; 7S|] in
+let $camlTOP11__switch_block384 = Int16_array [|5S; 10S; 2S; 7S|] in
 let code loopify(never) size(3) newer_version_of(match_naked_int16_16)
       match_naked_int16_16_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int16 =
-  let arg = %array_load.`int16` ($camlTOP11__switch_block331, t) in
+  let arg = %array_load.`int16` ($camlTOP11__switch_block384, t) in
   cont k (arg)
 in
 let $camlTOP11__match_naked_int16_17 =
-  closure match_naked_int16_16_1 @match_naked_int16
+  closure match_naked_int16_16_1 @match_naked_int16 &toplevel.alloc_region
 in
 let $camlTOP11 = Block 0 ($camlTOP11__match_naked_int16_17) in
 cont done ($camlTOP11)
@@ -317,26 +320,28 @@ match_symbol:
   ret
 |}]
 [%%expect_fexpr Simplify{|
-let $camlTOP12__immstring358 = "alpha" in
-let $camlTOP12__immstring360 = "beta" in
-let $camlTOP12__immstring362 = "gamma" in
-let $camlTOP12__immstring364 = "delta" in
+let $camlTOP12__immstring416 = "alpha" in
+let $camlTOP12__immstring418 = "beta" in
+let $camlTOP12__immstring420 = "gamma" in
+let $camlTOP12__immstring422 = "delta" in
 let code match_symbol_18 deleted in
-let $camlTOP12__switch_block375 =
-  Value_array [|$camlTOP12__immstring358;
-  $camlTOP12__immstring360;
-  $camlTOP12__immstring362;
-  $camlTOP12__immstring364|]
+let $camlTOP12__switch_block434 =
+  Value_array [|$camlTOP12__immstring416;
+  $camlTOP12__immstring418;
+  $camlTOP12__immstring420;
+  $camlTOP12__immstring422|]
 in
 let code loopify(never) size(2) newer_version_of(match_symbol_18)
       match_symbol_18_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  let arg = %array_load ($camlTOP12__switch_block375, t) in
+  let arg = %array_load ($camlTOP12__switch_block434, t) in
   cont k (arg)
 in
-let $camlTOP12__match_symbol_19 = closure match_symbol_18_1 @match_symbol in
+let $camlTOP12__match_symbol_19 =
+  closure match_symbol_18_1 @match_symbol &toplevel.alloc_region
+in
 let $camlTOP12 = Block 0 ($camlTOP12__match_symbol_19) in
 cont done ($camlTOP12)
 |}]
@@ -360,27 +365,27 @@ match_symbol_or_tagged_immediate:
   ret
 |}]
 [%%expect_fexpr Simplify{|
-let $camlTOP14__immstring410 = "foo" in
-let $camlTOP14__const_block412 = Block 1 ($camlTOP14__immstring410) in
-let $camlTOP14__const_block414 = Block 0 (42) in
+let $camlTOP14__immstring475 = "foo" in
+let $camlTOP14__const_block477 = Block 1 ($camlTOP14__immstring475) in
+let $camlTOP14__const_block479 = Block 0 (42) in
 let code match_symbol_or_tagged_immediate_20 deleted in
-let $camlTOP14__switch_block425 =
-  Value_array [|$camlTOP14__const_block412;
+let $camlTOP14__switch_block491 =
+  Value_array [|$camlTOP14__const_block477;
   1;
-  $camlTOP14__const_block414;
+  $camlTOP14__const_block479;
   0|]
 in
 let code loopify(never) size(2) newer_version_of(match_symbol_or_tagged_immediate_20)
       match_symbol_or_tagged_immediate_20_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 |1 | 0 of imm tagged |1 of val ] =
-  let arg = %array_load ($camlTOP14__switch_block425, t) in
+  let arg = %array_load ($camlTOP14__switch_block491, t) in
   cont k (arg)
 in
 let $camlTOP14__match_symbol_or_tagged_immediate_21 =
   closure match_symbol_or_tagged_immediate_20_1
-    @match_symbol_or_tagged_immediate
+    @match_symbol_or_tagged_immediate &toplevel.alloc_region
 in
 let $camlTOP14 = Block 0 ($camlTOP14__match_symbol_or_tagged_immediate_21) in
 cont done ($camlTOP14)
@@ -403,25 +408,26 @@ match_symbol_tagged_or_null:
   ret
 |}]
 [%%expect_fexpr Simplify{|
-let $camlTOP15__immstring452 = "foo" in
-let $camlTOP15__const_block454 = Block 1 ($camlTOP15__immstring452) in
-let $camlTOP15__const_block456 = Block 0 (42) in
+let $camlTOP15__immstring523 = "foo" in
+let $camlTOP15__const_block525 = Block 1 ($camlTOP15__immstring523) in
+let $camlTOP15__const_block527 = Block 0 (42) in
 let code match_symbol_tagged_or_null_22 deleted in
-let $camlTOP15__switch_block467 =
-  Value_array [|$camlTOP15__const_block454;
+let $camlTOP15__switch_block539 =
+  Value_array [|$camlTOP15__const_block525;
   null;
-  $camlTOP15__const_block456;
+  $camlTOP15__const_block527;
   0|]
 in
 let code loopify(never) size(2) newer_version_of(match_symbol_tagged_or_null_22)
       match_symbol_tagged_or_null_22_1 (t : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  let arg = %array_load ($camlTOP15__switch_block467, t) in
+  let arg = %array_load ($camlTOP15__switch_block539, t) in
   cont k (arg)
 in
 let $camlTOP15__match_symbol_tagged_or_null_23 =
   closure match_symbol_tagged_or_null_22_1 @match_symbol_tagged_or_null
+    &toplevel.alloc_region
 in
 let $camlTOP15 = Block 0 ($camlTOP15__match_symbol_tagged_or_null_23) in
 cont done ($camlTOP15)

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
@@ -1,25 +1,25 @@
 let $camlArguments_for_unboxed_closure__first_const = Block 0 () in
 (let code size(11)
        g_1 (h : val)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let x = %project_value_slot.[g].[x] (my_closure) in
    let y = %project_value_slot.[g].[y] (my_closure) in
-   apply h (y) -> k3 * k2
+   apply &my_alloc_region h (y) -> k3 * k2
      where k3 (apply_result : imm tagged) =
        let int_add = %int_barith.add (x, apply_result) in
        cont k1 (int_add)
  in
  let code inline(never) size(1)
-       id_2 (z) my_closure _region _ghost_region my_depth -> k1 * k2 =
+       id_2 (z) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    cont k1 (z)
  in
  let code inline(never) size(1)
        unused_3 (param)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
@@ -27,29 +27,34 @@ let $camlArguments_for_unboxed_closure__first_const = Block 0 () in
  in
  let code inline(never) size(6)
        u_4 (param : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let g = %project_value_slot.[u].[g] (my_closure) in
    let `id` = %project_value_slot.[u].[`id`] (my_closure) in
-   apply direct(g_1) inlined(always) (g : _ -> imm tagged) (`id`) -> k1 * k2
+   apply direct(g_1 &my_alloc_region) inlined(always)
+     (g : _ -> imm tagged) (`id`) -> k1 * k2
  in
  let code size(65)
        f_0 (x : imm tagged, y : imm tagged)
-         my_closure _region _ghost_region my_depth
+         my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let `region` = %begin_region () in
    let ghost_region = %begin_ghost_region () in
-   (let g = closure g_1 @g with { x = x; y = y } in
-    let `id` = closure id_2 @`id` in
-    let unused = closure unused_3 @unused in
-    let u = closure u_4 @u with { g = g; `id` = `id` } in
-    apply direct(u_4) (u : _ -> imm tagged) (0) -> k4 * k2
+   (let g = closure g_1 @g &my_alloc_region &`region`
+    with { x = x; y = y }
+    in
+    let `id` = closure id_2 @`id` &my_alloc_region &`region` in
+    let unused = closure unused_3 @unused &my_alloc_region &`region` in
+    let u = closure u_4 @u &my_alloc_region &`region`
+    with { g = g; `id` = `id` }
+    in
+    apply direct(u_4 &my_alloc_region) (u : _ -> imm tagged) (0) -> k4 * k2
       where k4 (apply_result : imm tagged) =
-        (apply direct(g_1) inlined(never)
+        (apply direct(g_1 &my_alloc_region) inlined(never)
            (g : _ -> imm tagged) (unused) -> k4 * k2
            where k4 (apply_result_1 : imm tagged) =
              let int_add = %int_barith.add (apply_result_1, apply_result) in
@@ -59,8 +64,8 @@ let $camlArguments_for_unboxed_closure__first_const = Block 0 () in
        let unit_1 = %end_ghost_region (ghost_region) in
        cont k1 (region_return)
  in
- let f = closure f_0 @f in
- let Pmakeblock = %block.[`0`] (f) in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (f) in
  cont k (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
@@ -4,21 +4,23 @@ let code unused_3 deleted in
 let code u_4 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(id_2)
-      id_2_1 (z) my_closure _region _ghost_region my_depth -> k * k1 =
+      id_2_1 (z) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (z)
 in
-let $camlArguments_for_unboxed_closure__id_6 = closure id_2_1 @`id` in
+let $camlArguments_for_unboxed_closure__id_6 =
+  closure id_2_1 @`id` &toplevel.alloc_region
+in
 let code inline(never) loopify(never) size(7) newer_version_of(u_4)
       u_4_1
         (u_into_my_closure_field_g_field_x, u_into_my_closure_field_g_field_y)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let g_into_g_field_x = u_into_my_closure_field_g_field_x in
   let g_into_g_field_y = u_into_my_closure_field_g_field_y in
   let x = g_into_g_field_x in
   let y = g_into_g_field_y in
-  apply direct(id_2_1) inlining_state(depth(1))
+  apply direct(id_2_1 &my_alloc_region) inlining_state(depth(1))
     $camlArguments_for_unboxed_closure__id_6 (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
@@ -26,27 +28,28 @@ let code inline(never) loopify(never) size(7) newer_version_of(u_4)
 in
 let code inline(never) loopify(never) size(1) newer_version_of(unused_3)
       unused_3_1 (param)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlArguments_for_unboxed_closure__unused_7 = closure unused_3_1 @unused
+let $camlArguments_for_unboxed_closure__unused_7 =
+  closure unused_3_1 @unused &toplevel.alloc_region
 in
 let code loopify(never) size(9) newer_version_of(g_1)
       g_1_1 (g_into_my_closure_field_x, h : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let x = g_into_my_closure_field_x in
-  apply h (poison.val.reaper_unused_argument) -> k2 * k1
+  apply &my_alloc_region h (poison.val.reaper_unused_argument) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
       cont k (int_add)
 in
 let code loopify(never) size(13) newer_version_of(f_0)
       f_0_1 (x : imm tagged, y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -54,10 +57,10 @@ let code loopify(never) size(13) newer_version_of(f_0)
   let g_into_g_field_y = y in
   let u_into_u_field_g_field_x = g_into_g_field_x in
   let u_into_u_field_g_field_y = g_into_g_field_y in
-  apply direct(u_4_1)
+  apply direct(u_4_1 &my_alloc_region)
      (u_into_u_field_g_field_x, u_into_u_field_g_field_y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
-      (apply direct(g_1_1) inlined(never)
+      (apply direct(g_1_1 &my_alloc_region) inlined(never)
          
            (g_into_g_field_x, $camlArguments_for_unboxed_closure__unused_7)
            -> k2 * k1
@@ -66,7 +69,9 @@ let code loopify(never) size(13) newer_version_of(f_0)
            let `unit` = %end_region (`region`) in
            cont k (int_add))
 in
-let $camlArguments_for_unboxed_closure__f_5 = closure f_0_1 @f in
+let $camlArguments_for_unboxed_closure__f_5 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlArguments_for_unboxed_closure =
   Block 0 ($camlArguments_for_unboxed_closure__f_5)
 in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
@@ -4,19 +4,21 @@ let code unused_3 deleted in
 let code u_4 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(id_2)
-      id_2_1 (z) my_closure _region _ghost_region my_depth -> k * k1 =
+      id_2_1 (z) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (z)
 in
-let $camlArguments_for_unboxed_closure__id_6 = closure id_2_1 @`id` in
+let $camlArguments_for_unboxed_closure__id_6 =
+  closure id_2_1 @`id` &toplevel.alloc_region
+in
 let code inline(never) loopify(never) size(10) newer_version_of(u_4)
       u_4_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let g = %project_value_slot.[u].[g] (my_closure) in
   let x = %project_value_slot.[g].[x] (g) in
   let y = %project_value_slot.[g].[y] (g) in
-  apply direct(id_2_1) inlining_state(depth(1))
+  apply direct(id_2_1 &my_alloc_region) inlining_state(depth(1))
     ($camlArguments_for_unboxed_closure__id_6 : _ -> imm tagged)
       (y)
       -> k2 * k1
@@ -26,38 +28,41 @@ let code inline(never) loopify(never) size(10) newer_version_of(u_4)
 in
 let code inline(never) loopify(never) size(1) newer_version_of(unused_3)
       unused_3_1 (param)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont k (0)
 in
-let $camlArguments_for_unboxed_closure__unused_7 = closure unused_3_1 @unused
+let $camlArguments_for_unboxed_closure__unused_7 =
+  closure unused_3_1 @unused &toplevel.alloc_region
 in
 let code loopify(never) size(11) newer_version_of(g_1)
       g_1_1 (h : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let x = %project_value_slot.[g].[x] (my_closure) in
   let y = %project_value_slot.[g].[y] (my_closure) in
-  apply h (y) -> k2 * k1
+  apply &my_alloc_region h (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
       cont k (int_add)
 in
 let code loopify(never) size(52) newer_version_of(f_0)
       f_0_1 (x : imm tagged, y : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
-  let g = closure g_1_1 @g with { x = x; y = y } in
-  let u = closure u_4_1 @u
+  let g = closure g_1_1 @g &my_alloc_region &`region`
+  with { x = x; y = y }
+  in
+  let u = closure u_4_1 @u &my_alloc_region &`region`
   with { g = g; `id` = $camlArguments_for_unboxed_closure__id_6 }
   in
-  apply direct(u_4_1) (u : _ -> imm tagged) (0) -> k2 * k1
+  apply direct(u_4_1 &my_alloc_region) (u : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
-      (apply direct(g_1_1) inlined(never)
+      (apply direct(g_1_1 &my_alloc_region) inlined(never)
          (g : _ -> imm tagged)
            ($camlArguments_for_unboxed_closure__unused_7)
            -> k2 * k1
@@ -66,7 +71,9 @@ let code loopify(never) size(52) newer_version_of(f_0)
            let `unit` = %end_region (`region`) in
            cont k (int_add))
 in
-let $camlArguments_for_unboxed_closure__f_5 = closure f_0_1 @f in
+let $camlArguments_for_unboxed_closure__f_5 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlArguments_for_unboxed_closure =
   Block 0 ($camlArguments_for_unboxed_closure__f_5)
 in

--- a/testsuite/tests/reaper/boxed_number_escape.reaper.local-fields.reference
+++ b/testsuite/tests/reaper/boxed_number_escape.reaper.local-fields.reference
@@ -1,11 +1,11 @@
 let code escape_0 deleted in
-let $camlBoxed_number_escape__int644 = 0L in
-let r = %block.mut.[`0`] ($camlBoxed_number_escape__int644) in
+let $camlBoxed_number_escape__int645 = 0L in
+let r = %block.mut.[`0`].`toplevel` ($camlBoxed_number_escape__int645) in
 let $camlBoxed_number_escape__escape_1 =
-  closure escape_0_1 @escape
+  closure escape_0_1 @escape &toplevel.alloc_region
 and code loopify(never) size(14) newer_version_of(escape_0)
       escape_0_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let r_1 =
@@ -14,7 +14,7 @@ and code loopify(never) size(14) newer_version_of(escape_0)
   in
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
-  let b = %box_num.`int64` (prim_1) in
+  let b = %box_num.`int64`.my_alloc_region (prim_1) in
   let Psetfield = %block_set.[`0`] (r_1, b) in
   let prim_2 = %num_conv.[`int64`].[`imm`] (prim_1) in
   let int_of_int64 = %tag_imm (prim_2) in

--- a/testsuite/tests/reaper/boxed_number_escape.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_escape.reaper.reference
@@ -1,11 +1,11 @@
 let code escape_0 deleted in
-let $camlBoxed_number_escape__int644 = 0L in
-let r = %block.mut.[`0`] ($camlBoxed_number_escape__int644) in
+let $camlBoxed_number_escape__int645 = 0L in
+let r = %block.mut.[`0`].`toplevel` ($camlBoxed_number_escape__int645) in
 let $camlBoxed_number_escape__escape_1 =
-  closure escape_0_1 @escape
+  closure escape_0_1 @escape &toplevel.alloc_region
 and code loopify(never) size(14) newer_version_of(escape_0)
       escape_0_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let r_1 =
@@ -13,7 +13,7 @@ and code loopify(never) size(14) newer_version_of(escape_0)
   in
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
-  let b = %box_num.`int64` (prim_1) in
+  let b = %box_num.`int64`.my_alloc_region (prim_1) in
   let Psetfield = %block_set.[`0`] (r_1, b) in
   let prim_2 = %num_conv.[`int64`].[`imm`] (prim_1) in
   let int_of_int64 = %tag_imm (prim_2) in

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
@@ -1,17 +1,15 @@
 let code merge_usages_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(merge_usages_1)
-      merge_usages_1_1 (u)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
+      merge_usages_1_1 (u) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (u)
 in
 let $camlBoxed_number_subkind_erasure__merge_usages_3 =
-  closure merge_usages_1_1 @merge_usages
+  closure merge_usages_1_1 @merge_usages &toplevel.alloc_region
 in
 let code loopify(never) size(50) newer_version_of(f_0)
       f_0_1 (b : imm tagged, x : int32 boxed, y : int64 boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 boxed =
   (let untagged = %untag_imm (b) in
@@ -21,34 +19,36 @@ let code loopify(never) size(50) newer_version_of(f_0)
     where k4 =
       let prim = %unbox_num.`int64` (y) in
       let prim_1 = %int_barith.`int64`.add (prim, prim) in
-      let int64_add = %box_num.`int64` (prim_1) in
+      let int64_add = %box_num.`int64`.my_alloc_region (prim_1) in
       let int32_add = poison.val.reaper_unused_boxed_number in
       cont k2 (int32_add, int64_add)
     where k3 =
       let prim = %unbox_num.`int64` (y) in
       let prim_1 = %int_barith.`int64`.mul (prim, prim) in
-      let int64_mul = %box_num.`int64` (prim_1) in
+      let int64_mul = %box_num.`int64`.my_alloc_region (prim_1) in
       let int32_mul = poison.val.reaper_unused_boxed_number in
       cont k2 (int32_mul, int64_mul)
     where k2 (a : val, b_1 : int64 boxed) =
-      (apply direct(merge_usages_1_1)
+      (apply direct(merge_usages_1_1 &my_alloc_region)
          $camlBoxed_number_subkind_erasure__merge_usages_3 (a) -> k4 * k1
          where k4 (function_return_0_merge_usages_1) =
            cont k3
          where k3 =
            cont k2
          where k2 =
-           (apply direct(merge_usages_1_1)
+           (apply direct(merge_usages_1_1 &my_alloc_region)
               $camlBoxed_number_subkind_erasure__merge_usages_3
                 (b_1)
                 -> k2 * k1
               where k2 (b_2 : int64 boxed) =
                 let prim = %unbox_num.`int64` (b_2) in
                 let prim_1 = %int_barith.`int64`.add (prim, prim) in
-                let int64_add = %box_num.`int64` (prim_1) in
+                let int64_add = %box_num.`int64`.my_alloc_region (prim_1) in
                 cont k (int64_add)))
 in
-let $camlBoxed_number_subkind_erasure__f_2 = closure f_0_1 @f in
+let $camlBoxed_number_subkind_erasure__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlBoxed_number_subkind_erasure =
   Block 0 ($camlBoxed_number_subkind_erasure__f_2)
 in

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.simplify.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.simplify.reference
@@ -1,17 +1,15 @@
 let code merge_usages_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(merge_usages_1)
-      merge_usages_1_1 (u)
-        my_closure _region _ghost_region my_depth
-        -> k * k1 =
+      merge_usages_1_1 (u) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (u)
 in
 let $camlBoxed_number_subkind_erasure__merge_usages_3 =
-  closure merge_usages_1_1 @merge_usages
+  closure merge_usages_1_1 @merge_usages &toplevel.alloc_region
 in
 let code loopify(never) size(65) newer_version_of(f_0)
       f_0_1 (b : imm tagged, x : int32 boxed, y : int64 boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 boxed =
   (let untagged = %untag_imm (b) in
@@ -21,21 +19,21 @@ let code loopify(never) size(65) newer_version_of(f_0)
     where k4 =
       let prim = %unbox_num.`int64` (y) in
       let prim_1 = %int_barith.`int64`.add (prim, prim) in
-      let int64_add = %box_num.`int64` (prim_1) in
+      let int64_add = %box_num.`int64`.my_alloc_region (prim_1) in
       let prim_2 = %unbox_num.`int32` (x) in
       let prim_3 = %int_barith.`int32`.add (prim_2, prim_2) in
-      let int32_add = %box_num.`int32` (prim_3) in
+      let int32_add = %box_num.`int32`.my_alloc_region (prim_3) in
       cont k2 (int32_add, int64_add)
     where k3 =
       let prim = %unbox_num.`int64` (y) in
       let prim_1 = %int_barith.`int64`.mul (prim, prim) in
-      let int64_mul = %box_num.`int64` (prim_1) in
+      let int64_mul = %box_num.`int64`.my_alloc_region (prim_1) in
       let prim_2 = %unbox_num.`int32` (x) in
       let prim_3 = %int_barith.`int32`.mul (prim_2, prim_2) in
-      let int32_mul = %box_num.`int32` (prim_3) in
+      let int32_mul = %box_num.`int32`.my_alloc_region (prim_3) in
       cont k2 (int32_mul, int64_mul)
     where k2 (a : int32 boxed, b_1 : int64 boxed) =
-      (apply direct(merge_usages_1_1)
+      (apply direct(merge_usages_1_1 &my_alloc_region)
          ($camlBoxed_number_subkind_erasure__merge_usages_3
           : _ -> int32 boxed)
            (a)
@@ -43,7 +41,7 @@ let code loopify(never) size(65) newer_version_of(f_0)
          where k3 (param) =
            cont k2
          where k2 =
-           (apply direct(merge_usages_1_1)
+           (apply direct(merge_usages_1_1 &my_alloc_region)
               ($camlBoxed_number_subkind_erasure__merge_usages_3
                : _ -> int64 boxed)
                 (b_1)
@@ -51,10 +49,12 @@ let code loopify(never) size(65) newer_version_of(f_0)
               where k2 (b_2 : int64 boxed) =
                 let prim = %unbox_num.`int64` (b_2) in
                 let prim_1 = %int_barith.`int64`.add (prim, prim) in
-                let int64_add = %box_num.`int64` (prim_1) in
+                let int64_add = %box_num.`int64`.my_alloc_region (prim_1) in
                 cont k (int64_add)))
 in
-let $camlBoxed_number_subkind_erasure__f_2 = closure f_0_1 @f in
+let $camlBoxed_number_subkind_erasure__f_2 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
 let $camlBoxed_number_subkind_erasure =
   Block 0 ($camlBoxed_number_subkind_erasure__f_2)
 in

--- a/testsuite/tests/reaper/code_size.reaper.reference
+++ b/testsuite/tests/reaper/code_size.reaper.reference
@@ -3,26 +3,26 @@ let code g_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(h_2)
       h_2_1 (Pmakeblock_into_u_field_0)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
   cont k (Pmakeblock_into_u_field_0)
 in
-let $camlCode_size__h_4 = closure h_2_1 @h in
+let $camlCode_size__h_4 = closure h_2_1 @h &toplevel.alloc_region in
 let code loopify(never) size(6) newer_version_of(g_1)
-      g_1_1 (y) my_closure _region _ghost_region my_depth -> k * k1 =
+      g_1_1 (y) my_closure &my_alloc_region my_depth -> k * k1 =
   let x = %project_value_slot.[g].[unboxed_field_x] (my_closure) in
   (let Pmakeblock_into_Pmakeblock_field_0 = x in
-   apply direct(h_2_1)
+   apply direct(h_2_1 &my_alloc_region)
      $camlCode_size__h_4 (Pmakeblock_into_Pmakeblock_field_0) -> k2 * k1)
     where k2 (`Pmakeblock_into_*match*_field_0`) =
       let Pfield = `Pmakeblock_into_*match*_field_0` in
       cont k (Pfield)
 in
 let code loopify(never) size(15) newer_version_of(f_0)
-      f_0_1 (x) my_closure _region _ghost_region my_depth -> k * k1 : val =
-  let g = closure g_1_1 @g with { unboxed_field_x = x } in
+      f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : val =
+  let g = closure g_1_1 @g &my_alloc_region with { unboxed_field_x = x } in
   cont k (g)
 in
-let $camlCode_size__f_3 = closure f_0_1 @f in
+let $camlCode_size__f_3 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlCode_size = Block 0 ($camlCode_size__f_3) in
 cont done ($camlCode_size)

--- a/testsuite/tests/reaper/code_size.simplify.reference
+++ b/testsuite/tests/reaper/code_size.simplify.reference
@@ -2,25 +2,25 @@ let code h_2 deleted in
 let code g_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(h_2)
-      h_2_1 (u) my_closure _region _ghost_region my_depth -> k * k1 =
+      h_2_1 (u) my_closure &my_alloc_region my_depth -> k * k1 =
   cont k (u)
 in
-let $camlCode_size__h_4 = closure h_2_1 @h in
+let $camlCode_size__h_4 = closure h_2_1 @h &toplevel.alloc_region in
 let code loopify(never) size(14) newer_version_of(g_1)
-      g_1_1 (y) my_closure _region _ghost_region my_depth -> k * k1 =
+      g_1_1 (y) my_closure &my_alloc_region my_depth -> k * k1 =
   let x = %project_value_slot.[g].[x] (my_closure) in
-  (let Pmakeblock = %block.[`0`] (x, y) in
-   apply direct(h_2_1)
+  (let Pmakeblock = %block.[`0`].my_alloc_region (x, y) in
+   apply direct(h_2_1 &my_alloc_region)
      ($camlCode_size__h_4 : _ -> [ 0 of val * val ]) (Pmakeblock) -> k2 * k1)
     where k2 (`*match*` : [ 0 of val * val ]) =
       let Pfield = %block_load.[`0`] (`*match*`) in
       cont k (Pfield)
 in
 let code loopify(never) size(23) newer_version_of(f_0)
-      f_0_1 (x) my_closure _region _ghost_region my_depth -> k * k1 : val =
-  let g = closure g_1_1 @g with { x = x } in
+      f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : val =
+  let g = closure g_1_1 @g &my_alloc_region with { x = x } in
   cont k (g)
 in
-let $camlCode_size__f_3 = closure f_0_1 @f in
+let $camlCode_size__f_3 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlCode_size = Block 0 ($camlCode_size__f_3) in
 cont done ($camlCode_size)

--- a/testsuite/tests/reaper/large_no_unbox.reaper.reference
+++ b/testsuite/tests/reaper/large_no_unbox.reaper.reference
@@ -4,7 +4,7 @@ let code f_0 deleted in
 let code inline(never) loopify(never) size(11) newer_version_of(large_2)
       large_2_1
         (param : [ 0 of imm tagged * imm tagged * imm tagged * imm tagged ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`3`] (param) in
@@ -16,13 +16,15 @@ let code inline(never) loopify(never) size(11) newer_version_of(large_2)
   let int_add_2 = %int_barith.add (int_add_1, Pfield) in
   cont k (int_add_2)
 in
-let $camlLarge_no_unbox__large_5 = closure large_2_1 @large in
+let $camlLarge_no_unbox__large_5 =
+  closure large_2_1 @large &toplevel.alloc_region
+in
 let code inline(never) loopify(never) size(5) newer_version_of(small_1)
       small_1_1
         (Pmakeblock_into_param_field_0,
          Pmakeblock_into_param_field_1,
          Pmakeblock_into_param_field_2)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = Pmakeblock_into_param_field_2 in
@@ -32,10 +34,12 @@ let code inline(never) loopify(never) size(5) newer_version_of(small_1)
   let int_add_1 = %int_barith.add (int_add, Pfield) in
   cont k (int_add_1)
 in
-let $camlLarge_no_unbox__small_4 = closure small_1_1 @small in
+let $camlLarge_no_unbox__small_4 =
+  closure small_1_1 @small &toplevel.alloc_region
+in
 let code loopify(never) size(36) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -44,10 +48,10 @@ let code loopify(never) size(36) newer_version_of(f_0)
    let int_add_2 = %int_barith.add (x, 6) in
    let int_add_3 = %int_barith.add (x, 5) in
    let Pmakeblock =
-     %block.[`0`].`local`[`region`]
+     %block.[`0`].my_alloc_region.`local`[`region`]
        (int_add_3, int_add_2, int_add_1, int_add)
    in
-   apply direct(large_2_1)
+   apply direct(large_2_1 &my_alloc_region)
      ($camlLarge_no_unbox__large_5 : _ -> imm tagged) (Pmakeblock) -> k2 * k1)
     where k2 (apply_result : imm tagged) =
       ((let int_add = %int_barith.add (x, 3) in
@@ -56,7 +60,7 @@ let code loopify(never) size(36) newer_version_of(f_0)
         let Pmakeblock_into_Pmakeblock_field_2 = int_add in
         let Pmakeblock_into_Pmakeblock_field_1 = int_add_1 in
         let Pmakeblock_into_Pmakeblock_field_0 = int_add_2 in
-        apply direct(small_1_1)
+        apply direct(small_1_1 &my_alloc_region)
           ($camlLarge_no_unbox__small_4 : _ -> imm tagged)
             (Pmakeblock_into_Pmakeblock_field_0,
              Pmakeblock_into_Pmakeblock_field_1,
@@ -67,6 +71,6 @@ let code loopify(never) size(36) newer_version_of(f_0)
            let `unit` = %end_region (`region`) in
            cont k (int_add))
 in
-let $camlLarge_no_unbox__f_3 = closure f_0_1 @f in
+let $camlLarge_no_unbox__f_3 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlLarge_no_unbox = Block 0 ($camlLarge_no_unbox__f_3) in
 cont done ($camlLarge_no_unbox)

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
@@ -1,20 +1,20 @@
-let $camlResult_types_of_identity__immstring16 =
+let $camlResult_types_of_identity__immstring18 =
   "result_types_of_identity.ml"
 in
-let $camlResult_types_of_identity__const_block18 =
-  Block 0 ($camlResult_types_of_identity__immstring16, 30, 2)
+let $camlResult_types_of_identity__const_block20 =
+  Block 0 ($camlResult_types_of_identity__immstring18, 30, 2)
 in
-let $camlResult_types_of_identity__Pmakeblock21 =
+let $camlResult_types_of_identity__Pmakeblock23 =
   Block 0 ($`*predef*`.caml_exn_Assert_failure,
-           $camlResult_types_of_identity__const_block18)
+           $camlResult_types_of_identity__const_block20)
 in
 let code always_0_0 deleted in
 let code loopify(never) size(16) newer_version_of(always_0_0)
       always_0_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(hidden_identity_0) inlined(never)
+  apply direct(hidden_identity_0 &my_alloc_region) inlined(never)
     ($Hidden_identity.camlHidden_identity__hidden_identity_1
      : _ -> imm tagged)
       (0)
@@ -23,11 +23,11 @@ let code loopify(never) size(16) newer_version_of(always_0_0)
       let prim = %phys_eq (apply_result, 0) in
       switch prim
         | 0 ->
-          k1 pop(regular k1) ($camlResult_types_of_identity__Pmakeblock21)
+          k1 pop(regular k1) ($camlResult_types_of_identity__Pmakeblock23)
         | 1 -> k (0)
 in
 let $camlResult_types_of_identity__always_0_1 =
-  closure always_0_0_1 @always_0
+  closure always_0_0_1 @always_0 &toplevel.alloc_region
 in
 let $camlResult_types_of_identity =
   Block 0 ($camlResult_types_of_identity__always_0_1)

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.reference
@@ -1,10 +1,10 @@
 let code always_0_0 deleted in
 let code loopify(never) size(5) newer_version_of(always_0_0)
       always_0_0_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(hidden_identity_0) inlined(never)
+  apply direct(hidden_identity_0 &my_alloc_region) inlined(never)
     ($Hidden_identity.camlHidden_identity__hidden_identity_1
      : _ -> imm tagged)
       (0)
@@ -13,7 +13,7 @@ let code loopify(never) size(5) newer_version_of(always_0_0)
       cont k (0)
 in
 let $camlResult_types_of_identity__always_0_1 =
-  closure always_0_0_1 @always_0
+  closure always_0_0_1 @always_0 &toplevel.alloc_region
 in
 let $camlResult_types_of_identity =
   Block 0 ($camlResult_types_of_identity__always_0_1)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
@@ -19,7 +19,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
       add_int64_0_1
         (int64_of_int_into_x_field_unboxed_int64 : int64,
          int64_of_int_into_y_field_unboxed_int64 : int64)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 =
   let prim = int64_of_int_into_y_field_unboxed_int64 in
@@ -28,13 +28,14 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
   let int64_add_into_int64_add_field_unboxed_int64 = prim_2 in
   cont k (int64_add_into_int64_add_field_unboxed_int64)
 in
-let $camlUnbox_boxed_numbers__add_int64_17 = closure add_int64_0_1 @add_int64
+let $camlUnbox_boxed_numbers__add_int64_17 =
+  closure add_int64_0_1 @add_int64 &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
       add_int32_1_1
         (int32_of_int_into_x_field_unboxed_int32 : int32,
          int32_of_int_into_y_field_unboxed_int32 : int32)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int32 =
   let prim = int32_of_int_into_y_field_unboxed_int32 in
@@ -43,13 +44,14 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
   let int32_add_into_int32_add_field_unboxed_int32 = prim_2 in
   cont k (int32_add_into_int32_add_field_unboxed_int32)
 in
-let $camlUnbox_boxed_numbers__add_int32_18 = closure add_int32_1_1 @add_int32
+let $camlUnbox_boxed_numbers__add_int32_18 =
+  closure add_int32_1_1 @add_int32 &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
       add_nativeint_2_1
         (nativeint_of_int_into_x_field_unboxed_nativeint : nativeint,
          nativeint_of_int_into_y_field_unboxed_nativeint : nativeint)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : nativeint =
   let prim = nativeint_of_int_into_y_field_unboxed_nativeint in
@@ -59,11 +61,11 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
   cont k (nativeint_add_into_nativeint_add_field_unboxed_nativeint)
 in
 let $camlUnbox_boxed_numbers__add_nativeint_19 =
-  closure add_nativeint_2_1 @add_nativeint
+  closure add_nativeint_2_1 @add_nativeint &toplevel.alloc_region
 in
 let code loopify(never) size(9) newer_version_of(test_int64_3)
       test_int64_3_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
@@ -72,7 +74,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
    let int64_of_int_into_int64_of_int_field_unboxed_int64_1 = prim_3 in
-   apply direct(add_int64_0_1)
+   apply direct(add_int64_0_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_int64_17 : _ -> int64)
        (int64_of_int_into_int64_of_int_field_unboxed_int64_1,
         int64_of_int_into_int64_of_int_field_unboxed_int64)
@@ -84,11 +86,11 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
       cont k (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__test_int64_20 =
-  closure test_int64_3_1 @test_int64
+  closure test_int64_3_1 @test_int64 &toplevel.alloc_region
 in
 let code loopify(never) size(11) newer_version_of(test_int32_4)
       test_int32_4_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
@@ -97,7 +99,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
    let int32_of_int_into_int32_of_int_field_unboxed_int32_1 = prim_3 in
-   apply direct(add_int32_1_1)
+   apply direct(add_int32_1_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_int32_18 : _ -> int32)
        (int32_of_int_into_int32_of_int_field_unboxed_int32_1,
         int32_of_int_into_int32_of_int_field_unboxed_int32)
@@ -109,11 +111,11 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
       cont k (int_of_int32)
 in
 let $camlUnbox_boxed_numbers__test_int32_21 =
-  closure test_int32_4_1 @test_int32
+  closure test_int32_4_1 @test_int32 &toplevel.alloc_region
 in
 let code loopify(never) size(10) newer_version_of(test_nativeint_5)
       test_nativeint_5_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
@@ -126,7 +128,7 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
    let nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1 =
      prim_3
    in
-   apply direct(add_nativeint_2_1)
+   apply direct(add_nativeint_2_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_nativeint_19 : _ -> nativeint)
        (nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1,
         nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint)
@@ -140,13 +142,13 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
       cont k (int_of_nativeint)
 in
 let $camlUnbox_boxed_numbers__test_nativeint_22 =
-  closure test_nativeint_5_1 @test_nativeint
+  closure test_nativeint_5_1 @test_nativeint &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(3) newer_version_of(add_float_6)
       add_float_6_1
         (float_of_int_into_x_field_unboxed_float : float,
          float_of_int_into_y_field_unboxed_float : float)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float =
   let prim = float_of_int_into_y_field_unboxed_float in
@@ -155,13 +157,14 @@ let code inline(never) loopify(never) size(3) newer_version_of(add_float_6)
   let float_add_into_float_add_field_unboxed_float = prim_2 in
   cont k (float_add_into_float_add_field_unboxed_float)
 in
-let $camlUnbox_boxed_numbers__add_float_23 = closure add_float_6_1 @add_float
+let $camlUnbox_boxed_numbers__add_float_23 =
+  closure add_float_6_1 @add_float &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(3) newer_version_of(add_float32_7)
       add_float32_7_1
         (float32_of_int_into_x_field_unboxed_float32 : float32,
          float32_of_int_into_y_field_unboxed_float32 : float32)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 =
   let prim = float32_of_int_into_y_field_unboxed_float32 in
@@ -171,11 +174,11 @@ let code inline(never) loopify(never) size(3) newer_version_of(add_float32_7)
   cont k (float32_add_into_float32_add_field_unboxed_float32)
 in
 let $camlUnbox_boxed_numbers__add_float32_24 =
-  closure add_float32_7_1 @add_float32
+  closure add_float32_7_1 @add_float32 &toplevel.alloc_region
 in
 let code loopify(never) size(12) newer_version_of(test_float_8)
       test_float_8_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
@@ -184,7 +187,7 @@ let code loopify(never) size(12) newer_version_of(test_float_8)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float`] (prim_2) in
    let float_of_int_into_float_of_int_field_unboxed_float_1 = prim_3 in
-   apply direct(add_float_6_1)
+   apply direct(add_float_6_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_float_23 : _ -> float)
        (float_of_int_into_float_of_int_field_unboxed_float_1,
         float_of_int_into_float_of_int_field_unboxed_float)
@@ -196,11 +199,11 @@ let code loopify(never) size(12) newer_version_of(test_float_8)
       cont k (int_of_float)
 in
 let $camlUnbox_boxed_numbers__test_float_25 =
-  closure test_float_8_1 @test_float
+  closure test_float_8_1 @test_float &toplevel.alloc_region
 in
 let code loopify(never) size(12) newer_version_of(test_float32_9)
       test_float32_9_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
@@ -209,7 +212,7 @@ let code loopify(never) size(12) newer_version_of(test_float32_9)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float32`] (prim_2) in
    let float32_of_int_into_float32_of_int_field_unboxed_float32_1 = prim_3 in
-   apply direct(add_float32_7_1)
+   apply direct(add_float32_7_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_float32_24 : _ -> float32)
        (float32_of_int_into_float32_of_int_field_unboxed_float32_1,
         float32_of_int_into_float32_of_int_field_unboxed_float32)
@@ -221,11 +224,11 @@ let code loopify(never) size(12) newer_version_of(test_float32_9)
       cont k (int_of_float32)
 in
 let $camlUnbox_boxed_numbers__test_float32_26 =
-  closure test_float32_9_1 @test_float32
+  closure test_float32_9_1 @test_float32 &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(3) newer_version_of(read_11)
       read_11_1 (read_into_my_closure_field_b_field_unboxed_int64 : int64)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let b_into_b_field_unboxed_int64 =
@@ -238,7 +241,7 @@ let code inline(never) loopify(never) size(3) newer_version_of(read_11)
 in
 let code loopify(never) size(10) newer_version_of(test_value_slot_10)
       test_value_slot_10_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
@@ -248,7 +251,7 @@ let code loopify(never) size(10) newer_version_of(test_value_slot_10)
   let read_into_read_field_b_field_unboxed_int64 =
     b_into_b_field_unboxed_int64
   in
-  apply direct(read_11_1)
+  apply direct(read_11_1 &my_alloc_region)
      (read_into_read_field_b_field_unboxed_int64) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
@@ -256,19 +259,20 @@ let code loopify(never) size(10) newer_version_of(test_value_slot_10)
       cont k (int_add)
 in
 let $camlUnbox_boxed_numbers__test_value_slot_27 =
-  closure test_value_slot_10_1 @test_value_slot
+  closure test_value_slot_10_1 @test_value_slot &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(6) newer_version_of(indirect_14)
       indirect_14_1 (read : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply read (0) -> k * k1
+  apply &my_alloc_region read (0) -> k * k1
 in
-let $camlUnbox_boxed_numbers__indirect_29 = closure indirect_14_1 @indirect
+let $camlUnbox_boxed_numbers__indirect_29 =
+  closure indirect_14_1 @indirect &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(4) newer_version_of(read_13)
       read_13_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let b_into_b_field_unboxed_int64 =
@@ -282,21 +286,21 @@ let code inline(never) loopify(never) size(4) newer_version_of(read_13)
 in
 let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_12)
       test_value_slot_not_unboxed_12_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
   let b_into_b_field_unboxed_int64 = prim_1 in
-  let read = closure read_13_1 @read
+  let read = closure read_13_1 @read &my_alloc_region &`region`
   with {
     unboxed_field_b_field_unboxed_int64 :
       int64 =
       b_into_b_field_unboxed_int64
   }
   in
-  apply direct(indirect_14_1)
+  apply direct(indirect_14_1 &my_alloc_region)
     $camlUnbox_boxed_numbers__indirect_29 (read) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
@@ -305,10 +309,11 @@ let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_12
 in
 let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_28 =
   closure test_value_slot_not_unboxed_12_1 @test_value_slot_not_unboxed
+    &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(3) newer_version_of(pair_first_15)
       pair_first_15_1 (Pmakeblock_into_p_field_0_field_unboxed_int64 : int64)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let int64_of_int_into_Pfield_field_unboxed_int64 =
@@ -320,11 +325,11 @@ let code inline(never) loopify(never) size(3) newer_version_of(pair_first_15)
   cont k (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__pair_first_30 =
-  closure pair_first_15_1 @pair_first
+  closure pair_first_15_1 @pair_first &toplevel.alloc_region
 in
 let code loopify(never) size(5) newer_version_of(test_pair_16)
       test_pair_16_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %untag_imm (a) in
@@ -333,13 +338,13 @@ let code loopify(never) size(5) newer_version_of(test_pair_16)
   let Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64 =
     int64_of_int_into_int64_of_int_field_unboxed_int64
   in
-  apply direct(pair_first_15_1)
+  apply direct(pair_first_15_1 &my_alloc_region)
     ($camlUnbox_boxed_numbers__pair_first_30 : _ -> imm tagged)
       (Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64)
       -> k * k1
 in
 let $camlUnbox_boxed_numbers__test_pair_31 =
-  closure test_pair_16_1 @test_pair
+  closure test_pair_16_1 @test_pair &toplevel.alloc_region
 in
 let $camlUnbox_boxed_numbers =
   Block 0 ($camlUnbox_boxed_numbers__test_int64_20,

--- a/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
@@ -17,56 +17,58 @@ let code pair_first_15 deleted in
 let code test_pair_16 deleted in
 let code inline(never) loopify(never) size(11) newer_version_of(add_int64_0)
       add_int64_0_1 (x : int64 boxed, y : int64 boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 boxed =
   let prim = %unbox_num.`int64` (y) in
   let prim_1 = %unbox_num.`int64` (x) in
   let prim_2 = %int_barith.`int64`.add (prim_1, prim) in
-  let int64_add = %box_num.`int64` (prim_2) in
+  let int64_add = %box_num.`int64`.my_alloc_region (prim_2) in
   cont k (int64_add)
 in
-let $camlUnbox_boxed_numbers__add_int64_17 = closure add_int64_0_1 @add_int64
+let $camlUnbox_boxed_numbers__add_int64_17 =
+  closure add_int64_0_1 @add_int64 &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(12) newer_version_of(add_int32_1)
       add_int32_1_1 (x : int32 boxed, y : int32 boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : int32 boxed =
   let prim = %unbox_num.`int32` (y) in
   let prim_1 = %unbox_num.`int32` (x) in
   let prim_2 = %int_barith.`int32`.add (prim_1, prim) in
-  let int32_add = %box_num.`int32` (prim_2) in
+  let int32_add = %box_num.`int32`.my_alloc_region (prim_2) in
   cont k (int32_add)
 in
-let $camlUnbox_boxed_numbers__add_int32_18 = closure add_int32_1_1 @add_int32
+let $camlUnbox_boxed_numbers__add_int32_18 =
+  closure add_int32_1_1 @add_int32 &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(11) newer_version_of(add_nativeint_2)
       add_nativeint_2_1 (x : nativeint boxed, y : nativeint boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : nativeint boxed =
   let prim = %unbox_num.`nativeint` (y) in
   let prim_1 = %unbox_num.`nativeint` (x) in
   let prim_2 = %int_barith.`nativeint`.add (prim_1, prim) in
-  let nativeint_add = %box_num.`nativeint` (prim_2) in
+  let nativeint_add = %box_num.`nativeint`.my_alloc_region (prim_2) in
   cont k (nativeint_add)
 in
 let $camlUnbox_boxed_numbers__add_nativeint_19 =
-  closure add_nativeint_2_1 @add_nativeint
+  closure add_nativeint_2_1 @add_nativeint &toplevel.alloc_region
 in
 let code loopify(never) size(21) newer_version_of(test_int64_3)
       test_int64_3_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
    let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
-   let int64_of_int = %box_num.`int64` (prim_1) in
+   let int64_of_int = %box_num.`int64`.my_alloc_region (prim_1) in
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
-   let int64_of_int_1 = %box_num.`int64` (prim_3) in
-   apply direct(add_int64_0_1)
+   let int64_of_int_1 = %box_num.`int64`.my_alloc_region (prim_3) in
+   apply direct(add_int64_0_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_int64_17 : _ -> int64 boxed)
        (int64_of_int_1, int64_of_int)
        -> k2 * k1)
@@ -77,20 +79,20 @@ let code loopify(never) size(21) newer_version_of(test_int64_3)
       cont k (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__test_int64_20 =
-  closure test_int64_3_1 @test_int64
+  closure test_int64_3_1 @test_int64 &toplevel.alloc_region
 in
 let code loopify(never) size(25) newer_version_of(test_int32_4)
       test_int32_4_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
    let prim_1 = %num_conv.[`imm`].[`int32`] (prim) in
-   let int32_of_int = %box_num.`int32` (prim_1) in
+   let int32_of_int = %box_num.`int32`.my_alloc_region (prim_1) in
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
-   let int32_of_int_1 = %box_num.`int32` (prim_3) in
-   apply direct(add_int32_1_1)
+   let int32_of_int_1 = %box_num.`int32`.my_alloc_region (prim_3) in
+   apply direct(add_int32_1_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_int32_18 : _ -> int32 boxed)
        (int32_of_int_1, int32_of_int)
        -> k2 * k1)
@@ -101,20 +103,20 @@ let code loopify(never) size(25) newer_version_of(test_int32_4)
       cont k (int_of_int32)
 in
 let $camlUnbox_boxed_numbers__test_int32_21 =
-  closure test_int32_4_1 @test_int32
+  closure test_int32_4_1 @test_int32 &toplevel.alloc_region
 in
 let code loopify(never) size(22) newer_version_of(test_nativeint_5)
       test_nativeint_5_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
    let prim_1 = %num_conv.[`imm`].[`nativeint`] (prim) in
-   let nativeint_of_int = %box_num.`nativeint` (prim_1) in
+   let nativeint_of_int = %box_num.`nativeint`.my_alloc_region (prim_1) in
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`nativeint`] (prim_2) in
-   let nativeint_of_int_1 = %box_num.`nativeint` (prim_3) in
-   apply direct(add_nativeint_2_1)
+   let nativeint_of_int_1 = %box_num.`nativeint`.my_alloc_region (prim_3) in
+   apply direct(add_nativeint_2_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_nativeint_19 : _ -> nativeint boxed)
        (nativeint_of_int_1, nativeint_of_int)
        -> k2 * k1)
@@ -125,47 +127,48 @@ let code loopify(never) size(22) newer_version_of(test_nativeint_5)
       cont k (int_of_nativeint)
 in
 let $camlUnbox_boxed_numbers__test_nativeint_22 =
-  closure test_nativeint_5_1 @test_nativeint
+  closure test_nativeint_5_1 @test_nativeint &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(10) newer_version_of(add_float_6)
       add_float_6_1 (x : float boxed, y : float boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
   let prim = %unbox_num.`float` (y) in
   let prim_1 = %unbox_num.`float` (x) in
   let prim_2 = %bfloat_arith.add (prim_1, prim) in
-  let float_add = %box_num.`float` (prim_2) in
+  let float_add = %box_num.`float`.my_alloc_region (prim_2) in
   cont k (float_add)
 in
-let $camlUnbox_boxed_numbers__add_float_23 = closure add_float_6_1 @add_float
+let $camlUnbox_boxed_numbers__add_float_23 =
+  closure add_float_6_1 @add_float &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(10) newer_version_of(add_float32_7)
       add_float32_7_1 (x : float32 boxed, y : float32 boxed)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 boxed =
   let prim = %unbox_num.fnt32 (y) in
   let prim_1 = %unbox_num.fnt32 (x) in
   let prim_2 = %bfloat_arith.`float32`.add (prim_1, prim) in
-  let float32_add = %box_num.fnt32 (prim_2) in
+  let float32_add = %box_num.fnt32.my_alloc_region (prim_2) in
   cont k (float32_add)
 in
 let $camlUnbox_boxed_numbers__add_float32_24 =
-  closure add_float32_7_1 @add_float32
+  closure add_float32_7_1 @add_float32 &toplevel.alloc_region
 in
 let code loopify(never) size(23) newer_version_of(test_float_8)
       test_float_8_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
    let prim_1 = %num_conv.[`imm`].[`float`] (prim) in
-   let float_of_int = %box_num.`float` (prim_1) in
+   let float_of_int = %box_num.`float`.my_alloc_region (prim_1) in
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float`] (prim_2) in
-   let float_of_int_1 = %box_num.`float` (prim_3) in
-   apply direct(add_float_6_1)
+   let float_of_int_1 = %box_num.`float`.my_alloc_region (prim_3) in
+   apply direct(add_float_6_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_float_23 : _ -> float boxed)
        (float_of_int_1, float_of_int)
        -> k2 * k1)
@@ -176,20 +179,20 @@ let code loopify(never) size(23) newer_version_of(test_float_8)
       cont k (int_of_float)
 in
 let $camlUnbox_boxed_numbers__test_float_25 =
-  closure test_float_8_1 @test_float
+  closure test_float_8_1 @test_float &toplevel.alloc_region
 in
 let code loopify(never) size(23) newer_version_of(test_float32_9)
       test_float32_9_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   (let prim = %untag_imm (b) in
    let prim_1 = %num_conv.[`imm`].[`float32`] (prim) in
-   let float32_of_int = %box_num.fnt32 (prim_1) in
+   let float32_of_int = %box_num.fnt32.my_alloc_region (prim_1) in
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float32`] (prim_2) in
-   let float32_of_int_1 = %box_num.fnt32 (prim_3) in
-   apply direct(add_float32_7_1)
+   let float32_of_int_1 = %box_num.fnt32.my_alloc_region (prim_3) in
+   apply direct(add_float32_7_1 &my_alloc_region)
      ($camlUnbox_boxed_numbers__add_float32_24 : _ -> float32 boxed)
        (float32_of_int_1, float32_of_int)
        -> k2 * k1)
@@ -200,11 +203,11 @@ let code loopify(never) size(23) newer_version_of(test_float32_9)
       cont k (int_of_float32)
 in
 let $camlUnbox_boxed_numbers__test_float32_26 =
-  closure test_float32_9_1 @test_float32
+  closure test_float32_9_1 @test_float32 &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(6) newer_version_of(read_11)
       read_11_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let b = %project_value_slot.[read].[b] (my_closure) in
@@ -215,34 +218,38 @@ let code inline(never) loopify(never) size(6) newer_version_of(read_11)
 in
 let code loopify(never) size(29) newer_version_of(test_value_slot_10)
       test_value_slot_10_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
-  let b = %box_num.`int64`.`local`[`region`] (prim_1) in
-  let read = closure read_11_1 @read with { b = b } in
-  apply direct(read_11_1) (read : _ -> imm tagged) (0) -> k2 * k1
+  let b = %box_num.`int64`.my_alloc_region.`local`[`region`] (prim_1) in
+  let read = closure read_11_1 @read &my_alloc_region &`region`
+  with { b = b }
+  in
+  apply direct(read_11_1 &my_alloc_region)
+    (read : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
       cont k (int_add)
 in
 let $camlUnbox_boxed_numbers__test_value_slot_27 =
-  closure test_value_slot_10_1 @test_value_slot
+  closure test_value_slot_10_1 @test_value_slot &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(6) newer_version_of(indirect_14)
       indirect_14_1 (read : val)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply read (0) -> k * k1
+  apply &my_alloc_region read (0) -> k * k1
 in
-let $camlUnbox_boxed_numbers__indirect_29 = closure indirect_14_1 @indirect
+let $camlUnbox_boxed_numbers__indirect_29 =
+  closure indirect_14_1 @indirect &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(6) newer_version_of(read_13)
       read_13_1 (param : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let b = %project_value_slot.[read_1].[b_1] (my_closure) in
@@ -253,15 +260,17 @@ let code inline(never) loopify(never) size(6) newer_version_of(read_13)
 in
 let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_12)
       test_value_slot_not_unboxed_12_1 (n : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let `region` = %begin_region () in
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
-  let b = %box_num.`int64`.`local`[`region`] (prim_1) in
-  let read = closure read_13_1 @read_1 with { b_1 = b } in
-  apply direct(indirect_14_1)
+  let b = %box_num.`int64`.my_alloc_region.`local`[`region`] (prim_1) in
+  let read = closure read_13_1 @read_1 &my_alloc_region &`region`
+  with { b_1 = b }
+  in
+  apply direct(indirect_14_1 &my_alloc_region)
     ($camlUnbox_boxed_numbers__indirect_29 : _ -> imm tagged)
       (read)
       -> k2 * k1
@@ -272,10 +281,11 @@ let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_12
 in
 let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_28 =
   closure test_value_slot_not_unboxed_12_1 @test_value_slot_not_unboxed
+    &toplevel.alloc_region
 in
 let code inline(never) loopify(never) size(6) newer_version_of(pair_first_15)
       pair_first_15_1 (p : [ 0 of int64 boxed * int64 boxed ])
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.[`0`] (p) in
@@ -285,27 +295,29 @@ let code inline(never) loopify(never) size(6) newer_version_of(pair_first_15)
   cont k (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__pair_first_30 =
-  closure pair_first_15_1 @pair_first
+  closure pair_first_15_1 @pair_first &toplevel.alloc_region
 in
 let code loopify(never) size(23) newer_version_of(test_pair_16)
       test_pair_16_1 (a : imm tagged, b : imm tagged)
-        my_closure _region _ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let prim = %untag_imm (b) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
-  let int64_of_int = %box_num.`int64` (prim_1) in
+  let int64_of_int = %box_num.`int64`.my_alloc_region (prim_1) in
   let prim_2 = %untag_imm (a) in
   let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
-  let int64_of_int_1 = %box_num.`int64` (prim_3) in
-  let Pmakeblock = %block.[`0`] (int64_of_int_1, int64_of_int) in
-  apply direct(pair_first_15_1)
+  let int64_of_int_1 = %box_num.`int64`.my_alloc_region (prim_3) in
+  let Pmakeblock =
+    %block.[`0`].my_alloc_region (int64_of_int_1, int64_of_int)
+  in
+  apply direct(pair_first_15_1 &my_alloc_region)
     ($camlUnbox_boxed_numbers__pair_first_30 : _ -> imm tagged)
       (Pmakeblock)
       -> k * k1
 in
 let $camlUnbox_boxed_numbers__test_pair_31 =
-  closure test_pair_16_1 @test_pair
+  closure test_pair_16_1 @test_pair &toplevel.alloc_region
 in
 let $camlUnbox_boxed_numbers =
   Block 0 ($camlUnbox_boxed_numbers__test_int64_20,


### PR DESCRIPTION
This is groundwork for zero-alloc checking with regions. For now, no checking takes place, these regions are erased when translating to cmm, and no primitives exist to create them or check them.