### PR TITLE
Remove SIMD primitives for float arrays

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -839,12 +839,11 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Pisnull -> unary (Ccall "caml_is_null")
     | Pstring_load_vec _ | Pbytes_load_vec _ | Pbytes_set_vec _
     | Pbigstring_load_vec _ | Pbigstring_set_vec _ | Pfloatarray_load_vec _
-    | Pfloat_array_load_vec _ | Pint_array_load_vec _
-    | Punboxed_float_array_load_vec _ | Punboxed_float32_array_load_vec _
-    | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
-    | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
-    | Punboxed_nativeint_array_load_vec _ | Pfloatarray_set_vec _
-    | Pfloat_array_set_vec _ | Pint_array_set_vec _
+    | Pint_array_load_vec _ | Punboxed_float_array_load_vec _
+    | Punboxed_float32_array_load_vec _ | Puntagged_int8_array_load_vec _
+    | Puntagged_int16_array_load_vec _ | Punboxed_int32_array_load_vec _
+    | Punboxed_int64_array_load_vec _ | Punboxed_nativeint_array_load_vec _
+    | Pfloatarray_set_vec _ | Pint_array_set_vec _
     | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
     | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
     | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _

--- a/jane/doc/extensions/_09-simd/intro.md
+++ b/jane/doc/extensions/_09-simd/intro.md
@@ -69,11 +69,11 @@ provided by the intrinsics libraries rather than Base or Core.
 module Int8x16 = Ocaml_simd_sse.Int8x16
 
 let text = "abcdefghijklmnopqrstuvwxyz"
-let floats = [| 1.0; 2.0 |]
+let floats = Float_array.of_array [| 1.0; 2.0 |]
 let ints = [| 1; 2 |]
 
 let _ = Int8x16.String.get text ~byte:0
-let _ = Float64x2.Float_array.get floats ~idx:0 (* Float array optimization required *)
+let _ = Float64x2.Floatarray.get floats ~idx:0
 let _ = Int64x2.Immediate_array.get_tagged ints ~idx:0
 ```
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -316,9 +316,6 @@ type primitive =
   | Pfloatarray_load_vec of { size : boxed_vector; unsafe : bool;
                               index_kind : array_index_kind;
                               mode : locality_mode; boxed : bool }
-  | Pfloat_array_load_vec of { size : boxed_vector; unsafe : bool;
-                               index_kind : array_index_kind;
-                               mode : locality_mode; boxed : bool }
   | Pint_array_load_vec of { size : boxed_vector; unsafe : bool;
                              index_kind : array_index_kind;
                              mode : locality_mode; boxed : bool }
@@ -345,8 +342,6 @@ type primitive =
                                            mode : locality_mode; boxed : bool }
   | Pfloatarray_set_vec of { size : boxed_vector; unsafe : bool;
                              index_kind : array_index_kind; boxed : bool }
-  | Pfloat_array_set_vec of { size : boxed_vector; unsafe : bool;
-                              index_kind : array_index_kind; boxed : bool }
   | Pint_array_set_vec of { size : boxed_vector; unsafe : bool;
                             index_kind : array_index_kind; boxed : bool }
   | Punboxed_float_array_set_vec of { size : boxed_vector; unsafe : bool;
@@ -2502,7 +2497,6 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pstring_load_vec { mode = m; boxed = true; _ }
   | Pbytes_load_vec { mode = m; boxed = true; _ }
   | Pfloatarray_load_vec { mode = m; boxed = true; _ }
-  | Pfloat_array_load_vec { mode = m; boxed = true; _ }
   | Pint_array_load_vec { mode = m; boxed = true; _ }
   | Punboxed_float_array_load_vec { mode = m; boxed = true; _ }
   | Punboxed_float32_array_load_vec { mode = m; boxed = true; _ }
@@ -2521,7 +2515,6 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pbytes_load_64 { boxed = false; _ }
   | Pbytes_load_vec { boxed = false; _ }
   | Pfloatarray_load_vec { boxed = false; _ }
-  | Pfloat_array_load_vec { boxed = false; _ }
   | Pint_array_load_vec { boxed = false; _ }
   | Punboxed_float_array_load_vec { boxed = false; _ }
   | Punboxed_float32_array_load_vec { boxed = false; _ }
@@ -2543,7 +2536,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pbigstring_load_vec { boxed = false; _ } -> None
   | Pbigstring_set_8 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pbigstring_set_f32 _ | Pbigstring_set_64 _ | Pbigstring_set_vec _
-  | Pfloatarray_set_vec _ | Pfloat_array_set_vec _ | Pint_array_set_vec _
+  | Pfloatarray_set_vec _ | Pint_array_set_vec _
   | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
   | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
   | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _
@@ -2641,7 +2634,6 @@ let primitive_can_raise prim =
   | Pbigstring_set_64 { unsafe = false; index_kind = _; boxed = _ }
   | Pbigstring_set_vec { checks = Some _; _ }
   | Pfloatarray_load_vec { unsafe = false; _ }
-  | Pfloat_array_load_vec { unsafe = false; _ }
   | Pint_array_load_vec { unsafe = false; _ }
   | Punboxed_float_array_load_vec { unsafe = false; _ }
   | Punboxed_float32_array_load_vec { unsafe = false; _ }
@@ -2651,7 +2643,6 @@ let primitive_can_raise prim =
   | Punboxed_int64_array_load_vec { unsafe = false; _ }
   | Punboxed_nativeint_array_load_vec { unsafe = false; _ }
   | Pfloatarray_set_vec { unsafe = false; _ }
-  | Pfloat_array_set_vec { unsafe = false; _ }
   | Pint_array_set_vec { unsafe = false; _ }
   | Punboxed_float_array_set_vec { unsafe = false; _ }
   | Punboxed_float32_array_set_vec { unsafe = false; _ }
@@ -2734,7 +2725,6 @@ let primitive_can_raise prim =
   | Pbigstring_set_64 { unsafe = true; index_kind = _; boxed = _ }
   | Pbigstring_set_vec { checks = None; _ }
   | Pfloatarray_load_vec { unsafe = true; _ }
-  | Pfloat_array_load_vec { unsafe = true; _ }
   | Pint_array_load_vec { unsafe = true; _ }
   | Punboxed_float_array_load_vec { unsafe = true; _ }
   | Punboxed_float32_array_load_vec { unsafe = true; _ }
@@ -2744,7 +2734,6 @@ let primitive_can_raise prim =
   | Punboxed_int64_array_load_vec { unsafe = true; _ }
   | Punboxed_nativeint_array_load_vec { unsafe = true; _ }
   | Pfloatarray_set_vec { unsafe = true; _ }
-  | Pfloat_array_set_vec { unsafe = true; _ }
   | Pint_array_set_vec { unsafe = true; _ }
   | Punboxed_float_array_set_vec { unsafe = true; _ }
   | Punboxed_float32_array_set_vec { unsafe = true; _ }
@@ -3040,7 +3029,7 @@ let primitive_result_layout (p : primitive) =
   | Pbytes_set_vec _
   | Pbigstring_set_8 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pbigstring_set_f32 _ | Pbigstring_set_64 _ | Pbigstring_set_vec _
-  | Pfloatarray_set_vec _ | Pfloat_array_set_vec _ | Pint_array_set_vec _
+  | Pfloatarray_set_vec _ | Pint_array_set_vec _
   | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
   | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
   | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _
@@ -3122,7 +3111,6 @@ let primitive_result_layout (p : primitive) =
   | Pbytes_load_vec { size; boxed = false; _ }
   | Pbigstring_load_vec { size; boxed = false; _ }
   | Pfloatarray_load_vec { size; boxed = false; _ }
-  | Pfloat_array_load_vec { size; boxed = false; _ }
   | Punboxed_float_array_load_vec { size; boxed = false; _ }
   | Punboxed_float32_array_load_vec { size; boxed = false; _ }
   | Pint_array_load_vec { size; boxed = false; _ }
@@ -3136,7 +3124,6 @@ let primitive_result_layout (p : primitive) =
   | Pbytes_load_vec { size; boxed = true; _ }
   | Pbigstring_load_vec { size; boxed = true; _ }
   | Pfloatarray_load_vec { size; boxed = true; _ }
-  | Pfloat_array_load_vec { size; boxed = true; _ }
   | Punboxed_float_array_load_vec { size; boxed = true; _ }
   | Punboxed_float32_array_load_vec { size; boxed = true; _ }
   | Pint_array_load_vec { size; boxed = true; _ }

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -309,9 +309,6 @@ type primitive =
   | Pfloatarray_load_vec of { size : boxed_vector; unsafe : bool;
                               index_kind : array_index_kind;
                               mode : locality_mode; boxed : bool }
-  | Pfloat_array_load_vec of { size : boxed_vector; unsafe : bool;
-                               index_kind : array_index_kind;
-                               mode : locality_mode; boxed : bool }
   | Pint_array_load_vec of { size : boxed_vector; unsafe : bool;
                              index_kind : array_index_kind;
                              mode : locality_mode; boxed : bool }
@@ -338,8 +335,6 @@ type primitive =
                                            mode : locality_mode; boxed : bool }
   | Pfloatarray_set_vec of { size : boxed_vector; unsafe : bool;
                              index_kind : array_index_kind; boxed : bool }
-  | Pfloat_array_set_vec of { size : boxed_vector; unsafe : bool;
-                              index_kind : array_index_kind; boxed : bool }
   | Pint_array_set_vec of { size : boxed_vector; unsafe : bool;
                             index_kind : array_index_kind; boxed : bool }
   | Punboxed_float_array_set_vec of { size : boxed_vector; unsafe : bool;

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -769,10 +769,6 @@ let primitive ppf = function
      fprintf ppf "floatarray.%sget%s%s%s"
        (if unsafe then "unsafe_" else "") (vector_width size)
        (if boxed then "" else "#") (locality_kind mode)
-  | Pfloat_array_load_vec {size; unsafe; mode; boxed} ->
-     fprintf ppf "float_array.%sget%s%s%s"
-      (if unsafe then "unsafe_" else "") (vector_width size)
-      (if boxed then "" else "#") (locality_kind mode)
   | Pint_array_load_vec {size; unsafe; mode; boxed} ->
      fprintf ppf "int_array.%sget%s%s%s"
       (if unsafe then "unsafe_" else "") (vector_width size)
@@ -807,10 +803,6 @@ let primitive ppf = function
       (if boxed then "" else "#") (locality_kind mode)
   | Pfloatarray_set_vec {size; unsafe; boxed} ->
      fprintf ppf "floatarray.%sset%s%s"
-      (if unsafe then "unsafe_" else "") (vector_width size)
-      (if boxed then "" else "#")
-  | Pfloat_array_set_vec {size; unsafe; boxed} ->
-     fprintf ppf "float_array.%sset%s%s"
       (if unsafe then "unsafe_" else "") (vector_width size)
       (if boxed then "" else "#")
   | Pint_array_set_vec {size; unsafe; boxed} ->
@@ -1022,7 +1014,6 @@ let name_of_primitive = function
   | Pbigstring_set_64 _ -> "Pbigstring_set_64"
   | Pbigstring_set_vec _ -> "Pbigstring_set_vec"
   | Pfloatarray_load_vec _ -> "Pfloatarray_load_vec"
-  | Pfloat_array_load_vec _ -> "Pfloat_array_load_vec"
   | Pint_array_load_vec _ -> "Pint_array_load_vec"
   | Punboxed_float_array_load_vec _ -> "Punboxed_float_array_load_vec"
   | Punboxed_float32_array_load_vec _ -> "Punboxed_float32_array_load_vec"
@@ -1032,7 +1023,6 @@ let name_of_primitive = function
   | Punboxed_int64_array_load_vec _ -> "Punboxed_int64_array_load_vec"
   | Punboxed_nativeint_array_load_vec _ -> "Punboxed_nativeint_array_load_vec"
   | Pfloatarray_set_vec _ -> "Pfloatarray_set_vec"
-  | Pfloat_array_set_vec _ -> "Pfloat_array_set_vec"
   | Pint_array_set_vec _ -> "Pint_array_set_vec"
   | Punboxed_float_array_set_vec _ -> "Punboxed_float_array_set_vec"
   | Punboxed_float32_array_set_vec _ -> "Punboxed_float32_array_set_vec"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -420,23 +420,23 @@ and fracture_prim lambda prim args loc =
   | Pbigstring_load_f32 _ | Pbigstring_load_64 _ | Pbigstring_load_vec _
   | Pbigstring_set_8 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pbigstring_set_f32 _ | Pbigstring_set_64 _ | Pbigstring_set_vec _
-  | Pfloatarray_load_vec _ | Pfloat_array_load_vec _ | Pint_array_load_vec _
+  | Pfloatarray_load_vec _ | Pint_array_load_vec _
   | Punboxed_float_array_load_vec _ | Punboxed_float32_array_load_vec _
   | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
   | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
   | Punboxed_nativeint_array_load_vec _ | Pfloatarray_set_vec _
-  | Pfloat_array_set_vec _ | Pint_array_set_vec _
-  | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
-  | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
-  | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _
-  | Punboxed_nativeint_array_set_vec _ | Pctconst _ | Pint_as_pointer _
-  | Patomic_load_field _ | Patomic_set_field _ | Patomic_exchange_field _
-  | Patomic_compare_exchange_field _ | Patomic_compare_set_field _
-  | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
-  | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field | Popaque _
-  | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Punbox_unit
-  | Punbox_vector _ | Pbox_vector _ | Pjoin_vec256 | Psplit_vec256
-  | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
+  | Pint_array_set_vec _ | Punboxed_float_array_set_vec _
+  | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
+  | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
+  | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
+  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _ | Patomic_set_field _
+  | Patomic_exchange_field _ | Patomic_compare_exchange_field _
+  | Patomic_compare_set_field _ | Patomic_fetch_add_field | Patomic_add_field
+  | Patomic_sub_field | Patomic_land_field | Patomic_lor_field
+  | Patomic_lxor_field | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
+  | Pobj_magic _ | Punbox_unit | Punbox_vector _ | Pbox_vector _ | Pjoin_vec256
+  | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
+  | Preinterpret_tuple_as_boxed_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64 | Parray_to_iarray
   | Parray_of_iarray | Pget_header _ | Ppeek _ | Ppoke _ | Pdls_get | Ptls_get

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -476,22 +476,21 @@ and eval_prim env prim =
   | Pbigstring_load_f32 _ | Pbigstring_load_64 _ | Pbigstring_load_vec _
   | Pbigstring_set_8 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pbigstring_set_f32 _ | Pbigstring_set_64 _ | Pbigstring_set_vec _
-  | Pfloatarray_load_vec _ | Pfloat_array_load_vec _ | Pint_array_load_vec _
+  | Pfloatarray_load_vec _ | Pint_array_load_vec _
   | Punboxed_float_array_load_vec _ | Punboxed_float32_array_load_vec _
   | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
   | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
   | Punboxed_nativeint_array_load_vec _ | Pfloatarray_set_vec _
-  | Pfloat_array_set_vec _ | Pint_array_set_vec _
-  | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
-  | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
-  | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _
-  | Punboxed_nativeint_array_set_vec _ | Pctconst _ | Pint_as_pointer _
-  | Patomic_load_field _ | Patomic_set_field _ | Patomic_exchange_field _
-  | Patomic_compare_exchange_field _ | Patomic_compare_set_field _
-  | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
-  | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
-  | Pprobe_is_enabled _ | Pobj_dup | Punbox_unit | Punbox_vector _
-  | Pbox_vector _ | Pjoin_vec256 | Psplit_vec256
+  | Pint_array_set_vec _ | Punboxed_float_array_set_vec _
+  | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
+  | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
+  | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
+  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _ | Patomic_set_field _
+  | Patomic_exchange_field _ | Patomic_compare_exchange_field _
+  | Patomic_compare_set_field _ | Patomic_fetch_add_field | Patomic_add_field
+  | Patomic_sub_field | Patomic_land_field | Patomic_lor_field
+  | Patomic_lxor_field | Pprobe_is_enabled _ | Pobj_dup | Punbox_unit
+  | Punbox_vector _ | Pbox_vector _ | Pjoin_vec256 | Psplit_vec256
   | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64 | Parray_to_iarray

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -968,7 +968,6 @@ let rec choice ctx t =
     | Pbigstring_set_16 _ | Pbigstring_set_32 _ | Pbigstring_set_f32 _
     | Pbigstring_set_64 _ | Pbigstring_set_vec _
     | Pfloatarray_load_vec _
-    | Pfloat_array_load_vec _
     | Pint_array_load_vec _
     | Puntagged_int8_array_load_vec _
     | Puntagged_int16_array_load_vec _
@@ -978,7 +977,6 @@ let rec choice ctx t =
     | Punboxed_int64_array_load_vec _
     | Punboxed_nativeint_array_load_vec _
     | Pfloatarray_set_vec _
-    | Pfloat_array_set_vec _
     | Pint_array_set_vec _
     | Punboxed_float_array_set_vec _
     | Punboxed_float32_array_set_vec _

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -491,11 +491,6 @@ let indexing_primitives =
 let array_vec_primitives =
   let array_types_and_primitives =
     [
-      ("float_array",
-       (fun ~size ~unsafe ~index_kind ~mode ~boxed ->
-         Pfloat_array_load_vec { size; unsafe; index_kind; mode; boxed }),
-       (fun ~size ~unsafe ~index_kind ~boxed ->
-         Pfloat_array_set_vec { size; unsafe; index_kind; boxed }));
       ("floatarray",
        (fun ~size ~unsafe ~index_kind ~mode ~boxed ->
          Pfloatarray_load_vec { size; unsafe; index_kind; mode; boxed }),
@@ -2509,12 +2504,12 @@ let lambda_primitive_needs_event_after = function
   | Pbigstring_load_vec _
   | Pbigstring_set_8 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pbigstring_set_f32 _ | Pbigstring_set_64 _ | Pbigstring_set_vec _
-  | Pfloatarray_load_vec _ | Pfloat_array_load_vec _ | Pint_array_load_vec _
+  | Pfloatarray_load_vec _ | Pint_array_load_vec _
   | Punboxed_float_array_load_vec _| Punboxed_float32_array_load_vec _
   | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
   | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
   | Punboxed_nativeint_array_load_vec _
-  | Pfloatarray_set_vec _ | Pfloat_array_set_vec _ | Pint_array_set_vec _
+  | Pfloatarray_set_vec _ | Pint_array_set_vec _
   | Punboxed_float_array_set_vec _| Punboxed_float32_array_set_vec _
   | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
   | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -458,7 +458,6 @@ let compute_static_size lam =
     | Pbytes_set_vec _
     | Pbigstring_set_vec _
     | Pfloatarray_set_vec _
-    | Pfloat_array_set_vec _
     | Pint_array_set_vec _
     | Punboxed_float_array_set_vec _
     | Punboxed_float32_array_set_vec _
@@ -487,7 +486,6 @@ let compute_static_size lam =
     | Pbytes_load_vec _
     | Pbigstring_load_vec _
     | Pfloatarray_load_vec _
-    | Pfloat_array_load_vec _
     | Pint_array_load_vec _
     | Punboxed_float_array_load_vec _
     | Punboxed_float32_array_load_vec _

--- a/middle_end/flambda2/docs/simd.md
+++ b/middle_end/flambda2/docs/simd.md
@@ -23,9 +23,8 @@ Unlike intrinsics, SIMD loads and stores are represented as flambda2-visible pri
   The prefix `u` indicates an unaligned operation (`MOVUPD`), and the suffix `u` omits bounds checking.
   Aligned load/store is available because bigstrings are allocated by `malloc`.
 
-- `float array`, `floatarray`, `float# array`: the corresponding primitives take an index in `float`s and are required to operate on `float64x2`s.
+- `floatarray`, `float# array`: the corresponding primitives take an index in `float`s and are required to operate on `float64x2`s.
   The address is computed as `array + index * 8`; the safe primitives bounds-check against `0, length - 1`.
-  The primitives on `float array` are only available when the float array optimization is enabled.
   Aligned load/store is not available because these values may be moved by the GC.
 
 - `nativeint# array`, `int64# array`: the corresponding primitives take an index in `nativeint`s/`int64`s and are required to operate on `int64x2`s.

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1283,18 +1283,18 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pbigstring_load_32 _ | Pbigstring_load_f32 _ | Pbigstring_load_64 _
       | Pbigstring_load_vec _ | Pbigstring_set_8 _ | Pbigstring_set_16 _
       | Pbigstring_set_32 _ | Pbigstring_set_f32 _ | Pbigstring_set_64 _
-      | Pbigstring_set_vec _ | Pfloatarray_load_vec _ | Pfloat_array_load_vec _
-      | Pint_array_load_vec _ | Punboxed_float_array_load_vec _
-      | Punboxed_float32_array_load_vec _ | Puntagged_int8_array_load_vec _
-      | Puntagged_int16_array_load_vec _ | Punboxed_int32_array_load_vec _
-      | Punboxed_int64_array_load_vec _ | Punboxed_nativeint_array_load_vec _
-      | Pfloatarray_set_vec _ | Pfloat_array_set_vec _ | Pint_array_set_vec _
-      | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
-      | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
-      | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _
-      | Punboxed_nativeint_array_set_vec _ | Pctconst _ | Pint_as_pointer _
-      | Popaque _ | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _
-      | Pmakelazyblock _ | Punbox_vector _ | Punbox_unit
+      | Pbigstring_set_vec _ | Pfloatarray_load_vec _ | Pint_array_load_vec _
+      | Punboxed_float_array_load_vec _ | Punboxed_float32_array_load_vec _
+      | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
+      | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
+      | Punboxed_nativeint_array_load_vec _ | Pfloatarray_set_vec _
+      | Pint_array_set_vec _ | Punboxed_float_array_set_vec _
+      | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
+      | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
+      | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
+      | Pctconst _ | Pint_as_pointer _ | Popaque _ | Pprobe_is_enabled _
+      | Pobj_dup | Pobj_magic _ | Pmakelazyblock _ | Punbox_vector _
+      | Punbox_unit
       | Pbox_vector (_, _)
       | Pjoin_vec256 | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
       | Preinterpret_tuple_as_boxed_vector _ | Pmake_unboxed_product _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2985,11 +2985,6 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let access_size = vec_accessor_width ~aligned size in
     [ bytes_like_set ~checks ~dbg ~machine_width ~access_size Bigstring
         ~boxed_or_tagged:boxed bigstring ~index_kind index new_value ]
-  | ( Pfloat_array_load_vec { size; unsafe; index_kind; mode; boxed },
-      [[array]; [index]] ) ->
-    check_float_array_optimisation_enabled dbg "Pfloat_array_load_vec";
-    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
-        ~boxed ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
   | ( Pfloatarray_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] )
   | ( Punboxed_float_array_load_vec { size; unsafe; index_kind; mode; boxed },
@@ -3035,12 +3030,6 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [[array]; [index]] ) ->
     [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
         ~boxed ~vec_kind:(vec_kind size) Naked_int16s array ~index_kind index ]
-  | ( Pfloat_array_set_vec { size; unsafe; index_kind; boxed },
-      [[array]; [index]; [new_value]] ) ->
-    check_float_array_optimisation_enabled dbg "Pfloat_array_set_vec";
-    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
-        ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index new_value
-    ]
   | ( Pfloatarray_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] )
   | ( Punboxed_float_array_set_vec { size; unsafe; index_kind; boxed },
@@ -3249,11 +3238,11 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Psetfloatfield _ | Psetufloatfield _ | Psetmixedfield _
       | Pbigstring_load_i8 _ | Pbigstring_load_i16 _ | Pbigstring_load_16 _
       | Pbigstring_load_32 _ | Pbigstring_load_f32 _ | Pbigstring_load_64 _
-      | Pbigstring_load_vec _ | Pfloatarray_load_vec _ | Pfloat_array_load_vec _
-      | Pint_array_load_vec _ | Punboxed_float_array_load_vec _
-      | Punboxed_float32_array_load_vec _ | Puntagged_int8_array_load_vec _
-      | Puntagged_int16_array_load_vec _ | Punboxed_int32_array_load_vec _
-      | Punboxed_int64_array_load_vec _ | Punboxed_nativeint_array_load_vec _
+      | Pbigstring_load_vec _ | Pfloatarray_load_vec _ | Pint_array_load_vec _
+      | Punboxed_float_array_load_vec _ | Punboxed_float32_array_load_vec _
+      | Puntagged_int8_array_load_vec _ | Puntagged_int16_array_load_vec _
+      | Punboxed_int32_array_load_vec _ | Punboxed_int64_array_load_vec _
+      | Punboxed_nativeint_array_load_vec _
       | Parrayrefu
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pgcignorableaddrarray_ref
             | Pintarray_ref | Pfloatarray_ref _ | Punboxedfloatarray_ref _
@@ -3297,14 +3286,13 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Pbytes_set_64 _ | Pbytes_set_vec _ | Pbigstring_set_8 _
       | Pbigstring_set_16 _ | Pbigstring_set_32 _ | Pbigstring_set_f32 _
       | Pbigstring_set_64 _ | Pbigstring_set_vec _ | Pfloatarray_set_vec _
-      | Pfloat_array_set_vec _ | Pint_array_set_vec _
-      | Punboxed_float_array_set_vec _ | Punboxed_float32_array_set_vec _
-      | Puntagged_int8_array_set_vec _ | Puntagged_int16_array_set_vec _
-      | Punboxed_int32_array_set_vec _ | Punboxed_int64_array_set_vec _
-      | Punboxed_nativeint_array_set_vec _ | Patomic_set_field _
-      | Patomic_exchange_field _ | Patomic_fetch_add_field | Patomic_add_field
-      | Patomic_sub_field | Patomic_land_field | Patomic_lxor_field
-      | Patomic_lor_field | Pset_idx _ ),
+      | Pint_array_set_vec _ | Punboxed_float_array_set_vec _
+      | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
+      | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
+      | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
+      | Patomic_set_field _ | Patomic_exchange_field _ | Patomic_fetch_add_field
+      | Patomic_add_field | Patomic_sub_field | Patomic_land_field
+      | Patomic_lxor_field | Patomic_lor_field | Pset_idx _ ),
       ( []
       | [_]
       | [_; _]

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -1145,13 +1145,6 @@ let transform_primitive0 env (prim : L.primitive) args loc =
     split_vec256_load ~loc ~mode ~index_kind ~boxed ~arr ~idx ~stride:8
       ~load:(fun _ ->
         L.Pfloatarray_load_vec { desc with size = Boxed_vec128; boxed = false })
-  | ( Pfloat_array_load_vec
-        ({ size = Boxed_vec256; mode; index_kind; boxed; _ } as desc),
-      [arr; idx] )
-    when L.split_vectors ->
-    split_vec256_load ~loc ~mode ~index_kind ~boxed ~arr ~idx ~stride:8
-      ~load:(fun _ ->
-        L.Pfloat_array_load_vec { desc with size = Boxed_vec128; boxed = false })
   | ( Pint_array_load_vec
         ({ size = Boxed_vec256; mode; index_kind; boxed; _ } as desc),
       [arr; idx] )
@@ -1241,13 +1234,6 @@ let transform_primitive0 env (prim : L.primitive) args loc =
     split_vec256_store ~loc ~index_kind ~boxed ~arr ~value ~idx ~stride:8
       ~store:(fun _ ->
         L.Pfloatarray_set_vec { desc with size = Boxed_vec128; boxed = false })
-  | ( Pfloat_array_set_vec
-        ({ size = Boxed_vec256; index_kind; boxed; _ } as desc),
-      [arr; idx; value] )
-    when L.split_vectors ->
-    split_vec256_store ~loc ~index_kind ~boxed ~arr ~value ~idx ~stride:8
-      ~store:(fun _ ->
-        L.Pfloat_array_set_vec { desc with size = Boxed_vec128; boxed = false })
   | ( Pint_array_set_vec ({ size = Boxed_vec256; index_kind; boxed; _ } as desc),
       [arr; idx; value] )
     when L.split_vectors ->

--- a/oxcaml/tests/simd/arrays.ml
+++ b/oxcaml/tests/simd/arrays.ml
@@ -754,15 +754,6 @@ end
 
 module Float_arrays (Primitives : sig
 
-  val float_array_get_float64x2 : float array -> int -> float64x2
-  val float_array_get_float64x2_unsafe : float array -> int -> float64x2
-
-  val float_iarray_get_float64x2 : float iarray -> int -> float64x2
-  val float_iarray_get_float64x2_unsafe : float iarray -> int -> float64x2
-
-  val float_array_set_float64x2 : float array -> int -> float64x2 -> unit
-  val float_array_set_float64x2_unsafe : float array -> int -> float64x2 -> unit
-
   val floatarray_get_float64x2 : floatarray -> int -> float64x2
   val floatarray_get_float64x2_unsafe : floatarray -> int -> float64x2
 
@@ -813,8 +804,6 @@ end)= struct
     let zw = interleave_low_32 z w in
     interleave_low_64s xy zw
 
-  let float_array () = [| 0.0; 1.0; 2.0; 3.0 |]
-  let float_iarray () = [: 0.0; 1.0; 2.0; 3.0 :]
   let floatarray () =
     let a = Array.Floatarray.create 4 in
     Array.Floatarray.set a 0 0.0;
@@ -825,94 +814,6 @@ end)= struct
   ;;
   let unboxed_float_array () = [| #0.0; #1.0; #2.0; #3.0 |]
   let unboxed_float32_array () = [| #0.0s; #1.0s; #2.0s; #3.0s; #4.0s; #5.0s; #6.0s; #7.0s |]
-
-  let () =
-    let float_array = float_array () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-
-    let f_45 = f64x2 4.0 5.0 in
-    let f_67 = f64x2 6.0 7.0 in
-    float_array_set_float64x2 float_array 0 f_45;
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_45) (float64x2_high_int64 f_45)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    float_array_set_float64x2 float_array 1 f_67;
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_67) (float64x2_high_int64 f_67)
-       (float64x2_low_int64 get) (float64x2_high_int64 get)
-  ;;
-
-  let () =
-    let float_array = float_array () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_array_get_float64x2_unsafe float_array 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_array_get_float64x2_unsafe float_array 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-
-    let f_45 = f64x2 4.0 5.0 in
-    let f_67 = f64x2 6.0 7.0 in
-    float_array_set_float64x2_unsafe float_array 0 f_45;
-    let get = float_array_get_float64x2_unsafe float_array 0 in
-    eq (float64x2_low_int64 f_45) (float64x2_high_int64 f_45)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    float_array_set_float64x2_unsafe float_array 1 f_67;
-    let get = float_array_get_float64x2_unsafe float_array 1 in
-    eq (float64x2_low_int64 f_67) (float64x2_high_int64 f_67)
-       (float64x2_low_int64 get) (float64x2_high_int64 get)
-  ;;
-
-  let () =
-    let a = float_array () in
-    let f_0 = f64x2 0.0 0.0 in
-    let fail a i =
-      try
-        let _ = float_array_get_float64x2 a i in
-        let _ = float_array_set_float64x2 a i f_0 in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [||] 0;
-    fail [|0.0|] 0;
-    fail [|0.0|] 1;
-    fail [|0.0|] (-1)
-  ;;
-
-  let () =
-    let float_array = float_array () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-
-    let f_45 = f64x2 4.0 5.0 in
-    let f_67 = f64x2 6.0 7.0 in
-    float_array_set_float64x2 float_array 0 f_45;
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_45) (float64x2_high_int64 f_45)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    float_array_set_float64x2 float_array 1 f_67;
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_67) (float64x2_high_int64 f_67)
-       (float64x2_low_int64 get) (float64x2_high_int64 get)
-  ;;
 
   let () =
     let floatarray = floatarray () in
@@ -956,36 +857,6 @@ end)= struct
     fail (Array.Floatarray.create 0) 0;
     let a = Array.Floatarray.create 1 in
     Array.Floatarray.set a 0 0.0;
-    fail a 0;
-    fail a 1;
-    fail a (-1)
-  ;;
-
-  let () =
-    let float_iarray = float_iarray () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_iarray_get_float64x2_unsafe float_iarray 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_iarray_get_float64x2_unsafe float_iarray 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-  ;;
-
-  let () =
-    let a = float_iarray () in
-    let fail a i =
-      try
-        let _ = float_iarray_get_float64x2 a i in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ();
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [::] 0;
-    let a = [: 0.0 :] in
     fail a 0;
     fail a 1;
     fail a (-1)
@@ -1126,15 +997,6 @@ end
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x2 : float array -> int -> float64x2 = "%caml_float_array_get128"
-  external float_array_get_float64x2_unsafe : float array -> int -> float64x2 = "%caml_float_array_get128u"
-
-  external float_iarray_get_float64x2 : float iarray -> int -> float64x2 = "%caml_float_array_get128"
-  external float_iarray_get_float64x2_unsafe : float iarray -> int -> float64x2 = "%caml_float_array_get128u"
-
-  external float_array_set_float64x2 : float array -> int -> float64x2 -> unit = "%caml_float_array_set128"
-  external float_array_set_float64x2_unsafe : float array -> int -> float64x2 -> unit = "%caml_float_array_set128u"
-
   external floatarray_get_float64x2 : floatarray -> int -> float64x2 = "%caml_floatarray_get128"
   external floatarray_get_float64x2_unsafe : floatarray -> int -> float64x2 = "%caml_floatarray_get128u"
 
@@ -1156,21 +1018,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x2 : float array -> int8# -> float64x2 = "%caml_float_array_get128_indexed_by_int8#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int8# -> float64x2 = "%caml_float_array_get128u_indexed_by_int8#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int8# -> float64x2 = "%caml_float_array_get128_indexed_by_int8#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int8# -> float64x2 = "%caml_float_array_get128u_indexed_by_int8#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int8# -> float64x2 -> unit = "%caml_float_array_set128_indexed_by_int8#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_stable.Int8_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int8# -> float64x2 -> unit = "%caml_float_array_set128u_indexed_by_int8#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_stable.Int8_u.of_int i) v
 
   external floatarray_get_float64x2 : floatarray -> int8# -> float64x2 = "%caml_floatarray_get128_indexed_by_int8#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_stable.Int8_u.of_int i)
@@ -1206,21 +1053,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x2 : float array -> int16# -> float64x2 = "%caml_float_array_get128_indexed_by_int16#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int16# -> float64x2 = "%caml_float_array_get128u_indexed_by_int16#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int16# -> float64x2 = "%caml_float_array_get128_indexed_by_int16#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int16# -> float64x2 = "%caml_float_array_get128u_indexed_by_int16#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int16# -> float64x2 -> unit = "%caml_float_array_set128_indexed_by_int16#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_stable.Int16_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int16# -> float64x2 -> unit = "%caml_float_array_set128u_indexed_by_int16#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_stable.Int16_u.of_int i) v
-
   external floatarray_get_float64x2 : floatarray -> int16# -> float64x2 = "%caml_floatarray_get128_indexed_by_int16#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_stable.Int16_u.of_int i)
   external floatarray_get_float64x2_unsafe : floatarray -> int16# -> float64x2 = "%caml_floatarray_get128u_indexed_by_int16#"
@@ -1254,21 +1086,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x2 : float array -> int32# -> float64x2 = "%caml_float_array_get128_indexed_by_int32#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int32# -> float64x2 = "%caml_float_array_get128u_indexed_by_int32#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int32# -> float64x2 = "%caml_float_array_get128_indexed_by_int32#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int32# -> float64x2 = "%caml_float_array_get128u_indexed_by_int32#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int32# -> float64x2 -> unit = "%caml_float_array_set128_indexed_by_int32#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int32# -> float64x2 -> unit = "%caml_float_array_set128u_indexed_by_int32#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
 
   external floatarray_get_float64x2 : floatarray -> int32# -> float64x2 = "%caml_floatarray_get128_indexed_by_int32#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
@@ -1304,21 +1121,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x2 : float array -> int64# -> float64x2 = "%caml_float_array_get128_indexed_by_int64#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int64# -> float64x2 = "%caml_float_array_get128u_indexed_by_int64#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int64# -> float64x2 = "%caml_float_array_get128_indexed_by_int64#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int64# -> float64x2 = "%caml_float_array_get128u_indexed_by_int64#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int64# -> float64x2 -> unit = "%caml_float_array_set128_indexed_by_int64#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int64# -> float64x2 -> unit = "%caml_float_array_set128u_indexed_by_int64#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-
   external floatarray_get_float64x2 : floatarray -> int64# -> float64x2 = "%caml_floatarray_get128_indexed_by_int64#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
   external floatarray_get_float64x2_unsafe : floatarray -> int64# -> float64x2 = "%caml_floatarray_get128u_indexed_by_int64#"
@@ -1352,21 +1154,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x2 : float array -> nativeint# -> float64x2 = "%caml_float_array_get128_indexed_by_nativeint#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> nativeint# -> float64x2 = "%caml_float_array_get128u_indexed_by_nativeint#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> nativeint# -> float64x2 = "%caml_float_array_get128_indexed_by_nativeint#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> nativeint# -> float64x2 = "%caml_float_array_get128u_indexed_by_nativeint#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> nativeint# -> float64x2 -> unit = "%caml_float_array_set128_indexed_by_nativeint#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> nativeint# -> float64x2 -> unit = "%caml_float_array_set128u_indexed_by_nativeint#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
 
   external floatarray_get_float64x2 : floatarray -> nativeint# -> float64x2 = "%caml_floatarray_get128_indexed_by_nativeint#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)

--- a/oxcaml/tests/simd/arrays256.ml
+++ b/oxcaml/tests/simd/arrays256.ml
@@ -787,15 +787,6 @@ end
 
 module Float_arrays (Primitives : sig
 
-  val float_array_get_float64x4 : float array -> int -> float64x4
-  val float_array_get_float64x4_unsafe : float array -> int -> float64x4
-
-  val float_iarray_get_float64x4 : float iarray -> int -> float64x4
-  val float_iarray_get_float64x4_unsafe : float iarray -> int -> float64x4
-
-  val float_array_set_float64x4 : float array -> int -> float64x4 -> unit
-  val float_array_set_float64x4_unsafe : float array -> int -> float64x4 -> unit
-
   val floatarray_get_float64x4 : floatarray -> int -> float64x4
   val floatarray_get_float64x4_unsafe : floatarray -> int -> float64x4
 
@@ -835,8 +826,6 @@ end) = struct
     in
     float32x8_of_int64s (pack_pair a b) (pack_pair c d) (pack_pair e f) (pack_pair g h)
 
-  let float_array () = [| 0.0; 1.0; 2.0; 3.0; 4.0 |]
-  let float_iarray () = [: 0.0; 1.0; 2.0; 3.0; 4.0 :]
   let floatarray () =
     let a = Array.Floatarray.create 5 in
     Array.Floatarray.set a 0 0.0;
@@ -848,51 +837,6 @@ end) = struct
   ;;
   let unboxed_float_array () = [| #0.0; #1.0; #2.0; #3.0; #4.0 |]
   let unboxed_float32_array () = [| #0.0s; #1.0s; #2.0s; #3.0s; #4.0s; #5.0s; #6.0s; #7.0s; #8.0s |]
-
-  let () =
-    let float_array = float_array () in
-    let f_0123 = f64x4 0.0 1.0 2.0 3.0 in
-    let f_1234 = f64x4 1.0 2.0 3.0 4.0 in
-    let get = float_array_get_float64x4_unsafe float_array 0 in
-    eq (float64x4_first_int64 f_0123) (float64x4_second_int64 f_0123) (float64x4_third_int64 f_0123) (float64x4_fourth_int64 f_0123)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-    let get = float_array_get_float64x4_unsafe float_array 1 in
-    eq (float64x4_first_int64 f_1234) (float64x4_second_int64 f_1234) (float64x4_third_int64 f_1234) (float64x4_fourth_int64 f_1234)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-
-    let f_4567 = f64x4 4.0 5.0 6.0 7.0 in
-    let f_6789 = f64x4 6.0 7.0 8.0 9.0 in
-    float_array_set_float64x4_unsafe float_array 0 f_4567;
-    let get = float_array_get_float64x4_unsafe float_array 0 in
-    eq (float64x4_first_int64 f_4567) (float64x4_second_int64 f_4567) (float64x4_third_int64 f_4567) (float64x4_fourth_int64 f_4567)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-    float_array_set_float64x4_unsafe float_array 1 f_6789;
-    let get = float_array_get_float64x4_unsafe float_array 1 in
-    eq (float64x4_first_int64 f_6789) (float64x4_second_int64 f_6789) (float64x4_third_int64 f_6789) (float64x4_fourth_int64 f_6789)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get)
-  ;;
-
-  let () =
-    let a = float_array () in
-    let f_0 = f64x4 0.0 0.0 0.0 0.0 in
-    let fail a i =
-      try
-        let _ = float_array_get_float64x4 a i in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ();
-      try
-        let _ = float_array_set_float64x4 a i f_0 in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [||] 0;
-    fail [|0.0|] 0;
-    fail [|0.0|] 1;
-    fail [|0.0|] (-1)
-  ;;
 
   let () =
     let floatarray = floatarray () in
@@ -932,34 +876,6 @@ end) = struct
     fail (Array.Floatarray.create 0) 0;
     let a = Array.Floatarray.create 1 in
     Array.Floatarray.set a 0 0.0;
-    fail a 0;
-    fail a 1;
-    fail a (-1)
-  ;;
-
-  let () =
-    let float_iarray = float_iarray () in
-    let f_0123 = f64x4 0.0 1.0 2.0 3.0 in
-    let f_1234 = f64x4 1.0 2.0 3.0 4.0 in
-    let get = float_iarray_get_float64x4_unsafe float_iarray 0 in
-    eq (float64x4_first_int64 f_0123) (float64x4_second_int64 f_0123) (float64x4_third_int64 f_0123) (float64x4_fourth_int64 f_0123) (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-    let get = float_iarray_get_float64x4_unsafe float_iarray 1 in
-    eq (float64x4_first_int64 f_1234) (float64x4_second_int64 f_1234) (float64x4_third_int64 f_1234) (float64x4_fourth_int64 f_1234) (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-  ;;
-
-  let () =
-    let a = float_iarray () in
-    let fail a i =
-      try
-        let _ = float_iarray_get_float64x4 a i in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ();
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [::] 0;
-    let a = [: 0.0 :] in
     fail a 0;
     fail a 1;
     fail a (-1)
@@ -1084,15 +1000,6 @@ end
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x4 : float array -> int -> float64x4 = "%caml_float_array_get256"
-  external float_array_get_float64x4_unsafe : float array -> int -> float64x4 = "%caml_float_array_get256u"
-
-  external float_iarray_get_float64x4 : float iarray -> int -> float64x4 = "%caml_float_array_get256"
-  external float_iarray_get_float64x4_unsafe : float iarray -> int -> float64x4 = "%caml_float_array_get256u"
-
-  external float_array_set_float64x4 : float array -> int -> float64x4 -> unit = "%caml_float_array_set256"
-  external float_array_set_float64x4_unsafe : float array -> int -> float64x4 -> unit = "%caml_float_array_set256u"
-
   external floatarray_get_float64x4 : floatarray -> int -> float64x4 = "%caml_floatarray_get256"
   external floatarray_get_float64x4_unsafe : floatarray -> int -> float64x4 = "%caml_floatarray_get256u"
 
@@ -1114,21 +1021,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x4 : float array -> int8# -> float64x4 = "%caml_float_array_get256_indexed_by_int8#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int8# -> float64x4 = "%caml_float_array_get256u_indexed_by_int8#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int8# -> float64x4 = "%caml_float_array_get256_indexed_by_int8#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int8# -> float64x4 = "%caml_float_array_get256u_indexed_by_int8#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int8# -> float64x4 -> unit = "%caml_float_array_set256_indexed_by_int8#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_stable.Int8_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int8# -> float64x4 -> unit = "%caml_float_array_set256u_indexed_by_int8#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_stable.Int8_u.of_int i) v
 
   external floatarray_get_float64x4 : floatarray -> int8# -> float64x4 = "%caml_floatarray_get256_indexed_by_int8#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_stable.Int8_u.of_int i)
@@ -1164,21 +1056,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x4 : float array -> int16# -> float64x4 = "%caml_float_array_get256_indexed_by_int16#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int16# -> float64x4 = "%caml_float_array_get256u_indexed_by_int16#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int16# -> float64x4 = "%caml_float_array_get256_indexed_by_int16#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int16# -> float64x4 = "%caml_float_array_get256u_indexed_by_int16#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int16# -> float64x4 -> unit = "%caml_float_array_set256_indexed_by_int16#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_stable.Int16_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int16# -> float64x4 -> unit = "%caml_float_array_set256u_indexed_by_int16#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_stable.Int16_u.of_int i) v
-
   external floatarray_get_float64x4 : floatarray -> int16# -> float64x4 = "%caml_floatarray_get256_indexed_by_int16#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_stable.Int16_u.of_int i)
   external floatarray_get_float64x4_unsafe : floatarray -> int16# -> float64x4 = "%caml_floatarray_get256u_indexed_by_int16#"
@@ -1212,21 +1089,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x4 : float array -> int32# -> float64x4 = "%caml_float_array_get256_indexed_by_int32#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int32# -> float64x4 = "%caml_float_array_get256u_indexed_by_int32#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int32# -> float64x4 = "%caml_float_array_get256_indexed_by_int32#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int32# -> float64x4 = "%caml_float_array_get256u_indexed_by_int32#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int32# -> float64x4 -> unit = "%caml_float_array_set256_indexed_by_int32#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int32# -> float64x4 -> unit = "%caml_float_array_set256u_indexed_by_int32#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
 
   external floatarray_get_float64x4 : floatarray -> int32# -> float64x4 = "%caml_floatarray_get256_indexed_by_int32#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
@@ -1262,21 +1124,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x4 : float array -> int64# -> float64x4 = "%caml_float_array_get256_indexed_by_int64#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int64# -> float64x4 = "%caml_float_array_get256u_indexed_by_int64#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int64# -> float64x4 = "%caml_float_array_get256_indexed_by_int64#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int64# -> float64x4 = "%caml_float_array_get256u_indexed_by_int64#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int64# -> float64x4 -> unit = "%caml_float_array_set256_indexed_by_int64#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int64# -> float64x4 -> unit = "%caml_float_array_set256u_indexed_by_int64#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-
   external floatarray_get_float64x4 : floatarray -> int64# -> float64x4 = "%caml_floatarray_get256_indexed_by_int64#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
   external floatarray_get_float64x4_unsafe : floatarray -> int64# -> float64x4 = "%caml_floatarray_get256u_indexed_by_int64#"
@@ -1310,21 +1157,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x4 : float array -> nativeint# -> float64x4 = "%caml_float_array_get256_indexed_by_nativeint#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> nativeint# -> float64x4 = "%caml_float_array_get256u_indexed_by_nativeint#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> nativeint# -> float64x4 = "%caml_float_array_get256_indexed_by_nativeint#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> nativeint# -> float64x4 = "%caml_float_array_get256u_indexed_by_nativeint#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> nativeint# -> float64x4 -> unit = "%caml_float_array_set256_indexed_by_nativeint#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> nativeint# -> float64x4 -> unit = "%caml_float_array_set256u_indexed_by_nativeint#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
 
   external floatarray_get_float64x4 : floatarray -> nativeint# -> float64x4 = "%caml_floatarray_get256_indexed_by_nativeint#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)

--- a/oxcaml/tests/simd/arrays256_u.ml
+++ b/oxcaml/tests/simd/arrays256_u.ml
@@ -792,15 +792,6 @@ end
 
 module Float_arrays (Primitives : sig
 
-  val float_array_get_float64x4 : float array -> int -> float64x4
-  val float_array_get_float64x4_unsafe : float array -> int -> float64x4
-
-  val float_iarray_get_float64x4 : float iarray -> int -> float64x4
-  val float_iarray_get_float64x4_unsafe : float iarray -> int -> float64x4
-
-  val float_array_set_float64x4 : float array -> int -> float64x4 -> unit
-  val float_array_set_float64x4_unsafe : float array -> int -> float64x4 -> unit
-
   val floatarray_get_float64x4 : floatarray -> int -> float64x4
   val floatarray_get_float64x4_unsafe : floatarray -> int -> float64x4
 
@@ -840,8 +831,6 @@ end) = struct
     in
     float32x8_of_int64s (pack_pair a b) (pack_pair c d) (pack_pair e f) (pack_pair g h)
 
-  let float_array () = [| 0.0; 1.0; 2.0; 3.0; 4.0 |]
-  let float_iarray () = [: 0.0; 1.0; 2.0; 3.0; 4.0 :]
   let floatarray () =
     let a = Array.Floatarray.create 5 in
     Array.Floatarray.set a 0 0.0;
@@ -853,51 +842,6 @@ end) = struct
   ;;
   let unboxed_float_array () = [| #0.0; #1.0; #2.0; #3.0; #4.0 |]
   let unboxed_float32_array () = [| #0.0s; #1.0s; #2.0s; #3.0s; #4.0s; #5.0s; #6.0s; #7.0s; #8.0s |]
-
-  let () =
-    let float_array = float_array () in
-    let f_0123 = f64x4 0.0 1.0 2.0 3.0 in
-    let f_1234 = f64x4 1.0 2.0 3.0 4.0 in
-    let get = float_array_get_float64x4_unsafe float_array 0 in
-    eq (float64x4_first_int64 f_0123) (float64x4_second_int64 f_0123) (float64x4_third_int64 f_0123) (float64x4_fourth_int64 f_0123)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-    let get = float_array_get_float64x4_unsafe float_array 1 in
-    eq (float64x4_first_int64 f_1234) (float64x4_second_int64 f_1234) (float64x4_third_int64 f_1234) (float64x4_fourth_int64 f_1234)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-
-    let f_4567 = f64x4 4.0 5.0 6.0 7.0 in
-    let f_6789 = f64x4 6.0 7.0 8.0 9.0 in
-    float_array_set_float64x4_unsafe float_array 0 f_4567;
-    let get = float_array_get_float64x4_unsafe float_array 0 in
-    eq (float64x4_first_int64 f_4567) (float64x4_second_int64 f_4567) (float64x4_third_int64 f_4567) (float64x4_fourth_int64 f_4567)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-    float_array_set_float64x4_unsafe float_array 1 f_6789;
-    let get = float_array_get_float64x4_unsafe float_array 1 in
-    eq (float64x4_first_int64 f_6789) (float64x4_second_int64 f_6789) (float64x4_third_int64 f_6789) (float64x4_fourth_int64 f_6789)
-       (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get)
-  ;;
-
-  let () =
-    let a = float_array () in
-    let f_0 = f64x4 0.0 0.0 0.0 0.0 in
-    let fail a i =
-      try
-        let _ = float_array_get_float64x4 a i in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ();
-      try
-        let _ = float_array_set_float64x4 a i f_0 in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [||] 0;
-    fail [|0.0|] 0;
-    fail [|0.0|] 1;
-    fail [|0.0|] (-1)
-  ;;
 
   let () =
     let floatarray = floatarray () in
@@ -937,34 +881,6 @@ end) = struct
     fail (Array.Floatarray.create 0) 0;
     let a = Array.Floatarray.create 1 in
     Array.Floatarray.set a 0 0.0;
-    fail a 0;
-    fail a 1;
-    fail a (-1)
-  ;;
-
-  let () =
-    let float_iarray = float_iarray () in
-    let f_0123 = f64x4 0.0 1.0 2.0 3.0 in
-    let f_1234 = f64x4 1.0 2.0 3.0 4.0 in
-    let get = float_iarray_get_float64x4_unsafe float_iarray 0 in
-    eq (float64x4_first_int64 f_0123) (float64x4_second_int64 f_0123) (float64x4_third_int64 f_0123) (float64x4_fourth_int64 f_0123) (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-    let get = float_iarray_get_float64x4_unsafe float_iarray 1 in
-    eq (float64x4_first_int64 f_1234) (float64x4_second_int64 f_1234) (float64x4_third_int64 f_1234) (float64x4_fourth_int64 f_1234) (float64x4_first_int64 get) (float64x4_second_int64 get) (float64x4_third_int64 get) (float64x4_fourth_int64 get);
-  ;;
-
-  let () =
-    let a = float_iarray () in
-    let fail a i =
-      try
-        let _ = float_iarray_get_float64x4 a i in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ();
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [::] 0;
-    let a = [: 0.0 :] in
     fail a 0;
     fail a 1;
     fail a (-1)
@@ -1089,15 +1005,6 @@ end
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x4 : float array -> int -> float64x4 = "%caml_float_array_get256#"
-  external float_array_get_float64x4_unsafe : float array -> int -> float64x4 = "%caml_float_array_get256u#"
-
-  external float_iarray_get_float64x4 : float iarray -> int -> float64x4 = "%caml_float_array_get256#"
-  external float_iarray_get_float64x4_unsafe : float iarray -> int -> float64x4 = "%caml_float_array_get256u#"
-
-  external float_array_set_float64x4 : float array -> int -> float64x4 -> unit = "%caml_float_array_set256#"
-  external float_array_set_float64x4_unsafe : float array -> int -> float64x4 -> unit = "%caml_float_array_set256u#"
-
   external floatarray_get_float64x4 : floatarray -> int -> float64x4 = "%caml_floatarray_get256#"
   external floatarray_get_float64x4_unsafe : floatarray -> int -> float64x4 = "%caml_floatarray_get256u#"
 
@@ -1119,21 +1026,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x4 : float array -> int8# -> float64x4 = "%caml_float_array_get256#_indexed_by_int8#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int8# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int8#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int8# -> float64x4 = "%caml_float_array_get256#_indexed_by_int8#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int8# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int8#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int8# -> float64x4 -> unit = "%caml_float_array_set256#_indexed_by_int8#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_stable.Int8_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int8# -> float64x4 -> unit = "%caml_float_array_set256u#_indexed_by_int8#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_stable.Int8_u.of_int i) v
 
   external floatarray_get_float64x4 : floatarray -> int8# -> float64x4 = "%caml_floatarray_get256#_indexed_by_int8#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_stable.Int8_u.of_int i)
@@ -1169,21 +1061,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x4 : float array -> int16# -> float64x4 = "%caml_float_array_get256#_indexed_by_int16#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int16# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int16#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int16# -> float64x4 = "%caml_float_array_get256#_indexed_by_int16#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int16# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int16#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int16# -> float64x4 -> unit = "%caml_float_array_set256#_indexed_by_int16#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_stable.Int16_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int16# -> float64x4 -> unit = "%caml_float_array_set256u#_indexed_by_int16#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_stable.Int16_u.of_int i) v
-
   external floatarray_get_float64x4 : floatarray -> int16# -> float64x4 = "%caml_floatarray_get256#_indexed_by_int16#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_stable.Int16_u.of_int i)
   external floatarray_get_float64x4_unsafe : floatarray -> int16# -> float64x4 = "%caml_floatarray_get256u#_indexed_by_int16#"
@@ -1217,21 +1094,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x4 : float array -> int32# -> float64x4 = "%caml_float_array_get256#_indexed_by_int32#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int32# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int32#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int32# -> float64x4 = "%caml_float_array_get256#_indexed_by_int32#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int32# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int32#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int32# -> float64x4 -> unit = "%caml_float_array_set256#_indexed_by_int32#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int32# -> float64x4 -> unit = "%caml_float_array_set256u#_indexed_by_int32#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
 
   external floatarray_get_float64x4 : floatarray -> int32# -> float64x4 = "%caml_floatarray_get256#_indexed_by_int32#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
@@ -1267,21 +1129,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x4 : float array -> int64# -> float64x4 = "%caml_float_array_get256#_indexed_by_int64#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> int64# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int64#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> int64# -> float64x4 = "%caml_float_array_get256#_indexed_by_int64#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> int64# -> float64x4 = "%caml_float_array_get256u#_indexed_by_int64#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> int64# -> float64x4 -> unit = "%caml_float_array_set256#_indexed_by_int64#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> int64# -> float64x4 -> unit = "%caml_float_array_set256u#_indexed_by_int64#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-
   external floatarray_get_float64x4 : floatarray -> int64# -> float64x4 = "%caml_floatarray_get256#_indexed_by_int64#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
   external floatarray_get_float64x4_unsafe : floatarray -> int64# -> float64x4 = "%caml_floatarray_get256u#_indexed_by_int64#"
@@ -1315,21 +1162,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x4 : float array -> nativeint# -> float64x4 = "%caml_float_array_get256#_indexed_by_nativeint#"
-  let float_array_get_float64x4 arr i = float_array_get_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_array_get_float64x4_unsafe : float array -> nativeint# -> float64x4 = "%caml_float_array_get256u#_indexed_by_nativeint#"
-  let float_array_get_float64x4_unsafe arr i = float_array_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_iarray_get_float64x4 : float iarray -> nativeint# -> float64x4 = "%caml_float_array_get256#_indexed_by_nativeint#"
-  let float_iarray_get_float64x4 arr i = float_iarray_get_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_iarray_get_float64x4_unsafe : float iarray -> nativeint# -> float64x4 = "%caml_float_array_get256u#_indexed_by_nativeint#"
-  let float_iarray_get_float64x4_unsafe arr i = float_iarray_get_float64x4_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_array_set_float64x4 : float array -> nativeint# -> float64x4 -> unit = "%caml_float_array_set256#_indexed_by_nativeint#"
-  let float_array_set_float64x4 arr i v = float_array_set_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
-  external float_array_set_float64x4_unsafe : float array -> nativeint# -> float64x4 -> unit = "%caml_float_array_set256u#_indexed_by_nativeint#"
-  let float_array_set_float64x4_unsafe arr i v = float_array_set_float64x4_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
 
   external floatarray_get_float64x4 : floatarray -> nativeint# -> float64x4 = "%caml_floatarray_get256#_indexed_by_nativeint#"
   let floatarray_get_float64x4 arr i = floatarray_get_float64x4 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)

--- a/oxcaml/tests/simd/arrays_u.ml
+++ b/oxcaml/tests/simd/arrays_u.ml
@@ -771,15 +771,6 @@ end
 
 module Float_arrays (Primitives : sig
 
-  val float_array_get_float64x2 : float array -> int -> float64x2
-  val float_array_get_float64x2_unsafe : float array -> int -> float64x2
-
-  val float_iarray_get_float64x2 : float iarray -> int -> float64x2
-  val float_iarray_get_float64x2_unsafe : float iarray -> int -> float64x2
-
-  val float_array_set_float64x2 : float array -> int -> float64x2 -> unit
-  val float_array_set_float64x2_unsafe : float array -> int -> float64x2 -> unit
-
   val floatarray_get_float64x2 : floatarray -> int -> float64x2
   val floatarray_get_float64x2_unsafe : floatarray -> int -> float64x2
 
@@ -830,8 +821,6 @@ end)= struct
     let zw = interleave_low_32 z w in
     interleave_low_64s xy zw
 
-  let float_array () = [| 0.0; 1.0; 2.0; 3.0 |]
-  let float_iarray () = [: 0.0; 1.0; 2.0; 3.0 :]
   let floatarray () =
     let a = Array.Floatarray.create 4 in
     Array.Floatarray.set a 0 0.0;
@@ -842,94 +831,6 @@ end)= struct
   ;;
   let unboxed_float_array () = [| #0.0; #1.0; #2.0; #3.0 |]
   let unboxed_float32_array () = [| #0.0s; #1.0s; #2.0s; #3.0s; #4.0s; #5.0s; #6.0s; #7.0s |]
-
-  let () =
-    let float_array = float_array () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-
-    let f_45 = f64x2 4.0 5.0 in
-    let f_67 = f64x2 6.0 7.0 in
-    float_array_set_float64x2 float_array 0 f_45;
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_45) (float64x2_high_int64 f_45)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    float_array_set_float64x2 float_array 1 f_67;
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_67) (float64x2_high_int64 f_67)
-       (float64x2_low_int64 get) (float64x2_high_int64 get)
-  ;;
-
-  let () =
-    let float_array = float_array () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_array_get_float64x2_unsafe float_array 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_array_get_float64x2_unsafe float_array 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-
-    let f_45 = f64x2 4.0 5.0 in
-    let f_67 = f64x2 6.0 7.0 in
-    float_array_set_float64x2_unsafe float_array 0 f_45;
-    let get = float_array_get_float64x2_unsafe float_array 0 in
-    eq (float64x2_low_int64 f_45) (float64x2_high_int64 f_45)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    float_array_set_float64x2_unsafe float_array 1 f_67;
-    let get = float_array_get_float64x2_unsafe float_array 1 in
-    eq (float64x2_low_int64 f_67) (float64x2_high_int64 f_67)
-       (float64x2_low_int64 get) (float64x2_high_int64 get)
-  ;;
-
-  let () =
-    let a = float_array () in
-    let f_0 = f64x2 0.0 0.0 in
-    let fail a i =
-      try
-        let _ = float_array_get_float64x2 a i in
-        let _ = float_array_set_float64x2 a i f_0 in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [||] 0;
-    fail [|0.0|] 0;
-    fail [|0.0|] 1;
-    fail [|0.0|] (-1)
-  ;;
-
-  let () =
-    let float_array = float_array () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-
-    let f_45 = f64x2 4.0 5.0 in
-    let f_67 = f64x2 6.0 7.0 in
-    float_array_set_float64x2 float_array 0 f_45;
-    let get = float_array_get_float64x2 float_array 0 in
-    eq (float64x2_low_int64 f_45) (float64x2_high_int64 f_45)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    float_array_set_float64x2 float_array 1 f_67;
-    let get = float_array_get_float64x2 float_array 1 in
-    eq (float64x2_low_int64 f_67) (float64x2_high_int64 f_67)
-       (float64x2_low_int64 get) (float64x2_high_int64 get)
-  ;;
 
   let () =
     let floatarray = floatarray () in
@@ -973,36 +874,6 @@ end)= struct
     fail (Array.Floatarray.create 0) 0;
     let a = Array.Floatarray.create 1 in
     Array.Floatarray.set a 0 0.0;
-    fail a 0;
-    fail a 1;
-    fail a (-1)
-  ;;
-
-  let () =
-    let float_iarray = float_iarray () in
-    let f_01 = f64x2 0.0 1.0 in
-    let f_12 = f64x2 1.0 2.0 in
-    let get = float_iarray_get_float64x2_unsafe float_iarray 0 in
-    eq (float64x2_low_int64 f_01) (float64x2_high_int64 f_01)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-    let get = float_iarray_get_float64x2_unsafe float_iarray 1 in
-    eq (float64x2_low_int64 f_12) (float64x2_high_int64 f_12)
-       (float64x2_low_int64 get) (float64x2_high_int64 get);
-  ;;
-
-  let () =
-    let a = float_iarray () in
-    let fail a i =
-      try
-        let _ = float_iarray_get_float64x2 a i in
-        Printf.printf "Did not fail on index %d\n" i
-      with | Invalid_argument s when s = "index out of bounds" -> ();
-    in
-    fail a (-1);
-    fail a 3;
-    fail a 4;
-    fail [::] 0;
-    let a = [: 0.0 :] in
     fail a 0;
     fail a 1;
     fail a (-1)
@@ -1143,15 +1014,6 @@ end
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x2 : float array -> int -> float64x2 = "%caml_float_array_get128#"
-  external float_array_get_float64x2_unsafe : float array -> int -> float64x2 = "%caml_float_array_get128u#"
-
-  external float_iarray_get_float64x2 : float iarray -> int -> float64x2 = "%caml_float_array_get128#"
-  external float_iarray_get_float64x2_unsafe : float iarray -> int -> float64x2 = "%caml_float_array_get128u#"
-
-  external float_array_set_float64x2 : float array -> int -> float64x2 -> unit = "%caml_float_array_set128#"
-  external float_array_set_float64x2_unsafe : float array -> int -> float64x2 -> unit = "%caml_float_array_set128u#"
-
   external floatarray_get_float64x2 : floatarray -> int -> float64x2 = "%caml_floatarray_get128#"
   external floatarray_get_float64x2_unsafe : floatarray -> int -> float64x2 = "%caml_floatarray_get128u#"
 
@@ -1173,21 +1035,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x2 : float array -> int8# -> float64x2 = "%caml_float_array_get128#_indexed_by_int8#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int8# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int8#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int8# -> float64x2 = "%caml_float_array_get128#_indexed_by_int8#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_stable.Int8_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int8# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int8#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_stable.Int8_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int8# -> float64x2 -> unit = "%caml_float_array_set128#_indexed_by_int8#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_stable.Int8_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int8# -> float64x2 -> unit = "%caml_float_array_set128u#_indexed_by_int8#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_stable.Int8_u.of_int i) v
 
   external floatarray_get_float64x2 : floatarray -> int8# -> float64x2 = "%caml_floatarray_get128#_indexed_by_int8#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_stable.Int8_u.of_int i)
@@ -1223,21 +1070,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x2 : float array -> int16# -> float64x2 = "%caml_float_array_get128#_indexed_by_int16#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int16# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int16#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int16# -> float64x2 = "%caml_float_array_get128#_indexed_by_int16#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_stable.Int16_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int16# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int16#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_stable.Int16_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int16# -> float64x2 -> unit = "%caml_float_array_set128#_indexed_by_int16#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_stable.Int16_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int16# -> float64x2 -> unit = "%caml_float_array_set128u#_indexed_by_int16#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_stable.Int16_u.of_int i) v
-
   external floatarray_get_float64x2 : floatarray -> int16# -> float64x2 = "%caml_floatarray_get128#_indexed_by_int16#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_stable.Int16_u.of_int i)
   external floatarray_get_float64x2_unsafe : floatarray -> int16# -> float64x2 = "%caml_floatarray_get128u#_indexed_by_int16#"
@@ -1271,21 +1103,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x2 : float array -> int32# -> float64x2 = "%caml_float_array_get128#_indexed_by_int32#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int32# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int32#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int32# -> float64x2 = "%caml_float_array_get128#_indexed_by_int32#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int32# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int32#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int32# -> float64x2 -> unit = "%caml_float_array_set128#_indexed_by_int32#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int32# -> float64x2 -> unit = "%caml_float_array_set128u#_indexed_by_int32#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_upstream_compatible.Int32_u.of_int i) v
 
   external floatarray_get_float64x2 : floatarray -> int32# -> float64x2 = "%caml_floatarray_get128#_indexed_by_int32#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_upstream_compatible.Int32_u.of_int i)
@@ -1321,21 +1138,6 @@ end)
 
 module _ = Float_arrays(struct
 
-  external float_array_get_float64x2 : float array -> int64# -> float64x2 = "%caml_float_array_get128#_indexed_by_int64#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> int64# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int64#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> int64# -> float64x2 = "%caml_float_array_get128#_indexed_by_int64#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> int64# -> float64x2 = "%caml_float_array_get128u#_indexed_by_int64#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> int64# -> float64x2 -> unit = "%caml_float_array_set128#_indexed_by_int64#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> int64# -> float64x2 -> unit = "%caml_float_array_set128u#_indexed_by_int64#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_upstream_compatible.Int64_u.of_int i) v
-
   external floatarray_get_float64x2 : floatarray -> int64# -> float64x2 = "%caml_floatarray_get128#_indexed_by_int64#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_upstream_compatible.Int64_u.of_int i)
   external floatarray_get_float64x2_unsafe : floatarray -> int64# -> float64x2 = "%caml_floatarray_get128u#_indexed_by_int64#"
@@ -1369,21 +1171,6 @@ module _ = Float_arrays(struct
 end)
 
 module _ = Float_arrays(struct
-
-  external float_array_get_float64x2 : float array -> nativeint# -> float64x2 = "%caml_float_array_get128#_indexed_by_nativeint#"
-  let float_array_get_float64x2 arr i = float_array_get_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_array_get_float64x2_unsafe : float array -> nativeint# -> float64x2 = "%caml_float_array_get128u#_indexed_by_nativeint#"
-  let float_array_get_float64x2_unsafe arr i = float_array_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_iarray_get_float64x2 : float iarray -> nativeint# -> float64x2 = "%caml_float_array_get128#_indexed_by_nativeint#"
-  let float_iarray_get_float64x2 arr i = float_iarray_get_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-  external float_iarray_get_float64x2_unsafe : float iarray -> nativeint# -> float64x2 = "%caml_float_array_get128u#_indexed_by_nativeint#"
-  let float_iarray_get_float64x2_unsafe arr i = float_iarray_get_float64x2_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)
-
-  external float_array_set_float64x2 : float array -> nativeint# -> float64x2 -> unit = "%caml_float_array_set128#_indexed_by_nativeint#"
-  let float_array_set_float64x2 arr i v = float_array_set_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
-  external float_array_set_float64x2_unsafe : float array -> nativeint# -> float64x2 -> unit = "%caml_float_array_set128u#_indexed_by_nativeint#"
-  let float_array_set_float64x2_unsafe arr i v = float_array_set_float64x2_unsafe arr (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
 
   external floatarray_get_float64x2 : floatarray -> nativeint# -> float64x2 = "%caml_floatarray_get128#_indexed_by_nativeint#"
   let floatarray_get_float64x2 arr i = floatarray_get_float64x2 arr (Stdlib_upstream_compatible.Nativeint_u.of_int i)

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -680,7 +680,6 @@ let prim_has_valid_reprs ~loc prim =
         ("512", "#", C.vec512);
       ] in
       let array_types = [
-        "float_array";
         "floatarray";
         "unboxed_float_array";
         "unboxed_float32_array";


### PR DESCRIPTION
This PR removes the SIMD primitives that operate on `float array` because these are not available with `--disable-flat-float-array`. Indeed, when the flat float array optimization is disabled, values of type `float array` are arrays of boxed floats, so SIMD instructions cannot be used on them. This PR does keep the primitives that operate on `floatarray` and `float# array`, so SIMD instructions are still available.

Since we would like to eventually work with the optimization disabled, it is easier to simply remove these primitives and encourage people who want to use the SIMD instructions to use `floatarray` or `float# array`.