### PR TITLE
Bytecode: Deeply copy "unboxed" products elements on array/idx accesses

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -472,7 +472,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
                 ),
               Ptagged_int_index ) ->
             if unsafe then Getvectitem else Ccall "caml_array_get_addr"
-          | Punboxedvectorarray_ref _, _ ->
+          | (Punspecializedarray_ref _ | Punboxedvectorarray_ref _), _ ->
             (* Handled by the outer match. *)
             assert false
         in
@@ -517,7 +517,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
                 ),
               Ptagged_int_index ) ->
             if unsafe then Setvectitem else Ccall "caml_array_set_addr"
-          | Punboxedvectorarray_set _, _ ->
+          | (Punspecializedarray_set _ | Punboxedvectorarray_set _), _ ->
             (* Handled by the outer match. *)
             assert false
         in
@@ -733,10 +733,28 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         let element_size = Prim (Lsrint, [word_size; tagged_immediate 3]) in
         Sequence (comp_expr arg, element_size)
       | [] | _ :: _ :: _ -> wrong_arity ~expected:1)
-    | Pget_idx _ -> binary (Ccall "caml_get_idx_bytecode")
-    | Pset_idx _ -> ternary (Ccall "caml_set_idx_bytecode")
-    | Pget_ptr _ -> unary (Ccall "caml_get_ptr_bytecode")
-    | Pset_ptr _ -> binary (Ccall "caml_set_ptr_bytecode")
+    | Pget_idx (layout, _) ->
+      let elt = Lambda.mixed_block_element_of_layout layout in
+      copy_mixed_block_element elt (binary (Ccall "caml_get_idx_bytecode"))
+    | Pset_idx (layout, _) -> (
+      let elt = Lambda.mixed_block_element_of_layout layout in
+      match args with
+      | [arr; idx; value] ->
+        let copied_value = copy_mixed_block_element elt (comp_expr value) in
+        Prim
+          ( Ccall "caml_set_idx_bytecode",
+            [comp_expr arr; comp_expr idx; copied_value] )
+      | _ -> wrong_arity ~expected:3)
+    | Pget_ptr (layout, _) ->
+      let elt = Lambda.mixed_block_element_of_layout layout in
+      copy_mixed_block_element elt (unary (Ccall "caml_get_ptr_bytecode"))
+    | Pset_ptr (layout, _) -> (
+      let elt = Lambda.mixed_block_element_of_layout layout in
+      match args with
+      | [ptr; value] ->
+        let copied_value = copy_mixed_block_element elt (comp_expr value) in
+        Prim (Ccall "caml_set_ptr_bytecode", [comp_expr ptr; copied_value])
+      | _ -> wrong_arity ~expected:2)
     | Pmake_idx_field pos ->
       Const (Const_block (0, [Const_base (Const_int pos)]))
     | Pmake_idx_mixed_field (_, pos, path) ->

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -688,7 +688,12 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
           (* In bytecode, [caml_obj_dup] only does a shallow copy, so each slot
              of the duplicate would alias the corresponding slot in the source.
-             For product arrays we deep-copy every slot. *)
+             For product arrays we deep-copy every slot.
+
+             This extra copying of products is currently defensive, though: in
+             practice [Translcore] only produces [Pduparray] of a product array
+             with a [Pmakearray] argument, which the case above already handles.
+          *)
           let src_arg =
             match args with [s] -> comp_expr s | _ -> wrong_arity ~expected:1
           in

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -240,22 +240,11 @@ let copy_unboxed_product shape ~path expr =
     (Lambda.project_from_mixed_block_shape shape ~path)
     expr
 
-(** [element_of_array_ref_kind k] returns the [mixed_block_element] describing
-    one element of an array of [array_ref_kind] [k]. *)
-let element_of_array_ref_kind (k : Lambda.array_ref_kind) :
-    unit Lambda.mixed_block_element =
-  Lambda.mixed_block_element_of_layout (Lambda.array_ref_kind_result_layout k)
-
-(** As [element_of_array_ref_kind] but on [array_kind]. *)
+(** [element_of_array_kind k] returns the [mixed_block_element] describing one
+    element of an array of [array_kind] [k]. *)
 let element_of_array_kind (k : Lambda.array_kind) :
     unit Lambda.mixed_block_element =
-  element_of_array_ref_kind (Lambda.array_ref_kind Lambda.alloc_heap k)
-
-(** As [element_of_array_ref_kind] but on [array_set_kind]. *)
-let element_of_array_set_kind (k : Lambda.array_set_kind) :
-    unit Lambda.mixed_block_element =
-  element_of_array_ref_kind
-    (Lambda.array_ref_kind_of_array_set_kind k Lambda.alloc_heap)
+  Lambda.mixed_block_element_of_layout (Lambda.element_layout_of_array_kind k)
 
 (** Build a chain of nested [Let] bindings around [body]. *)
 let lets (bindings : (Ident.t * Blambda.blambda) list) (body : Blambda.blambda)
@@ -429,24 +418,76 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       in
       Ccall (prefix ^ suffix)
     in
-    (* For product array ref kinds, deep-copy the read result so it doesn't
-       alias the array slot. For non-product kinds this is identity. *)
-    let copy_for_array_ref_kind ref_kind expr =
-      copy_mixed_block_element (element_of_array_ref_kind ref_kind) expr
-    in
-    (* As [ternary primitive] but deep-copies the value being set (the 3rd
-       argument). For non-product set kinds this is equivalent to [ternary
-       primitive]. *)
-    let array_set_with_copy_value set_kind primitive =
-      match args with
-      | [arr; idx; value] ->
-        let copied_value =
-          copy_mixed_block_element
-            (element_of_array_set_kind set_kind)
-            (comp_expr value)
+    (* [array_ref ~unsafe ref_kind index_kind] compiles a Parrayref{s,u} of the
+       given [ref_kind] and [index_kind] to Blambda. For product ref kinds the
+       result is deep-copied so it doesn't alias the array slot; for other
+       kinds the copy is identity. *)
+    let array_ref ~unsafe (ref_kind : Lambda.array_ref_kind)
+        (index_kind : Lambda.array_index_kind) =
+      match ref_kind with
+      | Punspecializedarray_ref _ ->
+        Misc.fatal_error
+          "Blambda_of_lambda: array primitive with Punspecializedarray_ref"
+      | Punboxedvectorarray_ref _ -> simd_is_not_supported ()
+      | _ ->
+        let primitive : Blambda.primitive =
+          match ref_kind, index_kind with
+          | _, Punboxed_or_untagged_integer_index _ ->
+            indexing_primitive index_kind
+              (if unsafe then "caml_array_unsafe_get" else "caml_array_get")
+          | Pgenarray_ref _, Ptagged_int_index ->
+            Ccall (if unsafe then "caml_array_unsafe_get" else "caml_array_get")
+          | ( (Pfloatarray_ref _ | Punboxedfloatarray_ref Unboxed_float64),
+              Ptagged_int_index ) ->
+            Ccall
+              (if unsafe
+               then "caml_floatarray_unsafe_get"
+               else "caml_floatarray_get")
+          | _, Ptagged_int_index ->
+            if unsafe then Getvectitem else Ccall "caml_array_get_addr"
         in
-        Blambda.Prim (primitive, [comp_expr arr; comp_expr idx; copied_value])
-      | _ -> wrong_arity ~expected:3
+        copy_mixed_block_element
+          (element_of_array_kind (Lambda.array_kind_of_array_ref_kind ref_kind))
+          (binary primitive)
+    in
+    (* [array_set ~unsafe set_kind index_kind] compiles a Parrayset{s,u} of the
+       given [set_kind] and [index_kind] to Blambda. For product set kinds the
+       value being written is deep-copied; for other kinds the copy is
+       identity. *)
+    let array_set ~unsafe (set_kind : Lambda.array_set_kind)
+        (index_kind : Lambda.array_index_kind) =
+      match set_kind with
+      | Punspecializedarray_set _ ->
+        Misc.fatal_error
+          "Blambda_of_lambda: array primitive with Punspecializedarray_ref"
+      | Punboxedvectorarray_set _ -> simd_is_not_supported ()
+      | _ -> (
+        let primitive : Blambda.primitive =
+          match set_kind, index_kind with
+          | _, Punboxed_or_untagged_integer_index _ ->
+            indexing_primitive index_kind
+              (if unsafe then "caml_array_unsafe_set" else "caml_array_set")
+          | Pgenarray_set _, Ptagged_int_index ->
+            Ccall (if unsafe then "caml_array_unsafe_set" else "caml_array_set")
+          | ( (Pfloatarray_set | Punboxedfloatarray_set Unboxed_float64),
+              Ptagged_int_index ) ->
+            Ccall
+              (if unsafe
+               then "caml_floatarray_unsafe_set"
+               else "caml_floatarray_set")
+          | _, Ptagged_int_index ->
+            if unsafe then Setvectitem else Ccall "caml_array_set_addr"
+        in
+        match args with
+        | [arr; idx; value] ->
+          let copied_value =
+            copy_mixed_block_element
+              (element_of_array_kind
+                 (Lambda.array_kind_of_array_set_kind set_kind))
+              (comp_expr value)
+          in
+          Prim (primitive, [comp_expr arr; comp_expr idx; copied_value])
+        | _ -> wrong_arity ~expected:3)
     in
     match (primitive : Lambda.primitive) with
     | Pphys_equal cmp -> (
@@ -627,7 +668,9 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         | Pgenarray | Pintarray | Paddrarray | Pgcignorableaddrarray
         | Punboxedoruntaggedintarray _ | Pfloatarray | Punboxedfloatarray _
         | Punboxedvectorarray _ ->
-          unary (Ccall "caml_obj_dup")))
+          unary (Ccall "caml_obj_dup")
+        | Punspecializedarray ->
+          Misc.fatal_error "Blambda_of_lambda: Pduparray Punspecializedarray"))
     | Pmakeblock (tag, _mut, shape, _) -> (
       match Lambda.mixed_block_of_block_shape shape with
       | None -> pseudo_event (variadic (Makeblock { tag }))
@@ -789,114 +832,14 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     (* In bytecode, nothing is ever actually stack-allocated, so we ignore the
        array modes (allocation for [Parrayref{s,u}], modification for
        [Parrayset{s,u}]). *)
-    | Parrayrefs ((Pgenarray_ref _ as ref_kind), index_kind, _)
-    | Parrayrefs
-        ( (( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
-           | Pfloatarray_ref _
-           | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
-           | Punboxedoruntaggedintarray_ref _ | Pgcscannableproductarray_ref _
-           | Pgcignorableproductarray_ref _ ) as ref_kind),
-          (Punboxed_or_untagged_integer_index _ as index_kind),
-          _ ) ->
-      copy_for_array_ref_kind ref_kind
-        (binary (indexing_primitive index_kind "caml_array_get"))
-    | Parrayrefs
-        ( ((Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _) as
-           ref_kind),
-          Ptagged_int_index,
-          _ ) ->
-      copy_for_array_ref_kind ref_kind (binary (Ccall "caml_floatarray_get"))
-    | Parrayrefs
-        ( (( Punboxedfloatarray_ref Unboxed_float32
-           | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
-           | Pgcignorableaddrarray_ref | Pintarray_ref
-           | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ )
-           as ref_kind),
-          Ptagged_int_index,
-          _ ) ->
-      copy_for_array_ref_kind ref_kind (binary (Ccall "caml_array_get_addr"))
-    | Parraysets ((Pgenarray_set _ as set_kind), index_kind)
-    | Parraysets
-        ( (( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
-           | Pfloatarray_set
-           | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
-           | Punboxedoruntaggedintarray_set _ | Pgcscannableproductarray_set _
-           | Pgcignorableproductarray_set _ ) as set_kind),
-          (Punboxed_or_untagged_integer_index _ as index_kind) ) ->
-      array_set_with_copy_value set_kind
-        (indexing_primitive index_kind "caml_array_set")
-    | Parraysets
-        ( ((Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set) as set_kind),
-          Ptagged_int_index ) ->
-      array_set_with_copy_value set_kind (Ccall "caml_floatarray_set")
-    | Parraysets
-        ( (( Punboxedfloatarray_set Unboxed_float32
-           | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
-           | Pgcignorableaddrarray_set | Pintarray_set
-           | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ )
-           as set_kind),
-          Ptagged_int_index ) ->
-      array_set_with_copy_value set_kind (Ccall "caml_array_set_addr")
-    | Parrayrefu ((Pgenarray_ref _ as ref_kind), index_kind, _)
-    | Parrayrefu
-        ( (( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
-           | Pfloatarray_ref _
-           | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
-           | Punboxedoruntaggedintarray_ref _ | Pgcscannableproductarray_ref _
-           | Pgcignorableproductarray_ref _ ) as ref_kind),
-          (Punboxed_or_untagged_integer_index _ as index_kind),
-          _ ) ->
-      copy_for_array_ref_kind ref_kind
-        (binary (indexing_primitive index_kind "caml_array_unsafe_get"))
-    | Parrayrefu
-        ( ((Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _) as
-           ref_kind),
-          Ptagged_int_index,
-          _ ) ->
-      copy_for_array_ref_kind ref_kind
-        (binary (Ccall "caml_floatarray_unsafe_get"))
-    | Parrayrefu
-        ( (( Punboxedfloatarray_ref Unboxed_float32
-           | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
-           | Pgcignorableaddrarray_ref | Pintarray_ref
-           | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ )
-           as ref_kind),
-          Ptagged_int_index,
-          _ ) ->
-      copy_for_array_ref_kind ref_kind (binary Getvectitem)
-    | Parraysetu ((Pgenarray_set _ as set_kind), index_kind)
-    | Parraysetu
-        ( (( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
-           | Pfloatarray_set
-           | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
-           | Punboxedoruntaggedintarray_set _ | Pgcscannableproductarray_set _
-           | Pgcignorableproductarray_set _ ) as set_kind),
-          (Punboxed_or_untagged_integer_index _ as index_kind) ) ->
-      array_set_with_copy_value set_kind
-        (indexing_primitive index_kind "caml_array_unsafe_set")
-    | Parraysetu
-        ( ((Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set) as set_kind),
-          Ptagged_int_index ) ->
-      array_set_with_copy_value set_kind (Ccall "caml_floatarray_unsafe_set")
-    | Parraysetu
-        ( (( Punboxedfloatarray_set Unboxed_float32
-           | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
-           | Pgcignorableaddrarray_set | Pintarray_set
-           | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ )
-           as set_kind),
-          Ptagged_int_index ) ->
-      array_set_with_copy_value set_kind Setvectitem
-    | Parrayrefs (Punboxedvectorarray_ref _, _, _)
-    | Parraysets (Punboxedvectorarray_set _, _)
-    | Parrayrefu (Punboxedvectorarray_ref _, _, _)
-    | Parraysetu (Punboxedvectorarray_set _, _) ->
-      simd_is_not_supported ()
-    | Parrayrefs (Punspecializedarray_ref _, _, _)
-    | Parraysets (Punspecializedarray_set _, _)
-    | Parrayrefu (Punspecializedarray_ref _, _, _)
-    | Parraysetu (Punspecializedarray_set _, _) ->
-      Misc.fatal_error
-        "Blambda_of_lambda: array primitive on Punspecializedarray"
+    | Parrayrefs (ref_kind, index_kind, _) ->
+      array_ref ~unsafe:false ref_kind index_kind
+    | Parrayrefu (ref_kind, index_kind, _) ->
+      array_ref ~unsafe:true ref_kind index_kind
+    | Parraysets (set_kind, index_kind) ->
+      array_set ~unsafe:false set_kind index_kind
+    | Parraysetu (set_kind, index_kind) ->
+      array_set ~unsafe:true set_kind index_kind
     | Pctconst c -> unary (caml_sys_const c)
     | Pisint _ -> unary Isint
     | Pisout -> binary (Intcomp Ultint)
@@ -1045,7 +988,9 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
            ends up aliasing the corresponding block in [src]. For unboxed
            product arrays we follow the blit with a pass that overwrites each
            slot in the destination range with a fresh deep copy of itself. *)
-        let elt = element_of_array_set_kind set_kind in
+        let elt =
+          element_of_array_kind (Lambda.array_kind_of_array_set_kind set_kind)
+        in
         let src_arg, srcofs_arg, dst_arg, dstofs_arg, len_arg =
           match args with
           | [s; so; d; doff; n] ->

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -253,18 +253,35 @@ let lets (bindings : (Ident.t * Blambda.blambda) list) (body : Blambda.blambda)
     (fun (id, arg) body -> Blambda.Let { id; arg; body })
     bindings body
 
-(** [for_each_slot ~length ~body] builds a [For] loop running [body] for each
-    index in [0 .. length - 1], passing the loop-index ident to [body]. *)
-let for_each_slot ~(length : Blambda.blambda)
-    ~(body : Ident.t -> Blambda.blambda) : Blambda.blambda =
-  let i = Ident.create_local "i" in
-  For
-    { id = i;
-      from = Const (Const_base (Const_int 0));
-      to_ = Prim (Offsetint (-1), [length]);
-      dir = Upto;
-      body = body i
-    }
+(** [in_place_copy_array_slice ~length ~offset ~array ~elt] evaluates [length],
+    then [offset], then [array], binding each to a local. Then, for each [i] in
+    [0 .. length - 1], it overwrites the slot at index [offset + i] with a fresh
+    deep copy of its current contents. Returns the (bound) array. *)
+let in_place_copy_array_slice ~(length : Blambda.blambda)
+    ~(offset : Blambda.blambda) ~(array : Blambda.blambda)
+    ~(elt : unit Lambda.mixed_block_element) : Blambda.blambda =
+  let len_id = Ident.create_local "len" in
+  let offset_id = Ident.create_local "offset" in
+  let arr_id = Ident.create_local "arr" in
+  let i_id = Ident.create_local "i" in
+  lets
+    [len_id, length; offset_id, offset; arr_id, array]
+    (Sequence
+       ( Blambda.For
+           { id = i_id;
+             from = Const (Const_base (Const_int 0));
+             to_ = Prim (Offsetint (-1), [Var len_id]);
+             dir = Upto;
+             body =
+               (let idx = Prim (Addint, [Var offset_id; Var i_id]) in
+                Prim
+                  ( Setvectitem,
+                    [ Var arr_id;
+                      idx;
+                      copy_mixed_block_element elt
+                        (Prim (Getvectitem, [Var arr_id; idx])) ] ))
+           },
+         Var arr_id ))
 
 let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
   let comp_fun ({ params; body; loc = _ } as lfunction : Lambda.lfunction) :
@@ -672,25 +689,20 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
           (* In bytecode, [caml_obj_dup] only does a shallow copy, so each slot
              of the duplicate would alias the corresponding slot in the source.
              For product arrays we deep-copy every slot. *)
-          let elt = element_of_array_kind kind in
           let src_arg =
             match args with [s] -> comp_expr s | _ -> wrong_arity ~expected:1
           in
           let src_id = Ident.create_local "dup_src" in
-          let dst_id = Ident.create_local "dup_dst" in
-          lets
-            [src_id, src_arg; dst_id, Prim (Ccall "caml_obj_dup", [Var src_id])]
-            (Sequence
-               ( for_each_slot
-                   ~length:(Prim (Vectlength, [Var src_id]))
-                   ~body:(fun i ->
-                     Prim
-                       ( Setvectitem,
-                         [ Var dst_id;
-                           Var i;
-                           copy_mixed_block_element elt
-                             (Prim (Getvectitem, [Var src_id; Var i])) ] )),
-                 Var dst_id ))
+          Let
+            { id = src_id;
+              arg = src_arg;
+              body =
+                in_place_copy_array_slice
+                  ~length:(Prim (Vectlength, [Var src_id]))
+                  ~offset:(tagged_immediate 0)
+                  ~array:(Prim (Ccall "caml_obj_dup", [Var src_id]))
+                  ~elt:(element_of_array_kind kind)
+            }
         | Pgenarray | Pintarray | Paddrarray | Pgcignorableaddrarray
         | Punboxedoruntaggedintarray _ | Pfloatarray | Punboxedfloatarray _
         | Punboxedvectorarray _ ->
@@ -971,7 +983,6 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
            same [init] block. For unboxed products (boxed in bytecode), we must
            overwrite each slot with a fresh deep copy so slots don't alias the
            caller's initializer or each other. *)
-        let elt = element_of_array_kind kind in
         let n_arg, init_arg =
           match args with
           | [n; init] -> comp_expr n, comp_expr init
@@ -982,21 +993,14 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
           | Alloc_heap -> "caml_array_make"
           | Alloc_local -> "caml_array_make_local"
         in
-        let n_id = Ident.create_local "n" in
         let init_id = Ident.create_local "init" in
-        let arr_id = Ident.create_local "arr" in
+        let n_id = Ident.create_local "n" in
         lets
-          [ init_id, init_arg;
-            n_id, n_arg;
-            arr_id, Prim (Ccall cname, [Var n_id; Var init_id]) ]
-          (Sequence
-             ( for_each_slot ~length:(Var n_id) ~body:(fun i ->
-                   Prim
-                     ( Setvectitem,
-                       [ Var arr_id;
-                         Var i;
-                         copy_mixed_block_element elt (Var init_id) ] )),
-               Var arr_id ))
+          [init_id, init_arg; n_id, n_arg]
+          (in_place_copy_array_slice ~length:(Var n_id)
+             ~offset:(tagged_immediate 0)
+             ~array:(Prim (Ccall cname, [Var n_id; Var init_id]))
+             ~elt:(element_of_array_kind kind))
       | Pgenarray | Pintarray | Paddrarray | Pgcignorableaddrarray
       | Punboxedoruntaggedintarray _ | Pfloatarray | Punboxedfloatarray _ -> (
         match locality with
@@ -1034,19 +1038,9 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
               [Var src_id; Var srcofs_id; Var dst_id; Var dstofs_id; Var len_id]
             )
         in
-        let copy_slot i =
-          let idx = Ident.create_local "idx" in
-          Blambda.Let
-            { id = idx;
-              arg = Prim (Addint, [Var dstofs_id; Var i]);
-              body =
-                Prim
-                  ( Setvectitem,
-                    [ Var dst_id;
-                      Var idx;
-                      copy_mixed_block_element elt
-                        (Prim (Getvectitem, [Var dst_id; Var idx])) ] )
-            }
+        let copy_pass =
+          in_place_copy_array_slice ~length:(Var len_id) ~offset:(Var dstofs_id)
+            ~array:(Var dst_id) ~elt
         in
         lets
           [ len_id, len_arg;
@@ -1054,8 +1048,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
             dst_id, dst_arg;
             srcofs_id, srcofs_arg;
             src_id, src_arg ]
-          (Sequence
-             (blit_call, for_each_slot ~length:(Var len_id) ~body:copy_slot))
+          (Sequence (Sequence (blit_call, copy_pass), unit))
       | Pgenarray_set _ | Pintarray_set | Paddrarray_set _
       | Pgcignorableaddrarray_set | Punboxedoruntaggedintarray_set _
       | Pfloatarray_set | Punboxedfloatarray_set _ ->

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -432,19 +432,32 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | _ ->
         let primitive : Blambda.primitive =
           match ref_kind, index_kind with
-          | _, Punboxed_or_untagged_integer_index _ ->
+          | Pgenarray_ref _, _
+          | ( ( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
+              | Pfloatarray_ref _
+              | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
+              | Punboxedoruntaggedintarray_ref _
+              | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _
+                ),
+              Punboxed_or_untagged_integer_index _ ) ->
             indexing_primitive index_kind
               (if unsafe then "caml_array_unsafe_get" else "caml_array_get")
-          | Pgenarray_ref _, Ptagged_int_index ->
-            Ccall (if unsafe then "caml_array_unsafe_get" else "caml_array_get")
-          | ( (Pfloatarray_ref _ | Punboxedfloatarray_ref Unboxed_float64),
+          | ( (Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _),
               Ptagged_int_index ) ->
             Ccall
               (if unsafe
                then "caml_floatarray_unsafe_get"
                else "caml_floatarray_get")
-          | _, Ptagged_int_index ->
+          | ( ( Punboxedfloatarray_ref Unboxed_float32
+              | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
+              | Pgcignorableaddrarray_ref | Pintarray_ref
+              | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _
+                ),
+              Ptagged_int_index ) ->
             if unsafe then Getvectitem else Ccall "caml_array_get_addr"
+          | Punboxedvectorarray_ref _, _ ->
+            (* Handled by the outer match. *)
+            assert false
         in
         copy_mixed_block_element
           (element_of_array_kind (Lambda.array_kind_of_array_ref_kind ref_kind))
@@ -464,19 +477,32 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | _ -> (
         let primitive : Blambda.primitive =
           match set_kind, index_kind with
-          | _, Punboxed_or_untagged_integer_index _ ->
+          | Pgenarray_set _, _
+          | ( ( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
+              | Pfloatarray_set
+              | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
+              | Punboxedoruntaggedintarray_set _
+              | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _
+                ),
+              Punboxed_or_untagged_integer_index _ ) ->
             indexing_primitive index_kind
               (if unsafe then "caml_array_unsafe_set" else "caml_array_set")
-          | Pgenarray_set _, Ptagged_int_index ->
-            Ccall (if unsafe then "caml_array_unsafe_set" else "caml_array_set")
-          | ( (Pfloatarray_set | Punboxedfloatarray_set Unboxed_float64),
+          | ( (Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set),
               Ptagged_int_index ) ->
             Ccall
               (if unsafe
                then "caml_floatarray_unsafe_set"
                else "caml_floatarray_set")
-          | _, Ptagged_int_index ->
+          | ( ( Punboxedfloatarray_set Unboxed_float32
+              | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
+              | Pgcignorableaddrarray_set | Pintarray_set
+              | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _
+                ),
+              Ptagged_int_index ) ->
             if unsafe then Setvectitem else Ccall "caml_array_set_addr"
+          | Punboxedvectorarray_set _, _ ->
+            (* Handled by the outer match. *)
+            assert false
         in
         match args with
         | [arr; idx; value] ->

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -960,8 +960,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         let init_id = Ident.create_local "init" in
         let arr_id = Ident.create_local "arr" in
         lets
-          [ n_id, n_arg;
-            init_id, init_arg;
+          [ init_id, init_arg;
+            n_id, n_arg;
             arr_id, Prim (Ccall cname, [Var n_id; Var init_id]) ]
           (Sequence
              ( for_each_slot ~length:(Var n_id) ~body:(fun i ->
@@ -1023,11 +1023,11 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
             }
         in
         lets
-          [ src_id, src_arg;
-            srcofs_id, srcofs_arg;
-            dst_id, dst_arg;
+          [ len_id, len_arg;
             dstofs_id, dstofs_arg;
-            len_id, len_arg ]
+            dst_id, dst_arg;
+            srcofs_id, srcofs_arg;
+            src_id, src_arg ]
           (Sequence
              (blit_call, for_each_slot ~length:(Var len_id) ~body:copy_slot))
       | Pgenarray_set _ | Pintarray_set | Paddrarray_set _

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -204,35 +204,78 @@ let static_cast ~src ~dst x =
        modulo 2^8 or 2^16. *)
     sign_extend dst x
 
-(** [copy_unboxed_product shape ~path expr] generates Blambda code that creates
-    a fresh deep copy of [expr] if the field at [path] in [shape] is an unboxed
-    product. For non-product elements, returns [expr] unchanged. For products,
-    allocates a fresh block and recursively copies each field.
+(** [copy_mixed_block_element elt expr] generates Blambda code that creates a
+    fresh deep copy of [expr] if [elt] is an unboxed product. For non-product
+    elements, returns [expr] unchanged. For products, allocates a fresh block
+    and recursively copies each field.
 
     This is needed because in bytecode, unboxed products are represented as
     boxed blocks. Without copying, reading or writing an unboxed product from/to
-    a mutable field would alias the original, causing mutations via set_idx to
-    affect both. *)
+    a mutable field (or to/from an array slot) would alias the original, causing
+    mutations to affect both. *)
+let rec copy_mixed_block_element (elt : _ Lambda.mixed_block_element)
+    (expr : Blambda.blambda) : Blambda.blambda =
+  match elt with
+  | Product elements ->
+    (* Bind expr to a variable so it's only evaluated once *)
+    let id = Ident.create_local "copy_src" in
+    let copied_fields =
+      Array.to_list
+        (Array.mapi
+           (fun i field_elt ->
+             copy_mixed_block_element field_elt (Prim (Getfield i, [Var id])))
+           elements)
+    in
+    Let { id; arg = expr; body = Prim (Makeblock { tag = 0 }, copied_fields) }
+  | Value _ | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16 | Bits32
+  | Bits64 | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
+    expr
+  | Splice_variable var -> Lambda.fatal_error_unevaluated_splice_var var
+
+(** [copy_unboxed_product shape ~path expr] generates Blambda code that creates
+    a fresh deep copy of [expr] if the field at [path] in [shape] is an unboxed
+    product. *)
 let copy_unboxed_product shape ~path expr =
-  let rec copy_element (elt : _ Lambda.mixed_block_element) expr =
-    match elt with
-    | Product elements ->
-      (* Bind expr to a variable so it's only evaluated once *)
-      let id = Ident.create_local "copy_src" in
-      let copied_fields =
-        Array.to_list
-          (Array.mapi
-             (fun i field_elt ->
-               copy_element field_elt (Prim (Getfield i, [Var id])))
-             elements)
-      in
-      Let { id; arg = expr; body = Prim (Makeblock { tag = 0 }, copied_fields) }
-    | Value _ | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16 | Bits32
-    | Bits64 | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
-      expr
-    | Splice_variable var -> Lambda.fatal_error_unevaluated_splice_var var
-  in
-  copy_element (Lambda.project_from_mixed_block_shape shape ~path) expr
+  copy_mixed_block_element
+    (Lambda.project_from_mixed_block_shape shape ~path)
+    expr
+
+(** [element_of_array_ref_kind k] returns the [mixed_block_element] describing
+    one element of an array of [array_ref_kind] [k]. *)
+let element_of_array_ref_kind (k : Lambda.array_ref_kind) :
+    unit Lambda.mixed_block_element =
+  Lambda.mixed_block_element_of_layout (Lambda.array_ref_kind_result_layout k)
+
+(** As [element_of_array_ref_kind] but on [array_kind]. *)
+let element_of_array_kind (k : Lambda.array_kind) :
+    unit Lambda.mixed_block_element =
+  element_of_array_ref_kind (Lambda.array_ref_kind Lambda.alloc_heap k)
+
+(** As [element_of_array_ref_kind] but on [array_set_kind]. *)
+let element_of_array_set_kind (k : Lambda.array_set_kind) :
+    unit Lambda.mixed_block_element =
+  element_of_array_ref_kind
+    (Lambda.array_ref_kind_of_array_set_kind k Lambda.alloc_heap)
+
+(** Build a chain of nested [Let] bindings around [body]. *)
+let lets (bindings : (Ident.t * Blambda.blambda) list) (body : Blambda.blambda)
+    : Blambda.blambda =
+  List.fold_right
+    (fun (id, arg) body -> Blambda.Let { id; arg; body })
+    bindings body
+
+(** [for_each_slot ~length ~body] builds a [For] loop running [body] for each
+    index in [0 .. length - 1], passing the loop-index ident to [body]. *)
+let for_each_slot ~(length : Blambda.blambda)
+    ~(body : Ident.t -> Blambda.blambda) : Blambda.blambda =
+  let i = Ident.create_local "i" in
+  For
+    { id = i;
+      from = Const (Const_base (Const_int 0));
+      to_ = Prim (Offsetint (-1), [length]);
+      dir = Upto;
+      body = body i
+    }
 
 let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
   let comp_fun ({ params; body; loc = _ } as lfunction : Lambda.lfunction) :
@@ -386,6 +429,25 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       in
       Ccall (prefix ^ suffix)
     in
+    (* For product array ref kinds, deep-copy the read result so it doesn't
+       alias the array slot. For non-product kinds this is identity. *)
+    let copy_for_array_ref_kind ref_kind expr =
+      copy_mixed_block_element (element_of_array_ref_kind ref_kind) expr
+    in
+    (* As [ternary primitive] but deep-copies the value being set (the 3rd
+       argument). For non-product set kinds this is equivalent to [ternary
+       primitive]. *)
+    let array_set_with_copy_value set_kind primitive =
+      match args with
+      | [arr; idx; value] ->
+        let copied_value =
+          copy_mixed_block_element
+            (element_of_array_set_kind set_kind)
+            (comp_expr value)
+        in
+        Blambda.Prim (primitive, [comp_expr arr; comp_expr idx; copied_value])
+      | _ -> wrong_arity ~expected:3
+    in
     match (primitive : Lambda.primitive) with
     | Pphys_equal cmp -> (
       match check_arity ~arity:2 with
@@ -428,13 +490,19 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Pmakearray (kind, _, _) ->
       pseudo_event
         (match kind with
-        (* arrays of unboxed types have the same representation
-           as the boxed ones on bytecode *)
-        | Pintarray | Paddrarray | Pgcignorableaddrarray
-        | Punboxedoruntaggedintarray _
-        | Punboxedfloatarray Unboxed_float32
-        | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
-          variadic (Makeblock { tag = 0 })
+        (* arrays of unboxed types have the same representation as the boxed
+           ones on bytecode. Product elements need an extra deep copy so the
+           array slot does not alias the caller's product block. *)
+        | ( Pintarray | Paddrarray | Pgcignorableaddrarray
+          | Punboxedoruntaggedintarray _
+          | Punboxedfloatarray Unboxed_float32
+          | Pgcscannableproductarray _ | Pgcignorableproductarray _ ) as kind ->
+          let elt = element_of_array_kind kind in
+          Prim
+            ( Makeblock { tag = 0 },
+              List.map
+                (fun a -> copy_mixed_block_element elt (comp_expr a))
+                args )
         | Pfloatarray | Punboxedfloatarray Unboxed_float64 ->
           variadic Makefloatblock
         | Punboxedvectorarray _ -> simd_is_not_supported ()
@@ -531,7 +599,35 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | [Lprim (Pmakearray (kind', _, m), args, _)] ->
         assert (kind = kind');
         comp_expr (Lambda.Lprim (Pmakearray (kind, mutability, m), args, loc))
-      | _ -> unary (Ccall "caml_obj_dup"))
+      | _ -> (
+        match kind with
+        | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+          (* In bytecode, [caml_obj_dup] only does a shallow copy, so each slot
+             of the duplicate would alias the corresponding slot in the source.
+             For product arrays we deep-copy every slot. *)
+          let elt = element_of_array_kind kind in
+          let src_arg =
+            match args with [s] -> comp_expr s | _ -> wrong_arity ~expected:1
+          in
+          let src_id = Ident.create_local "dup_src" in
+          let dst_id = Ident.create_local "dup_dst" in
+          lets
+            [src_id, src_arg; dst_id, Prim (Ccall "caml_obj_dup", [Var src_id])]
+            (Sequence
+               ( for_each_slot
+                   ~length:(Prim (Vectlength, [Var src_id]))
+                   ~body:(fun i ->
+                     Prim
+                       ( Setvectitem,
+                         [ Var dst_id;
+                           Var i;
+                           copy_mixed_block_element elt
+                             (Prim (Getvectitem, [Var src_id; Var i])) ] )),
+                 Var dst_id ))
+        | Pgenarray | Pintarray | Paddrarray | Pgcignorableaddrarray
+        | Punboxedoruntaggedintarray _ | Pfloatarray | Punboxedfloatarray _
+        | Punboxedvectorarray _ ->
+          unary (Ccall "caml_obj_dup")))
     | Pmakeblock (tag, _mut, shape, _) -> (
       match Lambda.mixed_block_of_block_shape shape with
       | None -> pseudo_event (variadic (Makeblock { tag }))
@@ -693,92 +789,103 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     (* In bytecode, nothing is ever actually stack-allocated, so we ignore the
        array modes (allocation for [Parrayref{s,u}], modification for
        [Parrayset{s,u}]). *)
-    | Parrayrefs (Pgenarray_ref _, index_kind, _)
+    | Parrayrefs ((Pgenarray_ref _ as ref_kind), index_kind, _)
     | Parrayrefs
-        ( ( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
-          | Pfloatarray_ref _
-          | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
-          | Punboxedoruntaggedintarray_ref _ | Pgcscannableproductarray_ref _
-          | Pgcignorableproductarray_ref _ ),
+        ( (( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
+           | Pfloatarray_ref _
+           | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
+           | Punboxedoruntaggedintarray_ref _ | Pgcscannableproductarray_ref _
+           | Pgcignorableproductarray_ref _ ) as ref_kind),
           (Punboxed_or_untagged_integer_index _ as index_kind),
           _ ) ->
-      binary (indexing_primitive index_kind "caml_array_get")
+      copy_for_array_ref_kind ref_kind
+        (binary (indexing_primitive index_kind "caml_array_get"))
     | Parrayrefs
-        ( (Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _),
+        ( ((Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _) as
+           ref_kind),
           Ptagged_int_index,
           _ ) ->
-      binary (Ccall "caml_floatarray_get")
+      copy_for_array_ref_kind ref_kind (binary (Ccall "caml_floatarray_get"))
     | Parrayrefs
-        ( ( Punboxedfloatarray_ref Unboxed_float32
-          | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
-          | Pgcignorableaddrarray_ref | Pintarray_ref
-          | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
+        ( (( Punboxedfloatarray_ref Unboxed_float32
+           | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
+           | Pgcignorableaddrarray_ref | Pintarray_ref
+           | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ )
+           as ref_kind),
           Ptagged_int_index,
           _ ) ->
-      binary (Ccall "caml_array_get_addr")
-    | Parraysets (Pgenarray_set _, index_kind)
+      copy_for_array_ref_kind ref_kind (binary (Ccall "caml_array_get_addr"))
+    | Parraysets ((Pgenarray_set _ as set_kind), index_kind)
     | Parraysets
-        ( ( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
-          | Pfloatarray_set
-          | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
-          | Punboxedoruntaggedintarray_set _ | Pgcscannableproductarray_set _
-          | Pgcignorableproductarray_set _ ),
+        ( (( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
+           | Pfloatarray_set
+           | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
+           | Punboxedoruntaggedintarray_set _ | Pgcscannableproductarray_set _
+           | Pgcignorableproductarray_set _ ) as set_kind),
           (Punboxed_or_untagged_integer_index _ as index_kind) ) ->
-      ternary (indexing_primitive index_kind "caml_array_set")
+      array_set_with_copy_value set_kind
+        (indexing_primitive index_kind "caml_array_set")
     | Parraysets
-        ( (Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set),
+        ( ((Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set) as set_kind),
           Ptagged_int_index ) ->
-      ternary (Ccall "caml_floatarray_set")
+      array_set_with_copy_value set_kind (Ccall "caml_floatarray_set")
     | Parraysets
-        ( ( Punboxedfloatarray_set Unboxed_float32
-          | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
-          | Pgcignorableaddrarray_set | Pintarray_set
-          | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
+        ( (( Punboxedfloatarray_set Unboxed_float32
+           | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
+           | Pgcignorableaddrarray_set | Pintarray_set
+           | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ )
+           as set_kind),
           Ptagged_int_index ) ->
-      ternary (Ccall "caml_array_set_addr")
-    | Parrayrefu (Pgenarray_ref _, index_kind, _)
+      array_set_with_copy_value set_kind (Ccall "caml_array_set_addr")
+    | Parrayrefu ((Pgenarray_ref _ as ref_kind), index_kind, _)
     | Parrayrefu
-        ( ( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
-          | Pfloatarray_ref _
-          | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
-          | Punboxedoruntaggedintarray_ref _ | Pgcscannableproductarray_ref _
-          | Pgcignorableproductarray_ref _ ),
+        ( (( Paddrarray_ref | Pgcignorableaddrarray_ref | Pintarray_ref
+           | Pfloatarray_ref _
+           | Punboxedfloatarray_ref (Unboxed_float64 | Unboxed_float32)
+           | Punboxedoruntaggedintarray_ref _ | Pgcscannableproductarray_ref _
+           | Pgcignorableproductarray_ref _ ) as ref_kind),
           (Punboxed_or_untagged_integer_index _ as index_kind),
           _ ) ->
-      binary (indexing_primitive index_kind "caml_array_unsafe_get")
+      copy_for_array_ref_kind ref_kind
+        (binary (indexing_primitive index_kind "caml_array_unsafe_get"))
     | Parrayrefu
-        ( (Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _),
+        ( ((Punboxedfloatarray_ref Unboxed_float64 | Pfloatarray_ref _) as
+           ref_kind),
           Ptagged_int_index,
           _ ) ->
-      binary (Ccall "caml_floatarray_unsafe_get")
+      copy_for_array_ref_kind ref_kind
+        (binary (Ccall "caml_floatarray_unsafe_get"))
     | Parrayrefu
-        ( ( Punboxedfloatarray_ref Unboxed_float32
-          | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
-          | Pgcignorableaddrarray_ref | Pintarray_ref
-          | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
+        ( (( Punboxedfloatarray_ref Unboxed_float32
+           | Punboxedoruntaggedintarray_ref _ | Paddrarray_ref
+           | Pgcignorableaddrarray_ref | Pintarray_ref
+           | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ )
+           as ref_kind),
           Ptagged_int_index,
           _ ) ->
-      binary Getvectitem
-    | Parraysetu (Pgenarray_set _, index_kind)
+      copy_for_array_ref_kind ref_kind (binary Getvectitem)
+    | Parraysetu ((Pgenarray_set _ as set_kind), index_kind)
     | Parraysetu
-        ( ( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
-          | Pfloatarray_set
-          | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
-          | Punboxedoruntaggedintarray_set _ | Pgcscannableproductarray_set _
-          | Pgcignorableproductarray_set _ ),
+        ( (( Paddrarray_set _ | Pgcignorableaddrarray_set | Pintarray_set
+           | Pfloatarray_set
+           | Punboxedfloatarray_set (Unboxed_float64 | Unboxed_float32)
+           | Punboxedoruntaggedintarray_set _ | Pgcscannableproductarray_set _
+           | Pgcignorableproductarray_set _ ) as set_kind),
           (Punboxed_or_untagged_integer_index _ as index_kind) ) ->
-      ternary (indexing_primitive index_kind "caml_array_unsafe_set")
+      array_set_with_copy_value set_kind
+        (indexing_primitive index_kind "caml_array_unsafe_set")
     | Parraysetu
-        ( (Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set),
+        ( ((Punboxedfloatarray_set Unboxed_float64 | Pfloatarray_set) as set_kind),
           Ptagged_int_index ) ->
-      ternary (Ccall "caml_floatarray_unsafe_set")
+      array_set_with_copy_value set_kind (Ccall "caml_floatarray_unsafe_set")
     | Parraysetu
-        ( ( Punboxedfloatarray_set Unboxed_float32
-          | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
-          | Pgcignorableaddrarray_set | Pintarray_set
-          | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
+        ( (( Punboxedfloatarray_set Unboxed_float32
+           | Punboxedoruntaggedintarray_set _ | Paddrarray_set _
+           | Pgcignorableaddrarray_set | Pintarray_set
+           | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ )
+           as set_kind),
           Ptagged_int_index ) ->
-      ternary Setvectitem
+      array_set_with_copy_value set_kind Setvectitem
     | Parrayrefs (Punboxedvectorarray_ref _, _, _)
     | Parraysets (Punboxedvectorarray_set _, _)
     | Parrayrefu (Punboxedvectorarray_ref _, _, _)
@@ -890,9 +997,39 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
          arrays epic for out plan to deal with it. *)
       match kind with
       | Punboxedvectorarray _ -> simd_is_not_supported ()
+      | (Pgcscannableproductarray _ | Pgcignorableproductarray _) as kind ->
+        (* In bytecode, [caml_array_make n init] makes every slot point to the
+           same [init] block. For unboxed products (boxed in bytecode), we must
+           overwrite each slot with a fresh deep copy so slots don't alias the
+           caller's initializer or each other. *)
+        let elt = element_of_array_kind kind in
+        let n_arg, init_arg =
+          match args with
+          | [n; init] -> comp_expr n, comp_expr init
+          | _ -> wrong_arity ~expected:2
+        in
+        let cname =
+          match locality with
+          | Alloc_heap -> "caml_array_make"
+          | Alloc_local -> "caml_array_make_local"
+        in
+        let n_id = Ident.create_local "n" in
+        let init_id = Ident.create_local "init" in
+        let arr_id = Ident.create_local "arr" in
+        lets
+          [ n_id, n_arg;
+            init_id, init_arg;
+            arr_id, Prim (Ccall cname, [Var n_id; Var init_id]) ]
+          (Sequence
+             ( for_each_slot ~length:(Var n_id) ~body:(fun i ->
+                   Prim
+                     ( Setvectitem,
+                       [ Var arr_id;
+                         Var i;
+                         copy_mixed_block_element elt (Var init_id) ] )),
+               Var arr_id ))
       | Pgenarray | Pintarray | Paddrarray | Pgcignorableaddrarray
-      | Punboxedoruntaggedintarray _ | Pfloatarray | Punboxedfloatarray _
-      | Pgcscannableproductarray _ | Pgcignorableproductarray _ -> (
+      | Punboxedoruntaggedintarray _ | Pfloatarray | Punboxedfloatarray _ -> (
         match locality with
         | Alloc_heap -> binary (Ccall "caml_array_make")
         | Alloc_local -> binary (Ccall "caml_array_make_local"))
@@ -902,10 +1039,55 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Parrayblit { src_mutability = _; dst_array_set_kind } -> (
       match dst_array_set_kind with
       | Punboxedvectorarray_set _ -> simd_is_not_supported ()
+      | (Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _) as
+        set_kind ->
+        (* [caml_array_blit] is a shallow copy: each blitted slot of [dst]
+           ends up aliasing the corresponding block in [src]. For unboxed
+           product arrays we follow the blit with a pass that overwrites each
+           slot in the destination range with a fresh deep copy of itself. *)
+        let elt = element_of_array_set_kind set_kind in
+        let src_arg, srcofs_arg, dst_arg, dstofs_arg, len_arg =
+          match args with
+          | [s; so; d; doff; n] ->
+            comp_expr s, comp_expr so, comp_expr d, comp_expr doff, comp_expr n
+          | _ -> wrong_arity ~expected:5
+        in
+        let src_id = Ident.create_local "blit_src" in
+        let srcofs_id = Ident.create_local "blit_srcofs" in
+        let dst_id = Ident.create_local "blit_dst" in
+        let dstofs_id = Ident.create_local "blit_dstofs" in
+        let len_id = Ident.create_local "blit_len" in
+        let blit_call =
+          Blambda.Prim
+            ( Ccall "caml_array_blit",
+              [Var src_id; Var srcofs_id; Var dst_id; Var dstofs_id; Var len_id]
+            )
+        in
+        let copy_slot i =
+          let idx = Ident.create_local "idx" in
+          Blambda.Let
+            { id = idx;
+              arg = Prim (Addint, [Var dstofs_id; Var i]);
+              body =
+                Prim
+                  ( Setvectitem,
+                    [ Var dst_id;
+                      Var idx;
+                      copy_mixed_block_element elt
+                        (Prim (Getvectitem, [Var dst_id; Var idx])) ] )
+            }
+        in
+        lets
+          [ src_id, src_arg;
+            srcofs_id, srcofs_arg;
+            dst_id, dst_arg;
+            dstofs_id, dstofs_arg;
+            len_id, len_arg ]
+          (Sequence
+             (blit_call, for_each_slot ~length:(Var len_id) ~body:copy_slot))
       | Pgenarray_set _ | Pintarray_set | Paddrarray_set _
       | Pgcignorableaddrarray_set | Punboxedoruntaggedintarray_set _
-      | Pfloatarray_set | Punboxedfloatarray_set _
-      | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ->
+      | Pfloatarray_set | Punboxedfloatarray_set _ ->
         n_ary (Ccall "caml_array_blit") ~arity:5
       | Punspecializedarray_set _ ->
         Misc.fatal_error "Blambda_of_lambda: Parrayblit Punspecializedarray_set"

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2877,19 +2877,44 @@ and layout_of_ignorable_kind = function
   | Punboxedoruntaggedint_ignorable i -> layout_unboxed_int i
   | Pproduct_ignorable kinds -> layout_of_ignorable_kinds kinds
 
-let array_ref_kind_result_layout = function
-  | Pintarray_ref -> layout_int
-  | Pfloatarray_ref _ -> layout_boxed_float Boxed_float64
-  | Punboxedfloatarray_ref bf -> layout_unboxed_float bf
-  | Pgenarray_ref _ | Paddrarray_ref | Pgcignorableaddrarray_ref ->
-    layout_value_field
-  | Punboxedoruntaggedintarray_ref i -> layout_unboxed_int i
-  | Punboxedvectorarray_ref bv -> layout_unboxed_vector bv
-  | Pgcscannableproductarray_ref kinds -> layout_of_scannable_kinds kinds
-  | Pgcignorableproductarray_ref kinds -> layout_of_ignorable_kinds kinds
-  | Punspecializedarray_ref _ ->
+let element_layout_of_array_kind = function
+  | Pintarray -> layout_int
+  | Pfloatarray -> layout_boxed_float Boxed_float64
+  | Punboxedfloatarray bf -> layout_unboxed_float bf
+  | Pgenarray | Paddrarray | Pgcignorableaddrarray -> layout_value_field
+  | Punboxedoruntaggedintarray i -> layout_unboxed_int i
+  | Punboxedvectorarray bv -> layout_unboxed_vector bv
+  | Pgcscannableproductarray kinds -> layout_of_scannable_kinds kinds
+  | Pgcignorableproductarray kinds -> layout_of_ignorable_kinds kinds
+  | Punspecializedarray ->
     Misc.fatal_error
-      "Lambda.array_ref_kind_result_layout: Punspecializedarray_ref"
+      "Lambda.element_layout_of_array_kind: Punspecializedarray_ref"
+
+let array_kind_of_array_ref_kind : array_ref_kind -> array_kind = function
+  | Pgenarray_ref _ -> Pgenarray
+  | Paddrarray_ref -> Paddrarray
+  | Pgcignorableaddrarray_ref -> Pgcignorableaddrarray
+  | Pintarray_ref -> Pintarray
+  | Pfloatarray_ref _ -> Pfloatarray
+  | Punboxedfloatarray_ref bf -> Punboxedfloatarray bf
+  | Punboxedoruntaggedintarray_ref i -> Punboxedoruntaggedintarray i
+  | Punboxedvectorarray_ref bv -> Punboxedvectorarray bv
+  | Pgcscannableproductarray_ref kinds -> Pgcscannableproductarray kinds
+  | Pgcignorableproductarray_ref kinds -> Pgcignorableproductarray kinds
+  | Punspecializedarray_ref _ -> Punspecializedarray
+
+let array_kind_of_array_set_kind : array_set_kind -> array_kind = function
+  | Pgenarray_set _ -> Pgenarray
+  | Paddrarray_set _ -> Paddrarray
+  | Pgcignorableaddrarray_set -> Pgcignorableaddrarray
+  | Pintarray_set -> Pintarray
+  | Pfloatarray_set -> Pfloatarray
+  | Punboxedfloatarray_set bf -> Punboxedfloatarray bf
+  | Punboxedoruntaggedintarray_set i -> Punboxedoruntaggedintarray i
+  | Punboxedvectorarray_set bv -> Punboxedvectorarray bv
+  | Pgcscannableproductarray_set (_, kinds) -> Pgcscannableproductarray kinds
+  | Pgcignorableproductarray_set kinds -> Pgcignorableproductarray kinds
+  | Punspecializedarray_set _ -> Punspecializedarray
 
 let rec layout_of_mixed_block_element element =
   match element with
@@ -3097,7 +3122,7 @@ let primitive_result_layout (p : primitive) =
   | Pbigstring_load_i16 { tagged = false; _ } ->
     layout_unboxed_int16
   | Parrayrefu (array_ref_kind, _, _) | Parrayrefs (array_ref_kind, _, _) ->
-    array_ref_kind_result_layout array_ref_kind
+    element_layout_of_array_kind (array_kind_of_array_ref_kind array_ref_kind)
   | Punbox_unit -> layout_unboxed_unit
   | Pstring_load_32 { boxed = true; _ } | Pbytes_load_32 { boxed = true; _ }
   | Pbigstring_load_32 { boxed = true; _ } ->
@@ -3416,10 +3441,6 @@ let array_element_size_in_bytes (array_kind : array_kind) =
   | Punspecializedarray ->
     Misc.fatal_error
       "Lambda.array_element_size_in_bytes: Punspecializedarray"
-
-let element_layout_of_array_kind ak =
-  (* [alloc_heap] is ignored by [array_ref_kind_result_layout]. *)
-  array_ref_kind_result_layout (array_ref_kind alloc_heap ak)
 
 let rec ignorable_product_element_kind_involves_int
     (kind : ignorable_product_element_kind) =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1466,7 +1466,8 @@ val will_be_reordered : _ mixed_block_element -> bool
 
 val primitive_result_layout : primitive -> layout
 
-val array_ref_kind_result_layout: array_ref_kind -> layout
+val array_kind_of_array_ref_kind : array_ref_kind -> array_kind
+val array_kind_of_array_set_kind : array_set_kind -> array_kind
 
 (** The mode will be discarded if unnecessary for the given [array_kind] *)
 val array_ref_kind : locality_mode -> array_kind -> array_ref_kind

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2735,7 +2735,7 @@ let get_expr_args_array ~scopes kind head { arg; mut; _ } rem =
       (* TODO: The resulting float should be allocated to at the mode of the
          array pattern, once that's available *)
       let ref_kind = Lambda.(array_ref_kind alloc_heap kind) in
-      let result_layout = array_ref_kind_result_layout ref_kind in
+      let result_layout = element_layout_of_array_kind kind in
       let am_mut = if Types.is_mutable am then Mutable else Immutable in
       { arg = Lprim
           (Parrayrefu (ref_kind, Ptagged_int_index, am_mut),

--- a/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
+++ b/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
@@ -142,9 +142,13 @@ let test_makearray_dynamic () =
     ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
       : (u array, _) idx_mut)
     10;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 1).#y)
+      : (u array, _) idx_mut)
+    20;
   assert (u.#y = 1);
   assert ((array_get a 0).#y = 10);
-  assert ((array_get a 1).#y = 1);
+  assert ((array_get a 1).#y = 20);
   assert ((array_get a 2).#y = 1)
 
 let test_arrayblit () =
@@ -155,9 +159,14 @@ let test_arrayblit () =
     ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
       : (u array, _) idx_mut)
     10;
+  Idx_mut.set dst
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 1).#y)
+      : (u array, _) idx_mut)
+    20;
   assert ((array_get src 0).#y = 1);
+  assert ((array_get src 1).#y = 2);
   assert ((array_get dst 0).#y = 10);
-  assert ((array_get dst 1).#y = 2)
+  assert ((array_get dst 1).#y = 20)
 
 (* ===== Nested scannable product ===== *)
 
@@ -249,9 +258,13 @@ let test_ignorable_makearray_dynamic () =
     ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
       : (ig array, _) idx_mut)
     10;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 1).#i)
+      : (ig array, _) idx_mut)
+    20;
   assert (v.#i = 1);
   assert ((array_get a 0).#i = 10);
-  assert ((array_get a 1).#i = 1);
+  assert ((array_get a 1).#i = 20);
   assert ((array_get a 2).#i = 1)
 
 let test_ignorable_arrayblit () =
@@ -262,9 +275,14 @@ let test_ignorable_arrayblit () =
     ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
       : (ig array, _) idx_mut)
     10;
+  Idx_mut.set dst
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 1).#i)
+      : (ig array, _) idx_mut)
+    20;
   assert ((array_get src 0).#i = 1);
+  assert ((array_get src 1).#i = 2);
   assert ((array_get dst 0).#i = 10);
-  assert ((array_get dst 1).#i = 2)
+  assert ((array_get dst 1).#i = 20)
 
 (* Regression tests: the evaluation order of arguments for [makearray_dynamic]
    and [array_blit] is consistent unboxed products and non-products. *)

--- a/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
+++ b/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
@@ -1,0 +1,235 @@
+(* TEST
+ include stdlib_stable;
+ flambda2;
+ {
+   native;
+ }{
+   bytecode;
+ }
+*)
+
+(* Regression test for a bytecode bug where unboxed products stored in arrays
+   (represented as boxed blocks in bytecode) were not deep-copied at array
+   reads, writes, allocations, and duplications, causing mutations via
+   [Idx_mut.set] to be visible through previously-read values or to affect
+   the source of a write/blit. *)
+
+open Stdlib_stable
+
+external[@layout_poly] array_get
+  : ('a : any mod separable). 'a array -> int -> 'a
+  = "%array_safe_get"
+
+external[@layout_poly] array_set
+  : ('a : any mod separable). 'a array -> int -> 'a -> unit
+  = "%array_safe_set"
+
+external[@layout_poly] array_unsafe_get
+  : ('a : any mod separable). 'a array -> int -> 'a
+  = "%array_unsafe_get"
+
+external[@layout_poly] array_unsafe_set
+  : ('a : any mod separable). 'a array -> int -> 'a -> unit
+  = "%array_unsafe_set"
+
+external[@layout_poly] makearray_dynamic
+  : ('a : any mod separable). int -> 'a -> 'a array
+  = "%makearray_dynamic"
+
+external[@layout_poly] array_blit
+  : ('a : any mod separable).
+    'a array -> int -> 'a array -> int -> int -> unit
+  = "%arrayblit"
+
+(* ===== Scannable product (all-value fields) ===== *)
+
+type u = #{ x : int; y : int }
+
+let test_makearray () =
+  let u = #{ x = 1; y = 1 } in
+  let a = [| u |] in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
+let test_makearray_multi () =
+  let u = #{ x = 1; y = 1 } in
+  let a = [| u; u |] in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10);
+  assert ((array_get a 1).#y = 1)
+
+let test_arrayset () =
+  let u = #{ x = 1; y = 1 } in
+  let a = [| #{ x = 0; y = 0 } |] in
+  array_set a 0 u;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
+let test_arrayget () =
+  let a = [| #{ x = 1; y = 1 } |] in
+  let u = array_get a 0 in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
+let test_unsafe_arrayset () =
+  let u = #{ x = 1; y = 1 } in
+  let a = [| #{ x = 0; y = 0 } |] in
+  array_unsafe_set a 0 u;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
+let test_unsafe_arrayget () =
+  let a = [| #{ x = 1; y = 1 } |] in
+  let u = array_unsafe_get a 0 in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
+let test_makearray_dynamic () =
+  let u = #{ x = 1; y = 1 } in
+  let a = makearray_dynamic 3 u in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10);
+  assert ((array_get a 1).#y = 1);
+  assert ((array_get a 2).#y = 1)
+
+let test_arrayblit () =
+  let src = [| #{ x = 1; y = 1 }; #{ x = 2; y = 2 } |] in
+  let dst = [| #{ x = 0; y = 0 }; #{ x = 0; y = 0 } |] in
+  array_blit src 0 dst 0 2;
+  Idx_mut.set dst
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert ((array_get src 0).#y = 1);
+  assert ((array_get dst 0).#y = 10);
+  assert ((array_get dst 1).#y = 2)
+
+(* ===== Nested scannable product ===== *)
+
+type inner = #{ a : int; b : int }
+type outer = #{ inner : inner; c : int }
+
+let test_nested_makearray () =
+  let o = #{ inner = #{ a = 1; b = 2 }; c = 3 } in
+  let a = [| o |] in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#inner.#a)
+      : (outer array, _) idx_mut)
+    99;
+  assert (o.#inner.#a = 1);
+  assert ((array_get a 0).#inner.#a = 99)
+
+let test_nested_arrayget () =
+  let a = [| #{ inner = #{ a = 1; b = 2 }; c = 3 } |] in
+  let o = array_get a 0 in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#inner.#a)
+      : (outer array, _) idx_mut)
+    99;
+  assert (o.#inner.#a = 1);
+  assert ((array_get a 0).#inner.#a = 99)
+
+(* ===== Ignorable product (contains non-value fields) ===== *)
+
+type ig = #{ i : int; f : float# }
+
+let test_ignorable_makearray () =
+  let v = #{ i = 1; f = #1.0 } in
+  let a = [| v |] in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert (v.#i = 1);
+  assert ((array_get a 0).#i = 10)
+
+let test_ignorable_arrayset () =
+  let v = #{ i = 1; f = #1.0 } in
+  let a = [| #{ i = 0; f = #0.0 } |] in
+  array_set a 0 v;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert (v.#i = 1);
+  assert ((array_get a 0).#i = 10)
+
+let test_ignorable_arrayget () =
+  let a = [| #{ i = 1; f = #1.0 } |] in
+  let v = array_get a 0 in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert (v.#i = 1);
+  assert ((array_get a 0).#i = 10)
+
+let test_ignorable_makearray_dynamic () =
+  let v = #{ i = 1; f = #1.0 } in
+  let a = makearray_dynamic 3 v in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert (v.#i = 1);
+  assert ((array_get a 0).#i = 10);
+  assert ((array_get a 1).#i = 1);
+  assert ((array_get a 2).#i = 1)
+
+let test_ignorable_arrayblit () =
+  let src = [| #{ i = 1; f = #1.0 }; #{ i = 2; f = #2.0 } |] in
+  let dst = [| #{ i = 0; f = #0.0 }; #{ i = 0; f = #0.0 } |] in
+  array_blit src 0 dst 0 2;
+  Idx_mut.set dst
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert ((array_get src 0).#i = 1);
+  assert ((array_get dst 0).#i = 10);
+  assert ((array_get dst 1).#i = 2)
+
+let () =
+  test_makearray ();
+  test_makearray_multi ();
+  test_arrayset ();
+  test_arrayget ();
+  test_unsafe_arrayset ();
+  test_unsafe_arrayget ();
+  test_makearray_dynamic ();
+  test_arrayblit ();
+  test_nested_makearray ();
+  test_nested_arrayget ();
+  test_ignorable_makearray ();
+  test_ignorable_arrayset ();
+  test_ignorable_arrayget ();
+  test_ignorable_makearray_dynamic ();
+  test_ignorable_arrayblit ();
+  print_endline "All tests passed"

--- a/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
+++ b/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
@@ -216,6 +216,59 @@ let test_ignorable_arrayblit () =
   assert ((array_get dst 0).#i = 10);
   assert ((array_get dst 1).#i = 2)
 
+(* Regression tests: the evaluation order of arguments for [makearray_dynamic]
+   and [array_blit] is consistent unboxed products and non-products. *)
+
+let collect_eval_order f =
+  let log = ref [] in
+  let record s () = log := s :: !log in
+  f record;
+  List.rev !log
+
+let test_eval_order_makearray_dynamic () =
+  let order_product =
+    collect_eval_order (fun record ->
+        let _ : u array =
+          makearray_dynamic
+            (record "n" (); 1)
+            (record "init" (); #{ x = 0; y = 0 })
+        in
+        ())
+  in
+  let order_int =
+    collect_eval_order (fun record ->
+        let _ : int array =
+          makearray_dynamic (record "n" (); 1) (record "init" (); 0)
+        in
+        ())
+  in
+  assert (order_product = order_int)
+
+let test_eval_order_arrayblit () =
+  let order_product =
+    collect_eval_order (fun record ->
+        let src = [| #{ x = 1; y = 1 } |] in
+        let dst = [| #{ x = 0; y = 0 } |] in
+        array_blit
+          (record "src" (); src)
+          (record "srcofs" (); 0)
+          (record "dst" (); dst)
+          (record "dstofs" (); 0)
+          (record "len" (); 1))
+  in
+  let order_int =
+    collect_eval_order (fun record ->
+        let src = [| 1 |] in
+        let dst = [| 0 |] in
+        array_blit
+          (record "src" (); src)
+          (record "srcofs" (); 0)
+          (record "dst" (); dst)
+          (record "dstofs" (); 0)
+          (record "len" (); 1))
+  in
+  assert (order_product = order_int)
+
 let () =
   test_makearray ();
   test_makearray_multi ();
@@ -232,4 +285,6 @@ let () =
   test_ignorable_arrayget ();
   test_ignorable_makearray_dynamic ();
   test_ignorable_arrayblit ();
+  test_eval_order_makearray_dynamic ();
+  test_eval_order_arrayblit ();
   print_endline "All tests passed"

--- a/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
+++ b/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.ml
@@ -87,6 +87,33 @@ let test_arrayget () =
   assert (u.#y = 1);
   assert ((array_get a 0).#y = 10)
 
+(* A whole-element [idx_mut] into a product array reads/writes the entire
+   product block.  Without deep-copying through [Pget_idx]/[Pset_idx] the
+   returned/stored value would alias the array slot. *)
+
+let test_idx_get_whole_element () =
+  let a = [| #{ x = 1; y = 1 } |] in
+  let whole : (u array, u) idx_mut = Idx_mut.unsafe_create_into_array 0 in
+  let u = Idx_mut.get a whole in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
+let test_idx_set_whole_element () =
+  let u = #{ x = 1; y = 1 } in
+  let a = [| #{ x = 0; y = 0 } |] in
+  let whole : (u array, u) idx_mut = Idx_mut.unsafe_create_into_array 0 in
+  Idx_mut.set a whole u;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#y)
+      : (u array, _) idx_mut)
+    10;
+  assert (u.#y = 1);
+  assert ((array_get a 0).#y = 10)
+
 let test_unsafe_arrayset () =
   let u = #{ x = 1; y = 1 } in
   let a = [| #{ x = 0; y = 0 } |] in
@@ -192,6 +219,29 @@ let test_ignorable_arrayget () =
   assert (v.#i = 1);
   assert ((array_get a 0).#i = 10)
 
+let test_ignorable_idx_get_whole_element () =
+  let a = [| #{ i = 1; f = #1.0 } |] in
+  let whole : (ig array, ig) idx_mut = Idx_mut.unsafe_create_into_array 0 in
+  let v = Idx_mut.get a whole in
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert (v.#i = 1);
+  assert ((array_get a 0).#i = 10)
+
+let test_ignorable_idx_set_whole_element () =
+  let v = #{ i = 1; f = #1.0 } in
+  let a = [| #{ i = 0; f = #0.0 } |] in
+  let whole : (ig array, ig) idx_mut = Idx_mut.unsafe_create_into_array 0 in
+  Idx_mut.set a whole v;
+  Idx_mut.set a
+    ((.idx_mut(Idx_mut.unsafe_create_into_array 0).#i)
+      : (ig array, _) idx_mut)
+    10;
+  assert (v.#i = 1);
+  assert ((array_get a 0).#i = 10)
+
 let test_ignorable_makearray_dynamic () =
   let v = #{ i = 1; f = #1.0 } in
   let a = makearray_dynamic 3 v in
@@ -274,6 +324,8 @@ let () =
   test_makearray_multi ();
   test_arrayset ();
   test_arrayget ();
+  test_idx_get_whole_element ();
+  test_idx_set_whole_element ();
   test_unsafe_arrayset ();
   test_unsafe_arrayget ();
   test_makearray_dynamic ();
@@ -283,6 +335,8 @@ let () =
   test_ignorable_makearray ();
   test_ignorable_arrayset ();
   test_ignorable_arrayget ();
+  test_ignorable_idx_get_whole_element ();
+  test_ignorable_idx_set_whole_element ();
   test_ignorable_makearray_dynamic ();
   test_ignorable_arrayblit ();
   test_eval_order_makearray_dynamic ();

--- a/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.reference
+++ b/testsuite/tests/typing-layouts-arrays/unboxed_product_array_no_alias.reference
@@ -1,0 +1,1 @@
+All tests passed


### PR DESCRIPTION
This fixes the same bug as in https://github.com/oxcaml/oxcaml/pull/5386 but for arrays and block indices. An adapted explanation follows.

### Summary

Unboxed products are represented as blocks on bytecode. This poses an issue when these products are nested within an array and individual components of them are mutated: on bytecode, these products can be aliased, even though they're not supposed to have any notion of identity.

For example, the below program which reads a nested unboxed product prints 1 with ocamlopt but 2 with ocamlc.

```ocaml
open Stdlib_stable

type t = #{ x : int; u : unit }

let () =
  let t = #{ x = 1; u = () } in (* should be immutable *)
  let a = [| t |] in
  let i = (.idx_mut(Idx_mut.unsafe_create_into_array 0).#x) in
  Idx_mut.set a i 2;
  Printf.printf t.#x
```
The solution in this PR is to copy the blocks corresponding to unboxed products when reading or writing. Eventually, we likely will want to represent products as actually unboxed in bytecode.

### Drive-by refactoring
In `Lambda`, delete `array_ref_kind_result_layout`, as it's less general than `element_layout_of_array_kind` (the latter takes an `array_kind`, which has less information than an `array_ref_kind`). This allows us to not create "fake" `array_ref_kind`s out of `array_kind`s.