### PR TITLE
Insert function and value slot projections in deterministic order

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2573,24 +2573,24 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
 
      Note that free variables corresponding to predefined exception identifiers
      have been filtered out by [close_functions], above. *)
-  let (value_slots_to_bind : Value_slot.t Variable.Map.t), vars_for_idents =
+  let (value_slots_to_bind : (Variable.t * Value_slot.t) list), vars_for_idents
+      =
     Ident.Map.fold
       (fun id value_slot (value_slots_to_bind, vars_for_idents) ->
         let var =
           Variable.create_with_same_name_as_ident id
             (Value_slot.kind value_slot)
         in
-        ( Variable.Map.add var value_slot value_slots_to_bind,
+        ( (var, value_slot) :: value_slots_to_bind,
           Ident.Map.add id var vars_for_idents ))
-      value_slots_from_idents
-      (Variable.Map.empty, Ident.Map.empty)
+      value_slots_from_idents ([], Ident.Map.empty)
   in
   let coerce_to_deeper =
     Coercion.change_depth
       ~from:(Rec_info_expr.var my_depth)
       ~to_:(Rec_info_expr.var next_depth)
   in
-  if has_lifted_closure && not (Variable.Map.is_empty value_slots_to_bind)
+  if has_lifted_closure && not (List.is_empty value_slots_to_bind)
   then
     Misc.fatal_errorf
       "Variables found in closure when trying to lift %a in \
@@ -2601,7 +2601,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
   let closure_vars_to_bind, closure_env =
     if has_lifted_closure
     then (* No projection needed *)
-      Variable.Map.empty, closure_env
+      [], closure_env
     else
       List.fold_left
         (fun (to_bind, env) function_decl ->
@@ -2622,9 +2622,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
               let function_slot =
                 Ident.Map.find let_rec_ident function_slots_from_idents
               in
-              ( Variable.Map.add variable function_slot to_bind,
-                variable,
-                function_slot )
+              (variable, function_slot) :: to_bind, variable, function_slot
           in
           let simple = Simple.with_coercion (Simple.var var) coerce_to_deeper in
           let approx = Function_slot.Map.find function_slot approx_map in
@@ -2634,7 +2632,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
           in
           let env = Env.add_var_approximation env var approx in
           to_bind, env)
-        (Variable.Map.empty, closure_env)
+        ([], closure_env)
         (Function_decls.to_list function_declarations)
   in
   let closure_env =
@@ -2724,8 +2722,8 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
          inserted at the point of use rather than at the top of the function. We
          should also check the behaviour of the backend w.r.t. CSE of
          projections from closures. *)
-      Variable.Map.fold
-        (fun var move_to (acc, body) ->
+      List.fold_left
+        (fun (acc, body) (var, move_to) ->
           let move : Flambda_primitive.unary_primitive =
             Project_function_slot { move_from = function_slot; move_to }
           in
@@ -2736,11 +2734,11 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
             Named.create_prim (Unary (move, my_closure')) Debuginfo.none
           in
           Let_with_acc.create acc (Bound_pattern.singleton var) named ~body)
-        closure_vars_to_bind (acc, body)
+        (acc, body) closure_vars_to_bind
     in
     let acc, body =
-      Variable.Map.fold
-        (fun var value_slot (acc, body) ->
+      List.fold_left
+        (fun (acc, body) (var, value_slot) ->
           let var = VB.create var Flambda_debug_uid.none Name_mode.normal in
           (* CR sspies: In the future, improve the debugging UIDs here if
              possible. *)
@@ -2753,7 +2751,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
               Debuginfo.none
           in
           Let_with_acc.create acc (Bound_pattern.singleton var) named ~body)
-        value_slots_to_bind (acc, body)
+        (acc, body) value_slots_to_bind
     in
     let next_depth_expr = Rec_info_expr.succ (Rec_info_expr.var my_depth) in
     let bound =

--- a/testsuite/tests/flambda2/examples/lifting.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lifting.simplify.reference
@@ -12,11 +12,11 @@ apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
                       my_closure _region _ghost_region my_depth
                       -> k * k1
                       : imm tagged =
-                let r2_1 = %project_value_slot.[f].[r2] ($camlLifting__f_1)
+                let r0_1 = %project_value_slot.[f].[r0] ($camlLifting__f_1)
                 in
                 let r1_1 = %project_value_slot.[f].[r1] ($camlLifting__f_1)
                 in
-                let r0_1 = %project_value_slot.[f].[r0] ($camlLifting__f_1)
+                let r2_1 = %project_value_slot.[f].[r2] ($camlLifting__f_1)
                 in
                 let int_add = %int_barith.add (x, r0_1) in
                 let int_add_1 = %int_barith.add (int_add, r1_1) in

--- a/testsuite/tests/flambda2/examples/tests13.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests13.raw.reference
@@ -19,10 +19,10 @@ let $camlTests13__first_const = Block 0 () in
          my_closure _region _ghost_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
+   let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
+   in
    let map_foo =
      %project_value_slot.[`fn[tests13.ml:27,2--118]`].[map_foo] (my_closure)
-   in
-   let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
    in
    let j = %int_barith.add (i, 3) in
    let Popaque = %opaque (j) in

--- a/testsuite/tests/flambda2/examples/tests13.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests13.simplify.reference
@@ -26,10 +26,10 @@ let code loopify(never) size(10) newer_version_of(`fn[tests13.ml:27,2--118]_1`)
       `fn[tests13.ml:27,2--118]_1_1` (param : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
+  let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
+  in
   let map_foo =
     %project_value_slot.[`fn[tests13.ml:27,2--118]`].[map_foo] (my_closure)
-  in
-  let i = %project_value_slot.[`fn[tests13.ml:27,2--118]`].[i] (my_closure)
   in
   let j = %int_barith.add (i, 3) in
   let Popaque = %opaque (j) in

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -108,9 +108,9 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let cmp = %project_value_slot.[rev_merge].[cmp] (my_closure) in
    let rev_append = %project_value_slot.[rev_merge].[rev_append] (my_closure)
    in
+   let cmp = %project_value_slot.[rev_merge].[cmp] (my_closure) in
    (let prim = %is_int (l1) in
     let Pisint = %tag_imm (prim) in
     (let untagged = %untag_imm (Pisint) in
@@ -205,10 +205,10 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
-   let cmp = %project_value_slot.[rev_merge_rev].[cmp_1] (my_closure) in
    let rev_append =
      %project_value_slot.[rev_merge_rev].[rev_append_1] (my_closure)
    in
+   let cmp = %project_value_slot.[rev_merge_rev].[cmp_1] (my_closure) in
    (let prim = %is_int (l1) in
     let Pisint = %tag_imm (prim) in
     (let untagged = %untag_imm (Pisint) in
@@ -302,10 +302,10 @@
    let next_depth = rec_info (succ my_depth) in
    let chop = %project_value_slot.[sort].[chop] (my_closure) in
    let cmp = %project_value_slot.[sort].[cmp_2] (my_closure) in
+   let rev_merge = %project_value_slot.[sort].[rev_merge] (my_closure) in
    let rev_merge_rev =
      %project_value_slot.[sort].[rev_merge_rev] (my_closure)
    in
-   let rev_merge = %project_value_slot.[sort].[rev_merge] (my_closure) in
    let rev_sort = %project_function_slot.[sort].[rev_sort] (my_closure) in
    (let prim = %int_comp.ne (n, 2) in
     let int_notequal = %tag_imm (prim) in
@@ -880,11 +880,11 @@
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
    let chop = %project_value_slot.[rev_sort].[chop] (my_closure) in
+   let cmp = %project_value_slot.[rev_sort].[cmp_2] (my_closure) in
    let rev_merge = %project_value_slot.[rev_sort].[rev_merge] (my_closure) in
    let rev_merge_rev =
      %project_value_slot.[rev_sort].[rev_merge_rev] (my_closure)
    in
-   let cmp = %project_value_slot.[rev_sort].[cmp_2] (my_closure) in
    let sort = %project_function_slot.[rev_sort].[sort] (my_closure) in
    (let prim = %int_comp.ne (n, 2) in
     let int_notequal = %tag_imm (prim) in
@@ -1460,11 +1460,11 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
    let next_depth = rec_info (succ my_depth) in
+   let length = %project_value_slot.[sort_uniq].[length] (my_closure) in
    let rev_append =
      %project_value_slot.[sort_uniq].[rev_append_2] (my_closure)
    in
    let chop = %project_value_slot.[sort_uniq].[chop_1] (my_closure) in
-   let length = %project_value_slot.[sort_uniq].[length] (my_closure) in
    let rev_merge = closure rev_merge_5 @rev_merge
    with { rev_append = rev_append; cmp = cmp }
    in

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -218,8 +218,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  let rev_merge = %project_value_slot.[rev_sort].[rev_merge] (my_closure) in
   let cmp = %project_value_slot.[rev_sort].[cmp_2] (my_closure) in
+  let rev_merge = %project_value_slot.[rev_sort].[rev_merge] (my_closure) in
   let sort = %project_function_slot.[rev_sort].[sort] (my_closure) in
   (let prim = %int_comp.ne (n, 2) in
    switch prim

--- a/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
@@ -7,8 +7,8 @@ let code loopify(never) size(16) newer_version_of(f_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let r = %project_value_slot.[f].[r] (my_closure) in
   let a = %project_value_slot.[f].[a] (my_closure) in
+  let r = %project_value_slot.[f].[r] (my_closure) in
   (let untagged = %untag_imm (a) in
    switch untagged
      | 0 -> k (0)
@@ -22,8 +22,8 @@ let code loopify(never) size(20) newer_version_of(g_3)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let s = %project_value_slot.[g].[s] (my_closure) in
   let b = %project_value_slot.[g].[b] (my_closure) in
+  let s = %project_value_slot.[g].[s] (my_closure) in
   (let untagged = %untag_imm (b) in
    switch untagged
      | 0 -> k (0)
@@ -38,10 +38,10 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let b = %project_value_slot.[h].[b] (my_closure) in
   let a = %project_value_slot.[h].[a] (my_closure) in
-  let g = %project_function_slot.[h].[g] (my_closure) in
+  let b = %project_value_slot.[h].[b] (my_closure) in
   let f = %project_function_slot.[h].[f] (my_closure) in
+  let g = %project_function_slot.[h].[g] (my_closure) in
   (let untagged = %untag_imm (b) in
    switch untagged
      | 0 -> k2 (0)

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
@@ -5,8 +5,8 @@ let $camlArguments_for_unboxed_closure__first_const = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   let y = %project_value_slot.[g].[y] (my_closure) in
    let x = %project_value_slot.[g].[x] (my_closure) in
+   let y = %project_value_slot.[g].[y] (my_closure) in
    apply h (y) -> k3 * k2
      where k3 (apply_result : imm tagged) =
        let int_add = %int_barith.add (x, apply_result) in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
@@ -16,8 +16,8 @@ let code inline(never) loopify(never) size(7) newer_version_of(u_4)
         : imm tagged =
   let g_into_g_field_x = u_into_my_closure_field_g_field_x in
   let g_into_g_field_y = u_into_my_closure_field_g_field_y in
-  let y = g_into_g_field_y in
   let x = g_into_g_field_x in
+  let y = g_into_g_field_y in
   apply direct(id_2_1) inlining_state(depth(1))
     $camlArguments_for_unboxed_closure__id_6 (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
@@ -14,8 +14,8 @@ let code inline(never) loopify(never) size(10) newer_version_of(u_4)
         -> k * k1
         : imm tagged =
   let g = %project_value_slot.[u].[g] (my_closure) in
-  let y = %project_value_slot.[g].[y] (g) in
   let x = %project_value_slot.[g].[x] (g) in
+  let y = %project_value_slot.[g].[y] (g) in
   apply direct(id_2_1) inlining_state(depth(1))
     ($camlArguments_for_unboxed_closure__id_6 : _ -> imm tagged)
       (y)
@@ -38,8 +38,8 @@ let code loopify(never) size(11) newer_version_of(g_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let y = %project_value_slot.[g].[y] (my_closure) in
   let x = %project_value_slot.[g].[x] (my_closure) in
+  let y = %project_value_slot.[g].[y] (my_closure) in
   apply h (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in


### PR DESCRIPTION
When introducing `%project_function_slot` and `%project_value_slot` primitives for the variables captured by a closure, we build a map from fresh variables to the corresponding slot, which we then simply iterate on to introduce let bindings. This causes the order in which we introduce these primitives to depend on the `Int_ids` ordering, which depends on hashing.

This patch uses lists instead of map, preserving a stable order of insertion of the `%project_function_slot` and `%project_value_slot` primitives (according to the order on their `Ident.t`).