### PR TITLE
Skip tag/untag round-trip when a mask sits between them (cmm)

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -783,6 +783,30 @@ let rec and_const e n dbg =
             match get_const y with
             | Some y -> and_const x (Nativeint.logand y n) dbg
             | None -> default ())
+          | Cop
+              ( Caddi,
+                [ Cop (Clsl, [c; (Cconst_int (k, _) as k_cst)], _);
+                  Cconst_int (offset, _) ],
+                _ )
+            when n >= 0n && is_defined_shift k
+                 && Nativeint.shift_right_logical (Nativeint.of_int offset) k
+                    = 0n ->
+            (* [((c lsl k) + offset) land n = ((c land (n lsr k)) lsl k) +
+               (offset land n)] when [n >= 0] and [0 <= offset < 2^k] (so the
+               [+] is carry-free). Both [n lsr k] and [offset land n] are
+               constants. In concert with the [asr]-of-[lsl]-of-[+] rule in
+               [asr_int], this collapses tag/AND/untag round-trips on unboxed
+               small integers. *)
+            let upper_mask = Nativeint.shift_right_logical n k in
+            let lower_offset =
+              Nativeint.to_int (Nativeint.logand (Nativeint.of_int offset) n)
+            in
+            let shifted =
+              if Nativeint.equal upper_mask 0n
+              then replace c ~with_:(Cconst_int (0, dbg))
+              else Cop (Clsl, [and_const c upper_mask dbg; k_cst], dbg)
+            in
+            add_const shifted lower_offset dbg
           | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) -> (
             let[@local] load memory_chunk =
               Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)
@@ -796,7 +820,7 @@ let rec and_const e n dbg =
             | _ -> default ())
           | _ -> default ()))
 
-let xor_int c1 c2 dbg =
+and xor_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logxor c1 c2)
@@ -804,7 +828,7 @@ let xor_int c1 c2 dbg =
       | Some c1, None -> xor_const c2 c1 dbg
       | None, None -> Cop (Cxor, [c1; c2], dbg))
 
-let or_int c1 c2 dbg =
+and or_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logor c1 c2)
@@ -812,7 +836,7 @@ let or_int c1 c2 dbg =
       | Some c1, None -> or_const c2 c1 dbg
       | None, None -> Cop (Cor, [c1; c2], dbg))
 
-let and_int c1 c2 dbg =
+and and_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logand c1 c2)
@@ -820,7 +844,7 @@ let and_int c1 c2 dbg =
       | Some c1, None -> and_const c2 c1 dbg
       | None, None -> Cop (Cand, [c1; c2], dbg))
 
-let rec lsr_int c1 c2 dbg =
+and lsr_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match c1, c2 with
       | c1, Cconst_int (0, _) -> c1
@@ -892,24 +916,19 @@ and asr_int c1 c2 dbg =
             when Nativeint.shift_right (const_exn y) n = 0n ->
             replace x ~with_:(Cconst_int (0, dbg))
           | Cop
-              ( Cand,
-                [ Cop
-                    ( Caddi,
-                      [ Cop (Clsl, [c; Cconst_int (x, _)], _);
-                        Cconst_int (offset, _) ],
-                      _ );
-                  ((Cconst_int _ | Cconst_natint _) as y) ],
+              ( Caddi,
+                [ (Cop (Clsl, [_; Cconst_int (x, _)], _) as lsl_term);
+                  Cconst_int (offset, _) ],
                 _ )
-            when x = n
-                 && Nativeint.shift_right_logical (Nativeint.of_int offset) x
-                    = 0n
-                 && const_exn y >= 0n ->
-            (* [asr (and ((c lsl k) + o) m) k = c land (m asr k)] when [0 <= o <
-               2^k] (so the [+] cannot carry into the high bits) and [m >= 0]
-               (so the sign extension by [asr] agrees with the zero high bits
-               the [land] produces). Removes the redundant tag/untag pair when a
-               mask sits between them. *)
-            and_const c (Nativeint.shift_right (const_exn y) n) dbg
+            when is_defined_shift x
+                 && Nativeint.shift_right_logical (Nativeint.of_int offset)
+                      (Int.min n x)
+                    = 0n ->
+            (* [asr ((c lsl x) + o) n = asr (c lsl x) n] when [0 <= o < 2^min(x,
+               n)]: [o < 2^x] makes the [+] carry-free, and [o < 2^n] means [asr
+               n] discards every bit of [o]. The next clause then handles [asr
+               (c lsl x) n] further. *)
+            asr_int lsl_term c2 dbg
           | _ -> Cop (Casr, [c1; c2], dbg)))
       | Cop (Casr, [x; (Cconst_int (n', _) as y)], z), c2
         when is_defined_shift n' ->

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -891,6 +891,25 @@ and asr_int c1 c2 dbg =
           | Cop (Cand, [x; ((Cconst_int _ | Cconst_natint _) as y)], _)
             when Nativeint.shift_right (const_exn y) n = 0n ->
             replace x ~with_:(Cconst_int (0, dbg))
+          | Cop
+              ( Cand,
+                [ Cop
+                    ( Caddi,
+                      [ Cop (Clsl, [c; Cconst_int (x, _)], _);
+                        Cconst_int (offset, _) ],
+                      _ );
+                  ((Cconst_int _ | Cconst_natint _) as y) ],
+                _ )
+            when x = n
+                 && Nativeint.shift_right_logical (Nativeint.of_int offset) x
+                    = 0n
+                 && const_exn y >= 0n ->
+            (* [asr (and ((c lsl k) + o) m) k = c land (m asr k)] when [0 <= o <
+               2^k] (so the [+] cannot carry into the high bits) and [m >= 0]
+               (so the sign extension by [asr] agrees with the zero high bits
+               the [land] produces). Removes the redundant tag/untag pair when a
+               mask sits between them. *)
+            and_const c (Nativeint.shift_right (const_exn y) n) dbg
           | _ -> Cop (Casr, [c1; c2], dbg)))
       | Cop (Casr, [x; (Cconst_int (n', _) as y)], z), c2
         when is_defined_shift n' ->

--- a/testsuite/tests/codegen/bytes.ml
+++ b/testsuite/tests/codegen/bytes.ml
@@ -229,7 +229,7 @@ bytes_safe_get_int32:
   movslq (%rax,%rbx), %rax
   ret
 .L0:
-  movq  camlTOP18__block602@GOTPCREL(%rip), %rax
+  movq  camlTOP20__block685@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/codegen/bytes.ml
+++ b/testsuite/tests/codegen/bytes.ml
@@ -38,6 +38,33 @@ bytes_set_uint8:
   ret
 |}]
 
+(* Storing an unsigned 8-bit value (e.g. [U8.t] in [lib/ox/kernel], whose
+   [to_int] is [Int8_u.to_int y land 0xff]) into a byte buffer goes through
+   tag (lsl 1 + 1), mask (land 0x1ff at the Cmm level) and untag (asr 1)
+   before reaching the byte store.  The [cmm_helpers] peephole collapses
+   the whole chain to a plain [movb]; the leftover [land 0xff] is absorbed
+   by [low_bits ~bits:8] on the store side. *)
+let bytes_set_uint8_from_u8 (buf : bytes) (y : int8#) =
+  Bytes.unsafe_set buf 0 (Int8_u.to_int y land 0xff)
+[%%expect_asm X86_64{|
+bytes_set_uint8_from_u8:
+  movb  %bl, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Same chain without the explicit [land 0xff]: a tag followed by an untag
+   into a byte store.  The byte store only sees the low 8 bits, so this
+   should emit the same code as [bytes_set_uint8_from_u8] above. *)
+let bytes_set_uint8_from_int8u_no_mask (buf : bytes) (y : int8#) =
+  Bytes.unsafe_set buf 0 (Int8_u.to_int y)
+[%%expect_asm X86_64{|
+bytes_set_uint8_from_int8u_no_mask:
+  movb  %bl, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
 
 let bytes_get_int8 (buf : bytes) (i : int) =
   Bytes.unsafe_get_int8 buf i


### PR DESCRIPTION
Adds a peephole clause in `asr_int` for the pattern
`asr (and ((c lsl k) + o) m) k` when `0 <= o < 2^k`
and `m >= 0`, rewriting it to `c land (m asr k)`.

This collapses the spurious `leaq`/`andl`/`sarq`
sequence emitted when an unboxed [int8#] is
tagged, masked, and untagged before a byte store:

```ocaml
let convert (x : bytes) (y : U8.t) = Bytes.unsafe_set x 0 (U8.to_char y)
```

used to produce:

```asm
        leaq    1(%rbx,%rbx), %rbx
        andl    $511, %ebx
        sarq    $1, %rbx
        movb    %bl, (%rax)
        movl    $1, %eax
        ret
```

and now produces:

```asm
        movb    %bl, (%rax)
        movl    $1, %eax
        ret
```