### PR TITLE
Annotate (==) and (!=) (phys equality) args as @ immutable

### DIFF
--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -86,8 +86,20 @@ external compare : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -
 let min x y = if x <= y then x else y
 let max x y = if x >= y then x else y
 
-external ( == ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%eq"
-external ( != ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%noteq"
+external ( == )
+  : ('a : value_or_null).
+     ('a[@local_opt]) @ immutable
+  -> ('a[@local_opt]) @ immutable
+  -> bool
+  @@ portable
+  = "%eq"
+external ( != )
+  : ('a : value_or_null).
+     ('a[@local_opt]) @ immutable
+  -> ('a[@local_opt]) @ immutable
+  -> bool
+  @@ portable
+  = "%noteq"
 
 (* Boolean operations *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -195,7 +195,12 @@ val max : ('a : value_or_null) . 'a -> 'a -> 'a
     The result is unspecified if one of the arguments contains
     the float value [nan]. *)
 
-external ( == ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%eq"
+external ( == )
+  : ('a : value_or_null).
+     ('a[@local_opt]) @ immutable
+  -> ('a[@local_opt]) @ immutable
+  -> bool
+  = "%eq"
 (** [e1 == e2] tests for physical equality of [e1] and [e2].
    On mutable types such as references, arrays, byte sequences, records with
    mutable fields and objects with mutable instance variables,
@@ -207,7 +212,11 @@ external ( == ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) ->
    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
-external ( != ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%noteq"
+external ( != )
+  : ('a : value_or_null).
+    ('a[@local_opt]) @ immutable
+  -> ('a[@local_opt]) @ immutable
+  -> bool = "%noteq"
 (** Negation of {!Stdlib.( == )}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)


### PR DESCRIPTION
Since these just read the (immediate) word, they can work on even things which cannot possibly be read from or written to.