### PR TITLE
Remove unboxed versions from records with `[@atomic]` fields

### DIFF
--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -291,8 +291,9 @@ let box : t# -> t = fun #{ i ; s } -> { i ; s }
 type u : immediate & value = t# = #{ i : int ; s : string }
 ```
 
-Records who store boxed floats flatly (all-float and float-and-float# records)
-and `[@@unboxed]` records do not get unboxed versions.
+Records who store boxed floats flatly (all-float and float-and-float# records),
+`[@@unboxed]` records, and records with `[@atomic]` fields do not get unboxed
+versions.
 
 *Limitations and future plans*:
 * Unboxed products may only be stored in blocks via records (i.e. they are not

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -55,7 +55,7 @@ module Basic = struct
     Atomic.Loc.compare_and_set (get_loc r) oldv newv
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Basic/328"
+(apply (field_imm 1 (global Toploop!)) "Basic/326"
   (let
     (get = (function {nlocal = 0} r (atomic_load_field_ptr r 1))
      get_imm = (function {nlocal = 0} r : int (atomic_load_field_imm r 1))
@@ -190,7 +190,7 @@ end : sig
   type t = { mutable x : int [@atomic] }
 end)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Ok/363" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Ok/356" (makeblock 0))
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
@@ -204,7 +204,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record/371"
+(apply (field_imm 1 (global Toploop!)) "Inline_record/364"
   (let
     (test =
        (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
@@ -226,7 +226,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/379"
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/372"
   (let
     (A =
        (makeblock_unique 248 "Extension_with_inline_record.A"
@@ -263,7 +263,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic
 float fields, which prevents the float record optimization. The
 fields of this record will be boxed instead of being
 represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/405"
+(apply (field_imm 1 (global Toploop!)) "Float_records/396"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -483,7 +483,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound in this record pattern:
 y
 Either bind these labels explicitly or add '; _' to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/488"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/459"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -352,6 +352,26 @@ Line 2, characters 16-25:
 2 | type u_atomic = t_atomic#
                     ^^^^^^^^^
 Error: The type "t_atomic" has no unboxed version.
+Hint: Records with [@atomic] fields don't get unboxed versions.
+|}]
+
+(* Same, but in a recursive group, in both orders. *)
+type t_atomic = { i : int; mutable j : int [@atomic] }
+and u_atomic = t_atomic#
+[%%expect{|
+Line 2, characters 0-24:
+2 | and u_atomic = t_atomic#
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type "t_atomic" has no unboxed version.
+|}]
+
+type u_atomic = t_atomic#
+and t_atomic = { i : int; mutable j : int [@atomic] }
+[%%expect{|
+Line 1, characters 0-25:
+1 | type u_atomic = t_atomic#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type "t_atomic" has no unboxed version.
 |}]
 
 (*************************************)

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -343,6 +343,17 @@ Error: The type "t" has no unboxed version.
 Hint: It is already an unboxed record.
 |}]
 
+(* Records with atomic fields don't get unboxed versions. *)
+type t_atomic = { i : int; mutable j : int [@atomic] }
+type u_atomic = t_atomic#
+[%%expect{|
+type t_atomic = { i : int; mutable j : int [@atomic]; }
+Line 2, characters 16-25:
+2 | type u_atomic = t_atomic#
+                    ^^^^^^^^^
+Error: The type "t_atomic" has no unboxed version.
+|}]
+
 (*************************************)
 (* Types that mode cross externality *)
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -5281,11 +5281,20 @@ let report_lookup_error_doc _loc env ppf = function
   | No_unboxed_version (lid, decl) ->
       fprintf ppf "@[The type %a has no unboxed version.@]"
         quoted_longident lid;
+      let has_atomic_field lbls =
+        List.exists
+          (fun (ld : Types.label_declaration) -> Types.is_atomic ld.ld_mutable)
+          lbls
+      in
       begin match decl.type_kind with
       | Type_record (_, Record_unboxed, _) ->
           fprintf ppf
             "@.@[@{<hint>Hint@}: \
              [%@%@unboxed] records don't get unboxed versions.@]"
+      | Type_record (lbls, _, _) when has_atomic_field lbls ->
+          fprintf ppf
+            "@.@[@{<hint>Hint@}: \
+             Records with [%@atomic] fields don't get unboxed versions.@]"
       | Type_record (_, (Record_float | Record_ufloat | Record_mixed _), _) ->
           fprintf ppf
             "@.@[@{<hint>Hint@}: Float records don't get unboxed versions.@]";

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1264,8 +1264,8 @@ let transl_declaration env sdecl (id, uid) =
 
    3. But not all of these [Record_dummy]s will end up with unboxed versions:
       they become [Record_float]/[Record_boxed]/[Record_mixed], and float
-      records don't have unboxed versions. These unboxed versions are removed in
-      [remove_unboxed_versions].
+      records and records with [@atomic] fields don't have unboxed versions.
+      These unboxed versions are removed in [remove_unboxed_versions].
 
    After steps 2 and 3, the set of unboxed versions decreases, so we check for
    newly-unbound unboxed paths with [check_unboxed_paths].
@@ -1309,6 +1309,7 @@ let record_gets_unboxed_version lbls repr =
   | Record_dummy { represent_as_float_array } ->
     not represent_as_float_array
   | Record_mixed shape -> not (shape_has_float_boxed shape)
+
 let gets_unboxed_version decl =
   (* This must be kept in sync with the match in [derive_unboxed_version] *)
   match decl.type_kind with
@@ -1428,8 +1429,8 @@ let derive_unboxed_versions decls env =
     decls
 
 (* Removes unboxed versions from type declarations not satisfying
-   [gets_unboxed_version]. In practice, it is float records that lose their
-   unboxed versions. See Note [Typechecking unboxed versions of types].
+   [gets_unboxed_version]. In practice, this is float records and records
+   with [@atomic] fields. See Note [Typechecking unboxed versions of types].
 
    Returns new decls and paths whose unboxed versions got removed. *)
 let remove_unboxed_versions decls =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1296,7 +1296,14 @@ let record_has_float_boxed = function
   | Record_variable ->
     fatal_error "record_has_float_boxed: unexpected variable representation"
 
-let record_gets_unboxed_version = function
+let record_has_atomic_field lbls =
+  List.exists
+    (fun (ld : Types.label_declaration) -> Types.is_atomic ld.ld_mutable)
+    lbls
+
+let record_gets_unboxed_version lbls repr =
+  not (record_has_atomic_field lbls) &&
+  match repr with
   | Record_unboxed | Record_inlined _ | Record_float | Record_ufloat -> false
   | Record_boxed | Record_variable -> true
   | Record_dummy { represent_as_float_array } ->
@@ -1313,14 +1320,15 @@ let gets_unboxed_version decl =
        unboxed version. Please enjoy convincing yourself that this is true
        (you'll want to consult [update_record_kind]). *)
     true
-  | Type_record (_, repr, _) -> record_gets_unboxed_version repr
+  | Type_record (lbls, repr, _) -> record_gets_unboxed_version lbls repr
 let derive_unboxed_version env path_in_group_has_unboxed_version decl =
   (* This must be kept in sync with the match in [gets_unboxed_version] *)
   match decl.type_kind with
   | Type_abstract _ | Type_open | Type_record_unboxed_product _
   | Type_variant _ ->
     None
-  | Type_record (_, repr, _) when not (record_gets_unboxed_version repr) ->
+  | Type_record (lbls, repr, _)
+    when not (record_gets_unboxed_version lbls repr) ->
     None
   | Type_record (lbls, _rep, umc) ->
     let keep_attribute a =

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -850,7 +850,8 @@ type type_declaration =
     type_unboxed_version : type_declaration option;
     (* stores the unboxed version of that this type introduces: this is [Some]
        for predefined types with unboxed versions (e.g. [float]) and boxed
-       records, but [None] for aliases of these types
+       records (besides records that flattens floats or have with atomic
+       fields), but [None] for aliases of these types
 
        invariants:
        1. there are no "twice-unboxed" types: the [type_declaration] stored here


### PR DESCRIPTION
These records will eventually have unboxed versions, but one won't be able to arbitrarily inspect its fields (it may not even be representable).

To perform the backwards-incompatible change sooner rather than later (to prevent people from depending on useful unboxed versions), we remove unboxed versions from atomic records now.