### PR TITLE
Fix: forbid non-`value` `[@atomic]` fields

### DIFF
--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -623,3 +623,14 @@ Line 2, characters 13-41:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Atomic record fields are not permitted in mixed blocks.
 |}]
+
+module Inline_record_atomic_in_mixed = struct
+  type t = A of { mutable f : int [@atomic]; u : int# }
+end
+
+[%%expect{|
+Line 2, characters 18-44:
+2 |   type t = A of { mutable f : int [@atomic]; u : int# }
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields are not permitted in mixed blocks.
+|}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -579,3 +579,25 @@ Line 3, characters 4-31:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Atomic record fields must have layout value.
 |}]
+
+module Non_value_atomic_single_float64 = struct
+type t = { mutable f : float# [@atomic] }
+end
+
+[%%expect{|
+Line 2, characters 11-39:
+2 | type t = { mutable f : float# [@atomic] }
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]
+
+module Non_value_atomic_single_bits32 = struct
+  type t = { mutable f : int32# [@atomic] }
+end
+
+[%%expect{|
+Line 2, characters 13-41:
+2 |   type t = { mutable f : int32# [@atomic] }
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -601,3 +601,25 @@ Line 2, characters 13-41:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Atomic record fields must have layout value.
 |}]
+
+module Inline_record_non_value_atomic = struct
+  type t = A of { mutable f : float# [@atomic] }
+end
+
+[%%expect{|
+Line 2, characters 18-46:
+2 |   type t = A of { mutable f : float# [@atomic] }
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]
+
+module Atomic_float_with_float_hash = struct
+  type t = { mutable f : float [@atomic]; u : float# }
+end
+
+[%%expect{|
+Line 2, characters 13-41:
+2 |   type t = { mutable f : float [@atomic]; u : float# }
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields are not permitted in mixed blocks.
+|}]

--- a/testsuite/tests/typing-layouts/any_in_record.ml
+++ b/testsuite/tests/typing-layouts/any_in_record.ml
@@ -406,3 +406,38 @@ Error: Signature mismatch:
        Hint: Is there a type that has a representable layout in the first
          but has layout any in the second?
 |}]
+
+(* [@@flatten_floats] *)
+
+type ('a : any) t = { a : 'a }
+[@@flatten_floats]
+[%%expect{|
+Lines 1-2, characters 0-18:
+1 | type ('a : any) t = { a : 'a }
+2 | [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}]
+
+type ('a : any) t = { a : 'a; f : float }
+[@@flatten_floats]
+[%%expect{|
+Lines 1-2, characters 0-18:
+1 | type ('a : any) t = { a : 'a; f : float }
+2 | [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}]
+
+type ('a : any) t = { a : 'a; f : float# }
+[@@flatten_floats]
+[%%expect{|
+Lines 1-2, characters 0-18:
+1 | type ('a : any) t = { a : 'a; f : float# }
+2 | [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}]

--- a/testsuite/tests/typing-layouts/any_in_types.ml
+++ b/testsuite/tests/typing-layouts/any_in_types.ml
@@ -131,11 +131,17 @@ end = struct
   type t = #{ i : int; r : Rec_unboxed_record_1.t }
 end
 
-(* Refining block with any to all-float64 record *)
 type ('a : any) t = { a : 'a }
 
+(* Refining block with any to all-float64 record *)
 let () =
   let t : float# t = { a = #1.0 } in
   let f = t.a in
   Printf.printf "Printing a float#: %f\n"
     (Stdlib_upstream_compatible.Float_u.to_float f)
+
+(* Refining block with any to float record *)
+let () =
+  let x : float t = { a = 1.0 } in
+  let y = x.a +. 1.0 in
+  Printf.printf "Printing a float: %f\n" y

--- a/testsuite/tests/typing-layouts/any_in_types.ml
+++ b/testsuite/tests/typing-layouts/any_in_types.ml
@@ -137,11 +137,22 @@ type ('a : any) t = { a : 'a }
 let () =
   let t : float# t = { a = #1.0 } in
   let f = t.a in
-  Printf.printf "Printing a float#: %f\n"
+  Printf.printf "Refining to float64 ==\n";
+  Printf.printf "%f\n"
     (Stdlib_upstream_compatible.Float_u.to_float f)
 
 (* Refining block with any to float record *)
 let () =
+  Printf.printf "Refining to float ==\n";
   let x : float t = { a = 1.0 } in
   let y = x.a +. 1.0 in
-  Printf.printf "Printing a float: %f\n" y
+  Printf.printf "%f\n" y
+
+(* Refining block with any to float-float64 record *)
+type ('a : any) mixed = { f : float; a : 'a }
+let () =
+  Printf.printf "Refining to mixed ==\n";
+  let x : float# mixed = { f = 1.; a = #10.0 } in
+  Printf.printf "%f\n" x.f;
+  Printf.printf "%f\n"
+    (Stdlib_upstream_compatible.Float_u.to_float x.a)

--- a/testsuite/tests/typing-layouts/any_in_types.ml
+++ b/testsuite/tests/typing-layouts/any_in_types.ml
@@ -130,3 +130,12 @@ and Rec_unboxed_record_2 : sig
 end = struct
   type t = #{ i : int; r : Rec_unboxed_record_1.t }
 end
+
+(* Refining block with any to all-float64 record *)
+type ('a : any) t = { a : 'a }
+
+let () =
+  let t : float# t = { a = #1.0 } in
+  let f = t.a in
+  Printf.printf "Printing a float#: %f\n"
+    (Stdlib_upstream_compatible.Float_u.to_float f)

--- a/testsuite/tests/typing-layouts/any_in_types.reference
+++ b/testsuite/tests/typing-layouts/any_in_types.reference
@@ -8,5 +8,10 @@ a
 b
 c
 d
-Printing a float#: 1.000000
-Printing a float: 2.000000
+Refining to float64 ==
+1.000000
+Refining to float ==
+2.000000
+Refining to mixed ==
+1.000000
+10.000000

--- a/testsuite/tests/typing-layouts/any_in_types.reference
+++ b/testsuite/tests/typing-layouts/any_in_types.reference
@@ -9,3 +9,4 @@ b
 c
 d
 Printing a float#: 1.000000
+Printing a float: 2.000000

--- a/testsuite/tests/typing-layouts/any_in_types.reference
+++ b/testsuite/tests/typing-layouts/any_in_types.reference
@@ -8,3 +8,4 @@ a
 b
 c
 d
+Printing a float#: 1.000000

--- a/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/testsuite/tests/typing-layouts/mixed_records.ml
@@ -473,3 +473,31 @@ Error: The "[@@flatten_floats]" attribute is only allowed on records with one or
        non-atomic "float" fields, one or more "float#" fields, and all other fields
        void.
 |}];;
+
+(* void accepted *)
+type t =
+  { a : float#;
+    b : float;
+    u : unit#;
+  } [@@flatten_floats]
+[%%expect{|
+type t = { a : float#; b : float; u : unit#; }
+|}];;
+
+(* product of voids not counted as void *)
+type bad =
+  { a : float#;
+    b : float;
+    u : #(unit# * unit#);
+  } [@@flatten_floats]
+[%%expect{|
+Lines 1-5, characters 0-22:
+1 | type bad =
+2 |   { a : float#;
+3 |     b : float;
+4 |     u : #(unit# * unit#);
+5 |   } [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}];;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2145,6 +2145,19 @@ let compute_record_repr
   (* Any record with a field of kind [any] can't be represented. *)
   | ~first_any:(Some id), .. ->
     Result.Error (Unrepresentable_field (Ident.name id))
+  | ~values:false, ~floats:false, ~atomic_floats:false,
+    ~float64s:true, ~non_float64_unboxed_fields:false,
+    ~voids:false, ~first_any:None, .. ->
+    if represent_as_float_array then begin
+      if refining_block_with_any then
+        (* CR-soon rtjoa: This fatal error is included for an abundance of
+           caution. We should make this function more defensive as a whole *)
+        Misc.fatal_error
+          "Typedecl.compute_record_repr: refining any with \
+           [@@represent_as_float_array]";
+      Ok Record_ufloat
+    end else
+      mixed_record ()
   (* For other mixed blocks, float fields are stored as flat
       only when they're unboxed.
   *)
@@ -2167,13 +2180,6 @@ let compute_record_repr
       ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:false, ~first_any:None, .. ->
     Ok Record_float
-  | ~values:false, ~floats:false, ~atomic_floats:false,
-    ~float64s:true, ~non_float64_unboxed_fields:false,
-    ~voids:false, ~first_any:None, .. ->
-    if represent_as_float_array then
-      Ok Record_ufloat
-    else
-      mixed_record ()
   (* Records with atomic float fields cannot use flat representation *)
   | ~atomic_floats:true, ~first_any:None, .. ->
     if warn && floats && not values

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2063,6 +2063,17 @@ let compute_record_repr
     ~represent_as_float_array
     ~flatten_floats
   =
+  (* Atomic fields must have layout value, independently of whether the
+     record is a mixed block. A single-field record with a non-value atomic
+     field would otherwise slip past the mixed-block patterns below. *)
+  List.iter2
+    (fun ((repr : Element_repr.t option), _) (lbl, _) ->
+       if Types.is_atomic lbl.Types.ld_mutable then
+         match repr with
+         | Some (Value_element _ | Float_element) -> ()
+         | Some (Unboxed_element _ | Void) | None ->
+           raise (Error (lbl.Types.ld_loc, Non_value_atomic_field)))
+    reprs lbls;
   let mixed_record () =
     let shape =
       Element_repr.mixed_product_shape loc reprs Record
@@ -2108,40 +2119,18 @@ let compute_record_repr
       Ok (Record_mixed shape)
     else
       mixed_record ()
-  (* Forbid atomic fields in mixed (or potentially mixed) blocks *)
+  (* Forbid atomic fields in mixed blocks. Non-value atomic fields are
+     already rejected upfront with [Non_value_atomic_field]. *)
   | ~values:true, ~voids:true, ~atomic_fields:true, ..
   | ~floats:true, ~voids:true, ~atomic_fields:true, ..
   | ~float64s:true, ~voids:true, ~atomic_fields:true, ..
   | ~values:true, ~float64s:true, ~atomic_fields:true, ..
   | ~non_float64_unboxed_fields:true, ~atomic_fields:true, ..
   | ~first_any:(Some _), ~atomic_fields:true, .. ->
-    let error =
-      (* Print a different error if an atomic field itself is
-          non-value *)
-      match
-        List.find_map
-          (fun ((repr : Element_repr.t option), lbl) ->
-              match repr with
-              | Some (Value_element _ | Float_element) | None -> None
-              | Some _ ->
-                if Types.is_atomic lbl.Types.ld_mutable
-                then Some lbl
-                else None)
-          (List.map2 (fun (repr, _) (lbl, _) -> repr, lbl)
-              reprs lbls)
-      with
-      | Some lbl ->
-        Error(lbl.Types.ld_loc, Non_value_atomic_field)
-      | None ->
-        (* Find the first atomic field, to get a better location for the
-            error *)
-        let lbl, _ =
-          List.find (fun (lbl, _) -> Types.is_atomic lbl.Types.ld_mutable)
-            lbls
-        in
-        Error(lbl.Types.ld_loc, Atomic_field_in_mixed_block)
+    let lbl, _ =
+      List.find (fun (lbl,_) -> Types.is_atomic lbl.Types.ld_mutable) lbls
     in
-    raise error
+    raise (Error(lbl.Types.ld_loc, Atomic_field_in_mixed_block))
   (* Any record with a field of kind [any] can't be represented. *)
   | ~first_any:(Some id), .. ->
     Result.Error (Unrepresentable_field (Ident.name id))

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2163,15 +2163,17 @@ let compute_record_repr
   *)
   | ~values:true, ~voids:true, ~atomic_fields:false, ..
   | ~floats:true, ~voids:true, ~atomic_fields:false, ..
+  | ~floats:true, ~float64s:true, ~atomic_fields:false, ..
   | ~float64s:true, ~voids:true, ~atomic_fields:false, ..
   | ~values:true, ~float64s:true, ~atomic_fields:false, ..
   | ~non_float64_unboxed_fields:true, ~atomic_fields:false, .. ->
     mixed_record ()
-  (* value-only records are stored as boxed records, as are records whose
-      declared types have fields of kind [any] *)
-  | ~values:true, ~float64s:false, ~non_float64_unboxed_fields: false,
+  (* value-only records are stored as boxed records, including records whose
+     declared types have fields of kind [any] *)
+  | ~values:true, ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:false, ..
-  | ~refining_block_with_any:true, .. ->
+  | ~refining_block_with_any:true, ~float64s:false,
+      ~non_float64_unboxed_fields:false, ~voids:false, .. ->
     Ok Record_boxed
   (* All-nonatomic-float and all-nonatomic-float64 records are stored as
       flat float records.

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2000,15 +2000,29 @@ let mixed_block_element env ty jkind =
   let unboxed_element = Element_repr.classify env ty jkind in
   Option.map Element_repr.to_shape_element unboxed_element
 
-let check_atomic_fields_have_value_layout reprs lbls =
+(* Atomic fields must have layout value and must not appear in mixed blocks
+   (records that have any non-value field). *)
+let check_atomic_fields reprs lbls =
+  let is_value (repr : Element_repr.t option) =
+    match repr with
+    | Some (Value_element _ | Float_element) -> true
+    | Some (Unboxed_element _ | Void) | None -> false
+  in
   List.iter2
-    (fun (repr : Element_repr.t option) (lbl : Types.label_declaration) ->
-       if Types.is_atomic lbl.ld_mutable then
-         match repr with
-         | Some (Value_element _ | Float_element) -> ()
-         | Some (Unboxed_element _ | Void) | None ->
-           raise (Error (lbl.ld_loc, Non_value_atomic_field)))
-    reprs lbls
+    (fun repr (lbl : Types.label_declaration) ->
+       if Types.is_atomic lbl.ld_mutable && not (is_value repr) then
+         raise (Error (lbl.ld_loc, Non_value_atomic_field)))
+    reprs lbls;
+  let has_non_value = List.exists (fun r -> not (is_value r)) reprs in
+  if has_non_value then
+    match
+      List.find_opt
+        (fun (lbl : Types.label_declaration) -> Types.is_atomic lbl.ld_mutable)
+        lbls
+    with
+    | Some (lbl : Types.label_declaration) ->
+      raise (Error (lbl.ld_loc, Atomic_field_in_mixed_block))
+    | None -> ()
 
 let update_constructor_representation
     env (cd_args : Types.constructor_arguments) arg_jkinds ~loc
@@ -2033,8 +2047,7 @@ let update_constructor_representation
             ld.Types.ld_type)
             fields arg_jkinds
         in
-        check_atomic_fields_have_value_layout
-          (List.map fst arg_reprs) fields;
+        check_atomic_fields (List.map fst arg_reprs) fields;
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
         |> Result.map_error (fun (Element_repr.Unrepresentable_element i) ->
              let bad_field = List.nth fields i in
@@ -2075,11 +2088,10 @@ let compute_record_repr
     ~represent_as_float_array
     ~flatten_floats
   =
-  (* Atomic fields must have layout value, independently of whether the
-     record is a mixed block. A single-field record with a non-value atomic
-     field would otherwise slip past the mixed-block patterns below. *)
-  check_atomic_fields_have_value_layout
-    (List.map fst reprs) (List.map fst lbls);
+  (* Reject atomic fields with a non-value layout or in mixed blocks. After
+     this, atomic_fields:true should imply Record_boxed (value-only or
+     atomic-float), so the match below need *)
+  check_atomic_fields (List.map fst reprs) (List.map fst lbls);
   let mixed_record () =
     let shape =
       Element_repr.mixed_product_shape loc reprs Record
@@ -2125,19 +2137,6 @@ let compute_record_repr
       Ok (Record_mixed shape)
     else
       mixed_record ()
-  (* Forbid atomic fields in mixed blocks. Non-value atomic fields are
-     already rejected upfront with [Non_value_atomic_field]. *)
-  | ~values:true, ~voids:true, ~atomic_fields:true, ..
-  | ~floats:true, ~voids:true, ~atomic_fields:true, ..
-  | ~floats:true, ~float64s:true, ~atomic_fields:true, ..
-  | ~float64s:true, ~voids:true, ~atomic_fields:true, ..
-  | ~values:true, ~float64s:true, ~atomic_fields:true, ..
-  | ~non_float64_unboxed_fields:true, ~atomic_fields:true, ..
-  | ~first_any:(Some _), ~atomic_fields:true, .. ->
-    let lbl, _ =
-      List.find (fun (lbl,_) -> Types.is_atomic lbl.Types.ld_mutable) lbls
-    in
-    raise (Error(lbl.Types.ld_loc, Atomic_field_in_mixed_block))
   (* Any record with a field of kind [any] can't be represented. *)
   | ~first_any:(Some id), .. ->
     Result.Error (Unrepresentable_field (Ident.name id))
@@ -2183,6 +2182,12 @@ let compute_record_repr
     if warn && floats && not values
     then Location.prerr_warning loc Warnings.Atomic_float_record_boxed;
     Ok Record_boxed
+  (* Any remaining atomic-bearing shape should have been rejected by
+     [check_atomic_fields] above. *)
+  | ~atomic_fields:true, .. ->
+    Misc.fatal_error
+      "Typedecl.compute_record_repr: atomic field should have been \
+       rejected by check_atomic_fields"
   | ~values:false, ~floats:false, ~atomic_floats:false,
       ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:_, ~atomic_fields:_, ~first_any:None, ..

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2000,6 +2000,16 @@ let mixed_block_element env ty jkind =
   let unboxed_element = Element_repr.classify env ty jkind in
   Option.map Element_repr.to_shape_element unboxed_element
 
+let check_atomic_fields_have_value_layout reprs lbls =
+  List.iter2
+    (fun (repr : Element_repr.t option) (lbl : Types.label_declaration) ->
+       if Types.is_atomic lbl.ld_mutable then
+         match repr with
+         | Some (Value_element _ | Float_element) -> ()
+         | Some (Unboxed_element _ | Void) | None ->
+           raise (Error (lbl.ld_loc, Non_value_atomic_field)))
+    reprs lbls
+
 let update_constructor_representation
     env (cd_args : Types.constructor_arguments) arg_jkinds ~loc
     ~is_extension_constructor
@@ -2023,6 +2033,8 @@ let update_constructor_representation
             ld.Types.ld_type)
             fields arg_jkinds
         in
+        check_atomic_fields_have_value_layout
+          (List.map fst arg_reprs) fields;
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
         |> Result.map_error (fun (Element_repr.Unrepresentable_element i) ->
              let bad_field = List.nth fields i in
@@ -2066,14 +2078,8 @@ let compute_record_repr
   (* Atomic fields must have layout value, independently of whether the
      record is a mixed block. A single-field record with a non-value atomic
      field would otherwise slip past the mixed-block patterns below. *)
-  List.iter2
-    (fun ((repr : Element_repr.t option), _) (lbl, _) ->
-       if Types.is_atomic lbl.Types.ld_mutable then
-         match repr with
-         | Some (Value_element _ | Float_element) -> ()
-         | Some (Unboxed_element _ | Void) | None ->
-           raise (Error (lbl.Types.ld_loc, Non_value_atomic_field)))
-    reprs lbls;
+  check_atomic_fields_have_value_layout
+    (List.map fst reprs) (List.map fst lbls);
   let mixed_record () =
     let shape =
       Element_repr.mixed_product_shape loc reprs Record
@@ -2123,6 +2129,7 @@ let compute_record_repr
      already rejected upfront with [Non_value_atomic_field]. *)
   | ~values:true, ~voids:true, ~atomic_fields:true, ..
   | ~floats:true, ~voids:true, ~atomic_fields:true, ..
+  | ~floats:true, ~float64s:true, ~atomic_fields:true, ..
   | ~float64s:true, ~voids:true, ~atomic_fields:true, ..
   | ~values:true, ~float64s:true, ~atomic_fields:true, ..
   | ~non_float64_unboxed_fields:true, ~atomic_fields:true, ..
@@ -2176,12 +2183,6 @@ let compute_record_repr
     if warn && floats && not values
     then Location.prerr_warning loc Warnings.Atomic_float_record_boxed;
     Ok Record_boxed
-  | ~voids:false, ~values:false, ~floats:true, ~atomic_floats:false,
-      ~atomic_fields:true, ~float64s:true,
-      ~non_float64_unboxed_fields:false, .. ->
-    Misc.fatal_error
-      "Typedecl.compute_record_repr: invariant broken in repr_summary \
-        (only floats, some atomic fields, no atomic floats?)"
   | ~values:false, ~floats:false, ~atomic_floats:false,
       ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:_, ~atomic_fields:_, ~first_any:None, ..

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2090,7 +2090,7 @@ let compute_record_repr
   =
   (* Reject atomic fields with a non-value layout or in mixed blocks. After
      this, atomic_fields:true should imply Record_boxed (value-only or
-     atomic-float), so the match below need *)
+     atomic-float) *)
   check_atomic_fields (List.map fst reprs) (List.map fst lbls);
   let mixed_record () =
     let shape =


### PR DESCRIPTION
Previously, this check wasn't performed for all cases of the record representation match, allowing  `[@atomic]` in on all-`float64` records.
```ocaml
type t = { mutable f : float# [@atomic] }
``` 